### PR TITLE
docs(agents): guidance audit + six new skills

### DIFF
--- a/.cursor/rules/pr-review.md
+++ b/.cursor/rules/pr-review.md
@@ -196,6 +196,14 @@ If `coverage_confidence` is not `high`, include a short coverage note such as:
 
 > Coverage note: this PR appears to center on an area that is only lightly modeled by `docs/design/CONCERNS.md`. I reviewed it with general concerns and adjacent subsystem logic, but review confidence is reduced there. If this area is important long-term, consider refining or adding a concern entry.
 
+## 6. Documentation drift check
+
+After synthesis, invoke `.cursor/skills/prevent-doc-drift/SKILL.md` in **review mode** to detect whether this PR introduces new subsystems, scripts, skills, docs, plugin routes, feature flags, or architecture changes that require updates to agent guidance (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules/`).
+
+If the skill emits a "Doc-drift updates recommended" section, include it verbatim in the review output. The PR author can apply the diffs themselves or invoke `prevent-doc-drift` in apply mode to commit them on the same branch.
+
+The doc-drift check is **non-blocking** — guidance drift does not block merge, but unfixed drift accumulates as tech debt future reviewers and agents will pay for.
+
 ## Existing review tables still apply
 
 Use the tables below as implementation detail for the relevant concerns, especially `security`, `correctness-and-reliability`, and `go-backend`.

--- a/.cursor/rules/systemPatterns.mdc
+++ b/.cursor/rules/systemPatterns.mdc
@@ -81,3 +81,134 @@ This Grafana App Plugin integrates as a sidebar panel using **Grafana Scenes** f
 **Analytics Events**:
 - `learning_path_progress` → Tracks path interaction with completion %
 - `badge_unlocked` → Tracks badge awards with trigger type
+
+## Frontend tier model
+
+Imports flow **downward only** through these tiers. Cross-tier rules are enforced by ESLint and `src/validation/architecture.test.ts`; exceptions require an explicit allowlist entry with justification.
+
+- **Tier 0 — Types & constants**: `types/`, `constants/`. Pure type definitions and configuration constants; no runtime behavior; safe to import from anywhere.
+- **Tier 1 — Engines & providers**: `context-engine/`, `docs-retrieval/`, `interactive-engine/`, `package-engine/`, `learning-paths/`, `requirements-manager/`, `recovery/`, `validation/`. Hold the business logic. Each exposes a barrel `index.ts`; consumers import only the public surface.
+- **Tier 2 — UI**: `components/`, `pages/`. Compose engines into rendered surfaces.
+- **Tier 3 — Support**: `lib/`, `security/`, `styles/`, `global-state/`, `integrations/`, `hooks/`, `utils/`, `test-utils/`, `bundled-interactives/`, `locales/`, `img/`, `cli/`. Auxiliary utilities and feature integrations; imported by Tier 1 and Tier 2.
+
+## Frontend subsystem reference
+
+Compact catalogue. For each subsystem: purpose, entry point (file an agent should read first), and its position in the tier model. Per-subsystem deep-dives live in `docs/developer/engines/`, `docs/developer/utils/README.md`, `docs/developer/constants/README.md`, and `docs/developer/learning-paths/README.md`.
+
+**Tier 0:**
+
+- `types/` — Centralized TypeScript type definitions. Entry: `types/index.ts` barrel. Key modules: `json-guide.types`, `package.types`, `interactive-actions.types`, `requirements.types`, `content.types`, `learning-paths.types`, `v1-recommender.types`.
+- `constants/` — Glob-scoped constants. Entry: `src/constants.ts` (root barrel) + `src/constants/` subdir (selectors, interactive-config, testIds, z-index). See `docs/developer/constants/README.md`.
+
+**Tier 1 — engines:**
+
+- `context-engine/` — Detects Grafana context (URL, datasources, dashboard) and calls the recommender. Entry: `context.service.ts`. Hook: `useContextPanel()`. See `docs/developer/engines/context-engine.md`.
+- `docs-retrieval/` — Multi-strategy content fetcher and renderer. Entry: `content-fetcher.ts` (`fetchUnifiedContent`). Renders via `content-renderer.tsx`. Journey-completion helpers in `learning-journey-helpers.ts`.
+- `interactive-engine/` — Executes interactive step actions. Entry: `interactive.hook.ts` (`useInteractiveElements`). Action handlers under `action-handlers/`. See `docs/developer/engines/interactive-engine.md`.
+- `package-engine/` — Package resolution + loading. Entry: `composite-resolver.ts` (`createCompositeResolver`). Resolver chain: bundled → online CDN → recommender API.
+- `learning-paths/` — Progress / badges / streaks / next-action. Entry: `learning-paths.hook.ts`. Badge definitions in `badges.ts`. See `docs/developer/learning-paths/README.md`.
+- `requirements-manager/` — Prereqs + postconditions for steps. Entry: `requirements-checker.hook.ts` (`useStepChecker`). State machine in `step-state.ts`. See `docs/developer/engines/requirements-manager.md`.
+- `recovery/` — Auto-recovery: decides whether the user is in the right place for a guide. Entry: `alignment-evaluator.ts` (`evaluateAlignment`).
+- `validation/` — Zod schemas + condition validators. Entry: `validate-guide.ts`. Architecture rules enforced by `architecture.test.ts`.
+
+**Tier 2 — UI:**
+
+- `components/` — React + Scenes UI. Major panels: `App/App.tsx` (root), `docs-panel/docs-panel.tsx` (~40 KB hub), `Home/`, `interactive-tutorial/`, `LearningPaths/`, `LiveSession/`, `block-editor/`, `floating-panel/`, `full-screen/`, `kiosk/`, `PrTester/`.
+- `pages/` — Grafana Scenes routing. Entries: `homePage.ts`, `docsPage.ts`. Both registered by `App.tsx`.
+
+**Tier 3 — support:**
+
+- `lib/` — Shared utilities. Sub-areas: `analytics.ts`, `user-storage.ts`, `dom/` (selector pipeline: detect → generate → validate → retry), `async-utils.ts`, `package-recommendations-client.ts`.
+- `security/` — URL allowlists, HTML / log sanitization. Entry: `security/index.ts`. Key: `parseUrlSafely`, `validateTutorialUrl`, `sanitizeDocumentationHTML`. See `.cursor/rules/frontend-security.mdc`.
+- `styles/` — Theme-aware CSS-in-JS factories (Emotion). One `*.styles.ts` per component.
+- `global-state/` — Cross-component stores (Zustand + React context). Files: `sidebar.ts`, `panel-mode.ts`, `link-interception.ts`, `interactive-navigation.ts`, `alignment-pending-context.ts`.
+- `integrations/` — Optional integrations: `assistant-integration/` (`<assistant>` tags), `coda/` (terminal), `workshop/` (action capture + replay). See `.cursor/rules/coda.mdc`, `docs/developer/ASSISTANT_INTEGRATION.md`, `docs/developer/integrations/workshop.md`.
+- `hooks/` — Cross-cutting hooks: `usePendingGuideLaunch`, `useAlignmentReevaluation`.
+- `utils/` — Business logic and utilities. Files: `dev-mode.ts`, `openfeature.ts`, `timeout-manager.ts`, `variable-substitution.ts`, `experiments.ts`, `find-doc-page.ts`. See `docs/developer/utils/README.md`.
+- `test-utils/` — Test fixtures. `openfeature-mock.ts`.
+- `bundled-interactives/` — Offline-fallback JSON guides + `repository.json`. Static asset directory; no code.
+- `locales/` — i18n translation files (en-US base + de-DE, fr-FR, es-ES, cs-CZ, etc.). Loaded via `@grafana/i18n`.
+- `img/` — Static SVG / PNG assets (logos, mascot illustrations, screenshots).
+- `cli/` — Authoring CLI (`pathfinder-cli`) and TypeScript MCP server (`src/cli/mcp/`). Entry: `cli/index.ts`. See `docs/developer/CLI_TOOLS.md` and `docs/developer/MCP_SERVER.md`.
+
+## Key dependency edges
+
+The load-bearing wiring. If you change a producer here, audit consumers carefully.
+
+| Producer                              | Consumer                                  | Contract                                                       |
+| ------------------------------------- | ----------------------------------------- | -------------------------------------------------------------- |
+| `bundled-interactives/repository.json` | `package-engine/loader.ts`               | Fallback content when online CDN unavailable                   |
+| `docs-retrieval` (`fetchUnifiedContent`) | `context-engine`, `components/docs-panel` | Multi-strategy fetch returns parsed guide                    |
+| `context-engine` (`getRecommendations`) | `components/docs-panel`, `Home`          | Returns scored `Recommendation[]` from recommender or bundled  |
+| `package-engine` (`createCompositeResolver`) | `docs-retrieval`, `context-engine`  | Bundled-first fallback chain                                   |
+| `requirements-manager` (`checkRequirements`) | `interactive-engine`, `components/interactive-tutorial` | Synchronous prereq verification          |
+| `interactive-engine` (`useInteractiveElements`) | `components/interactive-tutorial`     | Action execution + auto-completion detection                |
+| `lib/dom` (`resolveSelector`)          | `interactive-engine`                     | Selector pipeline: detect → generate → validate → retry        |
+| `global-state/sidebar`, `panel-mode`   | `components/docs-panel`, `App`           | Sidebar visibility + content/editor mode                       |
+| `security` (`parseUrlSafely`, `validateTutorialUrl`) | All subsystems handling URLs | Boundary validation for any URL crossing trust zones           |
+| `learning-paths` (`useGuideCompletion`) | `components/docs-panel`, `interactive-engine` | Progress events + badge unlock                          |
+| `recovery` (`evaluateAlignment`)       | `components/docs-panel`, `hooks/useAlignmentReevaluation` | Detects misalignment, triggers prompts            |
+
+## Backend architecture (`pkg/`)
+
+The Go backend is a **thin bridge** between the React frontend and the **Coda VM provisioning service**. No database — all state is ephemeral or delegated to Coda. Built on `grafana-plugin-sdk-go`.
+
+**File map:**
+
+| File                                | Role                                                                                                              |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `main.go`                           | Plugin entrypoint. Calls `app.Manage("grafana-pathfinder-app", plugin.NewApp, ...)`                                |
+| `plugin/app.go`                     | `App` struct (implements `instancemgmt.Instance`, `CallResourceHandler`, `StreamHandler`). Holds `CodaClient`, stream-sessions map, per-user VM cache. |
+| `plugin/resources.go`               | HTTP resource handlers — `http.ServeMux` wrapped in `httpadapter.New`. Input allowlists.                          |
+| `plugin/settings.go`                | Parses `JSONData` and decrypts `SecureJSONData`. Reads `CodaAPIURL`, `CodaRelayURL`, `EnrollmentKey`, `RefreshToken`. |
+| `plugin/stream.go`                  | Grafana Live `SubscribeStream` / `PublishStream` / `RunStream`. The largest file. VM resolution, SSH retry, heartbeat (3s), VM-expiry poll (15s). |
+| `plugin/terminal.go`                | `TerminalSession` — SSH session over a `WSConn`. PTY, stdin/stdout/stderr pipes, private-key normalization.        |
+| `plugin/wsconn.go`                  | `WSConn` — adapts gorilla/websocket as `net.Conn` for SSH-over-WebSocket. Pong-based read-deadline reset (90s).    |
+| `plugin/coda.go`                    | `CodaClient` — JWT-authenticated REST. VM CRUD, sample apps, alloy scenarios. Token refresh under `RWMutex`. Per-user quota: 3 VMs. |
+| `plugin/mcp.go`                     | **Experimental MCP spike** (PR #643). NON-PRODUCTION. Real AI authoring lives in TypeScript under `src/cli/mcp/`. |
+| `plugin/package_recommendations.go` | CDN package-index cache (6h TTL, single-flight dedup, 8-way parallel manifest fetch, bounded memory).            |
+| `plugin/static.go`                  | `embed.FS` declarations for `repository.json` + `guides/` content.                                                |
+
+**HTTP request flow (e.g., `POST /vms`):**
+
+1. Plugin SDK dispatches to `App.CallResource()`
+2. `http.ServeMux` routes to `App.handleVMs` → `handleCreateVM`
+3. Verifies Coda is registered, validates body, gets `X-Grafana-User` header, checks quota via `CodaClient.CountVMsForUser`
+4. `CodaClient.CreateVM` — refreshes token if needed via `setAuthHeader`, POSTs to `{codaAPIURL}/api/v1/vms`, returns `VM` struct
+5. `writeJSON(w, http.StatusCreated, vm)`
+
+**Terminal stream flow (`terminal/{vmId}/{nonce}/{template?}/{app?}`):**
+
+1. Frontend xterm.js subscribes via Grafana Live → `App.SubscribeStream` accepts
+2. `App.RunStream` begins:
+   - `resolveVMForUser` — 3-tier cache: in-memory `userVMs[userLogin]` → `CodaClient.FindActiveVMForUser` → quota cleanup if needed → `CodaClient.CreateVM`
+   - `waitForVMActive` — polls `GetVM` every 3s, emits `status` frames (`pending` / `provisioning` / `active`) to the client. Timeout: 60 attempts (~3 min)
+   - SSH retry loop (3 attempts):
+     - `ConnectSSHViaRelay(relayURL, vmID, creds, accessToken)` — dial `wss://{relayURL}/relay/{vmID}` with `Authorization: Bearer {token}`; wrap as `WSConn`; SSH handshake over the WebSocket
+     - On auth error: `GetVM` to refresh creds, retry (max 2 refreshes)
+     - On transient error: 5s delay, retry
+   - `NewTerminalSessionWithClient` — `RequestPty("xterm-256color", 24, 80, …)`, `session.Shell()`, start `forwardOutput` + `forwardStderr` goroutines
+   - Store session in `streamSessions[path]`
+   - Send `connected` frame with `vmId`
+   - Start heartbeat goroutine (3s) and VM-expiry poll goroutine (15s)
+   - Block on `<-streamCtx.Done()`
+3. `App.PublishStream` — receives `{type: "input"|"resize", data}` from frontend; looks up session in `streamSessions[path]`; forwards via `session.Write` or `session.Resize`
+4. SSH stdout/stderr → `forwardOutput` / `forwardStderr` → `onOutput` callback → `sender.SendFrame` with `TerminalStreamOutput{Type: "output", Data: ...}`
+
+**Stream message types** (`TerminalStreamOutput.Type`):
+
+- `output` — SSH stdout / stderr bytes
+- `status` — VM state update (`pending` / `provisioning` / `active` / `retrying`)
+- `error` — error message + imminent disconnect
+- `connected` — handshake complete, includes `vmId`
+- `disconnected` — stream ended cleanly
+- `heartbeat` — keep-alive (no payload)
+
+**Security boundaries:**
+
+- `isAllowedCodaURL` — `https` only, host in `.lg.grafana-dev.com` / `.grafana.com`
+- `IsAllowedRelayURL` — `wss` only, same host allowlist
+- Package-recommendations URL — `https` + explicit hostname allowlist
+- SSH `HostKeyCallback: InsecureIgnoreHostKey` — intentional, VMs are ephemeral
+
+For the full operational reference (failure modes, troubleshooting, scale considerations), load `docs/developer/CODA.md`. For agent-facing constraints on Coda code, load `.cursor/rules/coda.mdc`.

--- a/.cursor/skills/changelog/SKILL.md
+++ b/.cursor/skills/changelog/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: changelog
+description: Draft a CHANGELOG.md entry from merged PRs since the last release tag. Categorizes by conventional-commit prefix (Added / Fixed / Chore / Security / Changed / Removed), rewrites PR titles into sentence-case narrative bullets with PR refs, and commits to the current branch without pushing. Use when preparing a release, or call this skill from `/release-prep`.
+---
+
+# Changelog draft
+
+A focused skill that drafts the next CHANGELOG.md entry from real merged PRs. Replaces a multi-hour manual task with a reviewable diff. The user reviews, edits if needed, and pushes when they're satisfied.
+
+## Hard constraints
+
+These constraints are absolute and override any other instructions:
+
+1. **Only edit `CHANGELOG.md`.** Never source, `package.json`, tags, or other docs. Run `git diff --name-only` after edits and abort if anything other than `CHANGELOG.md` is staged.
+2. **Do not invent PR numbers.** Every entry must trace to a real merged PR retrieved via `gh pr list` / `gh pr view`. If a PR cannot be confirmed, omit it.
+3. **Do not push the commit or open a PR.** Leave the branch as-is so the user can review and push.
+4. **Sentence case in entries.** Per the [Grafana Writers' Toolkit](https://grafana.com/docs/writers-toolkit/write/style-guide/capitalization-punctuation/#capitalization). Capitalize proper nouns: Grafana, Loki, Prometheus, Tempo, Mimir, Alloy, Grafana Cloud, Grafana Enterprise, Grafana Labs.
+5. **Run `npm run prettier` on `CHANGELOG.md` before committing.** Prettier is the canonical formatter; never hand-format tables or wrap manually.
+6. **One commit.** Title: `chore: changelog for v<version>`. No co-author lines unless the user instructs.
+
+## Workflow
+
+### Phase 0 — Resolve scope
+
+1. Capture the last release tag:
+
+   ```
+   git tag --sort=-v:refname | head -1
+   ```
+
+   Format is `v<SemVer>` (e.g., `v2.10.0`).
+
+2. Determine the target version:
+   - If the user passed `/changelog <version>`, use that.
+   - Otherwise, defer the version suggestion until Phase 2 where you can count PR categories.
+
+3. Verify `package.json`'s `version` field. If it matches the target version, proceed. If it doesn't, warn the user but continue — `/release-prep` handles the bump separately.
+
+4. Capture the date of the last tag (used as the lower bound for the PR search):
+
+   ```
+   git log -1 --format=%cI v<last-version>
+   ```
+
+### Phase 1 — Gather PRs
+
+1. List merged PRs since the last tag:
+
+   ```
+   gh pr list --state merged --base main --search "merged:>=<last-tag-date>" \
+     --limit 200 \
+     --json number,title,body,labels,mergedAt,author,url
+   ```
+
+2. **Filter** the result:
+   - Drop Renovate / Dependabot dependency bumps unless they are security PRs. Heuristics for security:
+     - Title contains `[SECURITY]`
+     - Any label matches `automerge-security-update` or contains `security`
+   - Drop PRs whose subject is exclusively `chore(deps):` and have no security signal.
+   - Keep everything else.
+
+3. For each kept PR, fetch the first ~30 lines of the body via `gh pr view <number> --json body` if the original listing's body is truncated.
+
+4. Maintain a list of records: `{ number, title, body_snippet, labels, prefix, scope }` where `prefix` is the conventional commit prefix (`feat`, `fix`, `refactor`, `chore`, `docs`, `perf`, `test`, etc.) extracted from the title.
+
+### Phase 2 — Categorize and draft
+
+1. **Mapping** (prefix → CHANGELOG section):
+
+   | Prefix                               | Section                                                   |
+   | ------------------------------------ | --------------------------------------------------------- |
+   | `feat`                               | **Added**                                                 |
+   | `fix`                                | **Fixed**                                                 |
+   | `refactor`, `perf`, `test`, `style`  | **Chore**                                                 |
+   | `chore`                              | **Chore**                                                 |
+   | `docs`                               | **Chore** (unless docs are user-facing — judge from body) |
+   | `[SECURITY]` title or security label | **Security**                                              |
+   | `BREAKING:` body marker              | **Changed** + flag for blockquote preamble at top         |
+
+   Unprefixed PR titles (e.g., "Pathfinder MCP Server - Initial version") get heuristic categorization based on body content. When uncertain, default to **Chore**.
+
+2. **Draft each entry** as:
+
+   ```
+   - **<sentence-case title>**: <one or two sentence narrative>. (#<number>)
+   ```
+
+   Rules for the title:
+   - Drop the conventional prefix (`feat: ` / `fix(scope): `).
+   - Rewrite to sentence case. Capitalize only the first word and proper nouns.
+   - Keep the scope as part of the narrative if it adds clarity (e.g., "in the block editor", "for OSS recommender mode") rather than as a parenthetical.
+
+   Rules for the narrative:
+   - Pull the substantive sentence from the PR body's Summary section. Tighten — one or two sentences max.
+   - State user impact, not implementation. "Sidebar tabs survive the toggle" beats "Refactored useTabState hook".
+   - Don't quote the PR title verbatim — the bold title already does that.
+
+3. **Suggest the next version** based on the category counts:
+   - Any **Changed** entry triggered by `BREAKING:` → major bump
+   - Any **Added** → minor bump
+   - Else → patch bump
+
+   Print the suggestion before drafting the section. Example:
+
+   ```
+   Detected since v2.10.0:
+     - 3 feat (Added)
+     - 7 fix (Fixed)
+     - 5 chore (Chore)
+     - 0 breaking, 0 security
+
+   Suggested next version: 2.11.0 (minor bump)
+   ```
+
+   If the user supplied a version arg, validate it matches the suggestion. If it doesn't, warn but proceed with the user's version.
+
+4. **Order entries within each section** by:
+   - **Added**: most impactful first (longest body, most files touched). Use `gh pr view` metadata.
+   - **Fixed**: bugfix urgency — security-adjacent first, then UI / UX, then internal.
+   - **Chore**: dependency bumps last (or omitted entirely if low signal).
+
+### Phase 3 — Render and commit
+
+1. Read the current `CHANGELOG.md`.
+
+2. Locate the insertion point: immediately after the `# Changelog` heading, before the previous `## <previous-version>` heading.
+
+3. **Insert the new section** in this template:
+
+   ```markdown
+   ## <version>
+
+   <optional blockquote preamble for breaking changes; omit if none>
+
+   ### Added
+
+   - ...
+
+   ### Changed
+
+   - ...
+
+   ### Fixed
+
+   - ...
+
+   ### Security
+
+   - ...
+
+   ### Chore
+
+   - ...
+
+   ### Removed
+
+   - ...
+   ```
+
+   **Omit empty sub-sections.** A patch-only release with no entries can use the placeholder `_Patch release — version bump only._` instead of empty sections.
+
+4. **Format**: run `npm run prettier`. Confirm only `CHANGELOG.md` was changed:
+
+   ```
+   git diff --name-only
+   ```
+
+   If anything else appears, abort and revert.
+
+5. **Commit**:
+
+   ```
+   git add CHANGELOG.md
+   git commit -m "chore: changelog for v<version>"
+   ```
+
+   Do **not** push.
+
+6. **Print summary**:
+
+   ```
+   Drafted v<version> entry — N added, M fixed, P chore (Q security, R removed).
+   Review with `git diff HEAD~1` and edit before tagging.
+   ```
+
+## Reuses
+
+- `gh` CLI for PR data (same pattern as `maintain-docs`).
+- Conventional commit prefix parsing — small regex; no dependency.
+- `npm run prettier` for formatting.
+
+## Integration
+
+- **`/release-prep`** calls this skill as part of its draft-changelog phase. The skill must work as both a standalone invocation and a sub-step of `/release-prep`.
+- Pairs with manual edits — the draft is a starting point. Authors with deep context will tighten entries before tagging. That's expected and encouraged.
+
+## When to exit cleanly without making changes
+
+- No merged PRs since the last tag — exit with "No new PRs since v<last-version>. Nothing to draft."
+- The last tag does not exist (fresh repo, no tags) — exit with "No prior release tag found. Cannot determine scope. Pass a date range explicitly via `--since <date>`."
+- `CHANGELOG.md` does not exist — exit with "No CHANGELOG.md found. Create one before invoking this skill."
+
+## Context window management
+
+This skill is small by design:
+
+- Phase 0: 2-3 short `git` invocations.
+- Phase 1: one `gh pr list` call (the full result) + targeted `gh pr view` for any PR whose body was truncated.
+- Phase 2: in-memory categorization and drafting from the records.
+- Phase 3: read CHANGELOG.md (typically < 500 lines), insert the new section, write back.
+
+Total context per run: well under 10k tokens for a typical release with 10-25 PRs. Larger releases scale linearly.
+
+## Expected invocation patterns
+
+- **Before tagging**: maintainer runs `/changelog <next-version>` to draft the section, reviews + edits the commit, then tags.
+- **Called from `/release-prep`**: as part of the orchestrated pre-release flow.
+- **On-demand audit**: run `/changelog` without a version to see what would land in the next release. The skill prints the category counts and suggested bump without writing — useful for sprint reviews.
+
+## Output examples
+
+### Successful run
+
+```
+Drafted v2.11.0 entry — 3 added, 7 fixed, 5 chore.
+Review with `git diff HEAD~1` and edit before tagging.
+```
+
+### No PRs since last tag
+
+```
+No new PRs since v2.10.0 (tagged 2026-04-15). Nothing to draft.
+```
+
+### Aborted due to dirty working tree
+
+```
+Working tree is dirty. Commit or stash before running /changelog:
+
+ M src/components/Foo.tsx
+?? scratch.md
+
+Aborting without changes.
+```

--- a/.cursor/skills/i18n-sync/SKILL.md
+++ b/.cursor/skills/i18n-sync/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: i18n-sync
+description: Detect translation gaps across the 21 locales under `src/locales/`. For keys present in `en-US` but missing from another locale, add the key with an empty string value (matching the runtime fallback to the en-US default). Emit a gap report (filled / empty / stale counts per locale + the list of newly stubbed keys). Never invents translations; translators fill the empty stubs later.
+---
+
+# i18n sync
+
+Closes the translation gap between `en-US` (canonical) and the 20 other locales under `src/locales/`. The skill is **plumbing, not a translation engine** — it adds the missing keys with empty values so the JSON shape matches `en-US` and translators can fill them in later. Runtime behavior is unchanged: empty values fall back to the en-US default at render time.
+
+## Hard constraints
+
+These constraints are absolute and override any other instructions:
+
+1. **`en-US` is the canonical source.** Other locales must contain the same key set; values may be empty strings (intentional fallback) or filled with real translations. Never modify `en-US`.
+2. **Only edit `src/locales/*/grafana-pathfinder-app.json`.** Never touch source code.
+3. **Preserve existing translations exactly.** Do not retranslate, "improve", or normalize values — translators own them.
+4. **Match the `i18next-parser` config** (`src/locales/i18next-parser.config.js`):
+   - Keys sorted alphabetically within each nested object
+   - No `createOldCatalogs` artifacts
+   - `failOnWarnings: true` — extraction must remain clean after edits
+5. **Never fabricate values.** Missing keys get empty strings (`""`), not English text, not placeholder text, not auto-translated content.
+6. **Run `npm run prettier` after edits.** Run `npm run i18n-extract` to confirm extraction still passes.
+
+## Workflow
+
+### Phase 0 — Setup
+
+1. Read `src/locales/i18next-parser.config.js` and capture the `locales` array. Treat the parser config as the source of truth for which languages are supported. At time of writing this includes `en-US, de-DE, es-ES, fr-FR, it-IT, hu-HU, id-ID, ja-JP, ko-KR, nl-NL, pl-PL, pt-PT, pt-BR, ru-RU, sv-SE, tr-TR, zh-CN, zh-TW, zh-Hans, zh-Hant, cs-CZ` — but read the file, do not hardcode.
+
+2. Read `src/locales/en-US/grafana-pathfinder-app.json` as the canonical key tree.
+
+3. Confirm working tree is clean for `src/locales/`. If not, abort (translators may have in-progress work).
+
+### Phase 1 — Audit each non-English locale
+
+For each locale in the parser config (excluding `en-US`):
+
+1. Read `src/locales/<locale>/grafana-pathfinder-app.json`. If the file does not exist, treat as "all keys missing" (and create the file in Phase 2).
+
+2. Recursively walk the en-US key tree. For each leaf key in en-US:
+   - **Present + non-empty in locale** → filled
+   - **Present + empty string in locale** → empty stub (intentional, fine)
+   - **Absent from locale** → missing (will be stubbed in Phase 2)
+
+3. Walk the locale's tree. For each leaf key:
+   - **Absent from en-US** → stale (flag for human review; never auto-delete)
+
+4. Record counts per locale:
+
+   ```
+   { filled, empty_existing, missing, stale, total_canonical }
+   ```
+
+### Phase 2 — Stub missing keys
+
+For each locale with `missing > 0`:
+
+1. Read the current file (or start with an empty object if absent).
+
+2. For each missing key path (e.g., `contextPanel.userProfileBar.nameCardRole`):
+   - Navigate to the parent object, creating intermediate objects as needed.
+   - Add the key with value `""` (empty string).
+
+3. **Sort all keys alphabetically** within each nested object. This matches `i18next-parser`'s output. Do not change the structure beyond inserting the new keys and sorting.
+
+4. Preserve existing values byte-for-byte (apart from the alphabetical reordering, which is non-destructive).
+
+5. Write the file back.
+
+### Phase 3 — Stale-key handling
+
+Stale keys (in locale but not in en-US) are **not auto-deleted**. They may be:
+
+- Genuinely stale (translation for a feature that was removed) → human should delete
+- Pending an upstream merge that adds the key back → human should keep
+
+Flag stale keys in the gap report (Phase 5). Do not modify the file.
+
+### Phase 4 — Validate
+
+After all locale edits:
+
+1. **Prettier**:
+
+   ```
+   npm run prettier
+   ```
+
+   Confirm only `src/locales/*/grafana-pathfinder-app.json` files were touched:
+
+   ```
+   git diff --name-only
+   ```
+
+   If anything else changed, abort and revert.
+
+2. **i18n-extract**:
+
+   ```
+   npm run i18n-extract
+   ```
+
+   The parser config has `failOnWarnings: true`. If the run fails, surface the warning and abort.
+
+3. **JSON sanity**:
+
+   ```
+   for f in src/locales/*/grafana-pathfinder-app.json; do
+     jq empty "$f" || echo "BROKEN: $f"
+   done
+   ```
+
+   Each file must parse. If any fail, abort.
+
+### Phase 5 — Report
+
+Emit a gap report and commit:
+
+```
+## i18n gap report — <date>
+
+Canonical (en-US): N keys
+
+| Locale | Filled | Empty stubs | Missing → stubbed | Stale (flagged) |
+| ------ | ------ | ----------- | ----------------- | --------------- |
+| de-DE  | 86     | 0           | 5                 | 0               |
+| fr-FR  | 91     | 0           | 0                 | 0               |
+| ...    |        |             |                   |                 |
+
+### Newly stubbed keys per locale
+
+- de-DE:
+  - contextPanel.userProfileBar.nameCardRole
+  - contextPanel.userProfileBar.notificationToastPrompt
+  - ...
+
+### Stale keys (review for removal)
+
+- it-IT:
+  - oldFeature.deprecatedButton
+- ...
+
+### Locales unchanged
+
+- fr-FR, es-ES, pt-PT, pt-BR, ja-JP (no missing keys)
+```
+
+Then commit:
+
+```
+git add src/locales/*/grafana-pathfinder-app.json
+git commit -m "chore(i18n): stub missing keys across locales"
+```
+
+**Do not push.** The user reviews and pushes.
+
+## Reuses
+
+- `src/locales/i18next-parser.config.js` — canonical locale list + extraction config.
+- `npm run i18n-extract` — validates the result.
+- `npm run prettier` — formatting.
+
+## Integration
+
+- **Standalone**: maintainer runs `/i18n-sync` periodically (e.g., after a release that added new English strings).
+- **From `/release-prep`** (optional): can be invoked as a pre-release step to ensure non-English locales aren't shipping with new keys silently fall-back-only.
+- **CI augmentation**: a future CI gate could check that every locale has the same key set as en-US. This skill produces the artifact that would satisfy that gate.
+
+## When to exit cleanly without making changes
+
+- All locales already have the en-US key set in full and no stale keys exist — exit with "All 21 locales in sync with en-US. Nothing to do."
+- `src/locales/en-US/grafana-pathfinder-app.json` does not exist — exit with an error; canonical source missing.
+- The parser config file is missing — exit with an error.
+
+## Context window management
+
+- Phase 0: read 2 small files (parser config, en-US JSON).
+- Phase 1: read each locale file (~50-200 lines each, 20 locales) — bounded to ~4-5k tokens total.
+- Phase 2: in-memory edits.
+- Phase 3: in-memory flag.
+- Phase 4: stream prettier + extract output.
+- Phase 5: render report + commit.
+
+Total context per run: well under 20k tokens.
+
+## Expected invocation patterns
+
+- **Post-feature**: after a feature lands that added new `t('...', 'default')` calls and `i18n-extract` populated en-US, run `/i18n-sync` to propagate the keys (as empty stubs) into the other locales.
+- **Pre-release**: maintainer runs `/i18n-sync` as part of release prep to ensure the shipping snapshot is in sync.
+- **Translator handoff**: maintainer runs `/i18n-sync` before sending the translation files to translators so they have the canonical key set.
+
+## What this skill does NOT do
+
+- Translate English text into other languages (use a translation service, not this skill).
+- Delete stale keys (humans review and remove).
+- Modify `en-US/grafana-pathfinder-app.json` (canonical source — only changes via `npm run i18n-extract`).
+- Change `i18next-parser.config.js` (config is owned elsewhere).
+- Validate translations for accuracy (out of scope).
+
+## Behavior of empty stub values at runtime
+
+The repo uses `@grafana/i18n` which is built on i18next. When a key is requested via:
+
+```typescript
+t('contextPanel.start', 'Start');
+```
+
+and the active locale has `contextPanel.start: ""`, i18next falls through to either the next fallback locale or — if no fallback resolves — the second argument to `t()` (the en-US default). The empty-string sentinel is intentional and matches the runtime expectation. No user sees "" — they see the en-US default if their translation is missing.
+
+This is **why the skill stubs with `""` rather than copying the English text**: copying English would prevent the fallback from finding the up-to-date default if the English source ever changed (e.g., a typo fix). Empty stubs keep the locale's intent ("not yet translated") explicit.
+
+## Worked example
+
+Initial state (de-DE missing 3 keys present in en-US):
+
+```json
+// src/locales/de-DE/grafana-pathfinder-app.json
+{
+  "contextPanel": {
+    "categoryDocsPage": "Docs-Seite",
+    "categoryLearningJourney": "Lernpfad"
+  }
+}
+```
+
+```json
+// src/locales/en-US/grafana-pathfinder-app.json (canonical)
+{
+  "contextPanel": {
+    "categoryDocsPage": "Docs page",
+    "categoryInteractiveGuide": "Interactive guide",
+    "categoryLearningJourney": "Learning path",
+    "resume": "Resume",
+    "start": "Start"
+  }
+}
+```
+
+After `/i18n-sync`:
+
+```json
+// src/locales/de-DE/grafana-pathfinder-app.json
+{
+  "contextPanel": {
+    "categoryDocsPage": "Docs-Seite",
+    "categoryInteractiveGuide": "",
+    "categoryLearningJourney": "Lernpfad",
+    "resume": "",
+    "start": ""
+  }
+}
+```
+
+Report:
+
+```
+## i18n gap report — 2026-05-11
+
+Canonical (en-US): 5 keys
+
+| Locale | Filled | Empty stubs | Missing → stubbed | Stale |
+| ------ | ------ | ----------- | ----------------- | ----- |
+| de-DE  | 2      | 0           | 3                 | 0     |
+
+### Newly stubbed keys per locale
+
+- de-DE:
+  - contextPanel.categoryInteractiveGuide
+  - contextPanel.resume
+  - contextPanel.start
+
+Committed: chore(i18n): stub missing keys across locales
+```

--- a/.cursor/skills/pr-summary/SKILL.md
+++ b/.cursor/skills/pr-summary/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: pr-summary
+description: Generate a structured PR description from the current diff using `docs/design/CONCERNS.md` routing. Drafts canonical sections (Summary, What changed, Why, Test plan, Risk and reversibility) tailored to the change type (feat / fix / refactor / chore / docs). Outputs the draft for human review; can apply via `gh pr edit` after explicit confirmation. Pair with `/review` — this skill drafts, `/review` reviews.
+---
+
+# PR summary
+
+Drafts a complete PR description from the diff. Gives the author a coherent starting point and reviewers better context — the canonical sections (Summary, What changed, Why, Test plan, Risk and reversibility) map to the schema in `.cursor/rules/pr-review.md` so reviewers can route quickly.
+
+## Hard constraints
+
+These constraints are absolute and override any other instructions:
+
+1. **Output is a draft, not an auto-applied PR edit.** Print the draft body in a fenced markdown block. Only call `gh pr edit --body-file <tmp>` after the user explicitly confirms in the same turn.
+2. **Never invent test results.** The Test plan lists what should be run; never claim "all passing" unless the user has actually run the tests in this session and you have the output.
+3. **Activated concerns come from `docs/design/CONCERNS.md` routing** — `trigger_paths` and `trigger_keywords` matched by the diff. Do not list concerns the diff doesn't touch.
+4. **Sentence case** for headings, table cells, and bullet text. No title case. Proper nouns: Grafana, Loki, Prometheus, Tempo, Mimir, Alloy, Grafana Cloud, Grafana Enterprise, Grafana Labs.
+5. **No unrelated boilerplate.** A typo fix doesn't need a Risk section. A two-line fix doesn't need a phase table. Match section depth to change weight.
+6. **No source code edits.** This skill only reads — and at most calls `gh pr edit`.
+
+## Operating modes
+
+- **Draft mode** (default): print the draft body in a fenced block. Author copy-pastes into the PR description manually. No tool side effects.
+- **Apply mode**: if the user invokes `/pr-summary --apply` or replies "apply" after seeing the draft, write the body to a temp file and call `gh pr edit <number> --body-file <tmp>`. Confirm the PR number from `gh pr view --json number`.
+
+## Canonical structure
+
+```markdown
+## Summary
+
+<1-3 sentence pitch, or bullet list for multi-phase work>
+
+## What changed
+
+<concrete changes per touched subsystem; one bullet per area>
+
+## Why
+
+<motivation; link design docs if relevant>
+
+## Test plan
+
+- [ ] `npm run check`
+- [ ] <subsystem-specific verifications driven by activated concerns>
+- [ ] <manual reproduction steps if UI work>
+
+## Risk and reversibility
+
+<one paragraph; flag one-way doors per CONCERNS.md>
+
+<Fixes #NNN | Refs #MMM | Closes #PPP>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+### Variants by change type
+
+Different change shapes use different sections — match depth to weight:
+
+| Type           | Required sections                                             | Optional / typical                                                                 |
+| -------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **feat**       | Summary, What changed, Why, Test plan                         | Risk and reversibility; phase table for multi-phase                                |
+| **fix**        | Summary (problem + root cause + fix in 3-4 lines), Test plan  | Issue ref. Usually omit Why (self-evident).                                        |
+| **refactor**   | Summary, Why, **What's deliberately out of scope**, Test plan | Notes for review (phase order, gotchas)                                            |
+| **chore/deps** | Summary, What, Test plan                                      | Skip Why (usually self-evident). Renovate PRs handle themselves — detect and skip. |
+| **docs**       | Summary, What (list of docs), Test plan                       | Why (if non-obvious). Link to rendered docs when useful.                           |
+
+## Workflow
+
+### Phase 0 — Resolve scope
+
+1. Determine the base ref:
+
+   ```
+   gh pr view --json baseRefName -q .baseRefName 2>/dev/null \
+     || git symbolic-ref refs/remotes/origin/HEAD --short | sed 's@^origin/@@'
+   ```
+
+   Default to `main` if neither resolves.
+
+2. Capture the diff in three forms:
+
+   ```
+   git diff --stat <base>...HEAD
+   git diff --name-status <base>...HEAD
+   git log <base>..HEAD --format='%h %s%n%n%b%n---'
+   ```
+
+   The `git log` output preserves commit bodies so you can extract motivation.
+
+3. Read the **most recent commit body** in full — it usually contains the substantive `Why` content.
+
+4. If running on a PR branch, also capture: `gh pr view --json number,title,body,labels`. The existing title and body may already contain useful context to preserve.
+
+### Phase 1 — Classify the change
+
+1. Inspect commit subjects + diff stat. Pick a **primary class**:
+
+   | Signal                                                | Class                            |
+   | ----------------------------------------------------- | -------------------------------- |
+   | All commits prefixed `feat:` / `feat(scope):`         | `feat`                           |
+   | All commits prefixed `fix:` / `fix(scope):`           | `fix`                            |
+   | All commits prefixed `refactor:` / `refactor(scope):` | `refactor`                       |
+   | All commits prefixed `chore(deps):` or `chore:`       | `chore`                          |
+   | All commits prefixed `docs:`                          | `docs`                           |
+   | Mixed prefixes or no prefix                           | `mixed` (use the dominant class) |
+
+   For `mixed`, pick the class of the largest commit (by line count).
+
+2. Read `docs/design/CONCERNS.md` and walk the routing table. For each concern, compute whether its `trigger_paths` or `trigger_keywords` match any path in `git diff --name-status`. Track:
+   - `activated_concerns` — list of concern IDs that fired
+   - `activation_reason` — which path or keyword triggered each
+   - `likely_one_way_doors` — copy any concern's `one_way_doors` field if that concern was activated AND the changed files include the one-way-door surface
+
+3. Detect Renovate / Dependabot. If the branch name matches `renovate/` or `dependabot/`, exit early with a one-line draft: `chore(deps): <dep-name> bump to <version>`. Renovate's auto-generated body is fine as-is; do not overwrite.
+
+### Phase 2 — Draft each section
+
+**Summary**:
+
+- One to three sentences for a typical change.
+- Multi-phase / multi-commit features: use a bullet list, one bullet per phase, terse.
+- Lead with the user-facing change ("Sidebar tabs survive the toggle"), not the implementation ("Refactored useTabState").
+
+**What changed**:
+
+- Group by touched subsystem. Use the directory structure as the grouping key: `src/<engine>/`, `src/components/<panel>/`, `pkg/plugin/`, `docs/developer/`, etc.
+- One bullet per subsystem. Link to the canonical entry point if non-obvious (e.g., the engine's `index.ts`).
+- For backend HTTP route changes, name the route explicitly.
+
+**Why**:
+
+- Read the most recent commit body in full. Extract the substantive motivation paragraph.
+- If linked to a GitHub issue (commit body contains `Fixes #NNN` or `Refs #MMM`), read the issue title and add it as context.
+- If neither commit body nor issue gives clear motivation, emit `[FILL IN: motivation]` and let the author finish. **Do not fabricate.**
+- For `fix:` PRs, this section is usually unnecessary — the Summary already explains the problem.
+
+**Test plan**:
+
+- Start with `npm run check` as the always-applicable first checkbox.
+- Add subsystem-specific items based on `activated_concerns`. Examples:
+  - `security` activated → "Manual XSS / sanitization spot check on the new HTML render path"
+  - `coda-terminal` activated → "Manual SSH reconnect smoke test against a Coda VM"
+  - `interactive-engine` activated → "Run an interactive guide end-to-end via `npm run e2e`"
+  - `requirements-manager` activated → "Verify auto-recovery for at least one failed requirement"
+- Add manual reproduction steps for UI work — frame them as numbered steps a reviewer can execute.
+- **Never claim a test has passed.** Checkboxes stay unchecked unless the author runs them and updates manually.
+
+**Risk and reversibility**:
+
+- Include this section only if `likely_one_way_doors` is non-empty, or if the diff touches storage formats, telemetry, public APIs, plugin manifest, or backend HTTP contracts.
+- One paragraph. Flag specific irreversibilities and any mitigation (e.g., "Adding a new optional field to manifest.json; older versions ignore it. Reversible.").
+- For changes where revert would not restore the system (e.g., a one-way data migration), say so plainly.
+
+**Issue refs**:
+
+- Pull `Fixes #NNN` / `Refs #MMM` / `Closes #PPP` markers from commit bodies.
+- Use `Fixes` for resolved bugs (auto-closes the issue on merge), `Refs` for related work, `Closes` for feature issues.
+
+**Generated footer**:
+
+- Always append:
+  ```
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  ```
+- This matches existing repo convention for AI-authored PRs.
+
+### Phase 3 — Render output
+
+1. Compose the body using the canonical structure + variant rules.
+2. Print the suggested title: `<prefix>(<scope>): <title>` in sentence case.
+3. Print the body in a fenced markdown block — agents that consume this skill's output expect a single fenced block, not a free-form report.
+4. After the block, ask: "Apply this to PR #N via `gh pr edit`?" Wait for confirmation before mutating anything.
+
+### Phase 4 — Apply (only on explicit user confirmation)
+
+If the user confirms:
+
+1. Write the body to a temp file: `mktemp` or a known path.
+2. Call:
+
+   ```
+   gh pr edit <number> --title "<suggested-title>" --body-file <tmp>
+   ```
+
+3. Confirm success and print the PR URL.
+
+If the user does not confirm, exit cleanly without side effects.
+
+## Reuses
+
+- `docs/design/CONCERNS.md` — concern routing (16 IDs, trigger_paths, trigger_keywords, one_way_doors).
+- `.cursor/rules/pr-review.md` — reviewer schema for `activated_concerns`, `risk_signals`, `reversibility` (so the draft uses the same vocabulary the reviewer will).
+- `gh` CLI for reading PR metadata and applying edits.
+- Conventional commit prefix parsing — shared with `/changelog`.
+
+## Integration
+
+- **Pairs with `/review`**: this skill drafts, `/review` reviews. Same vocabulary, same concern routing.
+- Authors invoke this skill **after committing** but **before opening / updating** the PR.
+- Can be re-run on an existing PR to refresh the body after new commits land — the apply mode handles this.
+
+## When to exit cleanly without making changes
+
+- Diff is empty (no commits ahead of base) — exit with "No changes to summarize."
+- Branch is a Renovate / Dependabot auto-update — output a one-line draft and exit.
+- The user invokes `--apply` but no PR exists for this branch — exit with "No PR found for this branch. Run `gh pr create` first."
+
+## Context window management
+
+- Phase 0: ~3 short `git` invocations + one `gh pr view`.
+- Phase 1: read `CONCERNS.md` once; match against diff paths in memory.
+- Phase 2: read the most recent commit body in full; otherwise work from in-memory diff stats.
+- Phase 3: render + print.
+- Phase 4 (apply only): write temp file, run one `gh pr edit`.
+
+Total context per run: well under 30k tokens for a typical PR. Multi-phase features may need to read several commit bodies — still bounded.
+
+## Expected invocation patterns
+
+- **Before opening a PR**: author runs `/pr-summary` after their commits are in place, copies the draft into `gh pr create`.
+- **After landing new commits on an open PR**: author runs `/pr-summary --apply` to refresh the description.
+- **During code review**: reviewer runs `/pr-summary` against the same branch to compare what was written vs. what the diff actually does — a "did the description match reality" sanity check.
+
+## Worked example
+
+For a branch with three commits:
+
+```
+abc1234 feat(interactive-engine): add popout step type
+def5678 test(interactive-engine): cover popout in step state machine
+9876fed docs: update interactive-types.md with popout example
+```
+
+Draft output:
+
+````
+Suggested title: feat(interactive-engine): add popout step type
+
+```markdown
+## Summary
+
+Add a `popout` step type to the interactive tutorial system. When a guide step is marked `popout`, the action surface detaches into a floating overlay that survives layout changes, useful for guides that span scrolling regions.
+
+## What changed
+
+- `src/interactive-engine/action-handlers/popout-handler.ts` — new handler for the `popout` action type
+- `src/types/interactive-actions.types.ts` — extends the action union with `PopoutAction`
+- `src/interactive-engine/interactive-state-manager.ts` — handles the popout lifecycle (open / close / focus return)
+- `docs/developer/interactive-examples/interactive-types.md` — documents the new step type with an example
+
+## Why
+
+Guides that span multiple scrolling regions (e.g., side-by-side editor + preview) lose their action overlay when the user scrolls. Popout decouples the overlay from the scroll context so the guide remains anchored to the user's attention rather than the page geometry. Refs #791.
+
+## Test plan
+
+- [ ] `npm run check`
+- [ ] Manual: run a guide containing a `popout` step and verify the overlay survives scrolling
+- [ ] Manual: verify focus returns to the originating element when the popout closes
+
+## Risk and reversibility
+
+Reversible — popout is a new optional action type. Existing guides that don't use it are unaffected. No schema migration; guides that omit the field default to non-popout behavior.
+
+Refs #791
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Apply this to PR #872 via `gh pr edit`?
+````

--- a/.cursor/skills/prevent-doc-drift/SKILL.md
+++ b/.cursor/skills/prevent-doc-drift/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: prevent-doc-drift
+description: Per-PR documentation-drift prevention. When a PR adds new code subsystems, scripts, skills, docs, plugin routes, feature flags, or changes architecture relationships, this skill produces the AGENTS.md, CLAUDE.md, and .cursor/rules/ updates needed in the same PR so agent guidance never falls behind the code. Use this on /review or directly before merge.
+---
+
+# Prevent doc drift
+
+A **per-PR** doc-quality skill. It compares the PR diff against agent guidance files and updates them in the same PR so future agents are never working from a stale map.
+
+This skill is paired with `.cursor/skills/maintain-docs/`:
+
+- **`prevent-doc-drift` (this skill)** — runs on every PR; catches drift at the moment it's introduced.
+- **`maintain-docs`** — runs periodically across the whole repo; catches drift that this skill missed.
+
+Together they form a two-tier defence: the per-PR skill is the primary line, the periodic skill is the safety net.
+
+## Hard constraints
+
+These constraints are absolute and override any other instructions:
+
+1. **Only modify documentation files.** Allowed: `AGENTS.md`, `CLAUDE.md`, `README.md` at repo root; any `*.md` or `*.mdc` under `.cursor/rules/`, `.cursor/skills/`, or `docs/developer/`. **Forbidden**: any source file (`.ts`, `.tsx`, `.js`, `.jsx`, `.go`, `.json`, `.css`, `.html`), config files, lockfiles, and **any file under `docs/design/`** (design docs are author-curated by humans via the `design-review` skill).
+2. **Operate on the PR diff only.** Do not audit files outside the diff. If you find drift in a file the PR did not touch, add it to `docs/_maintenance-backlog.md` for `maintain-docs` to handle — do not silently fix it here.
+3. **Never fabricate.** Only document features, subsystems, services, scripts, and relationships that the diff actually adds. If you cannot confirm something exists from the diff plus a focused code read, omit it.
+4. **Before staging anything, verify the constraint.** Run `git diff --name-only` after edits and confirm every changed path is in the allowed list above. Abort if any disallowed file appears.
+5. **One commit max.** All doc updates land as a single follow-up commit on the same PR branch (or, if invoked from `/review`, as a recommended diff block in the review output — see "Operating modes" below).
+6. **Do not amend the PR's existing commits.** Create a new commit.
+
+## Operating modes
+
+The skill has two modes:
+
+- **Apply mode** (default when invoked directly): the working tree is the PR branch. Apply edits, stage, commit with a clear message, push.
+- **Review mode** (invoked from `/review`): output a single fenced patch block per file with the proposed edits. Do not modify the working tree. The reviewer agent embeds these in the review comment so the author can apply them.
+
+Decide which mode applies based on context: if a `gh pr` command can determine the current branch is a PR branch and the user invoked this skill directly, use apply mode. If the parent is `/review`, use review mode.
+
+## Workflow
+
+### Phase 0 — Resolve the diff
+
+1. Determine the base ref:
+   - If on a PR branch: `gh pr view --json baseRefName -q .baseRefName`
+   - Otherwise: `git merge-base HEAD main` (or whatever the repo's main branch is — check `git symbolic-ref refs/remotes/origin/HEAD`).
+2. Capture the diff in three forms — you'll use each:
+   - `git diff --name-status <base>...HEAD` (status flags A / M / D / R)
+   - `git diff --stat <base>...HEAD` (line counts)
+   - `git log <base>..HEAD --oneline` (commit subjects)
+3. From `package.json`, read the current set of npm scripts: `jq -r '.scripts | keys[]' package.json` (you'll diff this against the table in AGENTS.md).
+
+If the diff is empty or doc-only, exit cleanly with "no source changes — no drift possible."
+
+### Phase 1 — Categorize changes
+
+Walk the name-status output and bucket each path into one of these categories. A single file may land in multiple buckets; that's fine.
+
+| Bucket                             | Matches (path patterns)                                                                                 |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **New frontend subsystem**         | New directory at `src/<dir>/` (any first commit of a path matching `src/<name>/...`)                    |
+| **New backend file**               | New file at `pkg/**/*.go`                                                                               |
+| **New developer doc**              | New file at `docs/developer/**/*.md`                                                                    |
+| **New design doc**                 | New file at `docs/design/**/*.md` (we index it; we do **not** edit it)                                  |
+| **New rule**                       | New file at `.cursor/rules/*.mdc` or `.cursor/rules/*.md`                                               |
+| **New skill**                      | New directory at `.cursor/skills/<name>/` (look for new `SKILL.md`)                                     |
+| **New npm script**                 | Diff of `package.json` adds a key under `.scripts`                                                      |
+| **New plugin HTTP route**          | Diff of `pkg/plugin/resources.go` adds a `mux.Handle(...)` or `mux.HandleFunc(...)` call                |
+| **New plugin stream message type** | Diff of `pkg/plugin/stream.go` or `pkg/plugin/terminal.go` adds a new `TerminalStreamOutput.Type` value |
+| **New feature flag**               | Diff of `src/utils/openfeature.ts` or related adds a flag name                                          |
+| **New `data-test-*` attribute**    | Diff adds a new test-id constant in `src/constants/testIds.ts` or sets a new `data-test-*` literal      |
+| **Renamed / moved subsystem**      | Name-status `R<percent>` entries that change a `src/<dir>/` or `pkg/plugin/<file>` path                 |
+| **Removed subsystem**              | Name-status `D` entries that empty out a `src/<dir>/` or `pkg/plugin/<file>` path                       |
+| **Tier rule edit**                 | Diff of `src/validation/architecture.test.ts` or relevant ESLint config changes                         |
+
+For each match, capture the path(s), surrounding diff context, and one-sentence summary of what the change does (read up to ~30 lines of the new file or the diff hunk if needed).
+
+### Phase 2 — Detect required doc updates
+
+For each bucket with hits, consult the rules table below. Each rule lists the target doc file(s) and exactly what edit is required.
+
+| Bucket                                              | Target file(s)                                          | Required edit                                                                                                                                                                                                                        |
+| --------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| New frontend subsystem                              | `AGENTS.md`                                             | Add a row to the `src/` tree in "Code organization" with a one-line description. If Tier 1 (engine/provider), add to the tier list in "Subsystem tiers and key relationships" and consider adding an edge to "Key dependency edges". |
+| New frontend subsystem                              | `.cursor/rules/systemPatterns.mdc`                      | Add a one-paragraph entry in "Frontend subsystem reference" (purpose, entry point, tier).                                                                                                                                            |
+| New backend file                                    | `AGENTS.md`                                             | Add a row to the `pkg/` tree in "Code organization" with a one-line description.                                                                                                                                                     |
+| New developer doc                                   | `AGENTS.md`                                             | Add a row to the "On-demand context" table — file path, when-to-load description, glob trigger if applicable.                                                                                                                        |
+| New developer doc with `.cursor/rules/` counterpart | `.cursor/rules/<counterpart>.mdc`                       | Add a "For full reference, see `docs/developer/<file>.md`" link near the top of the rule file.                                                                                                                                       |
+| New design doc                                      | `AGENTS.md`                                             | Add a row to "On-demand context" with the note "Design intent (may not match implementation)" in the description.                                                                                                                    |
+| New rule                                            | `AGENTS.md`                                             | Add a row to "On-demand context" with glob trigger from the rule's frontmatter. If the rule has `alwaysApply: true` or always-on globs, also add an entry to the "Tiered rule architecture" section under "PR reviews".              |
+| New skill                                           | `CLAUDE.md`                                             | Add a row to the skills table — name, trigger, one-line purpose.                                                                                                                                                                     |
+| New skill                                           | `AGENTS.md`                                             | Add a row to "On-demand context" pointing at `.cursor/skills/<name>/SKILL.md`.                                                                                                                                                       |
+| New npm script                                      | `AGENTS.md`                                             | Add to the appropriate sub-section under "Local development commands". Group with related scripts (build, test, validate, dev-tools).                                                                                                |
+| New plugin HTTP route                               | `AGENTS.md`                                             | Add the route to the "HTTP resource API" bullet under "Backend request paths". Include method + path + one-line purpose.                                                                                                             |
+| New plugin stream message type                      | `AGENTS.md`                                             | Add the type to the "Stream message types" bullet under "Backend request paths".                                                                                                                                                     |
+| New plugin stream message type                      | `.cursor/rules/systemPatterns.mdc`                      | Add to the "Stream message types" bullet under "Backend architecture (pkg/)".                                                                                                                                                        |
+| New feature flag                                    | `docs/developer/FEATURE_FLAGS.md`                       | Add the flag — name, type, default, what it controls.                                                                                                                                                                                |
+| New `data-test-*` attribute                         | `docs/developer/E2E_TESTING_CONTRACT.md`                | Add the new selector to the relevant section.                                                                                                                                                                                        |
+| Renamed / moved subsystem                           | All doc files                                           | `grep -lr <old-path> AGENTS.md CLAUDE.md .cursor/rules/ docs/developer/` and rewrite each occurrence to the new path.                                                                                                                |
+| Removed subsystem                                   | `AGENTS.md`, `.cursor/rules/systemPatterns.mdc`, others | Remove the corresponding rows / paragraphs. If the removed feature represents an epic-scale change, recommend (in the PR description) a follow-up note in `docs/history/`.                                                           |
+| Tier rule edit                                      | `AGENTS.md`, `.cursor/rules/systemPatterns.mdc`         | If the architecture allowlist changed, update the tier model description to reflect the new exception with one sentence of justification.                                                                                            |
+
+**Sources of truth for the rules table**: when in doubt, prefer the code over any doc. If a rule says "add a row to the `src/` tree" but the tree is already accurate (because the contributor pre-emptively updated it), do nothing — log "no edit needed" and move on.
+
+### Phase 3 — Generate the edits
+
+For each required edit:
+
+1. Read the target file's current content (or the relevant section).
+2. Compose the minimal change needed — a new row, a new bullet, a new paragraph. **Match the surrounding format exactly**: column alignment in markdown tables, sentence case per the project's writing style (see AGENTS.md), backtick conventions for code identifiers.
+3. **Sentence case**: capitalize only the first word and proper nouns (Grafana, Loki, Prometheus, Tempo, Mimir, Alloy, Grafana Cloud, etc.). Never title case for headings, button labels, or table cells.
+4. **No emojis** unless the existing file already uses them.
+5. Avoid touching unrelated lines. Surgical edits only.
+
+If multiple rules target the same file (e.g., several new scripts), batch their edits into one Edit operation when possible.
+
+### Phase 4 — Apply or report
+
+**Apply mode:**
+
+1. Make the edits via `Edit` / `Write`.
+2. Run `git diff --name-only` and confirm every changed path is in the allowed list (per hard constraint #4). Abort and revert if not.
+3. Run `npm run prettier` to format markdown.
+4. Run `git diff --name-only` again after prettier; verify only doc files changed.
+5. Stage the changed doc files (do not use `git add -A`; stage by explicit path).
+6. Commit with a clear message:
+
+   ```
+   docs: keep agent guidance in sync with this PR's changes
+
+   - <one bullet per change>
+
+   Generated by .cursor/skills/prevent-doc-drift.
+   ```
+
+7. Do **not** push or open a separate PR — this commit rides the existing PR branch.
+8. Report a summary back to the user: which buckets were detected, which doc files were updated, line counts.
+
+**Review mode** (invoked from `/review`):
+
+Output a single section the reviewer can paste into the PR comment:
+
+```
+## Doc-drift updates recommended
+
+The following changes introduce new <bucket>, which require updates to agent guidance. Apply these diffs to keep the docs in sync:
+
+### AGENTS.md
+\`\`\`diff
+<unified diff>
+\`\`\`
+
+### CLAUDE.md
+\`\`\`diff
+<unified diff>
+\`\`\`
+
+(... per target file ...)
+```
+
+Do not modify the working tree in review mode.
+
+### Phase 5 — Backlog handoff
+
+If you detect drift the skill cannot fix (because it's outside the diff, or the change is too large for incremental editing), append to `docs/_maintenance-backlog.md` under "Work items":
+
+```
+- YYYY-MM-DD: <one-line description>. Rationale: <why prevent-doc-drift deferred>.
+```
+
+This hands the issue off to `maintain-docs` on its next run.
+
+## Detection heuristics (deeper guidance)
+
+### Detecting a "new frontend subsystem"
+
+A directory under `src/<name>/` is a subsystem if **any** of the following hold:
+
+- It has its own `index.ts` barrel export
+- It is referenced in `AGENTS.md`'s "Code organization" list (existing subsystems)
+- It contains a `README.md`
+- It is imported from at least two other `src/<other>/` directories
+
+If the diff only adds files _inside_ an existing subsystem, this is not a "new subsystem" — it's an internal addition. Decide based on the directory structure, not the file count.
+
+### Detecting whether a new subsystem is Tier 1
+
+Tier-1 markers (engines/providers):
+
+- The name contains `-engine`, `-manager`, `recovery`, or a similarly load-bearing identifier
+- It exports a service class or a hook that other subsystems depend on
+- It is imported by `components/`
+
+Tier-3 markers (support utilities):
+
+- Imports only `types/`, `constants/`, and possibly `lib/`
+- Provides utility functions, not orchestration
+- Not imported by `components/` directly (or imported only as a low-level helper)
+
+When uncertain, default to Tier 3 — over-promotion is harder to roll back than under-promotion.
+
+### Detecting renames in the diff
+
+`git diff --name-status` shows renames as `R<percent>` followed by old-path and new-path, e.g. `R98 src/old-engine/foo.ts src/new-engine/foo.ts`. Treat any rename with similarity ≥ 75 as a true rename worth propagating to docs.
+
+### Sentence-case checking
+
+Before committing, scan your edits for title-case violations:
+
+- Headings: only the first word capitalized (plus proper nouns)
+- Table cells: same rule
+- Description text: same rule
+
+The repo follows the [Grafana Writers' Toolkit](https://grafana.com/docs/writers-toolkit/write/style-guide/capitalization-punctuation/#capitalization). Proper nouns to capitalize: Grafana, Loki, Prometheus, Tempo, Mimir, Alloy, Grafana Cloud, Grafana Enterprise, Grafana Labs. Generic terms stay lowercase: dashboard, alert, data source, panel, query, plugin.
+
+## When to exit cleanly without making changes
+
+- The diff is doc-only (no source changes).
+- The diff contains only test-only changes, lint cleanups, dependency bumps, or version bumps — none introduce features.
+- The contributor pre-emptively updated the docs and the audit produces no required edits.
+
+In each case, report briefly: "No drift detected — exiting cleanly."
+
+## When to NOT run this skill
+
+- Branches that are not PR branches (running on `main` directly).
+- PRs that explicitly bypass the doc-drift contract (e.g., emergency hotfixes labelled `hotfix-no-docs` or similar). If the PR has such a label, exit cleanly with a note.
+- When the user has explicitly asked for source-code-only changes — in which case any doc edits are out of scope.
+
+## Integration with `/review`
+
+When `/review` runs, after the routed reviewers have produced their findings, invoke this skill in **review mode** to attach a "Doc-drift updates recommended" section. The reviewer agent should include the section verbatim in the review output. The PR author can then apply the diffs themselves or invoke this skill in apply mode to commit them.
+
+## Examples
+
+### Example 1: PR adds a new engine
+
+PR diff includes:
+
+```
+A  src/recommendation-cache/index.ts
+A  src/recommendation-cache/cache.ts
+A  src/recommendation-cache/cache.test.ts
+M  src/context-engine/context.service.ts  (imports new cache)
+```
+
+Detected buckets: **New frontend subsystem**.
+
+Detected updates:
+
+- `AGENTS.md` "Code organization" — add `recommendation-cache/` row to the `src/` tree
+- `AGENTS.md` "Subsystem tiers and key relationships" — add `recommendation-cache` to the Tier-1 list, add edge `context-engine` → `recommendation-cache` to the dependency table
+- `.cursor/rules/systemPatterns.mdc` "Frontend subsystem reference" — add a paragraph entry
+
+### Example 2: PR adds a new npm script and feature flag
+
+PR diff includes:
+
+```
+M  package.json                     (+ "validate:e2e": "...")
+M  src/utils/openfeature.ts          (+ "useNewRecommender" flag)
+```
+
+Detected buckets: **New npm script**, **New feature flag**.
+
+Detected updates:
+
+- `AGENTS.md` "Local development commands → Guide authoring and validation" — add `npm run validate:e2e` with one-line description
+- `docs/developer/FEATURE_FLAGS.md` — add `useNewRecommender` to the flag table
+
+### Example 3: PR adds a new plugin HTTP route
+
+PR diff includes:
+
+```
+M  pkg/plugin/resources.go          (+ mux.HandleFunc("/sessions", a.handleSessions))
+M  pkg/plugin/sessions.go           (new file)
+```
+
+Detected buckets: **New backend file**, **New plugin HTTP route**.
+
+Detected updates:
+
+- `AGENTS.md` "Code organization → Backend (pkg/)" — add `sessions.go` to the `plugin/` tree with one-line description
+- `AGENTS.md` "Backend request paths → HTTP resource API" — add `POST /sessions` (or appropriate method) to the bulleted route list
+
+### Example 4: contributor already updated docs
+
+PR diff includes a new subsystem **and** the corresponding rows in `AGENTS.md` and `.cursor/rules/systemPatterns.mdc`.
+
+The skill detects the new subsystem (Phase 1), runs the rules (Phase 2), then in Phase 3 reads each target file and finds the rows already present. It logs "no edit needed" for each and exits cleanly in Phase 4.
+
+## Context window management
+
+This skill stays small intentionally:
+
+- Phase 0 reads only the diff (one `gh` / `git` invocation each).
+- Phase 1 categorizes from the diff without reading full file contents (~30 lines max per new file).
+- Phase 2 reads only the target doc sections that need editing — never the whole file unless < 100 lines.
+- Phase 3 makes surgical edits via `Edit` (not `Write`).
+- Phase 4 runs prettier and verifies the changed-file list, then commits.
+
+Total context budget per run: under 30k tokens for a typical PR. Larger PRs may exceed this — in that case, prioritize: (1) new subsystems, (2) new docs, (3) new scripts, (4) everything else.

--- a/.cursor/skills/release-prep/SKILL.md
+++ b/.cursor/skills/release-prep/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: release-prep
+description: Orchestrate the pre-release flow for grafana-pathfinder-app — bump the version in package.json, draft a CHANGELOG entry (via the `changelog` skill), run `npm run check` and `npm run build`, then print the exact `git tag` command for the user to execute. Never creates or pushes the tag itself; tagging is a one-way door the user owns.
+---
+
+# Release prep
+
+Pre-release orchestrator. Handles the safe, reversible parts of cutting a release (version bump, changelog, validation) and stops short of the irreversible step (tag push) so the user reviews everything before the GitHub release workflow fires.
+
+This skill pairs with `.cursor/skills/changelog/SKILL.md`, which drafts the actual CHANGELOG entry. `release-prep` is the wrapper that runs `changelog` plus the surrounding validation.
+
+## Hard constraints
+
+These constraints are absolute and override any other instructions:
+
+1. **Never create or push the git tag.** Print the exact command for the user to run. The user controls the moment of release.
+2. **Never push commits.** Stay on the local branch.
+3. **`npm run check` must pass before claiming "ready".** If it fails, abort with the failure log and stop. Do not "fix-up and retry" — a failing check is real signal.
+4. **Only edit `package.json` (version bump) and `CHANGELOG.md`** (via the `changelog` skill). No other files.
+5. **If the proposed tag already exists**, abort.
+6. **If the working tree is dirty**, abort with `git status` output. Don't try to be clever about which dirt is safe.
+7. **One commit.** Title: `chore: prep v<version> release`. Contains the version bump + CHANGELOG draft.
+
+## Workflow
+
+### Phase 0 — Preconditions
+
+Verify the environment is safe to proceed:
+
+1. **Clean working tree**:
+
+   ```
+   git status --short
+   ```
+
+   Must be empty. Abort otherwise.
+
+2. **On main branch** (or a release branch — warn but allow):
+
+   ```
+   git branch --show-current
+   ```
+
+   Default expectation: `main`. If on another branch, warn the user — they may be cutting from a release branch intentionally, which is fine, but they should confirm.
+
+3. **In sync with origin**:
+
+   ```
+   git fetch origin
+   git log HEAD..origin/main --oneline
+   ```
+
+   Must be empty (no upstream commits we don't have). Otherwise abort with "Branch is behind origin/main by N commits. Pull first."
+
+4. **Capture the last tag**:
+
+   ```
+   git tag --sort=-v:refname | head -1
+   ```
+
+   Format `v<SemVer>`. If no tags exist, abort with "No prior release tag found. First release must be done manually."
+
+### Phase 1 — Resolve target version
+
+If the user passed `/release-prep <version>`, use it. Otherwise suggest one.
+
+**Version arg validation:**
+
+- Must be valid semver: `\d+\.\d+\.\d+` (no pre-release suffixes — the repo uses none).
+- Must be strictly greater than the last tag (no regressions).
+- Tag `v<version>` must not already exist: `git tag -l v<version>` returns nothing.
+
+**Auto-suggestion** (when no arg given):
+
+Invoke the `changelog` skill's Phase 1 + Phase 2 logic to count categories since the last tag, then suggest:
+
+- Any breaking change → major bump (`X.0.0`)
+- Any feat → minor bump (`X.Y.0`, reset patch to 0)
+- Else → patch bump (`X.Y.Z+1`)
+
+Print the suggestion and **wait for user confirmation** in the same turn before proceeding. Example:
+
+```
+Last release: v2.10.0
+Since then: 3 feat, 7 fix, 5 chore, 0 breaking
+Suggested: v2.11.0 (minor bump)
+
+Reply with the version to proceed, or override with a different one.
+```
+
+### Phase 2 — Bump version
+
+1. Read `package.json`. Locate the `"version"` field.
+2. Replace the value with the target version (no `v` prefix in `package.json` — just `"2.11.0"`).
+3. Run `npm run prettier` on `package.json` to keep formatting canonical.
+
+**Do not stage or commit yet** — combine with the CHANGELOG draft into one commit at the end of Phase 3.
+
+### Phase 3 — Draft CHANGELOG
+
+Invoke the `changelog` skill (or replicate its Phase 1-3 inline if the skill is unavailable). Pass the target version explicitly.
+
+When the `changelog` skill is invoked from `release-prep`, override its Phase 3 commit step:
+
+- The `changelog` skill normally commits with `chore: changelog for v<version>`.
+- When called as a sub-step of `release-prep`, **skip the commit** so we can combine `package.json` + `CHANGELOG.md` into one atomic release-prep commit.
+- Surface this expectation to the user in the run output: "CHANGELOG drafted in-tree but not yet committed; combining with version bump."
+
+### Phase 4 — Validate
+
+1. **Run `npm run check`** — the canonical pre-merge gate:
+
+   ```
+   npm run check
+   ```
+
+   This runs (per `package.json`): typecheck + lint + prettier-test + docs:sync-terms:check + lint:go + test:go + test:ci. If any step fails, **abort**. Print the failure log verbatim. Do not commit. Do not retry.
+
+2. **Run `npm run build`** — confirm the production bundle still builds:
+
+   ```
+   npm run build
+   ```
+
+   Failure here is rare but blocking. Abort if it fails.
+
+3. **Skip plugin signing.** Per `docs/developer/RELEASE_PROCESS.md`, signing is currently disabled (would require `policy_token` in repo secrets). If signing is re-enabled later, this skill should be updated to run `npm run sign` here.
+
+### Phase 5 — Commit and hand off
+
+1. Verify only the expected files changed:
+
+   ```
+   git diff --name-only
+   ```
+
+   Must be exactly:
+
+   ```
+   CHANGELOG.md
+   package.json
+   ```
+
+   If anything else appears, abort. The skill should never modify other files.
+
+2. **Commit** (do not push):
+
+   ```
+   git add CHANGELOG.md package.json
+   git commit -m "chore: prep v<version> release"
+   ```
+
+3. **Print the release summary**:
+
+   ```
+   Ready to release v<version>.
+
+   Previous: v<last-version>
+   Included: <N> PRs (<X> added, <Y> fixed, <Z> chore)
+
+   To cut the release, run:
+
+     git push origin main
+     git tag -a v<version> -m "Release v<version>"
+     git push origin v<version>
+
+   The `release.yml` workflow triggers on `v*` tag push and creates the GitHub release.
+   ```
+
+   Order matters: push the commit first so the tag points at an upstream-known SHA, then tag, then push the tag. Confirm this order with the user if they're unfamiliar.
+
+## Reuses
+
+- `.cursor/skills/changelog/SKILL.md` — drafts the changelog entry. Run as a sub-skill.
+- `npm run check` — single command for the pre-merge gate. Defined in `package.json`.
+- `npm run build` — production build verification.
+- `docs/developer/RELEASE_PROCESS.md` — canonical release reference. If this skill diverges from that doc, update the doc.
+
+## Integration
+
+- Invoked manually by the maintainer before each release.
+- Pairs with `release.yml` GitHub workflow (which fires on `v*` tag push) — the skill ends where the workflow begins.
+- Pairs with `/changelog` — release-prep calls it as a sub-step.
+
+## Abort conditions
+
+The skill must abort cleanly (no partial state, no commits) if any of these are true:
+
+| Condition                                     | Reason                                                    |
+| --------------------------------------------- | --------------------------------------------------------- |
+| Working tree dirty                            | Cannot reason about what state is being released          |
+| Branch behind origin                          | Upstream commits would be missing from the release        |
+| Tag `v<version>` already exists               | Cannot reuse a tag; double-tagging breaks GitHub releases |
+| Version is not strictly > last tag            | Regression — semver violation                             |
+| `npm run check` fails                         | Test suite or lint catches a real problem                 |
+| `npm run build` fails                         | Production bundle is broken                               |
+| `git diff --name-only` shows unexpected paths | Skill must only touch package.json + CHANGELOG.md         |
+
+When aborting, print the failure reason clearly and (where applicable) the exact log line that triggered the abort. Do not leave partial commits behind.
+
+## Context window management
+
+- Phase 0: a handful of `git` invocations; minimal context.
+- Phase 1: optional sub-invocation of `changelog` Phase 1-2 logic (PR list summary).
+- Phase 2: small edit to `package.json` via `Edit`.
+- Phase 3: delegate to `changelog` skill — its own context budget.
+- Phase 4: stream `npm run check` and `npm run build` output; on success, summarize; on failure, surface the relevant log lines.
+- Phase 5: one commit + report.
+
+Total context per run: under 30k tokens for a typical release. Pull `npm run check` into the conversation lazily — only surface failing lines, not the whole pass log.
+
+## Expected invocation patterns
+
+- **Routine release**: maintainer runs `/release-prep <version>` (or `/release-prep` for an auto-suggested version) before each release window.
+- **Sprint review**: maintainer runs `/release-prep` without confirming, captures the category counts + suggested version, and uses that to communicate scope. Then reverts the local changes and reruns once the release window is open.
+- **Post-incident hotfix**: maintainer runs `/release-prep <patch-version>` for an urgent fix. The skill enforces the same gates (`npm run check` must pass) without bypass.
+
+## What this skill does NOT do
+
+- Push commits or tags
+- Sign the plugin (disabled per RELEASE_PROCESS.md)
+- Run E2E tests (`npm run e2e` is not part of `npm run check`; if needed, the user runs it separately)
+- Coordinate cross-repo releases (e.g., `grafana-recommender`) — out of scope
+- Edit `docs/sources/` user-facing docs — those follow a different update cadence
+- Bump dependencies — `chore(deps)` PRs are independent of release prep
+
+## Worked example
+
+```
+> /release-prep
+
+Last release: v2.10.0 (2026-04-15)
+Since then: 3 feat, 7 fix, 5 chore, 0 breaking, 0 security
+Suggested: v2.11.0 (minor bump)
+
+Reply with the version to proceed.
+
+> 2.11.0
+
+✓ Working tree clean
+✓ On main, in sync with origin
+✓ No existing v2.11.0 tag
+✓ package.json bumped to 2.11.0
+✓ CHANGELOG drafted (3 added, 7 fixed, 5 chore)
+✓ npm run check (132 suites, 2511 tests, all passing)
+✓ npm run build (bundle produced)
+✓ Committed: chore: prep v2.11.0 release
+
+Ready to release v2.11.0.
+
+To cut the release, run:
+
+  git push origin main
+  git tag -a v2.11.0 -m "Release v2.11.0"
+  git push origin v2.11.0
+
+The `release.yml` workflow triggers on `v*` tag push and creates the GitHub release.
+```

--- a/.cursor/skills/secure/SKILL.md
+++ b/.cursor/skills/secure/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: secure
+description: Security audit — frontend (F1-F6 rules from `.cursor/rules/frontend-security.mdc`), Go backend (URL allowlists, token handling, hardcoded secrets, unbounded reads), MCP HTTP transport (size / wallclock / concurrency caps, Zod-validated tool inputs), and dependency audit (`npm audit` high+critical, Go module advisories). Reports findings with concrete remediation per rule. Never edits source — the user applies fixes.
+---
+
+# Security audit
+
+Skillifies the `/secure` slash-command label in `CLAUDE.md` with a real workflow. Audits the current working tree or a PR diff against the repo's canonical security rules, the backend's allowlist contracts, the MCP transport mitigations, and dependency advisories. Emits a severity-ordered findings list with concrete remediation. Never touches source — the security analyst applies fixes, not the skill.
+
+This skill complements:
+
+- **`prevent-doc-drift`** — catches missing docs for new security patterns.
+- **`/review`** — invokes this skill as a security pass when the `security` concern from `docs/design/CONCERNS.md` is activated.
+
+## Hard constraints
+
+These constraints are absolute and override any other instructions:
+
+1. **Never edit source files.** This skill is report-only. The reviewer applies fixes.
+2. **`[security]` is reserved for clear violations** — F1-F6 hits, backend allowlist bypasses, token leaks, or known CVEs. Speculative or theoretical risks use `[suggestion]` or `[question]` from the standard prefix table in `.cursor/rules/pr-review.md`. **False positives erode trust; prefer false negatives.**
+3. **Ground every F1-F6 finding** in `.cursor/rules/frontend-security.mdc`. Quote the rule ID and the canonical Do / Don't example when reporting.
+4. **For backend findings, quote the offending line** with `file:line` reference and the canonical pattern (e.g., `isAllowedCodaURL`, `IsAllowedRelayURL`, `setAuthHeader`).
+5. **Sentence case** for findings and remediation text.
+6. **Reads only.** No `gh pr edit`, no `git commit`, no file writes.
+
+## Workflow
+
+### Phase 0 — Scope
+
+Determine the target:
+
+- **PR-branch mode** (default when on a non-main branch): audit `git diff <base>...HEAD`.
+
+  ```
+  base=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo main)
+  git diff --name-only $base...HEAD
+  ```
+
+- **Working-tree mode** (when invoked on main or with uncommitted changes): audit modified + new files in `git status`.
+
+- **Full-tree mode** (when invoked with `/secure --full`): audit the whole repo. Slow but comprehensive. Use sparingly.
+
+Capture the list of files to audit; bucket by type:
+
+- `.ts`, `.tsx`, `.js`, `.jsx` → frontend audit (Phase 1)
+- `.go` under `pkg/**` → backend audit (Phase 2)
+- `src/cli/mcp/**` → MCP transport audit (Phase 3)
+- Always run Phase 4 (deps audit) regardless of touched files
+
+### Phase 1 — Frontend audit (F1-F6)
+
+For each `.ts` / `.tsx` / `.js` / `.jsx` file in scope, read the changed hunks and apply the detection table from `.cursor/rules/frontend-security.mdc`:
+
+| ID  | What to detect                                                                                                                      | Severity |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| F1  | Untrusted / dynamic SVG passed to `dangerouslySetInnerHTML` without `DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } })`      | Critical |
+| F2  | `dangerouslySetInnerHTML` used where `{}` auto-escape would do                                                                      | High     |
+| F3  | URL built via string concat (`apiBase + '/users?id=' + userId`) instead of `new URL()` + `URL.searchParams.set()`                   | High     |
+| F4  | `dangerouslySetInnerHTML` without `textUtil.sanitize()` (or `sanitizeDocumentationHTML()` from `src/security/`)                     | Critical |
+| F5  | Any of `.innerHTML`, `.outerHTML`, `.insertAdjacentHTML`                                                                            | Critical |
+| F6  | URL passed to `href` / `src` without `textUtil.sanitizeUrl()` or a scheme-allowlist check (`parseUrlSafely`, `isAllowedContentUrl`) | High     |
+
+**Detection rules:**
+
+- For F1 / F4: a match must combine `dangerouslySetInnerHTML` with a dynamic value. Static strings are fine. Check the source of the `__html` field — if it traces to a constant, skip.
+- For F3: only flag when the URL contains a user-controlled segment. URLs built entirely from constants are not findings.
+- For F5: any occurrence is a finding. The repo's canonical safe APIs are `document.createElement`, `element.textContent`, `element.setAttribute`.
+- For F6: scheme allowlist must reject `javascript:`, `data:`, and `vbscript:`. The repo's canonical helpers are in `src/security/url-validator.ts`.
+
+**Report each finding** with:
+
+- `[security][F<N>]` prefix
+- `file:line` reference
+- Quoted offending code (one line preferred; up to three for context)
+- Sentence-case description of the risk
+- Remediation: name the specific API to use, with the import path
+
+Example:
+
+```
+[security][F5] src/components/Foo.tsx:42 — Direct innerHTML assignment.
+
+  element.innerHTML = `<span>${userName}</span>`;
+
+Risk: XSS — `userName` is user-controlled and bypasses React's auto-escape.
+Remediation: use `element.textContent = userName` or render via JSX `<span>{userName}</span>`.
+See F5 in `.cursor/rules/frontend-security.mdc`.
+```
+
+### Phase 2 — Backend audit (`pkg/**`)
+
+For each `*.go` file in `pkg/` that the diff touches, check for:
+
+**B1. Allowlist bypass** (severity: Critical)
+
+- Any new HTTP request to an external URL that does not pass `isAllowedCodaURL`, `IsAllowedRelayURL`, or the equivalent host-allowlist check.
+- The canonical functions live in `pkg/plugin/resources.go` (`isAllowedCodaURL`, `isAllowedHost`, `IsAllowedRelayURL`) and `pkg/plugin/package_recommendations.go` (`allowedPackageRepositoryHosts`).
+- Remediation: route the URL through the existing allowlist function or extend the allowlist with a documented justification.
+
+**B2. JWT bearer without refresh** (severity: High)
+
+- Any new HTTP call using a JWT bearer that does not call `CodaClient.setAuthHeader` (which handles token refresh) or that hardcodes a token.
+- Remediation: route through `setAuthHeader(ctx, req)` per the pattern in `pkg/plugin/coda.go`.
+
+**B3. Hardcoded secrets** (severity: Critical)
+
+- Regex-match for: `Bearer\s+[A-Za-z0-9._-]{20,}` in source (not comments), `password\s*=\s*"[^"]{4,}"`, `token\s*=\s*"[^"]{20,}"`, and `secret\s*=\s*"[^"]{8,}"`.
+- Skip test fixtures (`*_test.go`) that intentionally use stub values.
+- Remediation: move to `pkg/plugin/settings.go` and decrypt via `SecureJSONData`.
+
+**B4. Unbounded payload reads** (severity: Medium)
+
+- `io.ReadAll(req.Body)` without a `http.MaxBytesReader` wrap on the request body.
+- Remediation: `req.Body = http.MaxBytesReader(w, req.Body, <limit>)` before reading.
+
+**B5. Path-traversal in resource handlers** (severity: High)
+
+- Any `path.Join` or string concat that incorporates a user-controlled segment into a filesystem path.
+- Remediation: validate the segment against an allowlist and prefer `filepath.Clean` + boundary check.
+
+**Quote each finding** with `file:line` and the canonical pattern reference.
+
+### Phase 3 — MCP transport audit
+
+If the diff touches `src/cli/mcp/**`, verify:
+
+**M1. New HTTP transport code includes the existing safety caps** (severity: High)
+
+- `MAX_REQUEST_BYTES` (1 MB body cap)
+- `PER_CALL_WALLCLOCK_MS` (30 s per-call timeout)
+- `MAX_CONCURRENT_REQUESTS` (100 cap → 503 over)
+- `KEEPALIVE_TIMEOUT_MS`, `HEADERS_TIMEOUT_MS`, `REQUEST_TIMEOUT_MS` (slowloris mitigations)
+
+Reference: `src/cli/mcp/transports/http.ts`. If a new transport surface lacks these, flag.
+
+**M2. Tool inputs validated via Zod** (severity: High)
+
+- Every new MCP tool must declare its input shape via a Zod schema rather than `unknown` / `Record<string, unknown>`.
+- Remediation: define a `z.object({...})` schema and parse with `.safeParse()` at the tool boundary.
+
+**M3. User content quoted, not interpolated** (severity: High)
+
+- If a tool emits a prompt or LLM-bound payload that includes user-supplied text, the text must be quoted (fenced block, XML tag, JSON value) — not interpolated bare into a free-form sentence.
+- Remediation: wrap user content in fenced markdown blocks or JSON values per the patterns in `docs/design/MCP-AGENT-UX-HARDENING.md`.
+
+**M4. State-mutating tools require confirmation** (severity: High)
+
+- New tools that mutate persistent state (publish, write, delete) must signal to the caller that confirmation is needed — per the `confirmationPrompt` and `clientGuidance` model in `docs/design/CLIENT-ORCHESTRATION-GUIDE.md` and `docs/design/APP-PLATFORM-PUBLISH-HANDOFF.md`.
+- Read-only tools (list, get, schema) are exempt.
+
+### Phase 4 — Dependency audit
+
+Always run:
+
+1. **`npm audit`** for production deps:
+
+   ```
+   npm audit --omit=dev --json 2>&1
+   ```
+
+   - Surface only **high** and **critical** advisories. Moderate / low are informational only.
+   - For each, print: advisory ID, affected package + version range, severity, "fixable via `npm audit fix`" indicator.
+
+2. **Go modules**:
+
+   ```
+   cd pkg && go list -m -json -u all 2>&1 | head -40
+   ```
+
+   - List modules that have an `Update` field (i.e., a newer version is available).
+   - Note any module name that matches the GOVULN database conventions (e.g., listed in `golang.org/x/vuln`). The skill does not run `govulncheck` automatically — note "run `govulncheck ./...` for authoritative scan" in the report.
+
+3. **Dev-only deps** (`npm audit` without `--omit=dev`) are informational. Report total counts but do not flag as blocking.
+
+### Phase 5 — Report
+
+Group findings by severity. Print in this order:
+
+```
+## Security audit — <date>
+
+Target: <scope description, e.g., "PR diff against main, 12 files">
+
+### Critical (N)
+
+- [security][F5] src/components/Foo.tsx:42 — Direct innerHTML assignment. ...
+- [security][B3] pkg/plugin/internal.go:18 — Hardcoded bearer token. ...
+
+### High (N)
+
+- ...
+
+### Medium (N)
+
+- ...
+
+### Low / Informational (N)
+
+- ...
+
+### Disposition
+
+<one line: clean | minor | blocking>
+
+<if blocking: "Do not merge until critical / high findings are addressed.">
+```
+
+**Disposition rules:**
+
+- `clean` — zero findings of medium or higher severity.
+- `minor` — at most medium findings; no critical or high.
+- `blocking` — at least one critical or high finding.
+
+Print a per-finding summary table at the end:
+
+```
+| ID  | Count |
+| --- | ----- |
+| F1  | 0     |
+| F2  | 1     |
+| ... | ...   |
+```
+
+This helps the reviewer scan the surface quickly.
+
+## Reuses
+
+- `.cursor/rules/frontend-security.mdc` — F1-F6 canonical rules and Do / Don't examples.
+- `src/security/` — canonical sanitization APIs (`parseUrlSafely`, `sanitizeDocumentationHTML`, `validateTutorialUrl`, etc.).
+- `pkg/plugin/resources.go` — backend allowlist functions.
+- `pkg/plugin/coda.go` — token refresh + auth header pattern.
+- `pkg/plugin/package_recommendations.go` — bounded memory + allowlist pattern.
+- `src/cli/mcp/transports/http.ts` — MCP HTTP transport safety caps.
+- `docs/design/CONCERNS.md` — security concern routing + one-way doors.
+- `docs/design/MCP-AGENT-UX-HARDENING.md` — MCP UX security guidance.
+- `docs/design/CLIENT-ORCHESTRATION-GUIDE.md`, `docs/design/APP-PLATFORM-PUBLISH-HANDOFF.md` — confirmation flow contracts.
+
+## Integration
+
+- **`/review`** invokes this skill as a security pass when the `security` concern from `docs/design/CONCERNS.md` is activated (per its `trigger_paths` / `trigger_keywords`).
+- **`/pr-summary`** consults `activated_concerns` from the same routing; if security activates, the Test plan section references this skill's manual checks.
+- **`prevent-doc-drift`** catches new security patterns that need documentation; this skill catches missing checks against the existing rules.
+
+## When to exit cleanly without making changes
+
+- Scope is empty (no touched files in any audited category) — exit with "No security-sensitive files in scope. Skipping audit." Still run Phase 4 (deps audit) and report.
+- Working tree on a non-PR branch with no diff — exit with "No diff to audit. Use `/secure --full` to scan the whole repo." Still report deps audit.
+
+## Context window management
+
+- Phase 0: list-only; small.
+- Phase 1: read each frontend file's changed hunks (not full files). For files under 200 lines, read the whole file once.
+- Phase 2: read each backend file's changed hunks; reference the canonical pattern from the in-context summary, do not re-read `coda.go` in full each time.
+- Phase 3: only runs when MCP code is touched.
+- Phase 4: streams `npm audit` and `go list -m -u all`; summarize, do not embed full output.
+- Phase 5: in-memory aggregation + render.
+
+Total context per run: under 30k tokens for a typical PR. Full-tree mode (`--full`) is larger but bounded by the audited file count.
+
+## Expected invocation patterns
+
+- **From `/review`**: when the security concern routes activate.
+- **Direct, before opening a PR**: author runs `/secure` to catch issues before reviewers do.
+- **Pre-release**: maintainer runs `/secure --full` before `/release-prep` to verify nothing slipped in over the release window.
+- **Post-incident**: after a security incident, run `/secure --full` to confirm the fix landed and nothing similar lingers.
+
+## What this skill does NOT do
+
+- Fix violations (decision locked in via plan-mode question — report-only).
+- Run `govulncheck` automatically (note it in the report; expensive to run on every invocation).
+- Audit `docs/` content for sensitive information leakage — that's `prevent-doc-drift` + `maintain-docs` territory.
+- Replace `npm audit` or CodeQL — this skill grounds findings in repo-specific rules, not as a general scanner.
+
+## Worked example output (clean run)
+
+```
+## Security audit — 2026-05-11
+
+Target: PR diff against main, 4 files touched
+
+### Critical (0)
+
+(none)
+
+### High (0)
+
+(none)
+
+### Medium (0)
+
+(none)
+
+### Low / Informational (2)
+
+- [info] npm audit: 12 moderate, 1 low vulnerabilities. None in production deps.
+- [info] go list: 3 modules with available updates; none with known CVEs.
+
+### Disposition
+
+clean
+```
+
+## Worked example output (with findings)
+
+```
+## Security audit — 2026-05-11
+
+Target: PR diff against main, 7 files touched
+
+### Critical (1)
+
+[security][F4] src/components/docs-panel/docs-panel.tsx:218 — `dangerouslySetInnerHTML` without sanitization.
+
+  <div dangerouslySetInnerHTML={{ __html: rawGuideContent }} />
+
+Risk: XSS — `rawGuideContent` is fetched from external CDN and not sanitized.
+Remediation: wrap with `sanitizeDocumentationHTML(rawGuideContent)` from `src/security/html-sanitizer.ts`.
+See F4 in `.cursor/rules/frontend-security.mdc`.
+
+### High (1)
+
+[security][B1] pkg/plugin/sessions.go:34 — External URL request bypasses host allowlist.
+
+  resp, err := http.Get(req.URL.String())
+
+Risk: allows arbitrary external requests from the plugin backend.
+Remediation: route through `isAllowedCodaURL(req.URL.String())` (see `pkg/plugin/resources.go:64-77`).
+
+### Medium (0)
+
+(none)
+
+### Low / Informational (1)
+
+- [info] npm audit: 27 vulnerabilities (1 low, 12 moderate, 8 high, 6 critical). High / critical are in dev deps only.
+
+### Disposition
+
+blocking — do not merge until F4 and B1 are addressed.
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,47 @@ mage test
 mage lint
 ```
 
+### Additional per-platform backend builds
+
+```bash
+npm run build:backend:darwin-arm64
+npm run build:backend:linux-arm64
+npm run build:backend:windows
+```
+
+### Guide authoring and validation
+
+```bash
+# Validate guides + packages
+npm run validate            # validate all bundled guides
+npm run validate:strict     # strict mode (no unknown fields)
+npm run validate:packages   # validate package manifests
+
+# Bundled-interactives repository
+npm run repository:build    # regenerate index.json + content snapshots
+npm run repository:check    # validate repository integrity
+
+# JSON guide schema export
+npm run schema:export       # export schema to dist/
+
+# Terms-and-conditions sync
+npm run docs:sync-terms        # sync TERMS_VERSION across docs/
+npm run docs:sync-terms:check  # CI drift check for terms
+```
+
+### Additional dev tools
+
+```bash
+# Internationalization
+npm run i18n-extract           # extract translatable strings into locales/
+
+# Live sessions / WebRTC signaling
+npm run peerjs-server          # start local PeerJS signaling server
+
+# Coverage in watch mode
+npm run test:coverage:watch
+```
+
 ### Development server
 
 The development server runs Grafana OSS in Docker with the plugin mounted. After running `npm run server`, access:
@@ -155,89 +196,165 @@ The development server runs Grafana OSS in Docker with the plugin mounted. After
 
 ```
 src/
-├── bundled-interactives/  # Bundled JSON guide files (fallback content)
-├── cli/                   # CLI tools for guide validation and authoring
-├── components/            # React and Scenes UI components
-├── constants/             # Configuration, selectors, z-index management
-├── context-engine/        # Detects user context and recommends content
-├── docs-retrieval/        # Content fetching and rendering pipeline
-├── global-state/          # App-wide state (sidebar, link interception)
-├── img/                   # Static image assets
-├── integrations/          # Assistant integration, workshop mode
-├── interactive-engine/    # Executes interactive tutorial actions
-├── learning-paths/        # Learning paths, badges, streak tracking
-├── lib/                   # Shared utilities (analytics, async, DOM helpers)
-├── locales/               # Internationalization translations
-├── pages/                 # Grafana Scenes page definitions and routing
-├── requirements-manager/  # Checks prerequisites for interactive steps
-├── security/              # HTML/log sanitization and security utilities
-├── styles/                # Theme-aware CSS-in-JS styling
-├── test-utils/            # Shared test helpers and fixtures
-├── types/                 # TypeScript type definitions
-├── utils/                 # Business logic hooks and utility functions
-└── validation/            # Guide and condition validation logic
+├── bundled-interactives/  # Bundled JSON guides + repository.json index for offline fallback
+├── cli/                   # Authoring CLI (validate / create / e2e / repository) + TypeScript MCP server under src/cli/mcp/
+├── components/            # React + Scenes UI: DocsPanel, Home, interactive-tutorial, LiveSession, block-editor, floating-panel, full-screen, kiosk
+├── constants/             # Glob-scoped constants (testIds, selectors, interactive-config, z-index); root barrel src/constants.ts re-exports defaults
+├── context-engine/        # Tier-1 engine: detects Grafana context, calls recommender API, fetches recommendations
+├── docs-retrieval/        # Tier-1 engine: multi-strategy content fetcher, JSON/HTML parsers, ContentRenderer, journey-completion helpers
+├── global-state/          # Cross-component stores: sidebar, panel-mode, link-interception, interactive-navigation, alignment-pending
+├── hooks/                 # Cross-cutting hooks: usePendingGuideLaunch, useAlignmentReevaluation
+├── img/                   # Static SVG/PNG assets
+├── integrations/          # Optional integrations: assistant-integration (<assistant> tags), coda terminal, workshop mode
+├── interactive-engine/    # Tier-1 engine: executes step actions, auto-completion, navigation manager, state machine
+├── learning-paths/        # Tier-1 engine: progress tracking, badges, streaks, next-action recommender, per-platform path data
+├── lib/                   # Shared utilities: analytics, user-storage, dom selector pipeline, async, hash, package-recommendations-client
+├── locales/               # i18n translation files (en-US, de-DE, fr-FR, es-ES, cs-CZ, etc.)
+├── package-engine/        # Tier-1 engine: package resolution. Composite resolver chain: bundled → online CDN → recommender API
+├── pages/                 # Grafana Scenes page definitions (homePage, docsPage)
+├── recovery/              # Auto-recovery: alignment evaluation, starting-location resolution, launch-source classification
+├── requirements-manager/  # Tier-1 engine: prereqs / postconditions, step state machine, fix-registry, user-friendly explanations
+├── security/              # URL allowlists, HTML/log sanitization (DOMPurify), domain whitelisting
+├── styles/                # Theme-aware CSS-in-JS (Emotion), Prism syntax highlighting
+├── test-utils/            # Shared test helpers + OpenFeature mocks
+├── types/                 # Tier-0: centralized TypeScript types imported by every other subsystem
+├── utils/                 # Hooks/utilities: dev-mode, openfeature, timeout-manager, variable-substitution, experiments, find-doc-page
+└── validation/            # Zod schemas + condition validators; architecture.test.ts enforces tier rules
 ```
 
 ### Backend (pkg/)
 
 ```
 pkg/
-├── main.go                # Plugin entrypoint
+├── main.go                # Plugin entrypoint — calls app.Manage with plugin.NewApp factory
 └── plugin/
-    ├── app.go             # Plugin app instance and lifecycle
-    ├── resources.go       # HTTP resource handlers
-    ├── settings.go        # Plugin settings/configuration
-    ├── stream.go          # Grafana Live streaming channels
-    ├── terminal.go        # Terminal/SSH connection handling
-    ├── coda.go            # Coda VM integration
-    └── wsconn.go          # WebSocket connection wrapper
+    ├── app.go                       # App struct, lifecycle, CodaClient init, stream-session + user-VM caches
+    ├── resources.go                 # HTTP resource handlers: /vms, /sample-apps, /alloy-scenarios, /mcp, /package-recommendations, /coda/register, /health
+    ├── settings.go                  # Parses JSONData + decrypts SecureJSONData (CodaAPIURL, CodaRelayURL, EnrollmentKey, RefreshToken)
+    ├── stream.go                    # Grafana Live SubscribeStream/PublishStream/RunStream — 3-tier VM resolution, SSH retry (3x), heartbeat (3s), VM expiry poll (15s)
+    ├── terminal.go                  # TerminalSession: SSH over WebSocket relay, PTY, stdin/stdout/stderr pipes, private-key normalization
+    ├── coda.go                      # CodaClient: JWT auth, VM CRUD, quota enforcement (max 3/user), token refresh with RWMutex
+    ├── mcp.go                       # Experimental MCP spike (PR #643) — non-production. Real AI authoring lives in src/cli/mcp/
+    ├── package_recommendations.go   # CDN package index cache (6h TTL, single-flight, 8-way parallel manifest fetch, bounded memory)
+    ├── static.go                    # embed.FS declarations for repository.json + guides/ content
+    └── wsconn.go                    # WebSocket-as-net.Conn adapter for SSH-over-WebSocket relay tunnel
 ```
+
+## Subsystem tiers and key relationships
+
+The frontend follows a layered tier model. Imports flow **downward only** to avoid cycles. Cross-tier rules are enforced by ESLint and `src/validation/architecture.test.ts`; exceptions require an explicit allowlist entry with justification.
+
+- **Tier 0 — Types & constants**: `types/`, `constants/`
+- **Tier 1 — Engines & providers**: `context-engine/`, `docs-retrieval/`, `interactive-engine/`, `package-engine/`, `learning-paths/`, `requirements-manager/`, `recovery/`, `validation/`
+- **Tier 2 — UI**: `components/`, `pages/`
+- **Tier 3 — Support**: `lib/`, `security/`, `styles/`, `global-state/`, `integrations/`, `hooks/`, `utils/`, `test-utils/`, `bundled-interactives/`, `locales/`, `img/`, `cli/`
+
+**Key dependency edges** (where the load-bearing wiring lives):
+
+| Edge                                           | Why                                                            |
+| ---------------------------------------------- | -------------------------------------------------------------- |
+| `context-engine` → `docs-retrieval`            | Fetches content for the recommendations it surfaces            |
+| `docs-retrieval` → `bundled-interactives`      | Fallback when the online CDN is unavailable                    |
+| `docs-retrieval` → `package-engine`            | Resolves package manifests + content                           |
+| `components/docs-panel` → `interactive-engine` | Executes step actions when the user clicks "Show me" / "Do it" |
+| `interactive-engine` → `requirements-manager`  | Checks prereqs before enabling / executing a step              |
+| `interactive-engine` → `lib/dom`               | Selector resolution + element detection                        |
+| `components/docs-panel` → `context-engine`     | Reads and renders recommendations                              |
+| `components/docs-panel` → `global-state`       | Sidebar, panel-mode, tab persistence                           |
+| `learning-paths` → `lib/user-storage`          | Persists progress + streak data                                |
+| `recovery` → `requirements-manager`            | Decides whether a failed requirement is auto-recoverable       |
+
+For per-subsystem entry points, public surfaces, and key files, load `.cursor/rules/systemPatterns.mdc`.
+
+## Backend request paths (`pkg/`)
+
+The Go backend is a thin bridge between the React frontend and the **Coda VM provisioning service**. No database — all state is ephemeral or delegated to Coda.
+
+**Three primary request paths:**
+
+1. **HTTP resource API** (`resources.go`) — REST for VM lifecycle and metadata. Routes:
+   - `POST /vms`, `GET /vms`, `GET /vms/{id}`, `DELETE /vms/{id}` — VM CRUD via `CodaClient`
+   - `GET /sample-apps`, `GET /alloy-scenarios` — catalog metadata
+   - `GET /package-recommendations` — cached CDN package index
+   - `POST /coda/register` — exchange enrollment key for tokens
+   - `POST /mcp`, `GET|POST /mcp/pending-launch` — _experimental spike_ (PR #643); production AI authoring lives in `src/cli/mcp/`
+   - All external URLs pass `isAllowedCodaURL` / `IsAllowedRelayURL` allowlists.
+
+2. **Streaming terminal** (`stream.go` + `terminal.go` + `wsconn.go`) — Grafana Live bidirectional channels.
+   - Channel path: `terminal/{vmId}/{nonce}/{template?}/{app_or_scenario?}`
+   - `SubscribeStream` authorizes; `RunStream` resolves the VM (3-tier cache: in-memory `userVMs` → `ListVMs` → `CreateVM`), waits for `state=active`, opens SSH via WebSocket relay (`ConnectSSHViaRelay`), then starts heartbeat (3s) and VM-expiry poll (15s) goroutines.
+   - `PublishStream` forwards keyboard input / resize from xterm.js into the SSH session.
+   - SSH retry: 3 attempts with credential refresh on auth failures.
+   - Stream message types: `output`, `error`, `connected`, `disconnected`, `status`, `heartbeat`.
+
+3. **Coda client** (`coda.go`) — JWT-authenticated REST. Token refresh under `RWMutex` (1-min cache buffer). Per-user VM quota: 3.
+
+For the full SSH / relay / credential-refresh reference, load `docs/developer/CODA.md`. For agent-facing constraints (URL allowlists, retry contracts, what NOT to change), load `.cursor/rules/coda.mdc`.
 
 ## On-demand context
 
 Load these files **only when working in the relevant domain**. Do not preload all of them.
 
-| File                                   | When to load                                                                                                                                                                                                                     | Auto-triggered by globs                                                                           |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `docs/design/CONCERNS.md`              | PR review routing, impact analysis, change risk classification, one-way door analysis, subsystem-aware debugging                                                                                                                 | --                                                                                                |
-| `projectbrief.mdc`                     | Understanding project scope and goals                                                                                                                                                                                            | --                                                                                                |
-| `techContext.mdc`                      | Tech stack, dependencies, build system                                                                                                                                                                                           | --                                                                                                |
-| `systemPatterns.mdc`                   | Architecture, component relationships                                                                                                                                                                                            | --                                                                                                |
-| `interactiveRequirements.mdc`          | Interactive tutorial system work                                                                                                                                                                                                 | --                                                                                                |
-| `frontend-security.mdc`                | Frontend security (from security team)                                                                                                                                                                                           | `*.ts`, `*.tsx`, `*.js`, `*.jsx`                                                                  |
-| `react-antipatterns.mdc`               | PR reviews (on hit), hooks/effects/state                                                                                                                                                                                         | --                                                                                                |
-| `schema-coupling.mdc`                  | JSON guide types or schemas                                                                                                                                                                                                      | `json-guide.types.ts`, `json-guide.schema.ts`                                                     |
-| `testingStrategy.mdc`                  | Writing or reviewing tests                                                                                                                                                                                                       | `*.test.ts`, `*.test.tsx`, `jest.config*`, `jest.setup*`                                          |
-| `pr-review.md`                         | PR review orchestration (`/review`)                                                                                                                                                                                              | --                                                                                                |
-| `E2E_TESTING_CONTRACT.md`              | E2E testing, `data-test-*` attributes                                                                                                                                                                                            | --                                                                                                |
-| `RELEASE_PROCESS.md`                   | Releasing, deploying, versioning                                                                                                                                                                                                 | --                                                                                                |
-| `FEATURE_FLAGS.md`                     | Feature flags, A/B experiments                                                                                                                                                                                                   | `openfeature.ts`                                                                                  |
-| `CLI_TOOLS.md`                         | CLI validation, guide authoring tooling                                                                                                                                                                                          | `src/cli/*`                                                                                       |
-| `MCP_SERVER.md`                        | Pathfinder authoring MCP server (`pathfinder-mcp`) — tools, transports (stdio/HTTP), how to add a tool, deploy artifact                                                                                                          | `src/cli/mcp/*`                                                                                   |
-| `interactive-examples/*.md`            | Authoring interactive guides (format, types, selectors)                                                                                                                                                                          | --                                                                                                |
-| `engines/*.md`                         | Engine subsystem internals (context, interactive, requirements)                                                                                                                                                                  | `src/context-engine/*`, `src/interactive-engine/*`, `src/requirements-manager/*`                  |
-| `ASSISTANT_INTEGRATION.md`             | Authoring customizable content with `<assistant>` tag                                                                                                                                                                            | `src/integrations/assistant-integration/*`                                                        |
-| `E2E_TESTING.md`                       | E2E guide test runner: CLI reference, options, troubleshooting, error classification, environment variables                                                                                                                      | --                                                                                                |
-| `DEV_MODE.md`                          | Dev mode configuration and debugging tools                                                                                                                                                                                       | `src/utils/dev-mode.ts`                                                                           |
-| `LOCAL_DEV.md`                         | Local development setup, prerequisites, Docker workflow                                                                                                                                                                          | --                                                                                                |
-| `LIVE_SESSIONS.md`                     | Live sessions feature (WebRTC, PeerJS)                                                                                                                                                                                           | `src/components/LiveSession/*`                                                                    |
-| `KNOWN_ISSUES.md`                      | Known bugs and workarounds                                                                                                                                                                                                       | --                                                                                                |
-| `integrations/workshop.md`             | Workshop mode, action capture and replay                                                                                                                                                                                         | `src/integrations/workshop/*`                                                                     |
-| `SCALE_TESTING.md`                     | Live session scale testing procedures                                                                                                                                                                                            | --                                                                                                |
-| `utils/README.md`                      | Utility directory layout, remaining hooks, timeout manager                                                                                                                                                                       | `src/utils/*`                                                                                     |
-| `constants/README.md`                  | Selector constants, interactive config, z-index management                                                                                                                                                                       | `src/constants/*`                                                                                 |
-| `learning-paths/README.md`             | Learning paths, badges, streaks, progress tracking                                                                                                                                                                               | `src/learning-paths/*`                                                                            |
-| `package-authoring.md`                 | Package authoring (two-file model, content.json/manifest.json, directory structure)                                                                                                                                              | --                                                                                                |
-| `CUSTOM_GUIDES.md`                     | Custom guides authored in the block editor — lifecycle (draft/published), creating, editing, publishing, unpublishing, and the guide library                                                                                     | `src/components/block-editor/*`                                                                   |
-| `EXTERNAL_API.md`                      | External (CI / Terraform / scripts) guide-import API. The Pathfinder Backend's K8s aggregator is callable directly with a Grafana SA token; companion bash helper at `scripts/upsert-guide.sh`.                                  | `scripts/upsert-guide.sh`                                                                         |
-| ESLint config + `architecture.test.ts` | Refactoring or reducing technical debt. The repo mechanically enforces rules via ESLint and `src/validation/architecture.test.ts`; their exclusions (`// eslint-disable`, test exceptions) serve as a map to existing tech debt. | --                                                                                                |
-| `go.mod`, `go.sum`                     | Go backend dependencies, version updates                                                                                                                                                                                         | `pkg/**/*.go`                                                                                     |
-| `magefile.go`                          | Go build tasks (mage targets)                                                                                                                                                                                                    | `pkg/**/*.go`                                                                                     |
-| `coda.mdc`                             | Coda VM system, terminal integration, backend SSH/relay                                                                                                                                                                          | `src/integrations/coda/*`, `pkg/plugin/coda.go`, `pkg/plugin/stream.go`, `pkg/plugin/terminal.go` |
-| `CODA.md`                              | Coda VM system, terminal integration (comprehensive)                                                                                                                                                                             | `src/integrations/coda/*`, `pkg/plugin/coda.go`, `pkg/plugin/stream.go`                           |
-| `docs/history/`                        | Historical implementation records for completed epics — key decisions, artifacts, and rationale. Read when you need the full context of past design choices (e.g., why recommender-based resolution, not static catalog).        | --                                                                                                |
+| File                                          | When to load                                                                                                                                                                                                                     | Auto-triggered by globs                                                                           |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `docs/design/CONCERNS.md`                     | PR review routing, impact analysis, change risk classification, one-way door analysis, subsystem-aware debugging                                                                                                                 | --                                                                                                |
+| `projectbrief.mdc`                            | Understanding project scope and goals                                                                                                                                                                                            | --                                                                                                |
+| `techContext.mdc`                             | Tech stack, dependencies, build system                                                                                                                                                                                           | --                                                                                                |
+| `systemPatterns.mdc`                          | Architecture, component relationships                                                                                                                                                                                            | --                                                                                                |
+| `interactiveRequirements.mdc`                 | Interactive tutorial system work                                                                                                                                                                                                 | --                                                                                                |
+| `frontend-security.mdc`                       | Frontend security (from security team)                                                                                                                                                                                           | `*.ts`, `*.tsx`, `*.js`, `*.jsx`                                                                  |
+| `react-antipatterns.mdc`                      | PR reviews (on hit), hooks/effects/state                                                                                                                                                                                         | --                                                                                                |
+| `schema-coupling.mdc`                         | JSON guide types or schemas                                                                                                                                                                                                      | `json-guide.types.ts`, `json-guide.schema.ts`                                                     |
+| `testingStrategy.mdc`                         | Writing or reviewing tests                                                                                                                                                                                                       | `*.test.ts`, `*.test.tsx`, `jest.config*`, `jest.setup*`                                          |
+| `pr-review.md`                                | PR review orchestration (`/review`)                                                                                                                                                                                              | --                                                                                                |
+| `E2E_TESTING_CONTRACT.md`                     | E2E testing, `data-test-*` attributes                                                                                                                                                                                            | --                                                                                                |
+| `RELEASE_PROCESS.md`                          | Releasing, deploying, versioning                                                                                                                                                                                                 | --                                                                                                |
+| `FEATURE_FLAGS.md`                            | Feature flags, A/B experiments                                                                                                                                                                                                   | `openfeature.ts`                                                                                  |
+| `CLI_TOOLS.md`                                | CLI validation, guide authoring tooling                                                                                                                                                                                          | `src/cli/*`                                                                                       |
+| `MCP_SERVER.md`                               | Pathfinder authoring MCP server (`pathfinder-mcp`) — tools, transports (stdio/HTTP), how to add a tool, deploy artifact                                                                                                          | `src/cli/mcp/*`                                                                                   |
+| `interactive-examples/*.md`                   | Authoring interactive guides (format, types, selectors)                                                                                                                                                                          | --                                                                                                |
+| `engines/*.md`                                | Engine subsystem internals (context, interactive, requirements)                                                                                                                                                                  | `src/context-engine/*`, `src/interactive-engine/*`, `src/requirements-manager/*`                  |
+| `ASSISTANT_INTEGRATION.md`                    | Authoring customizable content with `<assistant>` tag                                                                                                                                                                            | `src/integrations/assistant-integration/*`                                                        |
+| `E2E_TESTING.md`                              | E2E guide test runner: CLI reference, options, troubleshooting, error classification, environment variables                                                                                                                      | --                                                                                                |
+| `DEV_MODE.md`                                 | Dev mode configuration and debugging tools                                                                                                                                                                                       | `src/utils/dev-mode.ts`                                                                           |
+| `LOCAL_DEV.md`                                | Local development setup, prerequisites, Docker workflow                                                                                                                                                                          | --                                                                                                |
+| `LIVE_SESSIONS.md`                            | Live sessions feature (WebRTC, PeerJS)                                                                                                                                                                                           | `src/components/LiveSession/*`                                                                    |
+| `KNOWN_ISSUES.md`                             | Known bugs and workarounds                                                                                                                                                                                                       | --                                                                                                |
+| `integrations/workshop.md`                    | Workshop mode, action capture and replay                                                                                                                                                                                         | `src/integrations/workshop/*`                                                                     |
+| `SCALE_TESTING.md`                            | Live session scale testing procedures                                                                                                                                                                                            | --                                                                                                |
+| `utils/README.md`                             | Utility directory layout, remaining hooks, timeout manager                                                                                                                                                                       | `src/utils/*`                                                                                     |
+| `constants/README.md`                         | Selector constants, interactive config, z-index management                                                                                                                                                                       | `src/constants/*`                                                                                 |
+| `learning-paths/README.md`                    | Learning paths, badges, streaks, progress tracking                                                                                                                                                                               | `src/learning-paths/*`                                                                            |
+| `package-authoring.md`                        | Package authoring (two-file model, content.json/manifest.json, directory structure)                                                                                                                                              | --                                                                                                |
+| `CUSTOM_GUIDES.md`                            | Custom guides authored in the block editor — lifecycle (draft/published), creating, editing, publishing, unpublishing, and the guide library                                                                                     | `src/components/block-editor/*`                                                                   |
+| `EXTERNAL_API.md`                             | External (CI / Terraform / scripts) guide-import API. The Pathfinder Backend's K8s aggregator is callable directly with a Grafana SA token; companion bash helper at `scripts/upsert-guide.sh`.                                  | `scripts/upsert-guide.sh`                                                                         |
+| ESLint config + `architecture.test.ts`        | Refactoring or reducing technical debt. The repo mechanically enforces rules via ESLint and `src/validation/architecture.test.ts`; their exclusions (`// eslint-disable`, test exceptions) serve as a map to existing tech debt. | --                                                                                                |
+| `go.mod`, `go.sum`                            | Go backend dependencies, version updates                                                                                                                                                                                         | `pkg/**/*.go`                                                                                     |
+| `magefile.go`                                 | Go build tasks (mage targets)                                                                                                                                                                                                    | `pkg/**/*.go`                                                                                     |
+| `coda.mdc`                                    | Coda VM system, terminal integration, backend SSH/relay                                                                                                                                                                          | `src/integrations/coda/*`, `pkg/plugin/coda.go`, `pkg/plugin/stream.go`, `pkg/plugin/terminal.go` |
+| `CODA.md`                                     | Coda VM system, terminal integration (comprehensive)                                                                                                                                                                             | `src/integrations/coda/*`, `pkg/plugin/coda.go`, `pkg/plugin/stream.go`                           |
+| `docs/history/`                               | Historical implementation records for completed epics — key decisions, artifacts, and rationale. Read when you need the full context of past design choices (e.g., why recommender-based resolution, not static catalog).        | --                                                                                                |
+| `docs/developer/GETTING_STARTED.md`           | First-week onboarding for new developers — prerequisites, IDE setup, troubleshooting                                                                                                                                             | --                                                                                                |
+| `docs/developer/bugfix-patterns.md`           | Common bug-fix patterns observed across the codebase (companion to the `bugfix` skill)                                                                                                                                           | --                                                                                                |
+| `docs/design/PATHFINDER-AI-AUTHORING.md`      | Top-level AI-authoring design — read first before any AI-authoring task. Design intent (may not match implementation).                                                                                                           | `src/cli/*`, `src/components/block-editor/*`                                                      |
+| `docs/design/AGENT-AUTHORING.md`              | Authoring CLI design: schema-driven help, validate-on-write, idempotent retries, agent-oriented output. Design intent.                                                                                                           | `src/cli/commands/*`                                                                              |
+| `docs/design/HOSTED-AUTHORING-MCP.md`         | TS MCP server design — validation strategy, stdio/HTTP transports, auth. Pair with `MCP_SERVER.md` for implementation reality.                                                                                                   | `src/cli/mcp/*`                                                                                   |
+| `docs/design/AUTHORING-SESSION-ARTIFACTS.md`  | Stateless artifact-as-wire-state model for MCP tool contracts (validate-on-write, idempotency). Design intent.                                                                                                                   | `src/cli/mcp/*`                                                                                   |
+| `docs/design/APP-PLATFORM-PUBLISH-HANDOFF.md` | App Platform publish payload shape, draft vs published, `localExport` fallback. Design intent.                                                                                                                                   | `src/cli/mcp/*`, `src/components/block-editor/*`                                                  |
+| `docs/design/VIEWER-DEEP-LINK-CONTRACT.md`    | Viewer deep link format (`doc=api:<id>`), panel-mode contract, resource name stability. Design intent.                                                                                                                           | `src/components/docs-panel/*`                                                                     |
+| `docs/design/CLIENT-ORCHESTRATION-GUIDE.md`   | How AI clients use the MCP service — workflow, confirmation, publish-path selection. Design intent.                                                                                                                              | `src/integrations/assistant-integration/*`                                                        |
+| `docs/design/PATHFINDER-PACKAGE-DESIGN.md`    | Package model: two-file structure, manifest metadata, dependencies, repository structure. Canonical spec for `package-engine` and CLI tooling.                                                                                   | `src/types/package.schema.ts`, `src/package-engine/*`                                             |
+| `docs/design/TESTING_STRATEGY.md`             | E2E testing strategy with 4-layer model, test-environment routing, manifest metadata requirements. Pair with `E2E_TESTING.md` for runtime details.                                                                               | `src/types/package.schema.ts`                                                                     |
+| `docs/design/phases/*.md`                     | Phase-specific implementation plans for AI authoring (P0–P6)                                                                                                                                                                     | --                                                                                                |
+| `.cursor/skills/prevent-doc-drift/SKILL.md`   | **Skill** — runs on `/review` or before merge. Detects new features / architecture changes in a PR and produces the AGENTS.md / CLAUDE.md / `.cursor/rules/` updates needed in the same PR to prevent drift.                     | --                                                                                                |
+| `.cursor/skills/maintain-docs/SKILL.md`       | **Skill** — periodic doc-maintenance audit (orphans, drift, staleness). Complementary to `prevent-doc-drift`: runs across the whole repo on a schedule rather than per-PR.                                                       | --                                                                                                |
+| `.cursor/skills/changelog/SKILL.md`           | **Skill** — drafts CHANGELOG entries from merged PRs since the last release tag. Categorizes by conventional-commit prefix and rewrites titles into sentence-case narrative bullets. Called by `release-prep`.                   | --                                                                                                |
+| `.cursor/skills/release-prep/SKILL.md`        | **Skill** — orchestrates the pre-release flow (bump version + draft changelog + `npm run check` + build). Never creates or pushes the git tag; prints the exact command for the user to run.                                     | --                                                                                                |
+| `.cursor/skills/pr-summary/SKILL.md`          | **Skill** — drafts a structured PR description (Summary / What changed / Why / Test plan / Risk) from the diff using `CONCERNS.md` routing. Pairs with `/review` (drafts vs reviews).                                            | --                                                                                                |
+| `.cursor/skills/secure/SKILL.md`              | **Skill** — security audit. F1-F6 frontend rules, backend URL allowlists + token handling + hardcoded-secret scan, MCP transport caps, dependency advisories. Report-only with concrete remediation per finding.                 | --                                                                                                |
+| `.cursor/skills/i18n-sync/SKILL.md`           | **Skill** — detect translation gaps across 21 locales. Stubs missing keys with empty values (matching the runtime fallback to en-US) and emits a per-locale gap report. Never invents translations.                              | --                                                                                                |
 
-All `.mdc` files live in `.cursor/rules/`. `pr-review.md` is at `.cursor/rules/pr-review.md`. `E2E_TESTING_CONTRACT.md`, `RELEASE_PROCESS.md`, `FEATURE_FLAGS.md`, `CLI_TOOLS.md`, `MCP_SERVER.md`, `ASSISTANT_INTEGRATION.md`, `E2E_TESTING.md`, `DEV_MODE.md`, `LOCAL_DEV.md`, `LIVE_SESSIONS.md`, `KNOWN_ISSUES.md`, `SCALE_TESTING.md`, `CODA.md`, `package-authoring.md`, `CUSTOM_GUIDES.md`, `EXTERNAL_API.md`, `integrations/workshop.md`, `utils/README.md`, `constants/README.md`, and `learning-paths/README.md` are at `docs/developer/`. The `interactive-examples/` and `engines/` directories are also under `docs/developer/`.
+All `.mdc` files live in `.cursor/rules/`; `pr-review.md` is at `.cursor/rules/pr-review.md`. Developer-facing references (`*.md`) live under `docs/developer/`. Design docs live under `docs/design/` — these capture **design intent** and may not match implemented reality; verify against the code before acting on them. Skills live under `.cursor/skills/<name>/SKILL.md`.
 
 ## PR reviews
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,5 +4,36 @@
 
 ## Additional context for Claude Code
 
-- **Skills**: Reusable agent workflows live in `.cursor/skills/`. Read a skill's `SKILL.md` before using it.
+### Skills (`.cursor/skills/`)
+
+Reusable agent workflows. Read a skill's `SKILL.md` before invoking it.
+
+| Skill                | Trigger                          | Purpose                                                                                                                                |
+| -------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `bugfix`             | `/bugfix [issue-#]`              | Two-commit failing-test → fix workflow in a worktree                                                                                   |
+| `changelog`          | `/changelog [version]`           | Draft CHANGELOG entry from merged PRs since the last release tag                                                                       |
+| `design-review`      | conversation request             | Principal-engineer design partner; never writes code                                                                                   |
+| `e2e-guide-analysis` | run E2E on a guide               | Diagnose E2E failures, write a learning report                                                                                         |
+| `i18n-sync`          | `/i18n-sync`                     | Stub missing keys across 21 locales; emit a translation gap report                                                                     |
+| `maintain-docs`      | conversation request, periodic   | Whole-repo doc audit: orphans, drift, staleness — opens a PR                                                                           |
+| `plugin-bundle-size` | conversation request             | Reduce plugin bundle size via React.lazy + webpack code splitting                                                                      |
+| `pr-summary`         | `/pr-summary`                    | Draft structured PR description from the diff via `CONCERNS.md` routing                                                                |
+| `prevent-doc-drift`  | `/review`, pre-merge             | **Per-PR** drift prevention: detects new features / architecture in a PR and updates AGENTS.md, CLAUDE.md, `.cursor/rules/` in same PR |
+| `refactor`           | `/refactor-investigate <target>` | High-risk refactor with pre / extract / post-test gates                                                                                |
+| `release-prep`       | `/release-prep [version]`        | Bump version + draft changelog + run check; user creates the tag                                                                       |
+| `secure`             | `/secure`                        | Security audit: F1-F6 frontend + backend allowlists + MCP transport + deps                                                             |
+| `tidy-up`            | `/tidy-up`                       | Pre-commit gate (typecheck + lint + prettier + Go)                                                                                     |
+
+### Doc-quality skill pairing
+
+The repo has two complementary doc-quality skills:
+
+- **`prevent-doc-drift`** runs **per-PR** against the diff. Catches new subdirs / scripts / skills / docs / architecture changes at introduction and produces the doc edits in the same PR. Invoked from `/review` or directly.
+- **`maintain-docs`** runs **periodically** across the whole repo. Catches gradual drift between `.cursor/rules/` and `docs/developer/`, indexes orphans, validates staleness. Invoked manually or on a schedule.
+
+Treat them as complementary: prevent-doc-drift handles _new_ drift introduced by each PR; maintain-docs sweeps for _accumulated_ drift the per-PR skill missed.
+
+### Other Claude Code specifics
+
 - **Full pre-merge check**: `npm run check` runs typecheck + lint + prettier + lint:go + test:go + test:ci in one command.
+- **Memory system**: Long-lived user / project / feedback notes live in `~/.claude/projects/-Users-jayclifford-Repos-grafana-pathfinder-app/memory/`. See the `auto memory` section in the system prompt for the file format.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,4 +36,4 @@ Treat them as complementary: prevent-doc-drift handles _new_ drift introduced by
 ### Other Claude Code specifics
 
 - **Full pre-merge check**: `npm run check` runs typecheck + lint + prettier + lint:go + test:go + test:ci in one command.
-- **Memory system**: Long-lived user / project / feedback notes live in `~/.claude/projects/-Users-jayclifford-Repos-grafana-pathfinder-app/memory/`. See the `auto memory` section in the system prompt for the file format.
+- **Memory system**: Long-lived user / project / feedback notes live under `~/.claude/projects/<project-slug>/memory/`, where `<project-slug>` is the absolute path to this repo with `/` replaced by `-` (for example, a clone at `/Users/alice/code/grafana-pathfinder-app` resolves to `-Users-alice-code-grafana-pathfinder-app`). See the `auto memory` section in the system prompt for the file format.


### PR DESCRIPTION
## Summary

Two complementary updates to the agent toolchain under `.cursor/` and root-level guidance — fixes documentation drift accumulated across recent feature work, and adds six new skills that automate manual / error-prone workflows the team does today.

- **Agent-guidance audit** of `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules/*` against the current codebase. Three missing `src/` subsystems indexed, a 4-tier subsystem model with 10-edge dependency map, a backend request-paths summary, twelve previously-undocumented npm scripts, and thirteen on-demand context entries (nine design docs + supporting docs + skill index rows).
- **Six new skills** all following the existing `maintain-docs` SKILL.md format — hard constraints, workflow phases, integration points, context-window budget.

No source code touched. All eleven changed/new files pass `prettier --check`.

## What changed

| Path | Lines | Purpose |
| --- | --- | --- |
| `AGENTS.md` | +257 / -71 | Code organization fixes; new "Subsystem tiers and key relationships"; new "Backend request paths"; 12 npm scripts; 13 on-demand context entries; 7 skill rows |
| `CLAUDE.md` | +33 | Full 13-row skills index table; doc-quality skill pairing explainer |
| `.cursor/rules/systemPatterns.mdc` | +131 | Per-subsystem reference, key dependency edges, backend architecture with HTTP and streaming flow narratives |
| `.cursor/rules/pr-review.md` | +8 | Phase 6 invokes `prevent-doc-drift` in review mode |
| `.cursor/skills/prevent-doc-drift/SKILL.md` | +300 | Per-PR doc-drift detector — 14 buckets, 17-row rules table, apply / review modes |
| `.cursor/skills/changelog/SKILL.md` | +244 | Draft CHANGELOG entries from merged PRs since the last release tag |
| `.cursor/skills/release-prep/SKILL.md` | +258 | Orchestrate version bump + changelog + `npm run check`; user creates the tag |
| `.cursor/skills/pr-summary/SKILL.md` | +272 | Draft structured PR descriptions from the diff using CONCERNS.md routing |
| `.cursor/skills/secure/SKILL.md` | +340 | Security audit: F1-F6 frontend + backend allowlists + MCP transport + deps. Report-only |
| `.cursor/skills/i18n-sync/SKILL.md` | +273 | Stub missing keys across 21 locales; emit gap report. No invented translations |

**Skill design decisions** (locked in via plan-mode discussion):
- `release-prep` prepares everything; the user creates the tag manually (one-way door).
- `i18n-sync` stubs empty values for missing keys (matching the runtime fallback to en-US); no fake English-as-translation.
- `secure` reports findings with remediation; no auto-fixes on security-sensitive code.

## Test plan

- [x] `npx prettier --check` passes on all 11 changed/new files
- [ ] Spot-check `AGENTS.md` and `CLAUDE.md` skill rows align consistently in both files
- [ ] Review the on-demand context table for any broken links (target files all confirmed to exist at audit time)
- [ ] Verify the tier model + dependency edges in `systemPatterns.mdc` against `src/validation/architecture.test.ts`
- [ ] Optional: invoke `/prevent-doc-drift` on this PR as a recursive sanity check — should detect the six new skills and find that AGENTS.md and CLAUDE.md already index them

## Risk and reversibility

Fully reversible — documentation and skill specifications only. No source code, no schema, no runtime behavior change. The six new skills are dormant until explicitly invoked. The `prevent-doc-drift` hook in `pr-review.md` is non-blocking — guidance drift does not block merge.

Refs the agent-toolchain hardening discussion in this session's prior turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc- and process-only changes (agent guidance + skill specs) with no runtime code modifications; main risk is confusing or incorrect guidance that could mislead future automation.
> 
> **Overview**
> Updates agent guidance to better reflect current architecture and workflows, including a clearer frontend tier model, key dependency edges, and an expanded backend request/streaming reference in `.cursor/rules/systemPatterns.mdc` and `AGENTS.md`.
> 
> Adds several new `.cursor` skills (`changelog`, `release-prep`, `pr-summary`, `secure`, `i18n-sync`, `prevent-doc-drift`) to automate common maintenance/review tasks, and wires a **non-blocking** `prevent-doc-drift` step into the `/review` orchestrator (`.cursor/rules/pr-review.md`).
> 
> Refreshes root guidance (`AGENTS.md`, `CLAUDE.md`) with additional npm commands, an updated code-organization index, and a consolidated skills table for discoverability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968c3fafabc524ce028594bba8db18f40d9b8b31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->