### PR TITLE
Docs panel tab issues

### DIFF
--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -181,12 +181,12 @@ export class ContextPanel extends SceneObjectBase<ContextPanelState> {
   public constructor(
     onOpenLearningJourney?: (url: string, title: string) => void,
     onOpenDocsPage?: (url: string, title: string, packageInfo?: PackageOpenInfo) => void,
-    onOpenDevTools?: () => void
+    onOpenEditor?: () => void
   ) {
     super({
       onOpenLearningJourney,
       onOpenDocsPage,
-      onOpenDevTools,
+      onOpenEditor,
     });
   }
 
@@ -204,9 +204,9 @@ export class ContextPanel extends SceneObjectBase<ContextPanelState> {
     }
   }
 
-  public openDevTools() {
-    if (this.state.onOpenDevTools) {
-      this.state.onOpenDevTools();
+  public openEditor() {
+    if (this.state.onOpenEditor) {
+      this.state.onOpenEditor();
     }
   }
 

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -407,9 +407,11 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       }
     }
 
-    // Check if only default tabs remain (recommendations and possibly devtools)
+    // Check if only default tabs remain (recommendations and permanent utility tabs)
     // If so, always default to recommendations
-    const onlyDefaultTabsRemaining = newTabs.every((t) => t.id === 'recommendations' || t.id === 'devtools');
+    const onlyDefaultTabsRemaining = newTabs.every(
+      (t) => t.id === 'recommendations' || t.id === 'devtools' || t.id === 'editor'
+    );
     if (onlyDefaultTabsRemaining && newActiveTabId !== 'recommendations') {
       newActiveTabId = 'recommendations';
     }

--- a/src/types/content-panel.types.ts
+++ b/src/types/content-panel.types.ts
@@ -58,7 +58,7 @@ export interface PackageOpenInfo {
 export interface ContextPanelState extends SceneObjectState {
   onOpenLearningJourney?: (url: string, title: string) => void;
   onOpenDocsPage?: (url: string, title: string, packageInfo?: PackageOpenInfo) => void;
-  onOpenDevTools?: () => void;
+  onOpenEditor?: () => void;
 }
 
 /**


### PR DESCRIPTION
Fixes tab closing logic to include the editor tab and renames `onOpenDevTools` to `onOpenEditor` for clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state changes: renames a callback and adjusts tab-closing logic to treat `editor` as a permanent utility tab, which could affect active-tab selection but not data/security paths.
> 
> **Overview**
> **Fixes docs panel tab handling around the editor utility tab.** The context panel callback and method are renamed from `onOpenDevTools`/`openDevTools` to `onOpenEditor`/`openEditor`, with corresponding type updates in `ContextPanelState`.
> 
> Tab closing logic in `docs-panel.tsx` is updated so that when only default/permanent tabs remain, it correctly considers `editor` (in addition to `recommendations` and `devtools`) and defaults back to `recommendations` as the active tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5cdff39c5ae91d9c3e00dca9500ebb3cf56ff18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->