### PR TITLE
Highlight meaningful parent element for grid-overlaid inputs

### DIFF
--- a/src/interactive-engine/navigation-manager.ts
+++ b/src/interactive-engine/navigation-manager.ts
@@ -1,7 +1,7 @@
 import { waitForReactUpdates } from '../requirements-manager';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import logoSvg from '../img/logo.svg';
-import { isElementVisible, getScrollParent, getStickyHeaderOffset } from '../lib/dom';
+import { isElementVisible, getScrollParent, getStickyHeaderOffset, getVisibleHighlightTarget } from '../lib/dom';
 import { sanitizeDocumentationHTML } from '../security';
 
 export interface NavigationOptions {
@@ -575,8 +575,11 @@ export class NavigationManager {
     // Note: We always show the highlight draw animation (looks good)
     // skipAnimations only affects the comment box transition
 
+    // If selector targeted a hidden input (common in dropdowns), highlight the visible parent instead
+    const highlightTarget = getVisibleHighlightTarget(element);
+
     // Position the outline around the target element using CSS custom properties
-    const rect = element.getBoundingClientRect();
+    const rect = highlightTarget.getBoundingClientRect();
     const scrollTop = window.scrollY || document.documentElement.scrollTop;
     const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
 
@@ -634,12 +637,14 @@ export class NavigationManager {
 
     // Always set up position tracking (efficient with ResizeObserver)
     // Enable drift detection for guided mode (!enableAutoCleanup) for more responsive tracking
+    // FIX: Track the highlightTarget (visible parent) instead of original element
     const enableDriftDetection = !enableAutoCleanup;
-    this.setupPositionTracking(element, highlightOutline, commentBox, enableDriftDetection);
+    this.setupPositionTracking(highlightTarget, highlightOutline, commentBox, enableDriftDetection);
 
     // Set up smart auto-cleanup (unless disabled for guided mode)
+    // FIX: Use highlightTarget for auto-cleanup detection
     if (enableAutoCleanup) {
-      this.setupAutoCleanup(element);
+      this.setupAutoCleanup(highlightTarget);
     }
 
     return element;


### PR DESCRIPTION
Inputs like the **Platform** and **Architecture** in the Linux Server integration are hidden by the grid layout placed upon them and end up being boxed by their min-width which can often be very small.

Finding the parent input wrapper class fixes the highlighting of these boxes but doesn't provide a working **Do it** selector. I've not yet found a way to do that to truly fix the issues reported in https://github.com/grafana/interactive-tutorials/pull/75/files#diff-87b2253258583e549ca1bec3320be7f90b35a7e6cf488a8c1a5f20823c491bd0R11 and make that dropdown selectable.

<img width="983" height="278" alt="Screenshot 2026-01-28 at 07 42 58" src="https://github.com/user-attachments/assets/f22dc06c-daa9-4c52-af10-d72763d8cb93" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves highlight behavior for dropdowns where the selector hits a hidden, grid-overlaid `input` (e.g., React Select/Grafana).
> 
> - Adds `getVisibleHighlightTarget` in `dom-utils.ts` to resolve hidden empty `input` elements to their visible `*-input-wrapper` parent (with optional debug logging)
> - `NavigationManager.highlightWithComment` now uses `getVisibleHighlightTarget` for positioning, drift tracking, and auto-cleanup
> - Adds focused unit tests for `getVisibleHighlightTarget` covering passthrough cases, grid-overlay detection, ancestor search limits, and fallbacks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c3c7dce7d06c05ac825e14606ec4bf40f9dd1ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->