### PR TITLE
Fix docs and learning path title rendering

### DIFF
--- a/src/docs-retrieval/content-fetcher.test.ts
+++ b/src/docs-retrieval/content-fetcher.test.ts
@@ -150,24 +150,43 @@ describe('null content handling for learning journeys', () => {
     const mockGuide = {
       id: 'drilldown-logs-milestone-1',
       title: 'Milestone 1: Getting Started with Logs',
-      description: 'Learn how to explore logs in Grafana',
       blocks: [
-        { type: 'text', content: 'Welcome to the first milestone' },
-        { type: 'text', content: 'In this guide, you will learn...' },
+        { type: 'markdown', content: 'Welcome to the first milestone.' },
+        { type: 'markdown', content: 'In this guide, you will learn...' },
       ],
     };
     const journeyUrl = 'https://grafana.com/docs/learning-paths/drilldown-logs/milestone-1/';
 
-    // Mock fetch to return valid JSON for learning journey milestone
+    const jsonHeaders = new Headers();
+    jsonHeaders.set('Content-Type', 'application/json');
+    const htmlHeaders = new Headers();
+    htmlHeaders.set('Content-Type', 'text/html');
+    const notFoundHeaders = new Headers();
+    notFoundHeaders.set('Content-Type', 'text/html');
+
     (global.fetch as jest.Mock).mockImplementation((url: string) => {
-      const headers = new Headers();
-      headers.set('Content-Type', 'application/json');
-      // Return valid JSON for any request to this milestone
+      if (url.endsWith('content.json')) {
+        return Promise.resolve({
+          ok: true,
+          text: async () => JSON.stringify(mockGuide),
+          url,
+          headers: jsonHeaders,
+        });
+      }
+      if (url.endsWith('/milestone-1/') || url.endsWith('/milestone-1')) {
+        return Promise.resolve({
+          ok: true,
+          text: async () => '<html><body></body></html>',
+          url,
+          headers: htmlHeaders,
+        });
+      }
       return Promise.resolve({
-        ok: true,
-        text: async () => JSON.stringify(mockGuide),
-        url: url.endsWith('content.json') ? url : url + 'content.json',
-        headers,
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        url,
+        headers: notFoundHeaders,
       });
     });
 
@@ -188,6 +207,9 @@ describe('null content handling for learning journeys', () => {
       // The key test: verify the original guide structure is preserved
       // (whether native JSON or wrapped, the blocks should be there)
       expect(parsedContent.blocks.length).toBeGreaterThan(0);
+
+      // Verify metadata.title is taken from the JSON guide title, not defaulting to 'Documentation'
+      expect(result.content.metadata.title).toBe('Milestone 1: Getting Started with Logs');
     }
 
     // Verify fetch was called

--- a/src/docs-retrieval/content-fetcher.ts
+++ b/src/docs-retrieval/content-fetcher.ts
@@ -174,9 +174,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
     // Determine if this is native JSON content (content.json) that doesn't need wrapping
     const isNativeJson = fetchResult.isNativeJson || false;
 
-    // Extract basic metadata without DOM processing
-    // For native JSON, we still need to extract metadata from the content
-    const metadata = await extractMetadata(fetchResult.html, finalUrl, contentType);
+    const metadata = await extractMetadata(fetchResult.html, finalUrl, contentType, isNativeJson);
 
     let jsonContent: string;
 
@@ -200,7 +198,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
             };
           }
 
-          const htmlMetadata = await extractMetadata(htmlFetchResult.html, htmlUrl, contentType);
+          const htmlMetadata = await extractMetadata(htmlFetchResult.html, htmlUrl, contentType, false);
           let processedHtml = htmlFetchResult.html;
 
           if (contentType === 'learning-journey' && htmlMetadata.learningJourney) {
@@ -1030,8 +1028,13 @@ function getContentUrls(url: string): { jsonUrl: string; htmlUrl: string } {
  * Extract metadata from HTML without DOM processing
  * Uses simple string parsing instead of DOM manipulation
  */
-async function extractMetadata(html: string, url: string, contentType: ContentType): Promise<ContentMetadata> {
-  const title = extractTitle(html);
+async function extractMetadata(
+  html: string,
+  url: string,
+  contentType: ContentType,
+  isNativeJson: boolean
+): Promise<ContentMetadata> {
+  const title = isNativeJson ? extractTitleFromJson(html) : extractTitleFromHtml(html);
 
   if (contentType === 'learning-journey') {
     const learningJourney = await extractLearningJourneyMetadata(html, url);
@@ -1042,11 +1045,20 @@ async function extractMetadata(html: string, url: string, contentType: ContentTy
   }
 }
 
-/**
- * Extract page title using simple string parsing
- */
-function extractTitle(html: string): string {
-  // Try multiple title extraction strategies
+function extractTitleFromJson(json: string): string {
+  const parsed: unknown = JSON.parse(json);
+  if (
+    parsed !== null &&
+    typeof parsed === 'object' &&
+    'title' in parsed &&
+    typeof (parsed as { title: unknown }).title === 'string'
+  ) {
+    return (parsed as { title: string }).title || 'Documentation';
+  }
+  return 'Documentation';
+}
+
+function extractTitleFromHtml(html: string): string {
   const titlePatterns = [
     /<title[^>]*>([^<]+)<\/title>/i,
     /<h1[^>]*>([^<]+)<\/h1>/i,

--- a/src/docs-retrieval/content-renderer.tsx
+++ b/src/docs-retrieval/content-renderer.tsx
@@ -427,6 +427,7 @@ export const ContentRenderer = React.memo(function ContentRenderer({
         contentType={content.type}
         baseUrl={content.url}
         title={content.metadata.title}
+        isNativeJson={content.isNativeJson ?? false}
         onContentReady={onContentReady}
         activeRef={activeRef}
         className={className}
@@ -443,6 +444,7 @@ interface ContentWithVariablesProps {
   contentType: 'learning-journey' | 'single-doc' | 'interactive';
   baseUrl: string;
   title: string;
+  isNativeJson: boolean;
   onContentReady?: () => void;
   activeRef: React.RefObject<HTMLDivElement>;
   className?: string;
@@ -455,6 +457,7 @@ function ContentWithVariables({
   contentType,
   baseUrl,
   title,
+  isNativeJson,
   onContentReady,
   activeRef,
   className,
@@ -465,7 +468,6 @@ function ContentWithVariables({
   // This avoids breaking JSON structure when user values contain special characters
   const { responses } = useGuideResponses();
 
-  // Style for the title heading
   const titleStyle = css`
     font-size: 28px;
     font-weight: 500;
@@ -488,7 +490,7 @@ function ContentWithVariables({
         position: 'relative',
       }}
     >
-      {title && contentType === 'single-doc' && <h1 className={titleStyle}>{title}</h1>}
+      {title && isNativeJson && <h1 className={titleStyle}>{title}</h1>}
       <ContentProcessor
         html={processedContent}
         contentType={contentType}


### PR DESCRIPTION
For docs pages, ensure we render only one title which is extracted from the HTML and uses the content's first heading.

For learning path milestones that have content JSON, use the title from the JSON itself.
**Before**

<img width="733" height="296" alt="Screenshot 2026-03-11 at 15 47 12" src="https://github.com/user-attachments/assets/1040cf53-8ec3-4bd1-b130-f00bbc2ed193" />

<img width="686" height="265" alt="Screenshot 2026-03-11 at 15 46 57" src="https://github.com/user-attachments/assets/7baffa9f-5864-4340-88c1-788e25b9ef95" />

**After**
<img width="715" height="331" alt="Screenshot 2026-03-11 at 15 46 03" src="https://github.com/user-attachments/assets/7874c10c-e641-4a49-ac46-d905ad81dcb0" />

<img width="714" height="313" alt="Screenshot 2026-03-11 at 15 46 20" src="https://github.com/user-attachments/assets/6884f470-0cbb-42df-953f-4c6422e4e284" />

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>