### PR TITLE
ci: parallelize quality checks for faster E2E feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  NODE_VERSION: '22'
+
 jobs:
   # Setup job installs dependencies and caches node_modules for parallel jobs
   setup:
@@ -30,7 +33,7 @@ jobs:
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
           persist-credentials: false
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm' # Cross-run npm cache (speeds up npm ci)
       - run: npm ci
       - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -53,7 +56,7 @@ jobs:
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
           persist-credentials: false
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
       - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: node_modules
@@ -75,7 +78,7 @@ jobs:
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
           persist-credentials: false
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
       - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: node_modules
@@ -97,7 +100,7 @@ jobs:
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
           persist-credentials: false
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
       - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: node_modules
@@ -119,7 +122,7 @@ jobs:
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
           persist-credentials: false
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
       - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: node_modules
@@ -154,7 +157,7 @@ jobs:
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
           persist-credentials: false
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
       - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: node_modules
@@ -316,7 +319,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
         with:
-          node-version: '22'
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
       - name: Install dev dependencies


### PR DESCRIPTION
## Summary

- Restructure CI workflow so E2E tests start as soon as the build artifact is ready (~2.5 minutes earlier)
- Split monolithic build job into parallel quality check jobs (lint, typecheck, prettier, test)
- Add CI gate job for simpler branch protection configuration

## Changes

### New parallel job structure

```
setup → lint      ─┐
      → typecheck ─┤
      → prettier  ─┼→ ci-gate
      → test      ─┤
      → build     ─┘→ playwright-tests
```

| Job | Purpose |
|-----|---------|
| `setup` | Install deps, cache `node_modules` for intra-run sharing |
| `lint` | `npm run lint` (parallel) |
| `typecheck` | `npm run typecheck` (parallel) |
| `prettier` | `npm run prettier-test` (parallel) |
| `test` | `npm run test:ci` + coverage upload (parallel) |
| `build` | Build/sign/package plugin (parallel with quality checks) |
| `ci-gate` | Aggregates all required checks for branch protection |
| `resolve-versions` | Now runs independently, includes `has-e2e` check |

### Timeline improvement

| Phase | Before | After |
|-------|--------|-------|
| Setup + npm ci | 30s | 35s |
| Quality checks | 105s sequential | 0s (parallel) |
| Build + package | 90s | 90s |
| **E2E starts at** | **~4-5 min** | **~2 min** |

## Trade-offs

- **Billable minutes**: Slightly higher due to job startup overhead (~20s/job), but wall-clock time decreases significantly
- **E2E may run on failing PRs**: E2E starts before quality checks complete. Acceptable since quality checks usually pass.

## Post-merge tasks

Update branch protection rules:
1. Remove old "Build, lint and unit tests" requirement
2. Add `CI Gate` as required check
3. (Optional) Add `e2e test *` pattern for E2E matrix jobs

## Test plan

- [ ] Verify all jobs pass on this PR
- [ ] Confirm E2E tests still run correctly
- [ ] Check coverage artifact uploads successfully
- [ ] Verify plugin signing works (if token available)