### PR TITLE
fix(analytics): fixed issues with rudderstack events not firing

### DIFF
--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -1407,7 +1407,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                           getTranslatedTitle(tab.title)
                         )}
                       </span>
-                      {tab.id !== 'recommendations' && tab.id !== 'devtools' && (
+                      {tab.id !== 'recommendations' && (
                         <IconButton
                           name="times"
                           size="sm"
@@ -1520,7 +1520,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                             getTranslatedTitle(tab.title)
                           )}
                         </span>
-                        {tab.id !== 'recommendations' && tab.id !== 'devtools' && (
+                        {tab.id !== 'recommendations' && (
                           <IconButton
                             name="times"
                             size="sm"

--- a/src/global-state/link-interception.ts
+++ b/src/global-state/link-interception.ts
@@ -1,5 +1,6 @@
 import { getDocsLinkFromEvent } from 'global-state/utils.link-interception';
 import { sidebarState } from 'global-state/sidebar';
+import { reportAppInteraction, UserInteraction } from 'lib/analytics';
 
 export interface QueuedDocsLink {
   url: string;
@@ -25,6 +26,14 @@ class GlobalLinkInterceptionState {
 
     event.preventDefault();
 
+    // Track the intercepted link
+    reportAppInteraction(UserInteraction.GlobalDocsLinkIntercepted, {
+      intercepted_url: docsLink.url,
+      link_title: docsLink.title,
+      sidebar_was_open: sidebarState.getIsSidebarMounted(),
+      timestamp: Date.now(),
+    });
+
     // if sidebar is mounted, auto-open the link
     if (sidebarState.getIsSidebarMounted()) {
       document.dispatchEvent(
@@ -33,6 +42,7 @@ class GlobalLinkInterceptionState {
         })
       );
     } else {
+      sidebarState.setPendingOpenSource('link_interception');
       sidebarState.openSidebar('Interactive learning', {
         url: docsLink.url,
         title: docsLink.title,

--- a/src/global-state/sidebar.ts
+++ b/src/global-state/sidebar.ts
@@ -19,6 +19,7 @@ export class OpenExtensionSidebarEvent extends BusEventWithPayload<OpenExtension
  */
 class GlobalSidebarState {
   private _isSidebarMounted = false;
+  private _pendingOpenSource: string | null = null;
 
   public getIsSidebarMounted(): boolean {
     return this._isSidebarMounted;
@@ -26,6 +27,24 @@ class GlobalSidebarState {
 
   public setIsSidebarMounted(isSidebarMounted: boolean): void {
     this._isSidebarMounted = isSidebarMounted;
+  }
+
+  /**
+   * Sets the source for the next sidebar open event.
+   * This is consumed by the sidebar mount analytics and cleared after use.
+   */
+  public setPendingOpenSource(source: string): void {
+    this._pendingOpenSource = source;
+  }
+
+  /**
+   * Gets and clears the pending open source.
+   * Returns the source if set, otherwise returns 'sidebar_toggle' as default.
+   */
+  public consumePendingOpenSource(): string {
+    const source = this._pendingOpenSource || 'sidebar_toggle';
+    this._pendingOpenSource = null;
+    return source;
   }
 
   // Sidebar management
@@ -40,11 +59,8 @@ class GlobalSidebarState {
       })
     );
 
-    reportAppInteraction(UserInteraction.DocsPanelInteraction, {
-      action: 'open',
-      source: 'sidebar_mount',
-      timestamp: Date.now(),
-    });
+    // Note: Analytics are now fired in the ContextSidebar mount effect
+    // to properly track the source via consumePendingOpenSource()
   }
 
   public closeSidebar(): void {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -6,6 +6,7 @@
  */
 
 import { reportInteraction } from '@grafana/runtime';
+import pluginJson from '../plugin.json';
 
 // ============================================================================
 // USER INTERACTION TYPES
@@ -15,12 +16,10 @@ export enum UserInteraction {
   // Core Panel Interactions
   DocsPanelInteraction = 'docs_panel_interaction',
   PanelScroll = 'panel_scroll',
-  DismissDocsPanel = 'dismiss_docs_panel',
 
   // Navigation & Tab Management
   CloseTabClick = 'close_tab_click',
   OpenExtraResource = 'open_extra_resource',
-  OpenExtraResourceTab = 'open_extra_resource_tab',
 
   // Content Interactions
   SummaryClick = 'summary_click',
@@ -28,10 +27,6 @@ export enum UserInteraction {
   StartLearningJourneyClick = 'start_learning_journey_click',
   OpenResourceClick = 'open_resource_click',
   MilestoneArrowInteractionClick = 'milestone_arrow_interaction_click',
-  OpenDocumentationButton = 'open_documentation_button',
-
-  // Recommendations
-  ClickSidepathRecommendation = 'click_sidepath_recommendation',
 
   // Media Interactions
   VideoPlayClick = 'video_play_click',
@@ -39,12 +34,10 @@ export enum UserInteraction {
 
   // Feedback Systems
   GeneralPluginFeedbackButton = 'general_plugin_feedback_button',
-  SpecificLearningJourneyFeedbackButton = 'specific_learning_journey_feedback_button',
   EnableRecommendationsBanner = 'enable_recommendations_banner',
 
-  // Interactive Elements (Future Features)
+  // Interactive Elements
   ShowMeButtonClick = 'show_me_button_click',
-  ClickedHighlightedContentButton = 'clicked_highlighted_content_button',
   DoItButtonClick = 'do_it_button_click',
   DoSectionButtonClick = 'do_section_button_click',
   StepAutoCompleted = 'step_auto_completed',
@@ -75,6 +68,9 @@ const createInteractionName = (type: UserInteraction): string => {
 /**
  * Reports a user interaction event to Grafana analytics (Rudder Stack)
  *
+ * All events automatically include:
+ * - plugin_version: The current plugin version from plugin.json
+ *
  * @param type - The type of interaction from UserInteraction enum
  * @param properties - Additional properties to attach to the event
  */
@@ -84,7 +80,14 @@ export function reportAppInteraction(
 ): void {
   try {
     const interactionName = createInteractionName(type);
-    reportInteraction(interactionName, properties);
+
+    // Add global attributes to all events
+    const enrichedProperties = {
+      plugin_version: pluginJson.info.version,
+      ...properties,
+    };
+
+    reportInteraction(interactionName, enrichedProperties);
   } catch (error) {
     console.warn('Analytics reporting failed:', error);
   }


### PR DESCRIPTION
This pull request introduces several improvements focused on analytics tracking, sidebar interaction source attribution, and enhanced security for documentation links. The changes ensure that all sidebar open/close events are tracked with their originating source, analytics events include plugin versioning, and documentation URLs are validated for security. Additionally, analytics for interactive quiz events are now more detailed.

**Analytics and Sidebar Interaction Tracking:**

* All sidebar open/close events now include a precise `source` attribute, determined by the context in which the sidebar was triggered (e.g., command palette, auto-open, URL param). This is managed via the new `setPendingOpenSource` and `consumePendingOpenSource` methods in `sidebarState`, and analytics are fired on sidebar component mount/unmount. [[1]](diffhunk://#diff-4086d20fc44ac6526cc6b1fda492af385f79cf9924ec1001c627d12ad7c84ff9R32-R49) [[2]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560R194-R202) [[3]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560R213-R219)
* Analytics events now automatically include the current plugin version, ensuring better traceability across plugin releases. [[1]](diffhunk://#diff-af25af6c1c85456cbce5a4eda14f0b3965aacdd964420dde9a08ee5c7c2674afR9) [[2]](diffhunk://#diff-af25af6c1c85456cbce5a4eda14f0b3965aacdd964420dde9a08ee5c7c2674afR71-R73) [[3]](diffhunk://#diff-af25af6c1c85456cbce5a4eda14f0b3965aacdd964420dde9a08ee5c7c2674afL87-R90)
* Redundant or unused `UserInteraction` enum values have been removed for clarity and maintainability.

**Security and Documentation Link Handling:**

* Documentation URLs provided via parameters are now strictly validated using the new `isGitHubUrl` utility, preventing potential security issues with malformed or malicious URLs. [[1]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560R11) [[2]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560L313-R327)
* Improved error handling and user feedback for unsupported or malformed documentation parameters, with clearer warnings in the console.

**Quiz Analytics Enhancements:**

* Interactive quiz events now report detailed analytics, including selected and correct answers, attempt counts, multi-select status, and truncated question/answer texts for better insights. [[1]](diffhunk://#diff-b1c65c51f4916ff27eeaf6b1b9e48fc00bf75f4a3c5a52a30bc6913995a43850R172-R206) [[2]](diffhunk://#diff-b1c65c51f4916ff27eeaf6b1b9e48fc00bf75f4a3c5a52a30bc6913995a43850L188-R224) [[3]](diffhunk://#diff-b1c65c51f4916ff27eeaf6b1b9e48fc00bf75f4a3c5a52a30bc6913995a43850L216-R266)

**Global Link Interception:**

* Intercepted documentation links are now tracked with analytics, capturing the URL, link title, sidebar state, and timestamp.
* When a link is intercepted and the sidebar is not mounted, the source for the next sidebar open event is set to `link_interception` for accurate analytics attribution.

**UI/UX Adjustments:**

* The close button in the docs panel tabs is now available for all tabs except 'recommendations', improving consistency in tab management. [[1]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL1410-R1410) [[2]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL1523-R1523)