### PR TITLE
skill:maintain-docs add intent sections to engine docs, index orphaned docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,8 +164,11 @@ Load these files **only when working in the relevant domain**. Do not preload al
 | `E2E_TESTING.md`              | E2E guide test runner, Playwright-based guide verification      | --                                                                               |
 | `DEV_MODE.md`                 | Dev mode configuration and debugging tools                      | `src/utils/dev-mode.ts`                                                          |
 | `LOCAL_DEV.md`                | Local development setup, prerequisites, Docker workflow         | --                                                                               |
+| `LIVE_SESSIONS.md`            | Live sessions feature (WebRTC, PeerJS)                          | `src/components/LiveSession/*`                                                   |
+| `KNOWN_ISSUES.md`             | Known bugs and workarounds                                      | --                                                                               |
+| `integrations/workshop.md`    | Workshop mode, action capture and replay                        | `src/integrations/workshop/*`                                                    |
 
-All `.mdc` files live in `.cursor/rules/`. `pr-review.md` is at `.cursor/rules/pr-review.md`. `E2E_TESTING_CONTRACT.md`, `RELEASE_PROCESS.md`, `FEATURE_FLAGS.md`, `CLI_TOOLS.md`, `ASSISTANT_INTEGRATION.md`, `E2E_TESTING.md`, `DEV_MODE.md`, and `LOCAL_DEV.md` are at `docs/developer/`. The `interactive-examples/` and `engines/` directories are also under `docs/developer/`.
+All `.mdc` files live in `.cursor/rules/`. `pr-review.md` is at `.cursor/rules/pr-review.md`. `E2E_TESTING_CONTRACT.md`, `RELEASE_PROCESS.md`, `FEATURE_FLAGS.md`, `CLI_TOOLS.md`, `ASSISTANT_INTEGRATION.md`, `E2E_TESTING.md`, `DEV_MODE.md`, `LOCAL_DEV.md`, `LIVE_SESSIONS.md`, `KNOWN_ISSUES.md`, and `integrations/workshop.md` are at `docs/developer/`. The `interactive-examples/` and `engines/` directories are also under `docs/developer/`.
 
 ## PR reviews
 

--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -7,13 +7,11 @@ Items here require dedicated effort beyond incremental edits.
 
 ## MEDIUM priority
 
-- **2026-02-20**: `CLI_TOOLS.md` staleness — Doc last updated Feb 5, source (`src/cli/`) changed Feb 9 (4 days stale). Lower risk than engine docs but should be validated in next run.
-
-- **2026-02-20**: `E2E_TESTING_CONTRACT.md` staleness — Doc last updated Feb 10, E2E test directories changed Feb 17 (7 days stale). Needs validation that `data-test-*` attribute contracts are still accurate.
-
 - **2026-02-20**: `E2E_TESTING.md` staleness — Doc last updated Feb 6, `tests/` directory changed Feb 17 (11 days stale). Needs validation that the E2E guide test runner documentation is still accurate.
 
-- **2026-02-20**: Remaining orphaned docs — 20+ component READMEs, `LIVE_SESSIONS.md`, `KNOWN_ISSUES.md`, `SCALE_TESTING.md`, and `integrations/workshop.md` still have no path from AGENTS.md. Component READMEs could be indexed as a group entry. `LIVE_SESSIONS.md` and `KNOWN_ISSUES.md` are lower value but could be indexed cheaply.
+- **2026-02-20**: `context-engine.md` intent gap — Engine doc has no `<!-- intent -->` marker and no existing rationale headings. Needs rationale extraction from source code and design docs to create a Design intent section.
+
+- **2026-02-20**: Remaining orphaned docs — `SCALE_TESTING.md`, utility/subsystem READMEs (`utils/`, `styles/`, `provisioning/`, `pages/`, `src/`, `constants/`) still have no path from AGENTS.md. These are lower value but could be indexed cheaply as group entries.
 
 - **2026-02-20**: `docs/sources/` directory — Contains published Grafana documentation sources (`_index.md` files). Needs a decision: should these be indexed in AGENTS.md for agents, or are they out of scope? Currently orphaned.
 

--- a/docs/developer/engines/interactive-engine.md
+++ b/docs/developer/engines/interactive-engine.md
@@ -390,6 +390,33 @@ Located in `src/constants/interactive-config.ts`:
 - **Modal Detection**: Polling interval and debounce settings for modal state detection
 - **Position Tracking**: Drift detection threshold and check interval for guided mode highlights
 
+## Design intent
+
+<!-- intent -->
+
+**Purpose**: The Interactive Engine bridges static documentation and hands-on learning by providing the automation and interaction capabilities for "Show me" and "Do it" buttons in interactive guides — programmatically demonstrating actions or executing them within Grafana's live UI. (from [Overview](#overview) above and [Why This Engine Exists](#why-this-engine-exists) below)
+
+**Constraints**:
+
+- Auto-completion must be disabled by default and opt-in via Plugin Configuration — it is an experimental feature that intercepts user events globally (from [Auto-Completion System](#auto-completion-system) above; `NOTE` in `action-monitor.ts`)
+- Auto-completion must be force-disabled during automated section execution to prevent interference between the automation and the detection system (from [Auto-Completion System](#auto-completion-system) above)
+- Hover state is intentionally persisted until explicit cleanup — subsequent actions may need to interact with hover-revealed elements (from code comment in `hover-handler.ts`)
+- An emergency unblock method must always be available — if the interaction blocker enters an invalid state, users must have an escape hatch (from [Interactive State Manager](#interactive-state-manager) and [Global Interaction Blocker](#global-interaction-blocker) above)
+- External URLs in the navigate handler must be validated via `parseUrlSafely` to block `javascript:` and `data:` scheme injection (from [Handler Types](#handler-types) above)
+
+**Non-goals**:
+
+- Not a general-purpose browser automation framework — the engine is purpose-built for Grafana's interactive guide system and relies on Grafana-specific APIs and DOM structure
+- Not responsible for deciding _when_ a step should run — that is the Requirements Manager's role; this engine only handles _how_ to execute actions (from [Integration Points](#integration-points) above)
+
+**Key tradeoffs**:
+
+- Three separate overlay types (content, header, full-screen) over a single full-screen overlay, because Grafana's layout has distinct regions requiring targeted blocking while keeping modal detection responsive (from [Global Interaction Blocker](#global-interaction-blocker) above)
+- Custom DOM events (`interactive-action-completed`, `user-action-detected`) over React state propagation, because completion events need to cross component boundaries without prop drilling (from [Data Collected and Events](#data-collected-and-events) above)
+- CSS selector matching over text matching as the primary element targeting strategy, because selectors are more stable across UI changes — text matching is used as a fallback for buttons (from [Handler Types](#handler-types) above)
+
+**Stability**: evolving
+
 ## Why This Engine Exists
 
 The Interactive Engine exists to bridge the gap between static documentation and hands-on learning in Grafana:

--- a/docs/developer/engines/requirements-manager.md
+++ b/docs/developer/engines/requirements-manager.md
@@ -394,6 +394,32 @@ The requirements manager behavior is controlled through `INTERACTIVE_CONFIG.dela
 - `reactiveCheck` - Delay for reactive checks after step completions (default: **50ms**)
 - `requirementsRetry` - Auto-retry delay for failed requirements (default: **10000ms**)
 
+## Design intent
+
+<!-- intent -->
+
+**Purpose**: The Requirements Manager gates interactive tutorial step execution on prerequisite conditions and auto-completes steps when their objectives are already satisfied, enabling safe, user-friendly guided workflows within Grafana's dynamic UI. (from [Purpose](#purpose) and [Objectives vs Requirements](#objectives-vs-requirements) above)
+
+**Constraints**:
+
+- Objectives always take priority over requirements — if a step's objective is already met, it auto-completes without checking requirements (from [Objectives vs Requirements](#objectives-vs-requirements) above)
+- Unknown requirement types must pass with a warning, never block — fail-open prevents typos or future requirements from breaking existing guides (from [Key Design Decisions](#key-design-decisions) below)
+- All async operations must check component mounted state before updating to prevent memory leaks (from [Performance Considerations](#performance-considerations) below)
+- State transitions must go through an explicit reducer — no direct boolean flag manipulation (from [Step State Machine](#step-state-machine) above)
+
+**Non-goals**:
+
+- Not a general-purpose state machine framework — the step state machine is purpose-built for the requirements checking lifecycle (from [Step State Machine](#step-state-machine) above)
+- Not responsible for executing actions — only validates whether a step is eligible to run; actual execution is handled by the interactive engine (from [Integration Points](#integration-points) above)
+
+**Key tradeoffs**:
+
+- Event-driven checking over continuous polling, because performance matters more than guaranteed instant detection — optional heartbeat covers fragile requirements only (from [Key Design Decisions](#key-design-decisions) below)
+- Fail-open over fail-closed for unknown requirements, because user progress matters more than strict enforcement — typos and future requirement types degrade gracefully (from [Key Design Decisions](#key-design-decisions) below)
+- Context provider with singleton fallback over pure DI, because backward compatibility during migration allows gradual adoption without breaking existing code (from [React Context Provider](#react-context-provider) above)
+
+**Stability**: evolving
+
 ## Key Design Decisions
 
 **Event-Driven vs Polling**:


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-02-20.

### Changes made

- Added `## Design intent` section with `<!-- intent -->` marker to `docs/developer/engines/requirements-manager.md`, consolidating rationale from existing Key Design Decisions section into structured Purpose/Constraints/Non-goals/Key tradeoffs/Stability fields
- Added `## Design intent` section with `<!-- intent -->` marker to `docs/developer/engines/interactive-engine.md`, consolidating rationale from existing Why This Engine Exists section and code comments into structured fields
- Indexed 3 orphaned docs in AGENTS.md on-demand context table: `LIVE_SESSIONS.md` (with glob trigger), `KNOWN_ISSUES.md`, `integrations/workshop.md` (with glob trigger)
- Updated maintenance backlog: removed resolved items (CLI_TOOLS.md and E2E_TESTING_CONTRACT.md staleness validated as false positives, orphaned docs partially indexed), added new finding (context-engine.md intent gap)

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| MEDIUM (backlog) | CLI_TOOLS.md staleness — src/cli/ changed after doc | Validated: false positive (changes were in e2e command code, not the validate command documented by CLI_TOOLS.md) |
| MEDIUM (backlog) | E2E_TESTING_CONTRACT.md staleness — tests/ changed after doc | Validated: false positive (changes were in unrelated open-close spec, not data-test-* contract) |
| MEDIUM (new) | requirements-manager.md intent consolidation — has Key Design Decisions but no intent marker | Fixed in this PR |
| MEDIUM (new) | interactive-engine.md intent consolidation — has Why This Engine Exists but no intent marker | Fixed in this PR |
| MEDIUM (backlog) | Remaining orphaned docs (LIVE_SESSIONS, KNOWN_ISSUES, workshop) | Partially fixed — 3 docs indexed in AGENTS.md |
| MEDIUM (backlog) | E2E_TESTING.md staleness — 11 days stale | Deferred |
| MEDIUM (new) | context-engine.md intent gap — no intent section and no rationale headings | Deferred (added to backlog) |
| MEDIUM (backlog) | Remaining orphaned docs — SCALE_TESTING.md, utility/subsystem READMEs | Deferred |
| MEDIUM (backlog) | docs/sources/ directory needs indexing decision | Deferred |
| LOW (backlog) | Skills SKILL.md files not indexed | Deferred |

### Recommendations for separate work

- `context-engine.md` needs rationale extraction from source code and design docs to create a Design intent section (added to backlog)
- `E2E_TESTING.md` should be validated against current test runner implementation
- Remaining utility/subsystem READMEs could be indexed as a group AGENTS.md entry in a future run

### Validation checklist

- [x] All changed files are `.md` or `.mdc` (verified via `git diff --name-only`)
- [x] `npm run prettier` passed
- [x] No source code files were modified

Made with [Cursor](https://cursor.com)