### PR TITLE
chore(admin): added protection to faro

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
       },
       "devDependencies": {
         "@grafana/eslint-config": "^9.0.0",
+        "@grafana/faro-webpack-plugin": "^0.8.1",
         "@grafana/plugin-e2e": "^3.0.1",
         "@grafana/tsconfig": "^2.0.1",
         "@jest/test-sequencer": "^30.2.0",
@@ -1839,6 +1840,17 @@
         "typescript": ">=5.2.0"
       }
     },
+    "node_modules/@grafana/faro-bundlers-shared": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-bundlers-shared/-/faro-bundlers-shared-0.6.0.tgz",
+      "integrity": "sha512-aphGaqubY8uqHQDBhTT7kyc5eunlk1K/vxfj8tqL3h4QIbpOBYSAM3/NAT0s7GVVyxIBV7x+MTbohyy5/j4C/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ansis": "^4.0.0",
+        "tar": "^7.1.0"
+      }
+    },
     "node_modules/@grafana/faro-core": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.19.0.tgz",
@@ -2184,6 +2196,18 @@
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.1.0.tgz",
       "integrity": "sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@grafana/faro-webpack-plugin": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-webpack-plugin/-/faro-webpack-plugin-0.8.1.tgz",
+      "integrity": "sha512-8tzBSUsCkeha3seuebWz/6nyP3dS/DmzueqdUyFzyb+4dhEjPWMTXYic5rxzzDSxti9V5cgKFWr3jJ3yp3oxkw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grafana/faro-bundlers-shared": "^0.6.0",
+        "cross-fetch": "^4.0.0",
+        "webpack": "^5.89.0"
+      }
     },
     "node_modules/@grafana/i18n": {
       "version": "12.2.1",
@@ -3122,6 +3146,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -8479,6 +8516,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/ansis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
+      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -9376,6 +9423,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -9728,6 +9785,62 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/cross-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -16726,6 +16839,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mktemp": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
@@ -20938,6 +21064,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/teex": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@grafana/eslint-config": "^9.0.0",
+    "@grafana/faro-webpack-plugin": "^0.8.1",
     "@grafana/plugin-e2e": "^3.0.1",
     "@grafana/tsconfig": "^2.0.1",
     "@jest/test-sequencer": "^30.2.0",

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -12,7 +12,12 @@ import { sidebarState } from 'global-state/sidebar';
 import { isGrafanaDocsUrl, isGitHubUrl } from './security';
 
 // Initialize Faro metrics (before translations to capture early errors)
-await initializeFaroMetrics();
+// Wrapped in try-catch to prevent plugin load failure if Faro has issues
+try {
+  await initializeFaroMetrics();
+} catch (e) {
+  console.error('[Faro] Error initializing frontend metrics:', e);
+}
 
 // Initialize translations
 await initPluginTranslations(pluginJson.id);


### PR DESCRIPTION
This pull request introduces frontend metrics tracking using the Faro library and ensures robust initialization to prevent plugin load failures. The most important changes are as follows:

**Frontend Metrics Integration:**

* Added `@grafana/faro-webpack-plugin` as a development dependency in `package.json` to support Faro metrics tracking.

**Initialization Robustness:**

* Wrapped the `initializeFaroMetrics()` call in a try-catch block in `src/module.tsx` to log errors and prevent plugin load failure if Faro initialization encounters issues.