### PR TITLE
refactor(styles): remove dead CSS rules from interactive.styles.ts

### DIFF
--- a/src/styles/interactive.styles.ts
+++ b/src/styles/interactive.styles.ts
@@ -123,13 +123,6 @@ const getBaseInteractiveStyles = (theme: GrafanaTheme2) => ({
     },
   },
 
-  // Button container for "show/do" etc.
-  '.interactive-button-container': {
-    display: 'flex',
-    gap: theme.spacing(0.75),
-    alignItems: 'center',
-    flexShrink: 0,
-  },
   '.tab-content': {
     '& > div > pre': {
       marginTop: 0,
@@ -145,95 +138,6 @@ const getBaseInteractiveStyles = (theme: GrafanaTheme2) => ({
       marginTop: 0,
       marginLeft: 0,
       marginRight: 0,
-    },
-  },
-});
-
-// Button styles (shared across different interactive elements)
-const getInteractiveButtonStyles = (theme: GrafanaTheme2) => ({
-  // General interactive button base
-  '.interactive-button': {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: `${theme.spacing(0.5)} ${theme.spacing(1.25)}`,
-    border: `1px solid transparent`,
-    borderRadius: theme.shape.radius.default,
-    fontSize: '12px',
-    fontWeight: theme.typography.fontWeightMedium,
-    lineHeight: '1.3',
-    textDecoration: 'none',
-    cursor: 'pointer',
-    transition: 'all 0.15s ease-in-out',
-    position: 'relative',
-    minHeight: `${theme.spacing(3.5)}`,
-    whiteSpace: 'nowrap',
-    '&:disabled': {
-      opacity: 0.65,
-      cursor: 'not-allowed',
-      pointerEvents: 'none',
-    },
-    '&:focus': {
-      outline: 'none',
-      boxShadow: `0 0 0 2px ${theme.colors.primary.main}33`,
-    },
-    '&:active': {
-      transform: 'translateY(0)',
-      boxShadow: 'none',
-    },
-  },
-
-  // "Show me" button
-  '.interactive-show-button': {
-    backgroundColor: theme.colors.secondary.main,
-    color: theme.colors.secondary.contrastText,
-    border: `1px solid ${theme.colors.secondary.border}`,
-    '&:hover:not(:disabled)': {
-      backgroundColor: theme.colors.secondary.shade,
-      borderColor: theme.colors.secondary.shade,
-      transform: 'translateY(-1px)',
-      boxShadow: theme.shadows.z1,
-    },
-    '&:focus': {
-      boxShadow: `0 0 0 2px ${theme.colors.secondary.main}33`,
-    },
-  },
-
-  // "Do it" button
-  '.interactive-do-button': {
-    backgroundColor: theme.colors.primary.main,
-    color: theme.colors.primary.contrastText,
-    border: `1px solid ${theme.colors.primary.border}`,
-    '&:hover:not(:disabled)': {
-      backgroundColor: theme.colors.primary.shade,
-      borderColor: theme.colors.primary.shade,
-      transform: 'translateY(-1px)',
-      boxShadow: theme.shadows.z1,
-    },
-    '&:focus': {
-      boxShadow: `0 0 0 2px ${theme.colors.primary.main}33`,
-    },
-  },
-
-  // Section/sequence button
-  '.interactive-sequence-button': {
-    padding: `${theme.spacing(0.75)} ${theme.spacing(1.75)}`,
-    backgroundColor: theme.colors.background.primary,
-    color: theme.colors.text.primary,
-    border: `1px solid ${theme.colors.border.medium}`,
-    borderRadius: theme.shape.radius.default,
-    fontWeight: theme.typography.fontWeightMedium,
-    textTransform: 'uppercase',
-    letterSpacing: '0.05em',
-    fontSize: '11px',
-    '&:hover:not(:disabled)': {
-      backgroundColor: theme.colors.action.hover,
-      borderColor: theme.colors.border.strong,
-      transform: 'translateY(-1px)',
-      boxShadow: theme.shadows.z1,
-    },
-    '&:focus': {
-      boxShadow: `0 0 0 2px ${theme.colors.text.primary}33`,
     },
   },
 });
@@ -291,13 +195,6 @@ const getInteractiveSequenceStyles = (theme: GrafanaTheme2) => ({
       marginTop: theme.spacing(2),
       display: 'block',
       width: 'fit-content',
-    },
-
-    // Button container inside sequence
-    '.interactive-button-container': {
-      marginTop: theme.spacing(2),
-      marginLeft: 0,
-      justifyContent: 'flex-start',
     },
   },
 });
@@ -801,57 +698,6 @@ const getInteractiveComponentStyles = (theme: GrafanaTheme2) => ({
     fontSize: theme.typography.bodySmall.fontSize,
   },
 
-  '.interactive-step-description-text': {
-    fontSize: theme.typography.bodySmall.fontSize,
-    color: theme.colors.text.secondary,
-    fontStyle: 'italic',
-    textAlign: 'center',
-    padding: `${theme.spacing(0.5)} 0`,
-  },
-
-  '.interactive-step-action-btn': {
-    minWidth: '120px',
-  },
-
-  '.interactive-step-completed-indicator': {
-    color: theme.colors.success.main,
-    fontSize: '16px',
-    fontWeight: 'bold',
-
-    // Skipped state - blue instead of green
-    '&.skipped': {
-      color: theme.colors.info.main,
-    },
-  },
-
-  '.interactive-step-completion-group': {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(0.5),
-  },
-
-  '.interactive-step-redo-btn': {
-    padding: '2px 6px',
-    fontSize: '0.75rem',
-    border: `1px solid ${theme.colors.border.medium}`,
-    background: 'transparent',
-    color: theme.colors.text.secondary,
-    borderRadius: theme.shape.radius.default,
-    cursor: 'pointer',
-    minHeight: '20px',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    '&:hover': {
-      backgroundColor: theme.colors.action.hover,
-      borderColor: theme.colors.border.strong,
-      color: theme.colors.text.primary,
-    },
-    '&:active': {
-      transform: 'scale(0.95)',
-    },
-  },
-
   // ═══════════════════════════════════════════════════════════════════════════
   // REQUIREMENT/INFO STYLES - Subtle box for sequential step messaging
   // ═══════════════════════════════════════════════════════════════════════════
@@ -954,30 +800,6 @@ const getInteractiveComponentStyles = (theme: GrafanaTheme2) => ({
       content: '"⚠"',
       fontSize: '1rem',
       flexShrink: 0,
-    },
-  },
-
-  '.interactive-step-error-buttons': {
-    display: 'flex',
-    gap: theme.spacing(1),
-    marginTop: theme.spacing(0.5),
-    width: '100%',
-  },
-
-  '.interactive-error-retry-btn': {
-    padding: '4px 10px',
-    fontSize: '0.8rem',
-    fontWeight: 500,
-    border: `1px solid ${theme.colors.warning.border}`,
-    background: 'transparent',
-    color: theme.colors.warning.text,
-    borderRadius: '4px',
-    cursor: 'pointer',
-    transition: 'all 0.15s ease',
-    '&:hover': {
-      background: theme.colors.warning.main,
-      color: theme.colors.warning.contrastText,
-      borderColor: theme.colors.warning.main,
     },
   },
 
@@ -1466,7 +1288,6 @@ const getExpandableStyles = (theme: GrafanaTheme2) => ({
 export const getInteractiveStyles = (theme: GrafanaTheme2) =>
   css({
     ...getBaseInteractiveStyles(theme),
-    ...getInteractiveButtonStyles(theme),
     ...getInteractiveSequenceStyles(theme),
     ...getCodeBlockStyles(theme),
     ...getInteractiveComponentStyles(theme),


### PR DESCRIPTION
## Purpose

**This PR is strictly a dead-code removal. It deletes CSS class definitions that exist in `src/styles/interactive.styles.ts` but are not applied as a `className` anywhere in the codebase. The net functional effect is zero: no UI changes, no runtime behavior changes.**

No refactoring, no renames, no reordering, no file splits — that work is deferred to a follow-up PR. This PR only deletes.

## What changed

`src/styles/interactive.styles.ts`: −179 lines (file shrinks from 2,416 → 2,237).

Removed:

1. **`getInteractiveButtonStyles` helper** (87 lines) and its spread inside `getInteractiveStyles`. Classes: `.interactive-button`, `.interactive-show-button`, `.interactive-do-button`, `.interactive-sequence-button`.
2. **`.interactive-button-container`** — both occurrences (in `getBaseInteractiveStyles` and inside `getInteractiveSequenceStyles`).
3. **Seven dead step rules** in `getInteractiveComponentStyles`:
   - `.interactive-step-description-text`
   - `.interactive-step-action-btn` (the singular form — `.interactive-step-action-buttons` plural is live and preserved)
   - `.interactive-step-completed-indicator`
   - `.interactive-step-completion-group`
   - `.interactive-step-redo-btn`
   - `.interactive-step-error-buttons`
   - `.interactive-error-retry-btn`

## How I know this CSS is dead

For every removed class, I confirmed via exhaustive `ripgrep` across the repo that the class name does **not** appear as a `className` value (or any other applied form) outside the styles file itself.

### Methodology

For each class:

```
rg -l "<class-name>" -g '!src/styles/interactive.styles.ts'
```

This catches references in:
- React `className=` attributes (`.tsx`)
- Dynamic className strings, template literals, `clsx`/`classnames` arguments
- Test selectors and fixtures
- JSON guide content and bundled interactives (`src/bundled-interactives/`)
- Anywhere else in `src/`

### Per-class results

| Class | Refs outside styles file | Notes |
|---|---|---|
| `.interactive-button` | **0** | The literal string `interactive-button` does appear in `src/constants/selectors.ts` inside `INTERACTIVE_EVENT_TYPES`, but that is an **event-type identifier**, not a CSS class selector. Verified by inspection. |
| `.interactive-show-button` | **0** | |
| `.interactive-do-button` | **0** | |
| `.interactive-sequence-button` | **0** | |
| `.interactive-button-container` | **0** | |
| `.interactive-step-description-text` | **0** | |
| `.interactive-step-action-btn` | **0** | Distinct from the plural `.interactive-step-action-buttons` which **is** used (in `interactive-step.tsx`) and is **not** touched by this PR. |
| `.interactive-step-completed-indicator` | **0** | |
| `.interactive-step-completion-group` | **0** | |
| `.interactive-step-redo-btn` | **0** | |
| `.interactive-step-error-buttons` | **0** | |
| `.interactive-error-retry-btn` | **0** | |

### Bundled-interactives raw HTML

Custom guides can pass raw HTML through the sanitizer via the `html` block type, so I also explicitly grepped the bundled-interactives JSON for these class names in raw HTML payloads:

```
rg "interactive-(show-button|do-button|sequence-button|button-container|button)" src/bundled-interactives/
```

Zero matches.

### Historical context (explains the residue)

These classes are consistent with a legacy implementation that injected interactive buttons as raw HTML strings. The current React components (`InteractiveStep`, `InteractiveMultiStep`, `InteractiveGuided` in `src/components/interactive-tutorial/`) render their own buttons using Grafana UI components and don't reference these class names. The CSS was orphaned when the React refactor landed but never removed.

## Caveats and residual risk

**One grey area, called out explicitly:** externally authored custom guides (not in this repo) could theoretically include raw HTML using `class="interactive-button"` or related. After this PR, such HTML would render unstyled (default browser button appearance). This is:

- not detectable from inside this repo;
- low probability (these classes were never documented as a public authoring API);
- worth a one-line changelog note when the next release goes out.

The step-class deletions (items 3.1–3.7 above) carry no such risk — they only ever appeared inside the React component tree, where className strings are statically traceable, and grep is authoritative.

## Net functional effect

**Zero.** No class names that are applied anywhere in the codebase were removed. No CSS rules that apply to live DOM were removed. The file is exclusively smaller; no rule was moved, renamed, or merged.

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm run lint` on the changed file — clean
- [x] `npm run prettier-test` — clean
- [x] `npx jest src/styles/interactive.styles.test.ts` — 13/13 passing
- [x] File still parses and exports the same three public names unchanged: `getInteractiveStyles`, `addGlobalInteractiveStyles`, `updateInteractiveThemeColors`
- [x] All 6 importing files (`interactive.hook.ts`, `element-inspector.hook.ts`, `docs-panel.tsx`, `FloatingPanelContent.tsx`, `BlockPreview.tsx`, `interactive-engine/index.ts`) untouched

## Test plan

- [ ] Reviewer spot-checks one removed class with `rg <class-name> src/` to confirm zero references
- [ ] Smoke-test interactive tutorials in the dev server — step rendering, sequence rendering, and step completion/redo states should look identical to `main`
- [ ] Confirm no visual regression in `BlockPreview`, `FloatingPanelContent`, or `DocsPanel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
