### PR TITLE
fix(block-editor): preserve new guide when leaving JSON mode

### DIFF
--- a/src/components/block-editor/hooks/useGuideHistory.test.ts
+++ b/src/components/block-editor/hooks/useGuideHistory.test.ts
@@ -210,4 +210,37 @@ describe('useGuideHistory', () => {
 
     expect(result.current.canUndo).toBe(false);
   });
+
+  it('batched setState calls compose, not overwrite (regression: stale-closure prev)', () => {
+    // Reproduces the JSON-paste -> preview bug. When `handleExitJsonMode`
+    // calls `loadGuide(newGuide)` (object form) followed by
+    // `updateGuideMetadata({})` and `setViewMode('preview')` (function
+    // form) inside the same event, every function-form `prev` must reflect
+    // the latest queued state, not a stale closure capture. Otherwise the
+    // second call's `{...prev, ...}` overwrites the new guide with the old
+    // one and the user sees the old guide in preview.
+    const { result } = renderHook(() => useGuideHistory(makeState({ guide: { id: 'old', title: 'Old' } })));
+
+    act(() => {
+      // Step 1: replace whole state (object form) — analogous to loadGuide.
+      result.current.setState(
+        {
+          guide: { id: 'new', title: 'New' },
+          blocks: [],
+          viewMode: 'edit',
+          isDirty: false,
+        },
+        { skipHistory: true }
+      );
+      // Step 2: function-form mutation — analogous to updateGuideMetadata({}).
+      result.current.setState((prev) => ({ ...prev, isDirty: true }));
+      // Step 3: function-form mutation — analogous to setViewMode('preview').
+      result.current.setState((prev) => ({ ...prev, viewMode: 'preview' }), { skipHistory: true });
+    });
+
+    // Expected composition: the new guide, marked dirty, in preview mode.
+    expect(result.current.state.guide).toEqual({ id: 'new', title: 'New' });
+    expect(result.current.state.isDirty).toBe(true);
+    expect(result.current.state.viewMode).toBe('preview');
+  });
 });

--- a/src/components/block-editor/hooks/useGuideHistory.ts
+++ b/src/components/block-editor/hooks/useGuideHistory.ts
@@ -21,7 +21,7 @@
  * persisted by the caller (`useBlockPersistence`) as before.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { BlockEditorState } from '../types';
 
 /** Hard cap on history depth. Older entries are dropped from the bottom of `past`. */
@@ -106,10 +106,15 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
   // and silently overwrite previously queued updates — see the regression
   // test "batched setState calls compose, not overwrite" in
   // `useGuideHistory.test.ts` for the concrete failure mode.
+  //
+  // INVARIANT: every code path that calls `setStateInternal` MUST also
+  // write the same value to `latestStateRef.current` on the line above.
+  // Do NOT add a `useEffect(() => { latestStateRef.current = state }, [state])`
+  // to "rescue" the ref — that effect fires after paint and can run
+  // *between* a synchronous ref write in one event and a function-form
+  // `setState` in the next, reverting the ref to the previous render's
+  // `state` and reintroducing the exact bug across event boundaries.
   const latestStateRef = useRef<BlockEditorState>(initial);
-  useEffect(() => {
-    latestStateRef.current = state;
-  }, [state]);
 
   // Stacks live in refs so internal pushes don't force re-renders;
   // we drive the UI from `historyMeta` instead.

--- a/src/components/block-editor/hooks/useGuideHistory.ts
+++ b/src/components/block-editor/hooks/useGuideHistory.ts
@@ -21,7 +21,7 @@
  * persisted by the caller (`useBlockPersistence`) as before.
  */
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { BlockEditorState } from '../types';
 
 /** Hard cap on history depth. Older entries are dropped from the bottom of `past`. */
@@ -100,6 +100,17 @@ function getTotalHistoryBytes(entries: HistoryEntry[]): number {
 export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryReturn {
   const [state, setStateInternal] = useState<BlockEditorState>(initial);
 
+  // Tracks the latest state synchronously so that batched `setState` calls
+  // within a single event handler see each other's results. Without this,
+  // function-form updaters would receive a stale closure-captured `state`
+  // and silently overwrite previously queued updates — see the regression
+  // test "batched setState calls compose, not overwrite" in
+  // `useGuideHistory.test.ts` for the concrete failure mode.
+  const latestStateRef = useRef<BlockEditorState>(initial);
+  useEffect(() => {
+    latestStateRef.current = state;
+  }, [state]);
+
   // Stacks live in refs so internal pushes don't force re-renders;
   // we drive the UI from `historyMeta` instead.
   const pastRef = useRef<HistoryEntry[]>([]);
@@ -126,14 +137,21 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
 
   const setState: GuideStateSetter = useCallback(
     (action, options) => {
-      const next = typeof action === 'function' ? (action as (p: BlockEditorState) => BlockEditorState)(state) : action;
+      // Source `prev` from the synchronously-tracked ref, NOT closure `state`,
+      // so a chain of batched setState calls in a single event handler each
+      // see the previous call's result instead of all collapsing onto the
+      // stale render-time state.
+      const prev = latestStateRef.current;
+      const next = typeof action === 'function' ? (action as (p: BlockEditorState) => BlockEditorState)(prev) : action;
 
       // No-op transitions (same reference) skip history regardless.
-      if (next === state) {
+      if (next === prev) {
         return;
       }
 
-      // Apply the state update first (pure)
+      // Apply the state update first (pure). Update the ref synchronously so
+      // any further setState in the same batch sees `next` as its prev.
+      latestStateRef.current = next;
       setStateInternal(next);
 
       // Then handle history side effects outside the updater
@@ -143,9 +161,9 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
         const insideCoalesceWindow = key !== null && key === coalesceRef.current.key && now < coalesceRef.current.until;
 
         if (!insideCoalesceWindow) {
-          const estimatedSize = estimateSingleEntryBytes(state);
+          const estimatedSize = estimateSingleEntryBytes(prev);
           const past = pastRef.current;
-          past.push({ state, label: options?.label, estimatedSize });
+          past.push({ state: prev, label: options?.label, estimatedSize });
 
           // Count cap.
           while (past.length > MAX_HISTORY) {
@@ -164,7 +182,7 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
         refreshMeta();
       }
     },
-    [state, refreshMeta]
+    [refreshMeta]
   );
 
   const undo = useCallback(() => {
@@ -181,21 +199,23 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
 
     // Calculate next state outside updater
     const nextState = target.state;
+    const currentState = latestStateRef.current;
 
     // Update refs (side effects outside updater)
-    const estimatedSize = estimateSingleEntryBytes(state);
+    const estimatedSize = estimateSingleEntryBytes(currentState);
     pastRef.current = past;
-    futureRef.current.unshift({ state, label: target.label, estimatedSize });
+    futureRef.current.unshift({ state: currentState, label: target.label, estimatedSize });
 
     // Reset coalescing so the next setState starts a fresh entry.
     coalesceRef.current = { key: null, until: 0 };
 
     // Apply state change
+    latestStateRef.current = nextState;
     setStateInternal(nextState);
 
     // Refresh UI meta
     refreshMeta();
-  }, [state, refreshMeta]);
+  }, [refreshMeta]);
 
   const redo = useCallback(() => {
     const future = futureRef.current;
@@ -211,20 +231,22 @@ export function useGuideHistory(initial: BlockEditorState): UseGuideHistoryRetur
 
     // Calculate next state outside updater
     const nextState = target.state;
+    const currentState = latestStateRef.current;
 
     // Update refs (side effects outside updater)
-    const estimatedSize = estimateSingleEntryBytes(state);
+    const estimatedSize = estimateSingleEntryBytes(currentState);
     futureRef.current = future;
-    pastRef.current.push({ state, label: target.label, estimatedSize });
+    pastRef.current.push({ state: currentState, label: target.label, estimatedSize });
 
     coalesceRef.current = { key: null, until: 0 };
 
     // Apply state change
+    latestStateRef.current = nextState;
     setStateInternal(nextState);
 
     // Refresh UI meta
     refreshMeta();
-  }, [state, refreshMeta]);
+  }, [refreshMeta]);
 
   const resetHistory = useCallback(() => {
     pastRef.current = [];

--- a/src/components/block-editor/hooks/useJsonModeHandlers.test.ts
+++ b/src/components/block-editor/hooks/useJsonModeHandlers.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Integration test: paste a fresh JSON guide in JSON mode, switch to
+ * preview, and assert the editor's state actually reflects the new
+ * guide (not the previous one).
+ *
+ * Wires the real `useBlockEditor` (which sits on top of the real
+ * `useGuideHistory` ring buffer) into the real `useJsonModeHandlers`,
+ * because the bug only manifests when batched setState calls flow
+ * through the wrapped `setState`.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { useBlockEditor } from './useBlockEditor';
+import { useJsonModeHandlers } from './useJsonModeHandlers';
+import type { JsonGuide } from '../types';
+
+const oldGuide: JsonGuide = {
+  id: 'old-guide',
+  title: 'Old guide',
+  blocks: [{ type: 'markdown', content: 'old block content' }],
+};
+
+const newGuide: JsonGuide = {
+  id: 'new-guide',
+  title: 'New guide',
+  blocks: [{ type: 'markdown', content: 'brand new block content' }],
+};
+
+function useEditorAndJsonMode(initialGuide: JsonGuide) {
+  const editor = useBlockEditor({ initialGuide });
+  const jsonMode = useJsonModeHandlers({
+    editor,
+    recordingIntoSection: null,
+    recordingIntoConditionalBranch: null,
+    onStopRecording: () => {},
+    onClearSelection: () => {},
+    isSelectionMode: false,
+  });
+  return { editor, jsonMode };
+}
+
+describe('useJsonModeHandlers — JSON paste then preview', () => {
+  it('switching from JSON to preview applies the pasted guide (regression)', () => {
+    const { result } = renderHook(() => useEditorAndJsonMode(oldGuide));
+
+    // Enter JSON mode — captures the current guide as the JSON snapshot.
+    act(() => {
+      result.current.jsonMode.handleViewModeChange('json');
+    });
+    expect(result.current.editor.state.viewMode).toBe('json');
+
+    // Simulate the user pasting a completely new guide JSON.
+    act(() => {
+      result.current.jsonMode.handleJsonChange(JSON.stringify(newGuide, null, 2));
+    });
+    expect(result.current.jsonMode.isJsonValid).toBe(true);
+
+    // Switch to preview — must apply the new guide, not revert to the old one.
+    act(() => {
+      result.current.jsonMode.handleViewModeChange('preview');
+    });
+
+    expect(result.current.editor.state.viewMode).toBe('preview');
+    expect(result.current.editor.state.guide).toEqual({ id: 'new-guide', title: 'New guide' });
+    expect(result.current.editor.state.blocks).toHaveLength(1);
+    expect(result.current.editor.state.blocks[0]!.block).toEqual({
+      type: 'markdown',
+      content: 'brand new block content',
+    });
+    // `handleExitJsonMode` marks the editor dirty after a JSON edit.
+    expect(result.current.editor.state.isDirty).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix a stale-closure bug in `useGuideHistory.setState` that caused the block editor to revert to the **old** guide when pasting a fresh JSON guide and switching to **Preview**.
- Same defect also silently corrupted `handleLoadGuideFromBackend` and the persistence onLoad path whenever local state was dirty when the load fired — both now resolved by the same change.

## What changed

`useGuideHistory` now tracks the latest state in a synchronously-updated `latestStateRef`, and `setState` / `undo` / `redo` source `prev` from that ref instead of from closure-captured `state`. Subsequent batched `setState` calls in a single event handler now correctly compose instead of overwriting each other.

- `src/components/block-editor/hooks/useGuideHistory.ts` — the fix.
- `src/components/block-editor/hooks/useGuideHistory.test.ts` — unit regression test.
- `src/components/block-editor/hooks/useJsonModeHandlers.test.ts` — new file, integration test wiring the real editor through the user-facing paste-then-preview flow.

## Why

`handleExitJsonMode` runs three setState calls back-to-back in one event:

```
editor.loadGuide(newGuide);          // object form  -> queues new guide
editor.updateGuideMetadata({});      // function form -> uses STALE closure 'state' (old guide)
editor.setViewMode(targetMode);      // function form -> STALE again
```

Because the wrapped `setState` evaluated function-form updaters against the closure `state` and passed the result as a literal to React's `setStateInternal`, calls 2 and 3 received the old guide as `prev` and silently overwrote the new guide queued by call 1. End result: preview rendered the old guide.

The `latestStateRef` approach makes the wrapper behave the way React's native `setState((prev) => ...)` does for batched updates.

## Test plan

- [x] New unit test `'batched setState calls compose, not overwrite'` failed before the fix, passes after.
- [x] New integration test `'switching from JSON to preview applies the pasted guide'` failed before the fix, passes after.
- [x] Full block-editor suite (404 tests) green.
- [x] `npm run check` green: 186 suites, 3386 tests, 0 failures, plus typecheck / lint / prettier / Go.
- [ ] Manual: open the block editor with a guide loaded -> JSON view -> replace JSON with a different guide -> Preview -> renders the new guide.

## Risk and reversibility

Low risk, fully reversible. The change is contained to `useGuideHistory` internals; the public hook API (`setState` / `undo` / `redo` / `canUndo` / `canRedo` / `resetHistory`) is unchanged. No call sites needed modification — the fix is purely additive correctness for batched updates. Reverting is a single-file rollback.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `useGuideHistory` state wrapper used by the editor, so regressions could affect undo/redo and any batched `setState` flows. The change is localized and covered by new unit + integration regression tests.
> 
> **Overview**
> Fixes a stale-closure issue in `useGuideHistory` where function-form updates evaluated against a closure-captured `state` could overwrite earlier queued updates in the same event (e.g., JSON paste → switch to Preview reverting to the previous guide).
> 
> `useGuideHistory` now keeps a synchronously-updated `latestStateRef` and uses it as the source of truth for `setState`, `undo`, and `redo` (including history entry bookkeeping). Adds a unit regression test for batched composition behavior and a new integration test covering the JSON-mode paste-then-preview flow via `useBlockEditor` + `useJsonModeHandlers`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83921f3dba5b3c72b89653b813890fa98bcc73c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->