### PR TITLE
test: add unit tests for step state machine and check phases

### DIFF
--- a/src/requirements-manager/check-phases.test.ts
+++ b/src/requirements-manager/check-phases.test.ts
@@ -1,0 +1,679 @@
+/**
+ * Check Phases Tests
+ *
+ * Integration-style tests for check-phases.ts with real dependencies.
+ * Tests verify actual config values and explanation generation.
+ */
+
+import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
+
+import {
+  createBlockedState,
+  createCheckingState,
+  createEnabledState,
+  createErrorState,
+  createObjectivesCompletedState,
+  createRequirementsState,
+} from './check-phases';
+
+describe('check-phases', () => {
+  // ============================================================
+  // createCheckingState Tests
+  // ============================================================
+  describe('createCheckingState', () => {
+    it('should create checking state with correct flags', () => {
+      const state = createCheckingState(false);
+
+      expect(state.isChecking).toBe(true);
+      expect(state.isEnabled).toBe(false);
+      expect(state.isCompleted).toBe(false);
+      expect(state.isSkipped).toBe(false);
+    });
+
+    it('should use maxRetries from INTERACTIVE_CONFIG', () => {
+      const state = createCheckingState(false);
+
+      expect(state.maxRetries).toBe(INTERACTIVE_CONFIG.delays.requirements.maxRetries);
+    });
+
+    it('should initialize with zero retry count', () => {
+      const state = createCheckingState(false);
+
+      expect(state.retryCount).toBe(0);
+      expect(state.isRetrying).toBe(false);
+    });
+  });
+
+  // ============================================================
+  // createObjectivesCompletedState Tests
+  // ============================================================
+  describe('createObjectivesCompletedState', () => {
+    it('should create objectives completed state with correct flags', () => {
+      const state = createObjectivesCompletedState(false);
+
+      expect(state.isEnabled).toBe(true);
+      expect(state.isCompleted).toBe(true);
+      expect(state.isChecking).toBe(false);
+      expect(state.isSkipped).toBe(false);
+    });
+
+    it('should set completion reason to objectives', () => {
+      const state = createObjectivesCompletedState(false);
+
+      expect(state.completionReason).toBe('objectives');
+    });
+
+    it('should have "Already done!" explanation', () => {
+      const state = createObjectivesCompletedState(false);
+
+      expect(state.explanation).toBe('Already done!');
+    });
+
+    it('should use maxRetries from config', () => {
+      const state = createObjectivesCompletedState(false);
+
+      expect(state.maxRetries).toBe(INTERACTIVE_CONFIG.delays.requirements.maxRetries);
+    });
+  });
+
+  // ============================================================
+  // createBlockedState Tests
+  // ============================================================
+  describe('createBlockedState', () => {
+    it('should create blocked state with correct flags', () => {
+      const state = createBlockedState('step-1');
+
+      expect(state.isEnabled).toBe(false);
+      expect(state.isCompleted).toBe(false);
+      expect(state.isChecking).toBe(false);
+      expect(state.isSkipped).toBe(false);
+    });
+
+    it('should have "Complete previous step" explanation', () => {
+      const state = createBlockedState('step-1');
+
+      expect(state.explanation).toBe('Complete previous step');
+    });
+
+    it('should have sequential dependency error message', () => {
+      const state = createBlockedState('step-1');
+
+      expect(state.error).toBe('Sequential dependency not met');
+    });
+
+    it('should never allow skipping for sequential dependencies', () => {
+      // Test with various step IDs - canSkip should always be false
+      const state1 = createBlockedState('step-1');
+      const state2 = createBlockedState('section-1-step-2');
+      const state3 = createBlockedState('any-step');
+
+      expect(state1.canSkip).toBe(false);
+      expect(state2.canSkip).toBe(false);
+      expect(state3.canSkip).toBe(false);
+    });
+
+    it('should not allow fixing blocked state', () => {
+      const state = createBlockedState('step-1');
+
+      expect(state.canFixRequirement).toBe(false);
+      expect(state.fixType).toBeUndefined();
+      expect(state.targetHref).toBeUndefined();
+    });
+  });
+
+  // ============================================================
+  // createRequirementsState Tests - Basic
+  // ============================================================
+  describe('createRequirementsState', () => {
+    describe('passing requirements', () => {
+      it('should create enabled state when requirements pass', () => {
+        const state = createRequirementsState({ pass: true, error: [] }, 'exists-reftarget', undefined, false);
+
+        expect(state.isEnabled).toBe(true);
+        expect(state.isCompleted).toBe(false);
+        expect(state.error).toBeUndefined();
+        expect(state.canFixRequirement).toBe(false);
+      });
+
+      it('should not auto-complete when requirements pass', () => {
+        const state = createRequirementsState({ pass: true, error: [] }, 'exists-reftarget', undefined, false);
+
+        expect(state.isCompleted).toBe(false);
+        expect(state.completionReason).toBe('none');
+      });
+
+      it('should have no explanation when requirements pass', () => {
+        const state = createRequirementsState({ pass: true, error: [] }, 'exists-reftarget', undefined, false);
+
+        expect(state.explanation).toBeUndefined();
+      });
+    });
+
+    describe('failing requirements', () => {
+      it('should create disabled state when requirements fail', () => {
+        const state = createRequirementsState(
+          { pass: false, error: [{ pass: false, error: 'Element not found' }] },
+          'exists-reftarget',
+          undefined,
+          false
+        );
+
+        expect(state.isEnabled).toBe(false);
+        expect(state.isCompleted).toBe(false);
+        expect(state.error).toBe('Element not found');
+      });
+
+      it('should generate explanation from requirements', () => {
+        const state = createRequirementsState(
+          { pass: false, error: [{ pass: false, error: 'Error' }] },
+          'exists-reftarget',
+          undefined,
+          false
+        );
+
+        expect(state.explanation).toBeDefined();
+        // Explanation is generated by getRequirementExplanation
+        expect(state.explanation).toContain('target element');
+      });
+    });
+
+    describe('skippable parameter', () => {
+      it('should pass through skippable value', () => {
+        const skippable = createRequirementsState({ pass: false, error: [] }, 'exists-reftarget', undefined, true);
+        expect(skippable.canSkip).toBe(true);
+
+        const notSkippable = createRequirementsState({ pass: false, error: [] }, 'exists-reftarget', undefined, false);
+        expect(notSkippable.canSkip).toBe(false);
+      });
+    });
+  });
+
+  // ============================================================
+  // createRequirementsState Test Matrix (Comprehensive)
+  // ============================================================
+  describe('createRequirementsState test matrix', () => {
+    it('should handle all requirements passing', () => {
+      const result = createRequirementsState({ pass: true, error: [] }, 'test-req', undefined, false);
+
+      expect(result.isEnabled).toBe(true);
+      expect(result.error).toBeUndefined();
+      expect(result.canFixRequirement).toBe(false);
+    });
+
+    it('should handle single requirement failing', () => {
+      const result = createRequirementsState(
+        { pass: false, error: [{ pass: false, error: 'Element not found', requirement: 'exists:.target' }] },
+        'exists:.target',
+        undefined,
+        false
+      );
+
+      expect(result.isEnabled).toBe(false);
+      expect(result.error).toBe('Element not found');
+    });
+
+    it('should filter to only failed requirements', () => {
+      const result = createRequirementsState(
+        {
+          pass: false,
+          error: [
+            { pass: true, error: undefined },
+            { pass: false, error: 'Y', requirement: 'req-y' },
+          ],
+        },
+        'multiple-reqs',
+        undefined,
+        false
+      );
+
+      // Only failed error message should be included
+      expect(result.error).toBe('Y');
+    });
+
+    it('should join multiple failure errors', () => {
+      const result = createRequirementsState(
+        {
+          pass: false,
+          error: [
+            { pass: false, error: 'A', requirement: 'req-a' },
+            { pass: false, error: 'B', requirement: 'req-b' },
+          ],
+        },
+        'multiple-reqs',
+        undefined,
+        false
+      );
+
+      expect(result.error).toBe('A, B');
+    });
+
+    it('should extract fix info from first fixable error', () => {
+      const result = createRequirementsState(
+        {
+          pass: false,
+          error: [
+            { pass: false, error: 'Non-fixable', canFix: false },
+            { pass: false, error: 'Fixable', canFix: true, fixType: 'nav', targetHref: '/x' },
+          ],
+        },
+        'fixable-req',
+        undefined,
+        false
+      );
+
+      expect(result.canFixRequirement).toBe(true);
+      expect(result.fixType).toBe('nav');
+      expect(result.targetHref).toBe('/x');
+    });
+
+    it('should handle navmenu-open special case', () => {
+      const result = createRequirementsState(
+        { pass: false, error: [{ pass: false, error: 'Menu closed' }] },
+        'navmenu-open',
+        undefined,
+        false
+      );
+
+      expect(result.canFixRequirement).toBe(true);
+      expect(result.fixType).toBe('navigation');
+    });
+
+    it('should use hints to override explanation', () => {
+      const result = createRequirementsState(
+        { pass: false, error: [{ pass: false, error: 'Some error' }] },
+        'some-req',
+        'Custom hint text',
+        false
+      );
+
+      expect(result.explanation).toBe('Custom hint text');
+    });
+
+    it('should handle empty error array', () => {
+      const result = createRequirementsState({ pass: false, error: [] }, 'test-req', undefined, false);
+
+      // Should handle gracefully
+      expect(result.error).toBeUndefined();
+      expect(result.isEnabled).toBe(false);
+    });
+
+    it('should handle undefined error array', () => {
+      const result = createRequirementsState({ pass: false, error: undefined }, 'test-req', undefined, false);
+
+      // Should not crash and handle gracefully
+      expect(result.error).toBeUndefined();
+      expect(result.isEnabled).toBe(false);
+    });
+
+    it('should extract scrollContainer from fixable error', () => {
+      const result = createRequirementsState(
+        {
+          pass: false,
+          error: [{ pass: false, error: 'Need scroll', canFix: true, scrollContainer: '.panel-content' }],
+        },
+        'scroll-req',
+        undefined,
+        false
+      );
+
+      expect(result.scrollContainer).toBe('.panel-content');
+    });
+
+    it('should affect explanation text when skippable', () => {
+      const skippable = createRequirementsState(
+        { pass: false, error: [{ pass: false, error: 'Error' }] },
+        'exists-reftarget',
+        undefined,
+        true
+      );
+
+      const notSkippable = createRequirementsState(
+        { pass: false, error: [{ pass: false, error: 'Error' }] },
+        'exists-reftarget',
+        undefined,
+        false
+      );
+
+      // Skippable explanation should include skip information
+      expect(skippable.explanation).toContain('skip');
+      // Non-skippable should not mention skipping
+      expect(notSkippable.explanation).not.toContain('skip');
+    });
+
+    it('should use first failed requirement for explanation generation', () => {
+      const result = createRequirementsState(
+        {
+          pass: false,
+          error: [
+            { pass: false, error: 'First error', requirement: 'navmenu-open' },
+            { pass: false, error: 'Second error', requirement: 'has-plugin:test' },
+          ],
+        },
+        'multiple-reqs',
+        undefined,
+        false
+      );
+
+      // First failed requirement (navmenu-open) should influence explanation
+      expect(result.explanation).toContain('navigation menu');
+    });
+  });
+
+  // ============================================================
+  // createEnabledState Tests
+  // ============================================================
+  describe('createEnabledState', () => {
+    it('should create enabled state with correct flags', () => {
+      const state = createEnabledState(false);
+
+      expect(state.isEnabled).toBe(true);
+      expect(state.isCompleted).toBe(false);
+      expect(state.isChecking).toBe(false);
+      expect(state.isSkipped).toBe(false);
+    });
+
+    it('should have completion reason as none', () => {
+      const state = createEnabledState(false);
+
+      expect(state.completionReason).toBe('none');
+    });
+  });
+
+  // ============================================================
+  // createErrorState Tests
+  // ============================================================
+  describe('createErrorState', () => {
+    it('should create error state with correct flags', () => {
+      const state = createErrorState('Test error', 'exists-reftarget', undefined, undefined, false);
+
+      expect(state.isEnabled).toBe(false);
+      expect(state.isCompleted).toBe(false);
+      expect(state.isChecking).toBe(false);
+      expect(state.isSkipped).toBe(false);
+    });
+
+    it('should preserve error message', () => {
+      const state = createErrorState('Network timeout', 'test-req', undefined, undefined, false);
+
+      expect(state.error).toBe('Network timeout');
+    });
+
+    it('should generate explanation from requirements', () => {
+      const state = createErrorState('Error', 'navmenu-open', undefined, undefined, false);
+
+      expect(state.explanation).toContain('navigation menu');
+    });
+
+    it('should generate explanation from objectives when requirements undefined', () => {
+      const state = createErrorState('Error', undefined, 'exists:.target', undefined, false);
+
+      expect(state.explanation).toBeDefined();
+    });
+
+    it('should use hints for explanation when provided', () => {
+      const state = createErrorState('Error', 'test-req', undefined, 'Custom hint', false);
+
+      expect(state.explanation).toBe('Custom hint');
+    });
+
+    it('should handle skippable parameter in explanation', () => {
+      const skippable = createErrorState('Error', 'test-req', undefined, undefined, true);
+      const notSkippable = createErrorState('Error', 'test-req', undefined, undefined, false);
+
+      expect(skippable.explanation).toContain('skip');
+      expect(notSkippable.explanation).not.toContain('skip');
+    });
+
+    it('should not allow fixing error states', () => {
+      const state = createErrorState('Error', 'test-req', undefined, undefined, false);
+
+      expect(state.canFixRequirement).toBe(false);
+      expect(state.fixType).toBeUndefined();
+      expect(state.targetHref).toBeUndefined();
+    });
+
+    it('should use maxRetries from config', () => {
+      const state = createErrorState('Error', 'test-req', undefined, undefined, false);
+
+      expect(state.maxRetries).toBe(INTERACTIVE_CONFIG.delays.requirements.maxRetries);
+    });
+  });
+
+  // ============================================================
+  // Phase Orchestration Contract Tests
+  // ============================================================
+  describe('phase orchestration contracts', () => {
+    it('should short-circuit when objectives are met', () => {
+      const state = createObjectivesCompletedState(true);
+
+      expect(state.isCompleted).toBe(true);
+      expect(state.completionReason).toBe('objectives');
+      // Terminal state - no subsequent phases needed
+    });
+
+    it('should block step before checking requirements when not eligible', () => {
+      const state = createBlockedState('step-1');
+
+      expect(state.isEnabled).toBe(false);
+      expect(state.canSkip).toBe(false); // Sequential deps never skippable
+      expect(state.explanation).toBe('Complete previous step');
+    });
+
+    it('should enable step when requirements pass', () => {
+      const state = createRequirementsState({ pass: true, error: [] }, 'element-exists:.target', undefined, true);
+
+      expect(state.isEnabled).toBe(true);
+      expect(state.isCompleted).toBe(false); // Ready to execute, not auto-completed
+    });
+
+    it('should create enabled state for unconditional steps', () => {
+      const state = createEnabledState(false);
+
+      expect(state.isEnabled).toBe(true);
+      expect(state.canSkip).toBe(false);
+      expect(state.canFixRequirement).toBe(false);
+    });
+
+    it('should produce correct state through full phase sequence', () => {
+      // Simulate useStepChecker's decision flow:
+      // - objectivesMet = false (continue to next phase)
+      // - isEligible = true (continue to requirements check)
+      // - requirementsResult = failing
+      const requirementsResult = { pass: false, error: [{ pass: false, error: 'Not found' }] };
+
+      // Phase 1: Check objectives (not met, continue)
+      // Phase 2: Check eligibility (eligible, continue)
+      // Phase 3: Check requirements (failed)
+      const finalState = createRequirementsState(requirementsResult, 'element-exists:.btn', undefined, true);
+
+      expect(finalState.isEnabled).toBe(false);
+      expect(finalState.canSkip).toBe(true);
+      expect(finalState.error).toBe('Not found');
+    });
+
+    describe('contract invariants', () => {
+      it('should have isChecking false in all terminal states', () => {
+        // Only createCheckingState returns isChecking: true
+        expect(createCheckingState(false).isChecking).toBe(true);
+
+        // All other factories return isChecking: false
+        expect(createObjectivesCompletedState(false).isChecking).toBe(false);
+        expect(createBlockedState('step').isChecking).toBe(false);
+        expect(createRequirementsState({ pass: true, error: [] }, 'req', undefined, false).isChecking).toBe(false);
+        expect(createEnabledState(false).isChecking).toBe(false);
+        expect(createErrorState('err', 'req', undefined, undefined, false).isChecking).toBe(false);
+      });
+
+      it('should have maxRetries equal to config value in all states', () => {
+        const expectedMaxRetries = INTERACTIVE_CONFIG.delays.requirements.maxRetries;
+
+        expect(createCheckingState(false).maxRetries).toBe(expectedMaxRetries);
+        expect(createObjectivesCompletedState(false).maxRetries).toBe(expectedMaxRetries);
+        expect(createBlockedState('step').maxRetries).toBe(expectedMaxRetries);
+        expect(createRequirementsState({ pass: true, error: [] }, 'req', undefined, false).maxRetries).toBe(
+          expectedMaxRetries
+        );
+        expect(createEnabledState(false).maxRetries).toBe(expectedMaxRetries);
+        expect(createErrorState('err', 'req', undefined, undefined, false).maxRetries).toBe(expectedMaxRetries);
+      });
+
+      it('should have retryCount of 0 in all freshly created states', () => {
+        expect(createCheckingState(false).retryCount).toBe(0);
+        expect(createObjectivesCompletedState(false).retryCount).toBe(0);
+        expect(createBlockedState('step').retryCount).toBe(0);
+        expect(createRequirementsState({ pass: true, error: [] }, 'req', undefined, false).retryCount).toBe(0);
+        expect(createEnabledState(false).retryCount).toBe(0);
+        expect(createErrorState('err', 'req', undefined, undefined, false).retryCount).toBe(0);
+      });
+
+      it('should have completionReason "none" unless completed', () => {
+        expect(createCheckingState(false).completionReason).toBe('none');
+        expect(createBlockedState('step').completionReason).toBe('none');
+        expect(createRequirementsState({ pass: true, error: [] }, 'req', undefined, false).completionReason).toBe(
+          'none'
+        );
+        expect(createEnabledState(false).completionReason).toBe('none');
+        expect(createErrorState('err', 'req', undefined, undefined, false).completionReason).toBe('none');
+
+        // Only objectives completed has different reason
+        expect(createObjectivesCompletedState(false).completionReason).toBe('objectives');
+      });
+
+      it('should have isSkipped false except for skipped completion', () => {
+        // All factory functions return isSkipped: false
+        // isSkipped: true only occurs when completionReason: 'skipped'
+        expect(createCheckingState(false).isSkipped).toBe(false);
+        expect(createObjectivesCompletedState(false).isSkipped).toBe(false);
+        expect(createBlockedState('step').isSkipped).toBe(false);
+        expect(createRequirementsState({ pass: true, error: [] }, 'req', undefined, false).isSkipped).toBe(false);
+        expect(createEnabledState(false).isSkipped).toBe(false);
+        expect(createErrorState('err', 'req', undefined, undefined, false).isSkipped).toBe(false);
+      });
+    });
+  });
+
+  // ============================================================
+  // Factory Contract Tests (Consolidated)
+  // ============================================================
+  describe('factory contract tests', () => {
+    const skippableFactories = [
+      { name: 'createCheckingState', fn: (skip: boolean) => createCheckingState(skip) },
+      { name: 'createEnabledState', fn: (skip: boolean) => createEnabledState(skip) },
+      { name: 'createObjectivesCompletedState', fn: (skip: boolean) => createObjectivesCompletedState(skip) },
+    ];
+
+    describe.each(skippableFactories)('$name', ({ fn }) => {
+      it('should pass through skippable parameter', () => {
+        expect(fn(true).canSkip).toBe(true);
+        expect(fn(false).canSkip).toBe(false);
+      });
+
+      it('should have fix fields undefined or false', () => {
+        const state = fn(false);
+        expect(state.canFixRequirement).toBe(false);
+        expect(state.fixType).toBeUndefined();
+        expect(state.targetHref).toBeUndefined();
+      });
+    });
+
+    // Factories that should have no error (excludes error states and blocked states)
+    const noErrorFactories = [
+      { name: 'createCheckingState', fn: () => createCheckingState(false) },
+      { name: 'createEnabledState', fn: () => createEnabledState(false) },
+      { name: 'createObjectivesCompletedState', fn: () => createObjectivesCompletedState(false) },
+    ];
+
+    describe.each(noErrorFactories)('$name', ({ fn }) => {
+      it('should have no error', () => {
+        expect(fn().error).toBeUndefined();
+      });
+    });
+  });
+
+  // ============================================================
+  // Edge Cases
+  // ============================================================
+  describe('edge cases', () => {
+    it('should handle empty requirements string', () => {
+      const state = createRequirementsState(
+        { pass: false, error: [{ pass: false, error: 'Error' }] },
+        '',
+        undefined,
+        false
+      );
+
+      // Should not crash
+      expect(state.isEnabled).toBe(false);
+    });
+
+    it('should handle multiple fixable errors (first one wins)', () => {
+      const state = createRequirementsState(
+        {
+          pass: false,
+          error: [
+            { pass: false, error: 'First', canFix: true, fixType: 'first-type', targetHref: '/first' },
+            { pass: false, error: 'Second', canFix: true, fixType: 'second-type', targetHref: '/second' },
+          ],
+        },
+        'test-req',
+        undefined,
+        false
+      );
+
+      // First fixable error should win
+      expect(state.fixType).toBe('first-type');
+      expect(state.targetHref).toBe('/first');
+    });
+
+    it('should handle mix of passing and failing requirements', () => {
+      const state = createRequirementsState(
+        {
+          pass: false,
+          error: [
+            { pass: true },
+            { pass: false, error: 'Failed' },
+            { pass: true },
+            { pass: false, error: 'Also failed' },
+          ],
+        },
+        'test-req',
+        undefined,
+        false
+      );
+
+      // Only failing errors should be joined
+      expect(state.error).toBe('Failed, Also failed');
+    });
+
+    it('should handle very long error messages', () => {
+      const longError = 'x'.repeat(10000);
+      const state = createRequirementsState(
+        { pass: false, error: [{ pass: false, error: longError }] },
+        'test-req',
+        undefined,
+        false
+      );
+
+      expect(state.error).toBe(longError);
+    });
+
+    it('should handle null-ish values in error array', () => {
+      const state = createRequirementsState(
+        {
+          pass: false,
+          error: [
+            { pass: false, error: undefined },
+            { pass: false, error: '' },
+            { pass: false, error: 'Real error' },
+          ],
+        },
+        'test-req',
+        undefined,
+        false
+      );
+
+      // Should filter out empty/undefined errors
+      expect(state.error).toBe('Real error');
+    });
+  });
+});

--- a/src/requirements-manager/step-state.test.ts
+++ b/src/requirements-manager/step-state.test.ts
@@ -1,0 +1,761 @@
+/**
+ * Step State Machine Tests
+ *
+ * Integration-style tests for step-state.ts with real dependencies.
+ * No mocking - tests verify actual config values and state transitions.
+ */
+
+import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
+
+import {
+  createInitialState,
+  deriveIsChecking,
+  deriveIsCompleted,
+  deriveIsEnabled,
+  deriveIsRetrying,
+  deriveIsSkipped,
+  stepReducer,
+  toLegacyState,
+  type CompletionReason,
+  type StepAction,
+  type StepState,
+} from './step-state';
+
+describe('step-state', () => {
+  // ============================================================
+  // createInitialState Tests
+  // ============================================================
+  describe('createInitialState', () => {
+    it('should create state with default values', () => {
+      const state = createInitialState();
+
+      // Assert important invariants without coupling to full object shape
+      expect(state).toEqual(
+        expect.objectContaining({
+          status: 'idle',
+          completionReason: 'none',
+          retryCount: 0,
+          canSkip: false,
+          canFix: false,
+        })
+      );
+      // Verify config integration separately
+      expect(state.maxRetries).toBe(INTERACTIVE_CONFIG.delays.requirements.maxRetries);
+    });
+
+    it('should set canSkip to true when option provided', () => {
+      const state = createInitialState({ canSkip: true });
+
+      expect(state.canSkip).toBe(true);
+    });
+
+    it('should set canSkip to false when option explicitly false', () => {
+      const state = createInitialState({ canSkip: false });
+
+      expect(state.canSkip).toBe(false);
+    });
+
+    it('should default canSkip to false when undefined', () => {
+      const state = createInitialState({ canSkip: undefined });
+
+      expect(state.canSkip).toBe(false);
+    });
+
+    it('should use maxRetries from INTERACTIVE_CONFIG', () => {
+      const state = createInitialState();
+
+      expect(state.maxRetries).toBe(INTERACTIVE_CONFIG.delays.requirements.maxRetries);
+    });
+  });
+
+  // ============================================================
+  // stepReducer Tests - State Machine Transitions
+  // ============================================================
+  describe('stepReducer', () => {
+    let initialState: StepState;
+
+    beforeEach(() => {
+      initialState = createInitialState();
+    });
+
+    describe('START_CHECK action', () => {
+      it('should transition from idle to checking', () => {
+        const state = stepReducer(initialState, { type: 'START_CHECK' });
+
+        expect(state.status).toBe('checking');
+        expect(state.error).toBeUndefined();
+        expect(state.retryCount).toBe(0);
+      });
+
+      it('should transition from blocked to checking', () => {
+        const blockedState: StepState = {
+          ...initialState,
+          status: 'blocked',
+          error: 'Some error',
+        };
+
+        const state = stepReducer(blockedState, { type: 'START_CHECK' });
+
+        expect(state.status).toBe('checking');
+        expect(state.error).toBeUndefined();
+      });
+
+      it('should transition from enabled to checking', () => {
+        const enabledState: StepState = {
+          ...initialState,
+          status: 'enabled',
+        };
+
+        const state = stepReducer(enabledState, { type: 'START_CHECK' });
+
+        expect(state.status).toBe('checking');
+      });
+
+      it('should be a no-op from completed state', () => {
+        const completedState: StepState = {
+          ...initialState,
+          status: 'completed',
+          completionReason: 'manual',
+        };
+
+        const state = stepReducer(completedState, { type: 'START_CHECK' });
+
+        // State should be unchanged
+        expect(state).toBe(completedState);
+        expect(state.status).toBe('completed');
+      });
+
+      it('should reset retryCount to 0', () => {
+        const stateWithRetries: StepState = {
+          ...initialState,
+          status: 'blocked',
+          retryCount: 2,
+        };
+
+        const state = stepReducer(stateWithRetries, { type: 'START_CHECK' });
+
+        expect(state.retryCount).toBe(0);
+      });
+
+      it('should clear error when starting check', () => {
+        const stateWithError: StepState = {
+          ...initialState,
+          status: 'blocked',
+          error: 'Previous error message',
+        };
+
+        const state = stepReducer(stateWithError, { type: 'START_CHECK' });
+
+        expect(state.error).toBeUndefined();
+      });
+    });
+
+    describe('SET_BLOCKED action', () => {
+      it('should transition to blocked with error and explanation', () => {
+        const action: StepAction = {
+          type: 'SET_BLOCKED',
+          error: 'Element not found',
+          explanation: 'The target element is not visible',
+        };
+
+        const state = stepReducer(initialState, action);
+
+        expect(state.status).toBe('blocked');
+        expect(state.error).toBe('Element not found');
+        expect(state.explanation).toBe('The target element is not visible');
+      });
+
+      it('should clear fix-related fields', () => {
+        const stateWithFix: StepState = {
+          ...initialState,
+          canFix: true,
+          fixType: 'navigation',
+          targetHref: '/some/path',
+        };
+
+        const state = stepReducer(stateWithFix, { type: 'SET_BLOCKED', error: 'Blocked' });
+
+        expect(state.canFix).toBe(false);
+        expect(state.fixType).toBeUndefined();
+        expect(state.targetHref).toBeUndefined();
+      });
+
+      it('should handle SET_BLOCKED without explanation', () => {
+        const state = stepReducer(initialState, {
+          type: 'SET_BLOCKED',
+          error: 'Error only',
+        });
+
+        expect(state.error).toBe('Error only');
+        expect(state.explanation).toBeUndefined();
+      });
+    });
+
+    describe('SET_ENABLED action', () => {
+      it('should transition to enabled and clear error/explanation', () => {
+        const blockedState: StepState = {
+          ...initialState,
+          status: 'blocked',
+          error: 'Old error',
+          explanation: 'Old explanation',
+        };
+
+        const state = stepReducer(blockedState, { type: 'SET_ENABLED' });
+
+        expect(state.status).toBe('enabled');
+        expect(state.error).toBeUndefined();
+        expect(state.explanation).toBeUndefined();
+      });
+
+      it('should set fix capabilities when provided', () => {
+        const state = stepReducer(initialState, {
+          type: 'SET_ENABLED',
+          canFix: true,
+          fixType: 'navigation',
+          targetHref: '/dashboard',
+        });
+
+        expect(state.canFix).toBe(true);
+        expect(state.fixType).toBe('navigation');
+        expect(state.targetHref).toBe('/dashboard');
+      });
+
+      it('should default canFix to false when not provided', () => {
+        const state = stepReducer(initialState, { type: 'SET_ENABLED' });
+
+        expect(state.canFix).toBe(false);
+      });
+
+      it('should handle undefined optional parameters', () => {
+        const state = stepReducer(initialState, {
+          type: 'SET_ENABLED',
+          canFix: undefined,
+          fixType: undefined,
+          targetHref: undefined,
+        });
+
+        expect(state.canFix).toBe(false);
+        expect(state.fixType).toBeUndefined();
+        expect(state.targetHref).toBeUndefined();
+      });
+    });
+
+    describe('SET_COMPLETED action', () => {
+      const completionReasons: CompletionReason[] = ['objectives', 'manual', 'skipped'];
+
+      it.each(completionReasons)('should complete with reason: %s', (reason) => {
+        const state = stepReducer(initialState, {
+          type: 'SET_COMPLETED',
+          reason,
+        });
+
+        expect(state.status).toBe('completed');
+        expect(state.completionReason).toBe(reason);
+      });
+
+      it('should set default explanation when not provided', () => {
+        const state = stepReducer(initialState, {
+          type: 'SET_COMPLETED',
+          reason: 'manual',
+        });
+
+        expect(state.explanation).toBe('Completed');
+      });
+
+      it('should use provided explanation', () => {
+        const state = stepReducer(initialState, {
+          type: 'SET_COMPLETED',
+          reason: 'objectives',
+          explanation: 'Already done!',
+        });
+
+        expect(state.explanation).toBe('Already done!');
+      });
+
+      it('should clear error and canFix', () => {
+        const errorState: StepState = {
+          ...initialState,
+          error: 'Some error',
+          canFix: true,
+        };
+
+        const state = stepReducer(errorState, {
+          type: 'SET_COMPLETED',
+          reason: 'manual',
+        });
+
+        expect(state.error).toBeUndefined();
+        expect(state.canFix).toBe(false);
+      });
+    });
+
+    describe('SET_ERROR action', () => {
+      it('should transition to blocked with error details', () => {
+        const state = stepReducer(initialState, {
+          type: 'SET_ERROR',
+          error: 'Network timeout',
+          explanation: 'Check your connection',
+        });
+
+        expect(state.status).toBe('blocked');
+        expect(state.error).toBe('Network timeout');
+        expect(state.explanation).toBe('Check your connection');
+      });
+
+      it('should set fix information when provided', () => {
+        const state = stepReducer(initialState, {
+          type: 'SET_ERROR',
+          error: 'Nav menu closed',
+          canFix: true,
+          fixType: 'navigation',
+          targetHref: '/nav',
+        });
+
+        expect(state.canFix).toBe(true);
+        expect(state.fixType).toBe('navigation');
+        expect(state.targetHref).toBe('/nav');
+      });
+
+      it('should default canFix to false when not provided', () => {
+        const state = stepReducer(initialState, {
+          type: 'SET_ERROR',
+          error: 'Error',
+        });
+
+        expect(state.canFix).toBe(false);
+      });
+    });
+
+    describe('UPDATE_RETRY action', () => {
+      it('should update retry count', () => {
+        const state = stepReducer(initialState, {
+          type: 'UPDATE_RETRY',
+          retryCount: 2,
+          isRetrying: true,
+        });
+
+        expect(state.retryCount).toBe(2);
+      });
+
+      it('should preserve other state fields', () => {
+        const stateWithFields: StepState = {
+          ...initialState,
+          status: 'checking',
+          error: 'Some error',
+          explanation: 'Some explanation',
+        };
+
+        const state = stepReducer(stateWithFields, {
+          type: 'UPDATE_RETRY',
+          retryCount: 1,
+          isRetrying: true,
+        });
+
+        expect(state.status).toBe('checking');
+        expect(state.error).toBe('Some error');
+        expect(state.explanation).toBe('Some explanation');
+        expect(state.retryCount).toBe(1);
+      });
+
+      it('should handle boundary retry counts', () => {
+        const state1 = stepReducer(initialState, {
+          type: 'UPDATE_RETRY',
+          retryCount: 0,
+          isRetrying: false,
+        });
+        expect(state1.retryCount).toBe(0);
+
+        const state2 = stepReducer(initialState, {
+          type: 'UPDATE_RETRY',
+          retryCount: 3,
+          isRetrying: true,
+        });
+        expect(state2.retryCount).toBe(3);
+      });
+    });
+
+    describe('RESET action', () => {
+      it('should reset to initial state preserving canSkip', () => {
+        const completedState: StepState = {
+          ...initialState,
+          status: 'completed',
+          completionReason: 'manual',
+          error: 'old error',
+          explanation: 'old explanation',
+          canFix: true,
+          canSkip: true,
+        };
+
+        const state = stepReducer(completedState, { type: 'RESET' });
+
+        expect(state.status).toBe('idle');
+        expect(state.completionReason).toBe('none');
+        expect(state.error).toBeUndefined();
+        expect(state.explanation).toBeUndefined();
+        expect(state.canFix).toBe(false);
+        expect(state.canSkip).toBe(true); // Preserved from original state
+      });
+
+      it('should override canSkip when explicitly provided', () => {
+        const stateWithSkip: StepState = {
+          ...initialState,
+          canSkip: true,
+        };
+
+        const state = stepReducer(stateWithSkip, { type: 'RESET', canSkip: false });
+
+        expect(state.canSkip).toBe(false);
+      });
+
+      it('should preserve canSkip from state when not provided in action', () => {
+        const stateWithSkip: StepState = {
+          ...initialState,
+          canSkip: true,
+        };
+
+        const state = stepReducer(stateWithSkip, { type: 'RESET' });
+
+        expect(state.canSkip).toBe(true);
+      });
+    });
+
+    describe('unknown action', () => {
+      it('should return unchanged state for unknown action type', () => {
+        const unknownAction = { type: 'UNKNOWN_ACTION' } as unknown as StepAction;
+
+        const state = stepReducer(initialState, unknownAction);
+
+        expect(state).toBe(initialState);
+      });
+    });
+  });
+
+  // ============================================================
+  // State Transition Sequence Tests
+  // ============================================================
+  describe('state transition sequences', () => {
+    it('should complete full flow: idle → checking → enabled → checking → completed', () => {
+      let state = createInitialState();
+      expect(state.status).toBe('idle');
+
+      state = stepReducer(state, { type: 'START_CHECK' });
+      expect(state.status).toBe('checking');
+
+      state = stepReducer(state, { type: 'SET_ENABLED' });
+      expect(state.status).toBe('enabled');
+
+      state = stepReducer(state, { type: 'START_CHECK' });
+      expect(state.status).toBe('checking');
+
+      state = stepReducer(state, { type: 'SET_COMPLETED', reason: 'manual' });
+      expect(state.status).toBe('completed');
+      expect(state.completionReason).toBe('manual');
+    });
+
+    it('should handle error flow: idle → checking → blocked → checking → enabled', () => {
+      let state = createInitialState();
+      expect(state.status).toBe('idle');
+
+      state = stepReducer(state, { type: 'START_CHECK' });
+      expect(state.status).toBe('checking');
+
+      state = stepReducer(state, { type: 'SET_BLOCKED', error: 'Element not found' });
+      expect(state.status).toBe('blocked');
+      expect(state.error).toBe('Element not found');
+
+      state = stepReducer(state, { type: 'START_CHECK' });
+      expect(state.status).toBe('checking');
+      expect(state.error).toBeUndefined();
+
+      state = stepReducer(state, { type: 'SET_ENABLED' });
+      expect(state.status).toBe('enabled');
+    });
+
+    it('should handle skip flow: idle → checking → enabled → completed(skipped)', () => {
+      let state = createInitialState({ canSkip: true });
+      expect(state.status).toBe('idle');
+      expect(state.canSkip).toBe(true);
+
+      state = stepReducer(state, { type: 'START_CHECK' });
+      expect(state.status).toBe('checking');
+
+      state = stepReducer(state, { type: 'SET_ENABLED' });
+      expect(state.status).toBe('enabled');
+
+      state = stepReducer(state, { type: 'SET_COMPLETED', reason: 'skipped' });
+      expect(state.status).toBe('completed');
+      expect(state.completionReason).toBe('skipped');
+    });
+
+    it('should handle retry sequence with UPDATE_RETRY', () => {
+      let state = createInitialState();
+
+      state = stepReducer(state, { type: 'START_CHECK' });
+      expect(state.retryCount).toBe(0);
+
+      // First retry
+      state = stepReducer(state, { type: 'UPDATE_RETRY', retryCount: 1, isRetrying: true });
+      expect(state.retryCount).toBe(1);
+
+      // Second retry
+      state = stepReducer(state, { type: 'UPDATE_RETRY', retryCount: 2, isRetrying: true });
+      expect(state.retryCount).toBe(2);
+
+      // Success after retry
+      state = stepReducer(state, { type: 'SET_ENABLED' });
+      expect(state.status).toBe('enabled');
+      expect(state.retryCount).toBe(2); // Retry count preserved
+    });
+  });
+
+  // ============================================================
+  // Derive Function Tests
+  // ============================================================
+  describe('derive functions', () => {
+    describe('deriveIsEnabled', () => {
+      it('should return true only when status is enabled', () => {
+        expect(deriveIsEnabled({ ...createInitialState(), status: 'enabled' })).toBe(true);
+        expect(deriveIsEnabled({ ...createInitialState(), status: 'idle' })).toBe(false);
+        expect(deriveIsEnabled({ ...createInitialState(), status: 'checking' })).toBe(false);
+        expect(deriveIsEnabled({ ...createInitialState(), status: 'blocked' })).toBe(false);
+        expect(deriveIsEnabled({ ...createInitialState(), status: 'completed' })).toBe(false);
+      });
+    });
+
+    describe('deriveIsCompleted', () => {
+      it('should return true only when status is completed', () => {
+        expect(deriveIsCompleted({ ...createInitialState(), status: 'completed' })).toBe(true);
+        expect(deriveIsCompleted({ ...createInitialState(), status: 'idle' })).toBe(false);
+        expect(deriveIsCompleted({ ...createInitialState(), status: 'checking' })).toBe(false);
+        expect(deriveIsCompleted({ ...createInitialState(), status: 'blocked' })).toBe(false);
+        expect(deriveIsCompleted({ ...createInitialState(), status: 'enabled' })).toBe(false);
+      });
+    });
+
+    describe('deriveIsChecking', () => {
+      it('should return true only when status is checking', () => {
+        expect(deriveIsChecking({ ...createInitialState(), status: 'checking' })).toBe(true);
+        expect(deriveIsChecking({ ...createInitialState(), status: 'idle' })).toBe(false);
+        expect(deriveIsChecking({ ...createInitialState(), status: 'blocked' })).toBe(false);
+        expect(deriveIsChecking({ ...createInitialState(), status: 'enabled' })).toBe(false);
+        expect(deriveIsChecking({ ...createInitialState(), status: 'completed' })).toBe(false);
+      });
+    });
+
+    describe('deriveIsSkipped', () => {
+      it('should return true only when completed with skipped reason', () => {
+        expect(
+          deriveIsSkipped({
+            ...createInitialState(),
+            status: 'completed',
+            completionReason: 'skipped',
+          })
+        ).toBe(true);
+      });
+
+      it('should return false for completed with other reasons', () => {
+        expect(
+          deriveIsSkipped({
+            ...createInitialState(),
+            status: 'completed',
+            completionReason: 'manual',
+          })
+        ).toBe(false);
+        expect(
+          deriveIsSkipped({
+            ...createInitialState(),
+            status: 'completed',
+            completionReason: 'objectives',
+          })
+        ).toBe(false);
+      });
+
+      it('should return false for non-completed statuses', () => {
+        expect(
+          deriveIsSkipped({
+            ...createInitialState(),
+            status: 'enabled',
+            completionReason: 'skipped', // Invalid combo but should still be false
+          })
+        ).toBe(false);
+      });
+    });
+
+    describe('deriveIsRetrying', () => {
+      it('should return true only when checking with retryCount > 0', () => {
+        expect(
+          deriveIsRetrying({
+            ...createInitialState(),
+            status: 'checking',
+            retryCount: 1,
+          })
+        ).toBe(true);
+
+        expect(
+          deriveIsRetrying({
+            ...createInitialState(),
+            status: 'checking',
+            retryCount: 3,
+          })
+        ).toBe(true);
+      });
+
+      it('should return false when checking with retryCount 0', () => {
+        expect(
+          deriveIsRetrying({
+            ...createInitialState(),
+            status: 'checking',
+            retryCount: 0,
+          })
+        ).toBe(false);
+      });
+
+      it('should return false when not checking even with retryCount > 0', () => {
+        expect(
+          deriveIsRetrying({
+            ...createInitialState(),
+            status: 'blocked',
+            retryCount: 2,
+          })
+        ).toBe(false);
+
+        expect(
+          deriveIsRetrying({
+            ...createInitialState(),
+            status: 'enabled',
+            retryCount: 1,
+          })
+        ).toBe(false);
+      });
+    });
+  });
+
+  // ============================================================
+  // toLegacyState Tests
+  // ============================================================
+  describe('toLegacyState', () => {
+    it('should correctly map all fields', () => {
+      const state: StepState = {
+        status: 'enabled',
+        completionReason: 'none',
+        error: undefined,
+        explanation: 'Step is ready',
+        canFix: true,
+        fixType: 'navigation',
+        targetHref: '/dashboard',
+        retryCount: 1,
+        maxRetries: 3,
+        canSkip: true,
+      };
+
+      const legacy = toLegacyState(state);
+
+      expect(legacy).toEqual({
+        isEnabled: true,
+        isCompleted: false,
+        isChecking: false,
+        isSkipped: false,
+        completionReason: 'none',
+        explanation: 'Step is ready',
+        error: undefined,
+        canFixRequirement: true, // Note: canFix → canFixRequirement rename
+        canSkip: true,
+        fixType: 'navigation',
+        targetHref: '/dashboard',
+        retryCount: 1,
+        maxRetries: 3,
+        isRetrying: false, // Not checking, so not retrying
+      });
+    });
+
+    it('should derive isRetrying correctly in legacy format', () => {
+      const checkingState: StepState = {
+        ...createInitialState(),
+        status: 'checking',
+        retryCount: 2,
+      };
+
+      const legacy = toLegacyState(checkingState);
+
+      expect(legacy.isRetrying).toBe(true);
+      expect(legacy.isChecking).toBe(true);
+    });
+
+    it('should derive isSkipped correctly in legacy format', () => {
+      const skippedState: StepState = {
+        ...createInitialState(),
+        status: 'completed',
+        completionReason: 'skipped',
+      };
+
+      const legacy = toLegacyState(skippedState);
+
+      expect(legacy.isSkipped).toBe(true);
+      expect(legacy.isCompleted).toBe(true);
+    });
+
+    it('should match derive function outputs exactly', () => {
+      const states: StepState[] = [
+        { ...createInitialState(), status: 'idle' },
+        { ...createInitialState(), status: 'checking', retryCount: 1 },
+        { ...createInitialState(), status: 'blocked' },
+        { ...createInitialState(), status: 'enabled' },
+        { ...createInitialState(), status: 'completed', completionReason: 'manual' },
+        { ...createInitialState(), status: 'completed', completionReason: 'skipped' },
+      ];
+
+      for (const state of states) {
+        const legacy = toLegacyState(state);
+
+        expect(legacy.isEnabled).toBe(deriveIsEnabled(state));
+        expect(legacy.isCompleted).toBe(deriveIsCompleted(state));
+        expect(legacy.isChecking).toBe(deriveIsChecking(state));
+        expect(legacy.isSkipped).toBe(deriveIsSkipped(state));
+        expect(legacy.isRetrying).toBe(deriveIsRetrying(state));
+      }
+    });
+  });
+
+  // ============================================================
+  // Edge Cases
+  // ============================================================
+  describe('edge cases', () => {
+    it('should handle state preservation on no-op transitions', () => {
+      const completedState: StepState = {
+        ...createInitialState(),
+        status: 'completed',
+        completionReason: 'objectives',
+        explanation: 'Custom explanation',
+        canSkip: true,
+      };
+
+      // START_CHECK is no-op for completed
+      const state = stepReducer(completedState, { type: 'START_CHECK' });
+
+      expect(state).toBe(completedState);
+      expect(state.explanation).toBe('Custom explanation');
+      expect(state.canSkip).toBe(true);
+    });
+
+    it('should handle empty strings in action payloads', () => {
+      const state = stepReducer(createInitialState(), {
+        type: 'SET_BLOCKED',
+        error: '',
+        explanation: '',
+      });
+
+      expect(state.error).toBe('');
+      expect(state.explanation).toBe('');
+    });
+
+    it('should handle very long error messages', () => {
+      const longError = 'x'.repeat(10000);
+      const state = stepReducer(createInitialState(), {
+        type: 'SET_ERROR',
+        error: longError,
+      });
+
+      expect(state.error).toBe(longError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for `step-state.ts` (state machine reducer, derive functions, transitions)
- Add comprehensive unit tests for `check-phases.ts` (factory functions for step states)
- Tests use real config values (no mocking) for integration-style verification
- Consolidated factory contract tests via `describe.each` for better maintainability

## Test coverage

- 118 test cases covering state machine transitions, edge cases, and contract invariants
- Tests verify config integration, state derivation, and legacy state mapping

## Test plan

- [x] `npm test` passes (118 tests)
- [x] `npm run typecheck` passes  
- [x] `npm run prettier` passes

Made with [Cursor](https://cursor.com)