### PR TITLE
Add no-restricted-syntax ESLint rules for security and architecture (Phase 6)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,4 +40,57 @@ export default defineConfig([
     ],
   },
   ...baseConfig,
+
+  // Phase 6: Security and architecture lint rules (Epic #603)
+  // Mechanically enforce security patterns (F1, F5) and architecture patterns.
+  // Test files are excluded — they legitimately use innerHTML for DOM setup/teardown.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['**/*.test.*', '**/*.spec.*'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "JSXAttribute[name.name='dangerouslySetInnerHTML']",
+          message:
+            'Avoid dangerouslySetInnerHTML — it bypasses React and risks XSS (F1). ' +
+            'Use sanitizeDocumentationHTML() with parseHTMLToComponents() instead. ' +
+            'If raw HTML injection is truly needed, wrap with sanitizeDocumentationHTML() and add an eslint-disable with justification.',
+        },
+        {
+          selector: "AssignmentExpression[left.property.name='innerHTML']",
+          message:
+            'Avoid .innerHTML assignment — it bypasses React and risks XSS (F5). ' +
+            'Use textContent for plain text, or sanitizeDocumentationHTML() if HTML structure is required.',
+        },
+        {
+          selector: "ClassDeclaration[superClass.name='Component']",
+          message:
+            'Use function components with hooks instead of class components. ' +
+            'Exception: error boundaries require componentDidCatch which has no hook equivalent.',
+        },
+        {
+          selector: "ClassDeclaration[superClass.name='PureComponent']",
+          message: 'Use function components with React.memo() instead of PureComponent.',
+        },
+        {
+          selector: "ClassDeclaration[superClass.property.name='Component']",
+          message:
+            'Use function components with hooks instead of class components. ' +
+            'Exception: error boundaries require componentDidCatch which has no hook equivalent.',
+        },
+        {
+          selector: "ClassDeclaration[superClass.property.name='PureComponent']",
+          message: 'Use function components with React.memo() instead of PureComponent.',
+        },
+        {
+          selector: "JSXAttribute[name.name='draggable']:not([value.expression.value=false])",
+          message:
+            'Use @dnd-kit instead of the native HTML5 draggable attribute. ' +
+            'See components/block-editor/dnd-helpers.tsx for patterns. ' +
+            'draggable={false} to suppress native drag is acceptable.',
+        },
+      ],
+    },
+  },
 ]);

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -22,6 +22,7 @@ interface ErrorBoundaryState {
   errorInfo: React.ErrorInfo | null;
 }
 
+// eslint-disable-next-line no-restricted-syntax -- Error boundaries require componentDidCatch (no hook equivalent)
 class PluginErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryState> {
   state: ErrorBoundaryState = {
     hasError: false,

--- a/src/components/AppConfig/TermsAndConditions.tsx
+++ b/src/components/AppConfig/TermsAndConditions.tsx
@@ -81,6 +81,7 @@ const TermsAndConditions = ({ plugin }: TermsAndConditionsProps) => {
         <div
           data-testid={testIds.termsAndConditions.termsContent}
           className={styles.termsContent}
+          // eslint-disable-next-line no-restricted-syntax -- Static dev-controlled content, sanitized with DOMPurify as defense-in-depth
           dangerouslySetInnerHTML={{ __html: sanitizeDocumentationHTML(TERMS_AND_CONDITIONS_CONTENT) }}
         />
 

--- a/src/components/PrTester/PrTester.tsx
+++ b/src/components/PrTester/PrTester.tsx
@@ -544,7 +544,7 @@ export function PrTester({ onOpenDocsPage, onOpenLearningJourney }: PrTesterProp
               <div
                 key={file.directoryName}
                 className={`${styles.fileItem} ${draggedIndex === index ? styles.fileItemDragging : ''}`}
-                draggable
+                draggable // eslint-disable-line no-restricted-syntax -- Dev-only PR tester, native DnD acceptable here
                 onDragStart={() => handleDragStart(index)}
                 onDragOver={(e) => handleDragOver(e, index)}
                 onDragEnd={handleDragEnd}

--- a/src/components/docs-panel/components/MyLearningErrorBoundary.tsx
+++ b/src/components/docs-panel/components/MyLearningErrorBoundary.tsx
@@ -19,6 +19,7 @@ interface MyLearningErrorBoundaryProps {
  * Error boundary component that catches errors in MyLearningTab
  * and displays a fallback UI instead of crashing the entire panel.
  */
+// eslint-disable-next-line no-restricted-syntax -- Error boundaries require componentDidCatch (no hook equivalent)
 export class MyLearningErrorBoundary extends Component<MyLearningErrorBoundaryProps, MyLearningErrorBoundaryState> {
   state: MyLearningErrorBoundaryState = { hasError: false, error: null };
 

--- a/src/components/docs-panel/link-handler.hook.ts
+++ b/src/components/docs-panel/link-handler.hook.ts
@@ -602,7 +602,7 @@ function createImageLightbox(imageSrc: string, imageAlt: string, theme: GrafanaT
   closeButton.className = 'journey-image-modal-close';
   closeButton.setAttribute('aria-label', 'Close image');
 
-  // SVG close icon (safe - no user input)
+  // eslint-disable-next-line no-restricted-syntax -- Static SVG literal, no user input
   closeButton.innerHTML = `
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <line x1="18" y1="6" x2="6" y2="18"></line>

--- a/src/interactive-engine/action-handlers/guided-handler.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.ts
@@ -274,7 +274,7 @@ export class GuidedHandler {
 
     const textContainer = document.createElement('div');
     textContainer.className = 'interactive-comment-text';
-    // SECURITY: sanitize HTML before injection (F5)
+    // eslint-disable-next-line no-restricted-syntax -- Sanitized with DOMPurify via sanitizeDocumentationHTML (F5)
     textContainer.innerHTML = sanitizeDocumentationHTML(comment);
 
     const contentWrapper = document.createElement('div');
@@ -1076,6 +1076,7 @@ export class GuidedHandler {
     }
 
     // Update status based on state
+    /* eslint-disable no-restricted-syntax -- Static status icons + sanitized hint via sanitizeDocumentationHTML */
     if (state === 'checking') {
       statusElement.className = 'interactive-form-validation-status form-checking';
       statusElement.innerHTML = '<span class="interactive-form-spinner">⟳</span> Checking...';
@@ -1084,9 +1085,9 @@ export class GuidedHandler {
       statusElement.innerHTML = '<span class="interactive-form-success-icon">✓</span> Looks good!';
     } else if (state === 'invalid' && hint) {
       statusElement.className = 'interactive-form-validation-status form-hint-warning';
-      // SECURITY: sanitize hint before display (F4)
       statusElement.innerHTML = `<span class="interactive-form-warning-icon">⚠</span> ${sanitizeDocumentationHTML(hint)}`;
     }
+    /* eslint-enable no-restricted-syntax */
   }
 
   /**

--- a/src/interactive-engine/global-interaction-blocker.ts
+++ b/src/interactive-engine/global-interaction-blocker.ts
@@ -284,6 +284,7 @@ class GlobalInteractionBlocker {
       z-index: 10001;
     `;
 
+    // eslint-disable-next-line no-restricted-syntax -- Static HTML template for blocker UI, no user input
     this.statusIndicator.innerHTML = `
       <div style="
         width: 16px;

--- a/src/interactive-engine/navigation-manager.ts
+++ b/src/interactive-engine/navigation-manager.ts
@@ -78,6 +78,7 @@ export class NavigationManager {
     // Text content - sanitize the HTML
     const textContainer = document.createElement('div');
     textContainer.className = 'interactive-comment-text';
+    // eslint-disable-next-line no-restricted-syntax -- Sanitized with DOMPurify via sanitizeDocumentationHTML
     textContainer.innerHTML = sanitizeDocumentationHTML(comment);
 
     // Content wrapper
@@ -854,7 +855,7 @@ export class NavigationManager {
     // Close button (absolute positioned for simple tooltips)
     const closeButton = document.createElement('button');
     closeButton.className = 'interactive-comment-close';
-    closeButton.innerHTML = '×';
+    closeButton.innerHTML = '×'; // eslint-disable-line no-restricted-syntax -- Static HTML entity
     closeButton.setAttribute('aria-label', 'Close');
     closeButton.setAttribute('title', 'Exit (Esc)');
 
@@ -911,7 +912,7 @@ export class NavigationManager {
     // Description/comment
     const descriptionElement = document.createElement('p');
     descriptionElement.className = 'interactive-comment-description';
-    // SECURITY: Sanitize comment HTML before insertion to prevent XSS
+    // eslint-disable-next-line no-restricted-syntax -- Sanitized with DOMPurify via sanitizeDocumentationHTML
     descriptionElement.innerHTML = sanitizeDocumentationHTML(comment || '');
     contentSection.appendChild(descriptionElement);
 
@@ -951,7 +952,7 @@ export class NavigationManager {
         // Previous button
         const prevButton = document.createElement('button');
         prevButton.className = 'interactive-comment-nav-btn';
-        prevButton.innerHTML = '← Back';
+        prevButton.innerHTML = '← Back'; // eslint-disable-line no-restricted-syntax -- Static HTML literal
         prevButton.setAttribute('aria-label', 'Previous step');
         prevButton.disabled = !onPreviousCallback;
 
@@ -973,7 +974,7 @@ export class NavigationManager {
         const nextButton = document.createElement('button');
         const isLastStep = stepInfo && stepInfo.current === stepInfo.total - 1;
         nextButton.className = 'interactive-comment-nav-btn interactive-comment-nav-btn--primary';
-        nextButton.innerHTML = isLastStep ? 'Start creating' : 'Next →';
+        nextButton.innerHTML = isLastStep ? 'Start creating' : 'Next →'; // eslint-disable-line no-restricted-syntax -- Static HTML literal
         nextButton.setAttribute('aria-label', isLastStep ? 'Start creating' : 'Next step');
 
         if (onNextCallback) {
@@ -1031,6 +1032,7 @@ export class NavigationManager {
     if (options?.showKeyboardHint) {
       const keyboardHint = document.createElement('div');
       keyboardHint.className = 'interactive-comment-keyboard-hint';
+      // eslint-disable-next-line no-restricted-syntax -- Static HTML keyboard hint UI
       keyboardHint.innerHTML = `
         <span class="interactive-comment-kbd">←</span>
         <span class="interactive-comment-kbd">→</span>


### PR DESCRIPTION
## Summary

Adds `no-restricted-syntax` ESLint rules to mechanically enforce security patterns (F1, F5) and architecture conventions, completing Phase 6 of [Epic #603](https://github.com/grafana/grafana-pathfinder-app/issues/603).

**Four rules added to `eslint.config.mjs`:**

- **`dangerouslySetInnerHTML`** → error with message pointing to `sanitizeDocumentationHTML()` + `parseHTMLToComponents()`
- **`.innerHTML =` assignment** → error pointing to `textContent` or sanitizer
- **Class components** (`extends Component`/`PureComponent`) → error recommending function components (with note about error boundary exception)
- **Native `draggable` attribute** → error pointing to `@dnd-kit` (`draggable={false}` excluded via AST selector)

**Scoping:** Rules apply to `src/**/*.{ts,tsx}` excluding test files (`*.test.*`, `*.spec.*`), since tests legitimately use `innerHTML` for DOM setup/teardown.

**16 justified suppressions across 8 files:**

| Category | Count | Justification |
|---|---|---|
| Sanitized innerHTML (DOMPurify) | 6 | Content passed through `sanitizeDocumentationHTML()` |
| Static HTML literals | 6 | Hardcoded strings like `'← Back'`, `'×'`, SVG icons — no user input |
| Error boundaries (class components) | 2 | `componentDidCatch` has no hook equivalent |
| Sanitized dangerouslySetInnerHTML | 1 | Static content, sanitized as defense-in-depth |
| Dev-only native draggable | 1 | PrTester dev tool, not user-facing |

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint:fix` passes (rules land clean — no new violations beyond the 16 suppressed)
- [x] `npm run prettier` passes
- [x] `npm run test:ci` passes (86 suites, 1765 tests)
- [x] Verify new code without suppressions triggers the expected lint error and agent-oriented message

Closes Phase 6 of #603.

Made with [Cursor](https://cursor.com)