### PR TITLE
Package design updates for architectural constraints & terminology

### DIFF
--- a/docs/design/PACKAGE-IMPLEMENTATION-PLAN.md
+++ b/docs/design/PACKAGE-IMPLEMENTATION-PLAN.md
@@ -4,6 +4,49 @@ This is the phased implementation plan for the [Pathfinder package design](./PAT
 
 ---
 
+## Progressive refinement
+
+This plan is executed phase-by-phase. Each phase is assigned to an agent, and early-phase execution will tend to surface decisions that affect later phases. The plan is a living document: agents completing a phase should update it with findings, key decisions made, and any refinements to later phases that follow from those decisions.
+
+**Agent execution protocol:** Before implementing an assigned phase, always stop and review all completed phases, including any decisions recorded in them. If a prior-phase decision renders a later-phase specification ambiguous or contradictory, ask questions to drive out ambiguity before proceeding with implementation. Do not assume that the original specification for your phase is still correct — validate it against the current state of the codebase and all decisions made in prior phases. When you are finished executing a phase **update this document** with your key decisions, and remove implementation detail, to leave behind a document maximally useful to the next agent.
+
+---
+
+### Tier model
+
+The codebase enforces a layered tier model via ratchet tests (`src/validation/architecture.test.ts`) and ESLint `no-restricted-imports` rules (`eslint.config.mjs`). Files in tier N may only import from tier N or lower. Tier 2 engines are laterally isolated — they cannot import from other Tier 2 engines.
+
+| Tier | Directories                                                                                                                          | Role                                 |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
+| 0    | `types/`, `constants/`                                                                                                               | Foundational types and configuration |
+| 1    | `lib/`, `security/`, `styles/`, `global-state/`, `utils/`, `validation/`                                                             | Shared utilities and validation      |
+| 2    | `context-engine/`, `docs-retrieval/`, `interactive-engine/`, `requirements-manager/`, `learning-paths/`, **`package-engine/`** (new) | Domain engines (laterally isolated)  |
+| 3    | `integrations/`                                                                                                                      | Cross-engine orchestration           |
+| 4    | `components/`, `pages/`                                                                                                              | Presentation layer                   |
+| —    | `cli/`, `bundled-interactives/`, `test-utils/`, `img/`, `locales/`                                                                   | Excluded from tier enforcement       |
+
+**Key decisions for this plan:**
+
+- **Schemas at Tier 0.** All Zod schemas (`ContentJsonSchema`, `ManifestJsonSchema`, `DependencyClauseSchema`, `RepositoryJsonSchema`, etc.) and shared type definitions (`GraphNode`, `GraphEdge`, `PackageResolution`) live in `src/types/` so they are importable by CLI, runtime engines, validation, and UI code.
+- **Validation at Tier 1.** Content validation functions (`validateGuide()` and future `validatePackage()`, `validateManifest()`) live in `src/validation/` at Tier 1. This eliminates the existing lateral violations from `docs-retrieval → validation` and prevents new ones from `package-engine → validation`. The `validation/` directory was moved from Tier 2 to Tier 1 because its production code depends only on Tier 0 (Zod schemas and types). Architecture ratchet tests remain in `validation/` — they are test files, excluded from tier enforcement.
+- **Package engine at Tier 2.** The `PackageResolver`, package loader, dependency resolver, and static catalog fetcher live together in `src/package-engine/` as a new Tier 2 engine with its own barrel export (`index.ts`). Lateral isolation means it cannot import from `docs-retrieval`, `learning-paths`, `context-engine`, or other Tier 2 engines.
+- **Graph types at Tier 0, graph builder in CLI.** `GraphNode` and `GraphEdge` type definitions live in `src/types/` for broad importability. The graph construction logic (`build-graph` command) lives in `src/cli/` (excluded from tier enforcement).
+- **Completion state is a consumer concern.** The package engine provides structural dependency resolution ("which packages provide capability X?") but does not check completion state. Determining whether dependencies are satisfied requires completion data from `learning-paths` — callers at Tier 3+ combine both. This avoids a lateral coupling between `package-engine` and `learning-paths`.
+
+### Dual registration
+
+Every new `src/` directory must be registered in **both** `TIER_MAP` in `src/validation/import-graph.ts` and the tier constants in `eslint.config.mjs`. The tier map completeness ratchet test will fail if a directory is missing. The ESLint config mirrors the tier map for editor-time feedback. Tier changes (e.g., moving `validation` from Tier 2 to Tier 1) require updates in both places.
+
+### Barrel export discipline
+
+Every Tier 2 engine must have an `index.ts` barrel. External consumers must import through the barrel — the ratchet test enforces this. When creating the package engine, design the barrel export surface (`PackageResolver`, `PackageResolution`, loader functions) up front.
+
+### Strict indexed access
+
+`noUncheckedIndexedAccess` is enabled. All indexed lookups (e.g., `repository.json` package lookups by ID, catalog entries, step arrays) return `T | undefined`. Code must handle the `undefined` case explicitly.
+
+---
+
 ## Testing strategy alignment
 
 This plan is designed to support and further the [content testing strategy](./TESTING_STRATEGY.md) ("Enablement Observability"). Each phase names which testing layer(s) it extends:
@@ -24,7 +67,7 @@ This plan is designed to support and further the [content testing strategy](./TE
 | 2: Bundled repository migration             | Layer 1 + Layer 2 |
 | 3: Plugin runtime resolution                | Layer 2           |
 | 4: Pilot migration of interactive-tutorials | Layer 2 + Layer 3 |
-| 5: Learning journey integration             | Layer 1 + Layer 2 |
+| 5: Path and journey integration             | Layer 1 + Layer 2 |
 | 6: Layer 4 test environment routing         | Layer 4           |
 | 7: Repository registry service              | —                 |
 | 8: SCORM foundation                         | —                 |
@@ -42,8 +85,15 @@ This plan is designed to support and further the [content testing strategy](./TE
 
 **Deliverables:**
 
-- [ ] Define `ContentJsonSchema` for `content.json` (`schemaVersion`, `id`, `title`, `blocks`)
-- [ ] Define `ManifestJsonSchema` for `manifest.json` (flat metadata fields, flat dependency fields, `targeting`)
+- [ ] **Prerequisite tier changes:**
+  - [ ] Move `validation` from Tier 2 to Tier 1 in `TIER_MAP` (`src/validation/import-graph.ts`) and `TIER_2_ENGINES` / tier constants (`eslint.config.mjs`)
+  - [ ] Remove the 2 `eslint-disable-next-line` comments in `docs-retrieval/content-fetcher.ts` and `docs-retrieval/json-parser.ts` (lateral violations disappear when `validation` becomes Tier 1)
+  - [ ] Remove the corresponding 2 entries from `ALLOWED_LATERAL_VIOLATIONS` in `architecture.test.ts` (`docs-retrieval/json-parser.ts -> validation`, `docs-retrieval/content-fetcher.ts -> validation`)
+  - [ ] Verify `npm run test:ci` and `npm run lint` pass after tier change
+- [ ] **Schema definitions** (all in `src/types/`, Tier 0 — importable by CLI, runtime engines, validation, and UI):
+  - [ ] Define `ContentJsonSchema` for `content.json` (`schemaVersion`, `id`, `title`, `blocks`)
+  - [ ] Define `ManifestJsonSchema` for `manifest.json` (flat metadata fields, flat dependency fields, `targeting`)
+  - [ ] Define `RepositoryJsonSchema` for `repository.json` (bare package id → `{ path, ...metadata }` mapping)
 - [ ] **Package identity model:**
   - [ ] Package IDs are bare strings, globally unique (e.g., `"welcome-to-grafana"`)
   - [ ] No repository prefix in IDs (not `"repo/id"`, just `"id"`)
@@ -52,7 +102,7 @@ This plan is designed to support and further the [content testing strategy](./TE
   - [ ] Allows packages to move between repositories without ID changes
   - [ ] Resolution handled by PackageResolver (Phase 3), not by parsing ID syntax
 - [ ] **Manifest field requirements and defaults:**
-  - [ ] **Hard requirements (ERROR if missing):** `id`, `type`
+  - [ ] **Hard requirements (ERROR if missing):** `id`, `type` (valid values: `"guide"`, `"path"`, `"journey"` — no default)
   - [ ] **Defaults with INFO validation message:**
     - `repository` → `"interactive-tutorials"`
     - `language` → `"en"`
@@ -71,7 +121,7 @@ This plan is designed to support and further the [content testing strategy](./TE
   - [ ] **Defaults with INFO validation message:**
     - `author` → `undefined`
     - `testEnvironment` → default structure indicating Grafana Cloud is required
-  - [ ] **Conditional ERROR:** `steps` is required when `type: "journey"`
+  - [ ] **Conditional ERROR:** `steps` is required when `type: "path"` or `type: "journey"`
   - [ ] Schema uses Zod `.default()` chaining to apply defaults during parsing
   - [ ] CLI validation emits ERROR/WARN/INFO messages based on missing field severity
 - [ ] Include `testEnvironment` field in `ManifestJsonSchema` from day one with default structure
@@ -80,17 +130,17 @@ This plan is designed to support and further the [content testing strategy](./TE
 - [ ] Add `KNOWN_FIELDS._manifest` for `manifest.json` fields
 - [ ] Bump `CURRENT_SCHEMA_VERSION` to `"1.1.0"`
 - [ ] Define `repository.json` specification (bare package id → `{ path, ...metadata }` mapping, compiled build artifact)
-- [ ] Denormalize manifest metadata into `repository.json` entries: each entry uses bare package ID as key and includes `{ path, title, description, category, type, startingLocation, depends, recommends, suggests, provides, conflicts, replaces }` — enables dependency graph building without re-reading every `manifest.json`
+- [ ] Denormalize manifest metadata into `repository.json` entries: each entry uses bare package ID as key and includes `{ path, title, description, category, type, startingLocation, steps, depends, recommends, suggests, provides, conflicts, replaces }` — enables dependency graph building without re-reading every `manifest.json`
 - [ ] Example structure: `{ "welcome-to-grafana": { "path": "welcome-to-grafana/", "title": "...", "type": "guide", ... } }`
 - [ ] **Forward compatibility:** repository.json format serves both static catalog aggregation (Phase 4) and future repository registry ingestion (Phase 7). Design for dual use: build-time aggregation and runtime discovery.
 - [ ] Implement `pathfinder-cli build-repository` command (scans package tree, reads both `content.json` and `manifest.json` for each package, emits denormalized `repository.json` with bare IDs)
 - [ ] CI verification for plugin repo: rebuild bundled `repository.json` from scratch, diff against committed version, fail on divergence (committed lockfile approach — appropriate for low-velocity bundled content)
 - [ ] Note: `interactive-tutorials` uses CI-generated `repository.json` published to CDN rather than committed lockfile — see Phase 4 for that repository's publication strategy
-- [ ] Add Layer 1 unit tests for content schema, package schema, cross-file ID consistency, and repository index generation — extending the existing validation infrastructure in `src/validation/`
+- [ ] Add Layer 1 unit tests for content schema, package schema, cross-file ID consistency, and repository index generation — test suites live in `src/validation/` (test files are excluded from tier enforcement), schema definitions live in `src/types/` (Tier 0)
 - [ ] Run `validate:strict` to confirm all existing guides still pass
-- [ ] Update schema-coupling documentation
+- [ ] Update schema-coupling documentation to cover the new two-file model
 
-**Why first:** Everything downstream depends on the schema accepting these fields, the two-file model being defined, and the identity model being established. Without `repository.json`, package IDs cannot be resolved to filesystem paths — especially for nested journey step packages.
+**Why first:** Everything downstream depends on the schema accepting these fields, the two-file model being defined, and the identity model being established. Without `repository.json`, package IDs cannot be resolved to filesystem paths — especially for path and journey step packages.
 
 ### Phase 1: CLI package validation (Layer 1 completion)
 
@@ -105,9 +155,11 @@ This plan is designed to support and further the [content testing strategy](./TE
 - [ ] `--packages` flag: validate a tree of package directories
 - [ ] Asset reference validation: warn if `content.json` references assets not in `assets/`
 - [ ] **Dependency graph builder:**
+  - [ ] **Type definitions** (in `src/types/`, Tier 0): `GraphNode` and `GraphEdge` types live alongside other package types so they are importable by CLI, visualization components, the recommender, and any future runtime consumers
+  - [ ] **Graph builder logic** (in `src/cli/`, excluded from tier enforcement): the `build-graph` command constructs the graph; it can import freely from Tier 0 types and Tier 1 validation
   - [ ] `build-graph` command: iterate over a repository list (e.g., `["bundled-interactives", "interactive-tutorials"]`), read each `repository.json` denormalized index, construct in-memory graph from metadata
   - [ ] Graph representation: nodes (full manifest metadata from denormalized `repository.json`) + edges (typed relationships)
-  - [ ] Edge types: `depends`, `recommends`, `suggests`, `provides`, `conflicts`, `replaces`
+  - [ ] Edge types: `depends`, `recommends`, `suggests`, `provides`, `conflicts`, `replaces`, `steps`
   - [ ] Output format: D3 JSON with structure `{ nodes: GraphNode[], edges: GraphEdge[], metadata: {...} }`
   - [ ] `GraphNode` schema: `{ id, repository, title?, description?, category?, type, startingLocation, ...fullManifest }` (includes all manifest fields with defaults applied)
     - `id`: bare package ID (globally unique, e.g., `"welcome-to-grafana"`)
@@ -117,15 +169,17 @@ This plan is designed to support and further the [content testing strategy](./TE
   - [ ] CNF dependency clauses: simplified implementation creates edges to all mentioned packages regardless of AND/OR semantics (note as limitation for future work — OR clauses are imprecise in this representation)
   - [ ] Virtual capability handling in graph output:
     - Graph command output (D3 JSON): virtual capabilities appear as virtual nodes (distinguished by a `virtual: true` flag on the node) with `provides` edges from real packages. This preserves the abstraction in visualization.
-    - Runtime dependency resolution: virtual nodes are resolved to their providing packages directly (no virtual node in the resolution path — just "is any provider completed?")
+    - Runtime structural resolution (Phase 3): virtual nodes are resolved to their providing packages directly (no virtual node in the resolution path). The package engine answers "which packages provide this?" — satisfaction checking ("is any provider completed?") is a consumer concern at Tier 3+.
   - [ ] **Virtual capability resolution:**
     - [ ] Build a provides map: scan all packages' `provides` arrays to create a mapping from virtual capability name → set of providing package IDs
     - [ ] Dependency targets are satisfied if they match a real package ID **or** if any package in the catalog declares `provides: ["that-target"]`
     - [ ] Virtual capability names declared in `provides` do NOT need to exist as real packages — this follows the Debian virtual package model (e.g., `"datasource-configured"` is a virtual capability provided by multiple real packages)
   - [ ] Graph lint checks against global catalog (all WARN severity during migration phase, no ERROR):
     - Dependency target doesn't exist as a real package ID AND is not provided by any package in the catalog (broken reference)
+    - `steps` entries that don't resolve to existing packages in the catalog (broken step reference)
     - Cycle detection in `depends` chains (error-level semantic issue)
     - Cycle detection in `recommends` chains (warning-level semantic issue)
+    - Cycle detection in `steps` chains (error-level — a step cannot transitively contain its parent)
     - Orphaned packages (no incoming or outgoing edges)
     - Packages with undefined `description` or `category` (quality issue)
   - [ ] `graph` command: wrapper that invokes `build-graph` and outputs D3 JSON to stdout or file
@@ -167,13 +221,18 @@ This plan is designed to support and further the [content testing strategy](./TE
 
 **Deliverables:**
 
-- [ ] **PackageResolver implementation:**
+- [ ] **Package engine setup** (`src/package-engine/`, Tier 2):
+  - [ ] Create `src/package-engine/` directory with `index.ts` barrel export
+  - [ ] Register in `TIER_MAP` (`src/validation/import-graph.ts`) as tier 2 and in `TIER_2_ENGINES` / tier constants (`eslint.config.mjs`)
+  - [ ] Verify `npm run test:ci` passes with new engine registered (tier map completeness test)
+- [ ] **PackageResolver implementation** (in `src/package-engine/`):
   - [ ] Reads bundled `repository.json` to build in-memory package lookup
   - [ ] Resolves bare ID → content URL + manifest URL from bundled repository paths
-  - [ ] `resolve()` always returns ID and URLs; `loadContent` option fetches and populates manifest and content objects
-  - [ ] Resolution interface:
+  - [ ] `resolve()` returns a discriminated union — either package information or a rich error. Resolution can fail due to nonexistent ID, network failure, or other errors. Callers must discriminate before accessing data (works with `noUncheckedIndexedAccess`).
+  - [ ] Resolution interface (type definitions in `src/types/`, Tier 0):
     ```typescript
-    interface PackageResolution {
+    interface PackageResolutionSuccess {
+      ok: true;
       id: string;
       contentUrl: string;
       manifestUrl: string;
@@ -183,6 +242,16 @@ This plan is designed to support and further the [content testing strategy](./TE
       /** Populated when resolve options request content loading */
       content?: ContentJson;
     }
+    interface ResolutionError {
+      code: 'not-found' | 'network-error' | 'parse-error' | 'validation-error';
+      message: string;
+    }
+    interface PackageResolutionFailure {
+      ok: false;
+      id: string;
+      error: ResolutionError;
+    }
+    type PackageResolution = PackageResolutionSuccess | PackageResolutionFailure;
     interface ResolveOptions {
       /** When true, fetch and populate manifest and content on the resolution result */
       loadContent?: boolean;
@@ -192,17 +261,20 @@ This plan is designed to support and further the [content testing strategy](./TE
     }
     ```
   - [ ] Repositories are internal to the resolver — URLs pointing to indexes, not first-class objects
-- [ ] **Package loader:**
+- [ ] **Package loader** (in `src/package-engine/`):
   - [ ] Load directory packages (`content.json` + `manifest.json`) from resolved locations
-  - [ ] Fallback to single-file guides for backwards compatibility
+  - [ ] Fallback to single-file guides for backwards compatibility — the loader recognizes old-format single-file JSON and parses it using schemas from `src/types/` (Tier 0) and validation from `src/validation/` (Tier 1). This is self-contained within the package engine; no import from `docs-retrieval` is needed.
   - [ ] Handle local (bundled) content sources
-- [ ] **Dependency resolution from repository.json:**
-  - [ ] Resolve `depends`, `suggests`, and `provides` relationships using metadata from `repository.json` directly (not from CLI-generated graph)
-  - [ ] **Provides-aware resolution:** when checking whether a `depends` target is satisfied, check both real package completion and virtual capability satisfaction (i.e., has the user completed any package that `provides` the target capability?)
+  - [ ] **Transitional duplication note:** During the migration period, content loading logic will exist in both `docs-retrieval` (existing paths) and `package-engine` (new package loading + legacy fallback). The duplication is intentional — it avoids a lateral coupling between the two Tier 2 engines. Full resolution depends on work in the external `grafana-recommender` microservice (outside this plan's scope) to adopt package resolution; until then, both code paths must remain.
+- [ ] **Structural dependency resolution** (in `src/package-engine/`):
+  - [ ] Resolve structural `depends`, `suggests`, and `provides` relationships using metadata from `repository.json` directly (not from CLI-generated graph)
+  - [ ] **Provides-aware resolution (structural only):** given a dependency target, determine which packages provide that capability. Example: `getProviders("datasource-configured")` returns `["configure-prometheus", "configure-loki"]`. The package engine answers "which packages satisfy this?" — not "is it satisfied?"
+  - [ ] **Satisfaction checking is a consumer concern.** Determining whether a dependency is actually satisfied requires completion state from `learning-paths` (Tier 2). The package engine cannot import from `learning-paths` (lateral isolation). Consumers at Tier 3+ (integrations) or Tier 4 (components) combine structural resolution from the package engine with completion data from `learning-paths` to determine satisfaction.
   - [ ] Support navigation and recommendations based on dependency metadata
   - [ ] Handle circular dependencies gracefully
 - [ ] Plugin runtime does **not** consume the CLI-generated dependency graph — that artifact is for the recommender service, visualization, and lint tooling. This keeps client memory bounded as the content corpus grows.
-- [ ] Layer 2 unit tests for bundled resolution, package loader, and dependency resolver
+- [ ] **Barrel export surface** (`src/package-engine/index.ts`): export `PackageResolver`, the resolution type union, loader functions, and structural dependency query functions. Design for stability — consumers should not need internal imports.
+- [ ] Layer 2 unit tests for bundled resolution, package loader, and structural dependency resolver
 
 **Why fourth:** Completes the local end-to-end cycle: bundled content is migrated (Phase 2), and the plugin can now load and resolve it at runtime. Establishes the `PackageResolver` interface that later tiers (static catalog in Phase 4, registry service in Phase 7) will implement.
 
@@ -211,6 +283,8 @@ This plan is designed to support and further the [content testing strategy](./TE
 **Goal:** Migrate 3-5 guides from `interactive-tutorials` to the package format, add static catalog resolution for remote content, and validate the full authoring-to-testing pipeline across both bundled and external repositories.
 
 **Testing layers:** Layer 2 + Layer 3
+
+> **Re-planning note:** Phase 4 combines multiple distinct work streams (pilot migration, static catalog resolution, CDN publication, path migration tooling, e2e extension, documentation). When Phases 0-3 are complete, decompose Phase 4 into sub-phases based on decisions made during earlier phases. The right decomposition depends on context that does not yet exist.
 
 **Deliverables:**
 
@@ -224,21 +298,21 @@ This plan is designed to support and further the [content testing strategy](./TE
   - [ ] Published to CDN alongside guide content — always available to the plugin runtime without being a tracked file in the repository
   - [ ] Same `pathfinder-cli build-repository` command as Phase 0/2, different publication strategy: CI-generated + CDN-published rather than committed lockfile (appropriate for high-velocity content repository where guides change frequently)
   - [ ] Dependency graph JSON follows the same CI-generated + CDN-published pattern
-- [ ] **Static catalog resolution:**
+- [ ] **Static catalog resolution** (in `src/package-engine/` — extends the PackageResolver from Phase 3):
   - [ ] Build process: CLI aggregates all `repository.json` files (bundled committed lockfile + CDN-published remote indexes) into single `packages-catalog.json`, published to CDN
   - [ ] Catalog format includes denormalized metadata: `{ version: "1.0.0", packages: { [id]: { contentUrl, manifestUrl, repository, title, type, description, category, startingLocation, depends, recommends, suggests, provides, conflicts, replaces } } }` — structurally equivalent to `repository.json` but with URLs instead of paths, enabling dependency resolution from the catalog alone without additional per-package manifest fetches
   - [ ] Plugin fetch strategy: on startup, fetch catalog from CDN; cache in memory for session; fall back to bundled repository if fetch fails (offline/OSS support)
   - [ ] Plugin resolution flow: check bundled repository first (baseline content), then static catalog (extended content)
-  - [ ] Same `PackageResolver` interface — adds a second resolution tier
+  - [ ] Same `PackageResolver` interface and `PackageResolution` discriminated union — adds a second resolution tier
 - [ ] Verify plugin loads and renders `content.json` correctly from both bundled and remote sources
 - [ ] Verify `validate --packages` passes in CI (validates both files)
 - [ ] Extend e2e CLI to read `manifest.json` for pre-flight environment checks (Layer 3 enhancement)
 - [ ] Document the two-file package authoring workflow for content authors and metadata managers
-- [ ] **Journey migration tooling:**
-  - [ ] `migrate-journeys` command: tool-assisted migration of existing journey metadata
+- [ ] **Path migration tooling:**
+  - [ ] `migrate-paths` command: tool-assisted migration of existing learning path metadata
   - [ ] Reads `website/content/docs/learning-journeys/journeys.yaml` (external repo) for dependency graph data
   - [ ] Reads markdown front-matter from `website/content/docs/learning-journeys/*.md` for title, description, and metadata
-  - [ ] Generates draft `manifest.json` files for all `*-lj` directories in `interactive-tutorials`
+  - [ ] Generates draft `manifest.json` files (with `type: "path"`) for all `*-lj` directories in `interactive-tutorials`
   - [ ] Uses bare package IDs throughout (no repository prefix in `id` field or dependency references)
   - [ ] Sets `repository: "interactive-tutorials"` as provenance metadata (not used for resolution)
   - [ ] Maps `journeys.yaml` `links.to` relationships → `recommends` field in `manifest.json` using bare IDs (soft dependencies, not hard `depends`)
@@ -247,33 +321,43 @@ This plan is designed to support and further the [content testing strategy](./TE
 
 **Why fifth:** By this point, the end-to-end pipeline is already proven on bundled content (Phases 2-3). This phase extends to external content with confidence, adds the remote resolution tier, and validates the full authoring-to-testing pipeline across repositories. Layer 3 e2e integration validates the complete workflow.
 
-### Phase 5: Learning journey integration
+### Phase 5: Path and journey integration
 
-**Goal:** Journey metapackages are a working package type. The CLI validates journeys, the dependency graph treats them as first-class nodes, and learning paths can use package dependencies alongside curated `paths.json`. See [learning journeys](./PATHFINDER-PACKAGE-DESIGN.md#learning-journeys) for the full design.
+**Goal:** Paths and journeys are working metapackage types at two composition levels. A path (`type: "path"`) composes guides into an ordered sequence; a journey (`type: "journey"`) composes paths (or any packages) into a larger learning arc. The CLI validates both, the dependency graph treats them as first-class nodes, and learning paths can use package dependencies alongside curated `paths.json`. See [learning paths and journeys](./PATHFINDER-PACKAGE-DESIGN.md#learning-journeys) for the full design.
 
 **Testing layers:** Layer 1 + Layer 2
 
 **Deliverables:**
 
-- [ ] Add `type` field to `ManifestJsonSchema` (`"guide"` default, `"journey"`)
-- [ ] Add `steps` field to `ManifestJsonSchema` (ordered `string[]` of bare package IDs, valid when `type: "journey"`)
-- [ ] CLI: validate journey packages — `steps` array entries resolve to existing packages in the repository index (by bare ID), cover page `content.json`. Steps may be nested child directories (organizational convenience for journey-specific steps) or independent top-level packages (for shared/reused steps). The CLI validates via repository index resolution, not filesystem child-directory checks.
-- [ ] **Dependency graph representation for journeys:**
-  - [ ] Journey metapackages appear as regular nodes with `type: "journey"` (everything is a package)
-  - [ ] Journey steps appear as independent package nodes in the graph (they are packages, can be reused across multiple journeys)
-  - [ ] Journey metapackage has edges to its steps: linear `recommends` chain from journey node to each step in `steps` array order
+- [ ] **Path metapackages** (`type: "path"`):
+  - [ ] CLI: validate path packages — `steps` array entries resolve to existing packages in the repository index (by bare ID), cover page `content.json` optional
+  - [ ] Steps may be nested child directories (organizational convenience) or independent top-level packages (for reuse). The CLI validates via repository index resolution, not filesystem child-directory checks.
+  - [ ] Pilot: convert 1-2 existing `*-lj` directories to path metapackages with `manifest.json`
+  - [ ] Validate step reuse: confirm that a guide package can appear in multiple paths' `steps` arrays
+- [ ] **Journey metapackages** (`type: "journey"`):
+  - [ ] CLI: validate journey packages — `steps` array entries resolve to existing packages (typically paths, but any package type is valid)
+  - [ ] Journey-level `content.json` serves as a cover page (optional)
+  - [ ] Pilot: compose 1-2 journeys from existing paths to validate two-level composition
+- [ ] **`steps` field semantics (both levels):**
+  - [ ] `steps` is an ordered `string[]` of bare package IDs — the CLI validates that each entry resolves to an existing package but does NOT enforce the type of the referenced package. The type hierarchy (guides in paths, paths in journeys) is convention, not a schema constraint.
+  - [ ] Completion is set-based at each level: path complete = all steps complete; journey complete = all steps complete (transitively, all constituent guides)
+  - [ ] Ordering is advisory — the UI presents steps in array order but users may jump to any step
+- [ ] **Dependency graph representation:**
+  - [ ] Paths and journeys appear as regular nodes with their respective `type` values (everything is a package)
+  - [ ] Steps appear as independent package nodes in the graph (they are packages, can be reused across multiple metapackages)
+  - [ ] Metapackage has `steps` edges to each of its step packages in `steps` array order
   - [ ] `steps` array contains bare package IDs (e.g., `["step-1", "step-2"]`), no repository prefix
-  - [ ] Graph lint: journey `steps` references must resolve to existing packages in global catalog
-- [ ] Pilot: convert 1-2 existing `*-lj` directories to journey metapackages with `manifest.json`
-- [ ] Validate step reuse: confirm that a step package can appear in multiple journey `steps` arrays
-- [ ] Utility to compute learning paths from dependency DAG
-- [ ] Reconciliation: curated `paths.json` takes priority; dependency-derived paths fill gaps
+  - [ ] Graph lint: `steps` references must resolve to existing packages in global catalog
+  - [ ] Cycle detection in `steps` chains (error-level — a step cannot transitively contain its parent)
+- [ ] **Learning path reconciliation** (Tier 3+ — `integrations/` or `components/`):
+  - [ ] Utility to compute learning paths from dependency DAG — this logic needs both `package-engine` (structural dependency graph) and `learning-paths` (curated `paths.json`, completion state), so it must live at Tier 3+ where it can import from multiple Tier 2 engines
+  - [ ] Reconciliation: curated `paths.json` takes priority; dependency-derived paths fill gaps
 - [ ] UI: learning path cards use package metadata (description, category) when available
-- [ ] Align with docs partners' YAML format for learning journey relationships
-- [ ] Layer 1 unit tests for journey schema validation (`type`, `steps`, nested structure)
-- [ ] Layer 2 unit tests for journey-specific logic (step resolution, completion tracking, metapackage navigation)
+- [ ] Align with docs partners' YAML format for learning path relationships
+- [ ] Layer 1 unit tests for path and journey schema validation (`type`, `steps`, nested structure)
+- [ ] Layer 2 unit tests for metapackage-specific logic (step resolution, completion tracking, navigation across both levels)
 
-**Why sixth:** First user-visible payoff of the package model. Introduces the metapackage composition pattern that SCORM `"course"` and `"module"` types will later build on. Content authors and docs partners see dependency declarations reflected in the learning experience.
+**Why sixth:** First user-visible payoff of the package model. Introduces two-level metapackage composition (paths compose guides, journeys compose paths) that SCORM `"course"` and `"module"` types will later build on. Content authors and docs partners see dependency declarations reflected in the learning experience.
 
 ### Phase 6: Layer 4 test environment routing
 
@@ -320,7 +404,7 @@ This plan is designed to support and further the [content testing strategy](./TE
 - [ ] **Catalog aggregation:**
   - [ ] Service dynamically aggregates all `repository.json` files from known repositories
   - [ ] Maintains global catalog in memory/cache (refresh on interval or webhook trigger)
-  - [ ] Detects and reports package ID collisions across repositories (ERROR on duplicate IDs)
+  - [ ] Detects package ID collisions across repositories — the registry maintains a compound key (repository + package ID) internally, distinguishing the same bare ID published by different repositories. The `PackageResolver` resolves bare IDs using priority-based clobber semantics (first repository in priority order wins). This evolves the identity model: Phases 0-6 assume globally unique bare IDs; Phase 7 introduces registry-scoped uniqueness with deterministic resolution order.
 - [ ] **Repository discovery:**
   - [ ] Config-driven registry: service reads repository list from configuration file
   - [ ] Repositories can be added/removed without service code changes
@@ -344,17 +428,17 @@ This plan is designed to support and further the [content testing strategy](./TE
 
 ### Phase 8: SCORM foundation
 
-**Goal:** Extend the package format for SCORM import needs. Schema extensions only — not the importer itself. Builds on the `type` discriminator and metapackage composition model established by journeys in Phase 5.
+**Goal:** Extend the package format for SCORM import needs. Schema extensions only — not the importer itself. Builds on the `type` discriminator (Phase 0) and two-level metapackage composition model established by paths and journeys in Phase 5.
 
 **Deliverables:**
 
-- [ ] Extend `type` field with `"course"` and `"module"` values (journey's `"guide"` and `"journey"` already in place from Phase 5)
+- [ ] Extend `type` field with `"course"` and `"module"` values (`"guide"`, `"path"`, and `"journey"` already in place from Phase 0)
 - [ ] Add flat `source` field to `manifest.json` for provenance tracking
 - [ ] Add flat `keywords`, `rights`, `educationalContext`, `difficulty`, `estimatedDuration` fields to `manifest.json`
 - [ ] Course/module rendering in web display mode (table-of-contents page)
 - [ ] Design SCORM import pipeline CLI interface
 
-**Why ninth:** Extends the package format so it can receive SCORM-imported content. The journey metapackage model from Phase 5 provides the composition infrastructure; SCORM types refine it with import-specific semantics. The actual importer follows the phased plan in [SCORM.md](./SCORM.md).
+**Why ninth:** Extends the package format so it can receive SCORM-imported content. The path and journey metapackage model from Phase 5 provides the composition infrastructure; SCORM types refine it with import-specific semantics. The actual importer follows the phased plan in [SCORM.md](./SCORM.md).
 
 ### Phase 9+: SCORM import pipeline
 
@@ -364,15 +448,15 @@ Follows the 5-phase plan in the [SCORM analysis](./SCORM.md): parser, extractor,
 
 ## Summary
 
-| Phase                                       | Unlocks                                                                       | Testing layers    |
-| ------------------------------------------- | ----------------------------------------------------------------------------- | ----------------- |
-| 0: Schema foundation                        | Everything — `content.json` + `manifest.json` model, `testEnvironment` schema | Layer 1           |
-| 1: CLI package validation                   | CI validation, cross-file checks, dependency graph                            | Layer 1           |
-| 2: Bundled repository migration             | End-to-end proof on local corpus, bundled `repository.json`                   | Layer 1 + Layer 2 |
-| 3: Plugin runtime resolution                | PackageResolver consuming bundled repo, local resolution tier                 | Layer 2           |
-| 4: Pilot migration of interactive-tutorials | Remote content, static catalog, full authoring-to-testing pipeline            | Layer 2 + Layer 3 |
-| 5: Learning journey integration             | Metapackage model, `type`/`steps`, docs partner alignment                     | Layer 1 + Layer 2 |
-| 6: Layer 4 test environment routing         | Managed environment routing, version matrix, dataset provisioning             | Layer 4           |
-| 7: Repository registry service              | Dynamic multi-repo resolution, rapid content updates, ecosystem scale         | —                 |
-| 8: SCORM foundation                         | SCORM import readiness, extends `type` with course/module                     | —                 |
-| 9+: SCORM import pipeline                   | Full SCORM conversion pipeline                                                | —                 |
+| Phase                                       | Unlocks                                                                         | Testing layers    |
+| ------------------------------------------- | ------------------------------------------------------------------------------- | ----------------- |
+| 0: Schema foundation                        | Everything — `content.json` + `manifest.json` model, `testEnvironment` schema   | Layer 1           |
+| 1: CLI package validation                   | CI validation, cross-file checks, dependency graph                              | Layer 1           |
+| 2: Bundled repository migration             | End-to-end proof on local corpus, bundled `repository.json`                     | Layer 1 + Layer 2 |
+| 3: Plugin runtime resolution                | PackageResolver consuming bundled repo, local resolution tier                   | Layer 2           |
+| 4: Pilot migration of interactive-tutorials | Remote content, static catalog, full authoring-to-testing pipeline              | Layer 2 + Layer 3 |
+| 5: Path and journey integration             | Two-level metapackage model (paths + journeys), `steps`, docs partner alignment | Layer 1 + Layer 2 |
+| 6: Layer 4 test environment routing         | Managed environment routing, version matrix, dataset provisioning               | Layer 4           |
+| 7: Repository registry service              | Dynamic multi-repo resolution, rapid content updates, ecosystem scale           | —                 |
+| 8: SCORM foundation                         | SCORM import readiness, extends `type` with course/module                       | —                 |
+| 9+: SCORM import pipeline                   | Full SCORM conversion pipeline                                                  | —                 |

--- a/docs/design/package/learning-journeys.md
+++ b/docs/design/package/learning-journeys.md
@@ -1,112 +1,124 @@
-# Learning journeys
+# Learning paths and journeys
 
 > Part of the [Pathfinder package design](../PATHFINDER-PACKAGE-DESIGN.md).
 > See also: [Dependencies](./dependencies.md) · [Identity and resolution](./identity-and-resolution.md) · [Standards alignment](./standards-alignment.md) · [Implementation plan](../PACKAGE-IMPLEMENTATION-PLAN.md)
 
 ---
 
-A learning journey is an ordered sequence of guides that build toward a larger outcome. Not a single guide package, a series of packages that decompose a complex topic into manageable steps — "Set up infrastructure alerting," "Configure a Linux server integration," "Visualize trace data."
+The package model supports two levels of metapackage composition:
 
-Journeys are packages and contribute in the same way in the package system and the dependency graph. Other guides can `"depends": ["infrastructure-alerting"]` and mean "the user has completed the entire alerting journey." Journeys carry their own metadata, targeting, and `provides` capabilities — they are addressable, recommendable, and completable as a unit.
+- A **path** is an ordered sequence of guides that build toward a focused outcome — "Set up a Linux server integration," "Configure infrastructure alerting," "Create your first dashboard."
+- A **journey** is an ordered sequence of paths (or any packages) that build toward a larger learning arc — "Infrastructure mastery" composing linux-server-integration, kubernetes-integration, and alerting paths.
+
+Both are packages and contribute in the same way in the package system and the dependency graph. Other packages can `"depends": ["infrastructure-alerting"]` and mean "the user has completed the entire alerting path." Paths and journeys carry their own metadata, targeting, and `provides` capabilities — they are addressable, recommendable, and completable as a unit.
 
 ## The metapackage model
 
-Journeys follow the Debian **metapackage** pattern: a package whose primary purpose is to compose other packages into a coherent experience. In Debian, `ubuntu-desktop` is a metapackage that depends on `nautilus`, `gedit`, `gnome-terminal`, and hundreds of other packages. Installing `ubuntu-desktop` gives you a complete desktop environment. The metapackage is the identity handle for the collection; the components are real, independently maintained packages.
+Paths and journeys follow the Debian **metapackage** pattern: a package whose primary purpose is to compose other packages into a coherent experience. In Debian, `ubuntu-desktop` is a metapackage that depends on `nautilus`, `gedit`, `gnome-terminal`, and hundreds of other packages. Installing `ubuntu-desktop` gives you a complete desktop environment. The metapackage is the identity handle for the collection; the components are real, independently maintained packages.
 
-We adopt the same principle. A journey is a metapackage. Its steps are real packages — not a special "sub-unit" type, not scoped fragments, not second-class entities. The package system has **one kind of thing**: a package. Some packages are metapackages that compose other packages into a coherent learning experience.
+We adopt the same principle at two levels. A path is a metapackage that composes guides. A journey is a metapackage that composes paths. Steps at both levels are real packages — not a special "sub-unit" type, not scoped fragments, not second-class entities. The package system has **one kind of thing**: a package. Some packages are metapackages that compose other packages into coherent learning experiences.
 
-## Metapackage Advantages
+## Metapackage advantages
 
 We're adopting the Debian model so we can get the advantages they've had for 30 years of package management:
 
 - **One identity model.** Steps have bare IDs, just like any other package. No fragment notation, no scoped identity, no new addressing scheme.
 - **One set of tools.** The CLI validates steps with the same validation pipeline as standalone guides. The graph command shows steps as real nodes. The index builder can index them. Every tool that works for packages works for steps.
 - **One dependency model.** Steps can use `depends`, `recommends`, `provides`, and the full dependency vocabulary. The metapackage uses `steps` for ordering but the dependency graph handles the rest.
-- **Composition evolution.** A journey can add, remove, or reorder steps between versions without changing its external identity. The `steps` array in the journey manifest absorbs the evolution. Downstream dependents are unaffected.
+- **Composition evolution.** A path can add, remove, or reorder steps between versions without changing its external identity. The `steps` array in the path manifest absorbs the evolution. Downstream dependents are unaffected.
 - **Flavors and reuse.** Different metapackages can compose different subsets of a shared step pool. This is already visible in the content corpus:
 
-| Journey                    | Steps                                                                                               |
+| Path                       | Steps                                                                                               |
 | -------------------------- | --------------------------------------------------------------------------------------------------- |
 | `linux-server-integration` | select-platform, install-alloy, configure-alloy, install-dashboards-alerts, restart-test-connection |
 | `macos-integration`        | select-architecture, install-alloy, configure-alloy, install-dashboards-alerts, test-connection     |
 | `mysql-integration`        | select-platform, install-alloy, configure-alloy, install-dashboards-alerts, test-connection         |
 
-Three journeys share `install-alloy`, `configure-alloy`, and `install-dashboards-alerts`. If those steps are real packages, they can be authored once and composed into multiple journeys — exactly as Debian metapackages compose shared components into different desktop experiences.
+Three paths share `install-alloy`, `configure-alloy`, and `install-dashboards-alerts`. If those steps are real packages, they can be authored once and composed into multiple paths — exactly as Debian metapackages compose shared components into different desktop experiences. A journey like `infrastructure-mastery` can then compose these paths into a larger arc.
 
-Step reuse is a structural capability enabled by the model, not a requirement imposed by it. Many journeys will have steps unique to that journey. The model accommodates both patterns without special-casing either.
+Step reuse is a structural capability enabled by the model, not a requirement imposed by it. Many paths will have steps unique to that path. The model accommodates both patterns without special-casing either.
 
 ## What metapackages don't give us
 
 Two aspects of Debian metapackages do not apply:
 
-**Ordering.** In Debian, `Depends: A, B, C` has no ordering semantics. Journeys need an explicit linear sequence. The `steps` field (described below) is **new machinery** that does not come from the Debian model. It is layered on top of the metapackage concept.
+**Ordering.** In Debian, `Depends: A, B, C` has no ordering semantics. Paths and journeys need an explicit linear sequence. The `steps` field (described below) is **new machinery** that does not come from the Debian model. It is layered on top of the metapackage concept.
 
-**Removal semantics.** In Debian, removing a metapackage allows `apt autoremove` to garbage-collect orphaned dependencies. There is no analogue in Pathfinder — you do not "uncomplete" a journey or "uninstall" a step.
+**Removal semantics.** In Debian, removing a metapackage allows `apt autoremove` to garbage-collect orphaned dependencies. There is no analogue in Pathfinder — you do not "uncomplete" a path or "uninstall" a step.
 
 ## The `type` discriminator
 
-The `manifest.json` `type` field distinguishes guides from journeys. This field was anticipated in [standards alignment](./standards-alignment.md#the-type-discriminator-future) for SCORM; journeys are the first concrete use.
+The `manifest.json` `type` field distinguishes the three package types. It is a required field with no default — every manifest must declare its type.
 
-| Type                | Meaning                                                     | Has `steps`? | Has content blocks?   |
-| ------------------- | ----------------------------------------------------------- | ------------ | --------------------- |
-| `"guide"` (default) | Single standalone lesson                                    | No           | Yes                   |
-| `"journey"`         | Metapackage composing an ordered sequence of guides         | Yes          | Optional (cover page) |
-| `"course"`          | SCORM-imported course (future)                              | Future       | Future                |
-| `"module"`          | Grouping of related guides without strict ordering (future) | Future       | Future                |
+| Type        | Meaning                                                              | Has `steps`? | Has content blocks?   |
+| ----------- | -------------------------------------------------------------------- | ------------ | --------------------- |
+| `"guide"`   | Single standalone lesson                                             | No           | Yes                   |
+| `"path"`    | Metapackage composing an ordered sequence of guides                  | Yes          | Optional (cover page) |
+| `"journey"` | Metapackage composing an ordered sequence of paths (or any packages) | Yes          | Optional (cover page) |
+| `"course"`  | SCORM-imported course (future)                                       | Future       | Future                |
+| `"module"`  | Grouping of related guides without strict ordering (future)          | Future       | Future                |
 
-When `type` is absent, the default is `"guide"`. All existing packages continue to work without changes.
-
-The `"journey"` type establishes the composition pattern that `"course"` and `"module"` will refine for SCORM. See [relationship to SCORM](#relationship-to-scorm) below.
+The `"path"` and `"journey"` types establish the two-level composition pattern that `"course"` and `"module"` will refine for SCORM. See [relationship to SCORM](#relationship-to-scorm) below.
 
 ## The `steps` field
 
-Journey manifests declare step ordering via a `steps` array:
+Path and journey manifests declare step ordering via a `steps` array:
 
 ```typescript
-/** Ordered array of bare package IDs that form the journey. Advisory linear sequence. */
+/** Ordered array of bare package IDs. Advisory linear sequence. Required when type is "path" or "journey". */
 steps?: string[];
 ```
 
-Each entry in `steps` is a **bare package ID** that must resolve to an existing package in the repository index. The array defines the **recommended reading order** — the linear path the UI presents to users.
+Each entry in `steps` is a **bare package ID** that must resolve to an existing package in the repository index. The array defines the **recommended reading order** — the linear sequence the UI presents to users.
 
-Steps may be physically nested as child directories of the journey (organizational convenience for journey-specific steps) or may be independent top-level packages (for steps shared across multiple journeys). The `steps` array makes no assumption about physical location — resolution is handled by the repository index, following the same bare-ID-to-path resolution used everywhere else in the package system. This follows the Debian convention where metapackage dependencies are independently located packages, not physically contained within the metapackage.
+**Steps reference packages, not types.** The CLI validates that each entry in `steps` resolves to an existing package, but does NOT enforce the type of the referenced package. The type hierarchy (guides in paths, paths in journeys) is a **convention**, not a schema constraint. This follows the Debian model where metapackages can depend on any package, including other metapackages. In practice:
 
-The `steps` field is valid only when `type` is `"journey"`. The CLI validates that:
+- A path's steps are typically guides
+- A journey's steps are typically paths
+- But a journey can include guides directly if that's the right composition
+
+Steps may be physically nested as child directories of the metapackage (organizational convenience for steps specific to that path or journey) or may be independent top-level packages (for steps shared across multiple metapackages). The `steps` array makes no assumption about physical location — resolution is handled by the repository index, following the same bare-ID-to-path resolution used everywhere else in the package system. This follows the Debian convention where metapackage dependencies are independently located packages, not physically contained within the metapackage.
+
+The `steps` field is valid when `type` is `"path"` or `"journey"`. The CLI validates that:
 
 - Every entry in `steps` resolves to an existing package in the repository index
 - No duplicate entries exist in the array
-- The `steps` array is non-empty when `type` is `"journey"`
+- The `steps` array is non-empty when `type` is `"path"` or `"journey"`
+- No cycles exist in `steps` chains (a step cannot transitively contain its parent)
 
-## Journey directory structure
+## Directory structure
 
-A journey directory contains its own `manifest.json` (with `type: "journey"`) and an optional `content.json` at the journey level that serves as a cover page or introduction. Journey-specific steps may be nested as child directories; shared steps live as independent top-level packages.
+A path or journey directory contains its own `manifest.json` and an optional `content.json` that serves as a cover page or introduction. Steps specific to that metapackage may be nested as child directories; shared steps live as independent top-level packages.
 
 ```
 interactive-tutorials/
-├── infrastructure-alerting/                ← journey metapackage
-│   ├── manifest.json                       ← type: "journey", steps: [...]
+├── infrastructure-alerting/                ← path metapackage
+│   ├── manifest.json                       ← type: "path", steps: [...]
 │   ├── content.json                        ← optional cover/introduction page
-│   ├── find-data-to-alert/                 ← journey-specific step (nested)
+│   ├── find-data-to-alert/                 ← path-specific step (nested)
 │   │   └── content.json
-│   ├── build-your-query/                   ← journey-specific step (nested)
+│   ├── build-your-query/                   ← path-specific step (nested)
 │   │   └── content.json
-│   └── set-conditions/                     ← journey-specific step (nested)
+│   └── set-conditions/                     ← path-specific step (nested)
 │       └── content.json
 ├── install-alloy/                          ← shared step (top-level, reusable)
 │   ├── content.json
 │   └── manifest.json
 ├── configure-alloy/                        ← shared step (top-level, reusable)
 │   └── content.json
-├── linux-server-integration/               ← another journey reusing shared steps
-│   ├── manifest.json                       ← steps: ["select-platform", "install-alloy", "configure-alloy", ...]
-│   └── select-platform/                    ← journey-specific step (nested)
+├── linux-server-integration/               ← another path reusing shared steps
+│   ├── manifest.json                       ← type: "path", steps: ["select-platform", "install-alloy", ...]
+│   └── select-platform/                    ← path-specific step (nested)
 │       └── content.json
+├── infrastructure-mastery/                 ← journey metapackage (composes paths)
+│   ├── manifest.json                       ← type: "journey", steps: ["linux-server-integration", ...]
+│   └── content.json                        ← optional cover page
 ├── welcome-to-grafana/                     ← standalone guide (unchanged)
 │   ├── content.json
 │   └── manifest.json
 ```
 
-In this example, `install-alloy` and `configure-alloy` are shared steps that appear in the `steps` arrays of multiple journeys (`linux-server-integration`, `macos-integration`, `mysql-integration`). They live as independent top-level packages — following the Debian convention where metapackage dependencies live in the pool independently, not physically contained within any metapackage. Journey-specific steps like `find-data-to-alert` and `select-platform` are nested under their journey for organizational convenience.
+In this example, `install-alloy` and `configure-alloy` are shared steps that appear in the `steps` arrays of multiple paths (`linux-server-integration`, `macos-integration`, `mysql-integration`). They live as independent top-level packages — following the Debian convention where metapackage dependencies live in the pool independently, not physically contained within any metapackage. Path-specific steps like `find-data-to-alert` and `select-platform` are nested under their path for organizational convenience. The journey `infrastructure-mastery` composes paths rather than guides directly.
 
 This introduces **nested package directories** — a package directory that may contain child package directories. The CLI must understand that a directory can contain both its own `manifest.json` and child package directories. This is a structural extension of the [package structure](../PATHFINDER-PACKAGE-DESIGN.md#package-structure) convention. Nesting is optional; the `steps` array uses bare package IDs resolved via the repository index regardless of physical location.
 
@@ -114,30 +126,30 @@ Step packages follow the same conventions as any package: they contain at minimu
 
 ## Step ordering and completion semantics
 
-**Ordering is advisory.** The `steps` array defines the suggested linear path. The UI presents steps in this order and encourages sequential progression. However, users are always permitted to jump into any step directly. The "steps" of a learning journey are packages like any other, and so can be used independently subject to dependencies.
+**Ordering is advisory.** The `steps` array defines the suggested linear sequence. The UI presents steps in this order and encourages sequential progression. However, users are always permitted to jump into any step directly. Steps are packages like any other, and can be used independently subject to dependencies.
 
-**Completion is set-based.** "Completing the journey" means completing all steps, regardless of the order in which they were completed. A user who completes steps 1, 3, 5, 2, 4, 6, 7 has completed the journey identically to one who followed the linear path. Journey completion triggers the journey's `provides` capabilities and satisfies downstream `depends` references.
+**Completion is set-based at each level.** Completing a path means completing all its steps, regardless of order. Completing a journey means completing all its steps (typically paths), which transitively means completing all guides in all constituent paths. A user who completes steps 1, 3, 5, 2, 4, 6, 7 has completed the path identically to one who followed the linear order. Completion triggers the metapackage's `provides` capabilities and satisfies downstream `depends` references.
 
-**Partial progress is tracked.** A user who has completed 5 of 7 steps is 71% through the journey. The UI can display progress based on the set of completed steps relative to the total step count.
+**Partial progress is tracked.** A user who has completed 5 of 7 steps is 71% through the path. For journeys, progress can be displayed at two levels: path-level progress (3 of 5 paths complete) and aggregate guide-level progress (23 of 35 total guides complete). The UI determines which level to display based on context.
 
-## Journey-level metadata and dependencies
+## Metapackage-level metadata and dependencies
 
-Journey-level `manifest.json` carries metadata and dependencies for the journey as a whole. Steps inherit the journey's context — they do not independently declare targeting or participate in the dependency graph unless there is a specific reason to do so. Other than that, journey metadata is the same as package metadata, differingly only with:
+Path and journey `manifest.json` files carry metadata and dependencies for the metapackage as a whole. Metapackage metadata is the same as any package metadata, differing only in:
 
-- `type: "journey"`
-- `steps: ["step1", "step2"]`
+- `type: "path"` or `type: "journey"`
+- `steps: ["step1", "step2", ...]`
 
-**Decision: steps do not inherit metadata from the journey.** Steps are independently reusable packages — that is the core value proposition of the metapackage model. If step behavior changed depending on which journey references it (inherited targeting, inherited category), it would introduce context-dependent identity, undermining the "one kind of thing" principle. A step should behave the same whether it appears in `infrastructure-alerting`, `linux-server-integration`, or is referenced standalone. If a journey needs to customize how a step appears in its context (e.g., different introduction text), that is a presentation concern for the UI layer, not a metadata inheritance concern.
+**Decision: steps do not inherit metadata from the metapackage.** Steps are independently reusable packages — that is the core value proposition of the metapackage model. If step behavior changed depending on which path or journey references it (inherited targeting, inherited category), it would introduce context-dependent identity, undermining the "one kind of thing" principle. A step should behave the same whether it appears in `infrastructure-alerting`, `linux-server-integration`, or is referenced standalone. If a metapackage needs to customize how a step appears in its context (e.g., different introduction text), that is a presentation concern for the UI layer, not a metadata inheritance concern.
 
-## Example: complete journey package
+## Example: path metapackage
 
-**`infrastructure-alerting/manifest.json`** — journey metapackage:
+**`infrastructure-alerting/manifest.json`** — path composing guides:
 
 ```json
 {
   "schemaVersion": "1.1.0",
   "id": "infrastructure-alerting",
-  "type": "journey",
+  "type": "path",
   "repository": "interactive-tutorials",
   "description": "Create your first infrastructure alert rule in Grafana Cloud, from finding data to monitoring your rule.",
   "category": "take-action",
@@ -153,7 +165,7 @@ Journey-level `manifest.json` carries metadata and dependencies for the journey 
   ],
   "depends": ["welcome-to-grafana"],
   "provides": ["infrastructure-alerting-configured"],
-  "recommends": ["prometheus-lj"],
+  "recommends": ["prometheus-path"],
   "targeting": {
     "match": { "urlPrefixIn": ["/alerting"] }
   }
@@ -170,7 +182,7 @@ Journey-level `manifest.json` carries metadata and dependencies for the journey 
   "blocks": [
     {
       "type": "markdown",
-      "content": "# Infrastructure alerting\n\nLearn to create alert rules that monitor your infrastructure metrics and logs. This journey walks you through finding data, building queries, setting conditions, and activating your first alert rule."
+      "content": "# Infrastructure alerting\n\nLearn to create alert rules that monitor your infrastructure metrics and logs. This path walks you through finding data, building queries, setting conditions, and activating your first alert rule."
     }
   ]
 }
@@ -192,35 +204,57 @@ Journey-level `manifest.json` carries metadata and dependencies for the journey 
 }
 ```
 
+## Example: journey metapackage
+
+**`infrastructure-mastery/manifest.json`** — journey composing paths:
+
+```json
+{
+  "schemaVersion": "1.1.0",
+  "id": "infrastructure-mastery",
+  "type": "journey",
+  "repository": "interactive-tutorials",
+  "description": "Master infrastructure monitoring in Grafana — from server setup through alerting and optimization.",
+  "category": "take-action",
+  "steps": ["linux-server-integration", "kubernetes-integration", "infrastructure-alerting"],
+  "provides": ["infrastructure-mastery-complete"],
+  "targeting": {
+    "match": { "urlPrefixIn": ["/connections", "/alerting"] }
+  }
+}
+```
+
+Each step in the journey is a path that itself contains guide steps. Completing the journey means completing all three paths (and transitively, all guides within those paths).
+
 ## Relationship to `paths.json`
 
-Journey metapackages and curated learning paths (`paths.json`) coexist:
+Path and journey metapackages and curated learning paths (`paths.json`) coexist:
 
-- **`paths.json`** defines editorially curated paths with badges, estimated time, icons, and platform targeting. It is a lightweight, inadequate predecessor to the dependency graph specification — a stand-in for not yet having the structural model that journey metapackages provide.
-- **Journey metapackages** define structurally composed experiences with dependency semantics. They are the target replacement for `paths.json`.
+- **`paths.json`** defines editorially curated paths with badges, estimated time, icons, and platform targeting. It is a lightweight predecessor to the dependency graph specification — a stand-in for not yet having the structural model that path metapackages provide.
+- **Path and journey metapackages** define structurally composed experiences with dependency semantics. They are the target replacement for `paths.json`.
 
-**End-state:** `paths.json` will be retired after all migration work is complete. Journey metapackages subsume its role — ordering comes from `steps`, metadata comes from `manifest.json`, and dependency relationships come from the graph. During the transition, `paths.json` remains as a fallback and curated paths take priority over dependency-derived paths. A separate milestone will be needed to migrate everything that depends on `paths.json` (badges, icons, platform targeting, estimated time) into the package model before `paths.json` can be deleted.
+**End-state:** `paths.json` will be retired after all migration work is complete. Path metapackages subsume its role — ordering comes from `steps`, metadata comes from `manifest.json`, and dependency relationships come from the graph. During the transition, `paths.json` remains as a fallback and curated paths take priority over dependency-derived paths. A separate milestone will be needed to migrate everything that depends on `paths.json` (badges, icons, platform targeting, estimated time) into the package model before `paths.json` can be deleted.
 
-The reconciliation between these two mechanisms during transition is addressed in [the learning journey integration phase](../PACKAGE-IMPLEMENTATION-PLAN.md#phase-4-learning-journey-integration).
+The reconciliation between these two mechanisms during transition is addressed in [the path and journey integration phase](../PACKAGE-IMPLEMENTATION-PLAN.md#phase-5-path-and-journey-integration).
 
 ## Relationship to SCORM
 
-The journey metapackage model provides the concrete bridge to SCORM's content organization model:
+The path and journey metapackage model provides the concrete bridge to SCORM's content organization model:
 
-| SCORM concept                  | Package model equivalent         |
-| ------------------------------ | -------------------------------- |
-| Organization (tree of Items)   | Journey metapackage with `steps` |
-| Item (with sequencing rules)   | Step ordering via `steps` array  |
-| SCO (shareable content object) | Step package (guide)             |
-| Forward-only sequencing        | Advisory `steps` ordering        |
-| Prerequisites                  | `manifest.json` → `depends`      |
+| SCORM concept                  | Package model equivalent                 |
+| ------------------------------ | ---------------------------------------- |
+| Organization (tree of Items)   | Journey or path metapackage with `steps` |
+| Item (with sequencing rules)   | Step ordering via `steps` array          |
+| SCO (shareable content object) | Step package (guide)                     |
+| Forward-only sequencing        | Advisory `steps` ordering                |
+| Prerequisites                  | `manifest.json` → `depends`              |
 
-SCORM's `Organization` element is structurally equivalent to a journey metapackage: both compose content objects into an ordered sequence with metadata. The SCORM import pipeline (Phase 5-6) does not need to invent a composition model — it writes into the one established by journeys. The future `type: "course"` becomes a refinement of the journey concept (potentially with stricter sequencing semantics), not a separate system.
+SCORM's `Organization` element is structurally equivalent to a path or journey metapackage: both compose content objects into an ordered sequence with metadata. The SCORM import pipeline does not need to invent a composition model — it writes into the one established by paths and journeys. The future `type: "course"` becomes a refinement of the metapackage concept (potentially with stricter sequencing semantics), not a separate system.
 
-## Decision: journey nesting is scoped out for Phase 5
+## Decision: steps reference packages, not types
 
-**Decision:** Journey nesting is not supported in Phase 5. A journey's steps are guides (`type: "guide"` or absent). A journey cannot contain another journey as a step.
+**Decision:** The `steps` field references bare package IDs. The CLI validates that each entry resolves to an existing package, but does not enforce the package type of the referenced package.
 
-**Rationale:** The MVP can be successful without supporting nested journeys. Flat composition keeps validation, completion tracking, progress computation, and UI rendering simple. Recursive nesting adds complexity at every layer — what does "71% of a journey that contains a 50%-complete sub-journey" mean for progress display?
+**Rationale:** The type hierarchy (guides in paths, paths in journeys) is the conventional usage pattern, not an enforced constraint. This follows the Debian model where metapackages can depend on any package, including other metapackages. Enforcing type restrictions on `steps` would require the CLI to resolve and inspect the type of every referenced package during validation, adding complexity without clear benefit — content review already enforces sensible composition. The model naturally supports cases where a journey includes a standalone guide alongside its paths, without requiring that guide to be wrapped in a single-step path.
 
-**This is an MVP scoping choice, not a semantic limitation of the model.** The Debian package model permits metapackages to depend on other metapackages, and virtual capabilities can be provided by packages that themselves depend on other virtual capabilities. Nothing in the package identity model, the dependency vocabulary, or the `provides` mechanism prevents a future phase from allowing `steps` to reference other journeys. If hierarchical content organization is needed (course -> module -> lesson), it can be introduced as a backward-compatible extension — either through the SCORM `type` extensions (`"course"`, `"module"`) or by relaxing the `steps` constraint to accept `type: "journey"` entries.
+**Cycle detection is enforced.** While the type of steps is not restricted, cycles in `steps` chains are always an error. A step cannot transitively contain its parent metapackage. The graph builder detects and reports cycles.


### PR DESCRIPTION
- Making key decisions on which tiers the packages should live at
- Updating terminology for guide -> path -> journey (replacing earlier inconsistent and too simple model of guide -> journey)