### PR TITLE
Add annotations so Assistant adds labels for read/write for MCP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,8 @@
         "zod": "^4.1.13"
       },
       "bin": {
-        "pathfinder-cli": "dist/cli/cli/index.js",
-        "pathfinder-mcp": "dist/cli/cli/mcp-placeholder.js"
+        "pathfinder-cli": "./dist/cli/cli/index.js",
+        "pathfinder-mcp": "./dist/cli/cli/mcp/index.js"
       },
       "devDependencies": {
         "@grafana/eslint-config": "^9.0.0",

--- a/src/cli/mcp/tools/artifact-tools.ts
+++ b/src/cli/mcp/tools/artifact-tools.ts
@@ -21,6 +21,11 @@ export function registerArtifactTools(server: McpServer): void {
     {
       description:
         'Create a fresh authoring artifact (content.json + manifest.json) for a new guide. Returns { content, manifest } for use as input to subsequent authoring tools.',
+      annotations: {
+        title: 'Create Pathfinder package',
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
       inputSchema: {
         title: z.string().describe('Guide title shown to learners.'),
         id: z

--- a/src/cli/mcp/tools/authoring-start.ts
+++ b/src/cli/mcp/tools/authoring-start.ts
@@ -41,6 +41,10 @@ export function registerAuthoringStart(server: McpServer): void {
     {
       description:
         'First tool to call. Returns Pathfinder authoring context, workflow, and tool discovery hints. Read this once per authoring session before calling any mutation tool.',
+      annotations: {
+        title: 'Start Pathfinder authoring',
+        readOnlyHint: true,
+      },
       inputSchema: {},
     },
     async () => textResult(JSON.stringify(AUTHORING_CONTEXT, null, 2))

--- a/src/cli/mcp/tools/finalize.ts
+++ b/src/cli/mcp/tools/finalize.ts
@@ -31,6 +31,10 @@ export function registerFinalizeTool(server: McpServer): void {
     {
       description:
         'Finalize an artifact for publishing. Validates, then returns the App Platform write payload (resource, path templates, viewer link) and a localExport fallback. The MCP does not perform the write — the controlling agent (e.g. Grafana Assistant) does.',
+      annotations: {
+        title: 'Finalize Pathfinder artifact',
+        readOnlyHint: true,
+      },
       inputSchema: {
         artifact: z.object({
           content: z.record(z.string(), z.unknown()),

--- a/src/cli/mcp/tools/help.ts
+++ b/src/cli/mcp/tools/help.ts
@@ -17,6 +17,10 @@ export function registerHelpTool(server: McpServer): void {
     {
       description:
         'Returns the structured help surface for a CLI command, equivalent to `pathfinder-cli <command> --help --format json`. Pass an empty command for the list of commands.',
+      annotations: {
+        title: 'Show Pathfinder help',
+        readOnlyHint: true,
+      },
       inputSchema: {
         command: z
           .string()

--- a/src/cli/mcp/tools/inspection-tools.ts
+++ b/src/cli/mcp/tools/inspection-tools.ts
@@ -26,6 +26,10 @@ export function registerInspectionTools(server: McpServer): void {
     {
       description:
         'Inspect an artifact: tree summary, block lookup by id, or array enumeration at a JSONPath. Read-only; the artifact passes through unchanged.',
+      annotations: {
+        title: 'Inspect Pathfinder artifact',
+        readOnlyHint: true,
+      },
       inputSchema: {
         artifact: ArtifactSchema,
         blockId: z.string().optional().describe('Show details for a single block by id.'),
@@ -54,6 +58,10 @@ export function registerInspectionTools(server: McpServer): void {
     {
       description:
         'Validate an in-flight artifact against the canonical Pathfinder validation pipeline (Zod + cross-file checks + condition syntax). Read-only.',
+      annotations: {
+        title: 'Validate Pathfinder artifact',
+        readOnlyHint: true,
+      },
       inputSchema: {
         artifact: ArtifactSchema,
       },

--- a/src/cli/mcp/tools/mutation-tools.ts
+++ b/src/cli/mcp/tools/mutation-tools.ts
@@ -47,6 +47,11 @@ export function registerMutationTools(server: McpServer): void {
     {
       description:
         'Append a block to the package. Block type and field schemas mirror the CLI. Use pathfinder_help with command "add-block" to see per-type fields. Returns the updated artifact.',
+      annotations: {
+        title: 'Add Pathfinder block',
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
       inputSchema: {
         ...ArtifactInputSchema,
         type: z.enum(BlockTypeEnum as [string, ...string[]]).describe('Block type discriminator.'),
@@ -86,6 +91,11 @@ export function registerMutationTools(server: McpServer): void {
     'pathfinder_add_step',
     {
       description: 'Append a step to a multistep or guided block. Returns the updated artifact.',
+      annotations: {
+        title: 'Add Pathfinder step',
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
       inputSchema: {
         ...ArtifactInputSchema,
         parentId: z.string().describe('Parent multistep or guided block id.'),
@@ -104,6 +114,11 @@ export function registerMutationTools(server: McpServer): void {
     'pathfinder_add_choice',
     {
       description: 'Append a choice to a quiz block. Returns the updated artifact.',
+      annotations: {
+        title: 'Add Pathfinder choice',
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
       inputSchema: {
         ...ArtifactInputSchema,
         parentId: z.string().describe('Parent quiz block id.'),
@@ -122,6 +137,11 @@ export function registerMutationTools(server: McpServer): void {
     'pathfinder_edit_block',
     {
       description: 'Update fields on an existing block. Returns the updated artifact.',
+      annotations: {
+        title: 'Edit Pathfinder block',
+        readOnlyHint: false,
+        destructiveHint: true,
+      },
       inputSchema: {
         ...ArtifactInputSchema,
         id: z.string().describe('Block id to edit.'),
@@ -138,6 +158,11 @@ export function registerMutationTools(server: McpServer): void {
     'pathfinder_remove_block',
     {
       description: 'Remove a block by id. Returns the updated artifact.',
+      annotations: {
+        title: 'Remove Pathfinder block',
+        readOnlyHint: false,
+        destructiveHint: true,
+      },
       inputSchema: {
         ...ArtifactInputSchema,
         id: z.string().describe('Block id to remove.'),
@@ -160,6 +185,11 @@ export function registerMutationTools(server: McpServer): void {
     'pathfinder_set_manifest',
     {
       description: 'Update fields on the package manifest. Returns the updated artifact.',
+      annotations: {
+        title: 'Set Pathfinder manifest',
+        readOnlyHint: false,
+        destructiveHint: true,
+      },
       inputSchema: {
         ...ArtifactInputSchema,
         fields: FlagValuesSchema.describe('Manifest fields to set (description, category, language, etc.).'),


### PR DESCRIPTION
Add annotations to give labels for read and write. Also suggested to add titles, so added titles. Annotations from https://modelcontextprotocol.io/specification/2025-11-25/schema#toolannotations

readonly is false by default, but Assistant requires it to be explicitly set for it to show write as a label.


<img width="1258" height="1076" alt="image" src="https://github.com/user-attachments/assets/05a4b28f-c9b5-4269-bfa5-5556b602d8d2" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are metadata-only `annotations` on MCP tool registrations plus a package `bin` path fix; no underlying authoring/validation logic is modified.
> 
> **Overview**
> **Adds MCP tool `annotations`** across authoring tools so clients (e.g., Assistant) can label tools with a human-friendly title and whether they are *read-only* and/or *destructive* (e.g., `pathfinder_validate` vs `pathfinder_edit_block`).
> 
> **Updates packaging metadata** by adjusting `package-lock.json` `bin` entries to use `./dist/...` paths and pointing `pathfinder-mcp` at `dist/cli/cli/mcp/index.js` instead of the prior placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8afa9e11d3369898b5efde774c63ed6551639ed1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->