### PR TITLE
fix: prevent horizontal overflow oscillation from overlay elements

### DIFF
--- a/src/interactive-engine/navigation-manager.ts
+++ b/src/interactive-engine/navigation-manager.ts
@@ -159,23 +159,20 @@ export class NavigationManager {
       const highlightTop = parseFloat(highlightStyle.getPropertyValue('--highlight-top')) || 0;
       const highlightLeft = parseFloat(highlightStyle.getPropertyValue('--highlight-left')) || 0;
 
-      // Calculate highlight center (accounting for scroll)
-      const scrollTop = window.scrollY || document.documentElement.scrollTop;
-      const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-
+      // Calculate highlight center in viewport coords (position:fixed, no scroll offsets)
       let highlightCenterX: number;
       let highlightCenterY: number;
 
       if (this.driftDetectionIsDotMode) {
         // For dot mode, highlight position IS the center (dot is centered at that point)
-        highlightCenterX = highlightLeft - scrollLeft;
-        highlightCenterY = highlightTop - scrollTop;
+        highlightCenterX = highlightLeft;
+        highlightCenterY = highlightTop;
       } else {
         // For bounding box, calculate center from dimensions
         const highlightWidth = parseFloat(highlightStyle.getPropertyValue('--highlight-width')) || 0;
         const highlightHeight = parseFloat(highlightStyle.getPropertyValue('--highlight-height')) || 0;
-        highlightCenterX = highlightLeft - scrollLeft + highlightWidth / 2;
-        highlightCenterY = highlightTop - scrollTop + highlightHeight / 2;
+        highlightCenterX = highlightLeft + highlightWidth / 2;
+        highlightCenterY = highlightTop + highlightHeight / 2;
       }
 
       // Calculate drift distance
@@ -186,27 +183,22 @@ export class NavigationManager {
       // If drift exceeds threshold, update position immediately
       if (totalDrift > driftThreshold) {
         if (this.driftDetectionIsDotMode) {
-          // Update dot position at element center
-          const dotTop = elementRect.top + scrollTop + elementRect.height / 2;
-          const dotLeft = elementRect.left + scrollLeft + elementRect.width / 2;
+          // Update dot position at element center (viewport coords)
+          const dotTop = elementRect.top + elementRect.height / 2;
+          const dotLeft = elementRect.left + elementRect.width / 2;
           highlightStyle.setProperty('--highlight-top', `${dotTop}px`);
           highlightStyle.setProperty('--highlight-left', `${dotLeft}px`);
         } else {
-          // Update bounding box position
-          highlightStyle.setProperty('--highlight-top', `${elementRect.top + scrollTop - 4}px`);
-          highlightStyle.setProperty('--highlight-left', `${elementRect.left + scrollLeft - 4}px`);
+          // Update bounding box position (viewport coords)
+          highlightStyle.setProperty('--highlight-top', `${elementRect.top - 4}px`);
+          highlightStyle.setProperty('--highlight-left', `${elementRect.left - 4}px`);
           highlightStyle.setProperty('--highlight-width', `${elementRect.width + 8}px`);
           highlightStyle.setProperty('--highlight-height', `${elementRect.height + 8}px`);
         }
 
-        // Update comment box position (always body-attached, always absolute)
+        // Update comment box position (body-attached, position:fixed)
         if (this.driftDetectionComment) {
-          const highlightRect = this.calculateHighlightRect(
-            elementRect,
-            scrollTop,
-            scrollLeft,
-            this.driftDetectionIsDotMode
-          );
+          const highlightRect = this.calculateHighlightRect(elementRect, this.driftDetectionIsDotMode);
 
           const commentHeight = this.driftDetectionComment.offsetHeight;
           const { offsetX, offsetY } = this.calculateCommentPosition(elementRect, commentHeight);
@@ -241,33 +233,29 @@ export class NavigationManager {
   }
 
   /**
-   * Calculate highlight rect in absolute document coordinates.
+   * Calculate highlight rect in viewport coordinates (for position:fixed overlays).
    * For dot mode, returns a zero-dimension rect at element center.
    * For bounding box, returns padded rect around element.
    *
-   * @param rect - The element's bounding client rect
-   * @param scrollTop - Current vertical scroll offset
-   * @param scrollLeft - Current horizontal scroll offset
+   * @param rect - The element's bounding client rect (already in viewport coords)
    * @param isDotMode - Whether using dot indicator (true) or bounding box (false)
-   * @returns Highlight rect with top, left, width, height in document coordinates
+   * @returns Highlight rect with top, left, width, height in viewport coordinates
    */
   private calculateHighlightRect(
     rect: DOMRect,
-    scrollTop: number,
-    scrollLeft: number,
     isDotMode: boolean
   ): { top: number; left: number; width: number; height: number } {
     if (isDotMode) {
       return {
-        top: rect.top + scrollTop + rect.height / 2,
-        left: rect.left + scrollLeft + rect.width / 2,
+        top: rect.top + rect.height / 2,
+        left: rect.left + rect.width / 2,
         width: 0,
         height: 0,
       };
     }
     return {
-      top: rect.top + scrollTop - 4,
-      left: rect.left + scrollLeft - 4,
+      top: rect.top - 4,
+      left: rect.left - 4,
       width: rect.width + 8,
       height: rect.height + 8,
     };
@@ -310,13 +298,13 @@ export class NavigationManager {
         }
 
         const rect = element.getBoundingClientRect();
-        const scrollTop = window.scrollY || document.documentElement.scrollTop;
-        const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
 
         // Check for invalid positions:
         // 1. Element has collapsed to 0,0 (disappeared)
         // 2. Element is at top-left corner (0,0) with no scroll offset
         // 3. Element has zero or near-zero dimensions (skip for dot mode - dots work with any dimensions)
+        const scrollTop = window.scrollY || document.documentElement.scrollTop;
+        const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
         const isAtOrigin = rect.top === 0 && rect.left === 0 && scrollTop === 0 && scrollLeft === 0;
         const hasNoDimensions = rect.width < 1 || rect.height < 1;
 
@@ -336,24 +324,24 @@ export class NavigationManager {
           commentBox.style.display = '';
         }
 
-        // Update highlight position based on mode
+        // Update highlight position based on mode (viewport coords for position:fixed)
         if (isDotMode) {
           // For dots, position at element's center
-          const dotTop = rect.top + scrollTop + rect.height / 2;
-          const dotLeft = rect.left + scrollLeft + rect.width / 2;
+          const dotTop = rect.top + rect.height / 2;
+          const dotLeft = rect.left + rect.width / 2;
           highlightElement.style.setProperty('--highlight-top', `${dotTop}px`);
           highlightElement.style.setProperty('--highlight-left', `${dotLeft}px`);
         } else {
           // For bounding box, position with 4px padding
-          highlightElement.style.setProperty('--highlight-top', `${rect.top + scrollTop - 4}px`);
-          highlightElement.style.setProperty('--highlight-left', `${rect.left + scrollLeft - 4}px`);
+          highlightElement.style.setProperty('--highlight-top', `${rect.top - 4}px`);
+          highlightElement.style.setProperty('--highlight-left', `${rect.left - 4}px`);
           highlightElement.style.setProperty('--highlight-width', `${rect.width + 8}px`);
           highlightElement.style.setProperty('--highlight-height', `${rect.height + 8}px`);
         }
 
-        // Update comment box position (always body-attached, always absolute)
+        // Update comment box position (body-attached, position:fixed)
         if (commentBox) {
-          const highlightRect = this.calculateHighlightRect(rect, scrollTop, scrollLeft, isDotMode);
+          const highlightRect = this.calculateHighlightRect(rect, isDotMode);
 
           const commentHeight = commentBox.offsetHeight;
           const { offsetX, offsetY } = this.calculateCommentPosition(rect, commentHeight);
@@ -661,17 +649,15 @@ export class NavigationManager {
     const highlightTarget = getVisibleHighlightTarget(element);
 
     // Position the outline around the target element using CSS custom properties
+    // All overlay elements use position:fixed, so coordinates are viewport-relative
+    // (no scroll offsets needed — getBoundingClientRect already returns viewport coords)
     const rect = highlightTarget.getBoundingClientRect();
-    const scrollTop = window.scrollY || document.documentElement.scrollTop;
-    const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
 
     // Check if element has no valid position at all (truly invalid)
     const hasNoPosition = rect.top === 0 && rect.left === 0 && rect.width === 0 && rect.height === 0;
     if (hasNoPosition) {
       console.warn('Cannot highlight element: invalid position or dimensions', {
         rect,
-        scrollTop,
-        scrollLeft,
       });
       return element;
     }
@@ -695,17 +681,17 @@ export class NavigationManager {
 
     if (useDotIndicator) {
       highlightElement.className = 'interactive-highlight-dot';
-      // Position at element's center
-      const dotTop = rect.top + scrollTop + rect.height / 2;
-      const dotLeft = rect.left + scrollLeft + rect.width / 2;
+      // Position at element's center (viewport coords for position:fixed)
+      const dotTop = rect.top + rect.height / 2;
+      const dotLeft = rect.left + rect.width / 2;
       highlightElement.style.setProperty('--highlight-top', `${dotTop}px`);
       highlightElement.style.setProperty('--highlight-left', `${dotLeft}px`);
     } else {
       highlightElement.className = 'interactive-highlight-outline';
       // Note: We always show the highlight draw animation (looks good)
       // skipAnimations only affects the comment box transition
-      highlightElement.style.setProperty('--highlight-top', `${rect.top + scrollTop - 4}px`);
-      highlightElement.style.setProperty('--highlight-left', `${rect.left + scrollLeft - 4}px`);
+      highlightElement.style.setProperty('--highlight-top', `${rect.top - 4}px`);
+      highlightElement.style.setProperty('--highlight-left', `${rect.left - 4}px`);
       highlightElement.style.setProperty('--highlight-width', `${rect.width + 8}px`);
       highlightElement.style.setProperty('--highlight-height', `${rect.height + 8}px`);
     }
@@ -725,8 +711,8 @@ export class NavigationManager {
       onNextCallback ||
       onPreviousCallback
     ) {
-      // Calculate highlight rect in absolute document coordinates
-      const highlightRect = this.calculateHighlightRect(rect, scrollTop, scrollLeft, useDotIndicator);
+      // Calculate highlight rect in viewport coordinates (position:fixed)
+      const highlightRect = this.calculateHighlightRect(rect, useDotIndicator);
 
       commentBox = this.createCommentBox(
         effectiveComment || '',
@@ -1072,13 +1058,13 @@ export class NavigationManager {
     // Calculate position offsets relative to highlight
     const { offsetX, offsetY, position } = this.calculateCommentPosition(targetRect, actualHeight);
 
-    // Convert to absolute document coordinates (always body-attached)
-    const absoluteTop = highlightRect.top + offsetY;
-    const absoluteLeft = highlightRect.left + offsetX;
+    // Convert to viewport coordinates (position:fixed overlay)
+    const fixedTop = highlightRect.top + offsetY;
+    const fixedLeft = highlightRect.left + offsetX;
 
-    commentBox.style.position = 'absolute';
-    commentBox.style.top = `${absoluteTop}px`;
-    commentBox.style.left = `${absoluteLeft}px`;
+    commentBox.style.position = 'fixed';
+    commentBox.style.top = `${fixedTop}px`;
+    commentBox.style.left = `${fixedLeft}px`;
     commentBox.setAttribute('data-position', position);
 
     return commentBox;

--- a/src/styles/interactive.styles.ts
+++ b/src/styles/interactive.styles.ts
@@ -1507,7 +1507,7 @@ export const addGlobalInteractiveStyles = () => {
     }
     /* Global interactive highlight styles */
     .interactive-highlight-outline {
-      position: absolute;
+      position: fixed;
       top: var(--highlight-top);
       left: var(--highlight-left);
       width: var(--highlight-width);
@@ -1544,7 +1544,7 @@ export const addGlobalInteractiveStyles = () => {
 
     /* Hover highlight for element inspector (watch/record mode) */
     .interactive-hover-highlight-outline {
-      position: absolute;
+      position: fixed;
       top: var(--highlight-top);
       left: var(--highlight-left);
       width: var(--highlight-width);
@@ -1621,7 +1621,7 @@ export const addGlobalInteractiveStyles = () => {
      * Threshold defined in INTERACTIVE_CONFIG.highlighting.minDimensionForBox
      */
     .interactive-highlight-dot {
-      position: absolute;
+      position: fixed;
       top: var(--highlight-top);
       left: var(--highlight-left);
       width: 16px;
@@ -1757,7 +1757,7 @@ export const addGlobalInteractiveStyles = () => {
      * top and left are set directly in JS via inline styles
      */
     .interactive-comment-box {
-      position: absolute;
+      position: fixed;
       /* top and left are set via inline styles in navigation-manager.ts */
       width: 420px;
       max-width: calc(100vw - 32px);

--- a/src/utils/devtools/hover-highlight.util.ts
+++ b/src/utils/devtools/hover-highlight.util.ts
@@ -37,12 +37,10 @@ export function createHoverHighlight(element: HTMLElement): HTMLElement {
  */
 export function updateHoverHighlight(highlight: HTMLElement, element: HTMLElement): void {
   const rect = element.getBoundingClientRect();
-  const scrollTop = window.scrollY || document.documentElement.scrollTop;
-  const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
 
-  // Set CSS custom properties for positioning
-  highlight.style.setProperty('--highlight-top', `${rect.top + scrollTop}px`);
-  highlight.style.setProperty('--highlight-left', `${rect.left + scrollLeft}px`);
+  // Set CSS custom properties for positioning (viewport coords for position:fixed)
+  highlight.style.setProperty('--highlight-top', `${rect.top}px`);
+  highlight.style.setProperty('--highlight-left', `${rect.left}px`);
   highlight.style.setProperty('--highlight-width', `${rect.width}px`);
   highlight.style.setProperty('--highlight-height', `${rect.height}px`);
 }


### PR DESCRIPTION
## Summary
- Switched all overlay elements (highlight outlines, comment boxes, dot indicators) from `position: absolute` to `position: fixed`
- Removed scroll offset calculations (`scrollTop`/`scrollLeft`) from all positioning code — `getBoundingClientRect()` already returns viewport coordinates
- Fixes a feedback loop where overlays extending past the viewport caused horizontal overflow → position tracking fired → repositioning toggled the overflow → infinite oscillation that made the entire Grafana UI shake

## Details

The block editor tour (and any highlight/comment overlay) could trigger this because the elements were `position: absolute` on `document.body`. Even the 4px padding on highlight outlines was enough to push past the viewport edge, expanding the body's scrollable area. The position tracking system (ResizeObserver, scroll/resize listeners, drift detection RAF loop) would detect the layout shift, reposition elements, potentially remove the overflow, and repeat forever.

`position: fixed` elements don't contribute to document scroll dimensions, eliminating the root cause entirely.

### Files changed
- `src/styles/interactive.styles.ts` — CSS: `absolute` → `fixed` for 4 overlay classes
- `src/interactive-engine/navigation-manager.ts` — JS: removed scroll offsets from highlight positioning, comment box positioning, position tracking, and drift detection
- `src/utils/devtools/hover-highlight.util.ts` — JS: removed scroll offsets from hover highlight positioning

## Test plan
- [x] TypeScript type check passes
- [x] All 122 test suites pass (2416 tests)
- [x] ESLint + Prettier pass
- [ ] Manual: open block editor → click "Take a tour" → verify no horizontal overflow or shaking
- [ ] Manual: verify highlight overlays track elements correctly when scrolling
- [ ] Manual: verify guided mode highlights still position correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core overlay positioning math and CSS positioning mode; regressions could cause highlights/comment boxes to appear offset during scroll or within nested scroll containers.
> 
> **Overview**
> Prevents a UI “shaking” feedback loop by moving interactive overlay elements (highlight outline, hover highlight, dot indicator, and comment box) from `position: absolute` to `position: fixed`, so they no longer affect document scroll dimensions.
> 
> Updates `NavigationManager` highlight/comment positioning, position tracking, and drift detection to use pure viewport coordinates from `getBoundingClientRect()` (removing `scrollTop`/`scrollLeft` offsets) and adjusts `calculateHighlightRect`/comment box placement accordingly. `updateHoverHighlight` is similarly updated to set CSS variables in viewport coords.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eed2bc69462dd14706f12204600d44ba8a328d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->