### PR TITLE
feat(highlighted-guide): auto-launch guide tab on matched pages

### DIFF
--- a/docs/developer/EXPERIMENT_TESTING.md
+++ b/docs/developer/EXPERIMENT_TESTING.md
@@ -118,7 +118,7 @@ location.reload();
 
 ## `pathfinder.highlighted-guide-experiment`
 
-A/B test for guide content. Both `control` and `treatment` keep Pathfinder visible and auto-open the sidebar on matched pages — they differ only in which `guideId` is highlighted + auto-opened. Use this to compare two candidate guides on the same page.
+A/B test for guide content. Both `control` and `treatment` keep Pathfinder visible, auto-open the sidebar, **and auto-launch the configured `guideId` as a tab** on matched pages — using the same `auto-launch-tutorial` seam as the `?doc=` deep link. The user stays on the page they were on; no navigation happens. The Featured-slot injection still runs in parallel so the card is also visible in the recommendations tab. Use this to compare two candidate guides on the same page.
 
 ### Treatment — interactive package
 
@@ -150,9 +150,9 @@ __pathfinderExperiment.setOverride('pathfinder.highlighted-guide-experiment', {
 location.reload();
 ```
 
-### Injection-only mode (no auto-open)
+### Injection-only mode (no auto-open, no auto-launch)
 
-Use this to test the Featured-slot injection without the sidebar auto-popping:
+Use this to test the Featured-slot injection without the sidebar auto-popping or the guide auto-launching as a tab:
 
 ```js
 __pathfinderExperiment.setOverride('pathfinder.highlighted-guide-experiment', {
@@ -200,11 +200,11 @@ When the override is active and `variant !== 'excluded'`, the orchestrator emits
 
 Three events fire end-to-end for the highlighted-guide experiment. Filter the Rudderstack devtools (or your local analytics tap) for:
 
-| Event                               | When                                                                                       | Key properties                                                                                 |
-| ----------------------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| `pathfinder_feature_flag_evaluated` | First time you hit a matched `(hostname, flag, variant)` on this browser — see dedup below | `flag_key`, `flag_value`, `tracking_key`, `variant`                                            |
-| `pathfinder_docs_panel_interaction` | When the sidebar mounts after auto-open                                                    | `action: 'auto-open'`, `source: 'highlighted_guide_experiment'`                                |
-| `pathfinder_open_resource_click`    | When the user clicks the Featured card's "Start guide" button                              | `content_title`, `content_url`, `content_type`, `interaction_location: 'featured_card_button'` |
+| Event                               | When                                                                                                                                               | Key properties                                                                                                                                   |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pathfinder_feature_flag_evaluated` | First time you hit a matched `(hostname, flag, variant)` on this browser — see dedup below                                                         | `flag_key`, `flag_value`, `tracking_key`, `variant`                                                                                              |
+| `pathfinder_docs_panel_interaction` | When the sidebar mounts after auto-open                                                                                                            | `action: 'auto-open'`, `source: 'highlighted_guide_experiment'`                                                                                  |
+| `pathfinder_open_resource_click`    | Fires twice: once when the guide auto-launches as a tab (`trigger_source: 'auto_launch_tutorial'`), and again if the user clicks the Featured card | `content_title`, `content_url`, `content_type`, `interaction_location` (`docs_panel` for auto-launch, `featured_card_button` for the card click) |
 
 ### Why the exposure event might not fire
 
@@ -237,7 +237,9 @@ Variant reassignment is the **only** condition where the event auto-refires acro
 ## Common gotchas
 
 - **`__pathfinderExperiment` is undefined.** Pathfinder is dismounted — usually because you're in `control` on `pathfinder.experiment-variant` or `pathfinder.after-24h-experiment`. Clear `localStorage.grafana-pathfinder-flag-overrides` and reload, or write the override directly into `localStorage`.
-- **Auto-open lands on the wrong tab.** As of [PR #874](https://github.com/grafana/grafana-pathfinder-app/pull/874) the highlighted-guide auto-open pins the active tab to `recommendations` so the Featured slot is visible. If you still see the editor / devtools tab, your build is older than that PR.
+- **Auto-launch landed but I see the wrong tab.** The orchestrator dispatches `auto-launch-tutorial` which calls `openDocsPage` / `openLearningJourney` — those make the new guide tab active automatically. If you instead see the editor / devtools tab from a prior session, the configured `guideId` failed to resolve through `findDocPage`: check the console for `findDocPage returned null for guideId="…"` and fix the id (`bundled:<id>`, `api:<id>`, or a full URL on a whitelisted host).
+- **Auto-launch fires but the guide opens as the wrong type (docs page vs learning journey).** Set the flag's `docType` explicitly (`'docs-page' | 'learning-journey' | 'interactive'`). The operator override wins over `findDocPage`'s URL-based inference.
+- **The Featured card still appears even though the guide auto-launched.** Intentional — the card is kept as a re-entry point if the user closes the auto-launched tab. To suppress it, the `injectHighlightedGuide` seam in `src/context-engine/context.service.ts` would need to gate on auto-launch success.
 - **`resetCache: true` didn't clear my marker.** The reset is sentinel-guarded so an operator-facing `true` doesn't re-clear on every reload. Toggle it false → reload → true → reload, or wipe the storage prefix directly.
 - **Demos: floating-mode leftovers from older builds.** Pathfinder used to switch to floating mode for highlighted guides. If your `localStorage.grafana-pathfinder-app-panel-mode` is stuck on `'floating'`, run step 4 of the reset snippet.
 - **MTFF in production.** This whole flow is local-override only. MTFF flag values aren't editable from the browser — they come from the Grafana Cloud feature-flag service and are evaluated once per page load on boot.

--- a/docs/developer/FEATURE_FLAGS.md
+++ b/docs/developer/FEATURE_FLAGS.md
@@ -98,7 +98,7 @@ interface ExperimentConfig {
 
 **Type**: Object (`HighlightedGuideConfig`)
 
-**Purpose**: A/B test which guide performs better when surfaced as the featured guide on a specific Grafana page. Both arms keep Pathfinder visible — they differ only in which guide id is highlighted. When a matched page is visited, the Pathfinder sidebar auto-opens (once per browser per `guideId`) and the configured guide is prepended to the Featured slot of the recommendations panel.
+**Purpose**: A/B test which guide performs better when surfaced as the featured guide on a specific Grafana page. Both arms keep Pathfinder visible — they differ only in which guide id is highlighted. When a matched page is visited, the Pathfinder sidebar auto-opens (once per browser per `guideId`) **and the configured guide is auto-launched as a sidebar tab** — the same seam used by the `?doc=` deep link. The user stays on the page they were on; no `locationService.replace` is called. The Featured-slot injection still runs in parallel so the card remains a re-entry point if the user closes the auto-launched tab.
 
 This flag is independent of `pathfinder.experiment-variant`: it does not hide Pathfinder, and its auto-open will simply no-op when the user's existing experiment dismounts the plugin.
 
@@ -122,11 +122,11 @@ interface HighlightedGuideConfig {
 
 **Variant behavior**:
 
-| Variant     | Auto-open + injection | Notes                                                    |
-| ----------- | --------------------- | -------------------------------------------------------- |
-| `excluded`  | No                    | Normal Pathfinder behavior — flag is a no-op             |
-| `control`   | Yes (variant A)       | Open sidebar + inject the arm's `guideId` (e.g. guide A) |
-| `treatment` | Yes (variant B)       | Open sidebar + inject the arm's `guideId` (e.g. guide B) |
+| Variant     | Auto-launch + injection | Notes                                                                              |
+| ----------- | ----------------------- | ---------------------------------------------------------------------------------- |
+| `excluded`  | No                      | Normal Pathfinder behavior — flag is a no-op                                       |
+| `control`   | Yes (variant A)         | Open sidebar + auto-launch the arm's `guideId` as a tab + inject Featured (slot A) |
+| `treatment` | Yes (variant B)         | Open sidebar + auto-launch the arm's `guideId` as a tab + inject Featured (slot B) |
 
 A typical A/B setup serves the **same** `pages[]` to both arms with **different** `guideId` values, so the only thing varying between cohorts is the guide content. Analytics distinguishes which arm via the existing `TrackingHook` exposure event (`pathfinder_feature_flag_evaluated` with `tracking_key: highlighted_guide_experiment`).
 
@@ -134,9 +134,13 @@ A typical A/B setup serves the **same** `pages[]` to both arms with **different*
 
 **Once-per-browser semantics**: The auto-open marker is keyed `{hostname}:{guideId}` in localStorage (not sessionStorage). A new `guideId` from MTFF — including the arm-specific value at variant assignment time — produces a new key, so changing the experiment's guide naturally re-fires auto-open without operator intervention. Use `resetCache: true` to force-clear all markers for the current hostname (sentinel-guarded so true→true reloads don't repeatedly clear).
 
-**Injection-only mode**: When `autoOpen` is `false`, the sidebar auto-open is suppressed but the Featured-slot injection still runs on matched pages. Useful for a subtler treatment variant.
+**Injection-only mode**: When `autoOpen` is `false`, both the sidebar auto-open _and_ the auto-launch of the guide tab are suppressed, but the Featured-slot injection still runs on matched pages. Useful for a subtler treatment variant where the operator wants the card visible without forcibly opening the sidebar.
+
+**Auto-launch dispatch mechanics** (for QA / debugging): on a matched page, the orchestrator resolves the `guideId` through `findDocPage`, publishes `open-extension-sidebar`, waits for either `pathfinder-sidebar-mounted` or `pathfinder-panel-mounted`, then dispatches `auto-launch-tutorial` (the same event `?doc=` uses) tagged with `source: 'highlighted_guide_experiment'`. The `useAutoLaunchTutorial` hook routes that to `openDocsPage` / `openLearningJourney` depending on the resolved `type` (with the flag's `docType` winning over `findDocPage`'s URL-based inference). If `findDocPage` returns `null` for the configured `guideId` (typo, unsupported URL), the sidebar still opens and the Featured-slot card is the user's only entry point.
 
 **Tracking key**: `highlighted_guide_experiment`
+
+**Launch source**: Guide tabs opened by this flag are tagged with the `highlighted_guide_experiment` `LaunchSource` (aligned-by-construction — no alignment prompt is shown, since the operator already targeted the page).
 
 ---
 

--- a/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.test.tsx
+++ b/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.test.tsx
@@ -231,4 +231,101 @@ describe('LearningJourneyMilestoneToolbar', () => {
       expect.objectContaining({ interaction_location: 'milestone_progress_bar' })
     );
   });
+
+  // ===========================================================================
+  // Milestone-arrow analytics: destination semantic
+  // ===========================================================================
+  //
+  // The arrow-click events log the milestone the user is heading TO, not the
+  // one they clicked from. For a 6-milestone journey, a forward click from M5
+  // logs `current_milestone: 6` — so the analytics agrees with the toolbar's
+  // "Milestone 6 of 6" on the end milestone (the previous origin semantic
+  // topped out at `N - 1` and never surfaced the end-milestone landing).
+  describe('milestone arrow click analytics', () => {
+    it('forward click logs the destination milestone (current + 1), not the origin', () => {
+      // currentMilestone = 1, totalMilestones = 3 → forward click should log 2.
+      renderToolbar();
+      fireEvent.click(screen.getByLabelText('Next milestone'));
+
+      expect(reportAppInteractionMock).toHaveBeenCalledWith(
+        'milestone_arrow_interaction_click',
+        expect.objectContaining({
+          current_milestone: 2,
+          total_milestones: 3,
+          direction: 'forward',
+          interaction_location: 'milestone_progress_bar',
+        })
+      );
+    });
+
+    it('backward click logs the destination milestone (current - 1), not the origin', () => {
+      const tab = makeJourneyTab();
+      (tab.content as any).metadata.learningJourney.currentMilestone = 2;
+      renderToolbar({ activeTab: tab });
+      fireEvent.click(screen.getByLabelText('Previous milestone'));
+
+      expect(reportAppInteractionMock).toHaveBeenCalledWith(
+        'milestone_arrow_interaction_click',
+        expect.objectContaining({
+          current_milestone: 1,
+          total_milestones: 3,
+          direction: 'backward',
+          interaction_location: 'milestone_progress_bar',
+        })
+      );
+    });
+
+    it('forward click from the last content milestone logs current_milestone = totalMilestones (the end-journey value)', () => {
+      // currentMilestone = 3 of 3 → forward click lands on M3 (clamped).
+      // In practice `canNavigateNext()` returns false here, but the Math.min
+      // clamp is defence-in-depth and we still document the contract.
+      const tab = makeJourneyTab();
+      (tab.content as any).metadata.learningJourney.currentMilestone = 3;
+      renderToolbar({ activeTab: tab });
+      fireEvent.click(screen.getByLabelText('Next milestone'));
+
+      expect(reportAppInteractionMock).toHaveBeenCalledWith(
+        'milestone_arrow_interaction_click',
+        expect.objectContaining({
+          current_milestone: 3,
+          total_milestones: 3,
+          direction: 'forward',
+        })
+      );
+    });
+
+    it('backward click from M1 logs current_milestone = 0 (heading back to the cover overview)', () => {
+      // The cover is `currentMilestone: 0` in the data model and is the
+      // legitimate destination of a backward click from M1.
+      const tab = makeJourneyTab();
+      (tab.content as any).metadata.learningJourney.currentMilestone = 1;
+      renderToolbar({ activeTab: tab });
+      fireEvent.click(screen.getByLabelText('Previous milestone'));
+
+      expect(reportAppInteractionMock).toHaveBeenCalledWith(
+        'milestone_arrow_interaction_click',
+        expect.objectContaining({
+          current_milestone: 0,
+          total_milestones: 3,
+          direction: 'backward',
+        })
+      );
+    });
+
+    it('OpenExtraResource (Open in new tab) keeps the origin semantic — the user is reading this milestone, not navigating', () => {
+      // currentMilestone = 1 → the Open button logs `current_milestone: 1`
+      // (the page the user is currently viewing). This event is intentionally
+      // unchanged by the destination-semantic flip on the arrow clicks.
+      renderToolbar();
+      fireEvent.click(screen.getByLabelText('Open this page in new tab'));
+
+      expect(reportAppInteractionMock).toHaveBeenCalledWith(
+        'open_extra_resource',
+        expect.objectContaining({
+          current_milestone: 1,
+          total_milestones: 3,
+        })
+      );
+    });
+  });
 });

--- a/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
+++ b/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
@@ -103,10 +103,16 @@ export function LearningJourneyMilestoneToolbar({
   }
 
   const handlePrev = () => {
+    // Log the destination milestone (where the user is heading TO), not the
+    // origin. For a 6-milestone journey, a backward click from M2 logs
+    // current_milestone: 1 — matching the toolbar value the user sees after
+    // navigation lands. The Math.max clamp is defence-in-depth; the
+    // `panel.canNavigatePrevious()` disabled-button gate already prevents
+    // navigating past milestone 0 (cover).
     reportAppInteraction(UserInteraction.MilestoneArrowInteractionClick, {
       content_title: activeTab.title,
       content_url: activeTab.baseUrl,
-      current_milestone: lj.currentMilestone || 0,
+      current_milestone: Math.max(0, (lj.currentMilestone ?? 0) - 1),
       total_milestones: lj.totalMilestones || 0,
       direction: 'backward',
       interaction_location: 'milestone_progress_bar',
@@ -116,10 +122,16 @@ export function LearningJourneyMilestoneToolbar({
   };
 
   const handleNext = () => {
+    // Log the destination milestone (where the user is heading TO), not the
+    // origin. For a 6-milestone journey, a forward click from M5 logs
+    // current_milestone: 6 — so the analytics agrees with the toolbar's
+    // "Milestone 6 of 6" on the end milestone. The Math.min clamp is
+    // defence-in-depth; `panel.canNavigateNext()` already disables the
+    // arrow on the last milestone.
     reportAppInteraction(UserInteraction.MilestoneArrowInteractionClick, {
       content_title: activeTab.title,
       content_url: activeTab.baseUrl,
-      current_milestone: lj.currentMilestone || 0,
+      current_milestone: Math.min(lj.totalMilestones ?? 0, (lj.currentMilestone ?? 0) + 1),
       total_milestones: lj.totalMilestones || 0,
       direction: 'forward',
       interaction_location: 'milestone_progress_bar',

--- a/src/components/docs-panel/link-handler.hook.test.ts
+++ b/src/components/docs-panel/link-handler.hook.test.ts
@@ -177,6 +177,113 @@ describe('useLinkClickHandler', () => {
       fireEvent.click(prevButton);
       expect(mockModel.navigateToPreviousMilestone).toHaveBeenCalled();
     });
+
+    // -------------------------------------------------------------------------
+    // Milestone-arrow analytics: destination semantic
+    // -------------------------------------------------------------------------
+    //
+    // Mirrors the toolbar handler. The bottom-navigation buttons embedded in
+    // the rendered journey content fire `milestone_arrow_interaction_click`
+    // with the milestone the user is heading TO, not the origin.
+    it('logs the destination milestone (current + 1) on bottom-nav forward click', () => {
+      // Need to read the mock from the analytics module via the jest registry
+      // because the import at the top resolved to the mock implementation.
+      const { reportAppInteraction } = jest.requireMock('../../lib/analytics');
+
+      mockModel.getActiveTab.mockReturnValue({
+        id: 'tab1',
+        title: 'Test Journey',
+        baseUrl: 'https://grafana.com/docs/test-journey',
+        currentUrl: 'https://grafana.com/docs/test-journey/m2',
+        type: 'learning-journey',
+        content: {
+          type: 'learning-journey',
+          url: 'https://grafana.com/docs/test-journey/m2',
+          metadata: {
+            learningJourney: {
+              currentMilestone: 2,
+              totalMilestones: 6,
+            },
+          },
+        },
+        isLoading: false,
+        error: null,
+      });
+
+      renderHook(() =>
+        useLinkClickHandler({
+          contentRef,
+          activeTab: mockModel.getActiveTab(),
+          theme: mockTheme,
+          model: mockModel,
+        })
+      );
+
+      const nextButton = document.createElement('button');
+      nextButton.setAttribute('data-journey-nav', 'next');
+      contentDiv.appendChild(nextButton);
+
+      fireEvent.click(nextButton);
+
+      expect(reportAppInteraction).toHaveBeenCalledWith(
+        UserInteraction.MilestoneArrowInteractionClick,
+        expect.objectContaining({
+          current_milestone: 3,
+          total_milestones: 6,
+          direction: 'forward',
+          interaction_location: 'bottom_navigation',
+        })
+      );
+    });
+
+    it('logs the destination milestone (current - 1) on bottom-nav backward click', () => {
+      const { reportAppInteraction } = jest.requireMock('../../lib/analytics');
+
+      mockModel.getActiveTab.mockReturnValue({
+        id: 'tab1',
+        title: 'Test Journey',
+        baseUrl: 'https://grafana.com/docs/test-journey',
+        currentUrl: 'https://grafana.com/docs/test-journey/m3',
+        type: 'learning-journey',
+        content: {
+          type: 'learning-journey',
+          url: 'https://grafana.com/docs/test-journey/m3',
+          metadata: {
+            learningJourney: {
+              currentMilestone: 3,
+              totalMilestones: 6,
+            },
+          },
+        },
+        isLoading: false,
+        error: null,
+      });
+
+      renderHook(() =>
+        useLinkClickHandler({
+          contentRef,
+          activeTab: mockModel.getActiveTab(),
+          theme: mockTheme,
+          model: mockModel,
+        })
+      );
+
+      const prevButton = document.createElement('button');
+      prevButton.setAttribute('data-journey-nav', 'prev');
+      contentDiv.appendChild(prevButton);
+
+      fireEvent.click(prevButton);
+
+      expect(reportAppInteraction).toHaveBeenCalledWith(
+        UserInteraction.MilestoneArrowInteractionClick,
+        expect.objectContaining({
+          current_milestone: 2,
+          total_milestones: 6,
+          direction: 'backward',
+          interaction_location: 'bottom_navigation',
+        })
+      );
+    });
   });
 
   describe('Interactive Learning Links', () => {

--- a/src/components/docs-panel/link-handler.hook.ts
+++ b/src/components/docs-panel/link-handler.hook.ts
@@ -494,22 +494,27 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
         const activeTab = model.getActiveTab();
 
         if (navDirection === 'prev' && model.canNavigatePrevious()) {
+          // Log the destination milestone (where the user is heading TO), not
+          // the origin — mirrors the toolbar handler in
+          // LearningJourneyMilestoneToolbar.tsx so the two surfaces agree.
+          const ljPrev = activeTab?.content?.metadata.learningJourney;
           reportAppInteraction(UserInteraction.MilestoneArrowInteractionClick, {
             content_title: activeTab?.title || 'unknown',
             content_url: activeTab?.baseUrl || 'unknown',
-            current_milestone: activeTab?.content?.metadata.learningJourney?.currentMilestone || 0,
-            total_milestones: activeTab?.content?.metadata.learningJourney?.totalMilestones || 0,
+            current_milestone: Math.max(0, (ljPrev?.currentMilestone ?? 0) - 1),
+            total_milestones: ljPrev?.totalMilestones || 0,
             direction: 'backward',
             interaction_location: 'bottom_navigation',
             completion_percentage: activeTab?.content ? getJourneyProgress(activeTab.content) : 0,
           });
           model.navigateToPreviousMilestone();
         } else if (navDirection === 'next' && model.canNavigateNext()) {
+          const ljNext = activeTab?.content?.metadata.learningJourney;
           reportAppInteraction(UserInteraction.MilestoneArrowInteractionClick, {
             content_title: activeTab?.title || 'unknown',
             content_url: activeTab?.baseUrl || 'unknown',
-            current_milestone: activeTab?.content?.metadata.learningJourney?.currentMilestone || 0,
-            total_milestones: activeTab?.content?.metadata.learningJourney?.totalMilestones || 0,
+            current_milestone: Math.min(ljNext?.totalMilestones ?? 0, (ljNext?.currentMilestone ?? 0) + 1),
+            total_milestones: ljNext?.totalMilestones || 0,
             direction: 'forward',
             interaction_location: 'bottom_navigation',
             completion_percentage: activeTab?.content ? getJourneyProgress(activeTab.content) : 0,

--- a/src/hooks/useAutoLaunchTutorial.test.ts
+++ b/src/hooks/useAutoLaunchTutorial.test.ts
@@ -71,6 +71,28 @@ describe('useAutoLaunchTutorial', () => {
     expect(panel.openLearningJourney).not.toHaveBeenCalled();
   });
 
+  it('passes the highlighted_guide_experiment source through as a typed LaunchSource', () => {
+    // Regression for the highlighted-guide auto-launch wiring: the orchestrator
+    // dispatches `auto-launch-tutorial` with `source: 'highlighted_guide_experiment'`,
+    // which must round-trip through `coerceLaunchSource` (not get dropped to
+    // undefined like an unknown literal would).
+    const panel = makePanel();
+    renderHook(() => useAutoLaunchTutorial(asPanel(panel)));
+
+    dispatchAutoLaunch({
+      url: 'bundled:onboarding',
+      title: 'Onboarding',
+      type: 'docs-page',
+      source: 'highlighted_guide_experiment',
+    });
+
+    expect(panel.openDocsPage).toHaveBeenCalledWith(
+      'bundled:onboarding',
+      'Onboarding',
+      expect.objectContaining({ source: 'highlighted_guide_experiment' })
+    );
+  });
+
   it('coerces unknown source strings to undefined at the boundary (no typo poisoning)', () => {
     const panel = makePanel();
     renderHook(() => useAutoLaunchTutorial(asPanel(panel)));

--- a/src/recovery/launch-sources.test.ts
+++ b/src/recovery/launch-sources.test.ts
@@ -25,6 +25,7 @@ const ALL_LAUNCH_SOURCES = [
   'grot_guide_block',
   'experiment_treatment',
   'experiment_treatment_navigation',
+  'highlighted_guide_experiment',
   'auto_open',
   'floating_panel_dock',
   'fullscreen_handoff',

--- a/src/recovery/launch-sources.ts
+++ b/src/recovery/launch-sources.ts
@@ -30,6 +30,7 @@ export type LaunchSource =
   | 'grot_guide_block'
   | 'experiment_treatment'
   | 'experiment_treatment_navigation'
+  | 'highlighted_guide_experiment'
   | 'auto_open'
   | 'floating_panel_dock'
   | 'fullscreen_handoff'
@@ -82,6 +83,11 @@ export const ALIGNED_BY_CONSTRUCTION_SOURCES: ReadonlySet<LaunchSource> = new Se
   // Experiment treatments and auto-opens already coordinate location.
   'experiment_treatment',
   'experiment_treatment_navigation',
+  // Highlighted-guide experiment auto-opens the sidebar on a matched page and
+  // dispatches `auto-launch-tutorial` immediately after — the user is by
+  // definition on a page the operator configured for this guide, so no
+  // alignment prompt is needed.
+  'highlighted_guide_experiment',
   'auto_open',
   // Floating panel docking back to sidebar — tab already exists.
   'floating_panel_dock',

--- a/src/utils/experiments/highlighted-guide-orchestrator.test.ts
+++ b/src/utils/experiments/highlighted-guide-orchestrator.test.ts
@@ -2,7 +2,8 @@
  * Tests for highlighted-guide-orchestrator
  *
  * - initializeHighlightedGuideExperiment: flag read + resetCache state machine
- * - setupHighlightedGuideAutoOpen: guard order, sidebar auto-open, nav-listener arming
+ * - setupHighlightedGuideAutoOpen: guard order, sidebar auto-open, nav-listener
+ *   arming, and `auto-launch-tutorial` mount-then-dispatch wiring.
  */
 
 jest.mock('../../plugin.json', () => ({
@@ -27,12 +28,25 @@ jest.mock('../../lib/storage-keys', () => ({
 }));
 
 const mockSetPendingOpenSource = jest.fn();
+const mockGetIsSidebarMounted = jest.fn().mockReturnValue(false);
 jest.mock('../../global-state/sidebar', () => ({
   sidebarState: {
     setPendingOpenSource: (source: string, action: string) => mockSetPendingOpenSource(source, action),
+    getIsSidebarMounted: () => mockGetIsSidebarMounted(),
   },
 }));
 
+const mockFindDocPage = jest.fn();
+jest.mock('../find-doc-page', () => ({
+  findDocPage: (id: string) => mockFindDocPage(id),
+}));
+
+// Regression mock: the previous orchestrator pinned `recommendations` via
+// `tabStorage.setActiveTab` before auto-open so the user landed on the
+// Featured slot. The new auto-launch flow opens the guide as its own tab,
+// so pinning would flicker between tabs. This mock lets us assert it's
+// NEVER called — if anyone re-introduces `tabStorage.setActiveTab` in the
+// orchestrator, the assertion will fail.
 const mockSetActiveTab = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../lib/user-storage', () => ({
   tabStorage: {
@@ -126,6 +140,13 @@ describe('setupHighlightedGuideAutoOpen', () => {
     localStorage.clear();
     jest.clearAllMocks();
     mockIsExtensionSidebarOwnedByOther.mockReturnValue(false);
+    mockGetIsSidebarMounted.mockReturnValue(false);
+    // Default: findDocPage resolves so the auto-launch dispatch fires.
+    mockFindDocPage.mockReturnValue({
+      url: 'https://grafana.com/docs/onboarding',
+      title: 'Onboarding',
+      type: 'docs-page',
+    });
   });
 
   it('short-circuits on variant = excluded', () => {
@@ -148,11 +169,19 @@ describe('setupHighlightedGuideAutoOpen', () => {
   it('auto-opens and marks when page matches and no marker exists', () => {
     setupHighlightedGuideAutoOpen(baseConfig, '/connections/datasources/new', HOSTNAME);
     expect(mockSetPendingOpenSource).toHaveBeenCalledWith('highlighted_guide_experiment', 'auto-open');
-    expect(mockSetActiveTab).toHaveBeenCalledWith('recommendations');
     expect(mockAttemptAutoOpen).toHaveBeenCalled();
     expect(localStorage.getItem(`grafana-pathfinder-highlighted-guide-auto-open-${HOSTNAME}:bundled:onboarding`)).toBe(
       'true'
     );
+  });
+
+  it('does NOT pin the recommendations tab (the auto-launched guide tab takes focus instead)', () => {
+    // Regression: the previous behavior pinned `recommendations` via
+    // `tabStorage.setActiveTab` so the user landed on the Featured slot.
+    // The new flow auto-launches the guide as its own tab, so pinning would
+    // flicker.
+    setupHighlightedGuideAutoOpen(baseConfig, '/connections/datasources/new', HOSTNAME);
+    expect(mockSetActiveTab).not.toHaveBeenCalled();
   });
 
   it('skips auto-open when marker is already set for the same guideId', () => {
@@ -182,5 +211,159 @@ describe('setupHighlightedGuideAutoOpen', () => {
     mockIsExtensionSidebarOwnedByOther.mockReturnValue(true);
     setupHighlightedGuideAutoOpen(baseConfig, '/connections/datasources/new', HOSTNAME);
     expect(mockAttemptAutoOpen).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// auto-launch-tutorial dispatch
+// ============================================================================
+//
+// These tests pin the contract between `setupHighlightedGuideAutoOpen` and
+// the `useAutoLaunchTutorial` hook: after the sidebar (or panel) mounts, the
+// orchestrator must dispatch `auto-launch-tutorial` with a payload derived
+// from `findDocPage(guideId)` and tagged with `source: 'highlighted_guide_experiment'`.
+//
+// `useAutoLaunchTutorial.test.ts` separately verifies that the hook routes
+// that payload to `openDocsPage` / `openLearningJourney` without navigating
+// the user away from their current page.
+describe('setupHighlightedGuideAutoOpen → auto-launch-tutorial dispatch', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+    // Drain any `pathfinder-sidebar-mounted` / `pathfinder-panel-mounted`
+    // listeners installed by previous tests' `setupHighlightedGuideAutoOpen`
+    // calls. The orchestrator registers them with `{ once: true }`, so
+    // dispatching the events here causes them all to self-remove. We then
+    // flush the 500ms setTimeout each one queued so a stale `auto-launch-tutorial`
+    // can't fire mid-test once a real handler is wired up.
+    window.dispatchEvent(new Event('pathfinder-sidebar-mounted'));
+    document.dispatchEvent(new Event('pathfinder-panel-mounted'));
+    jest.runAllTimers();
+    jest.clearAllMocks();
+    mockIsExtensionSidebarOwnedByOther.mockReturnValue(false);
+    mockGetIsSidebarMounted.mockReturnValue(false);
+    mockFindDocPage.mockReturnValue({
+      url: 'https://grafana.com/docs/onboarding',
+      title: 'Onboarding',
+      type: 'docs-page',
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function captureAutoLaunch(): jest.Mock {
+    const handler = jest.fn();
+    document.addEventListener('auto-launch-tutorial', handler);
+    return handler;
+  }
+
+  it('dispatches auto-launch-tutorial on sidebar mount with findDocPage-resolved url/title/type', () => {
+    const handler = captureAutoLaunch();
+    setupHighlightedGuideAutoOpen(baseConfig, '/connections/datasources/new', HOSTNAME);
+
+    // attemptAutoOpen is mocked, so no real mount fires. Simulate it.
+    window.dispatchEvent(new Event('pathfinder-sidebar-mounted'));
+    jest.advanceTimersByTime(500);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event = handler.mock.calls[0][0] as CustomEvent;
+    expect(event.detail).toEqual({
+      url: 'https://grafana.com/docs/onboarding',
+      title: 'Onboarding',
+      type: 'docs-page',
+      source: 'highlighted_guide_experiment',
+    });
+  });
+
+  it('also dispatches on the floating panel mount event (whichever surface mounts first)', () => {
+    const handler = captureAutoLaunch();
+    setupHighlightedGuideAutoOpen(baseConfig, '/connections/datasources/new', HOSTNAME);
+
+    document.dispatchEvent(new Event('pathfinder-panel-mounted'));
+    jest.advanceTimersByTime(500);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches synchronously when the sidebar is already mounted (SPA nav case)', () => {
+    mockGetIsSidebarMounted.mockReturnValue(true);
+    const handler = captureAutoLaunch();
+
+    setupHighlightedGuideAutoOpen(baseConfig, '/connections/datasources/new', HOSTNAME);
+    jest.advanceTimersByTime(500);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors the docType operator override when set (forces the click-through flow)', () => {
+    // `findDocPage` returned type: 'docs-page'; the operator-configured
+    // `docType: 'learning-journey'` should win so the hook routes to
+    // `openLearningJourney`.
+    const handler = captureAutoLaunch();
+    setupHighlightedGuideAutoOpen(
+      { ...baseConfig, docType: 'learning-journey' },
+      '/connections/datasources/new',
+      HOSTNAME
+    );
+
+    window.dispatchEvent(new Event('pathfinder-sidebar-mounted'));
+    jest.advanceTimersByTime(500);
+
+    const event = handler.mock.calls[0][0] as CustomEvent;
+    expect(event.detail).toEqual(
+      expect.objectContaining({
+        type: 'learning-journey',
+        source: 'highlighted_guide_experiment',
+      })
+    );
+  });
+
+  it('fires exactly once even when both sidebar and panel mount events arrive', () => {
+    const handler = captureAutoLaunch();
+    setupHighlightedGuideAutoOpen(baseConfig, '/connections/datasources/new', HOSTNAME);
+
+    // Race condition: both surfaces mount (e.g. user toggles floating mode
+    // mid-flight). The orchestrator's `autoLaunched` guard must prevent a
+    // duplicate dispatch.
+    window.dispatchEvent(new Event('pathfinder-sidebar-mounted'));
+    document.dispatchEvent(new Event('pathfinder-panel-mounted'));
+    jest.advanceTimersByTime(500);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('still opens the sidebar but skips auto-launch when findDocPage returns null (fallback to Featured injection)', () => {
+    mockFindDocPage.mockReturnValue(null);
+    const handler = captureAutoLaunch();
+
+    setupHighlightedGuideAutoOpen(baseConfig, '/connections/datasources/new', HOSTNAME);
+    window.dispatchEvent(new Event('pathfinder-sidebar-mounted'));
+    jest.advanceTimersByTime(500);
+
+    // Sidebar still opens — the user gets the Featured-slot card from
+    // `injectHighlightedGuide` as a fallback.
+    expect(mockAttemptAutoOpen).toHaveBeenCalled();
+    // ...but no auto-launch event fires because we couldn't resolve the guide.
+    expect(handler).not.toHaveBeenCalled();
+    // Marker is still set so we don't retry on every reload of a misconfigured flag.
+    expect(localStorage.getItem(`grafana-pathfinder-highlighted-guide-auto-open-${HOSTNAME}:bundled:onboarding`)).toBe(
+      'true'
+    );
+  });
+
+  it('fires the pathfinder-auto-launch-pending coordination event synchronously on mount', () => {
+    // The floating panel listens for this to short-circuit its empty-state
+    // fallback before the 500ms auto-launch-tutorial dispatch lands.
+    const pendingHandler = jest.fn();
+    document.addEventListener('pathfinder-auto-launch-pending', pendingHandler);
+
+    setupHighlightedGuideAutoOpen(baseConfig, '/connections/datasources/new', HOSTNAME);
+    window.dispatchEvent(new Event('pathfinder-sidebar-mounted'));
+
+    // The pending event is dispatched BEFORE the 500ms setTimeout, so we
+    // shouldn't need to advance timers to observe it.
+    expect(pendingHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/experiments/highlighted-guide-orchestrator.ts
+++ b/src/utils/experiments/highlighted-guide-orchestrator.ts
@@ -6,7 +6,12 @@
  *   - Handles `resetCache: true` → false transitions using a separate sentinel
  *     key so a true→false→true sequence re-arms.
  *   - On a matched page, auto-opens the Pathfinder extension sidebar once per
- *     (hostname, guideId) — persisted in localStorage, NOT sessionStorage.
+ *     (hostname, guideId) — persisted in localStorage, NOT sessionStorage —
+ *     and dispatches `auto-launch-tutorial` so the configured guide opens as
+ *     a sidebar tab on mount (the same seam used by the `?doc=` deep link).
+ *     Crucially, no `locationService.replace` is called — the user stays on
+ *     the page they were on. The Featured-slot injection remains as a
+ *     re-entry point if the user later closes the auto-opened tab.
  *   - If the user lands off-target, installs a navigation listener so the
  *     sidebar opens when they later enter a matched page.
  *
@@ -20,7 +25,7 @@ import { locationService } from '@grafana/runtime';
 import pluginJson from '../../plugin.json';
 import { StorageKeys } from '../../lib/storage-keys';
 import { sidebarState } from '../../global-state/sidebar';
-import { tabStorage } from '../../lib/user-storage';
+import { findDocPage } from '../find-doc-page';
 import { getHighlightedGuideConfig, type HighlightedGuideConfig } from '../openfeature';
 import { attemptAutoOpen } from './experiment-orchestrator';
 import { isExtensionSidebarOwnedByOther } from './experiment-utils';
@@ -90,7 +95,9 @@ function handleHighlightedGuideResetCache(hostname: string, config: HighlightedG
  *   3. Page does NOT match — install a nav listener and return.
  *   4. Already auto-opened for this `guideId` — done.
  *   5. Extension sidebar owned by another plugin (e.g. Assistant) — don't steal.
- *   6. Auto-open: write marker, publish `open-extension-sidebar`.
+ *   6. Auto-open: write marker, publish `open-extension-sidebar`, then dispatch
+ *      `auto-launch-tutorial` on sidebar/panel mount so the configured guide
+ *      opens as a tab without navigating the user away from their current page.
  *
  * The nav listener uses the same logic, so a user navigating into a matched
  * page later in the same SPA navigation will trigger auto-open on first
@@ -138,13 +145,30 @@ export function setupHighlightedGuideAutoOpen(
     }
     markHighlightedGuideAutoOpened(hostname, config.guideId);
     sidebarState.setPendingOpenSource('highlighted_guide_experiment', 'auto-open');
-    // Pin the active tab to 'recommendations' so the sidebar lands on the
-    // Featured slot rather than whatever was last open (editor, devtools, etc.).
-    // attemptAutoOpen's 200ms delay covers the async write; if it fails we accept
-    // the user seeing their previous tab — the marker is still set, so we don't loop.
-    tabStorage.setActiveTab('recommendations').catch((error) => {
-      console.warn('[Pathfinder] Failed to pin recommendations tab for highlighted-guide auto-open:', error);
+
+    // Resolve the guide so we can dispatch `auto-launch-tutorial` on mount —
+    // same seam used by `?doc=` in `module.tsx`. If the guideId can't be
+    // resolved we still open the sidebar (Featured-slot injection in
+    // `context.service.ts` is the fallback path for misconfigured flags).
+    const docsPage = findDocPage(config.guideId);
+    if (!docsPage) {
+      console.warn(
+        `[Pathfinder] Highlighted-guide auto-open: findDocPage returned null for guideId="${config.guideId}". Opening sidebar without auto-launch; Featured-slot injection remains as fallback.`
+      );
+      attemptAutoOpen();
+      return;
+    }
+
+    installAutoLaunchOnMount({
+      url: docsPage.url,
+      title: docsPage.title,
+      // Operator override wins (lets the flag force the click-through flow
+      // when `findDocPage`'s URL-based inference misclassifies the guide,
+      // e.g. a docs URL that's really a learning journey). Otherwise honor
+      // the inferred type.
+      type: config.docType ?? docsPage.type,
     });
+
     attemptAutoOpen();
     console.log(`[Pathfinder] Highlighted-guide auto-open fired (${source}) for guideId:`, config.guideId);
   };
@@ -155,6 +179,55 @@ export function setupHighlightedGuideAutoOpen(
   // no-op on subsequent fires (marker is set). Cheap insurance against SPA
   // navigations into a matched page later in the session.
   installHighlightedGuideNavListener((path) => tryAutoOpen(path, 'navigation'));
+}
+
+/**
+ * Wire the `auto-launch-tutorial` dispatch to whichever panel surface mounts
+ * first. Mirrors the `dispatchAutoLaunch` pattern in `module.tsx` so the
+ * highlighted-guide experiment and `?doc=` deep links share the same
+ * mount-then-dispatch contract.
+ *
+ * The dispatch fires exactly once even when both `pathfinder-sidebar-mounted`
+ * and `pathfinder-panel-mounted` arrive (the floating panel can race the
+ * sidebar). If the sidebar is already mounted (SPA navigation case — the user
+ * already had the sidebar open from a prior page), we dispatch synchronously
+ * so the listener isn't left dangling waiting for a mount that already fired.
+ */
+function installAutoLaunchOnMount(detail: { url: string; title: string; type: string }): void {
+  let autoLaunched = false;
+  const dispatch = () => {
+    if (autoLaunched) {
+      return;
+    }
+    autoLaunched = true;
+    window.removeEventListener('pathfinder-sidebar-mounted', dispatch);
+    document.removeEventListener('pathfinder-panel-mounted', dispatch);
+
+    // Signal synchronously so the floating panel's empty-state fallback
+    // doesn't fire on top of an incoming guide (same coordination event as
+    // the `?doc=` flow).
+    document.dispatchEvent(new CustomEvent('pathfinder-auto-launch-pending'));
+
+    setTimeout(() => {
+      document.dispatchEvent(
+        new CustomEvent('auto-launch-tutorial', {
+          detail: {
+            url: detail.url,
+            title: detail.title,
+            type: detail.type,
+            source: 'highlighted_guide_experiment',
+          },
+        })
+      );
+    }, 500);
+  };
+
+  window.addEventListener('pathfinder-sidebar-mounted', dispatch, { once: true });
+  document.addEventListener('pathfinder-panel-mounted', dispatch, { once: true });
+
+  if (sidebarState.getIsSidebarMounted()) {
+    dispatch();
+  }
 }
 
 function installHighlightedGuideNavListener(tryAutoOpen: (path: string) => void): void {


### PR DESCRIPTION
## Summary

- The `pathfinder.highlighted-guide-experiment` flag now auto-launches the configured guide as a sidebar tab on matched pages, reusing the same `auto-launch-tutorial` seam that `?doc=` uses, while keeping the user on the page they were on (no `locationService.replace`).
- The Featured-slot injection still runs in parallel, so the card remains a re-entry point if the user closes the auto-launched tab.
- Adds `highlighted_guide_experiment` to the `LaunchSource` union as aligned-by-construction.

## What changed

| File | Change |
| --- | --- |
| `src/utils/experiments/highlighted-guide-orchestrator.ts` | New `installAutoLaunchOnMount` helper that listens for `pathfinder-sidebar-mounted` / `pathfinder-panel-mounted` (one-shot, guarded) and dispatches `auto-launch-tutorial` with `findDocPage`-resolved `url` / `title` / `type` and `source: 'highlighted_guide_experiment'`. The `tabStorage.setActiveTab('recommendations')` pin is dropped (the new guide tab takes focus). If `findDocPage` returns null, the sidebar still opens and the Featured-slot card is the fallback. The flag's `docType` overrides `findDocPage`'s inferred type so operators can correct misclassified guides. |
| `src/recovery/launch-sources.ts` | Add `'highlighted_guide_experiment'` to the `LaunchSource` union and `ALIGNED_BY_CONSTRUCTION_SOURCES`. |
| `src/utils/experiments/highlighted-guide-orchestrator.test.ts` | New describe block pins the dispatch matrix (payload, sidebar / panel mount, sync-when-already-mounted, `docType` override, one-shot guard, `findDocPage`-null fallback). Plus a regression test asserting `tabStorage.setActiveTab` is never called. |
| `src/hooks/useAutoLaunchTutorial.test.ts` | New test verifying the `highlighted_guide_experiment` source round-trips through `coerceLaunchSource` (not dropped to `undefined`). |
| `src/recovery/launch-sources.test.ts` | Extend the exhaustive classification list. |
| `docs/developer/FEATURE_FLAGS.md` | Document the auto-launch behavior, dispatch mechanics, and launch source. |
| `docs/developer/EXPERIMENT_TESTING.md` | Update QA recipes, analytics matrix, and troubleshooting (no more 'wrong tab on auto-open' entry; new 'auto-launch landed but wrong type' guidance). |

## Why

The previous flag only opened the sidebar and pinned the recommendations tab — the user still had to click Start on the Featured card. Operators running the experiment wanted parity with `?doc=`: open the guide directly while keeping the user on the matched page. Reusing the existing seam means a single source of truth for "open guide without navigating" and inherits the routing decision (`shouldOpenAsLearningJourney`), analytics (`OpenResourceClick` with `trigger_source: 'auto_launch_tutorial'`), and the floating / fullscreen mount handling.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors, 1 pre-existing warning in an unrelated test)
- [x] `npm run prettier-test`
- [x] `npm run test:ci` — 3674 tests passing
- [ ] Manual smoke test: override the flag with `__pathfinderExperiment.setOverride` (recipe in `EXPERIMENT_TESTING.md`), confirm the sidebar opens and the configured guide auto-launches as a tab without changing the Grafana route.
- [ ] Manual: confirm the Featured-slot card still appears in the recommendations tab when the user switches to it.
- [ ] Manual: confirm `autoOpen: false` keeps the previous Featured-only behavior (no sidebar, no auto-launch).

## Risk and reversibility

- **Low risk.** Reuses the `auto-launch-tutorial` event seam already covered by `useAutoLaunchTutorial.test.ts` and exercised in production by `?doc=`.
- **Featured injection is unchanged** — the existing `injectHighlightedGuide` continues to work; the new path is additive.
- **Easily reversed** by reverting the orchestrator change. The new `LaunchSource` literal is also low-risk: it's aligned-by-construction, so worst-case it skips an alignment prompt that wasn't useful here anyway.
- **One-way door check**: none. The flag value shape is unchanged (`docType` was already optional). No localStorage keys, analytics keys, or backend contracts have changed.