### PR TITLE
fix(dev-mode): quality of life in improvements to conditional blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1819,15 +1819,15 @@
       }
     },
     "node_modules/@grafana/data": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-12.3.1.tgz",
-      "integrity": "sha512-Aw7zpWflvLfuKcaYzPvsqKpNR43ZyGOooZJAEfJU/Xqg93TGkuSDImPndFEAIeQ6OwlFOQhkzbsz1GqmtKtpFg==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-12.3.2.tgz",
+      "integrity": "sha512-rWTsyBnoIHGEmCP4WZ15HXP8Z+zp+aw+CtmR+gDmypCS6IDSRWIsakuQmu5ZbWqrmQhE50jYpe2KQLae7IMS5Q==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@braintree/sanitize-url": "7.0.1",
-        "@grafana/i18n": "12.3.1",
-        "@grafana/schema": "12.3.1",
+        "@grafana/i18n": "12.3.2",
+        "@grafana/schema": "12.3.2",
         "@leeoniya/ufuzzy": "1.0.19",
         "@types/d3-interpolate": "^3.0.0",
         "@types/string-hash": "1.1.3",
@@ -1859,9 +1859,9 @@
       }
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.3.1.tgz",
-      "integrity": "sha512-65riVBmMDMIqndLL/dQcmVP/Jujn5nkTs9IbE5+nTjEniqLopWXlkz1OGt7k/Q32PRVmzNKJbFvNqp4msGWK7Q==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.3.2.tgz",
+      "integrity": "sha512-IQzQBI9LwkeKLd7WaJScLB75zIJ/Xw2rTU2H/B2hsgmrKe5ppGAAObNPm7+yhQQfEX78jo9SEHj8ywCYqHmLCw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -2271,9 +2271,9 @@
       }
     },
     "node_modules/@grafana/i18n": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.3.1.tgz",
-      "integrity": "sha512-yzcGZyIdHI0jR9WGxdmdwBZ3F/FPFnsYmVn/0jX407hEUb+/APJy39ru2tf5f7+/9fZDOCKQyqLJQ6ooEW2VsA==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.3.2.tgz",
+      "integrity": "sha512-1H/iVe52ipd4Vj3lFvMpH266tn8QibfTDEaDoNMHgR/TP68233035Z71Tgv1GZai72k3R4gEeSF+03pMAilaOg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -2324,17 +2324,17 @@
       }
     },
     "node_modules/@grafana/runtime": {
-      "version": "12.3.0-18562067081",
-      "resolved": "https://registry.npmjs.org/@grafana/runtime/-/runtime-12.3.0-18562067081.tgz",
-      "integrity": "sha512-OVyA6I4gqxB+EOphfP2FKK1R7wwy3qxLRWD/gLY0HrJ4Cm9fqHM3Y5rlZuE81fFhrPmVPSHLC2IxvPBEN3qjpA==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@grafana/runtime/-/runtime-12.3.2.tgz",
+      "integrity": "sha512-1MkDnS80lT8mj87cSI20adUCZzp8Hw+VjpwzWFsLGEmSWO1Ko+VhIpt05KpNiSzWBvmQzJ+s9n4AQymf88KHhw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@grafana/data": "12.3.0-18562067081",
-        "@grafana/e2e-selectors": "12.3.0-18562067081",
+        "@grafana/data": "12.3.2",
+        "@grafana/e2e-selectors": "12.3.2",
         "@grafana/faro-web-sdk": "^1.13.2",
-        "@grafana/schema": "12.3.0-18562067081",
-        "@grafana/ui": "12.3.0-18562067081",
+        "@grafana/schema": "12.3.2",
+        "@grafana/ui": "12.3.2",
         "@openfeature/core": "^1.9.0",
         "@openfeature/ofrep-web-provider": "^0.3.3",
         "@openfeature/web-sdk": "^1.6.1",
@@ -2349,366 +2349,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/@floating-ui/react": {
-      "version": "0.27.16",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.16.tgz",
-      "integrity": "sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.6",
-        "@floating-ui/utils": "^0.2.10",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/@grafana/data": {
-      "version": "12.3.0-18562067081",
-      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-12.3.0-18562067081.tgz",
-      "integrity": "sha512-d3TDqeMbyCuWrlPdavMXnQ3f0Zzy6IAyiBMwjLR0aiASDGNDEbURa+HtASEaEOdJwrAEc3tYvZWlpRwX9tIbyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@braintree/sanitize-url": "7.0.1",
-        "@grafana/i18n": "12.3.0-18562067081",
-        "@grafana/schema": "12.3.0-18562067081",
-        "@leeoniya/ufuzzy": "1.0.19",
-        "@types/d3-interpolate": "^3.0.0",
-        "@types/string-hash": "1.1.3",
-        "@types/systemjs": "6.15.3",
-        "d3-interpolate": "3.0.1",
-        "date-fns": "4.1.0",
-        "dompurify": "3.2.6",
-        "eventemitter3": "5.0.1",
-        "fast_array_intersect": "1.1.0",
-        "history": "4.10.1",
-        "lodash": "4.17.21",
-        "marked": "16.3.0",
-        "marked-mangle": "1.1.11",
-        "moment": "2.30.1",
-        "moment-timezone": "0.5.47",
-        "ol": "10.6.1",
-        "papaparse": "5.5.3",
-        "react-use": "17.6.0",
-        "rxjs": "7.8.2",
-        "string-hash": "^1.1.3",
-        "tinycolor2": "1.6.0",
-        "tslib": "2.8.1",
-        "uplot": "1.6.32",
-        "xss": "^1.0.14"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/@grafana/e2e-selectors": {
-      "version": "12.3.0-18562067081",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.3.0-18562067081.tgz",
-      "integrity": "sha512-F/2YAKjqpXbax57D+BbuHIetruX9JuGdKlOH21iqPO7OxNri3uCcydF+8R9xtRMfgZ6l2JafyPZOi4FDh1dwFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "semver": "^7.7.0",
-        "tslib": "2.8.1",
-        "typescript": "5.9.2"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/@grafana/i18n": {
-      "version": "12.3.0-18562067081",
-      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.3.0-18562067081.tgz",
-      "integrity": "sha512-0gM+COXfBjZlWQDkgBOIZtI09wrIiyIpD1ttUYEXhvZP1gfKiNR4lWOQbey9KgwxYTZybIzJQ85Y6HdOTXkcpg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@formatjs/intl-durationformat": "^0.7.0",
-        "@typescript-eslint/utils": "^8.33.1",
-        "fast-deep-equal": "^3.1.3",
-        "i18next": "^25.0.0",
-        "i18next-browser-languagedetector": "^8.0.0",
-        "i18next-pseudo": "^2.2.1",
-        "micro-memoize": "^4.1.2",
-        "react-i18next": "^15.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/@grafana/schema": {
-      "version": "12.3.0-18562067081",
-      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-12.3.0-18562067081.tgz",
-      "integrity": "sha512-gdhsM/c5PMwXD5d1A+G2jFTULiVprSQ7mElZBVZ8MHZJM9McXU992VZ/tYG2vZZhAJhXnZcmgugYxIWTLrSCrw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "2.8.1"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/@grafana/ui": {
-      "version": "12.3.0-18562067081",
-      "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-12.3.0-18562067081.tgz",
-      "integrity": "sha512-eA32jsWtRwemoWMdkDwTmdKNDDoe+l6MU0+hpl9ACY1sGxOg3ooK5hMThVRBi+pntxAlh3wQZvzojRUi2dqa7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@emotion/css": "11.13.5",
-        "@emotion/react": "11.14.0",
-        "@emotion/serialize": "1.3.3",
-        "@floating-ui/react": "0.27.16",
-        "@grafana/data": "12.3.0-18562067081",
-        "@grafana/e2e-selectors": "12.3.0-18562067081",
-        "@grafana/faro-web-sdk": "^1.13.2",
-        "@grafana/i18n": "12.3.0-18562067081",
-        "@grafana/schema": "12.3.0-18562067081",
-        "@hello-pangea/dnd": "18.0.1",
-        "@monaco-editor/react": "4.7.0",
-        "@popperjs/core": "2.11.8",
-        "@react-aria/dialog": "3.5.30",
-        "@react-aria/focus": "3.21.1",
-        "@react-aria/overlays": "3.29.1",
-        "@react-aria/utils": "3.30.1",
-        "@tanstack/react-virtual": "^3.5.1",
-        "@types/jquery": "3.5.33",
-        "@types/lodash": "4.17.20",
-        "@types/react-table": "7.7.20",
-        "calculate-size": "1.1.1",
-        "classnames": "2.5.1",
-        "clsx": "^2.1.1",
-        "d3": "7.9.0",
-        "date-fns": "4.1.0",
-        "downshift": "^9.0.6",
-        "hoist-non-react-statics": "3.3.2",
-        "i18next": "^25.0.0",
-        "i18next-browser-languagedetector": "^8.0.0",
-        "immutable": "5.1.3",
-        "is-hotkey": "0.2.0",
-        "jquery": "3.7.1",
-        "lodash": "4.17.21",
-        "micro-memoize": "^4.1.2",
-        "moment": "2.30.1",
-        "monaco-editor": "0.34.1",
-        "ol": "10.6.1",
-        "prismjs": "1.30.0",
-        "rc-cascader": "3.34.0",
-        "rc-drawer": "7.3.0",
-        "rc-picker": "4.11.3",
-        "rc-slider": "11.1.9",
-        "rc-tooltip": "6.4.0",
-        "react-calendar": "^6.0.0",
-        "react-colorful": "5.6.1",
-        "react-custom-scrollbars-2": "4.5.0",
-        "react-data-grid": "github:grafana/react-data-grid#a922856b5ede21d55db3fdffb6d38dc76bdc7c58",
-        "react-dropzone": "14.3.8",
-        "react-highlight-words": "0.21.0",
-        "react-hook-form": "^7.49.2",
-        "react-i18next": "^15.0.0",
-        "react-inlinesvg": "4.2.0",
-        "react-loading-skeleton": "3.5.0",
-        "react-router-dom": "5.3.4",
-        "react-router-dom-v5-compat": "^6.26.1",
-        "react-select": "5.10.2",
-        "react-table": "7.8.0",
-        "react-transition-group": "4.4.5",
-        "react-use": "17.6.0",
-        "react-window": "1.8.11",
-        "rxjs": "7.8.2",
-        "slate": "0.47.9",
-        "slate-plain-serializer": "0.7.13",
-        "slate-react": "0.22.10",
-        "tinycolor2": "1.6.0",
-        "tslib": "2.8.1",
-        "uplot": "1.6.32",
-        "uuid": "11.1.0",
-        "uwrap": "0.1.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/@react-aria/dialog": {
-      "version": "3.5.30",
-      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.30.tgz",
-      "integrity": "sha512-fiodaeMSTiC4qKNwnCLbNykyvfcxuz/PiU/pBNhWYd4lUrX1TauBQb0++o5/K6OHt8iB+A7/LSHRbPtyOSWE9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/interactions": "^3.25.5",
-        "@react-aria/overlays": "^3.29.1",
-        "@react-aria/utils": "^3.30.1",
-        "@react-types/dialog": "^3.5.21",
-        "@react-types/shared": "^3.32.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/@react-aria/focus": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.1.tgz",
-      "integrity": "sha512-hmH1IhHlcQ2lSIxmki1biWzMbGgnhdxJUM0MFfzc71Rv6YAzhlx4kX3GYn4VNcjCeb6cdPv4RZ5vunV4kgMZYQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/interactions": "^3.25.5",
-        "@react-aria/utils": "^3.30.1",
-        "@react-types/shared": "^3.32.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/@react-aria/overlays": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.29.1.tgz",
-      "integrity": "sha512-Yz92XNPnbrTnxrvNrY/fXJ3iWaYNrj0q24ddvZNNKDcWak0S1/mQeUwNb+PwS2AryhFU5VQqKz5rNsM96TKmPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/focus": "^3.21.1",
-        "@react-aria/i18n": "^3.12.12",
-        "@react-aria/interactions": "^3.25.5",
-        "@react-aria/ssr": "^3.9.10",
-        "@react-aria/utils": "^3.30.1",
-        "@react-aria/visually-hidden": "^3.8.27",
-        "@react-stately/overlays": "^3.6.19",
-        "@react-types/button": "^3.14.0",
-        "@react-types/overlays": "^3.9.1",
-        "@react-types/shared": "^3.32.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/@react-aria/utils": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.30.1.tgz",
-      "integrity": "sha512-zETcbDd6Vf9GbLndO6RiWJadIZsBU2MMm23rBACXLmpRztkrIqPEb2RVdlLaq1+GklDx0Ii6PfveVjx+8S5U6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.10",
-        "@react-stately/flags": "^3.1.2",
-        "@react-stately/utils": "^3.10.8",
-        "@react-types/shared": "^3.32.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
-    "node_modules/@grafana/runtime/node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/react-router-dom-v5-compat": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.0.tgz",
-      "integrity": "sha512-MAVRASbdQ3+ZOTPPjAa7jKcF0F9LkHWKB/iib3hf+jzzIazL4GEpMDDdTswCsqRQNU+zNnT3qD0WiNbzJ6ncPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "history": "^5.3.0",
-        "react-router": "6.30.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8",
-        "react-router-dom": "4 || 5"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/react-router-dom-v5-compat/node_modules/history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/react-router-dom-v5-compat/node_modules/react-router": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
-      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@grafana/runtime/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@grafana/scenes": {
@@ -2779,9 +2419,9 @@
       }
     },
     "node_modules/@grafana/schema": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-12.3.1.tgz",
-      "integrity": "sha512-Dd3JSwBOFS+Z0K6eoOsLngWvVQWW55rKJHKT0Q/v98FXa+owEpJra4nsyaIigccNx+WhNQmj2JV6p3/T87e80w==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-12.3.2.tgz",
+      "integrity": "sha512-X3ExqXvKg5zWV8WNimczM0wbhQoehdj05K/YRA/rD00Fuo8y0OuECFSsG/VhdLoIUM4VCqsHStaQymsYDFundg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -2796,9 +2436,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@grafana/ui": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-12.3.1.tgz",
-      "integrity": "sha512-bkjOJP0kcQSNs/hpId30OiJFWlfvBvFvcYrkOo1fXW1jQ6efGSwMfNeKIVhkRXYlcf+I2G8nwXmdOAJ8X6hXwA==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-12.3.2.tgz",
+      "integrity": "sha512-ke6ONJx2/nZDl9zkc5alDc9vx03UGO1P0njUmzQa/qDFuFuX9miyfqnHLK46AQUhDegVqCODrtKZ4EcuOHciGA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -2806,11 +2446,11 @@
         "@emotion/react": "11.14.0",
         "@emotion/serialize": "1.3.3",
         "@floating-ui/react": "0.27.16",
-        "@grafana/data": "12.3.1",
-        "@grafana/e2e-selectors": "12.3.1",
+        "@grafana/data": "12.3.2",
+        "@grafana/e2e-selectors": "12.3.2",
         "@grafana/faro-web-sdk": "^1.13.2",
-        "@grafana/i18n": "12.3.1",
-        "@grafana/schema": "12.3.1",
+        "@grafana/i18n": "12.3.2",
+        "@grafana/schema": "12.3.2",
         "@hello-pangea/dnd": "18.0.1",
         "@monaco-editor/react": "4.7.0",
         "@popperjs/core": "2.11.8",
@@ -2944,14 +2584,14 @@
       }
     },
     "node_modules/@grafana/ui/node_modules/react-router-dom-v5-compat": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.0.tgz",
-      "integrity": "sha512-MAVRASbdQ3+ZOTPPjAa7jKcF0F9LkHWKB/iib3hf+jzzIazL4GEpMDDdTswCsqRQNU+zNnT3qD0WiNbzJ6ncPw==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.3.tgz",
+      "integrity": "sha512-WWZtwGYyoaeUDNrhzzDkh4JvN5nU0MIz80Dxim6pznQrfS+dv0mvtVoHTA6HlUl/OiJl7WWjbsQwjTnYXejEHg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
+        "@remix-run/router": "1.23.2",
         "history": "^5.3.0",
-        "react-router": "6.30.0"
+        "react-router": "6.30.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2972,12 +2612,12 @@
       }
     },
     "node_modules/@grafana/ui/node_modules/react-router-dom-v5-compat/node_modules/react-router": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
-      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3063,15 +2703,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@internationalized/date": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.9.0.tgz",
-      "integrity": "sha512-yaN3brAnHRD+4KyyOsJyk49XUvj2wtbNACSqg0bz3u8t2VuzhC8Q5dfRnrSxjnnbDb+ienBnkn1TzQfE154vyg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
     "node_modules/@internationalized/message": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
@@ -3111,9 +2742,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5675,79 +5306,6 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@react-aria/i18n": {
-      "version": "3.12.12",
-      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.12.tgz",
-      "integrity": "sha512-JN6p+Xc6Pu/qddGRoeYY6ARsrk2Oz7UiQc9nLEPOt3Ch+blJZKWwDjcpo/p6/wVZdD/2BgXS7El6q6+eMg7ibw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@internationalized/date": "^3.9.0",
-        "@internationalized/message": "^3.1.8",
-        "@internationalized/number": "^3.6.5",
-        "@internationalized/string": "^3.2.7",
-        "@react-aria/ssr": "^3.9.10",
-        "@react-aria/utils": "^3.30.1",
-        "@react-types/shared": "^3.32.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/i18n/node_modules/@react-aria/utils": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.30.1.tgz",
-      "integrity": "sha512-zETcbDd6Vf9GbLndO6RiWJadIZsBU2MMm23rBACXLmpRztkrIqPEb2RVdlLaq1+GklDx0Ii6PfveVjx+8S5U6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.10",
-        "@react-stately/flags": "^3.1.2",
-        "@react-stately/utils": "^3.10.8",
-        "@react-types/shared": "^3.32.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/interactions": {
-      "version": "3.25.5",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.5.tgz",
-      "integrity": "sha512-EweYHOEvMwef/wsiEqV73KurX/OqnmbzKQa2fLxdULbec5+yDj6wVGaRHIzM4NiijIDe+bldEl5DG05CAKOAHA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.10",
-        "@react-aria/utils": "^3.30.1",
-        "@react-stately/flags": "^3.1.2",
-        "@react-types/shared": "^3.32.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/interactions/node_modules/@react-aria/utils": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.30.1.tgz",
-      "integrity": "sha512-zETcbDd6Vf9GbLndO6RiWJadIZsBU2MMm23rBACXLmpRztkrIqPEb2RVdlLaq1+GklDx0Ii6PfveVjx+8S5U6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.10",
-        "@react-stately/flags": "^3.1.2",
-        "@react-stately/utils": "^3.10.8",
-        "@react-types/shared": "^3.32.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
     "node_modules/@react-aria/overlays": {
       "version": "3.30.0",
       "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.30.0.tgz",
@@ -5952,40 +5510,6 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@react-aria/visually-hidden": {
-      "version": "3.8.27",
-      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.27.tgz",
-      "integrity": "sha512-hD1DbL3WnjPnCdlQjwe19bQVRAGJyN0Aaup+s7NNtvZUn7AjoEH78jo8TE+L8yM7z/OZUQF26laCfYqeIwWn4g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/interactions": "^3.25.5",
-        "@react-aria/utils": "^3.30.1",
-        "@react-types/shared": "^3.32.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden/node_modules/@react-aria/utils": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.30.1.tgz",
-      "integrity": "sha512-zETcbDd6Vf9GbLndO6RiWJadIZsBU2MMm23rBACXLmpRztkrIqPEb2RVdlLaq1+GklDx0Ii6PfveVjx+8S5U6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.10",
-        "@react-stately/flags": "^3.1.2",
-        "@react-stately/utils": "^3.10.8",
-        "@react-types/shared": "^3.32.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
     "node_modules/@react-stately/flags": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
@@ -5993,20 +5517,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@react-stately/overlays": {
-      "version": "3.6.19",
-      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.19.tgz",
-      "integrity": "sha512-swZXfDvxTYd7tKEpijEHBFFaEmbbnCvEhGlmrAz4K72cuRR9O5u+lcla8y1veGBbBSzrIdKNdBoIIJ+qQH+1TQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-stately/utils": "^3.10.8",
-        "@react-types/overlays": "^3.9.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-stately/utils": {
@@ -6021,52 +5531,6 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@react-types/button": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.14.0.tgz",
-      "integrity": "sha512-pXt1a+ElxiZyWpX0uznyjy5Z6EHhYxPcaXpccZXyn6coUo9jmCbgg14xR7Odo+JcbfaaISzZTDO7oGLVTcHnpA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-types/shared": "^3.32.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-types/dialog": {
-      "version": "3.5.21",
-      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.21.tgz",
-      "integrity": "sha512-jF1gN4bvwYamsLjefaFDnaSKxTa3Wtvn5f7WLjNVZ8ICVoiMBMdUJXTlPQHAL4YWqtCj4hK/3uimR1E+Pwd7Xw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-types/overlays": "^3.9.1",
-        "@react-types/shared": "^3.32.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-types/overlays": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.9.1.tgz",
-      "integrity": "sha512-UCG3TOu8FLk4j0Pr1nlhv0opcwMoqbGEOUvsSr6ITN6Qs2y0j+KYSYQ7a4+04m3dN//8+9Wjkkid8k+V1dV2CA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-types/shared": "^3.32.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-types/shared": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.32.0.tgz",
-      "integrity": "sha512-t+cligIJsZYFMSPFMvsJMjzlzde06tZMOIOFa1OV5Z0BcMowrb2g4mB57j/9nP28iJIRYn10xCniQts+qadrqQ==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
     "node_modules/@remirror/core-constants": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
@@ -6074,9 +5538,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -10870,6 +10334,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -11039,9 +10504,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -17221,6 +16686,7 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -19540,12 +19006,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
-      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -19555,14 +19021,14 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
-      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.1"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -21416,9 +20882,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
-      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -22168,9 +21634,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
-      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.20.0.tgz",
+      "integrity": "sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/src/components/block-editor/BlockList.tsx
+++ b/src/components/block-editor/BlockList.tsx
@@ -165,8 +165,8 @@ export function BlockList({ blocks, operations }: BlockListProps) {
    */
   const handleDropOnSectionInsert = useCallback(
     (activeId: string, activeData: DragData, sectionId: string, insertIndex: number) => {
-      // Guard against nesting sections/conditionals
-      if (activeData.blockType === 'section' || activeData.blockType === 'conditional') {
+      // Guard against nesting sections (conditionals ARE allowed in sections)
+      if (activeData.blockType === 'section') {
         return;
       }
 
@@ -238,7 +238,8 @@ export function BlockList({ blocks, operations }: BlockListProps) {
    */
   const handleDropOnSectionDrop = useCallback(
     (activeId: string, activeData: DragData, sectionId: string) => {
-      if (activeData.blockType === 'section' || activeData.blockType === 'conditional') {
+      // Guard against nesting sections (conditionals ARE allowed in sections)
+      if (activeData.blockType === 'section') {
         return;
       }
 
@@ -564,9 +565,7 @@ export function BlockList({ blocks, operations }: BlockListProps) {
     activeDragData !== null && (activeDragData.type === 'nested' || activeDragData.type === 'conditional');
 
   const isDraggingUnNestable =
-    activeDragData !== null &&
-    activeDragData.type === 'root' &&
-    (activeDragData.blockType === 'section' || activeDragData.blockType === 'conditional');
+    activeDragData !== null && activeDragData.type === 'root' && activeDragData.blockType === 'section';
 
   const isRootZoneRedundant = useCallback(
     (zoneIndex: number) => isInsertZoneRedundant(activeDragData, 'root-zone', zoneIndex),

--- a/src/components/block-editor/SectionNestedBlocks.tsx
+++ b/src/components/block-editor/SectionNestedBlocks.tsx
@@ -150,7 +150,7 @@ export function SectionNestedBlocks({
         ) : (
           <BlockPalette
             onSelect={(type) => onInsertBlockInSection(type, block.id)}
-            excludeTypes={['section', 'conditional']}
+            excludeTypes={['section']}
             embedded
           />
         )}

--- a/src/components/block-editor/forms/BranchBlocksEditor.tsx
+++ b/src/components/block-editor/forms/BranchBlocksEditor.tsx
@@ -1,0 +1,885 @@
+/**
+ * Branch Blocks Editor
+ *
+ * Component for editing blocks within conditional branches (whenTrue/whenFalse).
+ * Displays a list of blocks with drag-drop reordering, add/edit/delete functionality.
+ * Similar to StepEditor but for full JsonBlock arrays.
+ */
+
+import React, { useState, useCallback, useMemo } from 'react';
+import { Button, Field, Input, Select, Badge, IconButton, TextArea, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { css, cx } from '@emotion/css';
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  MeasuringStrategy,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { BLOCK_TYPE_METADATA, BLOCK_TYPE_ORDER, INTERACTIVE_ACTIONS } from '../constants';
+import { COMMON_REQUIREMENTS } from '../../../constants/interactive-config';
+import type { BlockType, JsonBlock, JsonInteractiveAction, BlockFormProps } from '../types';
+import {
+  isMarkdownBlock,
+  isInteractiveBlock,
+  isMultistepBlock,
+  isGuidedBlock,
+  isImageBlock,
+  isVideoBlock,
+  isQuizBlock,
+  isInputBlock,
+} from '../../../types/json-guide.types';
+
+// ============================================================================
+// Styles
+// ============================================================================
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  }),
+  header: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(1),
+    backgroundColor: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+    cursor: 'pointer',
+    userSelect: 'none',
+    '&:hover': {
+      backgroundColor: theme.colors.action.hover,
+    },
+  }),
+  headerIcon: css({
+    color: theme.colors.text.secondary,
+    transition: 'transform 0.2s ease',
+  }),
+  headerIconExpanded: css({
+    transform: 'rotate(90deg)',
+  }),
+  headerTitle: css({
+    flex: 1,
+    fontWeight: theme.typography.fontWeightMedium,
+  }),
+  blocksList: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    padding: theme.spacing(1),
+    backgroundColor: theme.colors.background.secondary,
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.colors.border.weak}`,
+    maxHeight: '400px',
+    overflowY: 'auto',
+  }),
+  blockItem: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(1),
+    backgroundColor: theme.colors.background.primary,
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.colors.border.weak}`,
+    cursor: 'grab',
+    transition: 'all 0.15s ease',
+    userSelect: 'none',
+    touchAction: 'none',
+    '&:hover': {
+      borderColor: theme.colors.border.medium,
+      boxShadow: theme.shadows.z1,
+    },
+    '&:active': {
+      cursor: 'grabbing',
+    },
+  }),
+  blockItemDragging: css({
+    opacity: 0.4,
+    cursor: 'grabbing',
+  }),
+  blockItemEditing: css({
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    cursor: 'default',
+    '&:active': {
+      cursor: 'default',
+    },
+  }),
+  dragHandle: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '20px',
+    color: theme.colors.text.disabled,
+    flexShrink: 0,
+    pointerEvents: 'none',
+  }),
+  blockContent: css({
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+  }),
+  blockHeader: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+  }),
+  blockPreview: css({
+    fontFamily: theme.typography.fontFamilyMonospace,
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  }),
+  blockActions: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    flexShrink: 0,
+  }),
+  editButton: css({
+    color: theme.colors.primary.text,
+    backgroundColor: theme.colors.primary.transparent,
+    borderRadius: theme.shape.radius.default,
+    transition: 'all 0.15s ease',
+    '&:hover': {
+      backgroundColor: theme.colors.primary.shade,
+      color: theme.colors.primary.contrastText,
+    },
+  }),
+  deleteButton: css({
+    opacity: 0.7,
+    color: theme.colors.error.text,
+    transition: 'all 0.15s ease',
+    '&:hover': {
+      opacity: 1,
+      backgroundColor: theme.colors.error.transparent,
+    },
+  }),
+  emptyState: css({
+    textAlign: 'center',
+    padding: theme.spacing(2),
+    color: theme.colors.text.secondary,
+    fontStyle: 'italic',
+  }),
+  addBlockSection: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  }),
+  addBlockForm: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(1.5),
+    backgroundColor: theme.colors.background.canvas,
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.colors.border.weak}`,
+  }),
+  formRow: css({
+    display: 'flex',
+    gap: theme.spacing(1),
+    alignItems: 'flex-end',
+  }),
+  formActions: css({
+    display: 'flex',
+    gap: theme.spacing(1),
+    justifyContent: 'flex-end',
+    marginTop: theme.spacing(1),
+  }),
+  editForm: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    padding: theme.spacing(1),
+    backgroundColor: theme.colors.background.canvas,
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.colors.border.medium}`,
+    marginTop: theme.spacing(1),
+  }),
+  quickAddChips: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.5),
+    marginTop: theme.spacing(0.5),
+  }),
+  requirementChip: css({
+    cursor: 'pointer',
+    '&:hover': {
+      opacity: 0.8,
+    },
+  }),
+});
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Get a preview string for any block type
+ */
+function getBlockPreview(block: JsonBlock): string {
+  if (isMarkdownBlock(block)) {
+    const firstLine = block.content.split('\n')[0];
+    return firstLine.slice(0, 50) + (firstLine.length > 50 ? '...' : '');
+  }
+  if (isInteractiveBlock(block)) {
+    return `${block.action}: ${block.reftarget || '(no target)'}`;
+  }
+  if (isMultistepBlock(block)) {
+    return `${block.steps.length} step${block.steps.length !== 1 ? 's' : ''}`;
+  }
+  if (isGuidedBlock(block)) {
+    return `${block.steps.length} guided step${block.steps.length !== 1 ? 's' : ''}`;
+  }
+  if (isImageBlock(block)) {
+    return block.alt || block.src;
+  }
+  if (isVideoBlock(block)) {
+    return block.title || block.src;
+  }
+  if (isQuizBlock(block)) {
+    return block.question.slice(0, 50) + (block.question.length > 50 ? '...' : '');
+  }
+  if (isInputBlock(block)) {
+    return block.prompt.slice(0, 50) + (block.prompt.length > 50 ? '...' : '');
+  }
+  if ('content' in block && typeof block.content === 'string') {
+    return block.content.slice(0, 50) + (block.content.length > 50 ? '...' : '');
+  }
+  return '';
+}
+
+/**
+ * Create a default block of a given type
+ */
+function createDefaultBlock(type: BlockType): JsonBlock {
+  switch (type) {
+    case 'markdown':
+      return { type: 'markdown', content: '' };
+    case 'interactive':
+      return { type: 'interactive', action: 'highlight', reftarget: '', content: '' };
+    case 'image':
+      return { type: 'image', src: '' };
+    case 'video':
+      return { type: 'video', src: '' };
+    case 'quiz':
+      return {
+        type: 'quiz',
+        question: '',
+        choices: [
+          { id: 'a', text: '', correct: true },
+          { id: 'b', text: '' },
+        ],
+      };
+    case 'input':
+      return { type: 'input', prompt: '', inputType: 'text', variableName: '' };
+    case 'multistep':
+      return { type: 'multistep', content: '', steps: [] };
+    case 'guided':
+      return { type: 'guided', content: '', steps: [] };
+    default:
+      return { type: 'markdown', content: '' };
+  }
+}
+
+// Block types allowed in conditional branches (no sections or conditionals)
+const ALLOWED_BRANCH_BLOCK_TYPES: BlockType[] = BLOCK_TYPE_ORDER.filter((t) => t !== 'section' && t !== 'conditional');
+
+const ACTION_OPTIONS: Array<SelectableValue<JsonInteractiveAction>> = INTERACTIVE_ACTIONS.map((a) => ({
+  value: a.value as JsonInteractiveAction,
+  label: a.label,
+}));
+
+// ============================================================================
+// Sortable Block Item
+// ============================================================================
+
+interface SortableBlockItemProps {
+  id: string;
+  index: number;
+  children: React.ReactNode;
+  disabled: boolean;
+}
+
+function SortableBlockItem({ id, index, children, disabled }: SortableBlockItemProps) {
+  const styles = useStyles2(getStyles);
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    data: { type: 'branch-block', index },
+    disabled,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cx(isDragging && styles.blockItemDragging)}
+      {...attributes}
+      {...listeners}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export interface BranchBlocksEditorProps {
+  /** Label for the branch (e.g., "When conditions pass") */
+  label: string;
+  /** Color variant for the header */
+  variant: 'success' | 'warning';
+  /** Current blocks in this branch */
+  blocks: JsonBlock[];
+  /** Called when blocks change */
+  onChange: (blocks: JsonBlock[]) => void;
+  /** Called to start/stop the element picker */
+  onPickerModeChange?: BlockFormProps['onPickerModeChange'];
+}
+
+export function BranchBlocksEditor({ label, variant, blocks, onChange, onPickerModeChange }: BranchBlocksEditorProps) {
+  const styles = useStyles2(getStyles);
+
+  // Expansion state
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  // Add block form state
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newBlockType, setNewBlockType] = useState<BlockType>('markdown');
+
+  // Edit block state
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
+  // Form fields for adding/editing
+  const [formContent, setFormContent] = useState('');
+  const [formAction, setFormAction] = useState<JsonInteractiveAction>('highlight');
+  const [formReftarget, setFormReftarget] = useState('');
+  const [formTargetvalue, setFormTargetvalue] = useState('');
+  const [formRequirements, setFormRequirements] = useState('');
+  const [formSrc, setFormSrc] = useState('');
+  const [formAlt, setFormAlt] = useState('');
+  const [formPrompt, setFormPrompt] = useState('');
+  const [formVariableName, setFormVariableName] = useState('');
+
+  // DnD sensors
+  const pointerSensor = useSensor(PointerSensor, {
+    activationConstraint: { distance: 8 },
+  });
+  const keyboardSensor = useSensor(KeyboardSensor, {
+    coordinateGetter: sortableKeyboardCoordinates,
+  });
+  const sensors = useSensors(pointerSensor, keyboardSensor);
+
+  // Block IDs for sortable context
+  const blockIds = useMemo(() => blocks.map((_, i) => `branch-block-${i}`), [blocks]);
+
+  // Reset form fields
+  const resetFormFields = useCallback(() => {
+    setFormContent('');
+    setFormAction('highlight');
+    setFormReftarget('');
+    setFormTargetvalue('');
+    setFormRequirements('');
+    setFormSrc('');
+    setFormAlt('');
+    setFormPrompt('');
+    setFormVariableName('');
+  }, []);
+
+  // Populate form fields from a block
+  const populateFormFromBlock = useCallback(
+    (block: JsonBlock) => {
+      resetFormFields();
+      if (isMarkdownBlock(block)) {
+        setFormContent(block.content);
+      } else if (isInteractiveBlock(block)) {
+        setFormContent(block.content);
+        setFormAction(block.action);
+        setFormReftarget(block.reftarget || '');
+        setFormTargetvalue(block.targetvalue || '');
+        setFormRequirements(block.requirements?.join(', ') || '');
+      } else if (isImageBlock(block)) {
+        setFormSrc(block.src);
+        setFormAlt(block.alt || '');
+      } else if (isVideoBlock(block)) {
+        setFormSrc(block.src);
+      } else if (isInputBlock(block)) {
+        setFormPrompt(block.prompt);
+        setFormVariableName(block.variableName);
+      }
+    },
+    [resetFormFields]
+  );
+
+  // Build block from form fields
+  const buildBlockFromForm = useCallback(
+    (type: BlockType): JsonBlock => {
+      switch (type) {
+        case 'markdown':
+          return { type: 'markdown', content: formContent };
+        case 'interactive': {
+          const reqArray = formRequirements
+            .split(',')
+            .map((r) => r.trim())
+            .filter((r) => r.length > 0);
+          return {
+            type: 'interactive',
+            action: formAction,
+            reftarget: formReftarget,
+            content: formContent,
+            ...(formTargetvalue && { targetvalue: formTargetvalue }),
+            ...(reqArray.length > 0 && { requirements: reqArray }),
+          };
+        }
+        case 'image':
+          return {
+            type: 'image',
+            src: formSrc,
+            ...(formAlt && { alt: formAlt }),
+          };
+        case 'video':
+          return { type: 'video', src: formSrc };
+        case 'input':
+          return {
+            type: 'input',
+            prompt: formPrompt,
+            inputType: 'text',
+            variableName: formVariableName,
+          };
+        default:
+          return createDefaultBlock(type);
+      }
+    },
+    [
+      formContent,
+      formAction,
+      formReftarget,
+      formTargetvalue,
+      formRequirements,
+      formSrc,
+      formAlt,
+      formPrompt,
+      formVariableName,
+    ]
+  );
+
+  // Handle drag end
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) {
+        return;
+      }
+      const oldIndex = parseInt(String(active.id).replace('branch-block-', ''), 10);
+      const newIndex = parseInt(String(over.id).replace('branch-block-', ''), 10);
+      if (isNaN(oldIndex) || isNaN(newIndex)) {
+        return;
+      }
+      const newBlocks = [...blocks];
+      const [movedBlock] = newBlocks.splice(oldIndex, 1);
+      newBlocks.splice(newIndex, 0, movedBlock);
+      onChange(newBlocks);
+    },
+    [blocks, onChange]
+  );
+
+  // Add a new block
+  const handleAddBlock = useCallback(() => {
+    const newBlock = buildBlockFromForm(newBlockType);
+    onChange([...blocks, newBlock]);
+    setShowAddForm(false);
+    resetFormFields();
+    setNewBlockType('markdown');
+  }, [blocks, onChange, newBlockType, buildBlockFromForm, resetFormFields]);
+
+  // Start editing a block
+  const handleStartEdit = useCallback(
+    (index: number) => {
+      const block = blocks[index];
+      setEditingIndex(index);
+      setNewBlockType(block.type as BlockType);
+      populateFormFromBlock(block);
+    },
+    [blocks, populateFormFromBlock]
+  );
+
+  // Save edited block
+  const handleSaveEdit = useCallback(() => {
+    if (editingIndex === null) {
+      return;
+    }
+    const updatedBlock = buildBlockFromForm(blocks[editingIndex].type as BlockType);
+    const newBlocks = [...blocks];
+    newBlocks[editingIndex] = updatedBlock;
+    onChange(newBlocks);
+    setEditingIndex(null);
+    resetFormFields();
+  }, [editingIndex, blocks, onChange, buildBlockFromForm, resetFormFields]);
+
+  // Cancel editing
+  const handleCancelEdit = useCallback(() => {
+    setEditingIndex(null);
+    resetFormFields();
+  }, [resetFormFields]);
+
+  // Delete a block
+  const handleDeleteBlock = useCallback(
+    (index: number) => {
+      const newBlocks = blocks.filter((_, i) => i !== index);
+      onChange(newBlocks);
+      if (editingIndex === index) {
+        setEditingIndex(null);
+        resetFormFields();
+      }
+    },
+    [blocks, onChange, editingIndex, resetFormFields]
+  );
+
+  // Start element picker for reftarget
+  const startPicker = useCallback(() => {
+    onPickerModeChange?.(true, (selector: string) => {
+      setFormReftarget(selector);
+    });
+  }, [onPickerModeChange]);
+
+  // Handle requirement chip click
+  const handleRequirementClick = useCallback((req: string) => {
+    setFormRequirements((prev) => {
+      if (prev.includes(req)) {
+        return prev;
+      }
+      return prev ? `${prev}, ${req}` : req;
+    });
+  }, []);
+
+  // Render form fields based on block type
+  // Note: formStyles is passed from parent scope where useStyles2 was called
+  const renderFormFields = (type: BlockType, isEditing: boolean) => {
+    switch (type) {
+      case 'markdown':
+        return (
+          <Field label="Content" description="Markdown formatted text">
+            <TextArea
+              value={formContent}
+              onChange={(e) => setFormContent(e.currentTarget.value)}
+              rows={3}
+              placeholder="Enter markdown content..."
+            />
+          </Field>
+        );
+
+      case 'interactive':
+        return (
+          <>
+            <div className={styles.formRow}>
+              <Field label="Action" style={{ flex: 1 }}>
+                <Select
+                  options={ACTION_OPTIONS}
+                  value={formAction}
+                  onChange={(v) => v.value && setFormAction(v.value)}
+                />
+              </Field>
+              <Field label="Target" style={{ flex: 2 }}>
+                <div style={{ display: 'flex', gap: '8px' }}>
+                  <Input
+                    value={formReftarget}
+                    onChange={(e) => setFormReftarget(e.currentTarget.value)}
+                    placeholder="CSS selector or button text"
+                    style={{ flex: 1 }}
+                  />
+                  {onPickerModeChange && (
+                    <Button
+                      variant="secondary"
+                      onClick={startPicker}
+                      type="button"
+                      icon="crosshair"
+                      aria-label="Pick element"
+                    />
+                  )}
+                </div>
+              </Field>
+            </div>
+            <Field label="Description" description="Text shown to the user">
+              <TextArea
+                value={formContent}
+                onChange={(e) => setFormContent(e.currentTarget.value)}
+                rows={2}
+                placeholder="Click the **Save** button..."
+              />
+            </Field>
+            {formAction === 'formfill' && (
+              <Field label="Value" description="Value to fill in the form field">
+                <Input
+                  value={formTargetvalue}
+                  onChange={(e) => setFormTargetvalue(e.currentTarget.value)}
+                  placeholder="Value to enter"
+                />
+              </Field>
+            )}
+            <Field label="Requirements" description="Conditions that must be met (comma-separated)">
+              <Input
+                value={formRequirements}
+                onChange={(e) => setFormRequirements(e.currentTarget.value)}
+                placeholder="e.g., exists-reftarget, on-page:/dashboard"
+              />
+            </Field>
+            <div className={styles.quickAddChips}>
+              {COMMON_REQUIREMENTS.slice(0, 5).map((req) => (
+                <Badge
+                  key={req}
+                  text={`+ ${req}`}
+                  color="blue"
+                  className={styles.requirementChip}
+                  onClick={() => handleRequirementClick(req)}
+                />
+              ))}
+            </div>
+          </>
+        );
+
+      case 'image':
+        return (
+          <>
+            <Field label="Image URL" required>
+              <Input
+                value={formSrc}
+                onChange={(e) => setFormSrc(e.currentTarget.value)}
+                placeholder="https://example.com/image.png"
+              />
+            </Field>
+            <Field label="Alt text" description="Description for accessibility">
+              <Input
+                value={formAlt}
+                onChange={(e) => setFormAlt(e.currentTarget.value)}
+                placeholder="Descriptive alt text"
+              />
+            </Field>
+          </>
+        );
+
+      case 'video':
+        return (
+          <Field label="Video URL" required description="YouTube or direct video URL">
+            <Input
+              value={formSrc}
+              onChange={(e) => setFormSrc(e.currentTarget.value)}
+              placeholder="https://youtube.com/watch?v=..."
+            />
+          </Field>
+        );
+
+      case 'input':
+        return (
+          <>
+            <Field label="Prompt" required description="Question or instruction for the user">
+              <TextArea
+                value={formPrompt}
+                onChange={(e) => setFormPrompt(e.currentTarget.value)}
+                rows={2}
+                placeholder="Enter your datasource name:"
+              />
+            </Field>
+            <Field label="Variable name" required description="Name to store the response">
+              <Input
+                value={formVariableName}
+                onChange={(e) => setFormVariableName(e.currentTarget.value)}
+                placeholder="myVariable"
+              />
+            </Field>
+          </>
+        );
+
+      default:
+        return (
+          <div style={{ color: 'var(--text-secondary)', fontStyle: 'italic' }}>
+            This block type has limited inline editing. Use the main editor for full editing capabilities.
+          </div>
+        );
+    }
+  };
+
+  const headerColorStyle =
+    variant === 'success'
+      ? { borderLeft: '3px solid var(--success-main, #73BF69)' }
+      : { borderLeft: '3px solid var(--warning-main, #FF9830)' };
+
+  return (
+    <div className={styles.container}>
+      {/* Collapsible header */}
+      <div
+        className={styles.header}
+        style={headerColorStyle}
+        onClick={() => setIsExpanded(!isExpanded)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => e.key === 'Enter' && setIsExpanded(!isExpanded)}
+      >
+        <span className={`${styles.headerIcon} ${isExpanded ? styles.headerIconExpanded : ''}`}>▶</span>
+        <span className={styles.headerTitle}>{label}</span>
+        <Badge text={`${blocks.length} block${blocks.length !== 1 ? 's' : ''}`} color="blue" />
+      </div>
+
+      {/* Blocks list */}
+      {isExpanded && (
+        <div className={styles.blocksList}>
+          {blocks.length === 0 ? (
+            <div className={styles.emptyState}>No blocks yet. Add a block below.</div>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              measuring={{ droppable: { strategy: MeasuringStrategy.WhileDragging } }}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext items={blockIds} strategy={verticalListSortingStrategy}>
+                {blocks.map((block, index) => {
+                  const meta = BLOCK_TYPE_METADATA[block.type as BlockType];
+                  const preview = getBlockPreview(block);
+                  const isEditing = editingIndex === index;
+
+                  return (
+                    <SortableBlockItem
+                      key={`branch-block-${index}`}
+                      id={`branch-block-${index}`}
+                      index={index}
+                      disabled={isEditing}
+                    >
+                      <div className={cx(styles.blockItem, isEditing && styles.blockItemEditing)}>
+                        {/* Block header row */}
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', width: '100%' }}>
+                          {!isEditing && (
+                            <div className={styles.dragHandle}>
+                              <span style={{ fontSize: '12px' }}>⋮⋮</span>
+                            </div>
+                          )}
+                          <div className={styles.blockContent}>
+                            <div className={styles.blockHeader}>
+                              <span>{meta?.icon}</span>
+                              <Badge text={meta?.name ?? block.type} color="blue" />
+                              {isInteractiveBlock(block) && <Badge text={block.action} color="purple" />}
+                            </div>
+                            {preview && !isEditing && (
+                              <div className={styles.blockPreview} title={preview}>
+                                {preview}
+                              </div>
+                            )}
+                          </div>
+                          <div className={styles.blockActions}>
+                            {!isEditing ? (
+                              <>
+                                <IconButton
+                                  name="edit"
+                                  size="sm"
+                                  aria-label="Edit"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleStartEdit(index);
+                                  }}
+                                  className={styles.editButton}
+                                  tooltip="Edit block"
+                                />
+                                <IconButton
+                                  name="trash-alt"
+                                  size="sm"
+                                  aria-label="Delete"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleDeleteBlock(index);
+                                  }}
+                                  className={styles.deleteButton}
+                                  tooltip="Delete block"
+                                />
+                              </>
+                            ) : (
+                              <>
+                                <Button size="sm" variant="primary" onClick={handleSaveEdit}>
+                                  Save
+                                </Button>
+                                <Button size="sm" variant="secondary" onClick={handleCancelEdit}>
+                                  Cancel
+                                </Button>
+                              </>
+                            )}
+                          </div>
+                        </div>
+
+                        {/* Inline edit form */}
+                        {isEditing && (
+                          <div className={styles.editForm}>{renderFormFields(block.type as BlockType, true)}</div>
+                        )}
+                      </div>
+                    </SortableBlockItem>
+                  );
+                })}
+              </SortableContext>
+            </DndContext>
+          )}
+
+          {/* Add block section */}
+          <div className={styles.addBlockSection}>
+            {showAddForm ? (
+              <div className={styles.addBlockForm}>
+                <Field label="Block type">
+                  <Select
+                    options={ALLOWED_BRANCH_BLOCK_TYPES.map((t) => ({
+                      value: t,
+                      label: BLOCK_TYPE_METADATA[t]?.name ?? t,
+                      description: BLOCK_TYPE_METADATA[t]?.description,
+                    }))}
+                    value={newBlockType}
+                    onChange={(v) => v.value && setNewBlockType(v.value)}
+                  />
+                </Field>
+                {renderFormFields(newBlockType, false)}
+                <div className={styles.formActions}>
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      setShowAddForm(false);
+                      resetFormFields();
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button variant="primary" onClick={handleAddBlock}>
+                    Add block
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <Button variant="secondary" icon="plus" onClick={() => setShowAddForm(true)} fullWidth>
+                Add block
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+BranchBlocksEditor.displayName = 'BranchBlocksEditor';

--- a/src/components/block-editor/forms/index.ts
+++ b/src/components/block-editor/forms/index.ts
@@ -16,3 +16,4 @@ export { GuidedBlockForm } from './GuidedBlockForm';
 export { QuizBlockForm } from './QuizBlockForm';
 export { InputBlockForm } from './InputBlockForm';
 export { TypeSwitchDropdown } from './TypeSwitchDropdown';
+export { BranchBlocksEditor } from './BranchBlocksEditor';

--- a/src/docs-retrieval/content-renderer.tsx
+++ b/src/docs-retrieval/content-renderer.tsx
@@ -748,6 +748,7 @@ function renderParsedElement(
           conditions={element.props.conditions || []}
           description={element.props.description}
           display={element.props.display || 'inline'}
+          reftarget={element.props.reftarget}
           whenTrueSectionConfig={element.props.whenTrueSectionConfig}
           whenFalseSectionConfig={element.props.whenFalseSectionConfig}
           whenTrueChildren={element.props.whenTrueChildren || []}

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -496,6 +496,7 @@ function convertConditionalBlock(block: JsonConditionalBlock, path: string, base
         conditions: block.conditions,
         description: block.description,
         display: block.display ?? 'inline',
+        reftarget: block.reftarget,
         // Per-branch section configs (each branch has its own title, requirements, objectives)
         whenTrueSectionConfig: block.whenTrueSectionConfig,
         whenFalseSectionConfig: block.whenFalseSectionConfig,

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -318,6 +318,7 @@ const ConditionalProps = {
   conditions: z.array(z.string()).min(1, 'At least one condition is required'),
   description: z.string().optional(),
   display: z.enum(['inline', 'section']).optional(),
+  reftarget: z.string().optional(),
   whenTrueSectionConfig: ConditionalSectionConfigSchema.optional(),
   whenFalseSectionConfig: ConditionalSectionConfigSchema.optional(),
 };
@@ -492,6 +493,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'whenFalse',
     'description',
     'display',
+    'reftarget',
     'whenTrueSectionConfig',
     'whenFalseSectionConfig',
   ]),

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -190,6 +190,8 @@ export interface JsonConditionalBlock {
   description?: string;
   /** Display mode: 'inline' (default) or 'section' for section-styled rendering */
   display?: ConditionalDisplayMode;
+  /** Target element for exists-reftarget condition (CSS selector or button text) */
+  reftarget?: string;
   /** Section config for the 'pass' branch (only used when display is 'section') */
   whenTrueSectionConfig?: ConditionalSectionConfig;
   /** Section config for the 'fail' branch (only used when display is 'section') */


### PR DESCRIPTION
This pull request introduces several improvements to the conditional block editing and rendering workflow, primarily enabling inline editing of branch blocks within the conditional block form, supporting a new `reftarget` field for "exists-reftarget" conditions, and updating drag-and-drop logic to allow conditionals to be nested inside sections. The changes also ensure that the new `reftarget` field is handled consistently throughout the codebase and that conditional block forms provide a more intuitive user experience.

**Conditional Block Editing Improvements**
* The conditional block form now supports inline editing of the `whenTrue` and `whenFalse` branches via a new `BranchBlocksEditor` component, allowing users to add and configure branch blocks directly within the form. [[1]](diffhunk://#diff-3cdf042a75932249184234eb63d6aab32cded9b80729cdd3b7b574c4b20f1ddbL5-R15) [[2]](diffhunk://#diff-3cdf042a75932249184234eb63d6aab32cded9b80729cdd3b7b574c4b20f1ddbL121-R138) [[3]](diffhunk://#diff-3cdf042a75932249184234eb63d6aab32cded9b80729cdd3b7b574c4b20f1ddbL154-R170) [[4]](diffhunk://#diff-3cdf042a75932249184234eb63d6aab32cded9b80729cdd3b7b574c4b20f1ddbR304-R320) [[5]](diffhunk://#diff-0fbc66cd7c89f413b117c21819182a05ef433894bb7030cfab687695141d7ee2R19)
* The form's UI and logic have been updated to remove the previous requirement to manage branch blocks via drag-and-drop in the main editor. [[1]](diffhunk://#diff-3cdf042a75932249184234eb63d6aab32cded9b80729cdd3b7b574c4b20f1ddbL5-R15) [[2]](diffhunk://#diff-3cdf042a75932249184234eb63d6aab32cded9b80729cdd3b7b574c4b20f1ddbL212-L217)

**Support for Target Element in Conditions**
* Added a `reftarget` field to conditional blocks, allowing users to specify a CSS selector or button text for "exists-reftarget" conditions. The field is editable in the form and propagated through all relevant types, schemas, and rendering logic. [[1]](diffhunk://#diff-3cdf042a75932249184234eb63d6aab32cded9b80729cdd3b7b574c4b20f1ddbR106) [[2]](diffhunk://#diff-3cdf042a75932249184234eb63d6aab32cded9b80729cdd3b7b574c4b20f1ddbR180-R182) [[3]](diffhunk://#diff-3cdf042a75932249184234eb63d6aab32cded9b80729cdd3b7b574c4b20f1ddbR199-R201) [[4]](diffhunk://#diff-3cdf042a75932249184234eb63d6aab32cded9b80729cdd3b7b574c4b20f1ddbR271-R294) [[5]](diffhunk://#diff-1db90066cc8b881bcdda3cb463138860fc47ea733df8cd666165b089963b0dfaR25-R26) [[6]](diffhunk://#diff-1db90066cc8b881bcdda3cb463138860fc47ea733df8cd666165b089963b0dfaR55) [[7]](diffhunk://#diff-1db90066cc8b881bcdda3cb463138860fc47ea733df8cd666165b089963b0dfaR100-R104) [[8]](diffhunk://#diff-1db90066cc8b881bcdda3cb463138860fc47ea733df8cd666165b089963b0dfaL120-R124) [[9]](diffhunk://#diff-96ff08d9a80127056e60e71e297d909c51c25a747b1b583d85f2440240ba8752R751) [[10]](diffhunk://#diff-f39c6ccab0920b08c0735c8a94a3f4802765ae5680680d380ef274e543e5d12cR499) [[11]](diffhunk://#diff-a87b5c1fae78117f8eb95a6c7d1342e7c63b4f2cbca0a33534321d0575a13141R321) [[12]](diffhunk://#diff-a87b5c1fae78117f8eb95a6c7d1342e7c63b4f2cbca0a33534321d0575a13141R496) [[13]](diffhunk://#diff-d698e84f601fba6a63dd9b1b75566888ee93c42b867e7032b7c3c521d5b08f69R193-R194)

**Drag-and-Drop and Nesting Logic Updates**
* Updated drag-and-drop logic in `BlockList` and `SectionNestedBlocks` so that conditional blocks can now be nested inside sections, but sections themselves cannot be nested. This makes it easier to build complex conditional flows. [[1]](diffhunk://#diff-9b4b68de7549367eab793815dd9defdf59820635f2d62a29f32333f1fa6d8f5eL168-R169) [[2]](diffhunk://#diff-9b4b68de7549367eab793815dd9defdf59820635f2d62a29f32333f1fa6d8f5eL241-R242) [[3]](diffhunk://#diff-9b4b68de7549367eab793815dd9defdf59820635f2d62a29f32333f1fa6d8f5eL567-R568) [[4]](diffhunk://#diff-cfd79995a5663baf263a71bb3283c382160f8d26bd9b1fc5d269b27cb6991059L153-R153)

**Conditional Evaluation and Reactivity**
* The conditional rendering logic now uses the provided `reftarget` when evaluating "exists-reftarget" conditions and re-evaluates conditions after interactive steps complete, ensuring that UI changes are accurately reflected. [[1]](diffhunk://#diff-1db90066cc8b881bcdda3cb463138860fc47ea733df8cd666165b089963b0dfaR100-R104) [[2]](diffhunk://#diff-1db90066cc8b881bcdda3cb463138860fc47ea733df8cd666165b089963b0dfaR146-R167)

**Schema and Type Updates**
* All relevant types and schemas have been updated to include the new `reftarget` field, ensuring type safety and validation throughout the codebase. [[1]](diffhunk://#diff-1db90066cc8b881bcdda3cb463138860fc47ea733df8cd666165b089963b0dfaR25-R26) [[2]](diffhunk://#diff-a87b5c1fae78117f8eb95a6c7d1342e7c63b4f2cbca0a33534321d0575a13141R321) [[3]](diffhunk://#diff-a87b5c1fae78117f8eb95a6c7d1342e7c63b4f2cbca0a33534321d0575a13141R496) [[4]](diffhunk://#diff-d698e84f601fba6a63dd9b1b75566888ee93c42b867e7032b7c3c521d5b08f69R193-R194)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core editor drag/drop and conditional evaluation behavior, which could affect guide rendering and block placement; changes are localized but user-facing and event-driven.
> 
> **Overview**
> Conditional blocks can now be fully edited from `ConditionalBlockForm`, including inline add/edit/delete/reorder of `whenTrue`/`whenFalse` branch blocks via the new `BranchBlocksEditor`, plus a new `reftarget` field (with element picker support) for `exists-reftarget` conditions.
> 
> Drag-and-drop rules were adjusted so **conditionals may be nested inside sections** (while still preventing section-in-section nesting), and conditional condition evaluation now uses the provided `reftarget` and re-checks after `interactive-step-completed` events.
> 
> Updates JSON types/schema/parser/renderer plumbing to carry `reftarget` end-to-end, and refreshes `package-lock.json` dependencies (Grafana packages and a few transitive updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7abcf8da0ae442f697f7e10efe6f515a5e6a8e7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->