### PR TITLE
feat(dev-tools): update dom selector logic

### DIFF
--- a/src/components/block-editor/BlockEditor.tsx
+++ b/src/components/block-editor/BlockEditor.tsx
@@ -74,6 +74,8 @@ export function BlockEditor({ initialGuide, onChange, onCopy, onDownload }: Bloc
   const [recordingIntoSection, setRecordingIntoSection] = useState<string | null>(null);
   const [recordingStartUrl, setRecordingStartUrl] = useState<string | null>(null);
   const pendingSectionIdRef = useRef<string | null>(null);
+  // Multi-step grouping toggle for section recording
+  const [isSectionMultiStepGroupingEnabled, setIsSectionMultiStepGroupingEnabled] = useState(true);
 
   // Conditional branch recording state
   const [recordingIntoConditionalBranch, setRecordingIntoConditionalBranch] = useState<{
@@ -101,7 +103,7 @@ export function BlockEditor({ initialGuide, onChange, onCopy, onDownload }: Bloc
   // Action recorder for section recording
   const actionRecorder = useActionRecorder({
     excludeSelectors,
-    enableModalDetection: true,
+    enableModalDetection: isSectionMultiStepGroupingEnabled,
   });
 
   // Callback to restore recording state after page refresh
@@ -1121,6 +1123,10 @@ export function BlockEditor({ initialGuide, onChange, onCopy, onDownload }: Bloc
               : `Conditional branch (${recordingIntoConditionalBranch?.branch === 'whenTrue' ? 'pass' : 'fail'})`
           }
           startingUrl={recordingStartUrl ?? undefined}
+          pendingMultiStepCount={actionRecorder.pendingGroupSteps.length}
+          isGroupingMultiStep={actionRecorder.activeModal !== null}
+          isMultiStepGroupingEnabled={isSectionMultiStepGroupingEnabled}
+          onToggleMultiStepGrouping={() => setIsSectionMultiStepGroupingEnabled((prev) => !prev)}
         />
       )}
 

--- a/src/components/block-editor/types.ts
+++ b/src/components/block-editor/types.ts
@@ -87,7 +87,21 @@ export interface BlockFormProps<T extends JsonBlock = JsonBlock> {
    * When starting (isActive=true), provides callbacks so parent can control the overlay.
    * The modal will show the RecordModeOverlay when active.
    */
-  onRecordModeChange?: (isActive: boolean, options?: { onStop: () => void; getStepCount: () => number }) => void;
+  onRecordModeChange?: (
+    isActive: boolean,
+    options?: {
+      onStop: () => void;
+      getStepCount: () => number;
+      /** Get number of steps pending in multi-step group (modal/dropdown detected) */
+      getPendingMultiStepCount?: () => number;
+      /** Check if currently grouping steps into a multi-step */
+      isGroupingMultiStep?: () => boolean;
+      /** Check if multi-step grouping is enabled */
+      isMultiStepGroupingEnabled?: () => boolean;
+      /** Toggle multi-step grouping on/off */
+      toggleMultiStepGrouping?: () => void;
+    }
+  ) => void;
   /**
    * Called when form is submitted AND recording should start (for section blocks).
    * Creates the block and immediately enters record mode targeting it.

--- a/src/utils/devtools/action-recorder.hook.ts
+++ b/src/utils/devtools/action-recorder.hook.ts
@@ -25,19 +25,20 @@ export interface ActionGroup {
 }
 
 // Selectors for detecting modals, dialogs, dropdowns, and popovers
+// NOTE: [data-floating-ui-portal] was removed - too aggressive, matches drilldown menus and tooltips
 const MODAL_SELECTORS = [
   '[role="dialog"]',
   '[role="menu"]',
   '[role="listbox"]',
   '[role="alertdialog"]',
-  '[role="tooltip"]',
+  // '[role="tooltip"]', // Removed - tooltips should not trigger grouping
   '.modal',
   '.ReactModal__Content',
   '.ReactModal__Overlay',
   '[data-popper-placement]',
   '.dropdown-menu',
   '[data-radix-popper-content-wrapper]',
-  '[data-floating-ui-portal]',
+  // '[data-floating-ui-portal]', // Removed - too broad, matches drilldowns/tooltips
   '.grafana-portal', // Grafana-specific portals
   '[class*="dropdown"]', // Catch various dropdown implementations
   '[class*="popover"]', // Catch popovers


### PR DESCRIPTION
## Summary

Enhances the selector generator to make selectors more stable.

**Key changes:**

- **Centralized configuration** - Extract all magic numbers and repeated arrays into `SELECTOR_CONFIG` and `STABILITY_SCORES` constants for easier tuning
- **New selector strategies** - Add placeholder and title attribute strategies for better input/icon button selection
- **Sibling-based context** - New `findSiblingContext()` function handles form inputs that follow labels
- **Narrower testid preference** - Refactored parent context search to prefer closer testid ancestors (two-pass algorithm)
- **Selector caching** - WeakMap-based cache with 5-second TTL to avoid regenerating selectors for the same element
- **Quality metrics** - `getSelectorInfo()` now returns `stabilityScore` (0-100) and `warnings[]` for fragile selectors
- **State attribute exclusion** - Exclude dynamic attributes (`data-state`, `data-focus`, `data-hover`, etc.) from compound selectors
- **Helper functions** - Added `tryUniqueSelector()`, `tryUniqueSelectorWithFallback()`, and `getTestIdAttr()` to reduce code duplication