### PR TITLE
skill:maintain-docs index interactive-examples and engine subsystem docs

### DIFF
--- a/.cursor/rules/interactiveRequirements.mdc
+++ b/.cursor/rules/interactiveRequirements.mdc
@@ -7,6 +7,8 @@ description: This document describes the requirements and design constraints of 
 
 This document describes the requirements and objectives system for interactive elements in the Grafana Documentation Plugin.
 
+For full reference on interactive guide authoring (JSON format, action types, selectors, guided interactions), see `docs/developer/interactive-examples/`.
+
 ## Overview
 
 Interactive elements in documentation content have a system of requirements that must be satisfied before they can be executed, and a potential system of objectives or goals, that the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,23 +143,25 @@ src/
 
 Load these files **only when working in the relevant domain**. Do not preload all of them.
 
-| File                          | When to load                             | Auto-triggered by globs                                  |
-| ----------------------------- | ---------------------------------------- | -------------------------------------------------------- |
-| `projectbrief.mdc`            | Understanding project scope and goals    | --                                                       |
-| `techContext.mdc`             | Tech stack, dependencies, build system   | --                                                       |
-| `systemPatterns.mdc`          | Architecture, component relationships    | --                                                       |
-| `interactiveRequirements.mdc` | Interactive tutorial system work         | --                                                       |
-| `frontend-security.mdc`       | Frontend security (from security team)   | `*.ts`, `*.tsx`, `*.js`, `*.jsx`                         |
-| `react-antipatterns.mdc`      | PR reviews (on hit), hooks/effects/state | --                                                       |
-| `schema-coupling.mdc`         | JSON guide types or schemas              | `json-guide.types.ts`, `json-guide.schema.ts`            |
-| `testingStrategy.mdc`         | Writing or reviewing tests               | `*.test.ts`, `*.test.tsx`, `jest.config*`, `jest.setup*` |
-| `pr-review.md`                | PR review orchestration (`/review`)      | --                                                       |
-| `E2E_TESTING_CONTRACT.md`     | E2E testing, `data-test-*` attributes    | --                                                       |
-| `RELEASE_PROCESS.md`          | Releasing, deploying, versioning         | --                                                       |
-| `FEATURE_FLAGS.md`            | Feature flags, A/B experiments           | `openfeature.ts`                                         |
-| `CLI_TOOLS.md`                | CLI validation, guide authoring tooling  | `src/cli/*`                                              |
+| File                          | When to load                                                    | Auto-triggered by globs                                                          |
+| ----------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `projectbrief.mdc`            | Understanding project scope and goals                           | --                                                                               |
+| `techContext.mdc`             | Tech stack, dependencies, build system                          | --                                                                               |
+| `systemPatterns.mdc`          | Architecture, component relationships                           | --                                                                               |
+| `interactiveRequirements.mdc` | Interactive tutorial system work                                | --                                                                               |
+| `frontend-security.mdc`       | Frontend security (from security team)                          | `*.ts`, `*.tsx`, `*.js`, `*.jsx`                                                 |
+| `react-antipatterns.mdc`      | PR reviews (on hit), hooks/effects/state                        | --                                                                               |
+| `schema-coupling.mdc`         | JSON guide types or schemas                                     | `json-guide.types.ts`, `json-guide.schema.ts`                                    |
+| `testingStrategy.mdc`         | Writing or reviewing tests                                      | `*.test.ts`, `*.test.tsx`, `jest.config*`, `jest.setup*`                         |
+| `pr-review.md`                | PR review orchestration (`/review`)                             | --                                                                               |
+| `E2E_TESTING_CONTRACT.md`     | E2E testing, `data-test-*` attributes                           | --                                                                               |
+| `RELEASE_PROCESS.md`          | Releasing, deploying, versioning                                | --                                                                               |
+| `FEATURE_FLAGS.md`            | Feature flags, A/B experiments                                  | `openfeature.ts`                                                                 |
+| `CLI_TOOLS.md`                | CLI validation, guide authoring tooling                         | `src/cli/*`                                                                      |
+| `interactive-examples/*.md`   | Authoring interactive guides (format, types, selectors)         | --                                                                               |
+| `engines/*.md`                | Engine subsystem internals (context, interactive, requirements) | `src/context-engine/*`, `src/interactive-engine/*`, `src/requirements-manager/*` |
 
-All `.mdc` files live in `.cursor/rules/`. `pr-review.md` is at `.cursor/rules/pr-review.md`. `E2E_TESTING_CONTRACT.md`, `RELEASE_PROCESS.md`, `FEATURE_FLAGS.md`, and `CLI_TOOLS.md` are at `docs/developer/`.
+All `.mdc` files live in `.cursor/rules/`. `pr-review.md` is at `.cursor/rules/pr-review.md`. `E2E_TESTING_CONTRACT.md`, `RELEASE_PROCESS.md`, `FEATURE_FLAGS.md`, and `CLI_TOOLS.md` are at `docs/developer/`. The `interactive-examples/` and `engines/` directories are also under `docs/developer/`.
 
 ## PR reviews
 

--- a/docs/developer/engines/requirements-manager.md
+++ b/docs/developer/engines/requirements-manager.md
@@ -1,5 +1,7 @@
 # Requirements Manager
 
+For prescriptive agent constraints on the requirements/objectives system, see `.cursor/rules/interactiveRequirements.mdc`. For the requirements authoring reference, see `docs/developer/interactive-examples/requirements-reference.md`.
+
 The Requirements Manager (`src/requirements-manager/`) validates requirements and objectives for interactive guide steps, providing a comprehensive system for controlling step execution eligibility and automatic completion.
 
 ## Overview

--- a/docs/developer/interactive-examples/requirements-reference.md
+++ b/docs/developer/interactive-examples/requirements-reference.md
@@ -1,5 +1,7 @@
 # Requirements reference
 
+For prescriptive agent constraints on the requirements system, see `.cursor/rules/interactiveRequirements.mdc`.
+
 Requirements control when interactive elements become enabled. They are specified as a `requirements` array on any interactive, section, guided, multistep, conditional, or quiz block. All requirements in the array must pass for the block to be enabled.
 
 ## Core concepts


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-02-20.

### Changes made

- Indexed `docs/developer/interactive-examples/` (6 files) in AGENTS.md on-demand context table — covers JSON guide format, action types, selectors, guided interactions, and authoring workflows
- Indexed `docs/developer/engines/` (3 files) in AGENTS.md on-demand context table — covers context-engine, interactive-engine, and requirements-manager subsystems
- Added cross-reference from `interactiveRequirements.mdc` to `docs/developer/interactive-examples/` for full authoring reference
- Added cross-reference from `docs/developer/interactive-examples/requirements-reference.md` to `interactiveRequirements.mdc` (bidirectional)
- Added cross-references from `docs/developer/engines/requirements-manager.md` to both the rule file and reference doc

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| HIGH | Interactive-examples docs (6 files) orphaned — no discovery path from AGENTS.md, no cross-ref from interactiveRequirements.mdc | Fixed in this PR |
| MEDIUM | Engine subsystem docs (3 files) orphaned — no discovery path from AGENTS.md | Fixed in this PR |
| MEDIUM | E2E_TESTING.md orphaned (separate from indexed E2E_TESTING_CONTRACT.md) | Deferred |
| MEDIUM | ASSISTANT_INTEGRATION.md orphaned — assistant tag customization guide | Deferred |
| MEDIUM | DEV_MODE.md orphaned — developer mode reference | Deferred |
| MEDIUM | LOCAL_DEV.md orphaned — local development guide | Deferred |
| MEDIUM | LIVE_SESSIONS.md orphaned — experimental collaborative feature | Deferred |
| LOW | SCALE_TESTING.md, KNOWN_ISSUES.md — supplementary docs | Deferred |
| LOW | Component README files (12 files) — stable, rarely changed | Deferred |
| LOW | docs/sources/ files (5 files) — external-facing docs | Deferred |

### Recommendations for separate work

- The interactiveRequirements.mdc rule file is 632 lines — significantly larger than a compact prescriptive rule file should be. Consider extracting detailed examples and implementation notes to docs/developer/ and keeping only constraints in the rule file. This is too large a restructuring for an incremental maintenance run.
- The docs/developer/LOCAL_DEV.md file overlaps substantially with the AGENTS.md "Local development commands" section. Consider consolidating to avoid drift.

### Validation checklist

- [x] All changed files are .md or .mdc (verified via git diff --name-only)
- [x] npm run prettier passed
- [x] No source code files were modified
