### PR TITLE
WIP: Main-area learning view with /learning route

### DIFF
--- a/docs/design/MAIN-AREA-EDUCATION.md
+++ b/docs/design/MAIN-AREA-EDUCATION.md
@@ -369,3 +369,149 @@ payloads. See the enum for the current set.
 
 - `locationService` is now imported in the panel (added for safety gate navigation).
   Phase 5 can reuse this import for chrome control navigation.
+
+---
+
+## Merge conflict guide
+
+This branch (`main-page-learning`) stays open while `main` continues to evolve.
+The following section maps every shared file touched by this branch to the intent
+behind each change, so that a future agent resolving merge conflicts can make
+semantically correct decisions rather than just accepting one side.
+
+### High-risk files
+
+#### `src/lib/analytics.ts` — `UserInteraction` enum
+
+**What we added:** Five new entries at the end of the enum, under the comment
+`// Main-Area Learning Surface`:
+
+```
+MainAreaPageView, MainAreaGuideLoaded, MainAreaGuideLoadFailed,
+MainAreaSafetyGateBlocked, MainAreaLinkIntercepted
+```
+
+**Merge rule:** Keep both sets of additions. Each group of enum values belongs to the
+feature that added it. There is no ordering dependency — append new groups after the
+last group. If the incoming change also adds entries at the end, accept both.
+
+---
+
+#### `src/module.tsx` — `?doc=` param guard for the learning route
+
+**What we added:** An `isLearningRoute` boolean that nulls out `docsParam` when the
+user is on the `/learning` route, and imports `ROUTES` from `./constants`.
+
+**Why:** `MainAreaLearningPanel` reads `?doc=` itself on mount. If the sidebar
+auto-open flow in `module.tsx` also reads it, both surfaces race to open the same
+guide, causing a double-load. The guard prevents that race.
+
+**Merge rule:** Preserve the `isLearningRoute` guard and the `ROUTES` import. If the
+incoming change refactors the `docsParam` block or moves param handling elsewhere,
+re-apply the same guard using `ROUTES.Learning`. The invariant is: the sidebar must
+not auto-open a guide when the user is on the learning route.
+
+---
+
+#### `src/components/App/App.tsx` — `learningPage` in `getSceneApp()`
+
+**What we added:** `learningPage` imported and inserted into the `pages` array in
+`getSceneApp()`.
+
+**Merge rule:** If the incoming change also adds a page to the array, accept both.
+The pages array is order-independent for routing purposes.
+
+---
+
+#### `src/docs-retrieval/content-fetcher.ts` — Grafana GitHub URL trust
+
+**What we added:** `isGrafanaGitHubRawUrl` and `isGrafanaGitHubRedirectUrl` checks
+inside the `isTrustedSource` / `isFinalUrlTrusted` conditionals in three functions:
+`fetchContent()`, `tryUrlVariations()`, and `fetchRawHtml()`.
+
+**Why these are separate from `isAllowedContentUrl`:** The main-area learning surface
+can load AI-authored guides hosted on `raw.githubusercontent.com` under the
+`grafana/*` org. `isAllowedContentUrl` covers grafana.com docs and
+interactive-learning.grafana.net — a separate trust boundary. Keeping them separate
+makes each boundary visible and independently auditable.
+
+**Merge rule:** If the incoming change modifies the `isTrustedSource` block (e.g.,
+adds a new allowed source), preserve the `isGrafanaGitHubRawUrl` and
+`isGrafanaGitHubRedirectUrl` lines. If `isAllowedContentUrl` is refactored to absorb
+GitHub URLs, remove these lines and verify the new function covers
+`raw.githubusercontent.com/grafana/*`.
+
+---
+
+#### `src/global-state/link-interception.ts` — Main-area link routing
+
+**What we added:** A guard at the top of `handleGlobalClick` that checks
+`mainAreaLearningState.getIsActive()` and, if true, dispatches a
+`pathfinder-open-in-main-area` custom event instead of opening the sidebar.
+
+**Why:** When the main-area surface is active, it exclusively owns the link-
+interception flow. The sidebar routing branch (below the guard) must not fire.
+These two surfaces are mutually exclusive — the main area replaces Grafana's content
+pane, so the sidebar's `openSidebar()` / queue flow would be invisible to the user.
+
+**Merge rule:** Preserve the `mainAreaLearningState.getIsActive()` guard and ensure
+it fires _before_ any sidebar routing. If the incoming change adds a new routing
+target (e.g., a third surface) to the same function, insert it as another `if` block
+_above_ the sidebar fallback. The priority order is: main-area → sidebar.
+
+---
+
+#### `src/utils/find-doc-page.ts` — `remote:` URL scheme
+
+**What we added:** A `remote:` case that accepts `remote:https://raw.githubusercontent.com/grafana/...`
+params, validates them against `isGrafanaGitHubRawUrl`, and returns an `interactive`
+DocPage.
+
+**Merge rule:** This case is positionally independent from the other cases. If the
+incoming change adds a new URL scheme (new `if (param.startsWith(...))` block), keep
+both. The `remote:` case belongs before `bundled:` because it is the more specific
+prefix. If the switch structure is refactored (e.g., to a lookup map), include
+`remote:` as an entry that calls `isGrafanaGitHubRawUrl` for validation.
+
+---
+
+#### `src/docs-retrieval/content-renderer.tsx` — `hideTitle` prop
+
+**What we added:** A `hideTitle?: boolean` prop on `ContentRenderer` and
+`ContentWithVariables` that suppresses the `<h1>` title when the rendering context
+provides its own title (e.g., the Grafana SceneAppPage page chrome).
+
+**Merge rule:** This is an additive, backward-compatible prop with a `false` default.
+If the incoming change modifies `ContentRenderer`'s props interface, include
+`hideTitle`. If the incoming change changes how the `<h1>` title is rendered, ensure
+the `hideTitle` condition still gates it.
+
+---
+
+#### `src/security/index.ts` — New barrel exports
+
+**What we added:** Two new exports: `isGrafanaGitHubRawUrl` and
+`isGrafanaGitHubRedirectUrl`, sourced from `./url-validator`.
+
+**Merge rule:** Barrel exports are additive. Accept both sides' additions. No
+ordering constraint.
+
+---
+
+#### `src/constants.ts` — `ROUTES.Learning`
+
+**What we added:** `Learning = 'learning'` entry in the `ROUTES` enum.
+
+**Merge rule:** Additive enum entry. If the incoming change adds other routes, keep
+both. If the incoming change renames an existing route, do not rename `Learning`.
+
+---
+
+### New files (no conflict risk)
+
+All files under `src/components/main-area-learning/`, `src/global-state/main-area-learning-state.ts`,
+`src/pages/learningPage.ts`, `src/utils/chrome-control.ts`, `src/utils/guide-safety.ts`,
+`src/security/url-validator.ts`, `src/bundled-interactives/main-area-demo/`, and
+`pkg/plugin/static/guides/main-area-demo.json` are entirely new. They will not conflict
+unless main adds a file at the same path (extremely unlikely). Accept all new files
+from this branch.

--- a/docs/design/MAIN-AREA-EDUCATION.md
+++ b/docs/design/MAIN-AREA-EDUCATION.md
@@ -1,0 +1,794 @@
+# Main-Area Education: Rendering Interactive Content Outside the Sidebar
+
+## Overview
+
+Render interactive learning content (guides, quizzes, terminal steps, code blocks) in
+Grafana's main app area at a dedicated route, as an alternative to the right-hand sidebar.
+This design covers **read-only and self-contained interactive content only** — guides
+whose "Show Me" / "Do It" steps target external Grafana DOM elements remain sidebar-only.
+
+### Goal URL
+
+```
+/a/grafana-pathfinder-app/learning?doc=bundled:prometheus-grafana-101
+```
+
+This mirrors the existing `?doc=` parameter used at the plugin root
+(`/a/grafana-pathfinder-app?doc=...&page=...`) for sidebar auto-launch. The `doc`
+parameter accepts Pathfinder package URL schemes only: `bundled:<id>`, `api:<name>`,
+or an HTTPS base URL pointing to a package directory
+(e.g. `https://interactive-learning.grafana.net/mypackage/`). Raw `/docs/...` paths and
+bare HTML URLs are not supported in this route — use the sidebar for those.
+
+The key difference: the root `?doc=` parameter opens content in the **sidebar** (and
+optionally redirects the main area via `?page=`). The `/learning?doc=` route renders
+content **in-place** in the main area, with no sidebar involvement.
+
+---
+
+## Architecture Context
+
+### What already exists
+
+| Component                                         | Location                                   | Role                                                            |
+| ------------------------------------------------- | ------------------------------------------ | --------------------------------------------------------------- |
+| `CombinedLearningJourneyPanel`                    | `src/components/docs-panel/docs-panel.tsx` | SceneObject that manages tabs, content loading, and rendering   |
+| `ContentRenderer`                                 | `src/docs-retrieval/content-renderer.tsx`  | Pure content renderer (HTML/JSON → React), no layout dependency |
+| `InteractiveSection/Step/Quiz/Terminal/CodeBlock` | `src/components/interactive-tutorial/`     | Self-contained interactive components using window events       |
+| `findDocPage()`                                   | `src/utils/find-doc-page.ts`               | Resolves all URL schemes → `{ url, title, type, targetPage }`   |
+| `fetchContent()`                                  | `src/docs-retrieval/content-fetcher.ts`    | Fetches and wraps content as `RawContent`                       |
+| `ROUTES` enum                                     | `src/constants.ts`                         | Route definitions (`Home = ''`, `Context = 'context'`)          |
+| `homePage` / `docsPage`                           | `src/pages/`                               | Existing SceneAppPage definitions                               |
+
+### Why this is feasible
+
+- `ContentRenderer` takes `RawContent` as a prop and has **zero sidebar dependencies**.
+- Interactive components (`InteractiveQuiz`, `TerminalStep`, `CodeBlockStep`) are leaf
+  components that communicate via window events and `user-storage.ts`. They work anywhere.
+- `CombinedLearningJourneyPanel` already renders identically in both the sidebar
+  (`ContextPanel.tsx`) and the full-page docs route (`docsPage.ts`).
+- The only hard-coded DOM assumption is `id="inner-docs-content"` for scroll tracking,
+  which lives inside `CombinedLearningJourneyPanel`'s own render tree.
+
+### What does NOT work in the main area
+
+- **"Show Me" steps**: `NavigationManager` highlights Grafana UI elements by CSS selector
+  (`refTarget`). In the main area, the guide _replaces_ the content those selectors target.
+- **"Do It" steps**: Execute actions (click buttons, fill forms) on Grafana DOM elements
+  that aren't visible when the guide occupies the main area.
+- **`openAndDockNavigation()`**: Manipulates the Grafana mega-menu toggle/dock buttons —
+  assumes sidebar-alongside-content layout.
+
+---
+
+## Phased Implementation Plan
+
+### Phase 1: Route, Page, and Basic Rendering
+
+**Goal**: A working `/learning` route that renders a `MainAreaLearningPanel` in the
+main app area, with `?doc=` parameter support for direct-linking to content.
+
+#### 1.1 Add the route
+
+**`src/constants.ts`** — add to `ROUTES` enum:
+
+```typescript
+export enum ROUTES {
+  Home = '',
+  Context = 'context',
+  Learning = 'learning', // NEW
+}
+```
+
+#### 1.2 Create the page definition
+
+**`src/pages/learningPage.ts`** (new file) — modeled on `docsPage.ts`:
+
+```typescript
+import { EmbeddedScene, SceneAppPage, SceneFlexItem, SceneFlexLayout } from '@grafana/scenes';
+import { prefixRoute } from '../utils/utils.routing';
+import { ROUTES } from '../constants';
+import { MainAreaLearningPanel } from '../components/main-area-learning/main-area-learning-panel';
+
+export const learningPage = new SceneAppPage({
+  title: 'Learning',
+  url: prefixRoute(ROUTES.Learning),
+  routePath: ROUTES.Learning,
+  getScene: learningScene,
+});
+
+function learningScene() {
+  return new EmbeddedScene({
+    body: new SceneFlexLayout({
+      children: [
+        new SceneFlexItem({
+          width: '100%',
+          height: '100%', // Full height, not fixed 600px like docsPage
+          body: new MainAreaLearningPanel({}),
+        }),
+      ],
+    }),
+  });
+}
+```
+
+#### 1.3 Register in the app
+
+**`src/components/App/App.tsx`** — add `learningPage` to the `SceneApp` pages array.
+
+#### 1.4 Build `MainAreaLearningPanel`
+
+**`src/components/main-area-learning/main-area-learning-panel.tsx`** (new file)
+
+Implement as a `SceneObjectBase` subclass with a `static Component` property — the same
+pattern as `CombinedLearningJourneyPanel`. Content loading state (loaded content,
+loading/error status) lives in `useState` within the `Component` function, not in
+`SceneObjectState`. This is required for correct integration with `SceneFlexItem`'s `body`
+prop.
+
+The `Component` function:
+
+1. Reads `?doc=` from the URL on mount (via `new URLSearchParams(window.location.search)`)
+2. Calls `findDocPage(docParam)` to resolve the URL
+3. Calls `fetchContent(resolvedUrl)` to load content
+4. Renders `ContentRenderer` with the loaded `RawContent`
+5. Wraps the content in a container with `id="main-area-docs-content"` for scroll tracking
+   (deliberately different from the sidebar's `inner-docs-content` to avoid ID conflicts
+   when both views are mounted simultaneously)
+6. Strips the `?doc=` param from the URL after processing (matching existing behavior in
+   `module.tsx`)
+
+**Loading and error states:**
+
+- **Loading**: Show `SkeletonLoader` while `fetchContent()` is in flight.
+- **Fetch error** (network failure, guide not found): Show a Grafana `Alert` component
+  (variant `"error"`) with the error message and a "Try again" button that re-triggers
+  the fetch.
+- **Unresolvable URL scheme** (invalid `?doc=` value that `findDocPage()` cannot parse):
+  Treat as missing param — fall through to the landing page (see 1.5).
+
+Key decisions:
+
+- **Single-content view, not tabbed** — the main area shows one guide at a time, not the
+  sidebar's tab UI. Sidebar = multi-tab companion; main area = focused reading.
+- **Full-height layout** — unlike `docsPage.ts` which uses `height: 600`, the learning
+  page fills the viewport. Use `height: '100%'` and let Grafana's Scene layout handle it.
+- **Reuse `ContentRenderer` directly** — don't wrap `CombinedLearningJourneyPanel`; the
+  main area wants a simpler, focused experience without the recommendation tab and tab bar.
+- **Static title "Learning"** — dynamic guide title in the breadcrumb is deferred to a
+  follow-up. V1 shows "Learning" as the `SceneAppPage` title.
+
+#### 1.5 Handle missing/invalid `?doc=`
+
+If no `?doc=` param or an invalid one: render the `MyLearningTab` component (the learning
+paths hub) as a landing page, so the URL `/a/grafana-pathfinder-app/learning` without
+params is useful on its own.
+
+**Content format restriction**: The `/learning` route accepts only Pathfinder package
+format — guides that have both a `content.json` and a `manifest.json`. Specifically:
+
+- `bundled:<id>` — always valid; bundled guides are in package format by definition.
+- `https://<base>/` (or any external base URL) — treated as a package base URL.
+  `content.json` is fetched from `<base>/content.json` and the manifest from
+  `<base>/manifest.json`. If either is missing or the response is not valid package JSON,
+  the request is rejected with an error.
+- `api:<name>` — valid only if the API returns a package-format response.
+- `/docs/...` paths and bare HTML URLs — **not supported** in the main area. Show a
+  clear error: "This content format is not supported in the learning view. Open it in the
+  Pathfinder sidebar instead." with a button that dispatches it to the sidebar.
+
+This restriction exists because the main-area learning view is designed around the package
+model's structured content and metadata (title, progress, step completion). Raw HTML docs
+lack the structure needed for the progress header and interactive safety gate.
+
+#### Tests — Phase 1
+
+| Test                      | Type        | What it validates                                                                         |
+| ------------------------- | ----------- | ----------------------------------------------------------------------------------------- |
+| Route registration        | Unit        | `ROUTES.Learning` exists and `prefixRoute` produces correct path                          |
+| `?doc=` parsing           | Unit        | `MainAreaLearningPanel` correctly extracts, resolves, and cleans query params             |
+| Invalid `?doc=` fallback  | Unit        | Invalid/missing param renders `MyLearningTab` landing                                     |
+| Content render            | Integration | `ContentRenderer` mounts and renders `RawContent` inside the panel                        |
+| Scroll container          | Unit        | The `main-area-docs-content` ID is present in the rendered DOM (not `inner-docs-content`) |
+| Package format validation | Unit        | `bundled:` and HTTPS package base URLs accepted; `/docs/` paths rejected with fallback UI |
+| Unsupported format UI     | Unit        | Non-package URLs render error alert with "Open in sidebar" button                         |
+| Loading state             | Unit        | `SkeletonLoader` is shown while `fetchContent()` is in flight                             |
+| Fetch error state         | Unit        | Network error renders error alert with "Try again" button                                 |
+
+---
+
+### Phase 2: Navigation and Deep Linking
+
+**Goal**: Wire up navigation so users can reach the main-area learning view from existing
+UI surfaces, and so links can be shared.
+
+#### 2.1 "Open in main area" from MyLearningTab
+
+**Decision: URL-based via prop override.** `MyLearningTab` stays route-agnostic. The
+caller provides the `onOpenGuide` handler and controls the destination.
+
+- When `MyLearningTab` is rendered inside `MainAreaLearningPanel` (i.e., as the landing
+  page at `/learning`), the panel provides an `onOpenGuide` handler that navigates to
+  `/a/grafana-pathfinder-app/learning?doc=<url>` using `locationService.push()` from
+  `@grafana/runtime`.
+- When `MyLearningTab` is rendered inside the sidebar, the sidebar provides an
+  `onOpenGuide` handler that dispatches to the sidebar as today.
+
+This requires that `MyLearningTab` accepts an `onOpenGuide` prop (verify the current
+interface and add the prop if not already present). No route-awareness or condition
+checking is needed inside `MyLearningTab` itself.
+
+#### 2.2 Link interception routing when on `/learning`
+
+**Decision**: When the user is on `/learning`, intercepted doc links open in the main area
+and bypass the sidebar entirely.
+
+**Implementation**: `link-interception.ts` must become context-aware. Add a check in
+`handleGlobalClick`:
+
+```typescript
+import { mainAreaLearningState } from '../components/main-area-learning/main-area-learning-state';
+
+// If main area is active, route to it instead of the sidebar
+if (mainAreaLearningState.getIsActive()) {
+  document.dispatchEvent(new CustomEvent('pathfinder-open-in-main-area', { detail: docsLink }));
+  return;
+}
+// ...existing sidebar logic
+```
+
+`mainAreaLearningState` is a small singleton (analogous to `sidebarState`) that
+`MainAreaLearningPanel` sets to active on mount and inactive on unmount.
+
+`MainAreaLearningPanel` listens for `pathfinder-open-in-main-area` (not
+`pathfinder-auto-open-docs`) to load new content in-place. This avoids the dual-handling
+problem where both the sidebar and main area would catch the same event.
+
+**New file**: `src/components/main-area-learning/main-area-learning-state.ts` — a small
+singleton with `getIsActive()`, `setIsActive(active: boolean)`.
+
+#### 2.3 MCP-driven guide launches
+
+For MCP-initiated launches (via `sidebarState.openWithGuide()`), the existing flow opens
+the sidebar. This remains unchanged — MCP guide launches always target the sidebar, not
+the main area. The main area's `pathfinder-open-in-main-area` event is for link
+interception only.
+
+#### 2.4 Clean URL history
+
+After loading content from `?doc=`, replace the URL with
+`/a/grafana-pathfinder-app/learning` (no query param) using
+`window.history.replaceState`. This matches the existing pattern in `module.tsx:179-182`.
+
+#### 2.5 Back navigation
+
+When the user navigates away from a guide (e.g., clicks a breadcrumb or the browser back
+button), return to the learning hub landing page. Consider storing the last-viewed guide
+URL in `user-storage.ts` (using a separate key from the sidebar's tab storage, to avoid
+clobbering sidebar state) so the user can resume.
+
+#### Tests — Phase 2
+
+| Test                           | Type        | What it validates                                                                                     |
+| ------------------------------ | ----------- | ----------------------------------------------------------------------------------------------------- |
+| Deep link round-trip           | Integration | Navigate to `/learning?doc=bundled:X` → content renders → URL cleaned                                 |
+| Main-area event routing        | Unit        | `pathfinder-open-in-main-area` event loads content in main area                                       |
+| Link interception bypass       | Unit        | When `mainAreaLearningState.isActive`, `handleGlobalClick` dispatches to main area instead of sidebar |
+| MyLearningTab navigation       | Unit        | `onOpenGuide` prop navigates to `/learning?doc=<url>` when provided by panel                          |
+| MCP launch unchanged           | Unit        | `sidebarState.openWithGuide()` still targets the sidebar regardless of route                          |
+| Back button                    | Integration | Browser back returns to landing page, not broken state                                                |
+| URL param cleanup              | Unit        | `?doc=` is stripped after processing; repeated visits don't re-trigger                                |
+| State active/inactive on mount | Unit        | `mainAreaLearningState` is set active on mount and inactive on unmount                                |
+
+---
+
+### Phase 3: Layout and Styling
+
+**Goal**: The main-area learning view looks polished and takes advantage of the wider
+viewport (vs. the narrow sidebar).
+
+#### 3.1 Responsive content width
+
+`ContentRenderer` currently renders in a narrow sidebar. In the main area, constrain
+content to a comfortable reading width (e.g., `max-width: 48rem; margin: 0 auto`) while
+allowing interactive components (terminals, code blocks) to use more width.
+
+#### 3.2 Adapt interactive component sizing
+
+- **`TerminalStep`** / **`CodeBlockStep`**: Allow wider/taller rendering in main area.
+  These components likely already use `100%` width but may benefit from increased
+  `min-height`.
+- **`InteractiveQuiz`**: Should work unchanged — it's a card-style layout.
+- **`InteractiveSection`**: Collapse/expand behavior should work as-is.
+
+#### 3.3 Progress bar and guide header
+
+Add a header area above the content showing:
+
+- Guide title
+- Progress indicator (reuse existing `interactiveCompletionStorage` data)
+- "Open in sidebar" link (for users who want to switch to side-by-side mode)
+
+#### 3.4 Handle the "Recommendations" panel
+
+`CombinedLearningJourneyPanel` always includes a Recommendations tab via `ContextPanel`.
+Since `MainAreaLearningPanel` uses `ContentRenderer` directly, this is a non-issue — but
+if you later want to show recommendations, they can be added as a separate section below
+the content.
+
+#### Tests — Phase 3
+
+| Test                   | Type            | What it validates                                                               |
+| ---------------------- | --------------- | ------------------------------------------------------------------------------- |
+| Max-width constraint   | Snapshot/visual | Content body has `max-width` applied                                            |
+| Terminal sizing        | Integration     | `TerminalStep` renders at wider width without overflow                          |
+| Progress display       | Unit            | Progress header reads from `interactiveCompletionStorage` and renders correctly |
+| Responsive breakpoints | Visual          | Layout degrades gracefully at narrow viewport widths                            |
+
+---
+
+### Phase 4: Content Safety Gate
+
+**Goal**: Prevent guides with "Show Me" / "Do It" steps (that target external DOM) from
+rendering broken in the main area.
+
+#### 4.1 Safety classification via parsed detection
+
+Since the main area is restricted to Pathfinder package format (see 1.5), all content goes
+through `json-parser.ts` and produces structured `ParsedContent`. There is no HTML/external
+content to classify.
+
+**`isMainAreaSafe(content: ParsedContent): boolean`** — inspect all interactive elements:
+
+- Check both `interactive` blocks (single-action) and `multistep` blocks (whose `steps`
+  array may contain DOM-targeting actions).
+- **Unsafe actions**: `'highlight' | 'button' | 'formfill' | 'hover'` — these target
+  Grafana DOM elements that are not visible when the main area is occupied.
+- **Safe actions**: `'noop'` and `'navigate'` — these do not target external DOM.
+  Note: `navigate` with `openGuide` set loads a guide into the sidebar, which is expected
+  and acceptable in a main-area context.
+- A guide is safe if it contains **no** steps with unsafe actions. A single unsafe step
+  makes the whole guide sidebar-only.
+- `showMe` and `doIt` flags do not affect classification — even if buttons are hidden,
+  the underlying action type determines safety.
+
+No `Option A` static metadata field is needed for V1. The automated detection covers all
+cases in the package-format-only content set.
+
+#### 4.2 Gate rendering
+
+In `MainAreaLearningPanel`, after fetching and parsing content, run the safety check:
+
+- If safe: render normally.
+- If unsafe: show a Grafana `Alert` (variant `"warning"`) explaining the guide requires
+  the sidebar, with an "Open in sidebar" button.
+
+**"Open in sidebar" button implementation** — varies by content source:
+
+- `bundled:<id>` — strip the `bundled:` prefix and call
+  `sidebarState.openWithGuide(id)`. Then navigate away from `/learning` using
+  `locationService.push('/a/grafana-pathfinder-app')` so the guide opens alongside the
+  normal Grafana UI.
+- External package URL — dispatch a `pathfinder-open-in-main-area` is wrong here;
+  instead dispatch `pathfinder-auto-open-docs` with the full URL, then navigate away from
+  `/learning`.
+- In both cases: navigate away from `/learning` immediately after dispatching, so the
+  sidebar-targeted content can work against the actual Grafana UI.
+
+#### 4.3 Surface safety in MyLearningTab
+
+On guide cards, indicate which guides can open in the main area vs. sidebar-only. This
+could be a subtle icon or tooltip — not a blocking gate, just information.
+
+#### Tests — Phase 4
+
+| Test                        | Type        | What it validates                                                                        |
+| --------------------------- | ----------- | ---------------------------------------------------------------------------------------- |
+| Detection accuracy          | Unit        | `isMainAreaSafe()` correctly classifies guides with showMe/doIt vs. quiz-only            |
+| Noop steps pass             | Unit        | Guides with only `noop` interactive steps are classified as safe                         |
+| Multistep block checked     | Unit        | Unsafe actions inside `multistep.steps` correctly classify the guide as unsafe           |
+| Navigate+openGuide safe     | Unit        | `navigate` action (with or without `openGuide`) is classified as safe                    |
+| Hidden buttons still unsafe | Unit        | Steps with `showMe: false` and `doIt: false` but unsafe `action` still fail safety check |
+| Unsafe redirect             | Integration | Unsafe guide shows warning alert with "Open in sidebar" button                           |
+| Bundled sidebar handoff     | Integration | "Open in sidebar" calls `sidebarState.openWithGuide(id)` and navigates away              |
+| External sidebar handoff    | Integration | "Open in sidebar" dispatches `pathfinder-auto-open-docs` and navigates away              |
+| Edge cases                  | Unit        | Mixed guides (some safe steps, some unsafe) are classified as unsafe                     |
+
+---
+
+### Phase 5: Chrome Controls (`&nav=` and `&sidebar=`)
+
+**Goal**: URL parameters that selectively show/hide the left navigation and right-hand
+extension sidebar, enabling a full-screen immersive learning experience.
+
+```
+/a/grafana-pathfinder-app/learning?doc=bundled:prometheus-grafana-101&nav=false&sidebar=false
+```
+
+#### How Grafana's UI chrome works (and what we can control)
+
+| Chrome element                        | How it's managed                                                                                                                                                | Can we control it?                                                                                                                                                                                                                                |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Left nav (mega-menu)**              | Toggle via `#mega-menu-toggle` button click; docking state in `localStorage['grafana.navigation.extensionSidebarDocked']`                                       | **Yes, with caveats.** We can programmatically click the toggle to collapse it. There is no clean API — `NavigationManager` already does this via `openAndDockNavigation()`. Closing is the reverse: click the toggle when nav items are visible. |
+| **Right sidebar (extension sidebar)** | Opened via `OpenExtensionSidebarEvent` through `getAppEvents().publish()`. Closed via `{ type: 'close-extension-sidebar', payload: {} }` on the same event bus. | **Yes.** We already publish these events in `sidebar.ts` and `TabBarActions.tsx`.                                                                                                                                                                 |
+| **Top bar / breadcrumbs**             | Part of Grafana's SceneAppPage shell. No known toggle.                                                                                                          | **No** — this is Grafana core chrome. Hiding it would require injecting CSS (`display: none` on the header), which is fragile across Grafana versions. Not recommended for Phase 5.                                                               |
+
+#### 5.1 Parse chrome control params
+
+In `MainAreaLearningPanel`, on mount:
+
+```typescript
+const params = new URLSearchParams(window.location.search);
+const showNav = params.get('nav') !== 'false'; // default: show
+const showSidebar = params.get('sidebar') !== 'false'; // default: show
+```
+
+These are **opt-out** — omitting them gives standard Grafana chrome. Only `=false`
+suppresses.
+
+#### 5.2 Left nav control (`&nav=false`)
+
+On mount when `nav=false`:
+
+1. Check if left nav is currently visible by querying for nav menu items:
+   `document.querySelectorAll('a[data-testid="data-testid Nav menu item"]').length > 0`
+2. If visible, click `#mega-menu-toggle` to collapse it.
+3. Store the **previous state** so we can restore on unmount.
+
+On unmount (user navigates away from `/learning`):
+
+- If we collapsed the nav, restore it by clicking `#mega-menu-toggle` again.
+
+**Important**: This uses the same DOM manipulation pattern as `NavigationManager.openAndDockNavigation()`
+but in reverse. It's not a clean API, but it's the same technique the interactive engine
+already relies on — if Grafana changes the nav toggle, both systems break together, which
+is better than having two different fragile approaches.
+
+#### 5.3 Right sidebar control (`&sidebar=false`)
+
+On mount when `sidebar=false`:
+
+1. Check if sidebar is mounted via `sidebarState.getIsSidebarMounted()`.
+2. If mounted, publish `{ type: 'close-extension-sidebar', payload: {} }` via
+   `getAppEvents()`.
+3. Store previous state for restoration.
+
+On unmount:
+
+- If we closed the sidebar and it was previously open, re-open it via
+  `sidebarState.openSidebar()`.
+
+**Edge case**: If the sidebar mounts _after_ our page loads (e.g., experiment
+orchestrator triggers it), we need to suppress that. Options:
+
+- Set a flag that the sidebar initialization in `module.tsx` checks.
+- Listen for `pathfinder-sidebar-mounted` and immediately close if `sidebar=false`
+  is active.
+
+Recommendation: use the listener approach — it's less invasive than modifying `module.tsx`
+initialization logic.
+
+#### 5.4 Restore on navigation
+
+Both nav and sidebar state must be restored when the user leaves the `/learning` route.
+Use a `useRef` to track whether **we** made the change — do not track "previous state."
+This avoids two failure modes: (a) React Strict Mode double-invoking the effect, and (b)
+the user manually restoring chrome while on the `/learning` route.
+
+```typescript
+const navCollapsedByUs = useRef(false);
+const sidebarClosedByUs = useRef(false);
+
+useEffect(() => {
+  // Apply: only change if we need to and the state isn't already what we want
+  if (!showNav && isNavVisible()) {
+    collapseNav();
+    navCollapsedByUs.current = true;
+  }
+  if (!showSidebar && sidebarState.getIsSidebarMounted()) {
+    closeSidebar();
+    sidebarClosedByUs.current = true;
+  }
+
+  return () => {
+    // Restore only if we made the change AND the state still matches what we set.
+    // If the user manually re-expanded the nav, isNavVisible() returns true here —
+    // we don't fight it.
+    if (navCollapsedByUs.current && !isNavVisible()) {
+      expandNav();
+    }
+    navCollapsedByUs.current = false;
+
+    if (sidebarClosedByUs.current && !sidebarState.getIsSidebarMounted()) {
+      sidebarState.openSidebar('Interactive learning');
+    }
+    sidebarClosedByUs.current = false;
+  };
+}, [showNav, showSidebar]);
+```
+
+**Why this handles Strict Mode:** In development, React runs effects twice
+(mount → cleanup → mount). On the first mount, we collapse the nav and set
+`navCollapsedByUs.current = true`. The cleanup restores the nav (it's collapsed, matching
+what we set) and clears the ref. On the second mount, the nav is visible again —
+we collapse it and set the ref again. In production only one mount ever runs, so behaviour
+is identical.
+
+**Why this handles user mid-session changes:** If the user manually re-expands the nav
+while on `/learning`, on unmount `isNavVisible()` returns `true` — the condition
+`!isNavVisible()` is false — so we do not collapse it. We never fight the user's choice.
+
+#### 5.5 Full-screen preset
+
+For convenience, consider a shorthand param that implies both:
+
+```
+&fullscreen=true  →  equivalent to &nav=false&sidebar=false
+```
+
+This keeps URLs cleaner for the most common immersive use case.
+
+#### Risks and mitigations
+
+| Risk                                               | Mitigation                                                                                                                                                                   |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Grafana changes nav toggle markup                  | Same risk `NavigationManager` already carries; add E2E test that verifies the toggle exists                                                                                  |
+| User manually re-opens nav/sidebar during learning | Don't fight it — only apply chrome changes on initial mount, don't continuously enforce                                                                                      |
+| Cleanup doesn't run (page crash, hard nav)         | Accept graceful degradation — user just sees normal chrome on next page load. Nav/sidebar state is already persistent in localStorage, so Grafana restores its own defaults. |
+| `sidebar=false` races with experiment auto-open    | The `pathfinder-sidebar-mounted` listener approach handles this; add a test for the race                                                                                     |
+
+#### Tests — Phase 5
+
+| Test                              | Type        | What it validates                                       |
+| --------------------------------- | ----------- | ------------------------------------------------------- |
+| Default chrome                    | Unit        | No params → nav and sidebar remain untouched            |
+| `nav=false` collapses nav         | Integration | Nav menu items removed from DOM after mount             |
+| `sidebar=false` closes sidebar    | Integration | `close-extension-sidebar` event published               |
+| Restore on unmount                | Integration | Nav/sidebar return to previous state when leaving route |
+| `fullscreen=true` shorthand       | Unit        | Equivalent to `nav=false&sidebar=false`                 |
+| Race with auto-open               | Integration | Sidebar stays closed even if experiment triggers open   |
+| Params only parsed on `/learning` | Unit        | Chrome params on other routes are ignored               |
+
+---
+
+## Analytics Instrumentation
+
+The main-area learning surface must be fully instrumented in parallel with the existing
+sidebar events. All events use `reportAppInteraction(UserInteraction.X, { ... })` from
+`src/lib/analytics.ts`.
+
+Add the following entries to the `UserInteraction` enum. Naming convention:
+`MainArea<Event>` to clearly segregate from sidebar events.
+
+| Event constant                  | Trigger                                                                           | Key payload fields                                                                     |
+| ------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `MainAreaPageView`              | `MainAreaLearningPanel` mounts (even with no `?doc=` param)                       | `has_doc_param: boolean`, `chrome_nav: string`, `chrome_sidebar: string`               |
+| `MainAreaGuideLoaded`           | Content successfully fetched and rendered                                         | `guide_url: string`, `guide_title: string`, `is_safe: boolean`, `load_time_ms: number` |
+| `MainAreaGuideLoadFailed`       | `fetchContent()` throws or returns an error                                       | `guide_url: string`, `error_message: string`                                           |
+| `MainAreaUnsupportedFormat`     | User attempts to load a non-package-format URL (e.g., `/docs/...`, bare HTML)     | `guide_url: string`, `url_scheme: string`                                              |
+| `MainAreaSafetyGateBlocked`     | Safety gate classifies a guide as unsafe for main area                            | `guide_url: string`, `unsafe_action_types: string[]`                                   |
+| `MainAreaOpenInSidebarClicked`  | User clicks "Open in sidebar" from the safety gate or unsupported-format fallback | `guide_url: string`, `trigger: 'safety_gate' \| 'unsupported_format'`                  |
+| `MainAreaLinkIntercepted`       | `handleGlobalClick` routes an intercepted link to the main area                   | `intercepted_url: string`, `link_title: string`                                        |
+| `MainAreaChromeControlApplied`  | `nav=false` or `sidebar=false` (or `fullscreen=true`) params are processed        | `nav_hidden: boolean`, `sidebar_hidden: boolean`                                       |
+| `MainAreaGuideNavigatedInPlace` | `pathfinder-open-in-main-area` event loads a new guide replacing the current one  | `new_url: string`, `previous_url: string`                                              |
+
+These events parallel the existing sidebar analytics (e.g., `DocsPanelInteraction`,
+`GlobalDocsLinkIntercepted`) but are clearly scoped to the main-area surface. Keeping them
+separate enables per-surface funnel analysis.
+
+---
+
+## File Inventory
+
+### New files
+
+| File                                                                  | Purpose                                                   |
+| --------------------------------------------------------------------- | --------------------------------------------------------- |
+| `src/pages/learningPage.ts`                                           | SceneAppPage route definition                             |
+| `src/components/main-area-learning/main-area-learning-panel.tsx`      | SceneObjectBase subclass + renderer for main-area content |
+| `src/components/main-area-learning/main-area-learning-panel.test.tsx` | Unit tests                                                |
+| `src/components/main-area-learning/main-area-learning-state.ts`       | Active-state singleton; used by link-interception routing |
+| `src/components/main-area-learning/main-area-learning-state.test.ts`  | Unit tests for singleton                                  |
+| `src/utils/guide-safety.ts`                                           | `isMainAreaSafe()` utility (Phase 4)                      |
+| `src/utils/guide-safety.test.ts`                                      | Safety classification tests                               |
+| `src/utils/chrome-control.ts`                                         | Nav/sidebar show/hide helpers (Phase 5)                   |
+| `src/utils/chrome-control.test.ts`                                    | Chrome control tests                                      |
+
+### Modified files
+
+| File                                             | Change                                                            |
+| ------------------------------------------------ | ----------------------------------------------------------------- |
+| `src/constants.ts`                               | Add `Learning = 'learning'` to `ROUTES`                           |
+| `src/components/App/App.tsx`                     | Register `learningPage` in `SceneApp` pages                       |
+| `src/components/LearningPaths/MyLearningTab.tsx` | Add `onOpenGuide` prop support if not present (Phase 2)           |
+| `src/global-state/link-interception.ts`          | Add `mainAreaLearningState.getIsActive()` routing check (Phase 2) |
+| `src/lib/analytics.ts`                           | Add `MainArea*` entries to `UserInteraction` enum                 |
+
+---
+
+## Resolved decisions
+
+1. **Tab persistence scope**: Separate storage keys. The main-area view must not clobber
+   the sidebar's tab state. Use a `main-area-last-viewed` key in `user-storage.ts`,
+   distinct from the sidebar's tab storage keys.
+
+2. **Concurrent rendering**: Fine as-is. Sidebar and main area use independent component
+   instances. The only shared state is step-completion (keyed by content URL, idempotent).
+   The `main-area-docs-content` scroll container ID (vs. the sidebar's `inner-docs-content`)
+   eliminates the only ID conflict.
+
+3. **Link interception routing**: When `/learning` is active, intercepted doc links are
+   routed to the main area via `pathfinder-open-in-main-area` event. See Phase 2.2.
+
+4. **Title/breadcrumb**: Static title "Learning" for V1. Dynamic guide title in the
+   breadcrumb is a follow-up.
+
+---
+
+## Implementation Log
+
+### Phase 1 — Completed 2026-04-11
+
+**Files created:**
+
+| File                                                                  | Purpose                                          |
+| --------------------------------------------------------------------- | ------------------------------------------------ |
+| `src/pages/learningPage.ts`                                           | SceneAppPage route definition                    |
+| `src/pages/learningPage.test.ts`                                      | Route registration tests                         |
+| `src/components/main-area-learning/main-area-learning-panel.tsx`      | SceneObjectBase + renderer for main-area content |
+| `src/components/main-area-learning/main-area-learning-panel.test.tsx` | Unit tests (22 tests)                            |
+| `src/components/main-area-learning/index.ts`                          | Barrel export                                    |
+
+**Files modified:**
+
+| File                         | Change                                                                                                                            |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `src/constants.ts`           | Added `Learning = 'learning'` to `ROUTES` enum                                                                                    |
+| `src/lib/analytics.ts`       | Added `MainAreaPageView`, `MainAreaGuideLoaded`, `MainAreaGuideLoadFailed`, `MainAreaUnsupportedFormat` to `UserInteraction` enum |
+| `src/constants/testIds.ts`   | Added `mainAreaLearning` test ID namespace (8 IDs)                                                                                |
+| `src/components/App/App.tsx` | Registered `learningPage` in SceneApp pages array                                                                                 |
+
+**Deviations from design:**
+
+- Initial state (landing, unsupported format) is computed synchronously via
+  `resolveDocParam()` passed to `useState(initializer)` rather than using `setState`
+  inside the mount effect. This avoids the `react-hooks/set-state-in-effect` lint rule.
+- Imports `fetchContent` and `ContentRenderer` from the `docs-retrieval` barrel
+  (`src/docs-retrieval/index.ts`) rather than directly from internal files, per the
+  architecture ratchet's barrel export discipline.
+- `fetchContent` is imported as `fetchUnifiedContent` (the barrel's export name) and
+  aliased back to `fetchContent` locally.
+
+**Notes for Phase 2 (Navigation and Deep Linking):**
+
+- `handleOpenGuideInMainArea` uses full-page navigation (`window.location.assign`).
+  Phase 2 should replace with `locationService.push()` for SPA navigation.
+- `mainAreaLearningState` singleton does not yet exist — Phase 2 needs to create
+  `src/components/main-area-learning/main-area-learning-state.ts` for the
+  `getIsActive()` / `setIsActive()` API used by link interception routing.
+- "Open in sidebar" button reuses `HomePanel`'s sidebar dispatch pattern
+  (`pathfinder-auto-open-docs` event + `sidebarState.openSidebar()` fallback).
+- Only 4 of 9 planned `MainArea*` analytics events are implemented. The remaining 5
+  (`MainAreaSafetyGateBlocked`, `MainAreaOpenInSidebarClicked`,
+  `MainAreaLinkIntercepted`, `MainAreaChromeControlApplied`,
+  `MainAreaGuideNavigatedInPlace`) should be added in Phases 2-5.
+- `MyLearningTab` already has the `onOpenGuide` prop — no changes were needed to its
+  interface. Phase 2 just needs to provide a different handler when rendered in the
+  main area vs. sidebar.
+
+### Phase 2 — Completed 2026-04-12
+
+**Files created:**
+
+| File                                                | Purpose                                              |
+| --------------------------------------------------- | ---------------------------------------------------- |
+| `src/global-state/main-area-learning-state.ts`      | Active-state singleton for link interception routing |
+| `src/global-state/main-area-learning-state.test.ts` | Unit tests for singleton                             |
+
+**Files modified:**
+
+| File                                                                  | Change                                                                                               |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `src/lib/analytics.ts`                                                | Added `MainAreaLinkIntercepted`, `MainAreaGuideNavigatedInPlace` to enum                             |
+| `src/components/main-area-learning/main-area-learning-panel.tsx`      | SPA navigation, active state wiring, `pathfinder-open-in-main-area` listener, mutable state refactor |
+| `src/components/main-area-learning/main-area-learning-panel.test.tsx` | Added 6 Phase 2 tests, updated mocks                                                                 |
+| `src/global-state/link-interception.ts`                               | Context-aware routing: main area check before sidebar dispatch                                       |
+
+**Deviations from design:**
+
+- `mainAreaLearningState` lives in `src/global-state/` (not `src/components/main-area-learning/`)
+  to comply with the architecture ratchet's tier import rules. `link-interception.ts`
+  (Tier 2 global-state) cannot import from `components/` (Tier 3).
+- SPA navigation uses in-place content loading via `loadContent()` rather than
+  `locationService.push()`. The component resolves and fetches content directly,
+  avoiding a URL round-trip. This is simpler and avoids re-mounting the component.
+- The frozen `initial` state pattern from Phase 1 was refactored to separate mutable
+  `useState` calls (initialized from `resolveDocParam`) so `handleOpenGuideInMainArea`
+  can transition from landing → content view. The mount effect still avoids synchronous
+  `setState` — only async `loadContent` and side-effect-only `reportAppInteraction`.
+- Removed `prefixRoute` and `ROUTES` imports from the panel (no longer needed).
+
+**Notes for Phase 3 (Layout and Styling):**
+
+- Content now loads in-place without page reload. Phase 3 styling should account for
+  smooth content transitions (e.g., skeleton → content → new skeleton → new content).
+- `loadContent` is reused for both initial mount and in-place navigation.
+- The `max-width: 48rem` constraint from the design should be applied to the content
+  container (`#main-area-docs-content`), not the outer panel container.
+
+**Notes for Phase 4 (Content Safety Gate):**
+
+- `handleOpenGuideInMainArea` is the right place to add the `isMainAreaSafe()` check.
+  Both direct calls (from `MyLearningTab`) and `pathfinder-open-in-main-area` events
+  flow through this callback.
+- 6 of 9 planned `MainArea*` analytics events are now implemented. Remaining 3:
+  `MainAreaSafetyGateBlocked`, `MainAreaOpenInSidebarClicked`,
+  `MainAreaChromeControlApplied` — for Phases 4-5.
+
+### Phase 3 — Completed 2026-04-12
+
+**Files created:**
+
+| File                                                               | Purpose                                                  |
+| ------------------------------------------------------------------ | -------------------------------------------------------- |
+| `src/components/main-area-learning/guide-progress-header.tsx`      | Progress header with title, completion %, sidebar button |
+| `src/components/main-area-learning/guide-progress-header.test.tsx` | Unit tests for progress header (8 tests)                 |
+
+**Files modified:**
+
+| File                                                                  | Change                                                                        |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `src/components/main-area-learning/main-area-learning-panel.tsx`      | Added `contentBody` style (max-width 48rem), integrated GuideProgressHeader   |
+| `src/components/main-area-learning/main-area-learning-panel.test.tsx` | Added 5 Phase 3 tests, `success` color in mock theme, completion storage mock |
+| `src/constants/testIds.ts`                                            | Added `progressHeader`, `progressBar`, `openInSidebarHeaderButton`            |
+
+**Deviations from design:**
+
+- None — implementation matches design spec.
+
+**Notes for Phase 4 (Content Safety Gate):**
+
+- `GuideProgressHeader` only renders when `content` is set. The safety gate (Phase 4)
+  prevents `setContent()` for unsafe guides, so the header naturally won't appear for
+  blocked guides.
+- The `handleOpenInSidebar` callback from the header reuses the same sidebar handoff
+  pattern as the unsupported format handler.
+
+### Phase 4 — Completed 2026-04-12
+
+**Files created:**
+
+| File                             | Purpose                                                |
+| -------------------------------- | ------------------------------------------------------ |
+| `src/utils/guide-safety.ts`      | `isMainAreaSafe()` — safety classifier for JSON guides |
+| `src/utils/guide-safety.test.ts` | Safety classification tests (23 tests)                 |
+
+**Files modified:**
+
+| File                                                                  | Change                                                                                        |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `src/components/main-area-learning/main-area-learning-panel.tsx`      | Safety gate in `loadContent`, `handleSafetyGateOpenInSidebar`, warning alert render block     |
+| `src/components/main-area-learning/main-area-learning-panel.test.tsx` | Added 5 Phase 4 tests, `guide-safety` mock, `locationService.push` mock, `openWithGuide` mock |
+| `src/lib/analytics.ts`                                                | Added `MainAreaSafetyGateBlocked`, `MainAreaOpenInSidebarClicked` to enum                     |
+| `src/constants/testIds.ts`                                            | Added `safetyGateWarning`, `safetyGateOpenInSidebarButton`                                    |
+| `docs/design/MAIN-AREA-EDUCATION.md`                                  | Phase 3 and Phase 4 implementation log entries                                                |
+
+**Deviations from design:**
+
+- `isMainAreaSafe()` operates on the raw JSON string (`RawContent.content`) rather than
+  `ParsedContent`. This avoids double-parsing — `ContentRenderer` already parses the
+  content internally. JSON.parse + recursive block walk is simpler and more efficient.
+- The safety check runs inside `loadContent()` (after `fetchContent` returns) rather
+  than in `handleOpenGuideInMainArea()`. This ensures the check runs for both initial
+  mount loads and in-place navigation, with a single code path.
+- `unsafe_action_types` analytics payload is a comma-joined string (not an array)
+  because `reportAppInteraction` only accepts `string | number | boolean` values.
+- Phase 4.3 (surface safety in MyLearningTab guide cards) is deferred — it requires
+  pre-classifying all guides at list render time, which needs a caching strategy.
+
+**Notes for Phase 5 (Chrome Controls):**
+
+- 8 of 9 planned `MainArea*` analytics events are now implemented. Remaining 1:
+  `MainAreaChromeControlApplied` — for Phase 5.
+- `locationService` is now imported in the panel (added for safety gate navigation).
+  Phase 5 can reuse this import for chrome control navigation.

--- a/docs/design/MAIN-AREA-EDUCATION.md
+++ b/docs/design/MAIN-AREA-EDUCATION.md
@@ -3,26 +3,16 @@
 ## Overview
 
 Render interactive learning content (guides, quizzes, terminal steps, code blocks) in
-Grafana's main app area at a dedicated route, as an alternative to the right-hand sidebar.
-This design covers **read-only and self-contained interactive content only** — guides
-whose "Show Me" / "Do It" steps target external Grafana DOM elements remain sidebar-only.
+Grafana's main app area at a dedicated `/learning` route, as an alternative to the
+right-hand sidebar. Only **read-only and self-contained interactive content** is supported
+— guides whose "Show Me" / "Do It" steps target external Grafana DOM elements remain
+sidebar-only (enforced by the safety gate in `guide-safety.ts`).
 
 ### Goal URL
 
 ```
 /a/grafana-pathfinder-app/learning?doc=bundled:prometheus-grafana-101
 ```
-
-This mirrors the existing `?doc=` parameter used at the plugin root
-(`/a/grafana-pathfinder-app?doc=...&page=...`) for sidebar auto-launch. The `doc`
-parameter accepts Pathfinder package URL schemes only: `bundled:<id>`, `api:<name>`,
-or an HTTPS base URL pointing to a package directory
-(e.g. `https://interactive-learning.grafana.net/mypackage/`). Raw `/docs/...` paths and
-bare HTML URLs are not supported in this route — use the sidebar for those.
-
-The key difference: the root `?doc=` parameter opens content in the **sidebar** (and
-optionally redirects the main area via `?page=`). The `/learning?doc=` route renders
-content **in-place** in the main area, with no sidebar involvement.
 
 ---
 
@@ -61,342 +51,7 @@ content **in-place** in the main area, with no sidebar involvement.
 
 ---
 
-## Phased Implementation Plan
-
-### Phase 1: Route, Page, and Basic Rendering
-
-**Goal**: A working `/learning` route that renders a `MainAreaLearningPanel` in the
-main app area, with `?doc=` parameter support for direct-linking to content.
-
-#### 1.1 Add the route
-
-**`src/constants.ts`** — add to `ROUTES` enum:
-
-```typescript
-export enum ROUTES {
-  Home = '',
-  Context = 'context',
-  Learning = 'learning', // NEW
-}
-```
-
-#### 1.2 Create the page definition
-
-**`src/pages/learningPage.ts`** (new file) — modeled on `docsPage.ts`:
-
-```typescript
-import { EmbeddedScene, SceneAppPage, SceneFlexItem, SceneFlexLayout } from '@grafana/scenes';
-import { prefixRoute } from '../utils/utils.routing';
-import { ROUTES } from '../constants';
-import { MainAreaLearningPanel } from '../components/main-area-learning/main-area-learning-panel';
-
-export const learningPage = new SceneAppPage({
-  title: 'Learning',
-  url: prefixRoute(ROUTES.Learning),
-  routePath: ROUTES.Learning,
-  getScene: learningScene,
-});
-
-function learningScene() {
-  return new EmbeddedScene({
-    body: new SceneFlexLayout({
-      children: [
-        new SceneFlexItem({
-          width: '100%',
-          height: '100%', // Full height, not fixed 600px like docsPage
-          body: new MainAreaLearningPanel({}),
-        }),
-      ],
-    }),
-  });
-}
-```
-
-#### 1.3 Register in the app
-
-**`src/components/App/App.tsx`** — add `learningPage` to the `SceneApp` pages array.
-
-#### 1.4 Build `MainAreaLearningPanel`
-
-**`src/components/main-area-learning/main-area-learning-panel.tsx`** (new file)
-
-Implement as a `SceneObjectBase` subclass with a `static Component` property — the same
-pattern as `CombinedLearningJourneyPanel`. Content loading state (loaded content,
-loading/error status) lives in `useState` within the `Component` function, not in
-`SceneObjectState`. This is required for correct integration with `SceneFlexItem`'s `body`
-prop.
-
-The `Component` function:
-
-1. Reads `?doc=` from the URL on mount (via `new URLSearchParams(window.location.search)`)
-2. Calls `findDocPage(docParam)` to resolve the URL
-3. Calls `fetchContent(resolvedUrl)` to load content
-4. Renders `ContentRenderer` with the loaded `RawContent`
-5. Wraps the content in a container with `id="main-area-docs-content"` for scroll tracking
-   (deliberately different from the sidebar's `inner-docs-content` to avoid ID conflicts
-   when both views are mounted simultaneously)
-6. Strips the `?doc=` param from the URL after processing (matching existing behavior in
-   `module.tsx`)
-
-**Loading and error states:**
-
-- **Loading**: Show `SkeletonLoader` while `fetchContent()` is in flight.
-- **Fetch error** (network failure, guide not found): Show a Grafana `Alert` component
-  (variant `"error"`) with the error message and a "Try again" button that re-triggers
-  the fetch.
-- **Unresolvable URL scheme** (invalid `?doc=` value that `findDocPage()` cannot parse):
-  Treat as missing param — fall through to the landing page (see 1.5).
-
-Key decisions:
-
-- **Single-content view, not tabbed** — the main area shows one guide at a time, not the
-  sidebar's tab UI. Sidebar = multi-tab companion; main area = focused reading.
-- **Full-height layout** — unlike `docsPage.ts` which uses `height: 600`, the learning
-  page fills the viewport. Use `height: '100%'` and let Grafana's Scene layout handle it.
-- **Reuse `ContentRenderer` directly** — don't wrap `CombinedLearningJourneyPanel`; the
-  main area wants a simpler, focused experience without the recommendation tab and tab bar.
-- **Static title "Learning"** — dynamic guide title in the breadcrumb is deferred to a
-  follow-up. V1 shows "Learning" as the `SceneAppPage` title.
-
-#### 1.5 Handle missing/invalid `?doc=`
-
-If no `?doc=` param or an invalid one: render the `MyLearningTab` component (the learning
-paths hub) as a landing page, so the URL `/a/grafana-pathfinder-app/learning` without
-params is useful on its own.
-
-**Content format restriction**: The `/learning` route accepts only Pathfinder package
-format — guides that have both a `content.json` and a `manifest.json`. Specifically:
-
-- `bundled:<id>` — always valid; bundled guides are in package format by definition.
-- `https://<base>/` (or any external base URL) — treated as a package base URL.
-  `content.json` is fetched from `<base>/content.json` and the manifest from
-  `<base>/manifest.json`. If either is missing or the response is not valid package JSON,
-  the request is rejected with an error.
-- `api:<name>` — valid only if the API returns a package-format response.
-- `/docs/...` paths and bare HTML URLs — **not supported** in the main area. Show a
-  clear error: "This content format is not supported in the learning view. Open it in the
-  Pathfinder sidebar instead." with a button that dispatches it to the sidebar.
-
-This restriction exists because the main-area learning view is designed around the package
-model's structured content and metadata (title, progress, step completion). Raw HTML docs
-lack the structure needed for the progress header and interactive safety gate.
-
-#### Tests — Phase 1
-
-| Test                      | Type        | What it validates                                                                         |
-| ------------------------- | ----------- | ----------------------------------------------------------------------------------------- |
-| Route registration        | Unit        | `ROUTES.Learning` exists and `prefixRoute` produces correct path                          |
-| `?doc=` parsing           | Unit        | `MainAreaLearningPanel` correctly extracts, resolves, and cleans query params             |
-| Invalid `?doc=` fallback  | Unit        | Invalid/missing param renders `MyLearningTab` landing                                     |
-| Content render            | Integration | `ContentRenderer` mounts and renders `RawContent` inside the panel                        |
-| Scroll container          | Unit        | The `main-area-docs-content` ID is present in the rendered DOM (not `inner-docs-content`) |
-| Package format validation | Unit        | `bundled:` and HTTPS package base URLs accepted; `/docs/` paths rejected with fallback UI |
-| Unsupported format UI     | Unit        | Non-package URLs render error alert with "Open in sidebar" button                         |
-| Loading state             | Unit        | `SkeletonLoader` is shown while `fetchContent()` is in flight                             |
-| Fetch error state         | Unit        | Network error renders error alert with "Try again" button                                 |
-
----
-
-### Phase 2: Navigation and Deep Linking
-
-**Goal**: Wire up navigation so users can reach the main-area learning view from existing
-UI surfaces, and so links can be shared.
-
-#### 2.1 "Open in main area" from MyLearningTab
-
-**Decision: URL-based via prop override.** `MyLearningTab` stays route-agnostic. The
-caller provides the `onOpenGuide` handler and controls the destination.
-
-- When `MyLearningTab` is rendered inside `MainAreaLearningPanel` (i.e., as the landing
-  page at `/learning`), the panel provides an `onOpenGuide` handler that navigates to
-  `/a/grafana-pathfinder-app/learning?doc=<url>` using `locationService.push()` from
-  `@grafana/runtime`.
-- When `MyLearningTab` is rendered inside the sidebar, the sidebar provides an
-  `onOpenGuide` handler that dispatches to the sidebar as today.
-
-This requires that `MyLearningTab` accepts an `onOpenGuide` prop (verify the current
-interface and add the prop if not already present). No route-awareness or condition
-checking is needed inside `MyLearningTab` itself.
-
-#### 2.2 Link interception routing when on `/learning`
-
-**Decision**: When the user is on `/learning`, intercepted doc links open in the main area
-and bypass the sidebar entirely.
-
-**Implementation**: `link-interception.ts` must become context-aware. Add a check in
-`handleGlobalClick`:
-
-```typescript
-import { mainAreaLearningState } from '../components/main-area-learning/main-area-learning-state';
-
-// If main area is active, route to it instead of the sidebar
-if (mainAreaLearningState.getIsActive()) {
-  document.dispatchEvent(new CustomEvent('pathfinder-open-in-main-area', { detail: docsLink }));
-  return;
-}
-// ...existing sidebar logic
-```
-
-`mainAreaLearningState` is a small singleton (analogous to `sidebarState`) that
-`MainAreaLearningPanel` sets to active on mount and inactive on unmount.
-
-`MainAreaLearningPanel` listens for `pathfinder-open-in-main-area` (not
-`pathfinder-auto-open-docs`) to load new content in-place. This avoids the dual-handling
-problem where both the sidebar and main area would catch the same event.
-
-**New file**: `src/components/main-area-learning/main-area-learning-state.ts` — a small
-singleton with `getIsActive()`, `setIsActive(active: boolean)`.
-
-#### 2.3 MCP-driven guide launches
-
-For MCP-initiated launches (via `sidebarState.openWithGuide()`), the existing flow opens
-the sidebar. This remains unchanged — MCP guide launches always target the sidebar, not
-the main area. The main area's `pathfinder-open-in-main-area` event is for link
-interception only.
-
-#### 2.4 Clean URL history
-
-After loading content from `?doc=`, replace the URL with
-`/a/grafana-pathfinder-app/learning` (no query param) using
-`window.history.replaceState`. This matches the existing pattern in `module.tsx:179-182`.
-
-#### 2.5 Back navigation
-
-When the user navigates away from a guide (e.g., clicks a breadcrumb or the browser back
-button), return to the learning hub landing page. Consider storing the last-viewed guide
-URL in `user-storage.ts` (using a separate key from the sidebar's tab storage, to avoid
-clobbering sidebar state) so the user can resume.
-
-#### Tests — Phase 2
-
-| Test                           | Type        | What it validates                                                                                     |
-| ------------------------------ | ----------- | ----------------------------------------------------------------------------------------------------- |
-| Deep link round-trip           | Integration | Navigate to `/learning?doc=bundled:X` → content renders → URL cleaned                                 |
-| Main-area event routing        | Unit        | `pathfinder-open-in-main-area` event loads content in main area                                       |
-| Link interception bypass       | Unit        | When `mainAreaLearningState.isActive`, `handleGlobalClick` dispatches to main area instead of sidebar |
-| MyLearningTab navigation       | Unit        | `onOpenGuide` prop navigates to `/learning?doc=<url>` when provided by panel                          |
-| MCP launch unchanged           | Unit        | `sidebarState.openWithGuide()` still targets the sidebar regardless of route                          |
-| Back button                    | Integration | Browser back returns to landing page, not broken state                                                |
-| URL param cleanup              | Unit        | `?doc=` is stripped after processing; repeated visits don't re-trigger                                |
-| State active/inactive on mount | Unit        | `mainAreaLearningState` is set active on mount and inactive on unmount                                |
-
----
-
-### Phase 3: Layout and Styling
-
-**Goal**: The main-area learning view looks polished and takes advantage of the wider
-viewport (vs. the narrow sidebar).
-
-#### 3.1 Responsive content width
-
-`ContentRenderer` currently renders in a narrow sidebar. In the main area, constrain
-content to a comfortable reading width (e.g., `max-width: 48rem; margin: 0 auto`) while
-allowing interactive components (terminals, code blocks) to use more width.
-
-#### 3.2 Adapt interactive component sizing
-
-- **`TerminalStep`** / **`CodeBlockStep`**: Allow wider/taller rendering in main area.
-  These components likely already use `100%` width but may benefit from increased
-  `min-height`.
-- **`InteractiveQuiz`**: Should work unchanged — it's a card-style layout.
-- **`InteractiveSection`**: Collapse/expand behavior should work as-is.
-
-#### 3.3 Progress bar and guide header
-
-Add a header area above the content showing:
-
-- Guide title
-- Progress indicator (reuse existing `interactiveCompletionStorage` data)
-- "Open in sidebar" link (for users who want to switch to side-by-side mode)
-
-#### 3.4 Handle the "Recommendations" panel
-
-`CombinedLearningJourneyPanel` always includes a Recommendations tab via `ContextPanel`.
-Since `MainAreaLearningPanel` uses `ContentRenderer` directly, this is a non-issue — but
-if you later want to show recommendations, they can be added as a separate section below
-the content.
-
-#### Tests — Phase 3
-
-| Test                   | Type            | What it validates                                                               |
-| ---------------------- | --------------- | ------------------------------------------------------------------------------- |
-| Max-width constraint   | Snapshot/visual | Content body has `max-width` applied                                            |
-| Terminal sizing        | Integration     | `TerminalStep` renders at wider width without overflow                          |
-| Progress display       | Unit            | Progress header reads from `interactiveCompletionStorage` and renders correctly |
-| Responsive breakpoints | Visual          | Layout degrades gracefully at narrow viewport widths                            |
-
----
-
-### Phase 4: Content Safety Gate
-
-**Goal**: Prevent guides with "Show Me" / "Do It" steps (that target external DOM) from
-rendering broken in the main area.
-
-#### 4.1 Safety classification via parsed detection
-
-Since the main area is restricted to Pathfinder package format (see 1.5), all content goes
-through `json-parser.ts` and produces structured `ParsedContent`. There is no HTML/external
-content to classify.
-
-**`isMainAreaSafe(content: ParsedContent): boolean`** — inspect all interactive elements:
-
-- Check both `interactive` blocks (single-action) and `multistep` blocks (whose `steps`
-  array may contain DOM-targeting actions).
-- **Unsafe actions**: `'highlight' | 'button' | 'formfill' | 'hover'` — these target
-  Grafana DOM elements that are not visible when the main area is occupied.
-- **Safe actions**: `'noop'` and `'navigate'` — these do not target external DOM.
-  Note: `navigate` with `openGuide` set loads a guide into the sidebar, which is expected
-  and acceptable in a main-area context.
-- A guide is safe if it contains **no** steps with unsafe actions. A single unsafe step
-  makes the whole guide sidebar-only.
-- `showMe` and `doIt` flags do not affect classification — even if buttons are hidden,
-  the underlying action type determines safety.
-
-No `Option A` static metadata field is needed for V1. The automated detection covers all
-cases in the package-format-only content set.
-
-#### 4.2 Gate rendering
-
-In `MainAreaLearningPanel`, after fetching and parsing content, run the safety check:
-
-- If safe: render normally.
-- If unsafe: show a Grafana `Alert` (variant `"warning"`) explaining the guide requires
-  the sidebar, with an "Open in sidebar" button.
-
-**"Open in sidebar" button implementation** — varies by content source:
-
-- `bundled:<id>` — strip the `bundled:` prefix and call
-  `sidebarState.openWithGuide(id)`. Then navigate away from `/learning` using
-  `locationService.push('/a/grafana-pathfinder-app')` so the guide opens alongside the
-  normal Grafana UI.
-- External package URL — dispatch a `pathfinder-open-in-main-area` is wrong here;
-  instead dispatch `pathfinder-auto-open-docs` with the full URL, then navigate away from
-  `/learning`.
-- In both cases: navigate away from `/learning` immediately after dispatching, so the
-  sidebar-targeted content can work against the actual Grafana UI.
-
-#### 4.3 Surface safety in MyLearningTab
-
-On guide cards, indicate which guides can open in the main area vs. sidebar-only. This
-could be a subtle icon or tooltip — not a blocking gate, just information.
-
-#### Tests — Phase 4
-
-| Test                        | Type        | What it validates                                                                        |
-| --------------------------- | ----------- | ---------------------------------------------------------------------------------------- |
-| Detection accuracy          | Unit        | `isMainAreaSafe()` correctly classifies guides with showMe/doIt vs. quiz-only            |
-| Noop steps pass             | Unit        | Guides with only `noop` interactive steps are classified as safe                         |
-| Multistep block checked     | Unit        | Unsafe actions inside `multistep.steps` correctly classify the guide as unsafe           |
-| Navigate+openGuide safe     | Unit        | `navigate` action (with or without `openGuide`) is classified as safe                    |
-| Hidden buttons still unsafe | Unit        | Steps with `showMe: false` and `doIt: false` but unsafe `action` still fail safety check |
-| Unsafe redirect             | Integration | Unsafe guide shows warning alert with "Open in sidebar" button                           |
-| Bundled sidebar handoff     | Integration | "Open in sidebar" calls `sidebarState.openWithGuide(id)` and navigates away              |
-| External sidebar handoff    | Integration | "Open in sidebar" dispatches `pathfinder-auto-open-docs` and navigates away              |
-| Edge cases                  | Unit        | Mixed guides (some safe steps, some unsafe) are classified as unsafe                     |
-
----
-
-### Phase 5: Chrome Controls (`&nav=` and `&sidebar=`)
+## Future Work: Chrome Controls (`&nav=` and `&sidebar=`)
 
 **Goal**: URL parameters that selectively show/hide the left navigation and right-hand
 extension sidebar, enabling a full-screen immersive learning experience.
@@ -411,22 +66,9 @@ extension sidebar, enabling a full-screen immersive learning experience.
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Left nav (mega-menu)**              | Toggle via `#mega-menu-toggle` button click; docking state in `localStorage['grafana.navigation.extensionSidebarDocked']`                                       | **Yes, with caveats.** We can programmatically click the toggle to collapse it. There is no clean API — `NavigationManager` already does this via `openAndDockNavigation()`. Closing is the reverse: click the toggle when nav items are visible. |
 | **Right sidebar (extension sidebar)** | Opened via `OpenExtensionSidebarEvent` through `getAppEvents().publish()`. Closed via `{ type: 'close-extension-sidebar', payload: {} }` on the same event bus. | **Yes.** We already publish these events in `sidebar.ts` and `TabBarActions.tsx`.                                                                                                                                                                 |
-| **Top bar / breadcrumbs**             | Part of Grafana's SceneAppPage shell. No known toggle.                                                                                                          | **No** — this is Grafana core chrome. Hiding it would require injecting CSS (`display: none` on the header), which is fragile across Grafana versions. Not recommended for Phase 5.                                                               |
+| **Top bar / breadcrumbs**             | Part of Grafana's SceneAppPage shell. No known toggle.                                                                                                          | **No** — this is Grafana core chrome. Hiding it would require injecting CSS (`display: none` on the header), which is fragile across Grafana versions. Not recommended.                                                                           |
 
-#### 5.1 Parse chrome control params
-
-In `MainAreaLearningPanel`, on mount:
-
-```typescript
-const params = new URLSearchParams(window.location.search);
-const showNav = params.get('nav') !== 'false'; // default: show
-const showSidebar = params.get('sidebar') !== 'false'; // default: show
-```
-
-These are **opt-out** — omitting them gives standard Grafana chrome. Only `=false`
-suppresses.
-
-#### 5.2 Left nav control (`&nav=false`)
+#### Left nav control (`&nav=false`)
 
 On mount when `nav=false`:
 
@@ -444,7 +86,7 @@ but in reverse. It's not a clean API, but it's the same technique the interactiv
 already relies on — if Grafana changes the nav toggle, both systems break together, which
 is better than having two different fragile approaches.
 
-#### 5.3 Right sidebar control (`&sidebar=false`)
+#### Right sidebar control (`&sidebar=false`)
 
 On mount when `sidebar=false`:
 
@@ -459,74 +101,22 @@ On unmount:
   `sidebarState.openSidebar()`.
 
 **Edge case**: If the sidebar mounts _after_ our page loads (e.g., experiment
-orchestrator triggers it), we need to suppress that. Options:
+orchestrator triggers it), we need to suppress that. The listener approach
+(`pathfinder-sidebar-mounted` → immediately close) is less invasive than modifying
+`module.tsx` initialization logic.
 
-- Set a flag that the sidebar initialization in `module.tsx` checks.
-- Listen for `pathfinder-sidebar-mounted` and immediately close if `sidebar=false`
-  is active.
-
-Recommendation: use the listener approach — it's less invasive than modifying `module.tsx`
-initialization logic.
-
-#### 5.4 Restore on navigation
+#### Restore on navigation
 
 Both nav and sidebar state must be restored when the user leaves the `/learning` route.
 Use a `useRef` to track whether **we** made the change — do not track "previous state."
 This avoids two failure modes: (a) React Strict Mode double-invoking the effect, and (b)
 the user manually restoring chrome while on the `/learning` route.
 
-```typescript
-const navCollapsedByUs = useRef(false);
-const sidebarClosedByUs = useRef(false);
-
-useEffect(() => {
-  // Apply: only change if we need to and the state isn't already what we want
-  if (!showNav && isNavVisible()) {
-    collapseNav();
-    navCollapsedByUs.current = true;
-  }
-  if (!showSidebar && sidebarState.getIsSidebarMounted()) {
-    closeSidebar();
-    sidebarClosedByUs.current = true;
-  }
-
-  return () => {
-    // Restore only if we made the change AND the state still matches what we set.
-    // If the user manually re-expanded the nav, isNavVisible() returns true here —
-    // we don't fight it.
-    if (navCollapsedByUs.current && !isNavVisible()) {
-      expandNav();
-    }
-    navCollapsedByUs.current = false;
-
-    if (sidebarClosedByUs.current && !sidebarState.getIsSidebarMounted()) {
-      sidebarState.openSidebar('Interactive learning');
-    }
-    sidebarClosedByUs.current = false;
-  };
-}, [showNav, showSidebar]);
-```
-
-**Why this handles Strict Mode:** In development, React runs effects twice
-(mount → cleanup → mount). On the first mount, we collapse the nav and set
-`navCollapsedByUs.current = true`. The cleanup restores the nav (it's collapsed, matching
-what we set) and clears the ref. On the second mount, the nav is visible again —
-we collapse it and set the ref again. In production only one mount ever runs, so behaviour
-is identical.
-
-**Why this handles user mid-session changes:** If the user manually re-expands the nav
-while on `/learning`, on unmount `isNavVisible()` returns `true` — the condition
-`!isNavVisible()` is false — so we do not collapse it. We never fight the user's choice.
-
-#### 5.5 Full-screen preset
-
-For convenience, consider a shorthand param that implies both:
+#### Full-screen preset
 
 ```
 &fullscreen=true  →  equivalent to &nav=false&sidebar=false
 ```
-
-This keeps URLs cleaner for the most common immersive use case.
 
 #### Risks and mitigations
 
@@ -537,72 +127,13 @@ This keeps URLs cleaner for the most common immersive use case.
 | Cleanup doesn't run (page crash, hard nav)         | Accept graceful degradation — user just sees normal chrome on next page load. Nav/sidebar state is already persistent in localStorage, so Grafana restores its own defaults. |
 | `sidebar=false` races with experiment auto-open    | The `pathfinder-sidebar-mounted` listener approach handles this; add a test for the race                                                                                     |
 
-#### Tests — Phase 5
-
-| Test                              | Type        | What it validates                                       |
-| --------------------------------- | ----------- | ------------------------------------------------------- |
-| Default chrome                    | Unit        | No params → nav and sidebar remain untouched            |
-| `nav=false` collapses nav         | Integration | Nav menu items removed from DOM after mount             |
-| `sidebar=false` closes sidebar    | Integration | `close-extension-sidebar` event published               |
-| Restore on unmount                | Integration | Nav/sidebar return to previous state when leaving route |
-| `fullscreen=true` shorthand       | Unit        | Equivalent to `nav=false&sidebar=false`                 |
-| Race with auto-open               | Integration | Sidebar stays closed even if experiment triggers open   |
-| Params only parsed on `/learning` | Unit        | Chrome params on other routes are ignored               |
-
 ---
 
-## Analytics Instrumentation
+## Analytics
 
-The main-area learning surface must be fully instrumented in parallel with the existing
-sidebar events. All events use `reportAppInteraction(UserInteraction.X, { ... })` from
-`src/lib/analytics.ts`.
-
-Add the following entries to the `UserInteraction` enum. Naming convention:
-`MainArea<Event>` to clearly segregate from sidebar events.
-
-| Event constant                  | Trigger                                                                           | Key payload fields                                                                     |
-| ------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `MainAreaPageView`              | `MainAreaLearningPanel` mounts (even with no `?doc=` param)                       | `has_doc_param: boolean`, `chrome_nav: string`, `chrome_sidebar: string`               |
-| `MainAreaGuideLoaded`           | Content successfully fetched and rendered                                         | `guide_url: string`, `guide_title: string`, `is_safe: boolean`, `load_time_ms: number` |
-| `MainAreaGuideLoadFailed`       | `fetchContent()` throws or returns an error                                       | `guide_url: string`, `error_message: string`                                           |
-| `MainAreaUnsupportedFormat`     | User attempts to load a non-package-format URL (e.g., `/docs/...`, bare HTML)     | `guide_url: string`, `url_scheme: string`                                              |
-| `MainAreaSafetyGateBlocked`     | Safety gate classifies a guide as unsafe for main area                            | `guide_url: string`, `unsafe_action_types: string[]`                                   |
-| `MainAreaOpenInSidebarClicked`  | User clicks "Open in sidebar" from the safety gate or unsupported-format fallback | `guide_url: string`, `trigger: 'safety_gate' \| 'unsupported_format'`                  |
-| `MainAreaLinkIntercepted`       | `handleGlobalClick` routes an intercepted link to the main area                   | `intercepted_url: string`, `link_title: string`                                        |
-| `MainAreaChromeControlApplied`  | `nav=false` or `sidebar=false` (or `fullscreen=true`) params are processed        | `nav_hidden: boolean`, `sidebar_hidden: boolean`                                       |
-| `MainAreaGuideNavigatedInPlace` | `pathfinder-open-in-main-area` event loads a new guide replacing the current one  | `new_url: string`, `previous_url: string`                                              |
-
-These events parallel the existing sidebar analytics (e.g., `DocsPanelInteraction`,
-`GlobalDocsLinkIntercepted`) but are clearly scoped to the main-area surface. Keeping them
-separate enables per-surface funnel analysis.
-
----
-
-## File Inventory
-
-### New files
-
-| File                                                                  | Purpose                                                   |
-| --------------------------------------------------------------------- | --------------------------------------------------------- |
-| `src/pages/learningPage.ts`                                           | SceneAppPage route definition                             |
-| `src/components/main-area-learning/main-area-learning-panel.tsx`      | SceneObjectBase subclass + renderer for main-area content |
-| `src/components/main-area-learning/main-area-learning-panel.test.tsx` | Unit tests                                                |
-| `src/components/main-area-learning/main-area-learning-state.ts`       | Active-state singleton; used by link-interception routing |
-| `src/components/main-area-learning/main-area-learning-state.test.ts`  | Unit tests for singleton                                  |
-| `src/utils/guide-safety.ts`                                           | `isMainAreaSafe()` utility (Phase 4)                      |
-| `src/utils/guide-safety.test.ts`                                      | Safety classification tests                               |
-| `src/utils/chrome-control.ts`                                         | Nav/sidebar show/hide helpers (Phase 5)                   |
-| `src/utils/chrome-control.test.ts`                                    | Chrome control tests                                      |
-
-### Modified files
-
-| File                                             | Change                                                            |
-| ------------------------------------------------ | ----------------------------------------------------------------- |
-| `src/constants.ts`                               | Add `Learning = 'learning'` to `ROUTES`                           |
-| `src/components/App/App.tsx`                     | Register `learningPage` in `SceneApp` pages                       |
-| `src/components/LearningPaths/MyLearningTab.tsx` | Add `onOpenGuide` prop support if not present (Phase 2)           |
-| `src/global-state/link-interception.ts`          | Add `mainAreaLearningState.getIsActive()` routing check (Phase 2) |
-| `src/lib/analytics.ts`                           | Add `MainArea*` entries to `UserInteraction` enum                 |
+Analytics events use the `MainArea<Event>` naming convention in the `UserInteraction`
+enum (`src/lib/analytics.ts`). All events fire via `reportAppInteraction()` with typed
+payloads. See the enum for the current set.
 
 ---
 
@@ -618,7 +149,8 @@ separate enables per-surface funnel analysis.
    eliminates the only ID conflict.
 
 3. **Link interception routing**: When `/learning` is active, intercepted doc links are
-   routed to the main area via `pathfinder-open-in-main-area` event. See Phase 2.2.
+   routed to the main area via `pathfinder-open-in-main-area` event. See
+   `src/global-state/link-interception.ts`.
 
 4. **Title/breadcrumb**: Static title "Learning" for V1. Dynamic guide title in the
    breadcrumb is a follow-up.
@@ -668,10 +200,6 @@ separate enables per-surface funnel analysis.
   `getIsActive()` / `setIsActive()` API used by link interception routing.
 - "Open in sidebar" button reuses `HomePanel`'s sidebar dispatch pattern
   (`pathfinder-auto-open-docs` event + `sidebarState.openSidebar()` fallback).
-- Only 4 of 9 planned `MainArea*` analytics events are implemented. The remaining 5
-  (`MainAreaSafetyGateBlocked`, `MainAreaOpenInSidebarClicked`,
-  `MainAreaLinkIntercepted`, `MainAreaChromeControlApplied`,
-  `MainAreaGuideNavigatedInPlace`) should be added in Phases 2-5.
 - `MyLearningTab` already has the `onOpenGuide` prop — no changes were needed to its
   interface. Phase 2 just needs to provide a different handler when rendered in the
   main area vs. sidebar.
@@ -721,9 +249,6 @@ separate enables per-surface funnel analysis.
 - `handleOpenGuideInMainArea` is the right place to add the `isMainAreaSafe()` check.
   Both direct calls (from `MyLearningTab`) and `pathfinder-open-in-main-area` events
   flow through this callback.
-- 6 of 9 planned `MainArea*` analytics events are now implemented. Remaining 3:
-  `MainAreaSafetyGateBlocked`, `MainAreaOpenInSidebarClicked`,
-  `MainAreaChromeControlApplied` — for Phases 4-5.
 
 ### Phase 3 — Completed 2026-04-12
 
@@ -788,7 +313,5 @@ separate enables per-surface funnel analysis.
 
 **Notes for Phase 5 (Chrome Controls):**
 
-- 8 of 9 planned `MainArea*` analytics events are now implemented. Remaining 1:
-  `MainAreaChromeControlApplied` — for Phase 5.
 - `locationService` is now imported in the panel (added for safety gate navigation).
   Phase 5 can reuse this import for chrome control navigation.

--- a/docs/design/MAIN-AREA-EDUCATION.md
+++ b/docs/design/MAIN-AREA-EDUCATION.md
@@ -1,5 +1,59 @@
 # Main-Area Education: Rendering Interactive Content Outside the Sidebar
 
+## Strategic Context and Design Rationale
+
+### Why this exists
+
+In a separate repository, we are developing AI skills that can write sophisticated
+Pathfinder packages automatically by consulting many different sources. The resulting
+packages are primarily **not interactive** — they are narrative and conceptual in form,
+with minimal or zero interactive sections (clicking buttons, performing multi-step
+actions, etc.). They are much more likely to contain things like images and video.
+
+The main-area learning view exists to **use Grafana Cloud as a proper shell for arbitrary
+educational content**. By dismissing the left nav and the right-hand sidebar, we reclaim
+the full viewport for content that doesn't need the Grafana UI alongside it.
+
+### The URL as integration primitive
+
+One of the core design decisions is a URL scheme where guides can be passed in and
+displayed in the learning area. This enables a critical integration point: the AI skill
+that writes content can subsequently **open Pathfinder at a particular URL and have that
+content displayed in the main app area**. The URL is the contract between the content
+authoring pipeline and the rendering surface.
+
+```
+/a/grafana-pathfinder-app/learning?doc=bundled:prometheus-grafana-101&fullscreen=true
+```
+
+### Future content forms
+
+This educational content surface is not limited to the current JSON guide format. Future
+content could include:
+
+- **PowerPoint / Google Slides** rendered as individual images inside Grafana Cloud
+- **Video-heavy guides** with narrative text and embedded media
+- **AI-generated narrative content** that is conceptual rather than procedural
+- **Mixed media presentations** combining text, images, diagrams, and code samples
+
+The architecture should accommodate these forms without requiring structural changes to
+the rendering pipeline.
+
+### Design principles
+
+1. **Grafana Cloud as a shell**: The learning view should be able to take over the full
+   viewport, using Grafana only as the host frame (authentication, routing, chrome).
+2. **URL-driven content**: Any content that can be addressed by URL should be displayable.
+   The URL is the integration seam between content authoring and content rendering.
+3. **Narrative-first**: The primary content type is read-and-learn, not click-and-do.
+   Interactive steps are a secondary concern, and content with DOM-targeting interactivity
+   is correctly routed to the sidebar.
+4. **Content pipeline independence**: The rendering surface should not need to know how
+   content was authored (AI skill, manual authoring, imported slides). It only needs a
+   URL and a content format it can render.
+
+---
+
 ## Overview
 
 Render interactive learning content (guides, quizzes, terminal steps, code blocks) in

--- a/pkg/plugin/static/guides/main-area-demo.json
+++ b/pkg/plugin/static/guides/main-area-demo.json
@@ -9,9 +9,9 @@
     },
     {
       "type": "image",
-      "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/Grafana_dashboard_for_MusicBrainz_Hetzner_Yamaoka_server_screenshot.webp/800px-Grafana_dashboard_for_MusicBrainz_Hetzner_Yamaoka_server_screenshot.webp.png",
-      "alt": "Grafana dashboard for a MusicBrainz server",
-      "width": 800
+      "src": "https://grafana.com/static/assets/img/grafana_logo.svg",
+      "alt": "Grafana Logo",
+      "width": 400
     },
     {
       "type": "section",
@@ -55,7 +55,7 @@
     },
     {
       "type": "video",
-      "src": "https://www.youtube.com/watch?v=QGbEA9NKQN0",
+      "src": "https://www.youtube.com/embed/QGbEA9NKQN0",
       "title": "What is Grafana? (Grafana for Beginners ep. 1)"
     },
     {

--- a/pkg/plugin/static/guides/main-area-demo.json
+++ b/pkg/plugin/static/guides/main-area-demo.json
@@ -1,0 +1,90 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "main-area-demo",
+  "title": "What is Grafana?",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "**Grafana** is an open-source analytics and visualization web application. It connects to time series databases and other data sources, allowing users to build dashboards that display metrics, logs, and traces. Grafana supports data sources including Prometheus, Graphite, InfluxDB, Elasticsearch, PostgreSQL, and MySQL.\n\nTorkel Odegaard released Grafana in January 2014 as an outgrowth of work on Graphite at Orbitz. The user interface was originally based on version 3 of Kibana. The company behind the project, initially named Raintank, rebranded as Grafana Labs and has raised over $500 million in venture capital funding, reaching a $6 billion valuation in 2024.\n\nSince 2021, Grafana has been licensed under the AGPLv3 (previously Apache 2.0). A commercial Grafana Enterprise edition adds features including LDAP team synchronization, data source permissions, and reporting."
+    },
+    {
+      "type": "image",
+      "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/Grafana_dashboard_for_MusicBrainz_Hetzner_Yamaoka_server_screenshot.webp/800px-Grafana_dashboard_for_MusicBrainz_Hetzner_Yamaoka_server_screenshot.webp.png",
+      "alt": "Grafana dashboard for a MusicBrainz server",
+      "width": 800
+    },
+    {
+      "type": "section",
+      "title": "History",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Grafana was first released in January 2014, initially targeting Graphite and InfluxDB as data sources. It later added support for relational databases including MySQL, PostgreSQL, and Microsoft SQL Server.\n\nGrafana Labs was founded in 2014 as Raintank and later adopted the Grafana name. The company raised $24 million in Series A funding in 2019, $50 million in Series B in 2020, $220 million in Series C in 2021 (at a $3 billion valuation), and $270 million in 2024 at a $6 billion valuation.\n\nGrafana Labs acquired several companies to expand its observability stack: Kausal (2018), k6 (2021, load testing), Pyroscope (2023, continuous profiling), Asserts.ai (2023, AI-assisted observability), and TailCtrl (2024, trace sampling)."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Architecture",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Grafana's backend is written in Go and its frontend in TypeScript using React. The application runs as a single binary that serves a web interface and connects to external data sources through a plugin system. Plugins fall into three categories: data source plugins (for querying backends), panel plugins (for visualization types), and app plugins (for bundled functionality).\n\nGrafana does not store metrics data itself. It queries external data sources at render time and can combine data from multiple sources in a single dashboard. Built-in data source support includes Prometheus, Graphite, InfluxDB, Elasticsearch, OpenSearch, Loki, MySQL, PostgreSQL, and Splunk.\n\nDashboards are defined as JSON documents and can be provisioned from files, version-controlled, and shared via Grafana's public dashboard library. Alerting rules can be defined against any data source, with notifications routed to email, Slack, PagerDuty, and other channels."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "LGTM Stack",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Grafana Labs develops a set of open-source backends that are often deployed together as the \"LGTM stack\" (Loki, Grafana, Tempo, Mimir):\n\n- **Loki** — a log aggregation system, first released in 2019, that indexes metadata rather than full log text.\n- **Mimir** — a horizontally scalable, Prometheus-compatible metrics backend, released in 2022 as a replacement for Cortex.\n- **Tempo** — a distributed tracing backend, released in 2021.\n- **Pyroscope** — a continuous profiling backend, released in 2023."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Adoption",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Grafana is used by Wikimedia's infrastructure, NASA, and the Tour de France (for real-time race telemetry). As of 2025, Grafana Labs reported over 7,000 paying customers, including Nvidia, Anthropic, and Uber."
+        }
+      ]
+    },
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/watch?v=QGbEA9NKQN0",
+      "title": "What is Grafana? (Grafana for Beginners ep. 1)"
+    },
+    {
+      "type": "quiz",
+      "question": "Which programming languages are used for Grafana's backend and frontend?",
+      "choices": [
+        {
+          "id": "a",
+          "text": "Python and JavaScript",
+          "hint": "Grafana's backend is not written in Python."
+        },
+        {
+          "id": "b",
+          "text": "Go and TypeScript",
+          "correct": true
+        },
+        {
+          "id": "c",
+          "text": "Rust and React",
+          "hint": "React is a framework, not a language. And Grafana's backend isn't written in Rust."
+        },
+        {
+          "id": "d",
+          "text": "Java and Vue.js",
+          "hint": "Grafana doesn't use Java or Vue.js."
+        }
+      ],
+      "completionMode": "max-attempts",
+      "maxAttempts": 2
+    }
+  ]
+}

--- a/src/bundled-interactives/index.json
+++ b/src/bundled-interactives/index.json
@@ -52,6 +52,12 @@
       "summary": "Learn to create a dashboard in Grafana Cloud. Covering features such as Explore, dashboard creation, visualizations and more",
       "filename": "first-dashboard-cloud/content.json",
       "url": ["/a/grafana-setupguide-app/home"]
+    },
+    {
+      "id": "main-area-demo",
+      "title": "What is Grafana?",
+      "filename": "main-area-demo/content.json",
+      "unlisted": true
     }
   ]
 }

--- a/src/bundled-interactives/main-area-demo/content.json
+++ b/src/bundled-interactives/main-area-demo/content.json
@@ -9,9 +9,9 @@
     },
     {
       "type": "image",
-      "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/Grafana_dashboard_for_MusicBrainz_Hetzner_Yamaoka_server_screenshot.webp/800px-Grafana_dashboard_for_MusicBrainz_Hetzner_Yamaoka_server_screenshot.webp.png",
-      "alt": "Grafana dashboard for a MusicBrainz server",
-      "width": 800
+      "src": "https://grafana.com/static/assets/img/grafana_logo.svg",
+      "alt": "Grafana Logo",
+      "width": 400
     },
     {
       "type": "section",
@@ -55,7 +55,7 @@
     },
     {
       "type": "video",
-      "src": "https://www.youtube.com/watch?v=QGbEA9NKQN0",
+      "src": "https://www.youtube.com/embed/QGbEA9NKQN0",
       "title": "What is Grafana? (Grafana for Beginners ep. 1)"
     },
     {

--- a/src/bundled-interactives/main-area-demo/content.json
+++ b/src/bundled-interactives/main-area-demo/content.json
@@ -1,0 +1,90 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "main-area-demo",
+  "title": "What is Grafana?",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "**Grafana** is an open-source analytics and visualization web application. It connects to time series databases and other data sources, allowing users to build dashboards that display metrics, logs, and traces. Grafana supports data sources including Prometheus, Graphite, InfluxDB, Elasticsearch, PostgreSQL, and MySQL.\n\nTorkel Odegaard released Grafana in January 2014 as an outgrowth of work on Graphite at Orbitz. The user interface was originally based on version 3 of Kibana. The company behind the project, initially named Raintank, rebranded as Grafana Labs and has raised over $500 million in venture capital funding, reaching a $6 billion valuation in 2024.\n\nSince 2021, Grafana has been licensed under the AGPLv3 (previously Apache 2.0). A commercial Grafana Enterprise edition adds features including LDAP team synchronization, data source permissions, and reporting."
+    },
+    {
+      "type": "image",
+      "src": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/Grafana_dashboard_for_MusicBrainz_Hetzner_Yamaoka_server_screenshot.webp/800px-Grafana_dashboard_for_MusicBrainz_Hetzner_Yamaoka_server_screenshot.webp.png",
+      "alt": "Grafana dashboard for a MusicBrainz server",
+      "width": 800
+    },
+    {
+      "type": "section",
+      "title": "History",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Grafana was first released in January 2014, initially targeting Graphite and InfluxDB as data sources. It later added support for relational databases including MySQL, PostgreSQL, and Microsoft SQL Server.\n\nGrafana Labs was founded in 2014 as Raintank and later adopted the Grafana name. The company raised $24 million in Series A funding in 2019, $50 million in Series B in 2020, $220 million in Series C in 2021 (at a $3 billion valuation), and $270 million in 2024 at a $6 billion valuation.\n\nGrafana Labs acquired several companies to expand its observability stack: Kausal (2018), k6 (2021, load testing), Pyroscope (2023, continuous profiling), Asserts.ai (2023, AI-assisted observability), and TailCtrl (2024, trace sampling)."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Architecture",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Grafana's backend is written in Go and its frontend in TypeScript using React. The application runs as a single binary that serves a web interface and connects to external data sources through a plugin system. Plugins fall into three categories: data source plugins (for querying backends), panel plugins (for visualization types), and app plugins (for bundled functionality).\n\nGrafana does not store metrics data itself. It queries external data sources at render time and can combine data from multiple sources in a single dashboard. Built-in data source support includes Prometheus, Graphite, InfluxDB, Elasticsearch, OpenSearch, Loki, MySQL, PostgreSQL, and Splunk.\n\nDashboards are defined as JSON documents and can be provisioned from files, version-controlled, and shared via Grafana's public dashboard library. Alerting rules can be defined against any data source, with notifications routed to email, Slack, PagerDuty, and other channels."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "LGTM Stack",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Grafana Labs develops a set of open-source backends that are often deployed together as the \"LGTM stack\" (Loki, Grafana, Tempo, Mimir):\n\n- **Loki** — a log aggregation system, first released in 2019, that indexes metadata rather than full log text.\n- **Mimir** — a horizontally scalable, Prometheus-compatible metrics backend, released in 2022 as a replacement for Cortex.\n- **Tempo** — a distributed tracing backend, released in 2021.\n- **Pyroscope** — a continuous profiling backend, released in 2023."
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "title": "Adoption",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Grafana is used by Wikimedia's infrastructure, NASA, and the Tour de France (for real-time race telemetry). As of 2025, Grafana Labs reported over 7,000 paying customers, including Nvidia, Anthropic, and Uber."
+        }
+      ]
+    },
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/watch?v=QGbEA9NKQN0",
+      "title": "What is Grafana? (Grafana for Beginners ep. 1)"
+    },
+    {
+      "type": "quiz",
+      "question": "Which programming languages are used for Grafana's backend and frontend?",
+      "choices": [
+        {
+          "id": "a",
+          "text": "Python and JavaScript",
+          "hint": "Grafana's backend is not written in Python."
+        },
+        {
+          "id": "b",
+          "text": "Go and TypeScript",
+          "correct": true
+        },
+        {
+          "id": "c",
+          "text": "Rust and React",
+          "hint": "React is a framework, not a language. And Grafana's backend isn't written in Rust."
+        },
+        {
+          "id": "d",
+          "text": "Java and Vue.js",
+          "hint": "Grafana doesn't use Java or Vue.js."
+        }
+      ],
+      "completionMode": "max-attempts",
+      "maxAttempts": 2
+    }
+  ]
+}

--- a/src/bundled-interactives/main-area-demo/manifest.json
+++ b/src/bundled-interactives/main-area-demo/manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": "main-area-demo",
+  "type": "guide",
+  "repository": "bundled",
+  "description": "QA test fixture for main-area learning view. Non-interactive narrative content with image and video blocks.",
+  "category": "test",
+  "author": {
+    "name": "Interactive Learning",
+    "team": "Grafana Developer Advocacy"
+  },
+  "startingLocation": "/",
+  "testEnvironment": {
+    "tier": "local",
+    "minVersion": "12.2.0"
+  }
+}

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -137,6 +137,7 @@ function getSceneApp() {
 }
 
 function App(props: AppRootProps) {
+  console.warn('[App] Mount URL:', window.location.href);
   const scene = useMemo(() => getSceneApp(), []);
 
   // Get configuration

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -8,6 +8,7 @@ import { css } from '@emotion/css';
 import { testIds } from '../../constants/testIds';
 import { homePage } from '../../pages/homePage';
 import { docsPage } from '../../pages/docsPage';
+import { learningPage } from '../../pages/learningPage';
 import { PluginPropsContext } from '../../utils/utils.plugin';
 import { getConfigWithDefaults } from '../../constants';
 import { onPluginStart } from '../../context-engine';
@@ -131,7 +132,7 @@ const getErrorStyles = (theme: GrafanaTheme2) => ({
 
 function getSceneApp() {
   return new SceneApp({
-    pages: [homePage, docsPage],
+    pages: [homePage, docsPage, learningPage],
   });
 }
 

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -137,7 +137,6 @@ function getSceneApp() {
 }
 
 function App(props: AppRootProps) {
-  console.warn('[App] Mount URL:', window.location.href);
   const scene = useMemo(() => getSceneApp(), []);
 
   // Get configuration

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -1714,7 +1714,7 @@ export function InteractiveSection({
               Cancel
             </Button>
           </div>
-        ) : (
+        ) : nonNoopSteps.length === 0 ? null : (
           <Button
             onClick={stepsCompleted && !isCompletedByObjectives ? handleResetSection : handleDoSection}
             disabled={

--- a/src/components/main-area-learning/guide-progress-header.test.tsx
+++ b/src/components/main-area-learning/guide-progress-header.test.tsx
@@ -64,14 +64,8 @@ beforeEach(() => {
 
 describe('GuideProgressHeader', () => {
   const defaultProps = {
-    title: 'Getting started with Prometheus',
     contentKey: 'bundled:prometheus-101',
   };
-
-  it('renders the guide title', () => {
-    render(<GuideProgressHeader {...defaultProps} />);
-    expect(screen.getByText('Getting started with Prometheus')).toBeInTheDocument();
-  });
 
   it('renders the progress header container', () => {
     render(<GuideProgressHeader {...defaultProps} />);
@@ -161,7 +155,7 @@ describe('GuideProgressHeader', () => {
       expect(screen.getByText('25% complete')).toBeInTheDocument();
     });
 
-    rerender(<GuideProgressHeader {...defaultProps} title="New guide" contentKey="bundled:new-guide" />);
+    rerender(<GuideProgressHeader {...defaultProps} contentKey="bundled:new-guide" />);
 
     await waitFor(() => {
       expect(screen.getByText('60% complete')).toBeInTheDocument();

--- a/src/components/main-area-learning/guide-progress-header.test.tsx
+++ b/src/components/main-area-learning/guide-progress-header.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Tests for GuideProgressHeader.
+ *
+ * Validates title display, progress loading from storage, real-time event
+ * updates, content key matching, and sidebar handoff button.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { GuideProgressHeader } from './guide-progress-header';
+import { interactiveCompletionStorage } from '../../lib/user-storage';
+import { testIds } from '../../constants/testIds';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockTheme = {
+  isDark: false,
+  spacing: (n: number) => `${n * 8}px`,
+  shape: { radius: { default: '4px', pill: '9999px' } },
+  colors: {
+    text: { primary: '#000', secondary: '#666', disabled: '#aaa' },
+    background: { primary: '#fff', secondary: '#f5f5f5' },
+    border: { weak: '#ddd' },
+    action: { hover: '#eee' },
+    success: { main: '#0f0' },
+  },
+  typography: {
+    h3: { fontSize: '24px' },
+    body: { fontSize: '14px' },
+    bodySmall: { fontSize: '12px' },
+    fontWeightMedium: 500,
+  },
+};
+
+jest.mock('@grafana/ui', () => ({
+  useStyles2: (fn: any) => fn(mockTheme),
+  Button: ({ children, onClick, ...rest }: any) => (
+    <button data-testid={rest['data-testid']} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('../../lib/user-storage', () => ({
+  interactiveCompletionStorage: {
+    get: jest.fn().mockResolvedValue(0),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (interactiveCompletionStorage.get as jest.Mock).mockResolvedValue(0);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GuideProgressHeader', () => {
+  const defaultProps = {
+    title: 'Getting started with Prometheus',
+    contentKey: 'bundled:prometheus-101',
+    onOpenInSidebar: jest.fn(),
+  };
+
+  it('renders the guide title', () => {
+    render(<GuideProgressHeader {...defaultProps} />);
+    expect(screen.getByText('Getting started with Prometheus')).toBeInTheDocument();
+  });
+
+  it('renders the progress header container', () => {
+    render(<GuideProgressHeader {...defaultProps} />);
+    expect(screen.getByTestId(testIds.mainAreaLearning.progressHeader)).toBeInTheDocument();
+  });
+
+  it('renders the progress bar', () => {
+    render(<GuideProgressHeader {...defaultProps} />);
+    expect(screen.getByTestId(testIds.mainAreaLearning.progressBar)).toBeInTheDocument();
+  });
+
+  it('shows progress percentage after async storage load', async () => {
+    (interactiveCompletionStorage.get as jest.Mock).mockResolvedValue(42);
+
+    render(<GuideProgressHeader {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('42% complete')).toBeInTheDocument();
+    });
+
+    expect(interactiveCompletionStorage.get).toHaveBeenCalledWith('bundled:prometheus-101');
+  });
+
+  it('hides progress text when progress is 0', async () => {
+    (interactiveCompletionStorage.get as jest.Mock).mockResolvedValue(0);
+
+    render(<GuideProgressHeader {...defaultProps} />);
+
+    // Wait for the async load to complete
+    await act(async () => {});
+
+    expect(screen.queryByText(/complete/)).not.toBeInTheDocument();
+  });
+
+  it('updates on interactive-progress-saved event with matching contentKey', async () => {
+    render(<GuideProgressHeader {...defaultProps} />);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('interactive-progress-saved', {
+          detail: {
+            contentKey: 'bundled:prometheus-101',
+            completionPercentage: 75,
+            hasProgress: true,
+          },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('75% complete')).toBeInTheDocument();
+    });
+  });
+
+  it('ignores interactive-progress-saved event with non-matching contentKey', async () => {
+    (interactiveCompletionStorage.get as jest.Mock).mockResolvedValue(10);
+
+    render(<GuideProgressHeader {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('10% complete')).toBeInTheDocument();
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('interactive-progress-saved', {
+          detail: {
+            contentKey: 'bundled:some-other-guide',
+            completionPercentage: 90,
+            hasProgress: true,
+          },
+        })
+      );
+    });
+
+    // Should still show 10%, not 90%
+    expect(screen.getByText('10% complete')).toBeInTheDocument();
+    expect(screen.queryByText('90% complete')).not.toBeInTheDocument();
+  });
+
+  it('calls onOpenInSidebar when button is clicked', () => {
+    const onOpenInSidebar = jest.fn();
+    render(<GuideProgressHeader {...defaultProps} onOpenInSidebar={onOpenInSidebar} />);
+
+    screen.getByTestId(testIds.mainAreaLearning.openInSidebarHeaderButton).click();
+
+    expect(onOpenInSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches progress when contentKey changes', async () => {
+    (interactiveCompletionStorage.get as jest.Mock).mockResolvedValueOnce(25).mockResolvedValueOnce(60);
+
+    const { rerender } = render(<GuideProgressHeader {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('25% complete')).toBeInTheDocument();
+    });
+
+    rerender(<GuideProgressHeader {...defaultProps} title="New guide" contentKey="bundled:new-guide" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('60% complete')).toBeInTheDocument();
+    });
+
+    expect(interactiveCompletionStorage.get).toHaveBeenCalledWith('bundled:new-guide');
+  });
+});

--- a/src/components/main-area-learning/guide-progress-header.test.tsx
+++ b/src/components/main-area-learning/guide-progress-header.test.tsx
@@ -2,7 +2,7 @@
  * Tests for GuideProgressHeader.
  *
  * Validates title display, progress loading from storage, real-time event
- * updates, content key matching, and sidebar handoff button.
+ * updates, and content key matching.
  */
 
 import React from 'react';
@@ -66,7 +66,6 @@ describe('GuideProgressHeader', () => {
   const defaultProps = {
     title: 'Getting started with Prometheus',
     contentKey: 'bundled:prometheus-101',
-    onOpenInSidebar: jest.fn(),
   };
 
   it('renders the guide title', () => {
@@ -151,15 +150,6 @@ describe('GuideProgressHeader', () => {
     // Should still show 10%, not 90%
     expect(screen.getByText('10% complete')).toBeInTheDocument();
     expect(screen.queryByText('90% complete')).not.toBeInTheDocument();
-  });
-
-  it('calls onOpenInSidebar when button is clicked', () => {
-    const onOpenInSidebar = jest.fn();
-    render(<GuideProgressHeader {...defaultProps} onOpenInSidebar={onOpenInSidebar} />);
-
-    screen.getByTestId(testIds.mainAreaLearning.openInSidebarHeaderButton).click();
-
-    expect(onOpenInSidebar).toHaveBeenCalledTimes(1);
   });
 
   it('re-fetches progress when contentKey changes', async () => {

--- a/src/components/main-area-learning/guide-progress-header.tsx
+++ b/src/components/main-area-learning/guide-progress-header.tsx
@@ -20,12 +20,11 @@ import { testIds } from '../../constants/testIds';
 type LayoutWidth = 'default' | 'wide' | 'full';
 
 interface GuideProgressHeaderProps {
-  title: string;
   contentKey: string;
   layoutWidth?: LayoutWidth;
 }
 
-export function GuideProgressHeader({ title, contentKey, layoutWidth = 'default' }: GuideProgressHeaderProps) {
+export function GuideProgressHeader({ contentKey, layoutWidth = 'default' }: GuideProgressHeaderProps) {
   const styles = useStyles2(getStyles);
   const headerMaxWidth = layoutWidth === 'full' ? 'none' : layoutWidth === 'wide' ? '72rem' : '48rem';
   const [progress, setProgress] = useState(0);
@@ -68,12 +67,13 @@ export function GuideProgressHeader({ title, contentKey, layoutWidth = 'default'
       style={{ maxWidth: headerMaxWidth }}
       data-testid={testIds.mainAreaLearning.progressHeader}
     >
-      <div className={styles.headerRow}>
-        <h2 className={styles.title}>{title}</h2>
-        <div className={styles.actions}>
-          {roundedProgress > 0 && <span className={styles.progressText}>{roundedProgress}% complete</span>}
+      {roundedProgress > 0 && (
+        <div className={styles.headerRow}>
+          <div className={styles.actions}>
+            <span className={styles.progressText}>{roundedProgress}% complete</span>
+          </div>
         </div>
-      </div>
+      )}
       <div className={styles.progressBar} data-testid={testIds.mainAreaLearning.progressBar}>
         <div className={styles.progressFill} style={{ width: `${roundedProgress}%` }} />
       </div>
@@ -91,21 +91,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   headerRow: css({
     display: 'flex',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-end',
     alignItems: 'center',
-    gap: theme.spacing(2),
     marginBottom: theme.spacing(1),
-  }),
-  title: css({
-    fontSize: theme.typography.h3.fontSize,
-    fontWeight: theme.typography.fontWeightMedium,
-    color: theme.colors.text.primary,
-    margin: 0,
-    lineHeight: 1.3,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    flex: 1,
   }),
   actions: css({
     display: 'flex',

--- a/src/components/main-area-learning/guide-progress-header.tsx
+++ b/src/components/main-area-learning/guide-progress-header.tsx
@@ -17,14 +17,23 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { interactiveCompletionStorage } from '../../lib/user-storage';
 import { testIds } from '../../constants/testIds';
 
+type LayoutWidth = 'default' | 'wide' | 'full';
+
 interface GuideProgressHeaderProps {
   title: string;
   contentKey: string;
   onOpenInSidebar: () => void;
+  layoutWidth?: LayoutWidth;
 }
 
-export function GuideProgressHeader({ title, contentKey, onOpenInSidebar }: GuideProgressHeaderProps) {
+export function GuideProgressHeader({
+  title,
+  contentKey,
+  onOpenInSidebar,
+  layoutWidth = 'default',
+}: GuideProgressHeaderProps) {
   const styles = useStyles2(getStyles);
+  const headerMaxWidth = layoutWidth === 'full' ? 'none' : layoutWidth === 'wide' ? '72rem' : '48rem';
   const [progress, setProgress] = useState(0);
 
   // Fetch initial progress from storage
@@ -60,7 +69,11 @@ export function GuideProgressHeader({ title, contentKey, onOpenInSidebar }: Guid
   const roundedProgress = Math.round(progress);
 
   return (
-    <div className={styles.header} data-testid={testIds.mainAreaLearning.progressHeader}>
+    <div
+      className={styles.header}
+      style={{ maxWidth: headerMaxWidth }}
+      data-testid={testIds.mainAreaLearning.progressHeader}
+    >
       <div className={styles.headerRow}>
         <h2 className={styles.title}>{title}</h2>
         <div className={styles.actions}>

--- a/src/components/main-area-learning/guide-progress-header.tsx
+++ b/src/components/main-area-learning/guide-progress-header.tsx
@@ -1,0 +1,134 @@
+/**
+ * Guide Progress Header
+ *
+ * Displays guide title, completion progress, and an "Open in sidebar" action
+ * above the content area in the main-area learning view.
+ *
+ * Progress updates via:
+ * - Initial async read from interactiveCompletionStorage
+ * - Real-time `interactive-progress-saved` window events from interactive components
+ */
+
+import React, { useState, useEffect } from 'react';
+import { Button, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+
+import { interactiveCompletionStorage } from '../../lib/user-storage';
+import { testIds } from '../../constants/testIds';
+
+interface GuideProgressHeaderProps {
+  title: string;
+  contentKey: string;
+  onOpenInSidebar: () => void;
+}
+
+export function GuideProgressHeader({ title, contentKey, onOpenInSidebar }: GuideProgressHeaderProps) {
+  const styles = useStyles2(getStyles);
+  const [progress, setProgress] = useState(0);
+
+  // Fetch initial progress from storage
+  useEffect(() => {
+    let cancelled = false;
+
+    interactiveCompletionStorage.get(contentKey).then((value) => {
+      if (!cancelled) {
+        setProgress(value);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [contentKey]);
+
+  // Listen for real-time progress updates from interactive components
+  useEffect(() => {
+    const handleProgressSaved = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      if (detail?.contentKey === contentKey && typeof detail?.completionPercentage === 'number') {
+        setProgress(detail.completionPercentage);
+      }
+    };
+
+    window.addEventListener('interactive-progress-saved', handleProgressSaved);
+    return () => {
+      window.removeEventListener('interactive-progress-saved', handleProgressSaved);
+    };
+  }, [contentKey]);
+
+  const roundedProgress = Math.round(progress);
+
+  return (
+    <div className={styles.header} data-testid={testIds.mainAreaLearning.progressHeader}>
+      <div className={styles.headerRow}>
+        <h2 className={styles.title}>{title}</h2>
+        <div className={styles.actions}>
+          {roundedProgress > 0 && <span className={styles.progressText}>{roundedProgress}% complete</span>}
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onOpenInSidebar}
+            data-testid={testIds.mainAreaLearning.openInSidebarHeaderButton}
+          >
+            Open in sidebar
+          </Button>
+        </div>
+      </div>
+      <div className={styles.progressBar} data-testid={testIds.mainAreaLearning.progressBar}>
+        <div className={styles.progressFill} style={{ width: `${roundedProgress}%` }} />
+      </div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  header: css({
+    maxWidth: '48rem',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    width: '100%',
+    marginBottom: theme.spacing(2),
+  }),
+  headerRow: css({
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+    marginBottom: theme.spacing(1),
+  }),
+  title: css({
+    fontSize: theme.typography.h3.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+    color: theme.colors.text.primary,
+    margin: 0,
+    lineHeight: 1.3,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    flex: 1,
+  }),
+  actions: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    flexShrink: 0,
+  }),
+  progressText: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    whiteSpace: 'nowrap',
+  }),
+  progressBar: css({
+    width: '100%',
+    height: '3px',
+    backgroundColor: theme.colors.background.secondary,
+    borderRadius: '2px',
+    overflow: 'hidden',
+  }),
+  progressFill: css({
+    height: '100%',
+    backgroundColor: theme.colors.success.main,
+    transition: 'width 0.3s ease',
+  }),
+});

--- a/src/components/main-area-learning/guide-progress-header.tsx
+++ b/src/components/main-area-learning/guide-progress-header.tsx
@@ -1,8 +1,8 @@
 /**
  * Guide Progress Header
  *
- * Displays guide title, completion progress, and an "Open in sidebar" action
- * above the content area in the main-area learning view.
+ * Displays guide title and completion progress above the content area
+ * in the main-area learning view.
  *
  * Progress updates via:
  * - Initial async read from interactiveCompletionStorage
@@ -10,7 +10,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Button, useStyles2 } from '@grafana/ui';
+import { useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 
@@ -22,16 +22,10 @@ type LayoutWidth = 'default' | 'wide' | 'full';
 interface GuideProgressHeaderProps {
   title: string;
   contentKey: string;
-  onOpenInSidebar: () => void;
   layoutWidth?: LayoutWidth;
 }
 
-export function GuideProgressHeader({
-  title,
-  contentKey,
-  onOpenInSidebar,
-  layoutWidth = 'default',
-}: GuideProgressHeaderProps) {
+export function GuideProgressHeader({ title, contentKey, layoutWidth = 'default' }: GuideProgressHeaderProps) {
   const styles = useStyles2(getStyles);
   const headerMaxWidth = layoutWidth === 'full' ? 'none' : layoutWidth === 'wide' ? '72rem' : '48rem';
   const [progress, setProgress] = useState(0);
@@ -78,14 +72,6 @@ export function GuideProgressHeader({
         <h2 className={styles.title}>{title}</h2>
         <div className={styles.actions}>
           {roundedProgress > 0 && <span className={styles.progressText}>{roundedProgress}% complete</span>}
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={onOpenInSidebar}
-            data-testid={testIds.mainAreaLearning.openInSidebarHeaderButton}
-          >
-            Open in sidebar
-          </Button>
         </div>
       </div>
       <div className={styles.progressBar} data-testid={testIds.mainAreaLearning.progressBar}>

--- a/src/components/main-area-learning/index.ts
+++ b/src/components/main-area-learning/index.ts
@@ -1,0 +1,1 @@
+export { MainAreaLearningPanel, MainAreaLearningPanelRenderer } from './main-area-learning-panel';

--- a/src/components/main-area-learning/main-area-learning-panel.test.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.test.tsx
@@ -1,0 +1,1089 @@
+/**
+ * Tests for MainAreaLearningPanelRenderer.
+ *
+ * Validates content loading, format restriction, error states, landing page
+ * fallback, URL cleanup, and analytics instrumentation.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { MainAreaLearningPanelRenderer } from './main-area-learning-panel';
+import { findDocPage } from '../../utils/find-doc-page';
+import { fetchUnifiedContent as fetchContent } from '../../docs-retrieval';
+import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import { sidebarState } from '../../global-state/sidebar';
+import { testIds } from '../../constants/testIds';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockLocationPush = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(),
+  reportInteraction: jest.fn(),
+  getAppEvents: jest.fn(() => ({ publish: jest.fn() })),
+  config: { bootData: { user: { id: 1 } } },
+  locationService: { push: (...args: any[]) => mockLocationPush(...args) },
+}));
+
+jest.mock('@grafana/scenes', () => ({
+  SceneObjectBase: class SceneObjectBase {},
+}));
+
+jest.mock('@grafana/ui', () => ({
+  useStyles2: (fn: any) => fn(mockTheme),
+  Alert: ({ children, title, severity, ...rest }: any) => (
+    <div data-testid={rest['data-testid']} data-severity={severity}>
+      <span>{title}</span>
+      {children}
+    </div>
+  ),
+  Button: ({ children, onClick, ...rest }: any) => (
+    <button data-testid={rest['data-testid']} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('@grafana/i18n', () => ({
+  t: jest.fn((_: string, def: string) => def),
+}));
+
+const mockTheme = {
+  isDark: false,
+  spacing: (n: number) => `${n * 8}px`,
+  shape: { radius: { default: '4px', pill: '9999px' } },
+  colors: {
+    text: { primary: '#000', secondary: '#666', disabled: '#aaa' },
+    background: { primary: '#fff', secondary: '#f5f5f5' },
+    border: { weak: '#ddd' },
+    action: { hover: '#eee' },
+    primary: { shade: '#333' },
+    error: { text: '#f00' },
+    success: { main: '#0f0' },
+  },
+  typography: {
+    h3: { fontSize: '24px' },
+    h5: { fontSize: '16px' },
+    body: { fontSize: '14px' },
+    bodySmall: { fontSize: '12px' },
+    fontWeightMedium: 500,
+  },
+  zIndex: { modal: 1000 },
+};
+
+jest.mock('../../utils/find-doc-page');
+jest.mock('../../docs-retrieval', () => ({
+  fetchUnifiedContent: jest.fn(),
+  ContentRenderer: React.memo(function MockContentRenderer({ content }: any) {
+    return <div data-testid="content-renderer">{content.url}</div>;
+  }),
+}));
+
+jest.mock('../SkeletonLoader', () => ({
+  SkeletonLoader: () => <div data-testid="skeleton-loader">Loading...</div>,
+}));
+
+let capturedOnOpenGuide: ((url: string, title: string) => void) | undefined;
+
+jest.mock('../LearningPaths', () => ({
+  MyLearningTab: ({ onOpenGuide }: { onOpenGuide: (url: string, title: string) => void }) => {
+    capturedOnOpenGuide = onOpenGuide;
+    return <div data-testid="my-learning-tab">MyLearningTab</div>;
+  },
+}));
+
+jest.mock('../docs-panel/components', () => ({
+  MyLearningErrorBoundary: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('../../global-state/sidebar', () => ({
+  sidebarState: {
+    getIsSidebarMounted: jest.fn(),
+    setPendingOpenSource: jest.fn(),
+    openSidebar: jest.fn(),
+    openWithGuide: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/guide-safety', () => ({
+  isMainAreaSafe: jest.fn(() => ({ safe: true, unsafeActionTypes: [] })),
+}));
+
+jest.mock('../../utils/chrome-control', () => ({
+  isNavVisible: jest.fn(() => false),
+  collapseNav: jest.fn(),
+  expandNav: jest.fn(),
+  closeExtensionSidebar: jest.fn(),
+  restoreSidebar: jest.fn(),
+}));
+
+jest.mock('../../global-state/link-interception', () => ({
+  linkInterceptionState: {
+    addToQueue: jest.fn(),
+  },
+}));
+
+jest.mock('../../global-state/main-area-learning-state', () => ({
+  mainAreaLearningState: { getIsActive: jest.fn(() => false), setIsActive: jest.fn() },
+}));
+
+jest.mock('../../lib/user-storage', () => ({
+  interactiveCompletionStorage: {
+    get: jest.fn().mockResolvedValue(0),
+    set: jest.fn().mockResolvedValue(undefined),
+    clear: jest.fn().mockResolvedValue(undefined),
+    getAll: jest.fn().mockResolvedValue({}),
+    cleanup: jest.fn().mockResolvedValue(undefined),
+    clearAll: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+const { interactiveCompletionStorage: mockCompletionStorage } = jest.requireMock('../../lib/user-storage');
+// Import after mock setup for assertions
+const { mainAreaLearningState: mockMainAreaState } = jest.requireMock('../../global-state/main-area-learning-state');
+const { isMainAreaSafe: mockIsMainAreaSafe } = jest.requireMock('../../utils/guide-safety');
+const {
+  isNavVisible: mockIsNavVisible,
+  collapseNav: mockCollapseNav,
+  expandNav: mockExpandNav,
+  closeExtensionSidebar: mockCloseExtensionSidebar,
+  restoreSidebar: mockRestoreSidebar,
+} = jest.requireMock('../../utils/chrome-control');
+
+jest.mock('../../lib/analytics', () => ({
+  reportAppInteraction: jest.fn(),
+  UserInteraction: {
+    MainAreaPageView: 'main_area_page_view',
+    MainAreaGuideLoaded: 'main_area_guide_loaded',
+    MainAreaGuideLoadFailed: 'main_area_guide_load_failed',
+    MainAreaUnsupportedFormat: 'main_area_unsupported_format',
+    MainAreaGuideNavigatedInPlace: 'main_area_guide_navigated_in_place',
+    MainAreaSafetyGateBlocked: 'main_area_safety_gate_blocked',
+    MainAreaOpenInSidebarClicked: 'main_area_open_in_sidebar_clicked',
+    MainAreaChromeControlApplied: 'main_area_chrome_control_applied',
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// URL helpers
+// ---------------------------------------------------------------------------
+
+let replaceStateSpy: jest.SpyInstance;
+
+function setUrlSearch(search: string) {
+  const url = `http://localhost/a/grafana-pathfinder-app/learning${search}`;
+  window.history.pushState({}, '', url);
+}
+
+function makeRawContent(url: string): any {
+  return {
+    content: '{}',
+    metadata: { title: 'Test Guide' },
+    type: 'interactive',
+    url,
+    lastFetched: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  capturedOnOpenGuide = undefined;
+  setUrlSearch('');
+  replaceStateSpy = jest.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  replaceStateSpy?.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MainAreaLearningPanelRenderer', () => {
+  // --- Landing page fallback -----------------------------------------------
+
+  describe('landing page', () => {
+    it('renders MyLearningTab when no ?doc= param', () => {
+      setUrlSearch('');
+      render(<MainAreaLearningPanelRenderer />);
+      expect(screen.getByTestId('my-learning-tab')).toBeInTheDocument();
+      expect(screen.getByTestId(testIds.mainAreaLearning.landingPage)).toBeInTheDocument();
+      // onOpenGuide callback is wired up to MyLearningTab
+      expect(capturedOnOpenGuide).toBeDefined();
+    });
+
+    it('renders MyLearningTab when findDocPage returns null', async () => {
+      setUrlSearch('?doc=unknown-thing');
+      (findDocPage as jest.Mock).mockReturnValue(null);
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(screen.getByTestId('my-learning-tab')).toBeInTheDocument();
+    });
+  });
+
+  // --- Loading state -------------------------------------------------------
+
+  describe('loading state', () => {
+    it('shows SkeletonLoader while fetchContent is in flight', async () => {
+      setUrlSearch('?doc=bundled:test-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test-guide',
+        title: 'Test Guide',
+      });
+      // Never resolve — keeps loading
+      (fetchContent as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(screen.getByTestId(testIds.mainAreaLearning.loadingState)).toBeInTheDocument();
+      expect(screen.getByTestId('skeleton-loader')).toBeInTheDocument();
+    });
+  });
+
+  // --- Content rendering ---------------------------------------------------
+
+  describe('content rendering', () => {
+    it('renders ContentRenderer with fetched RawContent', async () => {
+      setUrlSearch('?doc=bundled:test-guide');
+      const rawContent = makeRawContent('bundled:test-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test-guide',
+        title: 'Test Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('content-renderer')).toBeInTheDocument();
+      });
+    });
+
+    it('content container has id="main-area-docs-content"', async () => {
+      setUrlSearch('?doc=bundled:test-guide');
+      const rawContent = makeRawContent('bundled:test-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test-guide',
+        title: 'Test Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(testIds.mainAreaLearning.contentContainer)).toBeInTheDocument();
+      });
+
+      const container = screen.getByTestId(testIds.mainAreaLearning.contentContainer);
+      expect(container.id).toBe('main-area-docs-content');
+    });
+  });
+
+  // --- Error state ---------------------------------------------------------
+
+  describe('error state', () => {
+    it('shows error Alert with "Try again" on fetch failure', async () => {
+      setUrlSearch('?doc=bundled:broken');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:broken',
+        title: 'Broken Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({
+        content: null,
+        error: 'Network error',
+        errorType: 'network',
+      });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(testIds.mainAreaLearning.errorState)).toBeInTheDocument();
+      });
+      expect(screen.getByTestId(testIds.mainAreaLearning.retryButton)).toBeInTheDocument();
+    });
+
+    it('"Try again" re-triggers fetchContent', async () => {
+      setUrlSearch('?doc=bundled:broken');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:broken',
+        title: 'Broken Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({
+        content: null,
+        error: 'Network error',
+        errorType: 'network',
+      });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(testIds.mainAreaLearning.retryButton)).toBeInTheDocument();
+      });
+
+      // Reset mock and make it succeed on retry
+      const rawContent = makeRawContent('bundled:broken');
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      await act(async () => {
+        screen.getByTestId(testIds.mainAreaLearning.retryButton).click();
+      });
+
+      await waitFor(() => {
+        expect(fetchContent).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  // --- URL cleanup ---------------------------------------------------------
+
+  describe('URL cleanup', () => {
+    it('strips ?doc= param after processing', () => {
+      setUrlSearch('?doc=bundled:test-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test-guide',
+        title: 'Test Guide',
+      });
+      (fetchContent as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(replaceStateSpy).toHaveBeenCalled();
+    });
+  });
+
+  // --- Content format restriction ------------------------------------------
+
+  describe('content format restriction', () => {
+    it('rejects /docs/ paths with unsupported format error', () => {
+      setUrlSearch('?doc=/docs/grafana/latest/getting-started/');
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(screen.getByTestId(testIds.mainAreaLearning.unsupportedFormatError)).toBeInTheDocument();
+      expect(screen.getByTestId(testIds.mainAreaLearning.openInSidebarButton)).toBeInTheDocument();
+      expect(findDocPage).not.toHaveBeenCalled();
+    });
+
+    it('rejects grafana.com URLs with unsupported format error', () => {
+      setUrlSearch('?doc=https://grafana.com/docs/grafana/latest/');
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(screen.getByTestId(testIds.mainAreaLearning.unsupportedFormatError)).toBeInTheDocument();
+      expect(findDocPage).not.toHaveBeenCalled();
+    });
+
+    it('rejects docs.grafana.com URLs with unsupported format error', () => {
+      setUrlSearch('?doc=https://docs.grafana.com/docs/grafana/latest/');
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(screen.getByTestId(testIds.mainAreaLearning.unsupportedFormatError)).toBeInTheDocument();
+    });
+
+    it('accepts bundled: URLs', async () => {
+      setUrlSearch('?doc=bundled:test-guide');
+      const rawContent = makeRawContent('bundled:test-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test-guide',
+        title: 'Test Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('content-renderer')).toBeInTheDocument();
+      });
+    });
+
+    it('accepts api: URLs', async () => {
+      setUrlSearch('?doc=api:my-custom-guide');
+      const rawContent = makeRawContent('backend-guide:my-custom-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'backend-guide:my-custom-guide',
+        title: 'my-custom-guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('content-renderer')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // --- Analytics -----------------------------------------------------------
+
+  describe('analytics', () => {
+    it('fires MainAreaPageView on mount', () => {
+      setUrlSearch('');
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaPageView, {
+        has_doc_param: false,
+      });
+    });
+
+    it('fires MainAreaPageView with has_doc_param=true when param present', () => {
+      setUrlSearch('?doc=bundled:test');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test',
+        title: 'Test',
+      });
+      (fetchContent as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaPageView, {
+        has_doc_param: true,
+      });
+    });
+
+    it('fires MainAreaGuideLoaded on successful fetch', async () => {
+      setUrlSearch('?doc=bundled:test-guide');
+      const rawContent = makeRawContent('bundled:test-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test-guide',
+        title: 'Test Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(reportAppInteraction).toHaveBeenCalledWith(
+          UserInteraction.MainAreaGuideLoaded,
+          expect.objectContaining({
+            guide_url: 'bundled:test-guide',
+            guide_title: 'Test Guide',
+          })
+        );
+      });
+    });
+
+    it('fires MainAreaGuideLoadFailed on fetch error', async () => {
+      setUrlSearch('?doc=bundled:broken');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:broken',
+        title: 'Broken',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({
+        content: null,
+        error: 'Not found',
+        errorType: 'not-found',
+      });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaGuideLoadFailed, {
+          guide_url: 'bundled:broken',
+          error_message: 'Not found',
+        });
+      });
+    });
+
+    it('fires MainAreaUnsupportedFormat for /docs/ paths', () => {
+      setUrlSearch('?doc=/docs/grafana/latest/');
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaUnsupportedFormat, {
+        guide_url: '/docs/grafana/latest/',
+        url_scheme: 'raw_docs_path',
+      });
+    });
+
+    it('fires MainAreaUnsupportedFormat for grafana.com URLs', () => {
+      setUrlSearch('?doc=https://grafana.com/docs/grafana/latest/');
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaUnsupportedFormat, {
+        guide_url: 'https://grafana.com/docs/grafana/latest/',
+        url_scheme: 'grafana_docs_url',
+      });
+    });
+  });
+
+  // --- Sidebar handoff -----------------------------------------------------
+
+  describe('sidebar handoff', () => {
+    it('"Open in sidebar" dispatches to sidebar when mounted', () => {
+      setUrlSearch('?doc=/docs/grafana/latest/');
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
+      const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+
+      render(<MainAreaLearningPanelRenderer />);
+      screen.getByTestId(testIds.mainAreaLearning.openInSidebarButton).click();
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'pathfinder-auto-open-docs',
+          detail: expect.objectContaining({ url: '/docs/grafana/latest/' }),
+        })
+      );
+
+      dispatchSpy.mockRestore();
+    });
+  });
+
+  // --- Phase 2: Active state ------------------------------------------------
+
+  describe('active state', () => {
+    it('sets mainAreaLearningState active on mount', () => {
+      setUrlSearch('');
+      render(<MainAreaLearningPanelRenderer />);
+      expect(mockMainAreaState.setIsActive).toHaveBeenCalledWith(true);
+    });
+
+    it('sets mainAreaLearningState inactive on unmount', () => {
+      setUrlSearch('');
+      const { unmount } = render(<MainAreaLearningPanelRenderer />);
+      unmount();
+      expect(mockMainAreaState.setIsActive).toHaveBeenCalledWith(false);
+    });
+  });
+
+  // --- Phase 2: In-place navigation -----------------------------------------
+
+  describe('in-place navigation', () => {
+    it('handleOpenGuideInMainArea loads content without page reload', async () => {
+      setUrlSearch('');
+      const rawContent = makeRawContent('bundled:second-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:second-guide',
+        title: 'Second Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      // Landing page is shown initially
+      expect(screen.getByTestId('my-learning-tab')).toBeInTheDocument();
+      expect(capturedOnOpenGuide).toBeDefined();
+
+      // Trigger in-place navigation via the onOpenGuide callback
+      await act(async () => {
+        capturedOnOpenGuide!('bundled:second-guide', 'Second Guide');
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('content-renderer')).toBeInTheDocument();
+      });
+
+      // Landing page should be gone
+      expect(screen.queryByTestId('my-learning-tab')).not.toBeInTheDocument();
+    });
+
+    it('pathfinder-open-in-main-area event loads content in-place', async () => {
+      setUrlSearch('');
+      const rawContent = makeRawContent('bundled:event-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:event-guide',
+        title: 'Event Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      // Dispatch the custom event
+      await act(async () => {
+        document.dispatchEvent(
+          new CustomEvent('pathfinder-open-in-main-area', {
+            detail: { url: 'bundled:event-guide', title: 'Event Guide' },
+          })
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('content-renderer')).toBeInTheDocument();
+      });
+    });
+
+    it('fires MainAreaGuideNavigatedInPlace on in-place navigation via event', async () => {
+      setUrlSearch('');
+      const rawContent = makeRawContent('bundled:nav-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:nav-guide',
+        title: 'Nav Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await act(async () => {
+        document.dispatchEvent(
+          new CustomEvent('pathfinder-open-in-main-area', {
+            detail: { url: 'bundled:nav-guide', title: 'Nav Guide' },
+          })
+        );
+      });
+
+      await waitFor(() => {
+        expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaGuideNavigatedInPlace, {
+          new_url: 'bundled:nav-guide',
+          previous_url: '',
+        });
+      });
+    });
+
+    it('ignores unsupported URLs in handleOpenGuideInMainArea', () => {
+      setUrlSearch('');
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(capturedOnOpenGuide).toBeDefined();
+
+      // Call with an unsupported URL — should not trigger fetchContent
+      act(() => {
+        capturedOnOpenGuide!('/docs/grafana/latest/', 'Docs');
+      });
+
+      expect(fetchContent).not.toHaveBeenCalled();
+      // Landing page should still be shown
+      expect(screen.getByTestId('my-learning-tab')).toBeInTheDocument();
+    });
+  });
+
+  // --- Phase 3: Layout and styling -------------------------------------------
+
+  describe('layout and styling', () => {
+    it('content container has contentBody class with max-width constraint', async () => {
+      setUrlSearch('?doc=bundled:test-guide');
+      const rawContent = makeRawContent('bundled:test-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test-guide',
+        title: 'Test Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(testIds.mainAreaLearning.contentContainer)).toBeInTheDocument();
+      });
+
+      const container = screen.getByTestId(testIds.mainAreaLearning.contentContainer);
+      // The contentBody class is applied (Emotion generates a className)
+      expect(container.className).toBeTruthy();
+      expect(container.className.length).toBeGreaterThan(0);
+    });
+
+    it('renders GuideProgressHeader when content is loaded', async () => {
+      setUrlSearch('?doc=bundled:test-guide');
+      const rawContent = makeRawContent('bundled:test-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test-guide',
+        title: 'Test Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(testIds.mainAreaLearning.progressHeader)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Test Guide')).toBeInTheDocument();
+    });
+
+    it('progress header shows completion percentage from storage', async () => {
+      setUrlSearch('?doc=bundled:test-guide');
+      const rawContent = makeRawContent('bundled:test-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test-guide',
+        title: 'Test Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+      mockCompletionStorage.get.mockResolvedValue(42);
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByText('42% complete')).toBeInTheDocument();
+      });
+    });
+
+    it('progress header updates on interactive-progress-saved event', async () => {
+      setUrlSearch('?doc=bundled:test-guide');
+      const rawContent = makeRawContent('bundled:test-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test-guide',
+        title: 'Test Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+      mockCompletionStorage.get.mockResolvedValue(0);
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(testIds.mainAreaLearning.progressHeader)).toBeInTheDocument();
+      });
+
+      // Dispatch progress event
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent('interactive-progress-saved', {
+            detail: { contentKey: 'bundled:test-guide', completionPercentage: 75, hasProgress: true },
+          })
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('75% complete')).toBeInTheDocument();
+      });
+    });
+
+    it('does not show progress header on landing page', () => {
+      setUrlSearch('');
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(screen.queryByTestId(testIds.mainAreaLearning.progressHeader)).not.toBeInTheDocument();
+    });
+  });
+
+  // --- Phase 4: Content safety gate ------------------------------------------
+
+  describe('content safety gate', () => {
+    it('shows safety gate warning for unsafe guides', async () => {
+      setUrlSearch('?doc=bundled:unsafe-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:unsafe-guide',
+        title: 'Unsafe Guide',
+      });
+      const rawContent = makeRawContent('bundled:unsafe-guide');
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+      mockIsMainAreaSafe.mockReturnValue({ safe: false, unsafeActionTypes: ['highlight', 'button'] });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(testIds.mainAreaLearning.safetyGateWarning)).toBeInTheDocument();
+      });
+
+      // Content should NOT be rendered
+      expect(screen.queryByTestId('content-renderer')).not.toBeInTheDocument();
+      expect(screen.queryByTestId(testIds.mainAreaLearning.progressHeader)).not.toBeInTheDocument();
+    });
+
+    it('fires MainAreaSafetyGateBlocked analytics for unsafe guides', async () => {
+      setUrlSearch('?doc=bundled:unsafe-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:unsafe-guide',
+        title: 'Unsafe Guide',
+      });
+      const rawContent = makeRawContent('bundled:unsafe-guide');
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+      mockIsMainAreaSafe.mockReturnValue({ safe: false, unsafeActionTypes: ['highlight'] });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaSafetyGateBlocked, {
+          guide_url: 'bundled:unsafe-guide',
+          unsafe_action_types: 'highlight',
+        });
+      });
+    });
+
+    it('renders content normally for safe guides', async () => {
+      setUrlSearch('?doc=bundled:safe-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:safe-guide',
+        title: 'Safe Guide',
+      });
+      const rawContent = makeRawContent('bundled:safe-guide');
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+      mockIsMainAreaSafe.mockReturnValue({ safe: true, unsafeActionTypes: [] });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('content-renderer')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTestId(testIds.mainAreaLearning.safetyGateWarning)).not.toBeInTheDocument();
+    });
+
+    it('safety gate "Open in sidebar" calls openWithGuide for bundled URLs', async () => {
+      setUrlSearch('?doc=bundled:unsafe-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:unsafe-guide',
+        title: 'Unsafe Guide',
+      });
+      const rawContent = makeRawContent('bundled:unsafe-guide');
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+      mockIsMainAreaSafe.mockReturnValue({ safe: false, unsafeActionTypes: ['button'] });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(testIds.mainAreaLearning.safetyGateOpenInSidebarButton)).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        screen.getByTestId(testIds.mainAreaLearning.safetyGateOpenInSidebarButton).click();
+      });
+
+      expect(sidebarState.openWithGuide).toHaveBeenCalledWith('unsafe-guide');
+      expect(mockLocationPush).toHaveBeenCalledWith('/a/grafana-pathfinder-app');
+    });
+
+    it('safety gate resets when navigating to a new guide in-place', async () => {
+      setUrlSearch('');
+      mockIsMainAreaSafe.mockReturnValue({ safe: false, unsafeActionTypes: ['highlight'] });
+
+      const rawContent = makeRawContent('bundled:unsafe-guide');
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:unsafe-guide',
+        title: 'Unsafe Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      // Navigate to an unsafe guide via onOpenGuide
+      await act(async () => {
+        capturedOnOpenGuide!('bundled:unsafe-guide', 'Unsafe Guide');
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId(testIds.mainAreaLearning.safetyGateWarning)).toBeInTheDocument();
+      });
+
+      // Now navigate to a safe guide
+      const safeContent = makeRawContent('bundled:safe-guide');
+      mockIsMainAreaSafe.mockReturnValue({ safe: true, unsafeActionTypes: [] });
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:safe-guide',
+        title: 'Safe Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: safeContent });
+
+      await act(async () => {
+        capturedOnOpenGuide!('bundled:safe-guide', 'Safe Guide');
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('content-renderer')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTestId(testIds.mainAreaLearning.safetyGateWarning)).not.toBeInTheDocument();
+    });
+  });
+
+  // --- Phase 5: Chrome controls -----------------------------------------------
+
+  describe('chrome controls', () => {
+    it('does not touch nav or sidebar when no chrome params', () => {
+      setUrlSearch('');
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(mockCollapseNav).not.toHaveBeenCalled();
+      expect(mockCloseExtensionSidebar).not.toHaveBeenCalled();
+    });
+
+    it('collapses nav when nav=false and nav is visible', () => {
+      setUrlSearch('?nav=false');
+      mockIsNavVisible.mockReturnValue(true);
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(mockCollapseNav).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not collapse nav when nav=false but nav is already hidden', () => {
+      setUrlSearch('?nav=false');
+      mockIsNavVisible.mockReturnValue(false);
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(mockCollapseNav).not.toHaveBeenCalled();
+    });
+
+    it('closes sidebar when sidebar=false and sidebar is mounted', () => {
+      setUrlSearch('?sidebar=false');
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(mockCloseExtensionSidebar).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not close sidebar when sidebar=false but sidebar is not mounted', () => {
+      setUrlSearch('?sidebar=false');
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(false);
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      // Initial close not called (sidebar wasn't mounted)
+      expect(mockCloseExtensionSidebar).not.toHaveBeenCalled();
+    });
+
+    it('fullscreen=true collapses nav and closes sidebar', () => {
+      setUrlSearch('?fullscreen=true');
+      mockIsNavVisible.mockReturnValue(true);
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(mockCollapseNav).toHaveBeenCalledTimes(1);
+      expect(mockCloseExtensionSidebar).toHaveBeenCalledTimes(1);
+    });
+
+    it('restores nav on unmount when we collapsed it', () => {
+      setUrlSearch('?nav=false');
+      mockIsNavVisible.mockReturnValue(true);
+
+      const { unmount } = render(<MainAreaLearningPanelRenderer />);
+
+      // On unmount cleanup, isNavVisible returns false (nav is still collapsed)
+      mockIsNavVisible.mockReturnValue(false);
+      unmount();
+
+      expect(mockExpandNav).toHaveBeenCalledTimes(1);
+    });
+
+    it('restores sidebar on unmount when we closed it', () => {
+      setUrlSearch('?sidebar=false');
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
+
+      const { unmount } = render(<MainAreaLearningPanelRenderer />);
+
+      // On unmount cleanup, sidebar is still not mounted (we closed it)
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(false);
+      unmount();
+
+      expect(mockRestoreSidebar).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not restore nav if user manually re-expanded it', () => {
+      setUrlSearch('?nav=false');
+      mockIsNavVisible.mockReturnValue(true);
+
+      const { unmount } = render(<MainAreaLearningPanelRenderer />);
+
+      // User re-expanded nav — isNavVisible returns true on cleanup
+      mockIsNavVisible.mockReturnValue(true);
+      unmount();
+
+      expect(mockExpandNav).not.toHaveBeenCalled();
+    });
+
+    it('does not restore sidebar if user manually reopened it', () => {
+      setUrlSearch('?sidebar=false');
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
+
+      const { unmount } = render(<MainAreaLearningPanelRenderer />);
+
+      // User reopened sidebar — getIsSidebarMounted returns true on cleanup
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
+      unmount();
+
+      expect(mockRestoreSidebar).not.toHaveBeenCalled();
+    });
+
+    it('suppresses sidebar that mounts late via pathfinder-sidebar-mounted listener', () => {
+      setUrlSearch('?sidebar=false');
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(false);
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      // Sidebar wasn't mounted initially, so closeExtensionSidebar not called yet
+      expect(mockCloseExtensionSidebar).not.toHaveBeenCalled();
+
+      // Sidebar mounts late (e.g., experiment auto-open)
+      act(() => {
+        window.dispatchEvent(new CustomEvent('pathfinder-sidebar-mounted'));
+      });
+
+      expect(mockCloseExtensionSidebar).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes pathfinder-sidebar-mounted listener on unmount', () => {
+      setUrlSearch('?sidebar=false');
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(false);
+
+      const { unmount } = render(<MainAreaLearningPanelRenderer />);
+      unmount();
+
+      // Dispatch after unmount — should NOT trigger closeExtensionSidebar
+      mockCloseExtensionSidebar.mockClear();
+      act(() => {
+        window.dispatchEvent(new CustomEvent('pathfinder-sidebar-mounted'));
+      });
+
+      expect(mockCloseExtensionSidebar).not.toHaveBeenCalled();
+    });
+
+    it('fires MainAreaChromeControlApplied analytics when chrome params are active', () => {
+      setUrlSearch('?nav=false&sidebar=false');
+      mockIsNavVisible.mockReturnValue(true);
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaChromeControlApplied, {
+        nav_hidden: true,
+        sidebar_hidden: true,
+      });
+    });
+
+    it('does not fire MainAreaChromeControlApplied when no chrome params', () => {
+      setUrlSearch('');
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(reportAppInteraction).not.toHaveBeenCalledWith(
+        UserInteraction.MainAreaChromeControlApplied,
+        expect.anything()
+      );
+    });
+
+    it('strips chrome params from URL after processing', () => {
+      setUrlSearch('?nav=false&sidebar=false&fullscreen=true');
+      (fetchContent as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(replaceStateSpy).toHaveBeenCalled();
+      const calledUrl = replaceStateSpy.mock.calls[0][2] as string;
+      expect(calledUrl).not.toContain('nav=');
+      expect(calledUrl).not.toContain('sidebar=');
+      expect(calledUrl).not.toContain('fullscreen=');
+    });
+  });
+});

--- a/src/components/main-area-learning/main-area-learning-panel.test.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.test.tsx
@@ -25,7 +25,10 @@ jest.mock('@grafana/runtime', () => ({
   reportInteraction: jest.fn(),
   getAppEvents: jest.fn(() => ({ publish: jest.fn() })),
   config: { bootData: { user: { id: 1 } } },
-  locationService: { push: (...args: any[]) => mockLocationPush(...args) },
+  locationService: {
+    push: (...args: any[]) => mockLocationPush(...args),
+    getHistory: jest.fn(() => ({ listen: jest.fn(() => jest.fn()) })),
+  },
 }));
 
 jest.mock('@grafana/scenes', () => ({

--- a/src/components/main-area-learning/main-area-learning-panel.test.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.test.tsx
@@ -158,11 +158,7 @@ jest.mock('../../lib/analytics', () => ({
     MainAreaPageView: 'main_area_page_view',
     MainAreaGuideLoaded: 'main_area_guide_loaded',
     MainAreaGuideLoadFailed: 'main_area_guide_load_failed',
-    MainAreaUnsupportedFormat: 'main_area_unsupported_format',
-    MainAreaGuideNavigatedInPlace: 'main_area_guide_navigated_in_place',
     MainAreaSafetyGateBlocked: 'main_area_safety_gate_blocked',
-    MainAreaOpenInSidebarClicked: 'main_area_open_in_sidebar_clicked',
-    MainAreaChromeControlApplied: 'main_area_chrome_control_applied',
   },
 }));
 
@@ -503,28 +499,6 @@ describe('MainAreaLearningPanelRenderer', () => {
         });
       });
     });
-
-    it('fires MainAreaUnsupportedFormat for /docs/ paths', () => {
-      setUrlSearch('?doc=/docs/grafana/latest/');
-
-      render(<MainAreaLearningPanelRenderer />);
-
-      expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaUnsupportedFormat, {
-        guide_url: '/docs/grafana/latest/',
-        url_scheme: 'raw_docs_path',
-      });
-    });
-
-    it('fires MainAreaUnsupportedFormat for grafana.com URLs', () => {
-      setUrlSearch('?doc=https://grafana.com/docs/grafana/latest/');
-
-      render(<MainAreaLearningPanelRenderer />);
-
-      expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaUnsupportedFormat, {
-        guide_url: 'https://grafana.com/docs/grafana/latest/',
-        url_scheme: 'grafana_docs_url',
-      });
-    });
   });
 
   // --- Sidebar handoff -----------------------------------------------------
@@ -621,34 +595,6 @@ describe('MainAreaLearningPanelRenderer', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('content-renderer')).toBeInTheDocument();
-      });
-    });
-
-    it('fires MainAreaGuideNavigatedInPlace on in-place navigation via event', async () => {
-      setUrlSearch('');
-      const rawContent = makeRawContent('bundled:nav-guide');
-      (findDocPage as jest.Mock).mockReturnValue({
-        type: 'docs-page',
-        url: 'bundled:nav-guide',
-        title: 'Nav Guide',
-      });
-      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
-
-      render(<MainAreaLearningPanelRenderer />);
-
-      await act(async () => {
-        document.dispatchEvent(
-          new CustomEvent('pathfinder-open-in-main-area', {
-            detail: { url: 'bundled:nav-guide', title: 'Nav Guide' },
-          })
-        );
-      });
-
-      await waitFor(() => {
-        expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaGuideNavigatedInPlace, {
-          new_url: 'bundled:nav-guide',
-          previous_url: '',
-        });
       });
     });
 
@@ -1048,29 +994,6 @@ describe('MainAreaLearningPanelRenderer', () => {
       });
 
       expect(mockCloseExtensionSidebar).not.toHaveBeenCalled();
-    });
-
-    it('fires MainAreaChromeControlApplied analytics when chrome params are active', () => {
-      setUrlSearch('?nav=false&sidebar=false');
-      mockIsNavVisible.mockReturnValue(true);
-      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
-
-      render(<MainAreaLearningPanelRenderer />);
-
-      expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.MainAreaChromeControlApplied, {
-        nav_hidden: true,
-        sidebar_hidden: true,
-      });
-    });
-
-    it('does not fire MainAreaChromeControlApplied when no chrome params', () => {
-      setUrlSearch('');
-      render(<MainAreaLearningPanelRenderer />);
-
-      expect(reportAppInteraction).not.toHaveBeenCalledWith(
-        UserInteraction.MainAreaChromeControlApplied,
-        expect.anything()
-      );
     });
 
     it('strips chrome params from URL after processing', () => {

--- a/src/components/main-area-learning/main-area-learning-panel.test.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.test.tsx
@@ -346,8 +346,8 @@ describe('MainAreaLearningPanelRenderer', () => {
   // --- URL cleanup ---------------------------------------------------------
 
   describe('URL cleanup', () => {
-    it('strips ?doc= param after processing', () => {
-      setUrlSearch('?doc=bundled:test-guide');
+    it('preserves ?doc= param but strips chrome-control params', () => {
+      setUrlSearch('?doc=bundled:test-guide&source=test&nav=false&sidebar=false&fullscreen=true');
       (findDocPage as jest.Mock).mockReturnValue({
         type: 'docs-page',
         url: 'bundled:test-guide',
@@ -358,6 +358,12 @@ describe('MainAreaLearningPanelRenderer', () => {
       render(<MainAreaLearningPanelRenderer />);
 
       expect(replaceStateSpy).toHaveBeenCalled();
+      const calledUrl = replaceStateSpy.mock.calls[0][2] as string;
+      expect(calledUrl).toContain('doc=bundled');
+      expect(calledUrl).not.toContain('source=');
+      expect(calledUrl).not.toContain('nav=');
+      expect(calledUrl).not.toContain('sidebar=');
+      expect(calledUrl).not.toContain('fullscreen=');
     });
   });
 
@@ -1007,6 +1013,109 @@ describe('MainAreaLearningPanelRenderer', () => {
       expect(calledUrl).not.toContain('nav=');
       expect(calledUrl).not.toContain('sidebar=');
       expect(calledUrl).not.toContain('fullscreen=');
+    });
+  });
+
+  // --- Layout width ----------------------------------------------------------
+
+  describe('layout width', () => {
+    it('applies default width for guides without layout field', async () => {
+      setUrlSearch('?doc=bundled:test-guide');
+      const rawContent = makeRawContent('bundled:test-guide');
+      rawContent.content = JSON.stringify({ id: 'test', title: 'Test', blocks: [] });
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:test-guide',
+        title: 'Test Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        const container = screen.getByTestId(testIds.mainAreaLearning.contentContainer);
+        expect(container.className).toBeTruthy();
+      });
+    });
+
+    it('applies different className for guides with layout: "wide"', async () => {
+      setUrlSearch('?doc=bundled:wide-guide');
+      const rawContent = makeRawContent('bundled:wide-guide');
+      rawContent.content = JSON.stringify({ id: 'wide', title: 'Wide', layout: 'wide', blocks: [] });
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:wide-guide',
+        title: 'Wide Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        const container = screen.getByTestId(testIds.mainAreaLearning.contentContainer);
+        expect(container.className).toBeTruthy();
+      });
+    });
+
+    it('applies different className for guides with layout: "full"', async () => {
+      setUrlSearch('?doc=bundled:full-guide');
+      const rawContent = makeRawContent('bundled:full-guide');
+      rawContent.content = JSON.stringify({ id: 'full', title: 'Full', layout: 'full', blocks: [] });
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'docs-page',
+        url: 'bundled:full-guide',
+        title: 'Full Guide',
+      });
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        const container = screen.getByTestId(testIds.mainAreaLearning.contentContainer);
+        expect(container.className).toBeTruthy();
+      });
+    });
+  });
+
+  // --- Remote URL support ----------------------------------------------------
+
+  describe('remote URL support', () => {
+    it('loads remote GitHub content when doc=remote:...', async () => {
+      const remoteUrl = 'https://raw.githubusercontent.com/grafana/repo/main/guide.json';
+      setUrlSearch(`?doc=remote:${remoteUrl}`);
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'interactive',
+        url: remoteUrl,
+        title: 'Guide',
+      });
+      const rawContent = makeRawContent(remoteUrl);
+      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(testIds.mainAreaLearning.contentContainer)).toBeInTheDocument();
+      });
+
+      expect(fetchContent).toHaveBeenCalledWith(remoteUrl);
+    });
+
+    it('preserves remote doc param in URL after cleanup', () => {
+      const remoteUrl = 'https://raw.githubusercontent.com/grafana/repo/main/guide.json';
+      setUrlSearch(`?doc=remote:${remoteUrl}&nav=false`);
+      (findDocPage as jest.Mock).mockReturnValue({
+        type: 'interactive',
+        url: remoteUrl,
+        title: 'Guide',
+      });
+      (fetchContent as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+      render(<MainAreaLearningPanelRenderer />);
+
+      expect(replaceStateSpy).toHaveBeenCalled();
+      const calledUrl = replaceStateSpy.mock.calls[0][2] as string;
+      expect(calledUrl).toContain('doc=remote');
+      expect(calledUrl).not.toContain('nav=');
     });
   });
 });

--- a/src/components/main-area-learning/main-area-learning-panel.test.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.test.tsx
@@ -105,9 +105,6 @@ jest.mock('../docs-panel/components', () => ({
 jest.mock('../../global-state/sidebar', () => ({
   sidebarState: {
     getIsSidebarMounted: jest.fn(),
-    setPendingOpenSource: jest.fn(),
-    openSidebar: jest.fn(),
-    openWithGuide: jest.fn(),
   },
 }));
 
@@ -121,12 +118,6 @@ jest.mock('../../utils/chrome-control', () => ({
   expandNav: jest.fn(),
   closeExtensionSidebar: jest.fn(),
   restoreSidebar: jest.fn(),
-}));
-
-jest.mock('../../global-state/link-interception', () => ({
-  linkInterceptionState: {
-    addToQueue: jest.fn(),
-  },
 }));
 
 jest.mock('../../global-state/main-area-learning-state', () => ({
@@ -154,6 +145,19 @@ const {
   closeExtensionSidebar: mockCloseExtensionSidebar,
   restoreSidebar: mockRestoreSidebar,
 } = jest.requireMock('../../utils/chrome-control');
+
+jest.mock('../../styles/content-html.styles', () => ({
+  journeyContentHtml: () => 'journey-style',
+  docsContentHtml: () => 'docs-style',
+}));
+
+jest.mock('../../styles/interactive.styles', () => ({
+  getInteractiveStyles: () => 'interactive-style',
+}));
+
+jest.mock('../../styles/prism.styles', () => ({
+  getPrismStyles: () => 'prism-style',
+}));
 
 jest.mock('../../lib/analytics', () => ({
   reportAppInteraction: jest.fn(),
@@ -379,7 +383,6 @@ describe('MainAreaLearningPanelRenderer', () => {
       render(<MainAreaLearningPanelRenderer />);
 
       expect(screen.getByTestId(testIds.mainAreaLearning.unsupportedFormatError)).toBeInTheDocument();
-      expect(screen.getByTestId(testIds.mainAreaLearning.openInSidebarButton)).toBeInTheDocument();
       expect(findDocPage).not.toHaveBeenCalled();
     });
 
@@ -507,28 +510,6 @@ describe('MainAreaLearningPanelRenderer', () => {
           error_message: 'Not found',
         });
       });
-    });
-  });
-
-  // --- Sidebar handoff -----------------------------------------------------
-
-  describe('sidebar handoff', () => {
-    it('"Open in sidebar" dispatches to sidebar when mounted', () => {
-      setUrlSearch('?doc=/docs/grafana/latest/');
-      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
-      const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
-
-      render(<MainAreaLearningPanelRenderer />);
-      screen.getByTestId(testIds.mainAreaLearning.openInSidebarButton).click();
-
-      expect(dispatchSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'pathfinder-auto-open-docs',
-          detail: expect.objectContaining({ url: '/docs/grafana/latest/' }),
-        })
-      );
-
-      dispatchSpy.mockRestore();
     });
   });
 
@@ -789,31 +770,6 @@ describe('MainAreaLearningPanelRenderer', () => {
       });
 
       expect(screen.queryByTestId(testIds.mainAreaLearning.safetyGateWarning)).not.toBeInTheDocument();
-    });
-
-    it('safety gate "Open in sidebar" calls openWithGuide for bundled URLs', async () => {
-      setUrlSearch('?doc=bundled:unsafe-guide');
-      (findDocPage as jest.Mock).mockReturnValue({
-        type: 'docs-page',
-        url: 'bundled:unsafe-guide',
-        title: 'Unsafe Guide',
-      });
-      const rawContent = makeRawContent('bundled:unsafe-guide');
-      (fetchContent as jest.Mock).mockResolvedValue({ content: rawContent });
-      mockIsMainAreaSafe.mockReturnValue({ safe: false, unsafeActionTypes: ['button'] });
-
-      render(<MainAreaLearningPanelRenderer />);
-
-      await waitFor(() => {
-        expect(screen.getByTestId(testIds.mainAreaLearning.safetyGateOpenInSidebarButton)).toBeInTheDocument();
-      });
-
-      await act(async () => {
-        screen.getByTestId(testIds.mainAreaLearning.safetyGateOpenInSidebarButton).click();
-      });
-
-      expect(sidebarState.openWithGuide).toHaveBeenCalledWith('unsafe-guide');
-      expect(mockLocationPush).toHaveBeenCalledWith('/a/grafana-pathfinder-app');
     });
 
     it('safety gate resets when navigating to a new guide in-place', async () => {

--- a/src/components/main-area-learning/main-area-learning-panel.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.tsx
@@ -160,17 +160,20 @@ function computeInitialState(): PanelState {
   const docParam = urlParams.get('doc');
 
   if (!docParam) {
+    console.warn('[main-area-learning] No ?doc= param found in URL, showing landing page. URL:', window.location.href);
     return { status: 'landing', content: null, error: null, docUrl: null, originalParam: null };
   }
 
   // Format validation — MUST run before findDocPage() because findDocPage
   // resolves /docs/ paths (Case 4) which we explicitly don't support here
   if (isUnsupportedFormat(docParam)) {
+    console.warn('[main-area-learning] Unsupported format for doc param:', docParam);
     return { status: 'unsupported', content: null, error: null, docUrl: null, originalParam: docParam };
   }
 
   const docPage = findDocPage(docParam);
   if (!docPage) {
+    console.warn('[main-area-learning] findDocPage() returned null for doc param:', docParam);
     return { status: 'landing', content: null, error: null, docUrl: null, originalParam: null };
   }
 

--- a/src/components/main-area-learning/main-area-learning-panel.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.tsx
@@ -47,6 +47,24 @@ import type { RawContent } from '../../types/content.types';
 // HELPERS
 // ============================================================================
 
+type LayoutWidth = 'default' | 'wide' | 'full';
+
+/** Read the layout hint from a JSON guide's top-level properties. */
+function getLayoutWidth(content: RawContent): LayoutWidth {
+  try {
+    const parsed = JSON.parse(content.content);
+    if (parsed?.layout === 'wide') {
+      return 'wide';
+    }
+    if (parsed?.layout === 'full') {
+      return 'full';
+    }
+  } catch {
+    // Non-JSON or malformed — default prose width
+  }
+  return 'default';
+}
+
 /**
  * Returns true if the URL scheme is unsupported in the main-area learning view.
  * Raw /docs/ paths and Grafana.com doc URLs require the sidebar for proper rendering.
@@ -60,10 +78,9 @@ function isUnsupportedFormat(param: string): boolean {
   );
 }
 
-/** Strip handled params from current URL without navigation. */
+/** Strip ephemeral chrome-control params from URL; preserve ?doc= for bookmarking. */
 function cleanUrlParams(): void {
   const url = new URL(window.location.href);
-  url.searchParams.delete('doc');
   url.searchParams.delete('source');
   url.searchParams.delete('nav');
   url.searchParams.delete('sidebar');
@@ -407,22 +424,33 @@ export function MainAreaLearningPanelRenderer() {
         </Alert>
       )}
 
-      {state.status === 'content' && state.content && (
-        <>
-          <GuideProgressHeader
-            title={state.content.metadata?.title || ''}
-            contentKey={state.content.url || ''}
-            onOpenInSidebar={() => handleOpenInSidebar()}
-          />
-          <div
-            id="main-area-docs-content"
-            className={styles.contentBody}
-            data-testid={testIds.mainAreaLearning.contentContainer}
-          >
-            <ContentRenderer content={state.content} />
-          </div>
-        </>
-      )}
+      {state.status === 'content' &&
+        state.content &&
+        (() => {
+          const layout = getLayoutWidth(state.content);
+          const bodyClass =
+            layout === 'full'
+              ? styles.contentBodyFull
+              : layout === 'wide'
+                ? styles.contentBodyWide
+                : styles.contentBody;
+          return (
+            <>
+              <GuideProgressHeader
+                title={state.content.metadata?.title || ''}
+                contentKey={state.content.url || ''}
+                onOpenInSidebar={() => handleOpenInSidebar()}
+              />
+              <div
+                id="main-area-docs-content"
+                className={bodyClass}
+                data-testid={testIds.mainAreaLearning.contentContainer}
+              >
+                <ContentRenderer content={state.content} />
+              </div>
+            </>
+          );
+        })()}
 
       {state.status === 'landing' && (
         <div data-testid={testIds.mainAreaLearning.landingPage}>
@@ -453,6 +481,22 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginRight: 'auto',
     width: '100%',
     // Interactive components break out of prose width for better usability
+    '& [data-testid^="interactive-terminal-"], & [data-testid^="code-block-step-"]': {
+      maxWidth: 'none',
+    },
+  }),
+  contentBodyWide: css({
+    maxWidth: '72rem',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    width: '100%',
+    '& [data-testid^="interactive-terminal-"], & [data-testid^="code-block-step-"]': {
+      maxWidth: 'none',
+    },
+  }),
+  contentBodyFull: css({
+    maxWidth: 'none',
+    width: '100%',
     '& [data-testid^="interactive-terminal-"], & [data-testid^="code-block-step-"]': {
       maxWidth: 'none',
     },

--- a/src/components/main-area-learning/main-area-learning-panel.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.tsx
@@ -192,18 +192,26 @@ export function MainAreaLearningPanelRenderer() {
     stateRef.current = state;
   });
 
+  // Abort controller for content fetches — replaced on each navigation to cancel stale requests
+  const fetchControllerRef = useRef<AbortController | null>(null);
+
   // Chrome control params (captured before cleanUrlParams strips them)
   const [chromeParams] = useState(resolveChromeParams);
   const navCollapsedByUs = useRef(false);
   const sidebarClosedByUs = useRef(false);
 
-  const loadContent = useCallback(async (url: string, signal?: AbortSignal) => {
+  const loadContent = useCallback(async (url: string) => {
+    // Cancel any in-flight fetch before starting a new one
+    fetchControllerRef.current?.abort();
+    const controller = new AbortController();
+    fetchControllerRef.current = controller;
+
     dispatch({ type: 'start_loading' });
 
     const startTime = performance.now();
     const result = await fetchContent(url);
 
-    if (signal?.aborted) {
+    if (controller.signal.aborted) {
       return;
     }
 
@@ -239,7 +247,6 @@ export function MainAreaLearningPanelRenderer() {
 
   // Mount-time: fire analytics, clean URL, set active state, and kick off async fetch
   useEffect(() => {
-    const abortController = new AbortController();
     const { docUrl, originalParam } = stateRef.current;
 
     mainAreaLearningState.setIsActive(true);
@@ -251,12 +258,12 @@ export function MainAreaLearningPanelRenderer() {
     cleanUrlParams();
 
     if (docUrl) {
-      loadContent(docUrl, abortController.signal);
+      loadContent(docUrl);
     }
 
     return () => {
       mainAreaLearningState.setIsActive(false);
-      abortController.abort();
+      fetchControllerRef.current?.abort();
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -440,6 +447,7 @@ export function MainAreaLearningPanelRenderer() {
                 title={state.content.metadata?.title || ''}
                 contentKey={state.content.url || ''}
                 onOpenInSidebar={() => handleOpenInSidebar()}
+                layoutWidth={layout}
               />
               <div
                 id="main-area-docs-content"

--- a/src/components/main-area-learning/main-area-learning-panel.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.tsx
@@ -37,7 +37,6 @@ import { MyLearningTab } from '../LearningPaths';
 import { MyLearningErrorBoundary } from '../docs-panel/components';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
 import { sidebarState } from '../../global-state/sidebar';
-import { linkInterceptionState } from '../../global-state/link-interception';
 import { mainAreaLearningState } from '../../global-state/main-area-learning-state';
 import { testIds } from '../../constants/testIds';
 import { GuideProgressHeader } from './guide-progress-header';
@@ -364,36 +363,6 @@ export function MainAreaLearningPanelRenderer() {
     }
   }, [loadContent]);
 
-  const handleOpenInSidebar = useCallback((opts?: { navigateAway?: boolean }) => {
-    const { originalParam } = stateRef.current;
-    if (!originalParam) {
-      return;
-    }
-
-    // For safety gate + bundled URLs, use the direct openWithGuide API
-    if (opts?.navigateAway && originalParam.startsWith('bundled:')) {
-      sidebarState.openWithGuide(originalParam.slice('bundled:'.length));
-    } else {
-      const detail = { url: originalParam, title: 'Learning content' };
-      if (sidebarState.getIsSidebarMounted()) {
-        document.dispatchEvent(new CustomEvent('pathfinder-auto-open-docs', { detail }));
-      } else {
-        sidebarState.setPendingOpenSource('main_area_learning');
-        sidebarState.openSidebar('Interactive learning', {
-          url: detail.url,
-          title: detail.title,
-          timestamp: Date.now(),
-        });
-        linkInterceptionState.addToQueue({ ...detail, timestamp: Date.now() });
-      }
-    }
-
-    // Safety gate navigates away so the sidebar can render against the Grafana UI
-    if (opts?.navigateAway) {
-      locationService.push('/a/grafana-pathfinder-app');
-    }
-  }, []);
-
   // Load a guide in-place without page reload (SPA navigation)
   const handleOpenGuideInMainArea = useCallback(
     (url: string, _title: string) => {
@@ -437,14 +406,7 @@ export function MainAreaLearningPanelRenderer() {
           severity="error"
           data-testid={testIds.mainAreaLearning.unsupportedFormatError}
         >
-          <p>This content format is not supported in the learning view. Open it in the Pathfinder sidebar instead.</p>
-          <Button
-            variant="secondary"
-            onClick={() => handleOpenInSidebar()}
-            data-testid={testIds.mainAreaLearning.openInSidebarButton}
-          >
-            Open in sidebar
-          </Button>
+          <p>This content format is not supported in the learning view.</p>
         </Alert>
       )}
 
@@ -454,17 +416,7 @@ export function MainAreaLearningPanelRenderer() {
           severity="warning"
           data-testid={testIds.mainAreaLearning.safetyGateWarning}
         >
-          <p>
-            This guide includes interactive steps that need access to the Grafana UI. Open it in the Pathfinder sidebar
-            for the full experience.
-          </p>
-          <Button
-            variant="secondary"
-            onClick={() => handleOpenInSidebar({ navigateAway: true })}
-            data-testid={testIds.mainAreaLearning.safetyGateOpenInSidebarButton}
-          >
-            Open in sidebar
-          </Button>
+          <p>This guide includes interactive steps that need access to the Grafana UI.</p>
         </Alert>
       )}
 
@@ -492,7 +444,6 @@ export function MainAreaLearningPanelRenderer() {
               <GuideProgressHeader
                 title={state.content.metadata?.title || ''}
                 contentKey={state.content.url || ''}
-                onOpenInSidebar={() => handleOpenInSidebar()}
                 layoutWidth={layout}
               />
               <div

--- a/src/components/main-area-learning/main-area-learning-panel.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.tsx
@@ -254,6 +254,12 @@ export function MainAreaLearningPanelRenderer() {
     }
   }, []);
 
+  // Keep the SceneAppPage title in sync with the loaded guide title
+  useEffect(() => {
+    const title = state.status === 'content' ? (state.content?.metadata?.title ?? '') : '';
+    mainAreaLearningState.setTitle(title);
+  }, [state.status, state.content]);
+
   // Mount-time: fire analytics, clean URL, set active state, and kick off async fetch
   useEffect(() => {
     const { docUrl, originalParam } = stateRef.current;
@@ -441,11 +447,7 @@ export function MainAreaLearningPanelRenderer() {
                 : styles.contentBody;
           return (
             <>
-              <GuideProgressHeader
-                title={state.content.metadata?.title || ''}
-                contentKey={state.content.url || ''}
-                layoutWidth={layout}
-              />
+              <GuideProgressHeader contentKey={state.content.url || ''} layoutWidth={layout} />
               <div
                 id="main-area-docs-content"
                 className={bodyClass}
@@ -453,6 +455,7 @@ export function MainAreaLearningPanelRenderer() {
               >
                 <ContentRenderer
                   content={state.content}
+                  hideTitle
                   className={`${state.content.type === 'learning-journey' ? journeyStyles : docsStyles} ${interactiveStyles} ${prismStyles}`}
                 />
               </div>

--- a/src/components/main-area-learning/main-area-learning-panel.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.tsx
@@ -1,0 +1,494 @@
+/**
+ * Main-Area Learning Panel
+ *
+ * SceneObjectBase wrapper + React composition root for the /learning route.
+ * Renders interactive guides in Grafana's main app area (full-page, not sidebar).
+ *
+ * Content loading flow:
+ * 1. Read ?doc= param from URL
+ * 2. Validate format (package URLs only — no raw /docs/ paths)
+ * 3. Resolve via findDocPage()
+ * 4. Fetch via fetchContent()
+ * 5. Render via ContentRenderer
+ *
+ * Falls back to MyLearningTab as a landing page when no ?doc= param is present.
+ */
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
+import { Alert, Button, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+
+import { locationService } from '@grafana/runtime';
+
+import { findDocPage } from '../../utils/find-doc-page';
+import { isMainAreaSafe } from '../../utils/guide-safety';
+import {
+  isNavVisible,
+  collapseNav,
+  expandNav,
+  closeExtensionSidebar,
+  restoreSidebar,
+} from '../../utils/chrome-control';
+import { fetchUnifiedContent as fetchContent, ContentRenderer } from '../../docs-retrieval';
+import { SkeletonLoader } from '../SkeletonLoader';
+import { MyLearningTab } from '../LearningPaths';
+import { MyLearningErrorBoundary } from '../docs-panel/components';
+import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import { sidebarState } from '../../global-state/sidebar';
+import { linkInterceptionState } from '../../global-state/link-interception';
+import { mainAreaLearningState } from '../../global-state/main-area-learning-state';
+import { testIds } from '../../constants/testIds';
+import { GuideProgressHeader } from './guide-progress-header';
+import type { RawContent } from '../../types/content.types';
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Returns true if the URL scheme is unsupported in the main-area learning view.
+ * Raw /docs/ paths and Grafana.com doc URLs require the sidebar for proper rendering.
+ */
+function isUnsupportedFormat(param: string): boolean {
+  return (
+    param.startsWith('/docs/') ||
+    param.startsWith('/tutorials/') ||
+    param.startsWith('/docs/learning-journeys/') ||
+    param.startsWith('/docs/learning-paths/') ||
+    param.startsWith('https://grafana.com/') ||
+    param.startsWith('https://docs.grafana.com/')
+  );
+}
+
+/** Strip handled params from current URL without navigation. */
+function cleanUrlParams(): void {
+  const url = new URL(window.location.href);
+  url.searchParams.delete('doc');
+  url.searchParams.delete('source');
+  url.searchParams.delete('nav');
+  url.searchParams.delete('sidebar');
+  url.searchParams.delete('fullscreen');
+  window.history.replaceState({}, '', url.toString());
+}
+
+/**
+ * Parse chrome control params from the URL at render time.
+ * fullscreen=true is shorthand for nav=false&sidebar=false.
+ */
+function resolveChromeParams(): { hideNav: boolean; hideSidebar: boolean } {
+  const params = new URLSearchParams(window.location.search);
+  const fullscreen = params.get('fullscreen') === 'true';
+  const hideNav = fullscreen || params.get('nav') === 'false';
+  const hideSidebar = fullscreen || params.get('sidebar') === 'false';
+  return { hideNav, hideSidebar };
+}
+
+// ============================================================================
+// SCENE OBJECT
+// ============================================================================
+
+interface MainAreaLearningPanelState extends SceneObjectState {}
+
+export class MainAreaLearningPanel extends SceneObjectBase<MainAreaLearningPanelState> {
+  public static Component = MainAreaLearningPanelRenderer;
+}
+
+// ============================================================================
+// RENDERER
+// ============================================================================
+
+/**
+ * Parse ?doc= param from the URL at render time.
+ * Returns initial state synchronously so we avoid calling setState inside an effect.
+ */
+function resolveDocParam(): {
+  docParam: string | null;
+  isUnsupported: boolean;
+  urlScheme: string;
+  resolvedUrl: string | null;
+  showLanding: boolean;
+} {
+  const urlParams = new URLSearchParams(window.location.search);
+  const docParam = urlParams.get('doc');
+
+  if (!docParam) {
+    return { docParam: null, isUnsupported: false, urlScheme: '', resolvedUrl: null, showLanding: true };
+  }
+
+  // Format validation — MUST run before findDocPage() because findDocPage
+  // resolves /docs/ paths (Case 4) which we explicitly don't support here
+  if (isUnsupportedFormat(docParam)) {
+    const urlScheme = docParam.startsWith('https://') ? 'grafana_docs_url' : 'raw_docs_path';
+    return { docParam, isUnsupported: true, urlScheme, resolvedUrl: null, showLanding: false };
+  }
+
+  const docPage = findDocPage(docParam);
+  if (!docPage) {
+    return { docParam, isUnsupported: false, urlScheme: '', resolvedUrl: null, showLanding: true };
+  }
+
+  return { docParam, isUnsupported: false, urlScheme: '', resolvedUrl: docPage.url, showLanding: false };
+}
+
+export function MainAreaLearningPanelRenderer() {
+  const styles = useStyles2(getStyles);
+
+  // Compute initial state synchronously from URL params (avoids setState in effect).
+  // Individual state variables are mutable so in-place navigation can update them.
+  const [resolved] = useState(resolveDocParam);
+
+  const [loading, setLoading] = useState(!!resolved.resolvedUrl);
+  const [content, setContent] = useState<RawContent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showLanding, setShowLanding] = useState(resolved.showLanding);
+  const [unsupportedFormat, setUnsupportedFormat] = useState(resolved.isUnsupported);
+  const [unsafeGuide, setUnsafeGuide] = useState(false);
+
+  // Chrome control params (captured before cleanUrlParams strips them)
+  const [chromeParams] = useState(resolveChromeParams);
+  const navCollapsedByUs = useRef(false);
+  const sidebarClosedByUs = useRef(false);
+
+  // Store resolved URL for retry and analytics context
+  const docUrlRef = useRef<string | null>(resolved.resolvedUrl);
+  // Store original ?doc= param for sidebar handoff on unsupported format
+  const originalParamRef = useRef<string | null>(resolved.docParam);
+
+  const loadContent = useCallback(async (url: string, signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+
+    const startTime = performance.now();
+    const result = await fetchContent(url);
+
+    if (signal?.aborted) {
+      return;
+    }
+
+    const loadTimeMs = Math.round(performance.now() - startTime);
+
+    if (result.content) {
+      const safetyResult = isMainAreaSafe(result.content.content);
+      if (!safetyResult.safe) {
+        setUnsafeGuide(true);
+        setLoading(false);
+        reportAppInteraction(UserInteraction.MainAreaSafetyGateBlocked, {
+          guide_url: url,
+          unsafe_action_types: safetyResult.unsafeActionTypes.join(','),
+        });
+        return;
+      }
+
+      setContent(result.content);
+      reportAppInteraction(UserInteraction.MainAreaGuideLoaded, {
+        guide_url: url,
+        guide_title: result.content.metadata?.title || '',
+        is_safe: true,
+        load_time_ms: loadTimeMs,
+      });
+    } else {
+      const errorMessage = result.error || 'Failed to load content';
+      setError(errorMessage);
+      reportAppInteraction(UserInteraction.MainAreaGuideLoadFailed, {
+        guide_url: url,
+        error_message: errorMessage,
+      });
+    }
+
+    setLoading(false);
+  }, []);
+
+  // Mount-time: fire analytics, clean URL, set active state, and kick off async fetch
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    mainAreaLearningState.setIsActive(true);
+
+    reportAppInteraction(UserInteraction.MainAreaPageView, {
+      has_doc_param: !!resolved.docParam,
+    });
+
+    cleanUrlParams();
+
+    if (resolved.isUnsupported) {
+      reportAppInteraction(UserInteraction.MainAreaUnsupportedFormat, {
+        guide_url: resolved.docParam!,
+        url_scheme: resolved.urlScheme,
+      });
+    }
+
+    if (resolved.resolvedUrl) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: loadContent is async; all setState calls happen after await fetchContent()
+      loadContent(resolved.resolvedUrl, abortController.signal);
+    }
+
+    return () => {
+      mainAreaLearningState.setIsActive(false);
+      abortController.abort();
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Chrome control: hide nav/sidebar on mount, restore on unmount
+  useEffect(() => {
+    const { hideNav, hideSidebar } = chromeParams;
+
+    if (hideNav && isNavVisible()) {
+      collapseNav();
+      navCollapsedByUs.current = true;
+    }
+
+    if (hideSidebar && sidebarState.getIsSidebarMounted()) {
+      closeExtensionSidebar();
+      sidebarClosedByUs.current = true;
+    }
+
+    // Race condition: sidebar may mount after our page loads (experiment auto-open).
+    // Listen and suppress if sidebar=false is active.
+    let sidebarMountListener: (() => void) | null = null;
+    if (hideSidebar) {
+      sidebarMountListener = () => {
+        closeExtensionSidebar();
+        sidebarClosedByUs.current = true;
+      };
+      window.addEventListener('pathfinder-sidebar-mounted', sidebarMountListener);
+    }
+
+    if (hideNav || hideSidebar) {
+      reportAppInteraction(UserInteraction.MainAreaChromeControlApplied, {
+        nav_hidden: hideNav,
+        sidebar_hidden: hideSidebar,
+      });
+    }
+
+    return () => {
+      if (sidebarMountListener) {
+        window.removeEventListener('pathfinder-sidebar-mounted', sidebarMountListener);
+      }
+
+      // Restore only if we made the change AND the state still matches what we set.
+      // If the user manually re-expanded the nav, we don't fight it.
+      if (navCollapsedByUs.current && !isNavVisible()) {
+        expandNav();
+      }
+      navCollapsedByUs.current = false;
+
+      if (sidebarClosedByUs.current && !sidebarState.getIsSidebarMounted()) {
+        restoreSidebar();
+      }
+      sidebarClosedByUs.current = false;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleRetry = useCallback(() => {
+    if (docUrlRef.current) {
+      loadContent(docUrlRef.current);
+    }
+  }, [loadContent]);
+
+  const handleOpenInSidebar = useCallback(() => {
+    const param = originalParamRef.current;
+    if (!param) {
+      return;
+    }
+
+    const detail = { url: param, title: 'Learning content' };
+
+    reportAppInteraction(UserInteraction.MainAreaOpenInSidebarClicked, {
+      guide_url: param,
+      trigger: 'unsupported_format' as const,
+    });
+
+    if (sidebarState.getIsSidebarMounted()) {
+      document.dispatchEvent(new CustomEvent('pathfinder-auto-open-docs', { detail }));
+    } else {
+      sidebarState.setPendingOpenSource('main_area_learning');
+      sidebarState.openSidebar('Interactive learning', {
+        url: detail.url,
+        title: detail.title,
+        timestamp: Date.now(),
+      });
+      linkInterceptionState.addToQueue({ ...detail, timestamp: Date.now() });
+    }
+  }, []);
+
+  const handleSafetyGateOpenInSidebar = useCallback(() => {
+    const param = originalParamRef.current;
+    if (!param) {
+      return;
+    }
+
+    reportAppInteraction(UserInteraction.MainAreaOpenInSidebarClicked, {
+      guide_url: param,
+      trigger: 'safety_gate' as const,
+    });
+
+    if (param.startsWith('bundled:')) {
+      const guideId = param.slice('bundled:'.length);
+      sidebarState.openWithGuide(guideId);
+    } else {
+      const detail = { url: param, title: 'Learning content' };
+      if (sidebarState.getIsSidebarMounted()) {
+        document.dispatchEvent(new CustomEvent('pathfinder-auto-open-docs', { detail }));
+      } else {
+        sidebarState.setPendingOpenSource('main_area_learning');
+        sidebarState.openSidebar('Interactive learning', {
+          url: detail.url,
+          title: detail.title,
+          timestamp: Date.now(),
+        });
+        linkInterceptionState.addToQueue({ ...detail, timestamp: Date.now() });
+      }
+    }
+
+    locationService.push('/a/grafana-pathfinder-app');
+  }, []);
+
+  // Load a guide in-place without page reload (SPA navigation)
+  const handleOpenGuideInMainArea = useCallback(
+    (url: string, _title: string) => {
+      if (isUnsupportedFormat(url)) {
+        return;
+      }
+      const docPage = findDocPage(url);
+      if (!docPage) {
+        return;
+      }
+      setShowLanding(false);
+      setUnsupportedFormat(false);
+      setUnsafeGuide(false);
+      setError(null);
+      setContent(null);
+      docUrlRef.current = docPage.url;
+      originalParamRef.current = url;
+      loadContent(docPage.url);
+    },
+    [loadContent]
+  );
+
+  // Listen for pathfinder-open-in-main-area events (from link interception when main area is active)
+  useEffect(() => {
+    const handleOpenInMainArea = (event: Event) => {
+      const { url, title } = (event as CustomEvent).detail;
+      const previousUrl = docUrlRef.current || '';
+
+      reportAppInteraction(UserInteraction.MainAreaGuideNavigatedInPlace, {
+        new_url: url,
+        previous_url: previousUrl,
+      });
+
+      handleOpenGuideInMainArea(url, title);
+    };
+
+    document.addEventListener('pathfinder-open-in-main-area', handleOpenInMainArea);
+    return () => {
+      document.removeEventListener('pathfinder-open-in-main-area', handleOpenInMainArea);
+    };
+  }, [handleOpenGuideInMainArea]);
+
+  return (
+    <div className={styles.container} data-testid={testIds.mainAreaLearning.container}>
+      {loading && (
+        <div data-testid={testIds.mainAreaLearning.loadingState}>
+          <SkeletonLoader />
+        </div>
+      )}
+
+      {unsupportedFormat && (
+        <Alert
+          title="Unsupported content format"
+          severity="error"
+          data-testid={testIds.mainAreaLearning.unsupportedFormatError}
+        >
+          <p>This content format is not supported in the learning view. Open it in the Pathfinder sidebar instead.</p>
+          <Button
+            variant="secondary"
+            onClick={handleOpenInSidebar}
+            data-testid={testIds.mainAreaLearning.openInSidebarButton}
+          >
+            Open in sidebar
+          </Button>
+        </Alert>
+      )}
+
+      {unsafeGuide && !loading && (
+        <Alert
+          title="This guide requires the sidebar"
+          severity="warning"
+          data-testid={testIds.mainAreaLearning.safetyGateWarning}
+        >
+          <p>
+            This guide includes interactive steps that need access to the Grafana UI. Open it in the Pathfinder sidebar
+            for the full experience.
+          </p>
+          <Button
+            variant="secondary"
+            onClick={handleSafetyGateOpenInSidebar}
+            data-testid={testIds.mainAreaLearning.safetyGateOpenInSidebarButton}
+          >
+            Open in sidebar
+          </Button>
+        </Alert>
+      )}
+
+      {error && !loading && (
+        <Alert title="Failed to load content" severity="error" data-testid={testIds.mainAreaLearning.errorState}>
+          <p>{error}</p>
+          <Button variant="secondary" onClick={handleRetry} data-testid={testIds.mainAreaLearning.retryButton}>
+            Try again
+          </Button>
+        </Alert>
+      )}
+
+      {content && !loading && (
+        <>
+          <GuideProgressHeader
+            title={content.metadata?.title || ''}
+            contentKey={content.url || ''}
+            onOpenInSidebar={handleOpenInSidebar}
+          />
+          <div
+            id="main-area-docs-content"
+            className={styles.contentBody}
+            data-testid={testIds.mainAreaLearning.contentContainer}
+          >
+            <ContentRenderer content={content} />
+          </div>
+        </>
+      )}
+
+      {showLanding && !loading && (
+        <div data-testid={testIds.mainAreaLearning.landingPage}>
+          <MyLearningErrorBoundary>
+            <MyLearningTab onOpenGuide={handleOpenGuideInMainArea} />
+          </MyLearningErrorBoundary>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// STYLES
+// ============================================================================
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    overflow: 'auto',
+    padding: theme.spacing(2),
+  }),
+  contentBody: css({
+    maxWidth: '48rem',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    width: '100%',
+    // Interactive components break out of prose width for better usability
+    '& [data-testid^="interactive-terminal-"], & [data-testid^="code-block-step-"]': {
+      maxWidth: 'none',
+    },
+  }),
+});

--- a/src/components/main-area-learning/main-area-learning-panel.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.tsx
@@ -14,7 +14,7 @@
  * Falls back to MyLearningTab as a landing page when no ?doc= param is present.
  */
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useReducer, useState, useEffect, useCallback, useRef } from 'react';
 import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
 import { Alert, Button, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
@@ -55,8 +55,6 @@ function isUnsupportedFormat(param: string): boolean {
   return (
     param.startsWith('/docs/') ||
     param.startsWith('/tutorials/') ||
-    param.startsWith('/docs/learning-journeys/') ||
-    param.startsWith('/docs/learning-paths/') ||
     param.startsWith('https://grafana.com/') ||
     param.startsWith('https://docs.grafana.com/')
   );
@@ -96,69 +94,94 @@ export class MainAreaLearningPanel extends SceneObjectBase<MainAreaLearningPanel
 }
 
 // ============================================================================
-// RENDERER
+// CONTENT STATE MACHINE
 // ============================================================================
 
-/**
- * Parse ?doc= param from the URL at render time.
- * Returns initial state synchronously so we avoid calling setState inside an effect.
- */
-function resolveDocParam(): {
-  docParam: string | null;
-  isUnsupported: boolean;
-  urlScheme: string;
-  resolvedUrl: string | null;
-  showLanding: boolean;
-} {
+type PanelStatus = 'landing' | 'loading' | 'content' | 'error' | 'unsupported' | 'unsafe';
+
+interface PanelState {
+  status: PanelStatus;
+  content: RawContent | null;
+  error: string | null;
+  docUrl: string | null;
+  originalParam: string | null;
+}
+
+type PanelAction =
+  | { type: 'navigate_to_guide'; docUrl: string; originalParam: string }
+  | { type: 'content_loaded'; content: RawContent }
+  | { type: 'load_failed'; error: string }
+  | { type: 'unsafe_detected' }
+  | { type: 'start_loading' };
+
+function panelReducer(state: PanelState, action: PanelAction): PanelState {
+  switch (action.type) {
+    case 'navigate_to_guide':
+      return {
+        status: 'loading',
+        content: null,
+        error: null,
+        docUrl: action.docUrl,
+        originalParam: action.originalParam,
+      };
+    case 'start_loading':
+      return { ...state, status: 'loading', error: null };
+    case 'content_loaded':
+      return { ...state, status: 'content', content: action.content };
+    case 'load_failed':
+      return { ...state, status: 'error', error: action.error };
+    case 'unsafe_detected':
+      return { ...state, status: 'unsafe' };
+    default:
+      return state;
+  }
+}
+
+/** Compute initial reducer state from URL params (synchronous, no side effects). */
+function computeInitialState(): PanelState {
   const urlParams = new URLSearchParams(window.location.search);
   const docParam = urlParams.get('doc');
 
   if (!docParam) {
-    return { docParam: null, isUnsupported: false, urlScheme: '', resolvedUrl: null, showLanding: true };
+    return { status: 'landing', content: null, error: null, docUrl: null, originalParam: null };
   }
 
   // Format validation — MUST run before findDocPage() because findDocPage
   // resolves /docs/ paths (Case 4) which we explicitly don't support here
   if (isUnsupportedFormat(docParam)) {
-    const urlScheme = docParam.startsWith('https://') ? 'grafana_docs_url' : 'raw_docs_path';
-    return { docParam, isUnsupported: true, urlScheme, resolvedUrl: null, showLanding: false };
+    return { status: 'unsupported', content: null, error: null, docUrl: null, originalParam: docParam };
   }
 
   const docPage = findDocPage(docParam);
   if (!docPage) {
-    return { docParam, isUnsupported: false, urlScheme: '', resolvedUrl: null, showLanding: true };
+    return { status: 'landing', content: null, error: null, docUrl: null, originalParam: null };
   }
 
-  return { docParam, isUnsupported: false, urlScheme: '', resolvedUrl: docPage.url, showLanding: false };
+  return { status: 'loading', content: null, error: null, docUrl: docPage.url, originalParam: docParam };
 }
+
+// ============================================================================
+// RENDERER
+// ============================================================================
 
 export function MainAreaLearningPanelRenderer() {
   const styles = useStyles2(getStyles);
 
-  // Compute initial state synchronously from URL params (avoids setState in effect).
-  // Individual state variables are mutable so in-place navigation can update them.
-  const [resolved] = useState(resolveDocParam);
+  const [state, dispatch] = useReducer(panelReducer, undefined, computeInitialState);
 
-  const [loading, setLoading] = useState(!!resolved.resolvedUrl);
-  const [content, setContent] = useState<RawContent | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [showLanding, setShowLanding] = useState(resolved.showLanding);
-  const [unsupportedFormat, setUnsupportedFormat] = useState(resolved.isUnsupported);
-  const [unsafeGuide, setUnsafeGuide] = useState(false);
+  // Shadow state in a ref so callbacks can read current values without stale closures
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  });
 
   // Chrome control params (captured before cleanUrlParams strips them)
   const [chromeParams] = useState(resolveChromeParams);
   const navCollapsedByUs = useRef(false);
   const sidebarClosedByUs = useRef(false);
 
-  // Store resolved URL for retry and analytics context
-  const docUrlRef = useRef<string | null>(resolved.resolvedUrl);
-  // Store original ?doc= param for sidebar handoff on unsupported format
-  const originalParamRef = useRef<string | null>(resolved.docParam);
-
   const loadContent = useCallback(async (url: string, signal?: AbortSignal) => {
-    setLoading(true);
-    setError(null);
+    dispatch({ type: 'start_loading' });
 
     const startTime = performance.now();
     const result = await fetchContent(url);
@@ -172,8 +195,7 @@ export function MainAreaLearningPanelRenderer() {
     if (result.content) {
       const safetyResult = isMainAreaSafe(result.content.content);
       if (!safetyResult.safe) {
-        setUnsafeGuide(true);
-        setLoading(false);
+        dispatch({ type: 'unsafe_detected' });
         reportAppInteraction(UserInteraction.MainAreaSafetyGateBlocked, {
           guide_url: url,
           unsafe_action_types: safetyResult.unsafeActionTypes.join(','),
@@ -181,7 +203,7 @@ export function MainAreaLearningPanelRenderer() {
         return;
       }
 
-      setContent(result.content);
+      dispatch({ type: 'content_loaded', content: result.content });
       reportAppInteraction(UserInteraction.MainAreaGuideLoaded, {
         guide_url: url,
         guide_title: result.content.metadata?.title || '',
@@ -190,38 +212,29 @@ export function MainAreaLearningPanelRenderer() {
       });
     } else {
       const errorMessage = result.error || 'Failed to load content';
-      setError(errorMessage);
+      dispatch({ type: 'load_failed', error: errorMessage });
       reportAppInteraction(UserInteraction.MainAreaGuideLoadFailed, {
         guide_url: url,
         error_message: errorMessage,
       });
     }
-
-    setLoading(false);
   }, []);
 
   // Mount-time: fire analytics, clean URL, set active state, and kick off async fetch
   useEffect(() => {
     const abortController = new AbortController();
+    const { docUrl, originalParam } = stateRef.current;
 
     mainAreaLearningState.setIsActive(true);
 
     reportAppInteraction(UserInteraction.MainAreaPageView, {
-      has_doc_param: !!resolved.docParam,
+      has_doc_param: !!originalParam,
     });
 
     cleanUrlParams();
 
-    if (resolved.isUnsupported) {
-      reportAppInteraction(UserInteraction.MainAreaUnsupportedFormat, {
-        guide_url: resolved.docParam!,
-        url_scheme: resolved.urlScheme,
-      });
-    }
-
-    if (resolved.resolvedUrl) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: loadContent is async; all setState calls happen after await fetchContent()
-      loadContent(resolved.resolvedUrl, abortController.signal);
+    if (docUrl) {
+      loadContent(docUrl, abortController.signal);
     }
 
     return () => {
@@ -255,13 +268,6 @@ export function MainAreaLearningPanelRenderer() {
       window.addEventListener('pathfinder-sidebar-mounted', sidebarMountListener);
     }
 
-    if (hideNav || hideSidebar) {
-      reportAppInteraction(UserInteraction.MainAreaChromeControlApplied, {
-        nav_hidden: hideNav,
-        sidebar_hidden: hideSidebar,
-      });
-    }
-
     return () => {
       if (sidebarMountListener) {
         window.removeEventListener('pathfinder-sidebar-mounted', sidebarMountListener);
@@ -282,53 +288,23 @@ export function MainAreaLearningPanelRenderer() {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleRetry = useCallback(() => {
-    if (docUrlRef.current) {
-      loadContent(docUrlRef.current);
+    const { docUrl } = stateRef.current;
+    if (docUrl) {
+      loadContent(docUrl);
     }
   }, [loadContent]);
 
-  const handleOpenInSidebar = useCallback(() => {
-    const param = originalParamRef.current;
-    if (!param) {
+  const handleOpenInSidebar = useCallback((opts?: { navigateAway?: boolean }) => {
+    const { originalParam } = stateRef.current;
+    if (!originalParam) {
       return;
     }
 
-    const detail = { url: param, title: 'Learning content' };
-
-    reportAppInteraction(UserInteraction.MainAreaOpenInSidebarClicked, {
-      guide_url: param,
-      trigger: 'unsupported_format' as const,
-    });
-
-    if (sidebarState.getIsSidebarMounted()) {
-      document.dispatchEvent(new CustomEvent('pathfinder-auto-open-docs', { detail }));
+    // For safety gate + bundled URLs, use the direct openWithGuide API
+    if (opts?.navigateAway && originalParam.startsWith('bundled:')) {
+      sidebarState.openWithGuide(originalParam.slice('bundled:'.length));
     } else {
-      sidebarState.setPendingOpenSource('main_area_learning');
-      sidebarState.openSidebar('Interactive learning', {
-        url: detail.url,
-        title: detail.title,
-        timestamp: Date.now(),
-      });
-      linkInterceptionState.addToQueue({ ...detail, timestamp: Date.now() });
-    }
-  }, []);
-
-  const handleSafetyGateOpenInSidebar = useCallback(() => {
-    const param = originalParamRef.current;
-    if (!param) {
-      return;
-    }
-
-    reportAppInteraction(UserInteraction.MainAreaOpenInSidebarClicked, {
-      guide_url: param,
-      trigger: 'safety_gate' as const,
-    });
-
-    if (param.startsWith('bundled:')) {
-      const guideId = param.slice('bundled:'.length);
-      sidebarState.openWithGuide(guideId);
-    } else {
-      const detail = { url: param, title: 'Learning content' };
+      const detail = { url: originalParam, title: 'Learning content' };
       if (sidebarState.getIsSidebarMounted()) {
         document.dispatchEvent(new CustomEvent('pathfinder-auto-open-docs', { detail }));
       } else {
@@ -342,7 +318,10 @@ export function MainAreaLearningPanelRenderer() {
       }
     }
 
-    locationService.push('/a/grafana-pathfinder-app');
+    // Safety gate navigates away so the sidebar can render against the Grafana UI
+    if (opts?.navigateAway) {
+      locationService.push('/a/grafana-pathfinder-app');
+    }
   }, []);
 
   // Load a guide in-place without page reload (SPA navigation)
@@ -355,13 +334,7 @@ export function MainAreaLearningPanelRenderer() {
       if (!docPage) {
         return;
       }
-      setShowLanding(false);
-      setUnsupportedFormat(false);
-      setUnsafeGuide(false);
-      setError(null);
-      setContent(null);
-      docUrlRef.current = docPage.url;
-      originalParamRef.current = url;
+      dispatch({ type: 'navigate_to_guide', docUrl: docPage.url, originalParam: url });
       loadContent(docPage.url);
     },
     [loadContent]
@@ -371,13 +344,6 @@ export function MainAreaLearningPanelRenderer() {
   useEffect(() => {
     const handleOpenInMainArea = (event: Event) => {
       const { url, title } = (event as CustomEvent).detail;
-      const previousUrl = docUrlRef.current || '';
-
-      reportAppInteraction(UserInteraction.MainAreaGuideNavigatedInPlace, {
-        new_url: url,
-        previous_url: previousUrl,
-      });
-
       handleOpenGuideInMainArea(url, title);
     };
 
@@ -389,13 +355,13 @@ export function MainAreaLearningPanelRenderer() {
 
   return (
     <div className={styles.container} data-testid={testIds.mainAreaLearning.container}>
-      {loading && (
+      {state.status === 'loading' && (
         <div data-testid={testIds.mainAreaLearning.loadingState}>
           <SkeletonLoader />
         </div>
       )}
 
-      {unsupportedFormat && (
+      {state.status === 'unsupported' && (
         <Alert
           title="Unsupported content format"
           severity="error"
@@ -404,7 +370,7 @@ export function MainAreaLearningPanelRenderer() {
           <p>This content format is not supported in the learning view. Open it in the Pathfinder sidebar instead.</p>
           <Button
             variant="secondary"
-            onClick={handleOpenInSidebar}
+            onClick={() => handleOpenInSidebar()}
             data-testid={testIds.mainAreaLearning.openInSidebarButton}
           >
             Open in sidebar
@@ -412,7 +378,7 @@ export function MainAreaLearningPanelRenderer() {
         </Alert>
       )}
 
-      {unsafeGuide && !loading && (
+      {state.status === 'unsafe' && (
         <Alert
           title="This guide requires the sidebar"
           severity="warning"
@@ -424,7 +390,7 @@ export function MainAreaLearningPanelRenderer() {
           </p>
           <Button
             variant="secondary"
-            onClick={handleSafetyGateOpenInSidebar}
+            onClick={() => handleOpenInSidebar({ navigateAway: true })}
             data-testid={testIds.mainAreaLearning.safetyGateOpenInSidebarButton}
           >
             Open in sidebar
@@ -432,33 +398,33 @@ export function MainAreaLearningPanelRenderer() {
         </Alert>
       )}
 
-      {error && !loading && (
+      {state.status === 'error' && (
         <Alert title="Failed to load content" severity="error" data-testid={testIds.mainAreaLearning.errorState}>
-          <p>{error}</p>
+          <p>{state.error}</p>
           <Button variant="secondary" onClick={handleRetry} data-testid={testIds.mainAreaLearning.retryButton}>
             Try again
           </Button>
         </Alert>
       )}
 
-      {content && !loading && (
+      {state.status === 'content' && state.content && (
         <>
           <GuideProgressHeader
-            title={content.metadata?.title || ''}
-            contentKey={content.url || ''}
-            onOpenInSidebar={handleOpenInSidebar}
+            title={state.content.metadata?.title || ''}
+            contentKey={state.content.url || ''}
+            onOpenInSidebar={() => handleOpenInSidebar()}
           />
           <div
             id="main-area-docs-content"
             className={styles.contentBody}
             data-testid={testIds.mainAreaLearning.contentContainer}
           >
-            <ContentRenderer content={content} />
+            <ContentRenderer content={state.content} />
           </div>
         </>
       )}
 
-      {showLanding && !loading && (
+      {state.status === 'landing' && (
         <div data-testid={testIds.mainAreaLearning.landingPage}>
           <MyLearningErrorBoundary>
             <MyLearningTab onOpenGuide={handleOpenGuideInMainArea} />

--- a/src/components/main-area-learning/main-area-learning-panel.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.tsx
@@ -267,6 +267,42 @@ export function MainAreaLearningPanelRenderer() {
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // SPA navigation listener: catches late URL settlement (Scenes router may update
+  // the URL after the component mounts) and in-place navigation between docs.
+  // The initial computeInitialState handles the fast path; this is the fallback net.
+  useEffect(() => {
+    const history = locationService.getHistory();
+    const unlisten = history.listen((location: { search: string }) => {
+      const params = new URLSearchParams(location.search);
+      const docParam = params.get('doc');
+      const current = stateRef.current;
+
+      // Skip if the doc param hasn't changed (also ignores cleanUrlParams replaceState)
+      if (docParam === current.originalParam) {
+        return;
+      }
+
+      // No doc param — return to landing
+      if (!docParam) {
+        dispatch({ type: 'navigate_to_guide', docUrl: '', originalParam: '' });
+        return;
+      }
+
+      // Unsupported format — don't attempt to load
+      if (isUnsupportedFormat(docParam)) {
+        return;
+      }
+
+      const docPage = findDocPage(docParam);
+      if (docPage) {
+        dispatch({ type: 'navigate_to_guide', docUrl: docPage.url, originalParam: docParam });
+        loadContent(docPage.url);
+      }
+    });
+
+    return unlisten;
+  }, [loadContent]);
+
   // Chrome control: hide nav/sidebar on mount, restore on unmount
   useEffect(() => {
     const { hideNav, hideSidebar } = chromeParams;

--- a/src/components/main-area-learning/main-area-learning-panel.tsx
+++ b/src/components/main-area-learning/main-area-learning-panel.tsx
@@ -42,6 +42,9 @@ import { mainAreaLearningState } from '../../global-state/main-area-learning-sta
 import { testIds } from '../../constants/testIds';
 import { GuideProgressHeader } from './guide-progress-header';
 import type { RawContent } from '../../types/content.types';
+import { journeyContentHtml, docsContentHtml } from '../../styles/content-html.styles';
+import { getInteractiveStyles } from '../../styles/interactive.styles';
+import { getPrismStyles } from '../../styles/prism.styles';
 
 // ============================================================================
 // HELPERS
@@ -186,6 +189,10 @@ function computeInitialState(): PanelState {
 
 export function MainAreaLearningPanelRenderer() {
   const styles = useStyles2(getStyles);
+  const journeyStyles = useStyles2(journeyContentHtml);
+  const docsStyles = useStyles2(docsContentHtml);
+  const interactiveStyles = useStyles2(getInteractiveStyles);
+  const prismStyles = useStyles2(getPrismStyles);
 
   const [state, dispatch] = useReducer(panelReducer, undefined, computeInitialState);
 
@@ -493,7 +500,10 @@ export function MainAreaLearningPanelRenderer() {
                 className={bodyClass}
                 data-testid={testIds.mainAreaLearning.contentContainer}
               >
-                <ContentRenderer content={state.content} />
+                <ContentRenderer
+                  content={state.content}
+                  className={`${state.content.type === 'learning-journey' ? journeyStyles : docsStyles} ${interactiveStyles} ${prismStyles}`}
+                />
               </div>
             </>
           );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -219,4 +219,5 @@ export const DOCS_BASE_URL = DEFAULT_DOCS_BASE_URL;
 export enum ROUTES {
   Home = '',
   Context = 'context',
+  Learning = 'learning',
 }

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -323,6 +323,23 @@ export const testIds = {
     container: 'home-page-container',
   },
 
+  // Main-Area Learning
+  mainAreaLearning: {
+    container: 'main-area-learning-container',
+    contentContainer: 'main-area-docs-content',
+    loadingState: 'main-area-learning-loading',
+    errorState: 'main-area-learning-error',
+    retryButton: 'main-area-learning-retry',
+    unsupportedFormatError: 'main-area-learning-unsupported-format',
+    openInSidebarButton: 'main-area-learning-open-in-sidebar',
+    landingPage: 'main-area-learning-landing',
+    progressHeader: 'main-area-learning-progress-header',
+    progressBar: 'main-area-learning-progress-bar',
+    openInSidebarHeaderButton: 'main-area-learning-header-open-in-sidebar',
+    safetyGateWarning: 'main-area-learning-safety-gate-warning',
+    safetyGateOpenInSidebarButton: 'main-area-learning-safety-gate-open-in-sidebar',
+  },
+
   // Control Group Popup
   controlGroupPopup: {
     container: 'control-group-popup-container',

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -331,13 +331,10 @@ export const testIds = {
     errorState: 'main-area-learning-error',
     retryButton: 'main-area-learning-retry',
     unsupportedFormatError: 'main-area-learning-unsupported-format',
-    openInSidebarButton: 'main-area-learning-open-in-sidebar',
     landingPage: 'main-area-learning-landing',
     progressHeader: 'main-area-learning-progress-header',
     progressBar: 'main-area-learning-progress-bar',
-    openInSidebarHeaderButton: 'main-area-learning-header-open-in-sidebar',
     safetyGateWarning: 'main-area-learning-safety-gate-warning',
-    safetyGateOpenInSidebarButton: 'main-area-learning-safety-gate-open-in-sidebar',
   },
 
   // Control Group Popup

--- a/src/docs-retrieval/content-fetcher.test.ts
+++ b/src/docs-retrieval/content-fetcher.test.ts
@@ -1,6 +1,13 @@
 /**
  * Tests for content fetcher security validation and JSON-first fetching
  */
+
+let __mockDevMode = false;
+jest.mock('../utils/dev-mode', () => ({
+  ...jest.requireActual('../utils/dev-mode'),
+  isDevModeEnabledGlobal: () => __mockDevMode,
+}));
+
 import { fetchContent, simpleMarkdownToHtml } from './content-fetcher';
 
 // Mock AbortSignal.timeout for Node environments that don't support it
@@ -304,6 +311,137 @@ describe('fetchContent security validation', () => {
       expect(result.content).toBeNull();
       expect(result.error).toContain('Only Grafana.com documentation');
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchContent('url-package:...') — dev-mode URL package loading
+// ---------------------------------------------------------------------------
+
+describe('url-package: scheme (dev-mode URL packages)', () => {
+  const baseUrl = 'http://localhost:8080/my-package/';
+  const packageUrl = `url-package:${baseUrl}`;
+
+  const validContent = {
+    schemaVersion: '1.0',
+    id: 'my-package',
+    title: 'My Package Guide',
+    blocks: [{ type: 'markdown', content: 'Hello world' }],
+  };
+
+  const validManifest = {
+    id: 'my-package',
+    type: 'guide',
+  };
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    __mockDevMode = true;
+  });
+
+  afterEach(() => {
+    __mockDevMode = false;
+    jest.restoreAllMocks();
+  });
+
+  it('loads content.json and manifest.json from the base URL', async () => {
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.endsWith('content.json')) {
+        return Promise.resolve({ ok: true, json: async () => validContent });
+      }
+      if (url.endsWith('manifest.json')) {
+        return Promise.resolve({ ok: true, json: async () => validManifest });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    const result = await fetchContent(packageUrl);
+
+    expect(result.content).not.toBeNull();
+    expect(result.content?.isNativeJson).toBe(true);
+    expect(result.content?.url).toBe(baseUrl);
+    expect(result.content?.metadata.title).toBe('My Package Guide');
+    expect(result.content?.metadata.packageManifest).toBeDefined();
+
+    const parsed = JSON.parse(result.content!.content);
+    expect(parsed.id).toBe('my-package');
+    expect(parsed.blocks).toHaveLength(1);
+  });
+
+  it('succeeds when manifest.json is missing (404)', async () => {
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.endsWith('content.json')) {
+        return Promise.resolve({ ok: true, json: async () => validContent });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    const result = await fetchContent(packageUrl);
+
+    expect(result.content).not.toBeNull();
+    expect(result.content?.metadata.title).toBe('My Package Guide');
+    expect(result.content?.metadata.packageManifest).toBeUndefined();
+  });
+
+  it('returns error when content.json is missing (404)', async () => {
+    (global.fetch as jest.Mock).mockImplementation(() => Promise.resolve({ ok: false, status: 404 }));
+
+    const result = await fetchContent(packageUrl);
+
+    expect(result.content).toBeNull();
+    expect(result.error).toContain('content.json');
+    expect(result.errorType).toBe('not-found');
+  });
+
+  it('returns error when content.json fails schema validation', async () => {
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.endsWith('content.json')) {
+        return Promise.resolve({ ok: true, json: async () => ({ invalid: true }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    const result = await fetchContent(packageUrl);
+
+    expect(result.content).toBeNull();
+    expect(result.error).toContain('Invalid content.json');
+  });
+
+  it('returns error when dev mode is disabled', async () => {
+    __mockDevMode = false;
+
+    const result = await fetchContent(packageUrl);
+
+    expect(result.content).toBeNull();
+    expect(result.error).toContain('dev mode');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('continues without manifest when manifest.json is invalid', async () => {
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.endsWith('content.json')) {
+        return Promise.resolve({ ok: true, json: async () => validContent });
+      }
+      if (url.endsWith('manifest.json')) {
+        return Promise.resolve({ ok: true, json: async () => ({ not: 'a manifest' }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    const result = await fetchContent(packageUrl);
+
+    expect(result.content).not.toBeNull();
+    expect(result.content?.metadata.packageManifest).toBeUndefined();
+  });
+
+  it('handles network errors gracefully', async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new Error('Connection refused'));
+
+    const result = await fetchContent(packageUrl);
+
+    expect(result.content).toBeNull();
+    expect(result.error).toContain('Connection refused');
+    expect(result.errorType).toBe('network');
   });
 });
 

--- a/src/docs-retrieval/content-fetcher.ts
+++ b/src/docs-retrieval/content-fetcher.ts
@@ -131,6 +131,12 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
     // Defense-in-depth: Even if callers validate, fetchContent provides final check
     // In production: Only Grafana docs, interactive learning domains, and bundled content
     // In dev mode: Also allows localhost and GitHub raw URLs for testing
+    //
+    // isGrafanaGitHubRawUrl is intentionally NOT folded into isAllowedContentUrl.
+    // It enables the main-area learning surface to load AI-authored guides from
+    // github.com/grafana/* repos (raw.githubusercontent.com). isAllowedContentUrl
+    // covers grafana.com docs and interactive-learning.grafana.net; GitHub is a
+    // separate trust boundary and should remain separately visible here.
     const isDevMode = isDevModeEnabledGlobal();
     const isTrustedSource =
       isAllowedContentUrl(url) ||
@@ -738,6 +744,8 @@ async function tryUrlVariations(urls: string[], options: ContentFetchOptions): P
           // NOTE: response.url can be empty in proxied/intercepted environments
           // (e.g., Grafana Cloud). Fall back to the requested URL which was
           // already validated before entering this function.
+          // isGrafanaGitHubRawUrl / isGrafanaGitHubRedirectUrl are kept separate
+          // from isAllowedContentUrl — see the trust gate in fetchContent() for rationale.
           const finalUrl = response.url || urlVariation;
           const isDevMode = isDevModeEnabledGlobal();
           const isFinalUrlTrusted =
@@ -828,6 +836,8 @@ async function fetchRawHtml(url: string, options: ContentFetchOptions): Promise<
         // Per the Fetch API spec, synthetic Response objects have url === "".
         // When empty, fall back to the original request URL which was already
         // validated at the initial trust gate in fetchContent().
+        // isGrafanaGitHubRawUrl / isGrafanaGitHubRedirectUrl are kept separate
+        // from isAllowedContentUrl — see the trust gate in fetchContent() for rationale.
         const finalUrl = response.url || url;
         const isDevMode = isDevModeEnabledGlobal();
         const isFinalUrlTrusted =

--- a/src/docs-retrieval/content-fetcher.ts
+++ b/src/docs-retrieval/content-fetcher.ts
@@ -11,9 +11,10 @@ import {
   SingleDocMetadata,
   Milestone,
 } from '../types/content.types';
-import type { PackageResolver } from '../types';
+import type { PackageResolver, ManifestJson } from '../types';
 import type { ResolvedNavLink } from '../types/context.types';
 import { getPackageRenderType } from '../types/package.types';
+import { ContentJsonSchema, ManifestJsonObjectSchema } from '../types/package.schema';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
 import { DEFAULT_CONTENT_FETCH_TIMEOUT } from '../constants';
@@ -125,6 +126,10 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
     // Handle custom guides stored in backend CRDs
     if (url.startsWith('backend-guide:')) {
       return await fetchBackendInteractive(url);
+    }
+    // Handle dev-mode URL packages (content.json + manifest.json from directory URL)
+    if (url.startsWith('url-package:')) {
+      return await fetchUrlPackage(url.slice('url-package:'.length));
     }
 
     // SECURITY: Validate URL is from a trusted source before fetching
@@ -376,6 +381,74 @@ async function fetchBackendInteractive(url: string): Promise<ContentFetchResult>
       statusCode: (error as { status?: number })?.status,
     };
   }
+}
+
+/**
+ * Fetch a two-file package (content.json + manifest.json) from a directory URL.
+ * Dev-mode only — used by the `url:` doc param scheme for local testing.
+ */
+async function fetchUrlPackage(baseUrl: string): Promise<ContentFetchResult> {
+  if (!isDevModeEnabledGlobal()) {
+    return { content: null, error: 'URL packages are only available in dev mode', errorType: 'other' };
+  }
+
+  // SECURITY: Construct URLs safely using URL API (F3)
+  const contentUrl = new URL('content.json', baseUrl).toString();
+  const manifestUrl = new URL('manifest.json', baseUrl).toString();
+
+  let contentResponse: Response;
+  let manifestResponse: Response | null;
+  try {
+    [contentResponse, manifestResponse] = await Promise.all([fetch(contentUrl), fetch(manifestUrl).catch(() => null)]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Network error';
+    return { content: null, error: `Failed to fetch package from ${baseUrl}: ${message}`, errorType: 'network' };
+  }
+
+  if (!contentResponse.ok) {
+    return {
+      content: null,
+      error: `Failed to fetch ${contentUrl} (HTTP ${contentResponse.status})`,
+      errorType: contentResponse.status === 404 ? 'not-found' : 'network',
+    };
+  }
+
+  const rawContent = await contentResponse.json();
+  const contentResult = ContentJsonSchema.safeParse(rawContent);
+  if (!contentResult.success) {
+    return { content: null, error: `Invalid content.json: ${contentResult.error.message}`, errorType: 'other' };
+  }
+
+  let manifest: ManifestJson | undefined;
+  if (manifestResponse?.ok) {
+    try {
+      const rawManifest = await manifestResponse.json();
+      const manifestResult = ManifestJsonObjectSchema.loose().safeParse(rawManifest);
+      if (manifestResult.success) {
+        manifest = manifestResult.data as ManifestJson;
+      } else {
+        console.warn('[fetchUrlPackage] Invalid manifest.json (continuing without it):', manifestResult.error.message);
+      }
+    } catch {
+      console.warn('[fetchUrlPackage] Failed to parse manifest.json (continuing without it)');
+    }
+  }
+
+  const contentJson = contentResult.data;
+
+  return {
+    content: {
+      content: JSON.stringify(rawContent),
+      metadata: {
+        title: contentJson.title || manifest?.description || 'Dev package',
+        ...(manifest && { packageManifest: manifest as unknown as Record<string, unknown> }),
+      },
+      type: getPackageRenderType(manifest as unknown as Record<string, unknown> | undefined),
+      url: baseUrl,
+      lastFetched: new Date().toISOString(),
+      isNativeJson: true,
+    },
+  };
 }
 
 /**

--- a/src/docs-retrieval/content-fetcher.ts
+++ b/src/docs-retrieval/content-fetcher.ts
@@ -24,6 +24,8 @@ import {
   isLocalhostUrl,
   isInteractiveLearningUrl,
   isGitHubRawUrl,
+  isGrafanaGitHubRawUrl,
+  isGrafanaGitHubRedirectUrl,
   sanitizeHtmlUrl,
 } from '../security';
 import { isDevModeEnabledGlobal } from '../utils/dev-mode';
@@ -130,7 +132,10 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
     // In production: Only Grafana docs, interactive learning domains, and bundled content
     // In dev mode: Also allows localhost and GitHub raw URLs for testing
     const isDevMode = isDevModeEnabledGlobal();
-    const isTrustedSource = isAllowedContentUrl(url) || (isDevMode && (isLocalhostUrl(url) || isGitHubRawUrl(url)));
+    const isTrustedSource =
+      isAllowedContentUrl(url) ||
+      isGrafanaGitHubRawUrl(url) ||
+      (isDevMode && (isLocalhostUrl(url) || isGitHubRawUrl(url)));
 
     if (!isTrustedSource) {
       const errorMessage = isDevMode
@@ -737,6 +742,8 @@ async function tryUrlVariations(urls: string[], options: ContentFetchOptions): P
           const isDevMode = isDevModeEnabledGlobal();
           const isFinalUrlTrusted =
             isAllowedContentUrl(finalUrl) ||
+            isGrafanaGitHubRawUrl(finalUrl) ||
+            isGrafanaGitHubRedirectUrl(finalUrl) ||
             (isDevMode && isLocalhostUrl(finalUrl)) ||
             (isDevMode && isGitHubRawUrl(finalUrl));
 
@@ -825,6 +832,8 @@ async function fetchRawHtml(url: string, options: ContentFetchOptions): Promise<
         const isDevMode = isDevModeEnabledGlobal();
         const isFinalUrlTrusted =
           isAllowedContentUrl(finalUrl) ||
+          isGrafanaGitHubRawUrl(finalUrl) ||
+          isGrafanaGitHubRedirectUrl(finalUrl) ||
           (isDevMode && isLocalhostUrl(finalUrl)) ||
           (isDevMode && isGitHubRawUrl(finalUrl));
 

--- a/src/docs-retrieval/content-renderer.tsx
+++ b/src/docs-retrieval/content-renderer.tsx
@@ -94,6 +94,8 @@ interface ContentRendererProps {
   onGuideComplete?: () => void;
   className?: string;
   containerRef?: React.RefObject<HTMLDivElement>;
+  /** Suppress the guide's own h1 title. Use when the rendering context provides its own title (e.g. main-area SceneAppPage chrome). */
+  hideTitle?: boolean;
 }
 
 // Style to hide default browser selection highlight
@@ -112,6 +114,7 @@ export const ContentRenderer = React.memo(function ContentRenderer({
   onGuideComplete,
   className,
   containerRef,
+  hideTitle = false,
 }: ContentRendererProps) {
   const internalRef = useRef<HTMLDivElement>(null);
   const activeRef = containerRef || internalRef;
@@ -378,6 +381,7 @@ export const ContentRenderer = React.memo(function ContentRenderer({
         baseUrl={content.url}
         title={content.metadata.title}
         isNativeJson={content.isNativeJson ?? false}
+        hideTitle={hideTitle}
         onContentReady={onContentReady}
         activeRef={activeRef}
         className={className}
@@ -395,6 +399,7 @@ interface ContentWithVariablesProps {
   baseUrl: string;
   title: string;
   isNativeJson: boolean;
+  hideTitle?: boolean;
   onContentReady?: () => void;
   activeRef: React.RefObject<HTMLDivElement>;
   className?: string;
@@ -408,6 +413,7 @@ function ContentWithVariables({
   baseUrl,
   title,
   isNativeJson,
+  hideTitle = false,
   onContentReady,
   activeRef,
   className,
@@ -487,7 +493,7 @@ function ContentWithVariables({
         position: 'relative',
       }}
     >
-      {title && isNativeJson && <h1 className={titleStyle}>{title}</h1>}
+      {title && isNativeJson && !hideTitle && <h1 className={titleStyle}>{title}</h1>}
       <ContentProcessor
         html={processedContent}
         contentType={contentType}

--- a/src/global-state/link-interception.ts
+++ b/src/global-state/link-interception.ts
@@ -29,6 +29,11 @@ class GlobalLinkInterceptionState {
 
     // If main area is active, route to it instead of the sidebar
     if (mainAreaLearningState.getIsActive()) {
+      reportAppInteraction(UserInteraction.MainAreaLinkIntercepted, {
+        intercepted_url: docsLink.url,
+        link_title: docsLink.title,
+        timestamp: Date.now(),
+      });
       document.dispatchEvent(new CustomEvent('pathfinder-open-in-main-area', { detail: docsLink }));
       return;
     }

--- a/src/global-state/link-interception.ts
+++ b/src/global-state/link-interception.ts
@@ -27,7 +27,12 @@ class GlobalLinkInterceptionState {
 
     event.preventDefault();
 
-    // If main area is active, route to it instead of the sidebar
+    // If the main-area learning surface is active, it owns intercepted link
+    // routing. We dispatch a custom event rather than opening the sidebar so
+    // that the MainAreaLearningPanel can load the new guide in-place without
+    // any sidebar involvement. The sidebar branch below must not fire when the
+    // main area is active — these two surfaces are mutually exclusive owners
+    // of the link-interception flow.
     if (mainAreaLearningState.getIsActive()) {
       reportAppInteraction(UserInteraction.MainAreaLinkIntercepted, {
         intercepted_url: docsLink.url,

--- a/src/global-state/link-interception.ts
+++ b/src/global-state/link-interception.ts
@@ -29,10 +29,6 @@ class GlobalLinkInterceptionState {
 
     // If main area is active, route to it instead of the sidebar
     if (mainAreaLearningState.getIsActive()) {
-      reportAppInteraction(UserInteraction.MainAreaLinkIntercepted, {
-        intercepted_url: docsLink.url,
-        link_title: docsLink.title,
-      });
       document.dispatchEvent(new CustomEvent('pathfinder-open-in-main-area', { detail: docsLink }));
       return;
     }

--- a/src/global-state/link-interception.ts
+++ b/src/global-state/link-interception.ts
@@ -1,5 +1,6 @@
 import { getDocsLinkFromEvent } from 'global-state/utils.link-interception';
 import { sidebarState } from 'global-state/sidebar';
+import { mainAreaLearningState } from 'global-state/main-area-learning-state';
 import { reportAppInteraction, UserInteraction } from 'lib/analytics';
 
 export interface QueuedDocsLink {
@@ -25,6 +26,16 @@ class GlobalLinkInterceptionState {
     }
 
     event.preventDefault();
+
+    // If main area is active, route to it instead of the sidebar
+    if (mainAreaLearningState.getIsActive()) {
+      reportAppInteraction(UserInteraction.MainAreaLinkIntercepted, {
+        intercepted_url: docsLink.url,
+        link_title: docsLink.title,
+      });
+      document.dispatchEvent(new CustomEvent('pathfinder-open-in-main-area', { detail: docsLink }));
+      return;
+    }
 
     // Track the intercepted link
     reportAppInteraction(UserInteraction.GlobalDocsLinkIntercepted, {

--- a/src/global-state/main-area-learning-state.test.ts
+++ b/src/global-state/main-area-learning-state.test.ts
@@ -1,0 +1,22 @@
+import { mainAreaLearningState } from './main-area-learning-state';
+
+describe('mainAreaLearningState', () => {
+  afterEach(() => {
+    mainAreaLearningState.setIsActive(false);
+  });
+
+  it('returns false by default', () => {
+    expect(mainAreaLearningState.getIsActive()).toBe(false);
+  });
+
+  it('returns true after setIsActive(true)', () => {
+    mainAreaLearningState.setIsActive(true);
+    expect(mainAreaLearningState.getIsActive()).toBe(true);
+  });
+
+  it('returns false after setIsActive(false)', () => {
+    mainAreaLearningState.setIsActive(true);
+    mainAreaLearningState.setIsActive(false);
+    expect(mainAreaLearningState.getIsActive()).toBe(false);
+  });
+});

--- a/src/global-state/main-area-learning-state.ts
+++ b/src/global-state/main-area-learning-state.ts
@@ -10,6 +10,7 @@
 
 class MainAreaLearningState {
   private _isActive = false;
+  private _titleListener: ((title: string) => void) | null = null;
 
   getIsActive(): boolean {
     return this._isActive;
@@ -17,6 +18,23 @@ class MainAreaLearningState {
 
   setIsActive(active: boolean): void {
     this._isActive = active;
+  }
+
+  /** Notify the page title subscriber when the loaded guide title changes. */
+  setTitle(title: string): void {
+    this._titleListener?.(title);
+  }
+
+  /**
+   * Register a listener that is called whenever the guide title changes.
+   * Intended for use by learningPage to keep SceneAppPage.title in sync.
+   * Returns an unsubscribe function.
+   */
+  onTitleChange(listener: (title: string) => void): () => void {
+    this._titleListener = listener;
+    return () => {
+      this._titleListener = null;
+    };
   }
 }
 

--- a/src/global-state/main-area-learning-state.ts
+++ b/src/global-state/main-area-learning-state.ts
@@ -1,0 +1,23 @@
+/**
+ * Global state for the main-area learning view.
+ *
+ * Tracks whether the /learning route is currently active, enabling
+ * context-aware link interception routing. When active, intercepted
+ * doc links are routed to the main area instead of the sidebar.
+ *
+ * Analogous to sidebarState (src/global-state/sidebar.ts).
+ */
+
+class MainAreaLearningState {
+  private _isActive = false;
+
+  getIsActive(): boolean {
+    return this._isActive;
+  }
+
+  setIsActive(active: boolean): void {
+    this._isActive = active;
+  }
+}
+
+export const mainAreaLearningState = new MainAreaLearningState();

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -86,12 +86,7 @@ export enum UserInteraction {
   MainAreaPageView = 'main_area_page_view',
   MainAreaGuideLoaded = 'main_area_guide_loaded',
   MainAreaGuideLoadFailed = 'main_area_guide_load_failed',
-  MainAreaUnsupportedFormat = 'main_area_unsupported_format',
-  MainAreaLinkIntercepted = 'main_area_link_intercepted',
-  MainAreaGuideNavigatedInPlace = 'main_area_guide_navigated_in_place',
   MainAreaSafetyGateBlocked = 'main_area_safety_gate_blocked',
-  MainAreaOpenInSidebarClicked = 'main_area_open_in_sidebar_clicked',
-  MainAreaChromeControlApplied = 'main_area_chrome_control_applied',
 }
 
 // ============================================================================

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -81,6 +81,17 @@ export enum UserInteraction {
 
   // Access Control
   NoAccess = 'no_access',
+
+  // Main-Area Learning Surface
+  MainAreaPageView = 'main_area_page_view',
+  MainAreaGuideLoaded = 'main_area_guide_loaded',
+  MainAreaGuideLoadFailed = 'main_area_guide_load_failed',
+  MainAreaUnsupportedFormat = 'main_area_unsupported_format',
+  MainAreaLinkIntercepted = 'main_area_link_intercepted',
+  MainAreaGuideNavigatedInPlace = 'main_area_guide_navigated_in_place',
+  MainAreaSafetyGateBlocked = 'main_area_safety_gate_blocked',
+  MainAreaOpenInSidebarClicked = 'main_area_open_in_sidebar_clicked',
+  MainAreaChromeControlApplied = 'main_area_chrome_control_applied',
 }
 
 // ============================================================================

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -87,6 +87,7 @@ export enum UserInteraction {
   MainAreaGuideLoaded = 'main_area_guide_loaded',
   MainAreaGuideLoadFailed = 'main_area_guide_load_failed',
   MainAreaSafetyGateBlocked = 'main_area_safety_gate_blocked',
+  MainAreaLinkIntercepted = 'main_area_link_intercepted',
 }
 
 // ============================================================================

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -8,7 +8,7 @@ import { reportAppInteraction, UserInteraction } from './lib/analytics';
 // import { initializeFaroMetrics } from './lib/faro';
 import { initPluginTranslations } from '@grafana/i18n';
 import pluginJson from './plugin.json';
-import { getConfigWithDefaults, DocsPluginConfig } from './constants';
+import { getConfigWithDefaults, DocsPluginConfig, ROUTES } from './constants';
 import { linkInterceptionState } from './global-state/link-interception';
 import { sidebarState } from 'global-state/sidebar';
 import { suggestionState } from './global-state/suggestion';
@@ -129,7 +129,8 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   //
   // EXCEPTION: When the user is on the /learning route, the MainAreaLearningPanel
   // owns the ?doc= param — skip the sidebar auto-open flow entirely.
-  const isLearningRoute = window.location.pathname.endsWith('/learning');
+  // Uses ROUTES.Learning so that renaming the route updates this guard automatically.
+  const isLearningRoute = window.location.pathname.endsWith(`/${ROUTES.Learning}`);
   const urlParams = new URLSearchParams(window.location.search);
   const docsParam = isLearningRoute ? null : urlParams.get('doc');
   const pageParam = urlParams.get('page');

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -126,8 +126,12 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
 
   // Check for doc query parameter to auto-open specific docs page.
   // Dynamically imports findDocPage so the bundled JSON data stays out of module.js.
+  //
+  // EXCEPTION: When the user is on the /learning route, the MainAreaLearningPanel
+  // owns the ?doc= param — skip the sidebar auto-open flow entirely.
+  const isLearningRoute = window.location.pathname.endsWith('/learning');
   const urlParams = new URLSearchParams(window.location.search);
-  const docsParam = urlParams.get('doc');
+  const docsParam = isLearningRoute ? null : urlParams.get('doc');
   const pageParam = urlParams.get('page');
   // Optional source override for analytics — allows callers to identify the origin
   // of a ?doc= deep link (e.g. ?doc=foo&source=learning-hub)

--- a/src/pages/learningPage.test.ts
+++ b/src/pages/learningPage.test.ts
@@ -1,0 +1,13 @@
+import { ROUTES } from '../constants';
+import { prefixRoute } from '../utils/utils.routing';
+
+describe('Learning route', () => {
+  it('ROUTES.Learning exists and equals "learning"', () => {
+    expect(ROUTES.Learning).toBe('learning');
+  });
+
+  it('prefixRoute produces correct path', () => {
+    const result = prefixRoute(ROUTES.Learning);
+    expect(result).toContain('/learning');
+  });
+});

--- a/src/pages/learningPage.ts
+++ b/src/pages/learningPage.ts
@@ -1,0 +1,26 @@
+import { EmbeddedScene, SceneAppPage, SceneFlexItem, SceneFlexLayout } from '@grafana/scenes';
+import { prefixRoute } from '../utils/utils.routing';
+import { ROUTES } from '../constants';
+import { MainAreaLearningPanel } from '../components/main-area-learning/main-area-learning-panel';
+
+export const learningPage = new SceneAppPage({
+  title: 'Learning',
+  url: prefixRoute(ROUTES.Learning),
+  // routePath must be relative (not prefixed) — Grafana 12's RRv6 routing strips the plugin base URL
+  routePath: ROUTES.Learning,
+  getScene: learningScene,
+});
+
+function learningScene() {
+  return new EmbeddedScene({
+    body: new SceneFlexLayout({
+      children: [
+        new SceneFlexItem({
+          width: '100%',
+          height: '100%',
+          body: new MainAreaLearningPanel({}),
+        }),
+      ],
+    }),
+  });
+}

--- a/src/pages/learningPage.ts
+++ b/src/pages/learningPage.ts
@@ -8,6 +8,9 @@ export const learningPage = new SceneAppPage({
   url: prefixRoute(ROUTES.Learning),
   // routePath must be relative (not prefixed) — Grafana 12's RRv6 routing strips the plugin base URL
   routePath: ROUTES.Learning,
+  // Scenes strips unknown query params unless explicitly preserved.
+  // These params drive content loading and chrome control in MainAreaLearningPanel.
+  preserveUrlKeys: ['doc', 'fullscreen', 'nav', 'sidebar', 'source'],
   getScene: learningScene,
 });
 

--- a/src/pages/learningPage.ts
+++ b/src/pages/learningPage.ts
@@ -2,9 +2,10 @@ import { EmbeddedScene, SceneAppPage, SceneFlexItem, SceneFlexLayout } from '@gr
 import { prefixRoute } from '../utils/utils.routing';
 import { ROUTES } from '../constants';
 import { MainAreaLearningPanel } from '../components/main-area-learning/main-area-learning-panel';
+import { mainAreaLearningState } from '../global-state/main-area-learning-state';
 
 export const learningPage = new SceneAppPage({
-  title: 'Learning',
+  title: '',
   url: prefixRoute(ROUTES.Learning),
   // routePath must be relative (not prefixed) — Grafana 12's RRv6 routing strips the plugin base URL
   routePath: ROUTES.Learning,
@@ -12,6 +13,10 @@ export const learningPage = new SceneAppPage({
   // These params drive content loading and chrome control in MainAreaLearningPanel.
   preserveUrlKeys: ['doc', 'fullscreen', 'nav', 'sidebar', 'source'],
   getScene: learningScene,
+});
+
+mainAreaLearningState.onTitleChange((title) => {
+  learningPage.setState({ title });
 });
 
 function learningScene() {

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -15,6 +15,8 @@ export {
   isGrafanaDocsUrl,
   isInteractiveLearningUrl,
   isGitHubRawUrl,
+  isGrafanaGitHubRawUrl,
+  isGrafanaGitHubRedirectUrl,
   isLocalhostUrl,
   isAllowedContentUrl,
   validateTutorialUrl,

--- a/src/security/url-validator.test.ts
+++ b/src/security/url-validator.test.ts
@@ -10,6 +10,8 @@ import {
   validateTutorialUrl,
   validateRedirectPath,
   isGitHubRawUrl,
+  isGrafanaGitHubRawUrl,
+  isGrafanaGitHubRedirectUrl,
 } from './url-validator';
 
 // Mock the dev-mode module
@@ -451,6 +453,72 @@ describe('GitHub URL validators', () => {
     it('should reject invalid URLs', () => {
       expect(isGitHubRawUrl('not a url')).toBe(false);
       expect(isGitHubRawUrl('')).toBe(false);
+    });
+  });
+
+  describe('isGrafanaGitHubRawUrl', () => {
+    it('should accept Grafana org raw URLs', () => {
+      expect(isGrafanaGitHubRawUrl('https://raw.githubusercontent.com/grafana/repo/main/guide.json')).toBe(true);
+      expect(
+        isGrafanaGitHubRawUrl(
+          'https://raw.githubusercontent.com/grafana/pathfinder-guides/refs/heads/main/content.json'
+        )
+      ).toBe(true);
+      expect(isGrafanaGitHubRawUrl('https://raw.githubusercontent.com/grafana/deep/nested/path/file.html')).toBe(true);
+    });
+
+    it('should reject non-Grafana org URLs', () => {
+      expect(isGrafanaGitHubRawUrl('https://raw.githubusercontent.com/evil-org/repo/main/guide.json')).toBe(false);
+      expect(isGrafanaGitHubRawUrl('https://raw.githubusercontent.com/notgrafana/repo/main/guide.json')).toBe(false);
+    });
+
+    it('should be case-sensitive on org name', () => {
+      expect(isGrafanaGitHubRawUrl('https://raw.githubusercontent.com/Grafana/repo/main/guide.json')).toBe(false);
+      expect(isGrafanaGitHubRawUrl('https://raw.githubusercontent.com/GRAFANA/repo/main/guide.json')).toBe(false);
+    });
+
+    it('should reject non-HTTPS', () => {
+      expect(isGrafanaGitHubRawUrl('http://raw.githubusercontent.com/grafana/repo/main/guide.json')).toBe(false);
+    });
+
+    it('should reject domain hijack attempts', () => {
+      expect(isGrafanaGitHubRawUrl('https://raw.githubusercontent.com.evil.com/grafana/repo/main/guide.json')).toBe(
+        false
+      );
+      expect(isGrafanaGitHubRawUrl('https://a-raw.githubusercontent.com/grafana/repo/main/guide.json')).toBe(false);
+    });
+
+    it('should reject wrong hostname', () => {
+      expect(isGrafanaGitHubRawUrl('https://objects.githubusercontent.com/grafana/repo/main/guide.json')).toBe(false);
+      expect(isGrafanaGitHubRawUrl('https://github.com/grafana/repo/blob/main/file.json')).toBe(false);
+    });
+
+    it('should reject invalid inputs', () => {
+      expect(isGrafanaGitHubRawUrl('not a url')).toBe(false);
+      expect(isGrafanaGitHubRawUrl('')).toBe(false);
+    });
+  });
+
+  describe('isGrafanaGitHubRedirectUrl', () => {
+    it('should accept objects.githubusercontent.com URLs', () => {
+      expect(isGrafanaGitHubRedirectUrl('https://objects.githubusercontent.com/some-path')).toBe(true);
+      expect(
+        isGrafanaGitHubRedirectUrl('https://objects.githubusercontent.com/github-production-release-asset/123456')
+      ).toBe(true);
+    });
+
+    it('should reject non-HTTPS', () => {
+      expect(isGrafanaGitHubRedirectUrl('http://objects.githubusercontent.com/path')).toBe(false);
+    });
+
+    it('should reject wrong hostname', () => {
+      expect(isGrafanaGitHubRedirectUrl('https://raw.githubusercontent.com/grafana/repo/main/guide.json')).toBe(false);
+      expect(isGrafanaGitHubRedirectUrl('https://evil.com/objects.githubusercontent.com/path')).toBe(false);
+    });
+
+    it('should reject invalid inputs', () => {
+      expect(isGrafanaGitHubRedirectUrl('not a url')).toBe(false);
+      expect(isGrafanaGitHubRedirectUrl('')).toBe(false);
     });
   });
 });

--- a/src/security/url-validator.ts
+++ b/src/security/url-validator.ts
@@ -321,6 +321,59 @@ export function isGitHubRawUrl(urlString: string): boolean {
 }
 
 /**
+ * Check if URL is a Grafana-org GitHub raw content URL (PRODUCTION SAFE)
+ *
+ * Unlike isGitHubRawUrl() which allows any GitHub org in dev mode only,
+ * this function restricts to the Grafana GitHub org and is safe for production.
+ * Used by the main-area learning view to fetch AI-authored guides from GitHub.
+ *
+ * Security guarantees:
+ * - HTTPS only
+ * - Exact hostname match (raw.githubusercontent.com)
+ * - Path must start with /grafana/ (restricts to Grafana GitHub org)
+ */
+export function isGrafanaGitHubRawUrl(urlString: string): boolean {
+  const url = parseUrlSafely(urlString);
+  if (!url) {
+    return false;
+  }
+
+  if (url.protocol !== 'https:') {
+    return false;
+  }
+
+  if (url.hostname !== 'raw.githubusercontent.com') {
+    return false;
+  }
+
+  // Restrict to Grafana org — GitHub raw URLs are /{owner}/{repo}/{ref}/{path}
+  return url.pathname.startsWith('/grafana/');
+}
+
+/**
+ * Check if URL is a valid GitHub redirect target (PRODUCTION SAFE)
+ *
+ * GitHub may redirect raw.githubusercontent.com to objects.githubusercontent.com
+ * for LFS/blob storage. This function validates the redirect target hostname.
+ *
+ * IMPORTANT: Only use in redirect validation — NOT in the initial trust gate.
+ * The caller must ensure the original request URL already passed isGrafanaGitHubRawUrl().
+ * No path check is applied because GitHub LFS redirects don't preserve the org path.
+ */
+export function isGrafanaGitHubRedirectUrl(urlString: string): boolean {
+  const url = parseUrlSafely(urlString);
+  if (!url) {
+    return false;
+  }
+
+  if (url.protocol !== 'https:') {
+    return false;
+  }
+
+  return url.hostname === 'objects.githubusercontent.com';
+}
+
+/**
  * Default redirect path used when validation fails or input is missing.
  * Always redirects to Grafana home page as a safe fallback.
  */

--- a/src/utils/chrome-control.test.ts
+++ b/src/utils/chrome-control.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for chrome-control.ts helpers.
+ *
+ * Validates nav visibility detection, toggle behavior, sidebar close/restore,
+ * and idempotency of all operations.
+ */
+
+import { isNavVisible, collapseNav, expandNav, closeExtensionSidebar, restoreSidebar } from './chrome-control';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPublish = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  getAppEvents: () => ({ publish: mockPublish }),
+}));
+
+jest.mock('../global-state/sidebar', () => ({
+  sidebarState: {
+    openSidebar: jest.fn(),
+  },
+}));
+
+const { sidebarState } = jest.requireMock('../global-state/sidebar');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function addNavItems(count = 3): HTMLAnchorElement[] {
+  const items: HTMLAnchorElement[] = [];
+  for (let i = 0; i < count; i++) {
+    const a = document.createElement('a');
+    a.setAttribute('data-testid', 'data-testid Nav menu item');
+    document.body.appendChild(a);
+    items.push(a);
+  }
+  return items;
+}
+
+function addMegaMenuToggle(): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.id = 'mega-menu-toggle';
+  document.body.appendChild(button);
+  return button;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('isNavVisible', () => {
+  it('returns false when no nav items exist', () => {
+    expect(isNavVisible()).toBe(false);
+  });
+
+  it('returns true when nav items are in the DOM', () => {
+    addNavItems();
+    expect(isNavVisible()).toBe(true);
+  });
+});
+
+describe('collapseNav', () => {
+  it('clicks mega-menu-toggle when nav is visible', () => {
+    addNavItems();
+    const toggle = addMegaMenuToggle();
+    const clickSpy = jest.spyOn(toggle, 'click');
+
+    collapseNav();
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when nav is already hidden', () => {
+    const toggle = addMegaMenuToggle();
+    const clickSpy = jest.spyOn(toggle, 'click');
+
+    collapseNav();
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when toggle button is missing', () => {
+    addNavItems();
+    // No toggle button added — should not throw
+    expect(() => collapseNav()).not.toThrow();
+  });
+});
+
+describe('expandNav', () => {
+  it('clicks mega-menu-toggle when nav is hidden', () => {
+    const toggle = addMegaMenuToggle();
+    const clickSpy = jest.spyOn(toggle, 'click');
+
+    expandNav();
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when nav is already visible', () => {
+    addNavItems();
+    const toggle = addMegaMenuToggle();
+    const clickSpy = jest.spyOn(toggle, 'click');
+
+    expandNav();
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when toggle button is missing', () => {
+    // No nav items, no toggle — should not throw
+    expect(() => expandNav()).not.toThrow();
+  });
+});
+
+describe('closeExtensionSidebar', () => {
+  it('publishes close-extension-sidebar event', () => {
+    closeExtensionSidebar();
+
+    expect(mockPublish).toHaveBeenCalledWith({
+      type: 'close-extension-sidebar',
+      payload: {},
+    });
+  });
+});
+
+describe('restoreSidebar', () => {
+  it('calls sidebarState.openSidebar with correct title', () => {
+    restoreSidebar();
+
+    expect(sidebarState.openSidebar).toHaveBeenCalledWith('Interactive learning');
+  });
+});

--- a/src/utils/chrome-control.ts
+++ b/src/utils/chrome-control.ts
@@ -1,0 +1,55 @@
+/**
+ * Chrome control helpers for the main-area learning view.
+ *
+ * Pure DOM/state helpers that show/hide Grafana's left nav and right sidebar.
+ * Used by MainAreaLearningPanel to provide an immersive learning experience
+ * via &nav=false, &sidebar=false, and &fullscreen=true URL parameters.
+ */
+
+import { getAppEvents } from '@grafana/runtime';
+import { sidebarState } from '../global-state/sidebar';
+
+const NAV_ITEM_SELECTOR = 'a[data-testid="data-testid Nav menu item"]';
+
+/** Returns true if Grafana's left nav menu items are visible in the DOM. */
+export function isNavVisible(): boolean {
+  return document.querySelectorAll(NAV_ITEM_SELECTOR).length > 0;
+}
+
+/**
+ * Clicks #mega-menu-toggle to collapse the nav.
+ * No-op if nav is already hidden or toggle button is missing.
+ */
+export function collapseNav(): void {
+  if (!isNavVisible()) {
+    return;
+  }
+  const toggle = document.querySelector('#mega-menu-toggle') as HTMLButtonElement | null;
+  if (toggle) {
+    toggle.click();
+  }
+}
+
+/**
+ * Clicks #mega-menu-toggle to expand the nav.
+ * No-op if nav is already visible or toggle button is missing.
+ */
+export function expandNav(): void {
+  if (isNavVisible()) {
+    return;
+  }
+  const toggle = document.querySelector('#mega-menu-toggle') as HTMLButtonElement | null;
+  if (toggle) {
+    toggle.click();
+  }
+}
+
+/** Closes the extension sidebar via the Grafana event bus. */
+export function closeExtensionSidebar(): void {
+  getAppEvents().publish({ type: 'close-extension-sidebar', payload: {} });
+}
+
+/** Re-opens the Pathfinder sidebar after chrome control cleanup. */
+export function restoreSidebar(): void {
+  sidebarState.openSidebar('Interactive learning');
+}

--- a/src/utils/find-doc-page.test.ts
+++ b/src/utils/find-doc-page.test.ts
@@ -1,9 +1,11 @@
 jest.mock('../security', () => ({
   isGrafanaDocsUrl: jest.fn(() => false),
   isInteractiveLearningUrl: jest.fn(() => false),
+  isGrafanaGitHubRawUrl: jest.fn(() => false),
 }));
 
 import { findDocPage } from './find-doc-page';
+import { isGrafanaGitHubRawUrl } from '../security';
 
 describe('findDocPage', () => {
   describe('api: prefix (custom backend guides)', () => {
@@ -48,6 +50,44 @@ describe('findDocPage', () => {
 
     it('returns null for whitespace-only string', () => {
       expect(findDocPage('   ')).toBeNull();
+    });
+  });
+
+  describe('remote: prefix (GitHub-hosted guides)', () => {
+    beforeEach(() => {
+      (isGrafanaGitHubRawUrl as jest.Mock).mockReturnValue(false);
+    });
+
+    it('returns interactive DocPage for valid Grafana GitHub URL', () => {
+      (isGrafanaGitHubRawUrl as jest.Mock).mockReturnValue(true);
+      const url = 'https://raw.githubusercontent.com/grafana/repo/main/my-guide.json';
+      expect(findDocPage(`remote:${url}`)).toEqual({
+        type: 'interactive',
+        url,
+        title: 'My Guide',
+      });
+    });
+
+    it('derives title from last path segment, stripping extension', () => {
+      (isGrafanaGitHubRawUrl as jest.Mock).mockReturnValue(true);
+      const url = 'https://raw.githubusercontent.com/grafana/repo/main/grafana-13-tour.json';
+      expect(findDocPage(`remote:${url}`)?.title).toBe('Grafana 13 Tour');
+    });
+
+    it('handles .html extension', () => {
+      (isGrafanaGitHubRawUrl as jest.Mock).mockReturnValue(true);
+      const url = 'https://raw.githubusercontent.com/grafana/repo/main/intro.html';
+      expect(findDocPage(`remote:${url}`)?.title).toBe('Intro');
+    });
+
+    it('returns null for remote: with empty URL', () => {
+      expect(findDocPage('remote:')).toBeNull();
+      expect(findDocPage('remote:   ')).toBeNull();
+    });
+
+    it('returns null when URL fails security validation', () => {
+      (isGrafanaGitHubRawUrl as jest.Mock).mockReturnValue(false);
+      expect(findDocPage('remote:https://raw.githubusercontent.com/evil-org/repo/main/guide.json')).toBeNull();
     });
   });
 

--- a/src/utils/find-doc-page.test.ts
+++ b/src/utils/find-doc-page.test.ts
@@ -4,6 +4,29 @@ jest.mock('../security', () => ({
   isGrafanaGitHubRawUrl: jest.fn(() => false),
 }));
 
+jest.mock('../security/url-validator', () => ({
+  parseUrlSafely: jest.fn((url: string) => {
+    try {
+      return new URL(url);
+    } catch {
+      return null;
+    }
+  }),
+  isLocalhostUrl: jest.fn((url: string) => {
+    try {
+      const parsed = new URL(url);
+      return parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+    } catch {
+      return false;
+    }
+  }),
+}));
+
+const mockIsDevModeEnabledGlobal = jest.fn(() => false);
+jest.mock('./dev-mode', () => ({
+  isDevModeEnabledGlobal: () => mockIsDevModeEnabledGlobal(),
+}));
+
 import { findDocPage } from './find-doc-page';
 import { isGrafanaGitHubRawUrl } from '../security';
 
@@ -88,6 +111,66 @@ describe('findDocPage', () => {
     it('returns null when URL fails security validation', () => {
       (isGrafanaGitHubRawUrl as jest.Mock).mockReturnValue(false);
       expect(findDocPage('remote:https://raw.githubusercontent.com/evil-org/repo/main/guide.json')).toBeNull();
+    });
+  });
+
+  describe('url: prefix (dev-mode URL packages)', () => {
+    afterEach(() => {
+      mockIsDevModeEnabledGlobal.mockReturnValue(false);
+    });
+
+    it('returns url-package DocPage for valid localhost URL in dev mode', () => {
+      mockIsDevModeEnabledGlobal.mockReturnValue(true);
+      expect(findDocPage('url:http://localhost:8080/my-package/')).toEqual({
+        type: 'interactive',
+        url: 'url-package:http://localhost:8080/my-package/',
+        title: 'My Package',
+      });
+    });
+
+    it('normalizes URL by appending trailing slash', () => {
+      mockIsDevModeEnabledGlobal.mockReturnValue(true);
+      const result = findDocPage('url:http://localhost:8080/my-package');
+      expect(result?.url).toBe('url-package:http://localhost:8080/my-package/');
+    });
+
+    it('preserves existing trailing slash', () => {
+      mockIsDevModeEnabledGlobal.mockReturnValue(true);
+      const result = findDocPage('url:http://localhost:8080/my-package/');
+      expect(result?.url).toBe('url-package:http://localhost:8080/my-package/');
+    });
+
+    it('derives title from last path segment', () => {
+      mockIsDevModeEnabledGlobal.mockReturnValue(true);
+      expect(findDocPage('url:http://localhost:3333/grafana-101-tour/')?.title).toBe('Grafana 101 Tour');
+    });
+
+    it('returns null when dev mode is disabled', () => {
+      mockIsDevModeEnabledGlobal.mockReturnValue(false);
+      expect(findDocPage('url:http://localhost:8080/my-package/')).toBeNull();
+    });
+
+    it('returns null for non-localhost URL even in dev mode', () => {
+      mockIsDevModeEnabledGlobal.mockReturnValue(true);
+      expect(findDocPage('url:https://evil.com/my-package/')).toBeNull();
+    });
+
+    it('returns null for url: with empty URL', () => {
+      mockIsDevModeEnabledGlobal.mockReturnValue(true);
+      expect(findDocPage('url:')).toBeNull();
+      expect(findDocPage('url:   ')).toBeNull();
+    });
+
+    it('returns null for invalid URL format', () => {
+      mockIsDevModeEnabledGlobal.mockReturnValue(true);
+      expect(findDocPage('url:not-a-url')).toBeNull();
+    });
+
+    it('accepts 127.0.0.1 as localhost', () => {
+      mockIsDevModeEnabledGlobal.mockReturnValue(true);
+      const result = findDocPage('url:http://127.0.0.1:9000/pkg/');
+      expect(result).not.toBeNull();
+      expect(result?.url).toBe('url-package:http://127.0.0.1:9000/pkg/');
     });
   });
 

--- a/src/utils/find-doc-page.ts
+++ b/src/utils/find-doc-page.ts
@@ -1,4 +1,6 @@
 import { isGrafanaDocsUrl, isInteractiveLearningUrl, isGrafanaGitHubRawUrl } from '../security';
+import { parseUrlSafely, isLocalhostUrl } from '../security/url-validator';
+import { isDevModeEnabledGlobal } from './dev-mode';
 
 export interface DocPage {
   type: 'docs-page' | 'learning-journey' | 'interactive';
@@ -59,6 +61,31 @@ export function findDocPage(param: string): DocPage | null {
       type: 'interactive',
       url: rawUrl,
       title: title,
+    };
+  }
+
+  // Case: Dev-mode URL package (directory with content.json + manifest.json)
+  if (param.startsWith('url:')) {
+    if (!isDevModeEnabledGlobal()) {
+      console.warn('Security: url: doc scheme is only available in dev mode');
+      return null;
+    }
+    const rawUrl = param.slice('url:'.length).trim();
+    if (!rawUrl) {
+      return null;
+    }
+    const baseUrl = rawUrl.endsWith('/') ? rawUrl : rawUrl + '/';
+    const url = parseUrlSafely(baseUrl);
+    if (!url || !isLocalhostUrl(baseUrl)) {
+      console.warn('Security: url: scheme only allows localhost URLs in dev mode:', rawUrl);
+      return null;
+    }
+    const parts = baseUrl.split('/').filter(Boolean);
+    const slug = parts[parts.length - 1] || 'Dev package';
+    return {
+      type: 'interactive',
+      url: `url-package:${baseUrl}`,
+      title: formatSlug(slug),
     };
   }
 

--- a/src/utils/find-doc-page.ts
+++ b/src/utils/find-doc-page.ts
@@ -77,6 +77,11 @@ export function findDocPage(param: string): DocPage | null {
           targetPage: Array.isArray(interactive.url) ? interactive.url[0] : undefined,
         };
       }
+      const allIds = indexData?.interactives?.map((item: any) => item.id) ?? [];
+      console.warn(
+        `[find-doc-page] Bundled interactive "${param.replace('bundled:', '')}" not found in index.json. Available IDs:`,
+        allIds
+      );
     } catch (e) {
       console.warn('Failed to load bundled interactives index', e);
     }

--- a/src/utils/find-doc-page.ts
+++ b/src/utils/find-doc-page.ts
@@ -1,4 +1,4 @@
-import { isGrafanaDocsUrl, isInteractiveLearningUrl } from '../security';
+import { isGrafanaDocsUrl, isInteractiveLearningUrl, isGrafanaGitHubRawUrl } from '../security';
 
 export interface DocPage {
   type: 'docs-page' | 'learning-journey' | 'interactive';
@@ -34,6 +34,31 @@ export function findDocPage(param: string): DocPage | null {
       type: 'docs-page',
       url: `backend-guide:${resourceName}`,
       title: resourceName,
+    };
+  }
+
+  // Case: Remote GitHub-hosted content (AI-authored guides)
+  if (param.startsWith('remote:')) {
+    const rawUrl = param.slice('remote:'.length).trim();
+    if (!rawUrl) {
+      return null;
+    }
+
+    // SECURITY: Only allow whitelisted Grafana GitHub raw URLs
+    if (!isGrafanaGitHubRawUrl(rawUrl)) {
+      console.warn('Security: Rejected non-Grafana GitHub URL:', rawUrl);
+      return null;
+    }
+
+    const cleanedUrl = rawUrl.replace(/\.(json|html)$/i, '');
+    const parts = cleanedUrl.split('/').filter(Boolean);
+    const slug = parts[parts.length - 1] || 'Remote guide';
+    const title = formatSlug(slug);
+
+    return {
+      type: 'interactive',
+      url: rawUrl,
+      title: title,
     };
   }
 

--- a/src/utils/guide-safety.test.ts
+++ b/src/utils/guide-safety.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for isMainAreaSafe() guide safety classification.
+ *
+ * Validates that guides with DOM-targeting interactive actions (highlight,
+ * button, formfill, hover) are classified as unsafe for main-area rendering,
+ * while guides with safe actions (noop, navigate) or no interactive elements
+ * are classified as safe.
+ */
+
+import { isMainAreaSafe } from './guide-safety';
+
+function makeGuide(blocks: any[]): string {
+  return JSON.stringify({ id: 'test-guide', title: 'Test', blocks });
+}
+
+describe('isMainAreaSafe', () => {
+  // --- Safe guides -----------------------------------------------------------
+
+  it('classifies guide with only noop actions as safe', () => {
+    const result = isMainAreaSafe(makeGuide([{ type: 'interactive', action: 'noop', content: 'Step 1' }]));
+    expect(result.safe).toBe(true);
+    expect(result.unsafeActionTypes).toEqual([]);
+  });
+
+  it('classifies guide with only navigate actions as safe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([{ type: 'interactive', action: 'navigate', content: 'Go to dashboards' }])
+    );
+    expect(result.safe).toBe(true);
+  });
+
+  it('classifies navigate with openGuide as safe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        {
+          type: 'interactive',
+          action: 'navigate',
+          content: 'Open next guide',
+          openGuide: 'bundled:next-guide',
+        },
+      ])
+    );
+    expect(result.safe).toBe(true);
+  });
+
+  it('classifies empty blocks array as safe', () => {
+    const result = isMainAreaSafe(makeGuide([]));
+    expect(result.safe).toBe(true);
+    expect(result.unsafeActionTypes).toEqual([]);
+  });
+
+  it('classifies quiz-only guide as safe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        {
+          type: 'quiz',
+          question: 'What is Grafana?',
+          choices: [{ text: 'A monitoring tool', correct: true }],
+        },
+      ])
+    );
+    expect(result.safe).toBe(true);
+  });
+
+  it('classifies terminal-only guide as safe', () => {
+    const result = isMainAreaSafe(makeGuide([{ type: 'terminal', command: 'echo hello', content: 'Run this' }]));
+    expect(result.safe).toBe(true);
+  });
+
+  it('classifies markdown-only guide as safe', () => {
+    const result = isMainAreaSafe(makeGuide([{ type: 'markdown', content: '# Hello world' }]));
+    expect(result.safe).toBe(true);
+  });
+
+  it('treats non-JSON content as safe', () => {
+    const result = isMainAreaSafe('<h1>Some HTML</h1>');
+    expect(result.safe).toBe(true);
+    expect(result.unsafeActionTypes).toEqual([]);
+  });
+
+  it('treats content without blocks array as safe', () => {
+    const result = isMainAreaSafe(JSON.stringify({ id: 'no-blocks', title: 'Test' }));
+    expect(result.safe).toBe(true);
+  });
+
+  // --- Unsafe guides ---------------------------------------------------------
+
+  it('classifies guide with highlight action as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([{ type: 'interactive', action: 'highlight', reftarget: '#some-element', content: 'Look here' }])
+    );
+    expect(result.safe).toBe(false);
+    expect(result.unsafeActionTypes).toEqual(['highlight']);
+  });
+
+  it('classifies guide with button action as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([{ type: 'interactive', action: 'button', reftarget: '#submit-btn', content: 'Click this' }])
+    );
+    expect(result.safe).toBe(false);
+    expect(result.unsafeActionTypes).toEqual(['button']);
+  });
+
+  it('classifies guide with formfill action as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        {
+          type: 'interactive',
+          action: 'formfill',
+          reftarget: '#name-input',
+          targetvalue: 'test',
+          content: 'Fill this',
+        },
+      ])
+    );
+    expect(result.safe).toBe(false);
+    expect(result.unsafeActionTypes).toEqual(['formfill']);
+  });
+
+  it('classifies guide with hover action as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([{ type: 'interactive', action: 'hover', reftarget: '#menu', content: 'Hover here' }])
+    );
+    expect(result.safe).toBe(false);
+    expect(result.unsafeActionTypes).toEqual(['hover']);
+  });
+
+  it('classifies mixed guide (safe + unsafe steps) as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        { type: 'interactive', action: 'noop', content: 'Safe step' },
+        { type: 'interactive', action: 'highlight', reftarget: '#el', content: 'Unsafe step' },
+      ])
+    );
+    expect(result.safe).toBe(false);
+    expect(result.unsafeActionTypes).toEqual(['highlight']);
+  });
+
+  it('collects multiple unsafe action types', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        { type: 'interactive', action: 'highlight', reftarget: '#a', content: 'Step 1' },
+        { type: 'interactive', action: 'button', reftarget: '#b', content: 'Step 2' },
+        { type: 'interactive', action: 'formfill', reftarget: '#c', targetvalue: 'x', content: 'Step 3' },
+      ])
+    );
+    expect(result.safe).toBe(false);
+    expect(result.unsafeActionTypes).toContain('highlight');
+    expect(result.unsafeActionTypes).toContain('button');
+    expect(result.unsafeActionTypes).toContain('formfill');
+  });
+
+  // --- showMe/doIt flags don't affect classification -------------------------
+
+  it('classifies step with showMe:false and doIt:false but unsafe action as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        {
+          type: 'interactive',
+          action: 'button',
+          reftarget: '#btn',
+          content: 'Hidden buttons',
+          showMe: false,
+          doIt: false,
+        },
+      ])
+    );
+    expect(result.safe).toBe(false);
+    expect(result.unsafeActionTypes).toEqual(['button']);
+  });
+
+  // --- Multistep blocks ------------------------------------------------------
+
+  it('classifies multistep block with unsafe step actions as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        {
+          type: 'multistep',
+          content: 'Automated sequence',
+          steps: [
+            { action: 'button', reftarget: '#btn1' },
+            { action: 'formfill', reftarget: '#input1', targetvalue: 'val' },
+          ],
+        },
+      ])
+    );
+    expect(result.safe).toBe(false);
+    expect(result.unsafeActionTypes).toContain('button');
+    expect(result.unsafeActionTypes).toContain('formfill');
+  });
+
+  it('classifies multistep block with only noop steps as safe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        {
+          type: 'multistep',
+          content: 'Safe sequence',
+          steps: [{ action: 'noop' }, { action: 'navigate' }],
+        },
+      ])
+    );
+    expect(result.safe).toBe(true);
+  });
+
+  // --- Guided blocks ---------------------------------------------------------
+
+  it('classifies guided block with unsafe step actions as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        {
+          type: 'guided',
+          content: 'User-performed steps',
+          steps: [
+            { action: 'hover', reftarget: '#menu' },
+            { action: 'button', reftarget: '#item' },
+          ],
+        },
+      ])
+    );
+    expect(result.safe).toBe(false);
+    expect(result.unsafeActionTypes).toContain('hover');
+    expect(result.unsafeActionTypes).toContain('button');
+  });
+
+  // --- Nested blocks (sections) ----------------------------------------------
+
+  it('classifies unsafe action inside a section block as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        {
+          type: 'section',
+          title: 'Setup',
+          blocks: [
+            { type: 'interactive', action: 'noop', content: 'Safe' },
+            { type: 'interactive', action: 'highlight', reftarget: '#el', content: 'Unsafe' },
+          ],
+        },
+      ])
+    );
+    expect(result.safe).toBe(false);
+    expect(result.unsafeActionTypes).toEqual(['highlight']);
+  });
+
+  it('classifies deeply nested unsafe action as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        {
+          type: 'section',
+          title: 'Outer',
+          blocks: [
+            {
+              type: 'section',
+              title: 'Inner',
+              blocks: [{ type: 'interactive', action: 'formfill', reftarget: '#el', content: 'Deep' }],
+            },
+          ],
+        },
+      ])
+    );
+    expect(result.safe).toBe(false);
+  });
+
+  // --- Conditional blocks ----------------------------------------------------
+
+  it('classifies unsafe action in conditional passBlocks as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        {
+          type: 'conditional',
+          condition: 'some-check',
+          passBlocks: [{ type: 'interactive', action: 'button', reftarget: '#btn', content: 'Click' }],
+          failBlocks: [{ type: 'interactive', action: 'noop', content: 'Safe' }],
+        },
+      ])
+    );
+    expect(result.safe).toBe(false);
+  });
+
+  it('classifies unsafe action in conditional failBlocks as unsafe', () => {
+    const result = isMainAreaSafe(
+      makeGuide([
+        {
+          type: 'conditional',
+          condition: 'some-check',
+          passBlocks: [{ type: 'interactive', action: 'noop', content: 'Safe' }],
+          failBlocks: [{ type: 'interactive', action: 'hover', reftarget: '#el', content: 'Unsafe' }],
+        },
+      ])
+    );
+    expect(result.safe).toBe(false);
+  });
+});

--- a/src/utils/guide-safety.ts
+++ b/src/utils/guide-safety.ts
@@ -1,0 +1,88 @@
+/**
+ * Guide Safety Classification
+ *
+ * Determines whether a JSON guide is safe to render in the main-area learning
+ * view. Guides with interactive steps that target external Grafana DOM elements
+ * (highlight, button, formfill, hover) are unsafe — those selectors point to
+ * UI elements that are not visible when the guide occupies the main area.
+ *
+ * Safe actions: 'noop' (no DOM interaction) and 'navigate' (page navigation;
+ * openGuide loads into sidebar, which is acceptable).
+ */
+
+import type { JsonInteractiveAction } from '../types/json-guide.types';
+
+const UNSAFE_ACTIONS: ReadonlySet<JsonInteractiveAction> = new Set(['highlight', 'button', 'formfill', 'hover']);
+
+interface SafetyResult {
+  safe: boolean;
+  unsafeActionTypes: string[];
+}
+
+/**
+ * Check whether a guide's content string is safe for main-area rendering.
+ *
+ * Parses the raw JSON string and walks the blocks tree looking for interactive
+ * actions that target external DOM. Returns early as soon as all unsafe action
+ * types have been found, but collects unique types for analytics.
+ *
+ * Non-JSON or unparseable content is treated as safe (no interactive elements).
+ */
+export function isMainAreaSafe(contentString: string): SafetyResult {
+  try {
+    const guide = JSON.parse(contentString);
+    if (!Array.isArray(guide.blocks)) {
+      return { safe: true, unsafeActionTypes: [] };
+    }
+
+    const unsafeActions = new Set<string>();
+    collectUnsafeActions(guide.blocks, unsafeActions);
+
+    return {
+      safe: unsafeActions.size === 0,
+      unsafeActionTypes: [...unsafeActions],
+    };
+  } catch {
+    return { safe: true, unsafeActionTypes: [] };
+  }
+}
+
+function checkAction(action: string, unsafeActions: Set<string>): void {
+  if (UNSAFE_ACTIONS.has(action as JsonInteractiveAction)) {
+    unsafeActions.add(action);
+  }
+}
+
+function collectUnsafeActions(blocks: any[], unsafeActions: Set<string>): void {
+  for (const block of blocks) {
+    switch (block.type) {
+      case 'interactive':
+        checkAction(block.action, unsafeActions);
+        break;
+
+      case 'multistep':
+      case 'guided':
+        if (Array.isArray(block.steps)) {
+          for (const step of block.steps) {
+            checkAction(step.action, unsafeActions);
+          }
+        }
+        break;
+
+      case 'section':
+        if (Array.isArray(block.blocks)) {
+          collectUnsafeActions(block.blocks, unsafeActions);
+        }
+        break;
+
+      case 'conditional':
+        if (Array.isArray(block.passBlocks)) {
+          collectUnsafeActions(block.passBlocks, unsafeActions);
+        }
+        if (Array.isArray(block.failBlocks)) {
+          collectUnsafeActions(block.failBlocks, unsafeActions);
+        }
+        break;
+    }
+  }
+}

--- a/src/utils/guide-safety.ts
+++ b/src/utils/guide-safety.ts
@@ -43,6 +43,8 @@ export function isMainAreaSafe(contentString: string): SafetyResult {
       unsafeActionTypes: [...unsafeActions],
     };
   } catch {
+    // Non-JSON content (HTML, markdown, future media formats) has no interactive
+    // blocks by definition — always safe for main-area rendering.
     return { safe: true, unsafeActionTypes: [] };
   }
 }


### PR DESCRIPTION
## Summary

Adds a new **main-area learning view** at the `/learning` route — a full-page alternative to the sidebar panel for rendering interactive guides and doc content.

### Key changes

- **`/learning` route & page scene** — new `learningPage` registered in the SceneApp, renders `MainAreaLearningPanel`
- **`MainAreaLearningPanel`** — full-page learning panel with `?doc=` param routing, content fetching, progress header, and analytics integration
- **`GuideProgressHeader`** — displays guide title and completion progress in the page chrome
- **Guide safety & chrome control utilities** — `guide-safety.ts` validates guides before rendering; `chrome-control.ts` manages Grafana page chrome state
- **URL validator** — `security/url-validator.ts` with `parseUrlSafely` and `isLocalhostUrl` for safe URL handling
- **Dev-mode `url-package:` scheme** — `url:http://localhost:PORT/path/` doc param loads content.json + manifest.json from a local directory (dev mode + localhost only)
- **Remote GitHub URL support** — `find-doc-page.ts` now accepts raw GitHub content URLs
- **SPA navigation listener** — `link-interception.ts` intercepts in-app link clicks for proper SPA routing
- **`main-area-demo` test fixture** — bundled interactive for testing the main-area flow
- **Misc fixes** — header width, navigation race condition, "Do section" button hidden when 0 eligible steps, duplicate title rendering removed

### Test coverage

- Unit tests for `MainAreaLearningPanel`, `GuideProgressHeader`, `guide-safety`, `chrome-control`, `url-validator`, `find-doc-page`, and `content-fetcher` URL package handling
- ~1,900 lines of test code added

## Status

**🚧 Draft / WIP — not ready for review or merge.**

## Test plan

- [ ] Verify `/a/grafana-pathfinder-app/learning` route loads
- [ ] Test `?doc=bundled:main-area-demo` renders the demo guide
- [ ] Test `?doc=url:http://localhost:PORT/path/` in dev mode
- [ ] Verify progress header updates on section completion
- [ ] Confirm SPA navigation works for internal links
- [ ] Run `npm run check` (typecheck + lint + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)