### PR TITLE
Use `null` value content.json to avoid fetch errors

### DIFF
--- a/src/docs-retrieval/content-fetcher.test.ts
+++ b/src/docs-retrieval/content-fetcher.test.ts
@@ -92,6 +92,10 @@ describe('null content handling for learning journeys', () => {
 
   it('should fallback to unstyled.html when learning journey milestone content.json returns null', async () => {
     // Mock fetch to handle learning journey milestone requests:
+    // This simulates the actual flow:
+    // 1. Base URL is fetched - returns styled HTML (but code will try content.json first)
+    // 2. content.json is fetched - returns null (server signal to use HTML)
+    // 3. unstyled.html is fetched - returns the actual content
     (global.fetch as jest.Mock).mockImplementation((url: string) => {
       if (url.endsWith('content.json')) {
         const headers = new Headers();
@@ -112,6 +116,8 @@ describe('null content handling for learning journeys', () => {
           headers,
         });
       } else if (url.endsWith('/milestone-1/') || url.endsWith('/milestone-1')) {
+        // Base URL - returns styled HTML
+        // (In reality, the fetchRawHtml function will try content.json first before falling back)
         const headers = new Headers();
         headers.set('Content-Type', 'text/html; charset=utf-8');
         return Promise.resolve({


### PR DESCRIPTION
Right now the content fetcher tries `content.json` and falls back to `unstyled.html` if there's a 404.

However, our website CORS policy also tells the requester "no" for resources that don't exist so they see two fetch errors in the console logs.

We'd like to eliminate those logs which may confuse users into thinking there's an issue.

In https://github.com/grafana/website/pull/29069 the website flags that there's no `content.json` to use by responding with the JSON `null` value.
Pathfinder can use that to know to try `unstyled.html` without any failing requests.