### PR TITLE
fix(coda): Fix websocket timeout

### DIFF
--- a/pkg/plugin/app.go
+++ b/pkg/plugin/app.go
@@ -84,6 +84,12 @@ func (a *App) Dispose() {
 	streamSessionsMu.Unlock()
 }
 
+// ctxLogger returns a contextual logger that automatically includes traceID,
+// endpoint, pluginID, and other metadata from the context for better debugging.
+func (a *App) ctxLogger(ctx context.Context) log.Logger {
+	return a.logger.FromContext(ctx)
+}
+
 // CheckHealth handles health check requests.
 func (a *App) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	// Basic health check

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -122,11 +122,28 @@ func (a *App) handleTerminalInput(w http.ResponseWriter, r *http.Request) {
 	}
 	streamSessionsMu.Unlock()
 
+	ctxLogger := a.ctxLogger(r.Context())
 	if sess == nil || sess.session == nil {
-		a.logger.Warn("No active session found for terminal input",
+		ctxLogger.Warn("No active session found for terminal input",
 			"vmID", vmID,
 			"requestUser", userLogin,
 		)
+
+		// Check if VM still exists and is active - if so, tell frontend to reconnect
+		if a.coda != nil {
+			vm, err := a.coda.GetVM(r.Context(), vmID)
+			if err == nil && (vm.State == "active" || vm.State == "pooled") {
+				ctxLogger.Info("VM still active but session expired, requesting reconnect",
+					"vmID", vmID,
+					"vmState", vm.State,
+					"requestUser", userLogin,
+				)
+				w.Header().Set("X-Reconnect-Required", "true")
+				a.writeError(w, "Session expired, please reconnect", http.StatusGone) // 410
+				return
+			}
+		}
+
 		a.writeError(w, "No active session for VM", http.StatusNotFound)
 		return
 	}
@@ -135,14 +152,14 @@ func (a *App) handleTerminalInput(w http.ResponseWriter, r *http.Request) {
 	switch input.Type {
 	case "input":
 		if err := sess.session.Write([]byte(input.Data)); err != nil {
-			a.logger.Error("Failed to write to terminal", "vmID", vmID, "error", err)
+			ctxLogger.Error("Failed to write to terminal", "vmID", vmID, "error", err)
 			a.writeError(w, "Failed to write to terminal", http.StatusInternalServerError)
 			return
 		}
 	case "resize":
 		if input.Rows > 0 && input.Cols > 0 {
 			if err := sess.session.Resize(input.Rows, input.Cols); err != nil {
-				a.logger.Error("Failed to resize terminal", "vmID", vmID, "error", err)
+				ctxLogger.Error("Failed to resize terminal", "vmID", vmID, "error", err)
 				a.writeError(w, "Failed to resize terminal", http.StatusInternalServerError)
 				return
 			}
@@ -249,11 +266,12 @@ func (a *App) handleCodaRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.logger.Info("Registering with Coda API", "instanceId", req.InstanceID, "apiUrl", codaAPIURL)
+	ctxLogger := a.ctxLogger(r.Context())
+	ctxLogger.Info("Registering with Coda API", "instanceId", req.InstanceID, "apiUrl", codaAPIURL)
 
 	result, err := Register(r.Context(), codaAPIURL, enrollmentKey, req.InstanceID, req.InstanceURL)
 	if err != nil {
-		a.logger.Error("Failed to register with Coda", "error", err)
+		ctxLogger.Error("Failed to register with Coda", "error", err)
 		if strings.Contains(err.Error(), "invalid enrollment key") {
 			a.writeError(w, err.Error(), http.StatusUnauthorized)
 		} else {
@@ -262,7 +280,7 @@ func (a *App) handleCodaRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.logger.Info("Successfully registered with Coda", "instanceId", req.InstanceID, "jti", result.JTI)
+	ctxLogger.Info("Successfully registered with Coda", "instanceId", req.InstanceID, "jti", result.JTI)
 
 	a.writeJSON(w, result, http.StatusCreated)
 }
@@ -295,11 +313,12 @@ func (a *App) handleCreateVM(w http.ResponseWriter, r *http.Request) {
 		user = "unknown"
 	}
 
-	a.logger.Info("Creating VM", "template", req.Template, "user", user)
+	ctxLogger := a.ctxLogger(r.Context())
+	ctxLogger.Info("Creating VM", "template", req.Template, "user", user)
 
 	vm, err := a.coda.CreateVM(r.Context(), req.Template, user)
 	if err != nil {
-		a.logger.Error("Failed to create VM", "error", err)
+		ctxLogger.Error("Failed to create VM", "error", err)
 		// Check if this is an auth error
 		if strings.Contains(err.Error(), "authentication failed") {
 			a.writeError(w, err.Error(), http.StatusUnauthorized)
@@ -319,9 +338,10 @@ func (a *App) handleGetVM(w http.ResponseWriter, r *http.Request, vmID string) {
 		return
 	}
 
+	ctxLogger := a.ctxLogger(r.Context())
 	vm, err := a.coda.GetVM(r.Context(), vmID)
 	if err != nil {
-		a.logger.Error("Failed to get VM", "vmID", vmID, "error", err)
+		ctxLogger.Error("Failed to get VM", "vmID", vmID, "error", err)
 		if strings.Contains(err.Error(), "not found") {
 			a.writeError(w, "VM not found", http.StatusNotFound)
 		} else if strings.Contains(err.Error(), "authentication failed") {
@@ -342,12 +362,13 @@ func (a *App) handleDeleteVM(w http.ResponseWriter, r *http.Request, vmID string
 		return
 	}
 
+	ctxLogger := a.ctxLogger(r.Context())
 	// Get user from Grafana context header for authorization check
 	user := r.Header.Get("X-Grafana-User")
-	a.logger.Info("Deleting VM", "vmID", vmID, "user", user)
+	ctxLogger.Info("Deleting VM", "vmID", vmID, "user", user)
 
 	if err := a.coda.DeleteVM(r.Context(), vmID); err != nil {
-		a.logger.Error("Failed to delete VM", "vmID", vmID, "error", err)
+		ctxLogger.Error("Failed to delete VM", "vmID", vmID, "error", err)
 		// Check if this is an auth error
 		if strings.Contains(err.Error(), "authentication failed") {
 			a.writeError(w, err.Error(), http.StatusUnauthorized)
@@ -367,9 +388,10 @@ func (a *App) handleListVMs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ctxLogger := a.ctxLogger(r.Context())
 	vms, err := a.coda.ListVMs(r.Context())
 	if err != nil {
-		a.logger.Error("Failed to list VMs", "error", err)
+		ctxLogger.Error("Failed to list VMs", "error", err)
 		// Check if this is an auth error
 		if strings.Contains(err.Error(), "authentication failed") {
 			a.writeError(w, err.Error(), http.StatusUnauthorized)

--- a/pkg/plugin/stream.go
+++ b/pkg/plugin/stream.go
@@ -93,7 +93,8 @@ type TerminalStreamOutput struct {
 //   - "new": Backend will provision a fresh VM in RunStream
 //   - Any other value: Treated as existing VM ID (will be validated/replaced in RunStream)
 func (a *App) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
-	a.logger.Info("SubscribeStream called", "path", req.Path)
+	ctxLogger := a.ctxLogger(ctx)
+	ctxLogger.Info("SubscribeStream called", "path", req.Path)
 
 	// Parse channel path: terminal/{vmId} or terminal/{vmId}/{nonce}
 	parts := strings.Split(req.Path, "/")
@@ -107,7 +108,7 @@ func (a *App) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamR
 
 	// Check if Coda is configured (has JWT token)
 	if a.coda == nil {
-		a.logger.Error("Coda not registered for stream subscription")
+		ctxLogger.Error("Coda not registered for stream subscription")
 		return &backend.SubscribeStreamResponse{
 			Status: backend.SubscribeStreamStatusNotFound,
 		}, nil
@@ -115,7 +116,7 @@ func (a *App) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamR
 
 	// Allow "new" vmId - RunStream will provision a fresh VM
 	if vmID == "new" || vmID == "" {
-		a.logger.Info("Stream subscription accepted for new VM provisioning")
+		ctxLogger.Info("Stream subscription accepted for new VM provisioning")
 		return &backend.SubscribeStreamResponse{
 			Status: backend.SubscribeStreamStatusOK,
 		}, nil
@@ -126,7 +127,7 @@ func (a *App) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamR
 	vm, err := a.coda.GetVM(ctx, vmID)
 	if err != nil {
 		// VM not found - still accept, RunStream will provision a new one
-		a.logger.Info("VM not found, will provision in RunStream", "vmID", vmID)
+		ctxLogger.Info("VM not found, will provision in RunStream", "vmID", vmID)
 		return &backend.SubscribeStreamResponse{
 			Status: backend.SubscribeStreamStatusOK,
 		}, nil
@@ -135,14 +136,14 @@ func (a *App) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamR
 	// Only reject destroyed or error states at subscription time for better UX
 	// (avoids immediate subscription failure for expired VMs - RunStream handles replacement)
 	if vm.State == "destroyed" || vm.State == "destroying" || vm.State == "error" {
-		a.logger.Info("VM in terminal state, will provision replacement in RunStream", "vmID", vmID, "state", vm.State)
+		ctxLogger.Info("VM in terminal state, will provision replacement in RunStream", "vmID", vmID, "state", vm.State)
 		// Still accept - RunStream will handle provisioning a replacement
 		return &backend.SubscribeStreamResponse{
 			Status: backend.SubscribeStreamStatusOK,
 		}, nil
 	}
 
-	a.logger.Info("Stream subscription accepted", "vmID", vmID, "state", vm.State)
+	ctxLogger.Info("Stream subscription accepted", "vmID", vmID, "state", vm.State)
 
 	return &backend.SubscribeStreamResponse{
 		Status: backend.SubscribeStreamStatusOK,
@@ -153,12 +154,13 @@ func (a *App) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamR
 // This handles terminal input from the frontend (keyboard input, resize events).
 // This is the primary input path for bidirectional terminal communication.
 func (a *App) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
-	a.logger.Debug("PublishStream called", "path", req.Path, "dataLen", len(req.Data))
+	ctxLogger := a.ctxLogger(ctx)
+	ctxLogger.Debug("PublishStream called", "path", req.Path, "dataLen", len(req.Data))
 
 	// Parse channel path: terminal/{vmId} or terminal/{vmId}/{nonce}
 	parts := strings.Split(req.Path, "/")
 	if len(parts) < 2 || parts[0] != "terminal" {
-		a.logger.Warn("PublishStream: invalid path", "path", req.Path)
+		ctxLogger.Warn("PublishStream: invalid path", "path", req.Path)
 		return &backend.PublishStreamResponse{
 			Status: backend.PublishStreamStatusNotFound,
 		}, nil
@@ -172,7 +174,7 @@ func (a *App) PublishStream(ctx context.Context, req *backend.PublishStreamReque
 	streamSessionsMu.Unlock()
 
 	if !exists || sess == nil || sess.session == nil {
-		a.logger.Warn("PublishStream: no active session", "vmID", vmID, "path", req.Path)
+		ctxLogger.Warn("PublishStream: no active session", "vmID", vmID, "path", req.Path)
 		return &backend.PublishStreamResponse{
 			Status: backend.PublishStreamStatusNotFound,
 		}, nil
@@ -181,7 +183,7 @@ func (a *App) PublishStream(ctx context.Context, req *backend.PublishStreamReque
 	// Parse the input message
 	var input TerminalInput
 	if err := json.Unmarshal(req.Data, &input); err != nil {
-		a.logger.Error("PublishStream: failed to parse input", "error", err, "data", string(req.Data))
+		ctxLogger.Error("PublishStream: failed to parse input", "error", err, "data", string(req.Data))
 		return &backend.PublishStreamResponse{
 			Status: backend.PublishStreamStatusPermissionDenied,
 		}, nil
@@ -191,20 +193,20 @@ func (a *App) PublishStream(ctx context.Context, req *backend.PublishStreamReque
 	switch input.Type {
 	case "input":
 		if err := sess.session.Write([]byte(input.Data)); err != nil {
-			a.logger.Error("PublishStream: failed to write to SSH", "vmID", vmID, "error", err)
+			ctxLogger.Error("PublishStream: failed to write to SSH", "vmID", vmID, "error", err)
 		} else {
-			a.logger.Debug("PublishStream: wrote input to SSH", "vmID", vmID, "dataLen", len(input.Data))
+			ctxLogger.Debug("PublishStream: wrote input to SSH", "vmID", vmID, "dataLen", len(input.Data))
 		}
 	case "resize":
 		if input.Rows > 0 && input.Cols > 0 {
 			if err := sess.session.Resize(input.Rows, input.Cols); err != nil {
-				a.logger.Error("PublishStream: failed to resize terminal", "vmID", vmID, "error", err)
+				ctxLogger.Error("PublishStream: failed to resize terminal", "vmID", vmID, "error", err)
 			} else {
-				a.logger.Debug("PublishStream: resized terminal", "vmID", vmID, "rows", input.Rows, "cols", input.Cols)
+				ctxLogger.Debug("PublishStream: resized terminal", "vmID", vmID, "rows", input.Rows, "cols", input.Cols)
 			}
 		}
 	default:
-		a.logger.Warn("PublishStream: unknown input type", "type", input.Type)
+		ctxLogger.Warn("PublishStream: unknown input type", "type", input.Type)
 	}
 
 	return &backend.PublishStreamResponse{
@@ -291,6 +293,7 @@ const (
 
 // waitForVMActive polls until VM is active and returns it, sending status updates
 func (a *App) waitForVMActive(ctx context.Context, sender *backend.StreamSender, vmID string) (*VM, error) {
+	ctxLogger := a.ctxLogger(ctx)
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 
@@ -302,7 +305,7 @@ func (a *App) waitForVMActive(ctx context.Context, sender *backend.StreamSender,
 		case <-ticker.C:
 			vm, err := a.coda.GetVM(ctx, vmID)
 			if err != nil {
-				a.logger.Warn("Failed to poll VM status", "vmID", vmID, "error", err)
+				ctxLogger.Warn("Failed to poll VM status", "vmID", vmID, "error", err)
 				continue
 			}
 
@@ -336,7 +339,8 @@ func (a *App) waitForVMActive(ctx context.Context, sender *backend.StreamSender,
 // RunStream is called once for each active stream subscription.
 // It runs for the lifetime of the stream, sending data to the client.
 func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
-	a.logger.Info("RunStream started", "path", req.Path)
+	ctxLogger := a.ctxLogger(ctx)
+	ctxLogger.Info("RunStream started", "path", req.Path)
 
 	// Parse channel path: terminal/{vmId} or terminal/{vmId}/{nonce}
 	parts := strings.Split(req.Path, "/")
@@ -355,7 +359,7 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 
 	// Extract user login for per-user VM tracking
 	userLogin := getUserLogin(req)
-	a.logger.Info("User identified for VM tracking", "userLogin", userLogin)
+	ctxLogger.Info("User identified for VM tracking", "userLogin", userLogin)
 
 	var vm *VM
 	var err error
@@ -368,19 +372,19 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 
 	if hasExisting {
 		// User has a tracked VM - try to reuse it
-		a.logger.Info("Found existing VM for user", "userLogin", userLogin, "vmID", existingVmID)
+		ctxLogger.Info("Found existing VM for user", "userLogin", userLogin, "vmID", existingVmID)
 		vm, err = a.coda.GetVM(ctx, existingVmID)
 
 		if err != nil {
 			// VM doesn't exist anymore - remove from tracking and provision new
-			a.logger.Info("Tracked VM not found, will provision new", "userLogin", userLogin, "vmID", existingVmID, "error", err)
+			ctxLogger.Info("Tracked VM not found, will provision new", "userLogin", userLogin, "vmID", existingVmID, "error", err)
 			userVMsMu.Lock()
 			delete(userVMs, userLogin)
 			userVMsMu.Unlock()
 			hasExisting = false
 		} else if vm.State == "destroyed" || vm.State == "destroying" || vm.State == "error" {
 			// VM is in terminal state - remove from tracking and provision new
-			a.logger.Info("Tracked VM in terminal state, will provision new", "userLogin", userLogin, "vmID", existingVmID, "state", vm.State)
+			ctxLogger.Info("Tracked VM in terminal state, will provision new", "userLogin", userLogin, "vmID", existingVmID, "state", vm.State)
 			userVMsMu.Lock()
 			delete(userVMs, userLogin)
 			userVMsMu.Unlock()
@@ -388,14 +392,14 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 		} else {
 			// VM exists and is valid - reuse it
 			vmID = existingVmID
-			a.logger.Info("Reusing existing VM for user", "userLogin", userLogin, "vmID", vmID, "state", vm.State)
+			ctxLogger.Info("Reusing existing VM for user", "userLogin", userLogin, "vmID", vmID, "state", vm.State)
 			sendStreamStatusWithVmId(sender, vm.State, "Reconnecting to your existing VM...", vmID)
 		}
 	}
 
 	// If no existing valid VM, provision a new one
 	if !hasExisting {
-		a.logger.Info("Provisioning new VM for user", "userLogin", userLogin)
+		ctxLogger.Info("Provisioning new VM for user", "userLogin", userLogin)
 		sendStreamStatusWithVmId(sender, "provisioning", "Provisioning new VM...", "")
 
 		vm, err = a.coda.CreateVM(ctx, "vm-aws", userLogin)
@@ -411,20 +415,20 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 		userVMs[userLogin] = vmID
 		userVMsMu.Unlock()
 
-		a.logger.Info("New VM created and tracked for user", "userLogin", userLogin, "vmID", vmID, "state", vm.State)
+		ctxLogger.Info("New VM created and tracked for user", "userLogin", userLogin, "vmID", vmID, "state", vm.State)
 		sendStreamStatusWithVmId(sender, vm.State, "VM allocated, waiting for boot...", vmID)
 	}
 
 	// If VM is not active, poll and push status updates until it's ready
 	if vm.State != "active" || vm.Credentials == nil {
-		a.logger.Info("VM not ready, polling for status updates", "vmID", vmID, "state", vm.State)
+		ctxLogger.Info("VM not ready, polling for status updates", "vmID", vmID, "state", vm.State)
 
 		vm, err = a.waitForVMActive(ctx, sender, vmID)
 		if err != nil {
 			return err
 		}
 
-		a.logger.Info("VM is now active", "vmID", vmID)
+		ctxLogger.Info("VM is now active", "vmID", vmID)
 	}
 
 	// Create context that cancels when stream ends
@@ -443,7 +447,7 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 		frame.Fields = append(frame.Fields, data.NewField("data", nil, []string{string(jsonBytes)}))
 
 		if err := sender.SendFrame(frame, data.IncludeAll); err != nil {
-			a.logger.Error("Failed to send frame", "error", err)
+			ctxLogger.Error("Failed to send frame", "error", err)
 		}
 	}
 
@@ -467,7 +471,7 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 	var lastErr error
 
 	for vmAttempt := 1; vmAttempt <= maxVMAttempts; vmAttempt++ {
-		a.logger.Info("Starting SSH connection attempts for VM",
+		ctxLogger.Info("Starting SSH connection attempts for VM",
 			"vmID", vmID,
 			"vmAttempt", vmAttempt,
 			"maxVMAttempts", maxVMAttempts,
@@ -478,7 +482,7 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 			// Check context cancellation
 			select {
 			case <-ctx.Done():
-				a.logger.Info("Connection cancelled by user", "vmID", vmID)
+				ctxLogger.Info("Connection cancelled by user", "vmID", vmID)
 				return ctx.Err()
 			default:
 			}
@@ -491,13 +495,13 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 
 			// Validate relay URL against allowlist to prevent token exfiltration
 			if !IsAllowedRelayURL(a.settings.CodaRelayURL) {
-				a.logger.Error("Relay URL not in allowlist", "relayURL", a.settings.CodaRelayURL)
+				ctxLogger.Error("Relay URL not in allowlist", "relayURL", a.settings.CodaRelayURL)
 				sendStreamError(sender, "Relay URL is not a trusted host")
 				return errors.New("relay URL not in allowlist")
 			}
 
 			// Log credentials info (without sensitive data)
-			a.logger.Info("Creating SSH session via relay",
+			ctxLogger.Info("Creating SSH session via relay",
 				"vmID", vmID,
 				"host", vm.Credentials.PublicIP,
 				"port", vm.Credentials.SSHPort,
@@ -517,7 +521,7 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 			}
 			accessToken, err := a.coda.GetAccessToken(ctx)
 			if err != nil {
-				a.logger.Error("Failed to get access token for relay", "error", err)
+				ctxLogger.Error("Failed to get access token for relay", "error", err)
 				sendStreamError(sender, fmt.Sprintf("Authentication failed: %v", err))
 				return fmt.Errorf("failed to get access token: %w", err)
 			}
@@ -525,7 +529,7 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 			sshClient, err := ConnectSSHViaRelay(a.settings.CodaRelayURL, vmID, vm.Credentials, accessToken)
 			if err != nil {
 				lastErr = err
-				a.logger.Warn("Relay connection failed",
+				ctxLogger.Warn("Relay connection failed",
 					"vmID", vmID,
 					"error", err,
 					"vmAttempt", vmAttempt,
@@ -534,7 +538,7 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 
 				// Check if error is retryable and we have same-VM retries left
 				if isSSHRetryableError(err) && sshRetry < maxSSHRetriesPerVM {
-					a.logger.Info("SSH not ready, will retry same VM", "vmID", vmID, "sshRetry", sshRetry)
+					ctxLogger.Info("SSH not ready, will retry same VM", "vmID", vmID, "sshRetry", sshRetry)
 					sendStreamStatusWithVmId(sender, "retrying", fmt.Sprintf("SSH not ready, retrying (%d/%d)...", sshRetry, maxSSHRetriesPerVM), vmID)
 					time.Sleep(sshRetryDelay)
 					continue
@@ -544,12 +548,12 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 				break
 			}
 
-			a.logger.Info("Relay connection established, creating terminal session", "vmID", vmID)
+			ctxLogger.Info("Relay connection established, creating terminal session", "vmID", vmID)
 			session, err = NewTerminalSessionWithClient(vmID, sshClient, onOutput, onError)
 			if err != nil {
 				_ = sshClient.Close()
 				lastErr = err
-				a.logger.Warn("Failed to create terminal session with relay client",
+				ctxLogger.Warn("Failed to create terminal session with relay client",
 					"vmID", vmID,
 					"error", err,
 					"vmAttempt", vmAttempt,
@@ -558,7 +562,7 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 
 				// Check if error is retryable and we have same-VM retries left
 				if isSSHRetryableError(err) && sshRetry < maxSSHRetriesPerVM {
-					a.logger.Info("Session creation failed, will retry same VM", "vmID", vmID, "sshRetry", sshRetry)
+					ctxLogger.Info("Session creation failed, will retry same VM", "vmID", vmID, "sshRetry", sshRetry)
 					sendStreamStatusWithVmId(sender, "retrying", fmt.Sprintf("SSH not ready, retrying (%d/%d)...", sshRetry, maxSSHRetriesPerVM), vmID)
 					time.Sleep(sshRetryDelay)
 					continue
@@ -573,13 +577,13 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 
 		// If we got a session, we're done
 		if session != nil {
-			a.logger.Info("SSH connection successful", "vmID", vmID, "vmAttempt", vmAttempt)
+			ctxLogger.Info("SSH connection successful", "vmID", vmID, "vmAttempt", vmAttempt)
 			break
 		}
 
 		// All same-VM retries failed - provision new VM if under limit
 		if vmAttempt < maxVMAttempts {
-			a.logger.Info("All SSH retries failed for VM, provisioning new one",
+			ctxLogger.Info("All SSH retries failed for VM, provisioning new one",
 				"failedVmID", vmID,
 				"vmAttempt", vmAttempt,
 				"lastError", lastErr,
@@ -590,7 +594,7 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 			// Provision a fresh VM for the user
 			newVM, createErr := a.coda.CreateVM(ctx, "vm-aws", userLogin)
 			if createErr != nil {
-				a.logger.Error("Failed to provision fresh VM for retry", "error", createErr)
+				ctxLogger.Error("Failed to provision fresh VM for retry", "error", createErr)
 				sendStreamError(sender, fmt.Sprintf("Failed to provision replacement VM: %v", createErr))
 				return fmt.Errorf("failed to provision replacement VM: %w", createErr)
 			}
@@ -601,7 +605,7 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 			userVMs[userLogin] = vmID
 			userVMsMu.Unlock()
 
-			a.logger.Info("Fresh VM provisioned for retry", "newVmID", vmID, "state", newVM.State, "vmAttempt", vmAttempt+1, "userLogin", userLogin)
+			ctxLogger.Info("Fresh VM provisioned for retry", "newVmID", vmID, "state", newVM.State, "vmAttempt", vmAttempt+1, "userLogin", userLogin)
 			sendStreamStatusWithVmId(sender, newVM.State, fmt.Sprintf("VM %d allocated, waiting for boot...", vmAttempt+1), vmID)
 
 			// Wait for new VM to be active
@@ -614,7 +618,7 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 
 	if session == nil {
 		errMsg := fmt.Sprintf("SSH connection failed after %d VMs (last error: %v)", maxVMAttempts, lastErr)
-		a.logger.Error("All VM attempts exhausted", "lastError", lastErr)
+		ctxLogger.Error("All VM attempts exhausted", "lastError", lastErr)
 		sendStreamError(sender, errMsg)
 		return errors.New(errMsg)
 	}
@@ -644,12 +648,12 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 	frame.Fields = append(frame.Fields, data.NewField("data", nil, []string{string(jsonBytes)}))
 
 	if err := sender.SendFrame(frame, data.IncludeAll); err != nil {
-		a.logger.Error("Failed to send connected message", "vmID", vmID, "error", err)
+		ctxLogger.Error("Failed to send connected message", "vmID", vmID, "error", err)
 	} else {
-		a.logger.Info("Sent connected message to frontend", "vmID", vmID)
+		ctxLogger.Info("Sent connected message to frontend", "vmID", vmID)
 	}
 
-	a.logger.Info("Terminal session started", "vmID", vmID)
+	ctxLogger.Info("Terminal session started", "vmID", vmID)
 
 	// Poll VM state to detect expiry/destruction and disconnect gracefully
 	// Capture vmID and userLogin for the goroutine
@@ -665,17 +669,17 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 			case <-ticker.C:
 				polledVM, err := a.coda.GetVM(streamCtx, pollVmID)
 				if err != nil {
-					a.logger.Warn("VM state poll failed", "vmID", pollVmID, "error", err)
+					ctxLogger.Warn("VM state poll failed", "vmID", pollVmID, "error", err)
 					continue
 				}
 				if polledVM.State == "destroying" || polledVM.State == "destroyed" || polledVM.State == "error" {
-					a.logger.Info("VM no longer active, ending stream", "vmID", pollVmID, "state", polledVM.State, "userLogin", pollUserLogin)
+					ctxLogger.Info("VM no longer active, ending stream", "vmID", pollVmID, "state", polledVM.State, "userLogin", pollUserLogin)
 
 					// Remove VM from user tracking since it's no longer valid
 					userVMsMu.Lock()
 					if userVMs[pollUserLogin] == pollVmID {
 						delete(userVMs, pollUserLogin)
-						a.logger.Info("Removed expired VM from user tracking", "userLogin", pollUserLogin, "vmID", pollVmID)
+						ctxLogger.Info("Removed expired VM from user tracking", "userLogin", pollUserLogin, "vmID", pollVmID)
 					}
 					userVMsMu.Unlock()
 
@@ -701,6 +705,6 @@ func (a *App) RunStream(ctx context.Context, req *backend.RunStreamRequest, send
 	frame.Fields = append(frame.Fields, data.NewField("data", nil, []string{string(jsonBytes)}))
 	_ = sender.SendFrame(frame, data.IncludeAll)
 
-	a.logger.Info("RunStream ended", "vmID", vmID)
+	ctxLogger.Info("RunStream ended", "vmID", vmID)
 	return nil
 }

--- a/pkg/plugin/terminal.go
+++ b/pkg/plugin/terminal.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -56,7 +56,7 @@ func normalizePrivateKey(key string) string {
 // ConnectSSHViaRelay establishes an SSH connection through a WebSocket relay.
 // This is used when direct TCP access to the VM is not available (e.g., Grafana Cloud).
 func ConnectSSHViaRelay(relayURL string, vmID string, creds *Credentials, token string) (*ssh.Client, error) {
-	logger := log.DefaultLogger
+	logger := backend.Logger
 
 	if creds == nil {
 		return nil, fmt.Errorf("credentials are nil")
@@ -116,6 +116,13 @@ func ConnectSSHViaRelay(relayURL string, vmID string, creds *Credentials, token 
 		"vmID", vmID,
 		"dialDurationMs", dialDuration.Milliseconds(),
 	)
+
+	// Set up pong handler to reset read deadline when we receive pong responses.
+	// The relay sends pings every 30s; we extend our read deadline on each pong
+	// to keep the connection alive through load balancers with idle timeouts.
+	wsConn.SetPongHandler(func(appData string) error {
+		return wsConn.SetReadDeadline(time.Now().Add(90 * time.Second))
+	})
 
 	conn := NewWSConn(wsConn)
 
@@ -312,7 +319,7 @@ func (ts *TerminalSession) forwardStderr() {
 		n, err := ts.stderr.Read(buf)
 		if err != nil {
 			if err != io.EOF && !ts.isClosed() {
-				log.DefaultLogger.Warn("stderr read error", "error", err, "vmID", ts.VMID)
+				backend.Logger.Warn("Stderr read error", "error", err, "vmID", ts.VMID)
 			}
 			return
 		}

--- a/src/integrations/coda/useTerminalLive.hook.ts
+++ b/src/integrations/coda/useTerminalLive.hook.ts
@@ -162,6 +162,10 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
   const currentVmIdRef = useRef<string | null>(null);
   const inputDisposerRef = useRef<{ dispose: () => void } | null>(null);
   const handshakeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Track if we're currently attempting to reconnect (prevents loops)
+  const reconnectingRef = useRef<boolean>(false);
+  // Ref to hold attemptReconnect function (populated after connect is defined)
+  const attemptReconnectRef = useRef<(() => void) | null>(null);
 
   // Cleanup function
   const cleanup = useCallback(() => {
@@ -216,7 +220,15 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
       if (duration > 500) {
         connectionLog.warn('Slow input request', { vmId: id, durationMs: Math.round(duration) });
       }
-    } catch (err) {
+    } catch (err: unknown) {
+      // Check for 410 Gone - session expired but VM still active
+      const fetchError = err as { status?: number };
+      if (fetchError.status === 410) {
+        connectionLog.warn('Session expired, attempting reconnect', { vmId: id });
+        attemptReconnectRef.current?.();
+        return;
+      }
+
       connectionLog.error('Failed to send input', err, {
         vmId: id,
         inputLength: inputData.length,
@@ -247,7 +259,15 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
         user: userLogin,
       });
       httpLog.success(200, { vmId: id, rows, cols });
-    } catch (err) {
+    } catch (err: unknown) {
+      // Check for 410 Gone - session expired but VM still active
+      const fetchError = err as { status?: number };
+      if (fetchError.status === 410) {
+        connectionLog.warn('Session expired during resize, attempting reconnect', { vmId: id });
+        attemptReconnectRef.current?.();
+        return;
+      }
+
       httpLog.failure(err);
       connectionLog.error('Failed to send resize', err, {
         vmId: id,
@@ -407,6 +427,8 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
                     clearTimeout(handshakeTimeoutRef.current);
                     handshakeTimeoutRef.current = null;
                   }
+                  // Reset reconnecting flag on successful connection
+                  reconnectingRef.current = false;
 
                   // Update current VM ID ref from backend (needed for input routing)
                   if (msg.vmId) {
@@ -583,6 +605,28 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
     // Connect to stream - backend handles VM assignment and reuse
     connectLiveStream('new', terminal);
   }, [terminalRef, cleanup, connectLiveStream]);
+
+  // Populate attemptReconnect ref now that connect is defined
+  // Must be in useEffect to avoid updating ref during render
+  useEffect(() => {
+    attemptReconnectRef.current = () => {
+      if (reconnectingRef.current) {
+        return; // Already reconnecting
+      }
+      reconnectingRef.current = true;
+
+      const terminal = terminalRef.current;
+      if (terminal) {
+        terminal.writeln('\r\n\x1b[33m⚠ Session expired, reconnecting...\x1b[0m');
+      }
+
+      // Small delay to avoid rapid reconnection attempts
+      setTimeout(() => {
+        reconnectingRef.current = false;
+        connect();
+      }, 1000);
+    };
+  }, [connect, terminalRef]);
 
   /**
    * Disconnect from the terminal


### PR DESCRIPTION
This pull request refactors logging throughout the plugin to use a new context-aware logger, ensuring that all log messages automatically include relevant metadata such as trace IDs, endpoint, and plugin ID. This change improves debugging and traceability across the codebase. Additionally, some error handling is enhanced for terminal input sessions.

Key changes include:

**Logging improvements:**

* Introduced a new `ctxLogger` method in the `App` struct that returns a logger derived from the current context, embedding contextual information for all log entries. All logging statements in `resources.go` and `stream.go` are updated to use this contextual logger instead of the previous static logger. [[1]](diffhunk://#diff-23b0ea139e46e5971dd11250cfc24e313d42608acd515ca9172e85912be2062cR87-R92) [[2]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34R125-R146) [[3]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34L138-R162) [[4]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34L252-R274) [[5]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34L265-R283) [[6]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34L298-R321) [[7]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34R341-R344) [[8]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34R365-R371) [[9]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34R391-R394) [[10]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL96-R97) [[11]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL110-R119) [[12]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL129-R130) [[13]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL138-R146) [[14]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL156-R163) [[15]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL175-R177) [[16]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL184-R186) [[17]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL194-R209) [[18]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bR296) [[19]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL305-R308) [[20]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL339-R343) [[21]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL358-R362) [[22]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL371-R402) [[23]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL414-R431) [[24]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL446-R450) [[25]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL470-R474)

**Terminal session and error handling:**

* Enhanced session expiration handling in `handleTerminalInput`: if a session is missing but the VM is still active, the frontend is instructed to reconnect, improving user experience during session drops.
* All error and info logs related to terminal input, VM operations, and stream handling now use the context-aware logger, ensuring consistent and enriched log output. [[1]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34L138-R162) [[2]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34L252-R274) [[3]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34L265-R283) [[4]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34L298-R321) [[5]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34R341-R344) [[6]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34R365-R371) [[7]](diffhunk://#diff-e487a7a5a5bf91552350ae451c173394c7828d4208d38ddf41137af062fc0d34R391-R394) [[8]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL110-R119) [[9]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL129-R130) [[10]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL138-R146) [[11]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL156-R163) [[12]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL175-R177) [[13]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL184-R186) [[14]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL194-R209) [[15]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bR296) [[16]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL305-R308) [[17]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL339-R343) [[18]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL358-R362) [[19]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL371-R402) [[20]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL414-R431) [[21]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL446-R450) [[22]](diffhunk://#diff-046354eda5c4079e4a9ce37dc5b1f5130899786c8a251151ed16c38dce20680bL470-R474)

These changes collectively improve observability, debugging, and the maintainability of logging throughout the plugin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the terminal streaming/SSH relay path and adds automatic reconnection behavior; mistakes could cause reconnect loops or masked session failures, but changes are localized and largely additive.
> 
> **Overview**
> **Improves sandbox terminal session stability and observability.** The backend now derives a context-aware logger via `App.ctxLogger(ctx)` and uses it across VM/stream handlers so logs automatically include request metadata.
> 
> **Adds session-expiry recovery for terminal input.** When the HTTP input endpoint can’t find a session but the VM is still `active`/`pooled`, it returns `410 Gone` (with `X-Reconnect-Required`) so the frontend can transparently reconnect; the React hook now detects `410` on input/resize posts and triggers a guarded reconnect.
> 
> **Reduces relay WebSocket idle timeouts.** `ConnectSSHViaRelay` installs a pong handler that extends the read deadline on each pong to keep the connection alive through load balancers, and standardizes relay/terminal logging to use `backend.Logger`/contextual logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dac07c7ee1a394b8452a0dd1b6c9da2b9940a93d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->