### PR TITLE
skill:maintain-docs fix stale schema-coupling rule, update E2E docs, index component READMEs

### DIFF
--- a/.cursor/rules/schema-coupling.mdc
+++ b/.cursor/rules/schema-coupling.mdc
@@ -22,15 +22,16 @@ Every structural change to a type MUST have a corresponding schema change, and v
 If you add, remove, or change a field in `json-guide.types.ts`:
 
 1. **Update the corresponding Zod schema** in `json-guide.schema.ts`
-2. **Run `npm run typecheck`** - the `satisfies z.ZodType<T>` pattern will catch mismatches
-3. **Run `npm run validate`** - verify bundled guides still pass
-4. **Update the `KNOWN_FIELDS` export** if adding new fields (for unknown field detection)
+2. **Run `npm run typecheck`** to catch compile-time errors
+3. **Run `npm run test:ci`** — the tests in `src/validation/type-coupling.test.ts` verify that TypeScript types and Zod-inferred types stay compatible
+4. **Run `npm run validate`** - verify bundled guides still pass
+5. **Update the `KNOWN_FIELDS` export** if adding new fields (for unknown field detection)
 
 The file `json-guide.schema.ts` exposes a global schema version. When making changes to schema, 
 always consider advising the user to update the schema version following schema best practices, 
 and providing them guidance on forwards and backwards compatibility issues as appropriate.
 
-### Example: Adding a New Field
+### Example: Adding a new field
 
 ```typescript
 // 1. Add to type
@@ -39,15 +40,15 @@ export interface JsonGuide {
   newField?: string; // NEW
 }
 
-// 2. Add to schema
-export const JsonGuideSchema = z.object({
+// 2. Add to schema (JsonGuideSchemaStrict is the base; JsonGuideSchema = ...Strict.loose())
+export const JsonGuideSchemaStrict = z.object({
   // ... existing fields
   newField: z.string().optional(), // NEW - matches type
-}).passthrough() satisfies z.ZodType<JsonGuide>;
+});
 
-// 3. Add to KNOWN_FIELDS
-export const KNOWN_FIELDS = {
-  _guide: ['id', 'title', 'blocks', 'match', 'schemaVersion', 'newField'], // ADD HERE
+// 3. Add to KNOWN_FIELDS (uses ReadonlySet<string>)
+export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
+  _guide: new Set(['schemaVersion', 'id', 'title', 'blocks', 'newField']), // ADD HERE
   // ...
 };
 ```
@@ -58,7 +59,7 @@ If you change validation rules in `json-guide.schema.ts`:
 
 1. **Consider if the type needs updating** - e.g., making a field required
 2. **Update error messages** to be user-friendly
-3. **Run tests** - `npm run test:ci -- --testPathPatterns=validation`
+3. **Run tests** - `npm run test:ci -- --testPathPattern=validation`
 4. **Run `npm run validate:strict`** - ensure bundled guides comply
 
 ## Coupling Markers
@@ -79,22 +80,27 @@ export const JsonGuideSchema = z.object({ ... });
 
 When you see a `@coupling` tag, **always check the linked file** before making changes.
 
-## Forward Compatibility
+## Forward compatibility
 
-All schemas use `.passthrough()` to allow unknown fields. This means:
+The root schema uses `.loose()` to allow unknown fields at the guide level:
 
-- Newer guides with new fields will still parse successfully
+- `JsonGuideSchemaStrict` — strict mode, no extra fields
+- `JsonGuideSchema = JsonGuideSchemaStrict.loose()` — permissive mode for forward compatibility
+- Newer guides with new fields will still parse successfully via `JsonGuideSchema`
 - Unknown fields generate warnings, not errors (unless `--strict` mode)
-- The `KNOWN_FIELDS` object determines what triggers warnings
+- The `KNOWN_FIELDS` object (a `Record<string, ReadonlySet<string>>`) determines what triggers warnings
 
-## Validation Module Structure
+## Validation module structure
 
 ```
 src/validation/
-├── index.ts          # Public exports
-├── validate-guide.ts # Main validateGuide() function
-├── unknown-fields.ts # Forward compatibility warnings
-└── errors.ts         # Error formatting utilities
+├── index.ts               # Public exports
+├── validate-guide.ts      # Main validateGuide() function
+├── unknown-fields.ts      # Forward compatibility warnings
+├── errors.ts              # Error formatting utilities
+├── error-map.ts           # Custom Zod error map for better messages
+├── condition-validator.ts # Validates requirement/objective mini-grammar
+└── type-coupling.test.ts  # Verifies TypeScript ↔ Zod type compatibility
 
 src/types/
 ├── json-guide.types.ts  # TypeScript interfaces (source of truth)
@@ -107,10 +113,12 @@ src/types/
 npm run typecheck       # Catch type/schema drift at compile time
 npm run validate        # Validate bundled guides (warnings allowed)
 npm run validate:strict # Validate bundled guides (warnings = errors)
-npm run test:ci -- --testPathPatterns=validation  # Run validation tests
+npm run test:ci -- --testPathPattern=validation  # Run validation tests
 ```
 
-## Agent Checklist
+For full reference on the JSON guide format (block types, fields, interactive features), see `docs/developer/interactive-examples/json-guide-format.md`.
+
+## Agent checklist
 
 When modifying JSON guide types or schemas:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,8 +164,9 @@ Load these files **only when working in the relevant domain**. Do not preload al
 | `E2E_TESTING.md`              | E2E guide test runner, Playwright-based guide verification      | --                                                                               |
 | `DEV_MODE.md`                 | Dev mode configuration and debugging tools                      | `src/utils/dev-mode.ts`                                                          |
 | `LOCAL_DEV.md`                | Local development setup, prerequisites, Docker workflow         | --                                                                               |
+| `components/README.md`        | Component architecture overview and per-component docs          | --                                                                               |
 
-All `.mdc` files live in `.cursor/rules/`. `pr-review.md` is at `.cursor/rules/pr-review.md`. `E2E_TESTING_CONTRACT.md`, `RELEASE_PROCESS.md`, `FEATURE_FLAGS.md`, `CLI_TOOLS.md`, `ASSISTANT_INTEGRATION.md`, `E2E_TESTING.md`, `DEV_MODE.md`, and `LOCAL_DEV.md` are at `docs/developer/`. The `interactive-examples/` and `engines/` directories are also under `docs/developer/`.
+All `.mdc` files live in `.cursor/rules/`. `pr-review.md` is at `.cursor/rules/pr-review.md`. `E2E_TESTING_CONTRACT.md`, `RELEASE_PROCESS.md`, `FEATURE_FLAGS.md`, `CLI_TOOLS.md`, `ASSISTANT_INTEGRATION.md`, `E2E_TESTING.md`, `DEV_MODE.md`, and `LOCAL_DEV.md` are at `docs/developer/`. The `interactive-examples/`, `engines/`, and `components/` directories are also under `docs/developer/`. The `components/` directory contains a parent `README.md` with the overall architecture, plus per-component READMEs in subdirectories (e.g., `docs/developer/components/App/README.md`).
 
 ## PR reviews
 

--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -11,9 +11,7 @@ Items here require dedicated effort beyond incremental edits.
 
 - **2026-02-20**: `E2E_TESTING_CONTRACT.md` staleness — Doc last updated Feb 10, E2E test directories changed Feb 17 (7 days stale). Needs validation that `data-test-*` attribute contracts are still accurate.
 
-- **2026-02-20**: `E2E_TESTING.md` staleness — Doc last updated Feb 6, `tests/` directory changed Feb 17 (11 days stale). Needs validation that the E2E guide test runner documentation is still accurate.
-
-- **2026-02-20**: Remaining orphaned docs — 20+ component READMEs, `LIVE_SESSIONS.md`, `KNOWN_ISSUES.md`, `SCALE_TESTING.md`, and `integrations/workshop.md` still have no path from AGENTS.md. Component READMEs could be indexed as a group entry. `LIVE_SESSIONS.md` and `KNOWN_ISSUES.md` are lower value but could be indexed cheaply.
+- **2026-02-20**: Remaining orphaned docs — `LIVE_SESSIONS.md`, `KNOWN_ISSUES.md`, `SCALE_TESTING.md`, `integrations/workshop.md`, and utility/subsystem READMEs (`utils/`, `styles/`, `provisioning/`, `pages/`, `src/`, `constants/`) still have no path from AGENTS.md. These are lower value but could be indexed cheaply as group entries.
 
 - **2026-02-20**: `docs/sources/` directory — Contains published Grafana documentation sources (`_index.md` files). Needs a decision: should these be indexed in AGENTS.md for agents, or are they out of scope? Currently orphaned.
 


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-02-20.

### Changes made

- **schema-coupling.mdc** (staleness fix, 3 pts): Fixed 5 factual errors — `satisfies z.ZodType<T>` replaced with type-coupling test reference, `.passthrough()` replaced with `.loose()`, `KNOWN_FIELDS` example updated from arrays to `ReadonlySet<string>`, removed nonexistent `match` field from example, added `error-map.ts` and `condition-validator.ts` to validation module structure, added cross-reference to `docs/developer/interactive-examples/json-guide-format.md`
- **E2E_TESTING.md** (staleness fix, 3 pts): Added runner module structure diagram (`tests/e2e-runner/guide-runner/`), added guided substep timeout and button appear timeout to timing table, added error classification section (infrastructure/content-drift/product-regression/unknown)
- **AGENTS.md** (index orphaned docs, 1 pt): Added `components/README.md` group entry for 10+ orphaned component READMEs, updated location text to describe the components directory structure
- **Maintenance backlog**: Removed resolved items (E2E_TESTING.md staleness, component README orphans), updated remaining orphaned docs item

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| HIGH | `schema-coupling.mdc` 2+ months stale (Dec 12 doc vs Feb 9 source) — 5 factual errors | Fixed in this PR |
| MEDIUM | `E2E_TESTING.md` 11 days stale (Feb 6 doc vs Feb 17 source) — missing runner structure, timing, error classification | Fixed in this PR |
| MEDIUM | Orphaned component READMEs (10+ files) with no path from AGENTS.md | Fixed in this PR |
| MEDIUM | `CLI_TOOLS.md` 4 days stale (Feb 5 doc vs Feb 9 source) | Deferred (backlog) |
| MEDIUM | `E2E_TESTING_CONTRACT.md` 7 days stale (Feb 10 doc vs Feb 17 source) | Deferred (backlog) |
| MEDIUM | Remaining orphaned docs (LIVE_SESSIONS, KNOWN_ISSUES, SCALE_TESTING, workshop, utility READMEs) | Deferred (backlog) |
| MEDIUM | `docs/sources/` directory needs indexing decision | Deferred (backlog) |
| LOW | Skills SKILL.md files not indexed in AGENTS.md | Deferred (backlog) |

### Recommendations for separate work

- `CLI_TOOLS.md` and `E2E_TESTING_CONTRACT.md` staleness validation should be prioritized in the next run (both in backlog since Feb 20)
- Remaining orphaned docs (LIVE_SESSIONS, KNOWN_ISSUES, etc.) can be indexed as lightweight group entries in a future run

### Validation checklist

- [x] All changed files are `.md` or `.mdc` (verified via `git diff --name-only`)
- [x] `npm run prettier` passed
- [x] No source code files were modified


Made with [Cursor](https://cursor.com)