### PR TITLE
fix(bundled-guides): refresh Prometheus + Loki 101 for new dashboard editor flow

### DIFF
--- a/src/bundled-interactives/loki-grafana-101/content.json
+++ b/src/bundled-interactives/loki-grafana-101/content.json
@@ -13,12 +13,12 @@
     },
     {
       "type": "markdown",
-      "content": "## Section 1: Set Up Your Loki Data Source\n\nWe'll configure Loki as a data source so you can visualize logs alongside your metrics."
+      "content": "## Section 1: Set up your Loki data source\n\nWe'll configure Loki as a data source so you can visualize logs alongside your metrics."
     },
     {
       "type": "section",
       "id": "setup-datasource",
-      "title": "Set Up Your Loki Data Source",
+      "title": "Set up your Loki data source",
       "requirements": ["navmenu-open"],
       "blocks": [
         {
@@ -53,25 +53,21 @@
           "content": "Click **Add new data source** to create your Loki connection."
         },
         {
-          "type": "guided",
-          "content": "Configure the Loki data source with a **name** and **connection URL**.",
-          "steps": [
-            {
-              "action": "formfill",
-              "reftarget": "input[id='basic-settings-name']",
-              "targetvalue": "loki-datasource",
-              "requirements": ["exists-reftarget"],
-              "description": "Name your data source **loki-datasource**"
-            },
-            {
-              "action": "formfill",
-              "reftarget": "input[id='connection-url']",
-              "targetvalue": "http://loki:3100",
-              "requirements": ["exists-reftarget"],
-              "description": "Set the URL to **http://loki:3100**",
-              "tooltip": "This URL `http://loki:3100` is the default endpoint for Loki servers. Port **3100** is the standard Loki port."
-            }
-          ]
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[id='basic-settings-name']",
+          "targetvalue": "loki-datasource",
+          "requirements": ["exists-reftarget"],
+          "content": "Name your data source **loki-datasource** so you can easily find it later."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[id='connection-url']",
+          "targetvalue": "http://loki:3100",
+          "requirements": ["exists-reftarget"],
+          "content": "Set the **URL** to **http://loki:3100** to connect to your Loki server.",
+          "tooltip": "This URL `http://loki:3100` is the default endpoint for Loki servers. Port **3100** is the standard Loki port."
         },
         {
           "type": "interactive",
@@ -84,12 +80,12 @@
     },
     {
       "type": "markdown",
-      "content": "## Section 2: Add Loki Panel to Existing Dashboard\n\nNext, add a logs panel to the **Alloy Self Monitoring** dashboard you created previously."
+      "content": "## Section 2: Add a Loki panel to your existing dashboard\n\nNext, add a logs panel to the **Alloy Self Monitoring** dashboard you created in the previous tutorial. Adding logs alongside your metrics gives you a single place to investigate both.\n\n> **Tip:** If your dashboard is already in **edit mode** or the **edit sidebar** is already open, use the **Skip** option on the first two steps below to jump straight to adding the visualization."
     },
     {
       "type": "section",
       "id": "create-dashboard",
-      "title": "Add Loki Panel to Existing Dashboard",
+      "title": "Add a Loki panel to your existing dashboard",
       "requirements": ["section-completed:section-setup-datasource"],
       "blocks": [
         {
@@ -117,26 +113,36 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "button[data-testid=\"data-testid Edit dashboard button\"]",
+          "reftarget": "div[data-testid='data-testid dashboard controls'] button[data-testid='data-testid Edit dashboard button']",
           "requirements": ["exists-reftarget"],
-          "content": "Click **Edit** to edit the dashboard.",
+          "content": "Click **Edit** in the dashboard controls to enter edit mode.",
+          "tooltip": "Edit mode unlocks the dashboard so you can add, rearrange, or modify panels. If you're already in edit mode, use **Skip** to move on.",
           "skippable": true
         },
         {
-          "type": "multistep",
-          "content": "Use **Add** → **Visualization** to create a new panel.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid=\"data-testid Add button\"]",
-              "requirements": ["exists-reftarget"]
-            },
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid=\"data-testid Add new visualization menu item\"]",
-              "requirements": ["exists-reftarget"]
-            }
-          ]
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Sidebar container'] button[data-testid='data-testid Dashboard Sidebar new button']",
+          "requirements": ["exists-reftarget"],
+          "content": "Open the **edit sidebar** by clicking the **+ New** button in the right-hand sidebar.",
+          "tooltip": "The edit sidebar is where you add new panels, rows, and other elements to a dashboard. If the sidebar is already expanded, use **Skip** to continue.",
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='data-testid Sidebar container'] div[data-testid='data-testid sidebar add new panel']",
+          "requirements": ["exists-reftarget"],
+          "content": "Click **Visualization** in the sidebar to add a new panel to the dashboard.",
+          "tooltip": "A **Visualization** is a single panel that renders a query as a chart, table, logs view, or other display. Choosing this drops an empty panel onto your dashboard, ready to be configured."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Configure visualization",
+          "requirements": ["exists-reftarget"],
+          "content": "Click **Configure visualization** to open the panel editor.",
+          "tooltip": "The panel editor is where you pick a data source, write your query, choose a visualization type, and tweak titles, thresholds, and other options before saving the panel back to the dashboard."
         },
         {
           "type": "multistep",
@@ -163,17 +169,13 @@
           "tooltip": "Code mode lets you write raw **LogQL** queries directly, similar to how PromQL works for Prometheus. This gives you full control over your log queries."
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "textarea.inputarea",
+          "targetvalue": "{container=\"alloy\"}",
+          "requirements": ["exists-reftarget"],
           "content": "Enter this LogQL query:\n\n`{container=\"alloy\"}`",
-          "steps": [
-            {
-              "action": "formfill",
-              "reftarget": "textarea.inputarea",
-              "targetvalue": "{container=\"alloy\"}",
-              "requirements": ["exists-reftarget"],
-              "tooltip": "This is **LogQL** (Loki Query Language)! The query `{container=\"alloy\"}` filters logs from containers named \"alloy\". The curly braces `{}` are used for label matching in Loki."
-            }
-          ]
+          "tooltip": "This is **LogQL** (Loki Query Language)! The query `{container=\"alloy\"}` filters logs from containers named \"alloy\". The curly braces `{}` are used for label matching in Loki."
         },
         {
           "type": "interactive",
@@ -184,48 +186,35 @@
           "tooltip": "The **Refresh** button executes your LogQL query and displays the log results from your Loki data source."
         },
         {
-          "type": "multistep",
-          "content": "Change the **Visualization type** to **Logs**.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "button[data-testid=\"data-testid toggle-viz-picker\"]",
-              "requirements": ["exists-reftarget"],
-              "tooltip": "The **Logs** visualization is specifically designed for displaying log data with features like log level highlighting, filtering, and live tailing."
-            },
-            {
-              "action": "highlight",
-              "reftarget": "div[aria-label=\"Plugin visualization item Logs\"]",
-              "requirements": ["exists-reftarget"]
-            }
-          ]
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid=\"data-testid suggestion-Logs\"]",
+          "requirements": ["exists-reftarget"],
+          "content": "Change the **Visualization type** to **Logs** by selecting it from the suggestions.",
+          "tooltip": "The **Logs** visualization is specifically designed for displaying log data with features like log level highlighting, filtering, and live tailing."
         },
         {
-          "type": "guided",
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "grafana:components.PanelEditor.OptionsPane.fieldInput:Title",
+          "targetvalue": "/logs/i",
+          "formHint": "Enter a title that contains the word \"Logs\" (e.g., \"Alloy Logs\", \"My Logs\", \"Container Logs\")",
+          "requirements": ["exists-reftarget"],
           "content": "In the panel options, give the panel a title that includes **Logs** (e.g., \"Alloy Logs\", \"Container Logs\").",
-          "steps": [
-            {
-              "action": "formfill",
-              "reftarget": "input[data-testid=\"data-testid Panel editor option pane field input Title\"]",
-              "targetvalue": "/logs/i",
-              "formHint": "Enter a title that contains the word \"Logs\" (e.g., \"Alloy Logs\", \"My Logs\", \"Container Logs\")",
-              "requirements": ["exists-reftarget"],
-              "tooltip": "The **Title** is the name of the panel. It helps identify what logs you're viewing in the dashboard."
-            }
-          ]
+          "tooltip": "The **Title** is the name of the panel. It helps identify what logs you're viewing in the dashboard."
         },
         {
           "type": "multistep",
-          "content": "Click **Save Dashboard** to persist your changes.",
+          "content": "Click **Save dashboard** to persist your changes.",
           "steps": [
             {
-              "action": "button",
-              "reftarget": "Save Dashboard",
+              "action": "highlight",
+              "reftarget": "button[data-testid='data-testid Save dashboard button']",
               "requirements": ["exists-reftarget"]
             },
             {
-              "action": "button",
-              "reftarget": "Save",
+              "action": "highlight",
+              "reftarget": "button[data-testid=\"data-testid Save dashboard drawer button\"]",
               "requirements": ["exists-reftarget"]
             }
           ]
@@ -234,7 +223,7 @@
     },
     {
       "type": "markdown",
-      "content": "## Great job!\n\nYou now have Loki configured and a logs panel added to your existing dashboard. Consider exploring alerting for logs or drilling down between metrics and logs.\n\n- Configured the Loki data source (http://loki:3100)\n- Built a Logs visualization on the existing dashboard"
+      "content": "## Great job!\n\nYou now have Loki configured and a logs panel added to your existing dashboard. Consider exploring alerting for logs or drilling down between metrics and logs.\n\n- Configured the Loki data source (`http://loki:3100`)\n- Added a Logs visualization to the **Alloy Self Monitoring** dashboard"
     }
   ]
 }

--- a/src/bundled-interactives/prometheus-grafana-101/content.json
+++ b/src/bundled-interactives/prometheus-grafana-101/content.json
@@ -9,16 +9,16 @@
     },
     {
       "type": "markdown",
-      "content": "# Prometheus + Grafana 101\n\nWelcome to your Prometheus monitoring with Grafana journey! In this interactive guide, we'll take you on a tour of key locations in Grafana and help you set up your first Prometheus data source. By the end, you'll be familiar with:\n\n- Navigating Grafana's main sections\n- Understanding the key areas: Dashboards, Data Sources, Explore, and Alerting\n- Setting up and configuring a Prometheus data source\n- Creating your first dashboard with Prometheus metrics"
+      "content": "# Prometheus + Grafana 101\n\nWelcome to your Prometheus monitoring with Grafana journey! In this interactive guide, we'll take you on a tour of key locations in Grafana and help you set up your first Prometheus data source. By the end, you'll be familiar with:\n\n- Setting up and configuring a Prometheus data source\n- Using **Explore** to investigate your metrics with PromQL\n- Sending an Explore query straight to a new dashboard\n- Customizing a panel and saving your first dashboard"
     },
     {
       "type": "markdown",
-      "content": "## Section 1: Set Up Your Prometheus Data Source\n\nNow that you've seen the main areas, let's set up a Prometheus data source. Prometheus is a powerful monitoring system that's commonly used with Grafana for metrics collection and visualization."
+      "content": "## Section 1: Set up your Prometheus data source\n\nLet's start by configuring a Prometheus data source. Prometheus is a powerful monitoring system that's commonly used with Grafana for metrics collection and visualization."
     },
     {
       "type": "section",
       "id": "setup-datasource",
-      "title": "Set Up Your Prometheus Data Source",
+      "title": "Set up your Prometheus data source",
       "requirements": ["navmenu-open"],
       "blocks": [
         {
@@ -69,161 +69,32 @@
           "tooltip": "This URL `http://prometheus:9090` is the default endpoint for Prometheus servers. Port **9090** is the standard Prometheus port."
         },
         {
-          "type": "guided",
-          "content": "Explore Prometheus configuration settings and save your data source.",
-          "stepTimeout": 45000,
-          "steps": [
-            {
-              "action": "hover",
-              "reftarget": ".gf-form:has([data-testid=\"data-testid prometheus type\"]) label > svg[tabindex=\"0\"]",
-              "requirements": ["exists-reftarget"],
-              "tooltip": "The **Performance** section contains advanced settings that control how Grafana optimizes queries to your Prometheus server. Hovering over the information icon reveals detailed explanations about each setting."
-            },
-            {
-              "action": "highlight",
-              "reftarget": "grafana:components.DataSource.Prometheus.configPage.prometheusType",
-              "skippable": true,
-              "tooltip": "The **Prometheus type** dropdown lets you specify whether you're connecting to a standard Prometheus server or a compatible service like Cortex or Thanos, which helps Grafana optimize query behavior accordingly."
-            },
-            {
-              "action": "button",
-              "reftarget": "Save & test",
-              "tooltip": "Click **Save & test** to create your data source and verify the connection is working."
-            }
-          ]
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "#pageContent label:contains('Prometheus type')",
+          "requirements": ["exists-reftarget"],
+          "skippable": true,
+          "content": "Review the **Prometheus type** setting in the configuration page.",
+          "tooltip": "The **Prometheus type** dropdown lets you specify whether you're connecting to a standard Prometheus server or a compatible service like Cortex or Thanos, which helps Grafana optimize query behavior accordingly."
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save & test",
+          "requirements": ["exists-reftarget"],
+          "content": "Click **Save & test** to create your data source and verify the connection is working."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "## Section 2: Create Your First Dashboard\n\nNow let's put your new Prometheus data source to work! We'll create a dashboard and add your first visualization using the \"prometheus-datasource\" you just set up."
-    },
-    {
-      "type": "section",
-      "id": "create-dashboard",
-      "title": "Create Your First Dashboard",
-      "requirements": ["section-completed:section-setup-datasource"],
-      "blocks": [
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
-          "requirements": ["navmenu-open", "exists-reftarget"],
-          "content": "Click **Dashboards** in the left-side menu."
-        },
-        {
-          "type": "multistep",
-          "content": "Click the **New** button, then select **New dashboard**.",
-          "steps": [
-            {
-              "action": "button",
-              "reftarget": "New",
-              "requirements": ["exists-reftarget"]
-            },
-            {
-              "action": "highlight",
-              "reftarget": "a[href='/dashboard/new']",
-              "requirements": ["exists-reftarget"]
-            }
-          ]
-        },
-        {
-          "type": "multistep",
-          "content": "Click **Add visualization**, then select your **prometheus-datasource**.",
-          "steps": [
-            {
-              "action": "button",
-              "reftarget": "button[data-testid='data-testid Create new panel button']",
-              "requirements": ["exists-reftarget"]
-            },
-            {
-              "action": "button",
-              "reftarget": "prometheus-datasource",
-              "requirements": ["exists-reftarget"]
-            }
-          ]
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "div[data-testid=\"QueryEditorModeToggle\"] label[for^=\"option-code-radiogroup\"]",
-          "requirements": ["exists-reftarget"],
-          "content": "Switch to **Code** mode by clicking the raw query toggle to write PromQL directly."
-        },
-        {
-          "type": "interactive",
-          "action": "formfill",
-          "reftarget": "textarea.inputarea",
-          "targetvalue": "avg(alloy_component_controller_running_components{})",
-          "requirements": ["exists-reftarget"],
-          "content": "Enter this PromQL query:\n\n`avg(alloy_component_controller_running_components{})`",
-          "tooltip": "This is **PromQL** (Prometheus Query Language)! The `avg()` function calculates the average value, and `alloy_component_controller_running_components{}` is a metric that tracks running components. The empty `{}` means we're not filtering by labels."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
-          "requirements": ["exists-reftarget"],
-          "content": "Click the **Refresh** button to execute the query and see your Prometheus data.",
-          "tooltip": "The **Refresh** button is used to execute the query and see your Prometheus data."
-        },
-        {
-          "type": "multistep",
-          "content": "Click on the **Visualization type**, then select **Stat** to create a simple number display.",
-          "steps": [
-            {
-              "action": "highlight",
-              "reftarget": "grafana:components.PanelEditor.toggleVizPicker",
-              "tooltip": "Grafana offers **many visualization types**: *Time series* for trends, *Bar charts* for comparisons, *Heatmaps* for distributions, *Tables* for raw data, and *Stat* for single values. Choose based on your data story!"
-            },
-            {
-              "action": "highlight",
-              "reftarget": "div[aria-label=\"Plugin visualization item Stat\"]",
-              "requirements": ["exists-reftarget"]
-            }
-          ]
-        },
-        {
-          "type": "interactive",
-          "action": "formfill",
-          "reftarget": "grafana:components.PanelEditor.OptionsPane.fieldInput:Title",
-          "targetvalue": "Number of running components",
-          "content": "In the panel options, change the **Title** to **Number of running components**.",
-          "tooltip": "The **Title** is the name of the panel. It's used to identify the panel in the dashboard."
-        },
-        {
-          "type": "multistep",
-          "content": "Click **Save Dashboard**, name it **Alloy Self Monitoring**, and click **Save**.",
-          "steps": [
-            {
-              "action": "button",
-              "reftarget": "Save Dashboard",
-              "requirements": ["exists-reftarget"]
-            },
-            {
-              "action": "formfill",
-              "reftarget": "input[aria-label=\"Save dashboard title field\"]",
-              "targetvalue": "Alloy Self Monitoring",
-              "requirements": ["exists-reftarget"]
-            },
-            {
-              "action": "button",
-              "reftarget": "Save",
-              "requirements": ["exists-reftarget"]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "markdown",
-      "content": "## Section 3: Explore Your Metrics\n\nThe Explore tab is your playground for querying and analyzing data. It's perfect for ad-hoc queries, investigating issues, and experimenting with PromQL before adding panels to dashboards. Let's explore some common Prometheus queries!"
+      "content": "## Section 2: Explore your metrics\n\nBefore building a dashboard, it's a good practice to explore your data first. Think of **Explore** as your data playground - it's where you can experiment with PromQL queries, understand what your metrics look like, and test different approaches without committing to a dashboard.\n\nLet's get familiar with some common Prometheus queries before we send one to a dashboard."
     },
     {
       "type": "section",
       "id": "explore-metrics",
-      "title": "Explore Your Metrics",
-      "requirements": ["section-completed:section-create-dashboard"],
+      "title": "Explore your metrics",
+      "requirements": ["section-completed:section-setup-datasource"],
       "blocks": [
         {
           "type": "interactive",
@@ -306,23 +177,6 @@
           "content": "Run the query to visualize request rates over time."
         },
         {
-          "type": "interactive",
-          "action": "formfill",
-          "reftarget": "textarea.inputarea",
-          "targetvalue": "@@CLEAR@@ prometheus_build_info",
-          "requirements": ["exists-reftarget"],
-          "content": "Clear and query Prometheus build information:\n\n`prometheus_build_info`",
-          "tooltip": "The `prometheus_build_info` metric provides metadata about your Prometheus server, including version, branch, and Go version. It's a useful info metric with labels containing build details."
-        },
-        {
-          "type": "interactive",
-          "action": "highlight",
-          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
-          "requirements": ["exists-reftarget"],
-          "content": "Execute to see your Prometheus version and build details.",
-          "tooltip": "Info metrics like this one typically have a constant value of **1**, but their labels contain the valuable information about the system."
-        },
-        {
           "type": "multistep",
           "content": "Explore the **time range picker** to adjust your query window.",
           "steps": [
@@ -339,12 +193,134 @@
               "tooltip": "Try different time ranges to see how your metrics change over time. Shorter ranges give more detail, longer ranges show trends."
             }
           ]
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "textarea.inputarea",
+          "targetvalue": "@@CLEAR@@ avg(alloy_component_controller_running_components{})",
+          "requirements": ["exists-reftarget"],
+          "content": "Now let's pick the query we'll send to a dashboard. Clear the editor and enter:\n\n`avg(alloy_component_controller_running_components{})`",
+          "tooltip": "The `avg()` function calculates the average value, and `alloy_component_controller_running_components{}` tracks the number of running components in your Grafana Alloy instance. This produces a single number - perfect for a **Stat** panel on a dashboard."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='data-testid RefreshPicker run button']",
+          "requirements": ["exists-reftarget"],
+          "content": "Run the query to see the current number of running Alloy components."
         }
       ]
     },
     {
       "type": "markdown",
-      "content": "## Congratulations!\n\nAmazing work! You've completed your comprehensive Prometheus + Grafana 101 tutorial. You now know:\n\n- How to create and configure a Prometheus data source\n- How to set up the Prometheus server URL (http://prometheus:9090)\n- How to create a new dashboard and add visualizations\n- How to write and execute PromQL queries using Code mode\n- How to use the Explore tab for ad-hoc querying and investigation\n- Essential PromQL functions like `sum()`, `rate()`, and `by` grouping\n- How to work with fundamental Prometheus metrics like `up` and build info\n- How to navigate time ranges for analyzing different periods\n\n**Key PromQL Patterns You Learned:**\n\n- `up` - Monitor target health\n- `sum() by (label)` - Aggregate and group metrics\n- `rate(metric[5m])` - Calculate per-second rates over time windows\n- `prometheus_build_info` - Access system metadata through info metrics\n\n**Next Steps:** Continue with [Loki + Grafana 101](bundled:loki-grafana-101) to add logs alongside your metrics, or dive deeper into PromQL to create more sophisticated queries and alerting rules!"
+      "content": "## Section 3: Create a dashboard from Explore\n\nGreat work! You've explored your Prometheus metrics and landed on a query worth keeping. Now let's transform that query into a permanent, shareable dashboard.\n\nGrafana lets you send any Explore query directly to a new or existing dashboard - no need to retype the query in the panel editor. Let's create your first dashboard."
+    },
+    {
+      "type": "section",
+      "id": "create-dashboard",
+      "title": "Create a dashboard from Explore",
+      "requirements": ["section-completed:section-explore-metrics"],
+      "blocks": [
+        {
+          "type": "multistep",
+          "content": "Use the **Add** button to send your query to a new dashboard.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "button[aria-label=\"Add\"]",
+              "requirements": ["exists-reftarget"]
+            },
+            {
+              "action": "highlight",
+              "reftarget": "button:contains(\"Add to dashboard\")",
+              "requirements": ["exists-reftarget"]
+            },
+            {
+              "action": "highlight",
+              "reftarget": "button:contains(\"Open dashboard\")",
+              "requirements": ["exists-reftarget"],
+              "tooltip": "One of Grafana's best features is the seamless transition from Explore to dashboards. Instead of manually recreating your queries, you can send them directly from Explore to a new or existing dashboard. This workflow saves time and ensures your carefully crafted queries make it to your dashboard exactly as you tested them."
+            }
+          ]
+        },
+        {
+          "type": "multistep",
+          "content": "Open the panel editor to customize your visualization.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "button[data-testid=\"data-testid Panel menu New Panel\"]",
+              "requirements": ["exists-reftarget"]
+            },
+            {
+              "action": "highlight",
+              "reftarget": "a[data-testid=\"data-testid Panel menu item Edit\"]",
+              "requirements": ["exists-reftarget"],
+              "tooltip": "Welcome to your new dashboard! The panel editor is where the magic happens. Each visualization on a dashboard is called a \"panel,\" and the panel editor gives you complete control over how your data looks and behaves."
+            }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "grafana:components.PanelEditor.toggleVizPicker",
+          "requirements": ["exists-reftarget"],
+          "content": "Open the visualization picker to change the panel type.",
+          "tooltip": "Grafana offers **many visualization types**: *Time series* for trends, *Bar charts* for comparisons, *Heatmaps* for distributions, *Tables* for raw data, and *Stat* for single values. Choose based on your data story!"
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid=\"data-testid Tab Visualizations\"]",
+          "requirements": ["exists-reftarget"],
+          "content": "Select **All visualizations** to browse every panel type.",
+          "tooltip": "Stat is not always listed under suggested visualizations. Open **All visualizations** to find it."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid=\"data-testid Plugin visualization item Stat\"]",
+          "requirements": ["exists-reftarget"],
+          "content": "Change the visualization to **Stat** to display the number of running components as a single value.",
+          "tooltip": "The **Stat** panel is ideal for single-value metrics like our `avg()` query. It shows the current value prominently and can also include sparklines, thresholds, and color coding."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "grafana:components.PanelEditor.OptionsPane.fieldInput:Title",
+          "targetvalue": "Number of running components",
+          "requirements": ["exists-reftarget"],
+          "content": "In the panel options, change the **Title** to **Number of running components**.",
+          "tooltip": "The **Title** is the name of the panel. It's used to identify the panel in the dashboard."
+        },
+        {
+          "type": "multistep",
+          "content": "Click **Save dashboard**, name it **Alloy Self Monitoring**, and click **Save**.",
+          "steps": [
+            {
+              "action": "highlight",
+              "reftarget": "button[data-testid='data-testid Save dashboard button']",
+              "requirements": ["exists-reftarget"]
+            },
+            {
+              "action": "formfill",
+              "reftarget": "input[aria-label=\"Save dashboard title field\"]",
+              "targetvalue": "Alloy Self Monitoring",
+              "requirements": ["exists-reftarget"]
+            },
+            {
+              "action": "highlight",
+              "reftarget": "button[data-testid=\"data-testid Save dashboard drawer button\"]",
+              "requirements": ["exists-reftarget"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "## Congratulations!\n\nAmazing work! You've completed your Prometheus + Grafana 101 tutorial. You now know how to:\n\n- Create and configure a Prometheus data source\n- Use the Explore tab for ad-hoc PromQL querying\n- Write essential PromQL with `sum()`, `rate()`, and `by` grouping\n- Adjust the time range to focus on specific windows\n- Send an Explore query straight to a new dashboard with **Add to dashboard**\n- Customize a panel's visualization type and title\n- Save your first Grafana dashboard\n\n**Key PromQL patterns you learned:**\n\n- `up` - Monitor target health\n- `sum() by (label)` - Aggregate and group metrics\n- `rate(metric[5m])` - Calculate per-second rates over time windows\n- `avg(metric)` - Reduce a series to a single average value\n\n**Next steps:** Continue with [Loki + Grafana 101](bundled:loki-grafana-101) to add logs alongside your metrics, or dive deeper into PromQL to create more sophisticated queries and alerting rules!"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Refresh the bundled **Prometheus + Grafana 101** and **Loki + Grafana 101** guides so they match the current Grafana dashboard editor UX (edit sidebar instead of the top **Add → Visualization** menu).
- Switch all headings, section titles, and narrative copy to sentence case per the Grafana Writers' Toolkit.
- Flatten leftover `guided`-block wrappers into plain `interactive` steps and tighten tooltips/content throughout.

## What changed

### Loki 101 (`src/bundled-interactives/loki-grafana-101/content.json`)
- Section 2 description gains a **Tip** explaining that the first two steps can be skipped if the dashboard is already in edit mode or the sidebar is already open.
- Replaced the legacy **Add → Visualization** multistep with the new edit-sidebar flow:
  1. **Edit** (scoped to `dashboard controls`, `skippable: true`)
  2. **+ New** in the sidebar (`Dashboard Sidebar new button`, `skippable: true`)
  3. **Visualization** in the sidebar (`sidebar add new panel`)
  4. **Configure visualization** button
- Collapsed the three-step **Visualization type → Logs** multistep to a single step targeting `data-testid="data-testid suggestion-Logs"`.
- Sentence-case headings (`Set up your Loki data source`, `Add a Loki panel to your existing dashboard`).
- Old `guided` blocks for the data source name/URL and the LogQL query are now plain interactive steps so each becomes its own actionable card.

### Prometheus 101 (`src/bundled-interactives/prometheus-grafana-101/content.json`)
- Reframed Section 2 around **Explore** with cleaner PromQL examples (`up`, `sum() by (job)`, `rate(...)`, `avg(alloy_component_controller_running_components{})`).
- Added a new **Section 3: Create a dashboard from Explore** that walks the user through **Add → Add to dashboard → Open dashboard**, opening the panel editor from the new-panel menu, switching to the **Stat** visualization, titling the panel, and saving the dashboard as **Alloy Self Monitoring**.
- Sentence-case headings throughout; rewrote the closing summary to match the new flow and PromQL patterns the user actually learned.

## Why

- The previous **Add → Visualization** top-bar flow no longer matches what users see in current Grafana versions; the new sidebar-driven flow is the supported path and matches what the in-product UI now exposes.
- Marking the **Edit** and **+ New** steps skippable lets returning users who are already in edit mode (or who have the sidebar open) jump straight to adding a visualization without an awkward forced-click.
- Sentence case aligns the bundled guide copy with the Grafana Writers' Toolkit style guide referenced in `AGENTS.md`.
- Promoting the existing single-action `guided` blocks to `interactive` steps removes a layer of UI nesting for a one-step action, matching how the rest of the guides are authored.

## Test plan

- [ ] `npm run server` and open the **Loki + Grafana 101** guide; verify each step in Section 2 highlights the right element on a fresh dashboard.
- [ ] Re-run Section 2 with the dashboard already in edit mode → confirm **Skip** appears on the **Edit** step and advances cleanly.
- [ ] Re-run Section 2 with the edit sidebar already open → confirm **Skip** appears on the **+ New** step and advances cleanly.
- [ ] Confirm the **Logs** visualization step picks up `suggestion-Logs` and highlights/clicks the Logs suggestion card in the panel editor.
- [ ] Open **Prometheus + Grafana 101** and walk Section 2 (Explore) → Section 3 (dashboard) end-to-end; verify the **Add → Add to dashboard → Open dashboard** path works and the Stat panel saves under **Alloy Self Monitoring**.
- [ ] `npm run check` passes locally.

## Risk and reversibility

- **Risk:** Low. Changes are confined to two bundled `content.json` files — no runtime code paths, no schema changes. JSON validity verified locally and `prettier --check` is clean.
- **Reversibility:** Fully reversible by reverting the single commit on this branch; nothing downstream depends on the previous step IDs or selector strings.

Made with [Cursor](https://cursor.com)