### PR TITLE
fix(floating-panel): remove max width/height resize constraints

### DIFF
--- a/src/components/floating-panel/useDragResize.ts
+++ b/src/components/floating-panel/useDragResize.ts
@@ -5,8 +5,6 @@ import {
   type FloatingPanelGeometry,
   FLOATING_PANEL_MIN_WIDTH,
   FLOATING_PANEL_MIN_HEIGHT,
-  FLOATING_PANEL_MAX_WIDTH,
-  FLOATING_PANEL_MAX_HEIGHT,
 } from '../../constants/floating-panel';
 
 /** Clamp a value between min and max inclusive. */
@@ -149,16 +147,8 @@ function useResize(
       }
       const dx = e.clientX - resizeStartRef.current.startX;
       const dy = e.clientY - resizeStartRef.current.startY;
-      const newWidth = clamp(
-        resizeStartRef.current.originWidth + dx,
-        FLOATING_PANEL_MIN_WIDTH,
-        FLOATING_PANEL_MAX_WIDTH
-      );
-      const newHeight = clamp(
-        resizeStartRef.current.originHeight + dy,
-        FLOATING_PANEL_MIN_HEIGHT,
-        FLOATING_PANEL_MAX_HEIGHT
-      );
+      const newWidth = clamp(resizeStartRef.current.originWidth + dx, FLOATING_PANEL_MIN_WIDTH, window.innerWidth);
+      const newHeight = clamp(resizeStartRef.current.originHeight + dy, FLOATING_PANEL_MIN_HEIGHT, window.innerHeight);
       setGeometry((prev) => ({ ...prev, width: newWidth, height: newHeight }));
     },
     [setGeometry]

--- a/src/constants/floating-panel.ts
+++ b/src/constants/floating-panel.ts
@@ -10,10 +10,6 @@
 export const FLOATING_PANEL_MIN_WIDTH = 320;
 export const FLOATING_PANEL_MIN_HEIGHT = 280;
 
-/** Maximum panel dimensions (pixels) */
-export const FLOATING_PANEL_MAX_WIDTH = 600;
-export const FLOATING_PANEL_MAX_HEIGHT = 700;
-
 /** Default panel dimensions (pixels) */
 export const FLOATING_PANEL_DEFAULT_WIDTH = 400;
 export const FLOATING_PANEL_DEFAULT_HEIGHT = 400;


### PR DESCRIPTION
## Summary

- Removes the hard-coded 600px max-width and 700px max-height limits on the popout floating panel
- Panel can now be resized up to the full viewport size in both axes
- Default dimensions and minimum bounds are unchanged

## Test plan

- [ ] Open popout mode and resize the panel — confirm it can be dragged beyond the previous 600×700 limit
- [ ] Confirm the panel cannot be resized off-screen (viewport clamping still applies)
- [ ] Confirm default size on first open is unchanged (~400×400)