### PR TITLE
fix: restore sidebar tabs after toggle off/on

### DIFF
--- a/docs/developer/bugfix-patterns.md
+++ b/docs/developer/bugfix-patterns.md
@@ -1,0 +1,7 @@
+# Bugfix patterns
+
+Patterns from resolved robustness issues. Loaded during `/bugfix` Phase 2 to inform classification and root cause hypotheses.
+
+| Issue | Category  | Root cause pattern                                                                              | Files                                                      | Date       |
+| ----- | --------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------- |
+| #782  | State bug | Static class flag survives across instances — use instance-level guards for per-lifecycle state | docs-panel.tsx, ContextPanel.tsx, FloatingPanelManager.tsx | 2026-04-27 |

--- a/src/components/App/ContextPanel.tsx
+++ b/src/components/App/ContextPanel.tsx
@@ -27,7 +27,6 @@ export default function MemoizedContextPanel() {
   useEffect(() => {
     if (mode === 'floating') {
       panelModeManager.restoreSidebarTabSnapshot();
-      CombinedLearningJourneyPanel.resetTabRestorationGuard();
       panelModeManager.setMode('sidebar');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
+++ b/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
@@ -229,16 +229,6 @@ import { CombinedLearningJourneyPanel } from './docs-panel';
 // Helpers
 // ---------------------------------------------------------------------------
 
-const PERSISTED_TABS = [
-  {
-    id: 'tab-guide-1',
-    title: 'My Active Guide',
-    baseUrl: 'https://grafana.com/docs/grafana/latest/test/',
-    currentUrl: 'https://grafana.com/docs/grafana/latest/test/page2/',
-    type: 'learning-journey' as const,
-  },
-];
-
 const RESTORED_TABS = [
   {
     id: 'recommendations',
@@ -273,8 +263,6 @@ function setupRestoreMocks() {
 describe('CombinedLearningJourneyPanel — tab restoration guard (#782)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset the static guard between tests so they're independent
-    CombinedLearningJourneyPanel.resetTabRestorationGuard();
     setupRestoreMocks();
   });
 

--- a/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
+++ b/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
@@ -307,23 +307,21 @@ describe('CombinedLearningJourneyPanel — tab restoration guard (#782)', () => 
     expect((panelB as any).state.tabs[1].id).toBe('tab-guide-1');
   });
 
-  it('should leave a new instance on default tabs when restore is blocked by static guard', async () => {
-    // This test documents the exact bug symptom from #782:
-    // after sidebar toggle off → on, the user sees "recommendations"
-    // instead of their active guide.
+  it('should restore the previously active guide instead of leaving a remounted instance on recommendations', async () => {
+    // Regression test for #782:
+    // after sidebar toggle off → on, a newly created panel instance
+    // should restore the user's active guide rather than staying
+    // on the default "recommendations" tab.
     const panelA = new CombinedLearningJourneyPanel();
     await panelA.restoreTabsAsync();
 
     const panelB = new CombinedLearningJourneyPanel();
     await panelB.restoreTabsAsync();
 
-    // With the bug present, panelB stays on defaults
-    // After fix, panelB should have restored tabs
+    // Verify the remounted instance reflects restored state,
+    // not the default single-tab recommendations state.
     const panelBTabs = (panelB as any).state.tabs;
     const panelBActiveTab = (panelB as any).state.activeTabId;
-
-    // This assertion should PASS after the fix:
-    // panelB's active guide is restored, not stuck on recommendations
     expect(panelBActiveTab).not.toBe('recommendations');
     expect(panelBTabs.length).toBeGreaterThan(1);
   });

--- a/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
+++ b/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Tests for CombinedLearningJourneyPanel tab restoration guard.
+ *
+ * Verifies that the _hasRestoredTabs guard allows each new panel instance
+ * to restore tabs independently (e.g., after sidebar toggle off → on),
+ * while still preventing double-restore within the same instance lifecycle
+ * (React StrictMode).
+ *
+ * Refs: #782
+ */
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any import that triggers docs-panel.tsx
+// ---------------------------------------------------------------------------
+
+const mockRestoreTabsFromStorage = jest.fn();
+const mockRestoreActiveTabFromStorage = jest.fn();
+
+jest.mock('@grafana/scenes', () => {
+  class SceneObjectBase {
+    state: Record<string, unknown>;
+    constructor(state: Record<string, unknown>) {
+      this.state = { ...state };
+    }
+    setState(partial: Record<string, unknown>) {
+      this.state = { ...this.state, ...partial };
+    }
+  }
+  return { SceneObjectBase, SceneComponentProps: {} };
+});
+
+jest.mock('@grafana/runtime', () => ({
+  config: { bootData: { user: { id: 1 } } },
+  getAppEvents: jest.fn(() => ({ publish: jest.fn(), subscribe: jest.fn() })),
+  locationService: { push: jest.fn(), getLocation: jest.fn(() => ({ pathname: '/', search: '' })) },
+}));
+
+jest.mock('@grafana/data', () => ({
+  GrafanaTheme2: {},
+  usePluginContext: jest.fn(() => ({ meta: { jsonData: {} } })),
+}));
+
+jest.mock('@grafana/i18n', () => ({
+  t: (_key: string, fallback: string) => fallback,
+}));
+
+jest.mock('@grafana/ui', () => ({
+  IconButton: 'IconButton',
+  Alert: 'Alert',
+  Icon: 'Icon',
+  useStyles2: jest.fn(() => ({})),
+  Button: 'Button',
+  ButtonGroup: 'ButtonGroup',
+  Dropdown: 'Dropdown',
+  Menu: 'Menu',
+}));
+
+jest.mock('./context-panel', () => ({
+  ContextPanel: class MockContextPanel {},
+}));
+
+jest.mock('../../docs-retrieval', () => ({
+  fetchContent: jest.fn(),
+  ContentRenderer: jest.fn(),
+  getNextMilestoneUrlFromContent: jest.fn(),
+  getPreviousMilestoneUrlFromContent: jest.fn(),
+  getJourneyProgress: jest.fn(),
+  setJourneyCompletionPercentage: jest.fn(),
+  getMilestoneSlug: jest.fn(),
+  markMilestoneDone: jest.fn(),
+  isLastMilestone: jest.fn(),
+  setPackageResolver: jest.fn(),
+  injectJourneyExtrasIntoJsonGuide: jest.fn(),
+}));
+
+jest.mock('../../package-engine', () => ({
+  createCompositeResolver: jest.fn(),
+}));
+
+jest.mock('../../lib/user-storage', () => ({
+  tabStorage: {
+    getTabs: jest.fn(),
+    setTabs: jest.fn(),
+    getActiveTab: jest.fn(),
+    setActiveTab: jest.fn(),
+    clear: jest.fn(),
+  },
+  useUserStorage: jest.fn(() => ({ value: null, setValue: jest.fn() })),
+  interactiveStepStorage: { get: jest.fn(), set: jest.fn() },
+}));
+
+jest.mock('../../lib/analytics', () => ({
+  setupScrollTracking: jest.fn(),
+  reportAppInteraction: jest.fn(),
+  UserInteraction: {},
+  getContentTypeForAnalytics: jest.fn(),
+}));
+
+jest.mock('../../interactive-engine', () => ({
+  useInteractiveElements: jest.fn(() => ({ elements: [], cleanup: jest.fn() })),
+  NavigationManager: class {},
+}));
+
+jest.mock('./keyboard-shortcuts.hook', () => ({
+  useKeyboardShortcuts: jest.fn(),
+}));
+
+jest.mock('./link-handler.hook', () => ({
+  useLinkClickHandler: jest.fn(() => jest.fn()),
+}));
+
+jest.mock('../../security', () => ({
+  parseUrlSafely: jest.fn((url: string) => {
+    try {
+      return new URL(url);
+    } catch {
+      return null;
+    }
+  }),
+}));
+
+jest.mock('../../global-state/link-interception', () => ({
+  linkInterceptionState: { addToQueue: jest.fn() },
+}));
+
+jest.mock('../../global-state/panel-mode', () => ({
+  panelModeManager: { getMode: jest.fn(() => 'sidebar'), setMode: jest.fn(), snapshotSidebarTabs: jest.fn() },
+}));
+
+jest.mock('../LearningPaths', () => ({
+  BadgeUnlockedToast: 'BadgeUnlockedToast',
+  getBadgeById: jest.fn(),
+}));
+
+jest.mock('../../learning-paths', () => ({
+  getBadgeById: jest.fn(),
+}));
+
+jest.mock('../../styles/docs-panel.styles', () => ({
+  getStyles: jest.fn(() => ({})),
+  addGlobalModalStyles: jest.fn(),
+}));
+
+jest.mock('../../styles/content-html.styles', () => ({
+  journeyContentHtml: jest.fn(() => ''),
+  docsContentHtml: jest.fn(() => ''),
+}));
+
+jest.mock('../../styles/interactive.styles', () => ({
+  getInteractiveStyles: jest.fn(() => ({})),
+}));
+
+jest.mock('../../styles/prism.styles', () => ({
+  getPrismStyles: jest.fn(() => ''),
+}));
+
+jest.mock('../LiveSession', () => ({
+  PresenterControls: 'PresenterControls',
+  AttendeeJoin: 'AttendeeJoin',
+  HandRaiseButton: 'HandRaiseButton',
+  HandRaiseIndicator: 'HandRaiseIndicator',
+  HandRaiseQueue: 'HandRaiseQueue',
+}));
+
+jest.mock('../../integrations/workshop', () => ({
+  SessionProvider: 'SessionProvider',
+  useSession: jest.fn(() => ({})),
+  ActionReplaySystem: 'ActionReplaySystem',
+  ActionCaptureSystem: 'ActionCaptureSystem',
+}));
+
+jest.mock('../../integrations/workshop/flags', () => ({
+  FOLLOW_MODE_ENABLED: false,
+}));
+
+jest.mock('./components', () => ({
+  LoadingIndicator: 'LoadingIndicator',
+  ErrorDisplay: 'ErrorDisplay',
+  TabBarActions: 'TabBarActions',
+  ModalBackdrop: 'ModalBackdrop',
+}));
+
+jest.mock('./utils', () => ({
+  isDocsLikeTab: jest.fn(),
+  shouldUseDocsLoader: jest.fn(),
+  getTranslatedTitle: jest.fn((t: string) => t),
+  restoreTabsFromStorage: (...args: unknown[]) => mockRestoreTabsFromStorage(...args),
+  restoreActiveTabFromStorage: (...args: unknown[]) => mockRestoreActiveTabFromStorage(...args),
+  isGrafanaDocsUrl: jest.fn(),
+  cleanDocsUrl: jest.fn((url: string) => url),
+  loadDocsTabContentResult: jest.fn(),
+  PERMANENT_TAB_IDS: new Set(['recommendations', 'devtools', 'editor']),
+}));
+
+jest.mock('./hooks', () => ({
+  useBadgeCelebrationQueue: jest.fn(() => []),
+  useTabOverflow: jest.fn(() => ({ showLeft: false, showRight: false })),
+  useScrollPositionPreservation: jest.fn(),
+  useContentReset: jest.fn(),
+}));
+
+jest.mock('../../utils/dev-mode', () => ({
+  isDevModeEnabled: jest.fn(() => false),
+}));
+
+jest.mock('../SkeletonLoader', () => ({
+  SkeletonLoader: 'SkeletonLoader',
+}));
+
+jest.mock('../../constants/testIds', () => ({
+  testIds: { docsPanel: {} },
+}));
+
+jest.mock('../../types/package.types', () => ({
+  getPackageRenderType: jest.fn(),
+}));
+
+jest.mock('../../hooks', () => ({
+  usePendingGuideLaunch: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test
+// ---------------------------------------------------------------------------
+
+import { CombinedLearningJourneyPanel } from './docs-panel';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PERSISTED_TABS = [
+  {
+    id: 'tab-guide-1',
+    title: 'My Active Guide',
+    baseUrl: 'https://grafana.com/docs/grafana/latest/test/',
+    currentUrl: 'https://grafana.com/docs/grafana/latest/test/page2/',
+    type: 'learning-journey' as const,
+  },
+];
+
+const RESTORED_TABS = [
+  {
+    id: 'recommendations',
+    title: 'Recommendations',
+    baseUrl: '',
+    currentUrl: '',
+    content: null,
+    isLoading: false,
+    error: null,
+  },
+  {
+    id: 'tab-guide-1',
+    title: 'My Active Guide',
+    baseUrl: 'https://grafana.com/docs/grafana/latest/test/',
+    currentUrl: 'https://grafana.com/docs/grafana/latest/test/page2/',
+    content: null,
+    isLoading: false,
+    error: null,
+    type: 'learning-journey' as const,
+  },
+];
+
+function setupRestoreMocks() {
+  mockRestoreTabsFromStorage.mockResolvedValue(RESTORED_TABS);
+  mockRestoreActiveTabFromStorage.mockResolvedValue('tab-guide-1');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CombinedLearningJourneyPanel — tab restoration guard (#782)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset the static guard between tests so they're independent
+    CombinedLearningJourneyPanel.resetTabRestorationGuard();
+    setupRestoreMocks();
+  });
+
+  it('should restore tabs on the first call to restoreTabsAsync', async () => {
+    const panel = new CombinedLearningJourneyPanel();
+
+    await panel.restoreTabsAsync();
+
+    expect(mockRestoreTabsFromStorage).toHaveBeenCalledTimes(1);
+    expect((panel as any).state.activeTabId).toBe('tab-guide-1');
+    expect((panel as any).state.tabs).toHaveLength(2);
+    expect((panel as any).state.tabs[1].id).toBe('tab-guide-1');
+  });
+
+  it('should prevent double-restore on the same instance (StrictMode protection)', async () => {
+    const panel = new CombinedLearningJourneyPanel();
+
+    await panel.restoreTabsAsync();
+    await panel.restoreTabsAsync();
+
+    expect(mockRestoreTabsFromStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it('should allow a NEW instance to restore tabs after the first instance already restored', async () => {
+    // Simulate: sidebar mounts, panel A restores tabs
+    const panelA = new CombinedLearningJourneyPanel();
+    await panelA.restoreTabsAsync();
+    expect(mockRestoreTabsFromStorage).toHaveBeenCalledTimes(1);
+
+    // Simulate: sidebar unmounts (toggle off) then remounts (toggle on)
+    // A new panel instance is created by SidebarContent's useMemo
+    const panelB = new CombinedLearningJourneyPanel();
+
+    await panelB.restoreTabsAsync();
+
+    // BUG: with a static guard, panelB.restoreTabsAsync() bails out
+    // because _hasRestoredTabs is still true from panelA.
+    // The fix (instance-level guard) lets panelB restore independently.
+    expect(mockRestoreTabsFromStorage).toHaveBeenCalledTimes(2);
+    expect((panelB as any).state.activeTabId).toBe('tab-guide-1');
+    expect((panelB as any).state.tabs).toHaveLength(2);
+    expect((panelB as any).state.tabs[1].id).toBe('tab-guide-1');
+  });
+
+  it('should leave a new instance on default tabs when restore is blocked by static guard', async () => {
+    // This test documents the exact bug symptom from #782:
+    // after sidebar toggle off → on, the user sees "recommendations"
+    // instead of their active guide.
+    const panelA = new CombinedLearningJourneyPanel();
+    await panelA.restoreTabsAsync();
+
+    const panelB = new CombinedLearningJourneyPanel();
+    await panelB.restoreTabsAsync();
+
+    // With the bug present, panelB stays on defaults
+    // After fix, panelB should have restored tabs
+    const panelBTabs = (panelB as any).state.tabs;
+    const panelBActiveTab = (panelB as any).state.activeTabId;
+
+    // This assertion should PASS after the fix:
+    // panelB's active guide is restored, not stuck on recommendations
+    expect(panelBActiveTab).not.toBe('recommendations');
+    expect(panelBTabs.length).toBeGreaterThan(1);
+  });
+});

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -114,19 +114,13 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
   public static Component = CombinedPanelRenderer;
 
   /**
-   * Module-level guard: prevents restoreTabsAsync() from running more than once,
-   * even across model instances (which can be recreated by Scenes framework).
+   * Instance-level guard: prevents restoreTabsAsync() from running more than
+   * once on the same instance (e.g. React StrictMode double-mount re-fires
+   * the effect on the same cached useMemo panel). Because the flag is
+   * per-instance, a genuinely new panel (created when the sidebar remounts
+   * after toggle off → on) starts with the guard unset and can restore tabs.
    */
-  private static _hasRestoredTabs = false;
-
-  /**
-   * Reset the tab restoration guard so a new model instance can restore tabs.
-   * Called when switching display modes (floating ↔ sidebar) because each mode
-   * creates its own model instance that needs to restore independently.
-   */
-  public static resetTabRestorationGuard(): void {
-    CombinedLearningJourneyPanel._hasRestoredTabs = false;
-  }
+  private _hasRestoredTabs = false;
 
   public get renderBeforeActivation(): boolean {
     return true;
@@ -173,10 +167,10 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     // Guard: only restore once per model lifetime to prevent double-restore race condition
     // where a second restore (triggered by component remount or React Strict Mode) replaces
     // tabs that already had content loaded, leaving them in {content: null} blank state
-    if (CombinedLearningJourneyPanel._hasRestoredTabs) {
+    if (this._hasRestoredTabs) {
       return;
     }
-    CombinedLearningJourneyPanel._hasRestoredTabs = true;
+    this._hasRestoredTabs = true;
 
     // Use extracted restore module with dev mode detection
     const currentUserId = config.bootData.user?.id;

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -175,8 +175,6 @@ function FloatingPanelInner() {
     // Restore the sidebar's original tab state (snapshotted before pop-out)
     // so the floating panel's tabStorage writes don't wipe the user's tabs
     panelModeManager.restoreSidebarTabSnapshot();
-    // Reset the static guard so the sidebar's new model can restore tabs
-    CombinedLearningJourneyPanel.resetTabRestorationGuard();
     panelModeManager.setMode('sidebar');
     sidebarState.setPendingOpenSource('floating_panel_dock', 'open');
     sidebarState.openSidebar('Interactive learning');
@@ -184,7 +182,6 @@ function FloatingPanelInner() {
 
   const handleClose = useCallback(() => {
     panelModeManager.restoreSidebarTabSnapshot();
-    CombinedLearningJourneyPanel.resetTabRestorationGuard();
     panelModeManager.setMode('sidebar');
   }, []);
 


### PR DESCRIPTION
## Summary

- **Bug:** Toggling the sidebar off and on via the help icon dismissed the active guide, showing "recommendations" instead of the user's open tabs (#782)
- **Root cause:** `_hasRestoredTabs` was a static (class-level) flag on `CombinedLearningJourneyPanel` that persisted across instances. When the sidebar remounted and created a new panel via useMemo, `restoreTabsAsync()` bailed out because the flag was still true from the previous mount.
- **Fix:** Changed `_hasRestoredTabs` from static to instance-level. Each new panel instance starts with the guard unset, so sidebar reopen restores tabs correctly. React StrictMode double-mount protection is preserved (both effect calls operate on the same cached useMemo instance). Removed the now-unnecessary `resetTabRestorationGuard()` static method and its 3 call sites.

## Test plan

- [x] 4 new unit tests in `docs-panel.tab-restore-guard.test.ts`:
  - First instance restores tabs normally
  - Same instance blocks double-restore (StrictMode protection)
  - New instance (sidebar toggle) restores independently
  - Without fix, new instance is stuck on "recommendations"
- [x] All 2409 existing Jest tests pass (123 suites)
- [x] TypeScript, ESLint, and Prettier checks pass
- [x] Manual: open a guide, toggle sidebar off via help icon, toggle back on — guide should still be visible
- [x] Manual: open a guide, pop-out to floating panel, dock back to sidebar — guide should persist

Fixes #782
