### PR TITLE
fix: buffer pathfinder-suggest events before init and defer auto-opened flag

### DIFF
--- a/src/module.tsx
+++ b/src/module.tsx
@@ -14,6 +14,15 @@ import { sidebarState } from 'global-state/sidebar';
 import { suggestionState } from './global-state/suggestion';
 import { validateRedirectPath } from './security/url-validator';
 
+// Buffer pathfinder-suggest events that arrive before async init completes.
+// Registered synchronously (before any await) so events from faster-loading
+// apps are never lost. Replayed or discarded after experiment state is known.
+const pendingSuggestEvents: CustomEvent[] = [];
+const earlySuggestListener = ((event: CustomEvent) => {
+  pendingSuggestEvents.push(event);
+}) as EventListener;
+document.addEventListener('pathfinder-suggest', earlySuggestListener);
+
 // TODO: Re-enable Faro once collector CORS is configured correctly
 // Initialize Faro metrics (before translations to capture early errors)
 // Wrapped in try-catch to prevent plugin load failure if Faro has issues
@@ -336,122 +345,149 @@ if (shouldMountSidebar(mainVariant, after24hVariant)) {
     onClick: () => {},
   });
 
-  // Listen for external app suggestion events to open sidebar with featured content.
-  // Sets detail.status ('accepted' | 'rejected') and detail.reason so the caller
-  // can read the result synchronously after dispatchEvent returns.
-  document.addEventListener('pathfinder-suggest', ((event: CustomEvent) => {
-    const detail = event.detail;
-    if (!detail) {
-      console.warn('[Pathfinder] pathfinder-suggest event missing detail');
-      return;
-    }
-    if (!Array.isArray(detail.suggestions)) {
-      console.warn('[Pathfinder] pathfinder-suggest event missing suggestions array');
-      detail.status = 'rejected';
-      detail.reason = 'invalid_payload';
-      return;
-    }
+  // Swap in the real suggest handler and replay any buffered events
+  const realSuggestHandler = ((event: CustomEvent) => {
+    handlePathfinderSuggest(event, after24hVariant);
+  }) as EventListener;
+  document.removeEventListener('pathfinder-suggest', earlySuggestListener);
+  document.addEventListener('pathfinder-suggest', realSuggestHandler);
 
-    const valid = detail.suggestions.filter(
-      (s: unknown) =>
-        s &&
-        typeof s === 'object' &&
-        typeof (s as Record<string, unknown>).title === 'string' &&
-        typeof (s as Record<string, unknown>).url === 'string'
-    );
+  for (const buffered of pendingSuggestEvents) {
+    handlePathfinderSuggest(buffered, after24hVariant);
+  }
+  pendingSuggestEvents.length = 0;
+} else {
+  // Control group: discard buffered events and remove early listener
+  document.removeEventListener('pathfinder-suggest', earlySuggestListener);
+  pendingSuggestEvents.length = 0;
+}
 
-    if (valid.length === 0) {
-      console.warn('[Pathfinder] pathfinder-suggest event had no valid suggestions (need title + url)');
-      detail.status = 'rejected';
-      detail.reason = 'no_valid_suggestions';
-      return;
-    }
+// ============================================================================
+// PATHFINDER-SUGGEST EVENT HANDLER
+// ============================================================================
 
-    // Check if another plugin is occupying the sidebar
-    try {
-      const dockedValue = localStorage.getItem('grafana.navigation.extensionSidebarDocked');
-      if (dockedValue) {
-        let dockedPluginId: string | undefined;
-        try {
-          dockedPluginId = JSON.parse(dockedValue)?.pluginId;
-        } catch {
-          // Older Grafana versions may store a plain string
-        }
+/**
+ * Handles external app suggestion events to open the sidebar with featured content.
+ * Sets detail.status ('accepted' | 'rejected') and detail.reason so the caller
+ * can read the result synchronously after dispatchEvent returns.
+ *
+ * The "already opened" flag is deferred until the sidebar actually mounts
+ * (via the pathfinder-sidebar-mounted event) so the flag is never burned
+ * if the sidebar fails to open for any reason.
+ */
+function handlePathfinderSuggest(event: CustomEvent, experimentVariant: string): void {
+  const detail = event.detail;
+  if (!detail) {
+    console.warn('[Pathfinder] pathfinder-suggest event missing detail');
+    return;
+  }
+  if (!Array.isArray(detail.suggestions)) {
+    console.warn('[Pathfinder] pathfinder-suggest event missing suggestions array');
+    detail.status = 'rejected';
+    detail.reason = 'invalid_payload';
+    return;
+  }
 
-        if (dockedPluginId && dockedPluginId !== pluginJson.id) {
-          console.warn('[Pathfinder] pathfinder-suggest rejected: sidebar occupied by', dockedPluginId);
-          detail.status = 'rejected';
-          detail.reason = 'sidebar_in_use';
-          return;
-        }
+  const valid = detail.suggestions.filter(
+    (s: unknown) =>
+      s &&
+      typeof s === 'object' &&
+      typeof (s as Record<string, unknown>).title === 'string' &&
+      typeof (s as Record<string, unknown>).url === 'string'
+  );
+
+  if (valid.length === 0) {
+    console.warn('[Pathfinder] pathfinder-suggest event had no valid suggestions (need title + url)');
+    detail.status = 'rejected';
+    detail.reason = 'no_valid_suggestions';
+    return;
+  }
+
+  // Check if another plugin is occupying the sidebar
+  try {
+    const dockedValue = localStorage.getItem('grafana.navigation.extensionSidebarDocked');
+    if (dockedValue) {
+      let dockedPluginId: string | undefined;
+      try {
+        dockedPluginId = JSON.parse(dockedValue)?.pluginId;
+      } catch {
+        // Older Grafana versions may store a plain string
       }
-    } catch {
-      // localStorage unavailable -- proceed optimistically
-    }
 
-    suggestionState.setSuggestions(valid);
-
-    const suggestedTitles = valid.map((s: Record<string, unknown>) => s.title).join(', ');
-    const suggestedUrls = valid.map((s: Record<string, unknown>) => s.url).join(', ');
-
-    // If Pathfinder is already docked, just update the featured zone without re-opening
-    if (sidebarState.getIsSidebarMounted()) {
-      reportAppInteraction(UserInteraction.DocsPanelInteraction, {
-        action: 'suggest',
-        source: 'external_app',
-        suggestion_count: valid.length,
-        suggested_titles: suggestedTitles,
-        suggested_urls: suggestedUrls,
-        sidebar_already_open: true,
-      });
-      detail.status = 'accepted';
-      return;
-    }
-
-    // For 24h experiment treatment: only auto-open once, but always store suggestions
-    // Uses localStorage (persists across browser sessions) as cache, with Grafana user storage as cross-device source of truth
-    if (after24hVariant === 'treatment') {
-      const hostname = window.location.hostname;
-      const autoOpenedKey = `grafana-interactive-learning-panel-auto-opened-${hostname}`;
-      const alreadyOpened = localStorage.getItem(autoOpenedKey) === 'true';
-
-      if (alreadyOpened) {
-        // Suggestions are already stored above - user will see them when they manually open
-        reportAppInteraction(UserInteraction.DocsPanelInteraction, {
-          action: 'suggest',
-          source: 'external_app',
-          suggestion_count: valid.length,
-          suggested_titles: suggestedTitles,
-          suggested_urls: suggestedUrls,
-          sidebar_already_opened_by_experiment: true,
-        });
-        detail.status = 'accepted';
-        detail.reason = 'suggestions_stored_no_reopen';
+      if (dockedPluginId && dockedPluginId !== pluginJson.id) {
+        console.warn('[Pathfinder] pathfinder-suggest rejected: sidebar occupied by', dockedPluginId);
+        detail.status = 'rejected';
+        detail.reason = 'sidebar_in_use';
         return;
       }
-
-      // First trigger - mark as opened in localStorage (sync, persists across sessions)
-      localStorage.setItem(autoOpenedKey, 'true');
-
-      // Also persist to Grafana user storage for cross-device durability (async, fire-and-forget)
-      // Uses dynamic import to keep user-storage.ts out of module.js
-      import('./lib/user-storage').then(({ experimentAutoOpenStorage }) => {
-        experimentAutoOpenStorage.markGlobalAutoOpened().catch(() => {
-          // Silently fail - localStorage is the primary guard
-        });
-      });
     }
+  } catch {
+    // localStorage unavailable -- proceed optimistically
+  }
 
+  suggestionState.setSuggestions(valid);
+
+  const suggestedTitles = valid.map((s: Record<string, unknown>) => s.title).join(', ');
+  const suggestedUrls = valid.map((s: Record<string, unknown>) => s.url).join(', ');
+
+  // If Pathfinder is already docked, just update the featured zone without re-opening
+  if (sidebarState.getIsSidebarMounted()) {
     reportAppInteraction(UserInteraction.DocsPanelInteraction, {
       action: 'suggest',
       source: 'external_app',
       suggestion_count: valid.length,
       suggested_titles: suggestedTitles,
       suggested_urls: suggestedUrls,
-      sidebar_already_open: false,
+      sidebar_already_open: true,
     });
-    sidebarState.setPendingOpenSource('external_suggestion', 'auto-open');
-    sidebarState.openSidebar('Interactive learning');
     detail.status = 'accepted';
-  }) as EventListener);
+    return;
+  }
+
+  // For 24h experiment treatment: only auto-open once, but always store suggestions.
+  // Uses localStorage as cache, with Grafana user storage as cross-device source of truth.
+  if (experimentVariant === 'treatment') {
+    const hostname = window.location.hostname;
+    const autoOpenedKey = `grafana-interactive-learning-panel-auto-opened-${hostname}`;
+    const alreadyOpened = localStorage.getItem(autoOpenedKey) === 'true';
+
+    if (alreadyOpened) {
+      reportAppInteraction(UserInteraction.DocsPanelInteraction, {
+        action: 'suggest',
+        source: 'external_app',
+        suggestion_count: valid.length,
+        suggested_titles: suggestedTitles,
+        suggested_urls: suggestedUrls,
+        sidebar_already_opened_by_experiment: true,
+      });
+      detail.status = 'accepted';
+      detail.reason = 'suggestions_stored_no_reopen';
+      return;
+    }
+
+    // Defer flag write until sidebar actually mounts — if it never opens
+    // the flag stays unset and the next page load can retry.
+    window.addEventListener(
+      'pathfinder-sidebar-mounted',
+      () => {
+        localStorage.setItem(autoOpenedKey, 'true');
+        import('./lib/user-storage').then(({ experimentAutoOpenStorage }) => {
+          experimentAutoOpenStorage.markGlobalAutoOpened().catch(() => {});
+        });
+      },
+      { once: true }
+    );
+  }
+
+  reportAppInteraction(UserInteraction.DocsPanelInteraction, {
+    action: 'suggest',
+    source: 'external_app',
+    suggestion_count: valid.length,
+    suggested_titles: suggestedTitles,
+    suggested_urls: suggestedUrls,
+    sidebar_already_open: false,
+  });
+  sidebarState.setPendingOpenSource('external_suggestion', 'auto-open');
+  sidebarState.openSidebar('Interactive learning');
+  detail.status = 'accepted';
 }

--- a/src/utils/experiments/experiment-debug.ts
+++ b/src/utils/experiments/experiment-debug.ts
@@ -97,6 +97,7 @@ export function createExperimentDebugger(experimentConfig: ExperimentConfig): vo
       console.log('[Pathfinder] Current state:');
       console.log('  localStorage:', {
         [storageKeys.resetProcessed]: localStorage.getItem(storageKeys.resetProcessed),
+        [storageKeys.autoOpened]: localStorage.getItem(storageKeys.autoOpened),
       });
       console.log('  sessionStorage (global):', {
         [storageKeys.autoOpened]: sessionStorage.getItem(storageKeys.autoOpened),
@@ -111,6 +112,7 @@ export function createExperimentDebugger(experimentConfig: ExperimentConfig): vo
 
       // Clear localStorage
       localStorage.removeItem(storageKeys.resetProcessed);
+      localStorage.removeItem(storageKeys.autoOpened);
 
       // Clear sessionStorage (global keys)
       sessionStorage.removeItem(storageKeys.autoOpened);
@@ -155,6 +157,7 @@ export function createExperimentDebugger(experimentConfig: ExperimentConfig): vo
       const state = {
         localStorage: {
           resetProcessed: localStorage.getItem(storageKeys.resetProcessed),
+          autoOpened: localStorage.getItem(storageKeys.autoOpened),
         },
         sessionStorage: {
           autoOpened: sessionStorage.getItem(storageKeys.autoOpened),


### PR DESCRIPTION
## Summary

- Buffer `pathfinder-suggest` events that arrive before async experiment init completes, so events from faster-loading apps are never lost
- Defer the auto-opened localStorage flag write until the sidebar actually mounts (`pathfinder-sidebar-mounted` event), preventing the flag from being burned if the sidebar fails to open
- Extract `handlePathfinderSuggest` into a standalone function for clarity
- Add `autoOpened` localStorage key to the experiment debugger state inspector and reset logic

## Test plan

- [ ] Verify suggest events dispatched before init completes are buffered and replayed
- [ ] Verify auto-opened flag is only written after sidebar mounts
- [ ] Verify experiment debugger correctly displays and resets the `autoOpened` localStorage key
- [ ] Run `npm run test:ci`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global DOM event handling and auto-open gating via `localStorage`, which can affect when/if the sidebar opens and how experiments are tracked across sessions. Limited scope but touches user-facing behavior and analytics triggers.
> 
> **Overview**
> Ensures `pathfinder-suggest` events aren’t dropped during async plugin/experiment initialization by registering an early listener, buffering incoming events, then replaying them once experiment state is known (or discarding them for control groups).
> 
> Refactors the suggest flow into `handlePathfinderSuggest()` and changes the 24h experiment behavior to **only mark the “auto-opened” flag after the sidebar actually mounts** (`pathfinder-sidebar-mounted`), avoiding permanently suppressing auto-open if the sidebar fails to open.
> 
> Updates the experiment debugger to display and clear the `autoOpened` `localStorage` key in its cache inspection/reset output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80f565a5e227230d5145e3cff5b987806c8156e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->