### PR TITLE
fix(docs): support bundled and github links also solve unstyled learning journeys

### DIFF
--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -1743,8 +1743,11 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                       onClick={() => {
                         const url = activeTab.content?.url || activeTab.baseUrl;
                         if (url) {
+                          // Strip /unstyled.html from URL for browser viewing (users want the styled docs page)
+                          const cleanUrl = url.replace(/\/unstyled\.html$/, '');
+
                           reportAppInteraction(UserInteraction.OpenExtraResource, {
-                            content_url: url,
+                            content_url: cleanUrl,
                             content_type: activeTab.type || 'learning-journey',
                             link_text: activeTab.title,
                             source_page: activeTab.content?.url || activeTab.baseUrl || 'unknown',
@@ -1759,7 +1762,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                           });
                           // Delay to ensure analytics event is sent before opening new tab
                           setTimeout(() => {
-                            window.open(url, '_blank', 'noopener,noreferrer');
+                            window.open(cleanUrl, '_blank', 'noopener,noreferrer');
                           }, 100);
                         }
                       }}


### PR DESCRIPTION
This pull request improves how documentation and interactive resources are handled and opened in the application. The main changes focus on cleaning up URLs for a better user experience and enhancing the logic for finding and displaying documentation pages, including support for bundled interactives and GitHub URLs.

**Docs Panel URL Handling Improvements:**
* When users open a documentation resource, the code now strips `/unstyled.html` from the URL to show the styled version of docs, improving readability and user experience. The cleaned URL is used for both analytics reporting and opening the new tab. [[1]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fR1746-R1750) [[2]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL1762-R1765)

**Enhanced Documentation Page Lookup Logic:**
* The `findDocPage` function in `src/module.tsx` now supports three cases:
  - **Bundled interactives:** Recognizes URLs starting with `bundled:` and loads metadata from `index.json`, returning a docs page object if found.
  - **GitHub URLs:** Detects and validates GitHub links, ensures correct protocol, extracts a title, and returns a docs page object for valid GitHub URLs.
  - **Static links:** Retains the existing logic for loading Grafana.com docs from static JSON files.