### PR TITLE
Add flat JSON

### DIFF
--- a/docs/design/flat-content.json
+++ b/docs/design/flat-content.json
@@ -1,0 +1,18 @@
+[
+  {
+    "schemaVersion": "0.1.0",
+    "packages": [
+      {
+        "name": "prometheus-grafana-101",
+        "version": "1.2.3",
+        "title": "Prometheus & Grafana 101",
+        "content": [
+          {
+            "type": "markdown",
+            "content": "# Prometheus & Grafana 101\n\nIn this guide..."
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/docs/design/flat-metadata.json
+++ b/docs/design/flat-metadata.json
@@ -1,0 +1,67 @@
+[
+  {
+    "schemaVersion": "0.1.0",
+    "packages": [
+      {
+        "name": "prometheus-grafana-101",
+        "version": "1.2.3",
+        "authors": [
+          "Foobar team",
+          "someemail@domain.tld",
+          "That Other Team"
+        ],
+        "build-depends": [
+          {
+            "grafana/grafana": "12.0.0"
+          },
+          "thing-without-version"
+        ],
+        "install-depends": [
+          {
+            "grafana/grafana": "12.0.0"
+          },
+          "package-foo"
+        ],
+        "course-depends": [
+          {
+            "welcome-to-grafana": "1.2.3"
+          },
+          "thing-without-version",
+          "and-this",
+          "and-that",
+          [
+            "this",
+            "is",
+            "a",
+            "logical",
+            "or"
+          ]
+        ],
+        "course-depends-ordered": [
+          "pre-work",
+          "actual-work",
+          "more-work",
+          "victory-lap"
+        ],
+        "course-recommends": [
+          "first-dashboard"
+        ],
+        "course-suggests": [
+          "loki-grafana-101",
+          "prometheus-advanced-queries"
+        ],
+        "course-provides": [
+          "datasource-configured"
+        ],
+        "recommender-match": [
+          {
+            "urlPrefixIn": "/connections"
+          },
+          {
+            "targetPlatform": "oss"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Signed-off-by: Richard Hartmann <richih@richih.org>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding example JSON files; no runtime code paths are affected.
> 
> **Overview**
> Adds two new design documents, `docs/design/flat-content.json` and `docs/design/flat-metadata.json`, to illustrate a proposed *flat JSON schema* (v0.1.0) for packaging course content and associated metadata.
> 
> The metadata example covers authors plus multiple dependency relationship types (build/install/course, ordered deps, recommends/suggests/provides) and simple recommender matching fields, serving as a reference for expected shapes (including versioned/unversioned entries and OR-lists).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43fe265280eeefae11794ee1b67883fcff507418. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->