### PR TITLE
fix(analytics): fixed rudder stack type

### DIFF
--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -13,7 +13,7 @@ import { locationService, config } from '@grafana/runtime';
 // Import refactored context system
 import { getStyles } from '../../styles/context-panel.styles';
 import { useContextPanel, Recommendation } from '../../context-engine';
-import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import { reportAppInteraction, UserInteraction, getContentTypeForAnalytics } from '../../lib/analytics';
 import { getConfigWithDefaults } from '../../constants';
 import { isDevModeEnabled } from '../../utils/dev-mode';
 import { testIds } from '../testIds';
@@ -191,7 +191,10 @@ const RecommendationsSection = memo(function RecommendationsSection({
                             reportAppInteraction(UserInteraction.OpenResourceClick, {
                               content_title: recommendation.title,
                               content_url: recommendation.url,
-                              content_type: recommendation.type === 'docs-page' ? 'docs' : 'learning-journey',
+                              content_type: getContentTypeForAnalytics(
+                                recommendation.url,
+                                recommendation.type === 'docs-page' ? 'docs' : 'learning-journey'
+                              ),
                               interaction_location: 'featured_card_button',
                               match_accuracy: recommendation.matchAccuracy || 0,
                               ...(recommendation.type !== 'docs-page' && {
@@ -228,7 +231,10 @@ const RecommendationsSection = memo(function RecommendationsSection({
                                 reportAppInteraction(UserInteraction.SummaryClick, {
                                   content_title: recommendation.title,
                                   content_url: recommendation.url,
-                                  content_type: recommendation.type === 'docs-page' ? 'docs' : 'learning-journey',
+                                  content_type: getContentTypeForAnalytics(
+                                    recommendation.url,
+                                    recommendation.type === 'docs-page' ? 'docs' : 'learning-journey'
+                                  ),
                                   action: recommendation.summaryExpanded ? 'collapse' : 'expand',
                                   match_accuracy: recommendation.matchAccuracy || 0,
                                   ...(recommendation.type !== 'docs-page' && {
@@ -318,7 +324,10 @@ const RecommendationsSection = memo(function RecommendationsSection({
                                   reportAppInteraction(UserInteraction.OpenResourceClick, {
                                     content_title: recommendation.title,
                                     content_url: recommendation.url,
-                                    content_type: recommendation.type === 'docs-page' ? 'docs' : 'learning-journey',
+                                    content_type: getContentTypeForAnalytics(
+                                      recommendation.url,
+                                      recommendation.type === 'docs-page' ? 'docs' : 'learning-journey'
+                                    ),
                                     interaction_location: 'featured_summary_cta_button',
                                     match_accuracy: recommendation.matchAccuracy || 0,
                                     ...(recommendation.type !== 'docs-page' && {
@@ -389,7 +398,10 @@ const RecommendationsSection = memo(function RecommendationsSection({
                           reportAppInteraction(UserInteraction.OpenResourceClick, {
                             content_title: recommendation.title,
                             content_url: recommendation.url,
-                            content_type: recommendation.type === 'docs-page' ? 'docs' : 'learning-journey',
+                            content_type: getContentTypeForAnalytics(
+                              recommendation.url,
+                              recommendation.type === 'docs-page' ? 'docs' : 'learning-journey'
+                            ),
                             interaction_location: 'main_card_button',
                             match_accuracy: recommendation.matchAccuracy || 0,
                             ...(recommendation.type !== 'docs-page' && {
@@ -427,7 +439,10 @@ const RecommendationsSection = memo(function RecommendationsSection({
                               reportAppInteraction(UserInteraction.SummaryClick, {
                                 content_title: recommendation.title,
                                 content_url: recommendation.url,
-                                content_type: recommendation.type === 'docs-page' ? 'docs' : 'learning-journey',
+                                content_type: getContentTypeForAnalytics(
+                                  recommendation.url,
+                                  recommendation.type === 'docs-page' ? 'docs' : 'learning-journey'
+                                ),
                                 action: recommendation.summaryExpanded ? 'collapse' : 'expand',
                                 match_accuracy: recommendation.matchAccuracy || 0,
                                 ...(recommendation.type !== 'docs-page' && {
@@ -528,7 +543,10 @@ const RecommendationsSection = memo(function RecommendationsSection({
                                 reportAppInteraction(UserInteraction.OpenResourceClick, {
                                   content_title: recommendation.title,
                                   content_url: recommendation.url,
-                                  content_type: recommendation.type === 'docs-page' ? 'docs' : 'learning-journey',
+                                  content_type: getContentTypeForAnalytics(
+                                    recommendation.url,
+                                    recommendation.type === 'docs-page' ? 'docs' : 'learning-journey'
+                                  ),
                                   interaction_location: 'summary_cta_button',
                                   match_accuracy: recommendation.matchAccuracy || 0,
                                   ...(recommendation.type !== 'docs-page' && {
@@ -600,7 +618,10 @@ const RecommendationsSection = memo(function RecommendationsSection({
                             reportAppInteraction(UserInteraction.OpenResourceClick, {
                               content_title: item.title,
                               content_url: item.url,
-                              content_type: item.type === 'docs-page' ? 'docs' : 'learning-journey',
+                              content_type: getContentTypeForAnalytics(
+                                item.url,
+                                item.type === 'docs-page' ? 'docs' : 'learning-journey'
+                              ),
                               interaction_location: 'other_docs_list',
                               match_accuracy: item.matchAccuracy || 0,
                               ...(item.type !== 'docs-page' && {

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -22,7 +22,12 @@ import { useLinkClickHandler } from '../../utils/link-handler.hook';
 import { isDevModeEnabledGlobal, isDevModeEnabled } from '../../utils/dev-mode';
 import { parseUrlSafely, isAllowedContentUrl, isLocalhostUrl, isGitHubRawUrl } from '../../security';
 
-import { setupScrollTracking, reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import {
+  setupScrollTracking,
+  reportAppInteraction,
+  UserInteraction,
+  getContentTypeForAnalytics,
+} from '../../lib/analytics';
 import { tabStorage, useUserStorage } from '../../lib/user-storage';
 import { FeedbackButton } from '../FeedbackButton/FeedbackButton';
 import { SkeletonLoader } from '../SkeletonLoader';
@@ -1137,7 +1142,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
       reportAppInteraction(UserInteraction.OpenResourceClick, {
         content_title: title,
         content_url: url,
-        content_type: type === 'docs-page' ? 'docs' : 'learning-journey',
+        content_type: getContentTypeForAnalytics(url, type === 'docs-page' ? 'docs' : 'learning-journey'),
         trigger_source: 'auto_launch_tutorial',
         interaction_location: 'docs_panel',
         ...(type === 'learning-journey' && {
@@ -1409,7 +1414,10 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                           onClick={(e) => {
                             e.stopPropagation();
                             reportAppInteraction(UserInteraction.CloseTabClick, {
-                              content_type: tab.type || 'learning-journey',
+                              content_type: getContentTypeForAnalytics(
+                                tab.currentUrl || tab.baseUrl,
+                                tab.type || 'learning-journey'
+                              ),
                               tab_title: tab.title,
                               content_url: tab.currentUrl || tab.baseUrl,
                               interaction_location: 'tab_button',
@@ -1522,7 +1530,10 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                             onClick={(e) => {
                               e.stopPropagation();
                               reportAppInteraction(UserInteraction.CloseTabClick, {
-                                content_type: tab.type || 'learning-journey',
+                                content_type: getContentTypeForAnalytics(
+                                  tab.currentUrl || tab.baseUrl,
+                                  tab.type || 'learning-journey'
+                                ),
                                 tab_title: tab.title,
                                 content_url: tab.currentUrl || tab.baseUrl,
                                 close_location: 'dropdown',
@@ -1705,7 +1716,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                               onClick={() => {
                                 reportAppInteraction(UserInteraction.OpenExtraResource, {
                                   content_url: cleanUrl,
-                                  content_type: activeTab.type || 'docs',
+                                  content_type: getContentTypeForAnalytics(cleanUrl, activeTab.type || 'docs'),
                                   link_text: activeTab.title,
                                   source_page: activeTab.content?.url || activeTab.baseUrl || 'unknown',
                                   link_type: 'external_browser',
@@ -1838,7 +1849,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
 
                           reportAppInteraction(UserInteraction.OpenExtraResource, {
                             content_url: cleanUrl,
-                            content_type: activeTab.type || 'learning-journey',
+                            content_type: getContentTypeForAnalytics(cleanUrl, activeTab.type || 'learning-journey'),
                             link_text: activeTab.title,
                             source_page: activeTab.content?.url || activeTab.baseUrl || 'unknown',
                             link_type: 'external_browser',

--- a/src/docs-retrieval/components/interactive/interactive-quiz.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-quiz.tsx
@@ -191,6 +191,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
 
       return {
         step_id: stepId,
+        content_type: 'interactive_guide',
         quiz_question: truncatedQuestion,
         quiz_selected_answer: truncatedSelected,
         quiz_correct_answer: truncatedCorrect,

--- a/src/docs-retrieval/components/interactive/interactive-section.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-section.tsx
@@ -615,6 +615,7 @@ export function InteractiveSection({
     const docInfo = getSourceDocument(sectionId);
     reportAppInteraction(UserInteraction.DoSectionButtonClick, {
       ...docInfo,
+      content_type: 'interactive_guide',
       section_title: title,
       total_steps: stepComponents.length,
       interaction_location: 'interactive_section',

--- a/src/interactive-engine/auto-completion/useAutoDetection.ts
+++ b/src/interactive-engine/auto-completion/useAutoDetection.ts
@@ -304,4 +304,3 @@ export function useSingleActionDetection(options: {
     onActionDetected: handleActionDetected,
   });
 }
-

--- a/src/utils/link-handler.hook.test.ts
+++ b/src/utils/link-handler.hook.test.ts
@@ -7,6 +7,7 @@ jest.mock('../lib/analytics', () => ({
   reportAppInteraction: jest.fn(),
   enrichWithJourneyContext: jest.fn((props, _content) => props), // Pass through
   enrichWithStepContext: jest.fn((props) => props), // Pass through
+  getContentTypeForAnalytics: jest.fn((url, fallback) => fallback), // Pass through fallback
   UserInteraction: {
     StartLearningJourneyClick: 'start_learning_journey_click',
     OpenExtraResource: 'open_extra_resource',

--- a/src/utils/link-handler.hook.ts
+++ b/src/utils/link-handler.hook.ts
@@ -6,6 +6,7 @@ import {
   UserInteraction,
   enrichWithJourneyContext,
   enrichWithStepContext,
+  getContentTypeForAnalytics,
 } from '../lib/analytics';
 import { getJourneyProgress } from '../docs-retrieval/learning-journey-helpers';
 import {
@@ -124,7 +125,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
               UserInteraction.OpenExtraResource,
               enrichWithStepContext({
                 content_url: href,
-                content_type: 'docs',
+                content_type: getContentTypeForAnalytics(href, 'docs'),
                 link_text: linkText,
                 source_page: activeTab?.content?.url || 'unknown',
                 link_type: 'bundled_interactive',
@@ -208,7 +209,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
               UserInteraction.OpenExtraResource,
               enrichWithStepContext({
                 content_url: fullUrl,
-                content_type: contentType,
+                content_type: getContentTypeForAnalytics(fullUrl, contentType),
                 link_text: linkText,
                 source_page: activeTab?.content?.url || 'unknown',
                 link_type: isTutorial ? 'tutorial' : 'docs',
@@ -239,7 +240,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
                 enrichWithJourneyContext(
                   {
                     content_url: resolvedUrl,
-                    content_type: 'docs',
+                    content_type: getContentTypeForAnalytics(resolvedUrl, 'docs'),
                     link_text: linkText,
                     source_page: activeTab?.content?.url || 'unknown',
                     link_type: 'interactive_learning',
@@ -266,7 +267,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
                 enrichWithJourneyContext(
                   {
                     content_url: resolvedUrl,
-                    content_type: 'docs',
+                    content_type: getContentTypeForAnalytics(resolvedUrl, 'docs'),
                     link_text: linkText,
                     source_page: activeTab?.content?.url || 'unknown',
                     link_type: 'external_browser',
@@ -355,7 +356,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
               enrichWithJourneyContext(
                 {
                   content_url: fullUrl,
-                  content_type: 'docs',
+                  content_type: getContentTypeForAnalytics(fullUrl, 'docs'),
                   link_text: linkTitle,
                   source_page: activeTab?.content?.url || 'unknown',
                   link_type: 'side_journey',
@@ -416,7 +417,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
               enrichWithJourneyContext(
                 {
                   content_url: fullUrl,
-                  content_type: 'learning-journey',
+                  content_type: getContentTypeForAnalytics(fullUrl, 'learning-journey'),
                   link_text: linkTitle,
                   source_page: activeTab?.content?.url || 'unknown',
                   link_type: 'related_journey',

--- a/src/validation/type-coupling.test.ts
+++ b/src/validation/type-coupling.test.ts
@@ -91,10 +91,10 @@ describe('KNOWN_FIELDS sync', () => {
   };
 
   // Helper for schemas with .refine() - access the inner schema via Zod 4 API
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   const verifyFieldsFromEffects = (schema: z.ZodType<any>, typeName: string) => {
     // Zod 4: effects schemas expose innerType via _zod.def
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     const innerSchema = (schema as any)._zod?.def?.innerType;
     if (innerSchema && 'shape' in innerSchema) {
       const schemaKeys = Object.keys(innerSchema.shape);


### PR DESCRIPTION
This pull request improves the accuracy and consistency of analytics reporting for user interactions by introducing a new utility function, `getContentTypeForAnalytics`, which determines the correct `content_type` based on the URL. This ensures that interactions with interactive guides are properly classified, and analytics data is more reliable across the application. The changes also update all relevant reporting calls to use this new function and set `content_type` explicitly for interactive components.

**Analytics reporting improvements:**

- Added `getContentTypeForAnalytics` utility to `src/lib/analytics.ts`, which returns `'interactive_guide'` for interactive-learning CDN URLs or a fallback type otherwise. All analytics reporting calls now use this function to determine `content_type` instead of hardcoded logic. [[1]](diffhunk://#diff-af25af6c1c85456cbce5a4eda14f0b3965aacdd964420dde9a08ee5c7c2674afR70-R96) [[2]](diffhunk://#diff-af25af6c1c85456cbce5a4eda14f0b3965aacdd964420dde9a08ee5c7c2674afL9-R10) [[3]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L16-R16) [[4]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL25-R30) [[5]](diffhunk://#diff-bdf95d35514264ba75ee4d57357d6c4b03b9c715048fc09ef024c8b7ec758440R9)
- Updated all `reportAppInteraction` and related analytics calls in `src/components/docs-panel/context-panel.tsx`, `src/components/docs-panel/docs-panel.tsx`, and `src/utils/link-handler.hook.ts` to use `getContentTypeForAnalytics` for setting `content_type`. [[1]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L194-R197) [[2]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L231-R237) [[3]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L321-R330) [[4]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L392-R404) [[5]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L430-R445) [[6]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L531-R549) [[7]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L603-R624) [[8]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL1140-R1145) [[9]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL1412-R1420) [[10]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL1525-R1536) [[11]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL1708-R1719) [[12]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL1841-R1852) [[13]](diffhunk://#diff-bdf95d35514264ba75ee4d57357d6c4b03b9c715048fc09ef024c8b7ec758440L127-R128) [[14]](diffhunk://#diff-bdf95d35514264ba75ee4d57357d6c4b03b9c715048fc09ef024c8b7ec758440L211-R212) [[15]](diffhunk://#diff-bdf95d35514264ba75ee4d57357d6c4b03b9c715048fc09ef024c8b7ec758440L242-R243)

**Interactive content analytics:**

- Explicitly set `content_type: 'interactive_guide'` when reporting analytics for interactive quiz and section components to ensure proper classification. [[1]](diffhunk://#diff-b1c65c51f4916ff27eeaf6b1b9e48fc00bf75f4a3c5a52a30bc6913995a43850R194) [[2]](diffhunk://#diff-8e0561ff6e387f8e3752796058f6b72d45435fa3550b5ac283195554bdef79f1R618) [[3]](diffhunk://#diff-af25af6c1c85456cbce5a4eda14f0b3965aacdd964420dde9a08ee5c7c2674afR464)

**Dependency and test updates:**

- Switched analytics version reporting from `pluginJson.info.version` to `packageJson.version` for consistency.
- Updated analytics test mocks to include `getContentTypeForAnalytics`.

These changes collectively ensure analytics events are accurately categorized, particularly distinguishing interactive guides from other documentation types, which will improve downstream analytics and reporting.