### PR TITLE
fix(block-editor): add terminal-connect required default to prevent type-switch failure

### DIFF
--- a/src/components/block-editor/utils/block-conversion.test.ts
+++ b/src/components/block-editor/utils/block-conversion.test.ts
@@ -342,6 +342,31 @@ describe('convertBlockType', () => {
       expect(() => convertBlockType(source, 'input')).not.toThrow();
       expect(() => convertBlockType(source, 'image')).not.toThrow();
       expect(() => convertBlockType(source, 'video')).not.toThrow();
+      expect(() => convertBlockType(source, 'terminal')).not.toThrow();
+      expect(() => convertBlockType(source, 'terminal-connect')).not.toThrow();
+      expect(() => convertBlockType(source, 'code-block')).not.toThrow();
+    });
+
+    it('should convert image to terminal-connect without throwing (regression #619)', () => {
+      const source: JsonBlock = { type: 'image', src: 'https://example.com/img.png', alt: 'alt text' };
+      const result = convertBlockType(source, 'terminal-connect');
+      expect(result.type).toBe('terminal-connect');
+    });
+
+    it('should convert video to terminal-connect without throwing (regression #619)', () => {
+      const source: JsonBlock = { type: 'video', src: 'https://example.com/vid.mp4' };
+      const result = convertBlockType(source, 'terminal-connect');
+      expect(result.type).toBe('terminal-connect');
+    });
+
+    it('should convert code-block without content to terminal-connect without throwing (regression #619)', () => {
+      const source: JsonBlock = {
+        type: 'code-block',
+        reftarget: "div[data-testid='data-testid Code editor container']",
+        code: '',
+      };
+      const result = convertBlockType(source, 'terminal-connect');
+      expect(result.type).toBe('terminal-connect');
     });
   });
 });

--- a/src/components/block-editor/utils/block-conversion.ts
+++ b/src/components/block-editor/utils/block-conversion.ts
@@ -81,6 +81,7 @@ const REQUIRED_DEFAULTS: Partial<Record<BlockType, Record<string, unknown>>> = {
   multistep: { content: 'Complete these steps', steps: [{ action: 'noop' }] },
   guided: { content: 'Follow these steps', steps: [{ action: 'noop' }] },
   terminal: { command: 'echo "hello"' },
+  'terminal-connect': { content: 'Connect to terminal' },
   challenge: {
     title: 'Untitled challenge',
     successCriteria: 'coda-exit-zero:true',


### PR DESCRIPTION
This PR closes an edge case associated with the block editor and "switching block type".  That's a complex bit of code because we have a many-to-many problem. If you want to allow switching from one block type to another, there's an explosion of possibilities; and the bug was that a few didn't work.

## Summary

- Adds `'terminal-connect': { content: 'Connect to terminal' }` to `REQUIRED_DEFAULTS` in `block-conversion.ts`
- Adds regression tests covering `image → terminal-connect`, `video → terminal-connect`, and `code-block (no content) → terminal-connect`
- Extends the existing schema-validation test to also cover `terminal`, `terminal-connect`, and `code-block` as conversion targets

## What changed / why

`terminal-connect` requires `content: z.string().min(1)`. Neither `image` nor `video` blocks have a content field (they use `src`), so when converting either of those types to `terminal-connect`:

1. Content-field mapping is skipped (no source content field)
2. `REQUIRED_DEFAULTS['terminal-connect']` was `undefined` — no fallback applied
3. `JsonBlockSchema.safeParse` failed Zod validation → error thrown → error toast shown → block type unchanged

`code-block → terminal-connect` was also affected when the source block had no `content` value (content is optional on `code-block`).

## Test plan

- [x] New regression tests pass: `image → terminal-connect`, `video → terminal-connect`, `code-block (no content) → terminal-connect`
- [x] Existing 32 tests in `block-conversion.test.ts` all still pass
- [x] Full suite: `npm run test:ci`

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)