### PR TITLE
feat: introduce checkbox UI with enable/disable auto-collapse setting

### DIFF
--- a/src/components/block-editor/forms/ConditionalBlockForm.tsx
+++ b/src/components/block-editor/forms/ConditionalBlockForm.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { Button, Field, Input, TextArea, Badge, useStyles2, RadioButtonGroup } from '@grafana/ui';
+import { Button, Field, Input, TextArea, Badge, Checkbox, useStyles2, RadioButtonGroup } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { getBlockFormStyles } from '../block-editor.styles';
@@ -122,6 +122,13 @@ export function ConditionalBlockForm({
     initial?.whenFalseSectionConfig?.objectives?.join(', ') ?? ''
   );
 
+  const [whenTrueAutoCollapse, setWhenTrueAutoCollapse] = useState(
+    initial?.whenTrueSectionConfig?.autoCollapse ?? true
+  );
+  const [whenFalseAutoCollapse, setWhenFalseAutoCollapse] = useState(
+    initial?.whenFalseSectionConfig?.autoCollapse ?? true
+  );
+
   // Collapse state for branch sections
   const [passExpanded, setPassExpanded] = useState(true);
   const [failExpanded, setFailExpanded] = useState(true);
@@ -143,7 +150,8 @@ export function ConditionalBlockForm({
     const buildSectionConfig = (
       title: string,
       requirements: string,
-      objectives: string
+      objectives: string,
+      autoCollapseValue: boolean
     ): ConditionalSectionConfig | undefined => {
       const config: ConditionalSectionConfig = {};
       if (title.trim()) {
@@ -156,6 +164,10 @@ export function ConditionalBlockForm({
       const objArray = parseArray(objectives);
       if (objArray.length > 0) {
         config.objectives = objArray;
+      }
+      // Only include when explicitly false (true is default, omit to keep JSON clean)
+      if (!autoCollapseValue) {
+        config.autoCollapse = false;
       }
       // Only return config if it has any properties
       return Object.keys(config).length > 0 ? config : undefined;
@@ -181,11 +193,21 @@ export function ConditionalBlockForm({
       block.reftarget = reftarget.trim();
     }
     if (displayMode === 'section') {
-      const trueSectionConfig = buildSectionConfig(whenTrueTitle, whenTrueRequirements, whenTrueObjectives);
+      const trueSectionConfig = buildSectionConfig(
+        whenTrueTitle,
+        whenTrueRequirements,
+        whenTrueObjectives,
+        whenTrueAutoCollapse
+      );
       if (trueSectionConfig) {
         block.whenTrueSectionConfig = trueSectionConfig;
       }
-      const falseSectionConfig = buildSectionConfig(whenFalseTitle, whenFalseRequirements, whenFalseObjectives);
+      const falseSectionConfig = buildSectionConfig(
+        whenFalseTitle,
+        whenFalseRequirements,
+        whenFalseObjectives,
+        whenFalseAutoCollapse
+      );
       if (falseSectionConfig) {
         block.whenFalseSectionConfig = falseSectionConfig;
       }
@@ -202,9 +224,11 @@ export function ConditionalBlockForm({
     whenTrueTitle,
     whenTrueRequirements,
     whenTrueObjectives,
+    whenTrueAutoCollapse,
     whenFalseTitle,
     whenFalseRequirements,
     whenFalseObjectives,
+    whenFalseAutoCollapse,
   ]);
 
   const handleSubmit = useCallback(
@@ -360,6 +384,11 @@ export function ConditionalBlockForm({
                     rows={2}
                   />
                 </Field>
+                <Checkbox
+                  label="Auto-collapse on completion"
+                  checked={whenTrueAutoCollapse}
+                  onChange={(e) => setWhenTrueAutoCollapse(e.currentTarget.checked)}
+                />
               </div>
             )}
           </div>
@@ -403,6 +432,11 @@ export function ConditionalBlockForm({
                     rows={2}
                   />
                 </Field>
+                <Checkbox
+                  label="Auto-collapse on completion"
+                  checked={whenFalseAutoCollapse}
+                  onChange={(e) => setWhenFalseAutoCollapse(e.currentTarget.checked)}
+                />
               </div>
             )}
           </div>

--- a/src/components/block-editor/forms/SectionBlockForm.tsx
+++ b/src/components/block-editor/forms/SectionBlockForm.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useCallback, useRef } from 'react';
-import { Button, Field, Input, Badge, useStyles2, Alert } from '@grafana/ui';
+import { Button, Field, Input, Badge, Checkbox, useStyles2, Alert } from '@grafana/ui';
 import { getBlockFormStyles } from '../block-editor.styles';
 import { COMMON_REQUIREMENTS } from '../../../constants/interactive-config';
 import { testIds } from '../../../constants/testIds';
@@ -59,6 +59,7 @@ export function SectionBlockForm({
   const [title, setTitle] = useState(initial?.title ?? '');
   const [requirements, setRequirements] = useState(initial?.requirements?.join(', ') ?? '');
   const [objectives, setObjectives] = useState(initial?.objectives?.join(', ') ?? '');
+  const [autoCollapse, setAutoCollapse] = useState(initial?.autoCollapse ?? true);
 
   // Preserve nested blocks when editing (but don't display them in the form)
   const nestedBlocks = useRef<JsonBlock[]>(initial?.blocks ?? []);
@@ -82,8 +83,10 @@ export function SectionBlockForm({
       ...(title.trim() && { title: title.trim() }),
       ...(reqArray.length > 0 && { requirements: reqArray }),
       ...(objArray.length > 0 && { objectives: objArray }),
+      // Only include when explicitly false (true is default, omit to keep JSON clean)
+      ...(!autoCollapse && { autoCollapse: false }),
     };
-  }, [sectionId, title, requirements, objectives]);
+  }, [sectionId, title, requirements, objectives, autoCollapse]);
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -192,6 +195,14 @@ export function SectionBlockForm({
           placeholder="e.g., completed-setup, configured-datasource"
         />
       </Field>
+
+      {/* Auto-collapse on completion */}
+      <Checkbox
+        className={styles.checkbox}
+        label="Auto-collapse on completion (collapse this section when all steps are completed)"
+        checked={autoCollapse}
+        onChange={(e) => setAutoCollapse(e.currentTarget.checked)}
+      />
 
       <div className={styles.footer}>
         <Button variant="secondary" onClick={onCancel} type="button">

--- a/src/docs-retrieval/components/interactive/interactive-conditional.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-conditional.tsx
@@ -212,6 +212,7 @@ export function InteractiveConditional({
           requirements={sectionRequirements}
           objectives={sectionObjectives}
           className="conditional-section"
+          autoCollapse={sectionConfig?.autoCollapse}
         >
           {childrenToRender.map((child, index) =>
             renderElement(child, `${keyPrefix}-${conditionsPassed ? 'true' : 'false'}-${index}`)

--- a/src/docs-retrieval/content-renderer.tsx
+++ b/src/docs-retrieval/content-renderer.tsx
@@ -980,6 +980,7 @@ function renderParsedElement(
           objectives={element.props.objectives}
           hints={element.props.hints}
           id={element.props.id} // Pass the HTML id attribute
+          autoCollapse={element.props.autoCollapse}
         >
           {renderChildren(element.children)}
         </InteractiveSection>

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -453,6 +453,7 @@ function convertSectionBlock(block: JsonSectionBlock, path: string, baseUrl?: st
         id: block.id,
         requirements,
         objectives,
+        autoCollapse: block.autoCollapse,
       },
       children,
     },

--- a/src/types/component-props.types.ts
+++ b/src/types/component-props.types.ts
@@ -71,6 +71,8 @@ export interface InteractiveSectionProps extends BaseInteractiveProps {
   isSequence?: boolean;
   id?: string; // HTML id attribute for section identification
   skippable?: boolean; // Whether this section can be skipped if requirements fail
+  /** Author preference: auto-collapse on completion. Undefined defaults to true (current behavior). */
+  autoCollapse?: boolean;
 }
 
 /**

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -294,6 +294,7 @@ const SectionProps = {
   title: z.string().optional(),
   requirements: z.array(z.string()).optional(),
   objectives: z.array(z.string()).optional(),
+  autoCollapse: z.boolean().optional(),
 };
 
 const AssistantProps = {
@@ -311,6 +312,7 @@ const ConditionalSectionConfigSchema = z.object({
   title: z.string().optional(),
   requirements: z.array(z.string()).optional(),
   objectives: z.array(z.string()).optional(),
+  autoCollapse: z.boolean().optional(),
 });
 
 const ConditionalProps = {
@@ -485,7 +487,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'skippable',
     'completeEarly',
   ]),
-  section: new Set(['type', 'id', 'title', 'blocks', 'requirements', 'objectives']),
+  section: new Set(['type', 'id', 'title', 'blocks', 'requirements', 'objectives', 'autoCollapse']),
   conditional: new Set([
     'type',
     'conditions',
@@ -497,7 +499,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'whenTrueSectionConfig',
     'whenFalseSectionConfig',
   ]),
-  _conditionalSectionConfig: new Set(['title', 'requirements', 'objectives']),
+  _conditionalSectionConfig: new Set(['title', 'requirements', 'objectives', 'autoCollapse']),
   quiz: new Set([
     'type',
     'question',

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -149,6 +149,8 @@ export interface JsonSectionBlock {
   requirements?: string[];
   /** Objectives tracked for completion of this section */
   objectives?: string[];
+  /** Whether to auto-collapse this section on completion. Author preference (overrides user). Defaults to true when omitted. */
+  autoCollapse?: boolean;
 }
 
 // ============ CONDITIONAL BLOCK ============
@@ -171,6 +173,8 @@ export interface ConditionalSectionConfig {
   requirements?: string[];
   /** Objectives tracked for completion of this section */
   objectives?: string[];
+  /** Whether to auto-collapse this section on completion. Author preference (overrides user). Defaults to true when omitted. */
+  autoCollapse?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add auto-collapse toggle to section blocks, basic implementation. 

Need to think about how we want to structure permissions, hierarchically, and dev behavior. 
   - Preview mode over-rules all the other settings, but checking the json structure it adjusts it correctly so does work for end user.

### Review findings

1. **[P2] Missing test coverage for `autoCollapse`**
   The implementation adds `autoCollapse` behavior, but the test coverage described in the plan is still missing. Please add/extend tests in:
   - `/grafana-pathfinder-app/src/components/block-editor/BlockList.test.tsx`
   - `/grafana-pathfinder-app/src/components/block-editor/utils/json-roundtrip.test.ts`
   - A targeted `interactive-section` test around `/grafana-pathfinder-app/src/docs-retrieval/components/interactive/interactive-section.tsx:526` for:
     - `autoCollapse: false`
     - `autoCollapse: undefined` (default behavior)
   
   Without these, we risk regressions in editor roundtrip + runtime collapse behavior.

2. **[P3] Preview mode may suppress default auto-collapse behavior**
   At `grafana-pathfinder-app/src/docs-retrieval/components/interactive/interactive-section.tsx:526`, preview mode exits early when `autoCollapse` is `undefined`.  
   If default behavior is supposed to apply when unset, this likely prevents authors from seeing expected auto-collapse behavior in preview unless they explicitly toggle the flag.

### Open question

- In `grafana-pathfinder-app/src/components/block-editor/forms/ConditionalBlockForm.tsx:387`, the auto-collapse toggle is currently a bare checkbox.  
  Should this be wrapped in a labeled `Field` (matching the section form and plan) for UI consistency and clarity?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive runtime completion/collapse behavior and persistence semantics, which could affect user-visible section state across guides; coverage gaps may allow regressions in editor JSON roundtrips and preview behavior.
> 
> **Overview**
> Adds an author-controlled `autoCollapse` flag for interactive sections, exposed via new checkboxes in the section and conditional-block forms (per conditional branch) and serialized into the generated JSON only when explicitly set to `false`.
> 
> Threads `autoCollapse` through the JSON schema/types/parser and runtime renderer (`content-renderer`, `interactive-conditional`) into `InteractiveSection`, updating collapse-on-completion behavior to honor `autoCollapse=false`, allow explicit opt-in/out in preview mode, and avoid persisting auto-collapsed state to storage during preview.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c7c8edbe15b7981e4b98b42fbf16e76d7e12914. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->