### PR TITLE
refactor(analytics): scope pathfinder_feature_flag_evaluated to experiment exposures

### DIFF
--- a/src/utils/openfeature-tracking.ts
+++ b/src/utils/openfeature-tracking.ts
@@ -11,31 +11,37 @@ import { pathfinderFeatureFlags, type FeatureFlagName } from './openfeature';
 const reportedFlags = new Set<string>();
 
 /**
- * OpenFeature hook that tracks feature flag evaluations to analytics
+ * Variants for which we emit a FeatureFlagEvaluated exposure event.
  *
- * This hook fires after each flag evaluation and reports the flag key,
- * evaluated value, and tracking key to Rudder Stack via reportAppInteraction.
+ * We intentionally skip 'excluded' (user isn't in the experiment) so the
+ * event stream only contains real experiment exposures (control + treatment),
+ * which is what downstream A/B analysis needs.
+ */
+const TRACKED_EXPERIMENT_VARIANTS = new Set(['control', 'treatment']);
+
+/**
+ * OpenFeature hook that tracks experiment exposures to analytics.
  *
- * Only flags that have a `trackingKey` defined in pathfinderFeatureFlags
- * will be tracked. Each flag is only reported once per page load to avoid
- * duplicate events from multiple evaluations.
+ * Fires `pathfinder_feature_flag_evaluated` once per experiment flag per page
+ * load, but only when the user is actually assigned to an experiment arm
+ * (variant === 'control' or 'treatment'). Non-experiment flags (boolean
+ * kill-switches, auto-open toggles) and excluded users do NOT generate events.
  *
  * @example
- * const client = OpenFeature.getClient(OPENFEATURE_DOMAIN);
- * client.addHooks(new TrackingHook());
+ * OpenFeature.addHooks(new TrackingHook());
  */
 export class TrackingHook implements Hook {
   /**
-   * Called after a flag is successfully evaluated
+   * Called after a flag is successfully evaluated.
    *
-   * Only processes flags with the 'pathfinder.' prefix to avoid intercepting
-   * other plugins' flag evaluations when using API-level hooks.
-   *
-   * @param hookContext - Context about the flag evaluation
-   * @param evaluationDetails - Details about the evaluated flag value
+   * Filtering rules (in order):
+   *   1. Flag key must start with 'pathfinder.' (ignore other plugins' flags)
+   *   2. Flag must be defined in pathfinderFeatureFlags with a trackingKey
+   *   3. Flag must be an experiment flag (valueType === 'object' with a variant)
+   *   4. Variant must be 'control' or 'treatment' (skip 'excluded')
+   *   5. Flag must not have been reported yet this page load
    */
   after(hookContext: HookContext, evaluationDetails: EvaluationDetails<JsonValue>): void {
-    // Only process pathfinder flags - ignore other plugins' flags
     if (!hookContext.flagKey.startsWith('pathfinder.')) {
       return;
     }
@@ -43,22 +49,45 @@ export class TrackingHook implements Hook {
     const flagKey = hookContext.flagKey as FeatureFlagName;
     const flagDef = pathfinderFeatureFlags[flagKey];
 
-    // Only track flags that have a trackingKey defined
-    if (flagDef && 'trackingKey' in flagDef && flagDef.trackingKey) {
-      // Skip if already reported this page load
-      if (reportedFlags.has(flagKey)) {
-        return;
-      }
-
-      // Mark as reported and send analytics
-      reportedFlags.add(flagKey);
-
-      reportAppInteraction(UserInteraction.FeatureFlagEvaluated, {
-        flag_key: hookContext.flagKey,
-        flag_value: this.stringifyValue(evaluationDetails.value),
-        tracking_key: flagDef.trackingKey,
-      });
+    if (!flagDef || !('trackingKey' in flagDef) || !flagDef.trackingKey) {
+      return;
     }
+
+    // Only experiment flags (object-valued with a `variant` field) are exposures.
+    // Boolean flags like pathfinder.enabled / auto-open-sidebar are config, not
+    // experiment arms, so they don't generate exposure events.
+    if (flagDef.valueType !== 'object') {
+      return;
+    }
+
+    const variant = this.extractVariant(evaluationDetails.value);
+    if (!variant || !TRACKED_EXPERIMENT_VARIANTS.has(variant)) {
+      return;
+    }
+
+    if (reportedFlags.has(flagKey)) {
+      return;
+    }
+    reportedFlags.add(flagKey);
+
+    reportAppInteraction(UserInteraction.FeatureFlagEvaluated, {
+      flag_key: hookContext.flagKey,
+      flag_value: this.stringifyValue(evaluationDetails.value),
+      tracking_key: flagDef.trackingKey,
+      variant,
+    });
+  }
+
+  /**
+   * Safely extract a string `variant` field from a JSON flag value.
+   * Returns null if the value isn't an object or has no string variant.
+   */
+  private extractVariant(value: JsonValue): string | null {
+    if (value && typeof value === 'object' && !Array.isArray(value) && 'variant' in value) {
+      const raw = (value as { variant: unknown }).variant;
+      return typeof raw === 'string' ? raw : null;
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
## Summary

Narrows the `pathfinder_feature_flag_evaluated` analytics event so it only fires as a true A/B **exposure** event. Previously it fired up to 4 times per page load for every user (once per tracked `pathfinder.*` flag), which inflated event volume and muddled exposure analysis with flag-state telemetry.

New filter order in `TrackingHook.after()`:

1. Flag key starts with `pathfinder.`
2. Flag is defined in `pathfinderFeatureFlags` with a `trackingKey`
3. Flag is an experiment flag (`valueType === 'object'` with a `variant` field) — boolean kill-switches like `pathfinder.enabled` and `pathfinder.auto-open-sidebar` are **skipped**
4. Variant is `control` or `treatment` — `excluded` users are **skipped**
5. Not already reported this page load

Event now also carries `variant` as a first-class property for slicing in analytics.

### Effective behavior

| Flag | Fires? |
| --- | --- |
| `pathfinder.enabled` (boolean) | ❌ skipped |
| `pathfinder.auto-open-sidebar` (boolean) | ❌ skipped |
| `pathfinder.experiment-variant` (object) | ✅ only if `variant ∈ {control, treatment}` |
| `pathfinder.after-24h-experiment` (object) | ✅ only if `variant ∈ {control, treatment}` |

Upper bound: **2 events per page load**, **0 for excluded users**.

## Test plan

- [x] `npx jest src/utils/openfeature` — 32/32 pass
- [ ] Verify in dev that `pathfinder_feature_flag_evaluated` fires exactly once per experiment flag when assigned to `control`/`treatment`
- [ ] Verify no `pathfinder_feature_flag_evaluated` events fire for users whose experiment flags resolve to `excluded`
- [ ] Verify no events fire for `pathfinder.enabled` / `pathfinder.auto-open-sidebar` evaluations
- [ ] Confirm `variant` property appears on the event in Rudder Stack


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to analytics emission rules for feature-flag evaluations, primarily affecting event volume and experiment reporting (not runtime behavior).
> 
> **Overview**
> Narrows `TrackingHook.after()` analytics so `pathfinder_feature_flag_evaluated` is emitted **only** for experiment-style flags (`valueType: 'object'`) when the evaluated payload contains `variant` in `control`/`treatment`, skipping boolean/config flags and `excluded` users.
> 
> Adds `variant` as a first-class property on the emitted event, while still deduping to at most once per flag per page load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ab4efd41256881d85fe9391f0883f28a0b3aed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->