### PR TITLE
fix(interactive): add fixes to go there interactive step

### DIFF
--- a/src/components/block-editor/forms/StepEditor.tsx
+++ b/src/components/block-editor/forms/StepEditor.tsx
@@ -573,7 +573,18 @@ export function StepEditor({
                         menuPlacement="top"
                       />
                     </Field>
-                    {editAction !== 'noop' && (
+                    {/* Navigation path - for navigate actions only */}
+                    {editAction === 'navigate' && (
+                      <Field label="Path" style={{ marginBottom: 0, flex: 1 }}>
+                        <Input
+                          value={editReftarget}
+                          onChange={(e) => setEditReftarget(e.currentTarget.value)}
+                          placeholder="e.g., /dashboards, /d/abc123"
+                        />
+                      </Field>
+                    )}
+                    {/* Selector with picker - for actions that need a DOM element */}
+                    {editAction !== 'noop' && editAction !== 'navigate' && (
                       <>
                         <Field label="Selector" style={{ marginBottom: 0, flex: 1 }}>
                           <Input
@@ -664,14 +675,17 @@ export function StepEditor({
                     </Field>
                   )}
 
-                  <Checkbox
-                    className={styles.checkbox}
-                    label="Element may be off-screen (scroll to find)"
-                    description="Enable if the target is in a long list that requires scrolling. The system will scroll until the element is found."
-                    checked={editLazyRender}
-                    onChange={(e) => setEditLazyRender(e.currentTarget.checked)}
-                  />
-                  {editLazyRender && (
+                  {/* Lazy render only applies to actions with DOM elements */}
+                  {editAction !== 'navigate' && (
+                    <Checkbox
+                      className={styles.checkbox}
+                      label="Element may be off-screen (scroll to find)"
+                      description="Enable if the target is in a long list that requires scrolling. The system will scroll until the element is found."
+                      checked={editLazyRender}
+                      onChange={(e) => setEditLazyRender(e.currentTarget.checked)}
+                    />
+                  )}
+                  {editLazyRender && editAction !== 'navigate' && (
                     <Field label="Scroll container (optional)" style={{ marginBottom: 0 }}>
                       <div className={styles.addStepRow}>
                         <Input
@@ -840,7 +854,18 @@ export function StepEditor({
                 menuPlacement="top"
               />
             </Field>
-            {newAction !== 'noop' && (
+            {/* Navigation path - for navigate actions only */}
+            {newAction === 'navigate' && (
+              <Field label="Path" style={{ marginBottom: 0, flex: 1 }}>
+                <Input
+                  value={newReftarget}
+                  onChange={(e) => setNewReftarget(e.currentTarget.value)}
+                  placeholder="e.g., /dashboards, /d/abc123"
+                />
+              </Field>
+            )}
+            {/* Selector with picker - for actions that need a DOM element */}
+            {newAction !== 'noop' && newAction !== 'navigate' && (
               <>
                 <Field label="Selector" style={{ marginBottom: 0, flex: 1 }}>
                   <Input
@@ -923,14 +948,17 @@ export function StepEditor({
             </Field>
           )}
 
-          <Checkbox
-            className={styles.checkbox}
-            label="Element may be off-screen (scroll to find)"
-            description="Enable if the target is in a long list that requires scrolling. The system will scroll until the element is found."
-            checked={newLazyRender}
-            onChange={(e) => setNewLazyRender(e.currentTarget.checked)}
-          />
-          {newLazyRender && (
+          {/* Lazy render only applies to actions with DOM elements */}
+          {newAction !== 'navigate' && (
+            <Checkbox
+              className={styles.checkbox}
+              label="Element may be off-screen (scroll to find)"
+              description="Enable if the target is in a long list that requires scrolling. The system will scroll until the element is found."
+              checked={newLazyRender}
+              onChange={(e) => setNewLazyRender(e.currentTarget.checked)}
+            />
+          )}
+          {newLazyRender && newAction !== 'navigate' && (
             <Field label="Scroll container (optional)" style={{ marginBottom: 0 }}>
               <div className={styles.addStepRow}>
                 <Input


### PR DESCRIPTION
This pull request updates the block editor and interactive step logic to better support a new "navigate" action type. The changes clarify how form fields and behaviors are handled for navigation actions versus DOM-targeting actions, ensuring users see only relevant options for each action type. The logic for executing actions is also improved to handle navigation and no-op actions without unnecessary DOM checks.

**Improvements to action handling and form UI:**

* Updated `InteractiveBlockForm.tsx` and `StepEditor.tsx` so that when the action is "navigate", the form displays a "Navigation path" input instead of a DOM selector field, and hides options that only apply to DOM-targeting actions (like lazy render and button visibility). [[1]](diffhunk://#diff-440152e0e9dc3000f233d16d288ed24089178dd0ccc71a3c0abee23ac8ce9907R171-R173) [[2]](diffhunk://#diff-440152e0e9dc3000f233d16d288ed24089178dd0ccc71a3c0abee23ac8ce9907L185-R200) [[3]](diffhunk://#diff-440152e0e9dc3000f233d16d288ed24089178dd0ccc71a3c0abee23ac8ce9907L282-R296) [[4]](diffhunk://#diff-440152e0e9dc3000f233d16d288ed24089178dd0ccc71a3c0abee23ac8ce9907R335-R349) [[5]](diffhunk://#diff-e96adfb4ce2d494051bc543e7c9a8d514a5d4a9e9a74abe2a3f2740c2556503bL576-R587) [[6]](diffhunk://#diff-e96adfb4ce2d494051bc543e7c9a8d514a5d4a9e9a74abe2a3f2740c2556503bR678-R688) [[7]](diffhunk://#diff-e96adfb4ce2d494051bc543e7c9a8d514a5d4a9e9a74abe2a3f2740c2556503bL843-R868) [[8]](diffhunk://#diff-e96adfb4ce2d494051bc543e7c9a8d514a5d4a9e9a74abe2a3f2740c2556503bR951-R961)
* Ensured that lazy render and scroll container fields are only shown for actions that target DOM elements, not for navigation actions. [[1]](diffhunk://#diff-440152e0e9dc3000f233d16d288ed24089178dd0ccc71a3c0abee23ac8ce9907R335-R349) [[2]](diffhunk://#diff-e96adfb4ce2d494051bc543e7c9a8d514a5d4a9e9a74abe2a3f2740c2556503bR678-R688) [[3]](diffhunk://#diff-e96adfb4ce2d494051bc543e7c9a8d514a5d4a9e9a74abe2a3f2740c2556503bR951-R961)

**Execution logic improvements:**

* Modified `executeWithLazyScroll` in `interactive-step.tsx` to immediately execute "navigate" and "noop" actions without checking for DOM elements, since these actions do not require a target element.
* Clarified comments and logic around lazy scroll, making it clear that lazy scroll is only attempted if enabled and only for DOM-targeting actions. [[1]](diffhunk://#diff-46228912b69159ac5a38a083cea28122830d8cf4d4ff8d5cee7e4c20546b0bffL76-R83) [[2]](diffhunk://#diff-46228912b69159ac5a38a083cea28122830d8cf4d4ff8d5cee7e4c20546b0bffL97-R104)

**Minor UI/UX tweaks:**

* Standardized button and field labels for consistency (e.g., "Pick element" instead of "Pick Element").