### PR TITLE
skill:maintain-docs fix stale systemPatterns, CLI_TOOLS, and interactiveRequirements docs

### DIFF
--- a/.cursor/rules/interactiveRequirements.mdc
+++ b/.cursor/rules/interactiveRequirements.mdc
@@ -428,7 +428,7 @@ The requirements system manages several visual states:
 
 #### Core Interactive Attributes
 - `data-requirements`: Comma-separated list of guide-specific requirements
-- `data-targetaction`: Type of action to perform (button, formfill, highlight, sequence, multistep)
+- `data-targetaction`: Type of action to perform (button, formfill, highlight, sequence, multistep, code-block)
 - `data-reftarget`: Target element selector or button text to interact with
 - `data-targetvalue`: Value to use for formfill actions (optional)
 - `data-button-type`: Button type (show, do) to distinguish behavior

--- a/.cursor/rules/systemPatterns.mdc
+++ b/.cursor/rules/systemPatterns.mdc
@@ -31,7 +31,8 @@ This Grafana App Plugin integrates as a sidebar panel using **Grafana Scenes** f
 - **Interactive Engine** → Business logic in `src/interactive-engine/`
 - **Context Engine** → Context analysis in `src/context-engine/`
 - **Requirements Manager** → Requirements validation in `src/requirements-manager/`
-- **Utils** → General utilities in `src/utils/` (keyboard shortcuts, link handling)
+- **Utils** → General utilities in `src/utils/` (routing, plugin helpers, variable substitution, feature flag tracking, timeout management, experiments)
+- **Package Engine** → Package resolution, loading, and dependency queries in `src/package-engine/`
 - **Styles** → Theme-aware functions in `src/styles/*.styles.ts`
 
 ## Critical Implementation Paths
@@ -69,7 +70,7 @@ This Grafana App Plugin integrates as a sidebar panel using **Grafana Scenes** f
 - `streak` → Consecutive days of activity (3-day, 7-day milestones)
 
 **Learning Paths Critical Path**:
-1. `learning-paths/paths.json` → Define learning paths with ordered guide sequences
+1. `learning-paths/paths.json` / `learning-paths/paths-cloud.json` → OSS and Cloud path definitions; `learning-paths/paths-data.ts:getPathsData()` selects the correct set at runtime based on Grafana edition
 2. `learning-paths/badges.ts` → Badge definitions and trigger conditions
 3. `learning-paths/streak-tracker.ts` → Daily streak calculation logic
 4. `learning-paths/learning-paths.hook.ts` → Main React hook for state management

--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -10,6 +10,9 @@ Persistent tracker for the maintain-docs skill's persistent state across runs.
 
 <!-- Docs checked against source and found accurate. Format: date, doc path. Update date on re-validation. -->
 
+- **2026-03-20**: `.cursor/rules/systemPatterns.mdc` — Updated Utils description (removed stale keyboard-shortcuts/link-handling refs), added Package Engine subsystem, updated Learning Paths Critical Path for `paths-cloud.json` and `paths-data.ts`.
+- **2026-03-20**: `docs/developer/CLI_TOOLS.md` — Updated `--bundled` option description to reflect two-mode discovery (package directories + legacy flat JSON; `repository.json` exclusion; `static-links/` skip).
+- **2026-03-20**: `.cursor/rules/interactiveRequirements.mdc` — Added `code-block` to `data-targetaction` values in Core Interactive Attributes table.
 - **2026-03-20**: `docs/developer/interactive-examples/json-guide-format.md` — Updated "Bundling a JSON Guide" section to reflect new package directory structure (`my-guide/content.json` instead of flat `my-guide.json`, and cross-reference to `package-authoring.md` added).
 - **2026-03-20**: `docs/developer/CUSTOM_GUIDES.md` — Validated against `src/components/block-editor/` and custom guide backend. Indexed in `AGENTS.md`.
 - **2026-03-20**: `docs/developer/integrations/workshop.md` — Updated for `flags.ts` (follow-mode feature flag), `session-crypto.ts` (ECDSA P-256 presenter authentication), `session-manager.ts` and `session-state.tsx` (P2P session management). Added Session Manager, Session State, Session Crypto, and Feature Flags sections.

--- a/docs/developer/CLI_TOOLS.md
+++ b/docs/developer/CLI_TOOLS.md
@@ -45,7 +45,7 @@ node dist/cli/cli/index.js validate [options] [files...]
 
 ### Options
 
-- `--bundled`: Validate all bundled guides located in `src/bundled-interactives/`. This option automatically discovers all JSON files in the directory (excluding `index.json`) relative to the current working directory where the command is executed. When run in another repository, it will look for `src/bundled-interactives/` in that repository's directory structure.
+- `--bundled`: Validate all bundled guides located in `src/bundled-interactives/`. Discovery works in two modes: subdirectories containing `content.json` are validated as package guides (e.g. `first-dashboard/content.json`); flat JSON files at the root level are also loaded as legacy guides (excluding `index.json` and `repository.json`). The `static-links/` subdirectory is always skipped. The path is resolved relative to the current working directory, so when run in another repository it will look for `src/bundled-interactives/` in that repository's directory structure.
 - `--stdin`: Read a single JSON guide from stdin instead of files. Mutually exclusive with `--bundled`, `--package`, `--packages`, and file arguments.
 - `--strict`: Treat warnings as errors. The command will exit with a non-zero status code if any warnings are found.
 - `--format <format>`: Output format. Options are `text` (default) or `json`.


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-03-20.

### Changes made

- `systemPatterns.mdc`: Removed stale Utils description (keyboard-shortcuts and link-handling hooks removed); added Package Engine subsystem entry (src/package-engine/); updated Learning Paths Critical Path for paths-cloud.json and paths-data.ts runtime selector.
- `CLI_TOOLS.md`: Updated --bundled option description to reflect two-mode discovery (package dirs with content.json + flat JSON legacy; repository.json and static-links/ excluded). Verified against src/cli/utils/file-loader.ts.
- `interactiveRequirements.mdc`: Added code-block to data-targetaction values list (new handler added post-Feb 2026).
- `_maintenance-backlog.md`: Recorded validated docs for this run.

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| HIGH | systemPatterns.mdc stale — Package Engine absent, Utils description outdated, Learning Paths path stale | Fixed in this PR |
| HIGH | CLI_TOOLS.md stale — --bundled description wrong after bundled-interactives restructure | Fixed in this PR |
| MEDIUM | interactiveRequirements.mdc — code-block action type missing from data-targetaction values | Fixed in this PR |

### Recommendations for separate work

- E2E_TESTING.md does not document manifest pre-flight checks (testEnvironment tier/minVersion/plugins validation) introduced in src/cli/utils/manifest-preflight.ts. Recommend a targeted update covering what pre-flight checks run and how failures surface.

### Validation checklist

- [x] All changed files are .md or .mdc (verified via git diff --name-only)
- [x] Phase 2.5 verification passed (sub-agent claims spot-checked against source)
- [x] npm run prettier passed
- [x] No source code files were modified