### PR TITLE
chore: add Unreleased section to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Unreleased
+
+_Rolling section for changes merged since v2.10.0. Renamed to the next version number at release time._
+
+### Added
+
+- **Pathfinder MCP Server**: TypeScript MCP server (`pathfinder-mcp`) for AI-assisted guide authoring. Supports stdio and HTTP transports, structured `clientGuidance` handoff per client capability (Grafana App Platform / OSS / non-Grafana), and read-only CDN repository tools so MCP clients (Cursor, Claude Desktop, Grafana Assistant) can discover and deep-link to published packages without per-instance plugin involvement. (#831, #844)
+- **Block editor authoring resilience + sidebar UX overhaul**: Lint primitives for real-time guide validation, convergence on the canonical validation pipeline, new `ConditionChipsField` for requirements and objectives, `HealthStatusBar` with cross-block diagnostics, and per-block `LintBadge` display. (#848)
+- **Prompted implied 0th step for guide launches**: Auto-recovery now offers a starting-location prompt when a launched guide's implied 0th step is not satisfied at the user's current location. (#810)
+- **External guide-import API**: External (CI / Terraform / scripts) flow for upserting guides via the Pathfinder Backend's K8s aggregator. Companion bash helper at `scripts/upsert-guide.sh` accepts any guide JSON. (#829, #830)
+- **Single-block preview in the block editor**: Preview individual blocks without rendering the whole guide. (#618)
+
+### Fixed
+
+- **Dock-to-sidebar arrow direction**: The arrow on the dock-to-sidebar control now points in the correct direction. (#857)
+- **Floating panel popout viewport**: The floating panel popout stays in view across viewport size changes. (#854)
+
+### Security
+
+- **Disable npm install scripts**: Added `.npmrc` with `ignore-scripts=true` to mitigate supply-chain attacks that ship malicious lifecycle scripts (reference: the `lightning` npm package compromise). Husky hooks must now be installed explicitly via `npm run prepare` after a fresh clone; CI installs Playwright browsers explicitly via `npx playwright install --with-deps`. (#865)
+- **`golang.org/x/net` to v0.53.0**: Go module security advisory update. (#853)
+
+### Chore
+
+- **`lint-staged` to v17** (#859)
+- **`npm` to v11.14.0** (#860)
+- **`actions/cache` to v5** (#814)
+- **GitHub Actions pinned-digest updates**: `sigstore/cosign-installer` to v4 (#839), `docker/setup-buildx-action` to v4 (#838), `docker/login-action` to v4 (#837), and `docker/build-push-action` to v7 (#836).
+
 ## 2.10.0
 
 > **⚠️ Terms and conditions updated (TERMS_VERSION 1.1.0)**


### PR DESCRIPTION
## Summary

Add a rolling **Unreleased** section to `CHANGELOG.md` capturing the ~10 PRs merged to `main` since `v2.10.0`. Following the [Keep a Changelog](https://keepachangelog.com/) convention so contributors have a clear place to drop entries as work lands; the section gets renamed to the actual version number at release time (e.g., by the `release-prep` skill from #863).

No source code, no behaviour change — a single 29-line markdown addition.

## What's in the Unreleased section

| Category | Entries (PR refs) |
| --- | --- |
| **Added** | Pathfinder MCP Server (#831, #844) · Block editor authoring resilience + sidebar UX overhaul (#848) · Prompted implied 0th step (#810) · External guide-import API (#829, #830) · Single-block preview in block editor (#618) |
| **Fixed** | Dock-to-sidebar arrow direction (#857) · Floating panel popout viewport (#854) |
| **Security** | `.npmrc` `ignore-scripts=true` to mitigate supply-chain attacks (#865) · `golang.org/x/net` v0.53.0 (#853) |
| **Chore** | `lint-staged` v17 (#859) · `npm` 11.14.0 (#860) · `actions/cache` v5 (#814) · Pinned-digest action bumps for sigstore/cosign + docker actions (#836–#839) |

Entries follow the bold-title + narrative + PR-ref style from the existing `## 2.10.0` section. The drafts are intentionally tight — the team should polish wording before release (especially the MCP server entry, which spans two PRs and may want more explanation).

## Test plan

- [x] `npx prettier --check CHANGELOG.md` passes
- [ ] Spot-check each entry against its merged PR's actual scope
- [ ] When ready to release, rename `## Unreleased` to `## X.Y.Z` and let `/release-prep` take over

## Risk and reversibility

Fully reversible — markdown only. No source code, no schema, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that updates `CHANGELOG.md` with a new `Unreleased` section and has no runtime or build impact.
> 
> **Overview**
> Adds a new **`## Unreleased`** section to `CHANGELOG.md` (Keep a Changelog style) to serve as a rolling landing zone for changes merged since `v2.10.0`.
> 
> Populates the section with categorized entries (*Added/Fixed/Security/Chore*) referencing recent PRs, without any source or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c57678c61d4f59351caf252b9bd536ac94dc0b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->