### PR TITLE
fix(ui): point dock-to-sidebar arrow toward the right

### DIFF
--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -506,7 +506,7 @@ export function BlockEditorHeader({
           <Button
             variant="secondary"
             size="sm"
-            icon={panelMode === 'sidebar' ? 'corner-up-right' : 'corner-down-right'}
+            icon={panelMode === 'sidebar' ? 'corner-up-right' : 'corner-down-right-alt'}
             onClick={handleTogglePanelMode}
             tooltip={
               panelMode === 'sidebar'

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -506,7 +506,7 @@ export function BlockEditorHeader({
           <Button
             variant="secondary"
             size="sm"
-            icon={panelMode === 'sidebar' ? 'corner-up-right' : 'arrow-to-right'}
+            icon={panelMode === 'sidebar' ? 'corner-up-right' : 'corner-down-right'}
             onClick={handleTogglePanelMode}
             tooltip={
               panelMode === 'sidebar'

--- a/src/components/floating-panel/FloatingPanel.tsx
+++ b/src/components/floating-panel/FloatingPanel.tsx
@@ -213,7 +213,7 @@ export function FloatingPanel({
               />
             )}
             <IconButton
-              name="arrow-to-right"
+              name="angle-double-right"
               size="sm"
               tooltip="Dock to sidebar"
               onClick={handleSwitchToSidebar}


### PR DESCRIPTION
## Summary
- Fixes #849 - the dock-to-sidebar arrow pointed left even though the sidebar lives on the right.
- Grafana's `arrow-to-right` icon visually renders as an arrow pointing left into a wall, which gave the wrong affordance.
- Block editor toggle now uses `corner-down-right` (pairs symmetrically with the existing `corner-up-right` pop-out icon).
- Floating panel header dock button now uses `angle-double-right`.

## Test plan
- [ ] Open the block editor in floating panel mode and confirm the dock button arrow points right.
- [ ] On the floating panel header, confirm the dock-to-sidebar icon points right.
- [ ] In the block editor sidebar mode, confirm the pop-out icon (`corner-up-right`) is unchanged.

Generated with [Claude Code](https://claude.com/claude-code)
