### PR TITLE
fix(context): fixed local storage

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
       file: .config/docker-compose-base.yaml
       service: grafana
     environment:
-      GF_FEATURE_TOGGLES_ENABLE: appSidecar,extensionSidebar,localizationForPlugins,UserStorage
+      GF_FEATURE_TOGGLES_ENABLE: appSidecar,extensionSidebar,localizationForPlugins
 
   prometheus:
     image: prom/prometheus:${PROMETHEUS_VERSION:-v3.5.0}


### PR DESCRIPTION
This pull request addresses a race condition in the restoration of user tabs in the documentation panel by ensuring that user storage is properly initialized before any storage operations occur. It introduces a global storage instance that can be set from React components and used by non-React code, and moves the tab restoration logic to after storage initialization. Additionally, it removes an obsolete feature toggle from the Grafana service configuration.

**User Storage Initialization and Tab Restoration:**

* Introduced a global storage instance (`globalStorageInstance`) in `user-storage.ts`, which can be set from React components with `setGlobalStorage` and is used as the default storage for non-React code, falling back to localStorage if not initialized.
* Updated the `useUserStorage` hook to initialize and set the global storage instance, ensuring that all storage helpers (React and non-React) use the correct backend and that storage is only initialized once. [[1]](diffhunk://#diff-16684b6a0f5041f04522224a5330458248b732aceadaf22a23be504095cb95acR201-R220) [[2]](diffhunk://#diff-16684b6a0f5041f04522224a5330458248b732aceadaf22a23be504095cb95acR253-R267)
* In `docs-panel.tsx`, ensured that `useUserStorage` is called at the top of the `CombinedPanelRenderer` component so storage is initialized before any tab restoration, preventing race conditions. [[1]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL30-R30) [[2]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fR578-R581)
* Moved tab restoration logic to a `useEffect` that runs after storage initialization, and updated comments and method visibility to reflect this change. [[1]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL120-R124) [[2]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fR595-R609) [[3]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL622-L623)

**Configuration Cleanup:**

* Removed the obsolete `UserStorage` feature toggle from the Grafana service environment variables in `docker-compose.yaml`.