### PR TITLE
feat(interactives): Added disable show me

### DIFF
--- a/src/utils/docs-retrieval/components/interactive/interactive-section.tsx
+++ b/src/utils/docs-retrieval/components/interactive/interactive-section.tsx
@@ -25,6 +25,7 @@ export interface InteractiveStepProps extends BaseInteractiveProps {
   postVerify?: string;
   targetComment?: string;
   doIt?: boolean; // Control whether "Do it" button appears (defaults to true)
+  showMe?: boolean; // Control whether "Show me" button appears (defaults to true)
   skippable?: boolean; // Whether this step can be skipped if requirements fail
   title?: string;
   description?: string;
@@ -61,6 +62,7 @@ export interface StepInfo {
   requirements?: string;
   postVerify?: string;
   skippable?: boolean; // Whether this step can be skipped
+  showMe?: boolean; // Whether to show the "Show me" button and phase
   isMultiStep: boolean; // Flag to identify component type
 }
 
@@ -215,6 +217,7 @@ export function InteractiveSection({
           requirements: props.requirements,
           postVerify: props.postVerify,
           skippable: props.skippable,
+          showMe: props.showMe,
           isMultiStep: false,
         });
       } else if (React.isValidElement(child) && (child as any).type === InteractiveMultiStep) {
@@ -692,8 +695,8 @@ export function InteractiveSection({
           }
         }
 
-        // First, show the step (highlight it) - skip for multi-step components
-        if (!stepInfo.isMultiStep) {
+        // First, show the step (highlight it) - skip for multi-step components OR if showMe is false
+        if (!stepInfo.isMultiStep && stepInfo.showMe !== false) {
           await executeInteractiveAction(
             stepInfo.targetAction!,
             stepInfo.refTarget!,

--- a/src/utils/docs-retrieval/components/interactive/interactive-step.tsx
+++ b/src/utils/docs-retrieval/components/interactive/interactive-step.tsx
@@ -20,6 +20,7 @@ export const InteractiveStep = forwardRef<
       targetComment,
       postVerify,
       doIt = true, // Default to true - show "Do it" button unless explicitly disabled
+      showMe = true, // Default to true - show "Show me" button unless explicitly disabled
       skippable = false, // Default to false - only skippable if explicitly set
       title,
       description,
@@ -361,8 +362,8 @@ export const InteractiveStep = forwardRef<
 
         <div className="interactive-step-actions">
           <div className="interactive-step-action-buttons">
-            {/* For highlight-only actions, hide "Show me" button when completed - only show when not completed */}
-            {!isCompletedWithObjectives && (
+            {/* Only show "Show me" button when showMe prop is true */}
+            {showMe && !isCompletedWithObjectives && (
               <Button
                 onClick={handleShowAction}
                 disabled={

--- a/src/utils/docs-retrieval/content-renderer.tsx
+++ b/src/utils/docs-retrieval/content-renderer.tsx
@@ -403,6 +403,7 @@ function renderParsedElement(element: ParsedElement | ParsedElement[], key: stri
           hints={element.props.hints}
           targetComment={element.props.targetComment}
           doIt={element.props.doIt}
+          showMe={element.props.showMe}
           skippable={element.props.skippable}
           requirements={element.props.requirements}
           objectives={element.props.objectives}

--- a/src/utils/docs-retrieval/html-parser.ts
+++ b/src/utils/docs-retrieval/html-parser.ts
@@ -789,6 +789,7 @@ export function parseHTMLToComponents(html: string, baseUrl?: string): ContentPa
               targetValue: el.getAttribute('data-targetvalue'),
               targetComment: interactiveComment || el.getAttribute('data-targetcomment'), // Prefer extracted comment
               doIt: el.getAttribute('data-doit') !== 'false', // Default to true, only false if explicitly set to 'false'
+              showMe: el.getAttribute('data-showme') !== 'false', // Default to true, only false if explicitly set to 'false'
               skippable: el.getAttribute('data-skippable') === 'true', // Default to false, only true if explicitly set to 'true'
               title: undefined, // Remove title - content will be in children
               // Specific data attribute mappings for React prop names


### PR DESCRIPTION
This pull request adds support for a new `showMe` property to the interactive documentation components, allowing finer control over the visibility and behavior of the "Show me" button throughout the interactive step flow. The changes propagate this property through the type definitions, parsing logic, and rendering, ensuring consistent behavior and configurability.

### Interactive step configuration and rendering

* Added the `showMe` property to the `InteractiveStepProps` and `StepInfo` interfaces, enabling steps to specify whether the "Show me" button should be displayed. [[1]](diffhunk://#diff-8080a048f542e1da5fd7daca3c115a142447ae358629ad55fbc8b77ce88e1eaaR28) [[2]](diffhunk://#diff-8080a048f542e1da5fd7daca3c115a142447ae358629ad55fbc8b77ce88e1eaaR65)
* Updated the `InteractiveStep` component to default `showMe` to `true` and conditionally render the "Show me" button based on this property. [[1]](diffhunk://#diff-5576eb0af8af9386ec363af5906aaa3dfdd515846870c5999df5241e9d456e15R23) [[2]](diffhunk://#diff-5576eb0af8af9386ec363af5906aaa3dfdd515846870c5999df5241e9d456e15L364-R366)
* Passed the `showMe` property through the interactive step creation and rendering pipeline, including the `InteractiveSection` component and the element parser. [[1]](diffhunk://#diff-8080a048f542e1da5fd7daca3c115a142447ae358629ad55fbc8b77ce88e1eaaR220) [[2]](diffhunk://#diff-2f5d1484bb713811dc2787faa6c17544c56649413bf1c21856ab8981c6281159R406)

### Parsing and step execution logic

* Modified the HTML parser to extract the `data-showme` attribute, defaulting to `true` unless explicitly set to `'false'`, ensuring correct initial configuration from markup.
* Updated the interactive step execution logic to skip highlighting/showing steps if `showMe` is set to `false`, providing more granular control over the user flow.