### PR TITLE
Enable noUncheckedIndexedAccess for stricter null safety

### DIFF
--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -658,7 +658,7 @@ export const e2eCommand = new Command('e2e')
         } else {
           // Single guide: write detailed report
           try {
-            const report = generateReport(resultsWithData[0]);
+            const report = generateReport(resultsWithData[0]!);
             writeReport(report, options.output);
             console.log(`\n📄 JSON report written to: ${options.output}`);
           } catch (err) {

--- a/src/components/DomPathTooltip/DomPathTooltip.tsx
+++ b/src/components/DomPathTooltip/DomPathTooltip.tsx
@@ -45,7 +45,7 @@ function parseDomPath(path: string): Array<{ text: string; isTestId: boolean }> 
         }
 
         // Add the testid attribute in orange
-        segments.push({ text: testidAttr, isTestId: true });
+        segments.push({ text: testidAttr!, isTestId: true });
 
         // Add the part after testid (if any)
         if (after) {

--- a/src/components/PrTester/PrTester.tsx
+++ b/src/components/PrTester/PrTester.tsx
@@ -234,7 +234,7 @@ export function PrTester({ onOpenDocsPage, onOpenLearningJourney }: PrTesterProp
       return userSelectedFile;
     }
     // Default to first file
-    return files[0].directoryName;
+    return files[0]!.directoryName;
   }, [files, userSelectedFile]);
 
   // Build select options from files
@@ -440,7 +440,7 @@ export function PrTester({ onOpenDocsPage, onOpenLearningJourney }: PrTesterProp
       }
 
       const newOrderedFiles = [...orderedFiles];
-      const draggedFile = newOrderedFiles[draggedIndex];
+      const draggedFile = newOrderedFiles[draggedIndex]!;
       newOrderedFiles.splice(draggedIndex, 1);
       newOrderedFiles.splice(index, 0, draggedFile);
 

--- a/src/components/PrTester/github-api.test.ts
+++ b/src/components/PrTester/github-api.test.ts
@@ -207,7 +207,7 @@ describe('fetchPrContentFiles', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.files[0].directoryName).toBe('category/subcategory/guide');
+      expect(result.files[0]!.directoryName).toBe('category/subcategory/guide');
     }
   });
 
@@ -625,8 +625,8 @@ describe('fetchPrContentFiles', () => {
     if (result.success) {
       // Only valid content.json files should be included
       expect(result.files).toHaveLength(2);
-      expect(result.files[0].directoryName).toBe('valid');
-      expect(result.files[1].directoryName).toBe('another');
+      expect(result.files[0]!.directoryName).toBe('valid');
+      expect(result.files[1]!.directoryName).toBe('another');
     }
   });
 
@@ -691,7 +691,7 @@ describe('fetchPrContentFiles', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.files).toHaveLength(1);
-      expect(result.files[0].directoryName).toBe('safe-guide');
+      expect(result.files[0]!.directoryName).toBe('safe-guide');
     }
   });
 
@@ -721,7 +721,7 @@ describe('fetchPrContentFiles', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.files).toHaveLength(1);
-      expect(result.files[0].directoryName).toBe('safe');
+      expect(result.files[0]!.directoryName).toBe('safe');
     }
   });
 });

--- a/src/components/PrTester/github-api.ts
+++ b/src/components/PrTester/github-api.ts
@@ -86,13 +86,13 @@ export function parsePrUrl(url: string): ParsedPrUrl | null {
   }
 
   const [, owner, repo, prNumberStr] = match;
-  const prNumber = parseInt(prNumberStr, 10);
+  const prNumber = parseInt(prNumberStr!, 10);
 
   if (isNaN(prNumber) || prNumber <= 0) {
     return null;
   }
 
-  return { owner, repo, prNumber };
+  return { owner: owner!, repo: repo!, prNumber };
 }
 
 /**

--- a/src/components/block-editor/NestedBlockItem.tsx
+++ b/src/components/block-editor/NestedBlockItem.tsx
@@ -48,7 +48,7 @@ export function NestedBlockItem({
   // Get preview content - same logic as BlockItem
   const getPreview = (): string => {
     if ('content' in block && typeof block.content === 'string') {
-      const firstLine = block.content.split('\n')[0];
+      const firstLine = block.content.split('\n')[0] ?? '';
       return firstLine.slice(0, 60) + (firstLine.length > 60 ? '...' : '');
     }
     if ('reftarget' in block && typeof block.reftarget === 'string') {
@@ -145,7 +145,7 @@ export function NestedBlockItem({
             className={styles.deleteButton}
             tooltip="Delete block"
             ariaLabel="Delete"
-            blockType={meta.name.toLowerCase()}
+            blockType={meta?.name.toLowerCase() ?? block.type}
           />
         </div>
       </div>

--- a/src/components/block-editor/forms/BranchBlocksEditor.tsx
+++ b/src/components/block-editor/forms/BranchBlocksEditor.tsx
@@ -478,7 +478,7 @@ export function BranchBlocksEditor({ label, variant, blocks, onChange, onPickerM
       }
       const newBlocks = [...blocks];
       const [movedBlock] = newBlocks.splice(oldIndex, 1);
-      newBlocks.splice(newIndex, 0, movedBlock);
+      newBlocks.splice(newIndex, 0, movedBlock!);
       onChange(newBlocks);
     },
     [blocks, onChange]
@@ -497,6 +497,9 @@ export function BranchBlocksEditor({ label, variant, blocks, onChange, onPickerM
   const handleStartEdit = useCallback(
     (index: number) => {
       const block = blocks[index];
+      if (!block) {
+        return;
+      }
       setEditingIndex(index);
       setNewBlockType(block.type as BlockType);
       populateFormFromBlock(block);
@@ -509,7 +512,11 @@ export function BranchBlocksEditor({ label, variant, blocks, onChange, onPickerM
     if (editingIndex === null) {
       return;
     }
-    const blockType = blocks[editingIndex].type as BlockType;
+    const editingBlock = blocks[editingIndex];
+    if (!editingBlock) {
+      return;
+    }
+    const blockType = editingBlock.type as BlockType;
 
     // Safety check: prevent data loss for types without inline editing support
     // These types should use handleCancelEdit instead (UI shows Close button, not Save)

--- a/src/components/block-editor/forms/QuizBlockForm.tsx
+++ b/src/components/block-editor/forms/QuizBlockForm.tsx
@@ -245,7 +245,7 @@ export function QuizBlockForm({
       if (!checked) {
         const correctChoices = choices.filter((c) => c.correct);
         if (correctChoices.length > 1) {
-          const firstCorrectId = correctChoices[0].id;
+          const firstCorrectId = correctChoices[0]!.id;
           setChoices((prev) =>
             prev.map((c) => ({
               ...c,

--- a/src/components/block-editor/forms/StepEditor.tsx
+++ b/src/components/block-editor/forms/StepEditor.tsx
@@ -347,7 +347,7 @@ export function StepEditor({
       if (activeIndex !== -1 && overIndex !== -1 && activeIndex !== overIndex) {
         const newSteps = [...steps];
         const [removed] = newSteps.splice(activeIndex, 1);
-        newSteps.splice(overIndex, 0, removed);
+        newSteps.splice(overIndex, 0, removed!);
         onChange(newSteps);
       }
     },
@@ -382,6 +382,9 @@ export function StepEditor({
   const handleStartEdit = useCallback(
     (index: number) => {
       const step = steps[index];
+      if (!step) {
+        return;
+      }
       setEditingStepIndex(index);
       setEditAction(step.action);
       setEditReftarget(step.reftarget ?? '');
@@ -853,7 +856,7 @@ export function StepEditor({
                     </div>
                   ) : (
                     /* Display view for this step - sortable via @dnd-kit */
-                    <SortableStepItem id={stepIds[index]} index={index} disabled={editingStepIndex !== null}>
+                    <SortableStepItem id={stepIds[index]!} index={index} disabled={editingStepIndex !== null}>
                       {/* Drag handle */}
                       <div className={styles.dragHandle} title="Drag to reorder">
                         <span style={{ fontSize: '12px' }}>⋮⋮</span>

--- a/src/components/block-editor/hooks/useBlockEditor.ts
+++ b/src/components/block-editor/hooks/useBlockEditor.ts
@@ -322,7 +322,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
 
         const newBlocks = [...prev.blocks];
         const [removed] = newBlocks.splice(fromIndex, 1);
-        newBlocks.splice(toIndex, 0, removed);
+        newBlocks.splice(toIndex, 0, removed!);
 
         const newState = {
           ...prev,
@@ -382,17 +382,15 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         const block = prev.blocks[blockIndex];
         const sectionBlock = prev.blocks[sectionIndex];
 
-        // Can't nest sections or nest into non-sections
-        if (block.block.type === 'section' || !isSectionBlock(sectionBlock.block)) {
+        if (!block || !sectionBlock || block.block.type === 'section' || !isSectionBlock(sectionBlock.block)) {
           return prev;
         }
 
         // Remove block from root level
         const newBlocks = prev.blocks.filter((b) => b.id !== blockId);
 
-        // Add block to section's blocks array
         const section = newBlocks[sectionIndex > blockIndex ? sectionIndex - 1 : sectionIndex];
-        if (isSectionBlock(section.block)) {
+        if (section && isSectionBlock(section.block)) {
           const sectionBlocksCopy = [...section.block.blocks];
           const idx = insertIndex ?? sectionBlocksCopy.length;
           sectionBlocksCopy.splice(idx, 0, block.block);
@@ -425,19 +423,17 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const sectionEditorBlock = prev.blocks[sectionIndex];
-        if (!isSectionBlock(sectionEditorBlock.block)) {
+        if (!sectionEditorBlock || !isSectionBlock(sectionEditorBlock.block)) {
           return prev;
         }
 
-        // blockId format is `${sectionId}-${index}` - extract the index
         const nestedIndex = parseInt(blockId.split('-').pop() ?? '-1', 10);
         if (nestedIndex < 0 || nestedIndex >= sectionEditorBlock.block.blocks.length) {
           return prev;
         }
 
-        const blockToMove = sectionEditorBlock.block.blocks[nestedIndex];
+        const blockToMove = sectionEditorBlock.block.blocks[nestedIndex]!;
 
-        // Remove block from section
         const newSectionBlocks = sectionEditorBlock.block.blocks.filter((_, i) => i !== nestedIndex);
 
         const newBlocks = [...prev.blocks];
@@ -449,7 +445,6 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
           },
         };
 
-        // Create new EditorBlock and insert at specified index (or after section if not specified)
         const newEditorBlock: EditorBlock = {
           id: generateBlockId(),
           block: blockToMove,
@@ -482,7 +477,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const sectionEditorBlock = prev.blocks[sectionIndex];
-        if (!isSectionBlock(sectionEditorBlock.block)) {
+        if (!sectionEditorBlock || !isSectionBlock(sectionEditorBlock.block)) {
           return prev;
         }
 
@@ -523,7 +518,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const sectionEditorBlock = prev.blocks[sectionIndex];
-        if (!isSectionBlock(sectionEditorBlock.block)) {
+        if (!sectionEditorBlock || !isSectionBlock(sectionEditorBlock.block)) {
           return prev;
         }
 
@@ -565,7 +560,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const sectionEditorBlock = prev.blocks[sectionIndex];
-        if (!isSectionBlock(sectionEditorBlock.block)) {
+        if (!sectionEditorBlock || !isSectionBlock(sectionEditorBlock.block)) {
           return prev;
         }
 
@@ -602,7 +597,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const sectionEditorBlock = prev.blocks[sectionIndex];
-        if (!isSectionBlock(sectionEditorBlock.block)) {
+        if (!sectionEditorBlock || !isSectionBlock(sectionEditorBlock.block)) {
           return prev;
         }
 
@@ -611,7 +606,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
           return prev;
         }
 
-        const blockToDuplicate = sectionBlocksCopy[nestedIndex];
+        const blockToDuplicate = sectionBlocksCopy[nestedIndex]!;
         const duplicatedBlock = JSON.parse(JSON.stringify(blockToDuplicate));
         sectionBlocksCopy.splice(nestedIndex + 1, 0, duplicatedBlock);
 
@@ -646,7 +641,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const sectionEditorBlock = prev.blocks[sectionIndex];
-        if (!isSectionBlock(sectionEditorBlock.block)) {
+        if (!sectionEditorBlock || !isSectionBlock(sectionEditorBlock.block)) {
           return prev;
         }
 
@@ -662,7 +657,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const [removed] = sectionBlocksCopy.splice(fromIndex, 1);
-        sectionBlocksCopy.splice(toIndex, 0, removed);
+        sectionBlocksCopy.splice(toIndex, 0, removed!);
 
         const newBlocks = [...prev.blocks];
         newBlocks[sectionIndex] = {
@@ -699,7 +694,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const conditionalEditorBlock = prev.blocks[conditionalIndex];
-        if (!isConditionalBlock(conditionalEditorBlock.block)) {
+        if (!conditionalEditorBlock || !isConditionalBlock(conditionalEditorBlock.block)) {
           return prev;
         }
 
@@ -740,7 +735,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const conditionalEditorBlock = prev.blocks[conditionalIndex];
-        if (!isConditionalBlock(conditionalEditorBlock.block)) {
+        if (!conditionalEditorBlock || !isConditionalBlock(conditionalEditorBlock.block)) {
           return prev;
         }
 
@@ -782,7 +777,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const conditionalEditorBlock = prev.blocks[conditionalIndex];
-        if (!isConditionalBlock(conditionalEditorBlock.block)) {
+        if (!conditionalEditorBlock || !isConditionalBlock(conditionalEditorBlock.block)) {
           return prev;
         }
 
@@ -819,7 +814,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const conditionalEditorBlock = prev.blocks[conditionalIndex];
-        if (!isConditionalBlock(conditionalEditorBlock.block)) {
+        if (!conditionalEditorBlock || !isConditionalBlock(conditionalEditorBlock.block)) {
           return prev;
         }
 
@@ -828,7 +823,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
           return prev;
         }
 
-        const blockToDuplicate = branchBlocks[nestedIndex];
+        const blockToDuplicate = branchBlocks[nestedIndex]!;
         const duplicatedBlock = JSON.parse(JSON.stringify(blockToDuplicate));
         branchBlocks.splice(nestedIndex + 1, 0, duplicatedBlock);
 
@@ -863,7 +858,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const conditionalEditorBlock = prev.blocks[conditionalIndex];
-        if (!isConditionalBlock(conditionalEditorBlock.block)) {
+        if (!conditionalEditorBlock || !isConditionalBlock(conditionalEditorBlock.block)) {
           return prev;
         }
 
@@ -872,14 +867,14 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
           fromIndex < 0 ||
           fromIndex >= branchBlocks.length ||
           toIndex < 0 ||
-          toIndex > branchBlocks.length || // Allow toIndex === length for moving to end
+          toIndex > branchBlocks.length ||
           fromIndex === toIndex
         ) {
           return prev;
         }
 
         const [removed] = branchBlocks.splice(fromIndex, 1);
-        branchBlocks.splice(toIndex, 0, removed);
+        branchBlocks.splice(toIndex, 0, removed!);
 
         const newBlocks = [...prev.blocks];
         newBlocks[conditionalIndex] = {
@@ -913,37 +908,34 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const blockToNest = prev.blocks[blockIndex];
-
-        // Don't allow nesting sections or conditionals
-        if (blockToNest.block.type === 'section' || blockToNest.block.type === 'conditional') {
+        if (!blockToNest || blockToNest.block.type === 'section' || blockToNest.block.type === 'conditional') {
           return prev;
         }
 
-        // Find the conditional
         const conditionalIndex = prev.blocks.findIndex((b) => b.id === conditionalId);
         if (conditionalIndex === -1) {
           return prev;
         }
 
         const conditionalEditorBlock = prev.blocks[conditionalIndex];
-        if (!isConditionalBlock(conditionalEditorBlock.block)) {
+        if (!conditionalEditorBlock || !isConditionalBlock(conditionalEditorBlock.block)) {
           return prev;
         }
 
-        // Remove from root
         const newBlocks = prev.blocks.filter((_, i) => i !== blockIndex);
-
-        // Adjust conditional index if needed
         const adjustedConditionalIndex = blockIndex < conditionalIndex ? conditionalIndex - 1 : conditionalIndex;
 
-        // Add to conditional branch
-        const conditionalBlock = newBlocks[adjustedConditionalIndex].block as JsonConditionalBlock;
+        const adjustedBlock = newBlocks[adjustedConditionalIndex];
+        if (!adjustedBlock) {
+          return prev;
+        }
+        const conditionalBlock = adjustedBlock.block as JsonConditionalBlock;
         const branchBlocks = [...conditionalBlock[branch]];
         const idx = insertIndex ?? branchBlocks.length;
         branchBlocks.splice(idx, 0, blockToNest.block);
 
         newBlocks[adjustedConditionalIndex] = {
-          ...newBlocks[adjustedConditionalIndex],
+          ...adjustedBlock,
           block: {
             ...conditionalBlock,
             [branch]: branchBlocks,
@@ -973,7 +965,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const conditionalEditorBlock = prev.blocks[conditionalIndex];
-        if (!isConditionalBlock(conditionalEditorBlock.block)) {
+        if (!conditionalEditorBlock || !isConditionalBlock(conditionalEditorBlock.block)) {
           return prev;
         }
 
@@ -982,8 +974,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
           return prev;
         }
 
-        // Get the block to unnest
-        const blockToUnnest = branchBlocks[nestedIndex];
+        const blockToUnnest = branchBlocks[nestedIndex]!;
 
         // Remove from branch
         const newBranchBlocks = branchBlocks.filter((_, i) => i !== nestedIndex);
@@ -1038,7 +1029,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         }
 
         const conditionalEditorBlock = prev.blocks[conditionalIndex];
-        if (!isConditionalBlock(conditionalEditorBlock.block)) {
+        if (!conditionalEditorBlock || !isConditionalBlock(conditionalEditorBlock.block)) {
           return prev;
         }
 
@@ -1047,8 +1038,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
           return prev;
         }
 
-        // Get the block to move
-        const blockToMove = fromBranchBlocks[fromIndex];
+        const blockToMove = fromBranchBlocks[fromIndex]!;
 
         // Remove from source branch
         const newFromBranchBlocks = fromBranchBlocks.filter((_, i) => i !== fromIndex);
@@ -1100,7 +1090,12 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         const fromSectionEditorBlock = prev.blocks[fromSectionIndex];
         const toSectionEditorBlock = prev.blocks[toSectionIndex];
 
-        if (!isSectionBlock(fromSectionEditorBlock.block) || !isSectionBlock(toSectionEditorBlock.block)) {
+        if (
+          !fromSectionEditorBlock ||
+          !toSectionEditorBlock ||
+          !isSectionBlock(fromSectionEditorBlock.block) ||
+          !isSectionBlock(toSectionEditorBlock.block)
+        ) {
           return prev;
         }
 
@@ -1109,8 +1104,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
           return prev;
         }
 
-        // Get the block to move
-        const blockToMove = fromBlocks[fromIndex];
+        const blockToMove = fromBlocks[fromIndex]!;
 
         // Remove from source section
         const newFromBlocks = fromBlocks.filter((_, i) => i !== fromIndex);
@@ -1173,7 +1167,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
     // If blockIds are provided (from persistence), use them to preserve IDs across refreshes
     // Otherwise generate new IDs (for new/imported guides)
     const newBlocks: EditorBlock[] = guide.blocks.map((block, index) => ({
-      id: blockIds && blockIds[index] ? blockIds[index] : generateBlockId(),
+      id: blockIds?.[index] ?? generateBlockId(),
       block,
     }));
 
@@ -1251,7 +1245,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
     // It's a root-level block
     const rootIndex = blocks.findIndex((b) => b.id === id);
     if (rootIndex >= 0) {
-      return { isNested: false, block: blocks[rootIndex].block, rootIndex };
+      return { isNested: false, block: blocks[rootIndex]!.block, rootIndex };
     }
     return { isNested: false };
   };
@@ -1310,14 +1304,11 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
           steps,
         };
 
-        // Determine where to insert based on first selected block
-        const firstParsed = parsedBlocks[0];
+        const firstParsed = parsedBlocks[0]!;
         const insertIntoSection = firstParsed.isNested && firstParsed.sectionId;
 
-        // Remove root-level blocks that were merged
         const rootIdsToRemove = new Set(parsedBlocks.filter((p) => !p.isNested).map((p) => p.id));
 
-        // Group nested blocks by section for removal
         const nestedToRemove = new Map<string, number[]>();
         parsedBlocks
           .filter((p) => p.isNested && p.sectionId !== undefined && p.nestedIndex !== undefined)
@@ -1327,11 +1318,9 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
             nestedToRemove.set(p.sectionId!, existing);
           });
 
-        // Build new blocks array
         let newBlocks = prev.blocks
           .filter((b) => !rootIdsToRemove.has(b.id))
           .map((b) => {
-            // If this is a section with nested blocks to remove/insert, update it
             if (
               isSectionBlock(b.block) &&
               (nestedToRemove.has(b.id) || (insertIntoSection && b.id === firstParsed.sectionId))
@@ -1339,10 +1328,8 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
               const indicesToRemove = new Set(nestedToRemove.get(b.id) || []);
               let newSectionBlocks = b.block.blocks.filter((_, i) => !indicesToRemove.has(i));
 
-              // If inserting into this section, add at the position of the first removed block
               if (insertIntoSection && b.id === firstParsed.sectionId) {
                 const insertIdx = firstParsed.nestedIndex!;
-                // Count how many blocks before insertIdx were removed
                 const removedBefore = Array.from(indicesToRemove).filter((i) => i < insertIdx).length;
                 const adjustedIdx = insertIdx - removedBefore;
                 newSectionBlocks.splice(adjustedIdx, 0, multistepBlock);
@@ -1356,16 +1343,13 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
             return b;
           });
 
-        // If not inserting into a section, insert at root level
         if (!insertIntoSection) {
           const newEditorBlock: EditorBlock = {
             id: generateBlockId(),
             block: multistepBlock,
           };
 
-          // Find where to insert at root level
           let insertIndex = prev.blocks.findIndex((b) => b.id === firstParsed.id);
-          // Adjust for removed blocks before this index
           const removedBeforeInsert = prev.blocks.filter((b, i) => i < insertIndex && rootIdsToRemove.has(b.id)).length;
           insertIndex -= removedBeforeInsert;
 
@@ -1436,14 +1420,11 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
           steps,
         };
 
-        // Determine where to insert based on first selected block
-        const firstParsed = parsedBlocks[0];
+        const firstParsed = parsedBlocks[0]!;
         const insertIntoSection = firstParsed.isNested && firstParsed.sectionId;
 
-        // Remove root-level blocks that were merged
         const rootIdsToRemove = new Set(parsedBlocks.filter((p) => !p.isNested).map((p) => p.id));
 
-        // Group nested blocks by section for removal
         const nestedToRemove = new Map<string, number[]>();
         parsedBlocks
           .filter((p) => p.isNested && p.sectionId !== undefined && p.nestedIndex !== undefined)
@@ -1453,11 +1434,9 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
             nestedToRemove.set(p.sectionId!, existing);
           });
 
-        // Build new blocks array
         let newBlocks = prev.blocks
           .filter((b) => !rootIdsToRemove.has(b.id))
           .map((b) => {
-            // If this is a section with nested blocks to remove/insert, update it
             if (
               isSectionBlock(b.block) &&
               (nestedToRemove.has(b.id) || (insertIntoSection && b.id === firstParsed.sectionId))
@@ -1465,10 +1444,8 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
               const indicesToRemove = new Set(nestedToRemove.get(b.id) || []);
               let newSectionBlocks = b.block.blocks.filter((_, i) => !indicesToRemove.has(i));
 
-              // If inserting into this section, add at the position of the first removed block
               if (insertIntoSection && b.id === firstParsed.sectionId) {
                 const insertIdx = firstParsed.nestedIndex!;
-                // Count how many blocks before insertIdx were removed
                 const removedBefore = Array.from(indicesToRemove).filter((i) => i < insertIdx).length;
                 const adjustedIdx = insertIdx - removedBefore;
                 newSectionBlocks.splice(adjustedIdx, 0, guidedBlock);
@@ -1482,16 +1459,13 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
             return b;
           });
 
-        // If not inserting into a section, insert at root level
         if (!insertIntoSection) {
           const newEditorBlock: EditorBlock = {
             id: generateBlockId(),
             block: guidedBlock,
           };
 
-          // Find where to insert at root level
           let insertIndex = prev.blocks.findIndex((b) => b.id === firstParsed.id);
-          // Adjust for removed blocks before this index
           const removedBeforeInsert = prev.blocks.filter((b, i) => i < insertIndex && rootIdsToRemove.has(b.id)).length;
           insertIndex -= removedBeforeInsert;
 

--- a/src/components/block-editor/hooks/useRecordingActions.ts
+++ b/src/components/block-editor/hooks/useRecordingActions.ts
@@ -110,7 +110,7 @@ export function useRecordingActions(deps: RecordingActionsDependencies): UseReco
       const processed = groupRecordedStepsByGroupId(steps);
       processed.forEach((item) => {
         if (item.type === 'single') {
-          const interactiveBlock = convertStepToInteractiveBlock(item.steps[0]);
+          const interactiveBlock = convertStepToInteractiveBlock(item.steps[0]!);
           editor.addBlockToSection(interactiveBlock, sectionId);
         } else {
           const multistepBlock = convertStepsToMultistepBlock(item.steps);
@@ -128,7 +128,7 @@ export function useRecordingActions(deps: RecordingActionsDependencies): UseReco
       const processed = groupRecordedStepsByGroupId(steps);
       processed.forEach((item) => {
         if (item.type === 'single') {
-          const interactiveBlock = convertStepToInteractiveBlock(item.steps[0]);
+          const interactiveBlock = convertStepToInteractiveBlock(item.steps[0]!);
           editor.addBlockToConditionalBranch(conditionalId, branch, interactiveBlock);
         } else {
           const multistepBlock = convertStepsToMultistepBlock(item.steps);

--- a/src/components/block-editor/utils/block-conversion.test.ts
+++ b/src/components/block-editor/utils/block-conversion.test.ts
@@ -288,7 +288,7 @@ describe('convertBlockType', () => {
       const multistepResult = result as { steps: Array<{ action: string }> };
       expect(multistepResult.steps).toBeDefined();
       expect(multistepResult.steps.length).toBeGreaterThan(0);
-      expect(multistepResult.steps[0].action).toBe('noop');
+      expect(multistepResult.steps[0]!.action).toBe('noop');
     });
 
     it('should apply default steps when converting to guided', () => {
@@ -297,7 +297,7 @@ describe('convertBlockType', () => {
       const guidedResult = result as { steps: Array<{ action: string }> };
       expect(guidedResult.steps).toBeDefined();
       expect(guidedResult.steps.length).toBeGreaterThan(0);
-      expect(guidedResult.steps[0].action).toBe('noop');
+      expect(guidedResult.steps[0]!.action).toBe('noop');
     });
   });
 

--- a/src/components/block-editor/utils/block-preview.ts
+++ b/src/components/block-editor/utils/block-preview.ts
@@ -53,7 +53,7 @@ export function getBlockPreview(block: JsonBlock, options: BlockPreviewOptions =
   const { maxLength, noTargetText } = { ...DEFAULT_OPTIONS, ...options };
 
   if (isMarkdownBlock(block)) {
-    const firstLine = block.content.split('\n')[0];
+    const firstLine = block.content.split('\n')[0] ?? '';
     return truncate(firstLine, maxLength);
   }
 

--- a/src/components/block-editor/utils/json-position.test.ts
+++ b/src/components/block-editor/utils/json-position.test.ts
@@ -134,8 +134,8 @@ describe('addPositionsToErrors', () => {
     const errors = [{ message: 'Invalid type', path: ['blocks', 0, 'type'] }];
     const result = addPositionsToErrors(errors, json);
     expect(result).toHaveLength(1);
-    expect(result[0].line).toBe(3);
-    expect(result[0].message).toBe('Invalid type');
+    expect(result[0]!.line).toBe(3);
+    expect(result[0]!.message).toBe('Invalid type');
   });
 
   it('returns parse error when JSON is invalid', () => {
@@ -144,8 +144,8 @@ describe('addPositionsToErrors', () => {
     const result = addPositionsToErrors(errors, json);
     // Should return the parse error, not the validation error
     expect(result).toHaveLength(1);
-    expect(result[0].line).toBe(1);
-    expect(result[0].path).toEqual([]);
+    expect(result[0]!.line).toBe(1);
+    expect(result[0]!.path).toEqual([]);
   });
 
   it('handles errors with paths that do not exist in JSON', () => {
@@ -153,8 +153,8 @@ describe('addPositionsToErrors', () => {
     const errors = [{ message: 'Missing field', path: ['blocks', 0, 'type'] }];
     const result = addPositionsToErrors(errors, json);
     expect(result).toHaveLength(1);
-    expect(result[0].line).toBeUndefined();
-    expect(result[0].message).toBe('Missing field');
+    expect(result[0]!.line).toBeUndefined();
+    expect(result[0]!.message).toBe('Missing field');
   });
 
   it('enriches multiple errors with positions', () => {
@@ -170,9 +170,9 @@ describe('addPositionsToErrors', () => {
     ];
     const result = addPositionsToErrors(errors, json);
     expect(result).toHaveLength(3);
-    expect(result[0].line).toBe(2);
-    expect(result[1].line).toBe(3);
-    expect(result[2].line).toBe(4);
+    expect(result[0]!.line).toBe(2);
+    expect(result[1]!.line).toBe(3);
+    expect(result[2]!.line).toBe(4);
   });
 });
 

--- a/src/components/block-editor/utils/json-position.ts
+++ b/src/components/block-editor/utils/json-position.ts
@@ -25,7 +25,7 @@ function offsetToPosition(text: string, offset: number): { line: number; column:
   const lines = beforeOffset.split('\n');
   return {
     line: lines.length,
-    column: lines[lines.length - 1].length + 1,
+    column: (lines[lines.length - 1] ?? '').length + 1,
   };
 }
 
@@ -72,7 +72,7 @@ export function parseWithPositions(jsonString: string): ParseWithPositionsResult
 
   // If there are parse errors, return the first one with position
   if (parseErrors.length > 0) {
-    const error = parseErrors[0];
+    const error = parseErrors[0]!;
     const position = offsetToPosition(jsonString, error.offset);
     return {
       parseError: {

--- a/src/components/block-editor/utils/json-roundtrip.test.ts
+++ b/src/components/block-editor/utils/json-roundtrip.test.ts
@@ -349,8 +349,8 @@ describe('JSON Round-trip Conversion', () => {
       expect(multistep.type).toBe('multistep');
       expect(multistep.content).toBe('Follow these steps to configure the dashboard');
       expect(multistep.steps).toHaveLength(3);
-      expect(multistep.steps[0].action).toBe('button');
-      expect(multistep.steps[1].targetvalue).toBe('My Panel');
+      expect(multistep.steps[0]!.action).toBe('button');
+      expect(multistep.steps[1]!.targetvalue).toBe('My Panel');
       expect(multistep.requirements).toEqual(['on-page:/dashboard']);
     });
 
@@ -382,7 +382,7 @@ describe('JSON Round-trip Conversion', () => {
       const { result } = roundTrip(guide);
       expect(result.isValid).toBe(true);
       const multistep = result.guide?.blocks[0] as JsonMultistepBlock;
-      const step = multistep.steps[0];
+      const step = multistep.steps[0]!;
       expect(step.requirements).toEqual(['element-visible:input']);
       expect(step.tooltip).toBe('Enter search term');
       expect(step.description).toBe('Search for something');
@@ -447,7 +447,7 @@ describe('JSON Round-trip Conversion', () => {
       expect(quiz.type).toBe('quiz');
       expect(quiz.question).toBe('What is the capital of France?');
       expect(quiz.choices).toHaveLength(3);
-      expect(quiz.choices[1].correct).toBe(true);
+      expect(quiz.choices[1]!.correct).toBe(true);
       expect(quiz.completionMode).toBe('max-attempts');
       expect(quiz.maxAttempts).toBe(3);
     });

--- a/src/components/block-editor/utils/recorded-steps-processor.test.ts
+++ b/src/components/block-editor/utils/recorded-steps-processor.test.ts
@@ -27,8 +27,8 @@ describe('groupRecordedStepsByGroupId', () => {
     const result = groupRecordedStepsByGroupId(steps);
 
     expect(result).toHaveLength(2);
-    expect(result[0].type).toBe('single');
-    expect(result[1].type).toBe('single');
+    expect(result[0]!.type).toBe('single');
+    expect(result[1]!.type).toBe('single');
   });
 
   it('groups consecutive steps with same groupId', () => {
@@ -40,8 +40,8 @@ describe('groupRecordedStepsByGroupId', () => {
     const result = groupRecordedStepsByGroupId(steps);
 
     expect(result).toHaveLength(1);
-    expect(result[0].type).toBe('group');
-    expect(result[0].steps).toHaveLength(3);
+    expect(result[0]!.type).toBe('group');
+    expect(result[0]!.steps).toHaveLength(3);
   });
 
   it('separates different groupIds into different groups', () => {
@@ -54,10 +54,10 @@ describe('groupRecordedStepsByGroupId', () => {
     const result = groupRecordedStepsByGroupId(steps);
 
     expect(result).toHaveLength(2);
-    expect(result[0].type).toBe('group');
-    expect(result[0].steps).toHaveLength(2);
-    expect(result[1].type).toBe('group');
-    expect(result[1].steps).toHaveLength(2);
+    expect(result[0]!.type).toBe('group');
+    expect(result[0]!.steps).toHaveLength(2);
+    expect(result[1]!.type).toBe('group');
+    expect(result[1]!.steps).toHaveLength(2);
   });
 
   it('handles alternating grouped and ungrouped steps', () => {
@@ -71,12 +71,12 @@ describe('groupRecordedStepsByGroupId', () => {
     const result = groupRecordedStepsByGroupId(steps);
 
     expect(result).toHaveLength(4);
-    expect(result[0].type).toBe('single');
-    expect(result[1].type).toBe('group');
-    expect(result[1].steps).toHaveLength(2);
-    expect(result[2].type).toBe('single');
-    expect(result[3].type).toBe('group');
-    expect(result[3].steps).toHaveLength(1);
+    expect(result[0]!.type).toBe('single');
+    expect(result[1]!.type).toBe('group');
+    expect(result[1]!.steps).toHaveLength(2);
+    expect(result[2]!.type).toBe('single');
+    expect(result[3]!.type).toBe('group');
+    expect(result[3]!.steps).toHaveLength(1);
   });
 
   it('handles single step in a group', () => {
@@ -84,8 +84,8 @@ describe('groupRecordedStepsByGroupId', () => {
     const result = groupRecordedStepsByGroupId(steps);
 
     expect(result).toHaveLength(1);
-    expect(result[0].type).toBe('group');
-    expect(result[0].steps).toHaveLength(1);
+    expect(result[0]!.type).toBe('group');
+    expect(result[0]!.steps).toHaveLength(1);
   });
 
   it('handles group at end of sequence', () => {
@@ -93,9 +93,9 @@ describe('groupRecordedStepsByGroupId', () => {
     const result = groupRecordedStepsByGroupId(steps);
 
     expect(result).toHaveLength(2);
-    expect(result[0].type).toBe('single');
-    expect(result[1].type).toBe('group');
-    expect(result[1].steps).toHaveLength(2);
+    expect(result[0]!.type).toBe('single');
+    expect(result[1]!.type).toBe('group');
+    expect(result[1]!.steps).toHaveLength(2);
   });
 });
 
@@ -160,10 +160,10 @@ describe('convertStepsToMultistepBlock', () => {
     ];
     const block = convertStepsToMultistepBlock(steps);
 
-    expect(block.steps[0].action).toBe('fill');
-    expect(block.steps[0].reftarget).toBe('[data-testid="input"]');
-    expect(block.steps[0].targetvalue).toBe('hello');
-    expect(block.steps[0].tooltip).toBe('Fill input');
+    expect(block.steps[0]!.action).toBe('fill');
+    expect(block.steps[0]!.reftarget).toBe('[data-testid="input"]');
+    expect(block.steps[0]!.targetvalue).toBe('hello');
+    expect(block.steps[0]!.tooltip).toBe('Fill input');
   });
 
   it('uses fallback description for content when first step has no description', () => {
@@ -177,7 +177,7 @@ describe('convertStepsToMultistepBlock', () => {
     const steps = [makeStep({ description: undefined, action: 'hover' })];
     const block = convertStepsToMultistepBlock(steps);
 
-    expect(block.steps[0].tooltip).toBe('hover on element');
+    expect(block.steps[0]!.tooltip).toBe('hover on element');
   });
 });
 
@@ -187,7 +187,7 @@ describe('convertProcessedStepsToBlocks', () => {
     const blocks = convertProcessedStepsToBlocks(processed);
 
     expect(blocks).toHaveLength(1);
-    expect(blocks[0].type).toBe('interactive');
+    expect(blocks[0]!.type).toBe('interactive');
   });
 
   it('converts groups to multistep blocks', () => {
@@ -195,7 +195,7 @@ describe('convertProcessedStepsToBlocks', () => {
     const blocks = convertProcessedStepsToBlocks(processed);
 
     expect(blocks).toHaveLength(1);
-    expect(blocks[0].type).toBe('multistep');
+    expect(blocks[0]!.type).toBe('multistep');
   });
 
   it('handles mixed singles and groups', () => {
@@ -207,9 +207,9 @@ describe('convertProcessedStepsToBlocks', () => {
     const blocks = convertProcessedStepsToBlocks(processed);
 
     expect(blocks).toHaveLength(3);
-    expect(blocks[0].type).toBe('interactive');
-    expect(blocks[1].type).toBe('multistep');
-    expect(blocks[2].type).toBe('interactive');
+    expect(blocks[0]!.type).toBe('interactive');
+    expect(blocks[1]!.type).toBe('multistep');
+    expect(blocks[2]!.type).toBe('interactive');
   });
 
   it('returns empty array for empty input', () => {

--- a/src/components/block-editor/utils/recorded-steps-processor.ts
+++ b/src/components/block-editor/utils/recorded-steps-processor.ts
@@ -86,7 +86,7 @@ export function convertStepsToMultistepBlock(steps: RecordedStep[]): JsonMultist
 
   return {
     type: 'multistep',
-    content: steps[0].description || 'Complete the following steps',
+    content: steps[0]?.description || 'Complete the following steps',
     steps: multistepSteps,
   };
 }
@@ -99,7 +99,7 @@ export function convertProcessedStepsToBlocks(
 ): Array<JsonInteractiveBlock | JsonMultistepBlock> {
   return processedSteps.map((item) => {
     if (item.type === 'single') {
-      return convertStepToInteractiveBlock(item.steps[0]);
+      return convertStepToInteractiveBlock(item.steps[0]!);
     } else {
       return convertStepsToMultistepBlock(item.steps);
     }

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -333,10 +333,10 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     if (this.state.activeTabId === tabId) {
       if (tabIndex > 0 && tabIndex < currentTabs.length - 1) {
         // Choose the next tab if available
-        newActiveTabId = currentTabs[tabIndex + 1].id;
+        newActiveTabId = currentTabs[tabIndex + 1]!.id;
       } else if (tabIndex > 0) {
         // Choose the previous tab if at the end
-        newActiveTabId = currentTabs[tabIndex - 1].id;
+        newActiveTabId = currentTabs[tabIndex - 1]!.id;
       } else {
         // Default to recommendations if only tab
         newActiveTabId = 'recommendations';
@@ -716,7 +716,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   React.useEffect(() => {
     // Only restore if we haven't loaded tabs yet
     // Check if tabs only contain the default system tab (recommendations)
-    const hasOnlyDefaultTabs = tabs.length === 1 && tabs[0].id === 'recommendations';
+    const hasOnlyDefaultTabs = tabs.length === 1 && tabs[0]?.id === 'recommendations';
 
     if (hasOnlyDefaultTabs) {
       model.restoreTabsAsync();

--- a/src/components/docs-panel/hooks/useBadgeCelebrationQueue.ts
+++ b/src/components/docs-panel/hooks/useBadgeCelebrationQueue.ts
@@ -26,7 +26,7 @@ export function useBadgeCelebrationQueue(): UseBadgeCelebrationQueueResult {
         () => {
           const [nextBadge, ...remaining] = badgeCelebrationQueue;
           setBadgeCelebrationQueue(remaining);
-          setCurrentCelebrationBadge(nextBadge);
+          setCurrentCelebrationBadge(nextBadge ?? null);
           isProcessingQueueRef.current = false;
         },
         currentCelebrationBadge === null ? 0 : 500

--- a/src/components/docs-panel/keyboard-shortcuts.hook.test.ts
+++ b/src/components/docs-panel/keyboard-shortcuts.hook.test.ts
@@ -31,7 +31,7 @@ describe('useKeyboardShortcuts', () => {
       useKeyboardShortcuts({
         tabs: mockTabs,
         activeTabId: 'tab1',
-        activeTab: mockTabs[0],
+        activeTab: mockTabs[0]!,
         isRecommendationsTab: false,
         model: mockModel,
       })
@@ -48,7 +48,7 @@ describe('useKeyboardShortcuts', () => {
       useKeyboardShortcuts({
         tabs: mockTabs,
         activeTabId: 'recommendations',
-        activeTab: mockTabs[2],
+        activeTab: mockTabs[2]!,
         isRecommendationsTab: true,
         model: mockModel,
       })
@@ -64,7 +64,7 @@ describe('useKeyboardShortcuts', () => {
       useKeyboardShortcuts({
         tabs: mockTabs,
         activeTabId: 'tab1',
-        activeTab: mockTabs[0],
+        activeTab: mockTabs[0]!,
         isRecommendationsTab: false,
         model: mockModel,
       })
@@ -85,7 +85,7 @@ describe('useKeyboardShortcuts', () => {
       useKeyboardShortcuts({
         tabs: mockTabs,
         activeTabId: 'tab1',
-        activeTab: mockTabs[0],
+        activeTab: mockTabs[0]!,
         isRecommendationsTab: false,
         model: mockModel,
       })
@@ -105,7 +105,7 @@ describe('useKeyboardShortcuts', () => {
       useKeyboardShortcuts({
         tabs: mockTabs,
         activeTabId: 'recommendations',
-        activeTab: mockTabs[2],
+        activeTab: mockTabs[2]!,
         isRecommendationsTab: true,
         model: mockModel,
       })

--- a/src/components/docs-panel/keyboard-shortcuts.hook.ts
+++ b/src/components/docs-panel/keyboard-shortcuts.hook.ts
@@ -39,7 +39,7 @@ export function useKeyboardShortcuts({
         const nextIndex = event.shiftKey
           ? (currentIndex - 1 + tabs.length) % tabs.length
           : (currentIndex + 1) % tabs.length;
-        model.setActiveTab(tabs[nextIndex].id);
+        model.setActiveTab(tabs[nextIndex]!.id);
       }
 
       // Arrow keys for milestone navigation (only for learning journey tabs)

--- a/src/components/docs-panel/link-handler.hook.ts
+++ b/src/components/docs-panel/link-handler.hook.ts
@@ -80,8 +80,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
         ) {
           // Fallback: use the first milestone from content metadata
           const firstMilestone = activeTab.content.metadata.learningJourney.milestones[0];
-          if (firstMilestone.url) {
-            // Track analytics for fallback case
+          if (firstMilestone?.url) {
             reportAppInteraction(UserInteraction.StartLearningJourneyClick, {
               content_title: activeTab.title,
               content_url: activeTab.baseUrl,

--- a/src/components/docs-panel/utils/tab-storage-restore.test.ts
+++ b/src/components/docs-panel/utils/tab-storage-restore.test.ts
@@ -59,7 +59,7 @@ describe('tab-storage-restore', () => {
       const tabs = await restoreTabsFromStorage(storage, { isDevMode: false });
 
       expect(tabs).toHaveLength(1);
-      expect(tabs[0].id).toBe('recommendations');
+      expect(tabs[0]!.id).toBe('recommendations');
     });
 
     it('should return recommendations tab when storage returns empty array', async () => {
@@ -67,7 +67,7 @@ describe('tab-storage-restore', () => {
       const tabs = await restoreTabsFromStorage(storage, { isDevMode: false });
 
       expect(tabs).toHaveLength(1);
-      expect(tabs[0].id).toBe('recommendations');
+      expect(tabs[0]!.id).toBe('recommendations');
     });
 
     it('should restore valid learning journey tabs', async () => {
@@ -85,12 +85,12 @@ describe('tab-storage-restore', () => {
       const tabs = await restoreTabsFromStorage(storage, { isDevMode: false });
 
       expect(tabs).toHaveLength(2); // recommendations + restored tab
-      expect(tabs[0].id).toBe('recommendations');
-      expect(tabs[1].id).toBe('tab-1');
-      expect(tabs[1].title).toBe('Test Journey');
-      expect(tabs[1].baseUrl).toBe('https://grafana.com/docs/grafana/latest/test/');
-      expect(tabs[1].currentUrl).toBe('https://grafana.com/docs/grafana/latest/test/page1/');
-      expect(tabs[1].type).toBe('learning-journey');
+      expect(tabs[0]!.id).toBe('recommendations');
+      expect(tabs[1]!.id).toBe('tab-1');
+      expect(tabs[1]!.title).toBe('Test Journey');
+      expect(tabs[1]!.baseUrl).toBe('https://grafana.com/docs/grafana/latest/test/');
+      expect(tabs[1]!.currentUrl).toBe('https://grafana.com/docs/grafana/latest/test/page1/');
+      expect(tabs[1]!.type).toBe('learning-journey');
     });
 
     it('should restore devtools tab without URL validation', async () => {
@@ -108,8 +108,8 @@ describe('tab-storage-restore', () => {
       const tabs = await restoreTabsFromStorage(storage, { isDevMode: false });
 
       expect(tabs).toHaveLength(2); // recommendations + devtools
-      expect(tabs[1].id).toBe('devtools');
-      expect(tabs[1].type).toBe('devtools');
+      expect(tabs[1]!.id).toBe('devtools');
+      expect(tabs[1]!.type).toBe('devtools');
     });
 
     it('should reject tabs with invalid base URL', async () => {
@@ -128,7 +128,7 @@ describe('tab-storage-restore', () => {
 
       // Should only have recommendations tab (malicious tab rejected)
       expect(tabs).toHaveLength(1);
-      expect(tabs[0].id).toBe('recommendations');
+      expect(tabs[0]!.id).toBe('recommendations');
     });
 
     it('should reject tabs with invalid current URL', async () => {
@@ -147,7 +147,7 @@ describe('tab-storage-restore', () => {
 
       // Should only have recommendations tab (malicious current URL rejected)
       expect(tabs).toHaveLength(1);
-      expect(tabs[0].id).toBe('recommendations');
+      expect(tabs[0]!.id).toBe('recommendations');
     });
 
     it('should allow localhost URLs in dev mode', async () => {
@@ -165,7 +165,7 @@ describe('tab-storage-restore', () => {
       const tabs = await restoreTabsFromStorage(storage, { isDevMode: true });
 
       expect(tabs).toHaveLength(2); // recommendations + localhost tab
-      expect(tabs[1].baseUrl).toBe('http://localhost:3000/test');
+      expect(tabs[1]!.baseUrl).toBe('http://localhost:3000/test');
     });
 
     it('should reject localhost URLs when dev mode is disabled', async () => {
@@ -184,7 +184,7 @@ describe('tab-storage-restore', () => {
 
       // Should only have recommendations tab (localhost rejected)
       expect(tabs).toHaveLength(1);
-      expect(tabs[0].id).toBe('recommendations');
+      expect(tabs[0]!.id).toBe('recommendations');
     });
 
     it('should restore multiple valid tabs', async () => {
@@ -231,7 +231,7 @@ describe('tab-storage-restore', () => {
 
       // Should return default recommendations tab on error
       expect(tabs).toHaveLength(1);
-      expect(tabs[0].id).toBe('recommendations');
+      expect(tabs[0]!.id).toBe('recommendations');
     });
 
     it('should use baseUrl as currentUrl when currentUrl is missing', async () => {
@@ -248,7 +248,7 @@ describe('tab-storage-restore', () => {
       const storage = createMockTabStorage(persistedTabs);
       const tabs = await restoreTabsFromStorage(storage, { isDevMode: false });
 
-      expect(tabs[1].currentUrl).toBe('https://grafana.com/docs/grafana/latest/test/');
+      expect(tabs[1]!.currentUrl).toBe('https://grafana.com/docs/grafana/latest/test/');
     });
 
     it('should default to learning-journey type when type is missing', async () => {
@@ -265,7 +265,7 @@ describe('tab-storage-restore', () => {
       const storage = createMockTabStorage(persistedTabs);
       const tabs = await restoreTabsFromStorage(storage, { isDevMode: false });
 
-      expect(tabs[1].type).toBe('learning-journey');
+      expect(tabs[1]!.type).toBe('learning-journey');
     });
   });
 

--- a/src/components/docs-panel/utils/tab-visibility.ts
+++ b/src/components/docs-panel/utils/tab-visibility.ts
@@ -58,7 +58,7 @@ export function computeTabVisibility(
   const activeGuideTabIndex = guideTabs.findIndex((t) => t.id === activeTabId);
 
   if (activeGuideTabIndex >= maxVisibleGuideTabs) {
-    const visibleGuideTabsArray = [...guideTabs.slice(0, maxVisibleGuideTabs - 1), guideTabs[activeGuideTabIndex]];
+    const visibleGuideTabsArray = [...guideTabs.slice(0, maxVisibleGuideTabs - 1), guideTabs[activeGuideTabIndex]!];
     const overflowGuideTabsArray = [
       ...guideTabs.slice(maxVisibleGuideTabs - 1, activeGuideTabIndex),
       ...guideTabs.slice(activeGuideTabIndex + 1),

--- a/src/context-engine/context-security.test.ts
+++ b/src/context-engine/context-security.test.ts
@@ -562,7 +562,7 @@ describe('Security: Recommender Service URL Validation', () => {
 
       // Recommendations may be filtered or empty due to processing logic
       if (result.recommendations.length > 0) {
-        const rec = result.recommendations[0];
+        const rec = result.recommendations[0]!;
         expect(rec.summary).not.toContain('onerror');
         expect(rec.summary).not.toContain('<img');
       }
@@ -615,8 +615,8 @@ describe('Security: Recommender Service URL Validation', () => {
       expect(result).toBeDefined();
       // If recommendations exist, they should have sanitized fields
       if (result.recommendations.length > 0) {
-        expect(result.recommendations[0].title).toBeDefined();
-        expect(result.recommendations[0].summary).toBeDefined();
+        expect(result.recommendations[0]!.title).toBeDefined();
+        expect(result.recommendations[0]!.summary).toBeDefined();
       }
     });
   });

--- a/src/context-engine/context.service.ts
+++ b/src/context-engine/context.service.ts
@@ -925,7 +925,7 @@ export class ContextService {
       a: 'app',
     };
 
-    return entityMap[pathSegments[0]] || null;
+    return entityMap[pathSegments[0]!] ?? null;
   }
 
   /**

--- a/src/docs-retrieval/components/docs/youtube-video-renderer.tsx
+++ b/src/docs-retrieval/components/docs/youtube-video-renderer.tsx
@@ -53,7 +53,7 @@ export function YouTubeVideoRenderer({
     // Removed .* pattern in favor of more constrained alternatives
     const regex = /(?:youtube\.com\/(?:embed\/|watch\?.*v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
     const match = url.match(regex);
-    return match ? match[1] : null;
+    return match ? (match[1] ?? null) : null;
   }, []);
 
   // Get document info for analytics

--- a/src/docs-retrieval/components/interactive/data-attributes.contract.test.tsx
+++ b/src/docs-retrieval/components/interactive/data-attributes.contract.test.tsx
@@ -640,9 +640,9 @@ describe('E2E Contract: data-internal-actions', () => {
       expect(action).toHaveProperty('targetComment');
 
       // Verify against original data
-      expect(action.targetAction).toBe(mockInternalActions[index].targetAction);
-      expect(action.refTarget).toBe(mockInternalActions[index].refTarget);
-      expect(action.targetComment).toBe(mockInternalActions[index].targetComment);
+      expect(action.targetAction).toBe(mockInternalActions[index]!.targetAction);
+      expect(action.refTarget).toBe(mockInternalActions[index]!.refTarget);
+      expect(action.targetComment).toBe(mockInternalActions[index]!.targetComment);
     });
   });
 

--- a/src/docs-retrieval/components/interactive/interactive-guided.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-guided.tsx
@@ -213,8 +213,8 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
 
     // For exists-reftarget requirement, use the first internal action's target
     // This ensures the requirement checker knows which element to look for
-    const firstActionRefTarget = internalActions.length > 0 ? internalActions[0].refTarget : undefined;
-    const firstActionTargetAction = internalActions.length > 0 ? internalActions[0].targetAction : undefined;
+    const firstActionRefTarget = internalActions.length > 0 ? internalActions[0]!.refTarget : undefined;
+    const firstActionTargetAction = internalActions.length > 0 ? internalActions[0]!.targetAction : undefined;
 
     // Runtime validation: check for impossible requirement configurations
     useEffect(() => {
@@ -300,7 +300,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
           setCurrentStepStatus('waiting');
 
           // Execute guided step and wait for user completion
-          const result = await guidedHandler.executeGuidedStep(action, i, internalActions.length, stepTimeout);
+          const result = await guidedHandler.executeGuidedStep(action!, i, internalActions.length, stepTimeout);
 
           if (result === 'completed' || result === 'skipped') {
             setCurrentStepStatus('completed');

--- a/src/docs-retrieval/components/interactive/interactive-multi-step.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-multi-step.tsx
@@ -191,8 +191,8 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
 
     // For exists-reftarget requirement, use the first internal action's target
     // This ensures the requirement checker knows which element to look for
-    const firstActionRefTarget = internalActions.length > 0 ? internalActions[0].refTarget : undefined;
-    const firstActionTargetAction = internalActions.length > 0 ? internalActions[0].targetAction : undefined;
+    const firstActionRefTarget = internalActions.length > 0 ? internalActions[0]!.refTarget : undefined;
+    const firstActionTargetAction = internalActions.length > 0 ? internalActions[0]!.targetAction : undefined;
 
     // Get the interactive functions from the hook
     const {
@@ -312,7 +312,7 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
       try {
         // Execute each internal action in sequence
         for (let i = 0; i < internalActions.length; i++) {
-          const action = internalActions[i];
+          const action = internalActions[i]!;
 
           // Check for cancellation before each action
           if (isCancelledRef.current) {

--- a/src/docs-retrieval/components/interactive/interactive-quiz.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-quiz.tsx
@@ -151,7 +151,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
       if (selectedIds.size !== 1) {
         return false;
       }
-      return correctIds.has(Array.from(selectedIds)[0]);
+      return correctIds.has(Array.from(selectedIds)[0]!);
     }
   }, [selectedIds, correctIds, multiSelect]);
 

--- a/src/docs-retrieval/components/interactive/interactive-section.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-section.tsx
@@ -705,7 +705,7 @@ export function InteractiveSection({
 
         // Remove the target step and all steps after it
         for (let i = resetIndex; i < stepComponents.length; i++) {
-          const stepToRemove = stepComponents[i].stepId;
+          const stepToRemove = stepComponents[i]!.stepId;
           newSet.delete(stepToRemove);
         }
 
@@ -912,7 +912,7 @@ export function InteractiveSection({
           break;
         }
 
-        const stepInfo = stepComponents[i];
+        const stepInfo = stepComponents[i]!;
 
         // PAUSE: If this is a guided step, stop automated execution
         // User must manually click the guided step's "Do it" button

--- a/src/docs-retrieval/content-fetcher.ts
+++ b/src/docs-retrieval/content-fetcher.ts
@@ -562,7 +562,7 @@ interface FetchRawResult {
  */
 function isJsonContentUrl(url: string): boolean {
   // Check the URL path, ignoring query params and fragments
-  const urlPath = url.split('?')[0].split('#')[0];
+  const urlPath = url.split('?')[0]!.split('#')[0]!;
   return urlPath.endsWith('.json') || urlPath.endsWith('/content.json');
 }
 
@@ -902,7 +902,7 @@ function generateInteractiveLearningVariations(url: string): string[] {
   }
 
   // Clean the URL path (remove trailing slash)
-  const baseUrl = url.split('?')[0].split('#')[0].replace(/\/$/, '');
+  const baseUrl = url.split('?')[0]!.split('#')[0]!.replace(/\/$/, '');
 
   // If URL already points to content.json or unstyled.html, return as-is
   if (baseUrl.endsWith('/content.json') || baseUrl.endsWith('/unstyled.html')) {
@@ -921,7 +921,7 @@ function generateInteractiveLearningVariations(url: string): string[] {
  * Returns URLs to try in order of preference: JSON first, then HTML
  */
 function getContentUrls(url: string): { jsonUrl: string; htmlUrl: string } {
-  const baseUrl = url.split('?')[0].split('#')[0].replace(/\/$/, '');
+  const baseUrl = url.split('?')[0]!.split('#')[0]!.replace(/\/$/, '');
 
   // If URL already points to a specific file, return it as-is for JSON detection
   if (url.includes('/content.json')) {
@@ -1060,17 +1060,17 @@ function getLearningJourneyBaseUrl(url: string): string {
 
   const learningJourneyMatch = url.match(/^(https?:\/\/[^\/]+\/docs\/learning-journeys\/[^\/]+)/);
   if (learningJourneyMatch) {
-    return learningJourneyMatch[1];
+    return learningJourneyMatch[1]!;
   }
 
   const learningPathMatch = url.match(/^(https?:\/\/[^\/]+\/docs\/learning-paths\/[^\/]+)/);
   if (learningPathMatch) {
-    return learningPathMatch[1];
+    return learningPathMatch[1]!;
   }
 
   const tutorialMatch = url.match(/^(https?:\/\/[^\/]+\/tutorials\/[^\/]+)/);
   if (tutorialMatch) {
-    return tutorialMatch[1];
+    return tutorialMatch[1]!;
   }
 
   return url.replace(/\/milestone-\d+.*$/, '').replace(/\/$/, '');
@@ -1154,7 +1154,7 @@ function findCurrentMilestoneFromUrl(url: string, milestones: Milestone[]): numb
   // Legacy pattern matching for milestone URLs
   const milestoneMatch = cleanUrl.match(/\/milestone-(\d+)/);
   if (milestoneMatch) {
-    const milestoneNum = parseInt(milestoneMatch[1], 10);
+    const milestoneNum = parseInt(milestoneMatch[1]!, 10);
     return milestoneNum;
   }
 

--- a/src/docs-retrieval/content-renderer.tsx
+++ b/src/docs-retrieval/content-renderer.tsx
@@ -747,7 +747,7 @@ function TabsWrapper({ element }: { element: ParsedElement }) {
 
   React.useEffect(() => {
     if (tabsData.length > 0 && !activeTab) {
-      setActiveTab(tabsData[0].key);
+      setActiveTab(tabsData[0]!.key);
     }
   }, [tabsData, activeTab]);
 

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -126,7 +126,7 @@ export function parseJsonGuide(input: string | JsonGuide, baseUrl?: string): Con
   let hasAssistantElements = false;
 
   for (let i = 0; i < guide.blocks.length; i++) {
-    const block = guide.blocks[i];
+    const block = guide.blocks[i]!;
     try {
       // For assistant blocks, extract context from adjacent sibling blocks
       // This helps the AI understand the educational purpose of the content
@@ -361,7 +361,7 @@ function convertMarkdownBlock(block: JsonMarkdownBlock, path: string): Conversio
 
   // If only one element, return it directly
   if (elements.length === 1) {
-    return { element: elements[0] };
+    return { element: elements[0]! };
   }
 
   // Wrap multiple elements in a div
@@ -401,7 +401,7 @@ function convertHtmlBlock(block: JsonHtmlBlock, path: string, baseUrl?: string):
     // If only one element, return it directly
     if (elements.length === 1) {
       return {
-        element: elements[0],
+        element: elements[0]!,
         // Only show migration warning if no interactive elements detected
         warning: 'HTML blocks should be migrated to markdown/JSON blocks for better maintainability',
         hasInteractive: false,
@@ -433,7 +433,7 @@ function convertSectionBlock(block: JsonSectionBlock, path: string, baseUrl?: st
   const children: ParsedElement[] = [];
 
   for (let i = 0; i < block.blocks.length; i++) {
-    const childBlock = block.blocks[i];
+    const childBlock = block.blocks[i]!;
     const result = convertBlockToParsedElement(childBlock, `${path}.blocks[${i}]`, baseUrl);
     if (result.element) {
       children.push(result.element);
@@ -468,7 +468,7 @@ function convertConditionalBlock(block: JsonConditionalBlock, path: string, base
   // Convert whenTrue branch blocks
   const whenTrueChildren: ParsedElement[] = [];
   for (let i = 0; i < block.whenTrue.length; i++) {
-    const childBlock = block.whenTrue[i];
+    const childBlock = block.whenTrue[i]!;
     const result = convertBlockToParsedElement(childBlock, `${path}.whenTrue[${i}]`, baseUrl);
     if (result.element) {
       whenTrueChildren.push(result.element);
@@ -478,7 +478,7 @@ function convertConditionalBlock(block: JsonConditionalBlock, path: string, base
   // Convert whenFalse branch blocks
   const whenFalseChildren: ParsedElement[] = [];
   for (let i = 0; i < block.whenFalse.length; i++) {
-    const childBlock = block.whenFalse[i];
+    const childBlock = block.whenFalse[i]!;
     const result = convertBlockToParsedElement(childBlock, `${path}.whenFalse[${i}]`, baseUrl);
     if (result.element) {
       whenFalseChildren.push(result.element);
@@ -850,7 +850,7 @@ function convertAssistantBlock(
   let hasVideo = false;
 
   for (let i = 0; i < block.blocks.length; i++) {
-    const childBlock = block.blocks[i];
+    const childBlock = block.blocks[i]!;
     const childPath = `${path}.blocks[${i}]`;
 
     // Convert child block normally

--- a/src/docs-retrieval/validation-integration.test.ts
+++ b/src/docs-retrieval/validation-integration.test.ts
@@ -54,7 +54,7 @@ describe('Validation Integration Phase 1', () => {
       const result = parseJsonGuide(JSON.stringify(invalidGuide));
       expect(result.isValid).toBe(false);
       expect(result.errors.some((e) => e.message.includes('title'))).toBe(true);
-      expect(result.errors[0].type).toBe('schema_validation');
+      expect(result.errors[0]!.type).toBe('schema_validation');
     });
 
     it('should fail validation for guide with invalid blocks', () => {

--- a/src/global-state/utils.link-interception.ts
+++ b/src/global-state/utils.link-interception.ts
@@ -54,7 +54,7 @@ function extractTitle(url: string) {
     const urlObj = new URL(url);
     const pathSegments = urlObj.pathname.split('/').filter(Boolean);
     if (pathSegments.length > 0) {
-      const lastSegment = pathSegments[pathSegments.length - 1];
+      const lastSegment = pathSegments[pathSegments.length - 1]!;
       return lastSegment
         .split('-')
         .map((word) => word.charAt(0).toUpperCase() + word.slice(1))

--- a/src/integrations/assistant-integration/tools/datasource-metadata.tool.ts
+++ b/src/integrations/assistant-integration/tools/datasource-metadata.tool.ts
@@ -98,7 +98,7 @@ const findDatasource = (
   }
 
   // Return first supported datasource
-  return supported[0];
+  return supported[0] ?? null;
 };
 
 /**

--- a/src/integrations/assistant-integration/tools/grafana-context.tool.ts
+++ b/src/integrations/assistant-integration/tools/grafana-context.tool.ts
@@ -168,7 +168,7 @@ const formatContextForDisplay = (context: GrafanaContextArtifact): string => {
       if (!byType[ds.type]) {
         byType[ds.type] = [];
       }
-      byType[ds.type].push(ds.name);
+      byType[ds.type]!.push(ds.name);
     }
 
     for (const [type, names] of Object.entries(byType)) {

--- a/src/integrations/assistant-integration/useAssistantGeneration.hook.ts
+++ b/src/integrations/assistant-integration/useAssistantGeneration.hook.ts
@@ -199,7 +199,7 @@ export function cleanAssistantResponse(text: string): string {
 export function extractQueryFromResponse(text: string): string {
   const queryMatch = text.match(/QUERY:\s*(.+?)$/ms);
   if (queryMatch) {
-    let query = queryMatch[1].trim();
+    let query = queryMatch[1]!.trim();
     // Strip any surrounding backticks
     query = query.replace(/^`+|`+$/g, '');
     return query;

--- a/src/integrations/coda/useTerminalLive.hook.ts
+++ b/src/integrations/coda/useTerminalLive.hook.ts
@@ -145,7 +145,7 @@ export function useTerminalLive({ sessionId, terminalRef }: UseTerminalLiveOptio
   const executeCommand = useCallback(
     (terminal: Terminal, input: string): boolean => {
       const parts = input.split(/\s+/);
-      const cmd = parts[0].toLowerCase();
+      const cmd = parts[0]!.toLowerCase();
       const args = parts.slice(1).join(' ');
 
       // Handle special commands

--- a/src/integrations/workshop/action-replay.ts
+++ b/src/integrations/workshop/action-replay.ts
@@ -190,7 +190,7 @@ export class ActionReplaySystem {
       }
 
       // Use first matching element
-      const element = elements[0];
+      const element = elements[0]!;
 
       // Show highlight with comment
       // Pass false for enableAutoCleanup to keep highlight persistent until next action

--- a/src/interactive-engine/action-handlers/button-handler.test.ts
+++ b/src/interactive-engine/action-handlers/button-handler.test.ts
@@ -68,9 +68,9 @@ describe('ButtonHandler', () => {
 
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'running');
       expect(mockFindButtonByText).toHaveBeenCalledWith('test-button');
-      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockButtons[0]);
-      expect(mockNavigationManager.ensureElementVisible).toHaveBeenCalledWith(mockButtons[0]);
-      expect(mockNavigationManager.highlightWithComment).toHaveBeenCalledWith(mockButtons[0], undefined);
+      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockButtons[0]!);
+      expect(mockNavigationManager.ensureElementVisible).toHaveBeenCalledWith(mockButtons[0]!);
+      expect(mockNavigationManager.highlightWithComment).toHaveBeenCalledWith(mockButtons[0]!, undefined);
       expect(mockWaitForReactUpdates).not.toHaveBeenCalled(); // No completion in show mode
     });
 
@@ -79,9 +79,9 @@ describe('ButtonHandler', () => {
 
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'running');
       expect(mockFindButtonByText).toHaveBeenCalledWith('test-button');
-      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockButtons[0]);
-      expect(mockNavigationManager.ensureElementVisible).toHaveBeenCalledWith(mockButtons[0]);
-      expect(mockButtons[0].click).toHaveBeenCalled();
+      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockButtons[0]!);
+      expect(mockNavigationManager.ensureElementVisible).toHaveBeenCalledWith(mockButtons[0]!);
+      expect(mockButtons[0]!.click).toHaveBeenCalled();
       expect(mockWaitForReactUpdates).toHaveBeenCalled();
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'completed');
     });
@@ -102,7 +102,7 @@ describe('ButtonHandler', () => {
 
       await buttonHandler.execute(mockData, false);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible:', mockButtons[0]);
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible:', mockButtons[0]!);
       expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalled();
       expect(mockNavigationManager.highlightWithComment).toHaveBeenCalled();
     });
@@ -112,8 +112,8 @@ describe('ButtonHandler', () => {
 
       await buttonHandler.execute(mockData, true);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible:', mockButtons[0]);
-      expect(mockButtons[0].click).toHaveBeenCalled();
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible:', mockButtons[0]!);
+      expect(mockButtons[0]!.click).toHaveBeenCalled();
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'completed');
     });
   });

--- a/src/interactive-engine/action-handlers/focus-handler.test.ts
+++ b/src/interactive-engine/action-handlers/focus-handler.test.ts
@@ -81,9 +81,9 @@ describe('FocusHandler', () => {
 
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'running');
       expect(mockQuerySelectorAll).toHaveBeenCalledWith('test-selector');
-      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockElements[0]);
-      expect(mockNavigationManager.ensureElementVisible).toHaveBeenCalledWith(mockElements[0]);
-      expect(mockNavigationManager.highlightWithComment).toHaveBeenCalledWith(mockElements[0], undefined);
+      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockElements[0]!);
+      expect(mockNavigationManager.ensureElementVisible).toHaveBeenCalledWith(mockElements[0]!);
+      expect(mockNavigationManager.highlightWithComment).toHaveBeenCalledWith(mockElements[0]!, undefined);
       expect(mockWaitForReactUpdates).not.toHaveBeenCalled(); // No completion in show mode
     });
 
@@ -92,9 +92,9 @@ describe('FocusHandler', () => {
 
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'running');
       expect(mockQuerySelectorAll).toHaveBeenCalledWith('test-selector');
-      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockElements[0]);
-      expect(mockNavigationManager.ensureElementVisible).toHaveBeenCalledWith(mockElements[0]);
-      expect(mockElements[0].click).toHaveBeenCalled();
+      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockElements[0]!);
+      expect(mockNavigationManager.ensureElementVisible).toHaveBeenCalledWith(mockElements[0]!);
+      expect(mockElements[0]!.click).toHaveBeenCalled();
       expect(mockWaitForReactUpdates).toHaveBeenCalled();
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'completed');
     });
@@ -103,10 +103,10 @@ describe('FocusHandler', () => {
       await focusHandler.execute(mockData, true);
 
       // Should process all elements
-      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockElements[0]);
-      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockElements[1]);
-      expect(mockElements[0].click).toHaveBeenCalled();
-      expect(mockElements[1].click).toHaveBeenCalled();
+      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockElements[0]!);
+      expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalledWith(mockElements[1]!);
+      expect(mockElements[0]!.click).toHaveBeenCalled();
+      expect(mockElements[1]!.click).toHaveBeenCalled();
     });
 
     it('should handle errors gracefully', async () => {
@@ -150,7 +150,7 @@ describe('FocusHandler', () => {
 
       await focusHandler.execute(mockData, false);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible:', mockElements[0]);
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible:', mockElements[0]!);
       expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalled();
       expect(mockNavigationManager.highlightWithComment).toHaveBeenCalled();
     });
@@ -160,8 +160,8 @@ describe('FocusHandler', () => {
 
       await focusHandler.execute(mockData, true);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible:', mockElements[0]);
-      expect(mockElements[0].click).toHaveBeenCalled();
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible:', mockElements[0]!);
+      expect(mockElements[0]!.click).toHaveBeenCalled();
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'completed');
     });
   });

--- a/src/interactive-engine/action-handlers/focus-handler.ts
+++ b/src/interactive-engine/action-handlers/focus-handler.ts
@@ -25,7 +25,7 @@ export class FocusHandler {
       if (shouldSelectSingle) {
         // Use enhanced selector for single element with complex selector support
         const enhancedResult = querySelectorAllEnhanced(resolvedSelector);
-        targetElements = enhancedResult.elements.length > 0 ? [enhancedResult.elements[0]] : [];
+        targetElements = enhancedResult.elements.length > 0 ? [enhancedResult.elements[0]!] : [];
       } else {
         // Use enhanced selector for multiple elements with complex selector support
         const enhancedResult = querySelectorAllEnhanced(resolvedSelector);

--- a/src/interactive-engine/action-handlers/form-fill-handler.ts
+++ b/src/interactive-engine/action-handlers/form-fill-handler.ts
@@ -46,7 +46,7 @@ export class FormFillHandler {
       console.warn(`Multiple elements found matching selector: ${resolvedSelector}`);
     }
 
-    const targetElement = targetElements[0];
+    const targetElement = targetElements[0]!;
     return targetElement;
   }
 
@@ -284,9 +284,9 @@ export class FormFillHandler {
       // SECURITY: Safe regex - [^!=~]* prevents backtracking (no nested quantifiers)
       const opMatch = fullValue.match(/^([^!=~]*)(!=|=~|!~|=)(.*)$/);
       if (opMatch) {
-        const key = opMatch[1].trim();
-        const op = opMatch[2].trim();
-        const val = stripQuotes(opMatch[3].trim());
+        const key = opMatch[1]!.trim();
+        const op = opMatch[2]!.trim();
+        const val = stripQuotes(opMatch[3]!.trim());
         tokens = [key, op, val].filter(Boolean);
       } else {
         tokens = [stripQuotes(fullValue.trim())];

--- a/src/interactive-engine/action-handlers/guided-handler.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.ts
@@ -381,7 +381,7 @@ export class GuidedHandler {
             if (targetElements.length > 1) {
               console.warn(`Multiple buttons found matching selector: ${resolvedSelector}, using first button`);
             }
-            return targetElements[0];
+            return targetElements[0]!;
           }
         } catch (error) {
           console.warn(`Button selector matching failed for "${resolvedSelector}", trying text match:`, error);
@@ -395,7 +395,7 @@ export class GuidedHandler {
           if (targetElements.length > 1) {
             console.warn(`Multiple buttons found matching text: ${resolvedSelector}, using first button`);
           }
-          return targetElements[0];
+          return targetElements[0]!;
         }
       } catch (error) {
         // Fall through to enhanced selector as last resort
@@ -415,7 +415,7 @@ export class GuidedHandler {
         if (formElements.length > 1) {
           console.warn(`Multiple form elements found matching selector: ${resolvedSelector}, using first element`);
         }
-        return formElements[0];
+        return formElements[0]!;
       }
 
       // Try to find form element inside the matched element
@@ -440,7 +440,7 @@ export class GuidedHandler {
       console.warn(`Multiple elements found matching selector: ${resolvedSelector}, using first element`);
     }
 
-    return targetElements[0];
+    return targetElements[0]!;
   }
 
   /**

--- a/src/interactive-engine/action-handlers/hover-handler.ts
+++ b/src/interactive-engine/action-handlers/hover-handler.ts
@@ -50,7 +50,7 @@ export class HoverHandler {
       console.warn(`Multiple elements found matching selector: ${resolvedSelector}, using first element`);
     }
 
-    return targetElements[0];
+    return targetElements[0]!;
   }
 
   private async prepareElement(targetElement: HTMLElement): Promise<void> {

--- a/src/interactive-engine/interactive.hook.ts
+++ b/src/interactive-engine/interactive.hook.ts
@@ -291,7 +291,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
 
         // Find all interactive elements within the sequence container
         const interactiveElements = Array.from(
-          targetElements[0].querySelectorAll('.interactive[data-targetaction]:not([data-targetaction="sequence"])')
+          targetElements[0]!.querySelectorAll('.interactive[data-targetaction]:not([data-targetaction="sequence"])')
         );
 
         if (interactiveElements.length === 0) {

--- a/src/interactive-engine/sequence-manager.test.ts
+++ b/src/interactive-engine/sequence-manager.test.ts
@@ -121,7 +121,7 @@ describe('SequenceManager', () => {
       // Mock requirements to fail first, then pass
       mockCheckRequirementsFromData.mockResolvedValueOnce({ pass: false }).mockResolvedValueOnce({ pass: true });
 
-      await sequenceManager.runInteractiveSequence([mockElements[0]], false);
+      await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
 
       expect(mockCheckRequirementsFromData).toHaveBeenCalledTimes(2);
       expect(mockDispatchInteractiveAction).toHaveBeenCalledTimes(1);
@@ -130,7 +130,7 @@ describe('SequenceManager', () => {
     it('should stop retrying after max retries', async () => {
       mockCheckRequirementsFromData.mockResolvedValue({ pass: false });
 
-      await sequenceManager.runInteractiveSequence([mockElements[0]], false);
+      await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
 
       expect(mockCheckRequirementsFromData).toHaveBeenCalledTimes(INTERACTIVE_CONFIG.maxRetries);
       expect(mockDispatchInteractiveAction).not.toHaveBeenCalled();
@@ -139,7 +139,7 @@ describe('SequenceManager', () => {
     it('should handle errors gracefully', async () => {
       mockDispatchInteractiveAction.mockRejectedValueOnce(new Error('Test error'));
 
-      await sequenceManager.runInteractiveSequence([mockElements[0]], false);
+      await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
 
       expect(mockStateManager.logError).toHaveBeenCalledWith(
         'Error processing interactive element',
@@ -152,7 +152,7 @@ describe('SequenceManager', () => {
       // Mock action to fail first, then succeed
       mockDispatchInteractiveAction.mockRejectedValueOnce(new Error('Test error')).mockResolvedValueOnce(undefined);
 
-      await sequenceManager.runInteractiveSequence([mockElements[0]], false);
+      await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
 
       expect(mockDispatchInteractiveAction).toHaveBeenCalledTimes(2);
       expect(mockStateManager.logError).toHaveBeenCalledTimes(1);
@@ -161,7 +161,7 @@ describe('SequenceManager', () => {
     it('should use correct retry delay', async () => {
       mockCheckRequirementsFromData.mockResolvedValue({ pass: false });
 
-      await sequenceManager.runInteractiveSequence([mockElements[0]], false);
+      await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
 
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), INTERACTIVE_CONFIG.delays.perceptual.retry);
     });
@@ -187,7 +187,7 @@ describe('SequenceManager', () => {
     });
 
     it('should show then do for each element', async () => {
-      await sequenceManager.runStepByStepSequence([mockElements[0]]);
+      await sequenceManager.runStepByStepSequence([mockElements[0]!]);
 
       expect(mockDispatchInteractiveAction).toHaveBeenCalledTimes(2);
       expect(mockDispatchInteractiveAction).toHaveBeenNthCalledWith(1, expect.any(Object), false); // show
@@ -195,7 +195,7 @@ describe('SequenceManager', () => {
     });
 
     it('should check requirements before and after show', async () => {
-      await sequenceManager.runStepByStepSequence([mockElements[0]]);
+      await sequenceManager.runStepByStepSequence([mockElements[0]!]);
 
       expect(mockCheckRequirementsFromData).toHaveBeenCalledTimes(2);
     });
@@ -206,7 +206,7 @@ describe('SequenceManager', () => {
         .mockResolvedValueOnce({ pass: true })
         .mockResolvedValueOnce({ pass: true });
 
-      await sequenceManager.runStepByStepSequence([mockElements[0]]);
+      await sequenceManager.runStepByStepSequence([mockElements[0]!]);
 
       expect(mockCheckRequirementsFromData).toHaveBeenCalledTimes(3);
       expect(mockDispatchInteractiveAction).toHaveBeenCalledTimes(2);
@@ -218,7 +218,7 @@ describe('SequenceManager', () => {
         .mockResolvedValueOnce({ pass: false })
         .mockResolvedValueOnce({ pass: true });
 
-      await sequenceManager.runStepByStepSequence([mockElements[0]]);
+      await sequenceManager.runStepByStepSequence([mockElements[0]!]);
 
       expect(mockCheckRequirementsFromData).toHaveBeenCalledTimes(4); // Initial + after show + retry + final
       expect(mockDispatchInteractiveAction).toHaveBeenCalledTimes(3); // show + do + retry do
@@ -227,7 +227,7 @@ describe('SequenceManager', () => {
     it('should stop retrying after max retries', async () => {
       mockCheckRequirementsFromData.mockResolvedValue({ pass: false });
 
-      await sequenceManager.runStepByStepSequence([mockElements[0]]);
+      await sequenceManager.runStepByStepSequence([mockElements[0]!]);
 
       expect(mockCheckRequirementsFromData).toHaveBeenCalledTimes(INTERACTIVE_CONFIG.maxRetries);
       expect(mockDispatchInteractiveAction).not.toHaveBeenCalled();
@@ -236,7 +236,7 @@ describe('SequenceManager', () => {
     it('should handle errors gracefully', async () => {
       mockDispatchInteractiveAction.mockRejectedValueOnce(new Error('Test error'));
 
-      await sequenceManager.runStepByStepSequence([mockElements[0]]);
+      await sequenceManager.runStepByStepSequence([mockElements[0]!]);
 
       expect(mockStateManager.logError).toHaveBeenCalledWith(
         'Error in interactive step',
@@ -252,14 +252,14 @@ describe('SequenceManager', () => {
         .mockResolvedValueOnce(undefined)
         .mockResolvedValueOnce(undefined);
 
-      await sequenceManager.runStepByStepSequence([mockElements[0]]);
+      await sequenceManager.runStepByStepSequence([mockElements[0]!]);
 
       expect(mockDispatchInteractiveAction).toHaveBeenCalledTimes(3);
       expect(mockStateManager.logError).toHaveBeenCalledTimes(1);
     });
 
     it('should not wait for React updates after last element', async () => {
-      await sequenceManager.runStepByStepSequence([mockElements[0]]);
+      await sequenceManager.runStepByStepSequence([mockElements[0]!]);
 
       // Should call waitForReactUpdates for show and do, but not after the last do
       expect(mockWaitForReactUpdates).toHaveBeenCalledTimes(1); // Only one for show, not after do for single element
@@ -275,7 +275,7 @@ describe('SequenceManager', () => {
     it('should use correct retry delay', async () => {
       mockCheckRequirementsFromData.mockResolvedValue({ pass: false });
 
-      await sequenceManager.runStepByStepSequence([mockElements[0]]);
+      await sequenceManager.runStepByStepSequence([mockElements[0]!]);
 
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), INTERACTIVE_CONFIG.delays.perceptual.retry);
     });
@@ -301,7 +301,7 @@ describe('SequenceManager', () => {
       const testError = new Error('Test error');
       mockDispatchInteractiveAction.mockRejectedValue(testError);
 
-      await sequenceManager.runInteractiveSequence([mockElements[0]], false);
+      await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
 
       expect(mockStateManager.logError).toHaveBeenCalledWith(
         'Error processing interactive element',
@@ -314,7 +314,7 @@ describe('SequenceManager', () => {
       const testError = new Error('Test error');
       mockDispatchInteractiveAction.mockRejectedValue(testError);
 
-      await sequenceManager.runStepByStepSequence([mockElements[0]]);
+      await sequenceManager.runStepByStepSequence([mockElements[0]!]);
 
       expect(mockStateManager.logError).toHaveBeenCalledWith(
         'Error in interactive step',
@@ -328,7 +328,7 @@ describe('SequenceManager', () => {
     it('should use INTERACTIVE_CONFIG.maxRetries', async () => {
       mockCheckRequirementsFromData.mockResolvedValue({ pass: false });
 
-      await sequenceManager.runInteractiveSequence([mockElements[0]], false);
+      await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
 
       expect(mockCheckRequirementsFromData).toHaveBeenCalledTimes(INTERACTIVE_CONFIG.maxRetries);
     });
@@ -336,7 +336,7 @@ describe('SequenceManager', () => {
     it('should use INTERACTIVE_CONFIG.delays.perceptual.retry', async () => {
       mockCheckRequirementsFromData.mockResolvedValue({ pass: false });
 
-      await sequenceManager.runInteractiveSequence([mockElements[0]], false);
+      await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
 
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), INTERACTIVE_CONFIG.delays.perceptual.retry);
     });

--- a/src/learning-paths/fetch-path-guides.test.ts
+++ b/src/learning-paths/fetch-path-guides.test.ts
@@ -91,9 +91,9 @@ describe('fetchPathGuides', () => {
 
     expect(result).not.toBeNull();
     // "select-platform" has both menutitle and title — should use menutitle
-    expect(result!.guideMetadata['select-platform'].title).toBe('Select distribution');
+    expect(result!.guideMetadata['select-platform']!.title).toBe('Select distribution');
     // "configure-alloy" has only title, no menutitle
-    expect(result!.guideMetadata['configure-alloy'].title).toBe(
+    expect(result!.guideMetadata['configure-alloy']!.title).toBe(
       'Configure Grafana Alloy to use the Linux server integration'
     );
   });

--- a/src/learning-paths/streak-tracker.ts
+++ b/src/learning-paths/streak-tracker.ts
@@ -15,7 +15,7 @@ import type { StreakInfo } from '../types/learning-paths.types';
  * Gets today's date in YYYY-MM-DD format
  */
 export function getTodayDateString(): string {
-  return new Date().toISOString().split('T')[0];
+  return new Date().toISOString().split('T')[0]!;
 }
 
 /**
@@ -24,7 +24,7 @@ export function getTodayDateString(): string {
 export function getYesterdayDateString(): string {
   const yesterday = new Date();
   yesterday.setDate(yesterday.getDate() - 1);
-  return yesterday.toISOString().split('T')[0];
+  return yesterday.toISOString().split('T')[0]!;
 }
 
 /**
@@ -32,7 +32,7 @@ export function getYesterdayDateString(): string {
  */
 function parseDate(dateString: string): Date {
   const [year, month, day] = dateString.split('-').map(Number);
-  return new Date(Date.UTC(year, month - 1, day));
+  return new Date(Date.UTC(year!, month! - 1, day!));
 }
 
 /**
@@ -202,7 +202,7 @@ export function getMilestoneProgress(currentStreak: number): number {
 
   // Find the previous milestone
   const milestoneIndex = STREAK_MILESTONES.indexOf(nextMilestone as (typeof STREAK_MILESTONES)[number]);
-  const previousMilestone = milestoneIndex > 0 ? STREAK_MILESTONES[milestoneIndex - 1] : 0;
+  const previousMilestone = milestoneIndex > 0 ? STREAK_MILESTONES[milestoneIndex - 1]! : 0;
 
   const progress = currentStreak - previousMilestone;
   const total = nextMilestone - previousMilestone;

--- a/src/lib/dom/enhanced-selector.test.ts
+++ b/src/lib/dom/enhanced-selector.test.ts
@@ -26,7 +26,7 @@ describe('Enhanced Selector', () => {
       const result = querySelectorAllEnhanced('div[data-testid="uplot-main-div"]:nth-child(3)');
 
       expect(result.elements.length).toBe(1);
-      expect(result.elements[0].textContent).toContain('Third child - second uplot');
+      expect(result.elements[0]!.textContent).toContain('Third child - second uplot');
     });
 
     it('should handle :nth-of-type() correctly', () => {
@@ -43,7 +43,7 @@ describe('Enhanced Selector', () => {
       const result = querySelectorAllEnhanced('div[data-testid="uplot-main-div"]:nth-of-type(3)');
 
       expect(result.elements.length).toBe(1);
-      expect(result.elements[0].textContent).toContain('Third div - third uplot');
+      expect(result.elements[0]!.textContent).toContain('Third div - third uplot');
     });
 
     it('should demonstrate the limitation of :nth-child with multiple parents', () => {
@@ -65,7 +65,7 @@ describe('Enhanced Selector', () => {
       const result = querySelectorAllEnhanced('div[data-testid="uplot-main-div"]:nth-child(3)');
 
       expect(result.elements.length).toBe(1);
-      expect(result.elements[0].textContent).toContain('Parent3 - uplot2');
+      expect(result.elements[0]!.textContent).toContain('Parent3 - uplot2');
     });
   });
 
@@ -98,7 +98,7 @@ describe('Enhanced Selector', () => {
       const result = querySelectorAllEnhanced('div.card:has(p)');
 
       expect(result.elements.length).toBe(1);
-      expect(result.elements[0].textContent).toContain('Has paragraph');
+      expect(result.elements[0]!.textContent).toContain('Has paragraph');
     });
 
     it('should handle :nth-match() selector to get nth occurrence globally', () => {
@@ -119,7 +119,7 @@ describe('Enhanced Selector', () => {
       const result = querySelectorAllEnhanced('div[data-testid="uplot-main-div"]:nth-match(3)');
 
       expect(result.elements.length).toBe(1);
-      expect(result.elements[0].textContent).toContain('Third uplot');
+      expect(result.elements[0]!.textContent).toContain('Third uplot');
       expect(result.usedFallback).toBe(true);
     });
 
@@ -149,7 +149,7 @@ describe('Enhanced Selector', () => {
       const result = querySelectorAllEnhanced('div[data-testid="uplot-main-div"]:nth-match(1)');
 
       expect(result.elements.length).toBe(1);
-      expect(result.elements[0].textContent).toContain('First');
+      expect(result.elements[0]!.textContent).toContain('First');
     });
 
     it('should handle :nth-match with nested complex selectors like :has() and :contains()', () => {
@@ -177,7 +177,7 @@ describe('Enhanced Selector', () => {
       );
 
       expect(result.elements.length).toBe(1);
-      expect(result.elements[0].querySelector('p')?.textContent).toBe('adaptive-logs-api');
+      expect(result.elements[0]!.querySelector('p')?.textContent).toBe('adaptive-logs-api');
       expect(result.usedFallback).toBe(true);
 
       // Test finding a button within the matched container
@@ -186,7 +186,7 @@ describe('Enhanced Selector', () => {
       );
 
       expect(buttonResult.elements.length).toBe(1);
-      expect(buttonResult.elements[0].textContent).toBe('Button 4');
+      expect(buttonResult.elements[0]!.textContent).toBe('Button 4');
     });
 
     it('should handle chained :has() selectors with :contains() and :nth-match()', () => {
@@ -213,7 +213,7 @@ describe('Enhanced Selector', () => {
       );
 
       expect(result.elements.length).toBe(1);
-      expect(result.elements[0].textContent).toBe('Expand Dashboards');
+      expect(result.elements[0]!.textContent).toBe('Expand Dashboards');
       expect(result.usedFallback).toBe(true);
     });
 
@@ -252,7 +252,7 @@ describe('Enhanced Selector', () => {
       );
 
       expect(result.elements.length).toBe(1);
-      expect(result.elements[0].textContent).toBe('Dashboard');
+      expect(result.elements[0]!.textContent).toBe('Dashboard');
       expect(result.usedFallback).toBe(true);
 
       // Verify it finds the right container first
@@ -260,7 +260,7 @@ describe('Enhanced Selector', () => {
         'div[data-cy="wb-list-item"]:has(p:contains("adaptive-logs-api")):nth-match(1)'
       );
       expect(containerResult.elements.length).toBe(1);
-      expect(containerResult.elements[0].querySelector('p')?.textContent).toBe('adaptive-logs-api');
+      expect(containerResult.elements[0]!.querySelector('p')?.textContent).toBe('adaptive-logs-api');
     });
   });
 

--- a/src/lib/dom/grafana-selector.test.ts
+++ b/src/lib/dom/grafana-selector.test.ts
@@ -42,7 +42,7 @@ describe('grafana-selector', () => {
 
       const elements = findByGrafanaSelector('components.RefreshPicker.runButtonV2');
       expect(elements.length).toBe(1);
-      expect(elements[0].tagName).toBe('BUTTON');
+      expect(elements[0]!.tagName).toBe('BUTTON');
     });
 
     it('should find elements by aria-label', () => {
@@ -52,7 +52,7 @@ describe('grafana-selector', () => {
 
       const elements = findByGrafanaSelector('components.RefreshPicker.runButtonV2');
       expect(elements.length).toBe(1);
-      expect(elements[0].tagName).toBe('BUTTON');
+      expect(elements[0]!.tagName).toBe('BUTTON');
     });
 
     it('should return empty array if no elements found', () => {

--- a/src/lib/dom/grafana-selector.ts
+++ b/src/lib/dom/grafana-selector.ts
@@ -97,7 +97,7 @@ export function findByGrafanaSelector(selectorPath: string, selectorId?: string)
  */
 export function findOneByGrafanaSelector(selectorPath: string, selectorId?: string): HTMLElement | null {
   const elements = findByGrafanaSelector(selectorPath, selectorId);
-  return elements.length > 0 ? elements[0] : null;
+  return elements.length > 0 ? elements[0]! : null;
 }
 
 /**

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -1457,7 +1457,7 @@ export const learningProgressStorage = {
 
         // Calculate and update streak before changing lastActivityDate
         const { calculateUpdatedStreak } = await import('../learning-paths/streak-tracker');
-        const today = new Date().toISOString().split('T')[0];
+        const today = new Date().toISOString().split('T')[0]!;
         progress.streakDays = calculateUpdatedStreak(progress.streakDays, progress.lastActivityDate);
         progress.lastActivityDate = today;
 

--- a/src/requirements-manager/requirements-checker.utils.test.ts
+++ b/src/requirements-manager/requirements-checker.utils.test.ts
@@ -128,7 +128,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].error).toContain('Missing permission');
+      expect(result.error[0]!.error).toContain('Missing permission');
     });
   });
 
@@ -227,7 +227,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(true);
-      expect(result.error[0].pass).toBe(true);
+      expect(result.error[0]!.pass).toBe(true);
       expect(mockBackend.post).toHaveBeenCalledWith('/api/datasources/uid/prom-uid/test');
     });
 
@@ -245,8 +245,8 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].pass).toBe(false);
-      expect(result.error[0].error).toContain('test failed');
+      expect(result.error[0]!.pass).toBe(false);
+      expect(result.error[0]!.error).toContain('test failed');
     });
 
     it('should fail when data source not found', async () => {
@@ -260,8 +260,8 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].pass).toBe(false);
-      expect(result.error[0].error).toContain('not found');
+      expect(result.error[0]!.pass).toBe(false);
+      expect(result.error[0]!.error).toContain('not found');
     });
   });
 
@@ -291,7 +291,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(true);
-      expect(result.error[0].pass).toBe(true);
+      expect(result.error[0]!.pass).toBe(true);
     });
 
     it('should fail when plugin exists but is not enabled', async () => {
@@ -306,8 +306,8 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].pass).toBe(false);
-      expect(result.error[0].error).toContain('is installed but not enabled');
+      expect(result.error[0]!.pass).toBe(false);
+      expect(result.error[0]!.error).toContain('is installed but not enabled');
     });
 
     it('should fail when plugin does not exist', async () => {
@@ -321,8 +321,8 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].pass).toBe(false);
-      expect(result.error[0].error).toContain('not found');
+      expect(result.error[0]!.pass).toBe(false);
+      expect(result.error[0]!.error).toContain('not found');
     });
   });
 
@@ -397,7 +397,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].error).toContain('does not meet minimum requirement');
+      expect(result.error[0]!.error).toContain('does not meet minimum requirement');
     });
   });
 
@@ -441,7 +441,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].error).toContain('not logged in');
+      expect(result.error[0]!.error).toContain('not logged in');
     });
 
     it('should fail when no user data available', async () => {
@@ -507,7 +507,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].error).toContain('does not have editor permissions');
+      expect(result.error[0]!.error).toContain('does not have editor permissions');
     });
   });
 
@@ -548,7 +548,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].error).toContain('No dashboards found');
+      expect(result.error[0]!.error).toContain('No dashboards found');
     });
   });
 
@@ -582,7 +582,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].error).toContain('No forms found');
+      expect(result.error[0]!.error).toContain('No forms found');
     });
 
     it('should fail when forms have validation errors', async () => {
@@ -600,7 +600,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].error).toContain('Form validation failed');
+      expect(result.error[0]!.error).toContain('Form validation failed');
     });
   });
 
@@ -625,7 +625,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].error).toBe('No data sources found');
+      expect(result.error[0]!.error).toBe('No data sources found');
     });
   });
 
@@ -665,7 +665,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].error).toContain('must be completed first');
+      expect(result.error[0]!.error).toContain('must be completed first');
     });
 
     it('should fail when section does not exist', async () => {
@@ -675,7 +675,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].error).toContain('must be completed first');
+      expect(result.error[0]!.error).toContain('must be completed first');
     });
   });
 
@@ -687,9 +687,9 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(true);
-      expect(result.error[0].pass).toBe(true);
-      expect(result.error[0].context?.renderer).toBe('pathfinder');
-      expect(result.error[0].context?.context).toBe('app');
+      expect(result.error[0]!.pass).toBe(true);
+      expect(result.error[0]!.context?.renderer).toBe('pathfinder');
+      expect(result.error[0]!.context?.context).toBe('app');
     });
 
     it('should fail for renderer:website (always false in app)', async () => {
@@ -699,10 +699,10 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].pass).toBe(false);
-      expect(result.error[0].error).toContain('website context is not available in app');
-      expect(result.error[0].context?.renderer).toBe('website');
-      expect(result.error[0].context?.context).toBe('app');
+      expect(result.error[0]!.pass).toBe(false);
+      expect(result.error[0]!.error).toContain('website context is not available in app');
+      expect(result.error[0]!.context?.renderer).toBe('website');
+      expect(result.error[0]!.context?.context).toBe('app');
     });
 
     it('should fail for unknown renderer values', async () => {
@@ -712,10 +712,10 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].pass).toBe(false);
-      expect(result.error[0].error).toContain("Unknown renderer value: 'unknown'");
-      expect(result.error[0].context?.renderer).toBe('unknown');
-      expect(result.error[0].context?.supported).toEqual(['pathfinder', 'website']);
+      expect(result.error[0]!.pass).toBe(false);
+      expect(result.error[0]!.error).toContain("Unknown renderer value: 'unknown'");
+      expect(result.error[0]!.context?.renderer).toBe('unknown');
+      expect(result.error[0]!.context?.supported).toEqual(['pathfinder', 'website']);
     });
 
     it('should handle case-insensitive renderer values', async () => {
@@ -725,7 +725,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkRequirements(options);
       expect(result.pass).toBe(true);
-      expect(result.error[0].pass).toBe(true);
+      expect(result.error[0]!.pass).toBe(true);
     });
   });
 
@@ -741,9 +741,9 @@ describe('requirements-checker.utils', () => {
 
       expect(result.pass).toBe(true);
       expect(result.error).toHaveLength(1);
-      expect(result.error[0].requirement).toBe('unknown-requirement-type');
-      expect(result.error[0].pass).toBe(true);
-      expect(result.error[0].error).toContain('Warning: Unknown requirement type');
+      expect(result.error[0]!.requirement).toBe('unknown-requirement-type');
+      expect(result.error[0]!.pass).toBe(true);
+      expect(result.error[0]!.error).toContain('Warning: Unknown requirement type');
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("Unknown requirement type: 'unknown-requirement-type'")
@@ -825,7 +825,7 @@ describe('requirements-checker.utils', () => {
 
       const result = await checkPostconditions(options);
       expect(result.pass).toBe(false);
-      expect(result.error[0].pass).toBe(false);
+      expect(result.error[0]!.pass).toBe(false);
     });
 
     it('should handle multiple postconditions with one failing', async () => {

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -825,7 +825,10 @@ async function minVersionCheck(check: string): Promise<CheckResultError> {
     const requiredVersion = check.replace('min-version:', '');
     const currentVersion = config.buildInfo?.version || '0.0.0';
 
-    const parseVersion = (v: string) => v.split('.').map((n) => parseInt(n, 10));
+    const parseVersion = (v: string): [number, number, number] => {
+      const parts = v.split('.').map((n) => parseInt(n, 10));
+      return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+    };
     const [reqMajor, reqMinor, reqPatch] = parseVersion(requiredVersion);
     const [curMajor, curMinor, curPatch] = parseVersion(currentVersion);
 
@@ -1339,7 +1342,8 @@ async function guideVariableCheck(check: string): Promise<CheckResultError> {
       };
     }
 
-    const [, variableName, expectedValue] = match;
+    const variableName = match[1]!;
+    const expectedValue = match[2]!;
 
     // Get current guide ID from URL or use default
     // TODO: In a full implementation, pass guideId through context

--- a/src/requirements-manager/requirements-explanations.ts
+++ b/src/requirements-manager/requirements-explanations.ts
@@ -90,7 +90,7 @@ export function mapRequirementToUserFriendlyMessage(requirement: string): string
   for (const mapping of enhancedMappings) {
     const match = requirement.match(mapping.pattern);
     if (match) {
-      return mapping.message(match[1]);
+      return mapping.message(match[1]!);
     }
   }
 

--- a/src/security/security.test.ts
+++ b/src/security/security.test.ts
@@ -455,7 +455,7 @@ describe('Security: Image Lightbox XSS Prevention', () => {
     expect(safeTitle.textContent).toBe(maliciousAlt); // Original text preserved
     expect(safeTitle.querySelector('img')).toBeNull(); // NO img element created
     expect(safeTitle.childNodes.length).toBe(1); // Only a text node, no element nodes
-    expect(safeTitle.childNodes[0].nodeType).toBe(Node.TEXT_NODE); // Text node, not element
+    expect(safeTitle.childNodes[0]!.nodeType).toBe(Node.TEXT_NODE); // Text node, not element
 
     // SAFE approach (using setAttribute):
     const safeImg = document.createElement('img');

--- a/src/utils/devtools/step-parser.util.ts
+++ b/src/utils/devtools/step-parser.util.ts
@@ -28,8 +28,8 @@ export function parseStepString(input: string): StepDefinition[] {
     const parts = line.split('|').map((p) => p.trim());
     if (parts.length >= 2) {
       steps.push({
-        action: parts[0],
-        selector: parts[1],
+        action: parts[0]!,
+        selector: parts[1]!,
         value: parts[2] || undefined,
       });
     }

--- a/src/utils/devtools/tutorial-exporter.ts
+++ b/src/utils/devtools/tutorial-exporter.ts
@@ -126,7 +126,7 @@ export function combineStepsIntoMultistep(
 
   // Create the multistep structure
   const multistepHtml = formatMultistepAsHTML(
-    sortedIndices.map((i) => allSteps[i]),
+    sortedIndices.map((i) => allSteps[i]!),
     description
   );
 
@@ -144,7 +144,7 @@ export function combineStepsIntoMultistep(
       });
     } else if (!sortedIndices.includes(i)) {
       // Include non-selected steps
-      newSteps.push(allSteps[i]);
+      newSteps.push(allSteps[i]!);
     }
   }
 
@@ -192,7 +192,7 @@ export function combineStepsIntoGuided(
 
   // Create the guided structure
   const guidedHtml = formatGuidedAsHTML(
-    sortedIndices.map((i) => allSteps[i]),
+    sortedIndices.map((i) => allSteps[i]!),
     description
   );
 
@@ -210,7 +210,7 @@ export function combineStepsIntoGuided(
       });
     } else if (!sortedIndices.includes(i)) {
       // Include non-selected steps
-      newSteps.push(allSteps[i]);
+      newSteps.push(allSteps[i]!);
     }
   }
 
@@ -261,7 +261,7 @@ function escapeHtml(text: string): string {
     '<': '&lt;',
     '>': '&gt;',
   };
-  return text.replace(/[&<>]/g, (m) => map[m]);
+  return text.replace(/[&<>]/g, (m) => map[m]!);
 }
 
 /**
@@ -275,7 +275,7 @@ function escapeAttribute(text: string): string {
     '>': '&gt;',
     "'": '&#039;',
   };
-  return text.replace(/[&<>']/g, (m) => map[m]);
+  return text.replace(/[&<>']/g, (m) => map[m]!);
 }
 
 /**

--- a/src/utils/experiment-debug.ts
+++ b/src/utils/experiment-debug.ts
@@ -52,13 +52,13 @@ export function getParentPath(pattern: string): string {
   // Stop at /, *, or ? (query string)
   if (pattern.startsWith('/a/')) {
     const match = pattern.match(/^(\/a\/[^/*?]+)/);
-    return match ? match[1] : pattern;
+    return match ? match[1]! : pattern;
   }
 
   // For non-app paths, extract first segment (e.g., /dashboard)
   // Stop at /, *, or ? (query string)
   const match = pattern.match(/^(\/[^/*?]+)/);
-  return match ? match[1] : pattern;
+  return match ? match[1]! : pattern;
 }
 
 /**

--- a/src/utils/variable-substitution.ts
+++ b/src/utils/variable-substitution.ts
@@ -89,7 +89,7 @@ export function extractVariables(content: string): string[] {
 
   const pattern = createVariablePattern();
   while ((match = pattern.exec(content)) !== null) {
-    variables.add(match[1]);
+    variables.add(match[1]!);
   }
 
   return Array.from(variables);

--- a/src/validation/condition-validator.test.ts
+++ b/src/validation/condition-validator.test.ts
@@ -77,20 +77,20 @@ describe('Condition Validator', () => {
       it('rejects unknown condition type', () => {
         const issues = validateConditionString('foobar', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('unknown_type');
-        expect(issues[0].condition).toBe('foobar');
+        expect(issues[0]!.code).toBe('unknown_type');
+        expect(issues[0]!.condition).toBe('foobar');
       });
 
       it('rejects typos as unknown types', () => {
         const issues = validateConditionString('esists-reftarget', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('unknown_type');
+        expect(issues[0]!.code).toBe('unknown_type');
       });
 
       it('rejects parameterized prefix without colon as unknown type', () => {
         const issues = validateConditionString('has-datasource', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('unknown_type');
+        expect(issues[0]!.code).toBe('unknown_type');
       });
     });
 
@@ -98,20 +98,20 @@ describe('Condition Validator', () => {
       it('rejects fixed type with argument', () => {
         const issues = validateConditionString('is-admin:true', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('unexpected_argument');
-        expect(issues[0].condition).toBe('is-admin:true');
+        expect(issues[0]!.code).toBe('unexpected_argument');
+        expect(issues[0]!.condition).toBe('is-admin:true');
       });
 
       it('rejects exists-reftarget with argument', () => {
         const issues = validateConditionString('exists-reftarget:selector', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('unexpected_argument');
+        expect(issues[0]!.code).toBe('unexpected_argument');
       });
 
       it('rejects navmenu-open with argument', () => {
         const issues = validateConditionString('navmenu-open:docked', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('unexpected_argument');
+        expect(issues[0]!.code).toBe('unexpected_argument');
       });
     });
 
@@ -119,26 +119,26 @@ describe('Condition Validator', () => {
       it('rejects has-datasource: without argument', () => {
         const issues = validateConditionString('has-datasource:', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('missing_argument');
-        expect(issues[0].condition).toBe('has-datasource:');
+        expect(issues[0]!.code).toBe('missing_argument');
+        expect(issues[0]!.condition).toBe('has-datasource:');
       });
 
       it('rejects on-page: without argument', () => {
         const issues = validateConditionString('on-page:', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('missing_argument');
+        expect(issues[0]!.code).toBe('missing_argument');
       });
 
       it('rejects min-version: without argument', () => {
         const issues = validateConditionString('min-version:', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('missing_argument');
+        expect(issues[0]!.code).toBe('missing_argument');
       });
 
       it('rejects has-plugin: without argument', () => {
         const issues = validateConditionString('has-plugin:', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('missing_argument');
+        expect(issues[0]!.code).toBe('missing_argument');
       });
     });
 
@@ -146,36 +146,36 @@ describe('Condition Validator', () => {
       it('rejects on-page without leading slash', () => {
         const issues = validateConditionString('on-page:dashboards', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('invalid_format');
-        expect(issues[0].condition).toBe('on-page:dashboards');
+        expect(issues[0]!.code).toBe('invalid_format');
+        expect(issues[0]!.condition).toBe('on-page:dashboards');
       });
 
       it('rejects min-version with non-semver', () => {
         const issues = validateConditionString('min-version:latest', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('invalid_format');
+        expect(issues[0]!.code).toBe('invalid_format');
       });
 
       it('rejects min-version with partial version', () => {
         const issues = validateConditionString('min-version:11.0', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('invalid_format');
+        expect(issues[0]!.code).toBe('invalid_format');
       });
 
       it('rejects has-role with uppercase', () => {
         const issues = validateConditionString('has-role:ADMIN', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('invalid_format');
-        expect(issues[0].condition).toBe('has-role:ADMIN');
+        expect(issues[0]!.code).toBe('invalid_format');
+        expect(issues[0]!.condition).toBe('has-role:ADMIN');
       });
 
       it('rejects renderer with invalid value', () => {
         const issues = validateConditionString('renderer:invalid', ['test']);
         expect(issues).toHaveLength(1);
-        expect(issues[0].code).toBe('invalid_format');
-        expect(issues[0].condition).toBe('renderer:invalid');
-        expect(issues[0].message).toContain('pathfinder');
-        expect(issues[0].message).toContain('website');
+        expect(issues[0]!.code).toBe('invalid_format');
+        expect(issues[0]!.condition).toBe('renderer:invalid');
+        expect(issues[0]!.message).toContain('pathfinder');
+        expect(issues[0]!.message).toContain('website');
       });
     });
 
@@ -229,7 +229,7 @@ describe('Condition Validator', () => {
 
     it('includes correct path in errors', () => {
       const issues = validateConditions(['foobar'], ['blocks', 2, 'requirements']);
-      expect(issues[0].path).toEqual(['blocks', 2, 'requirements', 0]);
+      expect(issues[0]!.path).toEqual(['blocks', 2, 'requirements', 0]);
     });
   });
 
@@ -250,7 +250,7 @@ describe('Condition Validator', () => {
       };
       const issues = validateBlockConditions(guide);
       expect(issues).toHaveLength(1);
-      expect(issues[0].path).toEqual(['blocks', 0, 'requirements', 0]);
+      expect(issues[0]!.path).toEqual(['blocks', 0, 'requirements', 0]);
     });
 
     it('validates objectives in interactive blocks', () => {
@@ -269,7 +269,7 @@ describe('Condition Validator', () => {
       };
       const issues = validateBlockConditions(guide);
       expect(issues).toHaveLength(1);
-      expect(issues[0].code).toBe('missing_argument');
+      expect(issues[0]!.code).toBe('missing_argument');
     });
 
     it('validates verify field in interactive blocks', () => {
@@ -288,7 +288,7 @@ describe('Condition Validator', () => {
       };
       const issues = validateBlockConditions(guide);
       expect(issues).toHaveLength(1);
-      expect(issues[0].code).toBe('invalid_format');
+      expect(issues[0]!.code).toBe('invalid_format');
     });
 
     it('validates requirements in steps (multistep)', () => {
@@ -311,7 +311,7 @@ describe('Condition Validator', () => {
       };
       const issues = validateBlockConditions(guide);
       expect(issues).toHaveLength(1);
-      expect(issues[0].path).toEqual(['blocks', 0, 'steps', 0, 'requirements', 0]);
+      expect(issues[0]!.path).toEqual(['blocks', 0, 'steps', 0, 'requirements', 0]);
     });
 
     it('validates conditions in nested sections', () => {
@@ -336,7 +336,7 @@ describe('Condition Validator', () => {
       };
       const issues = validateBlockConditions(guide);
       expect(issues).toHaveLength(1);
-      expect(issues[0].path).toEqual(['blocks', 0, 'blocks', 0, 'requirements', 0]);
+      expect(issues[0]!.path).toEqual(['blocks', 0, 'blocks', 0, 'requirements', 0]);
     });
 
     it('validates requirements and objectives on sections', () => {

--- a/src/validation/condition-validator.ts
+++ b/src/validation/condition-validator.ts
@@ -227,7 +227,7 @@ export function validateConditions(
   const allIssues: ConditionIssue[] = [];
 
   for (let i = 0; i < conditions.length; i++) {
-    const issues = validateConditionString(conditions[i], [...basePath, i]);
+    const issues = validateConditionString(conditions[i]!, [...basePath, i]);
     allIssues.push(...issues);
   }
 

--- a/src/validation/validate-guide.test.ts
+++ b/src/validation/validate-guide.test.ts
@@ -218,7 +218,7 @@ describe('JsonGuideSchema', () => {
       expect(result.isValid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
       // Error message should mention the invalid 'action' field and list valid options
-      const errorMessage = result.errors[0].message.toLowerCase();
+      const errorMessage = result.errors[0]!.message.toLowerCase();
       expect(errorMessage).toContain('action');
       expect(errorMessage).toContain('expected one of');
       expect(errorMessage).toMatch(/highlight|button|formfill/);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./.config/tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true
   }
 }


### PR DESCRIPTION
## Summary

- Enables TypeScript's `noUncheckedIndexedAccess` compiler flag, making all array index and Record key lookups return `T | undefined` instead of `T`
- Fixes all 454 resulting type errors across 69 files with guards, optional chaining, nullish coalescing, and non-null assertions (where structurally guaranteed)
- Zero `@ts-expect-error` or `@ts-ignore` suppressions added

This eliminates a class of runtime null/undefined errors where code assumes indexed values exist without checking. It is the single highest-value TypeScript strictness flag not yet enabled.

**Epic #603 Phase 1** (Mechanical constraint enforcement for Agents)

Relates to #603

## Test plan

- [x] `npm run typecheck` passes clean
- [x] `npm run lint:fix` passes clean
- [x] `npm run prettier` passes clean
- [x] `npm run test:ci` — all 84 suites pass, 1707 tests pass
