### PR TITLE
chore(deps): partial Grafana 13 baseline + multi-version e2e fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@grafana/faro-react": "^2.0.2",
         "@grafana/faro-web-tracing": "^2.0.2",
         "@grafana/i18n": "^12.4.3",
-        "@grafana/scenes": "^7.3.13",
+        "@grafana/scenes": "^7.4.2",
         "@grafana/schema": "^12.4.3",
         "@grafana/ui": "^12.4.2",
         "@openfeature/ofrep-web-provider": "^0.3.5",
@@ -54,7 +54,7 @@
       "devDependencies": {
         "@grafana/eslint-config": "^9.0.0",
         "@grafana/faro-webpack-plugin": "^0.11.0",
-        "@grafana/plugin-e2e": "^3.4.0",
+        "@grafana/plugin-e2e": "^3.6.1",
         "@grafana/tsconfig": "^2.0.1",
         "@jest/test-sequencer": "^30.2.0",
         "@playwright/test": "^1.56.1",
@@ -156,20 +156,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@axe-core/playwright": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
-      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "peer": true,
-      "dependencies": {
-        "axe-core": "~4.11.1"
-      },
-      "peerDependencies": {
-        "playwright-core": ">= 1.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -200,6 +186,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -810,6 +797,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -833,6 +821,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -864,6 +853,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1745,6 +1735,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
       "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -1865,6 +1856,7 @@
       "resolved": "https://registry.npmjs.org/@grafana/data/-/data-12.4.3.tgz",
       "integrity": "sha512-XEZcD95AFJhWKKcPuinVkQFTkYPmlrFJv0jjsl8O23i0Bvdz27s8gvUGIU8uq1ugx/r3kxNDYCnftJLal8IKYA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@braintree/sanitize-url": "7.0.1",
         "@grafana/i18n": "12.4.3",
@@ -1906,7 +1898,6 @@
       "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.0.tgz",
       "integrity": "sha512-GPFmqIJJD8yom7ld4NxAFW2kFTqiOta/8KlsqDoasiNIWjwPp2fn3ILTuZ97a+W0D7Z1LJ9QKznFXOAhKpFRJQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "semver": "^7.7.0",
         "tslib": "2.8.1",
@@ -1918,7 +1909,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2343,6 +2333,7 @@
       "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.4.3.tgz",
       "integrity": "sha512-ECdz96IEk04rOZLMZSXTa6+6z+fgaIk9oHoyZC68Wzq1pkfQajdi7bnDCZ3Zsz5ikq1gEqIJpLgdL69Nd9lmdg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@formatjs/intl-durationformat": "^0.7.0",
         "@typescript-eslint/utils": "^8.33.1",
@@ -2358,13 +2349,13 @@
       }
     },
     "node_modules/@grafana/plugin-e2e": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.4.0.tgz",
-      "integrity": "sha512-UmYu0Xwlajkghcjddb5Ip7mFC3m2TlnuXtlfUUS7dBxEJMuSwm2Iq0XjvN0vihMbdlVnkRx4BL7kQ0MbkTVYBQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.6.1.tgz",
+      "integrity": "sha512-BQAEMk2yVymYA2cKbHEuGDqXwZ5MwWnCD+293QJgMey3G6ao4PbiZTaZ/c5BVyfWxLOZ3izqay0F7eU0Ncty9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "12.4.0-21983999378",
+        "@grafana/e2e-selectors": "13.1.0-24448182242",
         "semver": "^7.5.4",
         "uuid": "^13.0.0",
         "yaml": "^2.3.4"
@@ -2374,14 +2365,18 @@
       },
       "peerDependencies": {
         "@axe-core/playwright": "^4.11.1",
-        "@playwright/test": "^1.52.0",
-        "axe-core": "^4.11.1"
+        "@playwright/test": "^1.52.0"
+      },
+      "peerDependenciesMeta": {
+        "@axe-core/playwright": {
+          "optional": true
+        }
       }
     },
     "node_modules/@grafana/plugin-e2e/node_modules/@grafana/e2e-selectors": {
-      "version": "12.4.0-21983999378",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.0-21983999378.tgz",
-      "integrity": "sha512-Y0rZOywbGlcITX40Xp5SsydvX7qbNiDuUJwtsniL9ToHIZrBQsS24hHrKtHUpv1JJvQoH15MaqM+HPVevdPf7w==",
+      "version": "13.1.0-24448182242",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-24448182242.tgz",
+      "integrity": "sha512-C8VxaFh4PGWhPBOwol3Fo0UBp1//7XNnjg7WG+t3p0P8Q2cw5HZ2NgQt1OFq9radjmWEc3DJQZvxoelI4TIOJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2451,7 +2446,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.16.tgz",
       "integrity": "sha512-9O8N4SeG2z++TSM8QA/KTeKFBVCNEz/AGS7gWPJf6KFRzmRWixFRnCnkPHRDwSVZW6QPDO6uT0P2SpWNKCc9/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.6",
         "@floating-ui/utils": "^0.2.10",
@@ -2467,7 +2461,6 @@
       "resolved": "https://registry.npmjs.org/@grafana/data/-/data-12.4.0.tgz",
       "integrity": "sha512-clIlKlEHq3Ieho4ji5Yb4a5XMPheUzTNuNBwNHoHvtulzXQOtYmmKxjJ1sOwJWsMuqNwV+YdEhQqWKWsWaRd0g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@braintree/sanitize-url": "7.0.1",
         "@grafana/i18n": "12.4.0",
@@ -2509,7 +2502,6 @@
       "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.4.0.tgz",
       "integrity": "sha512-q+FqI+KjF2/jzzTv5gwDaJMmNmONjjT2SsX+SNOJby0b3Lx10B/6TSyPTEsOeeAEr59ClpQmNmSo4e1C2/v5MA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@formatjs/intl-durationformat": "^0.7.0",
         "@typescript-eslint/utils": "^8.33.1",
@@ -2529,7 +2521,6 @@
       "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-12.4.0.tgz",
       "integrity": "sha512-UEcsY6anwBuBdDt7C9Ke00p374iiBtPYiw+m+QnnXESCPW9x+nPZCF5utDs6irao6moIJmFU2Mm7F6I81BmKlA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       }
@@ -2539,7 +2530,6 @@
       "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-12.4.0.tgz",
       "integrity": "sha512-ikB/qMmwd2OWsPA3i1tjuvMb+ZWw/FEwi6PgWTiUaATnNA5hqkBXPowjvw4VTsX9h5vq2TILxrQnHjv9kiBn7A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@emotion/css": "11.13.5",
         "@emotion/react": "11.14.0",
@@ -2620,15 +2610,13 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@grafana/runtime/node_modules/react-data-grid": {
       "version": "7.0.0-beta.56",
       "resolved": "git+ssh://git@github.com/grafana/react-data-grid.git#a922856b5ede21d55db3fdffb6d38dc76bdc7c58",
       "integrity": "sha512-kE4U/hBd5rNeKT2poz+uMfVlaSqjVLVXs0ZAP674DImFnri/6ARhEtr+6szEboNepQgWXEJYIWtdZ7GbaBpexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clsx": "^2.0.0"
       },
@@ -2641,15 +2629,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@grafana/runtime/node_modules/react-router-dom": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
       "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -2668,7 +2654,6 @@
       "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.3.tgz",
       "integrity": "sha512-WWZtwGYyoaeUDNrhzzDkh4JvN5nU0MIz80Dxim6pznQrfS+dv0mvtVoHTA6HlUl/OiJl7WWjbsQwjTnYXejEHg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.23.2",
         "history": "^5.3.0",
@@ -2688,7 +2673,6 @@
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
       "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
@@ -2698,7 +2682,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -2715,10 +2698,11 @@
       }
     },
     "node_modules/@grafana/scenes": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@grafana/scenes/-/scenes-7.3.13.tgz",
-      "integrity": "sha512-8gvxDTIAnA9PG55pWD73WUgjgpB17+vpMbBg+nf4wlg35SvDSAJJfO2pFO2Udk3vdDl/qaZj8hoeYQcCdJMAEw==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@grafana/scenes/-/scenes-7.4.2.tgz",
+      "integrity": "sha512-2zekO8Q4FEjkUNDrrfFC468ZG8o8bSVlyC5Pprq597U32E/1gI4Hrc9bRemud/WG/meAcMKTbfKg4TYuIJRkqQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@emotion/css": "11.10.5",
         "@emotion/react": "11.10.5",
@@ -2819,6 +2803,7 @@
       "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-12.4.3.tgz",
       "integrity": "sha512-fFoYfBcCTDWliz37JsKf8GwqF5Ju64UJk9DsDBN0T5S7LJoKiIOEe5Gl3vJsmNgcYJhyKRedX/2RPYy+Cyo4LQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       }
@@ -2835,6 +2820,7 @@
       "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-12.4.2.tgz",
       "integrity": "sha512-IGXmL0nW2PbdXIpXhyUuPDgG6GEcTITKwDfR96HYhEF9bbYQ8gAmhy1rSKZnkw/wg7Jk97o8ukGLvrZ3w2VavQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@emotion/css": "11.13.5",
         "@emotion/react": "11.14.0",
@@ -3043,6 +3029,7 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
       "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -4591,6 +4578,7 @@
       "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.7.2.tgz",
       "integrity": "sha512-8QwhoxVNN2bFFkpWjbCyHCdkVjt/UTVn0o+OwcUUQoZnvPn46Oo1BxJQxUTibl/D/dAM/YQhxmg7ep7gYRxX4g==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@openfeature/core": "^1.9.0"
       }
@@ -4600,6 +4588,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5543,6 +5532,7 @@
       "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.56.1"
       },
@@ -6339,6 +6329,7 @@
       "integrity": "sha512-2r6cLcmdF6til66lx8esBYvBvsn7xCmLT50gw/n1rGGlTq/OxeNjBIh4c3VEaDGMa/5TybrZTia6sQUHdIWx1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.32.1",
         "eslint-visitor-keys": "^4.2.0",
@@ -6358,6 +6349,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -6637,7 +6629,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6658,7 +6649,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6723,6 +6713,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.15.3.tgz",
       "integrity": "sha512-bmXydIHfm2rEtGju39FiQNfzkFx9CDvJe+xem1dgEZ2P6Dj7nQX9LnA1ZscW7TuzbBRkL5p3dwuBIi3f62A66A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6945,6 +6936,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.15.3.tgz",
       "integrity": "sha512-n7y/MF9lAM5qlpuH5IR4/uq+kJPEJpe9NrEiH+NmkO/5KJ6cXzpJ6F4U17sMLf2SNCq+TWN9QK8QzoKxIn50VQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -7050,6 +7042,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.15.3.tgz",
       "integrity": "sha512-ycx/BgxR4rc9tf3ZyTdI98Z19yKLFfqM3UN+v42ChuIwkzyr9zyp7kG8dB9xN2lNqrD+5y/HyJobz/VJ7T90gA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -7093,6 +7086,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.15.3.tgz",
       "integrity": "sha512-Zm1BaU1TwFi3CQiisxjgnzzIus+q40bBKWLqXf6WEaus8Z6+vo1MT2pU52dBCMIRaW9XNDq3E5cmGtMc1AlveA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -7225,8 +7219,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7530,6 +7523,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
       "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -7581,6 +7575,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -7591,6 +7586,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -7741,6 +7737,7 @@
       "integrity": "sha512-R48VhmTJqplNyDxCyqqVkFSZIx1qX6PzwqgcXn1olLrzxcSBDlOsbtcnQuQhNtnNiJ4Xe5gREI1foajYaYU2Vg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.46.4",
@@ -7913,6 +7910,7 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -8923,6 +8921,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8995,6 +8994,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9348,7 +9348,7 @@
       "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
+      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -9804,6 +9804,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11040,6 +11041,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -11336,7 +11338,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11406,8 +11407,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-css": {
       "version": "2.1.0",
@@ -11956,6 +11956,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12016,6 +12017,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -12032,6 +12034,7 @@
       "integrity": "sha512-36DpldF95MlTX//n3/naULFVt8d1cV4jmSkx7ZKrE9ikkKHAgMLesuWp1SmwpVwAs5ndIM6abKd6PeOYZUgdWg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.78.0",
         "@es-joy/resolve.exports": "1.2.0",
@@ -12123,6 +12126,7 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -12156,6 +12160,7 @@
       "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/parser": "^7.24.4",
@@ -13911,6 +13916,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6"
       },
@@ -14120,7 +14126,8 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
       "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -17027,6 +17034,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -17575,7 +17583,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -17635,6 +17642,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
       "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -17957,7 +17965,8 @@
       "version": "0.34.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
       "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -18881,6 +18890,7 @@
       "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -18956,6 +18966,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -19086,7 +19097,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -19102,7 +19112,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -19115,8 +19124,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -19273,6 +19281,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -19302,6 +19311,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -19350,6 +19360,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
       "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -19832,6 +19843,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -19907,6 +19919,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -20131,6 +20144,7 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
       "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.23.2",
         "react-router": "6.30.3"
@@ -20336,7 +20350,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -20728,6 +20743,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -20826,6 +20842,7 @@
       "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
@@ -20930,6 +20947,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21284,6 +21302,7 @@
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.47.9.tgz",
       "integrity": "sha512-EK4O6b7lGt+g5H9PGw9O5KCM4RrOvOgE9mPi3rzQ0zDRlgAb2ga4TdpS6XNQbrsJWsc8I1fjaSsUeCqCUhhi9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^3.1.0",
         "direction": "^0.1.5",
@@ -22420,6 +22439,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22586,6 +22606,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -22628,7 +22649,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -22775,6 +22797,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23299,6 +23322,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -23348,6 +23372,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -24000,6 +24025,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@grafana/eslint-config": "^9.0.0",
     "@grafana/faro-webpack-plugin": "^0.11.0",
-    "@grafana/plugin-e2e": "^3.4.0",
+    "@grafana/plugin-e2e": "^3.6.1",
     "@grafana/tsconfig": "^2.0.1",
     "@jest/test-sequencer": "^30.2.0",
     "@playwright/test": "^1.56.1",
@@ -118,7 +118,7 @@
     "@grafana/faro-react": "^2.0.2",
     "@grafana/faro-web-tracing": "^2.0.2",
     "@grafana/i18n": "^12.4.3",
-    "@grafana/scenes": "^7.3.13",
+    "@grafana/scenes": "^7.4.2",
     "@grafana/schema": "^12.4.3",
     "@grafana/ui": "^12.4.2",
     "@openfeature/ofrep-web-provider": "^0.3.5",

--- a/tests/helpers/block-editor.helpers.ts
+++ b/tests/helpers/block-editor.helpers.ts
@@ -38,9 +38,12 @@ export async function openBlockEditor(page: Page): Promise<void> {
   // In Grafana with extension sidebar registered, clicking Help toggles the sidebar
   await page.locator('button[aria-label="Help"]').click();
 
-  // Dismiss any tooltip that appeared on the Help button
-  // This prevents tooltip from intercepting pointer events in Grafana dev/preview versions
+  // Dismiss any tooltip that appeared on the Help button. The keyboard Escape covers
+  // older Grafana versions; moving the cursor off the button covers Grafana 13+,
+  // which holds the Help tooltip ("Close interactive learning, help, and
+  // documentation") in the portal container until pointer leave.
   await page.keyboard.press('Escape');
+  await page.mouse.move(0, 0);
 
   // Wait for panel container to be visible
   const panelContainer = page.getByTestId(testIds.docsPanel.container);
@@ -50,9 +53,10 @@ export async function openBlockEditor(page: Page): Promise<void> {
   const editorTab = page.getByTestId(testIds.docsPanel.tab('editor'));
   await expect(editorTab).toBeVisible({ timeout: TIMEOUTS.DEV_MODE_PROPAGATE });
 
-  // Hover before click to dismiss any tooltips that may intercept pointer events
-  await editorTab.hover();
-  await editorTab.click();
+  // Click with force: true to bypass any lingering portal-rendered tooltip in
+  // Grafana 13+ that briefly intercepts pointer events between Help dismiss
+  // and the editor tab becoming hover-stable.
+  await editorTab.click({ force: true });
 
   // Wait for block editor to be visible
   const blockEditor = page.getByTestId(testIds.blockEditor.container);


### PR DESCRIPTION
## Summary

Pre-merge dependency review ahead of Grafana 13. The full v13 frontend bump is **blocked upstream** — `@grafana/ui@13.0.0` is not published to npm yet (only `13.1.0-<jobid>` canary prereleases exist). This PR ships the safe-now bumps and validates we still work end-to-end on Grafana 12 *and* 13 at runtime.

### What changed

| Package | Before | After | Reason |
| --- | --- | --- | --- |
| `@grafana/scenes` | `^7.3.13` | `^7.4.2` | Latest stable; scenes peers are `>=11.6` for ui/data/etc. so no version-mismatch risk |
| `@grafana/plugin-e2e` | `^3.4.0` | `^3.6.1` | Latest stable; brings axe-core integration |

Plus an e2e fixture fix in `tests/helpers/block-editor.helpers.ts` for a Grafana 13 Help-button tooltip that lingers in the portal container after the Escape key — moving the cursor off Help and `click({ force: true })` on the editor tab covers both v12 and v13.

### What didn't change (and why)

- `@grafana/data` / `@grafana/runtime` / `@grafana/schema` / `@grafana/i18n` — leaving at `^12.4.x`. Bumping these without a matching `@grafana/ui` v13 produces a [dual-package hazard](https://nodejs.org/api/packages.html#dual-package-hazard): npm installs `@grafana/data` 13.0.1 at the root and a transitive copy of `@grafana/data` 12.4.2 nested under `@grafana/ui`, and the two `GrafanaTheme2` types differ enough (v13 added `colors.scrollbar`) that every `useStyles2()` call fails typecheck.
- `@grafana/ui` — v13 stable returns 404 from npm; only canary prereleases tagged `13.1.0-<jobid>` are published.
- `@grafana/faro-react` / `@grafana/faro-web-tracing` — 2.1+ requires `react-router 7.x`; we're on `react-router-dom 6.x`. Separate, larger upgrade.
- `@grafana/runtime 12.4.3` — itself depends on `@grafana/ui 12.4.3` which doesn't exist; staying on 12.4.0 within the `^12.4.0` range.

### Multi-version E2E (validates the bumps + tooltip fix don't break across versions)

Local runs of `npm run e2e` against Docker images:

| Grafana version | Result |
| --- | --- |
| 12.4.2 | **13/13 passed** in 33.0s |
| 13.0.1 | **13/13 passed** in 32.4s |

12.3.0 (the plugin floor per `plugin.json grafanaDependency`) was not exercised locally for time, but CI's existing matrix via `grafana/plugin-actions/e2e-version` will run it.

### Renovate cleanup happening alongside this PR

| PR | Outcome |
| --- | --- |
| #787 npm 11.13.0 | ✅ Merged |
| #784 golang.org/x/crypto v0.50 | ✅ Merged |
| #785 plugin-ci-workflows v7.1 | ✅ Merged |
| #777 actions/setup-node digest | Held by Renovate `stability-days` (will self-resolve) |
| #761 pin dependencies | Held by Renovate `stability-days` |
| #776 lock-file maintenance | Stale; Renovate will rebase (lockfile changed in this PR anyway) |
| #762 grafana-plugin-sdk-go v0.291.1 | Real `go.sum` issue — comment left explaining; Renovate will retry |
| #755 Grafana v13 major | **Closed** — `@grafana/ui` v13 stable not published; full diagnosis in closure comment |
| #783 dev-tools major | Deferred — separate concern (eslint v10 + webpack-cli v7 + others) |

## Test plan

- [x] `npm run check` green on this branch
- [x] `npm run e2e` green locally on Grafana 12.4.2 (13/13 in 33s)
- [x] `npm run e2e` green locally on Grafana 13.0.1 (13/13 in 32s)
- [ ] CI matrix runs against multiple Grafana versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it upgrades a core Grafana frontend dependency (`@grafana/scenes`) and updates the E2E tooling stack, which could introduce subtle runtime or test-runner behavior changes.
> 
> **Overview**
> Updates dependencies toward a Grafana 13-compatible baseline by bumping `@grafana/scenes` to `7.4.2` and `@grafana/plugin-e2e` to `3.6.1`, with corresponding `package-lock.json` reshaping (notably peer/optional metadata changes).
> 
> Hardens the block editor Playwright helper (`openBlockEditor`) to handle Grafana 13’s lingering Help tooltip by moving the mouse off the Help button and using a forced click on the editor tab to avoid transient tooltip interception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9db0492b55b16f32c7544ec253bfb519c6f82a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->