### PR TITLE
feat(analytics): improved open feature implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,9 @@
         "@grafana/scenes": "^6.45.0",
         "@grafana/schema": "^12.2.1",
         "@grafana/ui": "^12.2.1",
-        "@openfeature/ofrep-web-provider": "^0.3.3",
+        "@openfeature/ofrep-web-provider": "^0.3.5",
         "@openfeature/react-sdk": "^0.4.0",
+        "@openfeature/web-sdk": "^1.7.2",
         "@tiptap/extension-link": "^3.10.4",
         "@tiptap/pm": "^3.10.4",
         "@tiptap/react": "^3.10.4",
@@ -4422,21 +4423,21 @@
       "peer": true
     },
     "node_modules/@openfeature/ofrep-core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/ofrep-core/-/ofrep-core-1.1.0.tgz",
-      "integrity": "sha512-8t4kCYA5Gagh+lF0z734VZ+19arZ0ETEjgtI2lDBeJHG/f7SrTBIDB/l0BM7PhOREQvICMdZ1JwiG7Doh1xj7Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/ofrep-core/-/ofrep-core-2.0.0.tgz",
+      "integrity": "sha512-7adN+3lvx7aAM/4BG8CHBGoRoePPtTa6EVygnNFMECcJvXiXFRcUTUq5lezvYdVG0LGSaw7zkd+hkc8Uwu3HNg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@openfeature/core": "^1.6.0"
       }
     },
     "node_modules/@openfeature/ofrep-web-provider": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@openfeature/ofrep-web-provider/-/ofrep-web-provider-0.3.3.tgz",
-      "integrity": "sha512-UznvMuKLKujHOXnmoc/WjPOZM3o2lL0gVr5YEpgaeu6JBQAiJOSpgkzZbu0SpHVUxdeRySevm2wVhEJzwArtWw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@openfeature/ofrep-web-provider/-/ofrep-web-provider-0.3.5.tgz",
+      "integrity": "sha512-BhFaEANBhd9GO8sIq/NBcdpQUP7R1QtFE8HjPdXWv6m3DabZ2LiGlCdpAUfVZEkq4cCuxaR0SehyVdheOKP/0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openfeature/ofrep-core": "^1.0.0"
+        "@openfeature/ofrep-core": "^2.0.0"
       },
       "peerDependencies": {
         "@openfeature/web-sdk": "^1.4.0"
@@ -4453,9 +4454,9 @@
       }
     },
     "node_modules/@openfeature/web-sdk": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.6.2.tgz",
-      "integrity": "sha512-Dcj4o4sBNT8QSAFTBWpj8nJhRm2lhJRoGSel6eiiV0gIZSQ4sCc8pi+2jey4Ffkw6S/cMvfbxjEj2CZiCgzZaA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.7.2.tgz",
+      "integrity": "sha512-8QwhoxVNN2bFFkpWjbCyHCdkVjt/UTVn0o+OwcUUQoZnvPn46Oo1BxJQxUTibl/D/dAM/YQhxmg7ep7gYRxX4g==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -91,8 +91,9 @@
   "dependencies": {
     "@emotion/css": "11.13.5",
     "@grafana/assistant": "^0.1.7",
-    "@openfeature/ofrep-web-provider": "^0.3.3",
+    "@openfeature/ofrep-web-provider": "^0.3.5",
     "@openfeature/react-sdk": "^0.4.0",
+    "@openfeature/web-sdk": "^1.7.2",
     "@grafana/data": "^12.2.1",
     "@grafana/faro-react": "^2.0.2",
     "@grafana/faro-web-tracing": "^2.0.2",

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -57,6 +57,9 @@ export enum UserInteraction {
 
   // A/B Experiment Tracking
   ExperimentPageEntered = 'experiment_page_entered',
+
+  // Feature Flag Tracking
+  FeatureFlagEvaluated = 'feature_flag_evaluated',
 }
 
 // ============================================================================

--- a/src/utils/openfeature-tracking.ts
+++ b/src/utils/openfeature-tracking.ts
@@ -1,0 +1,56 @@
+import type { Hook, HookContext, EvaluationDetails, JsonValue } from '@openfeature/web-sdk';
+
+import { reportAppInteraction, UserInteraction } from '../lib/analytics';
+import { pathfinderFeatureFlags, type FeatureFlagName } from './openfeature';
+
+/**
+ * OpenFeature hook that tracks feature flag evaluations to analytics
+ *
+ * This hook fires after each flag evaluation and reports the flag key,
+ * evaluated value, and tracking key to Rudder Stack via reportAppInteraction.
+ *
+ * Only flags that have a `trackingKey` defined in pathfinderFeatureFlags
+ * will be tracked.
+ *
+ * @example
+ * const client = OpenFeature.getClient(OPENFEATURE_DOMAIN);
+ * client.addHooks(new TrackingHook());
+ */
+export class TrackingHook implements Hook {
+  /**
+   * Called after a flag is successfully evaluated
+   *
+   * @param hookContext - Context about the flag evaluation
+   * @param evaluationDetails - Details about the evaluated flag value
+   */
+  after(hookContext: HookContext, evaluationDetails: EvaluationDetails<JsonValue>): void {
+    const flagKey = hookContext.flagKey as FeatureFlagName;
+    const flagDef = pathfinderFeatureFlags[flagKey];
+
+    // Only track flags that have a trackingKey defined
+    if (flagDef && 'trackingKey' in flagDef && flagDef.trackingKey) {
+      reportAppInteraction(UserInteraction.FeatureFlagEvaluated, {
+        flag_key: hookContext.flagKey,
+        flag_value: this.stringifyValue(evaluationDetails.value),
+        tracking_key: flagDef.trackingKey,
+      });
+    }
+  }
+
+  /**
+   * Safely stringify any flag value for analytics
+   */
+  private stringifyValue(value: JsonValue): string {
+    if (value === null || value === undefined) {
+      return 'null';
+    }
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return '[object]';
+      }
+    }
+    return String(value);
+  }
+}

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -1,49 +1,40 @@
-import { OpenFeature, useBooleanFlagValue, useStringFlagValue, useNumberFlagValue } from '@openfeature/react-sdk';
+import { ClientProviderStatus, OpenFeature, ProviderEvents, type Client, type JsonValue } from '@openfeature/web-sdk';
+import { useBooleanFlagValue, useStringFlagValue, useNumberFlagValue } from '@openfeature/react-sdk';
 import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';
 import { config } from '@grafana/runtime';
 
-/**
- * OpenFeature domain for grafana-pathfinder-app
- *
- * Using a domain isolates this plugin's provider from Grafana core and other plugins.
- * This is REQUIRED per OpenFeature best practices for frontend plugins.
- */
-export const OPENFEATURE_DOMAIN = 'grafana-pathfinder-app';
+import { TrackingHook } from './openfeature-tracking';
+
+// ============================================================================
+// TYPES
+// ============================================================================
 
 /**
- * Feature flag keys used in grafana-pathfinder-app
+ * Discriminated union for feature flag type definitions
  *
- * These flags are evaluated dynamically at runtime via the Multi-Tenant Feature Flag
- * Service (MTFF) in Grafana Cloud.
- *
- * Naming convention: prefix with component name (e.g., pathfinder.feature-name)
- *
+ * @param valueType - The type of the feature flag value
+ * @param values - The possible values for the feature flag
+ * @param defaultValue - The default value for the feature flag
+ * @param trackingKey - If provided, the feature flag value will be tracked using the given key
  */
-export const FeatureFlags = {
-  /**
-   * Controls whether the sidebar automatically opens on first Grafana load per session
-   * When true: sidebar opens automatically on first page load
-   * When false: sidebar only opens when user explicitly requests it
-   */
-  AUTO_OPEN_SIDEBAR_ON_LAUNCH: 'pathfinder.auto-open-sidebar',
-
-  /**
-   * A/B experiment variant for testing Pathfinder impact on onboarding
-   * - "excluded": Not in experiment, normal Pathfinder behavior (sidebar available)
-   * - "control": In experiment, no sidebar (native Grafana help only)
-   * - "treatment": In experiment, sidebar auto-opens on target pages
-   * Default: "excluded" to preserve normal behavior if flag not set
-   */
-  EXPERIMENT_VARIANT: 'pathfinder.experiment-variant',
-} as const;
+type FeatureFlag =
+  | { valueType: 'boolean'; values: readonly boolean[]; defaultValue: boolean; trackingKey?: string }
+  | { valueType: 'object'; values: readonly JsonValue[]; defaultValue: JsonValue; trackingKey?: string }
+  | { valueType: 'number'; values: readonly number[]; defaultValue: number; trackingKey?: string }
+  | { valueType: 'string'; values: readonly string[]; defaultValue: string; trackingKey?: string };
 
 /**
  * Experiment configuration returned by GOFF
  * Contains both the variant assignment and target pages for auto-open
+ *
+ * @param variant - The experiment variant assignment
+ * @param pages - Target pages where sidebar should auto-open (for treatment)
+ * @param resetCache - When toggled true, clears session storage to allow sidebar to auto-open again
  */
 export interface ExperimentConfig {
   variant: 'excluded' | 'control' | 'treatment';
   pages: string[];
+  resetCache?: boolean;
 }
 
 /**
@@ -53,12 +44,111 @@ export interface ExperimentConfig {
 export const DEFAULT_EXPERIMENT_CONFIG: ExperimentConfig = {
   variant: 'excluded',
   pages: [],
+  resetCache: false,
 };
 
+// ============================================================================
+// FEATURE FLAG DEFINITIONS
+// ============================================================================
+
 /**
- * Track initialization state to prevent double initialization
+ * All feature flags used in Grafana Pathfinder
+ *
+ * These flags are evaluated dynamically at runtime via the Multi-Tenant Feature Flag
+ * Service (MTFF) in Grafana Cloud.
+ *
+ * Naming convention: prefix with component name (e.g., pathfinder.feature-name)
  */
-let isInitialized = false;
+const pathfinderFeatureFlags = {
+  /**
+   * Controls whether the sidebar automatically opens on first Grafana load per session
+   * When true: sidebar opens automatically on first page load
+   * When false: sidebar only opens when user explicitly requests it
+   */
+  'pathfinder.auto-open-sidebar': {
+    valueType: 'boolean',
+    values: [true, false],
+    defaultValue: false,
+    trackingKey: 'auto_open_sidebar',
+  },
+  /**
+   * A/B experiment variant for testing Pathfinder impact on onboarding
+   * - "excluded": Not in experiment, normal Pathfinder behavior (sidebar available)
+   * - "control": In experiment, no sidebar (native Grafana help only)
+   * - "treatment": In experiment, sidebar auto-opens on target pages
+   * Default: "excluded" to preserve normal behavior if flag not set
+   */
+  'pathfinder.experiment-variant': {
+    valueType: 'object',
+    values: [DEFAULT_EXPERIMENT_CONFIG as unknown as JsonValue],
+    defaultValue: DEFAULT_EXPERIMENT_CONFIG as unknown as JsonValue,
+    trackingKey: 'experiment_variant',
+  },
+} as const satisfies Record<`pathfinder.${string}`, FeatureFlag>;
+
+// Helper to get typed keys from the flag definitions
+const getObjectKeys = <T extends object>(obj: T): Array<keyof T> => Object.keys(obj) as Array<keyof T>;
+
+const featureFlagNames = getObjectKeys(pathfinderFeatureFlags);
+
+// ============================================================================
+// TYPE EXPORTS
+// ============================================================================
+
+export type FeatureFlagName = (typeof featureFlagNames)[number];
+export type FlagValue<T extends FeatureFlagName> = (typeof pathfinderFeatureFlags)[T]['values'][number];
+export type FlagTrackingKey = (typeof pathfinderFeatureFlags)[keyof typeof pathfinderFeatureFlags] extends infer Flag
+  ? Flag extends { trackingKey: infer K }
+    ? K
+    : never
+  : never;
+
+/**
+ * Map of flag names to their tracking keys (only for flags with trackingKey defined)
+ */
+export const featureFlagTrackingKeys = Object.fromEntries(
+  featureFlagNames.reduce<Array<[FeatureFlagName, FlagTrackingKey]>>((acc, flagName) => {
+    const flagDef = pathfinderFeatureFlags[flagName];
+    if ('trackingKey' in flagDef && flagDef.trackingKey) {
+      acc.push([flagName, flagDef.trackingKey as FlagTrackingKey]);
+    }
+    return acc;
+  }, [])
+);
+
+/**
+ * Export the flag definitions for use by TrackingHook
+ */
+export { pathfinderFeatureFlags };
+
+// ============================================================================
+// BACKWARDS COMPATIBILITY - Legacy constants
+// ============================================================================
+
+/**
+ * @deprecated Use FeatureFlagName type and flag names directly instead
+ * Legacy feature flag keys - kept for backwards compatibility
+ */
+export const FeatureFlags = {
+  AUTO_OPEN_SIDEBAR_ON_LAUNCH: 'pathfinder.auto-open-sidebar' as const,
+  EXPERIMENT_VARIANT: 'pathfinder.experiment-variant' as const,
+} as const;
+
+// ============================================================================
+// OPENFEATURE CONFIGURATION
+// ============================================================================
+
+/**
+ * OpenFeature domain for grafana-pathfinder-app
+ *
+ * Using a domain isolates this plugin's provider from Grafana core and other plugins.
+ * This is REQUIRED per OpenFeature best practices for frontend plugins.
+ */
+export const OPENFEATURE_DOMAIN = 'grafana-pathfinder-app';
+
+// ============================================================================
+// INITIALIZATION
+// ============================================================================
 
 /**
  * Initialize OpenFeature with OFREPWebProvider for Grafana Cloud
@@ -67,52 +157,62 @@ let isInitialized = false;
  * runtime flag evaluation with targeting context.
  *
  * Call this once at plugin initialization (in module.tsx) before React components mount.
+ * Uses setProviderAndWait to ensure flags are ready before evaluation.
+ * Adds TrackingHook once to track all flag evaluations to analytics.
+ *
+ * @returns Promise that resolves when provider is ready
  *
  * @example
  * // In module.tsx
  * import { initializeOpenFeature } from './utils/openfeature';
- * initializeOpenFeature();
+ * await initializeOpenFeature();
  */
-export const initializeOpenFeature = (): void => {
-  // Prevent double initialization
-  if (isInitialized) {
+export async function initializeOpenFeature(): Promise<void> {
+  const namespace = config.namespace;
+
+  if (!namespace) {
+    console.warn('[OpenFeature] config.namespace not available, skipping initialization');
     return;
   }
 
-  // Check if provider already set for this domain (in case code runs twice)
-  // If getProvider(DOMAIN) returns the same as getProvider() (default), it means no provider is set
-  if (OpenFeature.getProvider(OPENFEATURE_DOMAIN) !== OpenFeature.getProvider()) {
-    isInitialized = true;
-    return;
-  }
-
-  try {
-    const namespace = config.namespace;
-
-    if (!namespace) {
-      console.warn('[OpenFeature] config.namespace not available, skipping initialization');
-      return;
+  await OpenFeature.setProviderAndWait(
+    OPENFEATURE_DOMAIN,
+    new OFREPWebProvider({
+      baseUrl: `/apis/features.grafana.app/v0alpha1/namespaces/${namespace}`,
+      pollInterval: -1, // Do not poll - flags are fetched once on init
+      timeoutMs: 10_000, // Timeout after 10 seconds
+    }),
+    {
+      // Multi-tenant feature flag service required context
+      targetingKey: namespace,
+      namespace: namespace,
     }
+  );
 
-    OpenFeature.setProvider(
-      OPENFEATURE_DOMAIN,
-      new OFREPWebProvider({
-        baseUrl: `/apis/features.grafana.app/v0alpha1/namespaces/${namespace}`,
-        pollInterval: -1, // Do not poll - flags are fetched once
-        timeoutMs: 10_000, // Timeout after 10 seconds
-      }),
-      {
-        // MTFF required context
-        targetingKey: namespace,
-        namespace: namespace,
-      }
-    );
+  // Add TrackingHook once after provider is ready
+  // This tracks ALL flag evaluations (sync and async) to analytics
+  const client = OpenFeature.getClient(OPENFEATURE_DOMAIN);
+  client.addHooks(new TrackingHook());
+}
 
-    isInitialized = true;
-  } catch (error) {
-    console.error('[OpenFeature] Failed to initialize provider:', error);
+// ============================================================================
+// CLIENT HELPERS
+// ============================================================================
+
+/**
+ * Helper to wait for a client to be ready
+ *
+ * @param client - The OpenFeature client
+ * @returns Promise that resolves when client is ready
+ */
+function waitForClientReady(client: Client): Promise<void> {
+  if (client.providerStatus === ClientProviderStatus.READY) {
+    return Promise.resolve();
   }
-};
+  return new Promise((resolve) => {
+    client.addHandler(ProviderEvents.Ready, () => resolve());
+  });
+}
 
 /**
  * Get an OpenFeature client for the pathfinder domain
@@ -122,20 +222,79 @@ export const initializeOpenFeature = (): void => {
  *
  * @example
  * const client = getFeatureFlagClient();
- * const isEnabled = client.getBooleanValue(FeatureFlags.AUTO_OPEN_SIDEBAR_ON_LAUNCH, false);
+ * const isEnabled = client.getBooleanValue('pathfinder.auto-open-sidebar', false);
  */
 export const getFeatureFlagClient = () => {
   return OpenFeature.getClient(OPENFEATURE_DOMAIN);
 };
 
+// ============================================================================
+// FLAG EVALUATION
+// ============================================================================
+
+/**
+ * Evaluates a feature flag from the GOFF service
+ *
+ * This is the primary async function for evaluating flags with guaranteed
+ * client readiness. It waits for the provider to be ready before evaluation.
+ * TrackingHook is added once during initializeOpenFeature(), so all evaluations
+ * (including this one) are automatically tracked.
+ *
+ * @param flagName - The name of the feature flag to evaluate
+ * @returns The value of the feature flag
+ *
+ * @example
+ * const autoOpen = await evaluateFeatureFlag('pathfinder.auto-open-sidebar');
+ */
+export async function evaluateFeatureFlag<T extends FeatureFlagName>(flagName: T): Promise<FlagValue<T>> {
+  try {
+    const client = OpenFeature.getClient(OPENFEATURE_DOMAIN);
+    await waitForClientReady(client);
+
+    const flagDef = pathfinderFeatureFlags[flagName] as FeatureFlag;
+
+    switch (flagDef.valueType) {
+      case 'boolean': {
+        const booleanValue = client.getBooleanValue(flagName, flagDef.defaultValue);
+        return booleanValue as unknown as FlagValue<T>;
+      }
+      case 'number': {
+        const numberValue = client.getNumberValue(flagName, flagDef.defaultValue);
+        return numberValue as unknown as FlagValue<T>;
+      }
+      case 'object': {
+        const objectValue = client.getObjectValue(flagName, flagDef.defaultValue);
+        return objectValue as unknown as FlagValue<T>;
+      }
+      case 'string': {
+        const stringValue = client.getStringValue(flagName, flagDef.defaultValue);
+        return stringValue as unknown as FlagValue<T>;
+      }
+      default:
+        throw new Error(`Invalid flag value type for flag ${flagName}`);
+    }
+  } catch (error) {
+    console.error(`[OpenFeature] Error evaluating flag '${flagName}':`, error);
+    return pathfinderFeatureFlags[flagName].defaultValue as FlagValue<T>;
+  }
+}
+
+// ============================================================================
+// BACKWARDS COMPATIBLE SYNC FUNCTIONS
+// ============================================================================
+// Note: All sync functions below are automatically tracked by the TrackingHook
+// that was added during initializeOpenFeature(). The hook fires for ALL
+// flag evaluations on the client, including sync getBooleanValue, etc.
+
 /**
  * Synchronously get a boolean feature flag value (for non-React code)
  *
- * Note: This returns the default value if the provider hasn't finished initializing.
- * For guaranteed up-to-date values, use the React hooks or await provider initialization.
+ * Note: With async initialization, the provider should be ready by the time
+ * this is called. Returns the default value on error.
+ * Automatically tracked by TrackingHook if the flag has a trackingKey defined.
  *
- * @param flagName - The feature flag name (use FeatureFlags constants)
- * @param defaultValue - Default value if flag evaluation fails or provider not ready
+ * @param flagName - The feature flag name
+ * @param defaultValue - Default value if flag evaluation fails
  * @returns The evaluated flag value or default
  *
  * @example
@@ -155,10 +314,9 @@ export const getFeatureFlagValue = (flagName: string, defaultValue: boolean): bo
  * Synchronously get a string feature flag value (for non-React code)
  *
  * Use this for flags that have string variants (e.g., A/B experiments).
- * Note: This returns the default value if the provider hasn't finished initializing.
  *
- * @param flagName - The feature flag name (use FeatureFlags constants)
- * @param defaultValue - Default value if flag evaluation fails or provider not ready
+ * @param flagName - The feature flag name
+ * @param defaultValue - Default value if flag evaluation fails
  * @returns The evaluated flag value or default
  *
  * @example
@@ -178,9 +336,9 @@ export const getStringFlagValue = (flagName: string, defaultValue: string): stri
  * Get experiment configuration from a feature flag that returns a JSON object
  *
  * Use this for experiment flags that need to return both a variant and additional config.
- * The flag should return an object with { variant: string, pages: string[] }
+ * The flag should return an object with { variant: string, pages: string[], resetCache?: boolean }
  *
- * @param flagName - The feature flag name (use FeatureFlags constants)
+ * @param flagName - The feature flag name
  * @returns The experiment configuration or DEFAULT_EXPERIMENT_CONFIG on error
  *
  * @example
@@ -188,12 +346,15 @@ export const getStringFlagValue = (flagName: string, defaultValue: string): stri
  * if (config.variant === 'treatment') {
  *   // Auto-open on config.pages
  * }
+ * if (config.resetCache) {
+ *   // Clear session storage to allow sidebar to auto-open again
+ * }
  */
 export const getExperimentConfig = (flagName: string): ExperimentConfig => {
   try {
     const client = getFeatureFlagClient();
-    // OpenFeature returns JsonValue - cast default to match expected type
-    const value = client.getObjectValue(flagName, DEFAULT_EXPERIMENT_CONFIG as any);
+    const value = client.getObjectValue(flagName, DEFAULT_EXPERIMENT_CONFIG as unknown as JsonValue);
+
     // Validate the response has required fields before using
     if (
       value &&
@@ -204,9 +365,11 @@ export const getExperimentConfig = (flagName: string): ExperimentConfig => {
       'pages' in value &&
       Array.isArray((value as Record<string, unknown>).pages)
     ) {
+      const record = value as Record<string, unknown>;
       return {
-        variant: (value as Record<string, unknown>).variant as ExperimentConfig['variant'],
-        pages: (value as Record<string, unknown>).pages as string[],
+        variant: record.variant as ExperimentConfig['variant'],
+        pages: record.pages as string[],
+        resetCache: typeof record.resetCache === 'boolean' ? record.resetCache : false,
       };
     }
     return DEFAULT_EXPERIMENT_CONFIG;
@@ -215,6 +378,10 @@ export const getExperimentConfig = (flagName: string): ExperimentConfig => {
     return DEFAULT_EXPERIMENT_CONFIG;
   }
 };
+
+// ============================================================================
+// URL PATTERN MATCHING
+// ============================================================================
 
 /**
  * Match a URL path against a pattern with optional wildcard support
@@ -253,6 +420,10 @@ export const matchPathPattern = (pattern: string, path: string): boolean => {
   return normalizedPath === normalizedPattern;
 };
 
+// ============================================================================
+// REACT HOOKS
+// ============================================================================
+
 /**
  * React hooks for feature flag evaluation
  *
@@ -263,7 +434,7 @@ export const matchPathPattern = (pattern: string, path: string): boolean => {
  *
  * @example
  * // In a React component
- * const autoOpen = useBooleanFlag(FeatureFlags.AUTO_OPEN_SIDEBAR_ON_LAUNCH, false);
+ * const autoOpen = useBooleanFlag('pathfinder.auto-open-sidebar', false);
  */
 export {
   useBooleanFlagValue as useBooleanFlag,


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the feature flag infrastructure, experiment handling, and analytics tracking in the Pathfinder app. The main focus is on enhancing feature flag evaluation and tracking, improving A/B experiment robustness, and expanding test utilities for OpenFeature. Key changes include adding a feature flag evaluation tracking hook, refining experiment session handling, and updating test mocks for the OpenFeature SDKs.

**Feature flag tracking and analytics:**

* Added a new `TrackingHook` class in `src/utils/openfeature-tracking.ts` that reports feature flag evaluations to analytics, using a new `feature_flag_evaluated` event in the `UserInteraction` enum. This enables automatic tracking of flag usage for flags with a defined `trackingKey`. [[1]](diffhunk://#diff-8e38b3532835b0cb19d7de8f9625514efe4bf688d76812d134ad0afee71a64c3R1-R56) [[2]](diffhunk://#diff-af25af6c1c85456cbce5a4eda14f0b3965aacdd964420dde9a08ee5c7c2674afR60-R62)

**A/B experiment and auto-open sidebar logic:**

* Refactored experiment config and sidebar auto-open logic in `src/module.tsx` to support a new `resetCache` flag (remotely clearing session state), separated session tracking for experiment treatments, and ensured once-per-session behavior for both control and treatment groups. This prevents repeated sidebar pop-ups ("Clippy" effect) and allows operators to remotely reset the session. [[1]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560R35-R81) [[2]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560R253-R268) [[3]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560R283-R296) [[4]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560R326-R345)

**OpenFeature SDK and test utilities:**

* Upgraded `@openfeature/ofrep-web-provider` and added `@openfeature/web-sdk` to `package.json`, enabling use of the latest OpenFeature APIs and hooks.
* Expanded `src/test-utils/openfeature-mock.ts` to provide comprehensive mocks for both the OpenFeature web SDK and React SDK, including support for `JsonValue`, provider status, events, and new APIs such as `getObjectValue` and `setProviderAndWait`. [[1]](diffhunk://#diff-8c20f5f5a2d8bb41414ea85fd5a030b1884d803f2a4b34de00b22e0b93690df2R22-R30) [[2]](diffhunk://#diff-8c20f5f5a2d8bb41414ea85fd5a030b1884d803f2a4b34de00b22e0b93690df2L42-R114) [[3]](diffhunk://#diff-8c20f5f5a2d8bb41414ea85fd5a030b1884d803f2a4b34de00b22e0b93690df2R128-R146)

**Testing improvements:**

* Updated `src/utils/openfeature.test.ts` to use the new mocks, test the presence of tracking keys, and validate that `initializeOpenFeature` uses `setProviderAndWait` as required by the upgraded SDK. [[1]](diffhunk://#diff-b75002c215951ac2316129a7151e8c532e99534c08ba862640445d9d0fafa71fL23-R47) [[2]](diffhunk://#diff-b75002c215951ac2316129a7151e8c532e99534c08ba862640445d9d0fafa71fR56-R61) [[3]](diffhunk://#diff-b75002c215951ac2316129a7151e8c532e99534c08ba862640445d9d0fafa71fR73-R102) [[4]](diffhunk://#diff-b75002c215951ac2316129a7151e8c532e99534c08ba862640445d9d0fafa71fL71-R114) [[5]](diffhunk://#diff-b75002c215951ac2316129a7151e8c532e99534c08ba862640445d9d0fafa71fL81-R158)

These changes collectively improve observability of feature flag usage, provide safer and more flexible experiment rollout, and ensure robust testing of feature flag infrastructure.