### PR TITLE
feat(dev-tools): merge multi-steps

### DIFF
--- a/src/components/block-editor/BlockItem.tsx
+++ b/src/components/block-editor/BlockItem.tsx
@@ -158,8 +158,9 @@ export function BlockItem({
     [handleToggleSelect]
   );
 
-  // Only allow selection of interactive blocks
-  const isSelectable = isSelectionMode && isInteractiveBlock(block.block);
+  // Allow selection of interactive, multistep, and guided blocks (for merging)
+  const isSelectable =
+    isSelectionMode && (isInteractiveBlock(block.block) || isMultistepBlock(block.block) || isGuidedBlock(block.block));
 
   const containerClass = [
     styles.container,
@@ -176,7 +177,13 @@ export function BlockItem({
         <div
           className={styles.selectionCheckbox}
           onClick={handleCheckboxClick}
-          title={isSelectable ? (isSelected ? 'Deselect' : 'Select') : 'Only interactive blocks can be selected'}
+          title={
+            isSelectable
+              ? isSelected
+                ? 'Deselect'
+                : 'Select'
+              : 'Only interactive, multistep, and guided blocks can be selected'
+          }
         >
           <Checkbox value={isSelected} disabled={!isSelectable} onChange={handleToggleSelect} />
         </div>

--- a/src/components/block-editor/BlockList.tsx
+++ b/src/components/block-editor/BlockList.tsx
@@ -449,8 +449,9 @@ function NestedBlockItem({
   const styles = useStyles2(getNestedBlockItemStyles);
   const meta = BLOCK_TYPE_METADATA[block.type as BlockType];
 
-  // Only interactive blocks can be selected for merging
-  const isSelectable = isSelectionMode && block.type === 'interactive';
+  // Interactive, multistep, and guided blocks can be selected for merging
+  const isSelectable =
+    isSelectionMode && (block.type === 'interactive' || block.type === 'multistep' || block.type === 'guided');
 
   // Get preview content - same logic as BlockItem
   const getPreview = (): string => {
@@ -486,7 +487,13 @@ function NestedBlockItem({
         <div
           className={styles.selectionCheckbox}
           onClick={handleCheckboxClick}
-          title={isSelectable ? (isSelected ? 'Deselect' : 'Select') : 'Only interactive blocks can be selected'}
+          title={
+            isSelectable
+              ? isSelected
+                ? 'Deselect'
+                : 'Select'
+              : 'Only interactive, multistep, and guided blocks can be selected'
+          }
         >
           <Checkbox value={isSelected} disabled={!isSelectable} onChange={onToggleSelect} />
         </div>


### PR DESCRIPTION
This pull request expands the block merging functionality in the block editor to allow not just interactive blocks, but also multistep and guided blocks to be merged into new multistep or guided blocks. It updates both the selection logic in the UI and the merging logic in the hooks to support these additional block types.

**Block selection and UI updates:**
- Updated selection logic in `BlockItem` and `NestedBlockItem` components to allow multistep and guided blocks to be selectable for merging, not just interactive blocks. The tooltip text was also updated to reflect this broader selection. [[1]](diffhunk://#diff-62045ffa9b904a28b02a4dbd8363602b719e7562118edecbf0218cc8fac907b5L161-R163) [[2]](diffhunk://#diff-62045ffa9b904a28b02a4dbd8363602b719e7562118edecbf0218cc8fac907b5L179-R186) [[3]](diffhunk://#diff-9b4b68de7549367eab793815dd9defdf59820635f2d62a29f32333f1fa6d8f5eL452-R454) [[4]](diffhunk://#diff-9b4b68de7549367eab793815dd9defdf59820635f2d62a29f32333f1fa6d8f5eL489-R496)

**Type guard and utility enhancements:**
- Added `isMultistepBlock` and `isGuidedBlock` type guard functions to improve type safety and clarity when checking block types.

**Merging logic improvements:**
- Enhanced the merging logic in `useBlockEditor` so that both the `mergeBlocksToMultistep` and `mergeBlocksToGuided` functions now accept and correctly process interactive, multistep, and guided blocks. They extract steps from multistep/guided blocks and sort the merged steps by their position in the document. [[1]](diffhunk://#diff-f2c4fb4483092c297d207e81be5b6f06ab5dcc13986290fccb671c7c589bbc11L1149-R1239) [[2]](diffhunk://#diff-f2c4fb4483092c297d207e81be5b6f06ab5dcc13986290fccb671c7c589bbc11L1280-R1365)

**Block ID parsing improvements:**
- Extended the `parseBlockId` utility to return additional indices (`rootIndex`, `sectionRootIndex`) for more accurate sorting of blocks by their position during merging.