### PR TITLE
skill:maintain-docs validate E2E timing, add context-engine intent, index orphaned docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,8 +167,11 @@ Load these files **only when working in the relevant domain**. Do not preload al
 | `LIVE_SESSIONS.md`            | Live sessions feature (WebRTC, PeerJS)                          | `src/components/LiveSession/*`                                                   |
 | `KNOWN_ISSUES.md`             | Known bugs and workarounds                                      | --                                                                               |
 | `integrations/workshop.md`    | Workshop mode, action capture and replay                        | `src/integrations/workshop/*`                                                    |
+| `SCALE_TESTING.md`            | Live session scale testing procedures                           | --                                                                               |
+| `utils/README.md`             | Utility directory layout, remaining hooks, timeout manager      | `src/utils/*`                                                                    |
+| `constants/README.md`         | Selector constants, interactive config, z-index management      | `src/constants/*`                                                                |
 
-All `.mdc` files live in `.cursor/rules/`. `pr-review.md` is at `.cursor/rules/pr-review.md`. `E2E_TESTING_CONTRACT.md`, `RELEASE_PROCESS.md`, `FEATURE_FLAGS.md`, `CLI_TOOLS.md`, `ASSISTANT_INTEGRATION.md`, `E2E_TESTING.md`, `DEV_MODE.md`, `LOCAL_DEV.md`, `LIVE_SESSIONS.md`, `KNOWN_ISSUES.md`, and `integrations/workshop.md` are at `docs/developer/`. The `interactive-examples/` and `engines/` directories are also under `docs/developer/`.
+All `.mdc` files live in `.cursor/rules/`. `pr-review.md` is at `.cursor/rules/pr-review.md`. `E2E_TESTING_CONTRACT.md`, `RELEASE_PROCESS.md`, `FEATURE_FLAGS.md`, `CLI_TOOLS.md`, `ASSISTANT_INTEGRATION.md`, `E2E_TESTING.md`, `DEV_MODE.md`, `LOCAL_DEV.md`, `LIVE_SESSIONS.md`, `KNOWN_ISSUES.md`, `SCALE_TESTING.md`, `integrations/workshop.md`, `utils/README.md`, and `constants/README.md` are at `docs/developer/`. The `interactive-examples/` and `engines/` directories are also under `docs/developer/`.
 
 ## PR reviews
 

--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -7,13 +7,15 @@ Items here require dedicated effort beyond incremental edits.
 
 ## MEDIUM priority
 
-- **2026-02-20**: `E2E_TESTING.md` staleness — Doc last updated Feb 6, `tests/` directory changed Feb 17 (11 days stale). Needs validation that the E2E guide test runner documentation is still accurate.
+- **2026-02-20**: `CLI_TOOLS.md` staleness — Doc last updated Feb 5, `src/cli/` had E2E CLI improvements (#538) on Feb 9. CLI options or behavior may have drifted.
 
-- **2026-02-20**: `context-engine.md` intent gap — Engine doc has no `<!-- intent -->` marker and no existing rationale headings. Needs rationale extraction from source code and design docs to create a Design intent section.
+- **2026-02-20**: `LIVE_SESSIONS.md` staleness — Doc last updated Feb 10, `src/components/LiveSession/` changed Feb 17 (#586, "learning journey" → "learning path" rename). May contain stale terminology.
 
-- **2026-02-20**: Remaining orphaned docs — `SCALE_TESTING.md`, utility/subsystem READMEs (`utils/`, `styles/`, `provisioning/`, `pages/`, `src/`, `constants/`) still have no path from AGENTS.md. These are lower value but could be indexed cheaply as group entries.
+- **2026-02-20**: Remaining orphaned component READMEs — `docs/developer/components/` subdirectory READMEs (App, AppConfig, block-editor, docs-panel, SelectorDebugPanel, PrTester, LearningPaths, LiveSession, FeedbackButton, parent README) and `docs/developer/pages/README.md`, `docs/developer/styles/README.md`, `docs/developer/src/README.md` have no path from AGENTS.md. These are lower value but could be indexed as a group.
 
 - **2026-02-20**: `docs/sources/` directory — Contains published Grafana documentation sources (`_index.md` files). Needs a decision: should these be indexed in AGENTS.md for agents, or are they out of scope? Currently orphaned.
+
+- **2026-02-20**: Intent gaps in non-engine docs — `ASSISTANT_INTEGRATION.md`, `LIVE_SESSIONS.md`, and `integrations/workshop.md` have no `<!-- intent -->` marker and no existing rationale headings. Lower priority than engine docs.
 
 ## LOW priority
 

--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -209,15 +209,19 @@ npx pathfinder-cli e2e bundled:e2e-framework-test
 
 ## Timing and timeouts
 
-| Constant           | Value          | Purpose                                      |
-| ------------------ | -------------- | -------------------------------------------- |
-| Base step timeout  | 30s            | Maximum time for a single step               |
-| Multistep bonus    | +5s per action | Added for each internal action in multisteps |
-| Button enable wait | 10s            | Wait for sequential dependencies             |
-| Fix button timeout | 10s            | Per fix operation                            |
-| Max fix attempts   | 3              | Retry limit before giving up                 |
+| Constant             | Value            | Purpose                                      |
+| -------------------- | ---------------- | -------------------------------------------- |
+| Base step timeout    | 30s              | Maximum time for a single step               |
+| Multistep bonus      | +5s per action   | Added for each internal action in multisteps |
+| Guided substep bonus | +30s per substep | Added for each substep in guided blocks      |
+| Button enable wait   | 10s              | Wait for sequential dependencies             |
+| Fix button timeout   | 10s              | Per fix operation                            |
+| Max fix attempts     | 3                | Retry limit before giving up                 |
 
-Example: A multistep with 5 internal actions gets a 55s timeout (30s base + 5×5s).
+Examples:
+
+- A multistep with 5 internal actions gets a 55s timeout (30s base + 5×5s).
+- A guided block with 3 substeps gets a 120s timeout (30s base + 3×30s).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-02-20.

### Changes made

- **E2E_TESTING.md staleness validation** (3pt): Validated all claims against source code (exit codes, CLI options, timing constants, selectors). Found and fixed one gap: guided substep timeout (30s per substep) was missing from the timing table — only multistep bonus (5s per action) was documented.
- **context-engine.md intent gap** (3pt): Added `## Design intent` section with `<!-- intent -->` marker. Extracted purpose from project brief, constraints from code comments (hook-level debouncing, static class state, HTTPS-only, privacy hashing), non-goals from project scope, and key tradeoffs (three-tier fallback, event buffer sizing, confidence threshold). All claims cite provenance.
- **Orphaned doc batch indexing** (1pt): Indexed `SCALE_TESTING.md`, `utils/README.md`, and `constants/README.md` in the AGENTS.md on-demand context table with appropriate glob triggers.
- **Maintenance backlog updated**: Resolved 3 items (E2E staleness, context-engine intent gap, orphaned docs batch). Added new findings (CLI_TOOLS staleness, LIVE_SESSIONS terminology, remaining component READMEs, non-engine intent gaps).

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| HIGH (backlog) | `E2E_TESTING.md` staleness — doc Feb 6, tests/ changed Feb 17 | Fixed in this PR — timing table updated |
| MEDIUM (backlog) | `context-engine.md` intent gap — no rationale headings | Fixed in this PR — intent section added |
| MEDIUM (backlog) | Orphaned docs — SCALE_TESTING, utility READMEs | Partially fixed — 3 docs indexed, component READMEs deferred |
| MEDIUM (backlog) | `docs/sources/` indexing decision | Deferred — needs human decision |
| MEDIUM | `CLI_TOOLS.md` staleness — CLI improvements #538 since doc | Deferred — added to backlog |
| MEDIUM | `LIVE_SESSIONS.md` staleness — "journey" → "path" rename | Deferred — added to backlog |
| MEDIUM | Intent gaps in ASSISTANT_INTEGRATION, LIVE_SESSIONS, workshop.md | Deferred — added to backlog |
| LOW (backlog) | Skills SKILL.md files not indexed | Deferred — auto-discovered by IDE |

### Recommendations for separate work

- `docs/developer/components/` has 11 orphaned README files. Consider either batch-indexing as a group or confirming they are out of scope for agent discovery.
- `docs/sources/` directory needs a human decision on whether published documentation sources should be indexed in AGENTS.md.
- `LIVE_SESSIONS.md` likely contains "learning journey" terminology that should be updated to "learning path" following the codebase rename in #586.

### Validation checklist

- [x] All changed files are `.md` or `.mdc` (verified via `git diff --name-only`)
- [x] `npm run prettier` passed
- [x] No source code files were modified

Made with [Cursor](https://cursor.com)