### PR TITLE
Add instructions for AI authoring documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ Use single code backticks for:
 Use triple code backticks followed by the syntax for code blocks, for example:
 
 ```javascript
-console.log("Hello World!");
+console.log('Hello World!');
 ```
 
 Introduce each code block with a short description.


### PR DESCRIPTION
The Docs Squad maintain the instructions in https://github.com/grafana/docs-ai to encourage AI authors to produce documentation according to Writers' Toolkit style: https://grafana.com/docs/writers-toolkit/.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
