### PR TITLE
skill:maintain-docs validate stale context-engine doc, index 4 orphaned docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,8 +160,12 @@ Load these files **only when working in the relevant domain**. Do not preload al
 | `CLI_TOOLS.md`                | CLI validation, guide authoring tooling                         | `src/cli/*`                                                                      |
 | `interactive-examples/*.md`   | Authoring interactive guides (format, types, selectors)         | --                                                                               |
 | `engines/*.md`                | Engine subsystem internals (context, interactive, requirements) | `src/context-engine/*`, `src/interactive-engine/*`, `src/requirements-manager/*` |
+| `ASSISTANT_INTEGRATION.md`    | Authoring customizable content with `<assistant>` tag           | `src/integrations/assistant-integration/*`                                       |
+| `E2E_TESTING.md`              | E2E guide test runner, Playwright-based guide verification      | --                                                                               |
+| `DEV_MODE.md`                 | Dev mode configuration and debugging tools                      | `src/utils/dev-mode.ts`                                                          |
+| `LOCAL_DEV.md`                | Local development setup, prerequisites, Docker workflow         | --                                                                               |
 
-All `.mdc` files live in `.cursor/rules/`. `pr-review.md` is at `.cursor/rules/pr-review.md`. `E2E_TESTING_CONTRACT.md`, `RELEASE_PROCESS.md`, `FEATURE_FLAGS.md`, and `CLI_TOOLS.md` are at `docs/developer/`. The `interactive-examples/` and `engines/` directories are also under `docs/developer/`.
+All `.mdc` files live in `.cursor/rules/`. `pr-review.md` is at `.cursor/rules/pr-review.md`. `E2E_TESTING_CONTRACT.md`, `RELEASE_PROCESS.md`, `FEATURE_FLAGS.md`, `CLI_TOOLS.md`, `ASSISTANT_INTEGRATION.md`, `E2E_TESTING.md`, `DEV_MODE.md`, and `LOCAL_DEV.md` are at `docs/developer/`. The `interactive-examples/` and `engines/` directories are also under `docs/developer/`.
 
 ## PR reviews
 

--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -1,0 +1,26 @@
+# Documentation maintenance backlog
+
+Persistent tracker for structural issues identified by the maintain-docs skill.
+Items here require dedicated effort beyond incremental edits.
+
+<!-- Each entry: date, description, rationale. Remove when resolved. -->
+
+## HIGH priority
+
+- **2026-02-20**: `authoring-interactive-journeys.md` staleness — Last updated Nov 18, 2025 (93 days stale). Source directories (`src/interactive-engine/`, `src/components/interactive/`) have changed extensively since then. The doc likely contains outdated authoring instructions. Needs full staleness validation and possibly a structural rewrite.
+
+- **2026-02-20**: `interactive-engine.md` staleness — Doc last updated Feb 10, source (`src/interactive-engine/`) last changed Feb 19 (9 days stale). The interactive engine is a high-traffic domain; needs staleness validation to catch any behavioral drift.
+
+## MEDIUM priority
+
+- **2026-02-20**: `CLI_TOOLS.md` staleness — Doc last updated Feb 5, source (`src/cli/`) changed Feb 9 (4 days stale). Lower risk than engine docs but should be validated in next run.
+
+- **2026-02-20**: `E2E_TESTING_CONTRACT.md` staleness — Doc last updated Feb 10, E2E test directories changed Feb 17 (7 days stale). Needs validation that `data-test-*` attribute contracts are still accurate.
+
+- **2026-02-20**: Remaining orphaned docs — 20+ component READMEs, `LIVE_SESSIONS.md`, `KNOWN_ISSUES.md`, `SCALE_TESTING.md`, and `integrations/workshop.md` still have no path from AGENTS.md. Component READMEs could be indexed as a group entry. `LIVE_SESSIONS.md` and `KNOWN_ISSUES.md` are lower value but could be indexed cheaply.
+
+- **2026-02-20**: `docs/sources/` directory — Contains published Grafana documentation sources (`_index.md` files). Needs a decision: should these be indexed in AGENTS.md for agents, or are they out of scope? Currently orphaned.
+
+## LOW priority
+
+- **2026-02-20**: Skills SKILL.md files not indexed — `.cursor/skills/` SKILL.md files (maintain-docs, design-review, e2e-guide-analysis, tidy-up) are not referenced in AGENTS.md. These are discovered automatically by `.cursor/skills/` glob patterns in the IDE, so indexing may be unnecessary. Confirm and close if not needed.


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-02-20.

### Changes made

- **Staleness validation: `context-engine.md`** (3pts heavy fix): Updated to reflect three source commits since Feb 10 — completion processing now handles both learning paths (via `journeyCompletionStorage`) and interactive guides (via `interactiveCompletionStorage`) with type-specific storage; added new `context.service.completion.test.ts` file to Core Components and Key Files listings; applied the "learning journey → learning path" cosmetic terminology rename throughout; updated URL filtering to include both `/docs/learning-journeys` and `/docs/learning-paths` variants.
- **Indexed `ASSISTANT_INTEGRATION.md`** (1pt): Authoring customizable content with `<assistant>` tag. Glob-triggered by `src/integrations/assistant-integration/*`.
- **Indexed `E2E_TESTING.md`** (1pt): E2E guide test runner documentation (Playwright-based guide verification).
- **Indexed `DEV_MODE.md`** (1pt): Dev mode configuration and debugging tools. Glob-triggered by `src/utils/dev-mode.ts`.
- **Indexed `LOCAL_DEV.md`** (1pt): Local development setup, prerequisites, Docker workflow.
- **Created `docs/_maintenance-backlog.md`**: Persistent tracker for structural issues deferred from this run.

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| HIGH | `authoring-interactive-journeys.md` 93 days stale (Nov 2025 → Feb 2026 source changes) | Deferred — added to backlog |
| HIGH | `context-engine.md` stale (Feb 10 doc vs Feb 17 source) | Fixed in this PR |
| HIGH | `interactive-engine.md` 9 days stale (Feb 10 doc vs Feb 19 source) | Deferred — added to backlog |
| HIGH | `ASSISTANT_INTEGRATION.md` orphaned, no discovery path | Fixed in this PR |
| HIGH | `E2E_TESTING.md` orphaned, operational doc | Fixed in this PR |
| HIGH | `DEV_MODE.md` orphaned, developer tooling | Fixed in this PR |
| MEDIUM | `CLI_TOOLS.md` 4 days stale (Feb 5 doc vs Feb 9 source) | Deferred — added to backlog |
| MEDIUM | `LOCAL_DEV.md` orphaned, dev setup guide | Fixed in this PR |
| MEDIUM | `E2E_TESTING_CONTRACT.md` 7 days stale (Feb 10 doc vs Feb 17 source) | Deferred — added to backlog |
| MEDIUM | `LIVE_SESSIONS.md` orphaned | Deferred — added to backlog |
| MEDIUM | 20+ component READMEs orphaned | Deferred — added to backlog |
| MEDIUM | `docs/sources/` directory — published docs, scope TBD | Deferred — added to backlog |
| LOW | `KNOWN_ISSUES.md` orphaned, supplementary | Deferred — added to backlog |
| LOW | `SCALE_TESTING.md` orphaned, supplementary | Deferred — added to backlog |
| LOW | Skills SKILL.md files not indexed (auto-discovered by IDE) | Deferred — added to backlog |

### Recommendations for separate work

- **`authoring-interactive-journeys.md` revalidation**: 93 days stale. Interactive authoring is a high-traffic domain. This doc likely needs extensive corrections and may require a structural rewrite. Recommend a dedicated staleness validation pass.
- **Component README group indexing**: 20+ component READMEs under `docs/developer/components/` could be indexed as a single group entry (e.g., `components/*/README.md`) in AGENTS.md, similar to the existing `engines/*.md` pattern.
- **`docs/sources/` scoping decision**: These are published Grafana documentation sources. A human decision is needed on whether agents should have a discovery path to these.

### Validation checklist

- [x] All changed files are `.md` or `.mdc` (verified via `git diff --name-only`)
- [x] `npm run prettier` passed
- [x] No source code files were modified

Made with [Cursor](https://cursor.com)