### PR TITLE
feat: move block editor out of dev mode into dedicated editor tab

### DIFF
--- a/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
+++ b/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
@@ -1,19 +1,10 @@
-import React, { useState, useCallback, lazy, Suspense, useEffect } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { Button, Badge, Icon, useStyles2, Stack } from '@grafana/ui';
 import { getDebugPanelStyles } from './debug-panel.styles';
 import { UrlTester } from 'components/UrlTester';
 import { PrTester } from 'components/PrTester';
-import { SkeletonLoader } from '../SkeletonLoader';
-
-// Lazy load BlockEditor to keep it out of main bundle when not needed
-const BlockEditor = lazy(() =>
-  import('../block-editor').then((module) => ({
-    default: module.BlockEditor,
-  }))
-);
 
 // localStorage keys for section expansion state
-const STORAGE_KEY_BLOCK_EDITOR = 'pathfinder-devtools-block-editor-expanded';
 const STORAGE_KEY_PR_TESTER = 'pathfinder-devtools-pr-tester-expanded';
 const STORAGE_KEY_URL_TESTER = 'pathfinder-devtools-url-tester-expanded';
 
@@ -41,20 +32,8 @@ export function SelectorDebugPanel({ onOpenDocsPage, onOpenLearningJourney }: Se
   const styles = useStyles2(getDebugPanelStyles);
 
   // Section expansion state - initialize from localStorage
-  const [blockEditorExpanded, setBlockEditorExpanded] = useState(() =>
-    getInitialExpanded(STORAGE_KEY_BLOCK_EDITOR, true)
-  );
   const [prTesterExpanded, setPrTesterExpanded] = useState(() => getInitialExpanded(STORAGE_KEY_PR_TESTER, false));
   const [UrlTesterExpanded, setUrlTesterExpanded] = useState(() => getInitialExpanded(STORAGE_KEY_URL_TESTER, false));
-
-  // Persist block editor expansion state
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY_BLOCK_EDITOR, String(blockEditorExpanded));
-    } catch {
-      // Ignore localStorage errors
-    }
-  }, [blockEditorExpanded]);
 
   // Persist PR tester expansion state
   useEffect(() => {
@@ -113,24 +92,6 @@ export function SelectorDebugPanel({ onOpenDocsPage, onOpenLearningJourney }: Se
         <Button variant="secondary" size="sm" onClick={handleLeaveDevMode} icon="times" fill="outline">
           Leave dev mode
         </Button>
-      </div>
-
-      {/* Block Editor */}
-      <div className={styles.section}>
-        <div className={styles.sectionHeader} onClick={() => setBlockEditorExpanded(!blockEditorExpanded)}>
-          <Stack direction="row" gap={1} alignItems="center">
-            <Icon name="edit" />
-            <h4 className={styles.sectionTitle}>Interactive guide editor</h4>
-          </Stack>
-          <Icon name={blockEditorExpanded ? 'angle-up' : 'angle-down'} />
-        </div>
-        {blockEditorExpanded && (
-          <div className={styles.sectionContent}>
-            <Suspense fallback={<SkeletonLoader type="recommendations" />}>
-              <BlockEditor />
-            </Suspense>
-          </div>
-        )}
       </div>
 
       {/* PR tester */}

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -87,8 +87,7 @@ const getHeaderStyles = (theme: GrafanaTheme2) => ({
   }),
   guideTitleContainer: css({
     display: 'flex',
-    alignItems: 'baseline',
-    gap: theme.spacing(1),
+    flexDirection: 'column',
     minWidth: 0,
     flex: 1,
     '&:hover .guide-id': {
@@ -121,9 +120,9 @@ const getHeaderStyles = (theme: GrafanaTheme2) => ({
     fontSize: theme.typography.bodySmall.fontSize,
     color: theme.colors.text.secondary,
     fontFamily: theme.typography.fontFamilyMonospace,
-    flexShrink: 0,
     opacity: 0,
     transition: 'opacity 0.15s',
+    padding: '0 2px',
   }),
   statusBadges: css({
     display: 'flex',

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -181,12 +181,12 @@ export class ContextPanel extends SceneObjectBase<ContextPanelState> {
   public constructor(
     onOpenLearningJourney?: (url: string, title: string) => void,
     onOpenDocsPage?: (url: string, title: string, packageInfo?: PackageOpenInfo) => void,
-    onOpenDevTools?: () => void
+    onOpenEditor?: () => void
   ) {
     super({
       onOpenLearningJourney,
       onOpenDocsPage,
-      onOpenDevTools,
+      onOpenEditor,
     });
   }
 
@@ -204,9 +204,9 @@ export class ContextPanel extends SceneObjectBase<ContextPanelState> {
     }
   }
 
-  public openDevTools() {
-    if (this.state.onOpenDevTools) {
-      this.state.onOpenDevTools();
+  public openEditor() {
+    if (this.state.onOpenEditor) {
+      this.state.onOpenEditor();
     }
   }
 

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -846,46 +846,42 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Empty deps - only run once after mount, tabs checked at mount time
 
-  // Ensure devtools tab exists when dev mode is enabled (permanent tab)
+  // Ensure permanent tabs (devtools, editor) exist when their gate is active.
+  // Merged into a single effect so both additions read from the same up-to-date
+  // tabs array, avoiding a stale-closure overwrite when both gates are true.
   React.useEffect(() => {
-    if (isDevMode) {
-      const hasDevToolsTab = tabs.some((t) => t.id === 'devtools');
-      if (!hasDevToolsTab) {
-        // Add devtools tab without switching to it
-        const devToolsTab: LearningJourneyTab = {
-          id: 'devtools',
-          title: 'Dev Tools',
-          baseUrl: '',
-          currentUrl: '',
-          content: null,
-          isLoading: false,
-          error: null,
-          type: 'devtools',
-        };
-        model.setState({ tabs: [...tabs, devToolsTab] });
-      }
-    }
-  }, [isDevMode, tabs, model]);
+    const missing: LearningJourneyTab[] = [];
 
-  // Ensure editor tab exists for admin/editor users (permanent tab)
-  React.useEffect(() => {
-    if (isEditorUser) {
-      const hasEditorTab = tabs.some((t) => t.id === 'editor');
-      if (!hasEditorTab) {
-        const editorTab: LearningJourneyTab = {
-          id: 'editor',
-          title: 'Guide editor',
-          baseUrl: '',
-          currentUrl: '',
-          content: null,
-          isLoading: false,
-          error: null,
-          type: 'editor',
-        };
-        model.setState({ tabs: [...tabs, editorTab] });
-      }
+    if (isDevMode && !tabs.some((t) => t.id === 'devtools')) {
+      missing.push({
+        id: 'devtools',
+        title: 'Dev Tools',
+        baseUrl: '',
+        currentUrl: '',
+        content: null,
+        isLoading: false,
+        error: null,
+        type: 'devtools',
+      });
     }
-  }, [isEditorUser, tabs, model]);
+
+    if (isEditorUser && !tabs.some((t) => t.id === 'editor')) {
+      missing.push({
+        id: 'editor',
+        title: 'Guide editor',
+        baseUrl: '',
+        currentUrl: '',
+        content: null,
+        isLoading: false,
+        error: null,
+        type: 'editor',
+      });
+    }
+
+    if (missing.length > 0) {
+      model.setState({ tabs: [...tabs, ...missing] });
+    }
+  }, [isDevMode, isEditorUser, tabs, model]);
 
   // Listen for auto-open events from global link interceptor
   // Place this HERE (not in ContextPanelRenderer) to avoid component remounting issues
@@ -984,6 +980,12 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
     chevronButtonRef,
     dropdownOpenTimeRef,
   } = useTabOverflow(tabs, activeTabId);
+
+  const PERMANENT_TAB_IDS = React.useMemo(() => new Set(['recommendations', 'devtools', 'editor']), []);
+  const overflowGuideTabs = React.useMemo(
+    () => overflowedTabs.filter((t) => !PERMANENT_TAB_IDS.has(t.id)),
+    [overflowedTabs, PERMANENT_TAB_IDS]
+  );
 
   // Content styles are applied at the component level via CSS classes
 
@@ -1470,7 +1472,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
             })}
         </div>
 
-        {overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools').length > 0 && (
+        {overflowGuideTabs.length > 0 && (
           <div className={styles.tabOverflow}>
             <button
               ref={chevronButtonRef}
@@ -1482,89 +1484,86 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                 setIsDropdownOpen(!isDropdownOpen);
               }}
               aria-label={t('docsPanel.showMoreTabs', 'Show {{count}} more tabs', {
-                count: overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools').length,
+                count: overflowGuideTabs.length,
               })}
               aria-expanded={isDropdownOpen}
               aria-haspopup="true"
               data-testid={testIds.docsPanel.tabOverflowButton}
             >
               <Icon name="angle-down" size="sm" />
-              <span>+{overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools').length}</span>
+              <span>+{overflowGuideTabs.length}</span>
             </button>
           </div>
         )}
 
-        {isDropdownOpen &&
-          overflowedTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools').length > 0 && (
-            <div
-              ref={dropdownRef}
-              className={styles.tabDropdown}
-              role="menu"
-              aria-label={t('docsPanel.moreTabsMenu', 'More tabs')}
-              data-testid={testIds.docsPanel.tabDropdown}
-            >
-              {overflowedTabs
-                .filter((tab) => tab.id !== 'recommendations' && tab.id !== 'devtools')
-                .map((tab) => {
-                  return (
-                    <button
-                      key={tab.id}
-                      className={`${styles.dropdownItem} ${tab.id === activeTabId ? styles.activeDropdownItem : ''}`}
-                      onClick={() => {
-                        model.setActiveTab(tab.id);
-                        setIsDropdownOpen(false);
-                      }}
-                      role="menuitem"
-                      aria-label={t('docsPanel.switchToTab', 'Switch to {{title}}', {
+        {isDropdownOpen && overflowGuideTabs.length > 0 && (
+          <div
+            ref={dropdownRef}
+            className={styles.tabDropdown}
+            role="menu"
+            aria-label={t('docsPanel.moreTabsMenu', 'More tabs')}
+            data-testid={testIds.docsPanel.tabDropdown}
+          >
+            {overflowGuideTabs.map((tab) => {
+              return (
+                <button
+                  key={tab.id}
+                  className={`${styles.dropdownItem} ${tab.id === activeTabId ? styles.activeDropdownItem : ''}`}
+                  onClick={() => {
+                    model.setActiveTab(tab.id);
+                    setIsDropdownOpen(false);
+                  }}
+                  role="menuitem"
+                  aria-label={t('docsPanel.switchToTab', 'Switch to {{title}}', {
+                    title: getTranslatedTitle(tab.title),
+                  })}
+                  data-testid={testIds.docsPanel.tabDropdownItem(tab.id)}
+                >
+                  <div className={styles.dropdownItemContent}>
+                    {tab.type === 'devtools' && <Icon name="bug" size="xs" className={styles.dropdownItemIcon} />}
+                    <span className={styles.dropdownItemTitle}>
+                      {tab.isLoading ? (
+                        <>
+                          <Icon name="sync" size="xs" />
+                          <span>{t('docsPanel.loading', 'Loading...')}</span>
+                        </>
+                      ) : (
+                        getTranslatedTitle(tab.title)
+                      )}
+                    </span>
+                    <IconButton
+                      name="times"
+                      size="sm"
+                      aria-label={t('docsPanel.closeTab', 'Close {{title}}', {
                         title: getTranslatedTitle(tab.title),
                       })}
-                      data-testid={testIds.docsPanel.tabDropdownItem(tab.id)}
-                    >
-                      <div className={styles.dropdownItemContent}>
-                        {tab.type === 'devtools' && <Icon name="bug" size="xs" className={styles.dropdownItemIcon} />}
-                        <span className={styles.dropdownItemTitle}>
-                          {tab.isLoading ? (
-                            <>
-                              <Icon name="sync" size="xs" />
-                              <span>{t('docsPanel.loading', 'Loading...')}</span>
-                            </>
-                          ) : (
-                            getTranslatedTitle(tab.title)
-                          )}
-                        </span>
-                        <IconButton
-                          name="times"
-                          size="sm"
-                          aria-label={t('docsPanel.closeTab', 'Close {{title}}', {
-                            title: getTranslatedTitle(tab.title),
-                          })}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            reportAppInteraction(UserInteraction.CloseTabClick, {
-                              content_type: getContentTypeForAnalytics(
-                                tab.currentUrl || tab.baseUrl,
-                                tab.type || 'learning-journey'
-                              ),
-                              tab_title: tab.title,
-                              content_url: tab.currentUrl || tab.baseUrl,
-                              close_location: 'dropdown',
-                              ...(tab.type === 'learning-journey' &&
-                                tab.content && {
-                                  completion_percentage: getJourneyProgress(tab.content),
-                                  current_milestone: tab.content.metadata?.learningJourney?.currentMilestone,
-                                  total_milestones: tab.content.metadata?.learningJourney?.totalMilestones,
-                                }),
-                            });
-                            model.closeTab(tab.id);
-                          }}
-                          className={styles.dropdownItemClose}
-                        />
-                      </div>
-                    </button>
-                  );
-                })}
-            </div>
-          )}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        reportAppInteraction(UserInteraction.CloseTabClick, {
+                          content_type: getContentTypeForAnalytics(
+                            tab.currentUrl || tab.baseUrl,
+                            tab.type || 'learning-journey'
+                          ),
+                          tab_title: tab.title,
+                          content_url: tab.currentUrl || tab.baseUrl,
+                          close_location: 'dropdown',
+                          ...(tab.type === 'learning-journey' &&
+                            tab.content && {
+                              completion_percentage: getJourneyProgress(tab.content),
+                              current_milestone: tab.content.metadata?.learningJourney?.currentMilestone,
+                              total_milestones: tab.content.metadata?.learningJourney?.totalMilestones,
+                            }),
+                        });
+                        model.closeTab(tab.id);
+                      }}
+                      className={styles.dropdownItemClose}
+                    />
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
 
         {/* Menu and close actions */}
         <TabBarActions className={styles.tabBarActions} />
@@ -1592,7 +1591,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
           }
 
           // Show editor tab (block editor for admin/editor users)
-          if (activeTabId === 'editor') {
+          if (activeTabId === 'editor' && isEditorUser) {
             return (
               <div className={styles.devToolsContent} data-testid="editor-tab-content">
                 <Suspense fallback={<SkeletonLoader type="recommendations" />}>

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -407,9 +407,11 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       }
     }
 
-    // Check if only default tabs remain (recommendations and possibly devtools)
+    // Check if only default tabs remain (recommendations and permanent utility tabs)
     // If so, always default to recommendations
-    const onlyDefaultTabsRemaining = newTabs.every((t) => t.id === 'recommendations' || t.id === 'devtools');
+    const onlyDefaultTabsRemaining = newTabs.every(
+      (t) => t.id === 'recommendations' || t.id === 'devtools' || t.id === 'editor'
+    );
     if (onlyDefaultTabsRemaining && newActiveTabId !== 'recommendations') {
       newActiveTabId = 'recommendations';
     }

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -94,6 +94,7 @@ import {
   isGrafanaDocsUrl,
   cleanDocsUrl,
   loadDocsTabContentResult,
+  PERMANENT_TAB_IDS,
 } from './utils';
 // Import extracted hooks
 import { useBadgeCelebrationQueue, useTabOverflow, useScrollPositionPreservation, useContentReset } from './hooks';
@@ -190,14 +191,15 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
 
   private initializeRestoredActiveTab(): void {
     const activeTab = this.state.tabs.find((t) => t.id === this.state.activeTabId);
-    if (activeTab && activeTab.id !== 'recommendations') {
-      // If we have an active tab but no content, load it
-      if (!activeTab.content && !activeTab.isLoading && !activeTab.error) {
-        if (shouldUseDocsLoader(activeTab)) {
-          this.loadDocsTabContent(activeTab.id, activeTab.currentUrl || activeTab.baseUrl);
-        } else {
-          this.loadTabContent(activeTab.id, activeTab.currentUrl || activeTab.baseUrl);
-        }
+    if (!activeTab || PERMANENT_TAB_IDS.has(activeTab.id)) {
+      return;
+    }
+
+    if (!activeTab.content && !activeTab.isLoading && !activeTab.error) {
+      if (shouldUseDocsLoader(activeTab)) {
+        this.loadDocsTabContent(activeTab.id, activeTab.currentUrl || activeTab.baseUrl);
+      } else {
+        this.loadTabContent(activeTab.id, activeTab.currentUrl || activeTab.baseUrl);
       }
     }
   }
@@ -407,12 +409,9 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       }
     }
 
-    // Check if only default/permanent tabs remain (recommendations, devtools, editor)
-    // If so, fall back to recommendations — unless the user is actively on the
-    // editor tab, which is a first-class content tab that shouldn't be yanked away.
-    const onlyDefaultTabsRemaining = newTabs.every(
-      (t) => t.id === 'recommendations' || t.id === 'devtools' || t.id === 'editor'
-    );
+    // If only permanent tabs remain, fall back to recommendations — unless the
+    // user is actively on the editor tab (a first-class content tab).
+    const onlyDefaultTabsRemaining = newTabs.every((t) => PERMANENT_TAB_IDS.has(t.id));
     if (onlyDefaultTabsRemaining && newActiveTabId !== 'recommendations' && newActiveTabId !== 'editor') {
       newActiveTabId = 'recommendations';
     }
@@ -437,15 +436,19 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     // Save active tab to storage
     this.saveTabsToStorage();
 
+    // Permanent tabs (recommendations, devtools, editor) render their own
+    // content and have no URL to load — skip the content-loading path.
+    if (PERMANENT_TAB_IDS.has(tabId)) {
+      return;
+    }
+
     // If switching to a tab that hasn't loaded content yet, load it
     const tab = this.state.tabs.find((t) => t.id === tabId);
-    if (tab && tabId !== 'recommendations' && !tab.isLoading && !tab.error) {
-      if (!tab.content) {
-        if (shouldUseDocsLoader(tab)) {
-          this.loadDocsTabContent(tabId, tab.currentUrl || tab.baseUrl);
-        } else {
-          this.loadTabContent(tabId, tab.currentUrl || tab.baseUrl);
-        }
+    if (tab && !tab.isLoading && !tab.error && !tab.content) {
+      if (shouldUseDocsLoader(tab)) {
+        this.loadDocsTabContent(tabId, tab.currentUrl || tab.baseUrl);
+      } else {
+        this.loadTabContent(tabId, tab.currentUrl || tab.baseUrl);
       }
     }
   }
@@ -999,10 +1002,9 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
     dropdownOpenTimeRef,
   } = useTabOverflow(tabs, activeTabId);
 
-  const PERMANENT_TAB_IDS = React.useMemo(() => new Set(['recommendations', 'devtools', 'editor']), []);
   const overflowGuideTabs = React.useMemo(
     () => overflowedTabs.filter((t) => !PERMANENT_TAB_IDS.has(t.id)),
-    [overflowedTabs, PERMANENT_TAB_IDS]
+    [overflowedTabs]
   );
 
   // Content styles are applied at the component level via CSS classes
@@ -1428,13 +1430,12 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
         </div>
 
         {/* Divider - only show when there are guide tabs */}
-        {visibleTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools' && t.id !== 'editor').length >
-          0 && <div className={styles.tabDivider} />}
+        {visibleTabs.filter((t) => !PERMANENT_TAB_IDS.has(t.id)).length > 0 && <div className={styles.tabDivider} />}
 
         {/* Guide tabs with titles */}
         <div className={styles.tabList} ref={tabListRef} data-testid={testIds.docsPanel.tabList}>
           {visibleTabs
-            .filter((tab) => tab.id !== 'recommendations' && tab.id !== 'devtools' && tab.id !== 'editor')
+            .filter((tab) => !PERMANENT_TAB_IDS.has(tab.id))
             .map((tab) => {
               return (
                 <button

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -202,7 +202,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     }
   }
 
-  private async saveTabsToStorage(): Promise<void> {
+  public async saveTabsToStorage(): Promise<void> {
     try {
       // Save user-opened tabs and devtools tab (devtools persists across refreshes)
       // Recommendations is a permanent tab and doesn't need persistence
@@ -888,10 +888,15 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
     if (missing.length > 0 || hasStaleEditorTab) {
       let updatedTabs = hasStaleEditorTab ? tabs.filter((t) => t.id !== 'editor') : tabs;
       updatedTabs = [...updatedTabs, ...missing];
-      model.setState({ tabs: updatedTabs });
 
+      const patch: Partial<CombinedPanelState> = { tabs: updatedTabs };
       if (hasStaleEditorTab && model.state.activeTabId === 'editor') {
-        model.setState({ activeTabId: 'recommendations' });
+        patch.activeTabId = 'recommendations';
+      }
+      model.setState(patch);
+
+      if (hasStaleEditorTab) {
+        model.saveTabsToStorage();
       }
     }
   }, [isDevMode, isEditorUser, tabs, model]);

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -407,12 +407,13 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       }
     }
 
-    // Check if only default tabs remain (recommendations and permanent utility tabs)
-    // If so, always default to recommendations
+    // Check if only default/permanent tabs remain (recommendations, devtools, editor)
+    // If so, fall back to recommendations — unless the user is actively on the
+    // editor tab, which is a first-class content tab that shouldn't be yanked away.
     const onlyDefaultTabsRemaining = newTabs.every(
       (t) => t.id === 'recommendations' || t.id === 'devtools' || t.id === 'editor'
     );
-    if (onlyDefaultTabsRemaining && newActiveTabId !== 'recommendations') {
+    if (onlyDefaultTabsRemaining && newActiveTabId !== 'recommendations' && newActiveTabId !== 'editor') {
       newActiveTabId = 'recommendations';
     }
 
@@ -880,8 +881,18 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
       });
     }
 
-    if (missing.length > 0) {
-      model.setState({ tabs: [...tabs, ...missing] });
+    // Remove editor tab if the current user is not an editor/admin (e.g. role
+    // downgrade or different user logged in with a persisted editor tab).
+    const hasStaleEditorTab = !isEditorUser && tabs.some((t) => t.id === 'editor');
+
+    if (missing.length > 0 || hasStaleEditorTab) {
+      let updatedTabs = hasStaleEditorTab ? tabs.filter((t) => t.id !== 'editor') : tabs;
+      updatedTabs = [...updatedTabs, ...missing];
+      model.setState({ tabs: updatedTabs });
+
+      if (hasStaleEditorTab && model.state.activeTabId === 'editor') {
+        model.setState({ activeTabId: 'recommendations' });
+      }
     }
   }, [isDevMode, isEditorUser, tabs, model]);
 

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -13,6 +13,13 @@ const SelectorDebugPanel = lazy(() =>
   }))
 );
 
+// Lazy load BlockEditor for the editor tab (admin/editor users)
+const BlockEditor = lazy(() =>
+  import('../block-editor').then((module) => ({
+    default: module.BlockEditor,
+  }))
+);
+
 // Lazy load Coda Terminal to keep it out of production bundles
 // Only loaded when dev mode is enabled and terminal feature is enabled
 const TerminalPanel = lazy(() =>
@@ -132,7 +139,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       (url: string, title: string) => this.openLearningJourney(url, title),
       (url: string, title: string, packageInfo?: PackageOpenInfo) =>
         this.openDocsPage(url, title, undefined, packageInfo),
-      () => this.openDevToolsTab()
+      () => this.openEditorTab()
     );
 
     super({
@@ -510,6 +517,36 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     this.saveTabsToStorage();
   }
 
+  /**
+   * Open the Editor tab (or switch to it if already open)
+   */
+  public openEditorTab(): void {
+    const existingTab = this.state.tabs.find((t) => t.id === 'editor');
+    if (existingTab) {
+      this.setState({ activeTabId: 'editor' });
+      this.saveTabsToStorage();
+      return;
+    }
+
+    const newTab: LearningJourneyTab = {
+      id: 'editor',
+      title: 'Guide editor',
+      baseUrl: '',
+      currentUrl: '',
+      content: null,
+      isLoading: false,
+      error: null,
+      type: 'editor',
+    };
+
+    this.setState({
+      tabs: [...this.state.tabs, newTab],
+      activeTabId: 'editor',
+    });
+
+    this.saveTabsToStorage();
+  }
+
   public async openDocsPage(
     url: string,
     title?: string,
@@ -654,6 +691,10 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   // SECURITY: Dev mode - hybrid approach (synchronous check with user ID scoping)
   const currentUserId = config.bootData.user?.id;
   const isDevMode = isDevModeEnabled(pluginConfig, currentUserId);
+
+  const currentUser = config.bootData?.user;
+  const isEditorUser =
+    currentUser?.orgRole === 'Editor' || currentUser?.orgRole === 'Admin' || currentUser?.isGrafanaAdmin === true;
 
   // SECURITY: Scoped logger that only emits in dev mode to prevent user data leaking to console.
   // Stored in a ref so it never causes effect re-runs when isDevMode toggles.
@@ -825,6 +866,26 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
       }
     }
   }, [isDevMode, tabs, model]);
+
+  // Ensure editor tab exists for admin/editor users (permanent tab)
+  React.useEffect(() => {
+    if (isEditorUser) {
+      const hasEditorTab = tabs.some((t) => t.id === 'editor');
+      if (!hasEditorTab) {
+        const editorTab: LearningJourneyTab = {
+          id: 'editor',
+          title: 'Guide editor',
+          baseUrl: '',
+          currentUrl: '',
+          content: null,
+          isLoading: false,
+          error: null,
+          type: 'editor',
+        };
+        model.setState({ tabs: [...tabs, editorTab] });
+      }
+    }
+  }, [isEditorUser, tabs, model]);
 
   // Listen for auto-open events from global link interceptor
   // Place this HERE (not in ContextPanelRenderer) to avoid component remounting issues
@@ -1324,6 +1385,16 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
           >
             <Icon name="document-info" size="md" />
           </button>
+          {isEditorUser && (
+            <button
+              className={`${styles.iconTab} ${activeTabId === 'editor' ? styles.iconTabActive : ''}`}
+              onClick={() => model.setActiveTab('editor')}
+              title={t('docsPanel.guideEditor', 'Guide editor')}
+              data-testid={testIds.docsPanel.tab('editor')}
+            >
+              <Icon name="edit" size="md" />
+            </button>
+          )}
           {isDevMode && (
             <button
               className={`${styles.iconTab} ${activeTabId === 'devtools' ? styles.iconTabActive : ''}`}
@@ -1337,14 +1408,13 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
         </div>
 
         {/* Divider - only show when there are guide tabs */}
-        {visibleTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools').length > 0 && (
-          <div className={styles.tabDivider} />
-        )}
+        {visibleTabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools' && t.id !== 'editor').length >
+          0 && <div className={styles.tabDivider} />}
 
         {/* Guide tabs with titles */}
         <div className={styles.tabList} ref={tabListRef} data-testid={testIds.docsPanel.tabList}>
           {visibleTabs
-            .filter((tab) => tab.id !== 'recommendations' && tab.id !== 'devtools')
+            .filter((tab) => tab.id !== 'recommendations' && tab.id !== 'devtools' && tab.id !== 'editor')
             .map((tab) => {
               return (
                 <button
@@ -1521,6 +1591,17 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
             );
           }
 
+          // Show editor tab (block editor for admin/editor users)
+          if (activeTabId === 'editor') {
+            return (
+              <div className={styles.devToolsContent} data-testid="editor-tab-content">
+                <Suspense fallback={<SkeletonLoader type="recommendations" />}>
+                  <BlockEditor />
+                </Suspense>
+              </div>
+            );
+          }
+
           // Show loading state with skeleton.
           // When a learning journey tab is reloading (milestone navigation), keep
           // the milestone bar visible so the user doesn't lose navigation context.
@@ -1615,7 +1696,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
                     </div>
                     <button
                       className={styles.returnToEditorButton}
-                      onClick={() => model.openDevToolsTab()}
+                      onClick={() => model.openEditorTab()}
                       data-testid={testIds.devTools.returnToEditorButton}
                     >
                       <Icon name="arrow-left" size="sm" />

--- a/src/components/docs-panel/types.ts
+++ b/src/components/docs-panel/types.ts
@@ -54,6 +54,9 @@ export interface DocsPanelModelOperations {
   /** Open the dev tools tab (or switch to it if already open) */
   openDevToolsTab(): void;
 
+  /** Open the editor tab (or switch to it if already open) */
+  openEditorTab(): void;
+
   /** Get the currently active tab */
   getActiveTab(): LearningJourneyTab | null;
 }

--- a/src/components/docs-panel/utils/index.ts
+++ b/src/components/docs-panel/utils/index.ts
@@ -4,7 +4,7 @@
 
 export { isDocsLikeTab, shouldUseDocsLoader } from './tab-validation';
 export { getTranslatedTitle } from './tab-translations';
-export { computeTabVisibility } from './tab-visibility';
+export { computeTabVisibility, PERMANENT_TAB_IDS } from './tab-visibility';
 export type { TabVisibilityResult } from './tab-visibility';
 export { restoreTabsFromStorage, restoreActiveTabFromStorage, createUrlValidator } from './tab-storage-restore';
 export type { UrlValidator, TabRestoreOptions } from './tab-storage-restore';

--- a/src/components/docs-panel/utils/tab-storage-restore.ts
+++ b/src/components/docs-panel/utils/tab-storage-restore.ts
@@ -110,6 +110,21 @@ export async function restoreTabsFromStorage(
         return;
       }
 
+      // Handle editor tab specially - it has no URLs to validate
+      if (data.type === 'editor') {
+        tabs.push({
+          id: 'editor',
+          title: 'Guide editor',
+          baseUrl: '',
+          currentUrl: '',
+          content: null,
+          isLoading: false,
+          error: null,
+          type: 'editor',
+        });
+        return;
+      }
+
       // SECURITY: Validate URLs before restoring from storage
       // This prevents XSS attacks via storage injection
       const isValidBase = validateUrl(data.baseUrl);

--- a/src/components/docs-panel/utils/tab-visibility.ts
+++ b/src/components/docs-panel/utils/tab-visibility.ts
@@ -15,9 +15,11 @@ export interface TabVisibilityResult {
   overflowedTabs: LearningJourneyTab[];
 }
 
+const PERMANENT_TAB_IDS = new Set(['recommendations', 'devtools', 'editor']);
+
 /**
  * Computes which tabs fit in the visible area and which move to overflow.
- * Permanent tabs (recommendations, devtools) are always in visibleTabs;
+ * Permanent tabs (recommendations, devtools, editor) are always in visibleTabs;
  * guide tabs are split by available width, with the active tab forced visible if it would be overflowed.
  */
 export function computeTabVisibility(
@@ -25,7 +27,7 @@ export function computeTabVisibility(
   containerWidth: number,
   activeTabId: string
 ): TabVisibilityResult {
-  const guideTabs = tabs.filter((t) => t.id !== 'recommendations' && t.id !== 'devtools');
+  const guideTabs = tabs.filter((t) => !PERMANENT_TAB_IDS.has(t.id));
 
   const permanentTabs = tabs.filter((t) => t.id === 'recommendations');
 

--- a/src/components/docs-panel/utils/tab-visibility.ts
+++ b/src/components/docs-panel/utils/tab-visibility.ts
@@ -15,7 +15,7 @@ export interface TabVisibilityResult {
   overflowedTabs: LearningJourneyTab[];
 }
 
-const PERMANENT_TAB_IDS = new Set(['recommendations', 'devtools', 'editor']);
+export const PERMANENT_TAB_IDS = new Set(['recommendations', 'devtools', 'editor']);
 
 /**
  * Computes which tabs fit in the visible area and which move to overflow.

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -240,7 +240,7 @@ export function reportAppInteraction(
  * Type definition for tabs compatible with scroll tracking
  */
 export interface ScrollTrackingTab {
-  type?: 'docs' | 'learning-journey' | 'devtools' | 'interactive';
+  type?: 'docs' | 'learning-journey' | 'devtools' | 'interactive' | 'editor';
   content?: {
     url?: string;
     metadata?: {

--- a/src/types/content-panel.types.ts
+++ b/src/types/content-panel.types.ts
@@ -58,7 +58,7 @@ export interface PackageOpenInfo {
 export interface ContextPanelState extends SceneObjectState {
   onOpenLearningJourney?: (url: string, title: string) => void;
   onOpenDocsPage?: (url: string, title: string, packageInfo?: PackageOpenInfo) => void;
-  onOpenDevTools?: () => void;
+  onOpenEditor?: () => void;
 }
 
 /**

--- a/src/types/content-panel.types.ts
+++ b/src/types/content-panel.types.ts
@@ -28,7 +28,7 @@ export interface LearningJourneyTab {
   content: RawContent | null;
   isLoading: boolean;
   error: string | null;
-  type?: 'learning-journey' | 'docs' | 'devtools' | 'interactive';
+  type?: 'learning-journey' | 'docs' | 'devtools' | 'interactive' | 'editor';
   packageInfo?: PackageOpenInfo;
   /** Cached milestone data from initial path package load, used to persist
    *  learningJourney metadata across milestone arrow navigation. */
@@ -44,7 +44,7 @@ export interface PersistedTabData {
   title: string;
   baseUrl: string;
   currentUrl?: string; // The specific milestone/page URL user was viewing (optional for backward compatibility)
-  type?: 'learning-journey' | 'docs' | 'devtools' | 'interactive';
+  type?: 'learning-journey' | 'docs' | 'devtools' | 'interactive' | 'editor';
   packageInfo?: PackageOpenInfo;
 }
 

--- a/tests/block-editor.spec.ts
+++ b/tests/block-editor.spec.ts
@@ -19,18 +19,18 @@ import { TIMEOUTS } from './constants';
 /**
  * Block Editor E2E Tests
  *
- * These tests verify the block editor functionality in dev mode.
- * Dev mode must be enabled via plugin settings API before tests run.
+ * These tests verify the block editor functionality available to admin/editor users.
+ * The block editor lives in its own "editor" tab, separate from the dev-mode-gated
+ * devtools tab. Dev mode is still enabled here because the recording test needs it
+ * for the recording overlay to function.
  *
  * Tests run serially to prevent race conditions from parallel execution
- * with shared Grafana dev mode state.
+ * with shared Grafana state.
  */
 
 test.describe.serial('Block Editor', () => {
-  // Enable dev mode before tests run
+  // Enable dev mode before tests run (needed for recording overlay tests)
   test.beforeAll(async ({ request }) => {
-    // Enable dev mode via plugin settings API
-    // Admin user ID is typically 1 in fresh Grafana instances
     await request.post('/api/plugins/grafana-pathfinder-app/settings', {
       data: {
         enabled: true,
@@ -61,13 +61,13 @@ test.describe.serial('Block Editor', () => {
     await clearBlockEditorState(page);
   });
 
-  test('should open block editor via dev tools tab', async ({ page }) => {
-    // Open dev tools panel using helper function
+  test('should open block editor via editor tab', async ({ page }) => {
+    // Open editor panel using helper function
     await openBlockEditor(page);
 
-    // Wait for dev tools content to load
-    const devToolsContent = page.getByTestId('devtools-tab-content');
-    await expect(devToolsContent).toBeVisible();
+    // Wait for editor content to load
+    const editorContent = page.getByTestId('editor-tab-content');
+    await expect(editorContent).toBeVisible();
 
     // Verify the block editor is visible
     const blockEditor = page.getByTestId(testIds.blockEditor.container);

--- a/tests/helpers/block-editor.helpers.ts
+++ b/tests/helpers/block-editor.helpers.ts
@@ -27,8 +27,8 @@ export async function waitForGrafanaReady(page: Page): Promise<void> {
 }
 
 /**
- * Open the block editor via the dev tools tab.
- * Assumes dev mode is enabled.
+ * Open the block editor via the editor tab.
+ * Available to admin and editor users (not gated by dev mode).
  */
 export async function openBlockEditor(page: Page): Promise<void> {
   // Wait for Grafana UI to be ready
@@ -46,14 +46,13 @@ export async function openBlockEditor(page: Page): Promise<void> {
   const panelContainer = page.getByTestId(testIds.docsPanel.container);
   await expect(panelContainer).toBeVisible();
 
-  // Wait for devtools tab to be visible (requires dev mode enabled)
-  // Use longer timeout as dev mode settings need to propagate
-  const devToolsTab = page.getByTestId(testIds.docsPanel.tab('devtools'));
-  await expect(devToolsTab).toBeVisible({ timeout: TIMEOUTS.DEV_MODE_PROPAGATE });
+  // Wait for editor tab to be visible (available to admin/editor users)
+  const editorTab = page.getByTestId(testIds.docsPanel.tab('editor'));
+  await expect(editorTab).toBeVisible({ timeout: TIMEOUTS.DEV_MODE_PROPAGATE });
 
   // Hover before click to dismiss any tooltips that may intercept pointer events
-  await devToolsTab.hover();
-  await devToolsTab.click();
+  await editorTab.hover();
+  await editorTab.click();
 
   // Wait for block editor to be visible
   const blockEditor = page.getByTestId(testIds.blockEditor.container);


### PR DESCRIPTION
## Summary

- Extract the block editor from the dev-mode-gated devtools tab into its own always-visible **editor tab** (edit icon) accessible to **admin and editor users** only
- The devtools tab (bug icon) remains unchanged for PR tester and URL tester, still gated behind dev mode
- Adds `'editor'` tab type across types, storage restore, tab visibility, and analytics
- WYSIWYG preview "Return to editor" button now navigates to the editor tab instead of devtools

Closes the scope originally attempted by #678 (now closed), with a narrower focus. Test ID centralization was already landed in #711.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes docs panel tab lifecycle/persistence and introduces role-gated UI paths that could affect tab restoration and navigation behavior across sessions/users.
> 
> **Overview**
> Moves the `BlockEditor` out of the dev-mode `SelectorDebugPanel` and into a new permanent `editor` tab that is shown only to Admin/Editor users, while keeping devtools (PR/URL testers) dev-mode gated.
> 
> Updates docs panel tab management to treat `editor` as a first-class permanent tab: adds `openEditorTab`, skips URL/content loading for permanent tabs, restores/persists the editor tab from storage, filters overflow/visibility logic via `PERMANENT_TAB_IDS`, and routes WYSIWYG preview “Return to editor” back to the editor tab.
> 
> Extends shared types/analytics to include the new `editor` tab type, and updates E2E helpers/tests to open the block editor via the editor tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc77ec028d9b02cd6f0bcc66cdc712142374c154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->