### PR TITLE
fix(quiz): reset quiz state on section reset

### DIFF
--- a/src/docs-retrieval/components/interactive/interactive-quiz.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-quiz.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { css, cx, keyframes } from '@emotion/css';
 import { Button, Icon, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
@@ -108,6 +108,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
     explanation,
     canSkip,
     markSkipped,
+    resetStep,
   } = useStepChecker({
     requirements,
     stepId,
@@ -115,7 +116,21 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
     skippable,
   });
 
-  // Compute effective completion state
+  useEffect(() => {
+    if (resetTrigger && resetTrigger > 0) {
+      setSelectedIds(new Set());
+      setAttempts(0);
+      setIsLocallyCompleted(false);
+      setLastResult('none');
+      setShowHint(null);
+      setIsRevealed(false);
+      setShakeKey(0);
+      if (resetStep) {
+        resetStep();
+      }
+    }
+  }, [resetTrigger]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const isCompleted = parentCompleted || stepCompleted || isLocallyCompleted;
 
   // Get correct answer IDs


### PR DESCRIPTION
## Summary

Fixes #558

`InteractiveQuiz` retains answered state after "Reset Section" — all other interactive block types (`step`, `multi-step`, `guided`) reset correctly.

## Root cause

`InteractiveSection` resets children via a `resetTrigger` counter prop. The quiz component accepted this prop but never watched it in a `useEffect`, so local state persisted through resets.

## Fix

Added `useEffect` on `resetTrigger` to clear all quiz state variables and call `resetStep()` from `useStepChecker`.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint:fix` passes
- [ ] `npm run test:ci` passes
- [ ] Manual: complete quiz blocks, reset section, confirm quizzes return to unanswered state