### PR TITLE
feat(cli): add --exclude to build-repository to skip subtrees

### DIFF
--- a/docs/developer/CLI_TOOLS.md
+++ b/docs/developer/CLI_TOOLS.md
@@ -209,6 +209,7 @@ node dist/cli/cli/index.js build-repository <root> [options]
 ### Options
 
 - `-o, --output <file>`: Output file path. If omitted, writes to stdout.
+- `-e, --exclude <paths...>`: Path(s) to exclude from the scan, relative to `<root>`. Excluded trees are not descended into. Use this when the root contains another repo (e.g. pathfinder-app) and you want to index only your packages.
 
 ### Examples
 
@@ -224,6 +225,12 @@ node dist/cli/cli/index.js build-repository src/bundled-interactives -o src/bund
 node dist/cli/cli/index.js build-repository src/bundled-interactives
 ```
 
+**Exclude a subtree (e.g. when running from a repo that has pathfinder-app checked out):**
+
+```bash
+node pathfinder-app/dist/cli/cli/index.js build-repository . -e pathfinder-app -o repository.json
+```
+
 There are convenience npm scripts:
 
 ```bash
@@ -233,7 +240,7 @@ npm run repository:check   # Rebuild to temp file and diff — fails if committe
 
 ### How discovery works
 
-The command walks the directory tree starting at `<root>`. Any subdirectory at any depth containing `manifest.json` is treated as a package. The `assets/` subtree is skipped during traversal. Directories without `manifest.json` are not packages.
+The command walks the directory tree starting at `<root>`. Any subdirectory at any depth containing `manifest.json` is treated as a package. The `assets/` subtree is skipped during traversal. Directories without `manifest.json` are not packages. If `--exclude` is used, any path equal to or under an excluded path is not descended into, so packages inside excluded trees are not discovered.
 
 ### Output format
 


### PR DESCRIPTION
## Summary

When `build-repository` is run from a root that contains another repo (e.g. pathfinder-app checked out inside interactive-tutorials for the CLI), the command discovers packages in both trees and can report duplicate package IDs.

This PR adds `-e, --exclude <paths...>` so callers can exclude subtrees from discovery.

## Changes

- **`discoverPackages(root, excludePaths?)`** — optional list of absolute paths to exclude; directories equal to or under an excluded path are not descended into.
- **`buildRepository(root, options?)`** — `options.exclude` (paths relative to root or absolute) resolved and passed to discovery.
- **CLI** — `-e, --exclude <paths...>` (variadic).
- **Tests** — five new tests: exclude subtree, multiple excludes, duplicate-ID avoidance when excluding the other tree, exclude relative to root, siblings preserved when one tree excluded.
- **Docs** — `CLI_TOOLS.md` updated with option description and example.

## Usage

From a repo that has pathfinder-app as a subdirectory:

```bash
node pathfinder-app/dist/cli/cli/index.js build-repository . -e pathfinder-app -o repository.json
```

Multiple excludes:

```bash
node pathfinder-app/dist/cli/cli/index.js build-repository . -e pathfinder-app -e other-vendor -o repository.json
```

## Design

Exclude paths are interpreted relative to the scan root (or absolute if given as such). Any directory that is the same as or under an excluded path is never entered during discovery, so packages inside excluded trees are not included in the generated `repository.json`. Aligns with the existing design: one repository index per content tree; the caller is responsible for passing the right root and can now exclude known subtrees that belong to another tree.