### PR TITLE
fix(docs-panel): surface toast when guide reset fails

### DIFF
--- a/src/components/docs-panel/hooks/useContentReset.test.ts
+++ b/src/components/docs-panel/hooks/useContentReset.test.ts
@@ -12,6 +12,17 @@ import type { LearningJourneyTab } from '../../../types/content-panel.types';
 // Mock dependencies
 jest.mock('../../../lib/analytics');
 jest.mock('../../../lib/user-storage');
+jest.mock('@grafana/runtime', () => {
+  const mockPublish = jest.fn();
+  return {
+    getAppEvents: jest.fn(() => ({ publish: mockPublish })),
+    __mockPublish: mockPublish,
+  };
+});
+
+jest.mock('@grafana/i18n', () => ({
+  t: jest.fn((_key: string, fallback: string) => fallback),
+}));
 
 const mockReportAppInteraction = reportAppInteraction as jest.MockedFunction<typeof reportAppInteraction>;
 const mockEnrichWithStepContext = enrichWithStepContext as jest.MockedFunction<typeof enrichWithStepContext>;
@@ -22,6 +33,7 @@ const mockInteractiveStepStorage = interactiveStepStorage as jest.Mocked<typeof 
 const mockInteractiveCompletionStorage = interactiveCompletionStorage as jest.Mocked<
   typeof interactiveCompletionStorage
 >;
+const { __mockPublish: mockPublish } = jest.requireMock('@grafana/runtime');
 
 describe('useContentReset', () => {
   let mockModel: any;
@@ -173,6 +185,12 @@ describe('useContentReset', () => {
 
     // Event should NOT have been dispatched after error
     expect(mockDispatchEvent).not.toHaveBeenCalled();
+
+    // User-facing toast should be surfaced via the app events bus.
+    expect(mockPublish).toHaveBeenCalledWith({
+      type: 'alert-error',
+      payload: ['Reset failed', "Couldn't reset guide progress. Please try again or reload the page."],
+    });
   });
 
   it('handles content reload errors', async () => {
@@ -188,6 +206,21 @@ describe('useContentReset', () => {
     expect(mockReportAppInteraction).toHaveBeenCalled();
     expect(mockInteractiveStepStorage.clearAllForContent).toHaveBeenCalled();
     expect(mockDispatchEvent).toHaveBeenCalled();
+
+    // User-facing toast should be surfaced via the app events bus.
+    expect(mockPublish).toHaveBeenCalledWith({
+      type: 'alert-error',
+      payload: ['Reset failed', "Couldn't reset guide progress. Please try again or reload the page."],
+    });
+  });
+
+  it('does not publish a toast on the happy path', async () => {
+    const { result } = renderHook(() => useContentReset({ model: mockModel }));
+
+    const tab = createMockTab({ type: 'interactive' });
+    await result.current('progress-key-123', tab);
+
+    expect(mockPublish).not.toHaveBeenCalled();
   });
 
   it('returns stable function reference', () => {

--- a/src/components/docs-panel/hooks/useContentReset.ts
+++ b/src/components/docs-panel/hooks/useContentReset.ts
@@ -8,6 +8,8 @@
  */
 
 import { useCallback } from 'react';
+import { getAppEvents } from '@grafana/runtime';
+import { t } from '@grafana/i18n';
 import {
   reportAppInteraction,
   UserInteraction,
@@ -82,7 +84,16 @@ export function useContentReset({ model }: UseContentResetOptions) {
         }
       } catch (error) {
         console.error('[DocsPanel] Failed to reset guide progress:', error);
-        // TODO: Show error toast to user
+        getAppEvents().publish({
+          type: 'alert-error',
+          payload: [
+            t('docsPanel.resetGuideErrorTitle', 'Reset failed'),
+            t(
+              'docsPanel.resetGuideErrorMessage',
+              "Couldn't reset guide progress. Please try again or reload the page."
+            ),
+          ],
+        });
         throw error; // Re-throw so caller can handle if needed
       }
     },

--- a/src/locales/en-US/grafana-pathfinder-app.json
+++ b/src/locales/en-US/grafana-pathfinder-app.json
@@ -43,6 +43,8 @@
     "previousMilestoneTooltip": "Previous milestone (Alt + ←)",
     "recommendations": "Recommendations",
     "resetGuide": "Reset guide",
+    "resetGuideErrorMessage": "Couldn't reset guide progress. Please try again or reload the page.",
+    "resetGuideErrorTitle": "Reset failed",
     "resetGuideTooltip": "Resets all interactive steps",
     "settings": "Settings",
     "showMoreTabs_one": "Show {{count}} more tab",


### PR DESCRIPTION
Completes #824 

## Summary

Replace the TODO in useContentReset's catch block with an alert-error toast published via getAppEvents. Adds the resetGuideErrorTitle / resetGuideErrorMessage en-US strings and extends the hook test to assert the toast on both error paths (plus a happy-path negative).

https://github.com/user-attachments/assets/5c3a144f-ac3a-4ee3-bd84-07d8055fdb82

## Test Plan
- [ ] Test a known broken guide, or short-circuit [useContentReset](https://github.com/grafana/grafana-pathfinder-app/blob/fix/add-toast-notification-for-reset-guide-error-824/src/components/docs-panel/hooks/useContentReset.ts#L40-L45) with an error like `throw new Error("Ooops");` to force catch block execution. Verify that the toast notification is displayed when "Reset guide" is clicked.
- [ ] Test a working guide / remove the short-circuit `Error`. Verify that the happy path does not display display an error notification.