### PR TITLE
fix(section): swap section header to "Steps" when no interactive steps

### DIFF
--- a/src/components/interactive-tutorial/hooks/use-section-requirements.ts
+++ b/src/components/interactive-tutorial/hooks/use-section-requirements.ts
@@ -26,6 +26,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getRequirementExplanation, dispatchFix } from '../../../requirements-manager';
+import { DEFAULT_INTERACTIVE_SECTION_TITLE } from '../interactive-section';
 
 interface SectionRequirementsResult {
   pass: boolean;
@@ -113,7 +114,7 @@ export function useSectionRequirements({
         targetaction: 'section',
         reftarget: sectionId,
         targetvalue: undefined,
-        textContent: title || 'Interactive section',
+        textContent: title || DEFAULT_INTERACTIVE_SECTION_TITLE,
         tagName: 'section',
       };
       const result = await checkRequirementsFromData(data);

--- a/src/components/interactive-tutorial/index.ts
+++ b/src/components/interactive-tutorial/index.ts
@@ -5,6 +5,8 @@ export {
   registerSectionSteps,
   getDocumentStepPosition,
   getTotalDocumentSteps,
+  DEFAULT_INTERACTIVE_SECTION_TITLE,
+  PASSIVE_SECTION_TITLE,
 } from './interactive-section';
 export { InteractiveStep } from './interactive-step';
 export { InteractiveMultiStep } from './interactive-multi-step';

--- a/src/components/interactive-tutorial/interactive-section.display-title.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.display-title.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Header-label contract: an author-supplied title is preserved verbatim.
+ * Otherwise the header is "Interactive section" when interactive steps
+ * exist, or "Steps" when every child is passive/noop.
+ */
+
+import React from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
+
+// ─── Mocks (shared harness) ─────────────────────────────────────────────────
+
+jest.mock('@grafana/ui', () => {
+  return require('../../test-utils/interactive-section-harness').createGrafanaUiMock();
+});
+
+jest.mock('@grafana/data', () => {
+  return require('../../test-utils/interactive-section-harness').createGrafanaDataMock();
+});
+
+jest.mock('../../lib/analytics', () => {
+  return require('../../test-utils/interactive-section-harness').createAnalyticsMock();
+});
+
+jest.mock('../../constants', () => {
+  return require('../../test-utils/interactive-section-harness').createConstantsMock();
+});
+
+jest.mock('../../constants/interactive-config', () => {
+  return require('../../test-utils/interactive-section-harness').createInteractiveConfigMock();
+});
+
+jest.mock('../../lib/user-storage', () => {
+  return require('../../test-utils/interactive-section-harness').createUserStorageMock();
+});
+
+jest.mock('../../global-state/alignment-pending-context', () => {
+  return require('../../test-utils/interactive-section-harness').createAlignmentContextMock();
+});
+
+jest.mock('../../interactive-engine', () => {
+  return require('../../test-utils/interactive-section-harness').createInteractiveEngineMock();
+});
+
+jest.mock('../../requirements-manager', () => {
+  return require('../../test-utils/interactive-section-harness').createRequirementsManagerMock();
+});
+
+jest.mock('../../docs-retrieval', () => {
+  return require('../../test-utils/interactive-section-harness').createDocsRetrievalMock();
+});
+
+jest.mock('./interactive-step', () => {
+  return require('../../test-utils/interactive-section-harness').createInteractiveStepMock();
+});
+
+jest.mock('./interactive-multi-step', () => {
+  return require('../../test-utils/interactive-section-harness').createInteractiveMultiStepMock();
+});
+
+jest.mock('./interactive-guided', () => {
+  return require('../../test-utils/interactive-section-harness').createInteractiveGuidedMock();
+});
+
+jest.mock('./interactive-quiz', () => {
+  return require('../../test-utils/interactive-section-harness').createInteractiveQuizMock();
+});
+
+jest.mock('./terminal-step', () => {
+  return require('../../test-utils/interactive-section-harness').createTerminalStepMock();
+});
+
+jest.mock('./terminal-connect-step', () => {
+  return require('../../test-utils/interactive-section-harness').createTerminalConnectStepMock();
+});
+
+jest.mock('./code-block-step', () => {
+  return require('../../test-utils/interactive-section-harness').createCodeBlockStepMock();
+});
+
+jest.mock('./interactive-conditional', () => {
+  return require('../../test-utils/interactive-section-harness').createInteractiveConditionalMock();
+});
+
+// ─── Imports after mocks ────────────────────────────────────────────────────
+
+import { InteractiveStep } from './interactive-step';
+import {
+  DEFAULT_INTERACTIVE_SECTION_TITLE,
+  InteractiveSection,
+  PASSIVE_SECTION_TITLE,
+  resetInteractiveCounters,
+} from './interactive-section';
+import { resetSectionHarness, silenceSectionWarnings } from '../../test-utils/interactive-section-harness';
+
+let warnSpy: jest.SpyInstance;
+beforeAll(() => {
+  warnSpy = silenceSectionWarnings();
+});
+afterAll(() => {
+  warnSpy.mockRestore();
+});
+
+beforeEach(() => {
+  resetSectionHarness();
+  resetInteractiveCounters();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function getHeaderTitle(): string {
+  const headers = document.querySelectorAll('.interactive-section-title');
+  expect(headers.length).toBeGreaterThan(0);
+  return headers[0]!.textContent ?? '';
+}
+
+describe('InteractiveSection — header label semantics', () => {
+  it('shows "Steps" when the title is the default fallback and the section has no interactive steps', async () => {
+    render(
+      <InteractiveSection id="passive-default" title={DEFAULT_INTERACTIVE_SECTION_TITLE} autoCollapse={false}>
+        <p>Read me — no actions here.</p>
+      </InteractiveSection>
+    );
+
+    await waitFor(() => expect(document.querySelector('.interactive-section-title')).toBeInTheDocument());
+    expect(getHeaderTitle()).toBe(PASSIVE_SECTION_TITLE);
+  });
+
+  it('shows "Steps" when the section is composed entirely of noop steps under the default title', async () => {
+    render(
+      <InteractiveSection id="noop-default" title={DEFAULT_INTERACTIVE_SECTION_TITLE} autoCollapse={false}>
+        <InteractiveStep targetAction="noop" refTarget="info-1">
+          Informational only.
+        </InteractiveStep>
+        <InteractiveStep targetAction="noop" refTarget="info-2">
+          Still informational.
+        </InteractiveStep>
+      </InteractiveSection>
+    );
+
+    await waitFor(() => expect(document.querySelector('.interactive-section-title')).toBeInTheDocument());
+    expect(getHeaderTitle()).toBe(PASSIVE_SECTION_TITLE);
+  });
+
+  it('keeps "Interactive section" when the default title is paired with at least one interactive step', async () => {
+    render(
+      <InteractiveSection id="interactive-default" title={DEFAULT_INTERACTIVE_SECTION_TITLE} autoCollapse={false}>
+        <InteractiveStep targetAction="highlight" refTarget=".a">
+          Click me.
+        </InteractiveStep>
+      </InteractiveSection>
+    );
+
+    await waitFor(() => expect(document.querySelector('.interactive-section-title')).toBeInTheDocument());
+    expect(getHeaderTitle()).toBe(DEFAULT_INTERACTIVE_SECTION_TITLE);
+  });
+
+  it('preserves an author-set title verbatim even when the section is fully passive', async () => {
+    render(
+      <InteractiveSection id="passive-authored" title="Read this carefully" autoCollapse={false}>
+        <p>Background reading.</p>
+      </InteractiveSection>
+    );
+
+    await waitFor(() => expect(document.querySelector('.interactive-section-title')).toBeInTheDocument());
+    expect(getHeaderTitle()).toBe('Read this carefully');
+  });
+});

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -97,6 +97,12 @@ import {
 // from `./section-registry`.
 export { registerSectionSteps, getTotalDocumentSteps, getDocumentStepPosition } from './section-registry';
 
+// Interactive Section title fallback
+export const DEFAULT_INTERACTIVE_SECTION_TITLE = 'Interactive section';
+
+// Interactive Section title fallback for sections with no interactive steps (passive content only)
+export const PASSIVE_SECTION_TITLE = 'Steps';
+
 // Reset every counter (registry + offsets + per-step-type anonymous-ID
 // counters). Called when new content loads. The registry's own state
 // lives in `./section-registry`; this function adds the step-module
@@ -277,6 +283,11 @@ export function InteractiveSection({
   // Calculate base completion (steps completed) - needed for completion logic
   // Noop steps are always considered complete (they're informational only)
   const nonNoopSteps = stepComponents.filter((s) => s.targetAction !== 'noop');
+
+  // Swap "Interactive section" → "Steps" when the title is the default
+  // fallback and no child step is interactive. Author-set titles pass through.
+  const displayTitle =
+    title === DEFAULT_INTERACTIVE_SECTION_TITLE && nonNoopSteps.length === 0 ? PASSIVE_SECTION_TITLE : title;
   const allInteractiveStepsCompleted =
     stepComponents.length > 0 && (nonNoopSteps.length === 0 || nonNoopSteps.every((s) => completedSteps.has(s.stepId)));
 
@@ -621,7 +632,7 @@ export function InteractiveSection({
         targetaction: 'section',
         reftarget: `section-${sectionId}`,
         targetvalue: undefined,
-        textContent: title || 'Interactive section',
+        textContent: title || DEFAULT_INTERACTIVE_SECTION_TITLE,
         tagName: 'section',
       };
 
@@ -685,7 +696,7 @@ export function InteractiveSection({
       targetvalue: undefined,
       requirements: undefined,
       tagName: 'section',
-      textContent: title || 'Interactive section',
+      textContent: title || DEFAULT_INTERACTIVE_SECTION_TITLE,
       timestamp: Date.now(),
       isPartOfSection: true,
     };
@@ -1252,7 +1263,7 @@ export function InteractiveSection({
           </button>
         )}
         <div className="interactive-section-title-container">
-          <span className="interactive-section-title">{title}</span>
+          <span className="interactive-section-title">{displayTitle}</span>
           {isCompleted && <span className="interactive-section-checkmark">✓</span>}
         </div>
         {hints && (

--- a/src/docs-retrieval/content-renderer.tsx
+++ b/src/docs-retrieval/content-renderer.tsx
@@ -24,6 +24,7 @@ import {
   resetInteractiveCounters,
   registerSectionSteps,
   getDocumentStepPosition,
+  DEFAULT_INTERACTIVE_SECTION_TITLE,
 } from '../components/interactive-tutorial';
 import {
   CodeBlock,
@@ -1007,7 +1008,7 @@ function renderParsedElement(
       return (
         <InteractiveSection
           key={key}
-          title={sub(element.props.title) || 'Interactive section'}
+          title={sub(element.props.title) || DEFAULT_INTERACTIVE_SECTION_TITLE}
           isSequence={element.props.isSequence}
           skippable={element.props.skippable}
           requirements={element.props.requirements}


### PR DESCRIPTION
Fixes #843 

## Summary

Sections rendered without an author-set title fall back to the "Interactive section" header even when every child is passive or noop. Swap the rendered header to "Steps" in that case, while preserving any author-supplied title verbatim. The fallback string is now exported as `DEFAULT_INTERACTIVE_SECTION_TITLE` so the renderer, the display swap, and the analytics textContent payloads share one identity.

## Testing

  Open the block editor, switch to JSON view to edit, then Preview view to verify the rendered header.

- [ ] **Passive section, no title** — In JSON view, add a `{ "type": "section", "blocks": [{ "type": "markdown", ... }] }` block (omit the title field). Preview: header reads "Steps".
- [ ] **All-noop section, no title** — Same as above but with blocks containing only `{ "type": "interactive", "action": "noop", ... }` entries. Preview: header reads "Steps".
- [ ] **No title + interactive step** — Section block with no title, containing at least one non-noop "type": "interactive" step (e.g. "action": "highlight"). Preview: header reads "Interactive section" (unchanged from before).
- [ ] **Author title + passive content** — Section with `"title": "Read this carefully"` and only markdown children. Preview: header reads "Read this carefully" verbatim — no swap.
- [ ] **Author title + interactive step** — Section with `"title": "My custom title"` and an interactive step. Preview: header reads "My custom title" (regression check).