### PR TITLE
feat(interactive): fixed first dashboard example to use internal data instead

### DIFF
--- a/src/bundled-interactives/first-dashboard.ts
+++ b/src/bundled-interactives/first-dashboard.ts
@@ -8,198 +8,177 @@ export const firstDashboardHtml = `<html>
         <title>Create a Dashboard of Grafana News</title>
     </head>
     <body>
-        <h1>Make your First Dashboard</h1>
-
-        <p>In this tutorial, we'll make your first dashboard, of Grafana news.  To do this, we'll learn the following
-            parts of Grafana in sequence:
-         <ul>
-             <li>Installing plugins to get access to data (in our case, RSS feeds)</li>
-             <li>Creating data sources, so we have something to visualize</li>
-             <li>Creating a dashboard that uses that datasource</li>
-             <li>Setting up basic Alerting</li>
-         </ul>
-        </p>
-
-        <h2>Step 1: Install a plugin</h2>
-
-        <p>We'll use the <em>Business News</em> plugin.</p>
-
-        <span id="install-plugin" class="interactive" data-objectives="has-plugin:volkovlabs-rss-datasource" data-requirements="navmenu-open" data-targetaction="sequence" data-reftarget="span#install-plugin"> 
-            <ul>
-              <!--
-              <li class="interactive" data-targetaction="multistep">
-                <span class="interactive" data-requirements="navmenu-open"
-                  data-reftarget="a[data-testid='data-testid Nav menu item'][href='/admin/plugins']"
-                  data-targetaction="highlight"></span>
-                <span class="interactive" data-reftarget="a[href='/plugins']" data-targetaction="highlight"></span>
-                <span class="interactive" data-reftarget="input[type='text']" data-targetaction="formfill" data-targetvalue="Business News"></span>
-                Do a 3 Step Dance Just Because
-              </li>
-              -->
-            
-              <li class="interactive" data-requirements="navmenu-open"
-                  data-reftarget="a[data-testid='data-testid Nav menu item'][href='/admin/plugins']"
-                  data-targetaction='highlight'>
-                Click Administration &gt; Plugins &amp; Data in the left-side menu.</li>
-
-              <li class="interactive" data-reftarget="a[href='/plugins']" data-targetaction='highlight'>
-                  Click the Plugins button
-              </li>
-
-              <li class="interactive" data-reftarget="input[type='text']" data-targetaction='formfill' data-targetvalue='Business News'>
-                 Use the search bar to search for "Business News" (the plugin we'll be using)
-              </li>
-
-              <li class="interactive" data-reftarget="a[href='/plugins/volkovlabs-rss-datasource']" data-targetaction='highlight'>
-                Click the Business News button that appears.
-              </li>
-
-              <li 
-                  class='interactive' 
-                  data-hint="You'll need to be logged in, and an administrator"
-                  data-requirements="is-admin"
-                  data-skippable="true"
-                  data-reftarget='Install' 
-                  data-targetaction='button'
-                  data-verify="has-plugin:volkovlabs-rss-datasource">
-                Click the <strong>Install</strong> button.
-                You need to have the Admin role to install a plugin.
-                You can skip this step if you don't have these permissions.
-              </li>
-            </ul>
-        </span>    
+        <h1>Create your first dashboard</h1>
         
-        <h2>Step 2: Create a Datasource</h2>
-
-        <p>A datasource lets us specify which feed we want to use, so we can query it in a dashboard.</p>
-
-        <span id="create-datasource" 
-            class="interactive" 
-            data-targetaction="sequence" 
-            data-reftarget="span#create-datasource"
-            data-requirements="navmenu-open,has-plugin:volkovlabs-rss-datasource"
-            data-objectives="has-datasource:volkovlabs-rss-datasource"> 
-            <ul>
-              <!-- Highlight a menu item and click it -->
-              <li class="interactive" 
-                  data-reftarget="a[data-testid='data-testid Nav menu item'][href='/connections']"
-                  data-targetaction='highlight'>
-                Click Connections in the left-side menu.</li>
-              <li class="interactive" data-reftarget="input[type='text']"
-                data-targetaction='formfill' data-targetvalue='Business News'>
-                Enter Business News in the search bar.</li>
-              <li class="interactive" 
-                  data-reftarget="a[href='/connections/datasources/volkovlabs-rss-datasource']"
-                  data-targetaction='highlight'>
-                Click Business News data source.</li>
-              <li class="interactive"
-                  data-reftarget="Add new data source"
-                  data-targetaction='button'>
-                Click Add new data source in the upper right.
-              </li>
-              <li class="interactive"
-                  data-reftarget="input[id='basic-settings-name']"
-                  data-targetaction='formfill' data-targetvalue='Reddit /r/grafana'>
-                Name the data source "Reddit /r/grafana"
-              </li>
-              <li class="interactive"
-                  data-reftarget="input[placeholder='https://feed']"
-                  data-targetaction="formfill" data-targetvalue="https://www.reddit.com/r/grafana/.rss">
-                Input the feed URL, which is <pre>https://www.reddit.com/r/grafana/.rss</pre>
-              </li>
-              <li class="interactive"
-                  data-reftarget="Save & Test"
-                  data-targetaction="button">
-                Click "Save &amp Test" to save the data source.
-              </li>
-            </ul>
-        </span>    
-                
-        <h2>Step 3: Create a Dashboard</h2>
-
-        <p>In this section, we'll use the datasource we created to create a visualization.</p>
+        <p>Welcome! In this tutorial, you'll learn how to create your first Grafana dashboard by following Jack and Jill on their hiking adventure. You'll start by exploring sample data in Explore, then transform that data into a beautiful visualization on a dashboard.</p>
         
-        <span id="create-dashboard" 
-              class='interactive' 
-              data-targetaction='sequence' 
-              data-reftarget="span#create-dashboard"
-              data-requirements="has-datasource:volkovlabs-rss-datasource">
+        <p>By the end of this tutorial, you'll understand how to query data, add labels to organize your metrics, and create meaningful visualizations that tell a story with your data.</p>
+        
+        <h2>Explore your data</h2>
+        
+        <p>Before building a dashboard, it's a good practice to explore your data first. Think of Explore as your data playground - it's where you can experiment with queries, understand what your data looks like, and test different approaches without committing to a dashboard.</p>
+        
+        <p>Let's start by tracking Jack and Jill's hiking altitude using sample data from Grafana's built-in TestData source.</p>
+
+        <span id="tutorial-section"
+              class="interactive"
+              data-targetaction="sequence"
+              data-reftarget="span#tutorial-section">
             <ul>
-              <li class="interactive" 
-                  data-reftarget="a[data-testid='data-testid Nav menu item'][href='/dashboards']"
-                  data-targetaction='highlight'>
-                Click Dashboards in the left-side menu.</li>
-              <li class="interactive"
-                  data-reftarget="/dashboard/new"
-                  data-targetaction='navigate'>
-                  Click the New > Dashboard button"
-              </li>
+            <li class="interactive"
+                data-targetaction='highlight'
+                data-reftarget='a[data-testid="data-testid Nav menu item"][href="/explore"]'>
+                <span class="interactive-comment">
+                    Explore is Grafana's investigation workspace. Unlike dashboards which display predefined visualizations, Explore lets you freely query your data sources and see results immediately. This makes it perfect for experimenting and understanding your data before committing to a dashboard design.
+                </span>
+                Navigate to <strong>Explore</strong> to begin querying data.
+            </li>
 
-              <li class="interactive" data-targetaction="multistep">
-                 <span class="interactive" data-targetaction="button" data-reftarget="Add Visualization"></span>
-                 <span class="interactive" data-targetaction="button" data-reftarget="Business News"></span>
-                  Click "Add Visualization", Select the Business News/Reddit /r/grafana option.
-              </li>
-              <!--
-              <li class="interactive" data-targetaction="button" data-reftarget="Add Visualization">
-                Click "Add Visualization", 
-              </li>
-              <li class="interactive" data-targetaction="button" data-reftarget="Business News">
-                Select the Business News/Reddit /r/grafana option.
-              </li>
-              -->
+            <li class="interactive" data-targetaction='multistep'>
+                <span class="interactive" data-targetaction='highlight' data-reftarget='input[data-testid="data-testid Select a data source"]'></span>
+                <span class="interactive" data-targetaction='highlight' data-reftarget='button:contains("gdev-testdata defaultTestData")'></span>
+                <span class="interactive-comment">
+                    In real-world scenarios, you'd connect to data sources like Prometheus for metrics, Loki for logs, or databases like PostgreSQL. For learning purposes, Grafana includes TestData - a built-in data source that generates realistic sample data without requiring any external setup. This lets you practice building dashboards right away.
+                </span>
+                Select the <strong>TestData</strong> data source to work with sample data.
+            </li>
 
-              <li class="interactive" data-targetaction="multistep">
-                <span class="interactive"
-                  data-reftarget='button[data-testid="data-testid toggle-viz-picker"]'
-                  data-targetaction="highlight"></span>
-                <span class="interactive"
-                  data-reftarget='div[aria-label="Plugin visualization item Table"]'
-                  data-targetaction="highlight"></span>
-                Click on the Visualization type, Search for "Table", Click Table.
-              </li>
+            <li class="interactive"
+                data-targetaction='formfill'
+                data-reftarget='input[id="test-data-scenario-select-A"]'
+                data-targetvalue='Random Walk'>
+                <span class="interactive-comment">
+                    Random Walk generates time series data that changes randomly over time, similar to how real metrics behave. Imagine tracking Jack's altitude as he climbs up and down hills - it goes up and down, but with natural variation. This type of data is perfect for simulating real-world metrics like CPU usage, temperature readings, or in our case, hiking altitude.
+                </span>
+                Choose <strong>Random Walk</strong> to simulate Jack's hiking altitude data.
+            </li>
 
-              <!--
-              <li class="interactive"
-                  data-reftarget='button[data-testid="data-testid toggle-viz-picker"]'
-                  data-targetaction='highlight'>
-                  Click on the Visualization type
-              </li>
-              <li>
-                  Search for "Table"
-              </li>
-              <li class="interactive"
-                  data-reftarget='div[data-test-id="Plugin visualization item Table"]'
-                  data-targetaction='highlight'>
-                  Click Table
-              </li>
-              -->
+            <li class="interactive"
+                data-targetaction='formfill'
+                data-reftarget='input[id="labels-A"]'
+                data-targetvalue='walker=jack'>
+                <span class="interactive-comment">
+                    Labels are key-value pairs that add context to your data. Think of them as tags that help you identify and filter your metrics. In our hiking story, we'll use labels to distinguish between Jack and Jill's individual altitude measurements. This is exactly how you'd use labels in production - to distinguish between different servers, applications, or users.
+                </span>
+                Add the label <strong>walker=jack</strong> to identify Jack's hiking data.
+            </li>
 
-              <li class="interactive" data-targetaction="multistep">
-                <span class="interactive" data-reftarget="Save Dashboard" data-targetaction="button"></span>
-                <span class="interactive" data-reftarget='input[aria-label="Save dashboard title field"]' 
-                  data-targetaction="formfill" data-targetvalue="Grafana News"></span>
-                <span class="interactive" data-reftarget="Save" data-targetaction="button"></span>
-                  Click Save Dashboard, name the dashboard "Grafana News" and click Save.
-              </li>
+            <li class="interactive"
+                data-targetaction='highlight'
+                data-reftarget='button:contains("Add query")'>
+                <span class="interactive-comment">
+                    Now let's add Jill's hiking data! In Grafana, you can display multiple queries on the same graph to compare and contrast data. This is incredibly powerful - imagine comparing CPU usage across different servers, or in our case, comparing Jack and Jill's hiking altitudes to see who climbed higher.
+                </span>
+                Click <strong>Add query</strong> to create a second data series for Jill.
+            </li>
 
-             <!--
-              <li class="interactive" data-reftarget="Save Dashboard" data-targetaction="button">
-                 Click Save Dashboard
-              </li>
-              <li class="interactive" data-reftarget='input[aria-label="Save dashboard title field"]' 
-                  data-targetaction="formfill" data-targetvalue="Grafana News">
-                  Name the dashboard "Grafana News"
-              </li>
+            <li class="interactive"
+                data-targetaction='formfill'
+                data-reftarget='input[id="labels-B"]'
+                data-targetvalue='walker=jill'>
+                <span class="interactive-comment">
+                    Now we'll add Jill's label to the second query. By using the same label key (<code>walker</code>) but different values (<code>jack</code> vs <code>jill</code>), Grafana can automatically differentiate between the two data series in visualizations. This labeling strategy is a best practice in observability - it keeps your data organized and queryable.
+                </span>
+                Add the label <strong>walker=jill</strong> to identify Jill's hiking data.
+            </li>
 
-              <li class="interactive" data-reftarget="Save" data-targetaction="button">
-                  Click Save
-              </li>
-            -->
             </ul>
         </span>
 
-        <p>That's it! You've got a basic dashboard.</p>
+        <h2>Create a dashboard</h2>
         
+        <p>Great work! You've explored Jack and Jill's hiking data and set up two labeled queries. Now comes the exciting part - transforming this raw data into a permanent, shareable dashboard.</p>
+        
+        <p>Dashboards are where your data comes to life. Unlike the temporary workspace of Explore, dashboards provide persistent visualizations that you and your team can reference anytime. Let's create your first one!</p>
+
+        <span id="dashboard-section"
+              class="interactive"
+              data-targetaction="sequence"
+              data-reftarget="span#dashboard-section">
+            <ul>
+            <li class="interactive" data-targetaction='multistep'>
+                <span class="interactive" data-targetaction='highlight' data-reftarget='button[aria-label="Add"]'></span>
+                <span class="interactive" data-targetaction='highlight' data-reftarget='button:contains("Add to dashboard")'></span>
+                <span class="interactive" data-targetaction='highlight' data-reftarget='button:contains("Open dashboard")'></span>
+                <span class="interactive-comment">
+                    One of Grafana's best features is the seamless transition from Explore to dashboards. Instead of manually recreating your queries, you can send them directly from Explore to a new or existing dashboard. This workflow saves time and ensures your carefully crafted queries make it to your dashboard exactly as you tested them.
+                </span>
+                Use the <strong>Add</strong> button to send your queries to a new dashboard.
+            </li>
+
+            <li class="interactive" data-targetaction='multistep'>
+                <span class="interactive" data-targetaction='highlight' data-reftarget='button[data-testid="data-testid Panel menu New Panel"]'></span>
+                <span class="interactive" data-targetaction='highlight' data-reftarget='a[data-testid="data-testid Panel menu item Edit"]'></span>
+                <span class="interactive-comment">
+                    Welcome to your new dashboard! The panel editor is where the magic happens. Each visualization on a dashboard is called a "panel," and the panel editor gives you complete control over how your data looks and behaves. Let's customize this panel to better tell Jack and Jill's hiking story.
+                </span>
+                Open the panel editor to customize your visualization.
+            </li>
+
+            <li class="interactive" data-targetaction='multistep'>
+                <span class="interactive" data-targetaction='highlight' data-reftarget='button[data-testid="data-testid toggle-viz-picker"]'></span>
+                <span class="interactive" data-targetaction='highlight' data-reftarget='div[data-testid="Plugin visualization item Bar chart"]'></span>
+                <span class="interactive-comment">
+                    Choosing the right visualization is key to telling your data's story. Time series graphs show trends over time, stat panels display single values, tables show raw data, and bar charts compare values side by side. For comparing Jack and Jill's final altitudes, a bar chart makes the difference instantly clear - you can see at a glance who climbed higher!
+                </span>
+                Change the visualization to <strong>Bar chart</strong> to compare altitudes.
+            </li>
+
+            <li class="interactive"
+                data-targetaction='formfill'
+                data-reftarget='input[data-testid="data-testid Panel editor option pane field input Title"]'
+                data-targetvalue='Jack and Jill Walk Altitude'>
+                <span class="interactive-comment">
+                    A good panel title transforms raw data into a story. Instead of generic names like "Query A" or "Metric 1," use descriptive titles that immediately convey what the data represents. This is especially important when sharing dashboards with teammates who might not know the context. Your future self will thank you too!
+                </span>
+                Give your panel a clear title: <strong>Jack and Jill Walk Altitude</strong>.
+            </li>
+
+            <li class="interactive"
+                data-targetaction='highlight'
+                data-reftarget='input[id="barchart-unit"]'
+                data-targetvalue='ALT'
+                data-doit='false'
+                >
+                <span class="interactive-comment">
+                    Units give meaning to numbers. Is that value 42 seconds, bytes, requests, or meters? Without units, numbers are just numbers. Grafana can automatically format values based on their units - bytes become KB/MB/GB, seconds become ms/s/m, and so on. This polish makes your dashboards professional and removes ambiguity.
+                </span>
+                We can give our walking data meaning by setting a unit.
+            </li>
+                <li class="interactive" data-targetaction="multistep">
+                <span class="interactive" data-reftarget="Save Dashboard" data-targetaction="button"></span>
+                <span class="interactive" data-reftarget='input[aria-label="Save dashboard title field"]' 
+                  data-targetaction="formfill" data-targetvalue="Walking Adventure"></span>
+                <span class="interactive" data-reftarget="Save" data-targetaction="button"></span>
+                Click <strong>Save Dashboard</strong>, name it <strong>Walking Adventure</strong>, and click <strong>Save</strong>.
+              </li>
+            </ul>
+        </span>
+
+        <h2>🎉 Congratulations!</h2>
+        
+        <p>You've just created your first Grafana dashboard! Let's recap what you learned:</p>
+        
+        <ul>
+            <li><strong>Explore first, dashboard later</strong> - Use Explore to experiment with queries before committing them to dashboards.</li>
+            <li><strong>Labels organize your data</strong> - Key-value pairs like <code>walker=jack</code> help you identify and filter time series data.</li>
+            <li><strong>Multiple queries tell richer stories</strong> - Comparing data series reveals patterns and insights you'd miss looking at them individually.</li>
+            <li><strong>Visualization choice matters</strong> - Bar charts for comparisons, time series for trends, tables for raw data - pick the right tool for your story.</li>
+            <li><strong>Polish makes perfect</strong> - Clear titles and proper units transform raw data into professional, understandable dashboards.</li>
+        </ul>
+        
+        <h3>What's next?</h3>
+        
+        <p>Now that you understand the basics, you're ready to explore more:</p>
+        
+        <ul>
+            <li><strong>Try different visualizations</strong> - Change your bar chart to a time series graph to see Jack and Jill's altitude over time.</li>
+            <li><strong>Add more panels</strong> - Dashboards can contain many panels. Try adding another panel to show different aspects of the data.</li>
+            <li><strong>Connect real data sources</strong> - The principles you learned with TestData apply to real sources like Prometheus, Loki, or databases.</li>
+            <li><strong>Explore transformations</strong> - Learn how to calculate rates, aggregate data, and perform advanced data manipulation.</li>
+        </ul>
+        
+        <p>Remember: every expert started exactly where you are now. The journey from first dashboard to complex monitoring systems is just a series of small steps, and you've taken the first one!</p>
+
     </body>
 </html>`;

--- a/src/bundled-interactives/index.json
+++ b/src/bundled-interactives/index.json
@@ -31,6 +31,14 @@
       "filename": "loki-grafana-101.ts",
       "exportName": "lokiGrafana101Html",
       "url": ["/"]
+    },
+    {
+      "id": "first-dashboard",
+      "title": "Create your first dashboard",
+      "summary": "Learn to create a dashboard in Grafana. Covering features such as Explore, dashboard creation, visualizations and more",
+      "filename": "first-dashboard.ts",
+      "exportName": "firstDashboardHtml",
+      "url": ["/"]
     }
   ]
 }

--- a/src/utils/action-handlers/form-fill-handler.ts
+++ b/src/utils/action-handlers/form-fill-handler.ts
@@ -108,8 +108,30 @@ export class FormFillHandler {
   private isAriaCombobox(element: HTMLElement): boolean {
     const role = element.getAttribute('role');
     const ariaAutocomplete = element.getAttribute('aria-autocomplete');
-    // Prefer ARIA role detection as it is stable across themes/classes
-    return role === 'combobox' && (ariaAutocomplete === 'list' || ariaAutocomplete === 'both');
+
+    // Primary: ARIA role detection (most reliable)
+    if (role === 'combobox' && (ariaAutocomplete === 'list' || ariaAutocomplete === 'both')) {
+      return true;
+    }
+
+    // Secondary: Check for Grafana's custom combobox pattern
+    // Many Grafana inputs have dropdown suffix but lack role="combobox"
+    // Look for parent wrapper with SVG dropdown icon (chevron-down)
+    const parent = element.parentElement;
+    if (parent && element.tagName.toLowerCase() === 'input') {
+      // Check if parent contains an SVG with a chevron-down path (dropdown indicator)
+      // This is more stable than CSS class names which are auto-generated
+      const svg = parent.querySelector('svg');
+      if (svg) {
+        // Look for the characteristic chevron-down path used in Grafana dropdowns
+        const path = svg.querySelector('path[d*="17,9.17"]');
+        if (path) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
   private parseClearCommand(value: string): { shouldClear: boolean; remainingValue: string } {


### PR DESCRIPTION
This pull request introduces a major rewrite of the "Create your first dashboard" interactive tutorial for Grafana. The new tutorial is more user-friendly and engaging, guiding users through the process of exploring data, adding labels, and building a dashboard using a narrative approach (Jack and Jill's hiking adventure). Additionally, the tutorial is now registered in the interactive index, and the form fill handler is improved for better compatibility with Grafana's custom dropdowns.

**Major improvements to the first dashboard tutorial:**

* Rewrote the `firstDashboardHtml` interactive (`first-dashboard.ts`) to provide a narrative-driven, step-by-step tutorial. The new version emphasizes exploring data before dashboard creation, explains key Grafana concepts (like labels and visualizations), and uses a relatable story to make learning more engaging.
* Updated the tutorial's registration in `index.json` so it appears in the interactive list, with a new title and summary.

**Enhancements to form fill automation:**

* Improved the `FormFillHandler.isAriaCombobox` method to better detect Grafana's custom dropdowns by checking for SVG chevron-down icons in addition to ARIA roles, increasing reliability across different themes and markup variations.