### PR TITLE
Selector generator issues

### DIFF
--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -73,6 +73,15 @@ describe('Selector Generator — Pipeline', () => {
       expect(retargetElement(span)).toBe(div);
     });
 
+    it('keeps interactive elements as-is even inside interactive ancestors', () => {
+      const wrapper = document.createElement('div');
+      wrapper.setAttribute('role', 'button');
+      const button = document.createElement('button');
+      wrapper.appendChild(button);
+      document.body.appendChild(wrapper);
+      expect(retargetElement(button)).toBe(button);
+    });
+
     it('keeps non-interactive containers as-is', () => {
       const section = document.createElement('section');
       section.setAttribute('data-testid', 'panel');

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -394,11 +394,18 @@ function getOverlayRole(overlay: HTMLElement | null): string | undefined {
  */
 export function retargetElement(element: HTMLElement): HTMLElement {
   const tag = element.tagName.toLowerCase();
+  const role = element.getAttribute('role');
 
   if ((SELECTOR_CONFIG.formControlTags as readonly string[]).includes(tag)) {
     return element;
   }
   if ((element as HTMLElement & { isContentEditable: boolean }).isContentEditable) {
+    return element;
+  }
+  if ((SELECTOR_CONFIG.interactiveTags as readonly string[]).includes(tag)) {
+    return element;
+  }
+  if (role && (SELECTOR_CONFIG.interactiveRoles as readonly string[]).includes(role)) {
     return element;
   }
 
@@ -771,9 +778,12 @@ function findDirectChildBranch(ancestor: HTMLElement, descendant: HTMLElement): 
   return current;
 }
 
-function disambiguate(candidate: Candidate, element: HTMLElement): Candidate[] {
+function disambiguate(
+  candidate: Candidate,
+  element: HTMLElement,
+  ancestorScopes: AncestorScope[] = findAllAncestorScopes(element)
+): Candidate[] {
   const results: Candidate[] = [];
-  const ancestorScopes = findAllAncestorScopes(element);
 
   // Strategy 1: Try each ancestor scope from closest to farthest
   for (const scope of ancestorScopes) {
@@ -891,7 +901,7 @@ function rankAndSelect(candidates: Candidate[], element: HTMLElement): ScoredCan
       continue;
     }
 
-    const disambiguated = disambiguate(candidate, element);
+    const disambiguated = disambiguate(candidate, element, ancestorScopes);
     for (const d of disambiguated) {
       scored.push({ ...d, matchCount: 1 });
     }
@@ -1050,21 +1060,6 @@ export function generateFallbackSelectors(element: HTMLElement, primarySelector:
  */
 export function clearSelectorCache(): void {
   // No-op
-}
-
-/**
- * Try a selector for uniqueness, falling back to a builder function if not unique.
- */
-export function tryUniqueSelectorWithFallback(
-  selector: string,
-  element: HTMLElement,
-  buildFallback: () => string
-): string {
-  const { matchCount, containsTarget } = testUniqueness(selector, element, 'css');
-  if (matchCount === 1 && containsTarget) {
-    return cleanDynamicAttributes(selector);
-  }
-  return cleanDynamicAttributes(buildFallback());
 }
 
 // ============================================================================


### PR DESCRIPTION
Improves selector generation accuracy for interactive elements, optimizes performance by reducing redundant computations, and removes unused code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the selector generator’s core retargeting and disambiguation behavior, which could alter which elements/selectors are produced across the app. The refactor is localized but impacts a broadly used utility.
> 
> **Overview**
> Fixes `retargetElement` to **not retarget already-interactive elements (tag or interactive `role`)**, even when nested inside another interactive ancestor, preventing clicks on e.g. a `button` inside a `role="button"` wrapper from being redirected.
> 
> Optimizes disambiguation by reusing a precomputed `ancestorScopes` list instead of recomputing it per candidate, and removes the unused `tryUniqueSelectorWithFallback` helper. Adds a regression test covering the nested-interactive retargeting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b1a3483efe4e18d5740f7291ed1ec0bb68d39bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->