### PR TITLE
fix(sections): number all content blocks in a section (#841)

### DIFF
--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -50,13 +50,28 @@ export function shouldNumberSectionChild(child: React.ReactNode): boolean {
  * Wrap each section child in an <li>, marking content blocks with
  * data-numbered="true" so CSS can apply sequential numbering. Media and
  * wrapper blocks (image/video/conditional) sit in the list without a number.
+ *
+ * data-step="true"  → React component (InteractiveStep, quiz, terminal, etc.)
+ *                     These carry their own CSS margin-top that naturally aligns
+ *                     the card with the ::before number at top: theme.spacing(2).
+ *                     The <li> needs no extra padding.
+ * data-step="false" → Plain HTML content (markdown <p>, headings, etc.)
+ *                     No built-in top margin, so the <li> gets paddingTop via CSS
+ *                     to push the content start down to match the number position.
  */
 export function wrapSectionChildrenForNumbering(children: React.ReactNode): React.ReactNode {
   return React.Children.map(children, (child, index) => {
     const numbered = shouldNumberSectionChild(child);
     const childKey = React.isValidElement(child) && child.key != null ? child.key : `section-child-${index}`;
+    // React components (interactive steps, quiz, terminal…) have typeof type === 'function'.
+    // Plain HTML elements (p, div, h2…) have typeof type === 'string'.
+    const isStep = React.isValidElement(child) && typeof child.type !== 'string';
     return (
-      <li key={childKey} data-numbered={numbered ? 'true' : undefined}>
+      <li
+        key={childKey}
+        data-numbered={numbered ? 'true' : undefined}
+        data-step={numbered ? String(isStep) : undefined}
+      >
         {child}
       </li>
     );

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -12,6 +12,8 @@ import { InteractiveQuiz, resetQuizCounter } from './interactive-quiz';
 import { TerminalStep, resetTerminalStepCounter } from './terminal-step';
 import { TerminalConnectStep, resetTerminalConnectStepCounter } from './terminal-connect-step';
 import { CodeBlockStep, resetCodeBlockStepCounter } from './code-block-step';
+import { InteractiveConditional } from './interactive-conditional';
+import { ImageRenderer, VideoRenderer, YouTubeVideoRenderer } from '../../docs-retrieval';
 import { reportAppInteraction, UserInteraction, getSourceDocument, calculateStepCompletion } from '../../lib/analytics';
 import { interactiveStepStorage, sectionCollapseStorage, interactiveCompletionStorage } from '../../lib/user-storage';
 import { INTERACTIVE_CONFIG, getInteractiveConfig } from '../../constants/interactive-config';
@@ -23,6 +25,43 @@ import { getResumeInfo as computeResumeInfo, computeStepEligibility } from './st
 
 // Simple counter for sequential section IDs
 let interactiveSectionCounter = 0;
+
+/**
+ * Per issue #841: media and wrapper blocks render in a section without a step
+ * number; everything else (markdown, code samples, interactive steps, quiz,
+ * terminal, input, etc.) participates in the section's `1. 2. 3.` sequence.
+ *
+ * Lookups happen at call time, not module-init time — the docs-retrieval barrel
+ * imports content-renderer, which imports back into this directory, so a top-
+ * level `new Set([ImageRenderer, ...])` would resolve to undefined under cycle
+ * load order. By checking inside the function, both modules have finished
+ * initializing by the first invocation.
+ */
+export function shouldNumberSectionChild(child: React.ReactNode): boolean {
+  if (!React.isValidElement(child)) {
+    // Plain strings / numbers / fragments — render but don't number.
+    return false;
+  }
+  const t = child.type;
+  return t !== ImageRenderer && t !== VideoRenderer && t !== YouTubeVideoRenderer && t !== InteractiveConditional;
+}
+
+/**
+ * Wrap each section child in an <li>, marking content blocks with
+ * data-numbered="true" so CSS can apply sequential numbering. Media and
+ * wrapper blocks (image/video/conditional) sit in the list without a number.
+ */
+export function wrapSectionChildrenForNumbering(children: React.ReactNode): React.ReactNode {
+  return React.Children.map(children, (child, index) => {
+    const numbered = shouldNumberSectionChild(child);
+    const childKey = React.isValidElement(child) && child.key != null ? child.key : `section-child-${index}`;
+    return (
+      <li key={childKey} data-numbered={numbered ? 'true' : undefined}>
+        {child}
+      </li>
+    );
+  });
+}
 
 // Global registry to track all steps across all sections in the document
 interface StepRegistryEntry {
@@ -1751,7 +1790,9 @@ export function InteractiveSection({
         </div>
       )}
 
-      {!isCollapsed && <ol className="interactive-section-content">{enhancedChildren}</ol>}
+      {!isCollapsed && (
+        <ol className="interactive-section-content">{wrapSectionChildrenForNumbering(enhancedChildren)}</ol>
+      )}
 
       <div className={`interactive-section-actions${isCollapsed ? ' collapsed' : ''}`}>
         {isCollapsed ? (

--- a/src/components/interactive-tutorial/section-numbering.test.tsx
+++ b/src/components/interactive-tutorial/section-numbering.test.tsx
@@ -129,6 +129,14 @@ describe('wrapSectionChildrenForNumbering', () => {
     expect(items[1]?.getAttribute('data-numbered')).toBe('true');
     expect(items[2]?.hasAttribute('data-numbered')).toBe(false);
     expect(items[3]?.getAttribute('data-numbered')).toBe('true');
+
+    // React component children (step, code-block) → data-step="true"
+    // Plain HTML children (<p>) → data-step="false"
+    // Unnumbered children (image) → no data-step at all
+    expect(items[0]?.getAttribute('data-step')).toBe('true'); // InteractiveStep
+    expect(items[1]?.getAttribute('data-step')).toBe('false'); // <p>
+    expect(items[2]?.hasAttribute('data-step')).toBe(false); // ImageRenderer (unnumbered)
+    expect(items[3]?.getAttribute('data-step')).toBe('true'); // CodeBlockStep
   });
 
   it('preserves the original child as the li.firstChild', () => {

--- a/src/components/interactive-tutorial/section-numbering.test.tsx
+++ b/src/components/interactive-tutorial/section-numbering.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Section numbering — issue #841
+ *
+ * Every content block inside a section should be numbered sequentially,
+ * regardless of whether it's interactive. Media and wrapper blocks
+ * (image / video / conditional) render in the same list but without a number,
+ * so an image between two steps doesn't break the 1-2-3 sequence and isn't
+ * itself numbered as "step 2".
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { shouldNumberSectionChild, wrapSectionChildrenForNumbering } from './interactive-section';
+import { InteractiveStep } from './interactive-step';
+import { InteractiveMultiStep } from './interactive-multi-step';
+import { InteractiveGuided } from './interactive-guided';
+import { InteractiveQuiz } from './interactive-quiz';
+import { TerminalStep } from './terminal-step';
+import { TerminalConnectStep } from './terminal-connect-step';
+import { CodeBlockStep } from './code-block-step';
+import { InteractiveConditional } from './interactive-conditional';
+import { InputBlock } from './input-block';
+import { GrotGuideBlock } from './grot-guide-block';
+import { ImageRenderer, VideoRenderer, YouTubeVideoRenderer } from '../../docs-retrieval';
+
+describe('shouldNumberSectionChild', () => {
+  describe('content blocks — numbered', () => {
+    it.each([
+      ['InteractiveStep', <InteractiveStep key="s" targetAction="highlight" refTarget=".x" />],
+      [
+        'InteractiveMultiStep',
+        <InteractiveMultiStep key="m" internalActions={[]}>
+          x
+        </InteractiveMultiStep>,
+      ],
+      [
+        'InteractiveGuided',
+        <InteractiveGuided key="g" internalActions={[]}>
+          x
+        </InteractiveGuided>,
+      ],
+      [
+        'InteractiveQuiz',
+        <InteractiveQuiz key="q" question="q" choices={[]}>
+          x
+        </InteractiveQuiz>,
+      ],
+      [
+        'TerminalStep',
+        <TerminalStep key="t" command="ls">
+          x
+        </TerminalStep>,
+      ],
+      [
+        'TerminalConnectStep',
+        <TerminalConnectStep key="tc" buttonText="connect">
+          x
+        </TerminalConnectStep>,
+      ],
+      [
+        'CodeBlockStep',
+        <CodeBlockStep key="cb" code="print('hi')" language="python" refTarget="">
+          x
+        </CodeBlockStep>,
+      ],
+      ['InputBlock', <InputBlock key="i" prompt="p" inputType="text" variableName="v" />],
+      [
+        'GrotGuideBlock',
+        <GrotGuideBlock key="gg" welcome={{ title: 'w', body: '', bodyHtml: '', ctas: [] }} screens={[]} />,
+      ],
+      ['markdown <p>', <p key="md">Some markdown</p>],
+      ['markdown <div class="markdown-block">', <div key="mb" className="markdown-block" />],
+      ['raw HTML <ul>', <ul key="ul" />],
+    ])('numbers %s', (_label, child) => {
+      expect(shouldNumberSectionChild(child)).toBe(true);
+    });
+  });
+
+  describe('media and wrapper blocks — not numbered', () => {
+    it('does not number ImageRenderer', () => {
+      expect(shouldNumberSectionChild(<ImageRenderer src="/x.png" alt="x" baseUrl="" />)).toBe(false);
+    });
+    it('does not number VideoRenderer', () => {
+      expect(shouldNumberSectionChild(<VideoRenderer src="/x.mp4" baseUrl="" />)).toBe(false);
+    });
+    it('does not number YouTubeVideoRenderer', () => {
+      expect(shouldNumberSectionChild(<YouTubeVideoRenderer src="https://youtu.be/x" />)).toBe(false);
+    });
+    it('does not number InteractiveConditional', () => {
+      expect(
+        shouldNumberSectionChild(
+          <InteractiveConditional
+            conditions={[]}
+            whenTrueChildren={[]}
+            whenFalseChildren={[]}
+            renderElement={() => null}
+            keyPrefix="k"
+          />
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('non-element children — not numbered', () => {
+    it('does not number text nodes', () => {
+      expect(shouldNumberSectionChild('plain text' as unknown as React.ReactNode)).toBe(false);
+    });
+    it('does not number null', () => {
+      expect(shouldNumberSectionChild(null)).toBe(false);
+    });
+  });
+});
+
+describe('wrapSectionChildrenForNumbering', () => {
+  it('wraps each child in <li> and tags numbered ones', () => {
+    const children = [
+      <InteractiveStep key="s" targetAction="highlight" refTarget=".a" />,
+      <p key="md">Markdown step</p>,
+      <ImageRenderer key="img" src="/x.png" alt="x" baseUrl="" />,
+      <CodeBlockStep key="cb" code="ls" language="bash" refTarget="" />,
+    ];
+
+    const { container } = render(<ol>{wrapSectionChildrenForNumbering(children)}</ol>);
+    const items = Array.from(container.querySelectorAll('ol > li'));
+
+    expect(items).toHaveLength(4);
+    // Three content blocks numbered; the image is not.
+    expect(items[0]?.getAttribute('data-numbered')).toBe('true');
+    expect(items[1]?.getAttribute('data-numbered')).toBe('true');
+    expect(items[2]?.hasAttribute('data-numbered')).toBe(false);
+    expect(items[3]?.getAttribute('data-numbered')).toBe('true');
+  });
+
+  it('preserves the original child as the li.firstChild', () => {
+    const { container } = render(
+      <ol>
+        {wrapSectionChildrenForNumbering([
+          <p key="md" data-testid="md">
+            hi
+          </p>,
+          <ImageRenderer key="img" src="/x.png" alt="x" baseUrl="" />,
+        ])}
+      </ol>
+    );
+
+    const items = container.querySelectorAll('ol > li');
+    expect(items[0]?.querySelector('[data-testid="md"]')).not.toBeNull();
+    expect(items[1]?.querySelector('img')).not.toBeNull();
+  });
+});

--- a/src/docs-retrieval/index.ts
+++ b/src/docs-retrieval/index.ts
@@ -43,7 +43,7 @@ export { ContentRenderer, useContentRenderer } from './content-renderer';
 export { parseJsonGuide, parseMarkdownToElements, isJsonGuideContent } from './json-parser';
 
 // Docs components
-export { CodeBlock } from './components/docs';
+export { CodeBlock, ImageRenderer, VideoRenderer, YouTubeVideoRenderer } from './components/docs';
 export type { CodeBlockProps } from './components/docs';
 
 // Guide response context (consumed by components/interactive-tutorial/)

--- a/src/styles/interactive.styles.ts
+++ b/src/styles/interactive.styles.ts
@@ -564,8 +564,14 @@ const getInteractiveComponentStyles = (theme: GrafanaTheme2) => ({
     listStyle: 'none', // Hide default markers since we use CSS counters
     counterReset: 'step-counter', // Initialize counter
 
-    // Increment counter for each step
-    '& > .interactive-step, & > .interactive-multistep, & > .interactive-guided': {
+    // Every direct child sits in a wrapper <li>. Only li[data-numbered="true"]
+    // participates in the sequential numbering — media (image/video) and wrapper
+    // (conditional) blocks render without a number. See issue #841.
+    '& > li': {
+      listStyle: 'none',
+    },
+
+    '& > li[data-numbered="true"]': {
       counterIncrement: 'step-counter',
       position: 'relative',
       paddingLeft: theme.spacing(4), // Space for the number

--- a/src/styles/interactive.styles.ts
+++ b/src/styles/interactive.styles.ts
@@ -581,13 +581,37 @@ const getInteractiveComponentStyles = (theme: GrafanaTheme2) => ({
         content: 'counter(step-counter) "."',
         position: 'absolute',
         left: 0,
-        top: theme.spacing(2), // Align with step content padding
+        top: theme.spacing(2), // Aligns with the content start offset (see below)
         color: theme.colors.text.secondary,
         fontWeight: theme.typography.fontWeightMedium,
         fontSize: theme.typography.body.fontSize,
         width: theme.spacing(3),
         textAlign: 'right',
       },
+    },
+
+    // Interactive step components (InteractiveStep, InteractiveMultiStep, etc.)
+    // carry their own CSS margin-top of theme.spacing(2), which naturally
+    // positions the card 16px below the <li> top — matching the number's
+    // top: theme.spacing(2). They also wrap content in a card with
+    // padding: theme.spacing(2) (16px) and border: 2px solid transparent,
+    // which insets the title text 18px from the card's left edge.
+    // Their <li> therefore needs NO extra padding.
+    //
+    // Plain content blocks (markdown <p>, headings, etc.) have no built-in
+    // margin-top OR card chrome, so they'd start at (top: 0, left: 0 inside
+    // the li padding) while the step's title sits at
+    // (top: theme.spacing(2), left: theme.spacing(2) + 2px) inside the li.
+    // [data-step="false"] marks those <li> items; paddingTop pushes their
+    // content down to align with the number, paddingLeft pushes them right
+    // to align horizontally with the step title text.
+    //
+    // Verified at runtime (issue #841 alignment fix):
+    //   step  title.x = li.x + 32 (li padding) + 2 (step border) + 16 (step padding) = li.x + 50
+    //   plain title.x = li.x + 32 + 18 (extra padding) = li.x + 50  ✓
+    '& > li[data-numbered="true"][data-step="false"]': {
+      paddingTop: theme.spacing(2),
+      paddingLeft: `calc(${theme.spacing(4)} + ${theme.spacing(2)} + 2px)`,
     },
 
     // Step status styles


### PR DESCRIPTION
## Summary

Closes #841.

Sections now number every content block sequentially, regardless of whether it's interactive. Previously, only `.interactive-step / .interactive-multistep / .interactive-guided` participated in the section's CSS counter, so a markdown block between two interactive steps broke the `1. 2. 3.` sequence and rendered flush-left. Authors had been using no-op interactive blocks as a workaround.

## What changed

- **`interactive-section.tsx`** -- children of the section's `<ol>` are wrapped in an `<li>`, with `data-numbered="true"` set on content blocks. The wrapping logic is exposed as `wrapSectionChildrenForNumbering` and `shouldNumberSectionChild` for test access.
- **`interactive.styles.ts`** -- CSS counter selector changed from a class allowlist to `& > li[data-numbered="true"]`. The `::before` step number and `paddingLeft` now live on the wrapper `<li>`.
- **`docs-retrieval/index.ts`** -- re-export `ImageRenderer`, `VideoRenderer`, `YouTubeVideoRenderer` from the barrel (consistent with the existing `CodeBlock` re-export, no new barrel-bypass entries).
- **`section-numbering.test.tsx`** (new, 20 cases) -- covers the denylist, numbered types (including markdown and code samples), and the wrapper's DOM output.

## Numbering rules

| Block kind                                                                                                                          | Numbered? |
| ----------------------------------------------------------------------------------------------------------------------------------- | --------- |
| markdown, code-block, interactive, multistep, guided, quiz, input, terminal, terminal-connect, html, assistant, grot-guide, raw HTML | **Yes**   |
| image, video, youtube-video, conditional                                                                                            | No        |

## Notes

- Component-identity lookup in `shouldNumberSectionChild` happens at call time, not module-init, to avoid a circular-import cycle through the docs-retrieval barrel (which re-exports `content-renderer.tsx`, which imports back into `components/interactive-tutorial/`).
- `li.interactive` dead CSS in `interactive.styles.ts:280-287` is **not** touched here -- it belongs to a larger legacy `getInteractiveSequenceStyles` block (the `<span data-targetaction="sequence">` HTML format whose parser was removed in `html-parser.ts:552-555`). That cleanup deserves its own focused PR.
- After this lands, authors no longer need the no-op interactive workaround. A follow-up could migrate bundled guides off the pattern, but that's author-owned content and out of scope here.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run prettier-test`
- [x] `npm run test:ci` (3300 passed; one unrelated SIGSEGV worker crash in `html-parser.test.ts` that passes on retry)
- [ ] **Visual smoke test in `npm run server`**: open a guide with a mixed-block section (markdown + interactive + code-block) and confirm sequential `1. 2. 3.` numbering with consistent indentation. (Author to verify before un-drafting -- no local Grafana available in this session.)
- [ ] Confirm an existing guide with image/video inside a section still renders the media inline without a number, and the surrounding steps keep their sequence.

Generated with [Claude Code](https://claude.com/claude-code)
