### PR TITLE
Add noop interactive action

### DIFF
--- a/src/components/wysiwyg-editor/forms/NoopActionForm.tsx
+++ b/src/components/wysiwyg-editor/forms/NoopActionForm.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { type InteractiveFormProps } from '../types';
+import BaseInteractiveForm from './BaseInteractiveForm';
+import { getActionConfig } from './actionConfig';
+import { ACTION_TYPES } from '../../../constants/interactive-config';
+
+const NoopActionForm = (props: InteractiveFormProps) => {
+  const config = getActionConfig(ACTION_TYPES.NOOP);
+  if (!config) {
+    throw new Error(`Action config not found for ${ACTION_TYPES.NOOP}`);
+  }
+  return <BaseInteractiveForm config={config} {...props} />;
+};
+
+export default NoopActionForm;

--- a/src/components/wysiwyg-editor/forms/actionConfig.ts
+++ b/src/components/wysiwyg-editor/forms/actionConfig.ts
@@ -26,6 +26,7 @@ function getActionConfigs(): Record<string, BaseInteractiveFormConfig> {
       [ACTION_TYPES.HOVER]: getActionFormConfig(ACTION_TYPES.HOVER)!,
       [ACTION_TYPES.MULTISTEP]: getActionFormConfig(ACTION_TYPES.MULTISTEP)!,
       [ACTION_TYPES.SEQUENCE]: getActionFormConfig(ACTION_TYPES.SEQUENCE)!,
+      [ACTION_TYPES.NOOP]: getActionFormConfig(ACTION_TYPES.NOOP)!,
     };
   }
   return _actionConfigsCache;

--- a/src/components/wysiwyg-editor/forms/actionRegistry.ts
+++ b/src/components/wysiwyg-editor/forms/actionRegistry.ts
@@ -16,6 +16,7 @@ import FormFillActionForm from './FormFillActionForm';
 import NavigateActionForm from './NavigateActionForm';
 import HoverActionForm from './HoverActionForm';
 import SequenceActionForm from './SequenceActionForm';
+import NoopActionForm from './NoopActionForm';
 
 /**
  * UI metadata for action selector display
@@ -346,6 +347,42 @@ export const ACTION_REGISTRY: Record<string, ActionDefinition> = {
     },
     formComponent: SequenceActionForm,
     hiddenInSelector: true, // Only available via toolbar "Add Section" button
+  },
+
+  [ACTION_TYPES.NOOP]: {
+    type: ACTION_TYPES.NOOP,
+    ui: {
+      icon: '📖',
+      name: 'No action',
+      description: 'Instructional only (no buttons)',
+      grafanaIcon: 'book',
+    },
+    formConfig: {
+      title: ACTION_TYPES.NOOP,
+      description: 'Instructional step with no Show me or Do it buttons',
+      actionType: ACTION_TYPES.NOOP,
+      fields: [
+        {
+          id: DATA_ATTRIBUTES.REQUIREMENTS,
+          label: 'Requirements:',
+          type: 'text',
+          placeholder: 'Optional',
+          hint: 'Requirements for displaying this step, for example, section-completed:previous-section',
+          showCommonOptions: true,
+        },
+      ],
+      infoBox:
+        'This creates an instructional step that displays content without Show me or Do it buttons. ' +
+        'Useful for manual steps that users must complete themselves, or for providing context between automated steps.',
+      buildAttributes: (values) => ({
+        [DATA_ATTRIBUTES.TARGET_ACTION]: ACTION_TYPES.NOOP,
+        [DATA_ATTRIBUTES.REQUIREMENTS]: values[DATA_ATTRIBUTES.REQUIREMENTS],
+        'data-doit': DEFAULT_VALUES.DO_IT_FALSE,
+        'data-showme': DEFAULT_VALUES.DO_IT_FALSE,
+        class: DEFAULT_VALUES.CLASS,
+      }),
+    },
+    formComponent: NoopActionForm,
   },
 };
 

--- a/src/constants/interactive-config.ts
+++ b/src/constants/interactive-config.ts
@@ -183,6 +183,7 @@ export const ACTION_TYPES = {
   HOVER: 'hover',
   MULTISTEP: 'multistep',
   SEQUENCE: 'sequence',
+  NOOP: 'noop',
 } as const;
 
 /**
@@ -271,6 +272,13 @@ export const ACTION_METADATA: ActionMetadata[] = [
     name: 'Sequence',
     description: 'Section with steps',
     grafanaIcon: 'folder-open',
+  },
+  {
+    type: ACTION_TYPES.NOOP,
+    icon: '📖',
+    name: 'No action',
+    description: 'Instructional only (no buttons)',
+    grafanaIcon: 'book',
   },
 ];
 

--- a/src/docs-retrieval/components/interactive/interactive-step.test.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-step.test.tsx
@@ -19,3 +19,32 @@ describe('InteractiveStep: showMeText label override', () => {
     expect(screen.getByRole('button', { name: 'Reveal' })).toBeInTheDocument();
   });
 });
+
+describe('InteractiveStep: noop action type', () => {
+  it('renders no buttons when both showMe and doIt are false (noop behavior)', () => {
+    render(
+      <InteractiveStep targetAction="noop" refTarget="" showMe={false} doIt={false}>
+        This is an instructional step with no actions
+      </InteractiveStep>
+    );
+
+    expect(screen.getByText('This is an instructional step with no actions')).toBeInTheDocument();
+
+    expect(screen.queryByRole('button', { name: /show me/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /do it/i })).not.toBeInTheDocument();
+  });
+
+  it('renders content correctly for noop action in a sequence context', () => {
+    render(
+      <InteractiveStep targetAction="noop" refTarget="" showMe={false} doIt={false} stepId="section-1-step-2">
+        <p>Read the documentation before proceeding</p>
+      </InteractiveStep>
+    );
+
+    expect(screen.getByText('Read the documentation before proceeding')).toBeInTheDocument();
+
+    const stepContainer = screen.getByText('Read the documentation before proceeding').closest('.interactive-step');
+    expect(stepContainer).toBeInTheDocument();
+    expect(stepContainer).toHaveAttribute('data-targetaction', 'noop');
+  });
+});

--- a/src/docs-retrieval/components/interactive/interactive-step.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-step.tsx
@@ -557,6 +557,8 @@ export const InteractiveStep = forwardRef<
           return `Hover over element`;
         case 'sequence':
           return `Run sequence`;
+        case 'noop':
+          return `Instructional step`;
         default:
           return targetAction;
       }

--- a/src/docs-retrieval/html-parser.ts
+++ b/src/docs-retrieval/html-parser.ts
@@ -934,8 +934,7 @@ export function parseHTMLToComponents(
           /\binteractive\b/.test(el.className || '') &&
           el.getAttribute('data-targetaction') &&
           el.getAttribute('data-targetaction') !== 'sequence' &&
-          el.getAttribute('data-targetaction') !== 'multistep' &&
-          el.getAttribute('data-targetaction') !== 'noop'
+          el.getAttribute('data-targetaction') !== 'multistep'
         ) {
           hasInteractiveElements = true;
 
@@ -943,7 +942,8 @@ export function parseHTMLToComponents(
           const targetAction = el.getAttribute('data-targetaction');
           const refTarget = el.getAttribute('data-reftarget');
 
-          if (!refTarget) {
+          // noop actions don't need a refTarget since they don't perform any actions
+          if (!refTarget && targetAction !== 'noop') {
             errorCollector.addError(
               'element_creation',
               `Interactive element missing required 'data-reftarget' attribute`,

--- a/src/docs-retrieval/html-parser.ts
+++ b/src/docs-retrieval/html-parser.ts
@@ -934,7 +934,8 @@ export function parseHTMLToComponents(
           /\binteractive\b/.test(el.className || '') &&
           el.getAttribute('data-targetaction') &&
           el.getAttribute('data-targetaction') !== 'sequence' &&
-          el.getAttribute('data-targetaction') !== 'multistep'
+          el.getAttribute('data-targetaction') !== 'multistep' &&
+          el.getAttribute('data-targetaction') !== 'noop'
         ) {
           hasInteractiveElements = true;
 

--- a/src/interactive-engine/auto-completion/action-matcher.ts
+++ b/src/interactive-engine/auto-completion/action-matcher.ts
@@ -12,7 +12,7 @@ import { findButtonByText } from '../../lib/dom';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 
 export interface StepActionConfig {
-  targetAction: 'button' | 'highlight' | 'formfill' | 'navigate' | 'sequence' | 'hover';
+  targetAction: 'button' | 'highlight' | 'formfill' | 'navigate' | 'sequence' | 'hover' | 'noop';
   refTarget: string;
   targetValue?: string;
 }

--- a/src/types/component-props.types.ts
+++ b/src/types/component-props.types.ts
@@ -26,7 +26,7 @@ export interface BaseInteractiveProps {
  * Single interactive step with show/do buttons
  */
 export interface InteractiveStepProps extends BaseInteractiveProps {
-  targetAction: 'button' | 'highlight' | 'formfill' | 'navigate' | 'sequence' | 'hover';
+  targetAction: 'button' | 'highlight' | 'formfill' | 'navigate' | 'sequence' | 'hover' | 'noop';
   refTarget: string;
   targetValue?: string;
   postVerify?: string;


### PR DESCRIPTION
Perform no interactive action for the step in an interactive sequence.

This creates an instructional step that displays content without Show me or Do it buttons. Useful for manual steps that users must complete themselves, or for providing context between automated steps.

It means you could have steps that go.
1. ONE
1. TWO
1. THREE (non interactive)
1. FOUR
1. FIVE

Instead of steps that go like:

1. ONE
1. TWO

Three

1. FOUR
1. FIVE