### PR TITLE
docs: avoid namesquat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,3 +379,9 @@ For PRs touching `pkg/**/*.go`, also verify:
 - `npm run test:go` passes
 - `go build ./...` succeeds
 - No new security issues (input validation, error handling, resource cleanup)
+
+## `npx` examples
+
+When generating `npx` examples of new potential CLIs and similar, these should all live under `pathfinder-cli@...`.
+For example, for a hypothetical new package `pathfinder-example`, write `npx pathfinder-cli@... example` instead of `npx pathfinder-example`.
+This ensures we don't get namesquatted.

--- a/docs/design/SCORM.md
+++ b/docs/design/SCORM.md
@@ -632,7 +632,7 @@ A single SCORM import always produces a **tree of package directories**, each co
 The SCORM importer should be a command-line tool, not a web UI. This aligns with the Content-as-Code philosophy: imported content enters the pipeline via PR, just like authored content. The CLI takes a SCORM ZIP as input and produces a directory of Pathfinder packages plus an import report.
 
 ```bash
-npx pathfinder-scorm-import \
+npx pathfinder-cli@... scorm-import \
   --input sales-training.zip \
   --output ./imported/sales-training/ \
   --cdn-base https://interactive-learning.grafana.net/guides/ \


### PR DESCRIPTION
We got namesquatted. Let's get rid of the name and instead force all such instances via `pathfinder-cli` by default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates CLI invocation examples; no runtime or build impact.
> 
> **Overview**
> Updates documentation to **standardize all `npx` CLI examples under `pathfinder-cli@...`** to reduce namesquatting risk.
> 
> Specifically adds an `AGENTS.md` guideline for writing `npx` examples and updates the SCORM importer design doc to use `npx pathfinder-cli@... scorm-import` instead of `npx pathfinder-scorm-import`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0995b2a5915d18574cc4ba9a4dce214dd5ad17c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->