### PR TITLE
feat: auto-extract selector from step format in Simple Selector Tester

### DIFF
--- a/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
+++ b/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
@@ -331,10 +331,10 @@ export function SelectorDebugPanel({ onOpenDocsPage }: SelectorDebugPanelProps =
                   <div>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
                       <Icon name="info-circle" size="sm" />
-                    <span>
-                      Oops! You pasted a selector in step format. We&apos;ve automatically extracted the selector for you,
-                      but note that other tools might expect plain CSS selectors.
-                    </span>
+                      <span>
+                        Oops! You pasted a selector in step format. We&apos;ve automatically extracted the selector for
+                        you, but note that other tools might expect plain CSS selectors.
+                      </span>
                     </div>
                     <div
                       style={{

--- a/src/utils/devtools/selector-tester.hook.ts
+++ b/src/utils/devtools/selector-tester.hook.ts
@@ -45,7 +45,7 @@ export function useSelectorTester({ executeInteractiveAction }: UseSelectorTeste
     async (selector: string, mode: 'show' | 'do'): Promise<TestResult> => {
       // Detect if input is in step format (contains pipe character)
       const isStepFormat = selector.trim().includes('|');
-      
+
       // Extract selector from step format (action|selector|value) or use as-is
       const cleanSelector = extractSelector(selector);
 

--- a/src/utils/devtools/step-parser.util.test.ts
+++ b/src/utils/devtools/step-parser.util.test.ts
@@ -215,4 +215,3 @@ formfill|input|test`;
     });
   });
 });
-

--- a/src/utils/devtools/step-parser.util.ts
+++ b/src/utils/devtools/step-parser.util.ts
@@ -97,7 +97,7 @@ export function formatStepsToString(steps: StepDefinition[]): string {
  */
 export function extractSelector(input: string): string {
   const trimmed = input.trim();
-  
+
   if (!trimmed) {
     return '';
   }
@@ -105,13 +105,13 @@ export function extractSelector(input: string): string {
   // Check if input contains pipe character (step format)
   if (trimmed.includes('|')) {
     const parts = trimmed.split('|').map((p) => p.trim());
-    
+
     // Step format requires at least 2 parts: action|selector
     // parts[0] = action, parts[1] = selector, parts[2] = optional value
     if (parts.length >= 2 && parts[1]) {
       return parts[1];
     }
-    
+
     // Malformed step format (e.g., "highlight|" with no selector)
     return '';
   }


### PR DESCRIPTION
## What's this feature?

This feature allows users to copy/paste selectors from Multistep Debug directly into Simple Selector Tester without manual reformatting.  

**How it works:** System detects step format, extracts the selector portion, and provides friendly feedback so users understand what happened.

Example: 

BEFORE: this would throw an error in Simple selector tester
`highlight|a[href="alerting/new/alerting"]|`

AFTER: 
You get an informative message + the right selector, which is: 
`a[href="alerting/new/alerting"]`

<img width="813" height="553" alt="image" src="https://github.com/user-attachments/assets/02efd2b7-da9c-4e78-ae6e-d6dc571d0bb3" />

[Screencast from 2025-11-26 13-11-13.webm](https://github.com/user-attachments/assets/e62983b3-262b-4ec8-adc2-6257ee971110)


## What changed
- Add extractSelector() function to intelligently parse step format (action|selector|value)
- Simple Selector Tester now accepts both plain selectors and step format
- Display friendly info alert when step format is detected and extracted
- Show the extracted selector to users for clarity and education
- Add comprehensive tests for extractSelector() function

