### PR TITLE
fix(context): OSS userID anonymised 

### DIFF
--- a/src/utils/context/context.service.ts
+++ b/src/utils/context/context.service.ts
@@ -251,7 +251,7 @@ export class ContextService {
       }
 
       const isCloud = config.bootData.settings.buildInfo.versionString.startsWith('Grafana Cloud');
-      
+
       const payload: ContextPayload = {
         path: contextData.currentPath,
         datasources: contextData.dataSources.map((ds) => ds.type.toLowerCase()),


### PR DESCRIPTION
This pull request introduces a small change to the logic for determining user information in the `ContextService`. The update ensures that user identifiers and platform values are set correctly based on whether the instance is running on Grafana Cloud or OSS.

* Updated `ContextService` in `src/utils/context/context.service.ts` to use a single `isCloud` variable for checking the platform, and now sets `user_id` to `'oss-user'` for OSS users instead of using their analytics identifier. The `platform` value is also set based on `isCloud`.