### PR TITLE
fix(dev-mode): stop auto grouping on multistep and record mode

### DIFF
--- a/src/components/block-editor/BlockFormModal.tsx
+++ b/src/components/block-editor/BlockFormModal.tsx
@@ -140,6 +140,8 @@ export function BlockFormModal({
   const [pendingMultiStepCount, setPendingMultiStepCount] = useState(0);
   const [isGroupingMultiStep, setIsGroupingMultiStep] = useState(false);
   const [isMultiStepGroupingEnabled, setIsMultiStepGroupingEnabled] = useState(true);
+  // Track whether the toggle callback is available (false when recording inside multistep/guided)
+  const [canToggleMultiStepGrouping, setCanToggleMultiStepGrouping] = useState(false);
 
   // State for type switch confirmation - lifted from TypeSwitchDropdown to avoid nested modal timing bugs
   const [pendingSwitch, setPendingSwitch] = useState<{
@@ -356,6 +358,8 @@ export function BlockFormModal({
         setPendingMultiStepCount(options.getPendingMultiStepCount?.() ?? 0);
         setIsGroupingMultiStep(options.isGroupingMultiStep?.() ?? false);
         setIsMultiStepGroupingEnabled(options.isMultiStepGroupingEnabled?.() ?? true);
+        // Track whether toggle is available (not available for step recording in multistep/guided)
+        setCanToggleMultiStepGrouping(options.toggleMultiStepGrouping !== undefined);
         setRecordStartUrl(window.location.href);
       } else if (!isActive) {
         recordStopCallbackRef.current = null;
@@ -368,6 +372,7 @@ export function BlockFormModal({
         setPendingMultiStepCount(0);
         setIsGroupingMultiStep(false);
         setIsMultiStepGroupingEnabled(true);
+        setCanToggleMultiStepGrouping(false);
         setRecordStartUrl(null);
       }
     },
@@ -512,7 +517,9 @@ export function BlockFormModal({
           pendingMultiStepCount={pendingMultiStepCount}
           isGroupingMultiStep={isGroupingMultiStep}
           isMultiStepGroupingEnabled={isMultiStepGroupingEnabled}
-          onToggleMultiStepGrouping={handleToggleMultiStepGrouping}
+          // Only show toggle when available (not available for step recording
+          // inside multistep/guided blocks since nested grouping isn't supported)
+          onToggleMultiStepGrouping={canToggleMultiStepGrouping ? handleToggleMultiStepGrouping : undefined}
         />
       )}
     </>


### PR DESCRIPTION
This pull request updates the `BlockFormModal` and `StepEditor` components to clarify and enforce that multi-step grouping is not available when recording steps inside a multi-step or guided block. The changes ensure the grouping toggle is only shown where supported and remove related state and logic from contexts where nested grouping isn't allowed.

**Multi-step grouping toggle logic improvements:**

* [`BlockFormModal.tsx`](diffhunk://#diff-322a3ea5c0dddde17f4477913ed76c57073f19e31622f68e3da264bd58a4ede0R143-R144): Adds a `canToggleMultiStepGrouping` state to track whether the grouping toggle should be available, and updates the logic to only show the toggle when supported (not during step recording inside multi-step/guided blocks). [[1]](diffhunk://#diff-322a3ea5c0dddde17f4477913ed76c57073f19e31622f68e3da264bd58a4ede0R143-R144) [[2]](diffhunk://#diff-322a3ea5c0dddde17f4477913ed76c57073f19e31622f68e3da264bd58a4ede0R361-R362) [[3]](diffhunk://#diff-322a3ea5c0dddde17f4477913ed76c57073f19e31622f68e3da264bd58a4ede0R375) [[4]](diffhunk://#diff-322a3ea5c0dddde17f4477913ed76c57073f19e31622f68e3da264bd58a4ede0L515-R522)

**StepEditor simplification and restrictions:**

* [`StepEditor.tsx`](diffhunk://#diff-e96adfb4ce2d494051bc543e7c9a8d514a5d4a9e9a74abe2a3f2740c2556503bL457-L471): Hard-codes `isMultiStepGroupingEnabled` to `false`, removes all state, refs, and callbacks related to toggling grouping, and omits the grouping toggle from the overlay options passed to the parent. This makes it clear that multi-step grouping is not supported during step recording in this context. [[1]](diffhunk://#diff-e96adfb4ce2d494051bc543e7c9a8d514a5d4a9e9a74abe2a3f2740c2556503bL457-L471) [[2]](diffhunk://#diff-e96adfb4ce2d494051bc543e7c9a8d514a5d4a9e9a74abe2a3f2740c2556503bL483-L486) [[3]](diffhunk://#diff-e96adfb4ce2d494051bc543e7c9a8d514a5d4a9e9a74abe2a3f2740c2556503bR569-R593) [[4]](diffhunk://#diff-e96adfb4ce2d494051bc543e7c9a8d514a5d4a9e9a74abe2a3f2740c2556503bL611-L612)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies and enforces that multi-step grouping is not available when recording steps inside `multistep/guided` contexts.
> 
> - `BlockFormModal.tsx`: Adds `canToggleMultiStepGrouping` state; derives availability from presence of `toggleMultiStepGrouping` option; resets on stop; conditionally passes `onToggleMultiStepGrouping` to `RecordModeOverlay` only when supported.
> - `StepEditor.tsx`: Hard-disables multi-step grouping (`isMultiStepGroupingEnabled = false`), removes related state/refs/callbacks, and omits `isMultiStepGroupingEnabled`/`toggleMultiStepGrouping` from `onRecordModeChange` options; `enableModalDetection` set based on the disabled flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34387b1620d1ff7b81678cc74fec7a781a058d86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->