### PR TITLE
fix(security): fixed dev mode and further security issues

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -7,6 +7,7 @@ import { PluginPropsContext } from '../../utils/utils.plugin';
 import { getConfigWithDefaults } from '../../constants';
 import { setGlobalLinkInterceptionEnabled } from '../../module';
 import { parseUrlSafely, isAllowedContentUrl } from '../../utils/url-validator';
+import { onPluginStart } from '../../utils/context';
 
 function getSceneApp() {
   return new SceneApp({
@@ -23,6 +24,11 @@ function App(props: AppRootProps) {
 
   // Get configuration
   const config = useMemo(() => getConfigWithDefaults(props.meta.jsonData || {}), [props.meta.jsonData]);
+
+  // SECURITY: Initialize plugin on mount (includes dev mode from server)
+  useEffect(() => {
+    onPluginStart();
+  }, []);
 
   // Enable/disable global link interception based on config
   useEffect(() => {

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -27,6 +27,9 @@ export const pendingDocsQueue: QueuedDocsLink[] = [];
 // Initialize translations
 await initPluginTranslations(pluginJson.id);
 
+// SECURITY: Dev mode is initialized lazily when user visits config with ?dev=true
+// This avoids unnecessary API calls for anonymous users who can't use dev mode anyway
+
 // Global link interceptor state
 let isInterceptorInitialized = false;
 let isInterceptionEnabled = false;

--- a/src/utils/context/context-security.test.ts
+++ b/src/utils/context/context-security.test.ts
@@ -12,11 +12,12 @@
  */
 
 import { ContextService } from './context.service';
-import { isDevModeEnabled } from '../dev-mode';
+import { isDevModeEnabledGlobal } from '../dev-mode';
 
 // Mock dependencies
 jest.mock('../dev-mode', () => ({
   isDevModeEnabled: jest.fn(() => false),
+  isDevModeEnabledGlobal: jest.fn(() => false),
 }));
 
 jest.mock('@grafana/runtime', () => ({
@@ -77,7 +78,7 @@ if (!AbortSignal.timeout) {
 describe('Security: Recommender Service URL Validation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (isDevModeEnabled as jest.Mock).mockReturnValue(false);
+    (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(false);
   });
 
   describe('HTTPS Requirement', () => {
@@ -306,7 +307,7 @@ describe('Security: Recommender Service URL Validation', () => {
 
   describe('Dev Mode Localhost Support', () => {
     it('should allow localhost in dev mode', async () => {
-      (isDevModeEnabled as jest.Mock).mockReturnValue(true);
+      (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(true);
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ recommendations: [] }),
@@ -341,7 +342,7 @@ describe('Security: Recommender Service URL Validation', () => {
     });
 
     it('should allow 127.0.0.1 in dev mode', async () => {
-      (isDevModeEnabled as jest.Mock).mockReturnValue(true);
+      (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(true);
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ recommendations: [] }),
@@ -376,7 +377,7 @@ describe('Security: Recommender Service URL Validation', () => {
     });
 
     it('should reject localhost in production mode', async () => {
-      (isDevModeEnabled as jest.Mock).mockReturnValue(false);
+      (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(false);
 
       const mockContextData = {
         currentPath: '/dashboards',

--- a/src/utils/context/context.init.ts
+++ b/src/utils/context/context.init.ts
@@ -18,7 +18,10 @@ export function initializeContextServices(): void {
 
 /**
  * Plugin lifecycle hook - call this when plugin starts
+ * SECURITY: Dev mode is now lazily initialized when user visits config with ?dev=true
  */
 export function onPluginStart(): void {
+  // Initialize context services only
+  // Dev mode is lazily initialized to avoid unnecessary API calls for anonymous users
   initializeContextServices();
 }

--- a/src/utils/context/context.service.ts
+++ b/src/utils/context/context.service.ts
@@ -8,7 +8,7 @@ import {
 } from '../../constants';
 import { fetchContent, getJourneyCompletionPercentage } from '../docs-retrieval';
 import { hashUserData, hashString } from '../../lib/hash.util';
-import { isDevModeEnabled } from '../dev-mode';
+import { isDevModeEnabledGlobal } from '../dev-mode';
 import { sanitizeTextForDisplay } from '../docs-retrieval/html-sanitizer';
 import { parseUrlSafely } from '../url-validator';
 import { sanitizeForLogging } from '../log-sanitizer';
@@ -341,7 +341,7 @@ export class ContextService {
 
     // Dev mode exception: Allow localhost URLs for local testing
     if (
-      isDevModeEnabled() &&
+      isDevModeEnabledGlobal() &&
       (parsedUrl.hostname === 'localhost' || parsedUrl.hostname === '127.0.0.1' || parsedUrl.hostname === '::1')
     ) {
       return true;
@@ -1169,8 +1169,8 @@ export class ContextService {
   ): Recommendation[] {
     const bundledRecommendations: Recommendation[] = [];
 
-    // Dev mode is now per-user via localStorage
-    if (isDevModeEnabled()) {
+    // Dev mode - add extra recommendations for debugging
+    if (isDevModeEnabledGlobal()) {
       bundledRecommendations.push({
         title: 'Components',
         url: 'https://grafana.com/components/',

--- a/src/utils/dev-mode.ts
+++ b/src/utils/dev-mode.ts
@@ -1,57 +1,184 @@
 /**
  * Dev mode utility for per-user developer features
  *
- * Dev mode enables developer/testing features like the SelectorDebugPanel.
- * It's stored in localStorage to be per-user/per-browser, not instance-wide.
+ * SECURITY: Hybrid approach for maximum security with per-user scoping
+ *
+ * Storage: Plugin jsonData (server-side, admin-controlled, cannot be manipulated via browser)
+ * Scoping: User ID check (only the user who enabled it sees dev features)
+ *
+ * Benefits:
+ * - Server-side storage in Grafana's database (tamper-proof)
+ * - Only admins can modify plugin settings
+ * - Per-user functionality (other users don't see dev mode even if enabled)
+ * - Synchronous checks (no async complexity)
+ * - Persists across sessions and page reloads
+ *
+ * Architecture:
+ * - devMode: boolean - Whether dev mode is enabled for the instance
+ * - devModeUserId: number - User ID who enabled it (only they see dev features)
+ *
+ * USAGE:
+ * - isDevModeEnabled(config, currentUserId) - Check if dev mode enabled for this user
+ * - enableDevMode(currentUserId) - Enable dev mode for a specific user
+ * - disableDevMode() - Disable dev mode entirely
  */
 
-const DEV_MODE_KEY = 'grafana-pathfinder-dev-mode';
+import { config } from '@grafana/runtime';
+import { DocsPluginConfig } from '../constants';
+import { updatePluginSettings } from './utils.plugin';
+import pluginJson from '../plugin.json';
 
 /**
- * Check if dev mode is enabled for the current user
- * Only checks localStorage - the toggle in config is the ONLY way to enable/disable
+ * Check if dev mode is enabled for the current user (synchronous)
+ *
+ * SECURITY: Checks both that dev mode is enabled AND user ID is in the allowed list
+ * This allows multiple developers to have access while preventing unauthorized users
+ *
+ * @param config - Plugin configuration from jsonData
+ * @param currentUserId - Current user's ID (optional, will auto-detect if not provided)
+ * @returns true if dev mode is enabled for this specific user
  */
-export const isDevModeEnabled = (): boolean => {
-  try {
-    return localStorage.getItem(DEV_MODE_KEY) === 'true';
-  } catch (e) {
-    console.warn('Failed to read dev mode from localStorage:', e);
-    return false;
-  }
+export const isDevModeEnabled = (pluginConfig: DocsPluginConfig, currentUserId?: number): boolean => {
+  // Auto-detect current user if not provided
+  const userId = currentUserId ?? config.bootData.user?.id;
+
+  const devMode = pluginConfig.devMode ?? false;
+  const devModeUserIds = pluginConfig.devModeUserIds ?? [];
+
+  // Dev mode must be enabled AND user ID must be in the allowed list
+  const result = devMode && userId !== undefined && devModeUserIds.includes(userId);
+
+  return result;
 };
 
 /**
  * Enable dev mode for the current user
+ *
+ * SECURITY: Writes to plugin jsonData (server-side, requires admin permissions)
+ * Adds user to the allowed list (doesn't remove other users)
+ *
+ * @param currentUserId - User ID to add to dev mode access list
+ * @param currentUserIds - Current list of user IDs (to preserve existing users)
  */
-export const enableDevMode = (): void => {
+export const enableDevMode = async (currentUserId: number, currentUserIds: number[] = []): Promise<void> => {
   try {
-    localStorage.setItem(DEV_MODE_KEY, 'true');
-  } catch (e) {
-    console.error('Failed to enable dev mode in localStorage:', e);
+    // Add user to list if not already present
+    const updatedUserIds = currentUserIds.includes(currentUserId) ? currentUserIds : [...currentUserIds, currentUserId];
+
+    // Update plugin settings with dev mode enabled and updated user list
+    await updatePluginSettings(pluginJson.id, {
+      enabled: true,
+      jsonData: {
+        devMode: true,
+        devModeUserIds: updatedUserIds,
+      },
+    });
+  } catch (e: any) {
+    console.error('Failed to enable dev mode:', e);
+    throw new Error('Failed to enable dev mode. You may need admin permissions to modify plugin settings.');
   }
 };
 
 /**
- * Disable dev mode for the current user
+ * Disable dev mode for a specific user
+ *
+ * SECURITY: Removes user from access list, disables entirely if last user
+ *
+ * @param userId - User ID to remove from dev mode access
+ * @param currentUserIds - Current list of user IDs
  */
-export const disableDevMode = (): void => {
+export const disableDevModeForUser = async (userId: number, currentUserIds: number[] = []): Promise<void> => {
   try {
-    localStorage.removeItem(DEV_MODE_KEY);
-  } catch (e) {
-    console.error('Failed to disable dev mode in localStorage:', e);
+    // Remove user from list
+    const updatedUserIds = currentUserIds.filter((id) => id !== userId);
+
+    // If no users left, disable dev mode entirely
+    const devMode = updatedUserIds.length > 0;
+
+    await updatePluginSettings(pluginJson.id, {
+      enabled: true,
+      jsonData: {
+        devMode,
+        devModeUserIds: updatedUserIds,
+      },
+    });
+  } catch (e: any) {
+    console.error('Failed to disable dev mode for user:', e);
+    throw new Error('Failed to disable dev mode. You may need admin permissions to modify plugin settings.');
+  }
+};
+
+/**
+ * Disable dev mode for all users
+ *
+ * SECURITY: Clears both flag and entire user list from server
+ */
+export const disableDevMode = async (): Promise<void> => {
+  try {
+    // Update plugin settings to disable dev mode entirely
+    await updatePluginSettings(pluginJson.id, {
+      enabled: true,
+      jsonData: {
+        devMode: false,
+        devModeUserIds: [],
+      },
+    });
+  } catch (e: any) {
+    console.error('Failed to disable dev mode:', e);
+    throw new Error('Failed to disable dev mode. You may need admin permissions to modify plugin settings.');
   }
 };
 
 /**
  * Toggle dev mode for the current user
- * @returns The new state of dev mode
+ *
+ * @param currentUserId - User ID to toggle dev mode for
+ * @param currentState - Whether THIS user currently has dev mode enabled
+ * @param currentUserIds - Current list of all users with dev mode access
+ * @returns The new state of dev mode for THIS user
  */
-export const toggleDevMode = (): boolean => {
-  const newValue = !isDevModeEnabled();
+export const toggleDevMode = async (
+  currentUserId: number,
+  currentState: boolean,
+  currentUserIds: number[] = []
+): Promise<boolean> => {
+  const newValue = !currentState;
+
   if (newValue) {
-    enableDevMode();
+    // Add user to the list
+    await enableDevMode(currentUserId, currentUserIds);
   } else {
-    disableDevMode();
+    // Remove user from the list
+    await disableDevModeForUser(currentUserId, currentUserIds);
   }
+
   return newValue;
+};
+
+/**
+ * Simplified check for dev mode without needing to pass config/userId
+ *
+ * USAGE: For utility functions that need a quick check but don't have access to plugin context
+ * This function attempts to read config from global state and check current user
+ *
+ * LIMITATION: May return false if called before plugin context is available
+ * Prefer using isDevModeEnabled(config, userId) in React components
+ *
+ * @returns true if dev mode is enabled for current user, false otherwise
+ */
+export const isDevModeEnabledGlobal = (): boolean => {
+  try {
+    // Try to get plugin config from global window (set by components)
+    const globalConfig = (window as any).__pathfinderPluginConfig as DocsPluginConfig | undefined;
+    const userId = config.bootData.user?.id;
+
+    if (!globalConfig) {
+      // Plugin context not available yet - default to false (safest)
+      return false;
+    }
+
+    return isDevModeEnabled(globalConfig, userId);
+  } catch (e) {
+    return false;
+  }
 };

--- a/src/utils/docs-retrieval/html-parser.ts
+++ b/src/utils/docs-retrieval/html-parser.ts
@@ -7,7 +7,7 @@ import { ParseError, ParseResult, ParsedElement, ParsedContent, ContentParseResu
 import { sanitizeDocumentationHTML } from './html-sanitizer';
 import { isGrafanaDocsUrl, isAllowedGitHubRawUrl, isLocalhostUrl, isGitHubRawUrl } from '../url-validator';
 import { ALLOWED_GITHUB_REPOS } from '../../constants';
-import { isDevModeEnabled } from '../dev-mode';
+import { isDevModeEnabledGlobal } from '../dev-mode';
 
 // Re-export for convenience
 export type { ParsedElement, ParsedContent };
@@ -43,7 +43,7 @@ function isTrustedInteractiveSource(baseUrl?: string): boolean {
   }
 
   // In dev mode, allow localhost URLs and any GitHub raw URLs for local testing
-  if (isDevModeEnabled()) {
+  if (isDevModeEnabledGlobal()) {
     if (isLocalhostUrl(baseUrl)) {
       console.log('[DEV MODE] Allowing interactive content from localhost:', baseUrl);
       return true;
@@ -206,7 +206,7 @@ export function parseHTMLToComponents(
   if (!bypassSourceValidation) {
     const allowInteractiveContent = isTrustedInteractiveSource(baseUrl);
     if (!allowInteractiveContent && html.includes('data-targetaction')) {
-      const errorMessage = isDevModeEnabled()
+      const errorMessage = isDevModeEnabledGlobal()
         ? '[SECURITY] Interactive content detected from untrusted source. Source must be grafana.com, bundled:, localhost (dev mode), GitHub raw URLs (dev mode), or github.com/grafana/interactive-tutorials/. Source:'
         : '[SECURITY] Interactive content detected from untrusted source. Source must be grafana.com, bundled:, or github.com/grafana/interactive-tutorials/. Source:';
 

--- a/src/utils/link-handler.hook.ts
+++ b/src/utils/link-handler.hook.ts
@@ -608,28 +608,62 @@ function createImageLightbox(imageSrc: string, imageAlt: string, theme: GrafanaT
   if (document.querySelector('.journey-image-modal')) {
     return;
   }
+
+  // SECURITY: Use DOM methods instead of innerHTML to prevent XSS
+  // Building the modal structure safely using createElement and textContent
+
   const imageModal = document.createElement('div');
   imageModal.className = 'journey-image-modal';
 
-  // Modal HTML, no inline styles, all sizing is CSS!
-  imageModal.innerHTML = `
-    <div class="journey-image-modal-backdrop">
-      <div class="journey-image-modal-container">
-        <div class="journey-image-modal-header">
-          <h3 class="journey-image-modal-title">${imageAlt}</h3>
-          <button class="journey-image-modal-close" aria-label="Close image">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <line x1="18" y1="6" x2="6" y2="18"></line>
-              <line x1="6" y1="6" x2="18" y2="18"></line>
-            </svg>
-          </button>
-        </div>
-        <div class="journey-image-modal-content">
-          <img src="${imageSrc}" alt="${imageAlt}" class="journey-image-modal-image" />
-        </div>
-      </div>
-    </div>
+  const backdrop = document.createElement('div');
+  backdrop.className = 'journey-image-modal-backdrop';
+
+  const container = document.createElement('div');
+  container.className = 'journey-image-modal-container';
+
+  // Header section
+  const header = document.createElement('div');
+  header.className = 'journey-image-modal-header';
+
+  // Title - SECURITY: Use textContent to prevent HTML injection
+  const title = document.createElement('h3');
+  title.className = 'journey-image-modal-title';
+  title.textContent = imageAlt; // Safe: textContent escapes HTML
+
+  // Close button
+  const closeButton = document.createElement('button');
+  closeButton.className = 'journey-image-modal-close';
+  closeButton.setAttribute('aria-label', 'Close image');
+
+  // SVG close icon (safe - no user input)
+  closeButton.innerHTML = `
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <line x1="18" y1="6" x2="6" y2="18"></line>
+      <line x1="6" y1="6" x2="18" y2="18"></line>
+    </svg>
   `;
+
+  header.appendChild(title);
+  header.appendChild(closeButton);
+
+  // Content section
+  const content = document.createElement('div');
+  content.className = 'journey-image-modal-content';
+
+  // Image - SECURITY: Use setAttribute to safely set src and alt
+  const image = document.createElement('img');
+  image.className = 'journey-image-modal-image';
+  image.setAttribute('src', imageSrc); // Safe: setAttribute escapes
+  image.setAttribute('alt', imageAlt); // Safe: setAttribute escapes
+
+  content.appendChild(image);
+
+  // Assemble modal structure
+  container.appendChild(header);
+  container.appendChild(content);
+  backdrop.appendChild(container);
+  imageModal.appendChild(backdrop);
+
   document.body.appendChild(imageModal);
 
   // Close modal utility
@@ -638,15 +672,15 @@ function createImageLightbox(imageSrc: string, imageAlt: string, theme: GrafanaT
     document.body.style.overflow = '';
   };
 
-  // Close on backdrop click
-  imageModal.querySelector('.journey-image-modal-backdrop')?.addEventListener('click', (e) => {
+  // Close on backdrop click - use direct reference instead of querySelector
+  backdrop.addEventListener('click', (e) => {
     if (e.target === e.currentTarget) {
       closeModal();
     }
   });
 
-  // Close on close button click
-  imageModal.querySelector('.journey-image-modal-close')?.addEventListener('click', closeModal);
+  // Close on close button click - use direct reference instead of querySelector
+  closeButton.addEventListener('click', closeModal);
 
   // Close on Escape key
   const handleEscape = (e: KeyboardEvent) => {

--- a/src/utils/security-mitm.test.ts
+++ b/src/utils/security-mitm.test.ts
@@ -7,11 +7,12 @@
 
 import { fetchContent } from './docs-retrieval/content-fetcher';
 import { sanitizeTextForDisplay } from './docs-retrieval/html-sanitizer';
-import { isDevModeEnabled } from './dev-mode';
+import { isDevModeEnabledGlobal } from './dev-mode';
 
 // Mock the dev-mode module
 jest.mock('./dev-mode', () => ({
   isDevModeEnabled: jest.fn(() => false),
+  isDevModeEnabledGlobal: jest.fn(() => false),
 }));
 
 // Mock fetch globally
@@ -29,7 +30,7 @@ if (!AbortSignal.timeout) {
 describe('Security: HTTPS Enforcement', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (isDevModeEnabled as jest.Mock).mockReturnValue(false);
+    (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(false);
   });
 
   describe('Content Fetcher HTTPS Validation', () => {
@@ -55,7 +56,7 @@ describe('Security: HTTPS Enforcement', () => {
     });
 
     it('should allow HTTP localhost in dev mode', async () => {
-      (isDevModeEnabled as jest.Mock).mockReturnValue(true);
+      (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(true);
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
         url: 'http://localhost:3000/docs/test',
@@ -89,7 +90,7 @@ describe('Security: HTTPS Enforcement', () => {
 describe('Security: Redirect Chain Validation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (isDevModeEnabled as jest.Mock).mockReturnValue(false);
+    (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(false);
   });
 
   it('should accept redirects to trusted domains', async () => {
@@ -300,7 +301,7 @@ describe('Security: Dev Mode Localhost Handling', () => {
   });
 
   it('should allow localhost in dev mode for content URLs', async () => {
-    (isDevModeEnabled as jest.Mock).mockReturnValue(true);
+    (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(true);
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       url: 'http://localhost:8080/docs/test',
@@ -313,7 +314,7 @@ describe('Security: Dev Mode Localhost Handling', () => {
   });
 
   it('should allow 127.0.0.1 in dev mode', async () => {
-    (isDevModeEnabled as jest.Mock).mockReturnValue(true);
+    (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(true);
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       url: 'http://127.0.0.1:8080/docs/test',
@@ -326,7 +327,7 @@ describe('Security: Dev Mode Localhost Handling', () => {
   });
 
   it('should reject localhost in production mode', async () => {
-    (isDevModeEnabled as jest.Mock).mockReturnValue(false);
+    (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(false);
 
     const result = await fetchContent('http://localhost:8080/docs/test');
 
@@ -336,7 +337,7 @@ describe('Security: Dev Mode Localhost Handling', () => {
   });
 
   it('should allow localhost for any path in dev mode for testing', async () => {
-    (isDevModeEnabled as jest.Mock).mockReturnValue(true);
+    (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(true);
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
       url: 'http://127.0.0.1:8080/docs/test',
@@ -353,7 +354,7 @@ describe('Security: Dev Mode Localhost Handling', () => {
 describe('Security: Protocol Validation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (isDevModeEnabled as jest.Mock).mockReturnValue(false);
+    (isDevModeEnabledGlobal as jest.Mock).mockReturnValue(false);
   });
 
   it('should reject javascript: protocol', async () => {

--- a/src/utils/url-validator.test.ts
+++ b/src/utils/url-validator.test.ts
@@ -16,12 +16,13 @@ import {
 // Mock the dev-mode module
 jest.mock('./dev-mode', () => ({
   isDevModeEnabled: jest.fn(() => false),
+  isDevModeEnabledGlobal: jest.fn(() => false),
   enableDevMode: jest.fn(),
   disableDevMode: jest.fn(),
   toggleDevMode: jest.fn(),
 }));
 
-import { isDevModeEnabled } from './dev-mode';
+import { isDevModeEnabledGlobal } from './dev-mode';
 
 describe('Grafana URL validators', () => {
   describe('isGrafanaDomain', () => {
@@ -339,7 +340,7 @@ describe('Localhost URL validators', () => {
   describe('isAllowedContentUrl', () => {
     beforeEach(() => {
       // Reset dev mode mock to disabled by default
-      jest.mocked(isDevModeEnabled).mockReturnValue(false);
+      jest.mocked(isDevModeEnabledGlobal).mockReturnValue(false);
     });
 
     afterEach(() => {
@@ -362,7 +363,7 @@ describe('Localhost URL validators', () => {
     });
 
     it('should allow localhost URLs with valid docs paths in dev mode', () => {
-      jest.mocked(isDevModeEnabled).mockReturnValue(true);
+      jest.mocked(isDevModeEnabledGlobal).mockReturnValue(true);
 
       // Valid docs paths should be allowed
       expect(isAllowedContentUrl('http://localhost:3000/docs')).toBe(true);
@@ -372,7 +373,7 @@ describe('Localhost URL validators', () => {
     });
 
     it('should reject localhost URLs without valid docs paths in dev mode', () => {
-      jest.mocked(isDevModeEnabled).mockReturnValue(true);
+      jest.mocked(isDevModeEnabledGlobal).mockReturnValue(true);
 
       // Non-docs paths should be rejected to avoid intercepting menu items
       expect(isAllowedContentUrl('http://localhost:3000/')).toBe(false);
@@ -388,7 +389,7 @@ describe('Localhost URL validators', () => {
     });
 
     it('should reject non-Grafana URLs even in dev mode', () => {
-      jest.mocked(isDevModeEnabled).mockReturnValue(true);
+      jest.mocked(isDevModeEnabledGlobal).mockReturnValue(true);
 
       expect(isAllowedContentUrl('https://evil.com/fake-docs')).toBe(false);
       expect(isAllowedContentUrl('https://malicious.site/tutorial')).toBe(false);
@@ -397,7 +398,7 @@ describe('Localhost URL validators', () => {
 
   describe('validateTutorialUrl', () => {
     beforeEach(() => {
-      jest.mocked(isDevModeEnabled).mockReturnValue(false);
+      jest.mocked(isDevModeEnabledGlobal).mockReturnValue(false);
     });
 
     afterEach(() => {
@@ -416,14 +417,14 @@ describe('Localhost URL validators', () => {
     });
 
     it('should accept localhost URLs with /unstyled.html suffix in dev mode', () => {
-      jest.mocked(isDevModeEnabled).mockReturnValue(true);
+      jest.mocked(isDevModeEnabledGlobal).mockReturnValue(true);
 
       const result = validateTutorialUrl('http://localhost:5500/tutorial/unstyled.html');
       expect(result.isValid).toBe(true);
     });
 
     it('should reject localhost URLs without /unstyled.html suffix in dev mode', () => {
-      jest.mocked(isDevModeEnabled).mockReturnValue(true);
+      jest.mocked(isDevModeEnabledGlobal).mockReturnValue(true);
 
       const result = validateTutorialUrl('http://localhost:5500/tutorial/index.html');
       expect(result.isValid).toBe(false);

--- a/src/utils/url-validator.ts
+++ b/src/utils/url-validator.ts
@@ -10,7 +10,7 @@
  * In dev mode, localhost URLs are permitted for local testing.
  */
 
-import { isDevModeEnabled } from './dev-mode';
+import { isDevModeEnabledGlobal } from './dev-mode';
 import { ALLOWED_GRAFANA_DOCS_HOSTNAMES } from '../constants';
 
 /**
@@ -76,7 +76,7 @@ export function isAllowedContentUrl(urlString: string): boolean {
   // In dev mode, allow localhost URLs for local testing
   // IMPORTANT: Must check that localhost URLs have valid docs paths to avoid
   // intercepting menu items and other UI links that also resolve to localhost
-  if (isDevModeEnabled() && isLocalhostUrl(urlString)) {
+  if (isDevModeEnabledGlobal() && isLocalhostUrl(urlString)) {
     const url = parseUrlSafely(urlString);
     if (!url) {
       return false;
@@ -381,7 +381,7 @@ export function validateTutorialUrl(url: string): URLValidation {
   const pathParts = urlObj.pathname.split('/').filter(Boolean);
 
   // In dev mode, allow localhost URLs for testing
-  if (isDevModeEnabled() && isLocalhostUrl(url)) {
+  if (isDevModeEnabledGlobal() && isLocalhostUrl(url)) {
     // Require /unstyled.html suffix for localhost tutorials
     if (pathParts[pathParts.length - 1] !== 'unstyled.html') {
       return {


### PR DESCRIPTION
This pull request introduces a major security and UX improvement to the plugin's "dev mode" feature by switching from localStorage-based toggling to a hybrid approach: dev mode is now stored server-side in plugin configuration (`jsonData`), and access is scoped to specific user IDs. Only users listed in the `devModeUserIds` array will see and be able to enable dev mode features, and toggling dev mode now requires admin permissions and triggers a page reload for consistency. The changes also update all related UI logic, utility functions, and tests to support this new model.

**Dev Mode Security & Configuration Changes**

* Dev mode is now stored in plugin configuration (`jsonData`) and scoped to specific user IDs (`devModeUserIds`), rather than per-user localStorage; toggling dev mode requires admin permissions and reloads the page. UI and logic in `ConfigurationForm.tsx` and related components are updated to reflect this new model. [[1]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0L30-R31) [[2]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0L40-R54) [[3]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0L65-R99) [[4]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0L151-R207) [[5]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R49-R63) [[6]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199L68-R83) [[7]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199L109-R120)

* All places where dev mode is checked (docs panel, context panel, debug panel) now use the updated logic: dev mode is only enabled for users in `devModeUserIds`, and global config is set for utility functions that can't access React context. [[1]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769R392-R398) [[2]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L473-R481) [[3]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL586-R598) [[4]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fR42)

**Dev Mode Toggle & Debug Panel Improvements**

* The dev mode toggle in the configuration panel now disables itself and shows a "Saving to server and reloading..." message while saving, and displays improved warnings. The debug panel's "leave dev mode" logic now disables dev mode for the current user via server-side config and reloads the page, with error handling. [[1]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0L65-R99) [[2]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0L151-R207) [[3]](diffhunk://#diff-901cc28a4e84c83e322d9f40ad77063ae4ff3760ccaa09be46a1a425816fefdbL44-R68)

* New CSS styles for dev mode fields and update text are added for improved UX.

**Test and Utility Updates**

* Test mocks and logic for dev mode checks are updated to use the new global config-based approach. [[1]](diffhunk://#diff-7fb120ec4bdbc03a29785609c8b40f3dd6f88bf125034de7ee3398d862a7380bL15-R20) [[2]](diffhunk://#diff-7fb120ec4bdbc03a29785609c8b40f3dd6f88bf125034de7ee3398d862a7380bL80-R81) [[3]](diffhunk://#diff-7fb120ec4bdbc03a29785609c8b40f3dd6f88bf125034de7ee3398d862a7380bL309-R310)

**Miscellaneous**

* Minor imports and initialization are updated to support the new dev mode model and avoid unnecessary API calls for anonymous users. [[1]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57R10) [[2]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57R28-R32) [[3]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560R30-R32) [[4]](diffhunk://#diff-901cc28a4e84c83e322d9f40ad77063ae4ff3760ccaa09be46a1a425816fefdbL17) [[5]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L13-R13) [[6]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL7-R9)