### PR TITLE
fix(u): fixed interactive styles

### DIFF
--- a/src/constants/interactive-z-index.ts
+++ b/src/constants/interactive-z-index.ts
@@ -1,0 +1,17 @@
+/**
+ * Z-Index constants for interactive overlays and highlights.
+ *
+ * IMPORTANT: These values are intentionally very high (9999+) because:
+ * 1. Pathfinder runs as a Grafana plugin and needs to appear above ALL Grafana UI
+ * 2. Grafana's own z-index values (modals, portals, tooltips) range up to ~2000
+ * 3. Interactive highlights/comments must be visible above everything for tutorials to work
+ * 4. These elements are appended to document.body, outside the normal stacking context
+ */
+export const INTERACTIVE_Z_INDEX = {
+  /** Overlay that blocks interaction with specific elements during tutorials */
+  BLOCKING_OVERLAY: 9999,
+  /** Visual highlight outline around target elements */
+  HIGHLIGHT_OUTLINE: 9999,
+  /** Comment boxes/tooltips that explain interactive steps */
+  COMMENT_BOX: 10002,
+} as const;

--- a/src/interactive-engine/global-interaction-blocker.ts
+++ b/src/interactive-engine/global-interaction-blocker.ts
@@ -1,5 +1,6 @@
 import { InteractiveElementData } from '../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
+import { INTERACTIVE_Z_INDEX } from '../constants/interactive-z-index';
 
 /**
  * Global interaction blocking state (singleton pattern)
@@ -157,7 +158,7 @@ class GlobalInteractionBlocker {
       overlay.style.width = `${rect.width}px`;
       overlay.style.height = `${rect.height}px`;
       overlay.style.background = 'transparent';
-      overlay.style.zIndex = '9999';
+      overlay.style.zIndex = String(INTERACTIVE_Z_INDEX.BLOCKING_OVERLAY);
       overlay.style.pointerEvents = 'auto';
     };
 

--- a/src/interactive-engine/navigation-manager.test.ts
+++ b/src/interactive-engine/navigation-manager.test.ts
@@ -219,21 +219,16 @@ describe('NavigationManager', () => {
     });
 
     it('should remove highlighted classes from elements', () => {
-      const element1 = document.createElement('div');
-      element1.className = 'interactive-highlighted';
-      const element2 = document.createElement('div');
-      element2.className = 'interactive-guided-active';
+      const element = document.createElement('div');
+      element.className = 'interactive-guided-active';
 
-      document.body.appendChild(element1);
-      document.body.appendChild(element2);
+      document.body.appendChild(element);
 
       navigationManager.clearAllHighlights();
 
-      expect(element1.classList.contains('interactive-highlighted')).toBe(false);
-      expect(element2.classList.contains('interactive-guided-active')).toBe(false);
+      expect(element.classList.contains('interactive-guided-active')).toBe(false);
 
-      document.body.removeChild(element1);
-      document.body.removeChild(element2);
+      document.body.removeChild(element);
     });
   });
 });

--- a/src/interactive-engine/navigation-manager.ts
+++ b/src/interactive-engine/navigation-manager.ts
@@ -103,8 +103,7 @@ export class NavigationManager {
     document.querySelectorAll('.interactive-comment-box').forEach((el) => el.remove());
 
     // Remove highlighted class from all elements
-    document.querySelectorAll('.interactive-highlighted, .interactive-guided-active').forEach((el) => {
-      el.classList.remove('interactive-highlighted');
+    document.querySelectorAll('.interactive-guided-active').forEach((el) => {
       el.classList.remove('interactive-guided-active');
     });
   }
@@ -276,7 +275,6 @@ export class NavigationManager {
       if (
         target.closest('.interactive-highlight-outline') ||
         target.closest('.interactive-comment-box') ||
-        target.closest('.interactive-highlighted') ||
         target === element ||
         element.contains(target)
       ) {
@@ -450,9 +448,6 @@ export class NavigationManager {
 
     // No DOM settling delay needed - scrollend event ensures scroll is complete
     // and DOM is stable. Highlight immediately for better responsiveness!
-
-    // Add highlight class for better styling
-    element.classList.add('interactive-highlighted');
 
     // Create a highlight outline element
     const highlightOutline = document.createElement('div');

--- a/src/styles/interactive.styles.ts
+++ b/src/styles/interactive.styles.ts
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
+import { INTERACTIVE_Z_INDEX } from '../constants/interactive-z-index';
 
 // Base interactive element styles
 const getBaseInteractiveStyles = (theme: GrafanaTheme2) => ({
@@ -162,14 +163,13 @@ const getInteractiveSequenceStyles = (theme: GrafanaTheme2) => ({
     borderRadius: theme.shape.radius.default,
     position: 'relative',
 
-    // List items inside sequences
-    'li.interactive': {
+    // Common styles for all list items
+    li: {
       paddingLeft: theme.spacing(2),
       paddingRight: theme.spacing(2),
       margin: `${theme.spacing(1)} 0`,
       display: 'flex',
       alignItems: 'center',
-      justifyContent: 'space-between',
       minHeight: '40px',
       position: 'relative',
       '&::before': {
@@ -189,30 +189,14 @@ const getInteractiveSequenceStyles = (theme: GrafanaTheme2) => ({
       },
     },
 
-    // Non-interactive list items
+    // Interactive-specific overrides
+    'li.interactive': {
+      justifyContent: 'space-between',
+    },
+
+    // Non-interactive specific overrides
     'li:not(.interactive)': {
-      margin: `${theme.spacing(1)} 0`,
       color: theme.colors.text.primary,
-      paddingLeft: theme.spacing(2),
-      paddingRight: theme.spacing(2),
-      display: 'flex',
-      alignItems: 'center',
-      minHeight: '40px',
-      position: 'relative',
-      '&::before': {
-        content: '"•"',
-        position: 'absolute',
-        left: `-${theme.spacing(2)}`,
-        top: '50%',
-        transform: 'translateY(-50%)',
-        color: theme.colors.text.secondary,
-        fontSize: '14px',
-        width: '16px',
-        height: '16px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      },
     },
 
     // Button in section
@@ -834,10 +818,6 @@ export const addGlobalInteractiveStyles = () => {
       }
     }
     /* Global interactive highlight styles */
-    .interactive-highlighted {
-      position: relative;
-      z-index: 1;
-    }
     .interactive-highlight-outline {
       position: absolute;
       top: var(--highlight-top);
@@ -845,7 +825,7 @@ export const addGlobalInteractiveStyles = () => {
       width: var(--highlight-width);
       height: var(--highlight-height);
       pointer-events: none;
-      z-index: 9999;
+      z-index: ${INTERACTIVE_Z_INDEX.HIGHLIGHT_OUTLINE};
       border-radius: 4px;
       /* Draw border clockwise using four gradient strokes (no fill) */
       --hl-color: rgba(255, 136, 0, 0.85);
@@ -871,9 +851,6 @@ export const addGlobalInteractiveStyles = () => {
       box-shadow: 0 0 0 4px rgba(180, 180, 180, 0.12);
       animation: subtle-highlight-pulse 1.6s ease-in-out infinite;
     }
-
-
-
 
     @keyframes interactive-draw-border {
       0% {
@@ -975,7 +952,7 @@ export const addGlobalInteractiveStyles = () => {
       max-width: 320px;
       min-width: 240px;
       pointer-events: none;
-      z-index: 10002;
+      z-index: ${INTERACTIVE_Z_INDEX.COMMENT_BOX};
       animation: fadeInComment 0.3s ease-out;
     }
 


### PR DESCRIPTION
This pull request refactors how interactive highlights and overlays are managed, focusing on improving z-index handling and simplifying highlight logic. The main changes include introducing a centralized z-index constants file, updating styles and logic to use these constants, and removing the legacy `.interactive-highlighted` class in favor of outline-based highlighting.

**Z-Index Management & Overlay Updates**
* Added new `src/constants/interactive-z-index.ts` file to centralize z-index values for interactive overlays, highlights, and comment boxes, ensuring they appear above all Grafana UI elements.
* Updated highlight and overlay logic in `global-interaction-blocker.ts` and styles in `interactive.styles.ts` to use the new z-index constants for consistency and maintainability. [[1]](diffhunk://#diff-7ed16bea62c42b4ef3f6d4fbcca8e048670ca9a426436c049d888bc096d4f8c7R3) [[2]](diffhunk://#diff-ab3fd87b84a4aff9f2fd63d20595f6df6c8eabb08128c30d1bb193511ebce832R4) [[3]](diffhunk://#diff-ab3fd87b84a4aff9f2fd63d20595f6df6c8eabb08128c30d1bb193511ebce832L837-R828) [[4]](diffhunk://#diff-ab3fd87b84a4aff9f2fd63d20595f6df6c8eabb08128c30d1bb193511ebce832L978-R955) [[5]](diffhunk://#diff-7ed16bea62c42b4ef3f6d4fbcca8e048670ca9a426436c049d888bc096d4f8c7L160-R161)

**Highlighting Logic Simplification**
* Removed usage of the `.interactive-highlighted` class throughout the codebase, switching to highlight outlines for visual feedback. This affects highlight application, removal, and hit-testing logic in `navigation-manager.ts`. [[1]](diffhunk://#diff-c2da8f2214b3cb6608ab8f59ef8bbb23c6c2b57e691dddaacea3cd3c860af925L106-R106) [[2]](diffhunk://#diff-c2da8f2214b3cb6608ab8f59ef8bbb23c6c2b57e691dddaacea3cd3c860af925L279) [[3]](diffhunk://#diff-c2da8f2214b3cb6608ab8f59ef8bbb23c6c2b57e691dddaacea3cd3c860af925L454-L456)

**Styles Refactoring**
* Refactored list item styles in `interactive.styles.ts` to apply common styling to all `li` elements, with specific overrides for `.interactive` and non-interactive items. [[1]](diffhunk://#diff-ab3fd87b84a4aff9f2fd63d20595f6df6c8eabb08128c30d1bb193511ebce832L165-L172) [[2]](diffhunk://#diff-ab3fd87b84a4aff9f2fd63d20595f6df6c8eabb08128c30d1bb193511ebce832L192-L215)

**Test Updates**
* Updated navigation manager tests to reflect the removal of `.interactive-highlighted`, ensuring tests only check for the remaining highlight class.