### PR TITLE
feat: rebrand devtools to always-visible editor tab, unify tab bar, comprehensive test ID audit

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -5,6 +5,7 @@ import React, { useMemo, useEffect, Component, ReactNode } from 'react';
 import { SceneApp } from '@grafana/scenes';
 import { Button, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
+import { testIds } from '../../constants/testIds';
 import { homePage } from '../../pages/homePage';
 import { docsPage } from '../../pages/docsPage';
 import { PluginPropsContext } from '../../utils/utils.plugin';
@@ -79,10 +80,10 @@ function ErrorFallback({ error, onReset }: { error: Error | null; onReset: () =>
         </p>
         {error && <code className={styles.errorCode}>{error.message}</code>}
         <div className={styles.actions}>
-          <Button variant="primary" onClick={onReset}>
+          <Button variant="primary" onClick={onReset} data-testid={testIds.app.errorTryAgain}>
             Try Again
           </Button>
-          <Button variant="secondary" onClick={() => window.location.reload()}>
+          <Button variant="secondary" onClick={() => window.location.reload()} data-testid={testIds.app.errorRefresh}>
             Refresh Page
           </Button>
         </div>

--- a/src/components/AppConfig/ConfigurationForm.tsx
+++ b/src/components/AppConfig/ConfigurationForm.tsx
@@ -387,7 +387,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
   };
 
   return (
-    <form onSubmit={onSubmit}>
+    <form onSubmit={onSubmit} data-testid={testIds.appConfig.form}>
       <FieldSet label="Plugin configuration" className={s.marginTopXl}>
         {/* Advanced configuration fields - only shown in dev mode */}
         {showAdvancedConfig && (
@@ -437,6 +437,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
                 <Input
                   type="checkbox"
                   id="dev-mode"
+                  data-testid={testIds.appConfig.devModeToggle}
                   checked={devModeEnabledForUser}
                   onChange={onChangeDevMode}
                   disabled={devModeToggling}
@@ -456,6 +457,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
                   <Input
                     type="checkbox"
                     id="assistant-dev-mode"
+                    data-testid={testIds.appConfig.assistantDevModeToggle}
                     checked={assistantDevModeEnabled}
                     onChange={onChangeAssistantDevMode}
                     disabled={assistantDevModeToggling}
@@ -498,6 +500,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
           <div className={s.toggleSection}>
             <Switch
               id="enable-global-link-interception"
+              data-testid={testIds.appConfig.globalLinkInterception}
               value={state.interceptGlobalDocsLinks}
               onChange={onToggleGlobalLinkInterception}
             />
@@ -540,6 +543,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
           <div className={s.toggleSection}>
             <Switch
               id="enable-open-panel-on-launch"
+              data-testid={testIds.appConfig.openPanelOnLaunch}
               value={state.openPanelOnLaunch}
               onChange={onToggleOpenPanelOnLaunch}
             />
@@ -577,7 +581,12 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
             className={s.marginTopXl}
           >
             <div className={s.toggleSection}>
-              <Switch id="enable-live-sessions" value={state.enableLiveSessions} onChange={onToggleLiveSessions} />
+              <Switch
+                id="enable-live-sessions"
+                data-testid={testIds.appConfig.liveSessionsToggle}
+                value={state.enableLiveSessions}
+                onChange={onToggleLiveSessions}
+              />
               <div className={s.toggleLabels}>
                 <Text variant="body" weight="medium">
                   Enable live collaborative learning sessions (Experimental)
@@ -609,12 +618,18 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
                   </div>
 
                   <Field label="Server host" description="Hostname or IP address">
-                    <Input value={state.peerjsHost} onChange={onChangePeerjsHost} placeholder={DEFAULT_PEERJS_HOST} />
+                    <Input
+                      data-testid={testIds.appConfig.peerjsHost}
+                      value={state.peerjsHost}
+                      onChange={onChangePeerjsHost}
+                      placeholder={DEFAULT_PEERJS_HOST}
+                    />
                   </Field>
 
                   <Field label="Server port" description="Port number">
                     <Input
                       type="number"
+                      data-testid={testIds.appConfig.peerjsPort}
                       value={state.peerjsPort}
                       onChange={onChangePeerjsPort}
                       placeholder={String(DEFAULT_PEERJS_PORT)}
@@ -622,7 +637,12 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
                   </Field>
 
                   <Field label="API Key" description="Authentication key">
-                    <Input value={state.peerjsKey} onChange={onChangePeerjsKey} placeholder={DEFAULT_PEERJS_KEY} />
+                    <Input
+                      data-testid={testIds.appConfig.peerjsKey}
+                      value={state.peerjsKey}
+                      onChange={onChangePeerjsKey}
+                      placeholder={DEFAULT_PEERJS_KEY}
+                    />
                   </Field>
                 </div>
               </>
@@ -657,7 +677,12 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
             className={s.marginTopXl}
           >
             <div className={s.toggleSection}>
-              <Switch id="enable-coda-terminal" value={state.enableCodaTerminal} onChange={onToggleCodaTerminal} />
+              <Switch
+                id="enable-coda-terminal"
+                data-testid={testIds.appConfig.codaTerminalToggle}
+                value={state.enableCodaTerminal}
+                onChange={onToggleCodaTerminal}
+              />
               <div className={s.toggleLabels}>
                 <Text variant="body" weight="medium">
                   Enable Coda terminal in sidebar (Experimental)
@@ -690,6 +715,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
                   >
                     <Input
                       width={60}
+                      data-testid={testIds.appConfig.codaApiUrl}
                       value={state.codaApiUrl}
                       onChange={onChangeCodaApiUrl}
                       placeholder="https://coda.example.com"
@@ -705,6 +731,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
                   >
                     <Input
                       width={60}
+                      data-testid={testIds.appConfig.codaRelayUrl}
                       value={state.codaRelayUrl}
                       onChange={onChangeCodaRelayUrl}
                       placeholder="wss://relay.example.com"
@@ -740,6 +767,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
                     <Input
                       type="password"
                       width={60}
+                      data-testid={testIds.appConfig.codaEnrollmentKey}
                       value={state.codaEnrollmentKey}
                       onChange={onChangeCodaEnrollmentKey}
                       placeholder={

--- a/src/components/ControlGroupDocPopup.tsx
+++ b/src/components/ControlGroupDocPopup.tsx
@@ -6,6 +6,7 @@
 
 import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import { testIds } from '../constants/testIds';
 import { Modal, useStyles2, Button } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
@@ -54,7 +55,7 @@ function ControlGroupDocPopup({ onDismiss }: ControlGroupDocPopupProps) {
           Sadly you do not have access to Interactive learning yet as we are under public preview. If you would like to
           be granted access please reach out to your Grafana representative.
         </p>
-        <Button variant="secondary" onClick={handleDismiss}>
+        <Button variant="secondary" onClick={handleDismiss} data-testid={testIds.controlGroupPopup.dismissButton}>
           Dismiss
         </Button>
       </div>
@@ -68,7 +69,7 @@ function ControlGroupDocPopup({ onDismiss }: ControlGroupDocPopupProps) {
  */
 export function showControlGroupDocPopup(): void {
   const container = document.createElement('div');
-  container.setAttribute('data-testid', 'control-group-doc-popup-container');
+  container.setAttribute('data-testid', testIds.controlGroupPopup.container);
   document.body.appendChild(container);
 
   const root = createRoot(container);

--- a/src/components/FeedbackButton/FeedbackButton.tsx
+++ b/src/components/FeedbackButton/FeedbackButton.tsx
@@ -3,6 +3,7 @@ import { reportAppInteraction, UserInteraction, calculateJourneyProgress } from 
 import { getFeedbackButtonStyles } from '../../styles/feedback-button.styles';
 import { useTheme2 } from '@grafana/ui';
 import { t } from '@grafana/i18n';
+import { testIds } from '../../constants/testIds';
 
 interface FeedbackButtonProps {
   className?: string;
@@ -71,6 +72,7 @@ export const FeedbackButton: React.FC<FeedbackButtonProps> = ({
       onClick={handleClick}
       aria-label={t('feedbackButton.ariaLabel', 'Give feedback about this plugin')}
       title={t('feedbackButton.title', 'Give feedback about this plugin')}
+      data-testid={testIds.feedbackButton.trigger}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/HelpFooter/HelpFooter.tsx
+++ b/src/components/HelpFooter/HelpFooter.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, LinkButton, useTheme2 } from '@grafana/ui';
 import { useHelpNavItem } from '@grafana/runtime';
 import { getHelpFooterStyles } from '../../styles/help-footer.styles';
+import { testIds } from '../../constants/testIds';
 
 interface HelpFooterProps {
   className?: string;
@@ -39,9 +40,9 @@ export const HelpFooter: React.FC<HelpFooterProps> = ({ className }) => {
   }
 
   return (
-    <div className={`${styles.helpFooter} ${className || ''}`}>
+    <div className={`${styles.helpFooter} ${className || ''}`} data-testid={testIds.helpFooter.container}>
       <div className={styles.helpButtons}>
-        {helpButtons.map((button: any) => {
+        {helpButtons.map((button: any, index: number) => {
           if (button.href) {
             return (
               <LinkButton
@@ -51,6 +52,7 @@ export const HelpFooter: React.FC<HelpFooterProps> = ({ className }) => {
                 icon={button.icon}
                 href={button.href}
                 target={button.target || '_blank'}
+                data-testid={testIds.helpFooter.link(index)}
               >
                 {button.label}
               </LinkButton>
@@ -58,7 +60,14 @@ export const HelpFooter: React.FC<HelpFooterProps> = ({ className }) => {
           }
 
           return (
-            <Button key={button.key} variant="secondary" size="sm" icon={button.icon} onClick={button.onClick}>
+            <Button
+              key={button.key}
+              variant="secondary"
+              size="sm"
+              icon={button.icon}
+              onClick={button.onClick}
+              data-testid={testIds.helpFooter.link(index)}
+            >
               {button.label}
             </Button>
           );

--- a/src/components/Home/HomePanel.test.tsx
+++ b/src/components/Home/HomePanel.test.tsx
@@ -9,6 +9,7 @@ import { render, screen } from '@testing-library/react';
 import { HomePanelRenderer } from './HomePanel';
 import { sidebarState } from '../../global-state/sidebar';
 import { linkInterceptionState } from '../../global-state/link-interception';
+import { testIds } from '../../constants/testIds';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -96,7 +97,7 @@ describe('HomePanelRenderer', () => {
 
     it('renders home-page container', () => {
       render(<HomePanelRenderer />);
-      expect(screen.getByTestId('home-page')).toBeInTheDocument();
+      expect(screen.getByTestId(testIds.homePage.container)).toBeInTheDocument();
     });
   });
 

--- a/src/components/Home/HomePanel.tsx
+++ b/src/components/Home/HomePanel.tsx
@@ -15,6 +15,7 @@ import { linkInterceptionState } from '../../global-state/link-interception';
 import { MyLearningTab } from '../LearningPaths';
 import { MyLearningErrorBoundary } from '../docs-panel/components';
 import { getHomePageStyles } from './home.styles';
+import { testIds } from '../../constants/testIds';
 
 // ============================================================================
 // SCENE OBJECT
@@ -50,7 +51,7 @@ export function HomePanelRenderer() {
   }, []);
 
   return (
-    <div className={styles.container} data-testid="home-page">
+    <div className={styles.container} data-testid={testIds.homePage.container}>
       <MyLearningErrorBoundary>
         <MyLearningTab onOpenGuide={handleOpenGuide} />
       </MyLearningErrorBoundary>

--- a/src/components/LearningPaths/BadgeUnlockedToast.tsx
+++ b/src/components/LearningPaths/BadgeUnlockedToast.tsx
@@ -10,6 +10,7 @@ import React, { useEffect, useRef } from 'react';
 import { useStyles2, Icon } from '@grafana/ui';
 
 import type { BadgeUnlockedToastProps } from '../../types/learning-paths.types';
+import { testIds } from '../../constants/testIds';
 import { getBadgeUnlockedToastStyles } from './learning-paths.styles';
 import { BadgeIcon } from './BadgeIcon';
 
@@ -74,7 +75,12 @@ export function BadgeUnlockedToast({ badge, onDismiss, queueCount = 0 }: BadgeUn
 
   return (
     <div className={styles.overlay} onClick={handleOverlayClick}>
-      <div className={styles.toast} role="dialog" aria-labelledby="badge-title">
+      <div
+        className={styles.toast}
+        role="dialog"
+        aria-labelledby="badge-title"
+        data-testid={testIds.learningPaths.badgeToast}
+      >
         {/* Confetti particles - static config, pure CSS animation */}
         <div className={styles.confettiContainer}>
           {CONFETTI_PARTICLES.map((particle, i) => (
@@ -119,7 +125,11 @@ export function BadgeUnlockedToast({ badge, onDismiss, queueCount = 0 }: BadgeUn
         <p className={styles.badgeDescription}>{badge.description}</p>
 
         {/* Dismiss button */}
-        <button className={styles.dismissButton} onClick={onDismiss}>
+        <button
+          className={styles.dismissButton}
+          onClick={onDismiss}
+          data-testid={testIds.learningPaths.badgeToastDismiss}
+        >
           Nice!
         </button>
       </div>

--- a/src/components/LearningPaths/LearningPathCard.tsx
+++ b/src/components/LearningPaths/LearningPathCard.tsx
@@ -9,6 +9,7 @@ import { useStyles2, Icon } from '@grafana/ui';
 import { cx } from '@emotion/css';
 
 import type { LearningPathCardProps } from '../../types/learning-paths.types';
+import { testIds } from '../../constants/testIds';
 import { getLearningPathCardStyles } from './learning-paths.styles';
 import { ProgressRing } from './ProgressRing';
 
@@ -78,7 +79,10 @@ export function LearningPathCard({
   const completedCount = guides.filter((g) => g.completed).length;
 
   return (
-    <div className={cx(styles.card, isCompleted && styles.cardCompleted)}>
+    <div
+      className={cx(styles.card, isCompleted && styles.cardCompleted)}
+      data-testid={testIds.learningPaths.card(path.id)}
+    >
       {/* Header - clickable to expand */}
       <div
         className={styles.header}
@@ -118,23 +122,39 @@ export function LearningPathCard({
         {/* Actions - fixed position at end */}
         <div className={styles.actions}>
           {!isCompleted && (
-            <button className={styles.actionButton} onClick={handleContinue}>
+            <button
+              className={styles.actionButton}
+              onClick={handleContinue}
+              data-testid={testIds.learningPaths.continueButton(path.id)}
+            >
               <Icon name="play" size="sm" />
               {getButtonText()}
             </button>
           )}
           {isCompleted && onReset && !isConfirmingReset && (
-            <button className={styles.resetButton} onClick={handleResetClick}>
+            <button
+              className={styles.resetButton}
+              onClick={handleResetClick}
+              data-testid={testIds.learningPaths.resetButton(path.id)}
+            >
               <Icon name="history" size="sm" />
               Restart
             </button>
           )}
           {isCompleted && onReset && isConfirmingReset && (
             <>
-              <button className={styles.confirmResetButton} onClick={handleConfirmReset}>
+              <button
+                className={styles.confirmResetButton}
+                onClick={handleConfirmReset}
+                data-testid={testIds.learningPaths.confirmResetButton(path.id)}
+              >
                 Confirm
               </button>
-              <button className={styles.cancelResetButton} onClick={handleCancelReset}>
+              <button
+                className={styles.cancelResetButton}
+                onClick={handleCancelReset}
+                data-testid={testIds.learningPaths.cancelResetButton(path.id)}
+              >
                 Cancel
               </button>
             </>
@@ -146,6 +166,7 @@ export function LearningPathCard({
               handleToggleExpand();
             }}
             aria-label={isExpanded ? 'Collapse' : 'Expand'}
+            data-testid={testIds.learningPaths.expandButton(path.id)}
           >
             <Icon name="angle-down" size="lg" />
           </button>

--- a/src/components/LearningPaths/LearningPathsPanel.tsx
+++ b/src/components/LearningPaths/LearningPathsPanel.tsx
@@ -9,6 +9,7 @@ import React, { useState, useCallback } from 'react';
 import { useStyles2, Icon, Modal } from '@grafana/ui';
 
 import { useLearningPaths, getBadgeById } from '../../learning-paths';
+import { testIds } from '../../constants/testIds';
 import { getLearningPathsPanelStyles } from './learning-paths.styles';
 import { LearningPathCard } from './LearningPathCard';
 import { BadgesDisplay } from './BadgesDisplay';
@@ -97,6 +98,7 @@ export function LearningPathsPanel({ onOpenGuide }: LearningPathsPanelProps) {
             className={styles.viewBadgesLink}
             onClick={() => setShowBadgesModal(true)}
             aria-label="View all badges"
+            data-testid={testIds.learningPaths.viewBadgesButton}
           >
             <Icon name="star" size="sm" />
             <span>Badges</span>

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -10,6 +10,7 @@ import { useStyles2, Icon } from '@grafana/ui';
 import { t } from '@grafana/i18n';
 
 import { useLearningPaths, BADGES, getPathsData } from '../../learning-paths';
+import { testIds } from '../../constants/testIds';
 import { LearningPathCard } from './LearningPathCard';
 import { BadgeIcon } from './BadgeIcon';
 import { SkeletonLoader } from '../SkeletonLoader';
@@ -61,9 +62,9 @@ function BadgeDetailCard({ badge, progress, onClose }: BadgeDetailCardProps) {
 
   return (
     <div className={styles.overlay} onClick={onClose}>
-      <div className={styles.card} onClick={(e) => e.stopPropagation()}>
+      <div className={styles.card} onClick={(e) => e.stopPropagation()} data-testid={testIds.learningPaths.badgesModal}>
         {/* Close button */}
-        <button className={styles.closeButton} onClick={onClose}>
+        <button className={styles.closeButton} onClick={onClose} data-testid={testIds.learningPaths.badgesModalClose}>
           <Icon name="times" size="lg" />
         </button>
 
@@ -167,6 +168,7 @@ function BadgeGridItem({ badge, index, completedGuides, streakDays, paths, style
       onClick={() => onSelect(badge)}
       style={{ animationDelay: `${index * 50}ms` }}
       title={isLegacy ? 'This badge was earned in a previous version' : undefined}
+      data-testid={testIds.learningPaths.badgeItem(badge.id)}
     >
       <div className={styles.badgeIconWrapper}>
         <BadgeIcon emoji={badge.emoji} icon={badge.icon} size="xl" emojiClassName={styles.badgeEmojiSmall} />
@@ -460,7 +462,11 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
           <Icon name="book-open" size="md" className={styles.sectionIcon} />
           <h2 className={styles.sectionTitle}>{t('myLearning.learningPaths', 'Learning paths')}</h2>
           {sortedPaths.length > 4 && (
-            <button className={styles.expandButton} onClick={() => setShowAllPaths(!showAllPaths)}>
+            <button
+              className={styles.expandButton}
+              onClick={() => setShowAllPaths(!showAllPaths)}
+              data-testid={testIds.learningPaths.showAllPathsButton}
+            >
               {showAllPaths
                 ? t('myLearning.showLess', 'Show less')
                 : t('myLearning.viewAll', 'View all ({{count}})', { count: sortedPaths.length })}
@@ -518,7 +524,11 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
         <div className={styles.sectionHeader}>
           <Icon name="star" size="md" className={styles.sectionIcon} />
           <h2 className={styles.sectionTitle}>{t('myLearning.badges', 'Badges')}</h2>
-          <button className={styles.expandButton} onClick={() => setShowAllBadges(!showAllBadges)}>
+          <button
+            className={styles.expandButton}
+            onClick={() => setShowAllBadges(!showAllBadges)}
+            data-testid={testIds.learningPaths.showAllBadgesButton}
+          >
             {showAllBadges
               ? t('myLearning.showLess', 'Show less')
               : t('myLearning.viewAll', 'View all ({{count}})', { count: totalBadges })}
@@ -559,6 +569,7 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
           className={styles.resetButton}
           onClick={handleResetProgress}
           title="Reset all learning progress (for testing)"
+          data-testid={testIds.learningPaths.resetProgressButton}
         >
           Reset progress
         </button>

--- a/src/components/LiveSession/AttendeeJoin.tsx
+++ b/src/components/LiveSession/AttendeeJoin.tsx
@@ -10,6 +10,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import { parseJoinCode, parseSessionFromUrl, useSession } from '../../integrations/workshop';
 import type { SessionOffer, AttendeeMode } from '../../types/collaboration.types';
+import { testIds } from '../../constants/testIds';
 
 /**
  * Get user-friendly error guidance based on error type
@@ -267,6 +268,7 @@ export function AttendeeJoin({ isOpen, onClose, onJoined }: AttendeeJoinProps) {
                     }
                   }}
                   autoFocus
+                  data-testid={testIds.liveSession.attendeeCodeInput}
                 />
                 <Button onClick={handleSubmitCode} variant="primary">
                   Next
@@ -299,7 +301,12 @@ export function AttendeeJoin({ isOpen, onClose, onJoined }: AttendeeJoinProps) {
 
             <div className={styles.section}>
               <label className={styles.label}>Your Name (Optional)</label>
-              <Input value={name} onChange={(e) => setName(e.currentTarget.value)} placeholder="Enter your name..." />
+              <Input
+                value={name}
+                onChange={(e) => setName(e.currentTarget.value)}
+                placeholder="Enter your name..."
+                data-testid={testIds.liveSession.attendeeNameInput}
+              />
             </div>
 
             <div className={styles.section}>
@@ -326,10 +333,19 @@ export function AttendeeJoin({ isOpen, onClose, onJoined }: AttendeeJoinProps) {
             {error !== null && <ErrorAlert error={error} className={styles.alert} />}
 
             <div className={styles.actions}>
-              <Button variant="secondary" onClick={() => setSessionOffer(null)}>
+              <Button
+                variant="secondary"
+                onClick={() => setSessionOffer(null)}
+                data-testid={testIds.liveSession.backButton}
+              >
                 Back
               </Button>
-              <Button variant="primary" onClick={handleJoinSession} disabled={isJoining}>
+              <Button
+                variant="primary"
+                onClick={handleJoinSession}
+                disabled={isJoining}
+                data-testid={testIds.liveSession.attendeeJoinButton}
+              >
                 {isJoining ? 'Joining...' : 'Join session'}
               </Button>
             </div>

--- a/src/components/LiveSession/HandRaiseIndicator.tsx
+++ b/src/components/LiveSession/HandRaiseIndicator.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { Button, Badge, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
+import { testIds } from '../../constants/testIds';
 
 /**
  * Props for HandRaiseIndicator
@@ -34,7 +35,13 @@ export function HandRaiseIndicator({ count, onClick }: HandRaiseIndicatorProps) 
 
   return (
     <div className={styles.container}>
-      <Button size="sm" variant="secondary" onClick={onClick} aria-label="View raised hands">
+      <Button
+        size="sm"
+        variant="secondary"
+        onClick={onClick}
+        aria-label="View raised hands"
+        data-testid={testIds.liveSession.handRaiseButton}
+      >
         <span className={styles.buttonContent}>
           <span className={styles.emoji}>✋</span>
           <Badge text={count.toString()} color="orange" className={styles.badge} />

--- a/src/components/LiveSession/HandRaiseQueue.tsx
+++ b/src/components/LiveSession/HandRaiseQueue.tsx
@@ -9,6 +9,7 @@ import { useStyles2, IconButton } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import type { HandRaiseInfo } from '../../types/collaboration.types';
+import { testIds } from '../../constants/testIds';
 
 /**
  * Props for HandRaiseQueue
@@ -87,10 +88,17 @@ export function HandRaiseQueue({ handRaises, isOpen, onClose, anchorRef }: HandR
   return (
     <>
       <div className={styles.backdrop} onClick={onClose} />
-      <div ref={modalRef} className={styles.modal}>
+      <div ref={modalRef} className={styles.modal} data-testid={testIds.liveSession.handRaiseQueue}>
         <div className={styles.header}>
           <h4 className={styles.title}>Raised Hands</h4>
-          <IconButton name="times" size="md" onClick={onClose} aria-label="Close" tooltip="Close" />
+          <IconButton
+            name="times"
+            size="md"
+            onClick={onClose}
+            aria-label="Close"
+            tooltip="Close"
+            data-testid={testIds.liveSession.handRaiseQueueClose}
+          />
         </div>
         <div className={styles.content}>
           {handRaises.length === 0 ? (

--- a/src/components/LiveSession/PresenterControls.tsx
+++ b/src/components/LiveSession/PresenterControls.tsx
@@ -11,6 +11,7 @@ import { css } from '@emotion/css';
 import { useSession } from '../../integrations/workshop';
 import { ConnectionIndicator } from './ConnectionIndicator';
 import type { SessionConfig, AttendeeInfo } from '../../types/collaboration.types';
+import { testIds } from '../../constants/testIds';
 
 /**
  * Props for PresenterControls
@@ -122,7 +123,12 @@ export function PresenterControls({ tutorialUrl }: PresenterControlsProps) {
                     className={styles.codeInput}
                     style={{ fontSize: '24px', fontWeight: 'bold', textAlign: 'center', letterSpacing: '4px' }}
                   />
-                  <Button variant="secondary" size="sm" onClick={() => copyToClipboard(sessionInfo.joinCode, 'code')}>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => copyToClipboard(sessionInfo.joinCode, 'code')}
+                    data-testid={testIds.liveSession.presenterCopyCode}
+                  >
                     {copied === 'code' ? '✓ Copied' : 'Copy'}
                   </Button>
                 </div>
@@ -132,7 +138,12 @@ export function PresenterControls({ tutorialUrl }: PresenterControlsProps) {
                 <label>Join URL</label>
                 <div className={styles.copyGroup}>
                   <Input value={sessionInfo.joinUrl} readOnly className={styles.urlInput} />
-                  <Button variant="secondary" size="sm" onClick={() => copyToClipboard(sessionInfo.joinUrl, 'url')}>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => copyToClipboard(sessionInfo.joinUrl, 'url')}
+                    data-testid={testIds.liveSession.presenterCopyUrl}
+                  >
                     {copied === 'url' ? '✓ Copied' : 'Copy'}
                   </Button>
                 </div>
@@ -148,7 +159,11 @@ export function PresenterControls({ tutorialUrl }: PresenterControlsProps) {
             </div>
 
             <div className={styles.actions}>
-              <Button variant="destructive" onClick={handleEndSession}>
+              <Button
+                variant="destructive"
+                onClick={handleEndSession}
+                data-testid={testIds.liveSession.presenterEndButton}
+              >
                 End Session
               </Button>
             </div>

--- a/src/components/PrTester/PrTester.tsx
+++ b/src/components/PrTester/PrTester.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Icon, Input, Combobox, useStyles2, RadioButtonGroup, type 
 import { SelectableValue } from '@grafana/data';
 import { getPrTesterStyles } from './pr-tester.styles';
 import { fetchPrContentFilesFromUrl, isValidPrUrl, type PrContentFile } from './github-api';
+import { testIds } from '../../constants/testIds';
 
 const PR_URL_STORAGE_KEY = 'pathfinder-pr-tester-url';
 const SELECTED_FILE_STORAGE_KEY = 'pathfinder-pr-tester-selected';
@@ -490,7 +491,7 @@ export function PrTester({ onOpenDocsPage, onOpenLearningJourney }: PrTesterProp
   };
 
   return (
-    <div className={styles.formGroup}>
+    <div className={styles.formGroup} data-testid={testIds.prTester.form}>
       {/* PR URL Input */}
       <label className={styles.label} htmlFor="prTesterInput">
         PR URL
@@ -501,6 +502,7 @@ export function PrTester({ onOpenDocsPage, onOpenLearningJourney }: PrTesterProp
         value={prUrl}
         onChange={handleUrlChange}
         placeholder="https://github.com/grafana/interactive-tutorials/pull/70"
+        data-testid={testIds.prTester.prNumberInput}
       />
       <p className={styles.helpText}>Paste a GitHub pull request URL. We will look for content.json files.</p>
 
@@ -512,6 +514,7 @@ export function PrTester({ onOpenDocsPage, onOpenLearningJourney }: PrTesterProp
           onClick={handleFetchPr}
           disabled={!prUrl.trim() || isFetching}
           icon={isFetching ? 'fa fa-spinner' : undefined}
+          data-testid={testIds.prTester.loadButton}
         >
           {isFetching ? 'Fetching...' : hasFetched ? 'Re-fetch PR' : 'Fetch PR'}
         </Button>
@@ -529,7 +532,12 @@ export function PrTester({ onOpenDocsPage, onOpenLearningJourney }: PrTesterProp
       {hasFetched && hasMultipleFiles && testMode === 'single' && (
         <div className={styles.selectContainer}>
           <label className={styles.label}>Guide to test</label>
-          <Combobox options={fileOptions} value={selectedFile} onChange={handleFileSelect} />
+          <Combobox
+            options={fileOptions}
+            value={selectedFile}
+            onChange={handleFileSelect}
+            data-testid={testIds.prTester.fileSelect}
+          />
         </div>
       )}
 

--- a/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
+++ b/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, lazy, Suspense, useEffect } from 'react';
 import { Button, Badge, Icon, useStyles2, Stack } from '@grafana/ui';
 import { getDebugPanelStyles } from './debug-panel.styles';
+import { testIds } from '../../constants/testIds';
 import { UrlTester } from 'components/UrlTester';
 import { PrTester } from 'components/PrTester';
 import { SkeletonLoader } from '../SkeletonLoader';
@@ -13,18 +14,32 @@ const BlockEditor = lazy(() =>
 );
 
 // localStorage keys for section expansion state
-const STORAGE_KEY_BLOCK_EDITOR = 'pathfinder-devtools-block-editor-expanded';
-const STORAGE_KEY_PR_TESTER = 'pathfinder-devtools-pr-tester-expanded';
-const STORAGE_KEY_URL_TESTER = 'pathfinder-devtools-url-tester-expanded';
+const STORAGE_KEY_BLOCK_EDITOR = 'pathfinder-editor-block-editor-expanded';
+const STORAGE_KEY_PR_TESTER = 'pathfinder-editor-pr-tester-expanded';
+const STORAGE_KEY_URL_TESTER = 'pathfinder-editor-url-tester-expanded';
+
+// Old keys for backward-compat migration
+const OLD_STORAGE_KEY_BLOCK_EDITOR = 'pathfinder-devtools-block-editor-expanded';
+const OLD_STORAGE_KEY_PR_TESTER = 'pathfinder-devtools-pr-tester-expanded';
+const OLD_STORAGE_KEY_URL_TESTER = 'pathfinder-devtools-url-tester-expanded';
 
 /**
- * Get initial expansion state from localStorage with fallback
+ * Get initial expansion state from localStorage with fallback.
+ * Migrates from old devtools-prefixed keys on first read.
  */
-function getInitialExpanded(storageKey: string, defaultValue: boolean): boolean {
+function getInitialExpanded(storageKey: string, oldStorageKey: string, defaultValue: boolean): boolean {
   try {
     const stored = localStorage.getItem(storageKey);
     if (stored !== null) {
       return stored === 'true';
+    }
+
+    // Migrate from old key if present
+    const oldStored = localStorage.getItem(oldStorageKey);
+    if (oldStored !== null) {
+      localStorage.setItem(storageKey, oldStored);
+      localStorage.removeItem(oldStorageKey);
+      return oldStored === 'true';
     }
   } catch {
     // Ignore localStorage errors
@@ -33,19 +48,28 @@ function getInitialExpanded(storageKey: string, defaultValue: boolean): boolean 
 }
 
 export interface SelectorDebugPanelProps {
+  isDevMode?: boolean;
   onOpenDocsPage?: (url: string, title: string) => void;
   onOpenLearningJourney?: (url: string, title: string) => void;
 }
 
-export function SelectorDebugPanel({ onOpenDocsPage, onOpenLearningJourney }: SelectorDebugPanelProps = {}) {
+export function SelectorDebugPanel({
+  isDevMode = false,
+  onOpenDocsPage,
+  onOpenLearningJourney,
+}: SelectorDebugPanelProps = {}) {
   const styles = useStyles2(getDebugPanelStyles);
 
-  // Section expansion state - initialize from localStorage
+  // Section expansion state - initialize from localStorage (with migration)
   const [blockEditorExpanded, setBlockEditorExpanded] = useState(() =>
-    getInitialExpanded(STORAGE_KEY_BLOCK_EDITOR, true)
+    getInitialExpanded(STORAGE_KEY_BLOCK_EDITOR, OLD_STORAGE_KEY_BLOCK_EDITOR, true)
   );
-  const [prTesterExpanded, setPrTesterExpanded] = useState(() => getInitialExpanded(STORAGE_KEY_PR_TESTER, false));
-  const [UrlTesterExpanded, setUrlTesterExpanded] = useState(() => getInitialExpanded(STORAGE_KEY_URL_TESTER, false));
+  const [prTesterExpanded, setPrTesterExpanded] = useState(() =>
+    getInitialExpanded(STORAGE_KEY_PR_TESTER, OLD_STORAGE_KEY_PR_TESTER, false)
+  );
+  const [urlTesterExpanded, setUrlTesterExpanded] = useState(() =>
+    getInitialExpanded(STORAGE_KEY_URL_TESTER, OLD_STORAGE_KEY_URL_TESTER, false)
+  );
 
   // Persist block editor expansion state
   useEffect(() => {
@@ -68,27 +92,24 @@ export function SelectorDebugPanel({ onOpenDocsPage, onOpenLearningJourney }: Se
   // Persist URL tester expansion state
   useEffect(() => {
     try {
-      localStorage.setItem(STORAGE_KEY_URL_TESTER, String(UrlTesterExpanded));
+      localStorage.setItem(STORAGE_KEY_URL_TESTER, String(urlTesterExpanded));
     } catch {
       // Ignore localStorage errors
     }
-  }, [UrlTesterExpanded]);
+  }, [urlTesterExpanded]);
 
   // Handle leaving dev mode
   const handleLeaveDevMode = useCallback(async () => {
     try {
-      // Get current user ID and user list from global config
       const globalConfig = (window as any).__pathfinderPluginConfig;
       const currentUserId = (window as any).grafanaBootData?.user?.id;
       const currentUserIds = globalConfig?.devModeUserIds ?? [];
 
-      // Import dynamically to avoid circular dependency
       const { disableDevModeForUser } = await import('../../utils/dev-mode');
 
       if (currentUserId) {
         await disableDevModeForUser(currentUserId, currentUserIds);
       } else {
-        // Fallback: disable for all if can't determine user
         const { disableDevMode } = await import('../../utils/dev-mode');
         await disableDevMode();
       }
@@ -97,26 +118,34 @@ export function SelectorDebugPanel({ onOpenDocsPage, onOpenLearningJourney }: Se
     } catch (error) {
       console.error('Failed to disable dev mode:', error);
 
-      // Show user-friendly error message
       const errorMessage = error instanceof Error ? error.message : 'Failed to disable dev mode. Please try again.';
       alert(errorMessage);
     }
   }, []);
 
   return (
-    <div className={styles.container} data-devtools-panel="true">
-      <div className={styles.header}>
-        <Stack direction="row" gap={1} alignItems="center">
-          <Icon name="bug" size="lg" />
-          <Badge text="Dev Mode" color="orange" className={styles.badge} />
-        </Stack>
-        <Button variant="secondary" size="sm" onClick={handleLeaveDevMode} icon="times" fill="outline">
-          Leave dev mode
-        </Button>
-      </div>
+    <div className={styles.container} data-devtools-panel="true" data-testid={testIds.editorPanel.container}>
+      {/* Dev mode header - only shown when dev mode is active */}
+      {isDevMode && (
+        <div className={styles.header} data-testid={testIds.editorPanel.devModeHeader}>
+          <Stack direction="row" gap={1} alignItems="center">
+            <Badge text="Dev mode" color="orange" className={styles.badge} />
+          </Stack>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleLeaveDevMode}
+            icon="times"
+            fill="outline"
+            data-testid={testIds.editorPanel.leaveDevModeButton}
+          >
+            Leave dev mode
+          </Button>
+        </div>
+      )}
 
-      {/* Block Editor */}
-      <div className={styles.section}>
+      {/* Block Editor - always visible */}
+      <div className={styles.section} data-testid={testIds.editorPanel.blockEditorSection}>
         <div className={styles.sectionHeader} onClick={() => setBlockEditorExpanded(!blockEditorExpanded)}>
           <Stack direction="row" gap={1} alignItems="center">
             <Icon name="edit" />
@@ -133,37 +162,41 @@ export function SelectorDebugPanel({ onOpenDocsPage, onOpenLearningJourney }: Se
         )}
       </div>
 
-      {/* PR tester */}
-      <div className={styles.section}>
-        <div className={styles.sectionHeader} onClick={() => setPrTesterExpanded(!prTesterExpanded)}>
-          <Stack direction="row" gap={1} alignItems="center">
-            <Icon name="code-branch" />
-            <h4 className={styles.sectionTitle}>PR tester</h4>
-          </Stack>
-          <Icon name={prTesterExpanded ? 'angle-up' : 'angle-down'} />
-        </div>
-        {prTesterExpanded && onOpenDocsPage && (
-          <div className={styles.sectionContent}>
-            <PrTester onOpenDocsPage={onOpenDocsPage} onOpenLearningJourney={onOpenLearningJourney} />
+      {/* PR tester - dev mode only */}
+      {isDevMode && (
+        <div className={styles.section} data-testid={testIds.editorPanel.prTesterSection}>
+          <div className={styles.sectionHeader} onClick={() => setPrTesterExpanded(!prTesterExpanded)}>
+            <Stack direction="row" gap={1} alignItems="center">
+              <Icon name="code-branch" />
+              <h4 className={styles.sectionTitle}>PR tester</h4>
+            </Stack>
+            <Icon name={prTesterExpanded ? 'angle-up' : 'angle-down'} />
           </div>
-        )}
-      </div>
+          {prTesterExpanded && onOpenDocsPage && (
+            <div className={styles.sectionContent}>
+              <PrTester onOpenDocsPage={onOpenDocsPage} onOpenLearningJourney={onOpenLearningJourney} />
+            </div>
+          )}
+        </div>
+      )}
 
-      {/* URL tester */}
-      <div className={styles.section}>
-        <div className={styles.sectionHeader} onClick={() => setUrlTesterExpanded(!UrlTesterExpanded)}>
-          <Stack direction="row" gap={1} alignItems="center">
-            <Icon name="external-link-alt" />
-            <h4 className={styles.sectionTitle}>URL tester</h4>
-          </Stack>
-          <Icon name={UrlTesterExpanded ? 'angle-up' : 'angle-down'} />
-        </div>
-        {UrlTesterExpanded && onOpenDocsPage && (
-          <div className={styles.sectionContent}>
-            <UrlTester onOpenDocsPage={onOpenDocsPage} onOpenLearningJourney={onOpenLearningJourney} />
+      {/* URL tester - dev mode only */}
+      {isDevMode && (
+        <div className={styles.section} data-testid={testIds.editorPanel.urlTesterSection}>
+          <div className={styles.sectionHeader} onClick={() => setUrlTesterExpanded(!urlTesterExpanded)}>
+            <Stack direction="row" gap={1} alignItems="center">
+              <Icon name="external-link-alt" />
+              <h4 className={styles.sectionTitle}>URL tester</h4>
+            </Stack>
+            <Icon name={urlTesterExpanded ? 'angle-up' : 'angle-down'} />
           </div>
-        )}
-      </div>
+          {urlTesterExpanded && onOpenDocsPage && (
+            <div className={styles.sectionContent}>
+              <UrlTester onOpenDocsPage={onOpenDocsPage} onOpenLearningJourney={onOpenLearningJourney} />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/UrlTester/UrlTester.tsx
+++ b/src/components/UrlTester/UrlTester.tsx
@@ -8,6 +8,7 @@ import {
   isLocalhostUrl,
   type UrlValidation,
 } from '../../security';
+import { testIds } from '../../constants/testIds';
 
 const STORAGE_KEY = 'pathfinder-url-tester-url';
 
@@ -124,7 +125,7 @@ export const UrlTester = ({ onOpenDocsPage, onOpenLearningJourney }: UrlTesterPr
   );
 
   return (
-    <form className={styles.formGroup} onSubmit={handleSubmit}>
+    <form className={styles.formGroup} onSubmit={handleSubmit} data-testid={testIds.urlTester.form}>
       <label className={styles.label} htmlFor="urlTesterInput">
         URL to test
       </label>
@@ -138,12 +139,19 @@ export const UrlTester = ({ onOpenDocsPage, onOpenLearningJourney }: UrlTesterPr
           setTestSuccess(false);
         }}
         placeholder="https://interactive-learning.grafana.net/tutorial-name"
+        data-testid={testIds.urlTester.urlInput}
       />
       <p className={styles.helpText}>
         Supported URLs: interactive-learning.grafana.net, raw.githubusercontent.com, grafana.com/docs, localhost
       </p>
       <Box marginTop={1}>
-        <Button variant="primary" size="sm" type="submit" disabled={!testUrl.trim() || !onOpenDocsPage}>
+        <Button
+          variant="primary"
+          size="sm"
+          type="submit"
+          disabled={!testUrl.trim() || !onOpenDocsPage}
+          data-testid={testIds.urlTester.loadButton}
+        >
           Test URL
         </Button>
       </Box>

--- a/src/components/block-editor/BlockEditor.tsx
+++ b/src/components/block-editor/BlockEditor.tsx
@@ -35,6 +35,7 @@ import { BlockEditorModals } from './BlockEditorModals';
 import { BlockEditorContextProvider, useBlockEditorContext } from './BlockEditorContext';
 import { ConfirmModal } from './NotificationModals';
 import { BACKEND_TRACKING_STORAGE_KEY, DEFAULT_GUIDE_METADATA } from './constants';
+import { testIds } from '../../constants/testIds';
 
 /** Converts a guide title to a URL-safe kebab-case slug */
 function slugifyTitle(title: string): string {
@@ -186,7 +187,7 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
       '.context-container',
       '[data-devtools-panel]',
       '[data-block-editor]',
-      '[data-testid="block-editor"]',
+      `[data-testid="${testIds.blockEditor.container}"]`,
       '[data-record-overlay]', // Stop recording button and overlay elements
     ],
     []
@@ -697,7 +698,7 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
   );
 
   return (
-    <div className={styles.container} data-testid="block-editor">
+    <div className={styles.container} data-testid={testIds.blockEditor.container}>
       {/* Header */}
       <BlockEditorHeader
         guideTitle={state.guide.title}

--- a/src/components/block-editor/BlockEditorContent.tsx
+++ b/src/components/block-editor/BlockEditorContent.tsx
@@ -13,6 +13,7 @@ import { BlockJsonEditor } from './BlockJsonEditor';
 import { BlockList } from './BlockList';
 import { BlockPreview } from './BlockPreview';
 import type { EditorBlock, BlockOperations, JsonGuide, ViewMode, JsonModeState, PositionedError } from './types';
+import { testIds } from '../../constants/testIds';
 
 export interface BlockEditorContentProps {
   /** Current view mode */
@@ -81,7 +82,7 @@ export function BlockEditorContent({
   const selectedCount = selectedBlockIds.size;
 
   return (
-    <div className={styles.content} data-testid="block-editor-content">
+    <div className={styles.content} data-testid={testIds.blockEditor.content}>
       {/* Selection controls - shown in edit mode, above blocks */}
       {viewMode === 'edit' && hasBlocks && (
         <div className={styles.selectionControls}>
@@ -89,26 +90,52 @@ export function BlockEditorContent({
             selectedCount >= 2 ? (
               <>
                 <span className={styles.selectionCount}>{selectedCount} blocks selected</span>
-                <Button variant="primary" size="sm" onClick={onMergeToMultistep}>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={onMergeToMultistep}
+                  data-testid={testIds.blockEditor.mergeMultistepButton}
+                >
                   Create multistep
                 </Button>
-                <Button variant="primary" size="sm" onClick={onMergeToGuided}>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={onMergeToGuided}
+                  data-testid={testIds.blockEditor.mergeGuidedButton}
+                >
                   Create guided
                 </Button>
-                <Button variant="secondary" size="sm" onClick={onClearSelection}>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={onClearSelection}
+                  data-testid={testIds.blockEditor.clearSelectionButton}
+                >
                   Cancel
                 </Button>
               </>
             ) : (
               <>
                 <span style={{ fontSize: '13px', color: '#888' }}>Click blocks to select them for merging</span>
-                <Button variant="secondary" size="sm" onClick={onClearSelection}>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={onClearSelection}
+                  data-testid={testIds.blockEditor.clearSelectionButton}
+                >
                   Cancel
                 </Button>
               </>
             )
           ) : (
-            <Button variant="secondary" size="sm" icon="check-square" onClick={onToggleSelectionMode}>
+            <Button
+              variant="secondary"
+              size="sm"
+              icon="check-square"
+              onClick={onToggleSelectionMode}
+              data-testid={testIds.blockEditor.toggleSelectionButton}
+            >
               Select blocks
             </Button>
           )}
@@ -133,10 +160,20 @@ export function BlockEditorContent({
           <div className={styles.emptyStateIcon}>📄</div>
           <p className={styles.emptyStateText}>Your guide is empty. Add your first block to get started.</p>
           <div style={{ display: 'flex', gap: '8px', marginTop: '8px' }}>
-            <Button variant="secondary" onClick={onLoadTemplate} icon="file-alt">
+            <Button
+              variant="secondary"
+              onClick={onLoadTemplate}
+              icon="file-alt"
+              data-testid={testIds.blockEditor.loadTemplateButton}
+            >
               Load example guide
             </Button>
-            <Button variant="secondary" onClick={onOpenTour} icon="question-circle">
+            <Button
+              variant="secondary"
+              onClick={onOpenTour}
+              icon="question-circle"
+              data-testid={testIds.blockEditor.openTourButton}
+            >
               Take a tour
             </Button>
           </div>

--- a/src/components/block-editor/BlockEditorFooter.tsx
+++ b/src/components/block-editor/BlockEditorFooter.tsx
@@ -10,6 +10,7 @@ import { useStyles2 } from '@grafana/ui';
 import { getBlockEditorStyles } from './block-editor.styles';
 import { BlockPalette } from './BlockPalette';
 import type { BlockType, ViewMode } from './types';
+import { testIds } from '../../constants/testIds';
 
 interface BlockEditorFooterProps {
   /** Current view mode (footer only shown in edit mode) */
@@ -30,7 +31,7 @@ export function BlockEditorFooter({ viewMode, onBlockTypeSelect }: BlockEditorFo
   }
 
   return (
-    <div data-testid="block-palette" className={styles.footer}>
+    <div data-testid={testIds.blockEditor.palette} className={styles.footer}>
       <BlockPalette onSelect={onBlockTypeSelect} embedded />
     </div>
   );

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -13,6 +13,7 @@ import { Button, Badge, ButtonGroup, Tooltip, Dropdown, Menu, useStyles2 } from 
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import type { ViewMode } from './types';
+import { testIds } from '../../constants/testIds';
 
 export interface BlockEditorHeaderProps {
   /** Guide title to display */
@@ -241,7 +242,7 @@ export function BlockEditorHeader({
         icon="times-circle"
         onClick={onUnpublish}
         disabled={isPostingToBackend}
-        data-testid="unpublish-button"
+        data-testid={testIds.blockEditor.unpublishButton}
       />
     );
   };
@@ -253,7 +254,7 @@ export function BlockEditorHeader({
       {isBackendAvailable && <Menu.Divider />}
       <Menu.Item label="Import" icon="upload" onClick={onOpenImport} />
       <Menu.Divider />
-      <Menu.Item label="Copy JSON" icon="copy" onClick={onCopy} data-testid="copy-json-button" />
+      <Menu.Item label="Copy JSON" icon="copy" onClick={onCopy} data-testid={testIds.blockEditor.copyJsonButton} />
       <Menu.Item label="Download JSON" icon="download-alt" onClick={onDownload} />
       <Menu.Item label="Create GitHub PR" icon="github" onClick={onOpenGitHubPR} />
       <Menu.Divider />
@@ -310,7 +311,7 @@ export function BlockEditorHeader({
           onClick={onSaveDraft}
           disabled={isPostingToBackend}
           tooltip="Save as draft without publishing"
-          data-testid="save-draft-button"
+          data-testid={testIds.blockEditor.saveDraftButton}
         >
           Save as draft
         </Button>
@@ -327,7 +328,7 @@ export function BlockEditorHeader({
             onClick={onSaveDraft}
             disabled={isPostingToBackend}
             tooltip="Save current changes to library draft"
-            data-testid="save-draft-button"
+            data-testid={testIds.blockEditor.saveDraftButton}
           >
             Update draft
           </Button>
@@ -341,7 +342,7 @@ export function BlockEditorHeader({
           onClick={onPostToBackend}
           disabled={isPostingToBackend}
           tooltip="Publish and make visible to users"
-          data-testid="post-to-backend-button"
+          data-testid={testIds.blockEditor.publishButton}
         >
           Publish
         </Button>
@@ -357,7 +358,7 @@ export function BlockEditorHeader({
         onClick={onPostToBackend}
         disabled={isPostingToBackend}
         tooltip="Save changes and keep published"
-        data-testid="post-to-backend-button"
+        data-testid={testIds.blockEditor.publishButton}
       >
         Update
       </Button>
@@ -405,11 +406,23 @@ export function BlockEditorHeader({
       <div className={styles.toolbarRow}>
         {/* Left: New + Library */}
         <div className={styles.leftSection}>
-          <Button variant="secondary" size="sm" icon="file-blank" onClick={onNewGuide}>
+          <Button
+            variant="secondary"
+            size="sm"
+            icon="file-blank"
+            onClick={onNewGuide}
+            data-testid={testIds.blockEditor.newGuideButton}
+          >
             New
           </Button>
           {isBackendAvailable && (
-            <Button variant="secondary" size="sm" icon="book-open" onClick={onOpenGuideLibrary}>
+            <Button
+              variant="secondary"
+              size="sm"
+              icon="book-open"
+              onClick={onOpenGuideLibrary}
+              data-testid={testIds.blockEditor.libraryButton}
+            >
               Library
             </Button>
           )}
@@ -417,7 +430,7 @@ export function BlockEditorHeader({
 
         {/* Right: View mode, publish, and more */}
         <div className={styles.rightSection}>
-          <ButtonGroup data-testid="view-mode-toggle">
+          <ButtonGroup data-testid={testIds.blockEditor.viewModeToggle}>
             <Button
               variant={viewMode === 'edit' ? 'primary' : 'secondary'}
               size="sm"
@@ -455,7 +468,7 @@ export function BlockEditorHeader({
                 size="sm"
                 icon="ellipsis-v"
                 tooltip="More actions"
-                data-testid="more-actions-button"
+                data-testid={testIds.blockEditor.moreActionsButton}
               />
             </Dropdown>
           </div>

--- a/src/components/block-editor/BlockEditorTour.tsx
+++ b/src/components/block-editor/BlockEditorTour.tsx
@@ -7,6 +7,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { NavigationManager } from '../../interactive-engine';
+import { testIds } from '../../constants/testIds';
 
 /**
  * Tour step definition
@@ -18,8 +19,6 @@ interface TourStep {
   title: string;
   /** Explanation text */
   content: string;
-  /** Optional action to describe what happens when clicking the target */
-  action?: 'highlight' | 'click';
 }
 
 /**
@@ -27,42 +26,36 @@ interface TourStep {
  */
 const TOUR_STEPS: TourStep[] = [
   {
-    target: '[data-testid="block-editor"]',
+    target: `[data-testid="${testIds.blockEditor.container}"]`,
     title: 'Welcome to the guide editor',
     content:
       'This is where you create interactive guides for Grafana. Guides combine markdown, interactive elements, and quizzes to help users learn.',
   },
   {
-    target: '[data-testid="guide-metadata-button"]',
-    title: 'Guide settings',
-    content:
-      'Click the gear icon to set your guide title and ID. The ID is used to load your guide and should be unique.',
-  },
-  {
-    target: '[data-testid="view-mode-toggle"]',
+    target: `[data-testid="${testIds.blockEditor.viewModeToggle}"]`,
     title: 'Edit and preview modes',
     content: 'Toggle between Edit mode (to modify blocks) and Preview mode (to see how your guide will look to users).',
   },
   {
-    target: '[data-testid="copy-json-button"]',
-    title: 'Export your guide',
+    target: `[data-testid="${testIds.blockEditor.moreActionsButton}"]`,
+    title: 'More actions',
     content:
-      'When ready, copy the JSON to clipboard, download it, or create a GitHub PR. The copy button is the quickest way to share your guide.',
+      'This menu contains import, export, and sharing options. Use it to copy or download the guide JSON, create a GitHub PR, or import an existing guide.',
   },
   {
-    target: '[data-testid="block-editor-content"]',
+    target: `[data-testid="${testIds.blockEditor.content}"]`,
     title: 'Your blocks appear here',
     content:
       'As you add blocks, they appear in this area. You can drag to reorder, click to edit, and use action buttons to duplicate or delete.',
   },
   {
-    target: '[data-testid="block-palette"]',
+    target: `[data-testid="${testIds.blockEditor.palette}"]`,
     title: 'Add blocks from here',
     content:
       'Click "Add Block" to see all available block types: Markdown for text, Interactive for UI actions, Quiz for knowledge checks, and more.',
   },
   {
-    target: '[data-testid="block-editor"]',
+    target: `[data-testid="${testIds.blockEditor.container}"]`,
     title: "You're ready to create!",
     content:
       "That's the basics! Start by loading the example guide to see how blocks work, or jump straight in and add your first block.",
@@ -92,13 +85,11 @@ export function BlockEditorTour({ onClose, steps = TOUR_STEPS }: BlockEditorTour
 
   // Navigate to next step
   const goToNext = useCallback(() => {
-    // Mark current step as completed
     setCompletedSteps((prev) => (prev.includes(currentStep) ? prev : [...prev, currentStep]));
 
     if (currentStep < totalSteps - 1) {
       setCurrentStep((prev) => prev + 1);
     } else {
-      // Tour complete
       navigationManager.clearAllHighlights();
       onClose();
     }
@@ -123,10 +114,8 @@ export function BlockEditorTour({ onClose, steps = TOUR_STEPS }: BlockEditorTour
       return;
     }
 
-    // Find the target element
     const element = document.querySelector(step.target) as HTMLElement | null;
 
-    // Build step info for progress display
     const stepInfo = {
       current: currentStep,
       total: totalSteps,
@@ -134,26 +123,22 @@ export function BlockEditorTour({ onClose, steps = TOUR_STEPS }: BlockEditorTour
     };
 
     if (element) {
-      // Use the unified NavigationManager highlight system
-      // Pass navigation callbacks for tour mode, and options for visual enhancements
-      // Skip animations after first step for smooth transitions
       await navigationManager.highlightWithComment(
         element,
         step.content,
-        false, // Disable auto-cleanup for tour mode
+        false,
         stepInfo,
-        undefined, // No skip callback for tour
-        handleClose, // Cancel callback
-        goToNext, // Next callback (for tour navigation)
-        currentStep > 0 ? goToPrevious : undefined, // Previous callback (disabled on first step)
+        undefined,
+        handleClose,
+        goToNext,
+        currentStep > 0 ? goToPrevious : undefined,
         {
           showKeyboardHint: true,
-          skipAnimations: currentStep > 0, // Instant transitions after first step
+          skipAnimations: currentStep > 0,
           stepTitle: step.title,
         }
       );
     } else {
-      // If element not found, show a centered comment
       navigationManager.showNoopComment(
         `<strong>${step.title}</strong><br><br>${step.content}<br><br><em style="opacity: 0.7">Target element not visible - it may appear in a different editor state.</em>`
       );
@@ -190,9 +175,7 @@ export function BlockEditorTour({ onClose, steps = TOUR_STEPS }: BlockEditorTour
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [currentStep, handleClose, goToNext, goToPrevious]);
 
-  // No JSX needed - the tour renders via NavigationManager's highlight system
   return null;
 }
 
-// Display name for debugging
 BlockEditorTour.displayName = 'BlockEditorTour';

--- a/src/components/block-editor/BlockItem.tsx
+++ b/src/components/block-editor/BlockItem.tsx
@@ -19,6 +19,7 @@ import {
   isInputBlock,
 } from '../../types/json-guide.types';
 import { getBlockPreview } from './utils';
+import { testIds } from '../../constants/testIds';
 
 export interface BlockItemProps {
   /** The block to render */
@@ -235,7 +236,7 @@ export function BlockItem({
             onClick={handleEdit}
             className={styles.editButton}
             tooltip="Edit block"
-            data-testid="block-edit-button"
+            data-testid={testIds.blockEditor.editButton}
           />
           <IconButton
             name="copy"
@@ -244,7 +245,7 @@ export function BlockItem({
             onClick={handleDuplicate}
             className={styles.actionButton}
             tooltip="Duplicate block"
-            data-testid="block-duplicate-button"
+            data-testid={testIds.blockEditor.duplicateButton}
           />
           <ConfirmDeleteButton
             onConfirm={onDelete}

--- a/src/components/block-editor/BlockJsonEditor.tsx
+++ b/src/components/block-editor/BlockJsonEditor.tsx
@@ -10,6 +10,7 @@ import React, { useRef, useEffect } from 'react';
 import { Alert, Button, CodeEditor, useStyles2 } from '@grafana/ui';
 import type { BlockJsonEditorProps } from './types';
 import { getStyles } from './block-json-editor.styles';
+import { testIds } from '../../constants/testIds';
 
 // Monaco types (imported dynamically via onEditorDidMount)
 type MonacoEditor = Parameters<NonNullable<React.ComponentProps<typeof CodeEditor>['onEditorDidMount']>>[0];
@@ -84,7 +85,7 @@ export function BlockJsonEditor({
   });
 
   return (
-    <div className={styles.container} data-testid="block-json-editor">
+    <div className={styles.container} data-testid={testIds.blockEditor.jsonEditor}>
       {/* Toolbar with undo button */}
       {canUndo && onUndo && (
         <div className={styles.toolbar}>

--- a/src/components/block-editor/BlockPreview.tsx
+++ b/src/components/block-editor/BlockPreview.tsx
@@ -15,6 +15,7 @@ import { getPrismStyles } from '../../styles/prism.styles';
 import { interactiveStepStorage, interactiveCompletionStorage } from '../../lib/user-storage';
 import type { JsonGuide } from './types';
 import type { RawContent } from '../../types/content.types';
+import { testIds } from '../../constants/testIds';
 
 export interface BlockPreviewProps {
   /** The guide to preview */
@@ -171,6 +172,7 @@ export function BlockPreview({ guide }: BlockPreviewProps) {
               onClick={handleReset}
               aria-label="Reset guide"
               title="Resets all interactive steps"
+              data-testid={testIds.blockEditor.previewResetButton}
             >
               <Icon name="history-alt" size="sm" />
               <span>Reset guide</span>

--- a/src/components/block-editor/ConfirmDeleteButton.tsx
+++ b/src/components/block-editor/ConfirmDeleteButton.tsx
@@ -8,6 +8,7 @@ import React, { useState, useCallback } from 'react';
 import { IconButton, ConfirmModal, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
+import { testIds } from '../../constants/testIds';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   deleteButton: css({
@@ -71,7 +72,7 @@ export function ConfirmDeleteButton({
         onClick={handleClick}
         className={className ?? styles.deleteButton}
         tooltip={tooltip}
-        data-testid="block-delete-button"
+        data-testid={testIds.blockEditor.deleteButton}
       />
 
       <ConfirmModal

--- a/src/components/block-editor/GuideMetadataForm.tsx
+++ b/src/components/block-editor/GuideMetadataForm.tsx
@@ -9,6 +9,7 @@ import { Button, Field, Input, Modal, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import type { BlockEditorState } from './types';
+import { testIds } from '../../constants/testIds';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   form: css({
@@ -66,16 +67,26 @@ export function GuideMetadataForm({ isOpen, guide, onUpdate, onClose }: GuideMet
       <div className={styles.form}>
         <div className={styles.row}>
           <Field label="Guide ID" description="Unique identifier for this guide (kebab-case recommended)" required>
-            <Input value={guide.id} onChange={handleIdChange} placeholder="my-guide-id" />
+            <Input
+              value={guide.id}
+              onChange={handleIdChange}
+              placeholder="my-guide-id"
+              data-testid={testIds.blockEditor.metadataIdInput}
+            />
           </Field>
         </div>
 
         <Field label="Title" description="Display title shown to users" required>
-          <Input value={guide.title} onChange={handleTitleChange} placeholder="My Guide Title" />
+          <Input
+            value={guide.title}
+            onChange={handleTitleChange}
+            placeholder="My Guide Title"
+            data-testid={testIds.blockEditor.metadataTitleInput}
+          />
         </Field>
 
         <div className={styles.footer}>
-          <Button variant="primary" onClick={onClose}>
+          <Button variant="primary" onClick={onClose} data-testid={testIds.blockEditor.metadataSaveButton}>
             Done
           </Button>
         </div>

--- a/src/components/block-editor/ImportGuideModal.tsx
+++ b/src/components/block-editor/ImportGuideModal.tsx
@@ -10,6 +10,7 @@ import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import type { JsonGuide } from './types';
 import { importGuideFromFile, parseAndValidateGuide, type ImportValidationResult } from './utils/block-import';
+import { testIds } from '../../constants/testIds';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   container: css({
@@ -396,7 +397,7 @@ export function ImportGuideModal({ isOpen, onImport, onClose, hasUnsavedChanges 
 
   return (
     <Modal title="Import guide" isOpen={isOpen} onDismiss={handleClose}>
-      <div className={styles.container}>
+      <div className={styles.container} data-testid={testIds.blockEditor.importModal}>
         {/* Mode selector */}
         <RadioButtonGroup
           options={MODE_OPTIONS}
@@ -419,6 +420,7 @@ export function ImportGuideModal({ isOpen, onImport, onClose, hasUnsavedChanges 
               role="button"
               tabIndex={0}
               aria-label="Drop zone for JSON file upload"
+              data-testid={testIds.blockEditor.importDropZone}
             >
               {renderDropZoneContent()}
             </div>
@@ -493,14 +495,24 @@ export function ImportGuideModal({ isOpen, onImport, onClose, hasUnsavedChanges 
         {/* Footer */}
         <div className={styles.footer}>
           {(state.file || state.pastedJson.trim()) && (
-            <Button variant="secondary" onClick={handleReset} className={styles.resetButton}>
+            <Button
+              variant="secondary"
+              onClick={handleReset}
+              className={styles.resetButton}
+              data-testid={testIds.blockEditor.importResetButton}
+            >
               {mode === 'file' ? 'Choose different file' : 'Clear'}
             </Button>
           )}
-          <Button variant="secondary" onClick={handleClose}>
+          <Button variant="secondary" onClick={handleClose} data-testid={testIds.blockEditor.importCancelButton}>
             Cancel
           </Button>
-          <Button variant="primary" onClick={handleImportClick} disabled={!state.result?.isValid}>
+          <Button
+            variant="primary"
+            onClick={handleImportClick}
+            disabled={!state.result?.isValid}
+            data-testid={testIds.blockEditor.importButton}
+          >
             {showUnsavedWarning ? 'Confirm import' : 'Import'}
           </Button>
         </div>

--- a/src/components/block-editor/RecordModeOverlay.tsx
+++ b/src/components/block-editor/RecordModeOverlay.tsx
@@ -12,6 +12,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import { generateFullDomPath } from '../../utils/devtools';
 import { DomPathTooltip } from '../DomPathTooltip';
+import { testIds } from '../../constants/testIds';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   banner: css({
@@ -361,7 +362,12 @@ export function RecordModeOverlay({
             Return to start
           </button>
         )}
-        <button className={styles.bannerButton} onClick={handleStopClick} type="button">
+        <button
+          className={styles.bannerButton}
+          onClick={handleStopClick}
+          type="button"
+          data-testid={testIds.blockEditor.recordStopButton}
+        >
           Stop (Esc)
         </button>
       </div>

--- a/src/components/block-editor/forms/CodeBlockForm.tsx
+++ b/src/components/block-editor/forms/CodeBlockForm.tsx
@@ -12,6 +12,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { getBlockFormStyles } from '../block-editor.styles';
 import { TypeSwitchDropdown } from './TypeSwitchDropdown';
+import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock } from '../types';
 import type { JsonCodeBlockBlock } from '../../../types/json-guide.types';
 
@@ -188,7 +189,7 @@ export function CodeBlockForm({
         <Button type="submit" disabled={!isValid}>
           {isEditing ? 'Update' : 'Add'} block
         </Button>
-        <Button variant="secondary" onClick={onCancel}>
+        <Button variant="secondary" onClick={onCancel} data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>
       </div>

--- a/src/components/block-editor/forms/ConditionalBlockForm.tsx
+++ b/src/components/block-editor/forms/ConditionalBlockForm.tsx
@@ -13,6 +13,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { getBlockFormStyles } from '../block-editor.styles';
 import { COMMON_REQUIREMENTS } from '../../../constants/interactive-config';
 import { BranchBlocksEditor } from './BranchBlocksEditor';
+import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock } from '../types';
 import type {
   JsonConditionalBlock,
@@ -422,7 +423,7 @@ export function ConditionalBlockForm({
       )}
 
       <div className={styles.footer}>
-        <Button variant="secondary" onClick={onCancel} type="button">
+        <Button variant="secondary" onClick={onCancel} type="button" data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>
         <Button variant="primary" type="submit" disabled={!isValid}>

--- a/src/components/block-editor/forms/GuidedBlockForm.tsx
+++ b/src/components/block-editor/forms/GuidedBlockForm.tsx
@@ -10,6 +10,7 @@ import { getBlockFormStyles } from '../block-editor.styles';
 import { COMMON_REQUIREMENTS } from '../../../constants/interactive-config';
 import { StepEditor } from './StepEditor';
 import { TypeSwitchDropdown } from './TypeSwitchDropdown';
+import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock, JsonStep } from '../types';
 import type { JsonGuidedBlock } from '../../../types/json-guide.types';
 
@@ -216,7 +217,7 @@ export function GuidedBlockForm({
             )}
           </div>
         )}
-        <Button variant="secondary" onClick={onCancel} type="button">
+        <Button variant="secondary" onClick={onCancel} type="button" data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>
         <Button variant="primary" type="submit" disabled={!isValid}>

--- a/src/components/block-editor/forms/HtmlBlockForm.tsx
+++ b/src/components/block-editor/forms/HtmlBlockForm.tsx
@@ -8,6 +8,7 @@ import React, { useState, useCallback } from 'react';
 import { Button, Field, TextArea, Alert, useStyles2 } from '@grafana/ui';
 import { getBlockFormStyles } from '../block-editor.styles';
 import { TypeSwitchDropdown } from './TypeSwitchDropdown';
+import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock } from '../types';
 import type { JsonHtmlBlock } from '../../../types/json-guide.types';
 
@@ -78,7 +79,7 @@ export function HtmlBlockForm({
             <TypeSwitchDropdown currentType="html" onSwitch={onSwitchBlockType} blockData={initialData} />
           </div>
         )}
-        <Button variant="secondary" onClick={onCancel} type="button">
+        <Button variant="secondary" onClick={onCancel} type="button" data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>
         <Button variant="primary" type="submit" disabled={!isValid}>

--- a/src/components/block-editor/forms/ImageBlockForm.tsx
+++ b/src/components/block-editor/forms/ImageBlockForm.tsx
@@ -9,6 +9,7 @@ import { Button, Field, Input, Alert, useStyles2 } from '@grafana/ui';
 import { getBlockFormStyles } from '../block-editor.styles';
 import { TypeSwitchDropdown } from './TypeSwitchDropdown';
 import { PLACEHOLDER_URL } from '../utils';
+import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock } from '../types';
 import type { JsonImageBlock } from '../../../types/json-guide.types';
 
@@ -135,7 +136,7 @@ export function ImageBlockForm({
             <TypeSwitchDropdown currentType="image" onSwitch={onSwitchBlockType} blockData={initialData} />
           </div>
         )}
-        <Button variant="secondary" onClick={onCancel} type="button">
+        <Button variant="secondary" onClick={onCancel} type="button" data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>
         <Button variant="primary" type="submit" disabled={!isValid}>

--- a/src/components/block-editor/forms/InputBlockForm.tsx
+++ b/src/components/block-editor/forms/InputBlockForm.tsx
@@ -10,6 +10,7 @@ import { Button, Field, Input, TextArea, RadioButtonGroup, Checkbox, Badge, useS
 import { getBlockFormStyles } from '../block-editor.styles';
 import { COMMON_REQUIREMENTS } from '../../../constants/interactive-config';
 import { TypeSwitchDropdown } from './TypeSwitchDropdown';
+import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock } from '../types';
 import type { JsonInputBlock } from '../../../types/json-guide.types';
 
@@ -329,7 +330,7 @@ export function InputBlockForm({
             <TypeSwitchDropdown currentType="input" onSwitch={onSwitchBlockType} blockData={initialData} />
           </div>
         )}
-        <Button variant="secondary" onClick={onCancel} type="button">
+        <Button variant="secondary" onClick={onCancel} type="button" data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>
         <Button variant="primary" type="submit" disabled={!isValid}>

--- a/src/components/block-editor/forms/InteractiveBlockForm.tsx
+++ b/src/components/block-editor/forms/InteractiveBlockForm.tsx
@@ -23,6 +23,7 @@ import { INTERACTIVE_ACTIONS } from '../constants';
 import { COMMON_REQUIREMENTS } from '../../../constants/interactive-config';
 import { TypeSwitchDropdown } from './TypeSwitchDropdown';
 import { suggestDefaultRequirements, mergeRequirements } from './requirements-suggester';
+import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock, JsonInteractiveAction } from '../types';
 import type { JsonInteractiveBlock } from '../../../types/json-guide.types';
 
@@ -468,7 +469,7 @@ export function InteractiveBlockForm({
             <TypeSwitchDropdown currentType="interactive" onSwitch={onSwitchBlockType} blockData={initialData} />
           </div>
         )}
-        <Button variant="secondary" onClick={onCancel} type="button">
+        <Button variant="secondary" onClick={onCancel} type="button" data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>
         <Button variant="primary" type="submit" disabled={!isValid}>

--- a/src/components/block-editor/forms/MultistepBlockForm.tsx
+++ b/src/components/block-editor/forms/MultistepBlockForm.tsx
@@ -10,6 +10,7 @@ import { getBlockFormStyles } from '../block-editor.styles';
 import { COMMON_REQUIREMENTS } from '../../../constants/interactive-config';
 import { StepEditor } from './StepEditor';
 import { TypeSwitchDropdown } from './TypeSwitchDropdown';
+import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock, JsonStep } from '../types';
 import type { JsonMultistepBlock } from '../../../types/json-guide.types';
 
@@ -182,7 +183,7 @@ export function MultistepBlockForm({
             )}
           </div>
         )}
-        <Button variant="secondary" onClick={onCancel} type="button">
+        <Button variant="secondary" onClick={onCancel} type="button" data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>
         <Button variant="primary" type="submit" disabled={!isValid}>

--- a/src/components/block-editor/forms/TerminalBlockForm.tsx
+++ b/src/components/block-editor/forms/TerminalBlockForm.tsx
@@ -10,6 +10,7 @@ import React, { useState, useCallback } from 'react';
 import { Button, Field, Input, TextArea, Checkbox, useStyles2 } from '@grafana/ui';
 import { getBlockFormStyles } from '../block-editor.styles';
 import { TypeSwitchDropdown } from './TypeSwitchDropdown';
+import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock } from '../types';
 import type { JsonTerminalBlock } from '../../../types/json-guide.types';
 
@@ -117,7 +118,7 @@ export function TerminalBlockForm({
         <Button type="submit" disabled={!isValid}>
           {isEditing ? 'Update' : 'Add'} block
         </Button>
-        <Button variant="secondary" onClick={onCancel}>
+        <Button variant="secondary" onClick={onCancel} data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>
       </div>

--- a/src/components/block-editor/forms/TerminalConnectBlockForm.tsx
+++ b/src/components/block-editor/forms/TerminalConnectBlockForm.tsx
@@ -11,6 +11,7 @@ import { Button, Field, Input, Combobox, TextArea, useStyles2, type ComboboxOpti
 import { getBackendSrv } from '@grafana/runtime';
 import { getBlockFormStyles } from '../block-editor.styles';
 import { TypeSwitchDropdown } from './TypeSwitchDropdown';
+import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock } from '../types';
 import type { JsonTerminalConnectBlock } from '../../../types/json-guide.types';
 import { PLUGIN_BACKEND_URL } from '../../../constants';
@@ -167,7 +168,7 @@ export function TerminalConnectBlockForm({
         <Button type="submit" disabled={!isValid}>
           {isEditing ? 'Update' : 'Add'} block
         </Button>
-        <Button variant="secondary" onClick={onCancel}>
+        <Button variant="secondary" onClick={onCancel} data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>
       </div>

--- a/src/components/block-editor/forms/VideoBlockForm.tsx
+++ b/src/components/block-editor/forms/VideoBlockForm.tsx
@@ -10,6 +10,7 @@ import { getBlockFormStyles } from '../block-editor.styles';
 import { VIDEO_PROVIDERS } from '../constants';
 import { TypeSwitchDropdown } from './TypeSwitchDropdown';
 import { PLACEHOLDER_URL } from '../utils';
+import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock } from '../types';
 import type { JsonVideoBlock } from '../../../types/json-guide.types';
 
@@ -156,7 +157,7 @@ export function VideoBlockForm({
             <TypeSwitchDropdown currentType="video" onSwitch={onSwitchBlockType} blockData={initialData} />
           </div>
         )}
-        <Button variant="secondary" onClick={onCancel} type="button">
+        <Button variant="secondary" onClick={onCancel} type="button" data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>
         <Button variant="primary" type="submit" disabled={!isValid}>

--- a/src/components/docs-panel/CustomGuidesSection.tsx
+++ b/src/components/docs-panel/CustomGuidesSection.tsx
@@ -89,7 +89,11 @@ export function CustomGuidesSection({
                         </span>
                       </div>
                       <div className={styles.cardActions}>
-                        <button onClick={() => openCustomGuide(guide)} className={styles.startButton}>
+                        <button
+                          onClick={() => openCustomGuide(guide)}
+                          className={styles.startButton}
+                          data-testid={testIds.contextPanel.customGuideStartButton(index)}
+                        >
                           <Icon name="rocket" size="sm" />
                           {t('contextPanel.start', 'Start')}
                         </button>

--- a/src/components/docs-panel/components/ErrorDisplay.tsx
+++ b/src/components/docs-panel/components/ErrorDisplay.tsx
@@ -41,7 +41,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ error, contentType, 
           <p>{error}</p>
           {isRetryable && onRetry && (
             <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-              <Button size="sm" variant="secondary" onClick={onRetry}>
+              <Button size="sm" variant="secondary" onClick={onRetry} data-testid={testIds.docsPanel.retryButton}>
                 {t('docsPanel.retry', 'Retry')}
               </Button>
               <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>

--- a/src/components/docs-panel/components/TabBarActions.test.tsx
+++ b/src/components/docs-panel/components/TabBarActions.test.tsx
@@ -1,11 +1,11 @@
 /**
  * Tests for TabBarActions component.
- * Tests menu rendering and sidebar close functionality.
+ * Tests menu rendering, sidebar close, and tab switching functionality.
  */
 
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { TabBarActions } from './TabBarActions';
+import { TabBarActions, TabBarActionsProps } from './TabBarActions';
 import { testIds } from '../../../constants/testIds';
 import { PLUGIN_BASE_URL } from '../../../constants';
 
@@ -52,44 +52,114 @@ const {
   __mockConfig: mockConfig,
 } = jest.requireMock('@grafana/runtime');
 
+const defaultRightProps: TabBarActionsProps = {
+  position: 'right',
+  activeTabId: 'recommendations',
+  iconTabClass: 'icon-tab',
+  iconTabActiveClass: 'icon-tab-active',
+  onSetActiveTab: jest.fn(),
+};
+
+const defaultLeftProps: TabBarActionsProps = {
+  position: 'left',
+  activeTabId: 'recommendations',
+  iconTabClass: 'icon-tab',
+  iconTabActiveClass: 'icon-tab-active',
+  onSetActiveTab: jest.fn(),
+};
+
 describe('TabBarActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('rendering', () => {
-    it('renders menu button with correct aria-label', () => {
-      render(<TabBarActions />);
+  describe('right position rendering', () => {
+    it('renders menu button with accessible name', () => {
+      render(<TabBarActions {...defaultRightProps} />);
 
       const menuButton = screen.getByRole('button', { name: 'More options' });
       expect(menuButton).toBeInTheDocument();
     });
 
-    it('renders close button with correct test ID', () => {
-      render(<TabBarActions />);
+    it('renders close button with accessible name', () => {
+      render(<TabBarActions {...defaultRightProps} />);
 
-      const closeButton = screen.getByTestId(testIds.docsPanel.closeButton);
+      const closeButton = screen.getByRole('button', { name: 'Close sidebar' });
       expect(closeButton).toBeInTheDocument();
     });
 
-    it('renders My learning button with correct test ID', () => {
-      render(<TabBarActions />);
+    it('renders my learning button with accessible name', () => {
+      render(<TabBarActions {...defaultRightProps} />);
 
-      const myLearningButton = screen.getByTestId(testIds.docsPanel.myLearningTab);
+      const myLearningButton = screen.getByRole('button', { name: 'My learning' });
       expect(myLearningButton).toBeInTheDocument();
     });
 
+    it('renders editor button with accessible name', () => {
+      render(<TabBarActions {...defaultRightProps} />);
+
+      const editorButton = screen.getByRole('button', { name: 'Guide editor' });
+      expect(editorButton).toBeInTheDocument();
+    });
+
     it('applies className prop to container', () => {
-      const { container } = render(<TabBarActions className="custom-actions-class" />);
+      const { container } = render(<TabBarActions {...defaultRightProps} className="custom-actions-class" />);
 
       const wrapper = container.firstChild as HTMLElement;
       expect(wrapper).toHaveClass('custom-actions-class');
+    });
+
+    it('applies active class to editor button when editor tab is active', () => {
+      render(<TabBarActions {...defaultRightProps} activeTabId="editor" />);
+
+      const editorButton = screen.getByTestId(testIds.docsPanel.tab('editor'));
+      expect(editorButton).toHaveClass('icon-tab-active');
+    });
+
+    it('does not apply active class to editor button when another tab is active', () => {
+      render(<TabBarActions {...defaultRightProps} activeTabId="recommendations" />);
+
+      const editorButton = screen.getByTestId(testIds.docsPanel.tab('editor'));
+      expect(editorButton).not.toHaveClass('icon-tab-active');
+    });
+  });
+
+  describe('left position rendering', () => {
+    it('renders recommendations button with accessible name', () => {
+      render(<TabBarActions {...defaultLeftProps} />);
+
+      const recsButton = screen.getByRole('button', { name: 'Recommendations' });
+      expect(recsButton).toBeInTheDocument();
+    });
+
+    it('applies active class to recommendations button when active', () => {
+      render(<TabBarActions {...defaultLeftProps} activeTabId="recommendations" />);
+
+      const recsButton = screen.getByTestId(testIds.docsPanel.recommendationsTab);
+      expect(recsButton).toHaveClass('icon-tab-active');
+    });
+
+    it('does not apply active class when another tab is active', () => {
+      render(<TabBarActions {...defaultLeftProps} activeTabId="editor" />);
+
+      const recsButton = screen.getByTestId(testIds.docsPanel.recommendationsTab);
+      expect(recsButton).not.toHaveClass('icon-tab-active');
+    });
+
+    it('calls onSetActiveTab with recommendations when clicked', () => {
+      const onSetActiveTab = jest.fn();
+      render(<TabBarActions {...defaultLeftProps} onSetActiveTab={onSetActiveTab} />);
+
+      const recsButton = screen.getByTestId(testIds.docsPanel.recommendationsTab);
+      fireEvent.click(recsButton);
+
+      expect(onSetActiveTab).toHaveBeenCalledWith('recommendations');
     });
   });
 
   describe('close sidebar functionality', () => {
     it('publishes close-extension-sidebar event when close button is clicked', () => {
-      render(<TabBarActions />);
+      render(<TabBarActions {...defaultRightProps} />);
 
       const closeButton = screen.getByTestId(testIds.docsPanel.closeButton);
       fireEvent.click(closeButton);
@@ -103,7 +173,7 @@ describe('TabBarActions', () => {
     it('reports analytics when close button is clicked', () => {
       const { reportAppInteraction, UserInteraction } = require('../../../lib/analytics');
 
-      render(<TabBarActions />);
+      render(<TabBarActions {...defaultRightProps} />);
 
       const closeButton = screen.getByTestId(testIds.docsPanel.closeButton);
       fireEvent.click(closeButton);
@@ -115,9 +185,9 @@ describe('TabBarActions', () => {
     });
   });
 
-  describe('My learning button', () => {
+  describe('my learning button', () => {
     it('navigates to my learning home page when clicked', () => {
-      render(<TabBarActions />);
+      render(<TabBarActions {...defaultRightProps} />);
 
       const myLearningButton = screen.getByTestId(testIds.docsPanel.myLearningTab);
       fireEvent.click(myLearningButton);
@@ -126,15 +196,26 @@ describe('TabBarActions', () => {
     });
   });
 
-  describe('Settings menu item permissions', () => {
+  describe('editor button', () => {
+    it('calls onSetActiveTab with editor when clicked', () => {
+      const onSetActiveTab = jest.fn();
+      render(<TabBarActions {...defaultRightProps} onSetActiveTab={onSetActiveTab} />);
+
+      const editorButton = screen.getByTestId(testIds.docsPanel.tab('editor'));
+      fireEvent.click(editorButton);
+
+      expect(onSetActiveTab).toHaveBeenCalledWith('editor');
+    });
+  });
+
+  describe('settings menu item permissions', () => {
     beforeEach(() => {
-      // Reset mock config to Admin for each test
       mockConfig.bootData.user = { orgRole: 'Admin', isGrafanaAdmin: false };
     });
 
     it('enables Settings menu item for Admin users', () => {
       mockConfig.bootData.user = { orgRole: 'Admin', isGrafanaAdmin: false };
-      render(<TabBarActions />);
+      render(<TabBarActions {...defaultRightProps} />);
 
       const menuButton = screen.getByRole('button', { name: 'More options' });
       fireEvent.click(menuButton);
@@ -145,7 +226,7 @@ describe('TabBarActions', () => {
 
     it('enables Settings menu item for Grafana Admin users', () => {
       mockConfig.bootData.user = { orgRole: 'Viewer', isGrafanaAdmin: true };
-      render(<TabBarActions />);
+      render(<TabBarActions {...defaultRightProps} />);
 
       const menuButton = screen.getByRole('button', { name: 'More options' });
       fireEvent.click(menuButton);
@@ -156,7 +237,7 @@ describe('TabBarActions', () => {
 
     it('disables Settings menu item for Editor users', () => {
       mockConfig.bootData.user = { orgRole: 'Editor', isGrafanaAdmin: false };
-      render(<TabBarActions />);
+      render(<TabBarActions {...defaultRightProps} />);
 
       const menuButton = screen.getByRole('button', { name: 'More options' });
       fireEvent.click(menuButton);
@@ -167,7 +248,7 @@ describe('TabBarActions', () => {
 
     it('disables Settings menu item for Viewer users', () => {
       mockConfig.bootData.user = { orgRole: 'Viewer', isGrafanaAdmin: false };
-      render(<TabBarActions />);
+      render(<TabBarActions {...defaultRightProps} />);
 
       const menuButton = screen.getByRole('button', { name: 'More options' });
       fireEvent.click(menuButton);
@@ -178,7 +259,7 @@ describe('TabBarActions', () => {
 
     it('navigates to settings when enabled item is clicked', () => {
       mockConfig.bootData.user = { orgRole: 'Admin', isGrafanaAdmin: false };
-      render(<TabBarActions />);
+      render(<TabBarActions {...defaultRightProps} />);
 
       const menuButton = screen.getByRole('button', { name: 'More options' });
       fireEvent.click(menuButton);

--- a/src/components/docs-panel/components/TabBarActions.tsx
+++ b/src/components/docs-panel/components/TabBarActions.tsx
@@ -1,11 +1,12 @@
 /**
- * Tab bar actions component for docs-panel.
- * Contains the menu dropdown with feedback and settings options,
- * plus the close sidebar button.
+ * Unified tab bar actions component for docs-panel.
+ * Renders icon buttons for left (recommendations) or right (editor, my learning,
+ * options menu, close) positions. All buttons use the same iconTab/iconTabActive
+ * styles for consistent sizing and highlight behavior.
  */
 
 import React from 'react';
-import { IconButton, Dropdown, Menu, Tooltip } from '@grafana/ui';
+import { Icon, Dropdown, Menu, Tooltip } from '@grafana/ui';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents, locationService } from '@grafana/runtime';
 import { reportAppInteraction, UserInteraction } from '../../../lib/analytics';
@@ -13,15 +14,28 @@ import { PLUGIN_BASE_URL } from '../../../constants';
 import { testIds } from '../../../constants/testIds';
 
 export interface TabBarActionsProps {
-  /** CSS class name for the container */
+  /** Which side of the tab bar to render */
+  position: 'left' | 'right';
+  /** CSS class name for the container wrapper */
   className?: string;
+  /** Currently active tab ID (used for highlight) */
+  activeTabId: string;
+  /** iconTab CSS class */
+  iconTabClass: string;
+  /** iconTabActive CSS class (applied alongside iconTabClass when active) */
+  iconTabActiveClass: string;
+  /** Switch to a tab by ID */
+  onSetActiveTab: (tabId: string) => void;
 }
 
-/**
- * Renders the tab bar action buttons: menu dropdown and close sidebar button.
- * Menu contains feedback and settings options.
- */
-export const TabBarActions: React.FC<TabBarActionsProps> = ({ className }) => {
+export const TabBarActions: React.FC<TabBarActionsProps> = ({
+  position,
+  className,
+  activeTabId,
+  iconTabClass,
+  iconTabActiveClass,
+  onSetActiveTab,
+}) => {
   const user = config.bootData?.user;
   const canAccessPluginSettings = user?.isGrafanaAdmin === true || user?.orgRole === 'Admin';
 
@@ -52,7 +66,6 @@ export const TabBarActions: React.FC<TabBarActionsProps> = ({ className }) => {
       action: 'close_sidebar',
       source: 'header_close_button',
     });
-    // Close the extension sidebar
     const appEvents = getAppEvents();
     appEvents.publish({
       type: 'close-extension-sidebar',
@@ -64,16 +77,44 @@ export const TabBarActions: React.FC<TabBarActionsProps> = ({ className }) => {
     locationService.push(PLUGIN_BASE_URL);
   };
 
+  const tabClass = (isActive: boolean) => `${iconTabClass} ${isActive ? iconTabActiveClass : ''}`;
+
+  if (position === 'left') {
+    return (
+      <div className={className}>
+        <button
+          className={tabClass(activeTabId === 'recommendations')}
+          onClick={() => onSetActiveTab('recommendations')}
+          title={t('docsPanel.recommendations', 'Recommendations')}
+          aria-label={t('docsPanel.recommendations', 'Recommendations')}
+          data-testid={testIds.docsPanel.recommendationsTab}
+        >
+          <Icon name="document-info" size="md" />
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className={className}>
-      <IconButton
-        name="book-open"
-        size="sm"
-        tooltip={t('docsPanel.myLearning', 'My learning')}
+      <button
+        className={tabClass(activeTabId === 'editor')}
+        onClick={() => onSetActiveTab('editor')}
+        title={t('docsPanel.guideEditor', 'Guide editor')}
+        aria-label={t('docsPanel.guideEditor', 'Guide editor')}
+        data-testid={testIds.docsPanel.tab('editor')}
+      >
+        <Icon name="edit" size="md" />
+      </button>
+      <button
+        className={iconTabClass}
         onClick={handleMyLearningClick}
+        title={t('docsPanel.myLearning', 'My learning')}
         aria-label={t('docsPanel.myLearning', 'My learning')}
         data-testid={testIds.docsPanel.myLearningTab}
-      />
+      >
+        <Icon name="book-open" size="md" />
+      </button>
       <Dropdown
         placement="bottom-end"
         overlay={
@@ -98,21 +139,24 @@ export const TabBarActions: React.FC<TabBarActionsProps> = ({ className }) => {
           </Menu>
         }
       >
-        <IconButton
-          name="ellipsis-v"
-          size="sm"
-          aria-label={t('docsPanel.menuAriaLabel', 'More options')}
-          tooltip={t('docsPanel.menuTooltip', 'More options')}
-        />
+        <button
+          className={iconTabClass}
+          title={t('docsPanel.menuTooltip', 'More options')}
+          aria-label={t('docsPanel.menuTooltip', 'More options')}
+          data-testid={testIds.docsPanel.optionsMenuTrigger}
+        >
+          <Icon name="ellipsis-v" size="md" />
+        </button>
       </Dropdown>
-      <IconButton
-        name="times"
-        size="sm"
-        tooltip={t('docsPanel.closeSidebar', 'Close sidebar')}
+      <button
+        className={iconTabClass}
         onClick={handleCloseSidebar}
+        title={t('docsPanel.closeSidebar', 'Close sidebar')}
         aria-label="Close sidebar"
         data-testid={testIds.docsPanel.closeButton}
-      />
+      >
+        <Icon name="times" size="md" />
+      </button>
     </div>
   );
 };

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -93,12 +93,12 @@ export class ContextPanel extends SceneObjectBase<ContextPanelState> {
   public constructor(
     onOpenLearningJourney?: (url: string, title: string) => void,
     onOpenDocsPage?: (url: string, title: string) => void,
-    onOpenDevTools?: () => void
+    onOpenEditor?: () => void
   ) {
     super({
       onOpenLearningJourney,
       onOpenDocsPage,
-      onOpenDevTools,
+      onOpenEditor,
     });
   }
 
@@ -116,9 +116,9 @@ export class ContextPanel extends SceneObjectBase<ContextPanelState> {
     }
   }
 
-  public openDevTools() {
-    if (this.state.onOpenDevTools) {
-      this.state.onOpenDevTools();
+  public openEditor() {
+    if (this.state.onOpenEditor) {
+      this.state.onOpenEditor();
     }
   }
 
@@ -213,6 +213,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
           <Button
             icon="book-open"
             variant="secondary"
+            data-testid={testIds.contextPanel.emptyStateMyLearningButton}
             onClick={() => {
               // Close the extension sidebar
               const appEvents = getAppEvents();
@@ -278,7 +279,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
 
         {/* Featured Recommendations Section - Time-based featured content */}
         {suggestedGuidesExpanded && featuredRecommendations.length > 0 && (
-          <div className={styles.featuredSection} data-testid="featured-section">
+          <div className={styles.featuredSection} data-testid={testIds.contextPanel.featuredSection}>
             <div className={styles.featuredHeader}>
               <Icon name="star" className={styles.featuredIcon} />
               <h3 className={styles.featuredTitle}>{t('contextPanel.featured', 'Featured')}</h3>
@@ -290,7 +291,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                   className={`${styles.recommendationCard} ${styles.featuredCard} ${
                     recommendation.type === 'docs-page' ? styles.compactCard : ''
                   }`}
-                  data-testid={`featured-recommendation-card-${index}`}
+                  data-testid={testIds.contextPanel.featuredCard(index)}
                 >
                   <div
                     className={`${styles.recommendationCardContent} ${
@@ -337,6 +338,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                             }
                           }}
                           className={styles.startButton}
+                          data-testid={testIds.contextPanel.featuredStartButton(index)}
                         >
                           <Icon name={getRecommendationIcon(recommendation.type)} size="sm" />
                           {getRecommendationButtonText(recommendation.type, recommendation.completionPercentage)}
@@ -369,6 +371,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                                 toggleSummaryExpansion(recommendation.url);
                               }}
                               className={styles.summaryButton}
+                              data-testid={testIds.contextPanel.featuredSummaryButton(index)}
                             >
                               <Icon name="info-circle" size="sm" />
                               <span>{t('contextPanel.summary', 'Summary')}</span>

--- a/src/components/docs-panel/docs-panel.contract.test.tsx
+++ b/src/components/docs-panel/docs-panel.contract.test.tsx
@@ -65,7 +65,7 @@ describe('E2E Contract: Docs panel test IDs', () => {
     });
 
     it('tab(id) pattern', () => {
-      expect(testIds.docsPanel.tab('devtools')).toBe('docs-panel-tab-devtools');
+      expect(testIds.docsPanel.tab('editor')).toBe('docs-panel-tab-editor');
     });
 
     it('tabCloseButton(id) pattern', () => {
@@ -116,12 +116,18 @@ const SOURCE_CONTRACT: Array<{ file: string; references: string[] }> = [
       'testIds.docsPanel.tabBar',
       'testIds.docsPanel.tabList',
       'testIds.docsPanel.content',
-      'testIds.docsPanel.recommendationsTab',
       'testIds.docsPanel.tabOverflowButton',
       'testIds.docsPanel.tabDropdown',
       'testIds.docsPanel.tab(',
       'testIds.docsPanel.tabCloseButton(',
       'testIds.docsPanel.tabDropdownItem(',
+      'testIds.docsPanel.editorContent',
+      'testIds.docsPanel.openInNewTabButton',
+      'testIds.docsPanel.refreshTabButton',
+      'testIds.docsPanel.resetGuideButton',
+      'testIds.docsPanel.previousMilestone',
+      'testIds.docsPanel.nextMilestone',
+      'testIds.docsPanel.returnToMyLearning',
       'testIds.devTools.previewBanner',
       'testIds.devTools.previewModeIndicator',
       'testIds.devTools.returnToEditorButton',
@@ -129,10 +135,18 @@ const SOURCE_CONTRACT: Array<{ file: string; references: string[] }> = [
   },
   {
     file: 'components/TabBarActions.tsx',
-    references: ['testIds.docsPanel.closeButton', 'testIds.docsPanel.myLearningTab'],
+    references: [
+      'testIds.docsPanel.closeButton',
+      'testIds.docsPanel.myLearningTab',
+      'testIds.docsPanel.recommendationsTab',
+      'testIds.docsPanel.optionsMenuTrigger',
+    ],
   },
   { file: 'components/LoadingIndicator.tsx', references: ['testIds.docsPanel.loadingState'] },
-  { file: 'components/ErrorDisplay.tsx', references: ['testIds.docsPanel.errorState'] },
+  {
+    file: 'components/ErrorDisplay.tsx',
+    references: ['testIds.docsPanel.errorState', 'testIds.docsPanel.retryButton'],
+  },
 ];
 
 /**
@@ -253,7 +267,7 @@ describe('E2E Contract: Window globals assigned in docs-panel', () => {
 describe.skip('E2E Contract: Docs panel full render (covered by e2e)', () => {
   it.todo('renders container with docs-panel-container');
   it.todo('renders tab bar, tab list, content area with stable test IDs');
-  it.todo('renders recommendations tab; devtools tab when dev mode');
+  it.todo('renders recommendations tab and editor tab; dev tools visible in editor when dev mode');
   it.todo('default active tab is recommendations');
   it.todo('loading state shows docs-panel-loading-state');
   it.todo('error state shows docs-panel-error-state with retry');

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -120,7 +120,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     const contextPanel = new ContextPanel(
       (url: string, title: string) => this.openLearningJourney(url, title),
       (url: string, title: string) => this.openDocsPage(url, title),
-      () => this.openDevToolsTab()
+      () => this.openEditorTab()
     );
 
     super({
@@ -166,7 +166,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
 
   private initializeRestoredActiveTab(): void {
     const activeTab = this.state.tabs.find((t) => t.id === this.state.activeTabId);
-    if (activeTab && activeTab.id !== 'recommendations') {
+    if (activeTab && activeTab.id !== 'recommendations' && activeTab.id !== 'editor') {
       // If we have an active tab but no content, load it
       if (!activeTab.content && !activeTab.isLoading && !activeTab.error) {
         if (isDocsLikeTab(activeTab.type)) {
@@ -180,7 +180,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
 
   private async saveTabsToStorage(): Promise<void> {
     try {
-      // Save user-opened tabs and devtools tab (devtools persists across refreshes)
+      // Save user-opened tabs and editor tab (editor persists across refreshes)
       // Recommendations is a permanent tab and doesn't need persistence
       const tabsToSave: PersistedTabData[] = this.state.tabs
         .filter((tab) => tab.id !== 'recommendations')
@@ -343,9 +343,9 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       }
     }
 
-    // Check if only default tabs remain (recommendations and possibly devtools)
+    // Check if only default tabs remain (recommendations and possibly editor)
     // If so, always default to recommendations
-    const onlyDefaultTabsRemaining = newTabs.every((t) => t.id === 'recommendations' || t.id === 'devtools');
+    const onlyDefaultTabsRemaining = newTabs.every((t) => t.id === 'recommendations' || t.id === 'editor');
     if (onlyDefaultTabsRemaining && newActiveTabId !== 'recommendations') {
       newActiveTabId = 'recommendations';
     }
@@ -416,38 +416,33 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
   }
 
   /**
-   * Open the Dev Tools tab (or switch to it if already open)
-   * The devtools tab is now persisted to storage to survive page refreshes.
+   * Open the editor tab (or switch to it if already open)
+   * The editor tab is persisted to storage to survive page refreshes.
    */
-  public openDevToolsTab(): void {
-    // Check if devtools tab already exists
-    const existingTab = this.state.tabs.find((t) => t.id === 'devtools');
+  public openEditorTab(): void {
+    const existingTab = this.state.tabs.find((t) => t.id === 'editor');
     if (existingTab) {
-      // Just switch to it
-      this.setState({ activeTabId: 'devtools' });
-      // Still save to storage to persist the active tab change
+      this.setState({ activeTabId: 'editor' });
       this.saveTabsToStorage();
       return;
     }
 
-    // Create new devtools tab
     const newTab: LearningJourneyTab = {
-      id: 'devtools',
-      title: 'Dev Tools',
+      id: 'editor',
+      title: 'Guide editor',
       baseUrl: '',
       currentUrl: '',
       content: null,
       isLoading: false,
       error: null,
-      type: 'devtools',
+      type: 'editor',
     };
 
     this.setState({
       tabs: [...this.state.tabs, newTab],
-      activeTabId: 'devtools',
+      activeTabId: 'editor',
     });
 
-    // Save tabs to storage so devtools tab persists across page refreshes
     this.saveTabsToStorage();
   }
 
@@ -724,26 +719,23 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Empty deps - only run once after mount, tabs checked at mount time
 
-  // Ensure devtools tab exists when dev mode is enabled (permanent tab)
+  // Ensure editor tab exists (permanent tab, always visible)
   React.useEffect(() => {
-    if (isDevMode) {
-      const hasDevToolsTab = tabs.some((t) => t.id === 'devtools');
-      if (!hasDevToolsTab) {
-        // Add devtools tab without switching to it
-        const devToolsTab: LearningJourneyTab = {
-          id: 'devtools',
-          title: 'Dev Tools',
-          baseUrl: '',
-          currentUrl: '',
-          content: null,
-          isLoading: false,
-          error: null,
-          type: 'devtools',
-        };
-        model.setState({ tabs: [...tabs, devToolsTab] });
-      }
+    const hasEditorTab = tabs.some((t) => t.id === 'editor');
+    if (!hasEditorTab) {
+      const editorTab: LearningJourneyTab = {
+        id: 'editor',
+        title: 'Guide editor',
+        baseUrl: '',
+        currentUrl: '',
+        content: null,
+        isLoading: false,
+        error: null,
+        type: 'editor',
+      };
+      model.setState({ tabs: [...tabs, editorTab] });
     }
-  }, [isDevMode, tabs, model]);
+  }, [tabs, model]);
 
   // Listen for auto-open events from global link interceptor
   // Place this HERE (not in ContextPanelRenderer) to avoid component remounting issues
@@ -1103,6 +1095,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                   icon="users-alt"
                   onClick={() => setShowPresenterControls(true)}
                   tooltip="Start a live session to broadcast your actions to attendees"
+                  data-testid={testIds.liveSession.startButton}
                 >
                   Start live session
                 </Button>
@@ -1112,6 +1105,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                   icon="user"
                   onClick={() => setShowAttendeeJoin(true)}
                   tooltip="Join an existing live session"
+                  data-testid={testIds.liveSession.joinButton}
                 >
                   Join live session
                 </Button>
@@ -1119,7 +1113,13 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
             )}
             {isSessionActive && sessionRole === 'presenter' && (
               <>
-                <Button size="sm" variant="primary" icon="circle" onClick={() => setShowPresenterControls(true)}>
+                <Button
+                  size="sm"
+                  variant="primary"
+                  icon="circle"
+                  onClick={() => setShowPresenterControls(true)}
+                  data-testid={testIds.liveSession.sessionActiveButton}
+                >
                   Session active
                 </Button>
                 <div ref={handRaiseIndicatorRef}>
@@ -1163,6 +1163,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                           }
                         }}
                         tooltip="Only see highlights when presenter clicks Show Me"
+                        data-testid={testIds.liveSession.guidedButton}
                       >
                         Guided
                       </Button>
@@ -1192,6 +1193,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                           }
                         }}
                         tooltip="Execute actions automatically when presenter clicks Do It"
+                        data-testid={testIds.liveSession.followButton}
                       >
                         Follow
                       </Button>
@@ -1207,6 +1209,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                         }
                       }}
                       tooltip="Leave the live session"
+                      data-testid={testIds.liveSession.leaveButton}
                     >
                       Leave
                     </Button>
@@ -1220,37 +1223,25 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
 
       {/* Tab bar - always show permanent tabs, show guide tabs when open */}
       <div className={styles.tabBar} ref={tabBarRef} data-testid={testIds.docsPanel.tabBar}>
-        {/* Permanent icon-only tabs */}
-        <div className={styles.permanentTabs}>
-          <button
-            className={`${styles.iconTab} ${activeTabId === 'recommendations' ? styles.iconTabActive : ''}`}
-            onClick={() => model.setActiveTab('recommendations')}
-            title={t('docsPanel.recommendations', 'Recommendations')}
-            data-testid={testIds.docsPanel.recommendationsTab}
-          >
-            <Icon name="document-info" size="md" />
-          </button>
-          {isDevMode && (
-            <button
-              className={`${styles.iconTab} ${activeTabId === 'devtools' ? styles.iconTabActive : ''}`}
-              onClick={() => model.setActiveTab('devtools')}
-              title={t('docsPanel.devTools', 'Dev tools')}
-              data-testid={testIds.docsPanel.tab('devtools')}
-            >
-              <Icon name="bug" size="md" />
-            </button>
-          )}
-        </div>
+        {/* Left actions (recommendations) */}
+        <TabBarActions
+          position="left"
+          className={styles.permanentTabs}
+          activeTabId={activeTabId}
+          iconTabClass={styles.iconTab}
+          iconTabActiveClass={styles.iconTabActive}
+          onSetActiveTab={(tabId) => model.setActiveTab(tabId)}
+        />
 
         {/* Divider - only show when there are guide tabs */}
-        {visibleTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools').length > 0 && (
+        {visibleTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'editor').length > 0 && (
           <div className={styles.tabDivider} />
         )}
 
         {/* Guide tabs with titles */}
         <div className={styles.tabList} ref={tabListRef} data-testid={testIds.docsPanel.tabList}>
           {visibleTabs
-            .filter((tab) => tab.id !== 'recommendations' && tab.id !== 'devtools')
+            .filter((tab) => tab.id !== 'recommendations' && tab.id !== 'editor')
             .map((tab) => {
               return (
                 <button
@@ -1261,7 +1252,6 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                   data-testid={testIds.docsPanel.tab(tab.id)}
                 >
                   <div className={styles.tabContent}>
-                    {tab.type === 'devtools' && <Icon name="bug" size="xs" className={styles.tabIcon} />}
                     <span className={styles.tabTitle}>
                       {tab.isLoading ? (
                         <>
@@ -1306,7 +1296,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
             })}
         </div>
 
-        {overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools').length > 0 && (
+        {overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'editor').length > 0 && (
           <div className={styles.tabOverflow}>
             <button
               ref={chevronButtonRef}
@@ -1318,92 +1308,97 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                 setIsDropdownOpen(!isDropdownOpen);
               }}
               aria-label={t('docsPanel.showMoreTabs', 'Show {{count}} more tabs', {
-                count: overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools').length,
+                count: overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'editor').length,
               })}
               aria-expanded={isDropdownOpen}
               aria-haspopup="true"
               data-testid={testIds.docsPanel.tabOverflowButton}
             >
               <Icon name="angle-down" size="sm" />
-              <span>+{overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools').length}</span>
+              <span>+{overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'editor').length}</span>
             </button>
           </div>
         )}
 
-        {isDropdownOpen &&
-          overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools').length > 0 && (
-            <div
-              ref={dropdownRef}
-              className={styles.tabDropdown}
-              role="menu"
-              aria-label={t('docsPanel.moreTabsMenu', 'More tabs')}
-              data-testid={testIds.docsPanel.tabDropdown}
-            >
-              {overflowedTabs
-                .filter((tab) => tab.id !== 'recommendations' && tab.id !== 'devtools')
-                .map((tab) => {
-                  return (
-                    <button
-                      key={tab.id}
-                      className={`${styles.dropdownItem} ${tab.id === activeTabId ? styles.activeDropdownItem : ''}`}
-                      onClick={() => {
-                        model.setActiveTab(tab.id);
-                        setIsDropdownOpen(false);
-                      }}
-                      role="menuitem"
-                      aria-label={t('docsPanel.switchToTab', 'Switch to {{title}}', {
-                        title: getTranslatedTitle(tab.title),
-                      })}
-                      data-testid={testIds.docsPanel.tabDropdownItem(tab.id)}
-                    >
-                      <div className={styles.dropdownItemContent}>
-                        {tab.type === 'devtools' && <Icon name="bug" size="xs" className={styles.dropdownItemIcon} />}
-                        <span className={styles.dropdownItemTitle}>
-                          {tab.isLoading ? (
-                            <>
-                              <Icon name="sync" size="xs" />
-                              <span>{t('docsPanel.loading', 'Loading...')}</span>
-                            </>
-                          ) : (
-                            getTranslatedTitle(tab.title)
-                          )}
-                        </span>
-                        <IconButton
-                          name="times"
-                          size="sm"
-                          aria-label={t('docsPanel.closeTab', 'Close {{title}}', {
-                            title: getTranslatedTitle(tab.title),
-                          })}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            reportAppInteraction(UserInteraction.CloseTabClick, {
-                              content_type: getContentTypeForAnalytics(
-                                tab.currentUrl || tab.baseUrl,
-                                tab.type || 'learning-journey'
-                              ),
-                              tab_title: tab.title,
-                              content_url: tab.currentUrl || tab.baseUrl,
-                              close_location: 'dropdown',
-                              ...(tab.type === 'learning-journey' &&
-                                tab.content && {
-                                  completion_percentage: getJourneyProgress(tab.content),
-                                  current_milestone: tab.content.metadata?.learningJourney?.currentMilestone,
-                                  total_milestones: tab.content.metadata?.learningJourney?.totalMilestones,
-                                }),
-                            });
-                            model.closeTab(tab.id);
-                          }}
-                          className={styles.dropdownItemClose}
-                        />
-                      </div>
-                    </button>
-                  );
-                })}
-            </div>
-          )}
+        {isDropdownOpen && overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'editor').length > 0 && (
+          <div
+            ref={dropdownRef}
+            className={styles.tabDropdown}
+            role="menu"
+            aria-label={t('docsPanel.moreTabsMenu', 'More tabs')}
+            data-testid={testIds.docsPanel.tabDropdown}
+          >
+            {overflowedTabs
+              .filter((tab) => tab.id !== 'recommendations' && tab.id !== 'editor')
+              .map((tab) => {
+                return (
+                  <button
+                    key={tab.id}
+                    className={`${styles.dropdownItem} ${tab.id === activeTabId ? styles.activeDropdownItem : ''}`}
+                    onClick={() => {
+                      model.setActiveTab(tab.id);
+                      setIsDropdownOpen(false);
+                    }}
+                    role="menuitem"
+                    aria-label={t('docsPanel.switchToTab', 'Switch to {{title}}', {
+                      title: getTranslatedTitle(tab.title),
+                    })}
+                    data-testid={testIds.docsPanel.tabDropdownItem(tab.id)}
+                  >
+                    <div className={styles.dropdownItemContent}>
+                      <span className={styles.dropdownItemTitle}>
+                        {tab.isLoading ? (
+                          <>
+                            <Icon name="sync" size="xs" />
+                            <span>{t('docsPanel.loading', 'Loading...')}</span>
+                          </>
+                        ) : (
+                          getTranslatedTitle(tab.title)
+                        )}
+                      </span>
+                      <IconButton
+                        name="times"
+                        size="sm"
+                        aria-label={t('docsPanel.closeTab', 'Close {{title}}', {
+                          title: getTranslatedTitle(tab.title),
+                        })}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          reportAppInteraction(UserInteraction.CloseTabClick, {
+                            content_type: getContentTypeForAnalytics(
+                              tab.currentUrl || tab.baseUrl,
+                              tab.type || 'learning-journey'
+                            ),
+                            tab_title: tab.title,
+                            content_url: tab.currentUrl || tab.baseUrl,
+                            close_location: 'dropdown',
+                            ...(tab.type === 'learning-journey' &&
+                              tab.content && {
+                                completion_percentage: getJourneyProgress(tab.content),
+                                current_milestone: tab.content.metadata?.learningJourney?.currentMilestone,
+                                total_milestones: tab.content.metadata?.learningJourney?.totalMilestones,
+                              }),
+                          });
+                          model.closeTab(tab.id);
+                        }}
+                        className={styles.dropdownItemClose}
+                      />
+                    </div>
+                  </button>
+                );
+              })}
+          </div>
+        )}
 
-        {/* Menu and close actions */}
-        <TabBarActions className={styles.tabBarActions} />
+        {/* Right actions (editor, my learning, menu, close) */}
+        <TabBarActions
+          position="right"
+          className={styles.tabBarActions}
+          activeTabId={activeTabId}
+          iconTabClass={styles.iconTab}
+          iconTabActiveClass={styles.iconTabActive}
+          onSetActiveTab={(tabId) => model.setActiveTab(tabId)}
+        />
       </div>
 
       <div className={styles.content} data-testid={testIds.docsPanel.content}>
@@ -1413,12 +1408,13 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
             return <contextPanel.Component model={contextPanel} />;
           }
 
-          // Show dev tools tab
-          if (activeTabId === 'devtools') {
+          // Show editor tab
+          if (activeTabId === 'editor') {
             return (
-              <div className={styles.devToolsContent} data-testid="devtools-tab-content">
+              <div className={styles.devToolsContent} data-testid={testIds.docsPanel.editorContent}>
                 <Suspense fallback={<SkeletonLoader type="recommendations" />}>
                   <SelectorDebugPanel
+                    isDevMode={isDevMode}
                     onOpenDocsPage={(url: string, title: string) => model.openDocsPage(url, title, true)}
                     onOpenLearningJourney={(url: string, title: string) => model.openLearningJourney(url, title)}
                   />
@@ -1468,7 +1464,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                     </div>
                     <button
                       className={styles.returnToEditorButton}
-                      onClick={() => model.openDevToolsTab()}
+                      onClick={() => model.openEditorTab()}
                       data-testid={testIds.devTools.returnToEditorButton}
                     >
                       <Icon name="arrow-left" size="sm" />
@@ -1518,6 +1514,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                             <button
                               className={styles.secondaryActionButton}
                               aria-label={t('docsPanel.openInNewTab', 'Open this page in new tab')}
+                              data-testid={testIds.docsPanel.openInNewTabButton}
                               onClick={() => {
                                 reportAppInteraction(UserInteraction.OpenExtraResource, {
                                   content_url: cleanUrl,
@@ -1544,6 +1541,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                         <IconButton
                           tooltip="Refresh tab (dev mode only)"
                           name="sync"
+                          data-testid={testIds.docsPanel.refreshTabButton}
                           onClick={() => {
                             if (activeTab) {
                               reloadActiveTab(activeTab);
@@ -1556,6 +1554,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                           className={styles.secondaryActionButton}
                           aria-label={t('docsPanel.resetGuide', 'Reset guide')}
                           title={t('docsPanel.resetGuideTooltip', 'Resets all interactive steps')}
+                          data-testid={testIds.docsPanel.resetGuideButton}
                           onClick={async () => {
                             if (progressKey && activeTab) {
                               await handleResetGuide(progressKey, activeTab);
@@ -1587,6 +1586,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                           name="arrow-left"
                           size="sm"
                           aria-label={t('docsPanel.previousMilestone', 'Previous milestone')}
+                          data-testid={testIds.docsPanel.previousMilestone}
                           onClick={() => {
                             reportAppInteraction(UserInteraction.MilestoneArrowInteractionClick, {
                               content_title: activeTab.title,
@@ -1619,6 +1619,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                           name="arrow-right"
                           size="sm"
                           aria-label={t('docsPanel.nextMilestone', 'Next milestone')}
+                          data-testid={testIds.docsPanel.nextMilestone}
                           onClick={() => {
                             reportAppInteraction(UserInteraction.MilestoneArrowInteractionClick, {
                               content_title: activeTab.title,
@@ -1765,6 +1766,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                       variant="secondary"
                       icon="book-open"
                       size="md"
+                      data-testid={testIds.docsPanel.returnToMyLearning}
                       onClick={() => {
                         window.location.assign(PLUGIN_BASE_URL);
                       }}

--- a/src/components/docs-panel/types.ts
+++ b/src/components/docs-panel/types.ts
@@ -46,8 +46,8 @@ export interface DocsPanelModelOperations {
   /** Check if navigation to previous milestone is possible */
   canNavigatePrevious(): boolean;
 
-  /** Open the dev tools tab (or switch to it if already open) */
-  openDevToolsTab(): void;
+  /** Open the editor tab (or switch to it if already open) */
+  openEditorTab(): void;
 
   /** Get the currently active tab */
   getActiveTab(): LearningJourneyTab | null;

--- a/src/components/docs-panel/utils/tab-storage-restore.test.ts
+++ b/src/components/docs-panel/utils/tab-storage-restore.test.ts
@@ -93,23 +93,43 @@ describe('tab-storage-restore', () => {
       expect(tabs[1]!.type).toBe('learning-journey');
     });
 
-    it('should restore devtools tab without URL validation', async () => {
+    it('should restore editor tab without URL validation', async () => {
       const persistedTabs: PersistedTabData[] = [
         {
-          id: 'devtools',
-          title: 'Dev Tools',
+          id: 'editor',
+          title: 'Guide editor',
           baseUrl: '',
           currentUrl: '',
-          type: 'devtools',
+          type: 'editor',
         },
       ];
 
       const storage = createMockTabStorage(persistedTabs);
       const tabs = await restoreTabsFromStorage(storage, { isDevMode: false });
 
-      expect(tabs).toHaveLength(2); // recommendations + devtools
-      expect(tabs[1]!.id).toBe('devtools');
-      expect(tabs[1]!.type).toBe('devtools');
+      expect(tabs).toHaveLength(2); // recommendations + editor
+      expect(tabs[1]!.id).toBe('editor');
+      expect(tabs[1]!.type).toBe('editor');
+    });
+
+    it('should migrate old devtools tab type to editor', async () => {
+      const persistedTabs: PersistedTabData[] = [
+        {
+          id: 'devtools',
+          title: 'Dev Tools',
+          baseUrl: '',
+          currentUrl: '',
+          type: 'devtools' as any,
+        },
+      ];
+
+      const storage = createMockTabStorage(persistedTabs);
+      const tabs = await restoreTabsFromStorage(storage, { isDevMode: false });
+
+      expect(tabs).toHaveLength(2);
+      expect(tabs[1]!.id).toBe('editor');
+      expect(tabs[1]!.type).toBe('editor');
+      expect(tabs[1]!.title).toBe('Guide editor');
     });
 
     it('should reject tabs with invalid base URL', async () => {
@@ -204,11 +224,11 @@ describe('tab-storage-restore', () => {
           type: 'learning-journey',
         },
         {
-          id: 'devtools',
-          title: 'Dev Tools',
+          id: 'editor',
+          title: 'Guide editor',
           baseUrl: '',
           currentUrl: '',
-          type: 'devtools',
+          type: 'editor',
         },
       ];
 
@@ -249,6 +269,32 @@ describe('tab-storage-restore', () => {
       const tabs = await restoreTabsFromStorage(storage, { isDevMode: false });
 
       expect(tabs[1]!.currentUrl).toBe('https://grafana.com/docs/grafana/latest/test/');
+    });
+
+    it('should deduplicate when storage contains both editor and devtools entries', async () => {
+      const persistedTabs: PersistedTabData[] = [
+        {
+          id: 'editor',
+          title: 'Guide editor',
+          baseUrl: '',
+          currentUrl: '',
+          type: 'editor',
+        },
+        {
+          id: 'devtools',
+          title: 'Dev Tools',
+          baseUrl: '',
+          currentUrl: '',
+          type: 'devtools' as any,
+        },
+      ];
+
+      const storage = createMockTabStorage(persistedTabs);
+      const tabs = await restoreTabsFromStorage(storage, { isDevMode: false });
+
+      expect(tabs).toHaveLength(2); // recommendations + single editor tab
+      const editorTabs = tabs.filter((t) => t.id === 'editor');
+      expect(editorTabs).toHaveLength(1);
     });
 
     it('should default to learning-journey type when type is missing', async () => {
@@ -317,7 +363,35 @@ describe('tab-storage-restore', () => {
       expect(activeTabId).toBe('tab-1');
     });
 
-    it('should restore devtools as active tab if it exists', async () => {
+    it('should restore editor as active tab if it exists', async () => {
+      const storage = createMockTabStorage(null, 'editor');
+      const tabs = [
+        {
+          id: 'recommendations',
+          title: 'Recommendations',
+          baseUrl: '',
+          currentUrl: '',
+          content: null,
+          isLoading: false,
+          error: null,
+        },
+        {
+          id: 'editor',
+          title: 'Guide editor',
+          baseUrl: '',
+          currentUrl: '',
+          content: null,
+          isLoading: false,
+          error: null,
+          type: 'editor' as const,
+        },
+      ];
+
+      const activeTabId = await restoreActiveTabFromStorage(storage, tabs);
+      expect(activeTabId).toBe('editor');
+    });
+
+    it('should migrate old devtools active tab ID to editor', async () => {
       const storage = createMockTabStorage(null, 'devtools');
       const tabs = [
         {
@@ -330,19 +404,19 @@ describe('tab-storage-restore', () => {
           error: null,
         },
         {
-          id: 'devtools',
-          title: 'Dev Tools',
+          id: 'editor',
+          title: 'Guide editor',
           baseUrl: '',
           currentUrl: '',
           content: null,
           isLoading: false,
           error: null,
-          type: 'devtools' as const,
+          type: 'editor' as const,
         },
       ];
 
       const activeTabId = await restoreActiveTabFromStorage(storage, tabs);
-      expect(activeTabId).toBe('devtools');
+      expect(activeTabId).toBe('editor');
     });
 
     it('should default to recommendations when stored active tab does not exist', async () => {

--- a/src/components/docs-panel/utils/tab-storage-restore.ts
+++ b/src/components/docs-panel/utils/tab-storage-restore.ts
@@ -93,20 +93,26 @@ export async function restoreTabsFromStorage(
     ];
 
     const validateUrl = createUrlValidator(options.isDevMode);
+    let hasEditorTab = false;
 
     parsedData.forEach((data: PersistedTabData) => {
-      // Handle devtools tab specially - it has no URLs to validate
-      if (data.type === 'devtools') {
-        tabs.push({
-          id: 'devtools',
-          title: 'Dev Tools',
-          baseUrl: '',
-          currentUrl: '',
-          content: null,
-          isLoading: false,
-          error: null,
-          type: 'devtools',
-        });
+      // Handle editor tab specially - it has no URLs to validate.
+      // Accept old 'devtools' type for backward compat and migrate to 'editor'.
+      // Only add one editor tab even if storage contains both types.
+      if (data.type === 'editor' || (data.type as string) === 'devtools') {
+        if (!hasEditorTab) {
+          hasEditorTab = true;
+          tabs.push({
+            id: 'editor',
+            title: 'Guide editor',
+            baseUrl: '',
+            currentUrl: '',
+            content: null,
+            isLoading: false,
+            error: null,
+            type: 'editor',
+          });
+        }
         return;
       }
 
@@ -166,12 +172,11 @@ export async function restoreActiveTabFromStorage(tabStorage: TabStorage, tabs: 
     const activeTabId = await tabStorage.getActiveTab();
 
     if (activeTabId) {
-      const tabExists = tabs.some((t) => t.id === activeTabId);
+      // Migrate old 'devtools' active tab ID to 'editor'
+      const resolvedTabId = activeTabId === 'devtools' ? 'editor' : activeTabId;
+      const tabExists = tabs.some((t) => t.id === resolvedTabId);
 
-      // Restore the stored tab if it exists (including devtools - it should persist like normal tabs)
-      // The closeTab method ensures that when all tabs are closed, 'recommendations' is saved to storage
-      // So if storage has 'devtools', it means the user was legitimately on devtools when they refreshed
-      return tabExists ? activeTabId : 'recommendations';
+      return tabExists ? resolvedTabId : 'recommendations';
     }
   } catch (error) {
     console.error('Failed to restore active tab from storage:', error);

--- a/src/components/docs-panel/utils/tab-validation.test.ts
+++ b/src/components/docs-panel/utils/tab-validation.test.ts
@@ -21,8 +21,8 @@ describe('isDocsLikeTab', () => {
       expect(isDocsLikeTab('learning-journey')).toBe(false);
     });
 
-    it('returns false for "devtools" type', () => {
-      expect(isDocsLikeTab('devtools')).toBe(false);
+    it('returns false for "editor" type', () => {
+      expect(isDocsLikeTab('editor')).toBe(false);
     });
 
     it('returns false for undefined', () => {

--- a/src/components/docs-panel/utils/tab-visibility.test.ts
+++ b/src/components/docs-panel/utils/tab-visibility.test.ts
@@ -20,6 +20,7 @@ function tab(id: string, title: string): LearningJourneyTab {
 
 describe('computeTabVisibility', () => {
   const recs = tab('recommendations', 'Recommendations');
+  const editor = tab('editor', 'Guide editor');
   const guide1 = tab('guide-1', 'Guide 1');
   const guide2 = tab('guide-2', 'Guide 2');
   const guide3 = tab('guide-3', 'Guide 3');
@@ -27,6 +28,13 @@ describe('computeTabVisibility', () => {
   describe('when only permanent tabs exist', () => {
     it('returns all tabs as visible and no overflow', () => {
       const tabs = [recs];
+      const result = computeTabVisibility(tabs, 500, 'recommendations');
+      expect(result.visibleTabs).toEqual(tabs);
+      expect(result.overflowedTabs).toEqual([]);
+    });
+
+    it('returns recommendations and editor as visible', () => {
+      const tabs = [recs, editor];
       const result = computeTabVisibility(tabs, 500, 'recommendations');
       expect(result.visibleTabs).toEqual(tabs);
       expect(result.overflowedTabs).toEqual([]);
@@ -86,6 +94,24 @@ describe('computeTabVisibility', () => {
       const result = computeTabVisibility(tabs, 300, 'guide-1');
       expect(result.visibleTabs[0]).toEqual(recs);
       expect(result.visibleTabs[1]).toEqual(guide1);
+    });
+  });
+
+  describe('editor tab handling', () => {
+    it('includes editor in visible alongside guide tabs', () => {
+      const tabs = [recs, editor, guide1, guide2];
+      const result = computeTabVisibility(tabs, 200, 'guide-1');
+      expect(result.visibleTabs).toContainEqual(editor);
+      expect(result.overflowedTabs).not.toContainEqual(editor);
+    });
+
+    it('never places editor in overflow even when space is tight', () => {
+      const tabs = [recs, editor, guide1, guide2, guide3];
+      const result = computeTabVisibility(tabs, 200, 'guide-3');
+      expect(result.visibleTabs).toContainEqual(recs);
+      expect(result.visibleTabs).toContainEqual(editor);
+      expect(result.overflowedTabs).not.toContainEqual(recs);
+      expect(result.overflowedTabs).not.toContainEqual(editor);
     });
   });
 });

--- a/src/components/docs-panel/utils/tab-visibility.ts
+++ b/src/components/docs-panel/utils/tab-visibility.ts
@@ -17,7 +17,7 @@ export interface TabVisibilityResult {
 
 /**
  * Computes which tabs fit in the visible area and which move to overflow.
- * Permanent tabs (recommendations, devtools) are always in visibleTabs;
+ * Permanent tabs (recommendations, editor) are always in visibleTabs;
  * guide tabs are split by available width, with the active tab forced visible if it would be overflowed.
  */
 export function computeTabVisibility(
@@ -25,9 +25,9 @@ export function computeTabVisibility(
   containerWidth: number,
   activeTabId: string
 ): TabVisibilityResult {
-  const guideTabs = tabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools');
+  const guideTabs = tabs.filter((t) => t.id !== 'recommendations' && t.id !== 'editor');
 
-  const permanentTabs = tabs.filter((t) => t.id === 'recommendations');
+  const permanentTabs = tabs.filter((t) => t.id === 'recommendations' || t.id === 'editor');
 
   if (guideTabs.length === 0) {
     return { visibleTabs: tabs, overflowedTabs: [] };

--- a/src/components/interactive-tutorial/code-block-step.tsx
+++ b/src/components/interactive-tutorial/code-block-step.tsx
@@ -266,7 +266,13 @@ export const CodeBlockStep = forwardRef<
           <div className={styles.requirementMessage}>
             {checker.explanation}
             {skippable && (
-              <Button size="sm" variant="secondary" fill="text" onClick={markComplete}>
+              <Button
+                size="sm"
+                variant="secondary"
+                fill="text"
+                onClick={markComplete}
+                data-testid={testIds.interactive.skipButton(renderedStepId)}
+              >
                 Skip
               </Button>
             )}

--- a/src/components/interactive-tutorial/input-block.tsx
+++ b/src/components/interactive-tutorial/input-block.tsx
@@ -12,6 +12,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { useGuideResponsesOptional } from '../../docs-retrieval';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import { testIds } from '../../constants/testIds';
 
 /** Props for the InputBlock component */
 export interface InputBlockProps {
@@ -402,7 +403,12 @@ export function InputBlock({
         return (
           <div className={styles.inputContainer}>
             <Field label="" invalid={!!validationError} error={validationError}>
-              <Input value={textValue} onChange={handleTextChange} placeholder={placeholder} />
+              <Input
+                value={textValue}
+                onChange={handleTextChange}
+                placeholder={placeholder}
+                data-testid={testIds.interactive.inputField(variableName)}
+              />
             </Field>
           </div>
         );
@@ -453,7 +459,12 @@ export function InputBlock({
       {/* Actions - same for all input types */}
       <div className={styles.buttonContainer}>
         {skippable && !required && !isSaved && (
-          <Button variant="secondary" size="sm" onClick={handleSkip}>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleSkip}
+            data-testid={testIds.interactive.inputSkipButton(variableName)}
+          >
             Skip
           </Button>
         )}
@@ -466,12 +477,22 @@ export function InputBlock({
         )}
 
         {isSaved && (
-          <Button variant="secondary" size="sm" onClick={handleReset}>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleReset}
+            data-testid={testIds.interactive.inputResetButton(variableName)}
+          >
             Reset
           </Button>
         )}
 
-        <Button variant="primary" size="sm" onClick={handleSave}>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={handleSave}
+          data-testid={testIds.interactive.inputSaveButton(variableName)}
+        >
           {isSaved ? 'Update' : 'Save'}
         </Button>
       </div>

--- a/src/components/interactive-tutorial/interactive-quiz.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.tsx
@@ -466,7 +466,13 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
         )}
 
         {canSkip && !isCompleted && (
-          <Button variant="secondary" fill="text" onClick={handleSkip} disabled={disabled}>
+          <Button
+            variant="secondary"
+            fill="text"
+            onClick={handleSkip}
+            disabled={disabled}
+            data-testid={testIds.interactive.quizSkipButton(stepId)}
+          >
             Skip
           </Button>
         )}

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -162,8 +162,12 @@ export function InteractiveSection({
   // Detect if we're in preview mode (block editor preview)
   // Preview mode uses a special URL pattern: block-editor://preview/{guide-id}
   const isPreviewMode = useMemo(() => {
+    const activeTabId = (window as any).__DocsPluginActiveTabId as string | undefined;
+    if (activeTabId === 'editor') {
+      return true;
+    }
     const contentKey = getContentKey();
-    return contentKey.indexOf('devtools') > -1 || contentKey.startsWith('block-editor://preview/');
+    return contentKey.startsWith('block-editor://preview/');
   }, []);
 
   // Persist completed steps using new user storage system
@@ -1631,6 +1635,7 @@ export function InteractiveSection({
             type="button"
             title={isCollapsed ? 'Expand section' : 'Collapse section'}
             aria-label={isCollapsed ? 'Expand section' : 'Collapse section'}
+            data-testid={testIds.interactive.sectionToggle(sectionId)}
           >
             <span className="interactive-section-toggle-icon">{isCollapsed ? '▶' : '▼'}</span>
           </button>

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -1004,12 +1004,13 @@ export const InteractiveStep = forwardRef<
 
         {/* Lazy scroll failure message with retry */}
         {!isCompletedWithObjectives && lazyScrollError && (
-          <div className="interactive-step-lazy-error" data-testid={`lazy-scroll-error-${renderedStepId}`}>
+          <div className="interactive-step-lazy-error">
             <span className="interactive-lazy-error-text">{lazyScrollError}</span>
             <button
               className="interactive-lazy-retry-btn"
               onClick={handleLazyScrollRetry}
               disabled={isShowRunning || isDoRunning}
+              data-testid={testIds.interactive.lazyScrollRetryButton(renderedStepId)}
             >
               Retry
             </button>

--- a/src/components/interactive-tutorial/terminal-connect-step.tsx
+++ b/src/components/interactive-tutorial/terminal-connect-step.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useCallback, useEffect, forwardRef, useImperativeHandle, useRef } from 'react';
 import { Button, Icon, useStyles2 } from '@grafana/ui';
+import { testIds } from '../../constants/testIds';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 
@@ -216,7 +217,7 @@ export const TerminalConnectStep = forwardRef<
       <div
         className={containerClasses}
         data-test-step-state={stepState}
-        data-testid={`terminal-connect-step-${renderedStepId}`}
+        data-testid={testIds.interactive.terminalConnectStep(renderedStepId)}
       >
         {children && <div className={styles.content}>{children}</div>}
 
@@ -227,7 +228,12 @@ export const TerminalConnectStep = forwardRef<
                 <span className={`${styles.statusText} ${styles.connectedText}`}>
                   <Icon name="check" size="sm" /> Connected
                 </span>
-                <Button size="sm" variant="secondary" onClick={markComplete}>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={markComplete}
+                  data-testid={testIds.interactive.terminalSkipButton(renderedStepId)}
+                >
                   Continue
                 </Button>
               </>

--- a/src/components/interactive-tutorial/terminal-step.tsx
+++ b/src/components/interactive-tutorial/terminal-step.tsx
@@ -8,6 +8,7 @@
 
 import React, { useState, useCallback, forwardRef, useImperativeHandle, useRef, useMemo } from 'react';
 import { Button, Icon, useStyles2 } from '@grafana/ui';
+import { testIds } from '../../constants/testIds';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 
@@ -254,7 +255,7 @@ export const TerminalStep = forwardRef<
       <div
         className={containerClasses}
         data-test-step-state={stepState}
-        data-testid={`terminal-step-${renderedStepId}`}
+        data-testid={testIds.interactive.terminalStep(renderedStepId)}
       >
         {/* Description content */}
         {children && <div className={styles.content}>{children}</div>}
@@ -269,7 +270,13 @@ export const TerminalStep = forwardRef<
           <div className={styles.requirementMessage}>
             {checker.explanation}
             {skippable && (
-              <Button size="sm" variant="secondary" fill="text" onClick={markComplete}>
+              <Button
+                size="sm"
+                variant="secondary"
+                fill="text"
+                onClick={markComplete}
+                data-testid={testIds.interactive.terminalSkipButton(renderedStepId)}
+              >
                 Skip
               </Button>
             )}
@@ -279,7 +286,14 @@ export const TerminalStep = forwardRef<
         {/* Actions */}
         {isEnabled && !isCompleted && (
           <div className={styles.actions}>
-            <Button size="sm" variant="secondary" icon="copy" onClick={handleCopy} tooltip="Copy command to clipboard">
+            <Button
+              size="sm"
+              variant="secondary"
+              icon="copy"
+              onClick={handleCopy}
+              tooltip="Copy command to clipboard"
+              data-testid={testIds.interactive.terminalCopyButton(renderedStepId)}
+            >
               Copy
             </Button>
 

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -38,6 +38,15 @@ export const testIds = {
     recommendationsTab: 'docs-panel-tab-recommendations',
     loadingState: 'docs-panel-loading-state',
     errorState: 'docs-panel-error-state',
+    editorContent: 'docs-panel-editor-content',
+    optionsMenuTrigger: 'docs-panel-options-menu-trigger',
+    openInNewTabButton: 'docs-panel-open-new-tab',
+    resetGuideButton: 'docs-panel-reset-guide',
+    refreshTabButton: 'docs-panel-refresh-tab',
+    retryButton: 'docs-panel-retry-button',
+    previousMilestone: 'docs-panel-previous-milestone',
+    nextMilestone: 'docs-panel-next-milestone',
+    returnToMyLearning: 'docs-panel-return-to-my-learning',
   },
 
   // Context Panel - Recommendations and content
@@ -61,22 +70,26 @@ export const testIds = {
     customGuidesToggle: 'context-panel-custom-guides-toggle',
     customGuidesList: 'context-panel-custom-guides-list',
     customGuideItem: (index: number) => `context-panel-custom-guide-item-${index}`,
+    customGuideStartButton: (index: number) => `context-panel-custom-guide-start-${index}`,
     suggestedGuidesToggle: 'context-panel-suggested-guides-toggle',
     otherDocsSection: 'context-panel-other-docs-section',
     otherDocsToggle: 'context-panel-other-docs-toggle',
     otherDocsList: 'context-panel-other-docs-list',
     otherDocItem: (index: number) => `context-panel-other-doc-item-${index}`,
     emptyState: 'context-panel-empty-state',
+    emptyStateMyLearningButton: 'context-panel-empty-state-my-learning',
     errorAlert: 'context-panel-error-alert',
+    featuredSection: 'context-panel-featured-section',
+    featuredCard: (index: number) => `context-panel-featured-card-${index}`,
+    featuredStartButton: (index: number) => `context-panel-featured-start-${index}`,
+    featuredSummaryButton: (index: number) => `context-panel-featured-summary-${index}`,
   },
 
   // Dev Tools / Block Editor
   devTools: {
-    // Preview banner
     previewBanner: 'dev-tools-preview-banner',
     previewModeIndicator: 'dev-tools-preview-mode-indicator',
     returnToEditorButton: 'dev-tools-return-to-editor',
-    // Full screen mode (used by element picker and recording)
     fullScreen: {
       domPathTooltip: 'dev-tools-fullscreen-tooltip',
       minimizedSidebar: {
@@ -87,9 +100,20 @@ export const testIds = {
     },
   },
 
-  // interactive guide Elements
+  // Editor Panel (SelectorDebugPanel)
+  editorPanel: {
+    container: 'editor-panel-container',
+    devModeHeader: 'editor-panel-dev-mode-header',
+    leaveDevModeButton: 'editor-panel-leave-dev-mode',
+    blockEditorSection: 'editor-panel-block-editor-section',
+    prTesterSection: 'editor-panel-pr-tester-section',
+    urlTesterSection: 'editor-panel-url-tester-section',
+  },
+
+  // Interactive guide elements
   interactive: {
     section: (sectionId: string) => `interactive-section-${sectionId}`,
+    sectionToggle: (sectionId: string) => `interactive-section-toggle-${sectionId}`,
     step: (stepId: string) => `interactive-step-${stepId}`,
     showMeButton: (stepId: string) => `interactive-show-me-${stepId}`,
     doItButton: (stepId: string) => `interactive-do-it-${stepId}`,
@@ -108,10 +132,20 @@ export const testIds = {
     quiz: (quizId: string) => `interactive-quiz-${quizId}`,
     quizChoice: (quizId: string, choiceId: string) => `interactive-quiz-${quizId}-choice-${choiceId}`,
     quizCheckButton: (quizId: string) => `interactive-quiz-check-${quizId}`,
+    quizSkipButton: (quizId: string) => `interactive-quiz-skip-${quizId}`,
     conditional: (conditionalId: string) => `interactive-conditional-${conditionalId}`,
+    inputField: (stepId: string) => `interactive-input-${stepId}`,
+    inputSaveButton: (stepId: string) => `interactive-input-save-${stepId}`,
+    inputResetButton: (stepId: string) => `interactive-input-reset-${stepId}`,
+    inputSkipButton: (stepId: string) => `interactive-input-skip-${stepId}`,
+    terminalStep: (stepId: string) => `interactive-terminal-${stepId}`,
+    terminalConnectStep: (stepId: string) => `interactive-terminal-connect-${stepId}`,
+    terminalSkipButton: (stepId: string) => `interactive-terminal-skip-${stepId}`,
+    terminalCopyButton: (stepId: string) => `interactive-terminal-copy-${stepId}`,
+    lazyScrollRetryButton: (stepId: string) => `interactive-lazy-retry-${stepId}`,
   },
 
-  // Code Block Step - for inserting code into Monaco editors
+  // Code Block Step
   codeBlock: {
     step: (stepId: string) => `code-block-step-${stepId}`,
     showMeButton: (stepId: string) => `code-block-show-me-${stepId}`,
@@ -120,13 +154,24 @@ export const testIds = {
 
   // App Configuration
   appConfig: {
+    form: 'config-form',
     recommenderServiceUrl: 'config-recommender-service-url',
     tutorialUrl: 'config-tutorial-url',
     submit: 'config-submit',
-    // Legacy fields for backward compatibility
     apiKey: 'config-api-key',
     apiUrl: 'config-api-url',
-    // Interactive Features
+    devModeToggle: 'config-dev-mode-toggle',
+    assistantDevModeToggle: 'config-assistant-dev-mode-toggle',
+    globalLinkInterception: 'config-global-link-interception',
+    openPanelOnLaunch: 'config-open-panel-on-launch',
+    liveSessionsToggle: 'config-live-sessions-toggle',
+    peerjsHost: 'config-peerjs-host',
+    peerjsPort: 'config-peerjs-port',
+    peerjsKey: 'config-peerjs-key',
+    codaTerminalToggle: 'config-coda-terminal-toggle',
+    codaApiUrl: 'config-coda-api-url',
+    codaRelayUrl: 'config-coda-relay-url',
+    codaEnrollmentKey: 'config-coda-enrollment-key',
     interactiveFeatures: {
       toggle: 'config-interactive-auto-detection-toggle',
       debounce: 'config-interactive-debounce-input',
@@ -145,27 +190,162 @@ export const testIds = {
     termsContent: 'terms-content',
   },
 
-  // Block Editor - E2E test selectors for dev tools block editor
+  // Block Editor
   blockEditor: {
-    // Modals
+    container: 'block-editor-container',
+    content: 'block-editor-content',
+    palette: 'block-editor-palette',
+    jsonEditor: 'block-editor-json-editor',
     addBlockModal: 'block-editor-add-block-modal',
     blockFormModal: 'block-editor-form-modal',
-    // Palette
     addBlockButton: 'block-editor-add-block-button',
-    // Form controls
     submitButton: 'block-editor-submit-button',
     blockTypeButton: (type: string) => `block-editor-type-${type}`,
-    // Markdown form
     rawMarkdownTab: 'block-editor-raw-markdown-tab',
     richMarkdownTab: 'block-editor-rich-markdown-tab',
     markdownTextarea: 'block-editor-markdown-textarea',
-    // Section form
     sectionTitleInput: 'block-editor-section-title-input',
     sectionIdInput: 'block-editor-section-id-input',
     sectionAutoCollapseToggle: 'block-editor-section-auto-collapse-toggle',
     addAndRecordButton: 'block-editor-add-and-record-button',
-    // Section empty state and nested add button
     sectionEmptyState: 'block-editor-section-empty-state',
     sectionNestedAddButton: 'block-editor-section-add-nested-block',
+    editButton: 'block-editor-edit-button',
+    duplicateButton: 'block-editor-duplicate-button',
+    deleteButton: 'block-editor-delete-button',
+    unpublishButton: 'block-editor-unpublish-button',
+    copyJsonButton: 'block-editor-copy-json-button',
+    saveDraftButton: 'block-editor-save-draft-button',
+    publishButton: 'block-editor-publish-button',
+    viewModeToggle: 'block-editor-view-mode-toggle',
+    moreActionsButton: 'block-editor-more-actions-button',
+    newGuideButton: 'block-editor-new-guide-button',
+    libraryButton: 'block-editor-library-button',
+    blockItem: (blockId: string) => `block-editor-item-${blockId}`,
+    form: (formType: string) => `block-editor-form-${formType}`,
+    formCancelButton: 'block-editor-form-cancel',
+    recordStartButton: 'block-editor-record-start',
+    recordStopButton: 'block-editor-record-stop',
+    mergeMultistepButton: 'block-editor-merge-multistep',
+    mergeGuidedButton: 'block-editor-merge-guided',
+    clearSelectionButton: 'block-editor-clear-selection',
+    toggleSelectionButton: 'block-editor-toggle-selection',
+    loadTemplateButton: 'block-editor-load-template',
+    openTourButton: 'block-editor-open-tour',
+    importModal: 'block-editor-import-modal',
+    importButton: 'block-editor-import-button',
+    importCancelButton: 'block-editor-import-cancel',
+    importResetButton: 'block-editor-import-reset',
+    importDropZone: 'block-editor-import-drop-zone',
+    metadataIdInput: 'block-editor-metadata-id',
+    metadataTitleInput: 'block-editor-metadata-title',
+    metadataSaveButton: 'block-editor-metadata-save',
+    previewResetButton: 'block-editor-preview-reset',
+  },
+
+  // Learning Paths
+  learningPaths: {
+    card: (pathId: string) => `learning-path-card-${pathId}`,
+    continueButton: (pathId: string) => `learning-path-continue-${pathId}`,
+    resetButton: (pathId: string) => `learning-path-reset-${pathId}`,
+    confirmResetButton: (pathId: string) => `learning-path-confirm-reset-${pathId}`,
+    cancelResetButton: (pathId: string) => `learning-path-cancel-reset-${pathId}`,
+    expandButton: (pathId: string) => `learning-path-expand-${pathId}`,
+    viewBadgesButton: 'learning-paths-view-badges',
+    badgesModal: 'learning-paths-badges-modal',
+    badgesModalClose: 'learning-paths-badges-modal-close',
+    badgeItem: (badgeId: string) => `learning-paths-badge-${badgeId}`,
+    showAllPathsButton: 'learning-paths-show-all',
+    showAllBadgesButton: 'learning-paths-show-all-badges',
+    resetProgressButton: 'learning-paths-reset-progress',
+    badgeToast: 'learning-paths-badge-toast',
+    badgeToastDismiss: 'learning-paths-badge-toast-dismiss',
+  },
+
+  // Live Session
+  liveSession: {
+    startButton: 'live-session-start',
+    joinButton: 'live-session-join',
+    attendeeNameInput: 'live-session-attendee-name',
+    attendeeCodeInput: 'live-session-attendee-code',
+    attendeeJoinButton: 'live-session-attendee-join',
+    backButton: 'live-session-back',
+    guidedButton: 'live-session-guided',
+    followButton: 'live-session-follow',
+    leaveButton: 'live-session-leave',
+    presenterCopyCode: 'live-session-presenter-copy-code',
+    presenterCopyUrl: 'live-session-presenter-copy-url',
+    presenterEndButton: 'live-session-presenter-end',
+    presenterModalClose: 'live-session-presenter-modal-close',
+    handRaiseButton: 'live-session-hand-raise',
+    handRaiseQueue: 'live-session-hand-raise-queue',
+    handRaiseQueueClose: 'live-session-hand-raise-queue-close',
+    sessionActiveButton: 'live-session-active',
+  },
+
+  // PR Tester
+  prTester: {
+    form: 'pr-tester-form',
+    prNumberInput: 'pr-tester-pr-number',
+    fileSelect: 'pr-tester-file-select',
+    loadButton: 'pr-tester-load',
+  },
+
+  // URL Tester
+  urlTester: {
+    form: 'url-tester-form',
+    urlInput: 'url-tester-url-input',
+    loadButton: 'url-tester-load',
+  },
+
+  // Coda Terminal
+  codaTerminal: {
+    panel: 'coda-terminal-panel',
+    collapsedBar: 'coda-terminal-collapsed-bar',
+    expandButton: 'coda-terminal-expand',
+    collapseButton: 'coda-terminal-collapse',
+    closeButton: 'coda-terminal-close',
+    resizeHandle: 'coda-terminal-resize-handle',
+    connectButton: 'coda-terminal-connect',
+    disconnectButton: 'coda-terminal-disconnect',
+    cancelButton: 'coda-terminal-cancel',
+    searchToggle: 'coda-terminal-search-toggle',
+    searchInput: 'coda-terminal-search-input',
+    searchPrev: 'coda-terminal-search-prev',
+    searchNext: 'coda-terminal-search-next',
+    searchClose: 'coda-terminal-search-close',
+  },
+
+  // Home Page
+  homePage: {
+    container: 'home-page-container',
+  },
+
+  // Control Group Popup
+  controlGroupPopup: {
+    container: 'control-group-popup-container',
+    dismissButton: 'control-group-popup-dismiss',
+  },
+
+  // Feedback Button
+  feedbackButton: {
+    trigger: 'feedback-button',
+  },
+
+  // Help Footer
+  helpFooter: {
+    container: 'help-footer-container',
+    link: (index: number) => `help-footer-link-${index}`,
+  },
+
+  // App Error Fallback
+  app: {
+    errorTryAgain: 'app-error-try-again',
+    errorRefresh: 'app-error-refresh',
+  },
+
+  // Enable Recommender Banner
+  enableRecommender: {
+    configButton: 'enable-recommender-config-button',
   },
 };

--- a/src/integrations/coda/TerminalPanel.tsx
+++ b/src/integrations/coda/TerminalPanel.tsx
@@ -21,6 +21,7 @@ import '@xterm/xterm/css/xterm.css';
 import { useTerminalLive, ConnectionStatus } from './useTerminalLive.hook';
 import { useTerminalContext } from './TerminalContext';
 import { getTerminalPanelStyles } from './terminal-panel.styles';
+import { testIds } from '../../constants/testIds';
 import {
   setTerminalOpen,
   getTerminalHeight,
@@ -383,6 +384,7 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
             onClick={handleToggleExpand}
             role="button"
             tabIndex={0}
+            data-testid={testIds.codaTerminal.collapsedBar}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
                 handleToggleExpand();
@@ -404,7 +406,13 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
                 )}
                 <span>{getStatusText(status)}</span>
               </div>
-              <IconButton name="angle-up" size="sm" aria-label="Expand" tooltip="Expand terminal" />
+              <IconButton
+                name="angle-up"
+                size="sm"
+                aria-label="Expand"
+                tooltip="Expand terminal"
+                data-testid={testIds.codaTerminal.expandButton}
+              />
             </div>
           </div>
         </div>
@@ -419,7 +427,7 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
           // Hide when collapsed but keep in DOM to preserve terminal instance
           display: isExpanded ? 'flex' : 'none',
         }}
-        data-testid="coda-terminal-panel"
+        data-testid={testIds.codaTerminal.panel}
       >
         {/* Resize handle */}
         <div
@@ -428,6 +436,7 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
           role="separator"
           aria-orientation="horizontal"
           aria-label="Resize terminal panel"
+          data-testid={testIds.codaTerminal.resizeHandle}
           style={{ cursor: isResizing ? 'ns-resize' : undefined }}
         />
 
@@ -448,19 +457,37 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
             </div>
 
             {canConnect && (
-              <Button size="sm" variant="primary" onClick={handleConnect} className={styles.headerButton}>
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={handleConnect}
+                className={styles.headerButton}
+                data-testid={testIds.codaTerminal.connectButton}
+              >
                 Connect
               </Button>
             )}
 
             {canCancel && (
-              <Button size="sm" variant="secondary" onClick={handleDisconnect} className={styles.headerButton}>
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={handleDisconnect}
+                className={styles.headerButton}
+                data-testid={testIds.codaTerminal.cancelButton}
+              >
                 Cancel
               </Button>
             )}
 
             {canDisconnect && (
-              <Button size="sm" variant="destructive" onClick={handleDisconnect} className={styles.headerButton}>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={handleDisconnect}
+                className={styles.headerButton}
+                data-testid={testIds.codaTerminal.disconnectButton}
+              >
                 Disconnect
               </Button>
             )}
@@ -471,6 +498,7 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
               aria-label="Search"
               tooltip="Search in terminal (Ctrl+F)"
               onClick={handleSearchToggle}
+              data-testid={testIds.codaTerminal.searchToggle}
             />
 
             <IconButton
@@ -479,6 +507,7 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
               aria-label="Collapse"
               tooltip="Collapse terminal"
               onClick={handleToggleExpand}
+              data-testid={testIds.codaTerminal.collapseButton}
             />
 
             {onClose && (
@@ -488,6 +517,7 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
                 aria-label="Close terminal"
                 tooltip="Close terminal"
                 onClick={onClose}
+                data-testid={testIds.codaTerminal.closeButton}
               />
             )}
           </div>
@@ -503,6 +533,7 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
               placeholder="Search... (Enter=next, Shift+Enter=prev, Esc=close)"
               autoFocus
               width={30}
+              data-testid={testIds.codaTerminal.searchInput}
             />
             <IconButton
               name="arrow-up"
@@ -510,9 +541,24 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
               aria-label="Previous"
               tooltip="Previous match"
               onClick={handleSearchPrev}
+              data-testid={testIds.codaTerminal.searchPrev}
             />
-            <IconButton name="arrow-down" size="sm" aria-label="Next" tooltip="Next match" onClick={handleSearchNext} />
-            <IconButton name="times" size="sm" aria-label="Close search" tooltip="Close" onClick={handleSearchToggle} />
+            <IconButton
+              name="arrow-down"
+              size="sm"
+              aria-label="Next"
+              tooltip="Next match"
+              onClick={handleSearchNext}
+              data-testid={testIds.codaTerminal.searchNext}
+            />
+            <IconButton
+              name="times"
+              size="sm"
+              aria-label="Close search"
+              tooltip="Close"
+              onClick={handleSearchToggle}
+              data-testid={testIds.codaTerminal.searchClose}
+            />
           </div>
         )}
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -240,7 +240,7 @@ export function reportAppInteraction(
  * Type definition for tabs compatible with scroll tracking
  */
 export interface ScrollTrackingTab {
-  type?: 'docs' | 'learning-journey' | 'devtools' | 'interactive';
+  type?: 'docs' | 'learning-journey' | 'editor' | 'interactive';
   content?: {
     url?: string;
     metadata?: {

--- a/src/types/content-panel.types.ts
+++ b/src/types/content-panel.types.ts
@@ -19,7 +19,7 @@ export interface LearningJourneyTab {
   content: RawContent | null; // Unified content type
   isLoading: boolean;
   error: string | null;
-  type?: 'learning-journey' | 'docs' | 'devtools' | 'interactive';
+  type?: 'learning-journey' | 'docs' | 'editor' | 'interactive';
 }
 
 /**
@@ -31,13 +31,13 @@ export interface PersistedTabData {
   title: string;
   baseUrl: string;
   currentUrl?: string; // The specific milestone/page URL user was viewing (optional for backward compatibility)
-  type?: 'learning-journey' | 'docs' | 'devtools' | 'interactive';
+  type?: 'learning-journey' | 'docs' | 'editor' | 'interactive';
 }
 
 export interface ContextPanelState extends SceneObjectState {
   onOpenLearningJourney?: (url: string, title: string) => void;
   onOpenDocsPage?: (url: string, title: string) => void;
-  onOpenDevTools?: () => void;
+  onOpenEditor?: () => void;
 }
 
 /**

--- a/tests/block-editor.spec.ts
+++ b/tests/block-editor.spec.ts
@@ -61,20 +61,20 @@ test.describe.serial('Block Editor', () => {
     await clearBlockEditorState(page);
   });
 
-  test('should open block editor via dev tools tab', async ({ page }) => {
-    // Open dev tools panel using helper function
+  test('should open block editor via editor tab', async ({ page }) => {
+    // Open editor panel using helper function
     await openBlockEditor(page);
 
-    // Wait for dev tools content to load
-    const devToolsContent = page.getByTestId('devtools-tab-content');
-    await expect(devToolsContent).toBeVisible();
+    // Wait for editor tab content to load
+    const editorContent = page.getByTestId(testIds.docsPanel.editorContent);
+    await expect(editorContent).toBeVisible();
 
     // Verify the block editor is visible
-    const blockEditor = page.getByTestId('block-editor');
+    const blockEditor = page.getByTestId(testIds.blockEditor.container);
     await expect(blockEditor).toBeVisible();
 
     // The block editor should show the block palette in the footer
-    const blockPalette = page.getByTestId('block-palette');
+    const blockPalette = page.getByTestId(testIds.blockEditor.palette);
     await expect(blockPalette).toBeVisible();
   });
 
@@ -82,7 +82,7 @@ test.describe.serial('Block Editor', () => {
     await openBlockEditor(page);
 
     // Find the view mode toggle
-    const viewModeToggle = page.getByTestId('view-mode-toggle');
+    const viewModeToggle = page.getByTestId(testIds.blockEditor.viewModeToggle);
     await expect(viewModeToggle).toBeVisible();
 
     // Click preview mode button (eye icon) - Grafana Button uses tooltip which becomes aria-label
@@ -90,7 +90,7 @@ test.describe.serial('Block Editor', () => {
     await previewButton.click();
 
     // Block palette should be hidden in preview mode
-    const blockPalette = page.getByTestId('block-palette');
+    const blockPalette = page.getByTestId(testIds.blockEditor.palette);
     await expect(blockPalette).not.toBeVisible();
 
     // Click edit mode button (pen icon) to go back - tooltip is "Edit" not "Edit blocks"
@@ -290,11 +290,11 @@ test.describe.serial('Block Editor', () => {
     await createMarkdownBlock(page, 'original-content');
 
     // Wait for the block to be fully rendered
-    const blockContent = page.getByTestId('block-editor-content');
+    const blockContent = page.getByTestId(testIds.blockEditor.content);
     await expect(blockContent.locator('text=original-content')).toBeVisible();
 
     // Click edit button using helper (handles scroll/hover for dnd-kit overlays)
-    await clickBlockAction(page, 'block-edit-button');
+    await clickBlockAction(page, testIds.blockEditor.editButton);
 
     // Wait for edit modal to appear
     const editModal = page.getByTestId(testIds.blockEditor.blockFormModal);
@@ -336,7 +336,7 @@ test.describe.serial('Block Editor', () => {
     expect(blocks).toHaveLength(2);
 
     // Click delete button on the first block using helper (handles scroll/hover for dnd-kit overlays)
-    await clickBlockAction(page, 'block-delete-button');
+    await clickBlockAction(page, testIds.blockEditor.deleteButton);
 
     // Confirm deletion using helper (locates modal by role and text)
     await confirmDeleteBlock(page);

--- a/tests/helpers/block-editor.helpers.ts
+++ b/tests/helpers/block-editor.helpers.ts
@@ -27,7 +27,7 @@ export async function waitForGrafanaReady(page: Page): Promise<void> {
 }
 
 /**
- * Open the block editor via the dev tools tab.
+ * Open the block editor via the editor tab.
  * Assumes dev mode is enabled.
  */
 export async function openBlockEditor(page: Page): Promise<void> {
@@ -38,25 +38,24 @@ export async function openBlockEditor(page: Page): Promise<void> {
   // In Grafana with extension sidebar registered, clicking Help toggles the sidebar
   await page.locator('button[aria-label="Help"]').click();
 
-  // Dismiss any tooltip that appeared on the Help button
-  // This prevents tooltip from intercepting pointer events in Grafana dev/preview versions
-  await page.keyboard.press('Escape');
-
   // Wait for panel container to be visible
   const panelContainer = page.getByTestId(testIds.docsPanel.container);
   await expect(panelContainer).toBeVisible();
 
-  // Wait for devtools tab to be visible (requires dev mode enabled)
-  // Use longer timeout as dev mode settings need to propagate
-  const devToolsTab = page.getByTestId(testIds.docsPanel.tab('devtools'));
-  await expect(devToolsTab).toBeVisible({ timeout: TIMEOUTS.DEV_MODE_PROPAGATE });
+  // Dismiss any tooltip that appeared on the Help button by pressing Escape
+  // and clicking the panel body to move focus away from the tooltip trigger
+  await page.keyboard.press('Escape');
+  await panelContainer.click({ position: { x: 5, y: 5 } });
 
-  // Hover before click to dismiss any tooltips that may intercept pointer events
-  await devToolsTab.hover();
-  await devToolsTab.click();
+  // Wait for editor tab to be visible
+  const editorTab = page.getByTestId(testIds.docsPanel.tab('editor'));
+  await expect(editorTab).toBeVisible({ timeout: TIMEOUTS.DEV_MODE_PROPAGATE });
+
+  // Use force click to bypass any lingering tooltip overlays from Grafana's portal
+  await editorTab.click({ force: true });
 
   // Wait for block editor to be visible
-  const blockEditor = page.getByTestId('block-editor');
+  const blockEditor = page.getByTestId(testIds.blockEditor.container);
   await expect(blockEditor).toBeVisible();
 }
 
@@ -65,7 +64,7 @@ export async function openBlockEditor(page: Page): Promise<void> {
  */
 export async function createMarkdownBlock(page: Page, content: string): Promise<void> {
   // Click the Add Block button in the palette (there may be multiple add buttons when blocks exist)
-  await page.getByTestId('block-palette').getByTestId(testIds.blockEditor.addBlockButton).click();
+  await page.getByTestId(testIds.blockEditor.palette).getByTestId(testIds.blockEditor.addBlockButton).click();
 
   // Wait for modal and select Markdown
   const modal = page.getByTestId(testIds.blockEditor.addBlockModal);
@@ -95,7 +94,7 @@ export async function createSectionBlock(
   options?: { startRecording?: boolean }
 ): Promise<void> {
   // Click the Add Block button in the palette (there may be multiple add buttons when blocks exist)
-  await page.getByTestId('block-palette').getByTestId(testIds.blockEditor.addBlockButton).click();
+  await page.getByTestId(testIds.blockEditor.palette).getByTestId(testIds.blockEditor.addBlockButton).click();
 
   // Wait for modal and select Section
   const modal = page.getByTestId(testIds.blockEditor.addBlockModal);
@@ -125,7 +124,7 @@ export async function createSectionBlock(
  */
 export async function copyGuideJson(page: Page): Promise<Record<string, unknown>> {
   // Open the "More actions" dropdown menu first
-  await page.getByTestId('more-actions-button').click();
+  await page.getByTestId(testIds.blockEditor.moreActionsButton).click();
   // Then click the "Copy JSON" menu item by its label text (Menu.Item doesn't forward data-testid)
   await page.getByRole('menuitem', { name: 'Copy JSON' }).click();
 
@@ -217,7 +216,7 @@ export async function confirmDeleteBlock(page: Page): Promise<void> {
  * Uses the section empty state testId to scope the search.
  */
 export async function clickAddBlockInSection(page: Page): Promise<void> {
-  const blockEditor = page.getByTestId('block-editor');
+  const blockEditor = page.getByTestId(testIds.blockEditor.container);
   // Find the section container via the empty state testId
   const sectionEmptyState = blockEditor.getByTestId(testIds.blockEditor.sectionEmptyState);
   // The Add Block button is a sibling of the empty state div inside the same parent


### PR DESCRIPTION
## Summary

- Reapply of #677 which was prematurely merged and then reverted on main
- Rebrand devtools tab to editor tab: replace bug icon with edit icon, always visible (not gated by dev mode), PR/URL testers still require dev mode toggle inside the editor panel
- Backward-compat storage migration for devtools->editor tab type, active tab ID, and localStorage expansion keys
- Unify all tab bar icons into TabBarActions component with consistent iconTab/iconTabActive styling and left/right position support
- Comprehensive test ID audit: add ~100 new centralized test IDs across all component areas (Coda terminal, AppConfig, learning paths, live session, block editor forms, interactive tutorial extras, misc)
- Centralize ~20 hardcoded data-testid strings into testIds constants
- Update E2E tests to use centralized testIds references

## Test plan

- [ ] Verify editor tab is always visible in sidebar
- [ ] Verify PR/URL testers still require dev mode
- [ ] Verify backward-compat storage migration works (devtools -> editor)
- [ ] Run `npm run test:ci` to confirm all tests pass
- [ ] Run `npm run e2e` to confirm E2E tests pass with new test IDs


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors the docs panel tab model/UI and storage restore logic (including migration paths), which could affect tab persistence and navigation if regressions slip in; most other changes are additive `data-testid` attributes.
> 
> **Overview**
> Rebrands the sidebar `devtools` experience into an **always-visible `editor` tab** in the docs panel, including updates to tab persistence/restore so existing stored `devtools` tabs and active-tab IDs transparently migrate to `editor` and deduplicate.
> 
> Unifies the tab bar UI by expanding `TabBarActions` to render *both* left/right icon groups (recommendations + editor/my-learning/menu/close) with consistent active styling, and wires the new editor opener through `ContextPanel`/model APIs.
> 
> Performs a broad **test selector standardization** by centralizing hardcoded `data-testid` strings into `testIds` and adding many new `data-testid` hooks across app config, learning paths, live sessions, block editor (including tour/preview/forms), interactive steps/sections, and related tests/contract coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab797981dce8e896bda2b2172c75d0e9b7fc29c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->