### PR TITLE
fix: pluralize item count in guide section headers

### DIFF
--- a/src/components/docs-panel/CustomGuidesSection.tsx
+++ b/src/components/docs-panel/CustomGuidesSection.tsx
@@ -57,9 +57,7 @@ export function CustomGuidesSection({
           <span>{t('contextPanel.customGuides', 'Custom guides')}</span>
           <span className={styles.customGuidesCount}>
             <Icon name="list-ul" size="xs" />
-            {t('contextPanel.items', normalizedGuides.length === 1 ? '{{count}} item' : '{{count}} items', {
-              count: normalizedGuides.length,
-            })}
+            {t('contextPanel.items', '{{count}} items', { count: normalizedGuides.length })}
           </span>
           <Icon name={expanded ? 'angle-up' : 'angle-down'} size="sm" />
         </button>

--- a/src/components/docs-panel/CustomGuidesSection.tsx
+++ b/src/components/docs-panel/CustomGuidesSection.tsx
@@ -57,7 +57,9 @@ export function CustomGuidesSection({
           <span>{t('contextPanel.customGuides', 'Custom guides')}</span>
           <span className={styles.customGuidesCount}>
             <Icon name="list-ul" size="xs" />
-            {t('contextPanel.items', '{{count}} item', { count: normalizedGuides.length })}
+            {t('contextPanel.items', normalizedGuides.length === 1 ? '{{count}} item' : '{{count}} items', {
+              count: normalizedGuides.length,
+            })}
           </span>
           <Icon name={expanded ? 'angle-up' : 'angle-down'} size="sm" />
         </button>

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -358,7 +358,9 @@ export const RecommendationsSection = memo(function RecommendationsSection({
               <span>{t('contextPanel.suggestedGuides', 'Suggested guides')}</span>
               <span className={styles.suggestedGuidesCount}>
                 <Icon name="list-ul" size="xs" />
-                {t('contextPanel.items', '{{count}} item', { count: suggestedGuidesCount })}
+                {t('contextPanel.items', suggestedGuidesCount === 1 ? '{{count}} item' : '{{count}} items', {
+                  count: suggestedGuidesCount,
+                })}
               </span>
               <Icon name={suggestedGuidesExpanded ? 'angle-up' : 'angle-down'} size="sm" />
             </button>
@@ -989,7 +991,9 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                 <span>{t('contextPanel.otherDocumentation', 'Other Documentation')}</span>
                 <span className={styles.otherDocsCount}>
                   <Icon name="list-ul" size="xs" />
-                  {t('contextPanel.items', '{{count}} item', { count: secondaryDocs.length })}
+                  {t('contextPanel.items', secondaryDocs.length === 1 ? '{{count}} item' : '{{count}} items', {
+                    count: secondaryDocs.length,
+                  })}
                 </span>
                 <Icon name={otherDocsExpanded ? 'angle-up' : 'angle-down'} size="sm" />
               </button>

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -358,9 +358,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
               <span>{t('contextPanel.suggestedGuides', 'Suggested guides')}</span>
               <span className={styles.suggestedGuidesCount}>
                 <Icon name="list-ul" size="xs" />
-                {t('contextPanel.items', suggestedGuidesCount === 1 ? '{{count}} item' : '{{count}} items', {
-                  count: suggestedGuidesCount,
-                })}
+                {t('contextPanel.items', '{{count}} items', { count: suggestedGuidesCount })}
               </span>
               <Icon name={suggestedGuidesExpanded ? 'angle-up' : 'angle-down'} size="sm" />
             </button>
@@ -991,9 +989,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                 <span>{t('contextPanel.otherDocumentation', 'Other Documentation')}</span>
                 <span className={styles.otherDocsCount}>
                   <Icon name="list-ul" size="xs" />
-                  {t('contextPanel.items', secondaryDocs.length === 1 ? '{{count}} item' : '{{count}} items', {
-                    count: secondaryDocs.length,
-                  })}
+                  {t('contextPanel.items', '{{count}} items', { count: secondaryDocs.length })}
                 </span>
                 <Icon name={otherDocsExpanded ? 'angle-up' : 'angle-down'} size="sm" />
               </button>


### PR DESCRIPTION
## Motivation

This PR fixes #772.

## Summary

The `contextPanel.items` key already has `items_one`/`items_other` entries in the locale files. Passing count in the i18next options is sufficient for plural resolution, without relying on ad-hoc ternaries.

This PR applies the fix to all three occurrences: custom guides count, suggested guides count, and "Other Documentation" count.

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only UI copy change (translation fallback text) with no behavioral, data, or security impact.
> 
> **Overview**
> Updates the docs panel section headers to use the plural form in the `contextPanel.items` translation fallback (`"{{count}} items"`) when rendering item counts.
> 
> This change is applied consistently across **Custom guides**, **Suggested guides**, and **Other Documentation** count badges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccd1def0780d0d7a7beeb1e495c4a9de052ad408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->