### PR TITLE
docs: external guide-import API + upsert helper

### DIFF
--- a/docs/developer/EXTERNAL_API.md
+++ b/docs/developer/EXTERNAL_API.md
@@ -52,12 +52,10 @@ The repo ships [`scripts/upsert-guide.sh`](../../scripts/upsert-guide.sh),
 a small bash helper that handles the create-or-update dance for you:
 
 ```bash
-# spec.json:
+# spec.json — only `title` and `blocks` are strictly required; the
+# script fills in everything else.
 # {
-#   "id": "intro-to-loki",
 #   "title": "Intro to Loki",
-#   "schemaVersion": "1.0",
-#   "status": "draft",
 #   "blocks": [{ "type": "markdown", "content": "# Welcome" }]
 # }
 
@@ -69,23 +67,15 @@ scripts/upsert-guide.sh \
 
 The script:
 
-1. Auto-detects the stack namespace from `/api/frontend/settings` (or accepts `--namespace`).
-2. Slugifies the resource name from `spec.id` (or `spec.title` if `id` is empty).
-3. GETs the existing resource to discover its `resourceVersion`.
-4. POSTs (create) or PUTs (update) accordingly.
-5. Prints the persisted resource as JSON.
+1. **Auto-detects the input format** — accepts either a bare spec or a full Kubernetes envelope (e.g. from Library → Export).
+2. **Auto-detects the stack namespace** from `/api/frontend/settings` (or accepts `--namespace`).
+3. **Fills in missing required fields**: defaults `status` to `"published"` and `schemaVersion` to `"1.0.0"`, and backfills `spec.id` from the slugified `title` when absent.
+4. Slugifies the resource name from `spec.id` (or the slugified `spec.title` if `id` is missing).
+5. GETs the existing resource to discover its `resourceVersion`.
+6. POSTs (create) or PUTs (update) accordingly.
+7. Prints the persisted resource as JSON.
 
-If the spec you have is a **full editor export** (Library → Export — includes a
-Kubernetes envelope), pass `--from-export` and the script will pick out the
-`.spec` field for you:
-
-```bash
-scripts/upsert-guide.sh \
-  --stack learn.grafana.net \
-  --token "$GRAFANA_SA_TOKEN" \
-  --spec ./my-export.json \
-  --from-export
-```
+To upload as a draft instead of publishing, set `"status": "draft"` explicitly in the spec — values you supply are always preserved.
 
 Requirements: `curl`, `jq`. Run `scripts/upsert-guide.sh --help` for the full reference.
 

--- a/scripts/upsert-guide.sh
+++ b/scripts/upsert-guide.sh
@@ -22,10 +22,12 @@
 #     --token "$GRAFANA_SA_TOKEN" \
 #     --spec ./my-guide.json
 #
-# The spec file should contain just the InteractiveGuide spec (no
-# Kubernetes envelope). The editor's Library → Export emits a full
-# K8s envelope; strip it with `jq .spec my-export.json > my-spec.json`
-# first, or pass --from-export to skip the strip.
+# The spec file may be either a bare InteractiveGuide spec or a full
+# Kubernetes envelope (e.g. the editor's Library → Export); the script
+# auto-detects the format. Missing fields default to
+# `status: "published"` and `schemaVersion: "1.0.0"`, and `spec.id` is
+# backfilled from the slugified title when absent — so a guide JSON
+# containing just `title` and `blocks` uploads as-is.
 #
 # Requirements:
 #   - curl, jq
@@ -45,22 +47,25 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") --stack <host> --token <token> --spec <file> [--namespace <ns>] [--from-export]
+Usage: $(basename "$0") --stack <host> --token <token> --spec <file> [--namespace <ns>]
 
 Required:
   -s, --stack       Grafana stack hostname (e.g. learn.grafana.net or
                     <stack>.grafana.net). Without scheme.
   -t, --token       Service-account token (glsa_...) with Editor role.
-  -f, --spec        Path to a JSON file containing the InteractiveGuide
-                    spec (the editor's spec field, without K8s envelope).
+  -f, --spec        Path to a JSON file containing the InteractiveGuide.
+                    Either a bare spec or a full Kubernetes envelope
+                    (e.g. from Library → Export); format is auto-detected.
 
 Optional:
   -n, --namespace   Override stack namespace (e.g. stacks-12345). Auto-
                     detected from /api/frontend/settings if omitted.
-      --from-export Treat --spec as a full editor export (with K8s
-                    envelope) and read \`.spec\` from it instead of
-                    using the file as-is.
   -h, --help        Show this message.
+
+Defaults applied to the spec when missing:
+  status            "published"  (set "status": "draft" in the spec to override)
+  schemaVersion     "1.0.0"
+  id                slugified from .title
 
 Reads the spec, derives a slugified resource name from spec.id (or
 spec.title), GETs the existing guide to discover its resourceVersion,
@@ -73,7 +78,6 @@ STACK=
 TOKEN=
 SPEC=
 NAMESPACE=
-FROM_EXPORT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -81,7 +85,6 @@ while [[ $# -gt 0 ]]; do
     -t|--token) TOKEN="$2"; shift 2 ;;
     -f|--spec) SPEC="$2"; shift 2 ;;
     -n|--namespace) NAMESPACE="$2"; shift 2 ;;
-    --from-export) FROM_EXPORT=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "unknown argument: $1" >&2; usage >&2; exit 64 ;;
   esac
@@ -116,17 +119,26 @@ if [[ -z "$NAMESPACE" ]]; then
   fi
 fi
 
-# Extract the spec object — either the file as-is, or .spec from a
-# full editor export.
-if (( FROM_EXPORT )); then
+# Auto-detect the input format. A full Kubernetes envelope has
+# top-level `apiVersion` and an object `spec`; anything else is a
+# bare spec.
+IS_ENVELOPE=$(jq -r '
+  if (has("apiVersion") and has("spec") and (.spec | type) == "object")
+  then "yes" else "no" end
+' "$SPEC")
+if [[ "$IS_ENVELOPE" == "yes" ]]; then
   SPEC_JSON=$(jq '.spec' "$SPEC")
-  if [[ "$SPEC_JSON" == "null" ]]; then
-    echo "--from-export was set but $SPEC has no .spec field" >&2
-    exit 1
-  fi
 else
   SPEC_JSON=$(jq '.' "$SPEC")
 fi
+
+# Apply defaults for fields the CRD requires that authors commonly
+# omit. Existing values are preserved — set "status": "draft" in the
+# spec to upload as a draft instead of published.
+SPEC_JSON=$(echo "$SPEC_JSON" | jq '
+  (if (.schemaVersion // "") == "" then .schemaVersion = "1.0.0" else . end)
+  | (if (.status // "") == "" then .status = "published" else . end)
+')
 
 RAW_NAME=$(echo "$SPEC_JSON" | jq -r '.id // .title // empty')
 if [[ -z "$RAW_NAME" ]]; then
@@ -137,6 +149,12 @@ NAME=$(slugify "$RAW_NAME")
 if [[ -z "$NAME" ]]; then
   echo "spec.id/.title produced an empty slug after sanitisation" >&2
   exit 1
+fi
+
+# Backfill spec.id from the derived slug when missing, so the
+# persisted spec round-trips with a stable identifier.
+if [[ -z "$(echo "$SPEC_JSON" | jq -r '.id // ""')" ]]; then
+  SPEC_JSON=$(echo "$SPEC_JSON" | jq --arg id "$NAME" '.id = $id')
 fi
 
 BASE="https://${STACK}/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${NAMESPACE}/interactiveguides"


### PR DESCRIPTION
## Summary

- Add `docs/developer/EXTERNAL_API.md` — reference for the Pathfinder Backend's Kubernetes-style aggregator API at `/apis/pathfinderbackend.ext.grafana.com/v1alpha1/.../interactiveguides`, intended for CI, Terraform, and scripted guide imports. Same API the in-product editor uses, so guides created this way are indistinguishable from editor-authored ones.
- Add `scripts/upsert-guide.sh` — bash helper that handles the create-or-update dance (slugify name, GET to discover `resourceVersion`, then POST or PUT). Auto-detects namespace from `/api/frontend/settings`.
- Helper accepts **any** guide JSON: auto-detects bare spec vs. full Kubernetes envelope (no `--from-export` flag needed), and defaults `status: "published"`, `schemaVersion: "1.0.0"`, and `spec.id` (slugified from `title`) when absent. A guide containing just `title` and `blocks` uploads as-is. Explicit values in the spec are always preserved — set `"status": "draft"` to override.

## Test plan

- [ ] `scripts/upsert-guide.sh --help` — usage text reflects auto-detection and lists the defaults.
- [ ] Upload a bare-spec guide with only `title` + `blocks` against a real stack — creates with `status: "published"` and a slugified `spec.id`.
- [ ] Upload a guide that has `"status": "draft"` set explicitly — draft is preserved (not overwritten by the default).
- [ ] Upload a full editor export (Library → Export, full K8s envelope) — script detects the envelope and extracts `.spec` automatically.
- [ ] Re-run upsert on an existing guide — PUT succeeds with the current `resourceVersion`.
- [ ] Re-run with a stale `resourceVersion` (simulate by manually editing) — surfaces a 409 from the aggregator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes import semantics by defaulting missing `status` to `published` and modifying uploaded specs (backfilling `id`), which could unintentionally publish or alter guides if callers relied on prior defaults.
> 
> **Overview**
> Updates `scripts/upsert-guide.sh` to **auto-detect** whether `--spec` is a bare InteractiveGuide spec or a full Kubernetes export envelope, removing the `--from-export` flag.
> 
> The helper now **applies defaults and backfills identifiers** when omitted: sets `schemaVersion` to `"1.0.0"`, `status` to `"published"`, and populates missing `spec.id` from the slugified title; docs (`EXTERNAL_API.md`) are adjusted to reflect the new input expectations and draft override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33c1995a43c42395c1a6104ffbb421f735dcd3a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->