### PR TITLE
feat(interactive): add popout step type and editor popout mode

### DIFF
--- a/docs/developer/interactive-examples/interactive-types.md
+++ b/docs/developer/interactive-examples/interactive-types.md
@@ -123,6 +123,36 @@ With an optional `reftarget` to highlight an area for reference:
 }
 ```
 
+### popout
+
+- **Purpose**: dock or undock the docs panel without interacting with the page. Useful when something else needs the right-hand sidebar (e.g., Grafana Assistant) and the guide should move out of the way, or when the guide is in a floating window and should return to the sidebar.
+- **reftarget**: not used (omit).
+- **targetvalue**: required, must be either `"floating"` (undock to a floating window) or `"sidebar"` (dock back into the sidebar).
+- **Buttons**: a single button — labeled **Undock** when `targetvalue` is `"floating"`, **Dock** when `targetvalue` is `"sidebar"`. There is no "Show me" preview.
+- **Use when**: the guide needs to make room for another sidebar, or to bring itself back after the user finishes a side task.
+
+Move the guide out of the way:
+
+```json
+{
+  "type": "interactive",
+  "action": "popout",
+  "targetvalue": "floating",
+  "content": "Move this guide to a floating window so you can use the assistant on the right."
+}
+```
+
+Bring the guide back into the sidebar:
+
+```json
+{
+  "type": "interactive",
+  "action": "popout",
+  "targetvalue": "sidebar",
+  "content": "Dock this guide back into the sidebar."
+}
+```
+
 ## Block types
 
 ### section
@@ -211,6 +241,7 @@ See [guided-interactions.md](./guided-interactions.md) for detailed documentatio
 | Route change                            | `navigate`        |
 | Hover to reveal hidden UI               | `hover`           |
 | Informational step (no action)          | `noop`            |
+| Dock or undock the guide panel          | `popout`          |
 | Teach a linear section                  | `section`         |
 | Bundle micro-steps into one (automated) | `multistep`       |
 | User performs steps manually            | `guided`          |

--- a/src/components/block-editor/BlockEditorHeader.test.tsx
+++ b/src/components/block-editor/BlockEditorHeader.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { BlockEditorHeader } from './BlockEditorHeader';
+import { panelModeManager, type PanelMode } from '../../global-state/panel-mode';
+
+const baseProps = {
+  guideTitle: 'Test guide',
+  guideId: 'test-guide',
+  isDirty: false,
+  publishedStatus: 'not-saved' as const,
+  hasUnsyncedChanges: false,
+  viewMode: 'edit' as const,
+  onSetViewMode: jest.fn(),
+  onTitleCommit: jest.fn(),
+  onOpenTour: jest.fn(),
+  onOpenGuideLibrary: jest.fn(),
+  onOpenImport: jest.fn(),
+  onCopy: jest.fn(),
+  onDownload: jest.fn(),
+  onOpenGitHubPR: jest.fn(),
+  onSaveDraft: jest.fn(),
+  onPostToBackend: jest.fn(),
+  onUnpublish: jest.fn(),
+  onNewGuide: jest.fn(),
+  isBackendAvailable: true,
+};
+
+describe('BlockEditorHeader: pop out / dock button', () => {
+  let getModeSpy: jest.SpyInstance<PanelMode, []>;
+
+  beforeEach(() => {
+    getModeSpy = jest.spyOn(panelModeManager, 'getMode');
+  });
+
+  afterEach(() => {
+    getModeSpy.mockRestore();
+  });
+
+  it('renders "Pop out" when the panel is currently in sidebar mode', () => {
+    getModeSpy.mockReturnValue('sidebar');
+    render(<BlockEditorHeader {...baseProps} />);
+    expect(screen.getByRole('button', { name: 'Pop out editor' })).toBeInTheDocument();
+  });
+
+  it("dispatches 'pathfinder-request-pop-out' when clicked from sidebar mode", () => {
+    getModeSpy.mockReturnValue('sidebar');
+    const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+    try {
+      render(<BlockEditorHeader {...baseProps} />);
+      const button = screen.getByRole('button', { name: 'Pop out editor' });
+      button.click();
+      const popOutCall = dispatchSpy.mock.calls.find(
+        (call) => (call[0] as Event).type === 'pathfinder-request-pop-out'
+      );
+      expect(popOutCall).toBeDefined();
+    } finally {
+      dispatchSpy.mockRestore();
+    }
+  });
+
+  it('renders "Dock" when the panel is currently in floating mode', () => {
+    getModeSpy.mockReturnValue('floating');
+    render(<BlockEditorHeader {...baseProps} />);
+    expect(screen.getByRole('button', { name: 'Dock editor' })).toBeInTheDocument();
+  });
+
+  it("dispatches 'pathfinder-request-dock' when clicked from floating mode", () => {
+    getModeSpy.mockReturnValue('floating');
+    const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+    try {
+      render(<BlockEditorHeader {...baseProps} />);
+      const button = screen.getByRole('button', { name: 'Dock editor' });
+      button.click();
+      const dockCall = dispatchSpy.mock.calls.find((call) => (call[0] as Event).type === 'pathfinder-request-dock');
+      expect(dockCall).toBeDefined();
+    } finally {
+      dispatchSpy.mockRestore();
+    }
+  });
+
+  it("reacts to 'pathfinder-panel-mode-change' events at runtime", () => {
+    getModeSpy.mockReturnValue('sidebar');
+    render(<BlockEditorHeader {...baseProps} />);
+
+    expect(screen.getByRole('button', { name: 'Pop out editor' })).toBeInTheDocument();
+
+    act(() => {
+      document.dispatchEvent(new CustomEvent('pathfinder-panel-mode-change', { detail: { mode: 'floating' } }));
+    });
+
+    expect(screen.getByRole('button', { name: 'Dock editor' })).toBeInTheDocument();
+  });
+});

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -8,12 +8,13 @@
  * - Publishing controls
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Button, Badge, ButtonGroup, Tooltip, Dropdown, Menu, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import type { ViewMode } from './types';
 import { testIds } from '../../constants/testIds';
+import { panelModeManager, type PanelMode } from '../../global-state/panel-mode';
 
 export interface BlockEditorHeaderProps {
   /** Guide title to display */
@@ -192,6 +193,30 @@ export function BlockEditorHeader({
   // Inline title editing
   const [titleDraft, setTitleDraft] = useState(guideTitle);
   const titleInputRef = useRef<HTMLInputElement>(null);
+
+  // Track the current panel mode so the Pop out button can swap between
+  // "Pop out" (sidebar) and "Dock" (floating) at runtime.
+  const [panelMode, setPanelMode] = useState<PanelMode>(() => panelModeManager.getMode());
+  useEffect(() => {
+    const handleModeChange = (e: CustomEvent<{ mode: PanelMode }>) => {
+      setPanelMode(e.detail.mode);
+    };
+    document.addEventListener('pathfinder-panel-mode-change', handleModeChange as EventListener);
+    return () => {
+      document.removeEventListener('pathfinder-panel-mode-change', handleModeChange as EventListener);
+    };
+  }, []);
+
+  // Dispatch the same document-level events used by interactive popout steps.
+  // The sidebar's docs-panel handler picks up pop-out for the editor tab; the
+  // FloatingPanelManager handles dock requests.
+  const handleTogglePanelMode = useCallback(() => {
+    if (panelMode === 'sidebar') {
+      document.dispatchEvent(new CustomEvent('pathfinder-request-pop-out'));
+    } else {
+      document.dispatchEvent(new CustomEvent('pathfinder-request-dock'));
+    }
+  }, [panelMode]);
 
   // Keep draft in sync when title changes externally (e.g. guide loaded from library)
   useEffect(() => {
@@ -459,6 +484,22 @@ export function BlockEditorHeader({
               {renderBackendButton()}
             </>
           )}
+
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={panelMode === 'sidebar' ? 'corner-up-right' : 'arrow-to-right'}
+            onClick={handleTogglePanelMode}
+            tooltip={
+              panelMode === 'sidebar'
+                ? 'Pop out the editor into a floating window'
+                : 'Dock the editor back into the sidebar'
+            }
+            aria-label={panelMode === 'sidebar' ? 'Pop out editor' : 'Dock editor'}
+            data-testid="pathfinder-block-editor-toggle-popout"
+          >
+            {panelMode === 'sidebar' ? 'Pop out' : 'Dock'}
+          </Button>
 
           <div className={styles.moreButton}>
             <Dropdown overlay={moreMenu} placement="bottom-end">

--- a/src/components/block-editor/constants.ts
+++ b/src/components/block-editor/constants.ts
@@ -174,6 +174,17 @@ export const INTERACTIVE_ACTIONS = [
   { value: 'navigate', label: '🧭 Navigate', description: 'Go to a URL' },
   { value: 'hover', label: '👆 Hover', description: 'Hover over an element' },
   { value: 'noop', label: '📖 Info', description: 'Non-interactive informational step' },
+  { value: 'popout', label: '🪟 Popout', description: 'Dock or undock the guide panel' },
+] as const;
+
+/**
+ * Target mode options for popout interactive actions.
+ * - 'floating' undocks the guide into a floating window.
+ * - 'sidebar' docks the guide back into the Grafana sidebar.
+ */
+export const POPOUT_TARGET_MODES = [
+  { value: 'floating', label: 'Undock (move to floating window)' },
+  { value: 'sidebar', label: 'Dock (return to sidebar)' },
 ] as const;
 
 /**

--- a/src/components/block-editor/forms/InteractiveBlockForm.tsx
+++ b/src/components/block-editor/forms/InteractiveBlockForm.tsx
@@ -19,7 +19,7 @@ import {
   type ComboboxOption,
 } from '@grafana/ui';
 import { getBlockFormStyles } from '../block-editor.styles';
-import { INTERACTIVE_ACTIONS } from '../constants';
+import { INTERACTIVE_ACTIONS, POPOUT_TARGET_MODES } from '../constants';
 import { COMMON_REQUIREMENTS } from '../../../constants/interactive-config';
 import { TypeSwitchDropdown } from './TypeSwitchDropdown';
 import { suggestDefaultRequirements, mergeRequirements } from './requirements-suggester';
@@ -51,6 +51,17 @@ const ACTION_OPTIONS: Array<ComboboxOption<JsonInteractiveAction>> = INTERACTIVE
   label: a.label,
   description: a.description,
 }));
+
+type PopoutTargetMode = (typeof POPOUT_TARGET_MODES)[number]['value'];
+const POPOUT_TARGET_OPTIONS: Array<ComboboxOption<PopoutTargetMode>> = POPOUT_TARGET_MODES.map((m) => ({
+  value: m.value,
+  label: m.label,
+}));
+const DEFAULT_POPOUT_TARGET: PopoutTargetMode = 'floating';
+
+function isPopoutTargetMode(value: string): value is PopoutTargetMode {
+  return value === 'sidebar' || value === 'floating';
+}
 
 /**
  * Interactive block form component
@@ -129,30 +140,35 @@ export function InteractiveBlockForm({
           return o.length > 0;
         });
 
-      // noop actions don't need most of these fields
+      // noop and popout actions don't operate on a DOM element and skip most fields
       const isNoopAction = action === 'noop';
+      const isPopoutAction = action === 'popout';
+      // Treat both actions like noop for the bulk of the optional-field gating below.
+      const isStateOnlyAction = isNoopAction || isPopoutAction;
 
       const block: JsonInteractiveBlock = {
         type: 'interactive',
         action,
-        // Only include reftarget for non-noop actions
-        ...(!isNoopAction && reftarget.trim() && { reftarget: reftarget.trim() }),
+        // Only include reftarget for actions that operate on DOM elements
+        ...(!isStateOnlyAction && reftarget.trim() && { reftarget: reftarget.trim() }),
         content: content.trim(),
-        // The following fields are not relevant for noop actions
-        ...(!isNoopAction && targetvalue.trim() && { targetvalue: targetvalue.trim() }),
+        // formfill stores the value to fill; popout stores the target panel mode.
+        ...(!isStateOnlyAction && targetvalue.trim() && { targetvalue: targetvalue.trim() }),
+        ...(isPopoutAction &&
+          isPopoutTargetMode(targetvalue.trim()) && { targetvalue: targetvalue.trim() as PopoutTargetMode }),
         ...(!isNoopAction && tooltip.trim() && { tooltip: tooltip.trim() }),
         ...(!isNoopAction && reqArray.length > 0 && { requirements: reqArray }),
         ...(!isNoopAction && objArray.length > 0 && { objectives: objArray }),
         ...(!isNoopAction && skippable && { skippable }),
         ...(!isNoopAction && hint.trim() && { hint: hint.trim() }),
-        ...(!isNoopAction && formHint.trim() && { formHint: formHint.trim() }),
-        ...(!isNoopAction && !showMe && { showMe: false }),
-        ...(!isNoopAction && !doIt && { doIt: false }),
+        ...(!isStateOnlyAction && formHint.trim() && { formHint: formHint.trim() }),
+        ...(!isStateOnlyAction && !showMe && { showMe: false }),
+        ...(!isStateOnlyAction && !doIt && { doIt: false }),
         ...(!isNoopAction && completeEarly && { completeEarly }),
         ...(!isNoopAction && verify.trim() && { verify: verify.trim() }),
-        // Lazy render support for virtualized containers (not relevant for noop)
-        ...(!isNoopAction && lazyRender && { lazyRender }),
-        ...(!isNoopAction && lazyRender && scrollContainer.trim() && { scrollContainer: scrollContainer.trim() }),
+        // Lazy render support for virtualized containers (not relevant for noop/popout)
+        ...(!isStateOnlyAction && lazyRender && { lazyRender }),
+        ...(!isStateOnlyAction && lazyRender && scrollContainer.trim() && { scrollContainer: scrollContainer.trim() }),
         // Navigate: guide to open after navigation
         ...(action === 'navigate' && openGuide.trim() && { openGuide: openGuide.trim() }),
         // AI customization props
@@ -195,8 +211,16 @@ export function InteractiveBlockForm({
       if (suggestions.length > 0) {
         setRequirements((prev) => mergeRequirements(prev, suggestions));
       }
+      // For popout, seed a sensible default targetvalue so the form is valid
+      // out of the gate. For other actions, clear any popout-specific value
+      // that wouldn't make sense (e.g. switching back to formfill).
+      if (option.value === 'popout') {
+        setTargetvalue((prev) => (isPopoutTargetMode(prev) ? prev : DEFAULT_POPOUT_TARGET));
+      } else if (isPopoutTargetMode(targetvalue)) {
+        setTargetvalue('');
+      }
     },
-    [reftarget]
+    [reftarget, targetvalue]
   );
 
   const handleRequirementClick = useCallback((req: string) => {
@@ -238,9 +262,14 @@ export function InteractiveBlockForm({
 
   // noop actions don't require a reftarget since they're informational only
   // navigate actions use reftarget as a path, not a DOM selector
+  // popout actions toggle panel mode and use targetvalue, not reftarget
   const isNoop = action === 'noop';
   const isNavigate = action === 'navigate';
-  const isValid = (isNoop || reftarget.trim().length > 0) && content.trim().length > 0;
+  const isPopout = action === 'popout';
+  const isValid =
+    (isNoop || isPopout || reftarget.trim().length > 0) &&
+    content.trim().length > 0 &&
+    (!isPopout || isPopoutTargetMode(targetvalue.trim()));
   const showTargetValue = action === 'formfill';
 
   return (
@@ -277,8 +306,23 @@ export function InteractiveBlockForm({
         </>
       )}
 
-      {/* Target Selector with DOM Picker - hidden for noop and navigate actions */}
-      {!isNoop && !isNavigate && (
+      {/* Popout target mode - select where the panel should end up */}
+      {isPopout && (
+        <Field
+          label="Target panel mode"
+          description="Whether to undock the guide into a floating window or dock it back into the sidebar"
+          required
+        >
+          <Combobox
+            options={POPOUT_TARGET_OPTIONS}
+            value={isPopoutTargetMode(targetvalue) ? targetvalue : DEFAULT_POPOUT_TARGET}
+            onChange={(option) => setTargetvalue(option.value)}
+          />
+        </Field>
+      )}
+
+      {/* Target Selector with DOM Picker - hidden for noop, navigate, and popout actions */}
+      {!isNoop && !isNavigate && !isPopout && (
         <>
           <Field label="Target selector" description="CSS selector or Grafana selector for the target element" required>
             <div className={styles.selectorField}>
@@ -398,8 +442,8 @@ export function InteractiveBlockForm({
         />
       </Field>
 
-      {/* Tooltip - hidden for noop actions */}
-      {!isNoop && (
+      {/* Tooltip - hidden for noop and popout actions (they have no element to highlight) */}
+      {!isNoop && !isPopout && (
         <Field label="Tooltip" description="Tooltip shown when highlighting the element">
           <Input
             value={tooltip}
@@ -438,7 +482,8 @@ export function InteractiveBlockForm({
 
       {/* Button Visibility - hidden for noop actions */}
       {/* Navigate actions always show "Go there" button, no "Show me" option */}
-      {!isNoop && !isNavigate && (
+      {/* Popout actions are single-button "Dock"/"Undock" toggles */}
+      {!isNoop && !isNavigate && !isPopout && (
         <div className={styles.section}>
           <div className={styles.sectionTitle}>Button visibility</div>
           <Stack direction="row" gap={2}>
@@ -470,15 +515,18 @@ export function InteractiveBlockForm({
                 checked={skippable}
                 onChange={(e) => setSkippable(e.currentTarget.checked)}
               />
-              <Checkbox
-                className={styles.checkbox}
-                label="Complete early (mark complete before action)"
-                description="Marks the step as done immediately, before the action executes"
-                checked={completeEarly}
-                onChange={(e) => setCompleteEarly(e.currentTarget.checked)}
-              />
+              {/* completeEarly doesn't apply to popout - it's already a discrete state change */}
+              {!isPopout && (
+                <Checkbox
+                  className={styles.checkbox}
+                  label="Complete early (mark complete before action)"
+                  description="Marks the step as done immediately, before the action executes"
+                  checked={completeEarly}
+                  onChange={(e) => setCompleteEarly(e.currentTarget.checked)}
+                />
+              )}
               {/* Lazy render only applies to actions with DOM elements */}
-              {!isNavigate && (
+              {!isNavigate && !isPopout && (
                 <Checkbox
                   className={styles.checkbox}
                   label="Element may be off-screen (scroll to find)"
@@ -490,8 +538,8 @@ export function InteractiveBlockForm({
             </Stack>
           </div>
 
-          {/* Lazy Render Scroll Container - only for non-navigate actions */}
-          {lazyRender && !isNavigate && (
+          {/* Lazy Render Scroll Container - only for non-navigate, non-popout actions */}
+          {lazyRender && !isNavigate && !isPopout && (
             <Field
               label="Scroll container"
               description="CSS selector for the scroll container (default: .scrollbar-view)"

--- a/src/components/block-editor/forms/StepEditor.tsx
+++ b/src/components/block-editor/forms/StepEditor.tsx
@@ -38,7 +38,7 @@ import {
   sortableKeyboardCoordinates,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { INTERACTIVE_ACTIONS } from '../constants';
+import { INTERACTIVE_ACTIONS, POPOUT_TARGET_MODES } from '../constants';
 import { COMMON_REQUIREMENTS } from '../../../constants/interactive-config';
 import { useActionRecorder } from '../../../utils/devtools';
 import { suggestDefaultRequirements, mergeRequirements } from './requirements-suggester';
@@ -200,6 +200,17 @@ const ACTION_OPTIONS: Array<ComboboxOption<JsonInteractiveAction>> = INTERACTIVE
   value: a.value as JsonInteractiveAction,
   label: a.label,
 }));
+
+type PopoutTargetMode = (typeof POPOUT_TARGET_MODES)[number]['value'];
+const POPOUT_TARGET_OPTIONS: Array<ComboboxOption<PopoutTargetMode>> = POPOUT_TARGET_MODES.map((m) => ({
+  value: m.value,
+  label: m.label,
+}));
+const DEFAULT_POPOUT_TARGET: PopoutTargetMode = 'floating';
+
+function isPopoutTargetMode(value: string): value is PopoutTargetMode {
+  return value === 'sidebar' || value === 'floating';
+}
 
 export interface StepEditorProps {
   /** Current steps */
@@ -410,8 +421,15 @@ export function StepEditor({
 
   // Save edited step
   const handleSaveEdit = useCallback(() => {
-    // noop actions don't require a reftarget
-    if (editingStepIndex === null || (editAction !== 'noop' && !editReftarget.trim())) {
+    // noop and popout actions don't operate on a DOM element and skip reftarget
+    const editIsStateOnly = editAction === 'noop' || editAction === 'popout';
+    if (editingStepIndex === null) {
+      return;
+    }
+    if (!editIsStateOnly && !editReftarget.trim()) {
+      return;
+    }
+    if (editAction === 'popout' && !isPopoutTargetMode(editTargetvalue.trim())) {
       return;
     }
 
@@ -423,15 +441,20 @@ export function StepEditor({
 
     const updatedStep: JsonStep = {
       action: editAction,
-      reftarget: editReftarget.trim(),
+      // Only persist reftarget when the action operates on a DOM element
+      ...(!editIsStateOnly && { reftarget: editReftarget.trim() }),
       ...(editAction === 'formfill' && editTargetvalue.trim() && { targetvalue: editTargetvalue.trim() }),
       ...(editAction === 'formfill' && editFormHint.trim() && { formHint: editFormHint.trim() }),
       ...(editAction === 'formfill' && editValidateInput && { validateInput: true }),
+      ...(editAction === 'popout' &&
+        isPopoutTargetMode(editTargetvalue.trim()) && { targetvalue: editTargetvalue.trim() as PopoutTargetMode }),
       ...(isGuided
         ? editDescription.trim() && { description: editDescription.trim() }
         : editTooltip.trim() && { tooltip: editTooltip.trim() }),
-      ...(editLazyRender && { lazyRender: true }),
-      ...(editLazyRender && editScrollContainer.trim() && { scrollContainer: editScrollContainer.trim() }),
+      ...(!editIsStateOnly && editLazyRender && { lazyRender: true }),
+      ...(!editIsStateOnly &&
+        editLazyRender &&
+        editScrollContainer.trim() && { scrollContainer: editScrollContainer.trim() }),
       ...(reqArray.length > 0 && { requirements: reqArray }),
       ...(isGuided && editSkippable && { skippable: true }),
     };
@@ -508,8 +531,12 @@ export function StepEditor({
 
   // Handle adding a manual step
   const handleAddStep = useCallback(() => {
-    // noop actions don't require a reftarget
-    if (newAction !== 'noop' && !newReftarget.trim()) {
+    // noop and popout actions don't operate on a DOM element and skip reftarget
+    const newIsStateOnly = newAction === 'noop' || newAction === 'popout';
+    if (!newIsStateOnly && !newReftarget.trim()) {
+      return;
+    }
+    if (newAction === 'popout' && !isPopoutTargetMode(newTargetvalue.trim())) {
       return;
     }
 
@@ -521,15 +548,20 @@ export function StepEditor({
 
     const step: JsonStep = {
       action: newAction,
-      reftarget: newReftarget.trim(),
+      // Only persist reftarget when the action operates on a DOM element
+      ...(!newIsStateOnly && { reftarget: newReftarget.trim() }),
       ...(newAction === 'formfill' && newTargetvalue.trim() && { targetvalue: newTargetvalue.trim() }),
       ...(newAction === 'formfill' && newFormHint.trim() && { formHint: newFormHint.trim() }),
       ...(newAction === 'formfill' && newValidateInput && { validateInput: true }),
+      ...(newAction === 'popout' &&
+        isPopoutTargetMode(newTargetvalue.trim()) && { targetvalue: newTargetvalue.trim() as PopoutTargetMode }),
       ...(isGuided
         ? newDescription.trim() && { description: newDescription.trim() }
         : newTooltip.trim() && { tooltip: newTooltip.trim() }),
-      ...(newLazyRender && { lazyRender: true }),
-      ...(newLazyRender && newScrollContainer.trim() && { scrollContainer: newScrollContainer.trim() }),
+      ...(!newIsStateOnly && newLazyRender && { lazyRender: true }),
+      ...(!newIsStateOnly &&
+        newLazyRender &&
+        newScrollContainer.trim() && { scrollContainer: newScrollContainer.trim() }),
       ...(reqArray.length > 0 && { requirements: reqArray }),
       ...(isGuided && newSkippable && { skippable: true }),
     };
@@ -663,6 +695,12 @@ export function StepEditor({
                               if (suggestions.length > 0) {
                                 setEditRequirements((prev) => mergeRequirements(prev, suggestions));
                               }
+                              // Seed/clear popout target so the form is valid out of the gate
+                              if (opt.value === 'popout') {
+                                setEditTargetvalue((prev) => (isPopoutTargetMode(prev) ? prev : DEFAULT_POPOUT_TARGET));
+                              } else if (isPopoutTargetMode(editTargetvalue)) {
+                                setEditTargetvalue('');
+                              }
                             }}
                           />
                         </Field>
@@ -676,8 +714,18 @@ export function StepEditor({
                             />
                           </Field>
                         )}
+                        {/* Popout target mode - for popout actions only */}
+                        {editAction === 'popout' && (
+                          <Field label="Target" style={{ marginBottom: 0, flex: 1 }}>
+                            <Combobox
+                              options={POPOUT_TARGET_OPTIONS}
+                              value={isPopoutTargetMode(editTargetvalue) ? editTargetvalue : DEFAULT_POPOUT_TARGET}
+                              onChange={(opt) => setEditTargetvalue(opt.value)}
+                            />
+                          </Field>
+                        )}
                         {/* Selector with picker - for actions that need a DOM element */}
-                        {editAction !== 'noop' && editAction !== 'navigate' && (
+                        {editAction !== 'noop' && editAction !== 'navigate' && editAction !== 'popout' && (
                           <>
                             <Field label="Selector" style={{ marginBottom: 0, flex: 1 }}>
                               <Input
@@ -769,7 +817,7 @@ export function StepEditor({
                       )}
 
                       {/* Lazy render only applies to actions with DOM elements */}
-                      {editAction !== 'navigate' && (
+                      {editAction !== 'navigate' && editAction !== 'popout' && (
                         <Checkbox
                           className={styles.checkbox}
                           label="Element may be off-screen (scroll to find)"
@@ -778,7 +826,7 @@ export function StepEditor({
                           onChange={(e) => setEditLazyRender(e.currentTarget.checked)}
                         />
                       )}
-                      {editLazyRender && editAction !== 'navigate' && (
+                      {editLazyRender && editAction !== 'navigate' && editAction !== 'popout' && (
                         <Field label="Scroll container (optional)" style={{ marginBottom: 0 }}>
                           <div className={styles.addStepRow}>
                             <Input
@@ -848,7 +896,10 @@ export function StepEditor({
                         <Button
                           variant="primary"
                           onClick={handleSaveEdit}
-                          disabled={editAction !== 'noop' && !editReftarget.trim()}
+                          disabled={
+                            (editAction !== 'noop' && editAction !== 'popout' && !editReftarget.trim()) ||
+                            (editAction === 'popout' && !isPopoutTargetMode(editTargetvalue.trim()))
+                          }
                         >
                           Save changes
                         </Button>
@@ -869,15 +920,19 @@ export function StepEditor({
                           <Badge text={step.action} color="blue" />
                           {step.targetvalue && <Badge text={`= "${step.targetvalue}"`} color="purple" />}
                         </div>
-                        {/* Show description/tooltip if available, otherwise show selector (or "Info step" for noop) */}
+                        {/* Show description/tooltip if available, otherwise show selector (or "Info step" for noop, "Dock"/"Undock" for popout) */}
                         <div className={styles.stepSelector} title={step.reftarget}>
                           {step.action === 'noop'
                             ? isGuided
                               ? step.description || 'Informational step'
                               : step.tooltip || 'Informational step'
-                            : isGuided
-                              ? step.description || step.reftarget
-                              : step.tooltip || step.reftarget}
+                            : step.action === 'popout'
+                              ? step.targetvalue === 'sidebar'
+                                ? 'Dock to sidebar'
+                                : 'Undock to floating window'
+                              : isGuided
+                                ? step.description || step.reftarget
+                                : step.tooltip || step.reftarget}
                         </div>
                       </div>
 
@@ -940,6 +995,12 @@ export function StepEditor({
                   if (suggestions.length > 0) {
                     setNewRequirements((prev) => mergeRequirements(prev, suggestions));
                   }
+                  // Seed/clear popout target so the form is valid out of the gate
+                  if (opt.value === 'popout') {
+                    setNewTargetvalue((prev) => (isPopoutTargetMode(prev) ? prev : DEFAULT_POPOUT_TARGET));
+                  } else if (isPopoutTargetMode(newTargetvalue)) {
+                    setNewTargetvalue('');
+                  }
                 }}
               />
             </Field>
@@ -953,8 +1014,18 @@ export function StepEditor({
                 />
               </Field>
             )}
+            {/* Popout target mode - for popout actions only */}
+            {newAction === 'popout' && (
+              <Field label="Target" style={{ marginBottom: 0, flex: 1 }}>
+                <Combobox
+                  options={POPOUT_TARGET_OPTIONS}
+                  value={isPopoutTargetMode(newTargetvalue) ? newTargetvalue : DEFAULT_POPOUT_TARGET}
+                  onChange={(opt) => setNewTargetvalue(opt.value)}
+                />
+              </Field>
+            )}
             {/* Selector with picker - for actions that need a DOM element */}
-            {newAction !== 'noop' && newAction !== 'navigate' && (
+            {newAction !== 'noop' && newAction !== 'navigate' && newAction !== 'popout' && (
               <>
                 <Field label="Selector" style={{ marginBottom: 0, flex: 1 }}>
                   <Input
@@ -1038,7 +1109,7 @@ export function StepEditor({
           )}
 
           {/* Lazy render only applies to actions with DOM elements */}
-          {newAction !== 'navigate' && (
+          {newAction !== 'navigate' && newAction !== 'popout' && (
             <Checkbox
               className={styles.checkbox}
               label="Element may be off-screen (scroll to find)"
@@ -1047,7 +1118,7 @@ export function StepEditor({
               onChange={(e) => setNewLazyRender(e.currentTarget.checked)}
             />
           )}
-          {newLazyRender && newAction !== 'navigate' && (
+          {newLazyRender && newAction !== 'navigate' && newAction !== 'popout' && (
             <Field label="Scroll container (optional)" style={{ marginBottom: 0 }}>
               <div className={styles.addStepRow}>
                 <Input
@@ -1112,7 +1183,14 @@ export function StepEditor({
             <Button variant="secondary" onClick={() => setShowAddForm(false)}>
               Cancel
             </Button>
-            <Button variant="primary" onClick={handleAddStep} disabled={newAction !== 'noop' && !newReftarget.trim()}>
+            <Button
+              variant="primary"
+              onClick={handleAddStep}
+              disabled={
+                (newAction !== 'noop' && newAction !== 'popout' && !newReftarget.trim()) ||
+                (newAction === 'popout' && !isPopoutTargetMode(newTargetvalue.trim()))
+              }
+            >
               Add step
             </Button>
           </div>

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -1256,13 +1256,40 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
       const activeTab = currentTabs.find((tab) => tab.id === currentActiveTabId);
       const guideUrl = activeTab?.baseUrl || activeTab?.currentUrl;
 
-      if (activeTab && activeTab.id !== 'recommendations' && guideUrl) {
-        panelModeManager.setPendingGuide({ url: guideUrl, title: activeTab.title });
+      // Editor tab popout: the block editor itself moves into the floating panel.
+      // No pendingGuide handoff — the floating panel detects the editor tab and
+      // renders <BlockEditor /> directly (see FloatingPanelManager).
+      if (activeTab?.type === 'editor') {
+        reportAppInteraction(UserInteraction.FloatingPanelPopOut, {
+          guide_url: '',
+          guide_title: activeTab.title,
+        });
+        panelModeManager.snapshotSidebarTabs();
+        // The floating panel creates a new CombinedLearningJourneyPanel instance
+        // whose `restoreTabsAsync` call would otherwise be skipped by the static
+        // `_hasRestoredTabs` guard set by the sidebar. Reset it so the floating
+        // model can rehydrate the editor tab from localStorage.
+        CombinedLearningJourneyPanel.resetTabRestorationGuard();
+        panelModeManager.setMode('floating');
+        return;
       }
 
+      // Refuse to pop out when there's no guide context — without this guard the
+      // sidebar would close and the floating panel would have nothing to show.
+      // Surface a notification so the user understands why nothing happened.
+      if (!activeTab || activeTab.id === 'recommendations' || !guideUrl) {
+        getAppEvents().publish({
+          type: 'alert-info',
+          payload: ['Open a guide before popping out the panel.'],
+        });
+        return;
+      }
+
+      panelModeManager.setPendingGuide({ url: guideUrl, title: activeTab.title });
+
       reportAppInteraction(UserInteraction.FloatingPanelPopOut, {
-        guide_url: guideUrl || '',
-        guide_title: activeTab?.title || '',
+        guide_url: guideUrl,
+        guide_title: activeTab.title,
       });
 
       // Snapshot sidebar tabs before switching — the floating panel's model

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { lazy, Suspense, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { CombinedLearningJourneyPanel } from '../docs-panel/docs-panel';
 import { PathfinderFeatureProvider } from '../OpenFeatureProvider';
 import { usePendingGuideLaunch } from '../../hooks';
@@ -8,6 +8,16 @@ import { getConfigWithDefaults } from '../../constants';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
 import { FloatingPanel } from './FloatingPanel';
 import { FloatingPanelContent } from './FloatingPanelContent';
+import { SkeletonLoader } from '../SkeletonLoader';
+
+// Lazy-loaded so the editor only ships when the user actually pops it out.
+const BlockEditor = lazy(() =>
+  import('../block-editor').then((module) => ({
+    default: module.BlockEditor,
+  }))
+);
+
+const EDITOR_FLOATING_TITLE = 'Guide editor';
 
 /**
  * Root manager for the floating panel.
@@ -131,9 +141,12 @@ function FloatingPanelInner() {
 
   // Get active tab content
   const activeTab = tabs.find((t) => t.id === activeTabId);
+  const isEditorTab = activeTab?.type === 'editor';
   const content = activeTab?.content ?? null;
-  const title = activeTab?.title || 'Interactive learning';
-  const hasActiveGuide = activeTab != null && activeTab.id !== 'recommendations';
+  const title = isEditorTab ? EDITOR_FLOATING_TITLE : activeTab?.title || 'Interactive learning';
+  // hasActiveGuide drives the dock pill pulse and step-progress polling. The editor
+  // tab is its own kind of "active content" but isn't a guide, so leave it false.
+  const hasActiveGuide = activeTab != null && activeTab.id !== 'recommendations' && !isEditorTab;
 
   // Track interactive step progress from window globals set by the
   // interactive engine. Poll on a short interval since these globals
@@ -159,13 +172,14 @@ function FloatingPanelInner() {
   }, [hasActiveGuide]);
 
   // After restoration completes, if there's no guide to show and none
-  // is being loaded, fall back to sidebar mode.
+  // is being loaded, fall back to sidebar mode. The editor tab counts as
+  // valid floating content, so don't fall back when it's active.
   useEffect(() => {
-    if (restorationDone && !hasActiveGuide && !guideOpenInFlightRef.current) {
+    if (restorationDone && !hasActiveGuide && !isEditorTab && !guideOpenInFlightRef.current) {
       panelModeManager.setMode('sidebar');
     }
-  }, [restorationDone, hasActiveGuide]);
-  const guideUrl = activeTab?.baseUrl || activeTab?.currentUrl;
+  }, [restorationDone, hasActiveGuide, isEditorTab]);
+  const guideUrl = isEditorTab ? undefined : activeTab?.baseUrl || activeTab?.currentUrl;
 
   const handleSwitchToSidebar = useCallback(() => {
     reportAppInteraction(UserInteraction.FloatingPanelDock, {
@@ -182,6 +196,19 @@ function FloatingPanelInner() {
     sidebarState.openSidebar('Interactive learning');
   }, [guideUrl, title]);
 
+  // Symmetric counterpart to `pathfinder-request-pop-out` (see docs-panel.tsx).
+  // Dispatched by the popout interactive action so that guides can programmatically
+  // dock the floating panel back into the sidebar.
+  useEffect(() => {
+    const handleDockRequest = () => {
+      handleSwitchToSidebar();
+    };
+    document.addEventListener('pathfinder-request-dock', handleDockRequest);
+    return () => {
+      document.removeEventListener('pathfinder-request-dock', handleDockRequest);
+    };
+  }, [handleSwitchToSidebar]);
+
   const handleClose = useCallback(() => {
     panelModeManager.restoreSidebarTabSnapshot();
     CombinedLearningJourneyPanel.resetTabRestorationGuard();
@@ -197,7 +224,13 @@ function FloatingPanelInner() {
       onSwitchToSidebar={handleSwitchToSidebar}
       onClose={handleClose}
     >
-      <FloatingPanelContent content={content} />
+      {isEditorTab ? (
+        <Suspense fallback={<SkeletonLoader type="documentation" />}>
+          <BlockEditor />
+        </Suspense>
+      ) : (
+        <FloatingPanelContent content={content} />
+      )}
     </FloatingPanel>
   );
 }

--- a/src/components/interactive-tutorial/data-attributes.contract.test.tsx
+++ b/src/components/interactive-tutorial/data-attributes.contract.test.tsx
@@ -406,7 +406,7 @@ describe('E2E Contract: data-test-form-state', () => {
 // ============================================================================
 
 describe('E2E Contract: data-targetaction (existing)', () => {
-  const actionTypes = ['button', 'hover', 'highlight', 'formfill', 'navigate', 'noop'] as const;
+  const actionTypes = ['button', 'hover', 'highlight', 'formfill', 'navigate', 'noop', 'popout'] as const;
 
   it.each(actionTypes)('InteractiveStep: reflects "%s" action in data-targetaction', (actionType) => {
     render(
@@ -414,6 +414,7 @@ describe('E2E Contract: data-targetaction (existing)', () => {
         stepId={`test-action-${actionType}`}
         targetAction={actionType}
         refTarget={actionType === 'navigate' ? '/test' : 'button'}
+        targetValue={actionType === 'popout' ? 'floating' : undefined}
       >
         {actionType} action
       </InteractiveStep>

--- a/src/components/interactive-tutorial/interactive-step.test.tsx
+++ b/src/components/interactive-tutorial/interactive-step.test.tsx
@@ -87,3 +87,83 @@ describe('InteractiveStep: noop action type', () => {
     expect(stepContainer).toHaveAttribute('data-targetaction', 'noop');
   });
 });
+
+describe('InteractiveStep: popout action type', () => {
+  it("renders an 'Undock' button when targetvalue is 'floating'", () => {
+    render(
+      <InteractiveStep targetAction="popout" refTarget="" targetValue="floating">
+        Move me out of the way
+      </InteractiveStep>
+    );
+
+    expect(screen.getByRole('button', { name: 'Undock' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /do it/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /show me/i })).not.toBeInTheDocument();
+  });
+
+  it("renders a 'Dock' button when targetvalue is 'sidebar'", () => {
+    render(
+      <InteractiveStep targetAction="popout" refTarget="" targetValue="sidebar">
+        Put me back in the sidebar
+      </InteractiveStep>
+    );
+
+    expect(screen.getByRole('button', { name: 'Dock' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /do it/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /show me/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render a "Show me" button even when showMe is true', () => {
+    render(
+      <InteractiveStep targetAction="popout" refTarget="" targetValue="floating" showMe={true}>
+        Pop out
+      </InteractiveStep>
+    );
+
+    expect(screen.queryByRole('button', { name: /show me/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Undock' })).toBeInTheDocument();
+  });
+
+  it("dispatches 'pathfinder-request-pop-out' when Undock is clicked", async () => {
+    const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+    try {
+      render(
+        <InteractiveStep targetAction="popout" refTarget="" targetValue="floating" stepId="popout-undock-step">
+          Pop out
+        </InteractiveStep>
+      );
+
+      const button = screen.getByRole('button', { name: 'Undock' });
+      button.click();
+      // Allow the async pipeline to dispatch
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const popOutCall = dispatchSpy.mock.calls.find(
+        (call) => (call[0] as Event).type === 'pathfinder-request-pop-out'
+      );
+      expect(popOutCall).toBeDefined();
+    } finally {
+      dispatchSpy.mockRestore();
+    }
+  });
+
+  it("dispatches 'pathfinder-request-dock' when Dock is clicked", async () => {
+    const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+    try {
+      render(
+        <InteractiveStep targetAction="popout" refTarget="" targetValue="sidebar" stepId="popout-dock-step">
+          Dock
+        </InteractiveStep>
+      );
+
+      const button = screen.getByRole('button', { name: 'Dock' });
+      button.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const dockCall = dispatchSpy.mock.calls.find((call) => (call[0] as Event).type === 'pathfinder-request-dock');
+      expect(dockCall).toBeDefined();
+    } finally {
+      dispatchSpy.mockRestore();
+    }
+  });
+});

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -52,8 +52,8 @@ async function executeWithLazyScroll(
   action: () => Promise<void>,
   targetAction?: string
 ): Promise<LazyScrollResult> {
-  // Navigate and noop actions don't target DOM elements - execute immediately without element checking
-  if (targetAction === 'navigate' || targetAction === 'noop') {
+  // Navigate, noop, and popout actions don't target DOM elements - execute immediately without element checking
+  if (targetAction === 'navigate' || targetAction === 'noop' || targetAction === 'popout') {
     await action();
     return { success: true, elementFound: true };
   }
@@ -796,10 +796,20 @@ export const InteractiveStep = forwardRef<
           return `Run sequence`;
         case 'noop':
           return `Instructional step`;
+        case 'popout':
+          return currentTargetValue === 'sidebar'
+            ? 'Dock the guide back into the sidebar'
+            : 'Move the guide to a floating window';
         default:
           return targetAction;
       }
     };
+
+    // Popout actions are single-button (like navigate). Pre-compute the label
+    // so the do-button branch stays compact below.
+    const isPopoutAction = targetAction === 'popout';
+    const popoutButtonLabel = currentTargetValue === 'sidebar' ? 'Dock' : 'Undock';
+    const popoutButtonRunningLabel = currentTargetValue === 'sidebar' ? 'Docking...' : 'Undocking...';
 
     const isAnyActionRunning = isShowRunning || isDoRunning || isCurrentlyExecuting;
 
@@ -869,22 +879,28 @@ export const InteractiveStep = forwardRef<
 
         <div className="interactive-step-actions">
           <div className="interactive-step-action-buttons">
-            {/* Only show "Show me" button when showMe prop is true AND step is enabled AND not a navigate/noop action */}
+            {/* Only show "Show me" button when showMe prop is true AND step is enabled AND not a navigate/noop/popout action */}
             {/* Navigate actions don't have a sensible "show me" behavior - it's "go there" or nothing */}
+            {/* Popout actions are single-press toggles ("Dock"/"Undock") with no preview */}
             {/* Noop actions are informational only - no buttons needed */}
-            {showMe && !isNoopAction && targetAction !== 'navigate' && !isCompletedWithObjectives && finalIsEnabled && (
-              <Button
-                onClick={handleShowAction}
-                disabled={disabled || isAnyActionRunning || (checker.isChecking && !lazyScrollAvailable)}
-                size="sm"
-                variant="secondary"
-                className="interactive-step-show-btn"
-                data-testid={testIds.interactive.showMeButton(renderedStepId)}
-                title={hints || `${showMeText ? `${showMeText}:` : 'Show me:'} ${getActionDescription()}`}
-              >
-                {isShowRunning ? 'Showing...' : showMeText || 'Show me'}
-              </Button>
-            )}
+            {showMe &&
+              !isNoopAction &&
+              targetAction !== 'navigate' &&
+              !isPopoutAction &&
+              !isCompletedWithObjectives &&
+              finalIsEnabled && (
+                <Button
+                  onClick={handleShowAction}
+                  disabled={disabled || isAnyActionRunning || (checker.isChecking && !lazyScrollAvailable)}
+                  size="sm"
+                  variant="secondary"
+                  className="interactive-step-show-btn"
+                  data-testid={testIds.interactive.showMeButton(renderedStepId)}
+                  title={hints || `${showMeText ? `${showMeText}:` : 'Show me:'} ${getActionDescription()}`}
+                >
+                  {isShowRunning ? 'Showing...' : showMeText || 'Show me'}
+                </Button>
+              )}
 
             {/* Only show "Do it" button when doIt prop is true AND not a noop action */}
             {/* Noop actions are informational only - no buttons needed */}
@@ -908,16 +924,22 @@ export const InteractiveStep = forwardRef<
                     hints ||
                     (targetAction === 'navigate'
                       ? `Go there: ${getActionDescription()}`
-                      : `Do it: ${getActionDescription()}`)
+                      : isPopoutAction
+                        ? `${popoutButtonLabel}: ${getActionDescription()}`
+                        : `Do it: ${getActionDescription()}`)
                   }
                 >
                   {isDoRunning || isCurrentlyExecuting
                     ? targetAction === 'navigate'
                       ? 'Going...'
-                      : 'Executing...'
+                      : isPopoutAction
+                        ? popoutButtonRunningLabel
+                        : 'Executing...'
                     : targetAction === 'navigate'
                       ? 'Go there'
-                      : 'Do it'}
+                      : isPopoutAction
+                        ? popoutButtonLabel
+                        : 'Do it'}
                 </Button>
               )}
 

--- a/src/interactive-engine/action-handlers/index.ts
+++ b/src/interactive-engine/action-handlers/index.ts
@@ -4,4 +4,5 @@ export { NavigateHandler } from './navigate-handler';
 export { FormFillHandler } from './form-fill-handler';
 export { HoverHandler } from './hover-handler';
 export { GuidedHandler } from './guided-handler';
+export { PopoutHandler, type PopoutTargetMode } from './popout-handler';
 export { clearAndInsertCode, type CodeBlockInsertResult } from './code-block-handler';

--- a/src/interactive-engine/action-handlers/popout-handler.test.ts
+++ b/src/interactive-engine/action-handlers/popout-handler.test.ts
@@ -1,0 +1,93 @@
+import { PopoutHandler } from './popout-handler';
+import { InteractiveStateManager } from '../interactive-state-manager';
+import { InteractiveElementData } from '../../types/interactive.types';
+
+jest.mock('../interactive-state-manager');
+
+const mockStateManager = {
+  setState: jest.fn(),
+  handleError: jest.fn(),
+} as unknown as InteractiveStateManager;
+
+const mockWaitForReactUpdates = jest.fn().mockResolvedValue(undefined);
+
+function makeData(overrides: Partial<InteractiveElementData> = {}): InteractiveElementData {
+  return {
+    reftarget: '',
+    targetaction: 'popout',
+    targetvalue: 'floating',
+    tagName: 'button',
+    textContent: 'Popout step',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('PopoutHandler', () => {
+  let handler: PopoutHandler;
+  let dispatchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    handler = new PopoutHandler(mockStateManager, mockWaitForReactUpdates);
+    dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+  });
+
+  afterEach(() => {
+    dispatchSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it("dispatches 'pathfinder-request-pop-out' when targetvalue is 'floating'", async () => {
+    const data = makeData({ targetvalue: 'floating' });
+    const promise = handler.execute(data, true);
+    await jest.runAllTimersAsync();
+    await promise;
+
+    expect(mockStateManager.setState).toHaveBeenCalledWith(data, 'running');
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0]![0] as Event;
+    expect(event.type).toBe('pathfinder-request-pop-out');
+    expect(mockStateManager.setState).toHaveBeenCalledWith(data, 'completed');
+  });
+
+  it("dispatches 'pathfinder-request-dock' when targetvalue is 'sidebar'", async () => {
+    const data = makeData({ targetvalue: 'sidebar' });
+    const promise = handler.execute(data, true);
+    await jest.runAllTimersAsync();
+    await promise;
+
+    const event = dispatchSpy.mock.calls[0]![0] as Event;
+    expect(event.type).toBe('pathfinder-request-dock');
+    expect(mockStateManager.setState).toHaveBeenCalledWith(data, 'completed');
+  });
+
+  it('treats show mode the same as do mode (single-button action)', async () => {
+    // Popout has no preview - both buttonType paths should still dispatch and complete.
+    const data = makeData({ targetvalue: 'floating' });
+    const promise = handler.execute(data, false);
+    await jest.runAllTimersAsync();
+    await promise;
+
+    const event = dispatchSpy.mock.calls[0]![0] as Event;
+    expect(event.type).toBe('pathfinder-request-pop-out');
+    expect(mockStateManager.setState).toHaveBeenCalledWith(data, 'completed');
+  });
+
+  it('reports an error when targetvalue is missing or invalid', async () => {
+    const data = makeData({ targetvalue: 'nonsense' });
+    await handler.execute(data, true);
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(mockStateManager.handleError).toHaveBeenCalledWith(expect.any(Error), 'PopoutHandler', data, true);
+  });
+
+  it('reports an error when targetvalue is undefined', async () => {
+    const data = makeData({ targetvalue: undefined });
+    await handler.execute(data, true);
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(mockStateManager.handleError).toHaveBeenCalled();
+  });
+});

--- a/src/interactive-engine/action-handlers/popout-handler.ts
+++ b/src/interactive-engine/action-handlers/popout-handler.ts
@@ -1,0 +1,70 @@
+import { InteractiveStateManager } from '../interactive-state-manager';
+import { InteractiveElementData } from '../../types/interactive.types';
+import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
+
+/**
+ * Allowed targetvalue values for popout steps.
+ * - 'sidebar' docks the panel back into the Grafana sidebar.
+ * - 'floating' undocks the panel into a floating window.
+ */
+export type PopoutTargetMode = 'sidebar' | 'floating';
+
+const POPOUT_EVENT_BY_MODE: Record<PopoutTargetMode, string> = {
+  floating: 'pathfinder-request-pop-out',
+  sidebar: 'pathfinder-request-dock',
+};
+
+/**
+ * Handler for the `popout` interactive action.
+ *
+ * Toggles the docs panel between the sidebar and a floating window by
+ * dispatching a document-level event. The event is handled by:
+ * - `pathfinder-request-pop-out` -> `docs-panel.tsx` (existing handler)
+ * - `pathfinder-request-dock`    -> `FloatingPanelManager.tsx` (new handler)
+ *
+ * This is a single-button action (no separate "show" preview), modelled
+ * after the navigate handler's "Go there" pattern.
+ */
+export class PopoutHandler {
+  constructor(
+    private stateManager: InteractiveStateManager,
+    private waitForReactUpdates: () => Promise<void>
+  ) {}
+
+  async execute(data: InteractiveElementData, _perform: boolean): Promise<void> {
+    this.stateManager.setState(data, 'running');
+
+    try {
+      const mode = this.resolveTargetMode(data.targetvalue);
+      if (!mode) {
+        this.stateManager.handleError(
+          new Error(`PopoutHandler requires targetvalue of 'sidebar' or 'floating', got: ${String(data.targetvalue)}`),
+          'PopoutHandler',
+          data,
+          true
+        );
+        return;
+      }
+
+      document.dispatchEvent(new CustomEvent(POPOUT_EVENT_BY_MODE[mode]));
+
+      await this.markAsCompleted(data);
+    } catch (error) {
+      this.stateManager.handleError(error as Error, 'PopoutHandler', data);
+    }
+  }
+
+  private resolveTargetMode(value: string | undefined): PopoutTargetMode | null {
+    if (value === 'sidebar' || value === 'floating') {
+      return value;
+    }
+    return null;
+  }
+
+  private async markAsCompleted(data: InteractiveElementData): Promise<void> {
+    await this.waitForReactUpdates();
+    this.stateManager.setState(data, 'completed');
+    await new Promise((resolve) => setTimeout(resolve, INTERACTIVE_CONFIG.delays.debouncing.reactiveCheck));
+    await this.waitForReactUpdates();
+  }
+}

--- a/src/interactive-engine/interactive.hook.test.ts
+++ b/src/interactive-engine/interactive.hook.test.ts
@@ -37,6 +37,9 @@ jest.mock('./action-handlers', () => ({
     executeGuidedStep: jest.fn().mockResolvedValue('completed'),
     cancel: jest.fn(),
   })),
+  PopoutHandler: jest.fn().mockImplementation(() => ({
+    execute: jest.fn().mockResolvedValue(undefined),
+  })),
 }));
 
 // Mock managers

--- a/src/interactive-engine/interactive.hook.ts
+++ b/src/interactive-engine/interactive.hook.ts
@@ -17,6 +17,7 @@ import {
   FormFillHandler,
   HoverHandler,
   GuidedHandler,
+  PopoutHandler,
 } from './action-handlers';
 import type { UseInteractiveElementsOptions } from '../types/hooks.types';
 
@@ -88,6 +89,8 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
     [stateManager, navigationManager]
   );
 
+  const popoutHandler = useMemo(() => new PopoutHandler(stateManager, waitForReactUpdates), [stateManager]);
+
   // Inject the global style tag once on mount — idempotent, no cleanup needed.
   useEffect(() => {
     addGlobalInteractiveStyles();
@@ -146,6 +149,13 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
     [guidedHandler]
   );
 
+  const interactivePopout = useCallback(
+    async (data: InteractiveElementData, perform: boolean) => {
+      await popoutHandler.execute(data, perform);
+    },
+    [popoutHandler]
+  );
+
   // Define helper functions using refs to avoid circular dependencies
   const dispatchInteractiveAction = useCallback(
     async (data: InteractiveElementData, click: boolean) => {
@@ -161,9 +171,19 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
         await interactiveHover(data, click);
       } else if (data.targetaction === 'guided') {
         await interactiveGuided(data, click);
+      } else if (data.targetaction === 'popout') {
+        await interactivePopout(data, click);
       }
     },
-    [interactiveFocus, interactiveButton, interactiveFormFill, interactiveNavigate, interactiveHover, interactiveGuided]
+    [
+      interactiveFocus,
+      interactiveButton,
+      interactiveFormFill,
+      interactiveNavigate,
+      interactiveHover,
+      interactiveGuided,
+      interactivePopout,
+    ]
   );
 
   /**
@@ -401,6 +421,10 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
             await interactiveGuided(elementData, !isShowMode);
             break;
 
+          case 'popout':
+            await interactivePopout(elementData, !isShowMode);
+            break;
+
           case 'sequence':
             await interactiveSequence(elementData, isShowMode);
             break;
@@ -434,6 +458,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
       interactiveNavigate,
       interactiveHover,
       interactiveGuided,
+      interactivePopout,
       interactiveSequence,
       stateManager,
       navigationManager,

--- a/src/types/component-props.types.ts
+++ b/src/types/component-props.types.ts
@@ -26,7 +26,7 @@ export interface BaseInteractiveProps {
  * Single interactive step with show/do buttons
  */
 export interface InteractiveStepProps extends BaseInteractiveProps {
-  targetAction: 'button' | 'highlight' | 'formfill' | 'navigate' | 'sequence' | 'hover' | 'noop';
+  targetAction: 'button' | 'highlight' | 'formfill' | 'navigate' | 'sequence' | 'hover' | 'noop' | 'popout';
   refTarget: string;
   targetValue?: string;
   postVerify?: string;

--- a/src/types/interactive.types.ts
+++ b/src/types/interactive.types.ts
@@ -6,7 +6,8 @@ export type InteractiveActionType =
   | 'hover'
   | 'sequence'
   | 'multistep'
-  | 'guided'; // User-performed actions with detection
+  | 'guided' // User-performed actions with detection
+  | 'popout'; // Toggle the docs panel between sidebar and floating modes
 
 export interface InteractiveElementData {
   // Core interactive attributes

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -33,7 +33,22 @@ const SafeUrlSchema = z
  * Schema for interactive action types.
  * @coupling Type: JsonInteractiveAction
  */
-export const JsonInteractiveActionSchema = z.enum(['highlight', 'button', 'formfill', 'navigate', 'hover', 'noop']);
+export const JsonInteractiveActionSchema = z.enum([
+  'highlight',
+  'button',
+  'formfill',
+  'navigate',
+  'hover',
+  'noop',
+  'popout',
+]);
+
+/**
+ * Allowed targetvalue values for the `popout` action.
+ * - 'sidebar' docks the panel back into the Grafana sidebar.
+ * - 'floating' undocks the panel into a floating window.
+ */
+const POPOUT_TARGET_VALUES = ['sidebar', 'floating'] as const;
 
 // ============ QUIZ SCHEMAS ============
 
@@ -72,11 +87,11 @@ export const JsonStepSchema = z
   })
   .refine(
     (step) => {
-      // Non-noop actions require a reftarget
-      if (step.action !== 'noop' && (!step.reftarget || step.reftarget.trim() === '')) {
-        return false;
+      // Actions that don't operate on a DOM element don't require reftarget
+      if (step.action === 'noop' || step.action === 'popout') {
+        return true;
       }
-      return true;
+      return step.reftarget !== undefined && step.reftarget.trim() !== '';
     },
     { error: "Non-noop actions require 'reftarget'" }
   )
@@ -89,6 +104,16 @@ export const JsonStepSchema = z
       return true;
     },
     { error: "formfill with validateInput requires 'targetvalue'" }
+  )
+  .refine(
+    (step) => {
+      // popout requires a valid targetvalue indicating the target panel mode
+      if (step.action === 'popout') {
+        return step.targetvalue !== undefined && POPOUT_TARGET_VALUES.includes(step.targetvalue as never);
+      }
+      return true;
+    },
+    { error: "popout actions require 'targetvalue' to be 'sidebar' or 'floating'" }
   );
 
 // ============ ASSISTANT PROPS SCHEMA ============
@@ -185,11 +210,11 @@ export const JsonInteractiveBlockSchema = z
   })
   .refine(
     (block) => {
-      // Non-noop actions require a reftarget
-      if (block.action !== 'noop') {
-        return block.reftarget !== undefined && block.reftarget.trim() !== '';
+      // Actions that don't operate on a DOM element don't require reftarget
+      if (block.action === 'noop' || block.action === 'popout') {
+        return true;
       }
-      return true;
+      return block.reftarget !== undefined && block.reftarget.trim() !== '';
     },
     { error: "Non-noop actions require 'reftarget'" }
   )
@@ -202,6 +227,16 @@ export const JsonInteractiveBlockSchema = z
       return true;
     },
     { error: "formfill with validateInput requires 'targetvalue'" }
+  )
+  .refine(
+    (block) => {
+      // popout requires a valid targetvalue indicating the target panel mode
+      if (block.action === 'popout') {
+        return block.targetvalue !== undefined && POPOUT_TARGET_VALUES.includes(block.targetvalue as never);
+      }
+      return true;
+    },
+    { error: "popout actions require 'targetvalue' to be 'sidebar' or 'floating'" }
   );
 
 /**

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -209,8 +209,11 @@ export interface JsonConditionalBlock {
 /**
  * Action types for JSON guide interactive elements.
  * Named differently from collaboration.types.ts InteractiveAction to avoid conflicts.
+ *
+ * The `popout` action toggles the docs panel between sidebar and floating modes.
+ * It uses `targetvalue` ('sidebar' | 'floating') to select the target panel mode.
  */
-export type JsonInteractiveAction = 'highlight' | 'button' | 'formfill' | 'navigate' | 'hover' | 'noop';
+export type JsonInteractiveAction = 'highlight' | 'button' | 'formfill' | 'navigate' | 'hover' | 'noop' | 'popout';
 
 /**
  * Single-action interactive step.
@@ -224,7 +227,10 @@ export interface JsonInteractiveBlock extends AssistantProps {
   action: JsonInteractiveAction;
   /** CSS selector or Grafana selector for the target element (optional for noop actions) */
   reftarget?: string;
-  /** Value for formfill actions (supports regex patterns starting with ^ or $ or enclosed in /pattern/) */
+  /**
+   * Value for formfill actions (supports regex patterns starting with ^ or $ or enclosed in /pattern/).
+   * For popout actions, must be 'sidebar' (dock) or 'floating' (undock).
+   */
   targetvalue?: string;
   /** Markdown description shown to the user */
   content: string;
@@ -319,7 +325,10 @@ export interface JsonStep {
   action: JsonInteractiveAction;
   /** CSS selector or Grafana selector for the target element (optional for noop actions) */
   reftarget?: string;
-  /** Value for formfill actions (supports regex patterns starting with ^ or $ or enclosed in /pattern/) */
+  /**
+   * Value for formfill actions (supports regex patterns starting with ^ or $ or enclosed in /pattern/).
+   * For popout actions, must be 'sidebar' (dock) or 'floating' (undock).
+   */
   targetvalue?: string;
   /** Requirements for this specific step */
   requirements?: string[];

--- a/src/validation/validate-guide.test.ts
+++ b/src/validation/validate-guide.test.ts
@@ -217,6 +217,111 @@ describe('JsonGuideSchema', () => {
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
+    it("should accept popout block with targetvalue 'floating' (no reftarget required)", () => {
+      const guide = JSON.stringify({
+        id: 'test',
+        title: 'Test',
+        blocks: [
+          {
+            type: 'interactive',
+            action: 'popout',
+            targetvalue: 'floating',
+            content: 'Move me out of the way',
+          },
+        ],
+      });
+      const result = validateGuideFromString(guide);
+      expect(result.isValid).toBe(true);
+    });
+
+    it("should accept popout block with targetvalue 'sidebar' (no reftarget required)", () => {
+      const guide = JSON.stringify({
+        id: 'test',
+        title: 'Test',
+        blocks: [
+          {
+            type: 'interactive',
+            action: 'popout',
+            targetvalue: 'sidebar',
+            content: 'Put me back in the sidebar',
+          },
+        ],
+      });
+      const result = validateGuideFromString(guide);
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should reject popout block without targetvalue', () => {
+      const guide = JSON.stringify({
+        id: 'test',
+        title: 'Test',
+        blocks: [
+          {
+            type: 'interactive',
+            action: 'popout',
+            content: 'Missing targetvalue',
+          },
+        ],
+      });
+      const result = validateGuideFromString(guide);
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should reject popout block with an invalid targetvalue', () => {
+      const guide = JSON.stringify({
+        id: 'test',
+        title: 'Test',
+        blocks: [
+          {
+            type: 'interactive',
+            action: 'popout',
+            targetvalue: 'somewhere-else',
+            content: 'Invalid mode',
+          },
+        ],
+      });
+      const result = validateGuideFromString(guide);
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should accept popout step inside a multistep block', () => {
+      const guide = JSON.stringify({
+        id: 'test',
+        title: 'Test',
+        blocks: [
+          {
+            type: 'multistep',
+            content: 'Pop out then continue',
+            steps: [
+              { action: 'popout', targetvalue: 'floating' },
+              { action: 'button', reftarget: '[data-testid="next"]' },
+            ],
+          },
+        ],
+      });
+      const result = validateGuideFromString(guide);
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should reject a popout step inside multistep when targetvalue is invalid', () => {
+      const guide = JSON.stringify({
+        id: 'test',
+        title: 'Test',
+        blocks: [
+          {
+            type: 'multistep',
+            content: 'Pop out then continue',
+            steps: [{ action: 'popout', targetvalue: 'middle' }],
+          },
+        ],
+      });
+      const result = validateGuideFromString(guide);
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
     it('should provide clear error for invalid action enum values', () => {
       const guide = JSON.stringify({
         id: 'test',


### PR DESCRIPTION
## Summary

Adds a new `popout` interactive action that toggles the docs panel between the sidebar and a floating window, plus the supporting infrastructure to make the **block editor itself** popout-capable so authors can test the new step type end-to-end.

### New `popout` interactive action

- `JsonInteractiveAction` extended with `'popout'` in [json-guide.types.ts](src/types/json-guide.types.ts) and [json-guide.schema.ts](src/types/json-guide.schema.ts) (Zod). Refinements require `targetvalue` ∈ `{'sidebar', 'floating'}`; reftarget is not required.
- New [PopoutHandler](src/interactive-engine/action-handlers/popout-handler.ts) dispatches `pathfinder-request-pop-out` (when `targetvalue: 'floating'`) or the new `pathfinder-request-dock` (when `targetvalue: 'sidebar'`). Wired into the dispatch chain and `executeInteractiveAction` switch in [interactive.hook.ts](src/interactive-engine/interactive.hook.ts).
- [InteractiveStep](src/components/interactive-tutorial/interactive-step.tsx) renders a single **Dock** / **Undock** button (no Show me) — same pattern as `navigate`'s "Go there".
- [FloatingPanelManager](src/components/floating-panel/FloatingPanelManager.tsx) listens for `pathfinder-request-dock` (symmetric to the existing pop-out event in [docs-panel.tsx](src/components/docs-panel/docs-panel.tsx)).

### Block editor surface

- New `🪟 Popout` action in `INTERACTIVE_ACTIONS` ([constants.ts](src/components/block-editor/constants.ts)).
- [InteractiveBlockForm](src/components/block-editor/forms/InteractiveBlockForm.tsx) and [StepEditor](src/components/block-editor/forms/StepEditor.tsx) swap the selector input for a target-mode select (Floating / Sidebar) when `action === 'popout'`, omit reftarget, and validate `targetvalue`.

### Editor popout mode

- New **Pop out** / **Dock** button in [BlockEditorHeader](src/components/block-editor/BlockEditorHeader.tsx) that dispatches the same events and reflects current panel mode at runtime.
- The popout handler in [docs-panel.tsx](src/components/docs-panel/docs-panel.tsx) detects `activeTab.type === 'editor'` and routes to a dedicated path (no pendingGuide handoff).
- [FloatingPanelInner](src/components/floating-panel/FloatingPanelManager.tsx) lazy-loads `BlockEditor` and renders it inside the FloatingPanel chrome when the active tab is the editor tab.
- Bug fix surfaced during debugging: the popout flow now resets `CombinedLearningJourneyPanel._hasRestoredTabs` before `setMode('floating')` so the floating panel's new model can rehydrate the editor tab from localStorage.

### Tests

- New [popout-handler.test.ts](src/interactive-engine/action-handlers/popout-handler.test.ts) (5 cases) — both target modes, show=do equivalence, missing/invalid targetvalue.
- New [BlockEditorHeader.test.tsx](src/components/block-editor/BlockEditorHeader.test.tsx) (5 cases) — Pop out/Dock label per mode, dispatch events, runtime mode-change reaction.
- 6 new schema cases in [validate-guide.test.ts](src/validation/validate-guide.test.ts) covering both target modes, missing/invalid `targetvalue`, and popout inside multistep.
- 5 new step-render cases in [interactive-step.test.tsx](src/components/interactive-tutorial/interactive-step.test.tsx).
- `'popout'` added to the `actionTypes` matrix in [data-attributes.contract.test.tsx](src/components/interactive-tutorial/data-attributes.contract.test.tsx).
- [interactive.hook.test.ts](src/interactive-engine/interactive.hook.test.ts) action-handlers mock updated to include `PopoutHandler`.

### Docs

- New popout section + "Choosing the right type" row in [interactive-types.md](docs/developer/interactive-examples/interactive-types.md), sentence case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new interactive action and new panel-mode event flows that move UI between sidebar and floating panel; regressions could affect tutorial execution and panel/tab restoration behavior.
> 
> **Overview**
> Adds a new `popout` interactive action that toggles the docs panel between sidebar and floating modes via document events (`pathfinder-request-pop-out` / new `pathfinder-request-dock`), including a new `PopoutHandler` wired into the interactive engine and updated `InteractiveStep` UI to render a single Dock/Undock button (no Show-me preview).
> 
> Extends the block editor to author/validate `popout` steps (target-mode selector, schema/type updates, and form/step-editor gating), and adds an editor-level Pop out/Dock header button that reflects runtime panel mode.
> 
> Updates the pop-out flow so the editor tab can itself move into the floating panel (lazy-loaded `BlockEditor`), adds guards/notifications when popping out without an active guide, and adjusts tab restoration behavior to allow the floating model to rehydrate state. Includes docs and comprehensive unit/contract tests covering the new action and mode toggling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da7e89dde758fab6fe9d00f5f6f647dfca790ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->