### PR TITLE
feat(interactive):improved sequence manager

### DIFF
--- a/src/utils/use-sequential-step-state.hook.ts
+++ b/src/utils/use-sequential-step-state.hook.ts
@@ -1,0 +1,27 @@
+import { useSyncExternalStore } from 'react';
+import { SequentialRequirementsManager, RequirementsState } from './requirements-checker.hook';
+
+/**
+ * React 18 hook for subscribing to SequentialRequirementsManager state
+ * Uses useSyncExternalStore for proper external state synchronization
+ *
+ * This ensures React renders are synchronized with manager state updates,
+ * eliminating race conditions in step sequencing.
+ *
+ * @param stepId - The unique identifier for the step to subscribe to
+ * @returns The current state of the step, or undefined if not registered
+ */
+export function useSequentialStepState(stepId: string): RequirementsState | undefined {
+  const manager = SequentialRequirementsManager.getInstance();
+
+  return useSyncExternalStore(
+    // Subscribe function - React will call this to set up the subscription
+    (onStoreChange) => manager.subscribe(onStoreChange),
+
+    // Client snapshot - returns current state for this step
+    () => manager.getSnapshot().get(stepId),
+
+    // Server snapshot (same as client for this use case)
+    () => manager.getSnapshot().get(stepId)
+  );
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the synchronization and reliability of sequential requirements checking and step completion logic in the interactive documentation retrieval flow. The main focus is on eliminating race conditions, ensuring React state updates are synchronized with external state (via useSyncExternalStore), and improving the responsiveness and correctness of step and section completion checks.

**Synchronization and React state management:**

* Added a new `useSequentialStepState` hook using `useSyncExternalStore` to subscribe React components to the external state managed by `SequentialRequirementsManager`, ensuring React renders are always in sync with the latest step/section state and eliminating race conditions. (`src/utils/use-sequential-step-state.hook.ts`, [src/utils/use-sequential-step-state.hook.tsR1-R27](diffhunk://#diff-126900fad17c053c2bd4147b768577b17bd203ec29e0c26bc1e94016e4715009R1-R27))
* Updated `SequentialRequirementsManager` to provide a `getSnapshot` method and version tracking for proper integration with `useSyncExternalStore`. (`src/utils/requirements-checker.hook.ts`, [[1]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bR332) [[2]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bR378-R387)
* Refactored `useSequentialRequirements` and `useStepChecker` to use the new subscription model, removing custom force-update and debouncing logic in favor of React's built-in external store synchronization. (`src/utils/requirements-checker.hook.ts`, [[1]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bL661-R673) [[2]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bL677-L701) [[3]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bL770-R755); `src/utils/step-checker.hook.ts`, [[4]](diffhunk://#diff-7d74a6fc71afbf7061803544055202c089f09ba25dc18c84e805f33fa536edf9R95-R98) [[5]](diffhunk://#diff-7d74a6fc71afbf7061803544055202c089f09ba25dc18c84e805f33fa536edf9R649-R656)

**Elimination of race conditions and improved step completion:**

* Used `flushSync` in `InteractiveSection` to ensure state updates (such as completed steps and current step index) are applied synchronously before triggering eligibility checks, preventing race conditions where child components might not have re-rendered. (`src/utils/docs-retrieval/components/interactive/interactive-section.tsx`, [[1]](diffhunk://#diff-8080a048f542e1da5fd7daca3c115a142447ae358629ad55fbc8b77ce88e1eaaR2) [[2]](diffhunk://#diff-8080a048f542e1da5fd7daca3c115a142447ae358629ad55fbc8b77ce88e1eaaR419-R436) [[3]](diffhunk://#diff-8080a048f542e1da5fd7daca3c115a142447ae358629ad55fbc8b77ce88e1eaaL439-R455)
* Changed step and section completion logic to trigger reactive checks immediately (without debouncing) for critical paths, ensuring dependent steps and sections unlock as soon as possible. (`src/utils/requirements-checker.hook.ts`, [[1]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bL282-R291) [[2]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bL770-R755)

**General improvements and best practices:**

* Switched to using `useId()` for stable unique IDs in React, replacing `Date.now()` to avoid issues with unstable keys. (`src/utils/requirements-checker.hook.ts`, [src/utils/requirements-checker.hook.tsL661-R673](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bL661-R673))

These changes collectively make the step sequencing and requirements checking more robust, responsive, and maintainable.

**References:**
- [[1]](diffhunk://#diff-126900fad17c053c2bd4147b768577b17bd203ec29e0c26bc1e94016e4715009R1-R27) [[2]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bR332) [[3]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bR378-R387) [[4]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bL661-R673) [[5]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bL677-L701) [[6]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bL770-R755) [[7]](diffhunk://#diff-7d74a6fc71afbf7061803544055202c089f09ba25dc18c84e805f33fa536edf9R95-R98) [[8]](diffhunk://#diff-7d74a6fc71afbf7061803544055202c089f09ba25dc18c84e805f33fa536edf9R649-R656) [[9]](diffhunk://#diff-8080a048f542e1da5fd7daca3c115a142447ae358629ad55fbc8b77ce88e1eaaR2) [[10]](diffhunk://#diff-8080a048f542e1da5fd7daca3c115a142447ae358629ad55fbc8b77ce88e1eaaR419-R436) [[11]](diffhunk://#diff-8080a048f542e1da5fd7daca3c115a142447ae358629ad55fbc8b77ce88e1eaaL439-R455) [[12]](diffhunk://#diff-1c300674a87b7790c14a52ad10a05463e572c674321fcd2c8b1ba1433075210bL282-R291)