### PR TITLE
fix: exclude noop steps from resume/do-section step counts

### DIFF
--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -16,6 +16,7 @@ import { getConfigWithDefaults } from '../../constants';
 import type { InteractiveStepProps, InteractiveSectionProps, StepInfo } from '../../types/component-props.types';
 import { testIds } from '../../constants/testIds';
 import { getContentKey } from './get-content-key';
+import { getResumeInfo as computeResumeInfo, computeStepEligibility } from './step-section-utils';
 
 // Simple counter for sequential section IDs
 let interactiveSectionCounter = 0;
@@ -617,38 +618,16 @@ export function InteractiveSection({
 
   // PRE-COMPUTE eligibility for ALL steps once (React best practice)
   // This prevents expensive recalculation on every render
-  const stepEligibility = useMemo(() => {
-    return stepComponents.map((stepInfo, index) => {
-      // First step is always eligible (Trust but Verify)
-      if (index === 0) {
-        return true;
-      }
-
-      // Subsequent steps are eligible if all previous steps are completed
-      // Noop steps (informational only) are always considered "complete" for eligibility purposes
-      // since they have no action to perform
-      return stepComponents
-        .slice(0, index)
-        .every((prevStep) => prevStep.targetAction === 'noop' || completedSteps.has(prevStep.stepId));
-    });
-  }, [completedSteps, stepComponents]); // Only recalculate when these change
+  const stepEligibility = useMemo(
+    () => computeStepEligibility(stepComponents, completedSteps),
+    [completedSteps, stepComponents]
+  );
 
   // Calculate resume information for button display
-  const getResumeInfo = useCallback(() => {
-    if (stepComponents.length === 0) {
-      return { nextStepIndex: 0, remainingSteps: 0, isResume: false };
-    }
-
-    // Use currentStepIndex directly - no iteration needed!
-    const nextStepIndex = currentStepIndex;
-
-    // If currentStepIndex is beyond the end, it means all steps are completed
-    const allCompleted = nextStepIndex >= stepComponents.length;
-    const remainingSteps = allCompleted ? stepComponents.length : stepComponents.length - nextStepIndex;
-    const isResume = !allCompleted && nextStepIndex > 0;
-
-    return { nextStepIndex, remainingSteps, isResume };
-  }, [stepComponents.length, currentStepIndex]);
+  const getResumeInfo = useCallback(
+    () => computeResumeInfo(stepComponents, currentStepIndex),
+    [stepComponents, currentStepIndex]
+  );
 
   // Handle individual step completion
   const handleStepComplete = useCallback(
@@ -1629,7 +1608,7 @@ export function InteractiveSection({
               if (resumeInfo.isResume) {
                 return `Resume from step ${resumeInfo.nextStepIndex + 1}, ${resumeInfo.remainingSteps} steps remaining`;
               }
-              return hints || `Run through all ${stepComponents.length} steps in sequence`;
+              return hints || `Run through all ${nonNoopSteps.length} steps in sequence`;
             })()}
           >
             {(() => {
@@ -1643,7 +1622,7 @@ export function InteractiveSection({
               if (resumeInfo.isResume) {
                 return `▶ Resume (${resumeInfo.remainingSteps} steps)`;
               }
-              return `▶ Do Section (${stepComponents.length} steps)`;
+              return `▶ Do Section (${nonNoopSteps.length} steps)`;
             })()}
           </Button>
         )}

--- a/src/components/interactive-tutorial/step-section-utils.test.ts
+++ b/src/components/interactive-tutorial/step-section-utils.test.ts
@@ -1,0 +1,102 @@
+import { getResumeInfo, computeStepEligibility } from './step-section-utils';
+import type { StepInfo } from '../../types/component-props.types';
+
+// Minimal StepInfo factory — only fields used by these utilities
+function makeStep(id: string, targetAction?: string): StepInfo {
+  return {
+    stepId: id,
+    element: null as any,
+    index: 0,
+    targetAction,
+    isMultiStep: false,
+    isGuided: false,
+  };
+}
+
+const real = (id: string) => makeStep(id, 'click');
+const noop = (id: string) => makeStep(id, 'noop');
+
+// ─── getResumeInfo ────────────────────────────────────────────────────────────
+
+describe('getResumeInfo', () => {
+  it('returns zeroed state for an empty section', () => {
+    expect(getResumeInfo([], 0)).toEqual({ nextStepIndex: 0, remainingSteps: 0, isResume: false });
+  });
+
+  it('returns isResume: false and full interactive count at the start', () => {
+    const steps = [real('a'), real('b'), real('c')];
+    expect(getResumeInfo(steps, 0)).toEqual({ nextStepIndex: 0, remainingSteps: 3, isResume: false });
+  });
+
+  it('returns isResume: true when partially through a section', () => {
+    const steps = [real('a'), real('b'), real('c')];
+    const result = getResumeInfo(steps, 1);
+    expect(result).toEqual({ nextStepIndex: 1, remainingSteps: 2, isResume: true });
+  });
+
+  it('excludes noop steps from remainingSteps count', () => {
+    // The regression: 3 real + 2 noop steps should show 3, not 5
+    const steps = [noop('n1'), real('a'), noop('n2'), real('b'), real('c')];
+    expect(getResumeInfo(steps, 0).remainingSteps).toBe(3);
+  });
+
+  it('excludes noop steps ahead of currentStepIndex when resuming', () => {
+    const steps = [real('a'), noop('n1'), real('b'), noop('n2'), real('c')];
+    // Resuming from index 1 (n1): remaining real steps after index 1 are b and c
+    expect(getResumeInfo(steps, 1).remainingSteps).toBe(2);
+  });
+
+  it('returns remainingSteps: 0 when all noop steps', () => {
+    const steps = [noop('n1'), noop('n2'), noop('n3')];
+    expect(getResumeInfo(steps, 0).remainingSteps).toBe(0);
+  });
+
+  it('returns remainingSteps: 0 when all steps are completed', () => {
+    const steps = [real('a'), real('b')];
+    // currentStepIndex beyond end signals all completed
+    const result = getResumeInfo(steps, steps.length);
+    expect(result).toEqual({ nextStepIndex: 2, remainingSteps: 0, isResume: false });
+  });
+});
+
+// ─── computeStepEligibility ───────────────────────────────────────────────────
+
+describe('computeStepEligibility', () => {
+  it('returns empty array for empty steps', () => {
+    expect(computeStepEligibility([], new Set())).toEqual([]);
+  });
+
+  it('marks only the first step eligible when none are completed', () => {
+    const steps = [real('a'), real('b'), real('c')];
+    expect(computeStepEligibility(steps, new Set())).toEqual([true, false, false]);
+  });
+
+  it('unlocks the next step when the previous is completed', () => {
+    const steps = [real('a'), real('b'), real('c')];
+    expect(computeStepEligibility(steps, new Set(['a']))).toEqual([true, true, false]);
+  });
+
+  it('marks all steps eligible when all are completed', () => {
+    const steps = [real('a'), real('b'), real('c')];
+    expect(computeStepEligibility(steps, new Set(['a', 'b', 'c']))).toEqual([true, true, true]);
+  });
+
+  it('treats noop steps as always complete for eligibility', () => {
+    // noop at index 0 means index 1 is immediately eligible even with no completions
+    const steps = [noop('n1'), real('b'), real('c')];
+    expect(computeStepEligibility(steps, new Set())).toEqual([true, true, false]);
+  });
+
+  it('treats consecutive noops as always complete', () => {
+    const steps = [noop('n1'), noop('n2'), real('c')];
+    expect(computeStepEligibility(steps, new Set())).toEqual([true, true, true]);
+  });
+
+  it('noop steps are still gated by preceding incomplete real steps', () => {
+    const steps = [real('a'), noop('n1'), real('b'), real('c')];
+    // 'a' not completed → n1, b, c all locked
+    expect(computeStepEligibility(steps, new Set())).toEqual([true, false, false, false]);
+    // Complete 'a' → n1 unlocks; n1 is noop so b unlocks too; c still locked
+    expect(computeStepEligibility(steps, new Set(['a']))).toEqual([true, true, true, false]);
+  });
+});

--- a/src/components/interactive-tutorial/step-section-utils.ts
+++ b/src/components/interactive-tutorial/step-section-utils.ts
@@ -1,0 +1,48 @@
+import type { StepInfo } from '../../types/component-props.types';
+
+export interface ResumeInfo {
+  nextStepIndex: number;
+  remainingSteps: number;
+  isResume: boolean;
+}
+
+/**
+ * Computes resume button state for an interactive section.
+ *
+ * Noop steps are excluded from `remainingSteps` because they are informational
+ * markers, not interactive actions. This prevents the button from showing an
+ * inflated count like "Resume (5 steps)" when only 3 are real.
+ */
+export function getResumeInfo(stepComponents: StepInfo[], currentStepIndex: number): ResumeInfo {
+  if (stepComponents.length === 0) {
+    return { nextStepIndex: 0, remainingSteps: 0, isResume: false };
+  }
+
+  const allCompleted = currentStepIndex >= stepComponents.length;
+  const remainingSteps = allCompleted
+    ? 0
+    : stepComponents.slice(currentStepIndex).filter((s) => s.targetAction !== 'noop').length;
+
+  return {
+    nextStepIndex: currentStepIndex,
+    remainingSteps,
+    isResume: !allCompleted && currentStepIndex > 0,
+  };
+}
+
+/**
+ * Computes per-step eligibility for a sequential interactive section.
+ *
+ * The first step is always eligible. Subsequent steps are eligible only when
+ * every preceding step is either completed or a noop (informational) step.
+ */
+export function computeStepEligibility(stepComponents: StepInfo[], completedSteps: Set<string>): boolean[] {
+  return stepComponents.map((_, index) => {
+    if (index === 0) {
+      return true;
+    }
+    return stepComponents
+      .slice(0, index)
+      .every((prevStep) => prevStep.targetAction === 'noop' || completedSteps.has(prevStep.stepId));
+  });
+}


### PR DESCRIPTION
## Summary

- **Bug**: The \"Resume (N steps)\" and \"▶ Do Section (N steps)\" buttons in interactive sections counted noop steps as interactive steps, inflating the displayed count. A section with 3 real steps + 2 noop steps would show \"Resume (5 steps)\" instead of \"Resume (3 steps)\".
- **Root cause**: `getResumeInfo()` used `stepComponents.length` directly, while the rest of the completion logic already excluded noops via `nonNoopSteps`. The noop action is the intended mechanism for numbered non-interactive/informational steps.
- **Fix**: `getResumeInfo` now filters out `targetAction === 'noop'` before computing `remainingSteps`, consistent with how `nonNoopSteps` is used elsewhere. The \"Do Section\" button label and tooltip also now use the non-noop count.

## Refactor

As part of landing this fix, `getResumeInfo` and `computeStepEligibility` were extracted from `InteractiveSection` into a new `step-section-utils.ts` file. Both are pure functions (data in, data out — no hooks, no DOM, no side effects) and the extraction allows them to be unit-tested directly without mounting the full component.

## Test plan

- [x] `step-section-utils.test.ts` — unit tests for `getResumeInfo` (empty section, fresh start, resume mid-section, all-noop section, mixed noop+real, all completed) and `computeStepEligibility` (sequential unlock, noop transparency, consecutive noops, gating by preceding real steps)
- [x] `npm run typecheck` — clean
- [x] `npm run lint:fix` — clean
- [x] `npm run test:ci` — all passing