### PR TITLE
fix: expand GitHub URL whitelist to include CDN redirect targets

### DIFF
--- a/src/security/url-validator.test.ts
+++ b/src/security/url-validator.test.ts
@@ -8,6 +8,7 @@ import {
   isAllowedContentUrl,
   isInteractiveLearningUrl,
   validateTutorialUrl,
+  isGitHubRawUrl,
 } from './url-validator';
 
 // Mock the dev-mode module
@@ -269,6 +270,39 @@ describe('Localhost URL validators', () => {
       const result = validateTutorialUrl('not a valid url');
       expect(result.isValid).toBe(false);
       expect(result.errorMessage).toContain('Invalid URL format');
+    });
+  });
+});
+
+describe('GitHub URL validators', () => {
+  describe('isGitHubRawUrl', () => {
+    it('should accept raw.githubusercontent.com URLs', () => {
+      expect(isGitHubRawUrl('https://raw.githubusercontent.com/grafana/repo/main/file.json')).toBe(true);
+      expect(isGitHubRawUrl('https://raw.githubusercontent.com/owner/repo/sha123/path/to/content.json')).toBe(true);
+    });
+
+    it('should accept objects.githubusercontent.com URLs (redirect target)', () => {
+      // GitHub may redirect raw content to objects.githubusercontent.com for blob storage
+      expect(isGitHubRawUrl('https://objects.githubusercontent.com/some-path')).toBe(true);
+      expect(
+        isGitHubRawUrl('https://objects.githubusercontent.com/github-production-release-asset/123456')
+      ).toBe(true);
+    });
+
+    it('should reject non-GitHub URLs', () => {
+      expect(isGitHubRawUrl('https://evil.com/raw.githubusercontent.com/fake')).toBe(false);
+      expect(isGitHubRawUrl('https://raw.githubusercontent.com.evil.com/path')).toBe(false);
+      expect(isGitHubRawUrl('https://github.com/owner/repo/blob/main/file.json')).toBe(false);
+    });
+
+    it('should reject HTTP URLs (require HTTPS)', () => {
+      expect(isGitHubRawUrl('http://raw.githubusercontent.com/owner/repo/main/file.json')).toBe(false);
+      expect(isGitHubRawUrl('http://objects.githubusercontent.com/path')).toBe(false);
+    });
+
+    it('should reject invalid URLs', () => {
+      expect(isGitHubRawUrl('not a url')).toBe(false);
+      expect(isGitHubRawUrl('')).toBe(false);
     });
   });
 });

--- a/src/security/url-validator.ts
+++ b/src/security/url-validator.ts
@@ -279,13 +279,28 @@ export function isInteractiveLearningUrl(urlString: string): boolean {
 }
 
 /**
+ * Allowed GitHub content delivery hostnames (DEV MODE ONLY)
+ *
+ * GitHub may redirect raw content requests to different CDN endpoints.
+ * All of these are legitimate GitHub infrastructure domains.
+ */
+const ALLOWED_GITHUB_CONTENT_HOSTNAMES = [
+  'raw.githubusercontent.com', // Primary raw file content endpoint
+  'objects.githubusercontent.com', // Git LFS and blob storage (redirect target)
+];
+
+/**
  * Check if URL is a GitHub raw content URL (DEV MODE ONLY)
  *
  * Security: This function is ONLY used in dev mode to allow testing with GitHub content.
  * In production, GitHub URLs are not allowed.
  *
+ * Note: GitHub may redirect raw.githubusercontent.com requests to other CDN domains
+ * like objects.githubusercontent.com for blob storage. All legitimate GitHub content
+ * delivery domains are included in the allowlist.
+ *
  * @param urlString - The URL to validate
- * @returns true if valid GitHub raw URL, false otherwise
+ * @returns true if valid GitHub content URL, false otherwise
  */
 export function isGitHubRawUrl(urlString: string): boolean {
   const url = parseUrlSafely(urlString);
@@ -298,8 +313,8 @@ export function isGitHubRawUrl(urlString: string): boolean {
     return false;
   }
 
-  // Allow raw.githubusercontent.com for raw content
-  return url.hostname === 'raw.githubusercontent.com';
+  // Check hostname is in allowlist (exact match only)
+  return ALLOWED_GITHUB_CONTENT_HOSTNAMES.includes(url.hostname);
 }
 
 export interface UrlValidation {


### PR DESCRIPTION
When fetching content from raw.githubusercontent.com via the PR Tester, GitHub may redirect to other CDN domains like objects.githubusercontent.com for blob storage. This caused 'Redirect target is not in trusted domain list' errors when testing guides from PRs.

This fix expands the isGitHubRawUrl() allowlist to include:
- raw.githubusercontent.com (existing)
- objects.githubusercontent.com (new - redirect target for blob storage)

Security note: This function is only used in dev mode for PR testing. Production content fetching is not affected.

Closes issue reported in #proj-grafana-pathfinder Slack channel.