### PR TITLE
chore(context): migrate way from old datasource api 

### DIFF
--- a/src/requirements-manager/requirements-checker.utils.test.ts
+++ b/src/requirements-manager/requirements-checker.utils.test.ts
@@ -200,7 +200,7 @@ describe('requirements-checker.utils', () => {
       const result = await checkRequirements(options);
       expect(result.pass).toBe(true);
       expect(result.error[0].pass).toBe(true);
-      expect(mockBackend.post).toHaveBeenCalledWith('/api/datasources/1/test');
+      expect(mockBackend.post).toHaveBeenCalledWith('/api/datasources/uid/prom-uid/test');
     });
 
     it('should fail when data source test fails', async () => {

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -1171,7 +1171,7 @@ async function dashboardExistsCheck(check: string): Promise<CheckResultError> {
  *
  * How it works:
  * - Finds data source by name or type (case-insensitive)
- * - Calls Grafana's /api/datasources/{id}/test endpoint
+ * - Calls Grafana's /api/datasources/uid/{uid}/test endpoint
  * - Only passes if test returns status: 'success'
  *
  * Example usage:
@@ -1227,7 +1227,7 @@ async function datasourceConfiguredCheck(check: string): Promise<CheckResultErro
 
     try {
       // Use the data source test API
-      const testResult = await getBackendSrv().post(`/api/datasources/${targetDataSource.id}/test`);
+      const testResult = await getBackendSrv().post(`/api/datasources/uid/${targetDataSource.uid}/test`);
 
       const isConfigured = testResult && testResult.status === 'success';
 

--- a/src/types/context.types.ts
+++ b/src/types/context.types.ts
@@ -7,6 +7,7 @@
 
 export interface DataSource {
   id: number;
+  uid: string;
   name: string;
   type: string;
   url?: string;


### PR DESCRIPTION
This pull request updates the way data source tests are performed in the requirements checker by switching from using data source IDs to using UIDs, which is the recommended approach in recent Grafana APIs. It also updates the `DataSource` type to include the `uid` property, ensuring consistency throughout the codebase.

**API Endpoint Updates:**

* Changed all calls to the data source test API from using the numeric `id` to the string `uid` in the endpoint path (e.g., `/api/datasources/1/test` → `/api/datasources/uid/prom-uid/test`). This affects both the implementation and the related tests. [[1]](diffhunk://#diff-38e7dea167a50a7c3dcc446a3f5800743b9171f73d4638c22716081728c006dbL1174-R1174) [[2]](diffhunk://#diff-38e7dea167a50a7c3dcc446a3f5800743b9171f73d4638c22716081728c006dbL1230-R1230) [[3]](diffhunk://#diff-9dd19afe1671790777fbef5c79a4ff6a8546a0a39f6964901ab7e9a647c18cb8L203-R203)

**Type Definition Updates:**

* Added a `uid` property to the `DataSource` interface in `context.types.ts` to support the new API usage.