### PR TITLE
feat(block-editor): undo/redo, authorNote field, searchable palette

### DIFF
--- a/src/cli/__tests__/schema-options.test.ts
+++ b/src/cli/__tests__/schema-options.test.ts
@@ -270,6 +270,7 @@ describe('integration with the live JsonInteractiveBlockSchema', () => {
         '--assistant-enabled',
         '--assistant-id <string>',
         '--assistant-type <query|config|code|text>',
+        '--author-note <string>',
       ].sort()
     );
   });

--- a/src/components/block-editor/AuthorNoteModal.tsx
+++ b/src/components/block-editor/AuthorNoteModal.tsx
@@ -63,15 +63,18 @@ export function AuthorNoteModal({ isOpen, initialNote, onSave, onClose }: Author
 
   return (
     <Modal title="Author note" isOpen={isOpen} onDismiss={onClose}>
-      {/* Stop pointer / mouse / click bubbling. The Modal portals to
-          document.body, but React event bubbling follows the React
-          tree — without this, textarea clicks bubble up to the
-          owning BlockItem's SortableBlock drag listener and arm a
-          phantom drag that the user can't escape. */}
+      {/* Stop pointer / mouse / click / key bubbling. The Modal portals
+          to document.body, but React event bubbling follows the React
+          tree — without this, textarea events bubble up to the owning
+          BlockItem's SortableBlock listeners. Key blocking is the
+          critical one: dnd-kit's KeyboardSensor uses Space to activate
+          a drag, so typing a space in the note input would otherwise
+          arm a phantom drag (and the list would jump on every space). */}
       <div
         onPointerDown={(e) => e.stopPropagation()}
         onMouseDown={(e) => e.stopPropagation()}
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <p className={styles.help}>
           Author-only note attached to this block. Useful for TODOs, reminders, or context for collaborators. Not

--- a/src/components/block-editor/AuthorNoteModal.tsx
+++ b/src/components/block-editor/AuthorNoteModal.tsx
@@ -1,0 +1,109 @@
+/**
+ * `AuthorNoteModal` — a tiny modal for editing the editor-only
+ * `authorNote` field on any block.
+ *
+ * Shared across all block types (interactive, markdown, section, etc.)
+ * because every block carries the same `authorNote?: string` field
+ * post-Wave-2. Not part of the type-specific form modals — those stay
+ * focused on the runtime-meaningful fields. Notes are a sidecar
+ * concern: jot a TODO, leave a reminder, keep an authoring breadcrumb.
+ *
+ * Saving an empty string clears the note (and the indicator icon).
+ * The published export pipeline strips the field via `stripAuthorNotes`.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { Button, Modal, TextArea, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+
+export interface AuthorNoteModalProps {
+  isOpen: boolean;
+  initialNote: string;
+  onSave: (note: string) => void;
+  onClose: () => void;
+}
+
+export function AuthorNoteModal({ isOpen, initialNote, onSave, onClose }: AuthorNoteModalProps) {
+  const styles = useStyles2(getStyles);
+  const [draft, setDraft] = useState(initialNote);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Reset the draft every time the modal opens so reopening on a
+  // different block doesn't leak the previous block's note. The set
+  // happens during the open transition only (tracked via `wasOpen`)
+  // — React docs' "adjust state when prop changes" pattern, avoids
+  // the cascading-render warning that effect-based resets trip.
+  const [wasOpen, setWasOpen] = useState(isOpen);
+  if (isOpen !== wasOpen) {
+    if (isOpen) {
+      setDraft(initialNote);
+    }
+    setWasOpen(isOpen);
+  }
+
+  // Focus the textarea after render so authors can start typing
+  // immediately. setTimeout(0) avoids a Grafana Modal mounting race.
+  useEffect(() => {
+    if (isOpen) {
+      const id = window.setTimeout(() => textareaRef.current?.focus(), 0);
+      return () => window.clearTimeout(id);
+    }
+    return undefined;
+  }, [isOpen]);
+
+  const handleSave = () => {
+    onSave(draft.trim());
+    onClose();
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Modal title="Author note" isOpen={isOpen} onDismiss={onClose}>
+      {/* Stop pointer / mouse / click bubbling. The Modal portals to
+          document.body, but React event bubbling follows the React
+          tree — without this, textarea clicks bubble up to the
+          owning BlockItem's SortableBlock drag listener and arm a
+          phantom drag that the user can't escape. */}
+      <div
+        onPointerDown={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <p className={styles.help}>
+          Author-only note attached to this block. Useful for TODOs, reminders, or context for collaborators. Not
+          visible to readers and stripped from the published guide.
+        </p>
+        <TextArea
+          ref={(el) => {
+            textareaRef.current = el;
+          }}
+          value={draft}
+          onChange={(e) => setDraft(e.currentTarget.value)}
+          rows={5}
+          placeholder="e.g. Revisit this selector after the dashboard refactor"
+          data-testid="pathfinder-block-editor-author-note-textarea"
+        />
+        <Modal.ButtonRow>
+          <Button variant="secondary" onClick={onClose} fill="outline">
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleSave} data-testid="pathfinder-block-editor-author-note-save">
+            Save note
+          </Button>
+        </Modal.ButtonRow>
+      </div>
+    </Modal>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  help: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    margin: theme.spacing(0, 0, 1.5, 0),
+  }),
+});

--- a/src/components/block-editor/BlockEditor.tsx
+++ b/src/components/block-editor/BlockEditor.tsx
@@ -28,7 +28,7 @@ import { RecordModeOverlay } from './RecordModeOverlay';
 import { GuideLibraryModal } from './GuideLibraryModal';
 import { useActionRecorder } from '../../utils/devtools';
 import type { JsonGuide, JsonBlock, BlockOperations, BlockType, EditorBlock, PreviewTarget } from './types';
-import type { JsonSectionBlock } from '../../types/json-guide.types';
+import { isSectionBlock, isConditionalBlock, type JsonSectionBlock } from '../../types/json-guide.types';
 import { BlockEditorFooter } from './BlockEditorFooter';
 import { BlockEditorHeader } from './BlockEditorHeader';
 import { BlockEditorContent } from './BlockEditorContent';
@@ -556,6 +556,59 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
       // Preview
       onBlockPreview: handleRootBlockPreview,
       onNestedSectionBlockPreview: handleNestedSectionBlockPreview,
+
+      // Author-only note save handlers. Each one merges the new note
+      // onto the existing block via the appropriate update method.
+      onBlockAuthorNoteChange: (blockId, note) => {
+        const entry = state.blocks.find((b) => b.id === blockId);
+        if (!entry) {
+          return;
+        }
+        const next: JsonBlock = note
+          ? ({ ...entry.block, authorNote: note } as JsonBlock)
+          : (() => {
+              const copy = { ...(entry.block as unknown as Record<string, unknown>) };
+              delete copy.authorNote;
+              return copy as unknown as JsonBlock;
+            })();
+        editor.updateBlock(blockId, next);
+      },
+      onNestedBlockAuthorNoteChange: (sectionId, nestedIndex, note) => {
+        const section = state.blocks.find((b) => b.id === sectionId);
+        if (!section || !isSectionBlock(section.block)) {
+          return;
+        }
+        const child = section.block.blocks[nestedIndex];
+        if (!child) {
+          return;
+        }
+        const next: JsonBlock = note
+          ? ({ ...child, authorNote: note } as JsonBlock)
+          : (() => {
+              const copy = { ...(child as unknown as Record<string, unknown>) };
+              delete copy.authorNote;
+              return copy as unknown as JsonBlock;
+            })();
+        editor.updateNestedBlock(sectionId, nestedIndex, next);
+      },
+      onConditionalBranchBlockAuthorNoteChange: (conditionalId, branch, nestedIndex, note) => {
+        const conditional = state.blocks.find((b) => b.id === conditionalId);
+        if (!conditional || !isConditionalBlock(conditional.block)) {
+          return;
+        }
+        const child = conditional.block[branch][nestedIndex];
+        if (!child) {
+          return;
+        }
+        const next: JsonBlock = note
+          ? ({ ...child, authorNote: note } as JsonBlock)
+          : (() => {
+              const copy = { ...(child as unknown as Record<string, unknown>) };
+              delete copy.authorNote;
+              return copy as unknown as JsonBlock;
+            })();
+        editor.updateConditionalBranchBlock(conditionalId, branch, nestedIndex, next);
+      },
     }),
     [
       formState,
@@ -566,6 +619,7 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
       recordingActions,
       handleRootBlockPreview,
       handleNestedSectionBlockPreview,
+      state.blocks,
     ]
   );
 
@@ -1003,6 +1057,12 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
         hasBlocks={hasBlocks}
         isSelectionMode={selection.isSelectionMode}
         onToggleSelectionMode={selection.toggleSelectionMode}
+        onUndo={editor.undo}
+        onRedo={editor.redo}
+        canUndo={editor.canUndo}
+        canRedo={editor.canRedo}
+        undoLabel={editor.undoLabel}
+        redoLabel={editor.redoLabel}
       />
 
       <BlockEditorContent

--- a/src/components/block-editor/BlockEditorHeader.test.tsx
+++ b/src/components/block-editor/BlockEditorHeader.test.tsx
@@ -26,6 +26,12 @@ const baseProps = {
   hasBlocks: false,
   isSelectionMode: false,
   onToggleSelectionMode: jest.fn(),
+  onUndo: jest.fn(),
+  onRedo: jest.fn(),
+  canUndo: false,
+  canRedo: false,
+  undoLabel: null,
+  redoLabel: null,
 };
 
 describe('BlockEditorHeader: pop out / dock button', () => {

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -68,6 +68,18 @@ export interface BlockEditorHeaderProps {
   isSelectionMode: boolean;
   /** Toggle selection mode on/off */
   onToggleSelectionMode: () => void;
+  /** Step backwards through the in-session undo history. */
+  onUndo: () => void;
+  /** Step forwards through the in-session redo history. */
+  onRedo: () => void;
+  /** True iff undo is available. */
+  canUndo: boolean;
+  /** True iff redo is available. */
+  canRedo: boolean;
+  /** Optional label for the next undo target — surfaced as the button tooltip. */
+  undoLabel: string | null;
+  /** Optional label for the next redo target — surfaced as the button tooltip. */
+  redoLabel: string | null;
 }
 
 const getHeaderStyles = (theme: GrafanaTheme2) => ({
@@ -235,6 +247,12 @@ export function BlockEditorHeader({
   hasBlocks,
   isSelectionMode,
   onToggleSelectionMode,
+  onUndo,
+  onRedo,
+  canUndo,
+  canRedo,
+  undoLabel,
+  redoLabel,
 }: BlockEditorHeaderProps) {
   const styles = useStyles2(getHeaderStyles);
 
@@ -528,6 +546,37 @@ export function BlockEditorHeader({
                 aria-label={isSelectionMode ? 'Exit selection mode' : 'Select blocks for merging'}
                 tooltip={isSelectionMode ? 'Exit selection mode' : 'Select blocks for merging'}
                 data-testid={testIds.blockEditor.toggleSelectionButton}
+              />
+            </>
+          )}
+
+          {/* Undo / redo for the in-session history ring buffer. The
+              labels (when present) describe the next operation in the
+              stack — useful for tooltip-driven discoverability. The
+              `corner-up-left` / `corner-up-right` icons are the
+              conventional curved-arrow glyphs every word processor /
+              editor uses for undo/redo. */}
+          {viewMode === 'edit' && (
+            <>
+              <IconButton
+                name="corner-up-left"
+                size="sm"
+                variant="secondary"
+                onClick={onUndo}
+                disabled={!canUndo}
+                aria-label={undoLabel ? `Undo: ${undoLabel}` : 'Undo'}
+                tooltip={undoLabel ? `Undo: ${undoLabel}` : 'Undo'}
+                data-testid="pathfinder-block-editor-undo"
+              />
+              <IconButton
+                name="corner-up-right"
+                size="sm"
+                variant="secondary"
+                onClick={onRedo}
+                disabled={!canRedo}
+                aria-label={redoLabel ? `Redo: ${redoLabel}` : 'Redo'}
+                tooltip={redoLabel ? `Redo: ${redoLabel}` : 'Redo'}
+                data-testid="pathfinder-block-editor-redo"
               />
             </>
           )}

--- a/src/components/block-editor/BlockItem.tsx
+++ b/src/components/block-editor/BlockItem.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { Icon, IconButton, useStyles2, Badge, Checkbox, Tooltip } from '@grafana/ui';
+import { IconButton, useStyles2, Badge, Checkbox } from '@grafana/ui';
 import { getBlockItemStyles } from './block-editor.styles';
 import { AuthorNoteModal } from './AuthorNoteModal';
 import { ConfirmDeleteButton } from './ConfirmDeleteButton';
@@ -224,15 +224,6 @@ export function BlockItem({
               {block.block.display === 'section' && <Badge text="Section" color="green" />}
             </>
           )}
-          {/* Author-only note indicator. Tooltip shows the note text;
-              the field itself never reaches the published guide. */}
-          {block.block.authorNote && (
-            <Tooltip content={block.block.authorNote} placement="top">
-              <span aria-label={`Author note: ${block.block.authorNote}`} className={styles.authorNoteIcon}>
-                <Icon name="comment-alt" size="sm" />
-              </span>
-            </Tooltip>
-          )}
         </div>
       </div>
 
@@ -256,8 +247,17 @@ export function BlockItem({
         {/* Secondary actions — hidden by default, revealed on row hover or
             keyboard focus via the parent container's data-attribute
             selectors. They sit *before* Edit so the always-visible Edit
-            button stays anchored to the right edge of every row. */}
+            button stays anchored to the right edge of every row. Delete
+            is rendered first (leftmost) so the destructive action stays
+            furthest from Edit, reducing misclick risk. */}
         <div className={styles.secondaryActions} data-secondary-actions>
+          <ConfirmDeleteButton
+            onConfirm={onDelete}
+            className={styles.deleteButton}
+            tooltip="Delete block"
+            ariaLabel="Delete"
+            blockType={meta.name.toLowerCase()}
+          />
           {isSection && onRecord && (
             <IconButton
               name={isRecording ? 'square-shape' : 'circle'}
@@ -291,31 +291,42 @@ export function BlockItem({
             tooltip="Duplicate block"
             data-testid={testIds.blockEditor.duplicateButton}
           />
-          {/* Author note — opens the shared AuthorNoteModal. Same icon
-              as the inline indicator so authors learn the association.
-              Only rendered when the parent supplies the save callback. */}
-          {onAuthorNoteChange && (
+          {/* Author note (unset case) — hover-revealed alongside the other
+              secondary actions. When a note IS set, the same button is
+              rendered outside this hover-gated container so it stays
+              visible at rest as the "note exists" indicator. */}
+          {onAuthorNoteChange && !currentAuthorNote && (
             <IconButton
               name="comment-alt"
               size="sm"
-              aria-label={currentAuthorNote ? 'Edit author note' : 'Add author note'}
+              aria-label="Add author note"
               onClick={(e) => {
                 e.stopPropagation();
                 setNoteModalOpen(true);
               }}
               className={styles.actionButton}
-              tooltip={currentAuthorNote ? 'Edit author note' : 'Add author note'}
+              tooltip="Add author note"
               data-testid="pathfinder-block-editor-author-note-button"
             />
           )}
-          <ConfirmDeleteButton
-            onConfirm={onDelete}
-            className={styles.deleteButton}
-            tooltip="Delete block"
-            ariaLabel="Delete"
-            blockType={meta.name.toLowerCase()}
-          />
         </div>
+        {/* Author note (set case) — always-visible because it doubles as
+            the indicator that a note exists; tooltip carries the note
+            text so authors can peek without opening the modal. */}
+        {onAuthorNoteChange && currentAuthorNote && (
+          <IconButton
+            name="comment-alt"
+            size="sm"
+            aria-label={`Author note: ${currentAuthorNote}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              setNoteModalOpen(true);
+            }}
+            className={styles.actionButton}
+            tooltip={currentAuthorNote}
+            data-testid="pathfinder-block-editor-author-note-button"
+          />
+        )}
         {/* Edit is the primary action — always visible, right-anchored. */}
         <IconButton
           name="edit"

--- a/src/components/block-editor/BlockItem.tsx
+++ b/src/components/block-editor/BlockItem.tsx
@@ -4,9 +4,10 @@
  * Individual block wrapper with drag handle, type indicator, preview, and actions.
  */
 
-import React, { useCallback, useMemo } from 'react';
-import { IconButton, useStyles2, Badge, Checkbox } from '@grafana/ui';
+import React, { useCallback, useMemo, useState } from 'react';
+import { Icon, IconButton, useStyles2, Badge, Checkbox, Tooltip } from '@grafana/ui';
 import { getBlockItemStyles } from './block-editor.styles';
+import { AuthorNoteModal } from './AuthorNoteModal';
 import { ConfirmDeleteButton } from './ConfirmDeleteButton';
 import { LintBadge } from './LintBadge';
 import { BLOCK_TYPE_METADATA } from './constants';
@@ -60,6 +61,8 @@ export interface BlockItemProps {
   onPreview?: () => void;
   /** Whether this block preview is currently open */
   isPreviewActive?: boolean;
+  /** Save a new author-only note onto this block. */
+  onAuthorNoteChange?: (note: string) => void;
 }
 
 /**
@@ -85,6 +88,7 @@ export function BlockItem({
   isLastModified = false,
   onPreview,
   isPreviewActive = false,
+  onAuthorNoteChange,
 }: BlockItemProps) {
   const styles = useStyles2(getBlockItemStyles);
   const blockType = block.block.type as BlockType;
@@ -100,6 +104,11 @@ export function BlockItem({
   const isSection = isSectionBlock(block.block);
   const isConditional = isConditionalBlock(block.block);
   void totalBlocks;
+
+  // Author-note modal state. Lives at the row level so it can read /
+  // write the block's `authorNote` via the parent-supplied callback.
+  const [isNoteModalOpen, setNoteModalOpen] = useState(false);
+  const currentAuthorNote = block.block.authorNote ?? '';
 
   const handleEdit = useCallback(
     (e: React.MouseEvent) => {
@@ -215,6 +224,15 @@ export function BlockItem({
               {block.block.display === 'section' && <Badge text="Section" color="green" />}
             </>
           )}
+          {/* Author-only note indicator. Tooltip shows the note text;
+              the field itself never reaches the published guide. */}
+          {block.block.authorNote && (
+            <Tooltip content={block.block.authorNote} placement="top">
+              <span aria-label={`Author note: ${block.block.authorNote}`} className={styles.authorNoteIcon}>
+                <Icon name="comment-alt" size="sm" />
+              </span>
+            </Tooltip>
+          )}
         </div>
       </div>
 
@@ -225,7 +243,16 @@ export function BlockItem({
 
       {/* Actions */}
       {/* draggable={false} prevents drag from starting when clicking this area */}
-      <div className={styles.actions} draggable={false} onMouseDown={(e) => e.stopPropagation()}>
+      {/* `onPointerDown` stop is required — `@dnd-kit` listens on pointer
+          events (separate from mouse events), so the existing
+          `onMouseDown` stop alone wasn't preventing the SortableBlock
+          drag listener from arming when an action button was clicked. */}
+      <div
+        className={styles.actions}
+        draggable={false}
+        onMouseDown={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
         {/* Secondary actions — hidden by default, revealed on row hover or
             keyboard focus via the parent container's data-attribute
             selectors. They sit *before* Edit so the always-visible Edit
@@ -264,6 +291,23 @@ export function BlockItem({
             tooltip="Duplicate block"
             data-testid={testIds.blockEditor.duplicateButton}
           />
+          {/* Author note — opens the shared AuthorNoteModal. Same icon
+              as the inline indicator so authors learn the association.
+              Only rendered when the parent supplies the save callback. */}
+          {onAuthorNoteChange && (
+            <IconButton
+              name="comment-alt"
+              size="sm"
+              aria-label={currentAuthorNote ? 'Edit author note' : 'Add author note'}
+              onClick={(e) => {
+                e.stopPropagation();
+                setNoteModalOpen(true);
+              }}
+              className={styles.actionButton}
+              tooltip={currentAuthorNote ? 'Edit author note' : 'Add author note'}
+              data-testid="pathfinder-block-editor-author-note-button"
+            />
+          )}
           <ConfirmDeleteButton
             onConfirm={onDelete}
             className={styles.deleteButton}
@@ -294,6 +338,15 @@ export function BlockItem({
           tooltip={isCollapsed ? `Expand (${childCount} ${childCount === 1 ? 'block' : 'blocks'})` : 'Collapse'}
           aria-expanded={!isCollapsed}
           aria-label={isCollapsed ? 'Expand' : 'Collapse'}
+        />
+      )}
+
+      {onAuthorNoteChange && (
+        <AuthorNoteModal
+          isOpen={isNoteModalOpen}
+          initialNote={currentAuthorNote}
+          onSave={onAuthorNoteChange}
+          onClose={() => setNoteModalOpen(false)}
         />
       )}
     </div>

--- a/src/components/block-editor/BlockList.styles.ts
+++ b/src/components/block-editor/BlockList.styles.ts
@@ -308,6 +308,14 @@ export const getNestedBlockItemStyles = (theme: GrafanaTheme2) => ({
     minWidth: 0,
     flex: 1,
   }),
+  // Mirrors BlockItem: small editor-only note indicator. Stripped on export.
+  authorNoteIcon: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    color: theme.colors.text.secondary,
+    cursor: 'help',
+    flexShrink: 0,
+  }),
   actions: css({
     display: 'flex',
     flexDirection: 'row',

--- a/src/components/block-editor/BlockList.tsx
+++ b/src/components/block-editor/BlockList.tsx
@@ -105,6 +105,9 @@ export function BlockList({
     onMoveBlockBetweenSections,
     onBlockPreview,
     onNestedSectionBlockPreview,
+    onBlockAuthorNoteChange,
+    onNestedBlockAuthorNoteChange,
+    onConditionalBranchBlockAuthorNoteChange,
   } = operations;
   const styles = useStyles2(getBlockListStyles);
   const nestedStyles = useStyles2(getNestedStyles);
@@ -744,6 +747,7 @@ export function BlockList({
                         : undefined
                     }
                     isPreviewActive={isBlockItemPreviewActive}
+                    onAuthorNoteChange={onBlockAuthorNoteChange ? (note) => onBlockAuthorNoteChange(block.id, note) : undefined}
                   />
                 </SortableBlock>
 
@@ -775,6 +779,7 @@ export function BlockList({
                     onConditionalBranchBlockDelete={onConditionalBranchBlockDelete}
                     onConditionalBranchBlockDuplicate={onConditionalBranchBlockDuplicate}
                     onInsertBlockInConditional={onInsertBlockInConditional}
+                    onConditionalBranchBlockAuthorNoteChange={onConditionalBranchBlockAuthorNoteChange}
                     justDroppedId={justDroppedId}
                     lastModifiedId={lastModifiedId}
                   />
@@ -805,6 +810,7 @@ export function BlockList({
                     onNestedBlockDelete={onNestedBlockDelete}
                     onNestedBlockDuplicate={onNestedBlockDuplicate}
                     onInsertBlockInSection={onInsertBlockInSection}
+                    onNestedBlockAuthorNoteChange={onNestedBlockAuthorNoteChange}
                     justDroppedId={justDroppedId}
                     lastModifiedId={lastModifiedId}
                     onPreviewSection={onNestedSectionBlockPreview}

--- a/src/components/block-editor/BlockList.tsx
+++ b/src/components/block-editor/BlockList.tsx
@@ -747,7 +747,9 @@ export function BlockList({
                         : undefined
                     }
                     isPreviewActive={isBlockItemPreviewActive}
-                    onAuthorNoteChange={onBlockAuthorNoteChange ? (note) => onBlockAuthorNoteChange(block.id, note) : undefined}
+                    onAuthorNoteChange={
+                      onBlockAuthorNoteChange ? (note) => onBlockAuthorNoteChange(block.id, note) : undefined
+                    }
                   />
                 </SortableBlock>
 
@@ -779,9 +781,9 @@ export function BlockList({
                     onConditionalBranchBlockDelete={onConditionalBranchBlockDelete}
                     onConditionalBranchBlockDuplicate={onConditionalBranchBlockDuplicate}
                     onInsertBlockInConditional={onInsertBlockInConditional}
-                    onConditionalBranchBlockAuthorNoteChange={onConditionalBranchBlockAuthorNoteChange}
                     justDroppedId={justDroppedId}
                     lastModifiedId={lastModifiedId}
+                    onConditionalBranchBlockAuthorNoteChange={onConditionalBranchBlockAuthorNoteChange}
                   />
                 )}
 
@@ -810,7 +812,6 @@ export function BlockList({
                     onNestedBlockDelete={onNestedBlockDelete}
                     onNestedBlockDuplicate={onNestedBlockDuplicate}
                     onInsertBlockInSection={onInsertBlockInSection}
-                    onNestedBlockAuthorNoteChange={onNestedBlockAuthorNoteChange}
                     justDroppedId={justDroppedId}
                     lastModifiedId={lastModifiedId}
                     onPreviewSection={onNestedSectionBlockPreview}
@@ -818,6 +819,7 @@ export function BlockList({
                     pinnedNestedIndices={pinnedNestedIndices}
                     nestedPreviews={nestedPreviewByIndex}
                     previewClasses={previewClasses}
+                    onNestedBlockAuthorNoteChange={onNestedBlockAuthorNoteChange}
                   />
                 )}
 

--- a/src/components/block-editor/BlockPalette.tsx
+++ b/src/components/block-editor/BlockPalette.tsx
@@ -9,7 +9,7 @@ import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { Icon, Portal, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2, usePluginContext } from '@grafana/data';
 import { css } from '@emotion/css';
-import { BLOCK_TYPE_METADATA, BLOCK_TYPE_ORDER } from './constants';
+import { BLOCK_TYPE_METADATA, BLOCK_TYPE_ORDER, BLOCK_TYPE_GROUPS } from './constants';
 import { getConfigWithDefaults } from '../../constants';
 import { testIds } from '../../constants/testIds';
 import type { BlockType, OnBlockTypeSelect } from './types';
@@ -140,6 +140,45 @@ const getPaletteModalStyles = (theme: GrafanaTheme2) => ({
     padding: theme.spacing(2),
     overflowY: 'auto',
     maxHeight: 'calc(80vh - 60px)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+  }),
+  filterInput: css({
+    width: '100%',
+    padding: theme.spacing(1, 1.5),
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    backgroundColor: theme.colors.background.primary,
+    color: theme.colors.text.primary,
+    fontSize: theme.typography.body.fontSize,
+    fontFamily: theme.typography.fontFamily,
+    outline: 'none',
+    '&:focus': {
+      borderColor: theme.colors.primary.border,
+    },
+    '&::placeholder': {
+      color: theme.colors.text.secondary,
+    },
+  }),
+  groupHeader: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+    color: theme.colors.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    marginBottom: theme.spacing(0.75),
+  }),
+  group: css({
+    display: 'flex',
+    flexDirection: 'column',
+  }),
+  emptyFilter: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    fontStyle: 'italic',
+    textAlign: 'center',
+    padding: theme.spacing(2),
   }),
   grid: css({
     display: 'grid',
@@ -242,6 +281,46 @@ export function BlockPalette({
 
   const availableTypes = BLOCK_TYPE_ORDER.filter((type) => !effectiveExcludeTypes.includes(type));
 
+  // Type-to-filter input. Reset on every open transition (React docs'
+  // "adjust state when prop changes" pattern, avoids the cascading
+  // render warning effect-based resets trip).
+  const [filter, setFilter] = useState('');
+  const [paletteWasOpen, setPaletteWasOpen] = useState(isOpen);
+  if (isOpen !== paletteWasOpen) {
+    if (isOpen) {
+      setFilter('');
+    }
+    setPaletteWasOpen(isOpen);
+  }
+
+  // Filtered + grouped views derived from `availableTypes`. We keep
+  // the original group order; types within a group keep their
+  // BLOCK_TYPE_ORDER relative ordering.
+  const filteredGroups = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    const match = (type: BlockType): boolean => {
+      if (!q) {
+        return true;
+      }
+      const meta = BLOCK_TYPE_METADATA[type];
+      return (
+        type.toLowerCase().includes(q) ||
+        meta.name.toLowerCase().includes(q) ||
+        meta.description.toLowerCase().includes(q)
+      );
+    };
+    return BLOCK_TYPE_GROUPS.map((g) => ({
+      id: g.id,
+      label: g.label,
+      types: g.types.filter((t) => availableTypes.includes(t) && match(t)),
+    })).filter((g) => g.types.length > 0);
+  }, [availableTypes, filter]);
+
+  const totalFilteredTypes = useMemo(
+    () => filteredGroups.reduce((sum, g) => sum + g.types.length, 0),
+    [filteredGroups]
+  );
+
   // Handle escape key to close
   useEffect(() => {
     if (!isOpen) {
@@ -315,26 +394,44 @@ export function BlockPalette({
                 </button>
               </div>
               <div className={styles.content}>
-                <div className={styles.grid}>
-                  {availableTypes.map((type) => {
-                    const meta = BLOCK_TYPE_METADATA[type];
-                    return (
-                      <button
-                        key={type}
-                        className={styles.item}
-                        onClick={() => handleSelect(type)}
-                        type="button"
-                        data-testid={testIds.blockEditor.blockTypeButton(type)}
-                      >
-                        <span className={styles.itemIcon}>{meta.icon}</span>
-                        <div className={styles.itemContent}>
-                          <div className={styles.itemName}>{meta.name}</div>
-                          <div className={styles.itemDescription}>{meta.description}</div>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
+                <input
+                  type="text"
+                  className={styles.filterInput}
+                  placeholder="Filter block types..."
+                  value={filter}
+                  onChange={(e) => setFilter(e.target.value)}
+                  autoFocus
+                  data-testid="pathfinder-block-editor-palette-filter"
+                />
+                {totalFilteredTypes === 0 ? (
+                  <div className={styles.emptyFilter}>No block types match &quot;{filter}&quot;</div>
+                ) : (
+                  filteredGroups.map((group) => (
+                    <div key={group.id} className={styles.group}>
+                      <div className={styles.groupHeader}>{group.label}</div>
+                      <div className={styles.grid}>
+                        {group.types.map((type) => {
+                          const meta = BLOCK_TYPE_METADATA[type];
+                          return (
+                            <button
+                              key={type}
+                              className={styles.item}
+                              onClick={() => handleSelect(type)}
+                              type="button"
+                              data-testid={testIds.blockEditor.blockTypeButton(type)}
+                            >
+                              <span className={styles.itemIcon}>{meta.icon}</span>
+                              <div className={styles.itemContent}>
+                                <div className={styles.itemName}>{meta.name}</div>
+                                <div className={styles.itemDescription}>{meta.description}</div>
+                              </div>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))
+                )}
               </div>
             </div>
           </div>

--- a/src/components/block-editor/ConditionalBranches.tsx
+++ b/src/components/block-editor/ConditionalBranches.tsx
@@ -83,6 +83,7 @@ export function ConditionalBranches({
   onConditionalBranchBlockDelete,
   onConditionalBranchBlockDuplicate,
   onInsertBlockInConditional,
+  onConditionalBranchBlockAuthorNoteChange,
   justDroppedId,
   lastModifiedId,
 }: ConditionalBranchesProps) {
@@ -213,6 +214,7 @@ function ConditionalBranch({
   onConditionalBranchBlockDelete,
   onConditionalBranchBlockDuplicate,
   onInsertBlockInConditional,
+  onConditionalBranchBlockAuthorNoteChange,
   justDroppedId,
   lastModifiedId,
 }: ConditionalBranchProps) {
@@ -311,6 +313,11 @@ function ConditionalBranch({
                       }
                       isJustDropped={justDroppedId === `${block.id}-${branchKey}-${nestedIndex}`}
                       isLastModified={lastModifiedId === `${block.id}-${branchKey}-${nestedIndex}`}
+                      onAuthorNoteChange={
+                        onConditionalBranchBlockAuthorNoteChange
+                          ? (note) => onConditionalBranchBlockAuthorNoteChange(block.id, branch, nestedIndex, note)
+                          : undefined
+                      }
                     />
                   </div>
                 </SortableBlock>

--- a/src/components/block-editor/ConditionalBranches.tsx
+++ b/src/components/block-editor/ConditionalBranches.tsx
@@ -62,6 +62,13 @@ export interface ConditionalBranchesProps {
   justDroppedId?: string | null;
   /** ID of the last modified block (for persistent highlight) */
   lastModifiedId?: string | null;
+  /** Save a new editor-only author note onto a conditional-branch nested block. */
+  onConditionalBranchBlockAuthorNoteChange?: (
+    conditionalId: string,
+    branch: 'whenTrue' | 'whenFalse',
+    nestedIndex: number,
+    note: string
+  ) => void;
 }
 
 export function ConditionalBranches({
@@ -83,9 +90,9 @@ export function ConditionalBranches({
   onConditionalBranchBlockDelete,
   onConditionalBranchBlockDuplicate,
   onInsertBlockInConditional,
-  onConditionalBranchBlockAuthorNoteChange,
   justDroppedId,
   lastModifiedId,
+  onConditionalBranchBlockAuthorNoteChange,
 }: ConditionalBranchesProps) {
   const conditionalBlock = block.block as JsonConditionalBlock;
 
@@ -120,6 +127,7 @@ export function ConditionalBranches({
         onInsertBlockInConditional={onInsertBlockInConditional}
         justDroppedId={justDroppedId}
         lastModifiedId={lastModifiedId}
+        onConditionalBranchBlockAuthorNoteChange={onConditionalBranchBlockAuthorNoteChange}
       />
 
       {/* False branch */}
@@ -145,6 +153,7 @@ export function ConditionalBranches({
         onInsertBlockInConditional={onInsertBlockInConditional}
         justDroppedId={justDroppedId}
         lastModifiedId={lastModifiedId}
+        onConditionalBranchBlockAuthorNoteChange={onConditionalBranchBlockAuthorNoteChange}
       />
     </div>
   );
@@ -192,6 +201,13 @@ interface ConditionalBranchProps {
   justDroppedId?: string | null;
   /** ID of the last modified block (for persistent highlight) */
   lastModifiedId?: string | null;
+  /** Save a new editor-only author note onto a conditional-branch nested block. */
+  onConditionalBranchBlockAuthorNoteChange?: (
+    conditionalId: string,
+    branch: 'whenTrue' | 'whenFalse',
+    nestedIndex: number,
+    note: string
+  ) => void;
 }
 
 function ConditionalBranch({
@@ -214,9 +230,9 @@ function ConditionalBranch({
   onConditionalBranchBlockDelete,
   onConditionalBranchBlockDuplicate,
   onInsertBlockInConditional,
-  onConditionalBranchBlockAuthorNoteChange,
   justDroppedId,
   lastModifiedId,
+  onConditionalBranchBlockAuthorNoteChange,
 }: ConditionalBranchProps) {
   const isTrue = branch === 'whenTrue';
   const branchKey = isTrue ? 'true' : 'false';

--- a/src/components/block-editor/NestedBlockItem.tsx
+++ b/src/components/block-editor/NestedBlockItem.tsx
@@ -5,8 +5,9 @@
  * Uses same layout as root-level BlockItem for consistency.
  */
 
-import React, { useCallback } from 'react';
-import { useStyles2, Badge, IconButton, Checkbox } from '@grafana/ui';
+import React, { useCallback, useState } from 'react';
+import { Icon, useStyles2, Badge, IconButton, Checkbox, Tooltip } from '@grafana/ui';
+import { AuthorNoteModal } from './AuthorNoteModal';
 import { ConfirmDeleteButton } from './ConfirmDeleteButton';
 import { LintBadge } from './LintBadge';
 import { getNestedBlockItemStyles } from './BlockList.styles';
@@ -37,6 +38,8 @@ export interface NestedBlockItemProps {
   onPreview?: () => void;
   /** Whether this nested block preview is currently open */
   isPreviewActive?: boolean;
+  /** Save a new author-only note onto this nested block. */
+  onAuthorNoteChange?: (note: string) => void;
 }
 
 /**
@@ -57,9 +60,14 @@ export function NestedBlockItem({
   isLastModified = false,
   onPreview,
   isPreviewActive = false,
+  onAuthorNoteChange,
 }: NestedBlockItemProps) {
   const styles = useStyles2(getNestedBlockItemStyles);
   const meta = BLOCK_TYPE_METADATA[block.type as BlockType];
+
+  // Author-note modal state — same pattern as BlockItem.
+  const [isNoteModalOpen, setNoteModalOpen] = useState(false);
+  const currentAuthorNote = 'authorNote' in block && typeof block.authorNote === 'string' ? block.authorNote : '';
 
   // Interactive, multistep, and guided blocks can be selected for merging
   const isSelectable =
@@ -144,6 +152,14 @@ export function NestedBlockItem({
               </span>
             )
           )}
+          {/* Author-only note indicator. Stripped on export. */}
+          {'authorNote' in block && typeof block.authorNote === 'string' && block.authorNote && (
+            <Tooltip content={block.authorNote} placement="top">
+              <span aria-label={`Author note: ${block.authorNote}`} className={styles.authorNoteIcon}>
+                <Icon name="comment-alt" size="sm" />
+              </span>
+            </Tooltip>
+          )}
         </div>
       </div>
 
@@ -152,7 +168,12 @@ export function NestedBlockItem({
 
       {/* Actions */}
       {/* draggable={false} prevents drag from starting when clicking this area */}
-      <div className={styles.actions} draggable={false} onMouseDown={(e) => e.stopPropagation()}>
+      <div
+        className={styles.actions}
+        draggable={false}
+        onMouseDown={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
         {/* Secondary actions — hidden by default, revealed on row hover
             or keyboard focus. Edit stays anchored to the right edge. */}
         <div className={styles.secondaryActions} data-secondary-actions>
@@ -182,6 +203,20 @@ export function NestedBlockItem({
             className={styles.actionButton}
             tooltip="Duplicate block"
           />
+          {onAuthorNoteChange && (
+            <IconButton
+              name="comment-alt"
+              size="sm"
+              aria-label={currentAuthorNote ? 'Edit author note' : 'Add author note'}
+              onClick={(e) => {
+                e.stopPropagation();
+                setNoteModalOpen(true);
+              }}
+              className={styles.actionButton}
+              tooltip={currentAuthorNote ? 'Edit author note' : 'Add author note'}
+              data-testid="pathfinder-block-editor-author-note-button-nested"
+            />
+          )}
           <ConfirmDeleteButton
             onConfirm={onDelete ?? (() => {})}
             className={styles.deleteButton}
@@ -200,6 +235,15 @@ export function NestedBlockItem({
           tooltip="Edit block"
         />
       </div>
+
+      {onAuthorNoteChange && (
+        <AuthorNoteModal
+          isOpen={isNoteModalOpen}
+          initialNote={currentAuthorNote}
+          onSave={onAuthorNoteChange}
+          onClose={() => setNoteModalOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/block-editor/NestedBlockItem.tsx
+++ b/src/components/block-editor/NestedBlockItem.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import { Icon, useStyles2, Badge, IconButton, Checkbox, Tooltip } from '@grafana/ui';
+import { useStyles2, Badge, IconButton, Checkbox } from '@grafana/ui';
 import { AuthorNoteModal } from './AuthorNoteModal';
 import { ConfirmDeleteButton } from './ConfirmDeleteButton';
 import { LintBadge } from './LintBadge';
@@ -152,14 +152,6 @@ export function NestedBlockItem({
               </span>
             )
           )}
-          {/* Author-only note indicator. Stripped on export. */}
-          {'authorNote' in block && typeof block.authorNote === 'string' && block.authorNote && (
-            <Tooltip content={block.authorNote} placement="top">
-              <span aria-label={`Author note: ${block.authorNote}`} className={styles.authorNoteIcon}>
-                <Icon name="comment-alt" size="sm" />
-              </span>
-            </Tooltip>
-          )}
         </div>
       </div>
 
@@ -175,8 +167,17 @@ export function NestedBlockItem({
         onPointerDown={(e) => e.stopPropagation()}
       >
         {/* Secondary actions — hidden by default, revealed on row hover
-            or keyboard focus. Edit stays anchored to the right edge. */}
+            or keyboard focus. Edit stays anchored to the right edge.
+            Delete is leftmost so the destructive action stays furthest
+            from Edit, reducing misclick risk. */}
         <div className={styles.secondaryActions} data-secondary-actions>
+          <ConfirmDeleteButton
+            onConfirm={onDelete ?? (() => {})}
+            className={styles.deleteButton}
+            tooltip="Delete block"
+            ariaLabel="Delete"
+            blockType={meta?.name.toLowerCase() ?? block.type}
+          />
           {onPreview && (
             <IconButton
               name={isPreviewActive ? 'eye-slash' : 'eye'}
@@ -203,28 +204,40 @@ export function NestedBlockItem({
             className={styles.actionButton}
             tooltip="Duplicate block"
           />
-          {onAuthorNoteChange && (
+          {/* Author note (unset case) — hover-revealed. Set case is
+              rendered below, always-visible, so the button doubles as
+              the "note exists" indicator. */}
+          {onAuthorNoteChange && !currentAuthorNote && (
             <IconButton
               name="comment-alt"
               size="sm"
-              aria-label={currentAuthorNote ? 'Edit author note' : 'Add author note'}
+              aria-label="Add author note"
               onClick={(e) => {
                 e.stopPropagation();
                 setNoteModalOpen(true);
               }}
               className={styles.actionButton}
-              tooltip={currentAuthorNote ? 'Edit author note' : 'Add author note'}
+              tooltip="Add author note"
               data-testid="pathfinder-block-editor-author-note-button-nested"
             />
           )}
-          <ConfirmDeleteButton
-            onConfirm={onDelete ?? (() => {})}
-            className={styles.deleteButton}
-            tooltip="Delete block"
-            ariaLabel="Delete"
-            blockType={meta?.name.toLowerCase() ?? block.type}
-          />
         </div>
+        {/* Author note (set case) — always-visible indicator + edit
+            entry-point. Tooltip carries the note text. */}
+        {onAuthorNoteChange && currentAuthorNote && (
+          <IconButton
+            name="comment-alt"
+            size="sm"
+            aria-label={`Author note: ${currentAuthorNote}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              setNoteModalOpen(true);
+            }}
+            className={styles.actionButton}
+            tooltip={currentAuthorNote}
+            data-testid="pathfinder-block-editor-author-note-button-nested"
+          />
+        )}
         {/* Edit is the primary action — always visible, right-anchored. */}
         <IconButton
           name="edit"

--- a/src/components/block-editor/SectionNestedBlocks.tsx
+++ b/src/components/block-editor/SectionNestedBlocks.tsx
@@ -39,6 +39,7 @@ export interface SectionNestedBlocksProps {
   onNestedBlockDelete?: (sectionId: string, nestedIndex: number) => void;
   onNestedBlockDuplicate?: (sectionId: string, nestedIndex: number) => void;
   onInsertBlockInSection: (type: BlockType, sectionId: string, index?: number) => void;
+  onNestedBlockAuthorNoteChange?: (sectionId: string, nestedIndex: number, note: string) => void;
   // Animation
   justDroppedId?: string | null;
   /** ID of the last modified block (for persistent highlight) */
@@ -76,6 +77,7 @@ export function SectionNestedBlocks({
   onNestedBlockDelete,
   onNestedBlockDuplicate,
   onInsertBlockInSection,
+  onNestedBlockAuthorNoteChange,
   justDroppedId,
   lastModifiedId,
   onPreviewSection,
@@ -161,6 +163,11 @@ export function SectionNestedBlocks({
                           : undefined
                       }
                       isPreviewActive={isPreviewActive}
+                      onAuthorNoteChange={
+                        onNestedBlockAuthorNoteChange
+                          ? (note) => onNestedBlockAuthorNoteChange(block.id, nestedIndex, note)
+                          : undefined
+                      }
                     />
                   </div>
                 </SortableBlock>

--- a/src/components/block-editor/block-editor.styles.ts
+++ b/src/components/block-editor/block-editor.styles.ts
@@ -305,8 +305,8 @@ export const getBlockItemStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'center',
     justifyContent: 'center',
     width: '16px',
-    color: theme.colors.text.disabled,
-    opacity: 0.4,
+    color: theme.colors.text.secondary,
+    opacity: 0.7,
     transition: 'opacity 0.15s ease',
     flexShrink: 0,
     pointerEvents: 'none', // Visual indicator only - parent handles dragging
@@ -361,6 +361,16 @@ export const getBlockItemStyles = (theme: GrafanaTheme2) => ({
     whiteSpace: 'nowrap',
     minWidth: 0,
     flex: 1,
+  }),
+
+  // Small editor-only note indicator. Renders only when the block has an
+  // `authorNote`; the tooltip carries the note text. Stripped on export.
+  authorNoteIcon: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    color: theme.colors.text.secondary,
+    cursor: 'help',
+    flexShrink: 0,
   }),
 
   actions: css({

--- a/src/components/block-editor/constants.ts
+++ b/src/components/block-editor/constants.ts
@@ -140,6 +140,37 @@ export const BLOCK_TYPE_ORDER: BlockType[] = [
 ];
 
 /**
+ * Palette groupings — drives the section headers in `BlockPalette`.
+ * Order is preserved; types within each group keep their `BLOCK_TYPE_ORDER`
+ * relative ordering.
+ *
+ * - **Content** — passive, author-authored material the user reads.
+ * - **Interactive** — blocks that require user action or input at runtime.
+ * - **Structure** — containers and special-purpose framing blocks.
+ */
+export const BLOCK_TYPE_GROUPS: ReadonlyArray<{
+  id: 'content' | 'interactive' | 'structure';
+  label: string;
+  types: BlockType[];
+}> = [
+  {
+    id: 'content',
+    label: 'Content',
+    types: ['markdown', 'image', 'video', 'code-block'],
+  },
+  {
+    id: 'interactive',
+    label: 'Interactive',
+    types: ['interactive', 'multistep', 'guided', 'input', 'quiz', 'terminal', 'terminal-connect'],
+  },
+  {
+    id: 'structure',
+    label: 'Structure',
+    types: ['section', 'conditional', 'grot-guide'],
+  },
+] as const;
+
+/**
  * Local storage key for persisting editor state
  */
 export const BLOCK_EDITOR_STORAGE_KEY = 'pathfinder-block-editor-state';

--- a/src/components/block-editor/hooks/useBackendGuides.ts
+++ b/src/components/block-editor/hooks/useBackendGuides.ts
@@ -7,6 +7,7 @@ import { getBackendSrv, config } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
 import type { JsonGuide } from '../types';
 import { fetchBackendGuides } from '../../../utils/fetchBackendGuides';
+import { stripAuthorNotes } from '../utils/block-export';
 
 interface BackendGuide {
   metadata: {
@@ -131,16 +132,22 @@ export function useBackendGuides(): UseBackendGuidesReturn {
           metadata.resourceVersion = existingMetadata.resourceVersion;
         }
 
+        // Strip editor-only `authorNote` fields from every block before
+        // sending to the backend — author notes are private to the
+        // editor session and must never be persisted in the published
+        // resource.
+        const exportable = stripAuthorNotes(guide);
+
         // Wrap guide in Kubernetes resource format
         const k8sResource = {
           apiVersion: 'pathfinderbackend.ext.grafana.com/v1alpha1',
           kind: 'InteractiveGuide',
           metadata,
           spec: {
-            id: guide.id,
-            title: guide.title,
-            schemaVersion: guide.schemaVersion || '1.0',
-            blocks: guide.blocks,
+            id: exportable.id,
+            title: exportable.title,
+            schemaVersion: exportable.schemaVersion || '1.0',
+            blocks: exportable.blocks,
             status,
           },
         };

--- a/src/components/block-editor/hooks/useBlockEditor.ts
+++ b/src/components/block-editor/hooks/useBlockEditor.ts
@@ -5,7 +5,7 @@
  * Handles blocks array, selection, and guide metadata.
  */
 
-import { useState, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { EditorBlock, BlockEditorState, JsonBlock, JsonGuide, ViewMode } from '../types';
 import type {
   JsonSectionBlock,
@@ -17,6 +17,7 @@ import type {
 } from '../../../types/json-guide.types';
 import { DEFAULT_GUIDE_METADATA } from '../constants';
 import { copyNestedInstanceId } from '../nestedBlockInstanceId';
+import { useGuideHistory } from './useGuideHistory';
 
 /**
  * Type guard for section blocks
@@ -137,6 +138,20 @@ export interface UseBlockEditorReturn {
   /** Mark the current state as saved */
   markSaved: () => void;
 
+  // Undo / redo
+  /** Step backwards through the in-session history ring buffer. */
+  undo: () => void;
+  /** Step forwards through the in-session history ring buffer. */
+  redo: () => void;
+  /** True iff the undo stack has entries. */
+  canUndo: boolean;
+  /** True iff the redo stack has entries. */
+  canRedo: boolean;
+  /** Optional label for the next undo target — surfaced on the button tooltip. */
+  undoLabel: string | null;
+  /** Optional label for the next redo target. */
+  redoLabel: string | null;
+
   // Block merging operations
   /** Merge selected interactive blocks into a Multistep block */
   mergeBlocksToMultistep: (blockIds: string[]) => void;
@@ -212,7 +227,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
       block,
     })) ?? [];
 
-  const [state, setState] = useState<BlockEditorState>({
+  const { state, setState, undo, redo, canUndo, canRedo, undoLabel, redoLabel, resetHistory } = useGuideHistory({
     guide: {
       id: initialGuide?.id ?? DEFAULT_GUIDE_METADATA.id,
       title: initialGuide?.title ?? DEFAULT_GUIDE_METADATA.title,
@@ -250,7 +265,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Add a new block
@@ -278,7 +293,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
 
       return id;
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Update an existing block
@@ -296,7 +311,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Remove a block
@@ -314,7 +329,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Move a block
@@ -344,7 +359,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Duplicate a block
@@ -376,7 +391,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
 
       return newId;
     },
-    [state.blocks, notifyChange]
+    [state.blocks, notifyChange, setState]
   );
 
   // Nest a block inside a section
@@ -421,7 +436,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Unnest a block from a section back to root level
@@ -473,7 +488,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Add a block directly to a section
@@ -516,7 +531,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
 
       return id;
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Update a nested block
@@ -562,7 +577,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Delete a nested block
@@ -599,7 +614,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Duplicate a nested block
@@ -643,7 +658,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Move a nested block within its section
@@ -692,7 +707,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // ============ Conditional branch operations ============
@@ -737,7 +752,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
 
       return id;
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Update a block within a conditional branch
@@ -779,7 +794,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Delete a block from a conditional branch
@@ -816,7 +831,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Duplicate a block within a conditional branch
@@ -860,7 +875,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Move a block within a conditional branch
@@ -909,7 +924,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Nest a root block into a conditional branch
@@ -966,7 +981,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Unnest a block from a conditional branch back to root level
@@ -1021,7 +1036,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Move a block between conditional branches (true <-> false)
@@ -1083,7 +1098,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Move a block from one section to another
@@ -1155,16 +1170,22 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
-  // Set view mode
-  const setViewMode = useCallback((mode: ViewMode) => {
-    setState((prev) => ({
-      ...prev,
-      viewMode: mode,
-    }));
-  }, []);
+  // Set view mode — UI-only change, never enters undo history.
+  const setViewMode = useCallback(
+    (mode: ViewMode) => {
+      setState(
+        (prev) => ({
+          ...prev,
+          viewMode: mode,
+        }),
+        { skipHistory: true }
+      );
+    },
+    [setState]
+  );
 
   // Get guide as JsonGuide
   const getGuide = useCallback((): JsonGuide => {
@@ -1177,46 +1198,60 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
     };
   }, [state.guide, state.blocks]);
 
-  // Load a guide
-  const loadGuide = useCallback((guide: JsonGuide, blockIds?: string[]) => {
-    // If blockIds are provided (from persistence), use them to preserve IDs across refreshes
-    // Otherwise generate new IDs (for new/imported guides)
-    const newBlocks: EditorBlock[] = guide.blocks.map((block, index) => ({
-      id: blockIds?.[index] ?? generateBlockId(),
-      block,
-    }));
+  // Load a guide — full reset, undo across this point doesn't make sense.
+  const loadGuide = useCallback(
+    (guide: JsonGuide, blockIds?: string[]) => {
+      // If blockIds are provided (from persistence), use them to preserve IDs across refreshes
+      // Otherwise generate new IDs (for new/imported guides)
+      const newBlocks: EditorBlock[] = guide.blocks.map((block, index) => ({
+        id: blockIds?.[index] ?? generateBlockId(),
+        block,
+      }));
 
-    setState({
-      guide: {
-        id: guide.id,
-        title: guide.title,
-      },
-      blocks: newBlocks,
-      viewMode: 'edit',
-      isDirty: false,
-    });
-  }, []);
+      setState(
+        {
+          guide: {
+            id: guide.id,
+            title: guide.title,
+          },
+          blocks: newBlocks,
+          viewMode: 'edit',
+          isDirty: false,
+        },
+        { skipHistory: true }
+      );
+      resetHistory();
+    },
+    [setState, resetHistory]
+  );
 
-  // Reset to new guide
+  // Reset to new guide — full reset, undo across this point doesn't make sense.
   const resetGuide = useCallback(() => {
-    setState({
-      guide: { ...DEFAULT_GUIDE_METADATA },
-      blocks: [],
-      viewMode: 'edit',
-      isDirty: false,
-    });
-  }, []);
+    setState(
+      {
+        guide: { ...DEFAULT_GUIDE_METADATA },
+        blocks: [],
+        viewMode: 'edit',
+        isDirty: false,
+      },
+      { skipHistory: true }
+    );
+    resetHistory();
+  }, [setState, resetHistory]);
 
-  // Mark as saved
+  // Mark as saved — clears the dirty flag without recording history.
   const markSaved = useCallback(() => {
-    setState((prev) => {
-      // REACT: bail out if already saved - prevents infinite re-render loop (R5)
-      if (!prev.isDirty) {
-        return prev; // Same reference = no re-render
-      }
-      return { ...prev, isDirty: false };
-    });
-  }, []);
+    setState(
+      (prev) => {
+        // REACT: bail out if already saved - prevents infinite re-render loop (R5)
+        if (!prev.isDirty) {
+          return prev; // Same reference = no re-render
+        }
+        return { ...prev, isDirty: false };
+      },
+      { skipHistory: true }
+    );
+  }, [setState]);
 
   /**
    * Parse a block ID to determine if it's a nested block.
@@ -1380,7 +1415,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Merge interactive/multistep/guided blocks into a Guided block
@@ -1496,7 +1531,7 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
         return newState;
       });
     },
-    [notifyChange]
+    [notifyChange, setState]
   );
 
   // Memoize return value
@@ -1522,6 +1557,12 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
       resetGuide,
       isDirty: state.isDirty,
       markSaved,
+      undo,
+      redo,
+      canUndo,
+      canRedo,
+      undoLabel,
+      redoLabel,
       mergeBlocksToMultistep,
       mergeBlocksToGuided,
       addBlockToConditionalBranch,
@@ -1554,6 +1595,12 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
       loadGuide,
       resetGuide,
       markSaved,
+      undo,
+      redo,
+      canUndo,
+      canRedo,
+      undoLabel,
+      redoLabel,
       mergeBlocksToMultistep,
       mergeBlocksToGuided,
       addBlockToConditionalBranch,

--- a/src/components/block-editor/hooks/useGuideHistory.test.ts
+++ b/src/components/block-editor/hooks/useGuideHistory.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for the undo/redo ring buffer that backs the visual-mode editor.
+ *
+ * Covers the three behaviours that drive the rest of the wave:
+ *  - Plain push/undo/redo flow.
+ *  - Skip-history opt-out for UI-only mutations (view-mode, save-ack).
+ *  - Coalescing of consecutive same-key edits into one history entry.
+ *  - Count cap (`MAX_HISTORY`) — older entries are dropped.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { useGuideHistory, MAX_HISTORY, COALESCE_MS } from './useGuideHistory';
+import type { BlockEditorState } from '../types';
+
+function makeState(overrides?: Partial<BlockEditorState>): BlockEditorState {
+  return {
+    guide: { id: 'g', title: 't' },
+    blocks: [],
+    viewMode: 'edit',
+    isDirty: false,
+    ...overrides,
+  };
+}
+
+describe('useGuideHistory', () => {
+  it('starts with empty stacks', () => {
+    const { result } = renderHook(() => useGuideHistory(makeState()));
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+    expect(result.current.undoLabel).toBeNull();
+    expect(result.current.redoLabel).toBeNull();
+  });
+
+  it('pushes the previous state to past on every default setState', () => {
+    const { result } = renderHook(() => useGuideHistory(makeState({ guide: { id: 'g', title: 'a' } })));
+
+    act(() => {
+      result.current.setState((prev) => ({ ...prev, guide: { ...prev.guide, title: 'b' } }));
+    });
+
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+    expect(result.current.state.guide.title).toBe('b');
+  });
+
+  it('undo restores the previous state and exposes redo', () => {
+    const { result } = renderHook(() => useGuideHistory(makeState({ guide: { id: 'g', title: 'a' } })));
+
+    act(() => {
+      result.current.setState((prev) => ({ ...prev, guide: { ...prev.guide, title: 'b' } }));
+    });
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.state.guide.title).toBe('a');
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => {
+      result.current.redo();
+    });
+    expect(result.current.state.guide.title).toBe('b');
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it('a fresh setState after undo clears the redo stack', () => {
+    const { result } = renderHook(() => useGuideHistory(makeState({ guide: { id: 'g', title: 'a' } })));
+    act(() => result.current.setState((p) => ({ ...p, guide: { ...p.guide, title: 'b' } })));
+    act(() => result.current.undo());
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => result.current.setState((p) => ({ ...p, guide: { ...p.guide, title: 'c' } })));
+    expect(result.current.canRedo).toBe(false);
+    expect(result.current.state.guide.title).toBe('c');
+  });
+
+  it('skipHistory: true bypasses the past stack entirely', () => {
+    const { result } = renderHook(() => useGuideHistory(makeState({ viewMode: 'edit' })));
+
+    act(() => {
+      result.current.setState((prev) => ({ ...prev, viewMode: 'preview' }), { skipHistory: true });
+    });
+
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.state.viewMode).toBe('preview');
+  });
+
+  it('coalesces consecutive same-key edits into a single history entry', () => {
+    const { result } = renderHook(() => useGuideHistory(makeState({ guide: { id: 'g', title: 'a' } })));
+
+    act(() => {
+      result.current.setState((p) => ({ ...p, guide: { ...p.guide, title: 'ab' } }), {
+        coalesceKey: 'inlineEdit:title',
+      });
+    });
+    act(() => {
+      result.current.setState((p) => ({ ...p, guide: { ...p.guide, title: 'abc' } }), {
+        coalesceKey: 'inlineEdit:title',
+      });
+    });
+    act(() => {
+      result.current.setState((p) => ({ ...p, guide: { ...p.guide, title: 'abcd' } }), {
+        coalesceKey: 'inlineEdit:title',
+      });
+    });
+
+    // Single undo lands on the original 'a', not 'abc'.
+    expect(result.current.state.guide.title).toBe('abcd');
+    act(() => result.current.undo());
+    expect(result.current.state.guide.title).toBe('a');
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it('different coalesceKeys do not merge', () => {
+    const { result } = renderHook(() => useGuideHistory(makeState({ guide: { id: 'g', title: 'a' } })));
+
+    act(() => {
+      result.current.setState((p) => ({ ...p, guide: { ...p.guide, title: 'b' } }), {
+        coalesceKey: 'inlineEdit:title',
+      });
+    });
+    act(() => {
+      result.current.setState((p) => ({ ...p, guide: { ...p.guide, title: 'b', id: 'g2' } }), {
+        coalesceKey: 'inlineEdit:id',
+      });
+    });
+
+    // Two distinct entries — undo twice to get back to start.
+    act(() => result.current.undo());
+    expect(result.current.state.guide.id).toBe('g');
+    act(() => result.current.undo());
+    expect(result.current.state.guide.title).toBe('a');
+  });
+
+  it('coalesce window expires after COALESCE_MS', () => {
+    jest.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useGuideHistory(makeState({ guide: { id: 'g', title: 'a' } })));
+
+      act(() => {
+        result.current.setState((p) => ({ ...p, guide: { ...p.guide, title: 'b' } }), { coalesceKey: 'k' });
+      });
+      // Advance past the coalesce window — the next push must start a fresh entry.
+      act(() => {
+        jest.advanceTimersByTime(COALESCE_MS + 50);
+      });
+      act(() => {
+        result.current.setState((p) => ({ ...p, guide: { ...p.guide, title: 'c' } }), { coalesceKey: 'k' });
+      });
+
+      // Two entries — undo twice to get back to 'a'.
+      act(() => result.current.undo());
+      expect(result.current.state.guide.title).toBe('b');
+      act(() => result.current.undo());
+      expect(result.current.state.guide.title).toBe('a');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('drops the oldest entry when count exceeds MAX_HISTORY', () => {
+    const { result } = renderHook(() => useGuideHistory(makeState({ guide: { id: 'g', title: '0' } })));
+
+    for (let i = 1; i <= MAX_HISTORY + 5; i++) {
+      act(() => {
+        result.current.setState((p) => ({ ...p, guide: { ...p.guide, title: String(i) } }));
+      });
+    }
+
+    // Undo as many times as possible — should land on the oldest *kept*
+    // entry, which corresponds to title '5' (the original '0' through
+    // '4' were trimmed when count exceeded MAX_HISTORY).
+    while (result.current.canUndo) {
+      act(() => result.current.undo());
+    }
+    expect(result.current.state.guide.title).toBe('5');
+  });
+
+  it('resetHistory clears both stacks (used after loadGuide / resetGuide)', () => {
+    const { result } = renderHook(() => useGuideHistory(makeState({ guide: { id: 'g', title: 'a' } })));
+
+    act(() => result.current.setState((p) => ({ ...p, guide: { ...p.guide, title: 'b' } })));
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => result.current.resetHistory());
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it('exposes labels on undo/redo for tooltip use', () => {
+    const { result } = renderHook(() => useGuideHistory(makeState()));
+
+    act(() => {
+      result.current.setState((p) => ({ ...p, isDirty: true }), { label: 'Add block' });
+    });
+    expect(result.current.undoLabel).toBe('Add block');
+
+    act(() => result.current.undo());
+    expect(result.current.redoLabel).toBe('Add block');
+  });
+
+  it('no-op transitions (same reference) skip history', () => {
+    const { result } = renderHook(() => useGuideHistory(makeState()));
+
+    act(() => {
+      result.current.setState((prev) => prev); // identity update
+    });
+
+    expect(result.current.canUndo).toBe(false);
+  });
+});

--- a/src/components/block-editor/hooks/useGuideHistory.ts
+++ b/src/components/block-editor/hooks/useGuideHistory.ts
@@ -126,11 +126,8 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
 
   const setState: GuideStateSetter = useCallback(
     (action, options) => {
-      const next =
-        typeof action === 'function'
-          ? (action as (p: BlockEditorState) => BlockEditorState)(state)
-          : action;
-      
+      const next = typeof action === 'function' ? (action as (p: BlockEditorState) => BlockEditorState)(state) : action;
+
       // No-op transitions (same reference) skip history regardless.
       if (next === state) {
         return;
@@ -143,14 +140,13 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
       if (!options?.skipHistory) {
         const now = Date.now();
         const key = options?.coalesceKey ?? null;
-        const insideCoalesceWindow =
-          key !== null && key === coalesceRef.current.key && now < coalesceRef.current.until;
+        const insideCoalesceWindow = key !== null && key === coalesceRef.current.key && now < coalesceRef.current.until;
 
         if (!insideCoalesceWindow) {
           const estimatedSize = estimateSingleEntryBytes(state);
           const past = pastRef.current;
           past.push({ state, label: options?.label, estimatedSize });
-          
+
           // Count cap.
           while (past.length > MAX_HISTORY) {
             past.shift();
@@ -176,27 +172,27 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
     if (past.length === 0) {
       return;
     }
-    
+
     // Pop from past (pure calculation)
     const target = past.pop();
     if (!target) {
       return;
     }
-    
+
     // Calculate next state outside updater
     const nextState = target.state;
-    
+
     // Update refs (side effects outside updater)
     const estimatedSize = estimateSingleEntryBytes(state);
     pastRef.current = past;
     futureRef.current.unshift({ state, label: target.label, estimatedSize });
-    
+
     // Reset coalescing so the next setState starts a fresh entry.
     coalesceRef.current = { key: null, until: 0 };
-    
+
     // Apply state change
     setStateInternal(nextState);
-    
+
     // Refresh UI meta
     refreshMeta();
   }, [state, refreshMeta]);
@@ -206,26 +202,26 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
     if (future.length === 0) {
       return;
     }
-    
+
     // Shift from future (pure calculation)
     const target = future.shift();
     if (!target) {
       return;
     }
-    
+
     // Calculate next state outside updater
     const nextState = target.state;
-    
+
     // Update refs (side effects outside updater)
     const estimatedSize = estimateSingleEntryBytes(state);
     futureRef.current = future;
     pastRef.current.push({ state, label: target.label, estimatedSize });
-    
+
     coalesceRef.current = { key: null, until: 0 };
-    
+
     // Apply state change
     setStateInternal(nextState);
-    
+
     // Refresh UI meta
     refreshMeta();
   }, [state, refreshMeta]);

--- a/src/components/block-editor/hooks/useGuideHistory.ts
+++ b/src/components/block-editor/hooks/useGuideHistory.ts
@@ -1,0 +1,222 @@
+/**
+ * `useGuideHistory` — block-editor undo/redo backed by a ring buffer.
+ *
+ * Wraps `useState` with the same call signature so existing setState
+ * call sites in `useBlockEditor` keep working unchanged. Every set call
+ * pushes the *previous* state onto a `past` stack (capped at
+ * `MAX_HISTORY` entries and `MAX_HISTORY_BYTES` of estimated payload),
+ * and clears the `future` stack.
+ *
+ * Mutations that should NOT contribute to history (UI-only changes
+ * like view-mode toggles, full guide loads, save acks) opt out by
+ * passing `{ skipHistory: true }` as the second argument.
+ *
+ * Inline editors that fire on every blur/keystroke can pass a
+ * `coalesceKey` (e.g. `inlineEdit:<blockId>:title`) so consecutive
+ * mutations within the coalesce window merge into a single history
+ * entry — undo lands on the *original* pre-edit state, not on each
+ * intermediate keystroke.
+ *
+ * History is in-session only — never persisted. The current state is
+ * persisted by the caller (`useBlockPersistence`) as before.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import type { BlockEditorState } from '../types';
+
+/** Hard cap on history depth. Older entries are dropped from the bottom of `past`. */
+export const MAX_HISTORY = 20;
+
+/**
+ * Soft cap on the total serialized size of `past`. When exceeded, the
+ * oldest entries are dropped one by one until we're under the limit
+ * or only one entry remains. Prevents huge guides from blowing memory.
+ */
+export const MAX_HISTORY_BYTES = 1_000_000;
+
+/**
+ * Window during which mutations sharing a `coalesceKey` collapse into
+ * the same history entry. Tuned for inline-edit blur cycles
+ * (typically 100-500 ms apart).
+ */
+export const COALESCE_MS = 500;
+
+export interface HistoryOptions {
+  /** Skip pushing this transition to history (UI-only, full-reset, save-ack). */
+  skipHistory?: boolean;
+  /**
+   * If set, mutations sharing the same key within `COALESCE_MS` are
+   * merged into one history entry. The first mutation in a sequence
+   * still pushes; subsequent ones don't push but still extend the
+   * coalesce window.
+   */
+  coalesceKey?: string;
+  /** Optional human-readable label surfaced on undo/redo tooltips. */
+  label?: string;
+}
+
+interface HistoryEntry {
+  state: BlockEditorState;
+  label?: string;
+}
+
+export type GuideStateSetter = (
+  action: BlockEditorState | ((prev: BlockEditorState) => BlockEditorState),
+  options?: HistoryOptions
+) => void;
+
+export interface UseGuideHistoryReturn {
+  state: BlockEditorState;
+  setState: GuideStateSetter;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  /** Tooltip-friendly label for the next undo target ("Add block", etc.), or null. */
+  undoLabel: string | null;
+  /** Tooltip-friendly label for the next redo target, or null. */
+  redoLabel: string | null;
+  /** Drop all history (used after `loadGuide` / `resetGuide`). */
+  resetHistory: () => void;
+}
+
+function estimateBytes(entries: HistoryEntry[]): number {
+  // Rough — `JSON.stringify` is the canonical "size" measure we care
+  // about because that's what would land in localStorage if we ever
+  // persisted history. Skip if too many entries to avoid pathological
+  // O(n*size) loops on giant guides; the count cap fires first anyway.
+  if (entries.length === 0) {
+    return 0;
+  }
+  try {
+    return JSON.stringify(entries.map((e) => e.state)).length;
+  } catch {
+    return 0;
+  }
+}
+
+export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryReturn {
+  const [state, setStateInternal] = useState<BlockEditorState>(initial);
+
+  // Stacks live in refs so internal pushes don't force re-renders;
+  // we drive the UI from `historyMeta` instead.
+  const pastRef = useRef<HistoryEntry[]>([]);
+  const futureRef = useRef<HistoryEntry[]>([]);
+  const coalesceRef = useRef<{ key: string | null; until: number }>({ key: null, until: 0 });
+
+  const [historyMeta, setHistoryMeta] = useState<{
+    pastLen: number;
+    futureLen: number;
+    undoLabel: string | null;
+    redoLabel: string | null;
+  }>({ pastLen: 0, futureLen: 0, undoLabel: null, redoLabel: null });
+
+  const refreshMeta = useCallback(() => {
+    const past = pastRef.current;
+    const future = futureRef.current;
+    setHistoryMeta({
+      pastLen: past.length,
+      futureLen: future.length,
+      undoLabel: past[past.length - 1]?.label ?? null,
+      redoLabel: future[0]?.label ?? null,
+    });
+  }, []);
+
+  const setState: GuideStateSetter = useCallback(
+    (action, options) => {
+      setStateInternal((prev) => {
+        const next =
+          typeof action === 'function' ? (action as (p: BlockEditorState) => BlockEditorState)(prev) : action;
+        // No-op transitions (same reference) skip history regardless.
+        if (next === prev) {
+          return prev;
+        }
+
+        if (!options?.skipHistory) {
+          const now = Date.now();
+          const key = options?.coalesceKey ?? null;
+          const insideCoalesceWindow =
+            key !== null && key === coalesceRef.current.key && now < coalesceRef.current.until;
+
+          if (!insideCoalesceWindow) {
+            const past = pastRef.current;
+            past.push({ state: prev, label: options?.label });
+            // Count cap.
+            while (past.length > MAX_HISTORY) {
+              past.shift();
+            }
+            // Size cap (defensive, fires after count cap when payloads
+            // are individually huge).
+            while (past.length > 1 && estimateBytes(past) > MAX_HISTORY_BYTES) {
+              past.shift();
+            }
+            pastRef.current = past;
+            futureRef.current = [];
+          }
+
+          coalesceRef.current = key !== null ? { key, until: now + COALESCE_MS } : { key: null, until: 0 };
+          refreshMeta();
+        }
+
+        return next;
+      });
+    },
+    [refreshMeta]
+  );
+
+  const undo = useCallback(() => {
+    const past = pastRef.current;
+    if (past.length === 0) {
+      return;
+    }
+    setStateInternal((current) => {
+      const target = past.pop();
+      if (!target) {
+        return current;
+      }
+      pastRef.current = past;
+      futureRef.current.unshift({ state: current, label: target.label });
+      // Reset coalescing so the next setState starts a fresh entry.
+      coalesceRef.current = { key: null, until: 0 };
+      refreshMeta();
+      return target.state;
+    });
+  }, [refreshMeta]);
+
+  const redo = useCallback(() => {
+    const future = futureRef.current;
+    if (future.length === 0) {
+      return;
+    }
+    setStateInternal((current) => {
+      const target = future.shift();
+      if (!target) {
+        return current;
+      }
+      futureRef.current = future;
+      pastRef.current.push({ state: current, label: target.label });
+      coalesceRef.current = { key: null, until: 0 };
+      refreshMeta();
+      return target.state;
+    });
+  }, [refreshMeta]);
+
+  const resetHistory = useCallback(() => {
+    pastRef.current = [];
+    futureRef.current = [];
+    coalesceRef.current = { key: null, until: 0 };
+    refreshMeta();
+  }, [refreshMeta]);
+
+  return {
+    state,
+    setState,
+    undo,
+    redo,
+    canUndo: historyMeta.pastLen > 0,
+    canRedo: historyMeta.futureLen > 0,
+    undoLabel: historyMeta.undoLabel,
+    redoLabel: historyMeta.redoLabel,
+    resetHistory,
+  };
+}

--- a/src/components/block-editor/hooks/useGuideHistory.ts
+++ b/src/components/block-editor/hooks/useGuideHistory.ts
@@ -58,6 +58,8 @@ export interface HistoryOptions {
 interface HistoryEntry {
   state: BlockEditorState;
   label?: string;
+  /** Cached byte size of this entry's state (for incremental size tracking). */
+  estimatedSize: number;
 }
 
 export type GuideStateSetter = (
@@ -80,19 +82,19 @@ export interface UseGuideHistoryReturn {
   resetHistory: () => void;
 }
 
-function estimateBytes(entries: HistoryEntry[]): number {
-  // Rough — `JSON.stringify` is the canonical "size" measure we care
-  // about because that's what would land in localStorage if we ever
-  // persisted history. Skip if too many entries to avoid pathological
-  // O(n*size) loops on giant guides; the count cap fires first anyway.
-  if (entries.length === 0) {
-    return 0;
-  }
+function estimateSingleEntryBytes(state: BlockEditorState): number {
+  // Estimate size of a single state entry. This is called once per history
+  // push, avoiding the O(n*size) cost of serializing all entries on every edit.
   try {
-    return JSON.stringify(entries.map((e) => e.state)).length;
+    return JSON.stringify(state).length;
   } catch {
     return 0;
   }
+}
+
+function getTotalHistoryBytes(entries: HistoryEntry[]): number {
+  // Sum cached sizes (O(n) with no serialization cost).
+  return entries.reduce((sum, e) => sum + e.estimatedSize, 0);
 }
 
 export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryReturn {
@@ -124,44 +126,49 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
 
   const setState: GuideStateSetter = useCallback(
     (action, options) => {
-      setStateInternal((prev) => {
-        const next =
-          typeof action === 'function' ? (action as (p: BlockEditorState) => BlockEditorState)(prev) : action;
-        // No-op transitions (same reference) skip history regardless.
-        if (next === prev) {
-          return prev;
-        }
+      const next =
+        typeof action === 'function'
+          ? (action as (p: BlockEditorState) => BlockEditorState)(state)
+          : action;
+      
+      // No-op transitions (same reference) skip history regardless.
+      if (next === state) {
+        return;
+      }
 
-        if (!options?.skipHistory) {
-          const now = Date.now();
-          const key = options?.coalesceKey ?? null;
-          const insideCoalesceWindow =
-            key !== null && key === coalesceRef.current.key && now < coalesceRef.current.until;
+      // Apply the state update first (pure)
+      setStateInternal(next);
 
-          if (!insideCoalesceWindow) {
-            const past = pastRef.current;
-            past.push({ state: prev, label: options?.label });
-            // Count cap.
-            while (past.length > MAX_HISTORY) {
-              past.shift();
-            }
-            // Size cap (defensive, fires after count cap when payloads
-            // are individually huge).
-            while (past.length > 1 && estimateBytes(past) > MAX_HISTORY_BYTES) {
-              past.shift();
-            }
-            pastRef.current = past;
-            futureRef.current = [];
+      // Then handle history side effects outside the updater
+      if (!options?.skipHistory) {
+        const now = Date.now();
+        const key = options?.coalesceKey ?? null;
+        const insideCoalesceWindow =
+          key !== null && key === coalesceRef.current.key && now < coalesceRef.current.until;
+
+        if (!insideCoalesceWindow) {
+          const estimatedSize = estimateSingleEntryBytes(state);
+          const past = pastRef.current;
+          past.push({ state, label: options?.label, estimatedSize });
+          
+          // Count cap.
+          while (past.length > MAX_HISTORY) {
+            past.shift();
           }
-
-          coalesceRef.current = key !== null ? { key, until: now + COALESCE_MS } : { key: null, until: 0 };
-          refreshMeta();
+          // Size cap (defensive, fires after count cap when payloads
+          // are individually huge). Now uses incremental size tracking.
+          while (past.length > 1 && getTotalHistoryBytes(past) > MAX_HISTORY_BYTES) {
+            past.shift();
+          }
+          pastRef.current = past;
+          futureRef.current = [];
         }
 
-        return next;
-      });
+        coalesceRef.current = key !== null ? { key, until: now + COALESCE_MS } : { key: null, until: 0 };
+        refreshMeta();
+      }
     },
-    [refreshMeta]
+    [state, refreshMeta]
   );
 
   const undo = useCallback(() => {
@@ -169,37 +176,59 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
     if (past.length === 0) {
       return;
     }
-    setStateInternal((current) => {
-      const target = past.pop();
-      if (!target) {
-        return current;
-      }
-      pastRef.current = past;
-      futureRef.current.unshift({ state: current, label: target.label });
-      // Reset coalescing so the next setState starts a fresh entry.
-      coalesceRef.current = { key: null, until: 0 };
-      refreshMeta();
-      return target.state;
-    });
-  }, [refreshMeta]);
+    
+    // Pop from past (pure calculation)
+    const target = past.pop();
+    if (!target) {
+      return;
+    }
+    
+    // Calculate next state outside updater
+    const nextState = target.state;
+    
+    // Update refs (side effects outside updater)
+    const estimatedSize = estimateSingleEntryBytes(state);
+    pastRef.current = past;
+    futureRef.current.unshift({ state, label: target.label, estimatedSize });
+    
+    // Reset coalescing so the next setState starts a fresh entry.
+    coalesceRef.current = { key: null, until: 0 };
+    
+    // Apply state change
+    setStateInternal(nextState);
+    
+    // Refresh UI meta
+    refreshMeta();
+  }, [state, refreshMeta]);
 
   const redo = useCallback(() => {
     const future = futureRef.current;
     if (future.length === 0) {
       return;
     }
-    setStateInternal((current) => {
-      const target = future.shift();
-      if (!target) {
-        return current;
-      }
-      futureRef.current = future;
-      pastRef.current.push({ state: current, label: target.label });
-      coalesceRef.current = { key: null, until: 0 };
-      refreshMeta();
-      return target.state;
-    });
-  }, [refreshMeta]);
+    
+    // Shift from future (pure calculation)
+    const target = future.shift();
+    if (!target) {
+      return;
+    }
+    
+    // Calculate next state outside updater
+    const nextState = target.state;
+    
+    // Update refs (side effects outside updater)
+    const estimatedSize = estimateSingleEntryBytes(state);
+    futureRef.current = future;
+    pastRef.current.push({ state, label: target.label, estimatedSize });
+    
+    coalesceRef.current = { key: null, until: 0 };
+    
+    // Apply state change
+    setStateInternal(nextState);
+    
+    // Refresh UI meta
+    refreshMeta();
+  }, [state, refreshMeta]);
 
   const resetHistory = useCallback(() => {
     pastRef.current = [];

--- a/src/components/block-editor/types.ts
+++ b/src/components/block-editor/types.ts
@@ -200,6 +200,17 @@ export interface BlockOperations {
   onNestedBlockDuplicate: (sectionId: string, nestedIndex: number) => void;
   /** Move a nested block within its section */
   onNestedBlockMove: (sectionId: string, fromIndex: number, toIndex: number) => void;
+  /** Set the editor-only author note on a root block. */
+  onBlockAuthorNoteChange?: (blockId: string, note: string) => void;
+  /** Set the editor-only author note on a section-nested block. */
+  onNestedBlockAuthorNoteChange?: (sectionId: string, nestedIndex: number, note: string) => void;
+  /** Set the editor-only author note on a conditional-branch nested block. */
+  onConditionalBranchBlockAuthorNoteChange?: (
+    conditionalId: string,
+    branch: 'whenTrue' | 'whenFalse',
+    nestedIndex: number,
+    note: string
+  ) => void;
 
   // ============ CONDITIONAL BRANCH OPERATIONS ============
   /** Insert a new block into a conditional branch */

--- a/src/components/block-editor/utils/block-export.ts
+++ b/src/components/block-editor/utils/block-export.ts
@@ -4,8 +4,51 @@
  * Functions for exporting JSON guides to clipboard and file downloads.
  */
 
-import type { JsonGuide } from '../types';
+import type { JsonBlock, JsonGuide, JsonStep } from '../types';
 import { validateGuide as validateGuideCanonical, validateGuideFromString, toLegacyResult } from '../../../validation';
+
+/**
+ * Recursively remove editor-only `authorNote` fields from every block in
+ * a guide. Used by the export paths so author notes never ship in
+ * published JSON.
+ *
+ * Walks the standard nested-container fields (`blocks`, `whenTrue`,
+ * `whenFalse`, `steps`). Returns a new guide; does not mutate input.
+ */
+export function stripAuthorNotes(guide: JsonGuide): JsonGuide {
+  const stripBlock = (block: JsonBlock): JsonBlock => {
+    const cleaned: Record<string, unknown> = { ...(block as unknown as Record<string, unknown>) };
+    delete cleaned.authorNote;
+
+    // Recurse into known container fields. Each branch only runs when
+    // the field exists on the current variant; we don't add fields.
+    if (Array.isArray(cleaned.blocks)) {
+      cleaned.blocks = (cleaned.blocks as JsonBlock[]).map(stripBlock);
+    }
+    if (Array.isArray(cleaned.whenTrue)) {
+      cleaned.whenTrue = (cleaned.whenTrue as JsonBlock[]).map(stripBlock);
+    }
+    if (Array.isArray(cleaned.whenFalse)) {
+      cleaned.whenFalse = (cleaned.whenFalse as JsonBlock[]).map(stripBlock);
+    }
+    if (Array.isArray(cleaned.steps)) {
+      // Steps don't currently carry authorNote (they're a sub-shape, not
+      // a discriminated block) — passthrough but defensive in case the
+      // schema gains it later.
+      cleaned.steps = (cleaned.steps as JsonStep[]).map((step) => {
+        const cleanedStep = { ...(step as unknown as Record<string, unknown>) };
+        delete cleanedStep.authorNote;
+        return cleanedStep as unknown as JsonStep;
+      });
+    }
+    return cleaned as unknown as JsonBlock;
+  };
+
+  return {
+    ...guide,
+    blocks: guide.blocks.map(stripBlock),
+  };
+}
 
 /**
  * Copy JSON guide to clipboard
@@ -15,7 +58,8 @@ import { validateGuide as validateGuideCanonical, validateGuideFromString, toLeg
  * @returns Promise that resolves when copied
  */
 export async function copyGuideToClipboard(guide: JsonGuide, pretty = true): Promise<void> {
-  const json = pretty ? JSON.stringify(guide, null, 2) : JSON.stringify(guide);
+  const exportable = stripAuthorNotes(guide);
+  const json = pretty ? JSON.stringify(exportable, null, 2) : JSON.stringify(exportable);
 
   await navigator.clipboard.writeText(json);
 }
@@ -28,7 +72,8 @@ export async function copyGuideToClipboard(guide: JsonGuide, pretty = true): Pro
  * @param pretty - Whether to format with indentation (default: true)
  */
 export function downloadGuideAsFile(guide: JsonGuide, filename?: string, pretty = true): void {
-  const json = pretty ? JSON.stringify(guide, null, 2) : JSON.stringify(guide);
+  const exportable = stripAuthorNotes(guide);
+  const json = pretty ? JSON.stringify(exportable, null, 2) : JSON.stringify(exportable);
   const blob = new Blob([json], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
 

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -173,6 +173,16 @@ export const AssistantPropsSchema = z.object({
   assistantType: z.enum(['query', 'config', 'code', 'text']).optional(),
 });
 
+/**
+ * Schema for editor-only annotation fields. Spread into every block
+ * schema so authors can attach a private note to any block; stripped
+ * from published output by the editor's export path.
+ * @coupling Type: AuthorAnnotated
+ */
+export const AuthorAnnotatedSchema = z.object({
+  authorNote: z.string().optional(),
+});
+
 // ============ CONTENT BLOCK SCHEMAS ============
 
 /**
@@ -185,6 +195,8 @@ export const JsonMarkdownBlockSchema = z.object({
   content: z.string().min(1, 'Markdown content is required').describe('Markdown body shown to the user'),
   // Assistant customization props
   ...AssistantPropsSchema.shape,
+  // Editor-only annotation (stripped on export)
+  ...AuthorAnnotatedSchema.shape,
 });
 
 /**
@@ -195,6 +207,7 @@ export const JsonHtmlBlockSchema = z.object({
   type: z.literal('html'),
   id: z.string().optional().describe('Stable identifier for edit-block / remove-block addressing'),
   content: z.string().min(1, 'HTML content is required').describe('Sanitized HTML body shown to the user'),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 /**
@@ -208,6 +221,7 @@ export const JsonImageBlockSchema = z.object({
   alt: z.string().optional().describe('Alt text for accessibility'),
   width: z.number().optional().describe('Display width in pixels'),
   height: z.number().optional().describe('Display height in pixels'),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 /**
@@ -222,6 +236,7 @@ export const JsonVideoBlockSchema = z.object({
   title: z.string().optional().describe('Display title'),
   start: z.number().min(0).optional().describe('Start time in seconds'),
   end: z.number().min(0).optional().describe('End time in seconds'),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 // ============ INTERACTIVE BLOCK SCHEMAS ============
@@ -268,6 +283,8 @@ export const JsonInteractiveBlockSchema = z
     openGuide: z.string().optional().describe('Guide ID to open when this block completes'),
     // Assistant customization props
     ...AssistantPropsSchema.shape,
+    // Editor-only annotation (stripped on export)
+    ...AuthorAnnotatedSchema.shape,
   })
   .refine(
     (block) => {
@@ -312,6 +329,7 @@ export const JsonMultistepBlockSchema = z.object({
   requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions'),
   objectives: z.array(z.string()).optional().describe('Learning objectives this block addresses'),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 /**
@@ -328,6 +346,7 @@ export const JsonGuidedBlockSchema = z.object({
   objectives: z.array(z.string()).optional().describe('Learning objectives this block addresses'),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),
   completeEarly: z.boolean().optional().describe('Allow completion before all steps done'),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 /**
@@ -355,6 +374,7 @@ export const JsonQuizBlockSchema = z
     maxAttempts: z.number().optional().describe('Number of attempts allowed when completionMode=max-attempts'),
     requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions'),
     skippable: z.boolean().optional().describe('Allow user to skip this block'),
+    ...AuthorAnnotatedSchema.shape,
   })
   .superRefine((quiz, ctx) => {
     // Empty quizzes are a transient authoring state; the publish-time
@@ -421,6 +441,7 @@ export const JsonInputBlockSchema = z.object({
   requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions'),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),
   datasourceFilter: z.string().optional().describe('Filter for datasource input (e.g., loki, prometheus)'),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 // ============ TERMINAL BLOCK SCHEMA ============
@@ -438,6 +459,7 @@ export const JsonTerminalBlockSchema = z.object({
   objectives: z.array(z.string()).optional().describe('Learning objectives this block addresses'),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),
   hint: z.string().optional().describe('Hint text shown if user is stuck'),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 // ============ TERMINAL CONNECT BLOCK SCHEMA ============
@@ -454,6 +476,7 @@ export const JsonTerminalConnectBlockSchema = z.object({
   vmTemplate: z.string().optional().describe('VM template to provision'),
   vmApp: z.string().optional().describe('App to launch in the VM'),
   vmScenario: z.string().optional().describe('Scenario to run in the VM'),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 // ============ CODE BLOCK SCHEMA ============
@@ -476,6 +499,7 @@ export const JsonCodeBlockBlockSchema = z.object({
   objectives: z.array(z.string()).optional().describe('Learning objectives this block addresses'),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),
   hint: z.string().optional().describe('Hint text shown if user is stuck'),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 // ============ GROT GUIDE BLOCK SCHEMA ============
@@ -565,6 +589,7 @@ export const JsonGrotGuideBlockSchema = z
       .describe('Stable identifier; grot-guide blocks are authored in the dedicated editor, not the CLI'),
     welcome: GrotGuideWelcomeSchema,
     screens: z.array(GrotGuideScreenSchema).min(1, EMPTY_SCREENS_MESSAGE),
+    ...AuthorAnnotatedSchema.shape,
   })
   .refine(
     (block) => {
@@ -714,6 +739,7 @@ export const JsonBlockSchema = createBlockSchemaWithDepth(0);
 export const JsonSectionBlockSchema = z.object({
   ...SectionProps,
   blocks: z.lazy(() => z.array(JsonBlockSchema)),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 /**
@@ -724,6 +750,7 @@ export const JsonSectionBlockSchema = z.object({
 export const JsonAssistantBlockSchema = z.object({
   ...AssistantProps,
   blocks: z.lazy(() => z.array(JsonBlockSchema)),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 /**
@@ -735,6 +762,7 @@ export const JsonConditionalBlockSchema = z.object({
   ...ConditionalProps,
   whenTrue: z.lazy(() => z.array(JsonBlockSchema)),
   whenFalse: z.lazy(() => z.array(JsonBlockSchema)),
+  ...AuthorAnnotatedSchema.shape,
 });
 
 // ============ ROOT GUIDE SCHEMA ============
@@ -796,10 +824,13 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'scrollContainer',
   ]),
   _choice: new Set(['id', 'text', 'correct', 'hint']),
-  markdown: new Set(['type', 'id', 'content', 'assistantEnabled', 'assistantId', 'assistantType']),
-  html: new Set(['type', 'id', 'content']),
-  image: new Set(['type', 'id', 'src', 'alt', 'width', 'height']),
-  video: new Set(['type', 'id', 'src', 'provider', 'title', 'start', 'end']),
+  // `authorNote` is the editor-only annotation spread from
+  // `AuthorAnnotatedSchema` into every block type. It's stripped on
+  // export, but stays in the schema so authoring tools can persist it.
+  markdown: new Set(['type', 'id', 'content', 'assistantEnabled', 'assistantId', 'assistantType', 'authorNote']),
+  html: new Set(['type', 'id', 'content', 'authorNote']),
+  image: new Set(['type', 'id', 'src', 'alt', 'width', 'height', 'authorNote']),
+  video: new Set(['type', 'id', 'src', 'provider', 'title', 'start', 'end', 'authorNote']),
   interactive: new Set([
     'type',
     'id',
@@ -821,11 +852,13 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'verify',
     'lazyRender',
     'scrollContainer',
+    'openGuide',
     'assistantEnabled',
     'assistantId',
     'assistantType',
+    'authorNote',
   ]),
-  multistep: new Set(['type', 'id', 'content', 'steps', 'requirements', 'objectives', 'skippable']),
+  multistep: new Set(['type', 'id', 'content', 'steps', 'requirements', 'objectives', 'skippable', 'authorNote']),
   guided: new Set([
     'type',
     'id',
@@ -836,8 +869,9 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'objectives',
     'skippable',
     'completeEarly',
+    'authorNote',
   ]),
-  section: new Set(['type', 'id', 'title', 'blocks', 'requirements', 'objectives', 'autoCollapse']),
+  section: new Set(['type', 'id', 'title', 'blocks', 'requirements', 'objectives', 'autoCollapse', 'authorNote']),
   conditional: new Set([
     'type',
     'id',
@@ -849,6 +883,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'reftarget',
     'whenTrueSectionConfig',
     'whenFalseSectionConfig',
+    'authorNote',
   ]),
   _conditionalSectionConfig: new Set(['title', 'requirements', 'objectives']),
   quiz: new Set([
@@ -861,6 +896,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'maxAttempts',
     'requirements',
     'skippable',
+    'authorNote',
   ]),
   input: new Set([
     'type',
@@ -877,10 +913,30 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'requirements',
     'skippable',
     'datasourceFilter',
+    'authorNote',
   ]),
-  assistant: new Set(['type', 'id', 'assistantId', 'assistantType', 'blocks']),
-  terminal: new Set(['type', 'id', 'command', 'content', 'requirements', 'objectives', 'skippable', 'hint']),
-  'terminal-connect': new Set(['type', 'id', 'content', 'buttonText', 'vmTemplate', 'vmApp', 'vmScenario']),
+  assistant: new Set(['type', 'id', 'assistantId', 'assistantType', 'blocks', 'authorNote']),
+  terminal: new Set([
+    'type',
+    'id',
+    'command',
+    'content',
+    'requirements',
+    'objectives',
+    'skippable',
+    'hint',
+    'authorNote',
+  ]),
+  'terminal-connect': new Set([
+    'type',
+    'id',
+    'content',
+    'buttonText',
+    'vmTemplate',
+    'vmApp',
+    'vmScenario',
+    'authorNote',
+  ]),
   'code-block': new Set([
     'type',
     'id',
@@ -893,8 +949,9 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'objectives',
     'skippable',
     'hint',
+    'authorNote',
   ]),
-  'grot-guide': new Set(['type', 'id', 'welcome', 'screens']),
+  'grot-guide': new Set(['type', 'id', 'welcome', 'screens', 'authorNote']),
   _manifest: new Set([
     'schemaVersion',
     'id',

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -63,6 +63,22 @@ export interface AssistantProps {
   assistantType?: 'query' | 'config' | 'code' | 'text';
 }
 
+/**
+ * Editor-only annotation fields. Stripped before publish/export so the
+ * runtime never sees them.
+ *
+ * Currently just `authorNote` — a private comment the author leaves on
+ * a block (think: "TODO: revisit this selector"). Surfaced as a small
+ * note icon + tooltip in the editor; never rendered to readers.
+ */
+export interface AuthorAnnotated {
+  /**
+   * Editor-only note attached to this block. Visible to authors in the
+   * block list, never published. Stripped during export.
+   */
+  authorNote?: string;
+}
+
 // ============ CONTENT BLOCKS ============
 
 /**
@@ -70,7 +86,7 @@ export interface AssistantProps {
  * Content is rendered as formatted text with support for
  * headings, bold, italic, code, links, and lists.
  */
-export interface JsonMarkdownBlock extends AssistantProps {
+export interface JsonMarkdownBlock extends AssistantProps, AuthorAnnotated {
   type: 'markdown';
   /** Stable identifier for edit-block / remove-block addressing (auto-assigned by the CLI when omitted) */
   id?: string;
@@ -83,7 +99,7 @@ export interface JsonMarkdownBlock extends AssistantProps {
  * Used for migration path from HTML guides - prefer markdown for new content.
  * HTML is sanitized before rendering.
  */
-export interface JsonHtmlBlock {
+export interface JsonHtmlBlock extends AuthorAnnotated {
   type: 'html';
   /** Stable identifier for edit-block / remove-block addressing (auto-assigned by the CLI when omitted) */
   id?: string;
@@ -94,7 +110,7 @@ export interface JsonHtmlBlock {
 /**
  * Image block for displaying images.
  */
-export interface JsonImageBlock {
+export interface JsonImageBlock extends AuthorAnnotated {
   type: 'image';
   /** Stable identifier for edit-block / remove-block addressing (auto-assigned by the CLI when omitted) */
   id?: string;
@@ -111,7 +127,7 @@ export interface JsonImageBlock {
 /**
  * Video block for embedded video content.
  */
-export interface JsonVideoBlock {
+export interface JsonVideoBlock extends AuthorAnnotated {
   type: 'video';
   /** Stable identifier for edit-block / remove-block addressing (auto-assigned by the CLI when omitted) */
   id?: string;
@@ -132,7 +148,7 @@ export interface JsonVideoBlock {
  * Wraps multiple child blocks, each getting their own customize button.
  * Uses Grafana Assistant to customize content based on user's datasources and environment.
  */
-export interface JsonAssistantBlock {
+export interface JsonAssistantBlock extends AuthorAnnotated {
   type: 'assistant';
   /** Stable identifier for the assistant block (required for container blocks via CLI) */
   id?: string;
@@ -151,7 +167,7 @@ export interface JsonAssistantBlock {
  * Sections group related interactive steps and provide
  * sequential execution with "Do Section" functionality.
  */
-export interface JsonSectionBlock {
+export interface JsonSectionBlock extends AuthorAnnotated {
   type: 'section';
   /** Optional HTML id for the section */
   id?: string;
@@ -194,7 +210,7 @@ export interface ConditionalSectionConfig {
  * Evaluates conditions at runtime and displays the appropriate branch.
  * Uses the same condition syntax as requirements (e.g., has-datasource:prometheus).
  */
-export interface JsonConditionalBlock {
+export interface JsonConditionalBlock extends AuthorAnnotated {
   type: 'conditional';
   /** Stable identifier for the conditional block (required for container blocks via CLI) */
   id?: string;
@@ -233,7 +249,7 @@ export type JsonInteractiveAction = 'highlight' | 'button' | 'formfill' | 'navig
  * Use showMe/doIt to control button visibility.
  * Supports AI customization via AssistantProps.
  */
-export interface JsonInteractiveBlock extends AssistantProps {
+export interface JsonInteractiveBlock extends AssistantProps, AuthorAnnotated {
   type: 'interactive';
   /** Stable identifier for edit-block / remove-block addressing (auto-assigned by the CLI when omitted) */
   id?: string;
@@ -290,7 +306,7 @@ export interface JsonInteractiveBlock extends AssistantProps {
  * Multi-step block for automated action sequences.
  * System performs all steps automatically when "Do it" is clicked.
  */
-export interface JsonMultistepBlock {
+export interface JsonMultistepBlock extends AuthorAnnotated {
   type: 'multistep';
   /** Stable identifier for this block (required for container blocks via CLI) */
   id?: string;
@@ -310,7 +326,7 @@ export interface JsonMultistepBlock {
  * Guided block for user-performed action sequences.
  * System highlights elements and waits for user to perform actions.
  */
-export interface JsonGuidedBlock {
+export interface JsonGuidedBlock extends AuthorAnnotated {
   type: 'guided';
   /** Stable identifier for this block (required for container blocks via CLI) */
   id?: string;
@@ -372,7 +388,7 @@ export interface JsonStep {
  * Quiz block for knowledge assessment.
  * Supports single or multiple choice questions with configurable completion modes.
  */
-export interface JsonQuizBlock {
+export interface JsonQuizBlock extends AuthorAnnotated {
   type: 'quiz';
   /** Stable identifier for this block (required for container blocks via CLI) */
   id?: string;
@@ -416,7 +432,7 @@ export interface JsonQuizChoice {
  * - As targetvalue in interactive blocks
  * - As variable substitution in reftarget selectors (e.g., "button:contains({{myDatasource}})")
  */
-export interface JsonInputBlock {
+export interface JsonInputBlock extends AuthorAnnotated {
   type: 'input';
   /** Stable identifier for edit-block / remove-block addressing (auto-assigned by the CLI when omitted) */
   id?: string;
@@ -455,7 +471,7 @@ export interface JsonInputBlock {
  * Participates in sections and step counting like other interactive blocks.
  * @coupling Zod schema: JsonTerminalBlockSchema in json-guide.schema.ts
  */
-export interface JsonTerminalBlock {
+export interface JsonTerminalBlock extends AuthorAnnotated {
   type: 'terminal';
   /** Stable identifier for edit-block / remove-block addressing (auto-assigned by the CLI when omitted) */
   id?: string;
@@ -481,7 +497,7 @@ export interface JsonTerminalBlock {
  * Use this to provide a guided entry point for users to start using the terminal feature.
  * @coupling Zod schema: JsonTerminalConnectBlockSchema in json-guide.schema.ts
  */
-export interface JsonTerminalConnectBlock {
+export interface JsonTerminalConnectBlock extends AuthorAnnotated {
   type: 'terminal-connect';
   /** Stable identifier for edit-block / remove-block addressing (auto-assigned by the CLI when omitted) */
   id?: string;
@@ -506,7 +522,7 @@ export interface JsonTerminalConnectBlock {
  * Participates in sections and step counting like other interactive blocks.
  * @coupling Zod schema: JsonCodeBlockBlockSchema in json-guide.schema.ts
  */
-export interface JsonCodeBlockBlock {
+export interface JsonCodeBlockBlock extends AuthorAnnotated {
   type: 'code-block';
   /** Stable identifier for edit-block / remove-block addressing (auto-assigned by the CLI when omitted) */
   id?: string;
@@ -614,7 +630,7 @@ export type GrotGuideScreen = GrotGuideQuestionScreen | GrotGuideResultScreen;
  * Users start at the welcome screen, answer questions, and arrive at result screens.
  * @coupling Zod schema: JsonGrotGuideBlockSchema in json-guide.schema.ts
  */
-export interface JsonGrotGuideBlock {
+export interface JsonGrotGuideBlock extends AuthorAnnotated {
   type: 'grot-guide';
   /** Stable identifier for edit-block / remove-block addressing (not exposed via the authoring CLI; grot-guide is authored in the dedicated decision-tree editor) */
   id?: string;


### PR DESCRIPTION
Three orthogonal author-experience improvements:

- Undo/redo: in-session ring-buffer history (20 entries, 1MB cap, 500ms coalescing for consecutive same-field edits). Exposed via two icon buttons in the editor header. Wraps every mutating callback in useBlockEditor; loadGuide/setViewMode/resetGuide/markSaved bypass the stack via { skipHistory: true }.
- authorNote: optional editor-only annotation on every block, surfaced via a comment icon in BlockItem/NestedBlockItem secondary actions (modal editor on click). Stripped from clipboard copy, file download, and backend persistence so it never ships in published guides. Added to the schema for all 16 block discriminants.
- BlockPalette: type-to-filter input plus grouping under Content / Interactive / Structure headers — meaningful blank-page win at any sidebar width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new state-history semantics (undo/redo with coalescing and caps) and extends the guide schema with an editor-only `authorNote` field, which could affect editor state transitions and export/publish behavior if edge cases are missed.
> 
> **Overview**
> Adds **in-session undo/redo** to the block editor via a new `useGuideHistory` ring buffer (coalescing, count/size caps) and exposes it in the header with disabled states and tooltip labels.
> 
> Introduces an **editor-only `authorNote` annotation** on all block types: updates schema/types and CLI flags (`--author-note`), adds a shared `AuthorNoteModal`, and wires note editing into root/nested/conditional block rows; notes are explicitly stripped from clipboard/file exports and backend persistence.
> 
> Improves the **Block Palette UX** by adding a text filter and grouping block types under Content/Interactive/Structure, plus minor drag/action event handling tweaks (pointer-event stopPropagation and action ordering/visibility).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1ba86590a052c8c96e413dcc5db7c1d78b3f09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->