### PR TITLE
fix(ui): fixed tab theme

### DIFF
--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -806,6 +806,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   }, [calculateTabVisibility]);
 
   // ResizeObserver to track container width changes
+  // Re-run when tabs.length changes to handle tab bar appearing/disappearing
   useEffect(() => {
     const tabBar = tabBarRef.current;
     if (!tabBar) {
@@ -835,7 +836,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
     return () => {
       resizeObserver.disconnect();
     };
-  }, []);
+  }, [tabs.length]);
 
   // Content styles are applied at the component level via CSS classes
 
@@ -1281,108 +1282,11 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
             </Alert>
           )}
         </div>
-        <div className={styles.tabBar} ref={tabBarRef}>
-          <div className={styles.tabList} ref={tabListRef}>
-            {visibleTabs.map((tab) => {
-              const getTranslatedTitle = (title: string) => {
-                if (title === 'Recommendations') {
-                  return t('docsPanel.recommendations', 'Recommendations');
-                }
-                if (title === 'Learning Journey') {
-                  return t('docsPanel.learningJourney', 'Learning Journey');
-                }
-                if (title === 'Documentation') {
-                  return t('docsPanel.documentation', 'Documentation');
-                }
-                return title; // Custom titles stay as-is
-              };
-
-              return (
-                <button
-                  key={tab.id}
-                  className={`${styles.tab} ${tab.id === activeTabId ? styles.activeTab : ''}`}
-                  onClick={() => model.setActiveTab(tab.id)}
-                  title={getTranslatedTitle(tab.title)}
-                >
-                  <div className={styles.tabContent}>
-                    {tab.id !== 'recommendations' && (
-                      <Icon name={tab.type === 'docs' ? 'file-alt' : 'book'} size="xs" className={styles.tabIcon} />
-                    )}
-                    <span className={styles.tabTitle}>
-                      {tab.isLoading ? (
-                        <>
-                          <Icon name="sync" size="xs" />
-                          <span>{t('docsPanel.loading', 'Loading...')}</span>
-                        </>
-                      ) : (
-                        getTranslatedTitle(tab.title)
-                      )}
-                    </span>
-                    {tab.id !== 'recommendations' && (
-                      <IconButton
-                        name="times"
-                        size="sm"
-                        aria-label={t('docsPanel.closeTab', 'Close {{title}}', {
-                          title: getTranslatedTitle(tab.title),
-                        })}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          reportAppInteraction(UserInteraction.CloseTabClick, {
-                            content_type: tab.type || 'learning-journey',
-                            tab_title: tab.title,
-                            content_url: tab.currentUrl || tab.baseUrl,
-                            interaction_location: 'tab_button',
-                            ...(tab.type === 'learning-journey' &&
-                              tab.content && {
-                                completion_percentage: getJourneyProgress(tab.content),
-                                current_milestone: tab.content.metadata?.learningJourney?.currentMilestone,
-                                total_milestones: tab.content.metadata?.learningJourney?.totalMilestones,
-                              }),
-                          });
-                          model.closeTab(tab.id);
-                        }}
-                        className={styles.closeButton}
-                      />
-                    )}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-
-          {overflowedTabs.length > 0 && (
-            <div className={styles.tabOverflow}>
-              <button
-                ref={chevronButtonRef}
-                className={`${styles.tab} ${styles.chevronTab}`}
-                onClick={() => {
-                  if (!isDropdownOpen) {
-                    dropdownOpenTimeRef.current = Date.now();
-                  }
-                  setIsDropdownOpen(!isDropdownOpen);
-                }}
-                aria-label={t('docsPanel.showMoreTabs', 'Show {{count}} more tabs', { count: overflowedTabs.length })}
-                aria-expanded={isDropdownOpen}
-                aria-haspopup="true"
-              >
-                <div className={styles.tabContent}>
-                  <Icon name="angle-right" size="sm" className={styles.chevronIcon} />
-                  <span className={styles.tabTitle}>
-                    {t('docsPanel.moreTabs', '{{count}} more', { count: overflowedTabs.length })}
-                  </span>
-                </div>
-              </button>
-            </div>
-          )}
-
-          {isDropdownOpen && overflowedTabs.length > 0 && (
-            <div
-              ref={dropdownRef}
-              className={styles.tabDropdown}
-              role="menu"
-              aria-label={t('docsPanel.moreTabsMenu', 'More tabs')}
-            >
-              {overflowedTabs.map((tab) => {
+        {/* Only show tab bar if there are multiple tabs (more than just Recommendations) */}
+        {tabs.length > 1 && (
+          <div className={styles.tabBar} ref={tabBarRef}>
+            <div className={styles.tabList} ref={tabListRef}>
+              {visibleTabs.map((tab) => {
                 const getTranslatedTitle = (title: string) => {
                   if (title === 'Recommendations') {
                     return t('docsPanel.recommendations', 'Recommendations');
@@ -1399,25 +1303,15 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                 return (
                   <button
                     key={tab.id}
-                    className={`${styles.dropdownItem} ${tab.id === activeTabId ? styles.activeDropdownItem : ''}`}
-                    onClick={() => {
-                      model.setActiveTab(tab.id);
-                      setIsDropdownOpen(false);
-                    }}
-                    role="menuitem"
-                    aria-label={t('docsPanel.switchToTab', 'Switch to {{title}}', {
-                      title: getTranslatedTitle(tab.title),
-                    })}
+                    className={`${styles.tab} ${tab.id === activeTabId ? styles.activeTab : ''}`}
+                    onClick={() => model.setActiveTab(tab.id)}
+                    title={getTranslatedTitle(tab.title)}
                   >
-                    <div className={styles.dropdownItemContent}>
+                    <div className={styles.tabContent}>
                       {tab.id !== 'recommendations' && (
-                        <Icon
-                          name={tab.type === 'docs' ? 'file-alt' : 'book'}
-                          size="xs"
-                          className={styles.dropdownItemIcon}
-                        />
+                        <Icon name={tab.type === 'docs' ? 'file-alt' : 'book'} size="xs" className={styles.tabIcon} />
                       )}
-                      <span className={styles.dropdownItemTitle}>
+                      <span className={styles.tabTitle}>
                         {tab.isLoading ? (
                           <>
                             <Icon name="sync" size="xs" />
@@ -1440,7 +1334,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                               content_type: tab.type || 'learning-journey',
                               tab_title: tab.title,
                               content_url: tab.currentUrl || tab.baseUrl,
-                              close_location: 'dropdown',
+                              interaction_location: 'tab_button',
                               ...(tab.type === 'learning-journey' &&
                                 tab.content && {
                                   completion_percentage: getJourneyProgress(tab.content),
@@ -1450,7 +1344,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                             });
                             model.closeTab(tab.id);
                           }}
-                          className={styles.dropdownItemClose}
+                          className={styles.closeButton}
                         />
                       )}
                     </div>
@@ -1458,8 +1352,118 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                 );
               })}
             </div>
-          )}
-        </div>
+
+            {overflowedTabs.length > 0 && (
+              <div className={styles.tabOverflow}>
+                <button
+                  ref={chevronButtonRef}
+                  className={`${styles.tab} ${styles.chevronTab}`}
+                  onClick={() => {
+                    if (!isDropdownOpen) {
+                      dropdownOpenTimeRef.current = Date.now();
+                    }
+                    setIsDropdownOpen(!isDropdownOpen);
+                  }}
+                  aria-label={t('docsPanel.showMoreTabs', 'Show {{count}} more tabs', { count: overflowedTabs.length })}
+                  aria-expanded={isDropdownOpen}
+                  aria-haspopup="true"
+                >
+                  <div className={styles.tabContent}>
+                    <Icon name="angle-right" size="sm" className={styles.chevronIcon} />
+                    <span className={styles.tabTitle}>
+                      {t('docsPanel.moreTabs', '{{count}} more', { count: overflowedTabs.length })}
+                    </span>
+                  </div>
+                </button>
+              </div>
+            )}
+
+            {isDropdownOpen && overflowedTabs.length > 0 && (
+              <div
+                ref={dropdownRef}
+                className={styles.tabDropdown}
+                role="menu"
+                aria-label={t('docsPanel.moreTabsMenu', 'More tabs')}
+              >
+                {overflowedTabs.map((tab) => {
+                  const getTranslatedTitle = (title: string) => {
+                    if (title === 'Recommendations') {
+                      return t('docsPanel.recommendations', 'Recommendations');
+                    }
+                    if (title === 'Learning Journey') {
+                      return t('docsPanel.learningJourney', 'Learning Journey');
+                    }
+                    if (title === 'Documentation') {
+                      return t('docsPanel.documentation', 'Documentation');
+                    }
+                    return title; // Custom titles stay as-is
+                  };
+
+                  return (
+                    <button
+                      key={tab.id}
+                      className={`${styles.dropdownItem} ${tab.id === activeTabId ? styles.activeDropdownItem : ''}`}
+                      onClick={() => {
+                        model.setActiveTab(tab.id);
+                        setIsDropdownOpen(false);
+                      }}
+                      role="menuitem"
+                      aria-label={t('docsPanel.switchToTab', 'Switch to {{title}}', {
+                        title: getTranslatedTitle(tab.title),
+                      })}
+                    >
+                      <div className={styles.dropdownItemContent}>
+                        {tab.id !== 'recommendations' && (
+                          <Icon
+                            name={tab.type === 'docs' ? 'file-alt' : 'book'}
+                            size="xs"
+                            className={styles.dropdownItemIcon}
+                          />
+                        )}
+                        <span className={styles.dropdownItemTitle}>
+                          {tab.isLoading ? (
+                            <>
+                              <Icon name="sync" size="xs" />
+                              <span>{t('docsPanel.loading', 'Loading...')}</span>
+                            </>
+                          ) : (
+                            getTranslatedTitle(tab.title)
+                          )}
+                        </span>
+                        {tab.id !== 'recommendations' && (
+                          <IconButton
+                            name="times"
+                            size="sm"
+                            aria-label={t('docsPanel.closeTab', 'Close {{title}}', {
+                              title: getTranslatedTitle(tab.title),
+                            })}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              reportAppInteraction(UserInteraction.CloseTabClick, {
+                                content_type: tab.type || 'learning-journey',
+                                tab_title: tab.title,
+                                content_url: tab.currentUrl || tab.baseUrl,
+                                close_location: 'dropdown',
+                                ...(tab.type === 'learning-journey' &&
+                                  tab.content && {
+                                    completion_percentage: getJourneyProgress(tab.content),
+                                    current_milestone: tab.content.metadata?.learningJourney?.currentMilestone,
+                                    total_milestones: tab.content.metadata?.learningJourney?.totalMilestones,
+                                  }),
+                              });
+                              model.closeTab(tab.id);
+                            }}
+                            className={styles.dropdownItemClose}
+                          />
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       <div className={styles.content}>

--- a/src/styles/docs-panel.styles.ts
+++ b/src/styles/docs-panel.styles.ts
@@ -218,6 +218,20 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
     position: 'relative', // Positioning context for absolute dropdown
     flex: 1, // Take full width of parent container
     minWidth: 0, // Allow shrinking
+    // Smooth slide-down animation when tab bar appears
+    animation: 'slideDown 0.3s ease-out',
+    '@keyframes slideDown': {
+      from: {
+        maxHeight: 0,
+        opacity: 0,
+        transform: 'translateY(-8px)',
+      },
+      to: {
+        maxHeight: '60px',
+        opacity: 1,
+        transform: 'translateY(0)',
+      },
+    },
   }),
   tabList: css({
     label: 'combined-journey-tab-list',
@@ -249,6 +263,9 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
     '&:hover': {
       backgroundColor: 'transparent',
       color: theme.colors.text.primary,
+      '&::after': {
+        backgroundColor: theme.colors.action.hover,
+      },
     },
     '&:not(:first-child)': {
       marginLeft: theme.spacing(0.25),
@@ -257,12 +274,12 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
     '&::after': {
       content: '""',
       position: 'absolute',
-      left: theme.spacing(0.5),
-      right: theme.spacing(0.5),
-      bottom: '-1px',
+      left: 0,
+      right: 0,
+      bottom: 0,
       height: '2px',
       backgroundColor: 'transparent',
-      borderRadius: '1px',
+      borderRadius: theme.shape.radius.default,
       transition: 'background-color 0.2s ease',
     },
   }),
@@ -273,7 +290,7 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
     fontWeight: theme.typography.fontWeightMedium,
     // Primary blue underline like Grafana UI Tabs
     '&::after': {
-      backgroundColor: theme.colors.warning.main,
+      backgroundImage: theme.colors.gradients.brandHorizontal,
     },
   }),
   tabContent: css({
@@ -296,7 +313,6 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
     textOverflow: 'ellipsis',
     overflow: 'hidden',
     whiteSpace: 'nowrap',
-    fontSize: theme.typography.bodySmall.fontSize,
     fontWeight: 'inherit',
     color: 'inherit',
     flex: 1,
@@ -428,7 +444,6 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    fontSize: theme.typography.bodySmall.fontSize,
     fontWeight: 'inherit',
   }),
   dropdownItemClose: css({


### PR DESCRIPTION
This pull request improves the usability and visual polish of the docs panel tab bar by making its appearance conditional, ensuring it only shows when there are multiple tabs, and adding a smooth slide-down animation. Several style updates enhance the tab bar’s look and feel, including a gradient underline and better hover feedback.

**Docs Panel Tab Bar Logic:**
* The tab bar now only appears if there are multiple tabs (i.e., more than just the Recommendations tab), improving clarity and reducing UI clutter. [[1]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fR1285-R1286) [[2]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fR1466)
* The tab bar’s visibility logic is now tied to the number of tabs, ensuring the ResizeObserver effect updates correctly when tabs are added or removed. [[1]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fR809) [[2]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL838-R839)

**Tab Bar Styling and Animation:**
* Added a smooth slide-down animation for the tab bar when it appears, making the UI transition more polished.
* The active tab underline now uses a brand gradient instead of a solid warning color for a more modern look.
* Improved tab hover feedback and underline positioning for better accessibility and consistency. [[1]](diffhunk://#diff-91cff4c2633a8d3ac269cd306be21c55a988091b0761af6ac82f299081d2abceR266-R268) [[2]](diffhunk://#diff-91cff4c2633a8d3ac269cd306be21c55a988091b0761af6ac82f299081d2abceL260-R282)

**Minor Style Cleanups:**
* Removed redundant font size settings from tab label and dropdown styles to rely on inherited styles for consistency. [[1]](diffhunk://#diff-91cff4c2633a8d3ac269cd306be21c55a988091b0761af6ac82f299081d2abceL299) [[2]](diffhunk://#diff-91cff4c2633a8d3ac269cd306be21c55a988091b0761af6ac82f299081d2abceL431)