### PR TITLE
Tell agents to to run `test:ci` not `test` script

### DIFF
--- a/.cursor/rules/techContext.mdc
+++ b/.cursor/rules/techContext.mdc
@@ -19,7 +19,7 @@ description: Describes technologies, frameworks, and other tools used in this re
 - **Dev Environment**: Docker Compose with Grafana OSS for local testing
 - **Scripts**: `npm run dev` (watch mode), `npm run build` (production), `npm run server` (Docker)
 - **Code Quality**: ESLint + Prettier with Grafana configs, TypeScript strict mode
-- **Testing**: `npm run test` (Jest), `npm run e2e` (Playwright), `npm run typecheck`
+- **Testing**: `npm run test:ci` (Jest CI mode - for agents/automation), `npm test` (watch mode - for local dev), `npm run e2e` (Playwright), `npm run typecheck`
 
 ## Technical Constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,11 +77,11 @@ npm run dev
 # Run Grafana locally with Docker
 npm run server
 
-# Run tests in watch mode
-npm test
-
-# Run all tests (CI mode)
+# Run all tests (CI mode - agents should use this)
 npm run test:ci
+
+# Run tests in watch mode (for local development)
+npm test
 
 # Run tests with coverage
 npm run test:coverage

--- a/docs/developer/LOCAL_DEV.md
+++ b/docs/developer/LOCAL_DEV.md
@@ -52,7 +52,11 @@ Once started, open Grafana: http://localhost:3000
 ### Unit tests
 
 ```bash
-npm run test
+# Run all tests once (CI mode - recommended for agents/automation)
+npm run test:ci
+
+# Run tests in watch mode (for local development)
+npm test
 ```
 
 ### Type checks and lint


### PR DESCRIPTION
The `test` script runs continuously with `--watch` and therefore always hits a command execution timeout for agents.