### PR TITLE
fix(first-dashboard): repair guide selectors and reactive conditional rendering

### DIFF
--- a/src/bundled-interactives/first-dashboard-cloud/content.json
+++ b/src/bundled-interactives/first-dashboard-cloud/content.json
@@ -186,41 +186,33 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid=\"data-testid toggle-viz-picker\"]",
-          "content": "Let's change the visualisation type",
-          "tooltip": "Let's change the visualisation type",
+          "reftarget": "grafana:components.PanelEditor.toggleVizPicker",
+          "content": "Open the visualization picker to change the panel type.",
+          "tooltip": "Choosing the right visualization is key to telling your data's story. Time series graphs show trends over time, stat panels display single values, tables show raw data, and bar charts compare values side by side.",
           "requirements": ["exists-reftarget"]
         },
         {
-          "type": "conditional",
-          "conditions": ["exists-reftarget"],
-          "description": "Check whether we need to toggle to All visualisations",
-          "reftarget": "button[data-testid='data-testid Tab All visualizations']",
-          "whenTrue": [
-            {
-              "type": "interactive",
-              "action": "highlight",
-              "reftarget": "button[data-testid='data-testid Tab All visualizations']",
-              "content": "Let's select all visualisations.",
-              "tooltip": "Let's select all visualisations.",
-              "requirements": ["exists-reftarget"],
-              "skippable": true
-            }
-          ],
-          "whenFalse": []
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid=\"data-testid Tab Visualizations\"]",
+          "content": "Select **All visualizations** to browse every panel type.",
+          "tooltip": "Bar chart is not listed under suggested visualizations. Open **All visualizations** to find it.",
+          "requirements": ["exists-reftarget"]
         },
         {
           "type": "interactive",
           "action": "highlight",
           "reftarget": "div[data-testid=\"data-testid Plugin visualization item Bar chart\"]",
-          "content": "Choosing the right visualization is key to telling your data's story. Time series graphs show trends over time, stat panels display single values, tables show raw data, and bar charts compare values side by side. For comparing Jack and Jill's final altitudes, a bar chart makes the difference instantly clear - you can see at a glance who climbed higher!"
+          "content": "Change the visualization to **Bar chart** to compare altitudes.",
+          "tooltip": "For comparing Jack and Jill's final altitudes, a bar chart makes the difference instantly clear - you can see at a glance who climbed higher!",
+          "requirements": ["exists-reftarget"]
         },
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "input[data-testid=\"data-testid Panel editor option pane field input Title\"]",
-          "targetvalue": "Jack and Jill Walk Altitude",
-          "content": "Give your panel a clear title: **Jack and Jill Walk Altitude**.",
+          "reftarget": "grafana:components.PanelEditor.OptionsPane.fieldInput:Title",
+          "targetvalue": "Jack and Jill walk altitude",
+          "content": "Give your panel a clear title: **Jack and Jill walk altitude**.",
           "tooltip": "A good panel title transforms raw data into a story. Instead of generic names like \"Query A\" or \"Metric 1,\" use descriptive titles that immediately convey what the data represents. This is especially important when sharing dashboards with teammates who might not know the context. Your future self will thank you too!",
           "requirements": ["exists-reftarget"]
         },
@@ -235,7 +227,7 @@
         },
         {
           "type": "multistep",
-          "content": "Click **Save Dashboard**, name it **Walking Adventure**, and click **Save**.",
+          "content": "Click **Save dashboard**, name it **Walking adventure**, and click **Save**.",
           "steps": [
             {
               "action": "highlight",
@@ -245,12 +237,12 @@
             {
               "action": "formfill",
               "reftarget": "input[aria-label=\"Save dashboard title field\"]",
-              "targetvalue": "Walking Adventure",
+              "targetvalue": "Walking adventure",
               "requirements": ["exists-reftarget"]
             },
             {
-              "action": "button",
-              "reftarget": "Save",
+              "action": "highlight",
+              "reftarget": "button[data-testid=\"data-testid Save dashboard drawer button\"]",
               "requirements": ["exists-reftarget"]
             }
           ]

--- a/src/bundled-interactives/first-dashboard/content.json
+++ b/src/bundled-interactives/first-dashboard/content.json
@@ -130,26 +130,33 @@
           ]
         },
         {
-          "type": "multistep",
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "grafana:components.PanelEditor.toggleVizPicker",
+          "content": "Open the visualization picker to change the panel type.",
+          "tooltip": "Choosing the right visualization is key to telling your data's story. Time series graphs show trends over time, stat panels display single values, tables show raw data, and bar charts compare values side by side.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid=\"data-testid Tab Visualizations\"]",
+          "content": "Select **All visualizations** to browse every panel type.",
+          "tooltip": "Bar chart is not listed under suggested visualizations. Open **All visualizations** to find it.",
+          "requirements": ["exists-reftarget"]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid=\"data-testid Plugin visualization item Bar chart\"]",
           "content": "Change the visualization to **Bar chart** to compare altitudes.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid=\"data-testid toggle-viz-picker\"]",
-              "requirements": ["exists-reftarget"]
-            },
-            {
-              "action": "highlight",
-              "reftarget": "div[data-testid=\"Plugin visualization item Bar chart\"]",
-              "requirements": ["exists-reftarget"],
-              "tooltip": "Choosing the right visualization is key to telling your data's story. Time series graphs show trends over time, stat panels display single values, tables show raw data, and bar charts compare values side by side. For comparing Jack and Jill's final altitudes, a bar chart makes the difference instantly clear - you can see at a glance who climbed higher!"
-            }
-          ]
+          "tooltip": "For comparing Jack and Jill's final altitudes, a bar chart makes the difference instantly clear - you can see at a glance who climbed higher!",
+          "requirements": ["exists-reftarget"]
         },
         {
           "type": "interactive",
           "action": "formfill",
-          "reftarget": "input[data-testid=\"data-testid Panel editor option pane field input Title\"]",
+          "reftarget": "grafana:components.PanelEditor.OptionsPane.fieldInput:Title",
           "targetvalue": "Jack and Jill walk altitude",
           "requirements": ["exists-reftarget"],
           "content": "Give your panel a clear title: **Jack and Jill walk altitude**.",
@@ -169,8 +176,8 @@
           "content": "Click **Save dashboard**, name it **Walking adventure**, and click **Save**.",
           "steps": [
             {
-              "action": "button",
-              "reftarget": "Save Dashboard",
+              "action": "highlight",
+              "reftarget": "button[data-testid='data-testid Save dashboard button']",
               "requirements": ["exists-reftarget"]
             },
             {
@@ -180,8 +187,8 @@
               "requirements": ["exists-reftarget"]
             },
             {
-              "action": "button",
-              "reftarget": "Save",
+              "action": "highlight",
+              "reftarget": "button[data-testid=\"data-testid Save dashboard drawer button\"]",
               "requirements": ["exists-reftarget"]
             }
           ]

--- a/src/components/interactive-tutorial/interactive-conditional.test.tsx
+++ b/src/components/interactive-tutorial/interactive-conditional.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+import { testIds } from '../../constants/testIds';
+import { InteractiveConditional } from './interactive-conditional';
+
+const checkRequirementsFromData = jest.fn();
+
+jest.mock('../../interactive-engine', () => ({
+  useInteractiveElements: () => ({
+    checkRequirementsFromData,
+  }),
+}));
+
+describe('InteractiveConditional', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    checkRequirementsFromData.mockReset();
+    checkRequirementsFromData.mockResolvedValue({ pass: false, requirements: '', error: [] });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const renderConditional = (pass: boolean) => {
+    checkRequirementsFromData.mockResolvedValue({ pass, requirements: '', error: [] });
+    return render(
+      <InteractiveConditional
+        conditions={['exists-reftarget']}
+        reftarget={'button[data-testid="data-testid Tab Visualizations"]'}
+        whenTrueChildren={[
+          {
+            type: 'interactive-step',
+            props: { targetAction: 'highlight', refTarget: '.when-true-step' },
+            children: [],
+          },
+        ]}
+        whenFalseChildren={[]}
+        renderElement={(element, childKey) => (
+          <div data-testid={`rendered-${childKey}`} key={childKey}>
+            {element.type}
+          </div>
+        )}
+        keyPrefix="test"
+      />
+    );
+  };
+
+  it('shows whenTrue branch after interactive-action-completed without remounting', async () => {
+    renderConditional(false);
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(screen.queryByTestId('rendered-test-true-0')).not.toBeInTheDocument();
+
+    checkRequirementsFromData.mockResolvedValue({ pass: true, requirements: '', error: [] });
+
+    await act(async () => {
+      document.dispatchEvent(new CustomEvent('interactive-action-completed', { detail: {} }));
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rendered-test-true-0')).toBeInTheDocument();
+    });
+  });
+
+  it('re-evaluates on interactive-step-completed for exists-reftarget conditions', async () => {
+    renderConditional(false);
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    checkRequirementsFromData.mockResolvedValue({ pass: true, requirements: '', error: [] });
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent('interactive-step-completed', { detail: { stepId: 'prior-step' } }));
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rendered-test-true-0')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show loading spinner on re-evaluation when branch was already resolved', async () => {
+    checkRequirementsFromData.mockResolvedValue({ pass: true, requirements: '', error: [] });
+
+    render(
+      <InteractiveConditional
+        conditions={['exists-reftarget']}
+        reftarget="button.tab"
+        whenTrueChildren={[
+          {
+            type: 'interactive-step',
+            props: { targetAction: 'highlight', refTarget: '.step' },
+            children: [],
+          },
+        ]}
+        whenFalseChildren={[]}
+        renderElement={() => <div>child</div>}
+        keyPrefix="k"
+      />
+    );
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(screen.getByText('child')).toBeInTheDocument();
+    expect(screen.queryByText('Checking conditions...')).not.toBeInTheDocument();
+
+    checkRequirementsFromData.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ pass: false, requirements: '', error: [] }), 500);
+        })
+    );
+
+    await act(async () => {
+      document.dispatchEvent(new CustomEvent('interactive-action-completed', { detail: {} }));
+      jest.advanceTimersByTime(300);
+    });
+
+    // Branch stays visible while re-check is in flight (no loading takeover)
+    expect(screen.getByText('child')).toBeInTheDocument();
+    expect(screen.queryByText('Checking conditions...')).not.toBeInTheDocument();
+  });
+
+  it('exposes conditional test id after evaluation', async () => {
+    renderConditional(true);
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId(testIds.interactive.conditional('exists-reftarget'))).toHaveAttribute(
+        'data-passed',
+        'true'
+      );
+    });
+  });
+});

--- a/src/components/interactive-tutorial/interactive-conditional.test.tsx
+++ b/src/components/interactive-tutorial/interactive-conditional.test.tsx
@@ -146,3 +146,234 @@ describe('InteractiveConditional', () => {
     });
   });
 });
+
+/**
+ * Integration-style reproduction of the original first-dashboard failure mode.
+ * Drives the real InteractiveConditional with a real DOM mutation - no synthetic
+ * events. If the MutationObserver path is wired correctly, the whenTrue branch
+ * renders within the debounce window after the target element is injected.
+ */
+describe('InteractiveConditional - DOM mutation reproduction', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+    checkRequirementsFromData.mockReset();
+    // Realistic check: actually query the DOM, mirroring reftargetExistsCheck.
+    checkRequirementsFromData.mockImplementation(async (data: { reftarget?: string }) => {
+      const reftarget = data.reftarget ?? '';
+      const found = reftarget ? document.querySelector(reftarget) !== null : false;
+      return { pass: found, requirements: 'exists-reftarget', error: [] };
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders whenTrue branch when target element is injected post-mount', async () => {
+    render(
+      <InteractiveConditional
+        conditions={['exists-reftarget']}
+        reftarget={'button[data-testid="data-testid Tab Visualizations"]'}
+        whenTrueChildren={[
+          { type: 'interactive-step', props: { targetAction: 'highlight', refTarget: '.tab' }, children: [] },
+        ]}
+        whenFalseChildren={[]}
+        renderElement={(_element, childKey) => <div data-testid={`branch-${childKey}`}>branch</div>}
+        keyPrefix="repro"
+      />
+    );
+
+    // Initial evaluation: target does not exist, whenTrue branch is hidden.
+    await waitFor(() => {
+      expect(screen.queryByTestId('branch-repro-true-0')).not.toBeInTheDocument();
+    });
+
+    // Simulate the picker animation completing and injecting the tab.
+    const tab = document.createElement('button');
+    tab.setAttribute('data-testid', 'data-testid Tab Visualizations');
+    document.body.appendChild(tab);
+
+    // MutationObserver fires synchronously, then a 200ms debounce, then evaluateConditions.
+    // Plus the 250ms scheduleReevaluation delay - allow generous budget.
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('branch-repro-true-0')).toBeInTheDocument();
+      },
+      { timeout: 2000 }
+    );
+
+    // Conditional should expose data-passed="true" without any external action event firing.
+    const wrapper = screen.getByTestId(testIds.interactive.conditional('exists-reftarget'));
+    expect(wrapper).toHaveAttribute('data-passed', 'true');
+  });
+
+  it('does not re-subscribe MutationObserver when conditions array identity changes but contents are equal', async () => {
+    // testing-library's waitFor uses MutationObserver internally, so spying on the
+    // prototype catches both our observer and theirs. Track only observers that
+    // observe `document.body` with our specific options.
+    const observeCalls: MutationObserverInit[] = [];
+    const disconnectCalls: unknown[] = [];
+
+    const originalObserve = MutationObserver.prototype.observe;
+    const originalDisconnect = MutationObserver.prototype.disconnect;
+
+    MutationObserver.prototype.observe = function observe(
+      this: MutationObserver,
+      target: Node,
+      options?: MutationObserverInit
+    ) {
+      // Component observer: targets document.body with childList + subtree.
+      const isOurObserver =
+        target === document.body && options?.childList === true && options?.subtree === true && !options?.attributes;
+      if (isOurObserver && options) {
+        observeCalls.push(options);
+        // Tag so we can recognise disconnect from the same instance.
+        (this as unknown as { __ourObserver?: boolean }).__ourObserver = true;
+      }
+      return originalObserve.call(this, target, options);
+    } as typeof originalObserve;
+
+    MutationObserver.prototype.disconnect = function disconnect(this: MutationObserver) {
+      if ((this as unknown as { __ourObserver?: boolean }).__ourObserver) {
+        disconnectCalls.push(this);
+      }
+      return originalDisconnect.call(this);
+    } as typeof originalDisconnect;
+
+    try {
+      const Harness = ({ conds }: { conds: string[] }) => (
+        <InteractiveConditional
+          conditions={conds}
+          reftarget={'button[data-testid="data-testid Tab Visualizations"]'}
+          whenTrueChildren={[]}
+          whenFalseChildren={[]}
+          renderElement={(_e, k) => <div data-testid={`x-${k}`} />}
+          keyPrefix="stable"
+        />
+      );
+
+      const { rerender } = render(<Harness conds={['exists-reftarget']} />);
+
+      // Wait for the initial effect to commit the observer subscription.
+      await waitFor(() => {
+        expect(observeCalls.length).toBe(1);
+      });
+
+      const initialObserveCount = observeCalls.length;
+      const initialDisconnectCount = disconnectCalls.length;
+
+      // Re-render with a new array reference but same contents. Without
+      // conditionsKey memoization the observer would tear down and re-subscribe.
+      rerender(<Harness conds={['exists-reftarget']} />);
+      rerender(<Harness conds={['exists-reftarget']} />);
+      rerender(<Harness conds={['exists-reftarget']} />);
+
+      // Allow any pending effects to flush.
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(observeCalls.length).toBe(initialObserveCount);
+      expect(disconnectCalls.length).toBe(initialDisconnectCount);
+    } finally {
+      MutationObserver.prototype.observe = originalObserve;
+      MutationObserver.prototype.disconnect = originalDisconnect;
+    }
+  });
+
+  it('discards stale evaluation results when a newer run supersedes them', async () => {
+    // Pre-seed: no target element.
+    let resolveFirst: ((value: { pass: boolean; requirements: string; error: never[] }) => void) | undefined;
+    let resolveSecond: ((value: { pass: boolean; requirements: string; error: never[] }) => void) | undefined;
+    let call = 0;
+
+    checkRequirementsFromData.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          call += 1;
+          if (call === 1) {
+            resolveFirst = resolve;
+          } else if (call === 2) {
+            resolveSecond = resolve;
+          } else {
+            resolve({ pass: true, requirements: '', error: [] });
+          }
+        })
+    );
+
+    render(
+      <InteractiveConditional
+        conditions={['exists-reftarget']}
+        reftarget={'button.race'}
+        whenTrueChildren={[
+          { type: 'interactive-step', props: { targetAction: 'highlight', refTarget: '.race' }, children: [] },
+        ]}
+        whenFalseChildren={[]}
+        renderElement={(_e, k) => <div data-testid={`race-${k}`}>race</div>}
+        keyPrefix="race"
+      />
+    );
+
+    // Wait until both runs have been started: the initial mount evaluation,
+    // plus a re-evaluation triggered by an action event below.
+    await waitFor(() => {
+      expect(resolveFirst).toBeDefined();
+    });
+
+    // Trigger a second run.
+    window.dispatchEvent(new CustomEvent('interactive-action-completed', { detail: {} }));
+
+    await waitFor(() => {
+      expect(resolveSecond).toBeDefined();
+    });
+
+    // Resolve the SECOND (newer) run first - the fresh result is "pass: true",
+    // so the whenTrue branch should appear.
+    resolveSecond!({ pass: true, requirements: '', error: [] });
+    await waitFor(() => {
+      expect(screen.getByTestId('race-race-true-0')).toBeInTheDocument();
+    });
+
+    // Now resolve the FIRST (stale) run with the OPPOSITE result. Without the
+    // runId race guard this would flip the branch back off. With it, the stale
+    // result is dropped.
+    resolveFirst!({ pass: false, requirements: '', error: [] });
+
+    // Give React a chance to flush.
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(screen.getByTestId('race-race-true-0')).toBeInTheDocument();
+  });
+
+  it('unmounts whenTrue branch when the target element disappears', async () => {
+    // Pre-seed the target so the conditional renders true on first evaluation.
+    const tab = document.createElement('button');
+    tab.setAttribute('data-testid', 'data-testid Tab Visualizations');
+    document.body.appendChild(tab);
+
+    render(
+      <InteractiveConditional
+        conditions={['exists-reftarget']}
+        reftarget={'button[data-testid="data-testid Tab Visualizations"]'}
+        whenTrueChildren={[
+          { type: 'interactive-step', props: { targetAction: 'highlight', refTarget: '.tab' }, children: [] },
+        ]}
+        whenFalseChildren={[]}
+        renderElement={(_element, childKey) => <div data-testid={`branch-${childKey}`}>branch</div>}
+        keyPrefix="reverse"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('branch-reverse-true-0')).toBeInTheDocument();
+    });
+
+    // Remove the element - MutationObserver should fire and the branch should disappear.
+    tab.remove();
+
+    await waitFor(
+      () => {
+        expect(screen.queryByTestId('branch-reverse-true-0')).not.toBeInTheDocument();
+      },
+      { timeout: 2000 }
+    );
+  });
+});

--- a/src/components/interactive-tutorial/interactive-conditional.tsx
+++ b/src/components/interactive-tutorial/interactive-conditional.tsx
@@ -45,6 +45,11 @@ function conditionsToRequirementsString(conditions: string[]): string {
   return conditions.join(',');
 }
 
+/** True when conditions may flip after DOM updates (e.g. viz picker opens). */
+function conditionsNeedDomWatch(conditions: string[]): boolean {
+  return conditions.some((c) => c.trim() === 'exists-reftarget' || c.includes('exists-reftarget'));
+}
+
 /**
  * Interactive conditional component that evaluates conditions and renders appropriate branch
  */
@@ -88,40 +93,55 @@ export function InteractiveConditional({
   const requirementsString = conditionsToRequirementsString(conditions);
 
   // Function to evaluate conditions
-  const evaluateConditions = useCallback(async () => {
-    if (!isMountedRef.current) {
-      return;
-    }
-
-    setIsChecking(true);
-
-    try {
-      // Create requirement data for checking
-      // Use provided reftarget for exists-reftarget condition, fallback to placeholder
-      const requirementData = {
-        requirements: requirementsString,
-        targetaction: 'conditional',
-        reftarget: reftarget || 'conditional-block',
-        targetvalue: undefined,
-        textContent: description || 'Conditional block',
-        tagName: 'div',
-      };
-
-      const result = await checkRequirementsFromData(requirementData);
-
-      if (isMountedRef.current) {
-        setConditionsPassed(result.pass);
-        setIsChecking(false);
+  const evaluateConditions = useCallback(
+    async (options?: { isReevaluation?: boolean }) => {
+      if (!isMountedRef.current) {
+        return;
       }
-    } catch (error) {
-      console.warn('Failed to evaluate conditional conditions:', error);
-      if (isMountedRef.current) {
-        // Default to false branch on error
-        setConditionsPassed(false);
-        setIsChecking(false);
+
+      // Only block the UI with a spinner on the first evaluation. Re-checks keep the
+      // current branch mounted so steps can appear without a full content refresh.
+      if (!options?.isReevaluation) {
+        setIsChecking(true);
       }
-    }
-  }, [requirementsString, checkRequirementsFromData, description, reftarget]);
+
+      try {
+        // Create requirement data for checking
+        // Use provided reftarget for exists-reftarget condition, fallback to placeholder
+        const requirementData = {
+          requirements: requirementsString,
+          targetaction: 'conditional',
+          reftarget: reftarget || 'conditional-block',
+          targetvalue: undefined,
+          textContent: description || 'Conditional block',
+          tagName: 'div',
+        };
+
+        const result = await checkRequirementsFromData(requirementData);
+
+        if (isMountedRef.current) {
+          setConditionsPassed(result.pass);
+          setIsChecking(false);
+        }
+      } catch (error) {
+        console.warn('Failed to evaluate conditional conditions:', error);
+        if (isMountedRef.current) {
+          // Default to false branch on error
+          setConditionsPassed(false);
+          setIsChecking(false);
+        }
+      }
+    },
+    [requirementsString, checkRequirementsFromData, description, reftarget]
+  );
+
+  const scheduleReevaluation = useCallback(() => {
+    const delay = conditionsNeedDomWatch(conditions) ? 250 : 100;
+    const timeoutId = setTimeout(() => {
+      evaluateConditions({ isReevaluation: true });
+    }, delay);
+    return () => clearTimeout(timeoutId);
+  }, [conditions, evaluateConditions]);
 
   // Evaluate on mount and re-evaluate when relevant events occur
   useEffect(() => {
@@ -132,24 +152,26 @@ export function InteractiveConditional({
 
     // Listen for events that might change condition results
     const handleDataSourcesChanged = () => {
-      evaluateConditions();
+      scheduleReevaluation();
     };
 
     const handlePluginsChanged = () => {
-      evaluateConditions();
+      scheduleReevaluation();
     };
 
     const handleLocationChanged = () => {
-      evaluateConditions();
+      scheduleReevaluation();
     };
 
     // Re-evaluate after interactive steps complete - the step may have changed UI state
     // This handles exists-reftarget conditions where elements appear after actions
     const handleStepCompleted = () => {
-      // Small delay to let DOM settle after the step's action
-      setTimeout(() => {
-        evaluateConditions();
-      }, 100);
+      scheduleReevaluation();
+    };
+
+    // Highlight/button actions dispatch on document before section step-completed
+    const handleActionCompleted = () => {
+      scheduleReevaluation();
     };
 
     // Subscribe to relevant events
@@ -157,6 +179,7 @@ export function InteractiveConditional({
     window.addEventListener('plugins-changed', handlePluginsChanged);
     window.addEventListener('popstate', handleLocationChanged);
     window.addEventListener('interactive-step-completed', handleStepCompleted);
+    document.addEventListener('interactive-action-completed', handleActionCompleted);
 
     // REACT: cleanup subscriptions (R1)
     return () => {
@@ -165,8 +188,41 @@ export function InteractiveConditional({
       window.removeEventListener('plugins-changed', handlePluginsChanged);
       window.removeEventListener('popstate', handleLocationChanged);
       window.removeEventListener('interactive-step-completed', handleStepCompleted);
+      document.removeEventListener('interactive-action-completed', handleActionCompleted);
     };
-  }, [evaluateConditions]);
+  }, [evaluateConditions, scheduleReevaluation]);
+
+  // exists-reftarget: re-check when Grafana portals/pickers inject new nodes (e.g. viz picker tabs)
+  useEffect(() => {
+    if (!conditionsNeedDomWatch(conditions)) {
+      return;
+    }
+
+    let debounceId: ReturnType<typeof setTimeout> | undefined;
+
+    const observer = new MutationObserver(() => {
+      if (debounceId) {
+        clearTimeout(debounceId);
+      }
+      debounceId = setTimeout(() => {
+        evaluateConditions({ isReevaluation: true });
+      }, 200);
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-testid', 'class', 'aria-label', 'aria-expanded'],
+    });
+
+    return () => {
+      if (debounceId) {
+        clearTimeout(debounceId);
+      }
+      observer.disconnect();
+    };
+  }, [conditions, evaluateConditions]);
 
   // Show loading state while checking
   if (isChecking && conditionsPassed === null) {

--- a/src/components/interactive-tutorial/interactive-conditional.tsx
+++ b/src/components/interactive-tutorial/interactive-conditional.tsx
@@ -46,8 +46,8 @@ function conditionsToRequirementsString(conditions: string[]): string {
 }
 
 /** True when conditions may flip after DOM updates (e.g. viz picker opens). */
-function conditionsNeedDomWatch(conditions: string[]): boolean {
-  return conditions.some((c) => c.trim() === 'exists-reftarget' || c.includes('exists-reftarget'));
+function conditionsKeyNeedsDomWatch(conditionsKey: string): boolean {
+  return conditionsKey.includes('exists-reftarget');
 }
 
 /**
@@ -69,14 +69,16 @@ export function InteractiveConditional({
   const [isChecking, setIsChecking] = useState(true);
   const { checkRequirementsFromData } = useInteractiveElements();
 
-  // Generate a stable ID for this conditional
+  // Stable string identity for `conditions`. The parent passes a fresh array
+  // on every render (parsed from JSON), so keying effects off the array would
+  // tear down and re-attach the MutationObserver on every parent render. The
+  // joined string is referentially stable as long as the underlying values are.
+  const conditionsKey = useMemo(() => conditions.join(','), [conditions]);
+
+  // Generate a stable ID for this conditional (derived from the stable key).
   const conditionalId = useMemo(
-    () =>
-      conditions
-        .join('-')
-        .replace(/[^a-zA-Z0-9-]/g, '')
-        .slice(0, 50) || 'unknown',
-    [conditions]
+    () => conditionsKey.replace(/[^a-zA-Z0-9-]/g, '').slice(0, 50) || 'unknown',
+    [conditionsKey]
   );
 
   // Track mounted state to prevent state updates after unmount
@@ -88,6 +90,16 @@ export function InteractiveConditional({
       isMountedRef.current = false;
     };
   }, []);
+
+  // Race guard: when multiple re-evaluations are in flight (MutationObserver
+  // burst + step-completed + action-completed), only the most-recently-started
+  // run is allowed to commit its result. Without this, an older slow promise
+  // can overwrite the result of a newer faster one and flip the branch.
+  const runIdRef = useRef(0);
+
+  // Track scheduled re-eval timers so we can cancel them on unmount or when a
+  // new schedule supersedes an older one. setTimeouts pile up otherwise.
+  const reevalTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   // Convert conditions to requirements string format
   const requirementsString = conditionsToRequirementsString(conditions);
@@ -105,6 +117,9 @@ export function InteractiveConditional({
         setIsChecking(true);
       }
 
+      runIdRef.current += 1;
+      const myRunId = runIdRef.current;
+
       try {
         // Create requirement data for checking
         // Use provided reftarget for exists-reftarget condition, fallback to placeholder
@@ -119,35 +134,53 @@ export function InteractiveConditional({
 
         const result = await checkRequirementsFromData(requirementData);
 
-        if (isMountedRef.current) {
-          setConditionsPassed(result.pass);
-          setIsChecking(false);
+        // Drop the result if a newer run has started after we awaited - prevents
+        // a stale "false" landing after a fresh "true" (and vice versa).
+        if (!isMountedRef.current || myRunId !== runIdRef.current) {
+          return;
         }
+        setConditionsPassed(result.pass);
+        setIsChecking(false);
       } catch (error) {
         console.warn('Failed to evaluate conditional conditions:', error);
-        if (isMountedRef.current) {
-          // Default to false branch on error
-          setConditionsPassed(false);
-          setIsChecking(false);
+        if (!isMountedRef.current || myRunId !== runIdRef.current) {
+          return;
         }
+        // Default to false branch on error
+        setConditionsPassed(false);
+        setIsChecking(false);
       }
     },
     [requirementsString, checkRequirementsFromData, description, reftarget]
   );
 
+  const needsDomWatch = conditionsKeyNeedsDomWatch(conditionsKey);
+
+  // Stable ref to the latest evaluator. Lets long-lived subscriptions
+  // (MutationObserver, event listeners) invoke the current evaluator without
+  // having to include it in their dep arrays, which would tear down and
+  // re-attach the subscription on every parent render.
+  const evaluateRef = useRef(evaluateConditions);
+  useEffect(() => {
+    evaluateRef.current = evaluateConditions;
+  }, [evaluateConditions]);
+
   const scheduleReevaluation = useCallback(() => {
-    const delay = conditionsNeedDomWatch(conditions) ? 250 : 100;
-    const timeoutId = setTimeout(() => {
-      evaluateConditions({ isReevaluation: true });
+    if (reevalTimerRef.current) {
+      clearTimeout(reevalTimerRef.current);
+    }
+    const delay = needsDomWatch ? 250 : 100;
+    reevalTimerRef.current = setTimeout(() => {
+      reevalTimerRef.current = undefined;
+      evaluateRef.current({ isReevaluation: true });
     }, delay);
-    return () => clearTimeout(timeoutId);
-  }, [conditions, evaluateConditions]);
+  }, [needsDomWatch]);
 
   // Evaluate on mount and re-evaluate when relevant events occur
   useEffect(() => {
     // Initial evaluation (deferred to avoid synchronous setState in effect)
     const initialCheckTimeout = setTimeout(() => {
-      evaluateConditions();
+      evaluateRef.current();
     }, 0);
 
     // Listen for events that might change condition results
@@ -169,7 +202,10 @@ export function InteractiveConditional({
       scheduleReevaluation();
     };
 
-    // Highlight/button actions dispatch on document before section step-completed
+    // `interactive-action-completed` is dispatched from two places with two
+    // different targets: interactive-state-manager fires on `document`, while
+    // challenge-block fires on `window`. Subscribe to both so conditional
+    // re-evaluation never depends on which path completed the action.
     const handleActionCompleted = () => {
       scheduleReevaluation();
     };
@@ -179,22 +215,32 @@ export function InteractiveConditional({
     window.addEventListener('plugins-changed', handlePluginsChanged);
     window.addEventListener('popstate', handleLocationChanged);
     window.addEventListener('interactive-step-completed', handleStepCompleted);
+    window.addEventListener('interactive-action-completed', handleActionCompleted);
     document.addEventListener('interactive-action-completed', handleActionCompleted);
 
     // REACT: cleanup subscriptions (R1)
     return () => {
       clearTimeout(initialCheckTimeout);
+      if (reevalTimerRef.current) {
+        clearTimeout(reevalTimerRef.current);
+        reevalTimerRef.current = undefined;
+      }
       window.removeEventListener('datasources-changed', handleDataSourcesChanged);
       window.removeEventListener('plugins-changed', handlePluginsChanged);
       window.removeEventListener('popstate', handleLocationChanged);
       window.removeEventListener('interactive-step-completed', handleStepCompleted);
+      window.removeEventListener('interactive-action-completed', handleActionCompleted);
       document.removeEventListener('interactive-action-completed', handleActionCompleted);
     };
-  }, [evaluateConditions, scheduleReevaluation]);
+  }, [scheduleReevaluation]);
 
-  // exists-reftarget: re-check when Grafana portals/pickers inject new nodes (e.g. viz picker tabs)
+  // exists-reftarget: re-check when Grafana portals/pickers inject new nodes (e.g. viz picker tabs).
+  // We watch only structural changes (childList + subtree) - attribute churn from panel re-renders
+  // is the noisy part and element-existence transitions are childList events anyway.
+  // Depends only on `needsDomWatch` (effectively a one-shot boolean per conditional) - the latest
+  // evaluator is reached via `evaluateRef` so re-renders never tear down the observer.
   useEffect(() => {
-    if (!conditionsNeedDomWatch(conditions)) {
+    if (!needsDomWatch) {
       return;
     }
 
@@ -205,15 +251,13 @@ export function InteractiveConditional({
         clearTimeout(debounceId);
       }
       debounceId = setTimeout(() => {
-        evaluateConditions({ isReevaluation: true });
+        evaluateRef.current({ isReevaluation: true });
       }, 200);
     });
 
     observer.observe(document.body, {
       childList: true,
       subtree: true,
-      attributes: true,
-      attributeFilter: ['data-testid', 'class', 'aria-label', 'aria-expanded'],
     });
 
     return () => {
@@ -222,7 +266,7 @@ export function InteractiveConditional({
       }
       observer.disconnect();
     };
-  }, [conditions, evaluateConditions]);
+  }, [needsDomWatch]);
 
   // Show loading state while checking
   if (isChecking && conditionsPassed === null) {


### PR DESCRIPTION
## Summary

- Repairs the **OSS and Cloud** `first-dashboard` guides so the dashboard-creation flow works end-to-end without page refreshes.
- Fixes the underlying engine bug where `InteractiveConditional` did not re-render branches when `exists-reftarget` flipped after an action (e.g. opening the visualization picker).

## What changed

### Guide content (`src/bundled-interactives/first-dashboard*/content.json`)

- Replaced the `conditional` wrapper around "All visualizations" with an explicit step using the canonical `data-testid Tab Visualizations` selector. Bar chart only lives under that tab, so the previous conditional silently skipped the step on first render and forced a refresh.
- Switched brittle raw selectors to Grafana's canonical e2e ids:
  - `grafana:components.PanelEditor.toggleVizPicker`
  - `grafana:components.PanelEditor.OptionsPane.fieldInput:Title`
- Added missing `tooltip` and `exists-reftarget` requirement on the Bar chart step.
- Save flow: the final "Save" in the drawer now targets `button[data-testid="data-testid Save dashboard drawer button"]` via `highlight` instead of the text-based `button` action.
- Sentence-case names per the writers' toolkit: "Walking adventure", "Jack and Jill walk altitude".
- Cloud guide brought up to parity with the OSS guide for the dashboard section.

### Engine (`src/components/interactive-tutorial/interactive-conditional.tsx`)

- Listen to `interactive-action-completed` on `document` (highlight/button actions dispatch there before the section's `interactive-step-completed`).
- Add a debounced `MutationObserver` when conditions include `exists-reftarget`, so branches re-render the moment a portal-injected element (e.g. picker tabs) appears.
- Keep the current branch mounted during re-evaluation — the "Checking conditions…" spinner now only appears on the initial check, not on every action.

### Tests

- New `interactive-conditional.test.tsx` covers:
  - `whenTrue` branch appears after `interactive-action-completed` without remount.
  - `whenTrue` branch appears after `interactive-step-completed` for `exists-reftarget` conditions.
  - No loading spinner takeover on re-evaluation of an already-resolved branch.
  - Stable `data-testid` + `data-passed` after evaluation.

## Why

Multiple users hit the same dead end at "Change the visualization to Bar chart": the picker opened on the Suggestions tab, Bar chart wasn't visible, and the conditional that should have inserted an "All visualizations" step required a page refresh to evaluate. The combination of selector fragility, late conditional evaluation, and a spinner overlay on every re-check was the failure mode.

## Test plan

- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npx prettier --check` on changed files — clean
- [x] Targeted Jest run (`interactive-conditional|bundled-repository|parity|package-content|first-dashboard|build-repository|loader`) — 109/109 passing
- [x] `pathfinder-cli validate` on both guide JSONs — both valid
- [x] Manual run-through of `first-dashboard` against a local Grafana container (Explore → labels → Add to dashboard → Edit panel → All visualizations → Bar chart → title → unit → Save)
- [ ] Same manual run-through for `first-dashboard-cloud` against a Grafana Cloud instance

## Risk and reversibility

- Selector changes are scoped to two bundled guides and are testable in-product.
- Engine change adds two new event/observer subscriptions but only activates the MutationObserver when conditions include `exists-reftarget`; otherwise the behaviour is unchanged from a steady-state perspective. The branch is now kept mounted during re-evaluation, which is a UX improvement but worth a quick eyeball for any consumer that relied on the spinner state.
- Fully revertible — no schema, storage, or backend changes.

Made with [Cursor](https://cursor.com)