### PR TITLE
Multistep actions in wysiyg

### DIFF
--- a/docs/developer/interactive-examples/interactive-types.md
+++ b/docs/developer/interactive-examples/interactive-types.md
@@ -109,6 +109,11 @@ This guide explains the supported interactive types, when to use each, what `dat
 </li>
 ```
 
+**Note**: Normally, multistep actions do not have reftargets, since they act as containers for other
+interactive actions. If you specify the requirement of `exists-reftarget` for a multistep action,
+you are recommended to also specify `data-reftarget` to be equal to the first reftarget of the
+first interactive action in the multistep sequence.
+
 ## Choosing the right type
 
 - **Click by CSS selector**: highlight

--- a/src/docs-retrieval/components/interactive/interactive-guided.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-guided.tsx
@@ -10,7 +10,7 @@ import {
   matchesStepAction,
   type DetectedActionEvent,
 } from '../../../interactive-engine';
-import { waitForReactUpdates, useStepChecker } from '../../../requirements-manager';
+import { waitForReactUpdates, useStepChecker, validateInteractiveRequirements } from '../../../requirements-manager';
 import { getInteractiveConfig } from '../../../constants/interactive-config';
 import { getConfigWithDefaults } from '../../../constants';
 import { findButtonByText, querySelectorAllEnhanced } from '../../../lib/dom';
@@ -134,6 +134,18 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
 
     // Combined completion state
     const isCompleted = parentCompleted || isLocallyCompleted;
+
+    // Runtime validation: check for impossible requirement configurations
+    useEffect(() => {
+      validateInteractiveRequirements(
+        {
+          requirements,
+          refTarget: undefined, // Guided containers have no refTarget (internal actions do)
+          stepId: renderedStepId,
+        },
+        'InteractiveGuided'
+      );
+    }, [requirements, renderedStepId]);
 
     // Use step checker hook for requirements and objectives
     const checker = useStepChecker({

--- a/src/docs-retrieval/components/interactive/interactive-multi-step.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-multi-step.tsx
@@ -3,7 +3,7 @@ import { Button } from '@grafana/ui';
 import { usePluginContext } from '@grafana/data';
 
 import { useInteractiveElements, matchesStepAction, type DetectedActionEvent } from '../../../interactive-engine';
-import { useStepChecker } from '../../../requirements-manager';
+import { useStepChecker, validateInteractiveRequirements } from '../../../requirements-manager';
 import { reportAppInteraction, UserInteraction, buildInteractiveStepProperties } from '../../../lib/analytics';
 import { INTERACTIVE_CONFIG, getInteractiveConfig } from '../../../constants/interactive-config';
 import { getConfigWithDefaults } from '../../../constants';
@@ -190,6 +190,18 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
       stopSectionBlocking,
       isSectionBlocking,
     } = useInteractiveElements();
+
+    // Runtime validation: check for impossible requirement configurations
+    useEffect(() => {
+      validateInteractiveRequirements(
+        {
+          requirements,
+          refTarget: undefined, // Multistep containers have no refTarget
+          stepId: renderedStepId,
+        },
+        'InteractiveMultiStep'
+      );
+    }, [requirements, renderedStepId]);
 
     // Use step checker hook for overall multi-step requirements and objectives
     const checker = useStepChecker({

--- a/src/docs-retrieval/components/interactive/interactive-step.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-step.tsx
@@ -7,6 +7,7 @@ import {
   useStepChecker,
   getPostVerifyExplanation,
   checkPostconditions,
+  validateInteractiveRequirements,
 } from '../../../requirements-manager';
 import { reportAppInteraction, UserInteraction, buildInteractiveStepProperties } from '../../../lib/analytics';
 import type { InteractiveStepProps } from '../../../types/component-props.types';
@@ -92,6 +93,18 @@ export const InteractiveStep = forwardRef<
 
     // Combined completion state (parent takes precedence for coordination)
     const isCompleted = parentCompleted || isLocallyCompleted;
+
+    // Runtime validation: check for impossible requirement configurations
+    useEffect(() => {
+      validateInteractiveRequirements(
+        {
+          requirements,
+          refTarget,
+          stepId: renderedStepId,
+        },
+        'InteractiveStep'
+      );
+    }, [requirements, refTarget, renderedStepId]);
 
     // Get the interactive functions from the hook
     const { executeInteractiveAction, verifyStepResult } = useInteractiveElements();

--- a/src/requirements-manager/index.ts
+++ b/src/requirements-manager/index.ts
@@ -24,7 +24,7 @@ export { useStepChecker } from './step-checker.hook';
 export type { UseStepCheckerProps, UseStepCheckerReturn } from '../types/hooks.types';
 
 // Pure requirements checking utilities
-export { checkRequirements, checkPostconditions } from './requirements-checker.utils';
+export { checkRequirements, checkPostconditions, validateInteractiveRequirements } from './requirements-checker.utils';
 
 export type { RequirementsCheckResult, CheckResultError, RequirementsCheckOptions } from './requirements-checker.utils';
 

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -1424,3 +1424,60 @@ async function formValidCheck(check: string): Promise<CheckResultError> {
     };
   }
 }
+
+/**
+ * Validates interactive element props and logs errors for impossible configurations
+ *
+ * This utility detects impossible requirement combinations and logs console errors
+ * to help authors catch configuration mistakes during development.
+ *
+ * Specifically, it checks if an element has 'exists-reftarget' requirement but
+ * no refTarget, which would make the step impossible to pass.
+ *
+ * @param props - Interactive element props to validate
+ * @param elementType - Human-readable element type (e.g., 'InteractiveStep', 'InteractiveMultiStep')
+ * @returns true if validation passed, false if errors were logged
+ */
+export function validateInteractiveRequirements(
+  props: {
+    requirements?: string;
+    refTarget?: string;
+    stepId?: string;
+    originalHTML?: string;
+  },
+  elementType: string
+): boolean {
+  const { requirements, refTarget, stepId, originalHTML } = props;
+
+  // If no requirements, nothing to validate
+  if (!requirements) {
+    return true;
+  }
+
+  // Check if requirements include 'exists-reftarget'
+  const requirementList = requirements.split(',').map((r) => r.trim());
+  const hasExistsReftarget = requirementList.includes('exists-reftarget');
+
+  // If 'exists-reftarget' is present but no refTarget, this is an impossible configuration
+  if (hasExistsReftarget && !refTarget) {
+    const errorMessage = [
+      `[${elementType}] Invalid requirement configuration:`,
+      `  - Element has 'exists-reftarget' requirement but no refTarget`,
+      `  - Step ID: ${stepId || 'unknown'}`,
+      `  - This step can never pass because there is no target element to check`,
+      `  - Fix: Either add a data-reftarget attribute or remove 'exists-reftarget' from requirements`,
+    ];
+
+    if (originalHTML) {
+      errorMessage.push(
+        `  - Original HTML: ${originalHTML.substring(0, 200)}${originalHTML.length > 200 ? '...' : ''}`
+      );
+    }
+
+    console.error(errorMessage.join('\n'));
+
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
* Multistep actions didn't work, now they do
* When recording actions (For multistep) automatically stop the recorder on submit
* Found boundary condition about the use of requirements and `exists-reftarget` which doesn't make sense on multistep
* Fixed HTML generation in the wysiwyg
* Added runtime verification of scenarios that might not make sense, so we can catch errors with the way guides are
written