### PR TITLE
fix(security): fixed iframes, github links

### DIFF
--- a/src/utils/docs-retrieval/html-parser.test.ts
+++ b/src/utils/docs-retrieval/html-parser.test.ts
@@ -19,3 +19,46 @@ describe('html-parser: data-showme-text', () => {
     expect(step.props.showMeText).toBe('Reveal');
   });
 });
+
+describe('html-parser: sandbox attribute handling', () => {
+  it('preserves empty sandbox attribute as empty string (not boolean true)', () => {
+    const html = `<iframe src="https://example.com" sandbox=""></iframe>`;
+    const baseUrl = 'https://grafana.com/docs/test/';
+    const result = parseHTMLToComponents(html, baseUrl);
+
+    expect(result.isValid).toBe(true);
+    expect(result.data).toBeTruthy();
+    const iframe = (result.data as any).elements.find((el: any) => el.type === 'iframe');
+    expect(iframe).toBeTruthy();
+    expect(iframe.props.sandbox).toBe('');
+    expect(iframe.props.sandbox).not.toBe(true);
+  });
+
+  it('sanitizer enforces maximum sandbox restrictions (empty string)', () => {
+    // Even if HTML provides sandbox token values, the sanitizer replaces them with
+    // empty string for maximum security (note: this test goes through sanitization)
+    const html = `<iframe src="https://example.com" sandbox="allow-scripts allow-same-origin"></iframe>`;
+    const baseUrl = 'https://grafana.com/docs/test/';
+    const result = parseHTMLToComponents(html, baseUrl);
+
+    expect(result.isValid).toBe(true);
+    expect(result.data).toBeTruthy();
+    const iframe = (result.data as any).elements.find((el: any) => el.type === 'iframe');
+    expect(iframe).toBeTruthy();
+    // Sanitizer enforces empty sandbox="" for maximum security, regardless of input
+    expect(iframe.props.sandbox).toBe('');
+  });
+
+  it('still converts boolean attributes correctly (disabled, checked, etc)', () => {
+    const html = `<input type="checkbox" disabled="" checked="">`;
+    const baseUrl = 'https://grafana.com/docs/test/';
+    const result = parseHTMLToComponents(html, baseUrl);
+
+    expect(result.isValid).toBe(true);
+    expect(result.data).toBeTruthy();
+    const input = (result.data as any).elements.find((el: any) => el.type === 'input');
+    expect(input).toBeTruthy();
+    expect(input.props.disabled).toBe(true);
+    expect(input.props.checked).toBe(true);
+  });
+});

--- a/src/utils/docs-retrieval/html-parser.ts
+++ b/src/utils/docs-retrieval/html-parser.ts
@@ -151,8 +151,14 @@ function mapHtmlAttributesToReactProps(element: Element, errorCollector: Parsing
         // Map HTML attribute names to React prop names
         const reactPropName = attributeMap[attrName] || attrName;
 
+        // SECURITY (F6): Preserve empty string for sandbox attribute
+        // Empty sandbox="" means maximum restrictions, not a boolean true
+        // Other enumerated attributes that use empty strings meaningfully
+        const preserveEmptyString = new Set(['sandbox']);
+
         // Convert boolean attributes for React (e.g., disabled="" → disabled={true})
-        if (attrValue === '' || attrValue === attrName) {
+        // But preserve empty strings for attributes where they have specific meaning
+        if ((attrValue === '' || attrValue === attrName) && !preserveEmptyString.has(attrName)) {
           props[reactPropName] = true;
         } else {
           props[reactPropName] = attrValue;

--- a/src/utils/url-validator.ts
+++ b/src/utils/url-validator.ts
@@ -166,6 +166,41 @@ export function isYouTubeDomain(urlString: string): boolean {
 }
 
 /**
+ * Check if URL is a valid Vimeo domain
+ *
+ * Security: Validates hostname is an exact match to known Vimeo domains
+ *
+ * @param urlString - The URL to validate
+ * @returns true if valid Vimeo URL, false otherwise
+ *
+ * @example
+ * isVimeoDomain('https://player.vimeo.com/video/123456') // true
+ * isVimeoDomain('https://vimeo.com.evil.com/video/') // false
+ */
+export function isVimeoDomain(urlString: string): boolean {
+  const url = parseUrlSafely(urlString);
+  if (!url) {
+    return false;
+  }
+
+  // Only allow https protocol
+  if (url.protocol !== 'https:') {
+    return false;
+  }
+
+  // Exact hostname matching (no subdomain wildcards)
+  const allowedHosts = [
+    'player.vimeo.com',
+    'vimeo.com',
+    'www.vimeo.com',
+    'vimeocdn.com', // CDN domain for Vimeo scripts
+    'f.vimeocdn.com', // Froogaloop API domain
+  ];
+
+  return allowedHosts.includes(url.hostname);
+}
+
+/**
  * Check if URL is a valid GitHub raw content URL from allowed repositories
  *
  * SECURITY: Validates both repository AND branch/ref to prevent PR/commit-based attacks


### PR DESCRIPTION
This pull request focuses on strengthening and unifying security checks for external documentation URLs throughout the codebase, particularly for user-configurable, fetched, and embedded content. It also improves HTML sanitization for iframes, especially video embeds, and fixes attribute handling for React rendering. The changes ensure that only trusted sources (Grafana docs, approved GitHub repos, and localhost in dev mode) are allowed, and that iframe sandboxing is maximally restrictive except for trusted video platforms.

**Security and URL Validation Improvements:**

- Centralized and unified logic for validating external documentation URLs across all major entry points (`App.tsx`, `docs-panel.tsx`, `module.tsx`, `global-link-interceptor.hook.ts`, `link-handler.hook.ts`). Now, only Grafana docs, approved GitHub repos, and (in dev mode) localhost/GitHub URLs are allowed, matching the same logic everywhere. [[1]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57L7-R18) [[2]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57L43-R61) [[3]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL9-R27) [[4]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL162-R194) [[5]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560L14-R22) [[6]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560L88-R105) [[7]](diffhunk://#diff-d2c1f91060b805b2c9f9cf8609cfa53b808c6b36fd1edd2e585ceef68bee7cf7L3-R11) [[8]](diffhunk://#diff-d2c1f91060b805b2c9f9cf8609cfa53b808c6b36fd1edd2e585ceef68bee7cf7L14-R36) [[9]](diffhunk://#diff-bdf95d35514264ba75ee4d57357d6c4b03b9c715048fc09ef024c8b7ec758440L11-R19) [[10]](diffhunk://#diff-bdf95d35514264ba75ee4d57357d6c4b03b9c715048fc09ef024c8b7ec758440R48-L71)

- In the content fetcher, redirects are now handled using the `URL` constructor for safety, with strict same-origin and trusted-domain checks on redirect targets to prevent cross-origin and open redirect attacks.

**HTML Sanitization and Iframe Handling:**

- The HTML sanitizer now distinguishes between trusted video platforms (YouTube, Vimeo) and other iframes. Video iframes are allowed without sandbox restrictions (to avoid playback errors), while all others receive `sandbox=""` and `referrerpolicy="no-referrer"` for maximum security. [[1]](diffhunk://#diff-9b2303bba7888dcf38db9c174d74e507a11fab951bd1f738f499093c6cf664f6L6-R6) [[2]](diffhunk://#diff-9b2303bba7888dcf38db9c174d74e507a11fab951bd1f738f499093c6cf664f6L16-R17) [[3]](diffhunk://#diff-9b2303bba7888dcf38db9c174d74e507a11fab951bd1f738f499093c6cf664f6L298-R322)

- The sanitizer and HTML-to-React parser now correctly preserve an empty string for the `sandbox` attribute (meaning maximum restrictions), instead of treating it as a boolean, and include tests for this behavior. [[1]](diffhunk://#diff-1d6ec3c5a93bbb8c1efd18786f6d7f3ea4440d0cce258f1e64ac326b883e64f9R154-R161) [[2]](diffhunk://#diff-d73757544cd1999073db8c474a350144a439204217b13e99579d6cb4bd2ff6f5R22-R64)

**Bug Fixes and Minor Improvements:**

- Fixed a bug in generating raw GitHub URLs for content fetching by correcting the path format (removing `/refs/heads/` from the constructed URL).

- Simplified the logic for constructing `unstyled.html` URLs in the link handler.

**Testing and Documentation:**

- Added comprehensive tests to ensure correct handling of the `sandbox` attribute and boolean HTML attributes in the HTML parser.

These changes significantly harden the app against XSS and open redirect vulnerabilities, ensure consistent security policy enforcement, and improve the reliability of embedded documentation content.

**References:**  
[[1]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57L7-R18) [[2]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57L43-R61) [[3]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL9-R27) [[4]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL162-R194) [[5]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560L14-R22) [[6]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560L88-R105) [[7]](diffhunk://#diff-fdb7f7c27090da3f5e37c5391ec999608b1d007a150f8ceae2805b9b0e022172L428-R472) [[8]](diffhunk://#diff-fdb7f7c27090da3f5e37c5391ec999608b1d007a150f8ceae2805b9b0e022172L537-R570) [[9]](diffhunk://#diff-d73757544cd1999073db8c474a350144a439204217b13e99579d6cb4bd2ff6f5R22-R64) [[10]](diffhunk://#diff-1d6ec3c5a93bbb8c1efd18786f6d7f3ea4440d0cce258f1e64ac326b883e64f9R154-R161) [[11]](diffhunk://#diff-9b2303bba7888dcf38db9c174d74e507a11fab951bd1f738f499093c6cf664f6L6-R6) [[12]](diffhunk://#diff-9b2303bba7888dcf38db9c174d74e507a11fab951bd1f738f499093c6cf664f6L16-R17) [[13]](diffhunk://#diff-9b2303bba7888dcf38db9c174d74e507a11fab951bd1f738f499093c6cf664f6L298-R322) [[14]](diffhunk://#diff-d2c1f91060b805b2c9f9cf8609cfa53b808c6b36fd1edd2e585ceef68bee7cf7L3-R11) [[15]](diffhunk://#diff-d2c1f91060b805b2c9f9cf8609cfa53b808c6b36fd1edd2e585ceef68bee7cf7L14-R36) [[16]](diffhunk://#diff-bdf95d35514264ba75ee4d57357d6c4b03b9c715048fc09ef024c8b7ec758440L11-R19) [[17]](diffhunk://#diff-bdf95d35514264ba75ee4d57357d6c4b03b9c715048fc09ef024c8b7ec758440R48-L71)