### PR TITLE
skill:maintain-docs validate utils/README.md, fix learning path terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Get help exactly when and where you need it. Interactive learning brings context
 Interactive learning is your in-app learning companion. It provides:
 
 - **Smart recommendations** – Get relevant docs and guides based on what you're working on
-- **Interactive guides** – Follow step-by-step guided learning journeys with "Show Me" and "Do It" features
+- **Interactive guides** – Follow step-by-step guided learning paths with "Show Me" and "Do It" features
 - **Tab-based navigation** – Open multiple docs and guides in tabs, just like a browser
-- **Milestone tracking** – See your progress through learning journeys with clear milestones
+- **Milestone tracking** – See your progress through learning paths with clear milestones
 - **Always available** – Access help without switching windows or searching documentation sites
 
 ## How to access Interactive learning
@@ -29,7 +29,7 @@ Once you open Interactive learning:
 
 1. **Review recommendations** – See docs and guides tailored to what you're doing in Grafana
 2. **Open content in tabs** – Click "View" or "Start" to open content in a new tab
-3. **Navigate guides** – Use the milestone navigation at the bottom to move through learning journeys
+3. **Navigate guides** – Use the milestone navigation at the bottom to move through learning paths
 4. **Try interactive features** – Click "Show Me" to see where things are, or "Do It" to have Interactive learning guide you through actions
 5. **Manage your tabs** – Close tabs you're done with, or keep them open for reference
 
@@ -53,7 +53,7 @@ Admins can configure Interactive learning from the plugin's configuration page i
 
 #### 1. Configuration (basic settings)
 
-- **Auto-launch guide URL** – Set a specific learning journey or documentation page to automatically open when Grafana starts (useful for demos and onboarding)
+- **Auto-launch guide URL** – Set a specific learning path or documentation page to automatically open when Grafana starts (useful for demos and onboarding)
 - **Global link interception** – (Experimental) When enabled, clicking documentation links anywhere in Grafana will open them in Interactive learning instead of a new tab
 
 #### 2. Recommendations

--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -1,22 +1,34 @@
 # Documentation maintenance backlog
 
-Persistent tracker for structural issues identified by the maintain-docs skill.
-Items here require dedicated effort beyond incremental edits.
+Persistent tracker for the maintain-docs skill's persistent state across runs.
 
-<!-- Each entry: date, description, rationale. Remove when resolved. -->
+## Work items
 
-## MEDIUM priority
+<!-- Structural issues requiring dedicated effort. Format: date, description, rationale. Remove when resolved. -->
 
-- **2026-02-20**: `CLI_TOOLS.md` staleness — Doc last updated Feb 5, `src/cli/` had E2E CLI improvements (#538) on Feb 9. CLI options or behavior may have drifted.
-
-- **2026-02-20**: `LIVE_SESSIONS.md` staleness — Doc last updated Feb 10, `src/components/LiveSession/` changed Feb 17 (#586, "learning journey" → "learning path" rename). May contain stale terminology.
+- **2026-02-20**: `src/learning-paths/` new subsystem needs documentation — New directory (12 files, created Feb 16-18) covering learning paths, badges, streak tracking, and guide fetching. No dedicated doc exists. Recommend creating `docs/developer/learning-paths/README.md` in a feature branch.
 
 - **2026-02-20**: Remaining orphaned component READMEs — `docs/developer/components/` subdirectory READMEs (App, AppConfig, block-editor, docs-panel, SelectorDebugPanel, PrTester, LearningPaths, LiveSession, FeedbackButton, parent README) and `docs/developer/pages/README.md`, `docs/developer/styles/README.md`, `docs/developer/src/README.md` have no path from AGENTS.md. These are lower value but could be indexed as a group.
 
-- **2026-02-20**: `docs/sources/` directory — Contains published Grafana documentation sources (`_index.md` files). Needs a decision: should these be indexed in AGENTS.md for agents, or are they out of scope? Currently orphaned.
-
 - **2026-02-20**: Intent gaps in non-engine docs — `ASSISTANT_INTEGRATION.md`, `LIVE_SESSIONS.md`, and `integrations/workshop.md` have no `<!-- intent -->` marker and no existing rationale headings. Lower priority than engine docs.
 
-## LOW priority
+## Validated docs
 
-- **2026-02-20**: Skills SKILL.md files not indexed — `.cursor/skills/` SKILL.md files (maintain-docs, design-review, e2e-guide-analysis, tidy-up) are not referenced in AGENTS.md. These are discovered automatically by `.cursor/skills/` glob patterns in the IDE, so indexing may be unnecessary. Confirm and close if not needed.
+<!-- Docs checked against source and found accurate. Format: date, doc path. Update date on re-validation. -->
+
+- **2026-02-20**: `docs/developer/utils/README.md` — Validated against `src/utils/` and `src/utils/devtools/`. Fixed stale file listings (3 deleted devtools files removed, 3 new utility files and 2 devtools structural files added), corrected export names in `openfeature.ts` and `utils.plugin.ts` sections.
+
+## Exclusions
+
+<!-- Files confirmed as not needing an AGENTS.md entry. Format: path, reason. -->
+
+- `docs/developer/provisioning/README.md` — 4-line stub with only external links to Grafana provisioning docs. No agent-relevant content.
+- `.cursor/skills/maintain-docs/SKILL.md` — Discovered automatically by IDE via `.cursor/skills/` glob pattern. No AGENTS.md entry needed.
+- `.cursor/skills/design-review/SKILL.md` — Same as above.
+- `.cursor/skills/e2e-guide-analysis/SKILL.md` — Same as above.
+- `.cursor/skills/tidy-up/SKILL.md` — Same as above.
+- `docs/sources/_index.md` — End-user documentation published to Grafana.com. Not agent-relevant for implementation tasks.
+- `docs/sources/getting-started/_index.md` — Same as above.
+- `docs/sources/administrators-reference/_index.md` — Same as above.
+- `docs/sources/architecture/_index.md` — Same as above.
+- `docs/sources/upgrade-notes/_index.md` — Same as above.

--- a/docs/developer/components/PrTester/README.md
+++ b/docs/developer/components/PrTester/README.md
@@ -53,7 +53,7 @@ PR Tester exists to:
 - Create ordered sequence of guides
 - Drag-and-drop reordering
 - Test guides in logical sequence
-- Opens as connected learning journey
+- Opens as connected learning path
 - Ideal for multi-guide PRs
 
 ### Content File Detection

--- a/docs/developer/components/README.md
+++ b/docs/developer/components/README.md
@@ -10,7 +10,7 @@ The components are organized into logical groups with clear responsibilities:
 
 - **App/**: Root application component with error boundary and routing logic
 - **AppConfig/**: Plugin configuration interface for admin settings and feature flags
-- **docs-panel/**: Core documentation features (recommendations, learning journeys, content rendering)
+- **docs-panel/**: Core documentation features (recommendations, learning paths, content rendering)
 
 ### Content Authoring and Development Tools
 
@@ -89,7 +89,7 @@ Contains the admin configuration components for:
 Contains the main documentation functionality including:
 
 - Context-aware recommendations engine
-- Interactive learning journeys with milestone navigation
+- Interactive learning paths with milestone navigation
 - Document viewer with tabbed interface
 - Live session integration for collaborative learning
 - Learning progress tracking

--- a/docs/developer/components/docs-panel/README.md
+++ b/docs/developer/components/docs-panel/README.md
@@ -1,6 +1,6 @@
 # Docs Panel Components
 
-The core documentation functionality of the plugin, including context-aware recommendations, interactive learning journeys, live session integration, and comprehensive content rendering.
+The core documentation functionality of the plugin, including context-aware recommendations, interactive learning paths, live session integration, and comprehensive content rendering.
 
 ## Location
 
@@ -13,7 +13,7 @@ The core documentation functionality of the plugin, including context-aware reco
 The docs-panel exists to:
 
 - Provide AI-powered context-aware documentation recommendations
-- Render interactive learning journeys with milestone navigation
+- Render interactive learning paths with milestone navigation
 - Enable live collaborative learning sessions
 - Track learning progress and achievements
 - Offer tabbed interface for multiple content streams
@@ -29,7 +29,7 @@ The docs-panel exists to:
 **Role**:
 
 - Manages multiple content tabs (recommendations, my learning, content tabs)
-- Handles navigation between milestones within learning journeys
+- Handles navigation between milestones within learning paths
 - Integrates live session features for collaborative learning
 - Provides unified interface for different content types
 - Coordinates with interactive engine for step execution
@@ -39,7 +39,7 @@ The docs-panel exists to:
 
 - **Multi-tab Interface**: Fixed tabs (Recommendations, My Learning) + dynamic content tabs
 - **Content Type Support**: Learning journeys, documentation pages, interactive guides
-- **Milestone Navigation**: Previous/Next navigation within learning journeys
+- **Milestone Navigation**: Previous/Next navigation within learning paths
 - **Live Sessions**: Real-time collaborative learning with presenter/attendee modes
 - **Session Integration**: Action capture and replay for synchronized experiences
 - **Real-time Loading**: Lazy loading of content when tabs are activated
@@ -261,7 +261,7 @@ CombinedLearningJourneyPanel (SceneObjectBase)
 - Created when user opens content
 - Persisted across sessions
 - Closeable by user
-- Support for learning journeys and docs
+- Support for learning paths and docs
 - Milestone navigation (journeys)
 
 **Tab State:**
@@ -321,7 +321,7 @@ CombinedLearningJourneyPanel (SceneObjectBase)
 
 ## Usage Patterns
 
-### Opening Learning Journeys
+### Opening Learning Paths
 
 ```typescript
 // From context panel recommendations

--- a/docs/developer/src/README.md
+++ b/docs/developer/src/README.md
@@ -4,7 +4,7 @@ Remove any remaining comments before publishing as these may be displayed on Gra
 
 # Grafana Pathfinder - Source Code
 
-This directory contains the complete source code for Grafana Pathfinder, which provides contextual documentation recommendations and interactive learning journeys within Grafana.
+This directory contains the complete source code for Grafana Pathfinder, which provides contextual documentation recommendations and interactive learning paths within Grafana.
 
 ## Architecture Overview
 
@@ -24,7 +24,7 @@ Contains all React and Grafana Scenes components:
 
 - `App/` - Main application component and scene initialization
 - `AppConfig/` - Plugin configuration interface for admin settings
-- `docs-panel/` - Core documentation panel components (recommendations and learning journeys)
+- `docs-panel/` - Core documentation panel components (recommendations and learning paths)
 
 ### `/constants` - Configuration & Constants
 

--- a/docs/developer/styles/README.md
+++ b/docs/developer/styles/README.md
@@ -106,7 +106,7 @@ addGlobalInteractiveStyles();
 
 #### Milestone Styles (`getMilestoneStyles`)
 
-- Progress indicators for learning journeys
+- Progress indicators for learning paths
 - Navigation button styling
 - Progress bar animations
 - Milestone counter display
@@ -142,7 +142,7 @@ export const getStyles = (theme: GrafanaTheme2) => ({
 **Purpose**: Specialized styling for rendered HTML content from documentation sources
 **Role**:
 
-- Styles for learning journey and docs content
+- Styles for learning path and docs content
 - HTML element styling (headings, paragraphs, lists, etc.)
 - Interactive element styling (code blocks, images, etc.)
 - Responsive and accessible design patterns
@@ -151,7 +151,7 @@ export const getStyles = (theme: GrafanaTheme2) => ({
 
 #### `journeyContentHtml(theme: GrafanaTheme2)`
 
-- Comprehensive styling for learning journey content
+- Comprehensive styling for learning path content
 - Code block styling with copy buttons
 - Image styling with lightbox cursors
 - Interactive element styling

--- a/docs/developer/utils/README.md
+++ b/docs/developer/utils/README.md
@@ -26,18 +26,21 @@ Only the following hooks remain in `src/utils/`:
 - `timeout-manager.ts` - Centralized timeout/debounce management
 - `dev-mode.ts` - Development mode utilities
 - `openfeature.ts` - Feature toggle utilities
+- `openfeature-tracking.ts` - OpenFeature hook for tracking flag evaluations to analytics
+- `experiment-debug.ts` - Debug utilities for the experiment system (`window.__pathfinderExperiment`)
+- `variable-substitution.ts` - Template variable (`{{variableName}}`) substitution for dynamic content
 
 ### 🔧 **Development Tools** (`devtools/`)
 
+- `index.ts` - Barrel export for all devtools utilities
+- `dev-tools.types.ts` - Shared types (`StepDefinition`, `SelectorInfo`, `ExtractedSelector`)
 - `action-recorder.hook.ts` - Record user actions for guide creation
+- `action-recorder.util.ts` - Action recording utilities (selector extraction, step filtering)
 - `element-inspector.hook.ts` - DOM element inspection
-- `selector-capture.hook.ts` - CSS selector generation
-- `selector-generator.util.ts` - Automated selector generation
-- `selector-tester.hook.ts` - Test CSS selectors
-- `step-executor.hook.ts` - Test step execution
+- `hover-highlight.util.ts` - Visual element highlighting during inspection
+- `selector-generator.util.ts` - Automated CSS selector generation
 - `step-parser.util.ts` - Parse step definitions
-- `tutorial-exporter.ts` - Export tutorials
-- `action-recorder.util.ts` - Action recording utilities
+- `tutorial-exporter.ts` - Export tutorials in various formats
 
 ### 🔒 **Security & Safety**
 
@@ -120,9 +123,8 @@ Only the following hooks remain in `src/utils/`:
 
 **Key Exports**:
 
-- `PluginPropsContext` - React context provider
-- `usePluginProps()` - Hook for accessing plugin props
-- `usePluginMeta()` - Hook for accessing plugin metadata
+- `PluginPropsContext` - React context for sharing `AppRootProps`
+- `updatePluginSettings()` - Function to update plugin settings via API
 
 **Used By**:
 
@@ -193,12 +195,17 @@ function prefixRoute(route: string): string {
 
 **Key Exports**:
 
-- `FeatureFlags` - Feature flag constants
-- `getFeatureToggle()` - Function to check feature toggle state
+- `pathfinderFeatureFlags` - Feature flag definitions (names, default values, tracking keys)
+- `evaluateFeatureFlag()` - Async function to evaluate a flag's value
+- `getFeatureFlagValue()` - Synchronous boolean flag check
+- `getStringFlagValue()` - Synchronous string flag check
+- `initializeOpenFeature()` - Initialize the OpenFeature SDK
+- `ExperimentConfig` / `getExperimentConfig()` - Experiment configuration types and accessor
 
 **Used By**:
 
-- `src/components/AppConfig/ConfigurationForm.tsx` - Feature configuration
+- `src/utils/experiment-debug.ts` - Experiment debugging console tools
+- `src/utils/openfeature-tracking.ts` - Flag evaluation analytics tracking
 - Components requiring feature flag checks
 
 ---
@@ -241,32 +248,31 @@ function prefixRoute(route: string): string {
 
 ## Development Tools (`devtools/`)
 
-The `devtools/` subdirectory contains development-only utilities for creating and testing interactive guides:
+The `devtools/` subdirectory contains development-only utilities for creating and testing interactive guides. All public exports are consolidated through `index.ts`.
+
+### Structure
+
+- **`index.ts`** - Barrel export for all devtools utilities
+- **`dev-tools.types.ts`** - Shared types (`StepDefinition`, `SelectorInfo`, `ExtractedSelector`)
 
 ### Action Recording
 
 - **`action-recorder.hook.ts`** - React hook for recording user actions
-- **`action-recorder.util.ts`** - Action recording utilities
+- **`action-recorder.util.ts`** - Selector extraction and step filtering utilities
 
 ### Element Inspection
 
 - **`element-inspector.hook.ts`** - DOM element inspection hook
 - **`hover-highlight.util.ts`** - Visual element highlighting
 
-### Selector Tools
+### Selector Generation
 
-- **`selector-capture.hook.ts`** - Capture CSS selectors from user interactions
-- **`selector-generator.util.ts`** - Generate CSS selectors automatically
-- **`selector-tester.hook.ts`** - Test CSS selectors against DOM
+- **`selector-generator.util.ts`** - Generate CSS selectors from DOM events
 
-### Step Execution
+### Step Parsing & Export
 
-- **`step-executor.hook.ts`** - Execute test steps programmatically
-- **`step-parser.util.ts`** - Parse step definitions
-
-### Export
-
-- **`tutorial-exporter.ts`** - Export tutorials in various formats
+- **`step-parser.util.ts`** - Parse step definitions from strings
+- **`tutorial-exporter.ts`** - Export tutorials in various formats (HTML, guided, multistep)
 
 ---
 

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -47,9 +47,9 @@ hero:
 Interactive learning brings contextual documentation and interactive guides directly into Grafana, so you can learn and build without leaving your workflow:
 
 - **Smart recommendations** - Get relevant docs and guides based on what you're working on.
-- **interactive guides** - Follow step-by-step guided learning journeys with Show me and Do it features.
+- **interactive guides** - Follow step-by-step guided learning paths with Show me and Do it features.
 - **Tab-based navigation** - Open multiple docs and guides in tabs, just like a browser.
-- **Milestone tracking** - See your progress through learning journeys with clear milestones.
+- **Milestone tracking** - See your progress through learning paths with clear milestones.
 - **Always available** - Access help without switching windows or searching documentation sites.
 
 Interactive learning is currently available in public preview for Grafana OSS and will soon be arriving to Grafana Cloud.

--- a/docs/sources/administrators-reference/_index.md
+++ b/docs/sources/administrators-reference/_index.md
@@ -48,7 +48,7 @@ This feature is useful for demo scenarios or onboarding new users.
 **To configure auto-launch:**
 
 1. Navigate to the **Plugin Configuration** section.
-2. Enter the full URL of a learning journey or documentation page in the **Auto-launch guide URL** field.
+2. Enter the full URL of a learning path or documentation page in the **Auto-launch guide URL** field.
 3. Click **Save configuration**.
 
 Example URL:


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-02-20.

### Changes made

- **utils/README.md staleness validation (3 pts)**: Validated against `src/utils/` and `src/utils/devtools/`. Removed 3 deleted devtools files (`selector-capture.hook.ts`, `selector-tester.hook.ts`, `step-executor.hook.ts`), added 3 new utility files (`experiment-debug.ts`, `openfeature-tracking.ts`, `variable-substitution.ts`), added 2 devtools structural files (`index.ts`, `dev-tools.types.ts`), corrected stale export names in `openfeature.ts` section (`FeatureFlags` → `pathfinderFeatureFlags`, `getFeatureToggle` → `evaluateFeatureFlag`/`getFeatureFlagValue`/etc.) and `utils.plugin.ts` section (`usePluginProps`/`usePluginMeta` → `updatePluginSettings`).

- **README.md terminology fix (1 pt)**: Updated 4 instances of "learning journeys" → "learning paths" to align with the #586 rename (Feb 17).

- **Orphaned doc terminology fix (1 pt, grouped)**: Fixed "learning journey(s)" → "learning path(s)" across 7 orphaned docs: `docs-panel/README.md`, `components/README.md`, `PrTester/README.md`, `src/README.md`, `styles/README.md`, `docs/sources/_index.md`, `docs/sources/administrators-reference/_index.md`.

- **Backlog migration**: Migrated `docs/_maintenance-backlog.md` from old format to new template with Validated docs and Exclusions sections. Closed resolved items (CLI_TOOLS.md and LIVE_SESSIONS.md staleness). Added exclusions for skills SKILL.md files, provisioning README, and docs/sources/ files.

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| HIGH | `utils/README.md` staleness — significant structural changes in `src/utils/` since Nov 2025 (devtools refactored, new files) | Fixed in this PR |
| HIGH | `README.md` terminology — 4 instances of "learning journeys" should be "learning paths" after #586 | Fixed in this PR |
| MEDIUM | Orphaned docs with stale "learning journey" terminology (7 files) | Fixed in this PR |
| MEDIUM | `src/learning-paths/` — new subsystem (12 files, Feb 16-18), no dedicated doc | Deferred (backlog) |
| MEDIUM | Orphaned component READMEs (10+ files) have no path from AGENTS.md | Deferred (backlog) |
| MEDIUM | Intent gaps in non-engine docs (`ASSISTANT_INTEGRATION.md`, `LIVE_SESSIONS.md`, `workshop.md`) | Deferred (backlog) |
| MEDIUM | CLI_TOOLS.md backlog staleness item — no structural changes found | Closed (resolved) |
| MEDIUM | LIVE_SESSIONS.md backlog staleness item — terminology already fixed | Closed (resolved) |
| LOW | `provisioning/README.md` orphaned — 4-line stub | Excluded |
| LOW | Skills SKILL.md not indexed — IDE auto-discovery | Excluded |
| LOW | `docs/sources/` orphaned — end-user facing, not agent-relevant | Excluded |

### Recommendations for separate work

- **`src/learning-paths/` documentation**: New subsystem with 12 files (badges, streaks, path fetching, next-action hook) created Feb 16-18. Needs a dedicated `docs/developer/learning-paths/README.md` and potentially an AGENTS.md entry.

### Validation checklist

- [x] All changed files are `.md` or `.mdc` (verified via `git diff --name-only`)
- [x] Phase 2.5 verification passed (all factual claims spot-checked against source)
- [x] `npm run prettier` passed
- [x] No source code files were modified

Made with [Cursor](https://cursor.com)