### PR TITLE
fix: validate image URL before submit

### DIFF
--- a/src/components/block-editor/forms/ImageBlockForm.tsx
+++ b/src/components/block-editor/forms/ImageBlockForm.tsx
@@ -33,6 +33,9 @@ function isValidUrl(value: string): boolean {
   if (/^javascript:/i.test(trimmed)) {
     return false;
   }
+  if (/^data:/i.test(trimmed)) {
+    return false;
+  }
   // Accept http/https URLs
   if (/^https?:\/\//i.test(trimmed)) {
     return true;

--- a/src/components/block-editor/forms/ImageBlockForm.tsx
+++ b/src/components/block-editor/forms/ImageBlockForm.tsx
@@ -21,7 +21,7 @@ function isImageBlock(block: JsonBlock): block is JsonImageBlock {
 }
 
 /**
- * Validate a URL string — rejects empty, javascript: URIs, and accepts
+ * Validate a URL string — rejects empty, javascript: and data: URIs, and accepts
  * http/https, protocol-relative, and relative paths (including ../ and nested).
  */
 function isValidUrl(value: string): boolean {
@@ -100,7 +100,7 @@ export function ImageBlockForm({
         </Alert>
       )}
 
-      <Field label="Image URL" description="Full URL to the image" required error={urlError ?? undefined}>
+      <Field label="Image URL" description="Full URL to the image" required invalid={!!urlError} error={urlError ?? undefined}>
         <Input
           value={src}
           onChange={(e) => {

--- a/src/components/block-editor/forms/ImageBlockForm.tsx
+++ b/src/components/block-editor/forms/ImageBlockForm.tsx
@@ -25,15 +25,25 @@ function isImageBlock(block: JsonBlock): block is JsonImageBlock {
  */
 function isValidUrl(value: string): boolean {
   const trimmed = value.trim();
-  if (!trimmed) return false;
+  if (!trimmed) {
+    return false;
+  }
   // Reject javascript: and data: URIs for security
-  if (/^javascript:/i.test(trimmed)) return false;
+  if (/^javascript:/i.test(trimmed)) {
+    return false;
+  }
   // Accept http/https URLs
-  if (/^https?:\/\//i.test(trimmed)) return true;
+  if (/^https?:\/\//i.test(trimmed)) {
+    return true;
+  }
   // Accept protocol-relative URLs
-  if (/^\/\//.test(trimmed)) return true;
+  if (/^\/\//.test(trimmed)) {
+    return true;
+  }
   // Accept relative paths (e.g., /images/foo.png, ../img.png)
-  if (/^\//.test(trimmed) || /^[a-zA-Z0-9_.-]+\.(png|jpe?g|gif|webp|svg|avif)$/i.test(trimmed)) return true;
+  if (/^\//.test(trimmed) || /^[a-zA-Z0-9_.-]+\.(png|jpe?g|gif|webp|svg|avif)$/i.test(trimmed)) {
+    return true;
+  }
   return false;
 }
 

--- a/src/components/block-editor/forms/ImageBlockForm.tsx
+++ b/src/components/block-editor/forms/ImageBlockForm.tsx
@@ -77,6 +77,10 @@ export function ImageBlockForm({
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
+      if (!isValidUrl(src)) {
+        setUrlError('Please enter a valid image URL (e.g., https://example.com/image.png)');
+        return;
+      }
       const block: JsonImageBlock = {
         type: 'image',
         src: src.trim(),

--- a/src/components/block-editor/forms/ImageBlockForm.tsx
+++ b/src/components/block-editor/forms/ImageBlockForm.tsx
@@ -21,7 +21,8 @@ function isImageBlock(block: JsonBlock): block is JsonImageBlock {
 }
 
 /**
- * Validate a URL string — rejects empty, relative paths, and javascript: URIs.
+ * Validate a URL string — rejects empty, javascript: URIs, and accepts
+ * http/https, protocol-relative, and relative paths (including ../ and nested).
  */
 function isValidUrl(value: string): boolean {
   const trimmed = value.trim();
@@ -40,8 +41,12 @@ function isValidUrl(value: string): boolean {
   if (/^\/\//.test(trimmed)) {
     return true;
   }
-  // Accept relative paths (e.g., /images/foo.png, ../img.png)
-  if (/^\//.test(trimmed) || /^[a-zA-Z0-9_.-]+\.(png|jpe?g|gif|webp|svg|avif)$/i.test(trimmed)) {
+  // Accept absolute relative paths (e.g., /images/foo.png)
+  if (/^\/[a-zA-Z0-9_.\/\-]+$/.test(trimmed)) {
+    return true;
+  }
+  // Accept relative paths with ../ or ./ (e.g., ../img.png, ./images/foo.png)
+  if (/^(?:[a-zA-Z0-9_.\-]+\/)*[a-zA-Z0-9_.\-]+\.(png|jpe?g|gif|webp|svg|avif)$/i.test(trimmed)) {
     return true;
   }
   return false;

--- a/src/components/block-editor/forms/ImageBlockForm.tsx
+++ b/src/components/block-editor/forms/ImageBlockForm.tsx
@@ -49,7 +49,7 @@ function isValidUrl(value: string): boolean {
     return true;
   }
   // Accept relative paths with ../ or ./ (e.g., ../img.png, ./images/foo.png)
-  if (/^(?:[a-zA-Z0-9_.\-]+\/)*[a-zA-Z0-9_.\-]+\.(png|jpe?g|gif|webp|svg|avif)$/i.test(trimmed)) {
+  if (/^(?:[a-zA-Z0-9_.\-]+\/)*[a-zA-Z0-9_.\-]+\.(png|jpe?g|gif|webp|svg|avif)(\?[a-zA-Z0-9_.\-=%&+~#]*)?(#[a-zA-Z0-9_.\-=%&+~#]*)?$/i.test(trimmed)) {
     return true;
   }
   return false;
@@ -94,7 +94,7 @@ export function ImageBlockForm({
       };
       onSubmit(block);
     },
-    [src, alt, width, height, onSubmit, urlError]
+    [src, alt, width, height, onSubmit]
   );
 
   const isValid = isValidUrl(src);

--- a/src/components/block-editor/forms/ImageBlockForm.tsx
+++ b/src/components/block-editor/forms/ImageBlockForm.tsx
@@ -76,6 +76,7 @@ export function ImageBlockForm({
   const [alt, setAlt] = useState(initial?.alt ?? '');
   const [width, setWidth] = useState(initial?.width?.toString() ?? '');
   const [height, setHeight] = useState(initial?.height?.toString() ?? '');
+  const [urlError, setUrlError] = useState<string | null>(null);
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -93,11 +94,10 @@ export function ImageBlockForm({
       };
       onSubmit(block);
     },
-    [src, alt, width, height, onSubmit]
+    [src, alt, width, height, onSubmit, urlError]
   );
 
   const isValid = isValidUrl(src);
-  const [urlError, setUrlError] = useState<string | null>(null);
 
   return (
     <form onSubmit={handleSubmit} className={styles.form}>

--- a/src/components/block-editor/forms/ImageBlockForm.tsx
+++ b/src/components/block-editor/forms/ImageBlockForm.tsx
@@ -44,8 +44,8 @@ function isValidUrl(value: string): boolean {
   if (/^\/\//.test(trimmed)) {
     return true;
   }
-  // Accept absolute relative paths (e.g., /images/foo.png)
-  if (/^\/[a-zA-Z0-9_.\/\-]+$/.test(trimmed)) {
+  // Accept absolute relative paths (e.g., /images/foo.png, /assets/img%20name.png?v=2)
+  if (/^\/[a-zA-Z0-9_.\/\-?=&%#]+$/.test(trimmed)) {
     return true;
   }
   // Accept relative paths with ../ or ./ (e.g., ../img.png, ./images/foo.png)

--- a/src/components/block-editor/forms/ImageBlockForm.tsx
+++ b/src/components/block-editor/forms/ImageBlockForm.tsx
@@ -21,6 +21,23 @@ function isImageBlock(block: JsonBlock): block is JsonImageBlock {
 }
 
 /**
+ * Validate a URL string — rejects empty, relative paths, and javascript: URIs.
+ */
+function isValidUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  // Reject javascript: and data: URIs for security
+  if (/^javascript:/i.test(trimmed)) return false;
+  // Accept http/https URLs
+  if (/^https?:\/\//i.test(trimmed)) return true;
+  // Accept protocol-relative URLs
+  if (/^\/\//.test(trimmed)) return true;
+  // Accept relative paths (e.g., /images/foo.png, ../img.png)
+  if (/^\//.test(trimmed) || /^[a-zA-Z0-9_.-]+\.(png|jpe?g|gif|webp|svg|avif)$/i.test(trimmed)) return true;
+  return false;
+}
+
+/**
  * Image block form component
  */
 export function ImageBlockForm({
@@ -57,7 +74,8 @@ export function ImageBlockForm({
     [src, alt, width, height, onSubmit]
   );
 
-  const isValid = src.trim().length > 0;
+  const isValid = isValidUrl(src);
+  const [urlError, setUrlError] = useState<string | null>(null);
 
   return (
     <form onSubmit={handleSubmit} className={styles.form}>
@@ -67,12 +85,21 @@ export function ImageBlockForm({
         </Alert>
       )}
 
-      <Field label="Image URL" description="Full URL to the image" required>
+      <Field label="Image URL" description="Full URL to the image" required error={urlError ?? undefined}>
         <Input
           value={src}
-          onChange={(e) => setSrc(e.currentTarget.value)}
+          onChange={(e) => {
+            setSrc(e.currentTarget.value);
+            setUrlError(null);
+          }}
           placeholder="https://example.com/image.png"
           autoFocus
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !isValidUrl(src)) {
+              setUrlError('Please enter a valid image URL (e.g., https://example.com/image.png)');
+              e.preventDefault();
+            }
+          }}
         />
       </Field>
 


### PR DESCRIPTION
## Summary
Add URL validation to `ImageBlockForm` to prevent invalid URLs, javascript: URIs, and malformed paths from being silently accepted. The form previously only checked if the URL was non-empty — now it validates the URL format and shows inline error feedback when the user tries to submit an invalid URL.

### Changes
- Added `isValidUrl()` helper that validates URL format
- Rejects `javascript:` URIs for security
- Accepts `http://`, `https://`, protocol-relative, and relative paths
- Shows inline error message on form submit when URL is invalid
- Clears error message when user modifies the URL field

### Testing
- Tested locally by running `npm run typecheck` and `npm run lint`
- Manual testing of form behavior with valid/invalid URLs

## Related
Closes #826

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized to the `ImageBlockForm` UI; it tightens input validation and could only affect users by rejecting previously-accepted (but malformed/unsafe) image URLs.
> 
> **Overview**
> **Adds stricter image URL validation to the block editor.** `ImageBlockForm` now validates `src` with a new `isValidUrl` helper (rejecting empty values and `javascript:`/`data:` URIs while allowing http(s), protocol-relative, and relative paths).
> 
> On invalid input, the form shows an inline error on the URL field, prevents Enter/submit from proceeding, clears the error on edit, and disables the submit button based on the new validation instead of a non-empty check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d952c24c043b4d90b344944f097f0ba2ad1f1b3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->