### PR TITLE
feat: add kiosk session ID tracking for analytics

### DIFF
--- a/src/components/kiosk/KioskTile.test.tsx
+++ b/src/components/kiosk/KioskTile.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { KioskTile } from './KioskTile';
+import type { KioskRule } from './kiosk-rules';
+import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+
+jest.mock('@grafana/ui', () => ({
+  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+  useStyles2: () => ({}),
+}));
+
+jest.mock('../../lib/analytics', () => ({
+  reportAppInteraction: jest.fn(),
+  UserInteraction: {
+    KioskDemoStarted: 'kiosk_demo_started',
+  },
+}));
+
+jest.mock('../../constants/testIds', () => ({
+  testIds: {
+    kioskMode: {
+      tile: (i: number) => `kiosk-tile-${i}`,
+      tileTitle: (i: number) => `kiosk-tile-title-${i}`,
+    },
+  },
+}));
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('KioskTile', () => {
+  const mockOpen = jest.fn();
+  const mockRandomUUID = jest.fn(() => '00000000-0000-4000-a000-000000000001');
+
+  const rule: KioskRule = {
+    title: 'First Dashboard',
+    url: 'https://interactive-learning.grafana.net/guides/first-dashboard',
+    description: 'Build your first dashboard',
+    type: 'interactive',
+    targetUrl: 'https://play.grafana.org',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.open = mockOpen;
+    Object.defineProperty(globalThis, 'crypto', {
+      value: { randomUUID: mockRandomUUID },
+      writable: true,
+    });
+  });
+
+  it('opens deep link with doc and kiosk_session params on click', () => {
+    render(<KioskTile rule={rule} index={0} />);
+    fireEvent.click(screen.getByTestId('kiosk-tile-0'));
+
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+    const openedUrl = new URL(mockOpen.mock.calls[0][0]);
+    expect(openedUrl.origin).toBe('https://play.grafana.org');
+    expect(openedUrl.searchParams.get('doc')).toBe(rule.url);
+    expect(openedUrl.searchParams.get('kiosk_session')).toBe('00000000-0000-4000-a000-000000000001');
+    expect(mockOpen.mock.calls[0][1]).toBe('_blank');
+    expect(mockOpen.mock.calls[0][2]).toBe('noopener,noreferrer');
+  });
+
+  it('fires KioskDemoStarted analytics event before opening the tab', () => {
+    render(<KioskTile rule={rule} index={0} />);
+    fireEvent.click(screen.getByTestId('kiosk-tile-0'));
+
+    expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.KioskDemoStarted, {
+      kiosk_session_id: '00000000-0000-4000-a000-000000000001',
+      guide_url: rule.url,
+      guide_title: rule.title,
+      guide_type: rule.type,
+      target_instance: rule.targetUrl,
+    });
+
+    const analyticsCallOrder = (reportAppInteraction as jest.Mock).mock.invocationCallOrder[0]!;
+    const openCallOrder = mockOpen.mock.invocationCallOrder[0]!;
+    expect(analyticsCallOrder).toBeLessThan(openCallOrder);
+  });
+
+  it('falls back to window.location.origin when targetUrl is not set', () => {
+    const ruleWithoutTarget: KioskRule = { ...rule, targetUrl: undefined };
+    render(<KioskTile rule={ruleWithoutTarget} index={0} />);
+    fireEvent.click(screen.getByTestId('kiosk-tile-0'));
+
+    const openedUrl = new URL(mockOpen.mock.calls[0][0]);
+    expect(openedUrl.origin).toBe(window.location.origin);
+
+    expect(reportAppInteraction).toHaveBeenCalledWith(
+      UserInteraction.KioskDemoStarted,
+      expect.objectContaining({
+        target_instance: window.location.origin,
+      })
+    );
+  });
+
+  it('generates a new session ID on each click', () => {
+    let callCount = 0;
+    mockRandomUUID.mockImplementation(() => {
+      callCount++;
+      return `00000000-0000-4000-a000-00000000000${callCount}`;
+    });
+
+    render(<KioskTile rule={rule} index={0} />);
+    const tile = screen.getByTestId('kiosk-tile-0');
+
+    fireEvent.click(tile);
+    fireEvent.click(tile);
+
+    const firstUrl = new URL(mockOpen.mock.calls[0][0]);
+    const secondUrl = new URL(mockOpen.mock.calls[1][0]);
+    expect(firstUrl.searchParams.get('kiosk_session')).not.toBe(secondUrl.searchParams.get('kiosk_session'));
+  });
+
+  it('produces a valid UUID v4 format in the kiosk_session param', () => {
+    mockRandomUUID.mockReturnValue('550e8400-e29b-41d4-a716-446655440000');
+
+    render(<KioskTile rule={rule} index={1} />);
+    fireEvent.click(screen.getByTestId('kiosk-tile-1'));
+
+    const openedUrl = new URL(mockOpen.mock.calls[0][0]);
+    expect(openedUrl.searchParams.get('kiosk_session')).toMatch(UUID_REGEX);
+  });
+});

--- a/src/components/kiosk/KioskTile.test.tsx
+++ b/src/components/kiosk/KioskTile.test.tsx
@@ -94,6 +94,17 @@ describe('KioskTile', () => {
     );
   });
 
+  it('preserves sub-path in targetUrl when building the deep link', () => {
+    const ruleWithSubPath: KioskRule = { ...rule, targetUrl: 'https://example.com/grafana' };
+    render(<KioskTile rule={ruleWithSubPath} index={0} />);
+    fireEvent.click(screen.getByTestId('kiosk-tile-0'));
+
+    const openedUrl = new URL(mockOpen.mock.calls[0][0]);
+    expect(openedUrl.pathname).toBe('/grafana/');
+    expect(openedUrl.searchParams.get('doc')).toBe(rule.url);
+    expect(openedUrl.searchParams.get('kiosk_session')).toBe('00000000-0000-4000-a000-000000000001');
+  });
+
   it('generates a new session ID on each click', () => {
     let callCount = 0;
     mockRandomUUID.mockImplementation(() => {

--- a/src/components/kiosk/KioskTile.tsx
+++ b/src/components/kiosk/KioskTile.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { Icon, useStyles2 } from '@grafana/ui';
 import { testIds } from '../../constants/testIds';
+import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
 import { getKioskOverlayStyles } from './kiosk-mode.styles';
 import type { KioskRule } from './kiosk-rules';
 
@@ -14,9 +15,21 @@ export const KioskTile: React.FC<KioskTileProps> = ({ rule, index }) => {
 
   const handleClick = useCallback(() => {
     const base = (rule.targetUrl || window.location.origin).replace(/\/+$/, '');
-    const docParam = encodeURIComponent(rule.url);
-    window.open(`${base}/?doc=${docParam}`, '_blank', 'noopener,noreferrer');
-  }, [rule.targetUrl, rule.url]);
+    const sessionId = crypto.randomUUID();
+
+    reportAppInteraction(UserInteraction.KioskDemoStarted, {
+      kiosk_session_id: sessionId,
+      guide_url: rule.url,
+      guide_title: rule.title,
+      guide_type: rule.type,
+      target_instance: rule.targetUrl || window.location.origin,
+    });
+
+    const url = new URL('/', base);
+    url.searchParams.set('doc', rule.url);
+    url.searchParams.set('kiosk_session', sessionId);
+    window.open(url.toString(), '_blank', 'noopener,noreferrer');
+  }, [rule.targetUrl, rule.url, rule.title, rule.type]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/src/components/kiosk/KioskTile.tsx
+++ b/src/components/kiosk/KioskTile.tsx
@@ -25,7 +25,7 @@ export const KioskTile: React.FC<KioskTileProps> = ({ rule, index }) => {
       target_instance: rule.targetUrl || window.location.origin,
     });
 
-    const url = new URL('/', base);
+    const url = new URL(base + '/');
     url.searchParams.set('doc', rule.url);
     url.searchParams.set('kiosk_session', sessionId);
     window.open(url.toString(), '_blank', 'noopener,noreferrer');

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,70 @@
+import { reportAppInteraction, UserInteraction } from './analytics';
+import { reportInteraction } from '@grafana/runtime';
+
+jest.mock('@grafana/runtime', () => ({
+  reportInteraction: jest.fn(),
+}));
+
+jest.mock('../../package.json', () => ({
+  version: '1.0.0-test',
+}));
+
+jest.mock('../security/url-validator', () => ({
+  isInteractiveLearningUrl: jest.fn(() => false),
+}));
+
+const mockReportInteraction = reportInteraction as jest.Mock;
+
+describe('reportAppInteraction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete (window as any).__pathfinderKioskSessionId;
+  });
+
+  it('includes kiosk_session_id when window global is set', () => {
+    (window as any).__pathfinderKioskSessionId = 'test-session-abc';
+
+    reportAppInteraction(UserInteraction.DocsPanelInteraction, { action: 'open' });
+
+    expect(mockReportInteraction).toHaveBeenCalledWith(
+      'pathfinder_docs_panel_interaction',
+      expect.objectContaining({
+        kiosk_session_id: 'test-session-abc',
+        action: 'open',
+        plugin_version: '1.0.0-test',
+      })
+    );
+  });
+
+  it('omits kiosk_session_id when window global is not set', () => {
+    reportAppInteraction(UserInteraction.DocsPanelInteraction, { action: 'open' });
+
+    expect(mockReportInteraction).toHaveBeenCalledTimes(1);
+    const properties = mockReportInteraction.mock.calls[0][1];
+    expect(properties).not.toHaveProperty('kiosk_session_id');
+  });
+
+  it('omits kiosk_session_id when window global is empty string', () => {
+    (window as any).__pathfinderKioskSessionId = '';
+
+    reportAppInteraction(UserInteraction.DocsPanelInteraction, {});
+
+    const properties = mockReportInteraction.mock.calls[0][1];
+    expect(properties).not.toHaveProperty('kiosk_session_id');
+  });
+
+  it('includes kiosk_session_id alongside other enriched properties', () => {
+    (window as any).__pathfinderKioskSessionId = 'kiosk-123';
+
+    reportAppInteraction(UserInteraction.ShowMeButtonClick, {
+      step_id: 'step-1',
+      content_type: 'interactive_guide',
+    });
+
+    const properties = mockReportInteraction.mock.calls[0][1];
+    expect(properties.kiosk_session_id).toBe('kiosk-123');
+    expect(properties.step_id).toBe('step-1');
+    expect(properties.content_type).toBe('interactive_guide');
+    expect(properties.plugin_version).toBe('1.0.0-test');
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -81,6 +81,9 @@ export enum UserInteraction {
 
   // Access Control
   NoAccess = 'no_access',
+
+  // Kiosk Mode
+  KioskDemoStarted = 'kiosk_demo_started',
 }
 
 // ============================================================================
@@ -216,6 +219,8 @@ export function reportAppInteraction(
     const experiments = shouldEnrichWithExperiments ? getExperimentsForAnalytics() : null;
     const variant = shouldEnrichWithExperiments ? getExperimentVariant() : null;
 
+    const kioskSessionId = (window as any).__pathfinderKioskSessionId as string | undefined;
+
     // Add global attributes to all events
     const enrichedProperties: Record<string, unknown> = {
       plugin_version: packageJson.version,
@@ -224,6 +229,7 @@ export function reportAppInteraction(
       ...(variant && { variant }),
       // Include experiments array if available (null check for graceful degradation)
       ...(experiments && { experiments }),
+      ...(kioskSessionId && { kiosk_session_id: kioskSessionId }),
     };
 
     reportInteraction(interactionName, enrichedProperties);

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -132,6 +132,11 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   // Optional source override for analytics — allows callers to identify the origin
   // of a ?doc= deep link (e.g. ?doc=foo&source=learning-hub)
   const sourceParam = urlParams.get('source');
+  const kioskSessionParam = urlParams.get('kiosk_session');
+
+  if (kioskSessionParam) {
+    (window as any).__pathfinderKioskSessionId = kioskSessionParam;
+  }
 
   // Use the source param if provided, otherwise default to 'url_param'
   const docOpenSource = sourceParam || 'url_param';
@@ -141,6 +146,7 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
     url.searchParams.delete('doc');
     url.searchParams.delete('page');
     url.searchParams.delete('source');
+    url.searchParams.delete('kiosk_session');
     window.history.replaceState({}, '', url.toString());
 
     import('./components/ControlGroupDocPopup').then(({ showControlGroupDocPopup }) => {
@@ -175,6 +181,7 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
           url.searchParams.delete('doc');
           url.searchParams.delete('page');
           url.searchParams.delete('source');
+          url.searchParams.delete('kiosk_session');
           window.history.replaceState({}, '', url.toString());
 
           sidebarState.setPendingOpenSource(docOpenSource, 'auto-open');
@@ -194,6 +201,7 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
           url.searchParams.delete('doc');
           url.searchParams.delete('page');
           url.searchParams.delete('source');
+          url.searchParams.delete('kiosk_session');
           window.history.replaceState({}, '', url.toString());
           attemptAutoOpen(200);
         }


### PR DESCRIPTION
## Summary

- Generates a unique UUID each time a kiosk tile is clicked, representing a new person at the kiosk
- Fires a new `pathfinder_kiosk_demo_started` analytics event on the kiosk instance with the session ID, guide URL, title, type, and target instance
- Passes the session ID via a `kiosk_session` query param in the deep link to the target Grafana instance
- On the target instance, reads and stores the session ID, then enriches **all** subsequent analytics events with `kiosk_session_id` -- enabling cross-instance correlation of guide interactions back to the originating kiosk demo

## Changes

| File | What changed |
|------|-------------|
| `src/lib/analytics.ts` | Added `KioskDemoStarted` enum value; enriched `reportAppInteraction` with `kiosk_session_id` from window global |
| `src/components/kiosk/KioskTile.tsx` | Generate UUID per click, fire `KioskDemoStarted` event, build deep link with URL API (F3), append `kiosk_session` param |
| `src/module.tsx` | Parse `kiosk_session` from URL, store on `window.__pathfinderKioskSessionId`, strip from visible URL in all 3 cleanup paths |
| `src/components/kiosk/KioskTile.test.tsx` | New -- 5 tests covering URL construction, analytics event, call ordering, target fallback, UUID uniqueness |
| `src/lib/analytics.test.ts` | New -- 4 tests verifying kiosk session enrichment presence/absence |

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:ci` passes (121 suites, 2399 tests)
- [x] New KioskTile tests verify deep link URL contains `kiosk_session` param with valid UUID
- [x] New KioskTile tests verify `KioskDemoStarted` event fires before `window.open`
- [x] New analytics tests verify `kiosk_session_id` is included/excluded correctly
- [ ] Manual: enable kiosk mode, click a tile, verify `pathfinder_kiosk_demo_started` event in network tab
- [ ] Manual: on target instance, verify subsequent analytics events contain `kiosk_session_id`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-cutting analytics enrichment and URL param handling at plugin init, so mistakes could impact event properties or deep-link behavior across instances, but changes are additive and covered by new unit tests.
> 
> **Overview**
> Adds **kiosk session correlation** for deep-linked demos by generating a per-click UUID in `KioskTile`, firing a new `UserInteraction.KioskDemoStarted` event, and appending `kiosk_session` to the opened `?doc=` URL.
> 
> On the receiving instance, `module.tsx` now reads `kiosk_session` into `window.__pathfinderKioskSessionId`, strips it from the URL during cleanup, and `reportAppInteraction` enriches **all analytics events** with `kiosk_session_id` when that global is set. New tests cover deep-link construction/call ordering in `KioskTile` and session-id enrichment behavior in analytics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ff8e0e5f8a3ea1db7e755fd9ece210298e01fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->