### PR TITLE
fix(interactive): added clear up of guided componenrs and cancel button

### DIFF
--- a/src/docs-retrieval/components/interactive/interactive-guided.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-guided.tsx
@@ -121,6 +121,15 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
       return new GuidedHandler(stateManager, navigationManager, waitForReactUpdates);
     }, []);
 
+    // Cleanup on unmount: cancel any running guided interaction and clear highlights
+    useEffect(() => {
+      return () => {
+        guidedHandler.cancel();
+        const navManager = new NavigationManager();
+        navManager.clearAllHighlights();
+      };
+    }, [guidedHandler]);
+
     // Handle reset trigger from parent section
     useEffect(() => {
       if (resetTrigger && resetTrigger > 0) {

--- a/src/styles/interactive.styles.ts
+++ b/src/styles/interactive.styles.ts
@@ -1038,7 +1038,6 @@ export const addGlobalInteractiveStyles = () => {
     /* Skip button for comment boxes (after instruction text) */
     .interactive-comment-skip-btn {
       position: static !important;
-      margin-top: 12px;
       padding: 6px 12px;
       border: 1px solid rgba(255, 255, 255, 0.2);
       background: rgba(255, 255, 255, 0.05);
@@ -1067,6 +1066,47 @@ export const addGlobalInteractiveStyles = () => {
     }
 
     .interactive-comment-skip-btn:active {
+      transform: scale(0.98);
+    }
+
+    /* Button container for skip and cancel buttons */
+    .interactive-comment-buttons {
+      display: flex;
+      gap: 8px;
+      margin-top: 12px;
+    }
+
+    /* Cancel button for comment boxes - always available during guided execution */
+    .interactive-comment-cancel-btn {
+      position: static !important;
+      padding: 6px 12px;
+      border: 1px solid rgba(255, 100, 100, 0.3);
+      background: rgba(255, 100, 100, 0.1);
+      color: rgba(255, 200, 200, 0.9);
+      border-radius: 4px;
+      cursor: pointer;
+      display: block !important;
+      font-size: 11px;
+      font-weight: 500;
+      line-height: 1.3;
+      pointer-events: auto;
+      transition: all 0.2s ease;
+      white-space: nowrap;
+      width: fit-content;
+      float: none !important;
+      top: auto !important;
+      right: auto !important;
+      left: auto !important;
+      bottom: auto !important;
+    }
+
+    .interactive-comment-cancel-btn:hover {
+      background: rgba(255, 100, 100, 0.25);
+      border-color: rgba(255, 100, 100, 0.5);
+      color: rgba(255, 220, 220, 1);
+    }
+
+    .interactive-comment-cancel-btn:active {
       transform: scale(0.98);
     }
 


### PR DESCRIPTION
This pull request adds a "Cancel" button to guided interactions, allowing users to abort the guided flow at any step via the comment box. The changes ensure that when cancelled, all highlights are cleared and the guided interaction is properly terminated. The implementation covers both the interactive engine logic and UI updates.

**Guided interaction improvements:**

* Added a "Cancel" button to the guided interaction comment box, always available during guided execution, allowing users to abort the flow at any step. [[1]](diffhunk://#diff-c2da8f2214b3cb6608ab8f59ef8bbb23c6c2b57e691dddaacea3cd3c860af925L601-R634) [[2]](diffhunk://#diff-c2da8f2214b3cb6608ab8f59ef8bbb23c6c2b57e691dddaacea3cd3c860af925L614-R650)
* Implemented a cancel listener in `GuidedHandler` that resolves when the cancel button is clicked, clears highlights, and ends the guided interaction. [[1]](diffhunk://#diff-ccee7cca373cfd7b0d300bbdf556eb68f6edcff2cc89432a55fcaa76aafc12f5R87-R89) [[2]](diffhunk://#diff-ccee7cca373cfd7b0d300bbdf556eb68f6edcff2cc89432a55fcaa76aafc12f5L99-R103) [[3]](diffhunk://#diff-ccee7cca373cfd7b0d300bbdf556eb68f6edcff2cc89432a55fcaa76aafc12f5R266-R277) [[4]](diffhunk://#diff-ccee7cca373cfd7b0d300bbdf556eb68f6edcff2cc89432a55fcaa76aafc12f5R355-R373)

**UI and style updates:**

* Updated comment box UI to display both "Skip" and "Cancel" buttons side-by-side, with a new button container for improved layout. [[1]](diffhunk://#diff-c2da8f2214b3cb6608ab8f59ef8bbb23c6c2b57e691dddaacea3cd3c860af925L601-R634) [[2]](diffhunk://#diff-c2da8f2214b3cb6608ab8f59ef8bbb23c6c2b57e691dddaacea3cd3c860af925L614-R650)
* Added styles for the cancel button and button container to visually distinguish the cancel action and improve overall appearance.

**Cleanup and lifecycle handling:**

* Ensured guided interaction is cancelled and highlights are cleared when the interactive component unmounts to prevent lingering UI artifacts.