### PR TITLE
fix: wire step reset callback from parent to InteractiveQuiz

### DIFF
--- a/src/docs-retrieval/components/interactive/interactive-quiz.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-quiz.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { css, cx, keyframes } from '@emotion/css';
 import { Button, Icon, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
@@ -114,6 +114,21 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
     isEligibleForChecking,
     skippable,
   });
+
+  // Handle reset trigger from parent section
+  // Resetting local state in response to an explicit parent signal is intentional,
+  // mirrors the pattern in interactive-step, interactive-multi-step, and interactive-guided.
+  useEffect(() => {
+    if (resetTrigger && resetTrigger > 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- explicit reset signal from parent, not a reactive side-effect
+      setSelectedIds(new Set());
+      setAttempts(0);
+      setIsLocallyCompleted(false);
+      setLastResult('none');
+      setShowHint(null);
+      setIsRevealed(false);
+    }
+  }, [resetTrigger]);
 
   // Compute effective completion state
   const isCompleted = parentCompleted || stepCompleted || isLocallyCompleted;

--- a/src/docs-retrieval/components/interactive/interactive-section.tsx
+++ b/src/docs-retrieval/components/interactive/interactive-section.tsx
@@ -1442,6 +1442,7 @@ export function InteractiveSection({
           isEligibleForChecking,
           isCompleted,
           onStepComplete: handleStepComplete,
+          onStepReset: handleStepReset,
           stepIndex: documentStepIndex,
           totalSteps: documentTotalSteps,
           sectionId: sectionId,


### PR DESCRIPTION
- Wire `onStepReset` callback to interactive-section component
- Add `useEffect` hook to `InteractiveQuiz` to handle reset triggers

Changes quiz behavior to reset, simple fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI-state reset wiring; risk is limited to quiz state being cleared at the wrong time if `resetTrigger` is misused.
> 
> **Overview**
> Fixes interactive quiz reset behavior when a parent `InteractiveSection` triggers a redo/reset.
> 
> `InteractiveSection` now passes `onStepReset` to `InteractiveQuiz`, and `InteractiveQuiz` listens to `resetTrigger` to clear its local UI state (selected choices, attempts, completion/result, hints, and revealed answers).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cd28d143d29bf911376acb7c64281f1eae89b67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->