### PR TITLE
ci: parallelise backend tests and remove build job overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,39 @@ jobs:
       - name: Check repository.json freshness
         run: npm run repository:check
 
+  # Backend tests run in parallel with the frontend build and quality checks.
+  # No dependency on setup: this job only needs Go, not node_modules.
+  test-backend:
+    name: Test backend
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Check for backend
+        id: check-for-backend
+        run: |
+          if [ -f "Magefile.go" ]; then
+            echo "has-backend=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Go environment
+        if: steps.check-for-backend.outputs.has-backend == 'true'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.25'
+
+      - name: Test backend
+        if: steps.check-for-backend.outputs.has-backend == 'true'
+        uses: magefile/mage-action@07f03e200d4d168576899f4d31ffebfa8fb195ff
+        with:
+          version: latest
+          args: coverage
+
   # Build job runs in parallel with quality checks
   build:
     name: Build
@@ -205,13 +238,6 @@ jobs:
         if: steps.check-for-backend.outputs.has-backend == 'true'
         run: npm run copy-static
 
-      - name: Test backend
-        if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@07f03e200d4d168576899f4d31ffebfa8fb195ff
-        with:
-          version: latest
-          args: coverage
-
       - name: Build backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
         uses: magefile/mage-action@07f03e200d4d168576899f4d31ffebfa8fb195ff
@@ -227,8 +253,6 @@ jobs:
       - name: Get plugin metadata
         id: metadata
         run: |
-          sudo apt-get install jq
-
           export GRAFANA_PLUGIN_ID=$(cat dist/plugin.json | jq -r .id)
           export GRAFANA_PLUGIN_VERSION=$(cat dist/plugin.json | jq -r .info.version)
           export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-${GRAFANA_PLUGIN_VERSION}.zip
@@ -246,7 +270,7 @@ jobs:
       # CRITICAL: Do not remove this validation step!
       - name: Check plugin.json
         run: |
-          docker run --pull=always \
+          docker run --pull=missing \
             -v $PWD/${{ steps.metadata.outputs.archive }}:/archive.zip \
             grafana/plugin-validator-cli -analyzer=metadatavalid /archive.zip
 
@@ -260,7 +284,7 @@ jobs:
   # CI gate job for branch protection - aggregates all required checks
   ci-gate:
     name: CI Gate
-    needs: [lint, typecheck, prettier, test, validate-packages, build]
+    needs: [lint, typecheck, prettier, test, validate-packages, build, test-backend]
     if: always()
     runs-on: ubuntu-latest
     permissions: {} # No permissions needed - only checks job results
@@ -273,6 +297,7 @@ jobs:
           echo "Test: ${{ needs.test.result }}"
           echo "Validate packages: ${{ needs.validate-packages.result }}"
           echo "Build: ${{ needs.build.result }}"
+          echo "Test backend: ${{ needs.test-backend.result }}"
 
           if [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.typecheck.result }}" != "success" ]] || \
@@ -283,6 +308,14 @@ jobs:
             echo "One or more required jobs failed"
             exit 1
           fi
+
+          # test-backend is skipped when no Magefile.go is present; that is expected
+          if [[ "${{ needs.test-backend.result }}" != "success" ]] && \
+             [[ "${{ needs.test-backend.result }}" != "skipped" ]]; then
+            echo "Backend tests failed"
+            exit 1
+          fi
+
           echo "All required jobs passed!"
 
   # Resolve E2E versions runs in parallel (no dependency on build)


### PR DESCRIPTION
## Summary

- **Extract `test-backend` job** — `mage coverage` previously ran inside the `build` job, sequentially after the frontend webpack build. It is now a standalone job with no upstream dependencies, running fully in parallel with `build`, `lint`, `typecheck`, `prettier`, `test`, and `validate-packages`. This removes backend test time from the critical path entirely.
- **Remove `sudo apt-get install jq`** — `jq` is pre-installed on `ubuntu-latest` runners; the apt install was redundant and triggered an index update on every run.
- **`--pull=missing` on plugin-validator** — replaced `--pull=always` so the Docker image is reused from the runner's layer cache when available instead of being pulled unconditionally.
- **`ci-gate` updated** — `test-backend` is now a required job. The gate allows a `skipped` result for repos that have no `Magefile.go`.

## Job graph (after)

```
setup ──┬── lint
        ├── typecheck
        ├── prettier
        ├── test
        ├── validate-packages
        └── build ──── playwright-tests

test-backend (no upstream deps)

resolve-versions (no upstream deps)

ci-gate (fan-in: all of the above)
```

## Notes

`test-backend` does **not** run `copy-static` before `mage coverage`. The `copy-static` step embeds the compiled frontend into the Go binary for production — it is kept in `build` before `mage buildAll`. If Go unit tests happen to require the embedded static files to be present, `copy-static` (or a placeholder equivalent) will need to be added to this new job. The CI result will make that immediately visible.

## Test plan

- [ ] CI run on this PR passes (all jobs green)
- [ ] Confirm `test-backend` and `build` run concurrently in the Actions timeline
- [ ] Confirm `ci-gate` passes when `test-backend` is skipped (no `Magefile.go`)
