### PR TITLE
feat(quiz): shuffle answer choices by default, with pin and opt-out

### DIFF
--- a/docs/design/AGENT-AUTHORING.md
+++ b/docs/design/AGENT-AUTHORING.md
@@ -201,7 +201,7 @@ Append a choice to a `quiz` block.
 pathfinder-cli add-choice <dir> --parent <id> [flags]
 ```
 
-Flags are derived from `JsonQuizChoiceSchema`. The `--parent` flag is required and must reference a block of type `quiz`.
+Flags are derived from `JsonQuizChoiceSchema`. The `--parent` flag is required and must reference a block of type `quiz`. Pass `--pinned` to keep this choice at its authored index when the quiz is shuffled (default behavior); see `--shuffle` on `add-block quiz` to control shuffling at the block level.
 
 **Output on success:**
 
@@ -845,6 +845,11 @@ pathfinder-cli add-choice my-guide/ --parent check-understanding \
 
 pathfinder-cli add-choice my-guide/ --parent check-understanding \
   --id c --text "SQL" --hint "Loki uses its own query language, not SQL."
+
+# Optional: pin "All of the above" so it stays last even when shuffled
+pathfinder-cli add-choice my-guide/ --parent check-understanding \
+  --id d --text "All of the above" --pinned \
+  --hint "Only one is correct."
 
 # Set manifest metadata
 pathfinder-cli set-manifest my-guide/ \

--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -521,24 +521,26 @@ Knowledge assessment with single or multiple choice questions.
 }
 ```
 
-| Field            | Type         | Required | Default          | Description                                     |
-| ---------------- | ------------ | -------- | ---------------- | ----------------------------------------------- |
-| `question`       | string       | ✅       | —                | Question text (supports markdown)               |
-| `choices`        | QuizChoice[] | ✅       | —                | Answer choices (see below)                      |
-| `multiSelect`    | boolean      | ❌       | `false`          | Allow multiple answers (checkboxes vs radio)    |
-| `completionMode` | string       | ❌       | `"correct-only"` | `"correct-only"` or `"max-attempts"`            |
-| `maxAttempts`    | number       | ❌       | `3`              | Attempts before revealing answer (max-attempts) |
-| `requirements`   | string[]     | ❌       | —                | Requirements for this quiz                      |
-| `skippable`      | boolean      | ❌       | `false`          | Allow skipping                                  |
+| Field            | Type         | Required | Default          | Description                                                                 |
+| ---------------- | ------------ | -------- | ---------------- | --------------------------------------------------------------------------- |
+| `question`       | string       | ✅       | —                | Question text (supports markdown)                                           |
+| `choices`        | QuizChoice[] | ✅       | —                | Answer choices (see below)                                                  |
+| `multiSelect`    | boolean      | ❌       | `false`          | Allow multiple answers (checkboxes vs radio)                                |
+| `completionMode` | string       | ❌       | `"correct-only"` | `"correct-only"` or `"max-attempts"`                                        |
+| `maxAttempts`    | number       | ❌       | `3`              | Attempts before revealing answer (max-attempts)                             |
+| `requirements`   | string[]     | ❌       | —                | Requirements for this quiz                                                  |
+| `skippable`      | boolean      | ❌       | `false`          | Allow skipping                                                              |
+| `shuffle`        | boolean      | ❌       | `true`           | Randomize choice display order. Set to `false` to render in authored order. |
 
 **Choice Structure:**
 
-| Field     | Type    | Required | Description                                   |
-| --------- | ------- | -------- | --------------------------------------------- |
-| `id`      | string  | ✅       | Choice identifier (e.g., "a", "b", "c")       |
-| `text`    | string  | ✅       | Choice text (supports markdown)               |
-| `correct` | boolean | ❌       | Is this a correct answer?                     |
-| `hint`    | string  | ❌       | Hint shown when this wrong choice is selected |
+| Field     | Type    | Required | Description                                                                                                             |
+| --------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `id`      | string  | ✅       | Choice identifier (e.g., "a", "b", "c")                                                                                 |
+| `text`    | string  | ✅       | Choice text (supports markdown)                                                                                         |
+| `correct` | boolean | ❌       | Is this a correct answer?                                                                                               |
+| `hint`    | string  | ❌       | Hint shown when this wrong choice is selected                                                                           |
+| `pinned`  | boolean | ❌       | When the quiz is shuffled, keep this choice at its authored index. Useful for "All of the above" / "None of the above". |
 
 **Completion Modes:**
 
@@ -559,6 +561,39 @@ Knowledge assessment with single or multiple choice questions.
     { "id": "b", "text": "Microsoft Word", "hint": "Word is not a data source!" },
     { "id": "c", "text": "Loki", "correct": true },
     { "id": "d", "text": "InfluxDB", "correct": true }
+  ]
+}
+```
+
+**Shuffle and Pinned Choices:**
+
+By default, quiz choices are shuffled on each view to prevent learners from memorizing answer positions. Authors can opt out at the block level, or pin individual choices to their authored index — useful for "All of the above" / "None of the above" answers that must stay in a specific slot.
+
+```json
+{
+  "type": "quiz",
+  "question": "Which Grafana data source uses PromQL?",
+  "choices": [
+    { "id": "a", "text": "Loki" },
+    { "id": "b", "text": "Prometheus", "correct": true },
+    { "id": "c", "text": "Tempo" },
+    { "id": "d", "text": "All of the above", "pinned": true, "hint": "Only one is correct." }
+  ]
+}
+```
+
+To preserve the authored order across all renders (e.g., when ordering matters pedagogically), set `shuffle: false`:
+
+```json
+{
+  "type": "quiz",
+  "question": "Order matters here — pick the lowest tier.",
+  "shuffle": false,
+  "choices": [
+    { "id": "a", "text": "Free", "correct": true },
+    { "id": "b", "text": "Pro" },
+    { "id": "c", "text": "Advanced" },
+    { "id": "d", "text": "Enterprise" }
   ]
 }
 ```

--- a/src/cli/__tests__/package-io.test.ts
+++ b/src/cli/__tests__/package-io.test.ts
@@ -444,6 +444,14 @@ describe('appendChoice', () => {
     }
     throw new Error('expected throw');
   });
+
+  it('preserves the pinned flag on the appended choice', () => {
+    const content = baseContent([quiz('q1', [{ id: 'a', text: 'A', correct: true }])]);
+    appendChoice(content, { id: 'd', text: 'All of the above', pinned: true }, 'q1');
+    const choices = (content.blocks[0] as JsonQuizBlock).choices;
+    expect(choices).toHaveLength(2);
+    expect(choices[1]!.pinned).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/block-editor/forms/QuizBlockForm.tsx
+++ b/src/components/block-editor/forms/QuizBlockForm.tsx
@@ -185,6 +185,12 @@ export function QuizBlockForm({
   const [maxAttempts, setMaxAttempts] = useState(initial?.maxAttempts ?? 3);
   const [requirements, setRequirements] = useState(initial?.requirements?.join(', ') ?? '');
   const [skippable, setSkippable] = useState(initial?.skippable ?? false);
+  const [shuffle, setShuffle] = useState(initial?.shuffle ?? true);
+
+  // Toggle pinned state on a choice
+  const handleTogglePinnedChoice = useCallback((id: string) => {
+    setChoices((prev) => prev.map((c) => (c.id === id ? { ...c, pinned: c.pinned ? undefined : true } : c)));
+  }, []);
 
   // Add a new choice
   const handleAddChoice = useCallback(() => {
@@ -291,6 +297,9 @@ export function QuizBlockForm({
         if (c.hint?.trim()) {
           cleaned.hint = c.hint.trim();
         }
+        if (c.pinned) {
+          cleaned.pinned = true;
+        }
         return cleaned;
       });
 
@@ -303,11 +312,14 @@ export function QuizBlockForm({
         ...(completionMode === 'max-attempts' && maxAttempts !== 3 && { maxAttempts }),
         ...(reqArray.length > 0 && { requirements: reqArray }),
         ...(skippable && { skippable }),
+        // Only emit `shuffle` when opting out — default is true, so omitting
+        // keeps authored JSON minimal (mirrors the multiSelect/skippable pattern).
+        ...(shuffle === false && { shuffle: false }),
       };
 
       onSubmit(block);
     },
-    [question, choices, multiSelect, completionMode, maxAttempts, requirements, skippable, onSubmit]
+    [question, choices, multiSelect, completionMode, maxAttempts, requirements, skippable, shuffle, onSubmit]
   );
 
   // Validation
@@ -345,6 +357,14 @@ export function QuizBlockForm({
             onChange={handleMultiSelectChange}
           />
         </div>
+      </Field>
+
+      {/* Shuffle */}
+      <Field
+        label="Shuffle answer order"
+        description="Randomize the order choices are displayed in. Pin individual choices below to keep them at their authored index."
+      >
+        <Checkbox value={shuffle} onChange={(e) => setShuffle(e.currentTarget.checked)} label="Shuffle on each view" />
       </Field>
 
       {/* Choices */}
@@ -390,6 +410,21 @@ export function QuizBlockForm({
 
                 {/* Actions */}
                 <div className={quizStyles.choiceActions}>
+                  <IconButton
+                    name="gf-pin"
+                    tooltip={
+                      shuffle
+                        ? choice.pinned
+                          ? 'Pinned to this position — unpin to allow shuffling'
+                          : 'Pin to this position (kept fixed when shuffling)'
+                        : 'Pin position (has no effect when shuffle is off)'
+                    }
+                    onClick={() => handleTogglePinnedChoice(choice.id)}
+                    aria-label={`${choice.pinned ? 'Unpin' : 'Pin'} choice ${choice.id}`}
+                    aria-pressed={!!choice.pinned}
+                    variant={choice.pinned ? 'primary' : 'secondary'}
+                    size="md"
+                  />
                   <IconButton
                     name="trash-alt"
                     tooltip="Remove choice"

--- a/src/components/block-editor/utils/json-roundtrip.test.ts
+++ b/src/components/block-editor/utils/json-roundtrip.test.ts
@@ -451,6 +451,31 @@ describe('JSON Round-trip Conversion', () => {
       expect(quiz.completionMode).toBe('max-attempts');
       expect(quiz.maxAttempts).toBe(3);
     });
+
+    test('quiz preserves shuffle and pinned fields', () => {
+      const guide: JsonGuide = {
+        ...baseGuide,
+        blocks: [
+          {
+            type: 'quiz',
+            question: 'Order matters here.',
+            shuffle: false,
+            choices: [
+              { id: 'a', text: 'Free', correct: true },
+              { id: 'b', text: 'Pro' },
+              { id: 'c', text: 'Advanced' },
+              { id: 'd', text: 'All of the above', pinned: true, hint: 'Only one is correct.' },
+            ],
+          },
+        ],
+      };
+      const { result } = roundTrip(guide);
+      expect(result.isValid).toBe(true);
+      const quiz = result.guide?.blocks[0] as JsonQuizBlock;
+      expect(quiz.shuffle).toBe(false);
+      expect(quiz.choices[3]!.pinned).toBe(true);
+      expect(quiz.choices[0]!.pinned).toBeUndefined();
+    });
   });
 
   describe('input blocks', () => {

--- a/src/components/interactive-tutorial/interactive-quiz.test.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.test.tsx
@@ -232,6 +232,164 @@ describe('InteractiveQuiz: shuffle behavior', () => {
   });
 });
 
+// ─── Stability across re-renders ─────────────────────────────────────────────
+
+describe('InteractiveQuiz: render-order stability', () => {
+  beforeEach(() => {
+    resetQuizCounter();
+  });
+
+  const choices: QuizChoice[] = [
+    { id: 'a', text: 'Alpha', correct: false },
+    { id: 'b', text: 'Bravo', correct: true },
+    { id: 'c', text: 'Charlie', correct: false },
+    { id: 'd', text: 'Delta', correct: false },
+  ];
+
+  const readChoiceOrder = () =>
+    screen
+      .getAllByRole('button')
+      .map((b) => b.textContent)
+      .filter((t): t is string => !!t && /^(Alpha|Bravo|Charlie|Delta)$/.test(t));
+
+  it('does not reshuffle when the parent re-renders with a new choices array reference', () => {
+    const spy = jest.spyOn(Math, 'random');
+    const seq = mulberry32(7);
+    spy.mockImplementation(() => seq());
+
+    try {
+      // Fresh array reference on each render — mirrors a parent that does not memoize.
+      const { rerender } = render(
+        <InteractiveQuiz question="Q" choices={[...choices]} shuffle={true}>
+          Q
+        </InteractiveQuiz>
+      );
+      const initial = readChoiceOrder();
+
+      for (let i = 0; i < 5; i++) {
+        rerender(
+          <InteractiveQuiz question="Q" choices={[...choices]} shuffle={true}>
+            Q
+          </InteractiveQuiz>
+        );
+        expect(readChoiceOrder()).toEqual(initial);
+      }
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('preserves the correct/completed state and rendered order through a parent re-render', () => {
+    const spy = jest.spyOn(Math, 'random');
+    const seq = mulberry32(7);
+    spy.mockImplementation(() => seq());
+
+    try {
+      const { rerender } = render(
+        <InteractiveQuiz question="Q" choices={[...choices]} shuffle={true}>
+          Q
+        </InteractiveQuiz>
+      );
+      const orderBefore = readChoiceOrder();
+
+      // Answer correctly.
+      fireEvent.click(screen.getByRole('button', { name: 'Bravo' }));
+      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
+      expect(screen.getByText(/Correct! Well done\./i)).toBeInTheDocument();
+
+      // Force a parent re-render with an unrelated prop change (and a fresh choices reference).
+      rerender(
+        <InteractiveQuiz question="Q (edited)" choices={[...choices]} shuffle={true}>
+          Q (edited)
+        </InteractiveQuiz>
+      );
+
+      // Completion message still shown.
+      expect(screen.getByText(/Correct! Well done\./i)).toBeInTheDocument();
+      // Rendered order is unchanged — the answered choice stays where the user clicked it.
+      expect(readChoiceOrder()).toEqual(orderBefore);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('preserves the incorrect/hint state and rendered order through a parent re-render', () => {
+    const withHints: QuizChoice[] = [
+      { id: 'a', text: 'Alpha', correct: false, hint: 'Alpha hint' },
+      { id: 'b', text: 'Bravo', correct: true },
+      { id: 'c', text: 'Charlie', correct: false, hint: 'Charlie hint' },
+    ];
+
+    const spy = jest.spyOn(Math, 'random');
+    const seq = mulberry32(7);
+    spy.mockImplementation(() => seq());
+
+    try {
+      const { rerender } = render(
+        <InteractiveQuiz question="Q" choices={[...withHints]} shuffle={true}>
+          Q
+        </InteractiveQuiz>
+      );
+      const orderBefore = screen
+        .getAllByRole('button')
+        .map((b) => b.textContent)
+        .filter((t): t is string => !!t && /^(Alpha|Bravo|Charlie)$/.test(t));
+
+      // Pick a wrong answer so the hint surfaces.
+      fireEvent.click(screen.getByRole('button', { name: 'Charlie' }));
+      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
+      expect(screen.getByText('Charlie hint')).toBeInTheDocument();
+
+      // Force a re-render with a new choices reference.
+      rerender(
+        <InteractiveQuiz question="Q" choices={[...withHints]} shuffle={true}>
+          Q
+        </InteractiveQuiz>
+      );
+
+      // Hint still visible, order unchanged.
+      expect(screen.getByText('Charlie hint')).toBeInTheDocument();
+      const orderAfter = screen
+        .getAllByRole('button')
+        .map((b) => b.textContent)
+        .filter((t): t is string => !!t && /^(Alpha|Bravo|Charlie)$/.test(t));
+      expect(orderAfter).toEqual(orderBefore);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('reshuffles when resetTrigger increments', () => {
+    // Use a seed where the first shuffle differs from the second.
+    const spy = jest.spyOn(Math, 'random');
+    const seq = mulberry32(7);
+    spy.mockImplementation(() => seq());
+
+    try {
+      const { rerender } = render(
+        <InteractiveQuiz question="Q" choices={choices} shuffle={true} resetTrigger={0}>
+          Q
+        </InteractiveQuiz>
+      );
+      const orderBefore = readChoiceOrder();
+
+      rerender(
+        <InteractiveQuiz question="Q" choices={choices} shuffle={true} resetTrigger={1}>
+          Q
+        </InteractiveQuiz>
+      );
+      const orderAfter = readChoiceOrder();
+
+      // Both orders contain the same set of choices.
+      expect(new Set(orderAfter)).toEqual(new Set(orderBefore));
+      // The reset effect drew fresh values from the RNG, so the order changed.
+      expect(orderAfter).not.toEqual(orderBefore);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 // ─── Deterministic RNG for tests ─────────────────────────────────────────────
 
 /**

--- a/src/components/interactive-tutorial/interactive-quiz.test.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * Tests for InteractiveQuiz — issue #851
+ *
+ * Quiz answer choices are shuffled by default to prevent learners from
+ * memorizing answer positions. Authors can opt out at the block level
+ * (shuffle=false) or pin individual choices to their authored index
+ * (pinned=true). Selection, completion, hints, and analytics are all
+ * keyed by `choice.id`, so reordering is safe.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InteractiveQuiz, resetQuizCounter, shuffleQuizChoices, type QuizChoice } from './interactive-quiz';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+jest.mock('../../lib/analytics', () => ({
+  reportAppInteraction: jest.fn(),
+  UserInteraction: { StepAutoCompleted: 'auto' },
+  buildInteractiveStepProperties: jest.fn((props) => props),
+}));
+
+jest.mock('./use-standalone-persistence', () => ({
+  useStandalonePersistence: jest.fn(),
+}));
+
+jest.mock('../../requirements-manager', () => ({
+  useStepChecker: jest.fn(() => ({
+    isEnabled: true,
+    isCompleted: false,
+    explanation: null,
+    canSkip: false,
+    markSkipped: jest.fn(),
+    resetStep: jest.fn(),
+  })),
+}));
+
+// ─── shuffleQuizChoices (pure helper) ────────────────────────────────────────
+
+describe('shuffleQuizChoices', () => {
+  const choices: QuizChoice[] = [
+    { id: 'a', text: 'Alpha', correct: false },
+    { id: 'b', text: 'Bravo', correct: true },
+    { id: 'c', text: 'Charlie', correct: false },
+    { id: 'd', text: 'Delta', correct: false },
+  ];
+
+  it('preserves all choices (same set, same length)', () => {
+    const rng = mulberry32(42);
+    const shuffled = shuffleQuizChoices(choices, rng);
+    expect(shuffled).toHaveLength(choices.length);
+    expect(new Set(shuffled.map((c) => c.id))).toEqual(new Set(choices.map((c) => c.id)));
+  });
+
+  it('reorders non-pinned choices', () => {
+    // mulberry32(7) yields a non-identity permutation for 4 items.
+    const rng = mulberry32(7);
+    const shuffled = shuffleQuizChoices(choices, rng);
+    const orderChanged = shuffled.some((c, i) => c.id !== choices[i]!.id);
+    expect(orderChanged).toBe(true);
+  });
+
+  it('keeps pinned choices at their authored index', () => {
+    const withPinned: QuizChoice[] = [
+      { id: 'a', text: 'Alpha', correct: false },
+      { id: 'b', text: 'Bravo', correct: true },
+      { id: 'c', text: 'Charlie', correct: false },
+      { id: 'd', text: 'All of the above', correct: false, pinned: true },
+    ];
+
+    // Run several deterministic seeds — pinned must always end up at index 3.
+    for (const seed of [1, 7, 42, 123, 9999]) {
+      const shuffled = shuffleQuizChoices(withPinned, mulberry32(seed));
+      expect(shuffled[3]!.id).toBe('d');
+    }
+  });
+
+  it('keeps multiple pinned choices at their authored indices', () => {
+    const withPinned: QuizChoice[] = [
+      { id: 'a', text: 'Intro', correct: false, pinned: true },
+      { id: 'b', text: 'Middle 1', correct: false },
+      { id: 'c', text: 'Middle 2', correct: true },
+      { id: 'd', text: 'Outro', correct: false, pinned: true },
+    ];
+
+    const shuffled = shuffleQuizChoices(withPinned, mulberry32(123));
+    expect(shuffled[0]!.id).toBe('a');
+    expect(shuffled[3]!.id).toBe('d');
+    expect(new Set([shuffled[1]!.id, shuffled[2]!.id])).toEqual(new Set(['b', 'c']));
+  });
+
+  it('returns a copy (does not mutate the input array)', () => {
+    const input = choices.slice();
+    const snapshot = input.map((c) => c.id);
+    shuffleQuizChoices(input, mulberry32(42));
+    expect(input.map((c) => c.id)).toEqual(snapshot);
+  });
+
+  it('handles 0 and 1 choice arrays', () => {
+    expect(shuffleQuizChoices([])).toEqual([]);
+    const one: QuizChoice[] = [{ id: 'a', text: 'A', correct: true }];
+    expect(shuffleQuizChoices(one)).toEqual(one);
+  });
+});
+
+// ─── Component rendering ─────────────────────────────────────────────────────
+
+describe('InteractiveQuiz: shuffle behavior', () => {
+  beforeEach(() => {
+    resetQuizCounter();
+  });
+
+  const choices: QuizChoice[] = [
+    { id: 'a', text: 'Alpha', correct: false },
+    { id: 'b', text: 'Bravo', correct: true },
+    { id: 'c', text: 'Charlie', correct: false },
+    { id: 'd', text: 'Delta', correct: false },
+  ];
+
+  it('renders in authored order when shuffle=false', () => {
+    render(
+      <InteractiveQuiz question="Pick one" choices={choices} shuffle={false}>
+        Pick one
+      </InteractiveQuiz>
+    );
+    const rendered = screen.getAllByRole('button').filter((b) => b.textContent?.match(/^(Alpha|Bravo|Charlie|Delta)$/));
+    expect(rendered.map((b) => b.textContent)).toEqual(['Alpha', 'Bravo', 'Charlie', 'Delta']);
+  });
+
+  it('renders in shuffled order when shuffle=true', () => {
+    // Seed Math.random with a value known to produce a non-identity permutation.
+    const spy = jest.spyOn(Math, 'random');
+    const seq = mulberry32(7);
+    spy.mockImplementation(() => seq());
+
+    try {
+      render(
+        <InteractiveQuiz question="Pick one" choices={choices} shuffle={true}>
+          Pick one
+        </InteractiveQuiz>
+      );
+      const rendered = screen
+        .getAllByRole('button')
+        .filter((b) => b.textContent?.match(/^(Alpha|Bravo|Charlie|Delta)$/));
+      const orderChanged = rendered.some((b, i) => b.textContent !== choices[i]!.text);
+      expect(orderChanged).toBe(true);
+      // All four choices still present.
+      expect(new Set(rendered.map((b) => b.textContent))).toEqual(new Set(['Alpha', 'Bravo', 'Charlie', 'Delta']));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('keeps a pinned choice at its authored index even when shuffled', () => {
+    const withPinned: QuizChoice[] = [
+      { id: 'a', text: 'Alpha', correct: false },
+      { id: 'b', text: 'Bravo', correct: false },
+      { id: 'c', text: 'Charlie', correct: true },
+      { id: 'd', text: 'All of the above', correct: false, pinned: true },
+    ];
+
+    // Try a handful of seeds — pinned choice must always be last.
+    for (const seed of [1, 7, 42]) {
+      const spy = jest.spyOn(Math, 'random');
+      const seq = mulberry32(seed);
+      spy.mockImplementation(() => seq());
+
+      try {
+        const { unmount } = render(
+          <InteractiveQuiz question="Q" choices={withPinned} shuffle={true}>
+            Q
+          </InteractiveQuiz>
+        );
+        const rendered = screen
+          .getAllByRole('button')
+          .filter((b) => b.textContent?.match(/^(Alpha|Bravo|Charlie|All of the above)$/));
+        expect(rendered[rendered.length - 1]!.textContent).toBe('All of the above');
+        unmount();
+      } finally {
+        spy.mockRestore();
+      }
+    }
+  });
+
+  it('selecting the correct answer completes the quiz regardless of rendered position', () => {
+    const spy = jest.spyOn(Math, 'random');
+    const seq = mulberry32(7);
+    spy.mockImplementation(() => seq());
+
+    try {
+      render(
+        <InteractiveQuiz question="Q" choices={choices} shuffle={true}>
+          Q
+        </InteractiveQuiz>
+      );
+
+      // Find the rendered "Bravo" button (correct=true) — its visual position
+      // is whatever the shuffle produced; we look up by text.
+      const correctButton = screen.getByRole('button', { name: 'Bravo' });
+      fireEvent.click(correctButton);
+      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
+
+      expect(screen.getByText(/Correct! Well done\./i)).toBeInTheDocument();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('shows the matching hint when a wrong shuffled choice is selected', () => {
+    const withHints: QuizChoice[] = [
+      { id: 'a', text: 'Alpha', correct: false, hint: 'Alpha hint' },
+      { id: 'b', text: 'Bravo', correct: true },
+      { id: 'c', text: 'Charlie', correct: false, hint: 'Charlie hint' },
+    ];
+
+    const spy = jest.spyOn(Math, 'random');
+    const seq = mulberry32(7);
+    spy.mockImplementation(() => seq());
+
+    try {
+      render(
+        <InteractiveQuiz question="Q" choices={withHints} shuffle={true}>
+          Q
+        </InteractiveQuiz>
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Charlie' }));
+      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
+      expect(screen.getByText('Charlie hint')).toBeInTheDocument();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+// ─── Deterministic RNG for tests ─────────────────────────────────────────────
+
+/**
+ * mulberry32 — small seedable PRNG. We use it instead of Math.random so the
+ * tests above are deterministic. https://stackoverflow.com/a/47593316
+ */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/src/components/interactive-tutorial/interactive-quiz.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.tsx
@@ -150,6 +150,14 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
   const [isRevealed, setIsRevealed] = useState(false);
   const [shakeKey, setShakeKey] = useState(0);
 
+  // Display order. Computed ONCE on mount via lazy init so a parent re-render
+  // cannot reorder choices mid-quiz. Re-shuffled only when the parent triggers
+  // a reset (see effect below). Selection, completion, hints, analytics, and
+  // test IDs are all id-keyed, so display-order changes never alter quiz state.
+  const [displayChoices, setDisplayChoices] = useState<QuizChoice[]>(() =>
+    shuffle ? shuffleQuizChoices(choices) : choices
+  );
+
   // Requirements checking
   const {
     isEnabled,
@@ -166,6 +174,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
   });
 
   // Handle reset trigger from parent section.
+  /* eslint-disable react-hooks/set-state-in-effect -- Intentional: reset quiz state when the parent section increments resetTrigger */
   useEffect(() => {
     if (resetTrigger && resetTrigger > 0) {
       setSelectedIds(new Set());
@@ -174,30 +183,20 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
       setLastResult('none');
       setShowHint(null);
       setIsRevealed(false);
+      // Re-shuffle on retry so the user can't lean on remembered positions.
+      setDisplayChoices(shuffle ? shuffleQuizChoices(choices) : choices);
       if (resetStep) {
         resetStep();
       }
     }
   }, [resetTrigger]); // eslint-disable-line react-hooks/exhaustive-deps
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Compute effective completion state
   const isCompleted = parentCompleted || stepCompleted || isLocallyCompleted;
 
   // Get correct answer IDs
   const correctIds = useMemo(() => new Set(choices.filter((c) => c.correct).map((c) => c.id)), [choices]);
-
-  // Compute display order. When `shuffle` is true, reshuffle on mount and any
-  // time `resetTrigger` increments (so retry yields a fresh order). Selection,
-  // completion, hints, analytics, and test IDs are all id-keyed, so changing
-  // render order is safe.
-  const displayChoices = useMemo(() => {
-    if (!shuffle) {
-      return choices;
-    }
-    return shuffleQuizChoices(choices);
-    // resetTrigger is intentional: a new value forces a reshuffle on retry.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [choices, shuffle, resetTrigger]);
 
   // Compute displayed selection: show correct answers if quiz is completed but no selection made yet
   // This handles the case where quiz was completed in a previous session (page refresh)

--- a/src/components/interactive-tutorial/interactive-quiz.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.tsx
@@ -15,6 +15,8 @@ export interface QuizChoice {
   text: string;
   correct: boolean;
   hint?: string;
+  /** When the quiz is shuffled, keep this choice at its authored index. */
+  pinned?: boolean;
 }
 
 export interface InteractiveQuizProps {
@@ -32,6 +34,11 @@ export interface InteractiveQuizProps {
   requirements?: string;
   /** Whether quiz can be skipped */
   skippable?: boolean;
+  /**
+   * Randomize choice display order (default: true). Choices with
+   * `pinned: true` keep their authored index even when shuffling.
+   */
+  shuffle?: boolean;
   /** Rendered children (question content) */
   children?: React.ReactNode;
 
@@ -60,6 +67,47 @@ export function resetQuizCounter(): void {
   quizCounter = 0;
 }
 
+/**
+ * Shuffle quiz choices while keeping any choice with `pinned: true` at its
+ * authored index. Non-pinned choices are Fisher–Yates shuffled into the
+ * remaining slots. `rng` defaults to `Math.random` and is overridable so
+ * tests can produce a deterministic order.
+ */
+export function shuffleQuizChoices(choices: QuizChoice[], rng: () => number = Math.random): QuizChoice[] {
+  if (choices.length <= 1) {
+    return choices.slice();
+  }
+
+  // Reserve pinned slots at their authored positions.
+  const result: Array<QuizChoice | undefined> = new Array(choices.length).fill(undefined);
+  const unpinned: QuizChoice[] = [];
+  for (let i = 0; i < choices.length; i++) {
+    const choice = choices[i]!;
+    if (choice.pinned) {
+      result[i] = choice;
+    } else {
+      unpinned.push(choice);
+    }
+  }
+
+  // Fisher–Yates on the non-pinned subset.
+  for (let i = unpinned.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = unpinned[i]!;
+    unpinned[i] = unpinned[j]!;
+    unpinned[j] = tmp;
+  }
+
+  // Fill empty slots in order with the shuffled non-pinned choices.
+  let cursor = 0;
+  for (let i = 0; i < result.length; i++) {
+    if (result[i] === undefined) {
+      result[i] = unpinned[cursor++];
+    }
+  }
+  return result as QuizChoice[];
+}
+
 export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
   question,
   choices,
@@ -68,6 +116,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
   maxAttempts = 3,
   requirements,
   skippable = false,
+  shuffle = true,
   children,
   stepId: providedStepId,
   isEligibleForChecking = true,
@@ -116,8 +165,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
     skippable,
   });
 
-  // Handle reset trigger from parent section
-  /* eslint-disable react-hooks/set-state-in-effect -- Intentional: reset quiz state when parent section triggers a reset */
+  // Handle reset trigger from parent section.
   useEffect(() => {
     if (resetTrigger && resetTrigger > 0) {
       setSelectedIds(new Set());
@@ -131,13 +179,25 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
       }
     }
   }, [resetTrigger]); // eslint-disable-line react-hooks/exhaustive-deps
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Compute effective completion state
   const isCompleted = parentCompleted || stepCompleted || isLocallyCompleted;
 
   // Get correct answer IDs
   const correctIds = useMemo(() => new Set(choices.filter((c) => c.correct).map((c) => c.id)), [choices]);
+
+  // Compute display order. When `shuffle` is true, reshuffle on mount and any
+  // time `resetTrigger` increments (so retry yields a fresh order). Selection,
+  // completion, hints, analytics, and test IDs are all id-keyed, so changing
+  // render order is safe.
+  const displayChoices = useMemo(() => {
+    if (!shuffle) {
+      return choices;
+    }
+    return shuffleQuizChoices(choices);
+    // resetTrigger is intentional: a new value forces a reshuffle on retry.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [choices, shuffle, resetTrigger]);
 
   // Compute displayed selection: show correct answers if quiz is completed but no selection made yet
   // This handles the case where quiz was completed in a previous session (page refresh)
@@ -395,7 +455,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
         })}
         key={shakeKey}
       >
-        {choices.map((choice) => {
+        {displayChoices.map((choice) => {
           const state = getChoiceState(choice);
           const isSelected = displayedSelection.has(choice.id);
 

--- a/src/docs-retrieval/content-renderer.tsx
+++ b/src/docs-retrieval/content-renderer.tsx
@@ -1090,6 +1090,7 @@ function renderParsedElement(
           maxAttempts={element.props.maxAttempts}
           requirements={element.props.requirements}
           skippable={element.props.skippable}
+          shuffle={element.props.shuffle}
           // Standalone step position (for guides without sections)
           stepIndex={standaloneStepPosition?.stepIndex}
           totalSteps={standaloneStepPosition?.totalSteps}

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -714,6 +714,7 @@ function convertQuizBlock(block: JsonQuizBlock, path: string): ConversionResult 
     text: choice.text,
     correct: choice.correct ?? false,
     hint: choice.hint,
+    pinned: choice.pinned ?? false,
   }));
 
   return {
@@ -727,6 +728,7 @@ function convertQuizBlock(block: JsonQuizBlock, path: string): ConversionResult 
         maxAttempts: block.maxAttempts ?? 3,
         requirements,
         skippable: block.skippable ?? false,
+        shuffle: block.shuffle ?? true,
       },
       children: questionElements,
     },

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -99,6 +99,7 @@ export const JsonQuizChoiceSchema = z.object({
   text: z.string().min(1, 'Choice text is required').describe('Visible choice text'),
   correct: z.boolean().optional().describe('Mark this choice as correct'),
   hint: z.string().optional().describe('Hint shown when this choice is selected'),
+  pinned: z.boolean().optional().describe('Keep this choice at its authored index when the quiz is shuffled'),
 });
 
 // ============ STEP SCHEMA ============
@@ -355,6 +356,10 @@ export const JsonQuizBlockSchema = z
     maxAttempts: z.number().optional().describe('Number of attempts allowed when completionMode=max-attempts'),
     requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions'),
     skippable: z.boolean().optional().describe('Allow user to skip this block'),
+    shuffle: z
+      .boolean()
+      .optional()
+      .describe('Randomize choice display order (default: true); pinned choices keep their authored index'),
   })
   .superRefine((quiz, ctx) => {
     // Empty quizzes are a transient authoring state; the publish-time
@@ -795,7 +800,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'lazyRender',
     'scrollContainer',
   ]),
-  _choice: new Set(['id', 'text', 'correct', 'hint']),
+  _choice: new Set(['id', 'text', 'correct', 'hint', 'pinned']),
   markdown: new Set(['type', 'id', 'content', 'assistantEnabled', 'assistantId', 'assistantType']),
   html: new Set(['type', 'id', 'content']),
   image: new Set(['type', 'id', 'src', 'alt', 'width', 'height']),
@@ -861,6 +866,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'maxAttempts',
     'requirements',
     'skippable',
+    'shuffle',
   ]),
   input: new Set([
     'type',

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -390,6 +390,12 @@ export interface JsonQuizBlock {
   requirements?: string[];
   /** Whether quiz can be skipped */
   skippable?: boolean;
+  /**
+   * Randomize choice display order (default: true). Set to false to render
+   * in authored order. Choices with `pinned: true` keep their authored index
+   * even when shuffling is enabled.
+   */
+  shuffle?: boolean;
 }
 
 /**
@@ -404,6 +410,12 @@ export interface JsonQuizChoice {
   correct?: boolean;
   /** Hint shown when this wrong choice is selected */
   hint?: string;
+  /**
+   * Keep this choice at its authored index when the quiz is shuffled.
+   * Useful for "All of the above" / "None of the above" answers that must
+   * stay in a specific slot. Has no effect when `shuffle` is false.
+   */
+  pinned?: boolean;
 }
 
 // ============ INPUT BLOCK ============


### PR DESCRIPTION
## Summary

Fixes #851 — quiz answers are no longer always rendered in authored order.

- **Default**: quiz choices are Fisher–Yates shuffled on each view (per-mount, plus on `resetTrigger`).
- **Opt-out per block**: set `shuffle: false` on the quiz block to render in authored order.
- **Pin per choice**: set `pinned: true` on a choice to keep it at its authored index even when the block is shuffled — useful for "All of the above" / "None of the above" anchors. No new vocabulary like `pinPosition: 'last'`; pin semantics come from the choice's authored index.

Selection, completion, hints, analytics, and test IDs are all id-keyed, so reordering the rendered list is safe end-to-end. The new helper `shuffleQuizChoices` accepts an injectable RNG so tests are deterministic.

Schema change is purely additive — two new optional fields on `JsonQuizBlockSchema` (`shuffle`) and `JsonQuizChoiceSchema` (`pinned`). **`CURRENT_SCHEMA_VERSION` is unchanged**; existing guides parse identically. CLI flag surface (`add-block quiz --shuffle`, `add-choice --pinned`) and MCP tool fields come automatically from `registerSchemaOptions`.

### Behavior change to flag

Guides without `shuffle` set will now shuffle. Authors who depend on a specific authored order should add `"shuffle": false` to the block. Worth a release note.

### Files changed (11)

- `src/types/json-guide.types.ts`, `src/types/json-guide.schema.ts` — types + Zod + `KNOWN_FIELDS`
- `src/docs-retrieval/json-parser.ts`, `src/docs-retrieval/content-renderer.tsx` — wire the new props through the pipeline
- `src/components/interactive-tutorial/interactive-quiz.tsx` — `shuffleQuizChoices` helper, `displayChoices` memo keyed on `[choices, shuffle, resetTrigger]`
- `src/components/block-editor/forms/QuizBlockForm.tsx` — "Shuffle answer order" checkbox + per-choice pin toggle (`gf-pin` icon)
- `docs/developer/interactive-examples/json-guide-format.md` — schema docs + two new JSON examples
- `docs/design/AGENT-AUTHORING.md` — `--pinned` mention + worked CLI example
- `src/components/interactive-tutorial/interactive-quiz.test.tsx` (new, 11 tests)
- `src/components/block-editor/utils/json-roundtrip.test.ts`, `src/cli/__tests__/package-io.test.ts` — round-trip + CLI coverage for the new fields

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run prettier-test` — clean
- [x] `npm run test:ci` — 168 suites / 3146 tests pass (includes 13 new tests covering shuffle, pin, hint lookup under shuffle, and round-trips)
- [x] `npm run check` — passes apart from `lint:go` (golangci-lint missing locally; no Go files touched, CI will run it)
- [ ] Manual UI: bundled quiz reloads several times — choices reorder, completion still works
- [ ] Manual UI: block editor — author a quiz with 4 choices, pin the last as "All of the above", verify it stays last across multiple reloads
- [ ] Manual UI: set `shuffle: false` and confirm authored order is preserved on reload
- [ ] CLI: `pathfinder-cli add-block quiz <dir> --id q1 ... --shuffle false` and `add-choice --pinned` both work
