### PR TITLE
chore(rudderstack) added assistant rudderstack

### DIFF
--- a/src/integrations/assistant-integration/AssistantSelectionPopover.tsx
+++ b/src/integrations/assistant-integration/AssistantSelectionPopover.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useLayoutEffect, RefObject } from 'react';
+import React, { useState, useLayoutEffect, RefObject, useCallback } from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import { OpenAssistantButton, type ChatContextItem } from '@grafana/assistant';
 import { buildAssistantPrompt } from './assistant-context.utils';
 import type { SelectionPosition } from '../../types/hooks.types';
+import { reportAppInteraction, UserInteraction, buildAssistantTextSelectionProperties } from '../../lib/analytics';
 
 interface AssistantSelectionPopoverProps {
   selectedText: string;
@@ -55,11 +56,17 @@ const AssistantSelectionPopoverComponent: React.FC<AssistantSelectionPopoverProp
   // REACT HOOKS v7: Store calculated positions in state to avoid accessing refs during render
   const [relativePosition, setRelativePosition] = useState<{ top: number; left: number } | null>(null);
 
+  // Track if we've already reported this selection to avoid duplicates
+  const [hasTrackedSelection, setHasTrackedSelection] = useState(false);
+
   // REACT HOOKS v7: Calculate position in useLayoutEffect instead of during render
   useLayoutEffect(() => {
     if (!position || !containerRef.current) {
       // REACT HOOKS v7: Wrap setState in Promise to make it asynchronous
-      Promise.resolve().then(() => setRelativePosition(null));
+      Promise.resolve().then(() => {
+        setRelativePosition(null);
+        setHasTrackedSelection(false); // Reset tracking when selection is cleared
+      });
       return;
     }
 
@@ -70,6 +77,36 @@ const AssistantSelectionPopoverComponent: React.FC<AssistantSelectionPopoverProp
     // REACT HOOKS v7: Wrap setState in Promise to make it asynchronous
     Promise.resolve().then(() => setRelativePosition({ top: relativeTop, left: relativeLeft }));
   }, [position, containerRef]);
+
+  // Track text selection when popover becomes visible
+  useLayoutEffect(() => {
+    if (selectedText && position && relativePosition && !hasTrackedSelection) {
+      reportAppInteraction(
+        UserInteraction.AssistantTextSelectionMade,
+        buildAssistantTextSelectionProperties({
+          selectedText,
+          selectionLength: selectedText.length,
+          buttonPlacement: position.buttonPlacement,
+        })
+      );
+      // REACT HOOKS v7: Wrap setState in Promise to make it asynchronous
+      Promise.resolve().then(() => setHasTrackedSelection(true));
+    }
+  }, [selectedText, position, relativePosition, hasTrackedSelection]);
+
+  // Handle "Ask Assistant" button click
+  const handleAskAssistantClick = useCallback(() => {
+    if (selectedText && position) {
+      reportAppInteraction(
+        UserInteraction.AssistantAskButtonClick,
+        buildAssistantTextSelectionProperties({
+          selectedText,
+          selectionLength: selectedText.length,
+          buttonPlacement: position.buttonPlacement,
+        })
+      );
+    }
+  }, [selectedText, position]);
 
   // Don't render if no selection or position
   if (!selectedText || !position || !relativePosition) {
@@ -106,6 +143,7 @@ const AssistantSelectionPopoverComponent: React.FC<AssistantSelectionPopoverProp
         }}
         onClick={(e) => {
           e.stopPropagation();
+          handleAskAssistantClick();
         }}
       >
         <OpenAssistantButton


### PR DESCRIPTION
This pull request adds detailed analytics tracking for user interactions with the Assistant integration, enabling better insight into how users customize and interact with assistant features. The changes introduce new analytics event types, helper functions for building analytics properties, and integrate tracking into key user actions such as customizing, reverting, and selecting text for the assistant.

**Analytics instrumentation for Assistant integration:**

* Added new user interaction event types to the `UserInteraction` enum for assistant customization, text selection, and related actions.
* Implemented helper functions `buildAssistantCustomizableProperties` and `buildAssistantTextSelectionProperties` in `src/lib/analytics.ts` to standardize analytics context and property building for assistant events.

**Integration of analytics tracking into Assistant UI components:**

* In `AssistantCustomizable.tsx`, instrumented the customize, success, error, and revert actions to report analytics events with relevant context and properties. [[1]](diffhunk://#diff-c4485068819df4e17d910a907bb8a86a62d25e030974d03d3c11c9f09590d35cR288-R292) [[2]](diffhunk://#diff-c4485068819df4e17d910a907bb8a86a62d25e030974d03d3c11c9f09590d35cR306-R313) [[3]](diffhunk://#diff-c4485068819df4e17d910a907bb8a86a62d25e030974d03d3c11c9f09590d35cR347-R378) [[4]](diffhunk://#diff-c4485068819df4e17d910a907bb8a86a62d25e030974d03d3c11c9f09590d35cR389-R401)
* In `AssistantSelectionPopover.tsx`, added tracking for when a user makes a text selection and clicks the "Ask Assistant" button, ensuring events are not duplicated for the same selection. [[1]](diffhunk://#diff-3da82c55ee0499110d3b744978ba972abd6a4efd7e31c149dba11da22e140bd5L1-R8) [[2]](diffhunk://#diff-3da82c55ee0499110d3b744978ba972abd6a4efd7e31c149dba11da22e140bd5R59-R69) [[3]](diffhunk://#diff-3da82c55ee0499110d3b744978ba972abd6a4efd7e31c149dba11da22e140bd5R81-R110) [[4]](diffhunk://#diff-3da82c55ee0499110d3b744978ba972abd6a4efd7e31c149dba11da22e140bd5R146)