### PR TITLE
feat: add callout block type

### DIFF
--- a/src/components/block-editor/BlockFormModal.tsx
+++ b/src/components/block-editor/BlockFormModal.tsx
@@ -36,6 +36,7 @@ const BLOCK_EDITOR_MODAL_ATTR = 'data-block-editor-modal';
 import { MarkdownBlockForm } from './forms/MarkdownBlockForm';
 import { HtmlBlockForm } from './forms/HtmlBlockForm';
 import { ImageBlockForm } from './forms/ImageBlockForm';
+import { CalloutBlockForm } from './forms/CalloutBlockForm';
 import { VideoBlockForm } from './forms/VideoBlockForm';
 import { SectionBlockForm } from './forms/SectionBlockForm';
 import { ConditionalBlockForm } from './forms/ConditionalBlockForm';
@@ -110,6 +111,7 @@ const FORM_COMPONENTS: Record<BlockType, React.ComponentType<BlockFormProps>> = 
   markdown: MarkdownBlockForm,
   html: HtmlBlockForm,
   image: ImageBlockForm,
+  callout: CalloutBlockForm,
   video: VideoBlockForm,
   section: SectionBlockForm,
   conditional: ConditionalBlockForm,

--- a/src/components/block-editor/constants.ts
+++ b/src/components/block-editor/constants.ts
@@ -32,6 +32,13 @@ export const BLOCK_TYPE_METADATA: Record<BlockType, BlockTypeMetadata> = {
     name: 'Image',
     description: 'Embedded image with optional dimensions',
   },
+  callout: {
+    type: 'callout',
+    icon: '📢',
+    grafanaIcon: 'info-circle',
+    name: 'Callout',
+    description: 'Highlighted message box (info, warning, success, error)',
+  },
   video: {
     type: 'video',
     icon: '🎬',
@@ -117,6 +124,7 @@ export const BLOCK_TYPE_METADATA: Record<BlockType, BlockTypeMetadata> = {
  */
 export const BLOCK_TYPE_ORDER: BlockType[] = [
   'markdown',
+  'callout',
   'image',
   'video',
   'section',

--- a/src/components/block-editor/forms/BranchBlocksEditor.tsx
+++ b/src/components/block-editor/forms/BranchBlocksEditor.tsx
@@ -267,6 +267,8 @@ function createDefaultBlock(type: BlockType): JsonBlock {
       return { type: 'multistep', content: '', steps: [] };
     case 'guided':
       return { type: 'guided', content: '', steps: [] };
+    case 'callout':
+      return { type: 'callout', variant: 'info', content: '' };
     default:
       return { type: 'markdown', content: '' };
   }

--- a/src/components/block-editor/forms/CalloutBlockForm.test.tsx
+++ b/src/components/block-editor/forms/CalloutBlockForm.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * CalloutBlockForm Tests
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CalloutBlockForm } from './CalloutBlockForm';
+import type { JsonCalloutBlock } from '../../../types/json-guide.types';
+
+// Mock Grafana UI to avoid theme issues
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  useStyles2: () => ({
+    form: 'form',
+    row: 'row',
+    footer: 'footer',
+    footerLeft: 'footerLeft',
+  }),
+}));
+
+describe('CalloutBlockForm', () => {
+  const mockOnSubmit = jest.fn();
+  const mockOnCancel = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render with empty defaults for new blocks', () => {
+    render(<CalloutBlockForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+    expect(screen.getByText('Add block')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Enter callout content (supports markdown)')).toBeInTheDocument();
+  });
+
+  it('should submit a callout block with correct data', () => {
+    render(<CalloutBlockForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+    // Fill in content
+    const contentInput = screen.getByPlaceholderText('Enter callout content (supports markdown)');
+    fireEvent.change(contentInput, { target: { value: 'This is important!' } });
+
+    // Fill in title
+    const titleInput = screen.getByPlaceholderText('e.g., Watch out, Tip, Important');
+    fireEvent.change(titleInput, { target: { value: 'Warning' } });
+
+    // Submit
+    fireEvent.click(screen.getByText('Add block'));
+
+    expect(mockOnSubmit).toHaveBeenCalledWith({
+      type: 'callout',
+      variant: 'info',
+      content: 'This is important!',
+      title: 'Warning',
+    });
+  });
+
+  it('should disable submit when content is empty', () => {
+    render(<CalloutBlockForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+    // Grafana Button wraps text in a span, so find the button element
+    const submitButton = screen.getByText('Add block').closest('button');
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('should populate form when editing an existing block', () => {
+    const existingBlock: JsonCalloutBlock = {
+      type: 'callout',
+      variant: 'warning',
+      content: 'Be careful!',
+      title: 'Caution',
+    };
+
+    render(
+      <CalloutBlockForm initialData={existingBlock} onSubmit={mockOnSubmit} onCancel={mockOnCancel} isEditing={true} />
+    );
+
+    expect(screen.getByText('Update block')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Caution')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Be careful!')).toBeInTheDocument();
+  });
+
+  it('should call onCancel when cancel is clicked', () => {
+    render(<CalloutBlockForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+
+  it('should not include title if empty', () => {
+    render(<CalloutBlockForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+
+    const contentInput = screen.getByPlaceholderText('Enter callout content (supports markdown)');
+    fireEvent.change(contentInput, { target: { value: 'No title callout' } });
+
+    fireEvent.click(screen.getByText('Add block'));
+
+    const submitted = mockOnSubmit.mock.calls[0][0];
+    expect(submitted.title).toBeUndefined();
+    expect(submitted.content).toBe('No title callout');
+  });
+});

--- a/src/components/block-editor/forms/CalloutBlockForm.tsx
+++ b/src/components/block-editor/forms/CalloutBlockForm.tsx
@@ -1,0 +1,106 @@
+/**
+ * Callout Block Form
+ *
+ * Form for creating/editing callout blocks.
+ * Follows the ImageBlockForm pattern.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { Button, Field, Input, TextArea, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { getBlockFormStyles } from '../block-editor.styles';
+import { TypeSwitchDropdown } from './TypeSwitchDropdown';
+import { testIds } from '../../../constants/testIds';
+import type { BlockFormProps, JsonBlock } from '../types';
+import type { JsonCalloutBlock } from '../../../types/json-guide.types';
+
+/**
+ * Type guard for callout blocks
+ */
+function isCalloutBlock(block: JsonBlock): block is JsonCalloutBlock {
+  return block.type === 'callout';
+}
+
+const VARIANT_OPTIONS = [
+  { label: 'ℹ️ Info', value: 'info' as const },
+  { label: '⚠️ Warning', value: 'warning' as const },
+  { label: '✅ Success', value: 'success' as const },
+  { label: '❌ Error', value: 'error' as const },
+];
+
+/**
+ * Callout block form component
+ */
+export function CalloutBlockForm({
+  initialData,
+  onSubmit,
+  onCancel,
+  isEditing = false,
+  onSwitchBlockType,
+}: BlockFormProps) {
+  const styles = useStyles2(getBlockFormStyles);
+
+  // Initialize from existing data or defaults
+  const initial = initialData && isCalloutBlock(initialData) ? initialData : null;
+  const [variant, setVariant] = useState<'info' | 'warning' | 'success' | 'error'>(initial?.variant ?? 'info');
+  const [title, setTitle] = useState(initial?.title ?? '');
+  const [content, setContent] = useState(initial?.content ?? '');
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const block: JsonCalloutBlock = {
+        type: 'callout',
+        variant,
+        content: content.trim(),
+        ...(title.trim() && { title: title.trim() }),
+      };
+      onSubmit(block);
+    },
+    [variant, title, content, onSubmit]
+  );
+
+  const isValid = content.trim().length > 0;
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.form}>
+      <Field label="Variant" description="Visual style of the callout">
+        <RadioButtonGroup options={VARIANT_OPTIONS} value={variant} onChange={(v) => setVariant(v)} />
+      </Field>
+
+      <Field label="Title" description="Optional heading displayed at the top of the callout">
+        <Input
+          value={title}
+          onChange={(e) => setTitle(e.currentTarget.value)}
+          placeholder="e.g., Watch out, Tip, Important"
+        />
+      </Field>
+
+      <Field label="Content" description="Markdown body text for the callout" required>
+        <TextArea
+          value={content}
+          onChange={(e) => setContent(e.currentTarget.value)}
+          placeholder="Enter callout content (supports markdown)"
+          rows={4}
+          autoFocus
+        />
+      </Field>
+
+      <div className={styles.footer}>
+        {isEditing && onSwitchBlockType && (
+          <div className={styles.footerLeft}>
+            <TypeSwitchDropdown currentType="callout" onSwitch={onSwitchBlockType} blockData={initialData} />
+          </div>
+        )}
+        <Button variant="secondary" onClick={onCancel} type="button" data-testid={testIds.blockEditor.formCancelButton}>
+          Cancel
+        </Button>
+        <Button variant="primary" type="submit" disabled={!isValid}>
+          {isEditing ? 'Update block' : 'Add block'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+// Add display name for debugging
+CalloutBlockForm.displayName = 'CalloutBlockForm';

--- a/src/components/block-editor/types.ts
+++ b/src/components/block-editor/types.ts
@@ -19,6 +19,7 @@ export type BlockType =
   | 'markdown'
   | 'html'
   | 'image'
+  | 'callout'
   | 'video'
   | 'section'
   | 'conditional'

--- a/src/components/block-editor/utils/block-conversion.test.ts
+++ b/src/components/block-editor/utils/block-conversion.test.ts
@@ -40,12 +40,12 @@ describe('getAvailableConversions', () => {
       expect(result).toContain('input');
     });
 
-    it('should return 11 options for any non-container type', () => {
-      // 12 non-container types minus 1 (the source type) = 11
-      expect(getAvailableConversions('markdown')).toHaveLength(11);
-      expect(getAvailableConversions('html')).toHaveLength(11);
-      expect(getAvailableConversions('quiz')).toHaveLength(11);
-      expect(getAvailableConversions('interactive')).toHaveLength(11);
+    it('should return 12 options for any non-container type', () => {
+      // 13 non-container types minus 1 (the source type) = 12
+      expect(getAvailableConversions('markdown')).toHaveLength(12);
+      expect(getAvailableConversions('html')).toHaveLength(12);
+      expect(getAvailableConversions('quiz')).toHaveLength(12);
+      expect(getAvailableConversions('interactive')).toHaveLength(12);
     });
   });
 });

--- a/src/components/block-editor/utils/block-conversion.ts
+++ b/src/components/block-editor/utils/block-conversion.ts
@@ -76,7 +76,7 @@ const REQUIRED_DEFAULTS: Partial<Record<BlockType, Record<string, unknown>>> = {
   quiz: { choices: [{ id: 'a', text: 'Option A', correct: true }] },
   input: { inputType: 'text', variableName: 'userInput' },
   image: { src: PLACEHOLDER_URL, alt: '' },
-  callout: { variant: 'info' },
+  callout: { variant: 'info', content: 'Callout content' },
   video: { src: PLACEHOLDER_URL },
   interactive: { action: 'noop' },
   multistep: { content: 'Complete these steps', steps: [{ action: 'noop' }] },

--- a/src/components/block-editor/utils/block-conversion.ts
+++ b/src/components/block-editor/utils/block-conversion.ts
@@ -26,6 +26,7 @@ const CONVERTIBLE_TYPES: readonly BlockType[] = [
   'markdown',
   'html',
   'image',
+  'callout',
   'video',
   'interactive',
   'multistep',
@@ -49,6 +50,7 @@ const COMMON_FIELDS = ['requirements', 'objectives', 'skippable'] as const;
 const CONTENT_FIELDS: Partial<Record<BlockType, string>> = {
   markdown: 'content',
   html: 'content',
+  callout: 'content',
   interactive: 'content',
   multistep: 'content',
   guided: 'content',
@@ -74,6 +76,7 @@ const REQUIRED_DEFAULTS: Partial<Record<BlockType, Record<string, unknown>>> = {
   quiz: { choices: [{ id: 'a', text: 'Option A', correct: true }] },
   input: { inputType: 'text', variableName: 'userInput' },
   image: { src: PLACEHOLDER_URL, alt: '' },
+  callout: { variant: 'info' },
   video: { src: PLACEHOLDER_URL },
   interactive: { action: 'noop' },
   multistep: { content: 'Complete these steps', steps: [{ action: 'noop' }] },

--- a/src/components/block-editor/utils/block-preview.ts
+++ b/src/components/block-editor/utils/block-preview.ts
@@ -9,6 +9,7 @@ import {
   isMarkdownBlock,
   isHtmlBlock,
   isImageBlock,
+  isCalloutBlock,
   isVideoBlock,
   isSectionBlock,
   isInteractiveBlock,
@@ -63,6 +64,12 @@ export function getBlockPreview(block: JsonBlock, options: BlockPreviewOptions =
     // Strip HTML tags and show text
     const text = block.content.replace(/<[^>]+>/g, ' ').trim();
     return truncate(text, maxLength);
+  }
+
+  if (isCalloutBlock(block)) {
+    const prefix = `[${block.variant}]`;
+    const text = block.title || block.content.split('\n')[0] || '';
+    return truncate(`${prefix} ${text}`, maxLength);
   }
 
   if (isImageBlock(block)) {

--- a/src/docs-retrieval/components/docs/callout-block.tsx
+++ b/src/docs-retrieval/components/docs/callout-block.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+export interface CalloutBlockProps {
+  variant: 'info' | 'warning' | 'success' | 'error';
+  title?: string;
+  children?: React.ReactNode;
+}
+
+const VARIANT_ICONS: Record<string, string> = {
+  info: 'ℹ️',
+  warning: '⚠️',
+  success: '✅',
+  error: '❌',
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  const variantColors = {
+    info: {
+      bg: theme.colors.info.transparent,
+      border: theme.colors.info.border,
+      text: theme.colors.info.text,
+    },
+    warning: {
+      bg: theme.colors.warning.transparent,
+      border: theme.colors.warning.border,
+      text: theme.colors.warning.text,
+    },
+    success: {
+      bg: theme.colors.success.transparent,
+      border: theme.colors.success.border,
+      text: theme.colors.success.text,
+    },
+    error: {
+      bg: theme.colors.error.transparent,
+      border: theme.colors.error.border,
+      text: theme.colors.error.text,
+    },
+  };
+
+  return {
+    ...Object.fromEntries(
+      Object.entries(variantColors).map(([variant, colors]) => [
+        variant,
+        css({
+          backgroundColor: colors.bg,
+          borderLeft: `4px solid ${colors.border}`,
+          padding: theme.spacing(2),
+          marginBottom: theme.spacing(2),
+          borderRadius: theme.shape.radius.default,
+        }),
+      ])
+    ),
+    title: css({
+      fontWeight: theme.typography.fontWeightBold,
+      marginBottom: theme.spacing(1),
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+    }),
+    content: css({
+      '& > *:last-child': {
+        marginBottom: 0,
+      },
+    }),
+    icon: css({
+      flexShrink: 0,
+    }),
+  };
+};
+
+export function CalloutBlock({ variant, title, children }: CalloutBlockProps) {
+  const styles = useStyles2(getStyles);
+  const icon = VARIANT_ICONS[variant] || VARIANT_ICONS.info;
+  const variantStyle = (styles as Record<string, string>)[variant] || (styles as Record<string, string>).info;
+
+  return (
+    <div className={variantStyle}>
+      {title && (
+        <div className={styles.title}>
+          <span className={styles.icon}>{icon}</span>
+          <span>{title}</span>
+        </div>
+      )}
+      <div className={styles.content}>{children}</div>
+    </div>
+  );
+}

--- a/src/docs-retrieval/components/docs/callout-block.tsx
+++ b/src/docs-retrieval/components/docs/callout-block.tsx
@@ -47,6 +47,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         css({
           backgroundColor: colors.bg,
           borderLeft: `4px solid ${colors.border}`,
+          color: colors.text,
           padding: theme.spacing(2),
           marginBottom: theme.spacing(2),
           borderRadius: theme.shape.radius.default,

--- a/src/docs-retrieval/components/docs/index.ts
+++ b/src/docs-retrieval/components/docs/index.ts
@@ -1,4 +1,5 @@
 // Documentation components
+export { CalloutBlock } from './callout-block';
 export { CodeBlock } from './code-block';
 export { ExpandableTable } from './expandable-table';
 export { ImageRenderer } from './image-renderer';
@@ -8,6 +9,7 @@ export { SideJourneyLink } from './side-journey-link';
 export { ContentParsingError } from './content-parsing-error';
 
 // Types
+export type { CalloutBlockProps } from './callout-block';
 export type { CodeBlockProps } from './code-block';
 export type { ExpandableTableProps } from './expandable-table';
 export type { ImageRendererProps } from './image-renderer';

--- a/src/docs-retrieval/content-renderer.tsx
+++ b/src/docs-retrieval/content-renderer.tsx
@@ -24,6 +24,7 @@ import {
   getDocumentStepPosition,
 } from '../components/interactive-tutorial';
 import {
+  CalloutBlock,
   CodeBlock,
   ExpandableTable,
   ImageRenderer,
@@ -1138,6 +1139,12 @@ function renderParsedElement(
           end={element.props.end}
           {...element.props}
         />
+      );
+    case 'callout-block':
+      return (
+        <CalloutBlock key={key} variant={element.props.variant} title={element.props.title}>
+          {renderChildren(element.children)}
+        </CalloutBlock>
       );
     case 'image-renderer':
       return (

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -23,6 +23,7 @@ import {
   type JsonMultistepBlock,
   type JsonGuidedBlock,
   type JsonImageBlock,
+  type JsonCalloutBlock,
   type JsonVideoBlock,
   type JsonQuizBlock,
   type JsonAssistantBlock,
@@ -236,6 +237,8 @@ function convertBlockByType(
       return convertGuidedBlock(block, path);
     case 'image':
       return convertImageBlock(block, path, baseUrl);
+    case 'callout':
+      return convertCalloutBlock(block, path, baseUrl);
     case 'video':
       return convertVideoBlock(block, path);
     case 'quiz':
@@ -662,6 +665,21 @@ function convertImageBlock(block: JsonImageBlock, path: string, baseUrl?: string
   };
 }
 
+function convertCalloutBlock(block: JsonCalloutBlock, path: string, baseUrl?: string): ConversionResult {
+  const children = parseMarkdownToElements(block.content, baseUrl);
+
+  return {
+    element: {
+      type: 'callout-block',
+      props: {
+        variant: block.variant,
+        title: block.title,
+      },
+      children,
+    },
+  };
+}
+
 function convertVideoBlock(block: JsonVideoBlock, path: string): ConversionResult {
   const isYouTube = block.provider === 'youtube' || block.src.includes('youtube.com') || block.src.includes('youtu.be');
 
@@ -862,6 +880,8 @@ function extractDefaultValueFromBlock(block: JsonBlock): string {
     case 'section':
       // Sections contain nested blocks - extract from title if available
       return block.title || '';
+    case 'callout':
+      return block.content;
     case 'image':
       // Images have alt text which could be customized
       return block.alt || '';

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -138,6 +138,17 @@ export const JsonImageBlockSchema = z.object({
 });
 
 /**
+ * Schema for callout block.
+ * @coupling Type: JsonCalloutBlock
+ */
+export const JsonCalloutBlockSchema = z.object({
+  type: z.literal('callout'),
+  variant: z.enum(['info', 'warning', 'success', 'error']),
+  content: z.string().min(1, 'Callout content is required'),
+  title: z.string().optional(),
+});
+
+/**
  * Schema for video block.
  * @coupling Type: JsonVideoBlock
  */
@@ -328,6 +339,7 @@ const NonRecursiveBlockSchema = z.union([
   JsonImageBlockSchema,
   JsonVideoBlockSchema,
   JsonInteractiveBlockSchema,
+  JsonCalloutBlockSchema,
   JsonMultistepBlockSchema,
   JsonGuidedBlockSchema,
   JsonQuizBlockSchema,
@@ -503,6 +515,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
   markdown: new Set(['type', 'content', 'assistantEnabled', 'assistantId', 'assistantType']),
   html: new Set(['type', 'content']),
   image: new Set(['type', 'src', 'alt', 'width', 'height']),
+  callout: new Set(['type', 'variant', 'content', 'title']),
   video: new Set(['type', 'src', 'provider', 'title', 'start', 'end']),
   interactive: new Set([
     'type',
@@ -620,6 +633,7 @@ export const VALID_BLOCK_TYPES = new Set([
   'markdown',
   'html',
   'image',
+  'callout',
   'video',
   'interactive',
   'multistep',

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -43,7 +43,8 @@ export type JsonBlock =
   | JsonInputBlock
   | JsonTerminalBlock
   | JsonTerminalConnectBlock
-  | JsonCodeBlockBlock;
+  | JsonCodeBlockBlock
+  | JsonCalloutBlock;
 
 // ============ ASSISTANT CUSTOMIZATION PROPS ============
 
@@ -99,6 +100,20 @@ export interface JsonImageBlock {
   width?: number;
   /** Display height in pixels */
   height?: number;
+}
+
+/**
+ * Callout block for highlighted admonition messages.
+ * Used to draw attention to tips, warnings, or important notes.
+ */
+export interface JsonCalloutBlock {
+  type: 'callout';
+  /** Callout variant determines visual styling (color, icon) */
+  variant: 'info' | 'warning' | 'success' | 'error';
+  /** Markdown body text */
+  content: string;
+  /** Optional heading displayed at the top of the callout */
+  title?: string;
 }
 
 /**
@@ -591,6 +606,13 @@ export function isTerminalConnectBlock(block: JsonBlock): block is JsonTerminalC
  */
 export function isCodeBlockBlock(block: JsonBlock): block is JsonCodeBlockBlock {
   return block.type === 'code-block';
+}
+
+/**
+ * Type guard for JsonCalloutBlock
+ */
+export function isCalloutBlock(block: JsonBlock): block is JsonCalloutBlock {
+  return block.type === 'callout';
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a new **Callout** block type to the block editor, as described in #703.

- Callout blocks support 4 variants: `info`, `warning`, `success`, `error`
- Optional title and required markdown content
- Fully integrated into the block editor palette, form modal, type conversion system, JSON parser, and content renderer
- Uses Grafana theme tokens for variant-appropriate styling (border, background colors)
- Follows the existing `image` block pattern end-to-end

### Files changed

**New files:**
- `CalloutBlockForm.tsx` — editor form component with variant selector, title, and content fields
- `CalloutBlockForm.test.tsx` — 6 unit tests for the form component
- `callout-block.tsx` — renderer component using Grafana theme tokens

**Modified files (11):**
- `json-guide.types.ts` — `JsonCalloutBlock` interface + type guard
- `json-guide.schema.ts` — Zod schema, KNOWN_FIELDS, VALID_BLOCK_TYPES
- `types.ts` — `BlockType` union
- `constants.ts` — palette metadata + ordering
- `BlockFormModal.tsx` — form registration
- `block-conversion.ts` — conversion support
- `block-preview.ts` — preview string generation
- `json-parser.ts` — JSON→ParsedElement converter
- `content-renderer.tsx` — render case
- `docs/index.ts` — export

## Test plan

- [x] `npx tsc --noEmit` passes (0 errors)
- [x] All 116 test suites pass (2299 tests, 0 failures)
- [x] Pre-commit hooks (prettier, lint-staged) pass
- [ ] Manual: create a callout block in the editor, verify all 4 variants render correctly
- [ ] Manual: verify callout blocks appear in the block palette and can be edited/deleted

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it extends the core block schema union and conversion/parser/rendering paths, which could affect validation and rendering of JSON guides if edge cases are missed. Changes are mostly additive and covered by new form tests, limiting regression scope.
> 
> **Overview**
> Adds a new **`callout`** block type (variants: `info`/`warning`/`success`/`error`) with optional `title` and required markdown `content`, and wires it into the editor palette, `BlockFormModal`, and default block creation.
> 
> Extends block type conversion and previews to support `callout`, including required defaults and updated conversion option counts.
> 
> Updates JSON guide typing/validation and the docs pipeline so `callout` blocks validate via Zod, parse into a new `callout-block` element, and render via a themed `CalloutBlock` component; includes unit tests for `CalloutBlockForm`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e14626c20506fb373c6494631d6428d675eccfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->