### PR TITLE
feat(deep-linking): centralize deep-linking with SPA nav listener

### DIFF
--- a/src/module.tsx
+++ b/src/module.tsx
@@ -1,5 +1,4 @@
 import { AppPlugin, AppPluginMeta, type AppRootProps, PluginExtensionPoints, usePluginContext } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
 import React, { lazy, Suspense, useEffect, useMemo } from 'react';
 import { LoadingPlaceholder } from '@grafana/ui';
 import { reportAppInteraction, UserInteraction } from './lib/analytics';
@@ -13,8 +12,8 @@ import { linkInterceptionState } from './global-state/link-interception';
 import { sidebarState } from 'global-state/sidebar';
 import { panelModeManager } from './global-state/panel-mode';
 import { suggestionState } from './global-state/suggestion';
-import { validateRedirectPath } from './security/url-validator';
-import { parsePathfinderDeepLink, stripPathfinderParams } from './utils/pathfinder-search-params';
+import { handlePathfinderDeepLink, installDeepLinkNavListener } from './utils/pathfinder-deep-link-handler';
+import { parsePathfinderDeepLink } from './utils/pathfinder-search-params';
 
 // Buffer pathfinder-suggest events that arrive before async init completes.
 // Registered synchronously (before any await) so events from faster-loading
@@ -141,170 +140,24 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   // Set global config immediately so other code can use it
   (window as any).__pathfinderPluginConfig = config;
 
-  // Check for doc query parameter to auto-open specific docs page.
-  // Dynamically imports findDocPage so the bundled JSON data stays out of module.js.
-  // Single typed read — `parsePathfinderDeepLink` is the source of truth for
-  // the param shape; previously the keys were duplicated across this file
-  // and would drift (e.g. one strip block used to omit `type`).
-  const deepLink = parsePathfinderDeepLink(window.location.search);
-  const docsParam = deepLink.doc;
-  const pageParam = deepLink.page;
-  const sourceParam = deepLink.source;
-  // Some package URLs (e.g. interactive-learning.grafana.net
-  // packages/<id>/content.json) classify as 'interactive' via findDocPage even though
-  // they back a learning journey. The ?type= URL hint is the escape hatch that lets
-  // share/refresh links preserve the journey kind (and milestone toolbar).
-  const typeParam = deepLink.type;
-  const kioskSessionParam = deepLink.kioskSession;
+  // Snapshotted before handlePathfinderDeepLink strips it from the URL.
+  const docsParam = parsePathfinderDeepLink(window.location.search).doc;
 
-  if (kioskSessionParam) {
-    (window as any).__pathfinderKioskSessionId = kioskSessionParam;
-  }
+  const sidebarMountable = shouldMountSidebar(pathfinderEnabled, mainVariant, after24hVariant);
+  const deepLinkDeps = {
+    shouldMountSidebar: sidebarMountable,
+    attemptAutoOpen,
+    loadControlGroupDocPopup: () => import('./components/ControlGroupDocPopup'),
+  };
 
-  // Check for panelMode param (e.g. ?panelMode=floating for workshop links).
-  // Set synchronously so mode is active before any components mount.
-  const panelModeParam = deepLink.panelMode;
-  if (panelModeParam === 'floating') {
-    panelModeManager.setMode('floating');
-    const cleanUrl = new URL(window.location.href);
-    cleanUrl.searchParams.delete('panelMode');
-    window.history.replaceState({}, '', cleanUrl.toString());
-  } else if (panelModeParam === 'fullscreen') {
-    panelModeManager.setMode('fullscreen');
-    const cleanUrl = new URL(window.location.href);
-    cleanUrl.searchParams.delete('panelMode');
-    window.history.replaceState({}, '', cleanUrl.toString());
-    // Route to the full screen page so the rest of init wires up auto-launch
-    // against that route. The doc + type params (if present) flow through the
-    // existing handler and are consumed by FullScreenPanel on mount.
-    let target = `/a/${pluginJson.id}/fullscreen`;
-    if (docsParam) {
-      const fullScreenParams = new URLSearchParams();
-      fullScreenParams.set('doc', docsParam);
-      if (typeParam) {
-        fullScreenParams.set('type', typeParam);
-      }
-      target += `?${fullScreenParams.toString()}`;
-    }
-    locationService.replace(target);
-  }
+  handlePathfinderDeepLink(deepLinkDeps);
+  // Re-runs on SPA navigations; plugin.init fires only once per session.
+  installDeepLinkNavListener(deepLinkDeps);
 
-  // Use the source param if provided, otherwise default to 'url_param'
-  const docOpenSource = sourceParam || 'url_param';
-
-  if (docsParam && !shouldMountSidebar(pathfinderEnabled, mainVariant, after24hVariant)) {
-    const url = new URL(window.location.href);
-    stripPathfinderParams(url);
-    window.history.replaceState({}, '', url.toString());
-
-    import('./components/ControlGroupDocPopup').then(({ showControlGroupDocPopup }) => {
-      showControlGroupDocPopup(docOpenSource);
-    });
+  // Control group + ?doc=: ControlGroupDocPopup already handled it.
+  // Don't widen to panelMode/kiosk — those must reach the mount blocks below.
+  if (docsParam && !sidebarMountable) {
     return;
-  }
-
-  if (docsParam) {
-    import('./utils/find-doc-page')
-      .then(({ findDocPage }) => {
-        const docsPage = findDocPage(docsParam);
-
-        // Determine redirect target (only when doc param is present)
-        // Only redirect when an explicit page param or bundled guide target is provided.
-        // Without one, stay on the current page — the user may be on a specific dashboard
-        // and redirecting would break on instances where users aren't logged in (e.g., Play).
-        // SECURITY: page is only processed when doc is also present,
-        // preventing the plugin page from becoming a general-purpose redirector
-        const rawRedirectTarget = pageParam || docsPage?.targetPage;
-        const redirectTarget = rawRedirectTarget ? validateRedirectPath(rawRedirectTarget) : null;
-
-        // Warn if docsParam is present but no docsPage is found
-        if (!docsPage) {
-          console.warn(
-            'Could not parse doc param:',
-            docsParam,
-            '- Supported formats: api:<resourceName>, bundled:<id>, interactive-learning.grafana.net/..., /docs/..., https://grafana.com/docs/...'
-          );
-          // Strip stale params so they don't re-fire on refresh
-          const url = new URL(window.location.href);
-          stripPathfinderParams(url);
-          window.history.replaceState({}, '', url.toString());
-
-          sidebarState.setPendingOpenSource(docOpenSource, 'auto-open');
-          attemptAutoOpen(200);
-          return;
-        }
-
-        const needsRedirect = redirectTarget && redirectTarget !== window.location.pathname;
-        const currentMode = panelModeManager.getMode();
-        const isFloatingMode = currentMode === 'floating';
-        const isFullScreenMode = currentMode === 'fullscreen';
-
-        sidebarState.setPendingOpenSource(docOpenSource, 'auto-open');
-
-        if (needsRedirect) {
-          locationService.replace(redirectTarget);
-        }
-
-        if (!needsRedirect) {
-          const url = new URL(window.location.href);
-          stripPathfinderParams(url);
-          window.history.replaceState({}, '', url.toString());
-        }
-
-        // In floating or full screen mode, the panel mounts on its own —
-        // don't open the extension sidebar (which would mount a second panel
-        // and collide on tab storage / __DocsPluginActiveTabId).
-        if (!isFloatingMode && !isFullScreenMode) {
-          attemptAutoOpen(needsRedirect ? 500 : 200);
-        }
-
-        // Guard: ensure auto-launch only fires once even if multiple mount events fire
-        let autoLaunched = false;
-        const dispatchAutoLaunch = () => {
-          if (autoLaunched) {
-            return;
-          }
-          autoLaunched = true;
-          // Clean up both listeners
-          window.removeEventListener('pathfinder-sidebar-mounted', dispatchAutoLaunch);
-          document.removeEventListener('pathfinder-panel-mounted', dispatchAutoLaunch);
-          // Signal synchronously so the floating panel knows a guide is incoming
-          // before its fallback-to-sidebar effect can fire
-          document.dispatchEvent(new CustomEvent('pathfinder-auto-launch-pending'));
-          setTimeout(() => {
-            document.dispatchEvent(
-              new CustomEvent('auto-launch-tutorial', {
-                detail: {
-                  url: docsPage.url,
-                  title: docsPage.title,
-                  // Honor an explicit ?type=learning-journey hint over findDocPage's
-                  // URL-based classification — package URLs like
-                  // interactive-learning.grafana.net/packages/<id>/content.json
-                  // classify as 'interactive' even when they back a journey.
-                  type: typeParam === 'learning-journey' ? 'learning-journey' : docsPage.type,
-                  source: docOpenSource,
-                },
-              })
-            );
-          }, 500);
-        };
-
-        // Listen for whichever panel type mounts first
-        window.addEventListener('pathfinder-sidebar-mounted', dispatchAutoLaunch, { once: true });
-        document.addEventListener('pathfinder-panel-mounted', dispatchAutoLaunch, { once: true });
-
-        if (sidebarState.getIsSidebarMounted()) {
-          dispatchAutoLaunch();
-        }
-      })
-      .catch((err) => {
-        console.error('[Pathfinder] Failed to load find-doc-page chunk:', err);
-        sidebarState.setPendingOpenSource(docOpenSource, 'auto-open');
-        attemptAutoOpen(200);
-        setTimeout(() => {
-          locationService.replace('/');
-        }, 300);
-      });
   }
 
   // Mount kiosk mode overlay manager if enabled and no ?doc= param

--- a/src/utils/pathfinder-deep-link-handler.test.ts
+++ b/src/utils/pathfinder-deep-link-handler.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for `pathfinder-deep-link-handler`.
+ *
+ * Locks down the SPA-navigation deep-link fix: `?doc=` arriving via runtime
+ * URL changes must trigger the same auto-open path as a cold load.
+ *
+ * Coverage:
+ *   - `handlePathfinderDeepLink` is a no-op when no Pathfinder params are
+ *     present, dedupes same-search re-fires, and routes to the panelMode /
+ *     control-group / find-doc-page branches.
+ *   - `installDeepLinkNavListener` wires `grafana:location-changed` and
+ *     (when available) `history.listen`, falling back to `popstate` only
+ *     when `locationService.getHistory()` throws.
+ */
+
+jest.mock('../plugin.json', () => ({
+  id: 'grafana-pathfinder-app',
+}));
+
+const mockLocationServiceReplace = jest.fn();
+const mockHistoryListen = jest.fn().mockReturnValue(() => {});
+let mockGetHistoryImpl: () => { listen: typeof mockHistoryListen } | null = () => ({ listen: mockHistoryListen });
+
+jest.mock('@grafana/runtime', () => ({
+  locationService: {
+    replace: (path: string) => mockLocationServiceReplace(path),
+    getHistory: () => mockGetHistoryImpl(),
+  },
+}));
+
+const mockSetMode = jest.fn();
+const mockGetMode = jest.fn().mockReturnValue('sidebar');
+jest.mock('../global-state/panel-mode', () => ({
+  panelModeManager: {
+    setMode: (mode: string) => mockSetMode(mode),
+    getMode: () => mockGetMode(),
+  },
+}));
+
+const mockSetPendingOpenSource = jest.fn();
+const mockGetIsSidebarMounted = jest.fn().mockReturnValue(false);
+jest.mock('../global-state/sidebar', () => ({
+  sidebarState: {
+    setPendingOpenSource: (source: string, action: string) => mockSetPendingOpenSource(source, action),
+    getIsSidebarMounted: () => mockGetIsSidebarMounted(),
+  },
+}));
+
+const mockValidateRedirectPath = jest.fn((path: string) => path);
+jest.mock('../security/url-validator', () => ({
+  validateRedirectPath: (path: string) => mockValidateRedirectPath(path),
+}));
+
+const mockFindDocPage = jest.fn();
+jest.mock('./find-doc-page', () => ({
+  findDocPage: (id: string) => mockFindDocPage(id),
+}));
+
+import {
+  __resetDeepLinkHandlerStateForTests,
+  handlePathfinderDeepLink,
+  installDeepLinkNavListener,
+} from './pathfinder-deep-link-handler';
+
+type Deps = Parameters<typeof handlePathfinderDeepLink>[0];
+
+// Drain pending promise microtasks before resuming
+const flushPromises = async (): Promise<void> => {
+  for (let i = 0; i < 4; i++) {
+    await Promise.resolve();
+  }
+};
+
+const mkDeps = (overrides: Partial<Deps> = {}): Deps => ({
+  shouldMountSidebar: true,
+  attemptAutoOpen: jest.fn(),
+  loadControlGroupDocPopup: jest.fn().mockResolvedValue({ showControlGroupDocPopup: jest.fn() }),
+  ...overrides,
+});
+
+const setSearch = (search: string) => {
+  // jsdom doesn't reflect `replaceState` calls into `window.location.search`
+  // reliably in all versions — set the URL via `history.replaceState` so the
+  // handler's `window.location.search` read matches what the test intends.
+  const url = new URL(window.location.href);
+  url.search = search;
+  window.history.replaceState({}, '', url.toString());
+};
+
+describe('handlePathfinderDeepLink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetDeepLinkHandlerStateForTests();
+    setSearch('');
+    mockGetMode.mockReturnValue('sidebar');
+    mockGetIsSidebarMounted.mockReturnValue(false);
+    mockFindDocPage.mockReturnValue({
+      url: 'https://grafana.com/docs/foo',
+      title: 'Foo',
+      type: 'docs-page',
+    });
+    mockGetHistoryImpl = () => ({ listen: mockHistoryListen });
+  });
+
+  it('returns false and does no work when no Pathfinder params are present', () => {
+    setSearch('?keep=this');
+    const deps = mkDeps();
+    expect(handlePathfinderDeepLink(deps)).toBe(false);
+    expect(deps.attemptAutoOpen).not.toHaveBeenCalled();
+    expect(mockSetPendingOpenSource).not.toHaveBeenCalled();
+  });
+
+  it('does not match param names that merely contain a trigger as a substring', () => {
+    // Another plugin's link might carry `my_doc=` or `kiosk_session_id=`; the
+    // old substring check matched them and started spurious handler runs.
+    for (const search of ['?my_doc=foo', '?kiosk_session_id=abc', '?some_panelMode=floating']) {
+      setSearch(search);
+      const deps = mkDeps();
+      expect(handlePathfinderDeepLink(deps)).toBe(false);
+      expect(deps.attemptAutoOpen).not.toHaveBeenCalled();
+    }
+  });
+
+  it('dedupes consecutive calls with the same search string', async () => {
+    setSearch('?doc=bundled%3Afoo');
+    const deps = mkDeps();
+
+    expect(handlePathfinderDeepLink(deps)).toBe(true);
+    // Second call with the exact same search string is a no-op even before
+    // strip-params would naturally short-circuit later fires.
+    setSearch('?doc=bundled%3Afoo');
+    expect(handlePathfinderDeepLink(deps)).toBe(false);
+
+    // `findDocPage` is loaded via dynamic import — drain the microtask queue
+    // so the inner `.then` callback settles before we assert.
+    await flushPromises();
+    expect(mockFindDocPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes the control-group branch when sidebar is not mountable', async () => {
+    setSearch('?doc=bundled%3Afoo&source=tile_click');
+    const showControlGroupDocPopup = jest.fn();
+    const loadControlGroupDocPopup = jest.fn().mockResolvedValue({ showControlGroupDocPopup });
+    const deps = mkDeps({ shouldMountSidebar: false, loadControlGroupDocPopup });
+
+    expect(handlePathfinderDeepLink(deps)).toBe(true);
+    expect(window.location.search).toBe('');
+
+    await flushPromises();
+    expect(showControlGroupDocPopup).toHaveBeenCalledWith('tile_click');
+    expect(mockFindDocPage).not.toHaveBeenCalled();
+  });
+
+  it('sets floating panel mode and strips panelMode from the URL', () => {
+    setSearch('?panelMode=floating&keep=this');
+    const deps = mkDeps();
+
+    expect(handlePathfinderDeepLink(deps)).toBe(true);
+    expect(mockSetMode).toHaveBeenCalledWith('floating');
+    expect(window.location.search).toBe('?keep=this');
+  });
+
+  it('routes fullscreen panelMode to the in-app fullscreen page with doc + type forwarded', () => {
+    setSearch('?panelMode=fullscreen&doc=bundled%3Afoo&type=learning-journey');
+    const deps = mkDeps();
+
+    expect(handlePathfinderDeepLink(deps)).toBe(true);
+    expect(mockSetMode).toHaveBeenCalledWith('fullscreen');
+
+    const target = mockLocationServiceReplace.mock.calls[0][0] as string;
+    expect(target).toContain('/a/grafana-pathfinder-app/fullscreen?');
+    const params = new URLSearchParams(target.split('?')[1]);
+    expect(params.get('doc')).toBe('bundled:foo');
+    expect(params.get('type')).toBe('learning-journey');
+  });
+
+  it('dispatches auto-launch-tutorial when the sidebar is already mounted (SPA-arrival case)', async () => {
+    jest.useFakeTimers();
+    try {
+      setSearch('?doc=bundled%3Afoo&source=url_param');
+      mockGetIsSidebarMounted.mockReturnValue(true);
+
+      const deps = mkDeps();
+      const events: CustomEvent[] = [];
+      const captureAutoLaunch = (e: Event) => events.push(e as CustomEvent);
+      document.addEventListener('auto-launch-tutorial', captureAutoLaunch);
+
+      expect(handlePathfinderDeepLink(deps)).toBe(true);
+
+      // Drain microtasks so the dynamic import + its `.then` callback settle
+      // before we advance fake timers for the auto-launch delay.
+      await flushPromises();
+
+      // The mount-then-dispatch waits 500ms before dispatching.
+      jest.advanceTimersByTime(500);
+      document.removeEventListener('auto-launch-tutorial', captureAutoLaunch);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.detail).toMatchObject({
+        url: 'https://grafana.com/docs/foo',
+        title: 'Foo',
+        type: 'docs-page',
+        source: 'url_param',
+      });
+      expect(deps.attemptAutoOpen).toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('honors explicit ?type=learning-journey over findDocPage classification', async () => {
+    jest.useFakeTimers();
+    try {
+      setSearch('?doc=bundled%3Afoo&type=learning-journey');
+      mockGetIsSidebarMounted.mockReturnValue(true);
+      // Simulate the case from the comments: package URL classifies as
+      // 'interactive' but is really a learning journey.
+      mockFindDocPage.mockReturnValue({
+        url: 'https://example.com/packages/foo/content.json',
+        title: 'Foo',
+        type: 'interactive',
+      });
+
+      const events: CustomEvent[] = [];
+      const captureAutoLaunch = (e: Event) => events.push(e as CustomEvent);
+      document.addEventListener('auto-launch-tutorial', captureAutoLaunch);
+
+      handlePathfinderDeepLink(mkDeps());
+      await flushPromises();
+      jest.advanceTimersByTime(500);
+      document.removeEventListener('auto-launch-tutorial', captureAutoLaunch);
+
+      expect(events[0]?.detail?.type).toBe('learning-journey');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('re-runs the handler when the user nav-aways and returns to the same ?doc=', async () => {
+    setSearch('?doc=bundled%3Afoo');
+    const deps = mkDeps();
+
+    // First arrival: handler runs and the async branch strips the search.
+    expect(handlePathfinderDeepLink(deps)).toBe(true);
+    await flushPromises();
+    expect(mockFindDocPage).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toBe('');
+
+    // User navigates away to a URL without Pathfinder params.
+    setSearch('?tab=overview');
+    expect(handlePathfinderDeepLink(deps)).toBe(false);
+
+    // User returns to the original ?doc= link.
+    setSearch('?doc=bundled%3Afoo');
+    expect(handlePathfinderDeepLink(deps)).toBe(true);
+    await flushPromises();
+    expect(mockFindDocPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('strips stale params when findDocPage returns null (bad doc) and still opens the sidebar', async () => {
+    setSearch('?doc=garbage');
+    mockFindDocPage.mockReturnValue(null);
+
+    const deps = mkDeps();
+    handlePathfinderDeepLink(deps);
+
+    await flushPromises();
+
+    expect(window.location.search).toBe('');
+    expect(deps.attemptAutoOpen).toHaveBeenCalledWith(200);
+    expect(mockSetPendingOpenSource).toHaveBeenCalledWith('url_param', 'auto-open');
+  });
+});
+
+describe('installDeepLinkNavListener', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetDeepLinkHandlerStateForTests();
+    setSearch('');
+    mockGetHistoryImpl = () => ({ listen: mockHistoryListen });
+  });
+
+  it('registers grafana:location-changed and history.listen', () => {
+    installDeepLinkNavListener(mkDeps());
+    expect(mockHistoryListen).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to popstate only when locationService.getHistory throws', () => {
+    mockGetHistoryImpl = () => {
+      throw new Error('not available');
+    };
+    const popstateSpy = jest.spyOn(window, 'addEventListener');
+
+    installDeepLinkNavListener(mkDeps());
+
+    expect(popstateSpy).toHaveBeenCalledWith('popstate', expect.any(Function));
+    popstateSpy.mockRestore();
+  });
+
+  it('skips the parse + dedup machinery on URL changes that carry no Pathfinder params', () => {
+    installDeepLinkNavListener(mkDeps());
+    // The listener captured `handler`; simulate a Grafana SPA navigation to
+    // a page without any pathfinder params and assert findDocPage was not
+    // touched (a strong proxy for "did the handler run").
+    setSearch('?tab=overview');
+    document.dispatchEvent(new CustomEvent('grafana:location-changed'));
+    expect(mockFindDocPage).not.toHaveBeenCalled();
+  });
+
+  it('re-runs the handler when the URL changes to include ?doc=', async () => {
+    installDeepLinkNavListener(mkDeps());
+
+    setSearch('?doc=bundled%3Afoo');
+    document.dispatchEvent(new CustomEvent('grafana:location-changed'));
+
+    await flushPromises();
+    expect(mockFindDocPage).toHaveBeenCalledWith('bundled:foo');
+  });
+});

--- a/src/utils/pathfinder-deep-link-handler.ts
+++ b/src/utils/pathfinder-deep-link-handler.ts
@@ -1,0 +1,230 @@
+/**
+ * Centralized `?doc=` / `?panelMode=` / `?kiosk_session=` deep-link handler.
+ *
+ * `plugin.init` fires only once — when Grafana loads the extension sidebar
+ * module, which can happen before the user navigates to a `?doc=` URL.
+ * `handlePathfinderDeepLink` is idempotent and deduplicated so it can be
+ * called on every navigation; `installDeepLinkNavListener` wires it up to
+ * `grafana:location-changed` / `history.listen` for SPA navigations.
+ */
+
+import { locationService } from '@grafana/runtime';
+
+import pluginJson from '../plugin.json';
+import { panelModeManager } from '../global-state/panel-mode';
+import { sidebarState } from '../global-state/sidebar';
+import { validateRedirectPath } from '../security/url-validator';
+import {
+  parsePathfinderDeepLink,
+  PATHFINDER_ACTIVATION_PARAMS,
+  stripPathfinderParams,
+} from './pathfinder-search-params';
+
+export interface DeepLinkHandlerDeps {
+  /** Whether the sidebar surface is mounted for this user/variant. */
+  shouldMountSidebar: boolean;
+  /** Schedule an `open-extension-sidebar` event after the given delay. */
+  attemptAutoOpen: (delay?: number) => void;
+  loadControlGroupDocPopup: () => Promise<{ showControlGroupDocPopup: (source: string) => void }>;
+}
+
+// Dedup gate — prevents re-processing the same URL from multiple listener transports.
+let lastProcessedSearch: string | null = null;
+
+/** Test-only escape hatch — resets dedup state between assertions. */
+export function __resetDeepLinkHandlerStateForTests(): void {
+  lastProcessedSearch = null;
+}
+
+/** Mutate the current URL in place and invalidate the dedup gate — the
+ *  stored search is pre-strip and would block re-arrivals at the same link. */
+function rewriteCurrentUrl(mutate: (url: URL) => void): void {
+  const url = new URL(window.location.href);
+  mutate(url);
+  window.history.replaceState({}, '', url.toString());
+  lastProcessedSearch = null;
+}
+
+/** Process Pathfinder deep-link params from the current URL. Idempotent. */
+export function handlePathfinderDeepLink(deps: DeepLinkHandlerDeps): boolean {
+  const search = window.location.search;
+  if (!hasAnyPathfinderParam(search)) {
+    return false;
+  }
+
+  if (search === lastProcessedSearch) {
+    return false;
+  }
+  lastProcessedSearch = search;
+
+  const deepLink = parsePathfinderDeepLink(search);
+  const { doc: docsParam, page: pageParam, source: sourceParam, type: typeParam } = deepLink;
+  const kioskSessionParam = deepLink.kioskSession;
+  const panelModeParam = deepLink.panelMode;
+
+  if (kioskSessionParam) {
+    (window as any).__pathfinderKioskSessionId = kioskSessionParam;
+  }
+
+  if (panelModeParam === 'floating') {
+    panelModeManager.setMode('floating');
+    rewriteCurrentUrl((url) => url.searchParams.delete('panelMode'));
+  } else if (panelModeParam === 'fullscreen') {
+    panelModeManager.setMode('fullscreen');
+    rewriteCurrentUrl((url) => url.searchParams.delete('panelMode'));
+    let target = `/a/${pluginJson.id}/fullscreen`;
+    if (docsParam) {
+      const fullScreenParams = new URLSearchParams();
+      fullScreenParams.set('doc', docsParam);
+      if (typeParam) {
+        fullScreenParams.set('type', typeParam);
+      }
+      target += `?${fullScreenParams.toString()}`;
+    }
+    locationService.replace(target);
+  }
+
+  const docOpenSource = sourceParam || 'url_param';
+
+  if (!docsParam) {
+    // panelMode-only / kiosk-only links: nothing more to dispatch.
+    return panelModeParam !== undefined || kioskSessionParam !== undefined;
+  }
+
+  // Control group: sidebar is dismounted; show the fallback popup instead.
+  if (!deps.shouldMountSidebar) {
+    rewriteCurrentUrl(stripPathfinderParams);
+    deps
+      .loadControlGroupDocPopup()
+      .then(({ showControlGroupDocPopup }) => showControlGroupDocPopup(docOpenSource))
+      .catch((err) => console.error('[Pathfinder] Failed to load control group popup:', err));
+    return true;
+  }
+
+  // Capture before the async import so listener re-fires don't mutate these.
+  const ctx = {
+    docsParam,
+    pageParam,
+    typeParam,
+    docOpenSource,
+  };
+
+  import('./find-doc-page')
+    .then(({ findDocPage }) => {
+      const docsPage = findDocPage(ctx.docsParam);
+
+      // SECURITY: page only processed when doc is also present (not a general redirector).
+      const rawRedirectTarget = ctx.pageParam || docsPage?.targetPage;
+      const redirectTarget = rawRedirectTarget ? validateRedirectPath(rawRedirectTarget) : null;
+
+      if (!docsPage) {
+        console.warn(
+          'Could not parse doc param:',
+          ctx.docsParam,
+          '- Supported formats: api:<resourceName>, bundled:<id>, interactive-learning.grafana.net/..., /docs/..., https://grafana.com/docs/...'
+        );
+        rewriteCurrentUrl(stripPathfinderParams);
+        sidebarState.setPendingOpenSource(ctx.docOpenSource, 'auto-open');
+        deps.attemptAutoOpen(200);
+        return;
+      }
+
+      const needsRedirect = redirectTarget && redirectTarget !== window.location.pathname;
+      const currentMode = panelModeManager.getMode();
+      const isFloatingMode = currentMode === 'floating';
+      const isFullScreenMode = currentMode === 'fullscreen';
+
+      sidebarState.setPendingOpenSource(ctx.docOpenSource, 'auto-open');
+
+      if (needsRedirect) {
+        locationService.replace(redirectTarget);
+        lastProcessedSearch = null;
+      } else {
+        rewriteCurrentUrl(stripPathfinderParams);
+      }
+
+      // Floating/fullscreen panels mount on their own; don't open a second sidebar.
+      if (!isFloatingMode && !isFullScreenMode) {
+        deps.attemptAutoOpen(needsRedirect ? 500 : 200);
+      }
+
+      installAutoLaunchOnMount({
+        url: docsPage.url,
+        title: docsPage.title,
+        // ?type= wins over URL-based classification (package URLs misclassify as 'interactive').
+        type: ctx.typeParam === 'learning-journey' ? 'learning-journey' : docsPage.type,
+        source: ctx.docOpenSource,
+      });
+    })
+    .catch((err) => {
+      console.error('[Pathfinder] Failed to load find-doc-page chunk:', err);
+      sidebarState.setPendingOpenSource(ctx.docOpenSource, 'auto-open');
+      deps.attemptAutoOpen(200);
+      setTimeout(() => {
+        locationService.replace('/');
+      }, 300);
+    });
+
+  return true;
+}
+
+/** Register a location listener that re-runs the handler on every SPA navigation. */
+export function installDeepLinkNavListener(deps: DeepLinkHandlerDeps): void {
+  const handler = () => {
+    if (!hasAnyPathfinderParam(window.location.search)) {
+      return;
+    }
+    handlePathfinderDeepLink(deps);
+  };
+
+  document.addEventListener('grafana:location-changed', handler);
+
+  try {
+    const history = locationService.getHistory();
+    if (history) {
+      const unlisten = history.listen(handler);
+      (window as any).__pathfinderDeepLinkNavUnlisten = unlisten;
+    }
+  } catch {
+    window.addEventListener('popstate', handler);
+  }
+}
+
+function hasAnyPathfinderParam(search: string): boolean {
+  if (!search) {
+    return false;
+  }
+
+  const params = new URLSearchParams(search);
+  return PATHFINDER_ACTIVATION_PARAMS.some((p) => params.has(p));
+}
+
+/** Dispatch `auto-launch-tutorial` once whichever panel surface mounts first. */
+function installAutoLaunchOnMount(detail: { url: string; title: string; type: string; source: string }): void {
+  let autoLaunched = false;
+  const dispatch = () => {
+    if (autoLaunched) {
+      return;
+    }
+    autoLaunched = true;
+    window.removeEventListener('pathfinder-sidebar-mounted', dispatch);
+    document.removeEventListener('pathfinder-panel-mounted', dispatch);
+
+    document.dispatchEvent(new CustomEvent('pathfinder-auto-launch-pending'));
+
+    setTimeout(() => {
+      document.dispatchEvent(
+        new CustomEvent('auto-launch-tutorial', {
+          detail,
+        })
+      );
+    }, 500);
+  };
+
+  window.addEventListener('pathfinder-sidebar-mounted', dispatch, { once: true });
+  document.addEventListener('pathfinder-panel-mounted', dispatch, { once: true });
+
+  if (sidebarState.getIsSidebarMounted()) {
+    dispatch();
+  }
+}

--- a/src/utils/pathfinder-search-params.ts
+++ b/src/utils/pathfinder-search-params.ts
@@ -22,6 +22,14 @@
 export const PATHFINDER_PARAMS = ['doc', 'type', 'source', 'page', 'kiosk_session', 'panelMode'] as const;
 export type PathfinderParam = (typeof PATHFINDER_PARAMS)[number];
 
+// Subset of PATHFINDER_PARAMS that activate the deep-link handler
+export const PATHFINDER_ACTIVATION_PARAMS = [
+  'doc',
+  'panelMode',
+  'kiosk_session',
+] as const satisfies readonly PathfinderParam[];
+export type PathfinderTriggerParam = (typeof PATHFINDER_ACTIVATION_PARAMS)[number];
+
 /** Tab/guide kind discriminator carried by `?type=`. */
 export type PathfinderDeepLinkType = 'learning-journey' | 'docs' | 'interactive';
 


### PR DESCRIPTION
## Summary

Previously the ?doc= / ?panelMode= / ?kiosk_session= deep-link flow lived inline in plugin.init in module.tsx, so it only fired once per Grafana session - at the moment the plugin module was loaded (i.e. when Grafana opens). This means pathfinder can be deep-linked externally, but not from another page in grafana.

Extract the consumption side of the deep-link contract into a new module utils/pathfinder-deep-link-handler.ts:
  - handlePathfinderDeepLink is idempotent and runnable any number of times. Dedupes via lastProcessedSearch so listeners can fire it freely.
  - installDeepLinkNavListener registers a single navigation listener using the fallback-ladder pattern from experiment-orchestrator.ts and highlighted-guide-orchestrator.ts: grafana:location-changed always, history.listen when the runtime exposes it, and popstate only as a defensive escape hatch when locationService.getHistory() is unavailable.

plugin.init now calls the handler for the initial load case and installs the listener so subsequent SPA navigations carrying ?doc= re-run the same flow. The kiosk and experiment auto-open branches keep their existing !docsParam gating via a pre-handler snapshot of the search string.

### Example:

The setup guide app devs [are attempting to nav to pathfinder](https://raintank-corp.slack.com/archives/C08VB4WC64R/p1779208488792399) from a link in one of its onboarding pages with the url `/a/grafana-pathfinder-app?doc=%2Fdocs%2Flearning-paths%2Fsend-traces-alloy%2F`, which took the user to the `grafana-pathfinder-app` "My Learning" page, but the querystring param was ignored. With this PR's change, it opens the pathfinder sidebar and requested doc.


https://github.com/user-attachments/assets/01cd391c-b35c-4536-8742-6d6ef3b24ef3

