### PR TITLE
feat(validation): add semantic lint rules for manifest milestones and dependency co-occurrence

### DIFF
--- a/src/cli/commands/schema.ts
+++ b/src/cli/commands/schema.ts
@@ -51,6 +51,11 @@ export const SCHEMA_REGISTRY: Record<string, SchemaRegistryEntry> = {
   manifest: {
     schema: ManifestJsonObjectSchema,
     description: 'Manifest JSON schema (manifest.json, without cross-field refinement)',
+    refinements: [
+      '"milestones" must be a non-empty array when type is "path" or "journey"',
+      '"milestones" is only valid when type is "path" or "journey" — type must be "path" or "journey" when milestones is present',
+      'Package IDs listed in "milestones" must not also appear in "recommends", "suggests", or "depends"',
+    ],
   },
   repository: {
     schema: RepositoryJsonSchema,

--- a/src/types/package.schema.ts
+++ b/src/types/package.schema.ts
@@ -142,19 +142,33 @@ export const ManifestJsonObjectSchema = z.object({
  * - ERROR: id, type (hard requirements)
  * - WARN: description, category, targeting, startingLocation (missing but recommended)
  * - INFO: repository, language, schemaVersion, dependency fields, author, testEnvironment (defaults applied)
- * - Conditional ERROR: milestones required when type is "path" or "journey"
+ * - Conditional ERROR: milestones required when type is "path" or "journey" (Rule 1)
+ * - Conditional ERROR: milestones only valid when type is "path" or "journey" (Rule 2)
  *
  * @coupling Type: ManifestJson
  */
-export const ManifestJsonSchema = ManifestJsonObjectSchema.refine(
-  (manifest) => {
-    if (manifest.type === 'path' || manifest.type === 'journey') {
-      return manifest.milestones !== undefined && manifest.milestones.length > 0;
-    }
-    return true;
-  },
-  { message: "'milestones' is required when type is 'path' or 'journey'" }
-);
+export const ManifestJsonSchema = ManifestJsonObjectSchema.superRefine((manifest, ctx) => {
+  const isMetapackage = manifest.type === 'path' || manifest.type === 'journey';
+  const hasMilestones = manifest.milestones !== undefined && manifest.milestones.length > 0;
+
+  // Rule 1: path/journey requires milestones
+  if (isMetapackage && !hasMilestones) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `"milestones" must be a non-empty array when type is "${manifest.type}" — ${manifest.type}s require an ordered sequence of packages`,
+      path: ['milestones'],
+    });
+  }
+
+  // Rule 2: milestones requires path/journey type
+  if (hasMilestones && !isMetapackage) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `"milestones" is only valid when type is "path" or "journey", but type is "${manifest.type}" — either change type to "path" or "journey", or remove the milestones array`,
+      path: ['type'],
+    });
+  }
+});
 
 // ============ SHARED METADATA SCHEMA FIELDS ============
 

--- a/src/validation/package-schema.test.ts
+++ b/src/validation/package-schema.test.ts
@@ -189,6 +189,46 @@ describe('ManifestJsonSchema', () => {
     const result = ManifestJsonSchema.safeParse({ id: 'test', type: 'guide' });
     expect(result.success).toBe(true);
   });
+
+  it('should reject guide with milestones set (Rule 2)', () => {
+    const result = ManifestJsonSchema.safeParse({
+      id: 'test',
+      type: 'guide',
+      milestones: ['step-1'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject journey without milestones (Rule 1)', () => {
+    const result = ManifestJsonSchema.safeParse({ id: 'test', type: 'journey' });
+    expect(result.success).toBe(false);
+  });
+
+  it('should report error on milestones field path when path type is missing milestones (Rule 1)', () => {
+    const result = ManifestJsonSchema.safeParse({ id: 'test', type: 'path' });
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    const milestonesIssue = result.error.issues.find(
+      (issue) => issue.path.length > 0 && issue.path[0] === 'milestones'
+    );
+    expect(milestonesIssue).toBeDefined();
+  });
+
+  it('should report error on type field path when guide has milestones (Rule 2)', () => {
+    const result = ManifestJsonSchema.safeParse({
+      id: 'test',
+      type: 'guide',
+      milestones: ['step-1'],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    const typeIssue = result.error.issues.find((issue) => issue.path.length > 0 && issue.path[0] === 'type');
+    expect(typeIssue).toBeDefined();
+  });
 });
 
 // ============ DependencyClauseSchema ============

--- a/src/validation/validate-package.test.ts
+++ b/src/validation/validate-package.test.ts
@@ -291,6 +291,126 @@ describe('validatePackage', () => {
   });
 });
 
+describe('validatePackage — milestone/dependency overlap (Rule 3)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should error when a milestone ID appears in recommends', () => {
+    const pkgDir = path.join(tmpDir, 'overlap-recommends');
+    writeJson(path.join(pkgDir, 'content.json'), { id: 'my-path', title: 'My path', blocks: [] });
+    writeJson(path.join(pkgDir, 'manifest.json'), {
+      id: 'my-path',
+      type: 'path',
+      milestones: ['step-1', 'step-2'],
+      recommends: ['step-1'],
+    });
+
+    const result = validatePackage(pkgDir);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((e) => e.code === 'milestone_dependency_overlap')).toBe(true);
+    expect(result.errors.some((e) => e.message.includes('"step-1"') && e.message.includes('"recommends"'))).toBe(true);
+  });
+
+  it('should error when a milestone ID appears in suggests', () => {
+    const pkgDir = path.join(tmpDir, 'overlap-suggests');
+    writeJson(path.join(pkgDir, 'content.json'), { id: 'my-path', title: 'My path', blocks: [] });
+    writeJson(path.join(pkgDir, 'manifest.json'), {
+      id: 'my-path',
+      type: 'path',
+      milestones: ['step-1', 'step-2'],
+      suggests: ['step-2'],
+    });
+
+    const result = validatePackage(pkgDir);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((e) => e.code === 'milestone_dependency_overlap')).toBe(true);
+    expect(result.errors.some((e) => e.message.includes('"step-2"') && e.message.includes('"suggests"'))).toBe(true);
+  });
+
+  it('should error when a milestone ID appears in depends', () => {
+    const pkgDir = path.join(tmpDir, 'overlap-depends');
+    writeJson(path.join(pkgDir, 'content.json'), { id: 'my-path', title: 'My path', blocks: [] });
+    writeJson(path.join(pkgDir, 'manifest.json'), {
+      id: 'my-path',
+      type: 'path',
+      milestones: ['step-1', 'step-2'],
+      depends: ['step-1'],
+    });
+
+    const result = validatePackage(pkgDir);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((e) => e.code === 'milestone_dependency_overlap')).toBe(true);
+    expect(result.errors.some((e) => e.message.includes('"step-1"') && e.message.includes('"depends"'))).toBe(true);
+  });
+
+  it('should emit one error per conflicting ID across multiple fields', () => {
+    const pkgDir = path.join(tmpDir, 'overlap-multi');
+    writeJson(path.join(pkgDir, 'content.json'), { id: 'my-path', title: 'My path', blocks: [] });
+    writeJson(path.join(pkgDir, 'manifest.json'), {
+      id: 'my-path',
+      type: 'path',
+      milestones: ['step-1', 'step-2', 'step-3'],
+      recommends: ['step-1'],
+      suggests: ['step-2'],
+    });
+
+    const result = validatePackage(pkgDir);
+    expect(result.isValid).toBe(false);
+    const overlapErrors = result.errors.filter((e) => e.code === 'milestone_dependency_overlap');
+    expect(overlapErrors).toHaveLength(2);
+  });
+
+  it('should detect overlap when milestone ID appears in an OR-group within depends', () => {
+    const pkgDir = path.join(tmpDir, 'overlap-or-group');
+    writeJson(path.join(pkgDir, 'content.json'), { id: 'my-path', title: 'My path', blocks: [] });
+    writeJson(path.join(pkgDir, 'manifest.json'), {
+      id: 'my-path',
+      type: 'path',
+      milestones: ['step-1'],
+      depends: [['step-1', 'alternative-step']],
+    });
+
+    const result = validatePackage(pkgDir);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((e) => e.code === 'milestone_dependency_overlap')).toBe(true);
+  });
+
+  it('should not error when milestone IDs appear only in provides or conflicts', () => {
+    const pkgDir = path.join(tmpDir, 'no-overlap-provides');
+    writeJson(path.join(pkgDir, 'content.json'), { id: 'my-path', title: 'My path', blocks: [] });
+    writeJson(path.join(pkgDir, 'manifest.json'), {
+      id: 'my-path',
+      type: 'path',
+      milestones: ['step-1', 'step-2'],
+      provides: ['step-1'],
+      conflicts: ['step-2'],
+    });
+
+    const result = validatePackage(pkgDir);
+    expect(result.errors.filter((e) => e.code === 'milestone_dependency_overlap')).toHaveLength(0);
+  });
+
+  it('should not error when no milestones are set', () => {
+    const pkgDir = path.join(tmpDir, 'no-milestones');
+    writeJson(path.join(pkgDir, 'content.json'), { id: 'my-guide', title: 'My guide', blocks: [] });
+    writeJson(path.join(pkgDir, 'manifest.json'), {
+      id: 'my-guide',
+      type: 'guide',
+      recommends: ['some-other-guide'],
+    });
+
+    const result = validatePackage(pkgDir);
+    expect(result.errors.filter((e) => e.code === 'milestone_dependency_overlap')).toHaveLength(0);
+  });
+});
+
 describe('validatePackageTree', () => {
   let tmpDir: string;
 

--- a/src/validation/validate-package.ts
+++ b/src/validation/validate-package.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 
 import { ContentJsonSchema, ManifestJsonSchema } from '../types/package.schema';
 import { CURRENT_SCHEMA_VERSION } from '../types/json-guide.schema';
+import type { DependencyList, ManifestJson } from '../types/package.types';
 import type { ValidationError, ValidationWarning } from './errors';
 import { readJsonFile } from './package-io';
 import { validateGuide, type ValidationResult } from './validate-guide';
@@ -133,6 +134,7 @@ export function validatePackage(packageDir: string, options: PackageValidationOp
       }
 
       emitManifestMessages(manifestRead.parsed as Record<string, unknown>, manifest, messages);
+      validateManifestSemantics(manifest, errors);
 
       if (manifest.testEnvironment) {
         validateTestEnvironment(manifest.testEnvironment, messages);
@@ -208,6 +210,38 @@ export function validatePackageTree(
 }
 
 // --- Internal helpers ---
+
+function validateManifestSemantics(manifest: ManifestJson, errors: ValidationError[]): void {
+  if (!manifest.milestones || manifest.milestones.length === 0) {
+    return;
+  }
+
+  const milestoneSet = new Set(manifest.milestones);
+  const flattenIds = (depList: DependencyList): string[] =>
+    depList.flatMap((clause) => (Array.isArray(clause) ? clause : [clause]));
+
+  const depFields: Array<[string, DependencyList]> = [
+    ['recommends', manifest.recommends ?? []],
+    ['suggests', manifest.suggests ?? []],
+    ['depends', manifest.depends ?? []],
+  ];
+
+  for (const [fieldName, depList] of depFields) {
+    for (const id of flattenIds(depList)) {
+      if (milestoneSet.has(id)) {
+        errors.push({
+          message:
+            `manifest.json: package ID "${id}" appears in both "milestones" and "${fieldName}" — ` +
+            `milestones define the path's ordered steps; "${fieldName}" on the path manifest is for ` +
+            `packages related to the path as a whole (e.g. prerequisites or follow-ons). ` +
+            `Remove "${id}" from "${fieldName}".`,
+          path: ['manifest.json', fieldName],
+          code: 'milestone_dependency_overlap',
+        });
+      }
+    }
+  }
+}
 
 function emitManifestMessages(
   raw: Record<string, unknown>,


### PR DESCRIPTION
## Summary

Adds three semantic lint rules to the `validate --packages` CLI tool that catch co-occurrence errors in `manifest.json` fields:

- **Rule 1 (schema):** `type="path"` or `type="journey"` must have a non-empty `milestones` array — error points at the `milestones` field
- **Rule 2 (schema):** a non-empty `milestones` array requires `type="path"` or `type="journey"` — error points at the `type` field
- **Rule 3 (imperative):** any package ID listed in `milestones` must not also appear in `recommends`, `suggests`, or `depends` — one error per conflicting ID, with a message explaining the semantic distinction

Rules 1 & 2 live in `ManifestJsonSchema` as a `.superRefine()`, replacing the existing `.refine()`, so they fire everywhere the schema is parsed (not just CLI) and carry proper field paths. Rule 3 lives in a new `validateManifestSemantics()` helper in `validate-package.ts` because it needs per-ID iteration with distinct, actionable error messages.

The `SCHEMA_REGISTRY` manifest entry now lists all three rules as `x-refinements` strings so cross-language consumers (e.g. Go) know to reimplement them.

## Test plan

- [ ] `npm run test:ci -- --testPathPatterns=validation` — all 382 validation tests pass (11 new tests added)
- [ ] `npm run typecheck` — no errors
- [ ] `npm run lint:fix` — no new warnings (pre-existing `Select` deprecation warning in `CodeBlockForm.tsx` is unrelated)

Closes part of #622