### PR TITLE
DRAFT: Learning Map (WIP)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.3.3",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@dagrejs/dagre": "^2.0.4",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -35,6 +36,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
+        "@xyflow/react": "^12.10.1",
         "dompurify": "^3.3.2",
         "idb": "^8.0.3",
         "jsonc-parser": "^3.3.1",
@@ -837,6 +839,21 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-2.0.4.tgz",
+      "integrity": "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "3.0.4"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-3.0.4.tgz",
+      "integrity": "sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg==",
+      "license": "MIT"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.3",
@@ -6953,6 +6970,15 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -6960,6 +6986,31 @@
       "license": "MIT",
       "dependencies": {
         "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -8555,6 +8606,38 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.1",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.1.tgz",
+      "integrity": "sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.75",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.75.tgz",
+      "integrity": "sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -9741,6 +9824,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
     },
     "node_modules/classnames": {
@@ -23701,6 +23790,34 @@
       "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
       "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
       "license": "MIT AND BSD-3-Clause"
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "node": ">=22"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^2.0.4",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -134,6 +135,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
+    "@xyflow/react": "^12.10.1",
     "dompurify": "^3.3.2",
     "idb": "^8.0.3",
     "jsonc-parser": "^3.3.1",

--- a/src/components/LearningGraph/LearningGraph.tsx
+++ b/src/components/LearningGraph/LearningGraph.tsx
@@ -1,0 +1,246 @@
+/**
+ * LearningGraph — React Flow canvas root.
+ *
+ * Wires together all hooks and sub-components:
+ * - Fetches graph.json via useGraphData
+ * - Manages filter state via useGraphFilters
+ * - Computes Dagre layout via useGraphLayout
+ * - Renders React Flow canvas with custom nodes and edges
+ * - Shows node detail tooltip on click
+ */
+
+import React, { useState, useMemo, useEffect } from 'react';
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Controls,
+  Background,
+  BackgroundVariant,
+  MiniMap,
+  useReactFlow,
+  type Node as RFNode,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+
+import { useStyles2, Spinner, Alert } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+
+import type { GraphNode } from '../../types/package.types';
+import { useGraphData } from './hooks/useGraphData';
+import { useGraphFilters } from './hooks/useGraphFilters';
+import { useGraphLayout } from './hooks/useGraphLayout';
+import {
+  GuideNode,
+  PathNode,
+  LearningGraphEdge,
+  LearningGraphTooltip,
+  LearningGraphFilters,
+  type GraphNodeData,
+} from './components';
+
+// ============ REACT FLOW CONFIGURATION ============
+
+const NODE_TYPES = {
+  guideNode: GuideNode,
+  pathNode: PathNode,
+};
+
+const EDGE_TYPES = {
+  learningEdge: LearningGraphEdge,
+};
+
+// ============ STYLES ============
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    wrapper: css({
+      display: 'flex',
+      flexDirection: 'column',
+      width: '100%',
+      height: 480,
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default,
+      overflow: 'hidden',
+      background: theme.colors.background.canvas,
+    }),
+    canvas: css({
+      flex: 1,
+      minHeight: 0,
+    }),
+    center: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: '100%',
+      gap: theme.spacing(1),
+      color: theme.colors.text.secondary,
+    }),
+    emptyState: css({
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: '100%',
+      gap: theme.spacing(1),
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+    }),
+    resetLink: css({
+      cursor: 'pointer',
+      textDecoration: 'underline',
+      background: 'none',
+      border: 'none',
+      color: 'inherit',
+      fontSize: 'inherit',
+    }),
+  };
+}
+
+// ============ AUTO FIT VIEW ============
+
+function AutoFitView({ nodeCount }: { nodeCount: number }) {
+  const { fitView } = useReactFlow();
+  useEffect(() => {
+    const id = setTimeout(() => fitView({ padding: 0.1, duration: 300 }), 50);
+    return () => clearTimeout(id);
+  }, [nodeCount, fitView]);
+  return null;
+}
+
+// ============ INNER CANVAS (needs ReactFlowProvider context) ============
+
+interface InnerCanvasProps {
+  graphUrl: string;
+  completedGuides: string[];
+  onOpenGuide: (url: string, title: string) => void;
+}
+
+function InnerCanvas({ graphUrl, completedGuides, onOpenGuide }: InnerCanvasProps) {
+  const styles = useStyles2(getStyles);
+  const { graph, status, error } = useGraphData(graphUrl);
+
+  const {
+    filters,
+    filteredGraph,
+    availableCategories,
+    toggleEdgeType,
+    setTypeFilter,
+    toggleCategory,
+    setCompletionFilter,
+    toggleWhatsNext,
+    togglePathExpanded,
+    resetFilters,
+  } = useGraphFilters(graph, completedGuides);
+
+  const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout(filteredGraph, completedGuides);
+
+  const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+
+  // Inject interaction callbacks into node data
+  const enrichedNodes = useMemo<RFNode[]>(() => {
+    return layoutNodes.map((n) => ({
+      ...n,
+      data: {
+        ...(n.data as GraphNodeData),
+        isExpanded: filters.expandedPaths.has(n.id),
+        onToggleExpand: togglePathExpanded,
+        onNodeClick: setSelectedNode,
+      } satisfies GraphNodeData,
+    }));
+  }, [layoutNodes, filters.expandedPaths, togglePathExpanded]);
+
+  if (status === 'loading') {
+    return (
+      <div className={styles.center}>
+        <Spinner size="lg" />
+        <span>Loading learning map…</span>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Alert title="Could not load learning map" severity="warning">
+        {error ?? 'Unknown error'}
+      </Alert>
+    );
+  }
+
+  if (status === 'success' && (!filteredGraph || filteredGraph.nodes.length === 0)) {
+    return (
+      <div className={styles.emptyState}>
+        <span>No guides match the current filters.</span>
+        <button className={styles.resetLink} onClick={resetFilters}>
+          Reset filters
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <LearningGraphFilters
+        filters={filters}
+        availableCategories={availableCategories}
+        onToggleEdgeType={toggleEdgeType}
+        onSetTypeFilter={setTypeFilter}
+        onToggleCategory={toggleCategory}
+        onSetCompletionFilter={setCompletionFilter}
+        onToggleWhatsNext={toggleWhatsNext}
+        onResetFilters={resetFilters}
+      />
+
+      <div className={styles.canvas}>
+        <ReactFlow
+          nodes={enrichedNodes}
+          edges={layoutEdges}
+          nodeTypes={NODE_TYPES}
+          edgeTypes={EDGE_TYPES}
+          fitView
+          fitViewOptions={{ padding: 0.1 }}
+          minZoom={0.3}
+          maxZoom={2}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={true}
+          proOptions={{ hideAttribution: true }}
+        >
+          <AutoFitView nodeCount={enrichedNodes.length} />
+          <Controls showInteractive={false} />
+          <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+          <MiniMap nodeStrokeWidth={3} zoomable pannable />
+        </ReactFlow>
+      </div>
+
+      {selectedNode && (
+        <LearningGraphTooltip
+          node={selectedNode}
+          isCompleted={completedGuides.includes(selectedNode.id)}
+          onClose={() => setSelectedNode(null)}
+          onOpenGuide={onOpenGuide}
+        />
+      )}
+    </>
+  );
+}
+
+// ============ PUBLIC COMPONENT ============
+
+interface LearningGraphProps {
+  graphUrl: string;
+  completedGuides: string[];
+  onOpenGuide: (url: string, title: string) => void;
+}
+
+export function LearningGraph({ graphUrl, completedGuides, onOpenGuide }: LearningGraphProps) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <ReactFlowProvider>
+      <div className={styles.wrapper}>
+        <InnerCanvas graphUrl={graphUrl} completedGuides={completedGuides} onOpenGuide={onOpenGuide} />
+      </div>
+    </ReactFlowProvider>
+  );
+}

--- a/src/components/LearningGraph/LearningGraphSection.tsx
+++ b/src/components/LearningGraph/LearningGraphSection.tsx
@@ -1,0 +1,116 @@
+/**
+ * LearningGraphSection — collapsible wrapper for the LearningGraph canvas.
+ *
+ * Starts collapsed so the ~200 KB React Flow bundle is only downloaded
+ * when the learner first opens the section (React.lazy + Suspense).
+ */
+
+import React, { Suspense, useState, useCallback } from 'react';
+import { useStyles2, Icon, Spinner } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+
+const LearningGraph = React.lazy(() => import('./LearningGraph').then((m) => ({ default: m.LearningGraph })));
+
+// ============ STYLES ============
+
+function getSectionStyles(theme: GrafanaTheme2) {
+  return {
+    section: css({
+      marginTop: theme.spacing(2),
+    }),
+    header: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      padding: `${theme.spacing(1)} ${theme.spacing(0)}`,
+      cursor: 'pointer',
+      userSelect: 'none',
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+      marginBottom: theme.spacing(1),
+      '&:hover': {
+        color: theme.colors.text.primary,
+      },
+    }),
+    headerTitle: css({
+      fontSize: theme.typography.h5.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+      color: theme.colors.text.primary,
+      margin: 0,
+      flex: 1,
+    }),
+    headerIcon: css({
+      color: theme.colors.text.secondary,
+    }),
+    beta: css({
+      fontSize: '10px',
+      padding: '1px 6px',
+      borderRadius: '3px',
+      background: theme.colors.warning.transparent,
+      color: theme.colors.warning.text,
+      border: `1px solid ${theme.colors.warning.border}`,
+      fontWeight: theme.typography.fontWeightMedium,
+    }),
+    fallback: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: 200,
+      gap: theme.spacing(1),
+      color: theme.colors.text.secondary,
+    }),
+  };
+}
+
+// ============ PROPS ============
+
+interface LearningGraphSectionProps {
+  graphUrl: string;
+  completedGuides: string[];
+  onOpenGuide: (url: string, title: string) => void;
+}
+
+// ============ COMPONENT ============
+
+export function LearningGraphSection({ graphUrl, completedGuides, onOpenGuide }: LearningGraphSectionProps) {
+  const styles = useStyles2(getSectionStyles);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleOpen = useCallback(() => setIsOpen((prev) => !prev), []);
+
+  return (
+    <div className={styles.section}>
+      <div
+        className={styles.header}
+        onClick={toggleOpen}
+        role="button"
+        aria-expanded={isOpen}
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggleOpen();
+          }
+        }}
+      >
+        <Icon name="sitemap" size="md" className={styles.headerIcon} />
+        <h2 className={styles.headerTitle}>Learning map</h2>
+        <span className={styles.beta}>Beta</span>
+        <Icon name={isOpen ? 'angle-up' : 'angle-down'} size="md" className={styles.headerIcon} />
+      </div>
+
+      {isOpen && (
+        <Suspense
+          fallback={
+            <div className={styles.fallback}>
+              <Spinner size="lg" />
+              <span>Loading learning map…</span>
+            </div>
+          }
+        >
+          <LearningGraph graphUrl={graphUrl} completedGuides={completedGuides} onOpenGuide={onOpenGuide} />
+        </Suspense>
+      )}
+    </div>
+  );
+}

--- a/src/components/LearningGraph/components/LearningGraphEdge.tsx
+++ b/src/components/LearningGraph/components/LearningGraphEdge.tsx
@@ -1,0 +1,82 @@
+/**
+ * Custom React Flow edge type for the LearningGraph.
+ *
+ * Renders different visual styles based on edge relationship type:
+ * - recommends: dashed blue animated
+ * - depends:    solid gray, heavier stroke
+ * - suggests:   dotted, semi-transparent
+ * - milestones: only visible when path is expanded (thin, internal)
+ */
+
+import React, { memo } from 'react';
+import { BaseEdge, getBezierPath, type EdgeProps } from '@xyflow/react';
+import { useTheme2 } from '@grafana/ui';
+import type { GraphEdgeType } from '../../../types/package.types';
+
+export interface LearningEdgeData extends Record<string, unknown> {
+  edgeType: GraphEdgeType;
+}
+
+function getEdgeStyle(
+  edgeType: GraphEdgeType,
+  theme: ReturnType<typeof useTheme2>
+): React.CSSProperties & { strokeDasharray?: string } {
+  switch (edgeType) {
+    case 'recommends':
+      return {
+        stroke: theme.colors.primary.main,
+        strokeWidth: 2,
+        strokeDasharray: '6 3',
+      };
+    case 'depends':
+      return {
+        stroke: theme.colors.text.secondary,
+        strokeWidth: 2.5,
+      };
+    case 'suggests':
+      return {
+        stroke: theme.colors.text.disabled,
+        strokeWidth: 1.5,
+        strokeDasharray: '2 4',
+        opacity: 0.7,
+      };
+    case 'milestones':
+      return {
+        stroke: theme.colors.border.medium,
+        strokeWidth: 1,
+      };
+    default:
+      return {
+        stroke: theme.colors.border.medium,
+        strokeWidth: 1.5,
+      };
+  }
+}
+
+export const LearningGraphEdge = memo(function LearningGraphEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+  markerEnd,
+}: EdgeProps) {
+  const theme = useTheme2();
+  const edgeType = (data as LearningEdgeData | undefined)?.edgeType ?? 'recommends';
+
+  const [edgePath] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  const style = getEdgeStyle(edgeType, theme);
+
+  return <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />;
+});

--- a/src/components/LearningGraph/components/LearningGraphFilters.tsx
+++ b/src/components/LearningGraph/components/LearningGraphFilters.tsx
@@ -1,0 +1,242 @@
+/**
+ * Compact filter bar for the LearningGraph.
+ *
+ * 5 controls:
+ * 1. Edge type toggles (pill buttons: Recommended / Prerequisites / Suggested)
+ * 2. Type filter (All / Paths / Guides)
+ * 3. Category multi-select pills
+ * 4. Completion filter (All / Not started / Completed)
+ * 5. "What's next" smart toggle
+ */
+
+import React from 'react';
+import { useStyles2, Icon } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import type { GraphEdgeType } from '../../../types/package.types';
+import type { GraphFilterState, CompletionFilter, TypeFilter } from '../types';
+
+interface LearningGraphFiltersProps {
+  filters: GraphFilterState;
+  availableCategories: string[];
+  onToggleEdgeType: (edgeType: GraphEdgeType) => void;
+  onSetTypeFilter: (typeFilter: TypeFilter) => void;
+  onToggleCategory: (category: string) => void;
+  onSetCompletionFilter: (filter: CompletionFilter) => void;
+  onToggleWhatsNext: () => void;
+  onResetFilters: () => void;
+}
+
+function getFilterStyles(theme: GrafanaTheme2) {
+  return {
+    bar: css({
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: theme.spacing(0.75),
+      alignItems: 'center',
+      padding: `${theme.spacing(0.75)} ${theme.spacing(1)}`,
+      background: theme.colors.background.secondary,
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+    }),
+    group: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+    }),
+    separator: css({
+      width: 1,
+      height: 16,
+      background: theme.colors.border.weak,
+      flexShrink: 0,
+    }),
+    pill: css({
+      padding: '2px 8px',
+      borderRadius: '12px',
+      border: `1px solid ${theme.colors.border.medium}`,
+      background: 'none',
+      color: theme.colors.text.secondary,
+      fontSize: '11px',
+      cursor: 'pointer',
+      transition: 'all 0.1s ease',
+      '&:hover': {
+        borderColor: theme.colors.primary.border,
+        color: theme.colors.text.primary,
+      },
+    }),
+    pillActive: css({
+      background: theme.colors.primary.transparent,
+      borderColor: theme.colors.primary.border,
+      color: theme.colors.primary.text,
+      fontWeight: theme.typography.fontWeightMedium,
+    }),
+    smartToggle: css({
+      padding: '2px 10px',
+      borderRadius: '12px',
+      border: `1px solid ${theme.colors.warning.border}`,
+      background: 'none',
+      color: theme.colors.text.secondary,
+      fontSize: '11px',
+      cursor: 'pointer',
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      transition: 'all 0.1s ease',
+      '&:hover': {
+        borderColor: theme.colors.warning.main,
+        color: theme.colors.text.primary,
+      },
+    }),
+    smartToggleActive: css({
+      background: theme.colors.warning.transparent,
+      borderColor: theme.colors.warning.border,
+      color: theme.colors.warning.text,
+      fontWeight: theme.typography.fontWeightMedium,
+    }),
+    resetButton: css({
+      padding: '2px 6px',
+      borderRadius: theme.shape.radius.default,
+      border: 'none',
+      background: 'none',
+      color: theme.colors.text.disabled,
+      fontSize: '11px',
+      cursor: 'pointer',
+      marginLeft: 'auto',
+      '&:hover': {
+        color: theme.colors.text.secondary,
+      },
+    }),
+  };
+}
+
+const EDGE_TYPE_LABELS: Array<{ type: GraphEdgeType; label: string }> = [
+  { type: 'recommends', label: 'Recommended' },
+  { type: 'depends', label: 'Prerequisites' },
+  { type: 'suggests', label: 'Suggested' },
+];
+
+const TYPE_FILTERS: Array<{ value: TypeFilter; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'paths', label: 'Paths' },
+  { value: 'journeys', label: 'Journeys' },
+  { value: 'guides', label: 'Guides' },
+];
+
+const COMPLETION_FILTERS: Array<{ value: CompletionFilter; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'not-started', label: 'Not started' },
+  { value: 'completed', label: 'Completed' },
+];
+
+export function LearningGraphFilters({
+  filters,
+  availableCategories,
+  onToggleEdgeType,
+  onSetTypeFilter,
+  onToggleCategory,
+  onSetCompletionFilter,
+  onToggleWhatsNext,
+  onResetFilters,
+}: LearningGraphFiltersProps) {
+  const styles = useStyles2(getFilterStyles);
+
+  return (
+    <div className={styles.bar} aria-label="Graph filters">
+      {/* 1. Edge type toggles */}
+      <div className={styles.group}>
+        {EDGE_TYPE_LABELS.map(({ type, label }) => {
+          const active = filters.edgeTypes.has(type);
+          return (
+            <button
+              key={type}
+              className={[styles.pill, active ? styles.pillActive : ''].filter(Boolean).join(' ')}
+              onClick={() => onToggleEdgeType(type)}
+              aria-pressed={active}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className={styles.separator} />
+
+      {/* 2. Type filter */}
+      <div className={styles.group}>
+        {TYPE_FILTERS.map(({ value, label }) => {
+          const active = filters.typeFilter === value;
+          return (
+            <button
+              key={value}
+              className={[styles.pill, active ? styles.pillActive : ''].filter(Boolean).join(' ')}
+              onClick={() => onSetTypeFilter(value)}
+              aria-pressed={active}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 3. Category filter (only shown when categories exist) */}
+      {availableCategories.length > 0 && (
+        <>
+          <div className={styles.separator} />
+          <div className={styles.group}>
+            {availableCategories.map((cat) => {
+              const active = filters.categories.has(cat);
+              return (
+                <button
+                  key={cat}
+                  className={[styles.pill, active ? styles.pillActive : ''].filter(Boolean).join(' ')}
+                  onClick={() => onToggleCategory(cat)}
+                  aria-pressed={active}
+                >
+                  {cat}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      <div className={styles.separator} />
+
+      {/* 4. Completion filter */}
+      <div className={styles.group}>
+        {COMPLETION_FILTERS.map(({ value, label }) => {
+          const active = filters.completionFilter === value;
+          return (
+            <button
+              key={value}
+              className={[styles.pill, active ? styles.pillActive : ''].filter(Boolean).join(' ')}
+              onClick={() => onSetCompletionFilter(value)}
+              aria-pressed={active}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className={styles.separator} />
+
+      {/* 5. What's next smart toggle */}
+      <button
+        className={[styles.smartToggle, filters.whatsNextMode ? styles.smartToggleActive : '']
+          .filter(Boolean)
+          .join(' ')}
+        onClick={onToggleWhatsNext}
+        aria-pressed={filters.whatsNextMode}
+        title="Show only guides you're eligible to start next"
+      >
+        <Icon name="bolt" size="xs" />
+        {`What's next`}
+      </button>
+
+      {/* Reset */}
+      <button className={styles.resetButton} onClick={onResetFilters} title="Reset all filters">
+        Reset
+      </button>
+    </div>
+  );
+}

--- a/src/components/LearningGraph/components/LearningGraphNode.tsx
+++ b/src/components/LearningGraph/components/LearningGraphNode.tsx
@@ -1,0 +1,218 @@
+/**
+ * Custom React Flow node types for the LearningGraph visualization.
+ *
+ * - GuideNode: standalone guide (rounded card)
+ * - PathNode: collapsed learning path (wider card with milestone count + expand toggle)
+ */
+
+import React, { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { useStyles2, Icon } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import type { GraphNode } from '../../../types/package.types';
+
+// ============ SHARED TYPES ============
+
+export interface GraphNodeData extends Record<string, unknown> {
+  graphNode: GraphNode;
+  isCompleted: boolean;
+  milestoneCount?: number;
+  isExpanded?: boolean;
+  onToggleExpand?: (id: string) => void;
+  onNodeClick?: (node: GraphNode) => void;
+}
+
+// ============ STYLES ============
+
+function getNodeStyles(theme: GrafanaTheme2) {
+  return {
+    node: css({
+      padding: theme.spacing(1, 1.5),
+      borderRadius: theme.shape.radius.default,
+      border: `1px solid ${theme.colors.border.medium}`,
+      background: theme.colors.background.primary,
+      cursor: 'pointer',
+      transition: 'box-shadow 0.15s ease, border-color 0.15s ease',
+      userSelect: 'none',
+      '&:hover': {
+        boxShadow: theme.shadows.z2,
+        borderColor: theme.colors.primary.border,
+      },
+    }),
+    nodeCompleted: css({
+      borderColor: theme.colors.success.border,
+      background: theme.colors.success.transparent,
+    }),
+    nodeInProgress: css({
+      borderColor: theme.colors.primary.border,
+    }),
+    pathNode: css({
+      padding: theme.spacing(1.25, 1.5),
+      borderRadius: theme.shape.radius.default,
+      border: `2px solid ${theme.colors.border.medium}`,
+      background: theme.colors.background.secondary,
+      cursor: 'pointer',
+      transition: 'box-shadow 0.15s ease, border-color 0.15s ease',
+      userSelect: 'none',
+      '&:hover': {
+        boxShadow: theme.shadows.z2,
+        borderColor: theme.colors.primary.border,
+      },
+    }),
+    pathNodeCompleted: css({
+      borderColor: theme.colors.success.border,
+      background: theme.colors.success.transparent,
+    }),
+    title: css({
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+      color: theme.colors.text.primary,
+      margin: 0,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      maxWidth: '160px',
+    }),
+    pathTitle: css({
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightBold,
+      color: theme.colors.text.primary,
+      margin: 0,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      maxWidth: '190px',
+    }),
+    meta: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      marginTop: theme.spacing(0.5),
+    }),
+    categoryBadge: css({
+      fontSize: '10px',
+      padding: '1px 5px',
+      borderRadius: '3px',
+      background: theme.colors.background.canvas,
+      color: theme.colors.text.secondary,
+      border: `1px solid ${theme.colors.border.weak}`,
+      textTransform: 'lowercase',
+      maxWidth: '100px',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    }),
+    completionDot: css({
+      width: 8,
+      height: 8,
+      borderRadius: '50%',
+      flexShrink: 0,
+    }),
+    completedDot: css({
+      background: theme.colors.success.main,
+    }),
+    incompleteDot: css({
+      background: theme.colors.border.medium,
+    }),
+    milestoneCount: css({
+      fontSize: '10px',
+      color: theme.colors.text.secondary,
+      marginLeft: 'auto',
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.25),
+    }),
+    expandButton: css({
+      background: 'none',
+      border: 'none',
+      padding: 0,
+      cursor: 'pointer',
+      color: theme.colors.text.secondary,
+      display: 'flex',
+      alignItems: 'center',
+      marginLeft: theme.spacing(0.5),
+      '&:hover': {
+        color: theme.colors.text.primary,
+      },
+    }),
+  };
+}
+
+// ============ GUIDE NODE ============
+
+export const GuideNode = memo(function GuideNode({ data, selected }: NodeProps) {
+  const styles = useStyles2(getNodeStyles);
+  const nodeData = data as GraphNodeData;
+  const { graphNode, isCompleted, onNodeClick } = nodeData;
+
+  const handleClick = () => {
+    onNodeClick?.(graphNode);
+  };
+
+  const nodeClass = [styles.node, isCompleted ? styles.nodeCompleted : ''].filter(Boolean).join(' ');
+
+  return (
+    <div className={nodeClass} onClick={handleClick} style={{ outline: selected ? '2px solid' : undefined }}>
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+
+      <p className={styles.title} title={graphNode.title ?? graphNode.id}>
+        {graphNode.title ?? graphNode.id}
+      </p>
+
+      <div className={styles.meta}>
+        <span className={[styles.completionDot, isCompleted ? styles.completedDot : styles.incompleteDot].join(' ')} />
+        {graphNode.category && <span className={styles.categoryBadge}>{graphNode.category}</span>}
+      </div>
+
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+    </div>
+  );
+});
+
+// ============ PATH NODE ============
+
+export const PathNode = memo(function PathNode({ data, selected }: NodeProps) {
+  const styles = useStyles2(getNodeStyles);
+  const nodeData = data as GraphNodeData;
+  const { graphNode, isCompleted, milestoneCount = 0, isExpanded = false, onToggleExpand, onNodeClick } = nodeData;
+
+  const handleToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onToggleExpand?.(graphNode.id);
+  };
+
+  const handleClick = () => {
+    onNodeClick?.(graphNode);
+  };
+
+  const nodeClass = [styles.pathNode, isCompleted ? styles.pathNodeCompleted : ''].filter(Boolean).join(' ');
+
+  return (
+    <div className={nodeClass} onClick={handleClick} style={{ outline: selected ? '2px solid' : undefined }}>
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+
+      <p className={styles.pathTitle} title={graphNode.title ?? graphNode.id}>
+        {graphNode.title ?? graphNode.id}
+      </p>
+
+      <div className={styles.meta}>
+        <span className={[styles.completionDot, isCompleted ? styles.completedDot : styles.incompleteDot].join(' ')} />
+        {graphNode.category && <span className={styles.categoryBadge}>{graphNode.category}</span>}
+        {milestoneCount > 0 && (
+          <span className={styles.milestoneCount}>
+            <Icon name="list-ul" size="xs" />
+            {milestoneCount}
+            {onToggleExpand && (
+              <button className={styles.expandButton} onClick={handleToggle} title={isExpanded ? 'Collapse' : 'Expand'}>
+                <Icon name={isExpanded ? 'angle-up' : 'angle-down'} size="xs" />
+              </button>
+            )}
+          </span>
+        )}
+      </div>
+
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+    </div>
+  );
+});

--- a/src/components/LearningGraph/components/LearningGraphTooltip.tsx
+++ b/src/components/LearningGraph/components/LearningGraphTooltip.tsx
@@ -1,0 +1,156 @@
+/**
+ * Detail tooltip shown when a node is clicked.
+ *
+ * Displays node metadata and a CTA that opens the guide in the Pathfinder
+ * sidebar via the auto-launch-tutorial custom event mechanism.
+ */
+
+import React, { useCallback } from 'react';
+import { useStyles2, Icon, Button } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import type { GraphNode } from '../../../types/package.types';
+import { resolveContentUrl } from '../utils';
+
+interface LearningGraphTooltipProps {
+  node: GraphNode;
+  isCompleted: boolean;
+  onClose: () => void;
+  onOpenGuide: (url: string, title: string) => void;
+}
+
+function getTooltipStyles(theme: GrafanaTheme2) {
+  return {
+    overlay: css({
+      position: 'fixed',
+      inset: 0,
+      zIndex: 1000,
+    }),
+    card: css({
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      background: theme.colors.background.primary,
+      border: `1px solid ${theme.colors.border.medium}`,
+      borderRadius: theme.shape.radius.default,
+      boxShadow: theme.shadows.z3,
+      padding: theme.spacing(2),
+      minWidth: 260,
+      maxWidth: 340,
+      zIndex: 1001,
+    }),
+    header: css({
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+      marginBottom: theme.spacing(1),
+    }),
+    title: css({
+      fontSize: theme.typography.h5.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+      color: theme.colors.text.primary,
+      margin: 0,
+      paddingRight: theme.spacing(1),
+    }),
+    closeButton: css({
+      background: 'none',
+      border: 'none',
+      cursor: 'pointer',
+      color: theme.colors.text.secondary,
+      padding: 0,
+      flexShrink: 0,
+      display: 'flex',
+      alignItems: 'center',
+      '&:hover': {
+        color: theme.colors.text.primary,
+      },
+    }),
+    typeBadge: css({
+      display: 'inline-block',
+      fontSize: '11px',
+      padding: '2px 8px',
+      borderRadius: '3px',
+      background: theme.colors.background.canvas,
+      color: theme.colors.text.secondary,
+      border: `1px solid ${theme.colors.border.weak}`,
+      marginBottom: theme.spacing(1),
+      textTransform: 'capitalize',
+    }),
+    completedBadge: css({
+      display: 'inline-block',
+      fontSize: '11px',
+      padding: '2px 8px',
+      borderRadius: '3px',
+      background: theme.colors.success.transparent,
+      color: theme.colors.success.text,
+      border: `1px solid ${theme.colors.success.border}`,
+      marginBottom: theme.spacing(1),
+      marginLeft: theme.spacing(0.5),
+    }),
+    description: css({
+      fontSize: theme.typography.bodySmall.fontSize,
+      color: theme.colors.text.secondary,
+      margin: `${theme.spacing(1)} 0`,
+      lineHeight: 1.5,
+    }),
+    actions: css({
+      marginTop: theme.spacing(1.5),
+      display: 'flex',
+      gap: theme.spacing(1),
+    }),
+  };
+}
+
+export function LearningGraphTooltip({ node, isCompleted, onClose, onOpenGuide }: LearningGraphTooltipProps) {
+  const styles = useStyles2(getTooltipStyles);
+
+  const handleOpen = useCallback(() => {
+    const contentUrl = resolveContentUrl(node);
+    const title = node.title ?? node.id;
+    onOpenGuide(contentUrl, title);
+    onClose();
+  }, [node, onOpenGuide, onClose]);
+
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  return (
+    <div className={styles.overlay} onClick={handleOverlayClick}>
+      <div className={styles.card} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <p className={styles.title}>{node.title ?? node.id}</p>
+          <button className={styles.closeButton} onClick={onClose} aria-label="Close">
+            <Icon name="times" size="md" />
+          </button>
+        </div>
+
+        <span className={styles.typeBadge}>{node.type}</span>
+        {isCompleted && <span className={styles.completedBadge}>Completed</span>}
+
+        {node.description && <p className={styles.description}>{node.description}</p>}
+
+        {node.category && (
+          <p className={styles.description}>
+            Category: <strong>{node.category}</strong>
+          </p>
+        )}
+
+        <div className={styles.actions}>
+          <Button size="sm" variant="primary" onClick={handleOpen}>
+            {isCompleted ? 'Review guide' : 'Start guide'}
+          </Button>
+          <Button size="sm" variant="secondary" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/LearningGraph/components/index.ts
+++ b/src/components/LearningGraph/components/index.ts
@@ -1,0 +1,5 @@
+export { GuideNode, PathNode } from './LearningGraphNode';
+export type { GraphNodeData } from './LearningGraphNode';
+export { LearningGraphEdge } from './LearningGraphEdge';
+export { LearningGraphTooltip } from './LearningGraphTooltip';
+export { LearningGraphFilters } from './LearningGraphFilters';

--- a/src/components/LearningGraph/hooks/index.ts
+++ b/src/components/LearningGraph/hooks/index.ts
@@ -1,0 +1,3 @@
+export { useGraphData } from './useGraphData';
+export { useGraphFilters } from './useGraphFilters';
+export { useGraphLayout } from './useGraphLayout';

--- a/src/components/LearningGraph/hooks/useGraphData.ts
+++ b/src/components/LearningGraph/hooks/useGraphData.ts
@@ -1,0 +1,85 @@
+/**
+ * Hook that fetches, parses, and caches the remote dependency graph JSON.
+ *
+ * The URL is validated before fetch (must be https:// on the allowlisted host).
+ * Fetched data is stored in component state; no global cache is used so that
+ * multiple mounted instances (unlikely but possible) stay independent.
+ */
+
+import { useState, useEffect, useRef } from 'react';
+import type { DependencyGraph } from '../../../types/package.types';
+import type { FetchStatus } from '../types';
+
+const ALLOWED_HOST = 'interactive-learning.grafana.net';
+
+function isAllowedGraphUrl(rawUrl: string): boolean {
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.protocol === 'https:' && parsed.hostname === ALLOWED_HOST;
+  } catch {
+    return false;
+  }
+}
+
+export interface UseGraphDataResult {
+  graph: DependencyGraph | null;
+  status: FetchStatus;
+  error: string | null;
+}
+
+export function useGraphData(graphUrl: string): UseGraphDataResult {
+  const [graph, setGraph] = useState<DependencyGraph | null>(null);
+  const [status, setStatus] = useState<FetchStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    abortRef.current?.abort();
+
+    if (!isAllowedGraphUrl(graphUrl)) {
+      const timer = setTimeout(() => {
+        setStatus('error');
+        setError(`Graph URL is not allowlisted: ${graphUrl}`);
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const timer = setTimeout(() => {
+      setStatus('loading');
+      setError(null);
+    }, 0);
+
+    const safeUrl = new URL(graphUrl);
+
+    fetch(safeUrl.toString(), { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status} fetching graph`);
+        }
+        return res.json() as Promise<DependencyGraph>;
+      })
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          setGraph(data);
+          setStatus('success');
+        }
+      })
+      .catch((err: unknown) => {
+        if (!controller.signal.aborted) {
+          const msg = err instanceof Error ? err.message : 'Unknown fetch error';
+          setError(msg);
+          setStatus('error');
+        }
+      });
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [graphUrl]);
+
+  return { graph, status, error };
+}

--- a/src/components/LearningGraph/hooks/useGraphFilters.ts
+++ b/src/components/LearningGraph/hooks/useGraphFilters.ts
@@ -1,0 +1,137 @@
+/**
+ * Hook that manages the 5-dimensional filter state and derives the filtered
+ * DependencyGraph output from the (collapsed) raw graph + filter state.
+ */
+
+import { useState, useMemo, useCallback } from 'react';
+import type { DependencyGraph, GraphEdgeType } from '../../../types/package.types';
+import { DEFAULT_FILTER_STATE, type GraphFilterState, type CompletionFilter, type TypeFilter } from '../types';
+import { collapseMilestones, applyFilters, extractCategories } from '../utils';
+
+export interface UseGraphFiltersResult {
+  filters: GraphFilterState;
+  filteredGraph: DependencyGraph | null;
+  availableCategories: string[];
+  toggleEdgeType: (edgeType: GraphEdgeType) => void;
+  setTypeFilter: (typeFilter: TypeFilter) => void;
+  toggleCategory: (category: string) => void;
+  setCompletionFilter: (completionFilter: CompletionFilter) => void;
+  toggleWhatsNext: () => void;
+  togglePathExpanded: (pathId: string) => void;
+  resetFilters: () => void;
+}
+
+export function useGraphFilters(rawGraph: DependencyGraph | null, completedGuides: string[]): UseGraphFiltersResult {
+  const [filters, setFilters] = useState<GraphFilterState>(DEFAULT_FILTER_STATE);
+
+  // Collapse milestone children into their parent paths.
+  // Expanded paths are skipped — their children remain as individual nodes.
+  // When a structural type filter (paths/journeys) is active, all containers of that
+  // type are also treated as expanded so their milestone guides are present in the
+  // graph and can be surfaced by applyFilters.
+  const collapsedGraph = useMemo(() => {
+    if (!rawGraph) {
+      return null;
+    }
+
+    let expandedPaths = filters.expandedPaths;
+    if (filters.typeFilter === 'paths' || filters.typeFilter === 'journeys') {
+      const targetType = filters.typeFilter === 'paths' ? 'path' : 'journey';
+      const containerIds = rawGraph.nodes.filter((n) => n.type === targetType).map((n) => n.id);
+      expandedPaths = new Set([...filters.expandedPaths, ...containerIds]);
+    }
+
+    return collapseMilestones(rawGraph, expandedPaths);
+  }, [rawGraph, filters.expandedPaths, filters.typeFilter]);
+
+  // Derive available categories from the collapsed graph
+  const availableCategories = useMemo(() => {
+    if (!collapsedGraph) {
+      return [];
+    }
+    return extractCategories(collapsedGraph);
+  }, [collapsedGraph]);
+
+  // Apply all active filters to produce the final filtered graph
+  const filteredGraph = useMemo(() => {
+    if (!collapsedGraph) {
+      return null;
+    }
+    return applyFilters(collapsedGraph, filters, completedGuides);
+  }, [collapsedGraph, filters, completedGuides]);
+
+  const toggleEdgeType = useCallback((edgeType: GraphEdgeType) => {
+    setFilters((prev) => {
+      const next = new Set(prev.edgeTypes);
+      if (next.has(edgeType)) {
+        next.delete(edgeType);
+      } else {
+        next.add(edgeType);
+      }
+      return { ...prev, edgeTypes: next };
+    });
+  }, []);
+
+  const setTypeFilter = useCallback((typeFilter: TypeFilter) => {
+    setFilters((prev) => ({ ...prev, typeFilter }));
+  }, []);
+
+  const toggleCategory = useCallback((category: string) => {
+    setFilters((prev) => {
+      const next = new Set(prev.categories);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return { ...prev, categories: next };
+    });
+  }, []);
+
+  const setCompletionFilter = useCallback((completionFilter: CompletionFilter) => {
+    setFilters((prev) => ({ ...prev, completionFilter }));
+  }, []);
+
+  const toggleWhatsNext = useCallback(() => {
+    setFilters((prev) => {
+      if (!prev.whatsNextMode) {
+        // Enabling smart mode — reset all other filters for clarity
+        return {
+          ...DEFAULT_FILTER_STATE,
+          whatsNextMode: true,
+          expandedPaths: prev.expandedPaths,
+        };
+      }
+      return { ...prev, whatsNextMode: false };
+    });
+  }, []);
+
+  const togglePathExpanded = useCallback((pathId: string) => {
+    setFilters((prev) => {
+      const next = new Set(prev.expandedPaths);
+      if (next.has(pathId)) {
+        next.delete(pathId);
+      } else {
+        next.add(pathId);
+      }
+      return { ...prev, expandedPaths: next };
+    });
+  }, []);
+
+  const resetFilters = useCallback(() => {
+    setFilters(DEFAULT_FILTER_STATE);
+  }, []);
+
+  return {
+    filters,
+    filteredGraph,
+    availableCategories,
+    toggleEdgeType,
+    setTypeFilter,
+    toggleCategory,
+    setCompletionFilter,
+    toggleWhatsNext,
+    togglePathExpanded,
+    resetFilters,
+  };
+}

--- a/src/components/LearningGraph/hooks/useGraphLayout.ts
+++ b/src/components/LearningGraph/hooks/useGraphLayout.ts
@@ -1,0 +1,26 @@
+/**
+ * Hook that converts a filtered DependencyGraph into React Flow node/edge arrays
+ * with Dagre-computed x/y positions.
+ *
+ * Memoized on (filteredGraph, completedGuides) so layout only reruns when
+ * the graph content changes.
+ */
+
+import { useMemo } from 'react';
+import type { Node as RFNode, Edge as RFEdge } from '@xyflow/react';
+import type { DependencyGraph } from '../../../types/package.types';
+import { buildDagreGraph } from '../utils';
+
+export interface UseGraphLayoutResult {
+  nodes: RFNode[];
+  edges: RFEdge[];
+}
+
+export function useGraphLayout(filteredGraph: DependencyGraph | null, completedGuides: string[]): UseGraphLayoutResult {
+  return useMemo(() => {
+    if (!filteredGraph || filteredGraph.nodes.length === 0) {
+      return { nodes: [], edges: [] };
+    }
+    return buildDagreGraph(filteredGraph, completedGuides);
+  }, [filteredGraph, completedGuides]);
+}

--- a/src/components/LearningGraph/index.ts
+++ b/src/components/LearningGraph/index.ts
@@ -1,0 +1,6 @@
+/**
+ * LearningGraph barrel.
+ *
+ * External consumers import only from this barrel — never from internal paths.
+ */
+export { LearningGraphSection } from './LearningGraphSection';

--- a/src/components/LearningGraph/types.ts
+++ b/src/components/LearningGraph/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Component-local types for the LearningGraph visualization.
+ * Shared types (DependencyGraph, GraphNode, GraphEdge) come from src/types/package.types.ts.
+ */
+
+import type { GraphEdgeType } from '../../types/package.types';
+
+// ============ FILTER STATE ============
+
+export type CompletionFilter = 'all' | 'not-started' | 'completed';
+export type TypeFilter = 'all' | 'paths' | 'journeys' | 'guides';
+
+export interface GraphFilterState {
+  /** Edge types to display in the graph */
+  edgeTypes: Set<GraphEdgeType>;
+  /** Node type filter */
+  typeFilter: TypeFilter;
+  /** Category filter — empty set = all categories */
+  categories: Set<string>;
+  /** Completion status filter */
+  completionFilter: CompletionFilter;
+  /** "What's next" smart mode — shows only eligible uncompleted nodes */
+  whatsNextMode: boolean;
+  /** Whether path nodes are expanded (showing milestone children) */
+  expandedPaths: Set<string>;
+}
+
+export const DEFAULT_FILTER_STATE: GraphFilterState = {
+  edgeTypes: new Set<GraphEdgeType>(['recommends']),
+  typeFilter: 'all',
+  categories: new Set<string>(),
+  completionFilter: 'all',
+  whatsNextMode: false,
+  expandedPaths: new Set<string>(),
+};
+
+// ============ FETCH STATE ============
+
+export type FetchStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface GraphDataState {
+  status: FetchStatus;
+  error: string | null;
+}

--- a/src/components/LearningGraph/utils/graph.utils.test.ts
+++ b/src/components/LearningGraph/utils/graph.utils.test.ts
@@ -1,0 +1,369 @@
+import type { DependencyGraph, GraphNode, GraphEdge } from '../../../types/package.types';
+import {
+  collapseMilestones,
+  applyFilters,
+  getEligibleNextGuides,
+  resolveContentUrl,
+  extractCategories,
+} from './graph.utils';
+import { DEFAULT_FILTER_STATE } from '../types';
+
+// ============ FIXTURES ============
+
+function makeNode(id: string, overrides: Partial<GraphNode> = {}): GraphNode {
+  return { id, type: 'guide', repository: 'test-repo', ...overrides };
+}
+
+function makeEdge(source: string, target: string, type: GraphEdge['type']): GraphEdge {
+  return { source, target, type };
+}
+
+function makeGraph(nodes: GraphNode[], edges: GraphEdge[]): DependencyGraph {
+  return {
+    nodes,
+    edges,
+    metadata: {
+      generatedAt: '2026-01-01T00:00:00Z',
+      repositories: ['test-repo'],
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+    },
+  };
+}
+
+// ============ resolveContentUrl ============
+
+describe('resolveContentUrl', () => {
+  it('builds a content.json URL from the node id', () => {
+    const node = makeNode('alerting-101');
+    expect(resolveContentUrl(node)).toBe('https://interactive-learning.grafana.net/packages/alerting-101/content.json');
+  });
+
+  it('handles ids with hyphens and numbers', () => {
+    const node = makeNode('prometheus-grafana-101');
+    expect(resolveContentUrl(node)).toContain('prometheus-grafana-101/content.json');
+  });
+});
+
+// ============ collapseMilestones ============
+
+describe('collapseMilestones', () => {
+  it('removes milestone children from top-level nodes', () => {
+    const path = makeNode('intro-path', { type: 'path', milestones: ['guide-a', 'guide-b'] });
+    const guideA = makeNode('guide-a');
+    const guideB = makeNode('guide-b');
+    const standalone = makeNode('standalone');
+
+    const graph = makeGraph(
+      [path, guideA, guideB, standalone],
+      [makeEdge('intro-path', 'guide-a', 'milestones'), makeEdge('intro-path', 'guide-b', 'milestones')]
+    );
+
+    const result = collapseMilestones(graph);
+
+    expect(result.nodes.map((n) => n.id)).toEqual(['intro-path', 'standalone']);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it('rewires edges targeting a milestone child to the parent path', () => {
+    const path = makeNode('my-path', { type: 'path' });
+    const child = makeNode('child-guide');
+    const downstream = makeNode('downstream');
+
+    const graph = makeGraph(
+      [path, child, downstream],
+      [makeEdge('my-path', 'child-guide', 'milestones'), makeEdge('child-guide', 'downstream', 'recommends')]
+    );
+
+    const result = collapseMilestones(graph);
+
+    expect(result.nodes.map((n) => n.id)).toEqual(['my-path', 'downstream']);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]).toMatchObject({ source: 'my-path', target: 'downstream', type: 'recommends' });
+  });
+
+  it('deduplicates rewired edges', () => {
+    const path = makeNode('path-a', { type: 'path' });
+    const childA = makeNode('child-a');
+    const childB = makeNode('child-b');
+    const downstream = makeNode('ds');
+
+    const graph = makeGraph(
+      [path, childA, childB, downstream],
+      [
+        makeEdge('path-a', 'child-a', 'milestones'),
+        makeEdge('path-a', 'child-b', 'milestones'),
+        makeEdge('child-a', 'ds', 'recommends'),
+        makeEdge('child-b', 'ds', 'recommends'),
+      ]
+    );
+
+    const result = collapseMilestones(graph);
+    const recommends = result.edges.filter((e) => e.type === 'recommends');
+    expect(recommends).toHaveLength(1);
+  });
+
+  it('leaves graphs without paths unchanged (no milestone edges)', () => {
+    const g1 = makeNode('g1');
+    const g2 = makeNode('g2');
+    const graph = makeGraph([g1, g2], [makeEdge('g1', 'g2', 'recommends')]);
+
+    const result = collapseMilestones(graph);
+    expect(result.nodes).toHaveLength(2);
+    expect(result.edges).toHaveLength(1);
+  });
+
+  it('leaves milestone children visible when their path is in expandedPaths', () => {
+    const path = makeNode('exp-path', { type: 'path' });
+    const childA = makeNode('child-a');
+    const childB = makeNode('child-b');
+
+    const graph = makeGraph(
+      [path, childA, childB],
+      [makeEdge('exp-path', 'child-a', 'milestones'), makeEdge('exp-path', 'child-b', 'milestones')]
+    );
+
+    const result = collapseMilestones(graph, new Set(['exp-path']));
+
+    expect(result.nodes.map((n) => n.id)).toEqual(expect.arrayContaining(['exp-path', 'child-a', 'child-b']));
+    expect(result.edges.filter((e) => e.type === 'milestones')).toHaveLength(2);
+  });
+
+  it('collapses other paths while leaving expanded ones intact', () => {
+    const pathA = makeNode('path-a', { type: 'path' });
+    const pathB = makeNode('path-b', { type: 'path' });
+    const childA = makeNode('child-of-a');
+    const childB = makeNode('child-of-b');
+
+    const graph = makeGraph(
+      [pathA, pathB, childA, childB],
+      [makeEdge('path-a', 'child-of-a', 'milestones'), makeEdge('path-b', 'child-of-b', 'milestones')]
+    );
+
+    // Only expand path-b
+    const result = collapseMilestones(graph, new Set(['path-b']));
+
+    // path-a's child should be collapsed (swallowed)
+    expect(result.nodes.map((n) => n.id)).not.toContain('child-of-a');
+    // path-b's child should remain visible
+    expect(result.nodes.map((n) => n.id)).toContain('child-of-b');
+  });
+
+  it('does not re-wire external edges that target children of an expanded path', () => {
+    const path = makeNode('exp-path', { type: 'path' });
+    const child = makeNode('child-guide');
+    const downstream = makeNode('downstream');
+
+    const graph = makeGraph(
+      [path, child, downstream],
+      [makeEdge('exp-path', 'child-guide', 'milestones'), makeEdge('child-guide', 'downstream', 'recommends')]
+    );
+
+    const result = collapseMilestones(graph, new Set(['exp-path']));
+
+    // The recommends edge should still point at child-guide, not re-wired to exp-path
+    const recommends = result.edges.find((e) => e.type === 'recommends');
+    expect(recommends).toMatchObject({ source: 'child-guide', target: 'downstream' });
+  });
+});
+
+// ============ applyFilters ============
+
+describe('applyFilters', () => {
+  const guide1 = makeNode('g1', { category: 'alerting' });
+  const guide2 = makeNode('g2', { category: 'dashboards' });
+  const path1 = makeNode('p1', { type: 'path', category: 'alerting' });
+  const baseGraph = makeGraph(
+    [guide1, guide2, path1],
+    [makeEdge('g1', 'g2', 'recommends'), makeEdge('p1', 'g2', 'depends')]
+  );
+
+  it('returns all nodes with default filters', () => {
+    const result = applyFilters(
+      baseGraph,
+      { ...DEFAULT_FILTER_STATE, edgeTypes: new Set(['recommends', 'depends']) },
+      []
+    );
+    expect(result.nodes).toHaveLength(3);
+  });
+
+  it('filters by type — paths only (no milestone edges → no milestone guides added)', () => {
+    const result = applyFilters(baseGraph, { ...DEFAULT_FILTER_STATE, typeFilter: 'paths', edgeTypes: new Set() }, []);
+    expect(result.nodes.map((n) => n.id)).toEqual(['p1']);
+  });
+
+  it('filters by type — paths: includes milestone guides of surviving path nodes', () => {
+    const path = makeNode('p-with-milestones', { type: 'path' });
+    const milestoneGuide = makeNode('milestone-g', { type: 'guide' });
+    const standaloneGuide = makeNode('standalone-g', { type: 'guide' });
+    const graph = makeGraph(
+      [path, milestoneGuide, standaloneGuide],
+      [makeEdge('p-with-milestones', 'milestone-g', 'milestones')]
+    );
+
+    const result = applyFilters(graph, { ...DEFAULT_FILTER_STATE, typeFilter: 'paths', edgeTypes: new Set() }, []);
+
+    expect(result.nodes.map((n) => n.id)).toContain('p-with-milestones');
+    expect(result.nodes.map((n) => n.id)).toContain('milestone-g');
+    // Standalone guides not attached as milestones are excluded
+    expect(result.nodes.map((n) => n.id)).not.toContain('standalone-g');
+  });
+
+  it('filters by type — paths: milestone guide milestone edges are kept', () => {
+    const path = makeNode('p1-ms', { type: 'path' });
+    const guide = makeNode('g-ms', { type: 'guide' });
+    const graph = makeGraph([path, guide], [makeEdge('p1-ms', 'g-ms', 'milestones')]);
+
+    const result = applyFilters(graph, { ...DEFAULT_FILTER_STATE, typeFilter: 'paths', edgeTypes: new Set() }, []);
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0]).toMatchObject({ source: 'p1-ms', target: 'g-ms', type: 'milestones' });
+  });
+
+  it('filters by type — paths: milestone guide respects completion filter', () => {
+    const path = makeNode('p-compl', { type: 'path' });
+    const completedGuide = makeNode('guide-done', { type: 'guide' });
+    const incompleteGuide = makeNode('guide-todo', { type: 'guide' });
+    const graph = makeGraph(
+      [path, completedGuide, incompleteGuide],
+      [makeEdge('p-compl', 'guide-done', 'milestones'), makeEdge('p-compl', 'guide-todo', 'milestones')]
+    );
+
+    const result = applyFilters(
+      graph,
+      { ...DEFAULT_FILTER_STATE, typeFilter: 'paths', completionFilter: 'not-started', edgeTypes: new Set() },
+      ['guide-done']
+    );
+
+    expect(result.nodes.map((n) => n.id)).toContain('guide-todo');
+    expect(result.nodes.map((n) => n.id)).not.toContain('guide-done');
+  });
+
+  it('filters by type — journeys: includes milestone guides of surviving journey nodes', () => {
+    const journey = makeNode('j1', { type: 'journey' });
+    const milestoneGuide = makeNode('j-guide', { type: 'guide' });
+    const standaloneGuide = makeNode('solo-g', { type: 'guide' });
+    const graph = makeGraph([journey, milestoneGuide, standaloneGuide], [makeEdge('j1', 'j-guide', 'milestones')]);
+
+    const result = applyFilters(graph, { ...DEFAULT_FILTER_STATE, typeFilter: 'journeys', edgeTypes: new Set() }, []);
+
+    expect(result.nodes.map((n) => n.id)).toContain('j1');
+    expect(result.nodes.map((n) => n.id)).toContain('j-guide');
+    expect(result.nodes.map((n) => n.id)).not.toContain('solo-g');
+  });
+
+  it('filters by category', () => {
+    const result = applyFilters(
+      baseGraph,
+      { ...DEFAULT_FILTER_STATE, categories: new Set(['alerting']), edgeTypes: new Set() },
+      []
+    );
+    expect(result.nodes.map((n) => n.id)).toEqual(expect.arrayContaining(['g1', 'p1']));
+    expect(result.nodes.map((n) => n.id)).not.toContain('g2');
+  });
+
+  it('filters completed nodes', () => {
+    const result = applyFilters(
+      baseGraph,
+      { ...DEFAULT_FILTER_STATE, completionFilter: 'completed', edgeTypes: new Set() },
+      ['g1']
+    );
+    expect(result.nodes.map((n) => n.id)).toEqual(['g1']);
+  });
+
+  it('filters not-started nodes', () => {
+    const result = applyFilters(
+      baseGraph,
+      { ...DEFAULT_FILTER_STATE, completionFilter: 'not-started', edgeTypes: new Set() },
+      ['g1']
+    );
+    expect(result.nodes.map((n) => n.id)).not.toContain('g1');
+    expect(result.nodes.map((n) => n.id)).toContain('g2');
+  });
+
+  it('removes edges whose type is not in the active set', () => {
+    const result = applyFilters(baseGraph, { ...DEFAULT_FILTER_STATE, edgeTypes: new Set(['recommends']) }, []);
+    expect(result.edges.every((e) => e.type === 'recommends')).toBe(true);
+  });
+
+  it('removes edges whose endpoints are filtered out', () => {
+    const result = applyFilters(
+      baseGraph,
+      { ...DEFAULT_FILTER_STATE, typeFilter: 'guides', edgeTypes: new Set(['recommends', 'depends']) },
+      []
+    );
+    // p1 is a path so it's excluded — the depends edge (p1→g2) should also be removed
+    expect(result.edges.every((e) => e.source !== 'p1' && e.target !== 'p1')).toBe(true);
+  });
+});
+
+// ============ getEligibleNextGuides ============
+
+describe('getEligibleNextGuides', () => {
+  it('returns nodes with no depends as eligible', () => {
+    const node = makeNode('free');
+    const graph = makeGraph([node], []);
+    const eligible = getEligibleNextGuides(graph, []);
+    expect(eligible.map((n) => n.id)).toContain('free');
+  });
+
+  it('excludes already-completed nodes', () => {
+    const node = makeNode('done');
+    const graph = makeGraph([node], []);
+    const eligible = getEligibleNextGuides(graph, ['done']);
+    expect(eligible).toHaveLength(0);
+  });
+
+  it('returns nodes whose single dependency is satisfied', () => {
+    const prereq = makeNode('prereq');
+    const next = makeNode('next', { depends: ['prereq'] });
+    const graph = makeGraph([prereq, next], [makeEdge('prereq', 'next', 'depends')]);
+
+    const eligible = getEligibleNextGuides(graph, ['prereq']);
+    expect(eligible.map((n) => n.id)).toContain('next');
+  });
+
+  it('excludes nodes with unsatisfied dependency', () => {
+    const next = makeNode('locked', { depends: ['missing'] });
+    const graph = makeGraph([next], []);
+    const eligible = getEligibleNextGuides(graph, []);
+    expect(eligible).toHaveLength(0);
+  });
+
+  it('handles OR-group dependencies (DependencyList with string[])', () => {
+    const node = makeNode('either', { depends: [['a', 'b']] });
+    const graph = makeGraph([node], []);
+
+    expect(getEligibleNextGuides(graph, ['a']).map((n) => n.id)).toContain('either');
+    expect(getEligibleNextGuides(graph, ['b']).map((n) => n.id)).toContain('either');
+    expect(getEligibleNextGuides(graph, [])).toHaveLength(0);
+  });
+
+  it('handles AND-style dependencies (all must be satisfied)', () => {
+    const node = makeNode('both', { depends: ['req1', 'req2'] });
+    const graph = makeGraph([node], []);
+
+    expect(getEligibleNextGuides(graph, ['req1'])).toHaveLength(0);
+    expect(getEligibleNextGuides(graph, ['req1', 'req2']).map((n) => n.id)).toContain('both');
+  });
+});
+
+// ============ extractCategories ============
+
+describe('extractCategories', () => {
+  it('returns sorted unique categories', () => {
+    const nodes = [
+      makeNode('a', { category: 'dashboards' }),
+      makeNode('b', { category: 'alerting' }),
+      makeNode('c', { category: 'dashboards' }),
+      makeNode('d'),
+    ];
+    const graph = makeGraph(nodes, []);
+    expect(extractCategories(graph)).toEqual(['alerting', 'dashboards']);
+  });
+
+  it('returns empty array when no categories', () => {
+    const graph = makeGraph([makeNode('x')], []);
+    expect(extractCategories(graph)).toEqual([]);
+  });
+});

--- a/src/components/LearningGraph/utils/graph.utils.ts
+++ b/src/components/LearningGraph/utils/graph.utils.ts
@@ -1,0 +1,333 @@
+/**
+ * Pure utility functions for the LearningGraph visualization.
+ *
+ * All functions here are stateless and side-effect-free — safe to unit test
+ * in isolation and safe to call during Dagre layout without React involvement.
+ */
+
+import dagre from '@dagrejs/dagre';
+import type { Node as RFNode, Edge as RFEdge } from '@xyflow/react';
+import type { DependencyGraph, GraphNode, GraphEdge } from '../../../types/package.types';
+import type { GraphFilterState } from '../types';
+
+// ============ URL RESOLUTION ============
+
+const GRAPH_BASE_URL = 'https://interactive-learning.grafana.net/packages';
+
+/**
+ * Constructs a convention-based content.json URL for a graph node.
+ *
+ * Isolated here as a single-function seam so a future package-resolution-service
+ * can replace this convention with a proper lookup without touching callers.
+ */
+export function resolveContentUrl(node: GraphNode): string {
+  const base = new URL(`${node.id}/content.json`, `${GRAPH_BASE_URL}/`);
+  return base.toString();
+}
+
+// ============ GRAPH COLLAPSE ============
+
+/**
+ * Collapses path nodes: each path absorbs its milestones children so that
+ * the top-level graph shows ~13 items instead of ~30.
+ *
+ * Paths listed in `expandedPaths` are left intact — their milestone children
+ * remain as individual nodes connected by their original milestone edges.
+ * External edges that pointed at those children are NOT re-wired; they keep
+ * their original endpoints so the expanded children appear correctly in layout.
+ *
+ * For collapsed paths: milestone edges are removed and any remaining edge whose
+ * source or target is a swallowed child is re-wired to the parent path node.
+ */
+export function collapseMilestones(graph: DependencyGraph, expandedPaths: Set<string> = new Set()): DependencyGraph {
+  // Build a map of milestone child id → parent path id
+  const childToPath = new Map<string, string>();
+  for (const edge of graph.edges) {
+    if (edge.type === 'milestones') {
+      childToPath.set(edge.target, edge.source);
+    }
+  }
+
+  // Children of EXPANDED paths stay visible — only collapse children of collapsed paths
+  const swallowedIds = new Set<string>();
+  for (const [childId, pathId] of childToPath.entries()) {
+    if (!expandedPaths.has(pathId)) {
+      swallowedIds.add(childId);
+    }
+  }
+
+  // Keep top-level nodes + children of any expanded path
+  const visibleNodes = graph.nodes.filter((n) => !swallowedIds.has(n.id));
+
+  const filteredEdges: GraphEdge[] = [];
+  for (const edge of graph.edges) {
+    if (edge.type === 'milestones') {
+      // Keep milestone edges only for expanded paths
+      const parentPathId = edge.source;
+      if (expandedPaths.has(parentPathId)) {
+        filteredEdges.push(edge);
+      }
+      continue;
+    }
+
+    // For non-milestone edges: re-wire endpoints that point at swallowed children
+    const src = swallowedIds.has(edge.source) ? (childToPath.get(edge.source) ?? edge.source) : edge.source;
+    const tgt = swallowedIds.has(edge.target) ? (childToPath.get(edge.target) ?? edge.target) : edge.target;
+    if (src === tgt) {
+      continue;
+    }
+    filteredEdges.push({ ...edge, source: src, target: tgt });
+  }
+
+  // Deduplicate non-milestone edges (same source + target + type)
+  const seen = new Set<string>();
+  const deduped = filteredEdges.filter((e) => {
+    if (e.type === 'milestones') {
+      return true; // milestone edges are already unique per child
+    }
+    const key = `${e.source}__${e.type}__${e.target}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+
+  return {
+    ...graph,
+    nodes: visibleNodes,
+    edges: deduped,
+    metadata: {
+      ...graph.metadata,
+      nodeCount: visibleNodes.length,
+      edgeCount: deduped.length,
+    },
+  };
+}
+
+// ============ FILTER APPLICATION ============
+
+/**
+ * Filters a (possibly collapsed) graph to only the nodes and edges that
+ * match all active filter criteria. Nodes with no remaining edges are
+ * retained unless type/category/completion filters explicitly exclude them
+ * (isolated nodes are still meaningful starting points).
+ */
+export function applyFilters(
+  graph: DependencyGraph,
+  filters: GraphFilterState,
+  completedGuides: string[]
+): DependencyGraph {
+  const completedSet = new Set(completedGuides);
+
+  // 1. Filter nodes by type, category, completion
+  let nodes = graph.nodes.filter((node) => {
+    // Type filter — structural types (paths/journeys) include milestone guides in step 1b below
+    if (filters.typeFilter === 'paths' && node.type !== 'path') {
+      return false;
+    }
+    if (filters.typeFilter === 'journeys' && node.type !== 'journey') {
+      return false;
+    }
+    if (filters.typeFilter === 'guides' && node.type !== 'guide') {
+      return false;
+    }
+
+    // Category filter (empty = all)
+    if (filters.categories.size > 0 && node.category && !filters.categories.has(node.category)) {
+      return false;
+    }
+
+    // Completion filter
+    const isCompleted = completedSet.has(node.id);
+    if (filters.completionFilter === 'completed' && !isCompleted) {
+      return false;
+    }
+    if (filters.completionFilter === 'not-started' && isCompleted) {
+      return false;
+    }
+
+    return true;
+  });
+
+  // 1b. When filtering by a structural type (paths/journeys), also include guide nodes
+  //     that are milestones of surviving nodes. The collapsed graph will already have
+  //     those guides present as nodes because the hook auto-expands containers when
+  //     this filter is active (see useGraphFilters).
+  if (filters.typeFilter === 'paths' || filters.typeFilter === 'journeys') {
+    const primaryIds = new Set(nodes.map((n) => n.id));
+    const milestoneTargets = new Set<string>();
+    for (const edge of graph.edges) {
+      if (edge.type === 'milestones' && primaryIds.has(edge.source)) {
+        milestoneTargets.add(edge.target);
+      }
+    }
+
+    if (milestoneTargets.size > 0) {
+      const milestoneGuides = graph.nodes.filter((n) => {
+        if (!milestoneTargets.has(n.id)) {
+          return false;
+        }
+        // Respect category filter for milestone guides
+        if (filters.categories.size > 0 && n.category && !filters.categories.has(n.category)) {
+          return false;
+        }
+        // Respect completion filter for milestone guides
+        const isCompleted = completedSet.has(n.id);
+        if (filters.completionFilter === 'completed' && !isCompleted) {
+          return false;
+        }
+        if (filters.completionFilter === 'not-started' && isCompleted) {
+          return false;
+        }
+        return true;
+      });
+      nodes = [...nodes, ...milestoneGuides];
+    }
+  }
+
+  // 2. "What's next" smart mode — keep only eligible uncompleted nodes
+  if (filters.whatsNextMode) {
+    const eligible = getEligibleNextGuides(graph, completedGuides);
+    const eligibleIds = new Set(eligible.map((n) => n.id));
+    nodes = nodes.filter((n) => eligibleIds.has(n.id));
+  }
+
+  const nodeIds = new Set(nodes.map((n) => n.id));
+
+  // 3. Filter edges: keep only edges whose type is active and both endpoints survive.
+  //    Milestone edges from expanded paths are always kept — they're internal structure,
+  //    not a user-facing relationship type, so they're not subject to the edge-type toggle.
+  //    When a structural type filter (paths/journeys) is active, milestone edges are also
+  //    kept so the graph shows the path → guide containment relationships.
+  const showingMilestonesByTypeFilter = filters.typeFilter === 'paths' || filters.typeFilter === 'journeys';
+  const edges = graph.edges.filter((edge) => {
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) {
+      return false;
+    }
+    if (edge.type === 'milestones') {
+      return filters.expandedPaths.has(edge.source) || showingMilestonesByTypeFilter;
+    }
+    return filters.edgeTypes.has(edge.type);
+  });
+
+  return {
+    ...graph,
+    nodes,
+    edges,
+    metadata: { ...graph.metadata, nodeCount: nodes.length, edgeCount: edges.length },
+  };
+}
+
+// ============ DAGRE LAYOUT ============
+
+const NODE_WIDTH = 200;
+const NODE_HEIGHT = 80;
+const PATH_NODE_WIDTH = 240;
+const PATH_NODE_HEIGHT = 96;
+
+export interface LayoutResult {
+  nodes: RFNode[];
+  edges: RFEdge[];
+}
+
+/**
+ * Runs Dagre on the filtered graph and returns React Flow node and edge arrays
+ * with `position` populated. Does not mutate input.
+ */
+export function buildDagreGraph(graph: DependencyGraph, completedGuides: string[]): LayoutResult {
+  const dagreGraph = new dagre.graphlib.Graph();
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setGraph({ rankdir: 'TB', ranksep: 80, nodesep: 40, marginx: 20, marginy: 20 });
+
+  const completedSet = new Set(completedGuides);
+
+  for (const node of graph.nodes) {
+    const isPath = node.type === 'path';
+    dagreGraph.setNode(node.id, {
+      width: isPath ? PATH_NODE_WIDTH : NODE_WIDTH,
+      height: isPath ? PATH_NODE_HEIGHT : NODE_HEIGHT,
+    });
+  }
+
+  for (const edge of graph.edges) {
+    dagreGraph.setEdge(edge.source, edge.target);
+  }
+
+  dagre.layout(dagreGraph);
+
+  const rfNodes: RFNode[] = graph.nodes.map((node) => {
+    const dagreNode = dagreGraph.node(node.id);
+    const isPath = node.type === 'path';
+    const w = isPath ? PATH_NODE_WIDTH : NODE_WIDTH;
+    const h = isPath ? PATH_NODE_HEIGHT : NODE_HEIGHT;
+    const isCompleted = completedSet.has(node.id);
+
+    return {
+      id: node.id,
+      type: isPath ? 'pathNode' : 'guideNode',
+      position: {
+        x: (dagreNode?.x ?? 0) - w / 2,
+        y: (dagreNode?.y ?? 0) - h / 2,
+      },
+      data: {
+        graphNode: node,
+        isCompleted,
+        milestoneCount: (node.milestones ?? []).length,
+      },
+      style: { width: w },
+    };
+  });
+
+  const rfEdges: RFEdge[] = graph.edges.map((edge, idx) => ({
+    id: `e-${edge.source}-${edge.type}-${edge.target}-${idx}`,
+    source: edge.source,
+    target: edge.target,
+    type: 'learningEdge',
+    data: { edgeType: edge.type },
+    animated: edge.type === 'recommends',
+  }));
+
+  return { nodes: rfNodes, edges: rfEdges };
+}
+
+// ============ ELIGIBLE NEXT GUIDES ============
+
+/**
+ * Returns nodes whose full `depends` chain is already satisfied (all required
+ * packages are in completedGuides), making them the learner's eligible next step.
+ *
+ * Only uncompleted nodes are returned.
+ */
+export function getEligibleNextGuides(graph: DependencyGraph, completedGuides: string[]): GraphNode[] {
+  const completedSet = new Set(completedGuides);
+
+  return graph.nodes.filter((node) => {
+    if (completedSet.has(node.id)) {
+      return false;
+    }
+
+    const depends = node.depends ?? [];
+    return depends.every((clause) => {
+      if (Array.isArray(clause)) {
+        // OR-group: at least one alternative must be completed
+        return clause.some((alt) => completedSet.has(alt));
+      }
+      // Single requirement
+      return completedSet.has(clause);
+    });
+  });
+}
+
+// ============ CATEGORY EXTRACTION ============
+
+/** Extracts a sorted list of unique categories from the graph nodes. */
+export function extractCategories(graph: DependencyGraph): string[] {
+  const cats = new Set<string>();
+  for (const node of graph.nodes) {
+    if (node.category) {
+      cats.add(node.category);
+    }
+  }
+  return Array.from(cats).sort();
+}

--- a/src/components/LearningGraph/utils/index.ts
+++ b/src/components/LearningGraph/utils/index.ts
@@ -1,0 +1,8 @@
+export {
+  resolveContentUrl,
+  collapseMilestones,
+  applyFilters,
+  buildDagreGraph,
+  getEligibleNextGuides,
+  extractCategories,
+} from './graph.utils';

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -22,6 +22,7 @@ import {
   interactiveCompletionStorage,
 } from '../../lib/user-storage';
 import type { EarnedBadge } from '../../types';
+import { LearningGraphSection } from '../LearningGraph';
 
 // Badge utilities extracted for testability
 import { getBadgeProgress, getBadgeRequirementText, type BadgeProgressInfo } from './badge-utils';
@@ -545,6 +546,13 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
           ))}
         </div>
       </div>
+
+      {/* Learning Map Section */}
+      <LearningGraphSection
+        graphUrl="https://interactive-learning.grafana.net/packages/graph.json"
+        completedGuides={progress.completedGuides}
+        onOpenGuide={onOpenGuide}
+      />
 
       {/* Preview Notice - at bottom to not distract from main content */}
       <div className={styles.previewNotice}>


### PR DESCRIPTION
## Summary

- Adds an interactive **Learning Map** graph to the My Learning tab, visualizing the full guide/path dependency graph from `interactive-learning.grafana.net`
- Custom React Flow canvas with Dagre hierarchical layout, path + guide node types, and animated/styled edges
- 5-dimensional filter bar: edge type toggles (Recommended/Prerequisites/Suggested), node type (All/Paths/Journeys/Guides), category pills, completion status, and "What's next" smart mode
- Path nodes collapse their milestone children by default; the caret expands them inline
- When filtering by **Paths** or **Journeys**, milestone guide children are automatically surfaced alongside their parent — guides don't disappear behind the type filter
- Node click opens a detail tooltip with an "Open guide" action that loads the guide in the sidebar

## Test plan

- [ ] Verify Learning Map loads on the My Learning tab and renders the graph
- [ ] Check All / Paths / Journeys / Guides filters show the correct node types
- [ ] Confirm Paths filter shows path nodes AND their milestone guides
- [ ] Confirm caret expand/collapse works on path nodes
- [ ] Test category and completion filters in combination with type filter
- [ ] Verify "What's next" mode only shows eligible uncompleted nodes
- [ ] Clicking a node opens the detail tooltip; "Open guide" loads the guide
- [ ] Unit tests pass: `npm run test:ci -- --testPathPatterns=graph.utils`
