### PR TITLE
Fix bug 428; navigation actions should say "Go there" instead of "Do it" and disable the "Show Me" action

### DIFF
--- a/src/docs-retrieval/components/interactive/interactive-step.test.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-step.test.tsx
@@ -20,6 +20,45 @@ describe('InteractiveStep: showMeText label override', () => {
   });
 });
 
+describe('InteractiveStep: navigate action type', () => {
+  it('renders "Go there" button instead of "Do it" for navigate actions', () => {
+    render(
+      <InteractiveStep targetAction="navigate" refTarget="/d/qD-rVv6Mz/state-timeline">
+        Navigate to the dashboard
+      </InteractiveStep>
+    );
+
+    expect(screen.getByRole('button', { name: 'Go there' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /do it/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render "Show me" button for navigate actions', () => {
+    render(
+      <InteractiveStep targetAction="navigate" refTarget="/d/qD-rVv6Mz/state-timeline" showMe={true}>
+        Navigate to the dashboard
+      </InteractiveStep>
+    );
+
+    // Even with showMe={true}, navigate actions should not show "Show me" button
+    expect(screen.queryByRole('button', { name: /show me/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go there' })).toBeInTheDocument();
+  });
+
+  it('renders correct content for navigate action', () => {
+    render(
+      <InteractiveStep targetAction="navigate" refTarget="/d/qD-rVv6Mz/state-timeline" stepId="section-1-step-1">
+        <strong>State Timeline</strong> — Dashboard for tracking service status
+      </InteractiveStep>
+    );
+
+    expect(screen.getByText(/State Timeline/)).toBeInTheDocument();
+
+    const stepContainer = screen.getByText(/State Timeline/).closest('.interactive-step');
+    expect(stepContainer).toBeInTheDocument();
+    expect(stepContainer).toHaveAttribute('data-targetaction', 'navigate');
+  });
+});
+
 describe('InteractiveStep: noop action type', () => {
   it('renders no buttons when both showMe and doIt are false (noop behavior)', () => {
     render(

--- a/src/docs-retrieval/components/interactive/interactive-step.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-step.tsx
@@ -548,8 +548,9 @@ export const InteractiveStep = forwardRef<
 
         <div className="interactive-step-actions">
           <div className="interactive-step-action-buttons">
-            {/* Only show "Show me" button when showMe prop is true AND step is enabled */}
-            {showMe && !isCompletedWithObjectives && finalIsEnabled && (
+            {/* Only show "Show me" button when showMe prop is true AND step is enabled AND not a navigate action */}
+            {/* Navigate actions don't have a sensible "show me" behavior - it's "go there" or nothing */}
+            {showMe && targetAction !== 'navigate' && !isCompletedWithObjectives && finalIsEnabled && (
               <Button
                 onClick={handleShowAction}
                 disabled={disabled || isAnyActionRunning}
@@ -591,7 +592,10 @@ export const InteractiveStep = forwardRef<
                     ? checker.isRetrying
                       ? `Checking requirements... (${checker.retryCount}/${checker.maxRetries})`
                       : 'Checking requirements...'
-                    : hints || `Do it: ${getActionDescription()}`
+                    : hints ||
+                      (targetAction === 'navigate'
+                        ? `Go there: ${getActionDescription()}`
+                        : `Do it: ${getActionDescription()}`)
                 }
               >
                 {checker.isChecking
@@ -599,8 +603,12 @@ export const InteractiveStep = forwardRef<
                     ? `Checking... (${checker.retryCount}/${checker.maxRetries})`
                     : 'Checking...'
                   : isDoRunning || isCurrentlyExecuting
-                    ? 'Executing...'
-                    : 'Do it'}
+                    ? targetAction === 'navigate'
+                      ? 'Going...'
+                      : 'Executing...'
+                    : targetAction === 'navigate'
+                      ? 'Go there'
+                      : 'Do it'}
               </Button>
             )}
 


### PR DESCRIPTION
Hide 'Show me' button and change 'Do it' button to 'Go there' for navigate actions to improve UX and fix issue #428.

---
[Slack Thread](https://raintank-corp.slack.com/archives/C08VB4WC64R/p1765467140758479?thread_ts=1765467140.758479&cid=C08VB4WC64R)

<a href="https://cursor.com/background-agent?bcId=bc-8e38a176-7e20-423f-9115-49fc8104e5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e38a176-7e20-423f-9115-49fc8104e5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

