### PR TITLE
fix(interactive): fixed scroll bug

### DIFF
--- a/src/interactive-engine/navigation-manager.ts
+++ b/src/interactive-engine/navigation-manager.ts
@@ -325,6 +325,12 @@ export class NavigationManager {
    */
   private setupAutoCleanup(element: HTMLElement): void {
     let hasTriggeredCleanup = false; // Flag to prevent double-cleanup
+    // FIX: Grace period to ignore scroll events from ensureElementVisible's scrollIntoView
+    // Without this, leftover scroll events immediately clear the highlight
+    let isInGracePeriod = true;
+    setTimeout(() => {
+      isInGracePeriod = false;
+    }, 150); // 150ms grace period for scroll events to settle
 
     const cleanup = () => {
       if (hasTriggeredCleanup) {
@@ -343,6 +349,11 @@ export class NavigationManager {
 
     // 1. Simple scroll detection - clear on any scroll (unless section is running)
     const scrollHandler = () => {
+      // FIX: Ignore scroll events during grace period (leftover from scrollIntoView)
+      if (isInGracePeriod) {
+        return;
+      }
+
       // Check if section blocking is active - if so, don't clear on scroll
       // This allows users to scroll during section execution without losing highlights
       const sectionBlocker = document.getElementById('interactive-blocking-overlay');


### PR DESCRIPTION
This pull request improves the user experience in the navigation system by preventing premature clearing of highlights caused by scroll events triggered programmatically (e.g., by `scrollIntoView`). The key change introduces a short grace period to ignore these leftover scroll events.

Highlight persistence improvements:

* Added a 150ms grace period (`isInGracePeriod`) after ensuring an element is visible to ignore scroll events that would otherwise immediately clear the highlight. (`src/interactive-engine/navigation-manager.ts`, [src/interactive-engine/navigation-manager.tsR328-R333](diffhunk://#diff-c2da8f2214b3cb6608ab8f59ef8bbb23c6c2b57e691dddaacea3cd3c860af925R328-R333))
* Updated the scroll event handler to check for the grace period and skip cleanup if it is active, preventing unwanted highlight removal. (`src/interactive-engine/navigation-manager.ts`, [src/interactive-engine/navigation-manager.tsR352-R356](diffhunk://#diff-c2da8f2214b3cb6608ab8f59ef8bbb23c6c2b57e691dddaacea3cd3c860af925R352-R356))