### PR TITLE
feat: lazy-load recommendation data and polish milestone UI

### DIFF
--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useEffect, useState } from 'react';
+import { cx } from '@emotion/css';
 
 import { SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
 import { Icon, useStyles2, Card, Alert, Button } from '@grafana/ui';
@@ -12,6 +13,7 @@ import { locationService, config, getAppEvents } from '@grafana/runtime';
 
 // Import refactored context system
 import { getStyles } from '../../styles/context-panel.styles';
+import { getSkeletonStyles } from '../../styles/skeleton.styles';
 import { useContextPanel, Recommendation } from '../../context-engine';
 import type { ResolvedNavLink } from '../../types/context.types';
 import { reportAppInteraction, UserInteraction, getContentTypeForAnalytics } from '../../lib/analytics';
@@ -254,6 +256,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
   toggleOtherDocsExpansion,
 }: RecommendationsSectionProps) {
   const styles = useStyles2(getStyles);
+  const skeletonStyles = useStyles2(getSkeletonStyles);
   const hasCustomGuidesContent = isLoadingCustomGuides || customGuides.length > 0;
   const suggestedGuidesCount = recommendations.length + featuredRecommendations.length;
 
@@ -480,6 +483,19 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                               {recommendation.summary && (
                                 <div className={styles.summaryContent}>
                                   <p className={styles.summaryText}>{recommendation.summary}</p>
+                                </div>
+                              )}
+
+                              {recommendation.isResolvingDeferred && !recommendation.milestones && (
+                                <div className={cx(skeletonStyles.skeleton, styles.deferredSkeleton)}>
+                                  {Array.from({
+                                    length: recommendation.totalSteps ? Math.min(recommendation.totalSteps, 3) : 2,
+                                  }).map((_, i) => (
+                                    <div key={i} className={styles.deferredSkeletonRow}>
+                                      <div className={styles.deferredSkeletonCircle}></div>
+                                      <div className={styles.deferredSkeletonBar}></div>
+                                    </div>
+                                  ))}
                                 </div>
                               )}
 
@@ -773,6 +789,19 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                             {recommendation.summary && (
                               <div className={styles.summaryContent}>
                                 <p className={styles.summaryText}>{recommendation.summary}</p>
+                              </div>
+                            )}
+
+                            {recommendation.isResolvingDeferred && !recommendation.milestones && (
+                              <div className={cx(skeletonStyles.skeleton, styles.deferredSkeleton)}>
+                                {Array.from({
+                                  length: recommendation.totalSteps ? Math.min(recommendation.totalSteps, 3) : 2,
+                                }).map((_, i) => (
+                                  <div key={i} className={styles.deferredSkeletonRow}>
+                                    <div className={styles.deferredSkeletonCircle}></div>
+                                    <div className={styles.deferredSkeletonBar}></div>
+                                  </div>
+                                ))}
                               </div>
                             )}
 

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -3,7 +3,7 @@
 
 import React, { useEffect, useLayoutEffect, useRef, useCallback, Suspense, lazy } from 'react';
 import { SceneObjectBase, SceneComponentProps } from '@grafana/scenes';
-import { IconButton, Alert, Icon, useStyles2, Button, ButtonGroup } from '@grafana/ui';
+import { IconButton, Alert, Icon, useStyles2, Button, ButtonGroup, Dropdown, Menu } from '@grafana/ui';
 
 // Lazy load dev tools to keep them out of production bundles
 // This component is only loaded when dev mode is enabled and the tab is opened
@@ -42,7 +42,6 @@ import {
   getContentTypeForAnalytics,
 } from '../../lib/analytics';
 import { tabStorage, useUserStorage, interactiveStepStorage } from '../../lib/user-storage';
-import { FeedbackButton } from '../FeedbackButton/FeedbackButton';
 import { SkeletonLoader } from '../SkeletonLoader';
 
 import {
@@ -1522,13 +1521,66 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
             );
           }
 
-          // Show loading state with skeleton
+          // Show loading state with skeleton.
+          // When a learning journey tab is reloading (milestone navigation), keep
+          // the milestone bar visible so the user doesn't lose navigation context.
           if (!isRecommendationsTab && activeTab?.isLoading) {
+            const ljMeta = activeTab.content?.metadata?.learningJourney;
+            const showBarWhileLoading =
+              ljMeta &&
+              activeTab.content?.type === 'learning-journey' &&
+              (activeTab.type === 'learning-journey' || !isDocsLikeTab(activeTab.type));
+
             return (
-              <LoadingIndicator
-                className={isDocsLikeTab(activeTab.type) ? styles.docsContent : styles.journeyContent}
-                contentType={isDocsLikeTab(activeTab.type) ? 'documentation' : 'learning-journey'}
-              />
+              <div className={isDocsLikeTab(activeTab.type) ? styles.docsContent : styles.journeyContent}>
+                {showBarWhileLoading && (
+                  <div className={styles.milestoneProgress}>
+                    <div className={styles.progressInfo}>
+                      <div className={styles.progressHeader}>
+                        <IconButton
+                          name="arrow-left"
+                          size="sm"
+                          aria-label={t('docsPanel.previousMilestone', 'Previous milestone')}
+                          onClick={() => model.navigateToPreviousMilestone()}
+                          tooltip={t('docsPanel.previousMilestoneTooltip', 'Previous milestone (Alt + ←)')}
+                          tooltipPlacement="top"
+                          disabled={true}
+                          className={styles.navButton}
+                        />
+                        <span className={styles.milestoneText}>
+                          {ljMeta.currentMilestone === 0
+                            ? t('docsPanel.milestoneIntroduction', 'Introduction ({{total}} milestones)', {
+                                total: ljMeta.totalMilestones,
+                              })
+                            : t('docsPanel.milestoneProgress', 'Milestone {{current}} of {{total}}', {
+                                current: ljMeta.currentMilestone,
+                                total: ljMeta.totalMilestones,
+                              })}
+                        </span>
+                        <IconButton
+                          name="arrow-right"
+                          size="sm"
+                          aria-label={t('docsPanel.nextMilestone', 'Next milestone')}
+                          onClick={() => model.navigateToNextMilestone()}
+                          tooltip={t('docsPanel.nextMilestoneTooltip', 'Next milestone (Alt + →)')}
+                          tooltipPlacement="top"
+                          disabled={true}
+                          className={styles.navButton}
+                        />
+                      </div>
+                      <div className={styles.progressBar}>
+                        <div
+                          className={styles.progressFill}
+                          style={{
+                            width: `${((ljMeta.currentMilestone || 0) / (ljMeta.totalMilestones || 1)) * 100}%`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
+                <LoadingIndicator contentType={isDocsLikeTab(activeTab.type) ? 'documentation' : 'learning-journey'} />
+              </div>
             );
           }
 
@@ -1588,7 +1640,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                   </div>
                 )}
 
-                {/* Content Meta for docs/interactive - now includes secondary open-in-new button */}
+                {/* Content Meta for docs/interactive - label left, primary actions + kebab right */}
                 {isDocsLikeTab(activeTab.type) && (
                   <div className={styles.contentMeta}>
                     <div className={styles.metaInfo}>
@@ -1598,17 +1650,11 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                           : t('docsPanel.documentation', 'Documentation')}
                       </span>
                     </div>
-                    <div
-                      style={{
-                        display: 'flex',
-                        gap: 8,
-                      }}
-                    >
+                    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
                       {(() => {
                         const url = activeTab.content?.url || activeTab.baseUrl;
                         if (isGrafanaDocsUrl(url)) {
                           const cleanUrl = cleanDocsUrl(url);
-
                           return (
                             <button
                               className={styles.secondaryActionButton}
@@ -1622,7 +1668,6 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                                   link_type: 'external_browser',
                                   interaction_location: 'docs_content_meta_right',
                                 });
-                                // Delay to ensure analytics event is sent before opening new tab
                                 setTimeout(() => {
                                   window.open(cleanUrl, '_blank', 'noopener,noreferrer');
                                 }, 100);
@@ -1635,17 +1680,6 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                         }
                         return null;
                       })()}
-                      {isDevMode && (
-                        <IconButton
-                          tooltip="Refresh tab (dev mode only)"
-                          name="sync"
-                          onClick={() => {
-                            if (activeTab) {
-                              reloadActiveTab(activeTab);
-                            }
-                          }}
-                        />
-                      )}
                       {(hasInteractiveProgress || activeTab.type === 'interactive') && (
                         <button
                           className={styles.secondaryActionButton}
@@ -1661,14 +1695,50 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                           <span>{t('docsPanel.resetGuide', 'Reset guide')}</span>
                         </button>
                       )}
-                      <FeedbackButton
-                        variant="secondary"
-                        contentUrl={activeTab.content?.url || activeTab.baseUrl}
-                        contentType={activeTab.type || 'learning-journey'}
-                        interactionLocation="docs_panel_header_feedback_button"
-                        currentMilestone={activeTab.content?.metadata?.learningJourney?.currentMilestone}
-                        totalMilestones={activeTab.content?.metadata?.learningJourney?.totalMilestones}
-                      />
+                      <Dropdown
+                        placement="bottom-end"
+                        overlay={
+                          <Menu>
+                            {isDevMode && (
+                              <Menu.Item
+                                label={t('docsPanel.refreshDev', 'Refresh (dev)')}
+                                icon="sync"
+                                onClick={() => {
+                                  if (activeTab) {
+                                    reloadActiveTab(activeTab);
+                                  }
+                                }}
+                              />
+                            )}
+                            <Menu.Item
+                              label={t('docsPanel.giveFeedback', 'Give feedback')}
+                              icon="comment-alt-message"
+                              onClick={() => {
+                                reportAppInteraction(UserInteraction.GeneralPluginFeedbackButton, {
+                                  interaction_location: 'docs_panel_header_feedback_menu',
+                                  panel_type: 'combined_learning_journey',
+                                  content_url: activeTab.content?.url || activeTab.baseUrl || '',
+                                  content_type: activeTab.type || 'docs',
+                                });
+                                setTimeout(() => {
+                                  window.open(
+                                    'https://docs.google.com/forms/d/e/1FAIpQLSdBvntoRShjQKEOOnRn4_3AWXomKYq03IBwoEaexlwcyjFe5Q/viewform?usp=header',
+                                    '_blank',
+                                    'noopener,noreferrer'
+                                  );
+                                }, 100);
+                              }}
+                            />
+                          </Menu>
+                        }
+                      >
+                        <IconButton
+                          name="ellipsis-v"
+                          size="sm"
+                          aria-label={t('docsPanel.menuAriaLabel', 'More options')}
+                          tooltip={t('docsPanel.menuTooltip', 'More options')}
+                        />
+                      </Dropdown>
                     </div>
                   </div>
                 )}
@@ -1792,17 +1862,6 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                           }
                           return null;
                         })()}
-                        {isDevMode && (
-                          <IconButton
-                            tooltip="Refresh tab (dev mode only)"
-                            name="sync"
-                            onClick={() => {
-                              if (activeTab) {
-                                reloadActiveTab(activeTab);
-                              }
-                            }}
-                          />
-                        )}
                         {(hasInteractiveProgress || activeTab.type === 'interactive') && (
                           <button
                             className={styles.secondaryActionButton}
@@ -1818,14 +1877,50 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                             <span>{t('docsPanel.resetGuide', 'Reset guide')}</span>
                           </button>
                         )}
-                        <FeedbackButton
-                          variant="secondary"
-                          contentUrl={activeTab.content?.url || activeTab.baseUrl}
-                          contentType={activeTab.type || 'learning-journey'}
-                          interactionLocation="milestone_progress_bar_feedback_button"
-                          currentMilestone={activeTab.content?.metadata?.learningJourney?.currentMilestone}
-                          totalMilestones={activeTab.content?.metadata?.learningJourney?.totalMilestones}
-                        />
+                        <Dropdown
+                          placement="bottom-end"
+                          overlay={
+                            <Menu>
+                              {isDevMode && (
+                                <Menu.Item
+                                  label={t('docsPanel.refreshDev', 'Refresh (dev)')}
+                                  icon="sync"
+                                  onClick={() => {
+                                    if (activeTab) {
+                                      reloadActiveTab(activeTab);
+                                    }
+                                  }}
+                                />
+                              )}
+                              <Menu.Item
+                                label={t('docsPanel.giveFeedback', 'Give feedback')}
+                                icon="comment-alt-message"
+                                onClick={() => {
+                                  reportAppInteraction(UserInteraction.GeneralPluginFeedbackButton, {
+                                    interaction_location: 'milestone_progress_bar_feedback_menu',
+                                    panel_type: 'combined_learning_journey',
+                                    content_url: activeTab.content?.url || activeTab.baseUrl || '',
+                                    content_type: activeTab.type || 'learning-journey',
+                                  });
+                                  setTimeout(() => {
+                                    window.open(
+                                      'https://docs.google.com/forms/d/e/1FAIpQLSdBvntoRShjQKEOOnRn4_3AWXomKYq03IBwoEaexlwcyjFe5Q/viewform?usp=header',
+                                      '_blank',
+                                      'noopener,noreferrer'
+                                    );
+                                  }, 100);
+                                }}
+                              />
+                            </Menu>
+                          }
+                        >
+                          <IconButton
+                            name="ellipsis-v"
+                            size="sm"
+                            aria-label={t('docsPanel.menuAriaLabel', 'More options')}
+                            tooltip={t('docsPanel.menuTooltip', 'More options')}
+                          />
+                        </Dropdown>
                       </div>
                       <div className={styles.progressBar}>
                         <div

--- a/src/context-engine/context-v1-recommend.test.ts
+++ b/src/context-engine/context-v1-recommend.test.ts
@@ -593,12 +593,12 @@ describe('V1 error handling and edge cases', () => {
   });
 });
 
-describe('Path package milestone resolution in processLearningJourneys', () => {
+describe('Path package deferred milestone resolution', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should populate milestones and totalSteps for path-type package recommendations', async () => {
+  it('should store pendingMilestoneIds and totalSteps for path-type package recommendations', async () => {
     const v1Response = makeV1Response({
       recommendations: [
         {
@@ -627,12 +627,13 @@ describe('Path package milestone resolution in processLearningJourneys', () => {
 
     const pathRec = result.recommendations.find((r) => r.title === 'Grafana Cloud Tour');
     expect(pathRec).toBeDefined();
-    expect(pathRec!.milestones).toHaveLength(2);
+    expect(pathRec!.pendingMilestoneIds).toEqual(['ms-1', 'ms-2']);
     expect(pathRec!.totalSteps).toBe(2);
-    expect(pathRec!.milestones![0]!.title).toBe('Milestone 1');
+    expect(pathRec!.milestones).toBeUndefined();
+    expect(pathRec!.pendingPathSlug).toBe('grafana-cloud-tour');
   });
 
-  it('should not populate milestones for guide-type package recommendations', async () => {
+  it('should not set pendingMilestoneIds for guide-type package recommendations', async () => {
     const v1Response = makeV1Response({
       recommendations: [
         {
@@ -659,17 +660,36 @@ describe('Path package milestone resolution in processLearningJourneys', () => {
 
     const guideRec = result.recommendations.find((r) => r.title === 'A Guide');
     expect(guideRec).toBeDefined();
-    expect(guideRec!.milestones).toBeUndefined();
+    expect(guideRec!.pendingMilestoneIds).toBeUndefined();
     expect(guideRec!.totalSteps).toBeUndefined();
+  });
+
+  it('should resolve deferred milestones via resolveDeferredData', async () => {
+    const rec: Recommendation = {
+      title: 'Cloud Tour',
+      url: '',
+      type: 'package',
+      contentUrl: 'https://cdn.example.com/packages/cloud-tour/content.json',
+      pendingMilestoneIds: ['ms-1', 'ms-2'],
+      pendingPathSlug: 'cloud-tour',
+    };
+
+    const resolved = await ContextService.resolveDeferredData(rec);
+
+    expect(resolved.milestones).toHaveLength(2);
+    expect(resolved.milestones![0]!.title).toBe('Milestone 1');
+    expect(resolved.totalSteps).toBe(2);
+    expect(resolved.pendingMilestoneIds).toBeUndefined();
+    expect(resolved.pendingPathSlug).toBeUndefined();
   });
 });
 
-describe('Package recommends/suggests nav link resolution', () => {
+describe('Package recommends/suggests deferred nav link resolution', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should resolve recommends and suggests into ResolvedNavLink arrays', async () => {
+  it('should store pendingRecommendIds and pendingSuggestIds instead of resolving eagerly', async () => {
     const v1Response = makeV1Response({
       recommendations: [
         {
@@ -698,15 +718,13 @@ describe('Package recommends/suggests nav link resolution', () => {
 
     const rec = result.recommendations.find((r) => r.title === 'Alerting 101');
     expect(rec).toBeDefined();
-    expect(rec!.resolvedRecommends).toHaveLength(2);
-    expect(rec!.resolvedRecommends![0]!.packageId).toBe('alerting-notifications');
-    expect(rec!.resolvedRecommends![0]!.title).toBe('Resolved: alerting-notifications');
-    expect(rec!.resolvedRecommends![0]!.contentUrl).toBe('bundled:alerting-notifications/content.json');
-    expect(rec!.resolvedSuggests).toHaveLength(1);
-    expect(rec!.resolvedSuggests![0]!.packageId).toBe('explore-drilldowns-101');
+    expect(rec!.pendingRecommendIds).toEqual(['alerting-notifications', 'slo-quickstart']);
+    expect(rec!.pendingSuggestIds).toEqual(['explore-drilldowns-101']);
+    expect(rec!.resolvedRecommends).toBeUndefined();
+    expect(rec!.resolvedSuggests).toBeUndefined();
   });
 
-  it('should not set resolvedRecommends/resolvedSuggests when manifest has no nav links', async () => {
+  it('should not set pendingRecommendIds/pendingSuggestIds when manifest has no nav links', async () => {
     const v1Response = makeV1Response({
       recommendations: [
         {
@@ -733,7 +751,28 @@ describe('Package recommends/suggests nav link resolution', () => {
 
     const rec = result.recommendations.find((r) => r.title === 'Simple Guide');
     expect(rec).toBeDefined();
-    expect(rec!.resolvedRecommends).toBeUndefined();
-    expect(rec!.resolvedSuggests).toBeUndefined();
+    expect(rec!.pendingRecommendIds).toBeUndefined();
+    expect(rec!.pendingSuggestIds).toBeUndefined();
+  });
+
+  it('should resolve deferred data via resolveDeferredData', async () => {
+    const rec: Recommendation = {
+      title: 'Alerting 101',
+      url: '',
+      type: 'package',
+      contentUrl: 'https://cdn.example.com/packages/alerting-101/content.json',
+      pendingRecommendIds: ['alerting-notifications', 'slo-quickstart'],
+      pendingSuggestIds: ['explore-drilldowns-101'],
+    };
+
+    const resolved = await ContextService.resolveDeferredData(rec);
+
+    expect(resolved.resolvedRecommends).toHaveLength(2);
+    expect(resolved.resolvedRecommends![0]!.packageId).toBe('alerting-notifications');
+    expect(resolved.resolvedRecommends![0]!.title).toBe('Resolved: alerting-notifications');
+    expect(resolved.resolvedSuggests).toHaveLength(1);
+    expect(resolved.resolvedSuggests![0]!.packageId).toBe('explore-drilldowns-101');
+    expect(resolved.pendingRecommendIds).toBeUndefined();
+    expect(resolved.pendingSuggestIds).toBeUndefined();
   });
 });

--- a/src/context-engine/context.hook.ts
+++ b/src/context-engine/context.hook.ts
@@ -289,21 +289,57 @@ export function useContextPanel(options: UseContextPanelOptions = {}): UseContex
       (rec.url !== '' && rec.url === recommendationUrl) ||
       (rec.contentUrl !== '' && rec.contentUrl === recommendationUrl);
 
+    const hasDeferredData = (rec: Recommendation) =>
+      (rec.pendingRecommendIds && rec.pendingRecommendIds.length > 0) ||
+      (rec.pendingSuggestIds && rec.pendingSuggestIds.length > 0) ||
+      (rec.pendingMilestoneIds && rec.pendingMilestoneIds.length > 0);
+
+    const updateRec = (rec: Recommendation): Recommendation => {
+      if (!matches(rec)) {
+        return rec;
+      }
+      const expanding = !rec.summaryExpanded;
+      return {
+        ...rec,
+        summaryExpanded: expanding,
+        ...(expanding && hasDeferredData(rec) ? { isResolvingDeferred: true } : {}),
+      };
+    };
+
     setContextData((prev) => ({
       ...prev,
-      recommendations: prev.recommendations.map((rec) => {
-        if (matches(rec)) {
-          return { ...rec, summaryExpanded: !rec.summaryExpanded };
-        }
-        return rec;
-      }),
-      featuredRecommendations: prev.featuredRecommendations.map((rec) => {
-        if (matches(rec)) {
-          return { ...rec, summaryExpanded: !rec.summaryExpanded };
-        }
-        return rec;
-      }),
+      recommendations: prev.recommendations.map(updateRec),
+      featuredRecommendations: prev.featuredRecommendations.map(updateRec),
     }));
+
+    // Lazily resolve deferred nav links and milestones on first expand
+    setContextData((prev) => {
+      const target =
+        prev.recommendations.find((r) => matches(r) && r.isResolvingDeferred) ??
+        prev.featuredRecommendations.find((r) => matches(r) && r.isResolvingDeferred);
+
+      if (!target) {
+        return prev;
+      }
+
+      ContextService.resolveDeferredData(target).then((resolved) => {
+        setContextData((current) => {
+          const applyResolved = (rec: Recommendation): Recommendation => {
+            if (!matches(rec)) {
+              return rec;
+            }
+            return { ...rec, ...resolved, summaryExpanded: rec.summaryExpanded, isResolvingDeferred: false };
+          };
+          return {
+            ...current,
+            recommendations: current.recommendations.map(applyResolved),
+            featuredRecommendations: current.featuredRecommendations.map(applyResolved),
+          };
+        });
+      });
+
+      return prev;
+    });
   }, []);
 
   const navigateToPath = useCallback((path: string) => {

--- a/src/context-engine/context.hook.ts
+++ b/src/context-engine/context.hook.ts
@@ -294,52 +294,62 @@ export function useContextPanel(options: UseContextPanelOptions = {}): UseContex
       (rec.pendingSuggestIds && rec.pendingSuggestIds.length > 0) ||
       (rec.pendingMilestoneIds && rec.pendingMilestoneIds.length > 0);
 
-    const updateRec = (rec: Recommendation): Recommendation => {
-      if (!matches(rec)) {
-        return rec;
-      }
-      const expanding = !rec.summaryExpanded;
-      return {
-        ...rec,
-        summaryExpanded: expanding,
-        ...(expanding && hasDeferredData(rec) ? { isResolvingDeferred: true } : {}),
-      };
-    };
+    let resolveTarget: Recommendation | undefined;
 
-    setContextData((prev) => ({
-      ...prev,
-      recommendations: prev.recommendations.map(updateRec),
-      featuredRecommendations: prev.featuredRecommendations.map(updateRec),
-    }));
-
-    // Lazily resolve deferred nav links and milestones on first expand
     setContextData((prev) => {
-      const target =
-        prev.recommendations.find((r) => matches(r) && r.isResolvingDeferred) ??
-        prev.featuredRecommendations.find((r) => matches(r) && r.isResolvingDeferred);
+      const updateRec = (rec: Recommendation): Recommendation => {
+        if (!matches(rec)) {
+          return rec;
+        }
+        const expanding = !rec.summaryExpanded;
+        if (expanding && hasDeferredData(rec) && !rec.isResolvingDeferred) {
+          resolveTarget = rec;
+        }
+        return {
+          ...rec,
+          summaryExpanded: expanding,
+          isResolvingDeferred: expanding && hasDeferredData(rec),
+        };
+      };
 
-      if (!target) {
-        return prev;
-      }
-
-      ContextService.resolveDeferredData(target).then((resolved) => {
-        setContextData((current) => {
-          const applyResolved = (rec: Recommendation): Recommendation => {
-            if (!matches(rec)) {
-              return rec;
-            }
-            return { ...rec, ...resolved, summaryExpanded: rec.summaryExpanded, isResolvingDeferred: false };
-          };
-          return {
-            ...current,
-            recommendations: current.recommendations.map(applyResolved),
-            featuredRecommendations: current.featuredRecommendations.map(applyResolved),
-          };
-        });
-      });
-
-      return prev;
+      return {
+        ...prev,
+        recommendations: prev.recommendations.map(updateRec),
+        featuredRecommendations: prev.featuredRecommendations.map(updateRec),
+      };
     });
+
+    if (resolveTarget) {
+      const clearResolving = () => {
+        setContextData((current) => ({
+          ...current,
+          recommendations: current.recommendations.map((rec) =>
+            matches(rec) ? { ...rec, isResolvingDeferred: false } : rec
+          ),
+          featuredRecommendations: current.featuredRecommendations.map((rec) =>
+            matches(rec) ? { ...rec, isResolvingDeferred: false } : rec
+          ),
+        }));
+      };
+
+      ContextService.resolveDeferredData(resolveTarget)
+        .then((resolved) => {
+          setContextData((current) => {
+            const applyResolved = (rec: Recommendation): Recommendation => {
+              if (!matches(rec)) {
+                return rec;
+              }
+              return { ...rec, ...resolved, summaryExpanded: rec.summaryExpanded, isResolvingDeferred: false };
+            };
+            return {
+              ...current,
+              recommendations: current.recommendations.map(applyResolved),
+              featuredRecommendations: current.featuredRecommendations.map(applyResolved),
+            };
+          });
+        })
+        .catch(clearResolving);
+    }
   }, []);
 
   const navigateToPath = useCallback((path: string) => {

--- a/src/context-engine/context.service.ts
+++ b/src/context-engine/context.service.ts
@@ -825,7 +825,7 @@ export class ContextService {
           try {
             const result = await fetchContent(rec.url);
             const milestones = result.content?.metadata.learningJourney?.milestones || [];
-            const summary = result.content?.metadata.learningJourney?.summary || '';
+            const summary = result.content?.metadata.learningJourney?.summary || rec.summary || '';
 
             return {
               ...rec,
@@ -840,7 +840,7 @@ export class ContextService {
               ...rec,
               totalSteps: 0,
               milestones: [],
-              summary: '',
+              summary: rec.summary || '',
               completionPercentage,
             };
           }
@@ -905,14 +905,14 @@ export class ContextService {
    * Returns the recommendation with resolved fields populated and pending
    * fields cleared, or the original recommendation if nothing needed resolving.
    */
-  static async resolveDeferredData(rec: Recommendation): Promise<Recommendation> {
+  static async resolveDeferredData(rec: Recommendation): Promise<Partial<Recommendation>> {
     const hasPendingNavLinks =
       (rec.pendingRecommendIds && rec.pendingRecommendIds.length > 0) ||
       (rec.pendingSuggestIds && rec.pendingSuggestIds.length > 0);
     const hasPendingMilestones = rec.pendingMilestoneIds && rec.pendingMilestoneIds.length > 0;
 
     if (!hasPendingNavLinks && !hasPendingMilestones) {
-      return rec;
+      return {};
     }
 
     const updates: Partial<Recommendation> = {};
@@ -957,7 +957,6 @@ export class ContextService {
     await Promise.all(promises);
 
     return {
-      ...rec,
       ...updates,
       pendingRecommendIds: undefined,
       pendingSuggestIds: undefined,

--- a/src/context-engine/context.service.ts
+++ b/src/context-engine/context.service.ts
@@ -804,19 +804,27 @@ export class ContextService {
             };
           }
 
+          // Skip the expensive fetchContent call when V1 already provided a
+          // summary. Milestones are deferred to expand time anyway, so we
+          // only need completion percentage here.
+          const completionPercentage =
+            rec.type === 'interactive'
+              ? await interactiveCompletionStorage.get(rec.url)
+              : await getJourneyCompletionPercentageAsync(rec.url);
+
+          if (rec.summary) {
+            return {
+              ...rec,
+              totalSteps: 0,
+              milestones: [],
+              completionPercentage,
+            };
+          }
+
           try {
             const result = await fetchContent(rec.url);
-            // Use correct storage based on type:
-            // - Interactives store completion via step completion in interactiveCompletionStorage
-            // - Learning journeys use journeyCompletionStorage
-            const completionPercentage =
-              rec.type === 'interactive'
-                ? await interactiveCompletionStorage.get(rec.url)
-                : await getJourneyCompletionPercentageAsync(rec.url);
-
-            // Extract learning journey data from the unified content
             const milestones = result.content?.metadata.learningJourney?.milestones || [];
-            const summary = result.content?.metadata.learningJourney?.summary || rec.summary || '';
+            const summary = result.content?.metadata.learningJourney?.summary || '';
 
             return {
               ...rec,
@@ -827,15 +835,11 @@ export class ContextService {
             };
           } catch (error) {
             console.warn(`Failed to fetch journey data for ${sanitizeForLogging(rec.title)}:`, error);
-            const completionPercentage =
-              rec.type === 'interactive'
-                ? await interactiveCompletionStorage.get(rec.url)
-                : await getJourneyCompletionPercentageAsync(rec.url);
             return {
               ...rec,
               totalSteps: 0,
               milestones: [],
-              summary: rec.summary || '',
+              summary: '',
               completionPercentage,
             };
           }
@@ -855,18 +859,23 @@ export class ContextService {
 
           let enriched: Record<string, unknown> = { completionPercentage };
 
+          // Defer milestone resolution to summary expand time (Tier 2 lazy-loading).
+          // Store raw IDs so the UI can show milestone count immediately while
+          // deferring the expensive per-ID resolve calls.
           if (isPath && Array.isArray(manifest?.milestones)) {
             const milestoneIds = (manifest!.milestones as unknown[]).filter((s): s is string => typeof s === 'string');
             const manifestId = typeof manifest?.id === 'string' ? manifest.id : '';
             const pathSlug = manifestId ? derivePathSlug(manifestId) : undefined;
-            try {
-              const milestones = await resolvePackageMilestones(milestoneIds, pathSlug);
-              enriched = { ...enriched, milestones, totalSteps: milestones.length };
-            } catch {
-              // keep enriched as-is
-            }
+            enriched = {
+              ...enriched,
+              pendingMilestoneIds: milestoneIds,
+              ...(pathSlug != null && { pendingPathSlug: pathSlug }),
+              totalSteps: milestoneIds.length,
+            };
           }
 
+          // Defer nav link resolution to summary expand time (Tier 1 lazy-loading).
+          // Store raw IDs so the context panel can resolve on first expand.
           const recommendIds = Array.isArray(manifest?.recommends)
             ? (manifest!.recommends as unknown[]).filter((s): s is string => typeof s === 'string')
             : [];
@@ -874,21 +883,11 @@ export class ContextService {
             ? (manifest!.suggests as unknown[]).filter((s): s is string => typeof s === 'string')
             : [];
 
-          if (recommendIds.length > 0 || suggestIds.length > 0) {
-            try {
-              const [resolvedRecommends, resolvedSuggests] = await Promise.all([
-                resolvePackageNavLinks(recommendIds),
-                resolvePackageNavLinks(suggestIds),
-              ]);
-              if (resolvedRecommends.length > 0) {
-                enriched = { ...enriched, resolvedRecommends };
-              }
-              if (resolvedSuggests.length > 0) {
-                enriched = { ...enriched, resolvedSuggests };
-              }
-            } catch {
-              // nav link resolution is best-effort
-            }
+          if (recommendIds.length > 0) {
+            enriched = { ...enriched, pendingRecommendIds: recommendIds };
+          }
+          if (suggestIds.length > 0) {
+            enriched = { ...enriched, pendingSuggestIds: suggestIds };
           }
 
           return { ...rec, ...enriched };
@@ -897,6 +896,73 @@ export class ContextService {
         return rec;
       })
     );
+  }
+
+  /**
+   * Lazily resolve deferred nav links and milestones for a recommendation.
+   * Called on first summary expand to avoid upfront HTTP fan-out.
+   * Returns the recommendation with resolved fields populated and pending
+   * fields cleared, or the original recommendation if nothing needed resolving.
+   */
+  static async resolveDeferredData(rec: Recommendation): Promise<Recommendation> {
+    const hasPendingNavLinks =
+      (rec.pendingRecommendIds && rec.pendingRecommendIds.length > 0) ||
+      (rec.pendingSuggestIds && rec.pendingSuggestIds.length > 0);
+    const hasPendingMilestones = rec.pendingMilestoneIds && rec.pendingMilestoneIds.length > 0;
+
+    if (!hasPendingNavLinks && !hasPendingMilestones) {
+      return rec;
+    }
+
+    const updates: Partial<Recommendation> = {};
+
+    const promises: Array<Promise<void>> = [];
+
+    if (hasPendingNavLinks) {
+      promises.push(
+        (async () => {
+          try {
+            const [resolvedRecommends, resolvedSuggests] = await Promise.all([
+              resolvePackageNavLinks(rec.pendingRecommendIds ?? []),
+              resolvePackageNavLinks(rec.pendingSuggestIds ?? []),
+            ]);
+            if (resolvedRecommends.length > 0) {
+              updates.resolvedRecommends = resolvedRecommends;
+            }
+            if (resolvedSuggests.length > 0) {
+              updates.resolvedSuggests = resolvedSuggests;
+            }
+          } catch {
+            // best-effort
+          }
+        })()
+      );
+    }
+
+    if (hasPendingMilestones) {
+      promises.push(
+        (async () => {
+          try {
+            const milestones = await resolvePackageMilestones(rec.pendingMilestoneIds!, rec.pendingPathSlug);
+            updates.milestones = milestones;
+            updates.totalSteps = milestones.length;
+          } catch {
+            // keep existing values
+          }
+        })()
+      );
+    }
+
+    await Promise.all(promises);
+
+    return {
+      ...rec,
+      ...updates,
+      pendingRecommendIds: undefined,
+      pendingSuggestIds: undefined,
+      pendingMilestoneIds: undefined,
+      pendingPathSlug: undefined,
+    };
   }
 
   /**

--- a/src/context-engine/context.service.ts
+++ b/src/context-engine/context.service.ts
@@ -804,15 +804,16 @@ export class ContextService {
             };
           }
 
-          // Skip the expensive fetchContent call when V1 already provided a
-          // summary. Milestones are deferred to expand time anyway, so we
-          // only need completion percentage here.
           const completionPercentage =
             rec.type === 'interactive'
               ? await interactiveCompletionStorage.get(rec.url)
               : await getJourneyCompletionPercentageAsync(rec.url);
 
-          if (rec.summary) {
+          // Skip the expensive fetchContent call when V1 already provided a
+          // summary AND the type doesn't need milestone data from content.
+          // Learning journeys extract milestones from content.json metadata,
+          // so they must always go through fetchContent.
+          if (rec.summary && rec.type !== 'learning-journey') {
             return {
               ...rec,
               totalSteps: 0,

--- a/src/docs-retrieval/content-fetcher.ts
+++ b/src/docs-retrieval/content-fetcher.ts
@@ -1393,30 +1393,38 @@ export async function resolvePackageMilestones(milestoneIds: string[], pathSlug?
     return [];
   }
 
+  const settled = await Promise.allSettled(
+    milestoneIds.map((id) => _packageResolver!.resolve(id, { loadContent: 'metadata-only' }))
+  );
+
   const milestones: Milestone[] = [];
   let sequenceNumber = 1;
 
-  for (const id of milestoneIds) {
-    try {
-      const resolution = await _packageResolver.resolve(id, { loadContent: true });
-      if (!resolution.ok) {
-        console.warn(`[resolvePackageMilestones] Skipping unresolvable milestone: ${id}`);
-        continue;
-      }
+  for (let i = 0; i < milestoneIds.length; i++) {
+    const result = settled[i]!;
+    const id = milestoneIds[i]!;
 
-      const title = resolution.content?.title ?? resolution.manifest?.description ?? id;
-
-      milestones.push({
-        number: sequenceNumber++,
-        title,
-        duration: '5-10 min',
-        url: resolution.contentUrl,
-        isActive: false,
-        ...(pathSlug != null && { websiteUrl: buildMilestoneWebsiteUrl(pathSlug, id) }),
-      });
-    } catch (err) {
-      console.warn(`[resolvePackageMilestones] Error resolving milestone ${id}:`, err);
+    if (result.status === 'rejected') {
+      console.warn(`[resolvePackageMilestones] Error resolving milestone ${id}:`, result.reason);
+      continue;
     }
+
+    const resolution = result.value;
+    if (!resolution.ok) {
+      console.warn(`[resolvePackageMilestones] Skipping unresolvable milestone: ${id}`);
+      continue;
+    }
+
+    const title = resolution.content?.title ?? resolution.manifest?.description ?? id;
+
+    milestones.push({
+      number: sequenceNumber++,
+      title,
+      duration: '5-10 min',
+      url: resolution.contentUrl,
+      isActive: false,
+      ...(pathSlug != null && { websiteUrl: buildMilestoneWebsiteUrl(pathSlug, id) }),
+    });
   }
 
   return milestones;
@@ -1434,30 +1442,38 @@ export async function resolvePackageNavLinks(packageIds: string[]): Promise<Reso
     return [];
   }
 
+  const settled = await Promise.allSettled(
+    packageIds.map((id) => _packageResolver!.resolve(id, { loadContent: 'metadata-only' }))
+  );
+
   const links: ResolvedNavLink[] = [];
 
-  for (const id of packageIds) {
-    try {
-      const resolution = await _packageResolver.resolve(id, { loadContent: true });
-      if (!resolution.ok) {
-        console.warn(`[resolvePackageNavLinks] Skipping unresolvable package: ${id}`);
-        continue;
-      }
+  for (let i = 0; i < packageIds.length; i++) {
+    const result = settled[i]!;
+    const id = packageIds[i]!;
 
-      const title = resolution.content?.title ?? resolution.manifest?.description ?? id;
-      const manifest: Record<string, unknown> | undefined = resolution.manifest
-        ? (resolution.manifest as unknown as Record<string, unknown>)
-        : undefined;
-
-      links.push({
-        packageId: id,
-        title,
-        contentUrl: resolution.contentUrl,
-        manifest,
-      });
-    } catch (err) {
-      console.warn(`[resolvePackageNavLinks] Error resolving package ${id}:`, err);
+    if (result.status === 'rejected') {
+      console.warn(`[resolvePackageNavLinks] Error resolving package ${id}:`, result.reason);
+      continue;
     }
+
+    const resolution = result.value;
+    if (!resolution.ok) {
+      console.warn(`[resolvePackageNavLinks] Skipping unresolvable package: ${id}`);
+      continue;
+    }
+
+    const title = resolution.content?.title ?? resolution.manifest?.description ?? id;
+    const manifest: Record<string, unknown> | undefined = resolution.manifest
+      ? (resolution.manifest as unknown as Record<string, unknown>)
+      : undefined;
+
+    links.push({
+      packageId: id,
+      title,
+      contentUrl: resolution.contentUrl,
+      manifest,
+    });
   }
 
   return links;
@@ -1497,56 +1513,58 @@ export async function fetchPackageContent(
   packageManifest?: Record<string, unknown>,
   preResolvedMilestones?: Milestone[]
 ): Promise<ContentFetchResult> {
-  const result = await fetchContent(contentUrl);
+  const renderType = getPackageRenderType(packageManifest);
+  const needsMilestones = renderType === 'learning-journey' && isPathManifest(packageManifest);
+
+  const manifestId = needsMilestones && typeof packageManifest?.id === 'string' ? packageManifest.id : '';
+  const pathSlug = manifestId ? derivePathSlug(manifestId) : undefined;
+  const milestoneIds = needsMilestones ? getManifestMilestoneIds(packageManifest) : [];
+  const shouldResolveMilestones =
+    needsMilestones && (!preResolvedMilestones || preResolvedMilestones.length === 0) && milestoneIds.length > 0;
+
+  // Run content fetch, milestone resolution, and baseUrl resolution in
+  // parallel. These are independent: the page body doesn't need milestones
+  // and milestones don't need the page body.
+  const [result, resolvedMilestones, baseUrlResolution] = await Promise.all([
+    fetchContent(contentUrl),
+    shouldResolveMilestones ? resolvePackageMilestones(milestoneIds, pathSlug) : Promise.resolve(undefined),
+    manifestId && _packageResolver
+      ? _packageResolver.resolve(manifestId, { loadContent: false }).catch(() => undefined)
+      : Promise.resolve(undefined),
+  ]);
 
   if (!result.content) {
     return result;
   }
 
-  const renderType = getPackageRenderType(packageManifest);
   let learningJourney: LearningJourneyMetadata | undefined;
   let contentString = result.content.content;
 
-  if (renderType === 'learning-journey' && isPathManifest(packageManifest)) {
-    const manifestId = typeof packageManifest?.id === 'string' ? packageManifest.id : '';
-    const pathSlug = manifestId ? derivePathSlug(manifestId) : undefined;
-    const milestoneIds = getManifestMilestoneIds(packageManifest);
+  if (needsMilestones) {
+    const milestones = preResolvedMilestones?.length ? preResolvedMilestones : resolvedMilestones;
 
-    if (milestoneIds.length > 0 || (preResolvedMilestones && preResolvedMilestones.length > 0)) {
-      const milestones =
-        preResolvedMilestones && preResolvedMilestones.length > 0
-          ? preResolvedMilestones
-          : await resolvePackageMilestones(milestoneIds, pathSlug);
-      if (milestones.length > 0) {
-        const milestoneIndex = milestones.findIndex((m) => m.url === contentUrl);
-        const currentMilestone = milestoneIndex >= 0 ? milestoneIndex + 1 : 0;
+    if (milestones && milestones.length > 0) {
+      const milestoneIndex = milestones.findIndex((m) => m.url === contentUrl);
+      const currentMilestone = milestoneIndex >= 0 ? milestoneIndex + 1 : 0;
 
-        let baseUrl = contentUrl;
-        if (milestoneIndex >= 0 && manifestId && _packageResolver) {
-          try {
-            const pathResolution = await _packageResolver.resolve(manifestId, { loadContent: false });
-            if (pathResolution.ok) {
-              baseUrl = pathResolution.contentUrl;
-            }
-          } catch {
-            // keep contentUrl as fallback
-          }
-        }
+      let baseUrl = contentUrl;
+      if (milestoneIndex >= 0 && baseUrlResolution && baseUrlResolution.ok) {
+        baseUrl = baseUrlResolution.contentUrl;
+      }
 
-        learningJourney = {
-          currentMilestone,
-          totalMilestones: milestones.length,
-          milestones,
-          baseUrl,
-          summary: result.content.metadata.singleDoc?.summary,
-          ...(pathSlug != null && {
-            websiteUrl: `https://grafana.com/docs/learning-paths/${pathSlug}/`,
-          }),
-        };
+      learningJourney = {
+        currentMilestone,
+        totalMilestones: milestones.length,
+        milestones,
+        baseUrl,
+        summary: result.content.metadata.singleDoc?.summary,
+        ...(pathSlug != null && {
+          websiteUrl: `https://grafana.com/docs/learning-paths/${pathSlug}/`,
+        }),
+      };
 
-        if (currentMilestone === 0) {
-          contentString = injectJourneyExtrasIntoJsonGuide(contentString, learningJourney);
-        }
+      if (currentMilestone === 0) {
+        contentString = injectJourneyExtrasIntoJsonGuide(contentString, learningJourney);
       }
     }
   }

--- a/src/package-engine/composite-resolver.test.ts
+++ b/src/package-engine/composite-resolver.test.ts
@@ -134,6 +134,51 @@ describe('CompositePackageResolver', () => {
       expect(result.ok).toBe(true);
     });
   });
+
+  describe('resolution caching', () => {
+    it('should return cached result for the same packageId and options', async () => {
+      (mockBundledResolver.resolve as jest.Mock).mockResolvedValue(SUCCESS_BUNDLED);
+
+      const composite = new CompositePackageResolver([mockBundledResolver]);
+      const first = await composite.resolve('test-guide');
+      const second = await composite.resolve('test-guide');
+
+      expect(first).toBe(second);
+      expect(mockBundledResolver.resolve).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cache separately for loadContent true vs false', async () => {
+      (mockBundledResolver.resolve as jest.Mock).mockResolvedValue(SUCCESS_BUNDLED);
+
+      const composite = new CompositePackageResolver([mockBundledResolver]);
+      await composite.resolve('test-guide', { loadContent: false });
+      await composite.resolve('test-guide', { loadContent: true });
+
+      expect(mockBundledResolver.resolve).toHaveBeenCalledTimes(2);
+    });
+
+    it('should cache separately for different package IDs', async () => {
+      (mockBundledResolver.resolve as jest.Mock).mockResolvedValue(SUCCESS_BUNDLED);
+
+      const composite = new CompositePackageResolver([mockBundledResolver]);
+      await composite.resolve('guide-a');
+      await composite.resolve('guide-b');
+
+      expect(mockBundledResolver.resolve).toHaveBeenCalledTimes(2);
+    });
+
+    it('should cache failures too (prevents repeated failed lookups)', async () => {
+      (mockBundledResolver.resolve as jest.Mock).mockResolvedValue(NOT_FOUND);
+
+      const composite = new CompositePackageResolver([mockBundledResolver]);
+      const first = await composite.resolve('missing');
+      const second = await composite.resolve('missing');
+
+      expect(first).toBe(second);
+      expect(first.ok).toBe(false);
+      expect(mockBundledResolver.resolve).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('createCompositeResolver', () => {

--- a/src/package-engine/composite-resolver.ts
+++ b/src/package-engine/composite-resolver.ts
@@ -20,12 +20,25 @@ import { RecommenderPackageResolver } from './recommender-resolver';
 
 export class CompositePackageResolver implements PackageResolver {
   private readonly resolvers: PackageResolver[];
+  private readonly cache = new Map<string, Promise<PackageResolution>>();
 
   constructor(resolvers: PackageResolver[]) {
     this.resolvers = resolvers;
   }
 
   async resolve(packageId: string, options?: ResolveOptions): Promise<PackageResolution> {
+    const cacheKey = `${packageId}:${options?.loadContent ?? false}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const promise = this.resolveUncached(packageId, options);
+    this.cache.set(cacheKey, promise);
+    return promise;
+  }
+
+  private async resolveUncached(packageId: string, options?: ResolveOptions): Promise<PackageResolution> {
     let lastFailure: PackageResolution | undefined;
 
     for (const resolver of this.resolvers) {

--- a/src/package-engine/recommender-resolver.test.ts
+++ b/src/package-engine/recommender-resolver.test.ts
@@ -255,6 +255,51 @@ describe('RecommenderPackageResolver', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('resolve with metadata-only', () => {
+    it('should skip content.json fetch and only load manifest', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FIXTURE_RESOLUTION),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FIXTURE_MANIFEST),
+      });
+
+      const result = await resolver.resolve('alerting-101', { loadContent: 'metadata-only' });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.content).toBeUndefined();
+        expect(result.manifest).toMatchObject(FIXTURE_MANIFEST);
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[1]![0]).toBe(FIXTURE_RESOLUTION.manifestUrl);
+    });
+
+    it('should succeed with no manifest when manifest fetch fails', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(FIXTURE_RESOLUTION),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+      const result = await resolver.resolve('alerting-101', { loadContent: 'metadata-only' });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.content).toBeUndefined();
+        expect(result.manifest).toBeUndefined();
+      }
+    });
+  });
 });
 
 // Custom matcher for URL prefix checking

--- a/src/package-engine/recommender-resolver.ts
+++ b/src/package-engine/recommender-resolver.ts
@@ -80,7 +80,8 @@ export class RecommenderPackageResolver implements PackageResolver {
     };
 
     if (options?.loadContent) {
-      const loaded = await this.loadFromCdn(resolutionData, packageId);
+      const metadataOnly = options.loadContent === 'metadata-only';
+      const loaded = await this.loadFromCdn(resolutionData, packageId, metadataOnly);
       if (!loaded.ok) {
         return loaded;
       }
@@ -93,17 +94,22 @@ export class RecommenderPackageResolver implements PackageResolver {
 
   private async loadFromCdn(
     resolutionData: V1PackageResolutionResponse,
-    packageId: string
-  ): Promise<{ ok: true; content: ContentJson; manifest?: ManifestJson } | PackageResolutionFailure> {
+    packageId: string,
+    metadataOnly = false
+  ): Promise<{ ok: true; content?: ContentJson; manifest?: ManifestJson } | PackageResolutionFailure> {
     try {
-      const contentResponse = await fetch(resolutionData.contentUrl);
-      if (!contentResponse.ok) {
-        return failure(packageId, 'network-error', `Failed to fetch content: HTTP ${contentResponse.status}`);
-      }
-      const rawContent = await contentResponse.json();
-      const contentResult = ContentJsonSchema.safeParse(rawContent);
-      if (!contentResult.success) {
-        return failure(packageId, 'validation-error', `Invalid content.json: ${contentResult.error.message}`);
+      let content: ContentJson | undefined;
+      if (!metadataOnly) {
+        const contentResponse = await fetch(resolutionData.contentUrl);
+        if (!contentResponse.ok) {
+          return failure(packageId, 'network-error', `Failed to fetch content: HTTP ${contentResponse.status}`);
+        }
+        const rawContent = await contentResponse.json();
+        const contentResult = ContentJsonSchema.safeParse(rawContent);
+        if (!contentResult.success) {
+          return failure(packageId, 'validation-error', `Invalid content.json: ${contentResult.error.message}`);
+        }
+        content = contentResult.data as ContentJson;
       }
 
       let manifest: ManifestJson | undefined;
@@ -122,7 +128,7 @@ export class RecommenderPackageResolver implements PackageResolver {
         }
       }
 
-      return { ok: true, content: contentResult.data as ContentJson, manifest };
+      return { ok: true, content, manifest };
     } catch (err) {
       const message = err instanceof Error ? err.message : 'CDN fetch failed';
       return failure(packageId, 'network-error', message);

--- a/src/package-engine/resolver.ts
+++ b/src/package-engine/resolver.ts
@@ -64,7 +64,8 @@ export class BundledPackageResolver implements PackageResolver {
     };
 
     if (options?.loadContent) {
-      const loadResult = await this.loadPackageContent(basePath, packageId);
+      const metadataOnly = options.loadContent === 'metadata-only';
+      const loadResult = await this.loadPackageContent(basePath, packageId, metadataOnly);
       if (!loadResult.ok) {
         return loadResult;
       }
@@ -77,15 +78,20 @@ export class BundledPackageResolver implements PackageResolver {
 
   private async loadPackageContent(
     basePath: string,
-    packageId: string
-  ): Promise<{ ok: true; content: ContentJson; manifest?: ManifestJson } | PackageResolutionFailure> {
-    const contentResult = loadBundledContent(basePath);
-    if (!contentResult.ok) {
-      return {
-        ok: false,
-        id: packageId,
-        error: contentResult.error,
-      };
+    packageId: string,
+    metadataOnly = false
+  ): Promise<{ ok: true; content?: ContentJson; manifest?: ManifestJson } | PackageResolutionFailure> {
+    let content: ContentJson | undefined;
+    if (!metadataOnly) {
+      const contentResult = loadBundledContent(basePath);
+      if (!contentResult.ok) {
+        return {
+          ok: false,
+          id: packageId,
+          error: contentResult.error,
+        };
+      }
+      content = contentResult.data;
     }
 
     const manifestResult = loadBundledManifest(basePath);
@@ -96,7 +102,7 @@ export class BundledPackageResolver implements PackageResolver {
 
     return {
       ok: true,
-      content: contentResult.data,
+      content,
       manifest: manifestResult.ok ? manifestResult.data : undefined,
     };
   }

--- a/src/styles/context-panel.styles.ts
+++ b/src/styles/context-panel.styles.ts
@@ -485,6 +485,35 @@ export const getMilestoneStyles = (theme: GrafanaTheme2) => ({
   }),
 });
 
+// Skeleton placeholders shown while deferred milestones/nav links resolve
+export const getDeferredSkeletonStyles = (theme: GrafanaTheme2) => ({
+  deferredSkeleton: css({
+    paddingTop: theme.spacing(1.5),
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+  }),
+  deferredSkeletonRow: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(0.75),
+  }),
+  deferredSkeletonCircle: css({
+    width: '20px',
+    height: '20px',
+    borderRadius: '50%',
+    flexShrink: 0,
+  }),
+  deferredSkeletonBar: css({
+    height: '14px',
+    flex: 1,
+    maxWidth: '70%',
+    borderRadius: theme.shape.radius.default,
+  }),
+});
+
 // Steps section styles (for step-by-step expansion)
 export const getStepsStyles = (theme: GrafanaTheme2) => ({
   stepsSection: css({
@@ -861,6 +890,7 @@ export const getStyles = (theme: GrafanaTheme2) => ({
   ...getCardMetadataStyles(theme),
   ...getSummaryStyles(theme),
   ...getMilestoneStyles(theme),
+  ...getDeferredSkeletonStyles(theme),
   ...getStepsStyles(theme),
   ...getFeaturedStyles(theme),
   ...getCustomGuidesStyles(theme),

--- a/src/styles/docs-panel.styles.ts
+++ b/src/styles/docs-panel.styles.ts
@@ -601,7 +601,7 @@ export const getContentStyles = (theme: GrafanaTheme2) => ({
     color: theme.colors.text.primary,
     border: `1px solid ${theme.colors.border.medium}`,
     borderRadius: theme.shape.radius.default,
-    padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+    padding: `${theme.spacing(0.5)} ${theme.spacing(0.75)}`,
     fontSize: theme.typography.bodySmall.fontSize,
     fontWeight: theme.typography.fontWeightMedium,
     cursor: 'pointer',
@@ -678,7 +678,7 @@ export const getContentStyles = (theme: GrafanaTheme2) => ({
 
 export const getMilestoneStyles = (theme: GrafanaTheme2) => ({
   milestoneProgress: css({
-    padding: theme.spacing(1),
+    padding: theme.spacing(1.5),
     backgroundColor: theme.colors.background.canvas,
     borderBottom: `1px solid ${theme.colors.border.weak}`,
     flexShrink: 0,
@@ -686,7 +686,7 @@ export const getMilestoneStyles = (theme: GrafanaTheme2) => ({
   progressInfo: css({
     display: 'flex',
     flexDirection: 'column',
-    gap: theme.spacing(0.5),
+    gap: theme.spacing(1),
     fontSize: theme.typography.bodySmall.fontSize,
     fontWeight: theme.typography.fontWeightMedium,
   }),
@@ -706,11 +706,10 @@ export const getMilestoneStyles = (theme: GrafanaTheme2) => ({
   milestoneActions: css({
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(1),
-    flexWrap: 'wrap',
-    '& > *': {
-      flex: '1 1 auto',
-    },
+    justifyContent: 'flex-end',
+    gap: theme.spacing(0.75),
+    padding: theme.spacing(1, 0, 0),
+    borderTop: `1px solid ${theme.colors.border.weak}`,
   }),
   navButton: css({
     display: 'flex',
@@ -760,6 +759,7 @@ export const getMilestoneStyles = (theme: GrafanaTheme2) => ({
     backgroundColor: theme.colors.background.secondary,
     borderRadius: '2px',
     overflow: 'hidden',
+    marginTop: theme.spacing(0.5),
   }),
   progressFill: css({
     height: '100%',

--- a/src/styles/feedback-button.styles.ts
+++ b/src/styles/feedback-button.styles.ts
@@ -40,7 +40,7 @@ export const getFeedbackButtonStyles = (theme: GrafanaTheme2) => ({
     display: 'inline-flex',
     alignItems: 'center',
     gap: theme.spacing(0.5),
-    padding: `${theme.spacing(0.5)} ${theme.spacing(1)}`,
+    padding: `${theme.spacing(0.5)} ${theme.spacing(0.75)}`,
     backgroundColor: 'transparent',
     color: theme.colors.text.primary,
     border: `1px solid ${theme.colors.border.medium}`,

--- a/src/types/context.types.ts
+++ b/src/types/context.types.ts
@@ -88,6 +88,17 @@ export interface Recommendation {
   /** Pre-resolved manifest.suggests nav links (package-backed only) */
   resolvedSuggests?: ResolvedNavLink[];
 
+  /** Raw package IDs from manifest.recommends, deferred until summary expand */
+  pendingRecommendIds?: string[];
+  /** Raw package IDs from manifest.suggests, deferred until summary expand */
+  pendingSuggestIds?: string[];
+  /** Raw milestone package IDs from manifest.milestones, deferred until summary expand */
+  pendingMilestoneIds?: string[];
+  /** Path slug for milestone website URL building, stored alongside pendingMilestoneIds */
+  pendingPathSlug?: string;
+  /** True while nav links or milestones are being lazily resolved */
+  isResolvingDeferred?: boolean;
+
   [key: string]: any;
 }
 

--- a/src/types/package.types.ts
+++ b/src/types/package.types.ts
@@ -243,8 +243,14 @@ export type PackageResolution = PackageResolutionSuccess | PackageResolutionFail
  * Options for {@link PackageResolver.resolve}.
  */
 export interface ResolveOptions {
-  /** When true, fetch and populate manifest and content on the resolution result */
-  loadContent?: boolean;
+  /**
+   * Controls how much content to load alongside the resolution result.
+   * - `true`: fetch and populate both manifest and content (full payload)
+   * - `'metadata-only'`: fetch manifest only, skip the heavier content.json
+   *   (sufficient for obtaining title from manifest.description and contentUrl)
+   * - `false` / `undefined`: resolve URLs only, no content fetching
+   */
+  loadContent?: boolean | 'metadata-only';
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Lazy-load recommendation enrichment data**: Defer milestone resolution, nav link resolution, and redundant content fetches from recommendation list building to user interaction time (summary expand). Reduces upfront HTTP calls from 100+ to ~1 (the POST /api/v1/recommend call).
- **Parallelise rendering pipeline**: Content fetch, milestone resolution, and baseUrl resolution in `fetchPackageContent` now run concurrently via `Promise.all`. Individual milestone and nav link resolution loops use `Promise.allSettled` instead of sequential awaits.
- **UI polish**: Milestone bar persists during loading, action buttons consolidated behind kebab overflow menu, improved vertical spacing and separators, compact button padding.

### Key changes

| Area | Change |
|------|--------|
| Recommendation list | Defer `resolvePackageMilestones` and `resolvePackageNavLinks` to summary expand time |
| Recommendation list | Skip `fetchContent` when V1 already provides summary |
| Package resolver | Add `metadata-only` resolve option (manifest only, skip content.json) |
| Package resolver | Add promise-based resolution cache to `CompositePackageResolver` |
| Content rendering | Parallelise `fetchPackageContent` internals (content + milestones + baseUrl) |
| Content rendering | Parallelise `resolvePackageMilestones` and `resolvePackageNavLinks` loops |
| Context panel | Show shimmer skeleton while deferred data resolves on expand |
| Docs panel | Keep milestone bar visible during milestone navigation loading |
| Docs panel | Move Give feedback + dev Refresh behind kebab menu on both bars |
| Docs panel | Drop redundant "Learning path" label, improve spacing |

## Test plan

- [x] `npm run check` passes (typecheck + lint + prettier + lint:go + test:go + test:ci)
- [x] 120 test suites, 2432 tests passing
- [ ] Manual: verify recommendations load without visible delay
- [ ] Manual: expand summary → milestones/nav links appear with shimmer skeleton
- [ ] Manual: open a learning path → milestone bar stays visible during navigation
- [ ] Manual: kebab menu works on both interactive guide and learning path bars
- [ ] Manual: Open and Reset guide buttons remain visible and functional


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes recommendation enrichment timing (deferred resolution) and package/content fetching concurrency/caching, which can affect loading states and navigation if edge cases regress.
> 
> **Overview**
> **Shifts recommendation enrichment to lazy loading:** package `milestones` and manifest `recommends`/`suggests` are no longer resolved during recommendation fetch; raw IDs are stored (`pending*` fields) and resolved on first summary expand via new `ContextService.resolveDeferredData`, with a shimmer skeleton shown while resolving.
> 
> **Reduces and parallelizes fetch work:** skips `fetchContent` when V1 already provides a summary for non-learning-journey recs, parallelizes `fetchPackageContent` (content + milestone resolution + base URL resolution), and updates milestone/nav-link resolution helpers to use `Promise.allSettled` for faster best-effort resolution.
> 
> **Improves package resolver performance and UI polish:** adds a promise-based resolution cache to `CompositePackageResolver`, introduces a `loadContent: 'metadata-only'` resolve option (manifest without `content.json`), and tweaks the docs panel to keep the milestone bar visible during loading plus consolidate feedback/dev refresh behind a kebab menu with spacing adjustments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a634ed343050eac301ce9d2ca028935a16c212e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->