### PR TITLE
feat(package-schema): rename manifest steps field to milestones

### DIFF
--- a/docs/design/PACKAGE-IMPLEMENTATION-PLAN.md
+++ b/docs/design/PACKAGE-IMPLEMENTATION-PLAN.md
@@ -113,7 +113,7 @@ This plan is designed to support and further the [content testing strategy](./TE
 - `validation` moved to Tier 1 in both `TIER_MAP` and `eslint.config.mjs`; lateral ratchet dropped from 11 → 9
 - Types in `src/types/package.types.ts`: `ContentJson`, `ManifestJson`, `RepositoryJson`, `RepositoryEntry`, `GraphNode`, `GraphEdge`, `DependencyGraph`, and all dependency/author/targeting types. Resolution types (`PackageResolution`, `PackageResolver`) removed — deferred to Phase 3 implementation.
 - Zod schemas in `src/types/package.schema.ts`: `ContentJsonSchema`, `ManifestJsonSchema`, `ManifestJsonObjectSchema`, `RepositoryJsonSchema`, `RepositoryEntrySchema`, `DependencyClauseSchema`, `DependencyListSchema`, `AuthorSchema`, `GuideTargetingSchema`, `TestEnvironmentSchema`, `PackageTypeSchema`, `GraphNodeSchema`, `GraphEdgeSchema`, `DependencyGraphSchema`
-- `ManifestJsonSchema` uses `.refine()` for the conditional `steps` requirement; `ManifestJsonObjectSchema` is the base shape before refinement for composition use
+- `ManifestJsonSchema` uses `.refine()` for the conditional `milestones` requirement; `ManifestJsonObjectSchema` is the base shape before refinement for composition use
 - `CURRENT_SCHEMA_VERSION` bumped to `"1.1.0"`; `KNOWN_FIELDS._manifest` added with 18 field names
 - `JsonGuideSchemaStrict` retained unchanged for backwards compatibility
 - `build-repository` CLI command implemented in `src/cli/commands/build-repository.ts`
@@ -137,8 +137,8 @@ This plan is designed to support and further the [content testing strategy](./TE
 - Severity-based validation messages: ERROR for required fields, WARN for recommended fields, INFO for defaulted fields
 - `testEnvironment` validation: warns on unrecognized tier values and invalid semver in minVersion
 - `build-graph` CLI command in `src/cli/commands/build-graph.ts`: reads `name:path` repository entries, outputs D3 JSON
-- Graph lint checks implemented: broken refs, broken steps, cycles (DFS-based), orphans, missing description/category
-- Cycle detection uses DFS with separate checks for depends (error), recommends (warn), steps (error)
+- Graph lint checks implemented: broken refs, broken milestones, cycles (DFS-based), orphans, missing description/category
+- Cycle detection uses DFS with separate checks for depends (error), recommends (warn), milestones (error)
 - CNF dependency clauses flattened: all mentioned package IDs get edges regardless of AND/OR semantics (noted as limitation)
 - Virtual capability nodes created for provides targets that don't match real packages (`virtual: true` flag)
 - `ValidationWarning.type` extended with `'missing-asset'` variant
@@ -450,9 +450,9 @@ The composite resolver is injected into `docs-retrieval` via dependency inversio
 
 **Testing layers:** Layer 1 + Layer 2
 
-**Early validation from Phase 4b:** The `interactive-tutorials` pilot migration has already produced a real `type: "path"` metapackage (`prometheus-lj`) with a 9-step `steps` array, `recommends` (`drilldown-metrics-lj`), `suggests` (`private-data-source-connect-lj`), and step-level `depends`/`recommends` chains. This validates the path metapackage model against real content before Phase 5 even begins. Cross-repo references (to not-yet-migrated learning paths) are handled gracefully as dangling references.
+**Early validation from Phase 4b:** The `interactive-tutorials` pilot migration has already produced a real `type: "path"` metapackage (`prometheus-lj`) with a 9-entry `milestones` array, `recommends` (`drilldown-metrics-lj`), `suggests` (`private-data-source-connect-lj`), and step-level `depends`/`recommends` chains. This validates the path metapackage model against real content before Phase 5 even begins. Cross-repo references (to not-yet-migrated learning paths) are handled gracefully as dangling references.
 
-**Architecture decision: graph navigation lives in the recommender.** The full dependency graph (all repositories, all `steps` arrays, all `depends`/`recommends`/`suggests` edges) lives in the recommender's cached repository indexes. The recommender is the natural place to compute graph-derived navigation because: (1) it already holds the complete topology across every repository; (2) it will eventually consume completion state for smarter recommendations; (3) keeping graph reasoning server-side means the frontend stays a renderer, not a graph engine.
+**Architecture decision: graph navigation lives in the recommender.** The full dependency graph (all repositories, all `milestones` arrays, all `depends`/`recommends`/`suggests` edges) lives in the recommender's cached repository indexes. The recommender is the natural place to compute graph-derived navigation because: (1) it already holds the complete topology across every repository; (2) it will eventually consume completion state for smarter recommendations; (3) keeping graph reasoning server-side means the frontend stays a renderer, not a graph engine.
 
 **Navigation enrichment design:** See `docs/design/V1-RECOMMEND.md` Phase 5 in `grafana-recommender` for the full `computeNavigation` implementation design. Both the standalone resolution response (`GET /api/v1/packages/{id}`) and package-backed recommendations in the v1 recommend response (`POST /api/v1/recommend`) carry the same `navigation` field:
 
@@ -467,12 +467,12 @@ The composite resolver is injected into `docs-retrieval` via dependency inversio
       {
         "id": "getting-started",
         "title": "Getting started with Grafana",
-        "steps": ["welcome-to-grafana", "prometheus-grafana-101", "first-dashboard", "loki-grafana-101"]
+        "milestones": ["welcome-to-grafana", "prometheus-grafana-101", "first-dashboard", "loki-grafana-101"]
       },
       {
         "id": "observability-basics",
         "title": "Observability basics",
-        "steps": [
+        "milestones": [
           "welcome-to-grafana",
           "first-dashboard",
           "prometheus-grafana-101",
@@ -488,37 +488,37 @@ The composite resolver is injected into `docs-retrieval` via dependency inversio
 }
 ```
 
-- `memberOf`: which paths/journeys this package participates in. Each entry carries the parent's `id`, `title`, and full `steps` array. The frontend derives everything it needs locally: position (`steps.indexOf(currentId)`), total (`steps.length`), next structural step, and completion-aware next (first incomplete step). This avoids baking structural navigation decisions into the recommender response that may conflict with the frontend's completion-aware logic.
+- `memberOf`: which paths/journeys this package participates in. Each entry carries the parent's `id`, `title`, and full `milestones` array. The frontend derives everything it needs locally: position (`milestones.indexOf(currentId)`), total (`milestones.length`), next structural milestone, and completion-aware next (first incomplete milestone). This avoids baking structural navigation decisions into the recommender response that may conflict with the frontend's completion-aware logic.
 - `recommends`: packages linked via `recommends` edges in the dependency graph — "where else might the user go from here?"
 - `suggests`: packages linked via `suggests` edges — optional or alternative paths, softer than `recommends`
 - `depends`: prerequisite packages from `depends` edges — the frontend can use this to show dependency status
 
 This replaces the earlier "learning path reconciliation at Tier 3+" design. The frontend does not need a Tier 3+ utility to stitch `package-engine` and `learning-paths` together — the recommender provides navigation directly.
 
-**Completion state phasing:** In Phase 5, the recommender computes `navigation` from structural graph data only (array order in `steps`, `recommends`/`suggests`/`depends` edges). The frontend overlays client-side completion state for display (e.g., showing which steps are done, highlighting the next incomplete step). In a future phase beyond this plan's scope, the frontend will send completion data to the recommender alongside context (using the existing `POST /api/v1/recommend` payload pattern), and the recommender will return completion-aware navigation. Server-side completion state is a further future concern. This phasing keeps the resolution response cacheable in Phase 5 while leaving a clean path to personalized navigation later.
+**Completion state phasing:** In Phase 5, the recommender computes `navigation` from structural graph data only (array order in `milestones`, `recommends`/`suggests`/`depends` edges). The frontend overlays client-side completion state for display (e.g., showing which steps are done, highlighting the next incomplete step). In a future phase beyond this plan's scope, the frontend will send completion data to the recommender alongside context (using the existing `POST /api/v1/recommend` payload pattern), and the recommender will return completion-aware navigation. Server-side completion state is a further future concern. This phasing keeps the resolution response cacheable in Phase 5 while leaving a clean path to personalized navigation later.
 
 **Deliverables:**
 
 - [ ] **Path metapackages** (`type: "path"`):
-  - [ ] CLI: validate path packages — `steps` array entries resolve to existing packages in the repository index (by bare ID), cover page `content.json` optional
-  - [ ] Steps may be nested child directories (organizational convenience) or independent top-level packages (for reuse). The CLI validates via repository index resolution, not filesystem child-directory checks.
+  - [ ] CLI: validate path packages — `milestones` array entries resolve to existing packages in the repository index (by bare ID), cover page `content.json` optional
+  - [ ] Milestones may be nested child directories (organizational convenience) or independent top-level packages (for reuse). The CLI validates via repository index resolution, not filesystem child-directory checks.
   - [ ] Pilot: convert 1-2 existing `*-lj` directories to path metapackages with `manifest.json`
-  - [ ] Validate step reuse: confirm that a guide package can appear in multiple paths' `steps` arrays
+  - [ ] Validate milestone reuse: confirm that a guide package can appear in multiple paths' `milestones` arrays
 - [ ] **Journey metapackages** (`type: "journey"`):
-  - [ ] CLI: validate journey packages — `steps` array entries resolve to existing packages (typically paths, but any package type is valid)
+  - [ ] CLI: validate journey packages — `milestones` array entries resolve to existing packages (typically paths, but any package type is valid)
   - [ ] Journey-level `content.json` serves as a cover page (optional)
   - [ ] Pilot: compose 1-2 journeys from existing paths to validate two-level composition
-- [ ] **`steps` field semantics (both levels):**
-  - [ ] `steps` is an ordered `string[]` of bare package IDs — the CLI validates that each entry resolves to an existing package but does NOT enforce the type of the referenced package. The type hierarchy (guides in paths, paths in journeys) is convention, not a schema constraint.
-  - [ ] Completion is set-based at each level: path complete = all steps complete; journey complete = all steps complete (transitively, all constituent guides)
-  - [ ] Ordering is advisory — the UI presents steps in array order but users may jump to any step
+- [ ] **`milestones` field semantics (both levels):**
+  - [ ] `milestones` is an ordered `string[]` of bare package IDs — the CLI validates that each entry resolves to an existing package but does NOT enforce the type of the referenced package. The type hierarchy (guides in paths, paths in journeys) is convention, not a schema constraint.
+  - [ ] Completion is set-based at each level: path complete = all milestones complete; journey complete = all milestones complete (transitively, all constituent guides)
+  - [ ] Ordering is advisory — the UI presents milestones in array order but users may jump to any milestone
 - [ ] **Dependency graph representation:**
   - [ ] Paths and journeys appear as regular nodes with their respective `type` values (everything is a package)
-  - [ ] Steps appear as independent package nodes in the graph (they are packages, can be reused across multiple metapackages)
-  - [ ] Metapackage has `steps` edges to each of its step packages in `steps` array order
-  - [ ] `steps` array contains bare package IDs (e.g., `["step-1", "step-2"]`), no repository prefix
-  - [ ] Graph lint: `steps` references must resolve to existing packages in global catalog
-  - [ ] Cycle detection in `steps` chains (error-level — a step cannot transitively contain its parent)
+  - [ ] Milestones appear as independent package nodes in the graph (they are packages, can be reused across multiple metapackages)
+  - [ ] Metapackage has `milestones` edges to each of its milestone packages in `milestones` array order
+  - [ ] `milestones` array contains bare package IDs (e.g., `["step-1", "step-2"]`), no repository prefix
+  - [ ] Graph lint: `milestones` references must resolve to existing packages in global catalog
+  - [ ] Cycle detection in `milestones` chains (error-level — a milestone cannot transitively contain its parent)
 - [ ] **Recommender navigation enrichment** (in `grafana-recommender` — see `docs/design/V1-RECOMMEND.md` Phase 5 for implementation design):
   - [ ] Implement `computeNavigation(packageID, repos)` in `cmd/recommender/v1recommend.go`
   - [ ] Extend `GET /api/v1/packages/{id}` resolution response with `navigation` field
@@ -535,10 +535,10 @@ This replaces the earlier "learning path reconciliation at Tier 3+" design. The 
   - [ ] UI: recommended content links using `navigation.recommends` and `navigation.suggests`
   - [ ] UI: learning path cards use package metadata (description, category) from the resolution response when available
   - [ ] Frontend overlays client-side completion state on the structural navigation for display
-- [ ] **`paths.json` deprecation path:** With navigation provided by the recommender's resolution response, curated `paths.json` becomes redundant once all paths are expressed as metapackages with `steps` arrays. During transition, `paths.json` continues to serve as the fallback for paths not yet migrated to metapackages.
+- [ ] **`paths.json` deprecation path:** With navigation provided by the recommender's resolution response, curated `paths.json` becomes redundant once all paths are expressed as metapackages with `milestones` arrays. During transition, `paths.json` continues to serve as the fallback for paths not yet migrated to metapackages.
 - [ ] Align with docs partners' YAML format for learning path relationships
-- [ ] Layer 1 unit tests for path and journey schema validation (`type`, `steps`, nested structure)
-- [ ] Layer 2 unit tests for frontend navigation display logic (progress computation from `memberOf[].steps`, completion-aware next step, path context selection, `recommends`/`suggests` rendering)
+- [ ] Layer 1 unit tests for path and journey schema validation (`type`, `milestones`, nested structure)
+- [ ] Layer 2 unit tests for frontend navigation display logic (progress computation from `memberOf[].milestones`, completion-aware next milestone, path context selection, `recommends`/`suggests` rendering)
 
 **Why sixth:** First user-visible payoff of the package model. Introduces two-level metapackage composition (paths compose guides, journeys compose paths) that SCORM `"course"` and `"module"` types will later build on. Content authors and docs partners see dependency declarations reflected in the learning experience. The recommender's enriched resolution response eliminates the need for client-side graph reasoning, keeping the frontend thin.
 

--- a/docs/design/PATHFINDER-PACKAGE-DESIGN.md
+++ b/docs/design/PATHFINDER-PACKAGE-DESIGN.md
@@ -258,8 +258,8 @@ interface ManifestJson {
 
   // --- Composition (metapackage model) ---
 
-  /** Ordered steps for paths and journeys (required when type is "path" or "journey") */
-  steps?: string[];
+  /** Ordered milestones for paths and journeys (required when type is "path" or "journey") */
+  milestones?: string[];
 
   // --- Metadata (flat, following Debian conventions) ---
 
@@ -322,8 +322,8 @@ interface JsonGuide {
 
   // --- Composition (metapackage model) ---
 
-  /** Ordered steps for paths and journeys (required when type is "path" or "journey") */
-  steps?: string[];
+  /** Ordered milestones for paths and journeys (required when type is "path" or "journey") */
+  milestones?: string[];
 
   // --- Metadata (flat) ---
 
@@ -472,7 +472,7 @@ The package model supports two levels of metapackage composition following the D
 - A **path** (`type: "path"`) is an ordered sequence of guides that build toward a focused outcome (e.g., "Set up a Linux server integration"). Paths are the primary composition unit — they compose guides into coherent learning experiences.
 - A **journey** (`type: "journey"`) is an ordered sequence of paths (or any packages) that build toward a larger learning arc (e.g., "Infrastructure mastery" composing linux-server-integration, kubernetes-integration, and alerting paths).
 
-Both are first-class packages with a `steps` array declaring the recommended reading order. Steps are real packages — not fragments or sub-units — enabling step reuse, a single identity model, and uniform tooling. The `steps` field references bare package IDs; the CLI validates that each entry resolves to an existing package but does not enforce the type of the referenced package. The type hierarchy (guides in paths, paths in journeys) is convention, not a schema constraint. Completion is set-based (all steps done, regardless of order), and ordering is advisory.
+Both are first-class packages with a `milestones` array declaring the recommended reading order. Milestones are real packages — not fragments or sub-units — enabling milestone reuse, a single identity model, and uniform tooling. The `milestones` field references bare package IDs; the CLI validates that each entry resolves to an existing package but does not enforce the type of the referenced package. The type hierarchy (guides in paths, paths in journeys) is convention, not a schema constraint. Completion is set-based (all milestones done, regardless of order), and ordering is advisory.
 
 > **Full detail:** [package/learning-journeys.md](./package/learning-journeys.md)
 
@@ -551,7 +551,7 @@ Until `build-index` is implemented, `index.json` continues to be maintained sepa
 
 For `content.json`: the existing `KNOWN_FIELDS._guide` applies unchanged. If `content.json` contains metadata/dependency/targeting fields (e.g., from a legacy single-file guide), they are accepted via `.passthrough()` but the canonical location is `manifest.json`.
 
-For `manifest.json`: a new `KNOWN_FIELDS._manifest` set includes `'schemaVersion'`, `'id'`, `'type'`, `'repository'`, `'steps'`, `'description'`, `'language'`, `'category'`, `'author'`, `'startingLocation'`, `'depends'`, `'recommends'`, `'suggests'`, `'provides'`, `'conflicts'`, `'replaces'`, and `'targeting'`.
+For `manifest.json`: a new `KNOWN_FIELDS._manifest` set includes `'schemaVersion'`, `'id'`, `'type'`, `'repository'`, `'milestones'`, `'description'`, `'language'`, `'category'`, `'author'`, `'startingLocation'`, `'depends'`, `'recommends'`, `'suggests'`, `'provides'`, `'conflicts'`, `'replaces'`, and `'targeting'`.
 
 ### Schema version
 

--- a/docs/design/package/learning-journeys.md
+++ b/docs/design/package/learning-journeys.md
@@ -23,9 +23,9 @@ We adopt the same principle at two levels. A path is a metapackage that composes
 We're adopting the Debian model so we can get the advantages they've had for 30 years of package management:
 
 - **One identity model.** Steps have bare IDs, just like any other package. No fragment notation, no scoped identity, no new addressing scheme.
-- **One set of tools.** The CLI validates steps with the same validation pipeline as standalone guides. The graph command shows steps as real nodes. The index builder can index them. Every tool that works for packages works for steps.
-- **One dependency model.** Steps can use `depends`, `recommends`, `provides`, and the full dependency vocabulary. The metapackage uses `steps` for ordering but the dependency graph handles the rest.
-- **Composition evolution.** A path can add, remove, or reorder steps between versions without changing its external identity. The `steps` array in the path manifest absorbs the evolution. Downstream dependents are unaffected.
+- **One set of tools.** The CLI validates milestones with the same validation pipeline as standalone guides. The graph command shows milestones as real nodes. The index builder can index them. Every tool that works for packages works for milestones.
+- **One dependency model.** Milestones can use `depends`, `recommends`, `provides`, and the full dependency vocabulary. The metapackage uses `milestones` for ordering but the dependency graph handles the rest.
+- **Composition evolution.** A path can add, remove, or reorder milestones between versions without changing its external identity. The `milestones` array in the path manifest absorbs the evolution. Downstream dependents are unaffected.
 - **Flavors and reuse.** Different metapackages can compose different subsets of a shared step pool. This is already visible in the content corpus:
 
 | Path                       | Steps                                                                                               |
@@ -34,15 +34,15 @@ We're adopting the Debian model so we can get the advantages they've had for 30 
 | `macos-integration`        | select-architecture, install-alloy, configure-alloy, install-dashboards-alerts, test-connection     |
 | `mysql-integration`        | select-platform, install-alloy, configure-alloy, install-dashboards-alerts, test-connection         |
 
-Three paths share `install-alloy`, `configure-alloy`, and `install-dashboards-alerts`. If those steps are real packages, they can be authored once and composed into multiple paths — exactly as Debian metapackages compose shared components into different desktop experiences. A journey like `infrastructure-mastery` can then compose these paths into a larger arc.
+Three paths share `install-alloy`, `configure-alloy`, and `install-dashboards-alerts`. If those milestones are real packages, they can be authored once and composed into multiple paths — exactly as Debian metapackages compose shared components into different desktop experiences. A journey like `infrastructure-mastery` can then compose these paths into a larger arc.
 
-Step reuse is a structural capability enabled by the model, not a requirement imposed by it. Many paths will have steps unique to that path. The model accommodates both patterns without special-casing either.
+Milestone reuse is a structural capability enabled by the model, not a requirement imposed by it. Many paths will have milestones unique to that path. The model accommodates both patterns without special-casing either.
 
 ## What metapackages don't give us
 
 Two aspects of Debian metapackages do not apply:
 
-**Ordering.** In Debian, `Depends: A, B, C` has no ordering semantics. Paths and journeys need an explicit linear sequence. The `steps` field (described below) is **new machinery** that does not come from the Debian model. It is layered on top of the metapackage concept.
+**Ordering.** In Debian, `Depends: A, B, C` has no ordering semantics. Paths and journeys need an explicit linear sequence. The `milestones` field (described below) is **new machinery** that does not come from the Debian model. It is layered on top of the metapackage concept.
 
 **Removal semantics.** In Debian, removing a metapackage allows `apt autoremove` to garbage-collect orphaned dependencies. There is no analogue in Pathfinder — you do not "uncomplete" a path or "uninstall" a step.
 
@@ -50,41 +50,41 @@ Two aspects of Debian metapackages do not apply:
 
 The `manifest.json` `type` field distinguishes the three package types. It is a required field with no default — every manifest must declare its type.
 
-| Type        | Meaning                                                              | Has `steps`? | Has content blocks?   |
-| ----------- | -------------------------------------------------------------------- | ------------ | --------------------- |
-| `"guide"`   | Single standalone lesson                                             | No           | Yes                   |
-| `"path"`    | Metapackage composing an ordered sequence of guides                  | Yes          | Optional (cover page) |
-| `"journey"` | Metapackage composing an ordered sequence of paths (or any packages) | Yes          | Optional (cover page) |
-| `"course"`  | SCORM-imported course (future)                                       | Future       | Future                |
-| `"module"`  | Grouping of related guides without strict ordering (future)          | Future       | Future                |
+| Type        | Meaning                                                              | Has `milestones`? | Has content blocks?   |
+| ----------- | -------------------------------------------------------------------- | ----------------- | --------------------- |
+| `"guide"`   | Single standalone lesson                                             | No                | Yes                   |
+| `"path"`    | Metapackage composing an ordered sequence of guides                  | Yes               | Optional (cover page) |
+| `"journey"` | Metapackage composing an ordered sequence of paths (or any packages) | Yes               | Optional (cover page) |
+| `"course"`  | SCORM-imported course (future)                                       | Future            | Future                |
+| `"module"`  | Grouping of related guides without strict ordering (future)          | Future            | Future                |
 
 The `"path"` and `"journey"` types establish the two-level composition pattern that `"course"` and `"module"` will refine for SCORM. See [relationship to SCORM](#relationship-to-scorm) below.
 
-## The `steps` field
+## The `milestones` field
 
-Path and journey manifests declare step ordering via a `steps` array:
+Path and journey manifests declare milestone ordering via a `milestones` array:
 
 ```typescript
 /** Ordered array of bare package IDs. Advisory linear sequence. Required when type is "path" or "journey". */
-steps?: string[];
+milestones?: string[];
 ```
 
-Each entry in `steps` is a **bare package ID** that must resolve to an existing package in the repository index. The array defines the **recommended reading order** — the linear sequence the UI presents to users.
+Each entry in `milestones` is a **bare package ID** that must resolve to an existing package in the repository index. The array defines the **recommended reading order** — the linear sequence the UI presents to users.
 
-**Steps reference packages, not types.** The CLI validates that each entry in `steps` resolves to an existing package, but does NOT enforce the type of the referenced package. The type hierarchy (guides in paths, paths in journeys) is a **convention**, not a schema constraint. This follows the Debian model where metapackages can depend on any package, including other metapackages. In practice:
+**Milestones reference packages, not types.** The CLI validates that each entry in `milestones` resolves to an existing package, but does NOT enforce the type of the referenced package. The type hierarchy (guides in paths, paths in journeys) is a **convention**, not a schema constraint. This follows the Debian model where metapackages can depend on any package, including other metapackages. In practice:
 
-- A path's steps are typically guides
-- A journey's steps are typically paths
+- A path's milestones are typically guides
+- A journey's milestones are typically paths
 - But a journey can include guides directly if that's the right composition
 
-Steps may be physically nested as child directories of the metapackage (organizational convenience for steps specific to that path or journey) or may be independent top-level packages (for steps shared across multiple metapackages). The `steps` array makes no assumption about physical location — resolution is handled by the repository index, following the same bare-ID-to-path resolution used everywhere else in the package system. This follows the Debian convention where metapackage dependencies are independently located packages, not physically contained within the metapackage.
+Milestones may be physically nested as child directories of the metapackage (organizational convenience for milestones specific to that path or journey) or may be independent top-level packages (for milestones shared across multiple metapackages). The `milestones` array makes no assumption about physical location — resolution is handled by the repository index, following the same bare-ID-to-path resolution used everywhere else in the package system. This follows the Debian convention where metapackage dependencies are independently located packages, not physically contained within the metapackage.
 
-The `steps` field is valid when `type` is `"path"` or `"journey"`. The CLI validates that:
+The `milestones` field is valid when `type` is `"path"` or `"journey"`. The CLI validates that:
 
-- Every entry in `steps` resolves to an existing package in the repository index
+- Every entry in `milestones` resolves to an existing package in the repository index
 - No duplicate entries exist in the array
-- The `steps` array is non-empty when `type` is `"path"` or `"journey"`
-- No cycles exist in `steps` chains (a step cannot transitively contain its parent)
+- The `milestones` array is non-empty when `type` is `"path"` or `"journey"`
+- No cycles exist in `milestones` chains (a milestone cannot transitively contain its parent)
 
 ## Directory structure
 
@@ -93,53 +93,53 @@ A path or journey directory contains its own `manifest.json` and an optional `co
 ```
 interactive-tutorials/
 ├── infrastructure-alerting/                ← path metapackage
-│   ├── manifest.json                       ← type: "path", steps: [...]
+│   ├── manifest.json                       ← type: "path", milestones: [...]
 │   ├── content.json                        ← optional cover/introduction page
-│   ├── find-data-to-alert/                 ← path-specific step (nested)
+│   ├── find-data-to-alert/                 ← path-specific milestone (nested)
 │   │   └── content.json
-│   ├── build-your-query/                   ← path-specific step (nested)
+│   ├── build-your-query/                   ← path-specific milestone (nested)
 │   │   └── content.json
-│   └── set-conditions/                     ← path-specific step (nested)
+│   └── set-conditions/                     ← path-specific milestone (nested)
 │       └── content.json
-├── install-alloy/                          ← shared step (top-level, reusable)
+├── install-alloy/                          ← shared milestone (top-level, reusable)
 │   ├── content.json
 │   └── manifest.json
-├── configure-alloy/                        ← shared step (top-level, reusable)
+├── configure-alloy/                        ← shared milestone (top-level, reusable)
 │   └── content.json
-├── linux-server-integration/               ← another path reusing shared steps
-│   ├── manifest.json                       ← type: "path", steps: ["select-platform", "install-alloy", ...]
-│   └── select-platform/                    ← path-specific step (nested)
+├── linux-server-integration/               ← another path reusing shared milestones
+│   ├── manifest.json                       ← type: "path", milestones: ["select-platform", "install-alloy", ...]
+│   └── select-platform/                    ← path-specific milestone (nested)
 │       └── content.json
 ├── infrastructure-mastery/                 ← journey metapackage (composes paths)
-│   ├── manifest.json                       ← type: "journey", steps: ["linux-server-integration", ...]
+│   ├── manifest.json                       ← type: "journey", milestones: ["linux-server-integration", ...]
 │   └── content.json                        ← optional cover page
 ├── welcome-to-grafana/                     ← standalone guide (unchanged)
 │   ├── content.json
 │   └── manifest.json
 ```
 
-In this example, `install-alloy` and `configure-alloy` are shared steps that appear in the `steps` arrays of multiple paths (`linux-server-integration`, `macos-integration`, `mysql-integration`). They live as independent top-level packages — following the Debian convention where metapackage dependencies live in the pool independently, not physically contained within any metapackage. Path-specific steps like `find-data-to-alert` and `select-platform` are nested under their path for organizational convenience. The journey `infrastructure-mastery` composes paths rather than guides directly.
+In this example, `install-alloy` and `configure-alloy` are shared milestones that appear in the `milestones` arrays of multiple paths (`linux-server-integration`, `macos-integration`, `mysql-integration`). They live as independent top-level packages — following the Debian convention where metapackage dependencies live in the pool independently, not physically contained within any metapackage. Path-specific milestones like `find-data-to-alert` and `select-platform` are nested under their path for organizational convenience. The journey `infrastructure-mastery` composes paths rather than guides directly.
 
-This introduces **nested package directories** — a package directory that may contain child package directories. The CLI must understand that a directory can contain both its own `manifest.json` and child package directories. This is a structural extension of the [package structure](../PATHFINDER-PACKAGE-DESIGN.md#package-structure) convention. Nesting is optional; the `steps` array uses bare package IDs resolved via the repository index regardless of physical location.
+This introduces **nested package directories** — a package directory that may contain child package directories. The CLI must understand that a directory can contain both its own `manifest.json` and child package directories. This is a structural extension of the [package structure](../PATHFINDER-PACKAGE-DESIGN.md#package-structure) convention. Nesting is optional; the `milestones` array uses bare package IDs resolved via the repository index regardless of physical location.
 
-Step packages follow the same conventions as any package: they contain at minimum `content.json` and may optionally include `manifest.json` for step-specific metadata (e.g., `testEnvironment` for E2E routing of individual steps). Most steps need only `content.json`.
+Milestone packages follow the same conventions as any package: they contain at minimum `content.json` and may optionally include `manifest.json` for milestone-specific metadata (e.g., `testEnvironment` for E2E routing of individual milestones). Most milestones need only `content.json`.
 
-## Step ordering and completion semantics
+## Milestone ordering and completion semantics
 
-**Ordering is advisory.** The `steps` array defines the suggested linear sequence. The UI presents steps in this order and encourages sequential progression. However, users are always permitted to jump into any step directly. Steps are packages like any other, and can be used independently subject to dependencies.
+**Ordering is advisory.** The `milestones` array defines the suggested linear sequence. The UI presents milestones in this order and encourages sequential progression. However, users are always permitted to jump into any milestone directly. Milestones are packages like any other, and can be used independently subject to dependencies.
 
-**Completion is set-based at each level.** Completing a path means completing all its steps, regardless of order. Completing a journey means completing all its steps (typically paths), which transitively means completing all guides in all constituent paths. A user who completes steps 1, 3, 5, 2, 4, 6, 7 has completed the path identically to one who followed the linear order. Completion triggers the metapackage's `provides` capabilities and satisfies downstream `depends` references.
+**Completion is set-based at each level.** Completing a path means completing all its milestones, regardless of order. Completing a journey means completing all its milestones (typically paths), which transitively means completing all guides in all constituent paths. A user who completes milestones 1, 3, 5, 2, 4, 6, 7 has completed the path identically to one who followed the linear order. Completion triggers the metapackage's `provides` capabilities and satisfies downstream `depends` references.
 
-**Partial progress is tracked.** A user who has completed 5 of 7 steps is 71% through the path. For journeys, progress can be displayed at two levels: path-level progress (3 of 5 paths complete) and aggregate guide-level progress (23 of 35 total guides complete). The UI determines which level to display based on context.
+**Partial progress is tracked.** A user who has completed 5 of 7 milestones is 71% through the path. For journeys, progress can be displayed at two levels: path-level progress (3 of 5 paths complete) and aggregate guide-level progress (23 of 35 total guides complete). The UI determines which level to display based on context.
 
 ## Metapackage-level metadata and dependencies
 
 Path and journey `manifest.json` files carry metadata and dependencies for the metapackage as a whole. Metapackage metadata is the same as any package metadata, differing only in:
 
 - `type: "path"` or `type: "journey"`
-- `steps: ["step1", "step2", ...]`
+- `milestones: ["step1", "step2", ...]`
 
-**Decision: steps do not inherit metadata from the metapackage.** Steps are independently reusable packages — that is the core value proposition of the metapackage model. If step behavior changed depending on which path or journey references it (inherited targeting, inherited category), it would introduce context-dependent identity, undermining the "one kind of thing" principle. A step should behave the same whether it appears in `infrastructure-alerting`, `linux-server-integration`, or is referenced standalone. If a metapackage needs to customize how a step appears in its context (e.g., different introduction text), that is a presentation concern for the UI layer, not a metadata inheritance concern.
+**Decision: milestones do not inherit metadata from the metapackage.** Milestones are independently reusable packages — that is the core value proposition of the metapackage model. If milestone behavior changed depending on which path or journey references it (inherited targeting, inherited category), it would introduce context-dependent identity, undermining the "one kind of thing" principle. A milestone should behave the same whether it appears in `infrastructure-alerting`, `linux-server-integration`, or is referenced standalone. If a metapackage needs to customize how a milestone appears in its context (e.g., different introduction text), that is a presentation concern for the UI layer, not a metadata inheritance concern.
 
 ## Example: path metapackage
 
@@ -154,7 +154,7 @@ Path and journey `manifest.json` files carry metadata and dependencies for the m
   "description": "Create your first infrastructure alert rule in Grafana Cloud, from finding data to monitoring your rule.",
   "category": "take-action",
   "author": { "team": "interactive-learning" },
-  "steps": [
+  "milestones": [
     "find-data-to-alert",
     "build-your-query",
     "set-conditions",
@@ -216,7 +216,7 @@ Path and journey `manifest.json` files carry metadata and dependencies for the m
   "repository": "interactive-tutorials",
   "description": "Master infrastructure monitoring in Grafana — from server setup through alerting and optimization.",
   "category": "take-action",
-  "steps": ["linux-server-integration", "kubernetes-integration", "infrastructure-alerting"],
+  "milestones": ["linux-server-integration", "kubernetes-integration", "infrastructure-alerting"],
   "provides": ["infrastructure-mastery-complete"],
   "targeting": {
     "match": { "urlPrefixIn": ["/connections", "/alerting"] }
@@ -224,7 +224,7 @@ Path and journey `manifest.json` files carry metadata and dependencies for the m
 }
 ```
 
-Each step in the journey is a path that itself contains guide steps. Completing the journey means completing all three paths (and transitively, all guides within those paths).
+Each milestone in the journey is a path that itself contains guide milestones. Completing the journey means completing all three paths (and transitively, all guides within those paths).
 
 ## Relationship to `paths.json`
 
@@ -233,7 +233,7 @@ Path and journey metapackages and curated learning paths (`paths.json`) coexist:
 - **`paths.json`** defines editorially curated paths with badges, estimated time, icons, and platform targeting. It is a lightweight predecessor to the dependency graph specification — a stand-in for not yet having the structural model that path metapackages provide.
 - **Path and journey metapackages** define structurally composed experiences with dependency semantics. They are the target replacement for `paths.json`.
 
-**End-state:** `paths.json` will be retired after all migration work is complete. Path metapackages subsume its role — ordering comes from `steps`, metadata comes from `manifest.json`, and dependency relationships come from the graph. During the transition, `paths.json` remains as a fallback and curated paths take priority over dependency-derived paths. A separate milestone will be needed to migrate everything that depends on `paths.json` (badges, icons, platform targeting, estimated time) into the package model before `paths.json` can be deleted.
+**End-state:** `paths.json` will be retired after all migration work is complete. Path metapackages subsume its role — ordering comes from `milestones`, metadata comes from `manifest.json`, and dependency relationships come from the graph. During the transition, `paths.json` remains as a fallback and curated paths take priority over dependency-derived paths. A separate milestone will be needed to migrate everything that depends on `paths.json` (badges, icons, platform targeting, estimated time) into the package model before `paths.json` can be deleted.
 
 The reconciliation between these two mechanisms during transition is addressed in [the path and journey integration phase](../PACKAGE-IMPLEMENTATION-PLAN.md#phase-5-path-and-journey-integration).
 
@@ -241,20 +241,20 @@ The reconciliation between these two mechanisms during transition is addressed i
 
 The path and journey metapackage model provides the concrete bridge to SCORM's content organization model:
 
-| SCORM concept                  | Package model equivalent                 |
-| ------------------------------ | ---------------------------------------- |
-| Organization (tree of Items)   | Journey or path metapackage with `steps` |
-| Item (with sequencing rules)   | Step ordering via `steps` array          |
-| SCO (shareable content object) | Step package (guide)                     |
-| Forward-only sequencing        | Advisory `steps` ordering                |
-| Prerequisites                  | `manifest.json` → `depends`              |
+| SCORM concept                  | Package model equivalent                      |
+| ------------------------------ | --------------------------------------------- |
+| Organization (tree of Items)   | Journey or path metapackage with `milestones` |
+| Item (with sequencing rules)   | Milestone ordering via `milestones` array     |
+| SCO (shareable content object) | Milestone package (guide)                     |
+| Forward-only sequencing        | Advisory `milestones` ordering                |
+| Prerequisites                  | `manifest.json` → `depends`                   |
 
 SCORM's `Organization` element is structurally equivalent to a path or journey metapackage: both compose content objects into an ordered sequence with metadata. The SCORM import pipeline does not need to invent a composition model — it writes into the one established by paths and journeys. The future `type: "course"` becomes a refinement of the metapackage concept (potentially with stricter sequencing semantics), not a separate system.
 
-## Decision: steps reference packages, not types
+## Decision: milestones reference packages, not types
 
-**Decision:** The `steps` field references bare package IDs. The CLI validates that each entry resolves to an existing package, but does not enforce the package type of the referenced package.
+**Decision:** The `milestones` field references bare package IDs. The CLI validates that each entry resolves to an existing package, but does not enforce the package type of the referenced package.
 
-**Rationale:** The type hierarchy (guides in paths, paths in journeys) is the conventional usage pattern, not an enforced constraint. This follows the Debian model where metapackages can depend on any package, including other metapackages. Enforcing type restrictions on `steps` would require the CLI to resolve and inspect the type of every referenced package during validation, adding complexity without clear benefit — content review already enforces sensible composition. The model naturally supports cases where a journey includes a standalone guide alongside its paths, without requiring that guide to be wrapped in a single-step path.
+**Rationale:** The type hierarchy (guides in paths, paths in journeys) is the conventional usage pattern, not an enforced constraint. This follows the Debian model where metapackages can depend on any package, including other metapackages. Enforcing type restrictions on `milestones` would require the CLI to resolve and inspect the type of every referenced package during validation, adding complexity without clear benefit — content review already enforces sensible composition. The model naturally supports cases where a journey includes a standalone guide alongside its paths, without requiring that guide to be wrapped in a single-milestone path.
 
-**Cycle detection is enforced.** While the type of steps is not restricted, cycles in `steps` chains are always an error. A step cannot transitively contain its parent metapackage. The graph builder detects and reports cycles.
+**Cycle detection is enforced.** While the type of milestones is not restricted, cycles in `milestones` chains are always an error. A milestone cannot transitively contain its parent metapackage. The graph builder detects and reports cycles.

--- a/src/cli/commands/build-graph.ts
+++ b/src/cli/commands/build-graph.ts
@@ -6,7 +6,7 @@
  *
  * Graph structure:
  * - Nodes: full manifest metadata from denormalized repository.json
- * - Edges: typed relationships (depends, recommends, suggests, provides, conflicts, replaces, steps)
+ * - Edges: typed relationships (depends, recommends, suggests, provides, conflicts, replaces, milestones)
  * - Virtual nodes: capability names from `provides` fields (distinguished by virtual: true)
  */
 
@@ -193,12 +193,12 @@ export function lintGraph(
       }
     }
 
-    if (entry.steps) {
-      for (const stepId of entry.steps) {
-        if (!realNodeIds.has(stepId)) {
+    if (entry.milestones) {
+      for (const milestoneId of entry.milestones) {
+        if (!realNodeIds.has(milestoneId)) {
           messages.push({
             severity: 'warn',
-            message: `${pkgId}: steps entry "${stepId}" does not resolve to an existing package`,
+            message: `${pkgId}: milestones entry "${milestoneId}" does not resolve to an existing package`,
           });
         }
       }
@@ -215,9 +215,9 @@ export function lintGraph(
     messages.push({ severity: 'warn', message: `Cycle in recommends chain: ${cycle.join(' → ')}` });
   }
 
-  const stepsCycles = detectCycles(allNodeIds, edges, new Set(['steps']));
-  for (const cycle of stepsCycles) {
-    messages.push({ severity: 'error', message: `Cycle in steps chain: ${cycle.join(' → ')}` });
+  const milestonesCycles = detectCycles(allNodeIds, edges, new Set(['milestones']));
+  for (const cycle of milestonesCycles) {
+    messages.push({ severity: 'error', message: `Cycle in milestones chain: ${cycle.join(' → ')}` });
   }
 
   const connectedNodes = new Set<string>();
@@ -286,7 +286,7 @@ export function buildGraph(repositoryPaths: Array<{ name: string; path: string }
       author: entry.author,
       type: entry.type,
       startingLocation: entry.startingLocation,
-      steps: entry.steps,
+      milestones: entry.milestones,
       depends: entry.depends,
       recommends: entry.recommends,
       suggests: entry.suggests,
@@ -334,9 +334,9 @@ export function buildGraph(repositoryPaths: Array<{ name: string; path: string }
       }
     }
 
-    if (entry.steps) {
-      for (const stepId of entry.steps) {
-        edges.push({ source: pkgId, target: stepId, type: 'steps' });
+    if (entry.milestones) {
+      for (const milestoneId of entry.milestones) {
+        edges.push({ source: pkgId, target: milestoneId, type: 'milestones' });
       }
     }
   }

--- a/src/cli/commands/build-repository.ts
+++ b/src/cli/commands/build-repository.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 
 import type { RepositoryEntry, RepositoryJson } from '../../types/package.types';
 // ManifestJsonObjectSchema (pre-refinement) is intentional: build-repository
-// applies graceful degradation — a path/journey manifest missing `steps` produces
+// applies graceful degradation — a path/journey manifest missing `milestones` produces
 // a repository entry rather than failing. The `validate` command enforces the
 // refinement (ManifestJsonSchema) for strict correctness checking.
 import { ContentJsonSchema, ManifestJsonObjectSchema, RepositoryJsonSchema } from '../../types/package.schema';
@@ -148,7 +148,7 @@ function readPackage(root: string, packageDir: string): PackageReadResult {
     entry.category = manifest.category;
     entry.author = manifest.author;
     entry.startingLocation = manifest.startingLocation;
-    entry.steps = manifest.steps;
+    entry.milestones = manifest.milestones;
     entry.depends = manifest.depends?.length ? manifest.depends : undefined;
     entry.recommends = manifest.recommends?.length ? manifest.recommends : undefined;
     entry.suggests = manifest.suggests?.length ? manifest.suggests : undefined;

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -547,7 +547,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'id',
     'type',
     'repository',
-    'steps',
+    'milestones',
     'description',
     'language',
     'category',

--- a/src/types/package.schema.ts
+++ b/src/types/package.schema.ts
@@ -115,7 +115,7 @@ export const ManifestJsonObjectSchema = z.object({
   type: PackageTypeSchema,
   repository: z.string().default('interactive-tutorials'),
 
-  steps: z.array(z.string().min(1)).optional(),
+  milestones: z.array(z.string().min(1)).optional(),
 
   description: z.string().optional(),
   language: z.string().default('en'),
@@ -142,18 +142,18 @@ export const ManifestJsonObjectSchema = z.object({
  * - ERROR: id, type (hard requirements)
  * - WARN: description, category, targeting, startingLocation (missing but recommended)
  * - INFO: repository, language, schemaVersion, dependency fields, author, testEnvironment (defaults applied)
- * - Conditional ERROR: steps required when type is "path" or "journey"
+ * - Conditional ERROR: milestones required when type is "path" or "journey"
  *
  * @coupling Type: ManifestJson
  */
 export const ManifestJsonSchema = ManifestJsonObjectSchema.refine(
   (manifest) => {
     if (manifest.type === 'path' || manifest.type === 'journey') {
-      return manifest.steps !== undefined && manifest.steps.length > 0;
+      return manifest.milestones !== undefined && manifest.milestones.length > 0;
     }
     return true;
   },
-  { message: "'steps' is required when type is 'path' or 'journey'" }
+  { message: "'milestones' is required when type is 'path' or 'journey'" }
 );
 
 // ============ SHARED METADATA SCHEMA FIELDS ============
@@ -169,7 +169,7 @@ const packageMetadataSchemaFields = {
   category: z.string().optional(),
   author: AuthorSchema.optional(),
   startingLocation: z.string().optional(),
-  steps: z.array(z.string()).optional(),
+  milestones: z.array(z.string()).optional(),
   depends: DependencyListSchema.optional(),
   recommends: DependencyListSchema.optional(),
   suggests: DependencyListSchema.optional(),
@@ -206,7 +206,7 @@ export const GraphEdgeTypeSchema = z.enum([
   'provides',
   'conflicts',
   'replaces',
-  'steps',
+  'milestones',
 ]) satisfies z.ZodType<GraphEdgeType>;
 
 /**

--- a/src/types/package.types.ts
+++ b/src/types/package.types.ts
@@ -106,7 +106,7 @@ export interface PackageMetadataFields {
   category?: string;
   author?: Author;
   startingLocation?: string;
-  steps?: string[];
+  milestones?: string[];
   depends?: DependencyList;
   recommends?: DependencyList;
   suggests?: DependencyList;
@@ -128,7 +128,7 @@ export interface ManifestJson {
   type: PackageType;
   repository?: string;
 
-  steps?: string[];
+  milestones?: string[];
 
   description?: string;
   language?: string;
@@ -247,7 +247,14 @@ export interface GraphNode extends PackageMetadataFields {
 }
 
 /** Edge types in the dependency graph */
-export type GraphEdgeType = 'depends' | 'recommends' | 'suggests' | 'provides' | 'conflicts' | 'replaces' | 'steps';
+export type GraphEdgeType =
+  | 'depends'
+  | 'recommends'
+  | 'suggests'
+  | 'provides'
+  | 'conflicts'
+  | 'replaces'
+  | 'milestones';
 
 /**
  * An edge in the dependency graph.

--- a/src/validation/build-graph.test.ts
+++ b/src/validation/build-graph.test.ts
@@ -149,18 +149,18 @@ describe('buildGraph', () => {
     expect(realNodes[0]!.virtual).toBeUndefined();
   });
 
-  it('should create steps edges', () => {
+  it('should create milestones edges', () => {
     const repoPath = writeRepository(tmpDir, 'repository.json', {
-      'my-path': { path: 'path/', type: 'path', steps: ['step-1', 'step-2'] },
+      'my-path': { path: 'path/', type: 'path', milestones: ['step-1', 'step-2'] },
       'step-1': { path: 'step-1/', type: 'guide' },
       'step-2': { path: 'step-2/', type: 'guide' },
     });
 
     const { graph } = buildGraph([{ name: 'test', path: repoPath }]);
 
-    const stepsEdges = graph.edges.filter((e) => e.source === 'my-path' && e.type === 'steps');
-    expect(stepsEdges).toHaveLength(2);
-    expect(stepsEdges.map((e) => e.target)).toEqual(['step-1', 'step-2']);
+    const milestonesEdges = graph.edges.filter((e) => e.source === 'my-path' && e.type === 'milestones');
+    expect(milestonesEdges).toHaveLength(2);
+    expect(milestonesEdges.map((e) => e.target)).toEqual(['step-1', 'step-2']);
   });
 
   it('should create conflicts and replaces edges', () => {
@@ -240,13 +240,13 @@ describe('buildGraph lint checks', () => {
     expect(msgs.filter((m) => m.message.includes('does not exist'))).toHaveLength(0);
   });
 
-  it('should warn on broken step references', () => {
+  it('should warn on broken milestone references', () => {
     const repoPath = writeRepository(tmpDir, 'repository.json', {
-      'my-path': { path: 'path/', type: 'path', steps: ['missing-step'] },
+      'my-path': { path: 'path/', type: 'path', milestones: ['missing-step'] },
     });
 
     const { lintMessages: msgs } = buildGraph([{ name: 'test', path: repoPath }]);
-    expect(msgs.some((m) => m.message.includes('missing-step') && m.message.includes('steps'))).toBe(true);
+    expect(msgs.some((m) => m.message.includes('missing-step') && m.message.includes('milestones'))).toBe(true);
   });
 
   it('should detect cycles in depends chains', () => {
@@ -261,14 +261,14 @@ describe('buildGraph lint checks', () => {
     expect(cycleMsgs.length).toBeGreaterThan(0);
   });
 
-  it('should detect cycles in steps chains', () => {
+  it('should detect cycles in milestones chains', () => {
     const repoPath = writeRepository(tmpDir, 'repository.json', {
-      'path-a': { path: 'a/', type: 'path', steps: ['path-b'] },
-      'path-b': { path: 'b/', type: 'path', steps: ['path-a'] },
+      'path-a': { path: 'a/', type: 'path', milestones: ['path-b'] },
+      'path-b': { path: 'b/', type: 'path', milestones: ['path-a'] },
     });
 
     const { lintMessages: msgs } = buildGraph([{ name: 'test', path: repoPath }]);
-    const cycleMsgs = lintMessages(msgs, 'error').filter((m) => m.message.includes('Cycle in steps'));
+    const cycleMsgs = lintMessages(msgs, 'error').filter((m) => m.message.includes('Cycle in milestones'));
     expect(cycleMsgs.length).toBeGreaterThan(0);
   });
 

--- a/src/validation/build-repository.test.ts
+++ b/src/validation/build-repository.test.ts
@@ -233,7 +233,7 @@ describe('buildRepository', () => {
     writeJson(path.join(tmpDir, 'journeys', 'infra-alerting', 'manifest.json'), {
       id: 'infra-alerting',
       type: 'journey',
-      steps: ['infra-alerting-find-data'],
+      milestones: ['infra-alerting-find-data'],
     });
 
     writeJson(path.join(tmpDir, 'journeys', 'infra-alerting', 'steps', 'find-data', 'content.json'), {
@@ -275,7 +275,7 @@ describe('buildRepository', () => {
     expect(repository['shadow']).toBeUndefined();
   });
 
-  it('should handle path-type packages with steps', () => {
+  it('should handle path-type packages with milestones', () => {
     writeJson(path.join(tmpDir, 'getting-started', 'content.json'), {
       id: 'getting-started',
       title: 'Getting started path',
@@ -285,7 +285,7 @@ describe('buildRepository', () => {
     writeJson(path.join(tmpDir, 'getting-started', 'manifest.json'), {
       id: 'getting-started',
       type: 'path',
-      steps: ['welcome-to-grafana', 'first-dashboard'],
+      milestones: ['welcome-to-grafana', 'first-dashboard'],
     });
 
     const { repository, errors } = buildRepository(tmpDir);
@@ -294,7 +294,7 @@ describe('buildRepository', () => {
     const entry = repository['getting-started'];
     expect(entry).toBeDefined();
     expect(entry!.type).toBe('path');
-    expect(entry!.steps).toEqual(['welcome-to-grafana', 'first-dashboard']);
+    expect(entry!.milestones).toEqual(['welcome-to-grafana', 'first-dashboard']);
   });
 
   it('should omit empty dependency arrays from entries', () => {

--- a/src/validation/package-schema.test.ts
+++ b/src/validation/package-schema.test.ts
@@ -151,41 +151,41 @@ describe('ManifestJsonSchema', () => {
 
   it('should accept all valid type values', () => {
     for (const type of ['guide', 'path', 'journey']) {
-      const input = type === 'guide' ? { id: 'test', type } : { id: 'test', type, steps: ['step-1'] };
+      const input = type === 'guide' ? { id: 'test', type } : { id: 'test', type, milestones: ['step-1'] };
       const result = ManifestJsonSchema.safeParse(input);
       expect(result.success).toBe(true);
     }
   });
 
-  it('should require steps when type is "path"', () => {
+  it('should require milestones when type is "path"', () => {
     const result = ManifestJsonSchema.safeParse({ id: 'test', type: 'path' });
     expect(result.success).toBe(false);
   });
 
-  it('should require steps when type is "journey"', () => {
+  it('should require milestones when type is "journey"', () => {
     const result = ManifestJsonSchema.safeParse({ id: 'test', type: 'journey' });
     expect(result.success).toBe(false);
   });
 
-  it('should accept path with steps', () => {
+  it('should accept path with milestones', () => {
     const result = ManifestJsonSchema.safeParse({
       id: 'test-path',
       type: 'path',
-      steps: ['guide-1', 'guide-2'],
+      milestones: ['guide-1', 'guide-2'],
     });
     expect(result.success).toBe(true);
   });
 
-  it('should reject path with empty steps array', () => {
+  it('should reject path with empty milestones array', () => {
     const result = ManifestJsonSchema.safeParse({
       id: 'test-path',
       type: 'path',
-      steps: [],
+      milestones: [],
     });
     expect(result.success).toBe(false);
   });
 
-  it('should not require steps when type is "guide"', () => {
+  it('should not require milestones when type is "guide"', () => {
     const result = ManifestJsonSchema.safeParse({ id: 'test', type: 'guide' });
     expect(result.success).toBe(true);
   });
@@ -358,12 +358,12 @@ describe('RepositoryJsonSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('should accept path entries with steps', () => {
+  it('should accept path entries with milestones', () => {
     const result = RepositoryJsonSchema.safeParse({
       'getting-started': {
         path: 'getting-started/',
         type: 'path',
-        steps: ['welcome', 'first-dashboard'],
+        milestones: ['welcome', 'first-dashboard'],
       },
     });
     expect(result.success).toBe(true);
@@ -444,7 +444,7 @@ describe('GraphEdgeSchema', () => {
   });
 
   it('should accept all edge types', () => {
-    const types = ['depends', 'recommends', 'suggests', 'provides', 'conflicts', 'replaces', 'steps'];
+    const types = ['depends', 'recommends', 'suggests', 'provides', 'conflicts', 'replaces', 'milestones'];
     for (const type of types) {
       const result = GraphEdgeSchema.safeParse({ source: 'a', target: 'b', type });
       expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary

- Renames the `steps` field in `manifest.json` to `milestones` across all TypeScript types, Zod schemas, CLI commands, unit tests, and design documents.
- Requested by the docs team to align terminology: ordered units within a learning path or journey are called **milestones** in their structure, not steps.
- The `steps` field in interactive tutorial blocks (`multistep`/`guided`) is **unrelated and unchanged**.

## What changed

| Area | Files |
|------|-------|
| TypeScript types | `src/types/package.types.ts` — `PackageMetadataFields`, `ManifestJson`, `GraphEdgeType` |
| Zod schemas | `src/types/package.schema.ts` — `ManifestJsonObjectSchema`, `.refine()` predicate + error message, `packageMetadataSchemaFields`, `GraphEdgeTypeSchema` |
| KNOWN_FIELDS | `src/types/json-guide.schema.ts` — `_manifest` set only |
| CLI build-repository | `src/cli/commands/build-repository.ts` — denormalization assignment |
| CLI build-graph | `src/cli/commands/build-graph.ts` — lint messages, cycle detection, node/edge construction |
| Unit tests | `package-schema.test.ts`, `build-graph.test.ts`, `build-repository.test.ts` |
| Design docs | `PATHFINDER-PACKAGE-DESIGN.md`, `PACKAGE-IMPLEMENTATION-PLAN.md`, `learning-journeys.md` |

## Test plan

- [x] `npm run typecheck` passes (0 errors)
- [x] `npm run lint:fix` passes (0 errors)
- [x] `npm run test:ci` passes (2112 tests, 0 failures across 104 suites)
- [x] `npm run test:go` passes
- [x] `go build ./...` passes