### PR TITLE
skill:maintain-docs validate stale utils and interactive-engine docs

### DIFF
--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -6,14 +6,16 @@ Persistent tracker for the maintain-docs skill's persistent state across runs.
 
 <!-- Structural issues requiring dedicated effort. Format: date, description, rationale. Remove when resolved. -->
 
+- **2026-02-25**: `docs/developer/constants/README.md` staleness check — 1 new file added (`src/constants/testIds.ts`) since last validation. Deferred due to budget constraints.
+
 ## Validated docs
 
 <!-- Docs checked against source and found accurate. Format: date, doc path. Update date on re-validation. -->
 
-- **2026-02-20**: `docs/developer/utils/README.md` — Validated against `src/utils/` and `src/utils/devtools/`. Fixed stale file listings (3 deleted devtools files removed, 3 new utility files and 2 devtools structural files added), corrected export names in `openfeature.ts` and `utils.plugin.ts` sections.
+- **2026-02-25**: `docs/developer/utils/README.md` — Re-validated against `src/utils/`. Removed deleted files (keyboard-shortcuts.hook.ts, link-handler.hook.ts), added new files (fetchBackendGuides.ts, usePublishedGuides.ts).
 - **2026-02-20**: `docs/developer/learning-paths/README.md` — Created and validated against `src/learning-paths/`. Covers path types, platform selection, badge system, streak tracking, progress management, hooks, and integration points.
 - **2026-02-20**: `docs/developer/engines/context-engine.md` — Updated earlier today; no structural source changes since update.
-- **2026-02-20**: `docs/developer/engines/interactive-engine.md` — Updated earlier today; no structural source changes since update.
+- **2026-02-25**: `docs/developer/engines/interactive-engine.md` — Re-validated. Updated action-detector.ts location from src/interactive-engine/auto-completion/ to src/lib/dom/.
 - **2026-02-20**: `docs/developer/engines/requirements-manager.md` — Updated earlier today; no structural source changes since update.
 - **2026-02-20**: `docs/developer/E2E_TESTING.md` — Updated earlier today; no structural source changes since update. Cross-reference to `testingStrategy.mdc` added.
 - **2026-02-20**: `docs/developer/E2E_TESTING_CONTRACT.md` — No structural source changes. Cross-reference to `testingStrategy.mdc` added.

--- a/docs/developer/engines/interactive-engine.md
+++ b/docs/developer/engines/interactive-engine.md
@@ -187,14 +187,14 @@ Located in `src/interactive-engine/auto-completion/`, this optional subsystem au
 ### Components
 
 - **`action-monitor.ts`** - Singleton that registers global DOM event listeners (click, input, change, mouseenter, keydown)
-- **`action-detector.ts`** - Analyzes DOM elements and events to determine action type (highlight, button, formfill, navigate, hover)
+- **`action-detector.ts`** (in `src/lib/dom/`) - Analyzes DOM elements and events to determine action type (highlight, button, formfill, navigate, hover). Shared with devtools and selector generator.
 - **`action-matcher.ts`** - Matches detected user actions against step configurations using CSS selectors, button text, or regex patterns
 - **`useAutoDetection.ts`** - React hook that subscribes to `user-action-detected` events and auto-completes matching steps
 - **`useFormValidation.ts`** - Debounced form validation hook with regex pattern matching support
 
 ### Action Detection Logic
 
-The `action-detector` determines action type based on element characteristics and available selectors:
+The action detector (`src/lib/dom/action-detector.ts`) determines action type based on element characteristics and available selectors:
 
 - **formfill**: Input fields, textareas, selects (except radio/checkbox)
 - **button**: Buttons identified by text content (text matching heuristic when no unique selector is available)
@@ -369,7 +369,7 @@ See: [`docs/developer/E2E_TESTING_CONTRACT.md`](../E2E_TESTING_CONTRACT.md) for 
 ### Internal Dependencies
 
 - **Requirements Manager** (`src/requirements-manager/`) - Pre/post-condition validation
-- **DOM Utilities** (`src/lib/dom/`) - Enhanced selector engine, element visibility checking, button finding
+- **DOM Utilities** (`src/lib/dom/`) - Enhanced selector engine, element visibility checking, button finding, action type detection
 - **Security** (`src/security/`) - HTML sanitization for comment content and URL validation for navigate handler
 - **Interactive Styles** (`src/styles/interactive.styles.ts`) - Global CSS for highlights and overlays
 - **Interactive Config** (`src/constants/interactive-config.ts`) - Timing delays, retry counts, modal detection settings

--- a/docs/developer/utils/README.md
+++ b/docs/developer/utils/README.md
@@ -10,16 +10,17 @@ Utility functions and helper modules. **Note**: Most business logic hooks have b
 - **Context hooks** → `src/context-engine/` (see `context-engine/context.hook.ts`)
 - **Requirements hooks** → `src/requirements-manager/` (see `requirements-manager/step-checker.hook.ts`)
 
-Only the following hooks remain in `src/utils/`:
+Only the following hook remains in `src/utils/`:
 
 ## File Organization
 
 ### 🎣 **React Hooks** (Remaining in utils/)
 
-- `keyboard-shortcuts.hook.ts` - Keyboard navigation shortcuts
-- `link-handler.hook.ts` - Link click handling and lightbox
+- `usePublishedGuides.ts` - Fetches published guides from the backend API
 
 ### 🛠️ **Utilities & Configuration**
+
+- `fetchBackendGuides.ts` - Shared utility for fetching backend guides from the API
 
 - `utils.plugin.ts` - Plugin props context management
 - `utils.routing.ts` - Route prefixing utilities
@@ -50,65 +51,54 @@ Only the following hooks remain in `src/utils/`:
 
 ## React Hooks (In utils/)
 
-### `keyboard-shortcuts.hook.ts` ⭐ **Navigation Shortcuts**
+### `usePublishedGuides.ts` ⭐ **Published Guides from Backend**
 
-**Purpose**: Provides keyboard shortcuts for efficient navigation
-**Location**: `src/utils/keyboard-shortcuts.hook.ts`
-
-**Role**:
-
-- Tab switching with Ctrl/Cmd+Tab
-- Tab closing with Ctrl/Cmd+W
-- Milestone navigation with Alt+Arrow keys
-
-**Shortcuts**:
-
-- `Ctrl/Cmd + W` - Close current tab
-- `Ctrl/Cmd + Tab` - Switch between tabs
-- `Alt + →` - Next milestone
-- `Alt + ←` - Previous milestone
-
-**Used By**:
-
-- `src/components/docs-panel/docs-panel.tsx` - Keyboard navigation
-
----
-
-### `link-handler.hook.ts` ⭐ **Link & Interaction Handler**
-
-**Purpose**: Handles clicks on various interactive elements in content
-**Location**: `src/utils/link-handler.hook.ts`
+**Purpose**: Fetches published interactive guides from the backend API
+**Location**: `src/utils/usePublishedGuides.ts`
 
 **Role**:
 
-- Journey start button handling
-- Image lightbox creation and management
-- Side journey and related journey link handling
-- Bottom navigation (Previous/Next) button handling
+- Loads guides from the backend on mount
+- Exposes loading and error state
+- Provides `refreshGuides()` for manual refresh
 
-**Key Features**:
+**Key Exports**:
 
-- **Journey Start**: Navigates to first milestone
-- **Image Lightbox**: Creates responsive modal with theme support
-- **External Links**: Opens side journeys in new tabs
-- **Internal Navigation**: Opens related journeys in new app tabs
-- **Bottom Navigation**: Milestone Previous/Next handling
-
-**Link Types Handled**:
-
-- `[data-journey-start="true"]` - Journey start buttons
-- `img` elements - Image lightbox
-- `[data-side-journey-link]` - External side journey links
-- `[data-related-journey-link]` - Internal related journey links
-- `.journey-bottom-nav-button` - Navigation buttons
+- `usePublishedGuides()` - Hook returning `{ guides, isLoading, error, refreshGuides }`
+- `PublishedGuide` - Type for guide metadata and spec
 
 **Used By**:
 
-- `src/components/docs-panel/docs-panel.tsx` - Content interaction handling
+- `src/components/docs-panel/context-panel.tsx` - Context panel custom guides
+- `src/components/docs-panel/CustomGuidesSection.tsx` - Custom guides section (type import)
 
 ---
 
 ## Utility Files
+
+### `fetchBackendGuides.ts` ⭐ **Backend Guides Fetcher**
+
+**Purpose**: Shared utility for fetching guides from the backend API
+**Location**: `src/utils/fetchBackendGuides.ts`
+
+**Role**:
+
+- Calls the pathfinder backend API for interactive guides in a namespace
+- Returns empty array when endpoint is unavailable (400, 403, 404, 405, 501, 503)
+- Re-throws other errors for caller handling
+
+**Key Function**:
+
+```typescript
+async function fetchBackendGuides(namespace: string): Promise<any[]>;
+```
+
+**Used By**:
+
+- `src/utils/usePublishedGuides.ts` - Published guides hook
+- `src/components/block-editor/hooks/useBackendGuides.ts` - Block editor backend guides
+
+---
 
 ### `utils.plugin.ts` ⭐ **Plugin Props Management**
 


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-02-25.

### Changes made

- **`docs/developer/utils/README.md`**: Removed deleted hooks (`keyboard-shortcuts.hook.ts`, `link-handler.hook.ts`), added new files (`fetchBackendGuides.ts`, `usePublishedGuides.ts`) with accurate descriptions, exports, and usage references
- **`docs/developer/engines/interactive-engine.md`**: Updated `action-detector.ts` location from `src/interactive-engine/auto-completion/` to `src/lib/dom/`, noted shared usage with devtools and selector generator, updated internal dependencies list
- **`docs/_maintenance-backlog.md`**: Updated validation timestamps for both docs, added deferred work item for `constants/README.md` staleness check

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| HIGH | `docs/developer/utils/README.md` stale — 2 deleted files, 2 new files since last validation | Fixed in this PR |
| HIGH | `docs/developer/engines/interactive-engine.md` stale — `action-detector.ts` moved to `src/lib/dom/` | Fixed in this PR |
| MEDIUM | `docs/developer/constants/README.md` staleness — 1 new file (`testIds.ts`) since last validation | Deferred (budget) |

### Recommendations for separate work

- `docs/developer/constants/README.md` needs staleness validation against `src/constants/testIds.ts` addition (tracked in backlog)

### Validation checklist

- [x] All changed files are `.md` or `.mdc` (verified via `git diff --name-only`)
- [x] Phase 2.5 verification passed (sub-agent output reviewed)
- [x] `npm run prettier` passed
- [x] No source code files were modified

Made with [Cursor](https://cursor.com)