### PR TITLE
fix(floating-panel): keep popout in view across viewport changes

### DIFF
--- a/src/components/floating-panel/useDragResize.ts
+++ b/src/components/floating-panel/useDragResize.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { panelModeManager } from '../../global-state/panel-mode';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
 import {
@@ -20,6 +20,27 @@ function clampToViewport(x: number, y: number, width: number, height: number): {
     x: clamp(x, 0, window.innerWidth - width),
     y: clamp(y, 0, window.innerHeight - height),
   };
+}
+
+/**
+ * Clamp the entire geometry — both dimensions and position — so the
+ * panel always renders within the current viewport. Used on mount and
+ * on window resize so a position saved on a larger screen can never
+ * leave the panel stranded off-screen when the user comes back on a
+ * smaller window.
+ *
+ * Width/height clamp is one-way (shrink only) and is NOT persisted by
+ * this function: the panel still renders smaller, but the next time the
+ * viewport is large enough we want the user's preferred size restored.
+ * Persisting only happens through explicit drag/resize gestures, where
+ * the saved value reflects user intent.
+ */
+function clampGeometryToViewport(g: FloatingPanelGeometry): FloatingPanelGeometry {
+  const width = Math.min(g.width, Math.max(FLOATING_PANEL_MIN_WIDTH, window.innerWidth));
+  const height = Math.min(g.height, Math.max(FLOATING_PANEL_MIN_HEIGHT, window.innerHeight));
+  const x = Math.max(0, Math.min(g.x, window.innerWidth - width));
+  const y = Math.max(0, Math.min(g.y, window.innerHeight - height));
+  return { ...g, x, y, width, height };
 }
 
 /**
@@ -162,7 +183,25 @@ function useResize(
  * initializing from persisted values and exposing drag + resize handlers.
  */
 export function useDragResize() {
-  const [geometry, setGeometry] = useState<FloatingPanelGeometry>(() => panelModeManager.getPanelGeometry());
+  // Initial geometry is the persisted user preference clamped to the
+  // current viewport — a position saved on a 30" monitor must never
+  // leave the panel stranded off-screen on a 13" laptop.
+  const [geometry, setGeometry] = useState<FloatingPanelGeometry>(() =>
+    clampGeometryToViewport(panelModeManager.getPanelGeometry())
+  );
+
+  // Re-clamp whenever the browser is resized. We re-read from the
+  // manager (the user's preferred geometry) and clamp that, rather than
+  // clamping the current rendered geometry — that way, growing the
+  // browser back restores the original size, instead of leaving us
+  // stuck with an earlier shrink.
+  useEffect(() => {
+    const handler = () => {
+      setGeometry(clampGeometryToViewport(panelModeManager.getPanelGeometry()));
+    };
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
 
   const drag = useDrag(geometry, setGeometry);
   const resize = useResize(geometry, setGeometry);


### PR DESCRIPTION
## Summary

The popout's persisted geometry was being applied raw on mount, so a position saved on a large monitor could leave the panel stranded off-screen when Pathfinder was opened on a smaller window. The popout *was* opening — just outside the visible viewport — making the feature appear broken. Resizing the browser smaller while the popout was open had the same effect.

## Fix

Two changes in `src/components/floating-panel/useDragResize.ts`:

1. **New `clampGeometryToViewport(g)` helper** — clamps width/height to fit `window.innerWidth/innerHeight` (with `FLOATING_PANEL_MIN_*` as floors), then clamps x/y so the rectangle stays in view. Defensive against tiny viewports (`Math.max(0, ...)` so x/y can't go negative if `innerWidth < width`).

2. **The combined hook now**:
   - Initialises state with `clampGeometryToViewport(panelModeManager.getPanelGeometry())` — first paint is always visible.
   - Adds a `window.resize` listener that **re-reads the persisted "preferred" geometry** from the manager and re-clamps it. Re-reading (rather than clamping the current rendered geometry) means: a viewport that grows back restores the user's saved size, instead of leaving us stuck with an earlier shrink.

The clamp never persists. Saved geometry only changes via explicit drag/resize gestures, where the value reflects user intent. So a 30"-monitor user's preferred size is restored next time they're on the big screen, even after they've used Pathfinder on a laptop in between.

## Test plan

- [ ] Open Pathfinder, pop out, drag panel to right edge of a wide browser window
- [ ] Shrink the browser horizontally — confirm the panel slides left to stay in view
- [ ] Re-expand the browser — confirm the panel returns to its right-edge position (preferred size restored)
- [ ] In a wide browser, position the popout near `(1500, 200)`, close Pathfinder, narrow the browser to ~1100px wide, reopen Pathfinder and click "Pop out" — confirm the panel opens visible (not off-screen)
- [ ] Verify saved geometry larger than viewport in both axes is clamped to fill the viewport at `(0, 0)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to floating panel positioning/sizing; main risk is unintended geometry adjustments during window resize.
> 
> **Overview**
> Ensures the floating panel never renders off-screen when restoring persisted geometry on different viewport sizes.
> 
> `useDragResize` now clamps the persisted geometry to the current viewport on initial mount and on `window` resize via a new `clampGeometryToViewport` helper, shrinking dimensions (without persisting) and adjusting `x/y` so the panel stays visible while still restoring the user’s preferred size when the viewport grows again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e78ea6044fa33d26290f96355bdbe019ac070fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->