### PR TITLE
fix(security): disable npm install scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,12 @@
+# Disable npm lifecycle scripts (preinstall / install / postinstall / prepare)
+# to mitigate supply-chain attacks that ship malicious postinstall hooks.
+# Reference: the `lightning` npm package compromise (2026), which used a
+# postinstall script to plant Claude Code and VS Code persistence hooks.
+#
+# Consequences:
+#   - Husky git hooks do NOT install on `npm install` / `npm ci`. After a
+#     fresh clone, run `npm run prepare` once to install them. See
+#     `docs/developer/LOCAL_DEV.md`.
+#   - Playwright browsers do NOT auto-download. CI installs them explicitly
+#     via `npx playwright install --with-deps` (see `.github/workflows/ci.yml`).
+ignore-scripts=true

--- a/docs/developer/LOCAL_DEV.md
+++ b/docs/developer/LOCAL_DEV.md
@@ -18,9 +18,10 @@ Quick verification: `node -v && npm -v && go version && docker --version && mage
 
 ```bash
 npm install
+npm run prepare    # install husky git hooks (pre-commit etc.)
 ```
 
-This installs frontend dependencies and runs the husky `prepare` hook to install pre-commit checks.
+The repo sets `ignore-scripts=true` in `.npmrc` as a supply-chain mitigation, so `npm install` skips all lifecycle scripts — including husky's `prepare`. Run `npm run prepare` once after the first clone to install pre-commit checks. CI explicitly installs Playwright browsers (`npx playwright install --with-deps`) where needed, so no other manual steps are required.
 
 ## Run in watch mode
 


### PR DESCRIPTION
## Summary

Add `.npmrc` with `ignore-scripts=true` to disable all npm lifecycle scripts (`preinstall` / `install` / `postinstall` / `prepare`) during `npm install` and `npm ci`. Mitigates supply-chain attacks that ship malicious postinstall hooks — most recently the `lightning` package compromise (Claude Code / VS Code persistence + a `Formatter` GitHub workflow that exfiltrates `${{ toJSON(secrets) }}`).

Closes the criterion the security team flagged this repo against:

> `grafana/grafana-pathfinder-app` — packageManager is npm (npm@11.14.0) but .npmrc missing or ignore-scripts not true

## Workflow-impact audit — does this break anything?

Audited every lifecycle script in `package.json` and every CI install path before landing. Net: **safe**, with one local-dev behaviour change that is documented.

| Surface                                         | Lifecycle script                                       | After this change             | Action                                                                  |
| ----------------------------------------------- | ------------------------------------------------------ | ----------------------------- | ----------------------------------------------------------------------- |
| `prepare: "husky"`                              | wires `.husky/` git hooks on `npm install`             | will not auto-run             | Local devs run `npm run prepare` once after first clone. Documented.    |
| `@playwright/test`                              | postinstall downloads browsers                         | will not auto-run             | **Already mitigated** — `ci.yml:398` explicitly runs `npx playwright install chromium --with-deps`. |
| `@swc/core`                                     | none (uses platform-specific `optionalDependencies`)   | unchanged                     | None.                                                                   |
| Other deps                                      | no lifecycle scripts observed                          | unchanged                     | None.                                                                   |
| `ci.yml`, `cli-publish.yml`, `is-compatible.yml`, `validate-guides.yml` | use `npm ci`, do not commit, do not rely on `prepare` running | unaffected | None.                                                                   |

The only `package.json` lifecycle script in the repo is `prepare: "husky"`. CI does not commit, so missing husky hooks have no effect there. Locally, the first `npm install` after this lands needs a one-time `npm run prepare` to install hooks — documented in `docs/developer/LOCAL_DEV.md`.

## What changed

- `.npmrc` (new) — `ignore-scripts=true` with an explanatory comment block referencing the `lightning` incident and the Playwright explicit-install pattern.
- `docs/developer/LOCAL_DEV.md` — "Install dependencies" section now shows the explicit `npm run prepare` step and explains why.

## Test plan

- [ ] Fresh clone + `npm install` succeeds; `.husky/_/` is **not** populated (husky `prepare` skipped, as expected)
- [ ] `npm run prepare` populates `.husky/_/` and `git commit` triggers `pre-commit` (lint-staged) as before
- [ ] `npm run check` passes locally (no script invocation involved)
- [ ] CI green: `ci.yml`, `cli-publish.yml`, `is-compatible.yml`, `validate-guides.yml` all run `npm ci` without depending on lifecycle scripts
- [ ] Playwright e2e still works in CI via the explicit `npx playwright install --with-deps` step
- [ ] No regression in `npm run server` (Docker Compose) — the install scripts disabled are not on the runtime path

## Risk and reversibility

Fully reversible — delete `.npmrc` to restore the prior behaviour. No source code changes. No CI workflow changes (the existing explicit Playwright install was already in place). The single behavioural change is local-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sets `ignore-scripts=true` for all npm installs, which can subtly break tooling that relies on lifecycle hooks (notably Husky and any dependency postinstalls), even though CI already installs Playwright browsers explicitly.
> 
> **Overview**
> Adds a repo-level `.npmrc` with `ignore-scripts=true` to **prevent all npm lifecycle scripts** (`preinstall`/`install`/`postinstall`/`prepare`) from running during `npm install`/`npm ci` as a supply-chain mitigation.
> 
> Updates `docs/developer/LOCAL_DEV.md` to require a one-time manual `npm run prepare` to install Husky git hooks after cloning, and notes that Playwright browser downloads are handled explicitly in CI rather than via postinstall.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 810c6d2bfb160c18d8f22f33e23df9485276b253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->