### PR TITLE
Recalculate objectives for enabled steps with objectives

### DIFF
--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -683,6 +683,10 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
   const isEnabledRef = useRef(state.isEnabled);
   isEnabledRef.current = state.isEnabled;
 
+  // Track objectives in ref to avoid stale closure issues
+  const objectivesRef = useRef(objectives);
+  objectivesRef.current = objectives;
+
   // Subscribe to context changes (EchoSrv events) AND URL changes for blocked steps
   // This ensures steps in "requirements not met" state get rechecked when user performs actions
   useEffect(() => {
@@ -710,9 +714,18 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     // Shared recheck function that checks current state via refs
     const triggerRecheckIfBlocked = () => {
       // Use refs to get current state without causing re-subscription
-      const isBlocked = !isCompletedRef.current && !isEnabledRef.current;
+      const isCompleted = isCompletedRef.current;
+      const isEnabled = isEnabledRef.current;
+      const isChecking = isCheckingRef.current;
+      const currentObjectives = objectivesRef.current; // Get latest objectives from ref
 
-      if (isBlocked && !isCheckingRef.current) {
+      // Recheck if:
+      // 1. Step is blocked (not enabled) - might become enabled after navigation
+      // 2. Step is enabled with objectives - objectives might be satisfied after navigation
+      const hasObjectives = currentObjectives && currentObjectives.trim() !== '';
+      const shouldRecheck = !isCompleted && !isChecking && (!isEnabled || hasObjectives);
+
+      if (shouldRecheck) {
         checkStepRef.current();
       }
     };
@@ -757,7 +770,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       document.removeEventListener('grafana:location-changed', handleUrlChange);
       clearInterval(urlCheckInterval);
     };
-  }, [isEligibleForChecking, state.isCompleted, state.fixType, lazyRender, stepId]); // Only re-subscribe when eligibility, completion, or lazy-scroll state changes
+  }, [isEligibleForChecking, state.isCompleted, state.fixType, lazyRender, stepId]); // Only re-subscribe when eligibility, completion, or lazy-scroll state changes (objectives tracked via ref)
 
   // Scoped heartbeat recheck for fragile prerequisites
   useEffect(() => {


### PR DESCRIPTION
I must admit I haven't fully understood the logic here yet so this PR is a bit premature.

However, in testing with Graft, this change makes it so that the objectives of all steps in the following guide are satisfied by any navigation to the objective page URL. Before, the steps weren't satisfied in dev mode unless I toggled between edit and preview tabs.

```json
{
  "id": "new-guide",
  "title": "New Guide",
  "blocks": [
    {
      "type": "section",
      "blocks": [
        {
          "type": "interactive",
          "action": "formfill",
          "reftarget": "input[data-testid='search-input-input']",
          "content": "Filter the connections by typing **Linux Server** in the search",
          "targetvalue": "Linux Server",
          "objectives": [
            "on-page:/connections/add-new-connection/linux-node"
          ],
          "verify": "on-page:/connections/add-new-connection/linux-node"
        },
        {
          "type": "interactive",
          "action": "highlight",
          "reftarget": "a[href='/connections/add-new-connection/linux-node']:nth-match(1)",
          "content": "Click **Linux Server**",
          "requirements": [
            "on-page:/connections/add-new-connection"
          ],
          "objectives": [
            "on-page:/connections/add-new-connection/linux-node"
          ],
          "verify": "on-page:/connections/add-new-connection/linux-node"
        }
      ],
      "id": "guide-section-77415",
      "title": "Add Linux Server connection",
      "objectives": [
        "on-page:/connections/add-new-connection/linux-node"
      ]
    }
  ],
  "match": {
    "urlPrefix": [],
    "tags": []
  }
}```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small hook logic change limited to when reactive rechecks fire; main risk is extra/unexpected recheck frequency on navigation for steps with objectives.
> 
> **Overview**
> Updates `useStepChecker`’s navigation/context-change recheck logic to also rerun checks for *enabled* steps that have non-empty `objectives`, not just for blocked steps.
> 
> Adds an `objectivesRef` to avoid stale closures and keeps the effect subscription deps unchanged while using the latest objectives to decide whether to trigger `checkStep` on URL/EchoSrv events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92b2c5cb8b4a039f383b0ee3a5fed6bbf70d27fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->