### PR TITLE
fix: resolve Windows CRLF line ending issue in entrypoint.sh

### DIFF
--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -50,5 +50,5 @@ RUN sed -i 's|</body>|<script src="http://localhost:35729/livereload.js"></scrip
 
 
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Ensure shell scripts always use LF line endings on all platforms
+*.sh text eol=lf
+*.bash text eol=lf
+*.zsh text eol=lf
+
+# Ensure consistent line endings for other text files
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+


### PR DESCRIPTION
## Problem

Dear team. I created this PR with help from Cursor. Totally understand if it's not a priority - just wanted to contribute back after hitting this locally.

Windows users might encounter `exec /entrypoint.sh: no such file or directory` when running `npm run server`.

Please test on macOS and Linux to ensure the fix doesn't introduce any regressions for non-Windows users.
## Root Cause

Git's default `core.autocrlf=true` on Windows checks out files with CRLF line endings. The Linux container cannot execute shell scripts with CRLF, causing the entrypoint to fail with the cryptic error above.

## Solution

This PR implements a two-layer fix:

1. **Immediate fix (Dockerfile):** Strip carriage returns during Docker build using `sed`
2. **Prevention (.gitattributes):** Enforce LF line endings for shell scripts across all platforms

## Impact

- ✅ Fixes the issue for Windows users
- ✅ Backward compatible (no impact on Linux/Mac users)
- ✅ Prevents future occurrences via `.gitattributes`

## Testing

Tested on Windows 10 with Docker Desktop - Grafana now starts successfully.