### PR TITLE
feat(snippets): reusable snippet references in interactive guides

### DIFF
--- a/.cursor/rules/systemPatterns.mdc
+++ b/.cursor/rules/systemPatterns.mdc
@@ -121,7 +121,7 @@ Compact catalogue. For each subsystem: purpose, entry point (file an agent shoul
 - `requirements-manager/` — Prereqs + postconditions for steps. Entry: `requirements-checker.hook.ts` (`useStepChecker`). State machine in `step-state.ts`. See `docs/developer/engines/requirements-manager.md`.
 - `learning-paths/` — Progress / badges / streaks / next-action. Entry: `learning-paths.hook.ts`. Badge definitions in `badges.ts`. See `docs/developer/learning-paths/README.md`.
 - `package-engine/` — Package resolution + loading. Entry: `composite-resolver.ts` (`createCompositeResolver`). Resolver chain: bundled → online CDN → recommender API.
-- `snippet-engine/` — Resolves `snippet-ref` blocks to their content. Entry: `caching-snippet-resolver.ts` (`getSnippetResolver`). Fetches from CDN at `<host>/shared/snippets/<id>.json`; no bundled fallback. `inline-refs.ts` splices resolved snippets into a guide before parsing.
+- `snippet-engine/` — Resolves `snippet-ref` blocks to their content. Entry: `caching-snippet-resolver.ts` (`getSnippetResolver`). Fetches from CDN at `<host>/guides/shared/snippets/<id>.json` (the `/guides/` prefix reflects the existing interactive-tutorials deploy convention); no bundled fallback. `inline-refs.ts` splices resolved snippets into a guide before parsing.
 - `hooks/` — Cross-cutting hooks: `useGuideProgressState`, `useAutoLaunchTutorial`, `useStepProgressFromEvents`.
 
 **Tier 3 — integrations:**

--- a/.cursor/rules/systemPatterns.mdc
+++ b/.cursor/rules/systemPatterns.mdc
@@ -88,7 +88,7 @@ Imports flow **downward only** through these tiers. Cross-tier rules are enforce
 
 - **Tier 0 — Types & constants**: `types/`, `constants/`. Pure type definitions and configuration constants; no runtime behavior; safe to import from anywhere.
 - **Tier 1 — Support**: `lib/`, `security/`, `styles/`, `global-state/`, `utils/`, `validation/`, `recovery/`. Auxiliary utilities, shared state, theme-aware styles, and validation helpers; importable by higher tiers.
-- **Tier 2 — Engines & hooks**: `context-engine/`, `docs-retrieval/`, `interactive-engine/`, `requirements-manager/`, `learning-paths/`, `package-engine/`, `hooks/`. Hold the business logic. Each engine exposes a barrel `index.ts`; consumers import only the public surface. Engines are laterally isolated — they cannot import from sibling Tier 2 engines.
+- **Tier 2 — Engines & hooks**: `context-engine/`, `docs-retrieval/`, `interactive-engine/`, `requirements-manager/`, `learning-paths/`, `package-engine/`, `snippet-engine/`, `hooks/`. Hold the business logic. Each engine exposes a barrel `index.ts`; consumers import only the public surface. Engines are laterally isolated — they cannot import from sibling Tier 2 engines.
 - **Tier 3 — Integrations**: `integrations/`. Optional integrations (assistant, coda, workshop). May import from Tiers 0–2.
 - **Tier 4 — UI**: `components/`, `pages/`. Compose engines and integrations into rendered surfaces.
 
@@ -121,6 +121,7 @@ Compact catalogue. For each subsystem: purpose, entry point (file an agent shoul
 - `requirements-manager/` — Prereqs + postconditions for steps. Entry: `requirements-checker.hook.ts` (`useStepChecker`). State machine in `step-state.ts`. See `docs/developer/engines/requirements-manager.md`.
 - `learning-paths/` — Progress / badges / streaks / next-action. Entry: `learning-paths.hook.ts`. Badge definitions in `badges.ts`. See `docs/developer/learning-paths/README.md`.
 - `package-engine/` — Package resolution + loading. Entry: `composite-resolver.ts` (`createCompositeResolver`). Resolver chain: bundled → online CDN → recommender API.
+- `snippet-engine/` — Resolves `snippet-ref` blocks to their content. Entry: `caching-snippet-resolver.ts` (`getSnippetResolver`). Fetches from CDN at `<host>/shared/snippets/<id>.json`; no bundled fallback. `inline-refs.ts` splices resolved snippets into a guide before parsing.
 - `hooks/` — Cross-cutting hooks: `useGuideProgressState`, `useAutoLaunchTutorial`, `useStepProgressFromEvents`.
 
 **Tier 3 — integrations:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@ Imports flow **downward only** to avoid cycles. Cross-tier rules are enforced by
 
 - **Tier 0 — Types & constants**: `types/`, `constants/`
 - **Tier 1 — Support**: `lib/`, `security/`, `styles/`, `global-state/`, `utils/`, `validation/`, `recovery/`
-- **Tier 2 — Engines & hooks**: `context-engine/`, `docs-retrieval/`, `interactive-engine/`, `requirements-manager/`, `learning-paths/`, `package-engine/`, `hooks/`
+- **Tier 2 — Engines & hooks**: `context-engine/`, `docs-retrieval/`, `interactive-engine/`, `requirements-manager/`, `learning-paths/`, `package-engine/`, `snippet-engine/`, `hooks/`
 - **Tier 3 — Integrations**: `integrations/`
 - **Tier 4 — UI**: `components/`, `pages/`
 
@@ -194,6 +194,7 @@ Excluded from tier analysis (not tiered): `test-utils/`, `cli/`, `bundled-intera
 | `context-engine` → `docs-retrieval`            | Fetches content for the recommendations it surfaces            |
 | `docs-retrieval` → `bundled-interactives`      | Fallback when the online CDN is unavailable                    |
 | `docs-retrieval` → `package-engine`            | Resolves package manifests + content                           |
+| `docs-retrieval` → `snippet-engine`            | Inlines `snippet-ref` blocks against the CDN at parse time     |
 | `components/docs-panel` → `interactive-engine` | Executes step actions when the user clicks "Show me" / "Do it" |
 | `interactive-engine` → `requirements-manager`  | Checks prereqs before enabling / executing a step              |
 | `interactive-engine` → `lib/dom`               | Selector resolution + element detection                        |

--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -6,6 +6,8 @@ Persistent tracker for the maintain-docs skill's persistent state across runs.
 
 <!-- Structural issues requiring dedicated effort. Format: date, description, rationale. Remove when resolved. -->
 
+- 2026-05-21: No CONCERNS.md concern covers `src/snippet-engine/`. Consider adding one or extending `package-engine` / `docs-retrieval-and-rendering` to include the new tier-1 engine. Rationale: prevent-doc-drift cannot edit `docs/design/CONCERNS.md`; surfacing here for a human review pass.
+
 ## Validated docs
 
 <!-- Docs checked against source and found accurate. Format: date, doc path. Update date on re-validation. -->

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,7 @@ const TIER_2_ENGINES = [
   'requirements-manager',
   'learning-paths',
   'package-engine',
+  'snippet-engine',
   'hooks',
 ];
 const TIER_1_PLUS = [

--- a/src/components/block-editor/BlockFormModal.tsx
+++ b/src/components/block-editor/BlockFormModal.tsx
@@ -49,6 +49,7 @@ import { TerminalConnectBlockForm } from './forms/TerminalConnectBlockForm';
 import { ChallengeBlockForm } from './forms/ChallengeBlockForm';
 import { CodeBlockForm } from './forms/CodeBlockForm';
 import { GrotGuideBlockForm } from './forms/GrotGuideBlockForm';
+import { SnippetRefBlockForm } from './forms/SnippetRefBlockForm';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   modal: css({
@@ -125,6 +126,7 @@ const FORM_COMPONENTS: Record<BlockType, React.ComponentType<BlockFormProps>> = 
   challenge: ChallengeBlockForm,
   'code-block': CodeBlockForm,
   'grot-guide': GrotGuideBlockForm,
+  'snippet-ref': SnippetRefBlockForm,
 };
 
 /**

--- a/src/components/block-editor/BlockPreview.test.tsx
+++ b/src/components/block-editor/BlockPreview.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { parseJsonGuide } from '../../docs-retrieval';
+import { BlockPreview } from './BlockPreview';
+import type { JsonGuide } from './types';
+
+jest.mock('../content-renderer/content-renderer', () => ({
+  ContentRenderer: () => <div data-testid="preview-content-renderer" />,
+}));
+
+jest.mock('./hooks/useGuidePreviewProgress', () => ({
+  useGuidePreviewProgress: () => ({ hasProgress: false, reset: jest.fn() }),
+}));
+
+const inlineSnippetRefsInGuideMock = jest.fn();
+jest.mock('../../snippet-engine', () => {
+  const actual = jest.requireActual('../../snippet-engine');
+  return {
+    ...actual,
+    inlineSnippetRefsInGuide: (...args: unknown[]) => inlineSnippetRefsInGuideMock(...args),
+  };
+});
+
+const snippetGuide: JsonGuide = {
+  id: 'preview-guide',
+  title: 'New guide',
+  blocks: [{ type: 'snippet-ref', snippetId: 'datasource-picker' }],
+};
+
+const resolvedGuide: JsonGuide = {
+  id: 'preview-guide',
+  title: 'New guide',
+  blocks: [{ type: 'markdown', content: 'Select the datasource.' }],
+};
+
+describe('BlockPreview snippet handling', () => {
+  beforeEach(() => {
+    inlineSnippetRefsInGuideMock.mockReset();
+    inlineSnippetRefsInGuideMock.mockResolvedValue(resolvedGuide);
+  });
+
+  it('does not surface a false unresolved-snippet warning for a valid ref', async () => {
+    // Validating the raw guide (no inlining) would emit the warning — the
+    // preview must resolve refs first so the author never sees it.
+    const raw = parseJsonGuide(snippetGuide);
+    expect((raw.warnings || []).some((w) => w.includes('Unresolved snippet reference'))).toBe(true);
+
+    render(<BlockPreview guide={snippetGuide} />);
+
+    await waitFor(() => expect(inlineSnippetRefsInGuideMock).toHaveBeenCalled());
+
+    expect(screen.queryByText(/Unresolved snippet reference/)).not.toBeInTheDocument();
+    expect(screen.getByTestId('preview-content-renderer')).toBeInTheDocument();
+  });
+
+  it('skips the inlining pass when the guide references no snippets', () => {
+    render(<BlockPreview guide={resolvedGuide} />);
+    expect(inlineSnippetRefsInGuideMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/block-editor/BlockPreview.tsx
+++ b/src/components/block-editor/BlockPreview.tsx
@@ -62,14 +62,11 @@ export function BlockPreview({ guide, showTitle = true, hideResetButton = false 
     };
   }, [progressKey]);
 
-  // ContentRenderer resolves snippet refs downstream before it renders, so
-  // validating the raw guide would flag every valid `snippet-ref` as
-  // unresolved. Mirror ContentRenderer: parse synchronously, then re-parse
-  // against the inlined guide when the guide references snippets.
+  // Validate the inlined guide, not the raw one — an un-inlined snippet-ref
+  // parses as an "unresolved" warning the renderer never actually shows.
   const baseValidation = useMemo(() => parseJsonGuide(guide), [guide]);
   const hasSnippetRefs = useMemo(() => guideHasSnippetRefs(guide), [guide]);
-  // Tag the result with the guide it was computed for so a stale result from
-  // a previous guide is ignored during render.
+  // `resolved` is tagged with its guide so a stale async result is ignored.
   const [resolved, setResolved] = useState<{ guide: JsonGuide; result: ContentParseResult } | null>(null);
 
   useEffect(() => {
@@ -90,16 +87,14 @@ export function BlockPreview({ guide, showTitle = true, hideResetButton = false 
 
   const resolvedValidation = resolved?.guide === guide ? resolved.result : null;
 
-  // While a snippet-referencing guide is still inlining, fall back to the base
-  // parse for structural errors but withhold its snippet-ref warnings — those
-  // resolve away once inlining completes.
+  // Until inlining finishes, show structural errors but withhold snippet-ref
+  // warnings — they resolve away.
   const resolving = hasSnippetRefs && resolvedValidation === null;
   const validation = resolvedValidation ?? baseValidation;
   const errors = validation.errors || [];
   const warnings = resolving ? [] : validation.warnings || [];
 
-  // Keyed on the guide alone so the async validation update never churns
-  // ContentRenderer's content identity.
+  // Keyed on the guide alone so the async validation update can't remount ContentRenderer.
   const { content, isEmpty } = useMemo(() => {
     if (!guide.blocks || guide.blocks.length === 0) {
       return { content: null, isEmpty: true };

--- a/src/components/block-editor/BlockPreview.tsx
+++ b/src/components/block-editor/BlockPreview.tsx
@@ -9,13 +9,14 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { useStyles2, Alert, Icon } from '@grafana/ui';
 import { getBlockPreviewStyles } from './block-editor.styles';
 import { parseJsonGuide } from '../../docs-retrieval';
+import { guideHasSnippetRefs, inlineSnippetRefsInGuide } from '../../snippet-engine';
 import { ContentRenderer } from '../content-renderer/content-renderer';
 import { journeyContentHtml } from '../../styles/content-html.styles';
 import { getInteractiveStyles } from '../../styles/interactive.styles';
 import { getPrismStyles } from '../../styles/prism.styles';
 import { useGuidePreviewProgress } from './hooks/useGuidePreviewProgress';
 import type { JsonGuide } from './types';
-import type { RawContent } from '../../types/content.types';
+import type { ContentParseResult, RawContent } from '../../types/content.types';
 import { testIds } from '../../constants/testIds';
 
 export interface BlockPreviewProps {
@@ -61,32 +62,50 @@ export function BlockPreview({ guide, showTitle = true, hideResetButton = false 
     };
   }, [progressKey]);
 
-  // Validate the guide and prepare for rendering
-  const { content, errors, warnings, isEmpty } = useMemo(() => {
-    // First validate the guide
-    const parseResult = parseJsonGuide(guide);
+  // ContentRenderer resolves snippet refs downstream before it renders, so
+  // validating the raw guide would flag every valid `snippet-ref` as
+  // unresolved. Mirror ContentRenderer: parse synchronously, then re-parse
+  // against the inlined guide when the guide references snippets.
+  const baseValidation = useMemo(() => parseJsonGuide(guide), [guide]);
+  const hasSnippetRefs = useMemo(() => guideHasSnippetRefs(guide), [guide]);
+  // Tag the result with the guide it was computed for so a stale result from
+  // a previous guide is ignored during render.
+  const [resolved, setResolved] = useState<{ guide: JsonGuide; result: ContentParseResult } | null>(null);
 
-    if (!parseResult.isValid) {
-      return {
-        content: null,
-        errors: parseResult.errors || [],
-        warnings: parseResult.warnings || [],
-        isEmpty: false,
-      };
+  useEffect(() => {
+    if (!hasSnippetRefs) {
+      return;
     }
+    let cancelled = false;
+    void (async () => {
+      const inlined = await inlineSnippetRefsInGuide(guide);
+      if (!cancelled) {
+        setResolved({ guide, result: parseJsonGuide(inlined) });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [guide, hasSnippetRefs]);
 
-    // Check if guide has no blocks
+  const resolvedValidation = resolved?.guide === guide ? resolved.result : null;
+
+  // While a snippet-referencing guide is still inlining, fall back to the base
+  // parse for structural errors but withhold its snippet-ref warnings — those
+  // resolve away once inlining completes.
+  const resolving = hasSnippetRefs && resolvedValidation === null;
+  const validation = resolvedValidation ?? baseValidation;
+  const errors = validation.errors || [];
+  const warnings = resolving ? [] : validation.warnings || [];
+
+  // Keyed on the guide alone so the async validation update never churns
+  // ContentRenderer's content identity.
+  const { content, isEmpty } = useMemo(() => {
     if (!guide.blocks || guide.blocks.length === 0) {
-      return {
-        content: null,
-        errors: [],
-        warnings: [],
-        isEmpty: true,
-      };
+      return { content: null, isEmpty: true };
     }
 
-    // Create RawContent structure expected by ContentRenderer
-    // ContentRenderer expects the raw JSON string as content
+    // ContentRenderer expects the raw JSON string as content.
     const rawContent: RawContent = {
       content: JSON.stringify(guide),
       metadata: {
@@ -98,12 +117,7 @@ export function BlockPreview({ guide, showTitle = true, hideResetButton = false 
       isNativeJson: true,
     };
 
-    return {
-      content: rawContent,
-      errors: [],
-      warnings: parseResult.warnings || [],
-      isEmpty: false,
-    };
+    return { content: rawContent, isEmpty: false };
   }, [guide, showTitle]);
 
   // Show error state if parsing failed

--- a/src/components/block-editor/SnippetPicker.tsx
+++ b/src/components/block-editor/SnippetPicker.tsx
@@ -2,12 +2,8 @@
  * Snippet Picker
  *
  * Modal-less inline picker rendered inside SnippetRefBlockForm. Lists
- * every snippet in the catalog (bundled + CDN), supports a search box,
- * and emits the chosen snippet ID upward via `onSelect`.
- *
- * v1 keeps this lean — no live preview pane yet. The author sees the
- * picked snippet's resolved blocks inside SnippetRefCard once the
- * block is inserted into the guide.
+ * every snippet in the CDN catalog, supports a search box, and emits the
+ * chosen snippet ID upward via `onSelect`.
  */
 
 import React, { useEffect, useMemo, useState } from 'react';

--- a/src/components/block-editor/SnippetPicker.tsx
+++ b/src/components/block-editor/SnippetPicker.tsx
@@ -133,7 +133,6 @@ export function SnippetPicker({ value, onSelect }: SnippetPickerProps) {
                 }}
               >
                 <div className={styles.rowHeader}>
-                  <Icon name="share-alt" />
                   <span>{entry.title}</span>
                 </div>
                 {entry.description && <div className={styles.rowMeta}>{entry.description}</div>}

--- a/src/components/block-editor/SnippetPicker.tsx
+++ b/src/components/block-editor/SnippetPicker.tsx
@@ -1,10 +1,4 @@
-/**
- * Snippet Picker
- *
- * Modal-less inline picker rendered inside SnippetRefBlockForm. Lists
- * every snippet in the CDN catalog, supports a search box, and emits the
- * chosen snippet ID upward via `onSelect`.
- */
+/** Inline picker for choosing a snippet from the CDN catalog. */
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { css } from '@emotion/css';
@@ -15,9 +9,7 @@ import { getSnippetResolver } from '../../snippet-engine';
 import type { SnippetCatalogEntry } from '../../types/json-snippet.types';
 
 interface SnippetPickerProps {
-  /** Currently-selected snippet ID (highlighted in the list). */
   value?: string;
-  /** Called when the author clicks a row. */
   onSelect: (snippetId: string) => void;
 }
 

--- a/src/components/block-editor/SnippetPicker.tsx
+++ b/src/components/block-editor/SnippetPicker.tsx
@@ -1,0 +1,164 @@
+/**
+ * Snippet Picker
+ *
+ * Modal-less inline picker rendered inside SnippetRefBlockForm. Lists
+ * every snippet in the catalog (bundled + CDN), supports a search box,
+ * and emits the chosen snippet ID upward via `onSelect`.
+ *
+ * v1 keeps this lean — no live preview pane yet. The author sees the
+ * picked snippet's resolved blocks inside SnippetRefCard once the
+ * block is inserted into the guide.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { css } from '@emotion/css';
+import { Field, Input, Spinner, useStyles2, Icon } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+
+import { getSnippetResolver } from '../../snippet-engine';
+import type { SnippetCatalogEntry } from '../../types/json-snippet.types';
+
+interface SnippetPickerProps {
+  /** Currently-selected snippet ID (highlighted in the list). */
+  value?: string;
+  /** Called when the author clicks a row. */
+  onSelect: (snippetId: string) => void;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+  }),
+  list: css({
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    maxHeight: '300px',
+    overflowY: 'auto',
+  }),
+  empty: css({
+    padding: theme.spacing(2),
+    color: theme.colors.text.secondary,
+    textAlign: 'center',
+  }),
+  loading: css({
+    padding: theme.spacing(2),
+    display: 'flex',
+    justifyContent: 'center',
+  }),
+  row: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.25),
+    padding: theme.spacing(1.5),
+    cursor: 'pointer',
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
+    '&:last-child': { borderBottom: 'none' },
+    '&:hover': { backgroundColor: theme.colors.action.hover },
+  }),
+  rowSelected: css({
+    backgroundColor: theme.colors.action.selected,
+  }),
+  rowHeader: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    fontWeight: theme.typography.fontWeightMedium,
+  }),
+  rowMeta: css({
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+});
+
+export function SnippetPicker({ value, onSelect }: SnippetPickerProps) {
+  const styles = useStyles2(getStyles);
+  const [entries, setEntries] = useState<SnippetCatalogEntry[] | null>(null);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const catalog = await getSnippetResolver().list();
+      if (cancelled) {
+        return;
+      }
+      setEntries(Object.values(catalog));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!entries) {
+      return [];
+    }
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      return entries;
+    }
+    return entries.filter((e) => {
+      const haystack = [e.id, e.title, e.description, e.category, ...(e.tags ?? [])]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [entries, query]);
+
+  return (
+    <div className={styles.container}>
+      <Field label="Search snippets">
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.currentTarget.value)}
+          placeholder="Title, description, tag, category…"
+          prefix={<Icon name="search" />}
+        />
+      </Field>
+      <div className={styles.list}>
+        {entries === null && (
+          <div className={styles.loading}>
+            <Spinner />
+          </div>
+        )}
+        {entries !== null && filtered.length === 0 && (
+          <div className={styles.empty}>No snippets match your search.</div>
+        )}
+        {entries !== null &&
+          filtered.map((entry) => {
+            const isSelected = entry.id === value;
+            return (
+              <div
+                key={entry.id}
+                className={`${styles.row} ${isSelected ? styles.rowSelected : ''}`}
+                onClick={() => onSelect(entry.id)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onSelect(entry.id);
+                  }
+                }}
+              >
+                <div className={styles.rowHeader}>
+                  <Icon name="share-alt" />
+                  <span>{entry.title}</span>
+                </div>
+                {entry.description && <div className={styles.rowMeta}>{entry.description}</div>}
+                <div className={styles.rowMeta}>
+                  <code>{entry.id}</code>
+                  {entry.category ? ` · ${entry.category}` : ''}
+                </div>
+              </div>
+            );
+          })}
+      </div>
+    </div>
+  );
+}
+
+SnippetPicker.displayName = 'SnippetPicker';

--- a/src/components/block-editor/constants.ts
+++ b/src/components/block-editor/constants.ts
@@ -123,6 +123,13 @@ export const BLOCK_TYPE_METADATA: Record<BlockType, BlockTypeMetadata> = {
     name: 'Grot guide',
     description: 'Choose-your-own-adventure decision tree',
   },
+  'snippet-ref': {
+    type: 'snippet-ref',
+    icon: '🧩',
+    grafanaIcon: 'share-alt',
+    name: 'Snippet',
+    description: 'Reuse a published snippet by reference (always loads the latest)',
+  },
 };
 
 /**
@@ -145,6 +152,7 @@ export const BLOCK_TYPE_ORDER: BlockType[] = [
   'quiz',
   'input',
   'grot-guide',
+  'snippet-ref',
 ];
 
 /**
@@ -157,7 +165,7 @@ export const BLOCK_TYPE_ORDER: BlockType[] = [
  * - **Structure** — containers and special-purpose framing blocks.
  */
 export const BLOCK_TYPE_GROUPS: ReadonlyArray<{
-  id: 'content' | 'interactive' | 'structure';
+  id: 'content' | 'interactive' | 'structure' | 'reusable';
   label: string;
   types: BlockType[];
 }> = [
@@ -175,6 +183,11 @@ export const BLOCK_TYPE_GROUPS: ReadonlyArray<{
     id: 'structure',
     label: 'Structure',
     types: ['section', 'conditional', 'grot-guide'],
+  },
+  {
+    id: 'reusable',
+    label: 'Reusable',
+    types: ['snippet-ref'],
   },
 ] as const;
 

--- a/src/components/block-editor/forms/SnippetRefBlockForm.tsx
+++ b/src/components/block-editor/forms/SnippetRefBlockForm.tsx
@@ -1,0 +1,82 @@
+/**
+ * Snippet Reference Block Form
+ *
+ * Author picks a snippet from the catalog. The resulting block is a thin
+ * reference: `{ type: 'snippet-ref', snippetId, authorNote? }`. The actual
+ * snippet content is resolved at render time, so the guide always picks
+ * up the latest published version.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { Button, Field, Input, useStyles2 } from '@grafana/ui';
+import { getBlockFormStyles } from '../block-editor.styles';
+import type { BlockFormProps, JsonBlock } from '../types';
+import type { JsonSnippetRefBlock } from '../../../types/json-guide.types';
+import { SnippetPicker } from '../SnippetPicker';
+
+function isSnippetRefBlock(block: JsonBlock): block is JsonSnippetRefBlock {
+  return block.type === 'snippet-ref';
+}
+
+export function SnippetRefBlockForm({ initialData, onSubmit, onCancel, isEditing = false }: BlockFormProps) {
+  const styles = useStyles2(getBlockFormStyles);
+  const initial = initialData && isSnippetRefBlock(initialData) ? initialData : null;
+
+  const [snippetId, setSnippetId] = useState(initial?.snippetId ?? '');
+  const [authorNote, setAuthorNote] = useState(initial?.authorNote ?? '');
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const trimmedId = snippetId.trim();
+      if (!trimmedId) {
+        return;
+      }
+      const block: JsonSnippetRefBlock = {
+        type: 'snippet-ref',
+        snippetId: trimmedId,
+        ...(authorNote.trim() && { authorNote: authorNote.trim() }),
+      };
+      onSubmit(block);
+    },
+    [snippetId, authorNote, onSubmit]
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.form}>
+      <Field
+        label="Snippet"
+        description="Pick a published snippet to reference. The guide always renders the latest version."
+        required
+      >
+        <SnippetPicker value={snippetId} onSelect={setSnippetId} />
+      </Field>
+
+      <Field
+        label="Snippet ID"
+        description="Set automatically when you pick a snippet above. Edit only if you know what you're doing."
+      >
+        <Input
+          value={snippetId}
+          onChange={(e) => setSnippetId(e.currentTarget.value)}
+          placeholder="e.g. create-prometheus-ds"
+        />
+      </Field>
+
+      <Field label="Author note (optional)" description="Editor-only — not shown to readers.">
+        <Input value={authorNote} onChange={(e) => setAuthorNote(e.currentTarget.value)} placeholder="" />
+      </Field>
+
+      <div className={styles.footer}>
+        <Button variant="secondary" onClick={onCancel} type="button">
+          Cancel
+        </Button>
+        <Button variant="primary" type="submit" disabled={!snippetId.trim()}>
+          {isEditing ? 'Update reference' : 'Add reference'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+SnippetRefBlockForm.displayName = 'SnippetRefBlockForm';

--- a/src/components/block-editor/forms/SnippetRefBlockForm.tsx
+++ b/src/components/block-editor/forms/SnippetRefBlockForm.tsx
@@ -1,10 +1,6 @@
 /**
- * Snippet Reference Block Form
- *
- * Author picks a snippet from the catalog. The resulting block is a thin
- * reference: `{ type: 'snippet-ref', snippetId, authorNote? }`. The actual
- * snippet content is resolved at render time, so the guide always picks
- * up the latest published version.
+ * Snippet reference block form. The author picks a snippet; the block stores
+ * only a reference, resolved to content at render time.
  */
 
 import React, { useCallback, useState } from 'react';

--- a/src/components/block-editor/forms/index.ts
+++ b/src/components/block-editor/forms/index.ts
@@ -16,6 +16,7 @@ export { GuidedBlockForm } from './GuidedBlockForm';
 export { QuizBlockForm } from './QuizBlockForm';
 export { InputBlockForm } from './InputBlockForm';
 export { CodeBlockForm } from './CodeBlockForm';
+export { SnippetRefBlockForm } from './SnippetRefBlockForm';
 export { TypeSwitchDropdown } from './TypeSwitchDropdown';
 export { BranchBlocksEditor } from './BranchBlocksEditor';
 

--- a/src/components/block-editor/types.ts
+++ b/src/components/block-editor/types.ts
@@ -31,7 +31,8 @@ export type BlockType =
   | 'terminal-connect'
   | 'challenge'
   | 'code-block'
-  | 'grot-guide';
+  | 'grot-guide'
+  | 'snippet-ref';
 
 /**
  * Block metadata for the palette

--- a/src/components/block-editor/utils/block-preview.ts
+++ b/src/components/block-editor/utils/block-preview.ts
@@ -19,6 +19,7 @@ import {
   isInputBlock,
   isTerminalBlock,
   isCodeBlockBlock,
+  isSnippetRefBlock,
   type JsonBlock,
 } from '../../../types/json-guide.types';
 
@@ -115,6 +116,10 @@ export function getBlockPreview(block: JsonBlock, options: BlockPreviewOptions =
   if (isCodeBlockBlock(block)) {
     const firstLine = block.code.split('\n')[0] ?? '';
     return truncate(firstLine, maxLength);
+  }
+
+  if (isSnippetRefBlock(block)) {
+    return `→ ${block.snippetId}`;
   }
 
   // Fallback for unknown block types with content

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useLayoutEffect, useMemo, useState, useCallback } from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { TabsBar, Tab, TabContent, Badge, Tooltip } from '@grafana/ui';
+import { TabsBar, Tab, TabContent, Badge, Tooltip, LoadingPlaceholder } from '@grafana/ui';
 
 import { RawContent, ContentParseResult } from '../../types/content.types';
 import {
@@ -553,45 +553,53 @@ function ContentProcessor({ html, contentType, baseUrl, onReady, responses }: Co
     [html]
   );
 
-  // Parse synchronously for first paint; the effect below re-parses with
-  // snippet refs inlined.
-  const initialParseResult: ContentParseResult = useMemo(() => {
+  // Synchronous parse for first paint. Always derived from the inputs, so a
+  // prop change is reflected immediately with no intermediate stale render.
+  const baseParseResult: ContentParseResult = useMemo(() => {
     if (isJsonGuideContent(html)) {
       return parseJsonGuide(html, baseUrl);
     }
     return parseHTMLToComponents(html, baseUrl);
   }, [html, baseUrl]);
-  const [parseResult, setParseResult] = useState<ContentParseResult>(initialParseResult);
 
-  useEffect(() => {
-    setParseResult(initialParseResult);
-  }, [initialParseResult]);
-
-  useEffect(() => {
+  // A guide may reference snippets that resolve asynchronously from the CDN.
+  const guideWithSnippetRefs = useMemo<JsonGuide | null>(() => {
     if (!isJsonGuideContent(html)) {
+      return null;
+    }
+    try {
+      const guide = JSON.parse(html) as JsonGuide;
+      return guideHasSnippetRefs(guide) ? guide : null;
+    } catch {
+      return null;
+    }
+  }, [html]);
+
+  // The resolved overlay is keyed to the inputs it was computed from, so an
+  // overlay from a previous guide never paints after html/baseUrl change.
+  const overlayKey = `${html} ${baseUrl}`;
+  const [snippetOverlay, setSnippetOverlay] = useState<{ key: string; result: ContentParseResult } | null>(null);
+
+  useEffect(() => {
+    if (!guideWithSnippetRefs) {
       return;
     }
     let cancelled = false;
     (async () => {
-      let parsedGuide: JsonGuide | undefined;
-      try {
-        parsedGuide = JSON.parse(html) as JsonGuide;
-      } catch {
-        return;
-      }
-      if (!guideHasSnippetRefs(parsedGuide)) {
-        return;
-      }
-      const resolved = await inlineSnippetRefsInGuide(parsedGuide);
+      const resolved = await inlineSnippetRefsInGuide(guideWithSnippetRefs);
       if (cancelled) {
         return;
       }
-      setParseResult(parseJsonGuide(resolved, baseUrl));
+      setSnippetOverlay({ key: overlayKey, result: parseJsonGuide(resolved, baseUrl) });
     })();
     return () => {
       cancelled = true;
     };
-  }, [html, baseUrl]);
+  }, [guideWithSnippetRefs, baseUrl, overlayKey]);
+
+  const overlayMatchesCurrent = snippetOverlay?.key === overlayKey;
+  const parseResult = overlayMatchesCurrent && snippetOverlay ? snippetOverlay.result : baseParseResult;
+  const isResolvingSnippets = guideWithSnippetRefs !== null && !overlayMatchesCurrent;
 
   // Start DOM monitoring if interactive elements are present
   useEffect(() => {
@@ -703,6 +711,16 @@ function ContentProcessor({ html, contentType, baseUrl, onReady, responses }: Co
           warnings={parseResult.warnings}
           fallbackHtml={html}
         />
+      </div>
+    );
+  }
+
+  // A guide composed entirely of snippet refs has no renderable elements until
+  // those refs resolve; show a loading state rather than the empty-content splash.
+  if (parsedContent.elements.length === 0 && isResolvingSnippets) {
+    return (
+      <div ref={ref}>
+        <LoadingPlaceholder text="Loading snippets" />
       </div>
     );
   }

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -553,11 +553,8 @@ function ContentProcessor({ html, contentType, baseUrl, onReady, responses }: Co
     [html]
   );
 
-  // Initial parse is synchronous so HTML and snippet-free JSON guides render
-  // on first paint without a loading flicker. Guides that contain
-  // `snippet-ref` blocks will surface as warnings on the first pass; the
-  // effect below then resolves the refs and replaces parseResult with a
-  // fully-inlined parse.
+  // Parse synchronously for first paint; the effect below re-parses with
+  // snippet refs inlined.
   const initialParseResult: ContentParseResult = useMemo(() => {
     if (isJsonGuideContent(html)) {
       return parseJsonGuide(html, baseUrl);
@@ -567,8 +564,6 @@ function ContentProcessor({ html, contentType, baseUrl, onReady, responses }: Co
   const [parseResult, setParseResult] = useState<ContentParseResult>(initialParseResult);
 
   useEffect(() => {
-    // Keep parseResult in sync when html/baseUrl change before async
-    // resolution kicks in.
     setParseResult(initialParseResult);
   }, [initialParseResult]);
 

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -19,7 +19,7 @@ import {
   GuideResponseProvider,
   useGuideResponses,
 } from '../../docs-retrieval';
-import { inlineSnippetRefsInGuide } from '../../snippet-engine';
+import { guideHasSnippetRefs, inlineSnippetRefsInGuide } from '../../snippet-engine';
 import type { JsonGuide } from '../../types/json-guide.types';
 import {
   InteractiveSection,
@@ -53,33 +53,6 @@ import {
 import { substituteVariables } from '../../utils/variable-substitution';
 import { STANDALONE_SECTION_ID } from '../../global-state/completion-store';
 import { subscribeProgressEvent } from '../../global-state/progress-events';
-
-/**
- * Walk a JsonGuide's block tree and return true as soon as a `snippet-ref`
- * block is encountered. Used to skip the async snippet-resolution pass on
- * guides that don't reference any snippets — the common case.
- */
-function guideHasSnippetRefs(guide: JsonGuide): boolean {
-  return blocksContainSnippetRef(guide.blocks);
-}
-
-function blocksContainSnippetRef(blocks: JsonGuide['blocks']): boolean {
-  for (const block of blocks) {
-    if (block.type === 'snippet-ref') {
-      return true;
-    }
-    if (block.type === 'section' || block.type === 'assistant') {
-      if (blocksContainSnippetRef(block.blocks)) {
-        return true;
-      }
-    } else if (block.type === 'conditional') {
-      if (blocksContainSnippetRef(block.whenTrue) || blocksContainSnippetRef(block.whenFalse)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
 
 /**
  * Scroll to and highlight an element with the given fragment ID
@@ -611,9 +584,6 @@ function ContentProcessor({ html, contentType, baseUrl, onReady, responses }: Co
       } catch {
         return;
       }
-      // Skip the async hop when the guide has no snippet refs anywhere.
-      // Counting refs synchronously avoids paying a microtask + state
-      // update on the common case.
       if (!guideHasSnippetRefs(parsedGuide)) {
         return;
       }

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useLayoutEffect, useMemo, useCallback } from 'react';
+import React, { useRef, useEffect, useLayoutEffect, useMemo, useState, useCallback } from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { TabsBar, Tab, TabContent, Badge, Tooltip } from '@grafana/ui';
@@ -19,6 +19,8 @@ import {
   GuideResponseProvider,
   useGuideResponses,
 } from '../../docs-retrieval';
+import { inlineSnippetRefsInGuide } from '../../snippet-engine';
+import type { JsonGuide } from '../../types/json-guide.types';
 import {
   InteractiveSection,
   InteractiveStep,
@@ -51,6 +53,33 @@ import {
 import { substituteVariables } from '../../utils/variable-substitution';
 import { STANDALONE_SECTION_ID } from '../../global-state/completion-store';
 import { subscribeProgressEvent } from '../../global-state/progress-events';
+
+/**
+ * Walk a JsonGuide's block tree and return true as soon as a `snippet-ref`
+ * block is encountered. Used to skip the async snippet-resolution pass on
+ * guides that don't reference any snippets — the common case.
+ */
+function guideHasSnippetRefs(guide: JsonGuide): boolean {
+  return blocksContainSnippetRef(guide.blocks);
+}
+
+function blocksContainSnippetRef(blocks: JsonGuide['blocks']): boolean {
+  for (const block of blocks) {
+    if (block.type === 'snippet-ref') {
+      return true;
+    }
+    if (block.type === 'section' || block.type === 'assistant') {
+      if (blocksContainSnippetRef(block.blocks)) {
+        return true;
+      }
+    } else if (block.type === 'conditional') {
+      if (blocksContainSnippetRef(block.whenTrue) || blocksContainSnippetRef(block.whenFalse)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 /**
  * Scroll to and highlight an element with the given fragment ID
@@ -551,13 +580,52 @@ function ContentProcessor({ html, contentType, baseUrl, onReady, responses }: Co
     [html]
   );
 
-  // Parse content with fail-fast error handling (memoized to avoid re-parsing on every render)
-  // Detect JSON vs HTML content and use appropriate parser
-  const parseResult: ContentParseResult = useMemo(() => {
+  // Initial parse is synchronous so HTML and snippet-free JSON guides render
+  // on first paint without a loading flicker. Guides that contain
+  // `snippet-ref` blocks will surface as warnings on the first pass; the
+  // effect below then resolves the refs and replaces parseResult with a
+  // fully-inlined parse.
+  const initialParseResult: ContentParseResult = useMemo(() => {
     if (isJsonGuideContent(html)) {
       return parseJsonGuide(html, baseUrl);
     }
     return parseHTMLToComponents(html, baseUrl);
+  }, [html, baseUrl]);
+  const [parseResult, setParseResult] = useState<ContentParseResult>(initialParseResult);
+
+  useEffect(() => {
+    // Keep parseResult in sync when html/baseUrl change before async
+    // resolution kicks in.
+    setParseResult(initialParseResult);
+  }, [initialParseResult]);
+
+  useEffect(() => {
+    if (!isJsonGuideContent(html)) {
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      let parsedGuide: JsonGuide | undefined;
+      try {
+        parsedGuide = JSON.parse(html) as JsonGuide;
+      } catch {
+        return;
+      }
+      // Skip the async hop when the guide has no snippet refs anywhere.
+      // Counting refs synchronously avoids paying a microtask + state
+      // update on the common case.
+      if (!guideHasSnippetRefs(parsedGuide)) {
+        return;
+      }
+      const resolved = await inlineSnippetRefsInGuide(parsedGuide);
+      if (cancelled) {
+        return;
+      }
+      setParseResult(parseJsonGuide(resolved, baseUrl));
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [html, baseUrl]);
 
   // Start DOM monitoring if interactive elements are present

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -309,6 +309,16 @@ function convertBlockByType(
     case 'assistant':
       // Legacy wrapper format - pass surrounding context for better AI understanding
       return convertAssistantBlock(block, path, baseUrl, surroundingContext);
+    case 'snippet-ref':
+      // Snippet refs are resolved upstream by inlineSnippetRefsInGuide before
+      // the parser runs. Reaching the parser means the resolver failed for a
+      // ref that wasn't pre-resolved — surface a warning so authors can see
+      // it in the editor's parse output. The renderer never sees this block
+      // because element is null.
+      return {
+        element: null,
+        warning: `Unresolved snippet reference at ${path}: ${block.snippetId}`,
+      };
     default:
       return {
         element: null,

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -310,11 +310,8 @@ function convertBlockByType(
       // Legacy wrapper format - pass surrounding context for better AI understanding
       return convertAssistantBlock(block, path, baseUrl, surroundingContext);
     case 'snippet-ref':
-      // Snippet refs are resolved upstream by inlineSnippetRefsInGuide before
-      // the parser runs. Reaching the parser means the resolver failed for a
-      // ref that wasn't pre-resolved — surface a warning so authors can see
-      // it in the editor's parse output. The renderer never sees this block
-      // because element is null.
+      // Refs are inlined upstream before parsing; reaching here means
+      // resolution failed. Warn — element stays null so the renderer skips it.
       return {
         element: null,
         warning: `Unresolved snippet reference at ${path}: ${block.snippetId}`,

--- a/src/snippet-engine/caching-snippet-resolver.test.ts
+++ b/src/snippet-engine/caching-snippet-resolver.test.ts
@@ -1,0 +1,91 @@
+import { CachingSnippetResolver } from './caching-snippet-resolver';
+import type { JsonSnippet, SnippetCatalog } from '../types/json-snippet.types';
+import type { SnippetCatalogProvider, SnippetResolution, SnippetResolver } from './types';
+
+function snippet(id: string): JsonSnippet {
+  return { id, title: id, description: `desc for ${id}`, blocks: [{ type: 'markdown', content: 'x' }] };
+}
+
+class StubResolver implements SnippetResolver, SnippetCatalogProvider {
+  public resolveCalls = 0;
+  public listCalls = 0;
+  constructor(
+    private readonly resolveImpl: (id: string) => Promise<SnippetResolution> | SnippetResolution,
+    private readonly catalog: SnippetCatalog = {}
+  ) {}
+  async resolve(id: string) {
+    this.resolveCalls += 1;
+    return this.resolveImpl(id);
+  }
+  async list() {
+    this.listCalls += 1;
+    return this.catalog;
+  }
+}
+
+describe('CachingSnippetResolver', () => {
+  it('passes resolutions through from the inner resolver', async () => {
+    const inner = new StubResolver((id) => ({ ok: true, id, source: 'online-cdn', snippet: snippet(id) }));
+    const cache = new CachingSnippetResolver(inner);
+
+    const result = await cache.resolve('foo');
+
+    expect(result.ok).toBe(true);
+    expect(inner.resolveCalls).toBe(1);
+  });
+
+  it('caches successful resolutions within the TTL', async () => {
+    const inner = new StubResolver((id) => ({ ok: true, id, source: 'online-cdn', snippet: snippet(id) }));
+    let now = 0;
+    const cache = new CachingSnippetResolver(inner, { ttlMs: 1000, now: () => now });
+
+    await cache.resolve('foo');
+    await cache.resolve('foo');
+    expect(inner.resolveCalls).toBe(1);
+
+    now = 1500;
+    await cache.resolve('foo');
+    expect(inner.resolveCalls).toBe(2);
+  });
+
+  it('does not cache failures', async () => {
+    const inner = new StubResolver((id) => ({ ok: false, id, error: { code: 'network-error', message: 'down' } }));
+    const cache = new CachingSnippetResolver(inner, { ttlMs: 1000, now: () => 0 });
+
+    await cache.resolve('foo');
+    await cache.resolve('foo');
+
+    expect(inner.resolveCalls).toBe(2);
+  });
+
+  it('dedupes concurrent in-flight requests for the same id', async () => {
+    let resolveSlowFetch: ((value: SnippetResolution) => void) | undefined;
+    const inner = new StubResolver(
+      () =>
+        new Promise<SnippetResolution>((resolve) => {
+          resolveSlowFetch = resolve;
+        })
+    );
+    const cache = new CachingSnippetResolver(inner);
+
+    const a = cache.resolve('foo');
+    const b = cache.resolve('foo');
+    expect(inner.resolveCalls).toBe(1);
+
+    resolveSlowFetch!({ ok: true, id: 'foo', source: 'online-cdn', snippet: snippet('foo') });
+    const [resA, resB] = await Promise.all([a, b]);
+    expect(resA).toBe(resB);
+  });
+
+  it('delegates list() to the inner resolver', async () => {
+    const inner = new StubResolver(() => ({ ok: false, id: 'x', error: { code: 'not-found', message: '' } }), {
+      foo: { id: 'foo', title: 'Foo', description: 'foo desc' },
+    });
+    const cache = new CachingSnippetResolver(inner);
+
+    const catalog = await cache.list();
+
+    expect(catalog.foo?.title).toBe('Foo');
+    expect(inner.listCalls).toBe(1);
+  });
+});

--- a/src/snippet-engine/caching-snippet-resolver.test.ts
+++ b/src/snippet-engine/caching-snippet-resolver.test.ts
@@ -8,18 +8,13 @@ function snippet(id: string): JsonSnippet {
 
 class StubResolver implements SnippetResolver, SnippetCatalogProvider {
   public resolveCalls = 0;
-  public listCalls = 0;
-  constructor(
-    private readonly resolveImpl: (id: string) => Promise<SnippetResolution> | SnippetResolution,
-    private readonly catalog: SnippetCatalog = {}
-  ) {}
+  constructor(private readonly resolveImpl: (id: string) => Promise<SnippetResolution> | SnippetResolution) {}
   async resolve(id: string) {
     this.resolveCalls += 1;
     return this.resolveImpl(id);
   }
-  async list() {
-    this.listCalls += 1;
-    return this.catalog;
+  async list(): Promise<SnippetCatalog> {
+    return {};
   }
 }
 
@@ -75,17 +70,5 @@ describe('CachingSnippetResolver', () => {
     resolveSlowFetch!({ ok: true, id: 'foo', source: 'online-cdn', snippet: snippet('foo') });
     const [resA, resB] = await Promise.all([a, b]);
     expect(resA).toBe(resB);
-  });
-
-  it('delegates list() to the inner resolver', async () => {
-    const inner = new StubResolver(() => ({ ok: false, id: 'x', error: { code: 'not-found', message: '' } }), {
-      foo: { id: 'foo', title: 'Foo', description: 'foo desc' },
-    });
-    const cache = new CachingSnippetResolver(inner);
-
-    const catalog = await cache.list();
-
-    expect(catalog.foo?.title).toBe('Foo');
-    expect(inner.listCalls).toBe(1);
   });
 });

--- a/src/snippet-engine/caching-snippet-resolver.ts
+++ b/src/snippet-engine/caching-snippet-resolver.ts
@@ -49,15 +49,19 @@ export class CachingSnippetResolver implements SnippetResolver, SnippetCatalogPr
       return existing;
     }
 
-    const promise = this.inner.resolve(snippetId).then((resolution) => {
-      // Only cache successes — a transient network failure shouldn't
-      // pin a guide to an error placeholder for the rest of the session.
-      if (resolution.ok) {
-        this.cache.set(snippetId, { resolution, expiresAt: this.now() + this.ttlMs });
-      }
-      this.inFlight.delete(snippetId);
-      return resolution;
-    });
+    const promise = this.inner
+      .resolve(snippetId)
+      .then((resolution) => {
+        // Only cache successes — a transient network failure shouldn't
+        // pin a guide to an error placeholder for the rest of the session.
+        if (resolution.ok) {
+          this.cache.set(snippetId, { resolution, expiresAt: this.now() + this.ttlMs });
+        }
+        return resolution;
+      })
+      .finally(() => {
+        this.inFlight.delete(snippetId);
+      });
 
     this.inFlight.set(snippetId, promise);
     return promise;

--- a/src/snippet-engine/caching-snippet-resolver.ts
+++ b/src/snippet-engine/caching-snippet-resolver.ts
@@ -1,14 +1,8 @@
 /**
- * Caching Snippet Resolver
- *
- * Wraps an underlying resolver with a short-lived in-memory cache
- * (TTL ~5 min) and in-flight request dedupe. Used by the parser splice
- * and the editor picker — both can race for the same snippet on first
- * open, and we don't want to hammer the CDN.
- *
- * The CDN is the single source of truth; there is no bundled fallback.
- * A network failure simply returns the failure resolution, which the
- * caller renders as an inert placeholder block.
+ * Wraps a resolver with a short-lived cache (~5 min TTL) and in-flight
+ * dedupe — the parser splice and editor picker can race for the same snippet
+ * on first open. Failures aren't cached; they surface as the caller's
+ * inert placeholder.
  */
 
 import type { SnippetCatalog } from '../types/json-snippet.types';
@@ -42,8 +36,6 @@ export class CachingSnippetResolver implements SnippetResolver, SnippetCatalogPr
       return cached.resolution;
     }
 
-    // Dedupe concurrent resolutions of the same id — picker + card +
-    // parser splice may all race for the same snippet on first open.
     const existing = this.inFlight.get(snippetId);
     if (existing) {
       return existing;
@@ -52,8 +44,8 @@ export class CachingSnippetResolver implements SnippetResolver, SnippetCatalogPr
     const promise = this.inner
       .resolve(snippetId)
       .then((resolution) => {
-        // Only cache successes — a transient network failure shouldn't
-        // pin a guide to an error placeholder for the rest of the session.
+        // Only cache successes — a transient failure shouldn't pin a guide
+        // to an error for the session.
         if (resolution.ok) {
           this.cache.set(snippetId, { resolution, expiresAt: this.now() + this.ttlMs });
         }
@@ -80,11 +72,7 @@ export class CachingSnippetResolver implements SnippetResolver, SnippetCatalogPr
 
 let sharedResolver: CachingSnippetResolver | undefined;
 
-/**
- * Singleton accessor for the standard resolver used by the parser and
- * the editor. Tests should construct their own instance via the
- * constructor and inject a mocked inner resolver.
- */
+/** Shared resolver used by the parser and editor. */
 export function getSnippetResolver(): CachingSnippetResolver {
   if (!sharedResolver) {
     sharedResolver = new CachingSnippetResolver(createOnlineSnippetResolver());

--- a/src/snippet-engine/caching-snippet-resolver.ts
+++ b/src/snippet-engine/caching-snippet-resolver.ts
@@ -1,0 +1,94 @@
+/**
+ * Caching Snippet Resolver
+ *
+ * Wraps an underlying resolver with a short-lived in-memory cache
+ * (TTL ~5 min) and in-flight request dedupe. Used by the parser splice
+ * and the editor picker — both can race for the same snippet on first
+ * open, and we don't want to hammer the CDN.
+ *
+ * The CDN is the single source of truth; there is no bundled fallback.
+ * A network failure simply returns the failure resolution, which the
+ * caller renders as an inert placeholder block.
+ */
+
+import type { SnippetCatalog } from '../types/json-snippet.types';
+
+import { createOnlineSnippetResolver } from './online-snippet-resolver';
+import type { SnippetCatalogProvider, SnippetResolution, SnippetResolver } from './types';
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  resolution: SnippetResolution;
+  expiresAt: number;
+}
+
+export class CachingSnippetResolver implements SnippetResolver, SnippetCatalogProvider {
+  private readonly inner: SnippetResolver & SnippetCatalogProvider;
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly inFlight = new Map<string, Promise<SnippetResolution>>();
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(inner: SnippetResolver & SnippetCatalogProvider, options: { ttlMs?: number; now?: () => number } = {}) {
+    this.inner = inner;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  async resolve(snippetId: string): Promise<SnippetResolution> {
+    const cached = this.cache.get(snippetId);
+    if (cached && cached.expiresAt > this.now()) {
+      return cached.resolution;
+    }
+
+    // Dedupe concurrent resolutions of the same id — picker + card +
+    // parser splice may all race for the same snippet on first open.
+    const existing = this.inFlight.get(snippetId);
+    if (existing) {
+      return existing;
+    }
+
+    const promise = this.inner.resolve(snippetId).then((resolution) => {
+      // Only cache successes — a transient network failure shouldn't
+      // pin a guide to an error placeholder for the rest of the session.
+      if (resolution.ok) {
+        this.cache.set(snippetId, { resolution, expiresAt: this.now() + this.ttlMs });
+      }
+      this.inFlight.delete(snippetId);
+      return resolution;
+    });
+
+    this.inFlight.set(snippetId, promise);
+    return promise;
+  }
+
+  async list(): Promise<SnippetCatalog> {
+    return this.inner.list();
+  }
+
+  /** Test-only: clear cache and in-flight tracking. */
+  clearForTests(): void {
+    this.cache.clear();
+    this.inFlight.clear();
+  }
+}
+
+let sharedResolver: CachingSnippetResolver | undefined;
+
+/**
+ * Singleton accessor for the standard resolver used by the parser and
+ * the editor. Tests should construct their own instance via the
+ * constructor and inject a mocked inner resolver.
+ */
+export function getSnippetResolver(): CachingSnippetResolver {
+  if (!sharedResolver) {
+    sharedResolver = new CachingSnippetResolver(createOnlineSnippetResolver());
+  }
+  return sharedResolver;
+}
+
+/** Test-only: reset the singleton between tests. */
+export function __resetSnippetResolverForTests(): void {
+  sharedResolver = undefined;
+}

--- a/src/snippet-engine/index.ts
+++ b/src/snippet-engine/index.ts
@@ -1,15 +1,6 @@
 /**
- * Snippet Engine — Tier 2
- *
- * Resolves `snippet-ref` blocks to their concrete content by fetching
- * from the CDN (`<host>/shared/snippets/...`). The CDN is the single
- * source of truth; there is no bundled fallback. A short-lived
- * in-memory cache + in-flight dedupe keep repeated lookups cheap.
- *
- * Consumers:
- *  - `docs-retrieval/content-renderer.tsx` — splices resolved snippets
- *    into guides before the parser runs.
- *  - `components/block-editor` — populates the Snippet Picker.
+ * Snippet engine: resolves `snippet-ref` blocks to CDN content, with a
+ * short-lived cache and in-flight dedupe.
  */
 
 export { CachingSnippetResolver, getSnippetResolver, __resetSnippetResolverForTests } from './caching-snippet-resolver';

--- a/src/snippet-engine/index.ts
+++ b/src/snippet-engine/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Snippet Engine — Tier 2
+ *
+ * Resolves `snippet-ref` blocks to their concrete content by fetching
+ * from the CDN (`<host>/shared/snippets/...`). The CDN is the single
+ * source of truth; there is no bundled fallback. A short-lived
+ * in-memory cache + in-flight dedupe keep repeated lookups cheap.
+ *
+ * Consumers:
+ *  - `docs-retrieval/content-renderer.tsx` — splices resolved snippets
+ *    into guides before the parser runs.
+ *  - `components/block-editor` — populates the Snippet Picker.
+ */
+
+export { CachingSnippetResolver, getSnippetResolver, __resetSnippetResolverForTests } from './caching-snippet-resolver';
+export {
+  OnlineCdnSnippetResolver,
+  createOnlineSnippetResolver,
+  deriveSnippetsBaseUrl,
+} from './online-snippet-resolver';
+export { inlineSnippetRefsInBlocks, inlineSnippetRefsInGuide } from './inline-refs';
+export type {
+  SnippetCatalogProvider,
+  SnippetResolution,
+  SnippetResolutionErrorCode,
+  SnippetResolutionFailure,
+  SnippetResolutionSuccess,
+  SnippetResolver,
+} from './types';

--- a/src/snippet-engine/index.ts
+++ b/src/snippet-engine/index.ts
@@ -18,7 +18,7 @@ export {
   createOnlineSnippetResolver,
   deriveSnippetsBaseUrl,
 } from './online-snippet-resolver';
-export { inlineSnippetRefsInBlocks, inlineSnippetRefsInGuide } from './inline-refs';
+export { guideHasSnippetRefs, inlineSnippetRefsInBlocks, inlineSnippetRefsInGuide } from './inline-refs';
 export type {
   SnippetCatalogProvider,
   SnippetResolution,

--- a/src/snippet-engine/inline-refs.test.ts
+++ b/src/snippet-engine/inline-refs.test.ts
@@ -6,7 +6,7 @@ function ok(id: string, blocks: JsonBlock[]): SnippetResolution {
   return {
     ok: true,
     id,
-    source: 'bundled',
+    source: 'online-cdn',
     snippet: {
       id,
       title: id,

--- a/src/snippet-engine/inline-refs.test.ts
+++ b/src/snippet-engine/inline-refs.test.ts
@@ -1,0 +1,120 @@
+import { inlineSnippetRefsInGuide } from './inline-refs';
+import type { SnippetResolution, SnippetResolver } from './types';
+import type { JsonBlock, JsonGuide } from '../types/json-guide.types';
+
+function ok(id: string, blocks: JsonBlock[]): SnippetResolution {
+  return {
+    ok: true,
+    id,
+    source: 'bundled',
+    snippet: {
+      id,
+      title: id,
+      description: `desc for ${id}`,
+      blocks,
+    },
+  };
+}
+
+function notFound(id: string): SnippetResolution {
+  return { ok: false, id, error: { code: 'not-found', message: `unknown snippet ${id}` } };
+}
+
+class StubResolver implements SnippetResolver {
+  constructor(private readonly map: Record<string, SnippetResolution>) {}
+  async resolve(id: string): Promise<SnippetResolution> {
+    return this.map[id] ?? notFound(id);
+  }
+}
+
+describe('inlineSnippetRefsInGuide', () => {
+  it('returns the guide unchanged when there are no refs', async () => {
+    const guide: JsonGuide = {
+      id: 'g',
+      title: 'g',
+      blocks: [{ type: 'markdown', content: 'hi' }],
+    };
+    const out = await inlineSnippetRefsInGuide(guide, new StubResolver({}));
+    expect(out).toEqual(guide);
+  });
+
+  it('replaces a top-level snippet-ref with the snippet blocks at the same position', async () => {
+    const guide: JsonGuide = {
+      id: 'g',
+      title: 'g',
+      blocks: [
+        { type: 'markdown', content: 'before' },
+        { type: 'snippet-ref', snippetId: 's' },
+        { type: 'markdown', content: 'after' },
+      ],
+    };
+    const resolver = new StubResolver({
+      s: ok('s', [
+        { type: 'markdown', content: 'one' },
+        { type: 'markdown', content: 'two' },
+      ]),
+    });
+    const out = await inlineSnippetRefsInGuide(guide, resolver);
+    expect(out.blocks).toEqual([
+      { type: 'markdown', content: 'before' },
+      { type: 'markdown', content: 'one' },
+      { type: 'markdown', content: 'two' },
+      { type: 'markdown', content: 'after' },
+    ]);
+  });
+
+  it('replaces a snippet-ref nested inside a section', async () => {
+    const guide: JsonGuide = {
+      id: 'g',
+      title: 'g',
+      blocks: [
+        {
+          type: 'section',
+          title: 'Setup',
+          blocks: [{ type: 'snippet-ref', snippetId: 's' }],
+        },
+      ],
+    };
+    const resolver = new StubResolver({ s: ok('s', [{ type: 'markdown', content: 'inner' }]) });
+    const out = await inlineSnippetRefsInGuide(guide, resolver);
+    expect(out.blocks[0]).toMatchObject({
+      type: 'section',
+      blocks: [{ type: 'markdown', content: 'inner' }],
+    });
+  });
+
+  it('replaces a snippet-ref nested in a conditional branch', async () => {
+    const guide: JsonGuide = {
+      id: 'g',
+      title: 'g',
+      blocks: [
+        {
+          type: 'conditional',
+          conditions: ['has-datasource:prometheus'],
+          whenTrue: [{ type: 'snippet-ref', snippetId: 's' }],
+          whenFalse: [],
+        },
+      ],
+    };
+    const resolver = new StubResolver({ s: ok('s', [{ type: 'markdown', content: 't' }]) });
+    const out = await inlineSnippetRefsInGuide(guide, resolver);
+    expect(out.blocks[0]).toMatchObject({
+      type: 'conditional',
+      whenTrue: [{ type: 'markdown', content: 't' }],
+      whenFalse: [],
+    });
+  });
+
+  it('renders an inert placeholder block when a snippet fails to resolve', async () => {
+    const guide: JsonGuide = {
+      id: 'g',
+      title: 'g',
+      blocks: [{ type: 'snippet-ref', snippetId: 'missing' }],
+    };
+    const out = await inlineSnippetRefsInGuide(guide, new StubResolver({}));
+    expect(out.blocks).toHaveLength(1);
+    const placeholder = out.blocks[0]!;
+    expect(placeholder.type).toBe('markdown');
+    expect((placeholder as { content: string }).content).toMatch(/missing/);
+  });
+});

--- a/src/snippet-engine/inline-refs.ts
+++ b/src/snippet-engine/inline-refs.ts
@@ -1,18 +1,8 @@
 /**
- * Inline Snippet References
- *
- * Walks a JsonGuide, finds every `snippet-ref` block at any depth
- * (top-level, inside sections, conditionals, assistants, multistep
- * containers), resolves each via the snippet resolver, and returns a
- * new guide with refs replaced by the snippet's `blocks` array spliced
- * in at the same position.
- *
- * Refs that fail to resolve are replaced by an inert markdown placeholder
- * block so the rest of the guide still renders. This is the
- * defense-in-depth boundary — by the time the parser sees the guide,
- * no `snippet-ref` blocks should remain.
- *
- * Pure function (apart from the injected resolver). Input is not mutated.
+ * Replaces every `snippet-ref` in a guide (at any depth) with the resolved
+ * snippet's blocks; failed refs become an inert markdown placeholder. This is
+ * the defense-in-depth boundary — no `snippet-ref` should reach the parser.
+ * Pure apart from the injected resolver; input is not mutated.
  */
 
 import type { JsonBlock, JsonGuide, JsonSnippetRefBlock } from '../types/json-guide.types';
@@ -31,11 +21,6 @@ function placeholderForFailure(failure: Extract<SnippetResolution, { ok: false }
   };
 }
 
-/**
- * Walk an array of blocks, replacing every snippet-ref with its
- * resolved body. Resolution is performed in parallel across the whole
- * tree to minimize total latency.
- */
 export async function inlineSnippetRefsInBlocks(
   blocks: JsonBlock[],
   resolver: SnippetResolver = getSnippetResolver()
@@ -58,7 +43,6 @@ export async function inlineSnippetRefsInBlocks(
   return spliceBlocks(blocks, resolutions);
 }
 
-/** Convenience wrapper: inline refs in a full guide. */
 export async function inlineSnippetRefsInGuide(
   guide: JsonGuide,
   resolver: SnippetResolver = getSnippetResolver()
@@ -67,11 +51,7 @@ export async function inlineSnippetRefsInGuide(
   return { ...guide, blocks };
 }
 
-/**
- * True as soon as a `snippet-ref` block appears anywhere in the guide's
- * block tree. Lets callers skip the async resolution pass on guides that
- * reference no snippets — the common case.
- */
+/** True if any block in the guide tree is a `snippet-ref`. */
 export function guideHasSnippetRefs(guide: JsonGuide): boolean {
   return blocksHaveSnippetRef(guide.blocks);
 }
@@ -100,9 +80,7 @@ function collectRefIds(blocks: JsonBlock[], out: Set<string>): void {
       out.add(block.snippetId);
       continue;
     }
-    // Recurse into container blocks. Snippets themselves cannot contain
-    // refs (schema-enforced), but guides can nest refs inside sections,
-    // conditionals, and assistants.
+    // Guides can nest refs inside sections, conditionals, and assistants.
     if (block.type === 'section' || block.type === 'assistant') {
       collectRefIds(block.blocks, out);
     } else if (block.type === 'conditional') {

--- a/src/snippet-engine/inline-refs.ts
+++ b/src/snippet-engine/inline-refs.ts
@@ -1,0 +1,128 @@
+/**
+ * Inline Snippet References
+ *
+ * Walks a JsonGuide, finds every `snippet-ref` block at any depth
+ * (top-level, inside sections, conditionals, assistants, multistep
+ * containers), resolves each via the snippet resolver, and returns a
+ * new guide with refs replaced by the snippet's `blocks` array spliced
+ * in at the same position.
+ *
+ * Refs that fail to resolve are replaced by an inert markdown placeholder
+ * block so the rest of the guide still renders. This is the
+ * defense-in-depth boundary — by the time the parser sees the guide,
+ * no `snippet-ref` blocks should remain.
+ *
+ * Pure function (apart from the injected resolver). Input is not mutated.
+ */
+
+import type { JsonBlock, JsonGuide, JsonSnippetRefBlock } from '../types/json-guide.types';
+
+import { getSnippetResolver } from './caching-snippet-resolver';
+import type { SnippetResolution, SnippetResolver } from './types';
+
+function isSnippetRef(block: JsonBlock): block is JsonSnippetRefBlock {
+  return block.type === 'snippet-ref';
+}
+
+function placeholderForFailure(failure: Extract<SnippetResolution, { ok: false }>): JsonBlock {
+  return {
+    type: 'markdown',
+    content: `_Snippet **${failure.id}** could not be loaded (${failure.error.code}). The author should check the snippet ID or refresh the catalog._`,
+  };
+}
+
+/**
+ * Walk an array of blocks, replacing every snippet-ref with its
+ * resolved body. Resolution is performed in parallel across the whole
+ * tree to minimize total latency.
+ */
+export async function inlineSnippetRefsInBlocks(
+  blocks: JsonBlock[],
+  resolver: SnippetResolver = getSnippetResolver()
+): Promise<JsonBlock[]> {
+  // Pre-collect every unique ref id so we can resolve them all in parallel
+  // before doing the splice walk. The resolver's internal cache also
+  // dedupes, but pre-collecting keeps the splice walk synchronous.
+  const ids = new Set<string>();
+  collectRefIds(blocks, ids);
+
+  if (ids.size === 0) {
+    return blocks;
+  }
+
+  const resolutions = new Map<string, SnippetResolution>();
+  await Promise.all(
+    [...ids].map(async (id) => {
+      resolutions.set(id, await resolver.resolve(id));
+    })
+  );
+
+  return spliceBlocks(blocks, resolutions);
+}
+
+/** Convenience wrapper: inline refs in a full guide. */
+export async function inlineSnippetRefsInGuide(
+  guide: JsonGuide,
+  resolver: SnippetResolver = getSnippetResolver()
+): Promise<JsonGuide> {
+  const blocks = await inlineSnippetRefsInBlocks(guide.blocks, resolver);
+  return { ...guide, blocks };
+}
+
+function collectRefIds(blocks: JsonBlock[], out: Set<string>): void {
+  for (const block of blocks) {
+    if (isSnippetRef(block)) {
+      out.add(block.snippetId);
+      continue;
+    }
+    // Recurse into container blocks. Snippets themselves cannot contain
+    // refs (schema-enforced), but guides can nest refs inside sections,
+    // conditionals, and assistants.
+    if (block.type === 'section' || block.type === 'assistant') {
+      collectRefIds(block.blocks, out);
+    } else if (block.type === 'conditional') {
+      collectRefIds(block.whenTrue, out);
+      collectRefIds(block.whenFalse, out);
+    }
+  }
+}
+
+function spliceBlocks(blocks: JsonBlock[], resolutions: Map<string, SnippetResolution>): JsonBlock[] {
+  const result: JsonBlock[] = [];
+  for (const block of blocks) {
+    if (isSnippetRef(block)) {
+      const resolution = resolutions.get(block.snippetId);
+      if (!resolution || !resolution.ok) {
+        result.push(
+          placeholderForFailure(
+            resolution ?? {
+              ok: false,
+              id: block.snippetId,
+              error: { code: 'not-found', message: 'resolver returned nothing' },
+            }
+          )
+        );
+        continue;
+      }
+      // Spread the snippet's blocks in place. Snippets are no-ref by
+      // schema, so we don't need to recurse into them.
+      result.push(...resolution.snippet.blocks);
+      continue;
+    }
+
+    if (block.type === 'section') {
+      result.push({ ...block, blocks: spliceBlocks(block.blocks, resolutions) });
+    } else if (block.type === 'assistant') {
+      result.push({ ...block, blocks: spliceBlocks(block.blocks, resolutions) });
+    } else if (block.type === 'conditional') {
+      result.push({
+        ...block,
+        whenTrue: spliceBlocks(block.whenTrue, resolutions),
+        whenFalse: spliceBlocks(block.whenFalse, resolutions),
+      });
+    } else {
+      result.push(block);
+    }
+  }
+  return result;
+}

--- a/src/snippet-engine/inline-refs.ts
+++ b/src/snippet-engine/inline-refs.ts
@@ -40,9 +40,7 @@ export async function inlineSnippetRefsInBlocks(
   blocks: JsonBlock[],
   resolver: SnippetResolver = getSnippetResolver()
 ): Promise<JsonBlock[]> {
-  // Pre-collect every unique ref id so we can resolve them all in parallel
-  // before doing the splice walk. The resolver's internal cache also
-  // dedupes, but pre-collecting keeps the splice walk synchronous.
+  // Resolve all unique ref ids in parallel before the synchronous splice walk.
   const ids = new Set<string>();
   collectRefIds(blocks, ids);
 
@@ -67,6 +65,33 @@ export async function inlineSnippetRefsInGuide(
 ): Promise<JsonGuide> {
   const blocks = await inlineSnippetRefsInBlocks(guide.blocks, resolver);
   return { ...guide, blocks };
+}
+
+/**
+ * True as soon as a `snippet-ref` block appears anywhere in the guide's
+ * block tree. Lets callers skip the async resolution pass on guides that
+ * reference no snippets — the common case.
+ */
+export function guideHasSnippetRefs(guide: JsonGuide): boolean {
+  return blocksHaveSnippetRef(guide.blocks);
+}
+
+function blocksHaveSnippetRef(blocks: JsonBlock[]): boolean {
+  for (const block of blocks) {
+    if (isSnippetRef(block)) {
+      return true;
+    }
+    if (block.type === 'section' || block.type === 'assistant') {
+      if (blocksHaveSnippetRef(block.blocks)) {
+        return true;
+      }
+    } else if (block.type === 'conditional') {
+      if (blocksHaveSnippetRef(block.whenTrue) || blocksHaveSnippetRef(block.whenFalse)) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 function collectRefIds(blocks: JsonBlock[], out: Set<string>): void {
@@ -104,8 +129,6 @@ function spliceBlocks(blocks: JsonBlock[], resolutions: Map<string, SnippetResol
         );
         continue;
       }
-      // Spread the snippet's blocks in place. Snippets are no-ref by
-      // schema, so we don't need to recurse into them.
       result.push(...resolution.snippet.blocks);
       continue;
     }

--- a/src/snippet-engine/online-snippet-resolver.test.ts
+++ b/src/snippet-engine/online-snippet-resolver.test.ts
@@ -121,21 +121,14 @@ describe('OnlineCdnSnippetResolver.list', () => {
     expect(result).toEqual(catalog);
   });
 
-  it('returns an empty catalog on a non-ok HTTP response', async () => {
+  it('returns an empty catalog on any fetch failure (non-ok, malformed body, or rejection)', async () => {
     mockFetchResolved({ ok: false, status: 500 });
-
     expect(await createOnlineSnippetResolver().list()).toEqual({});
-  });
 
-  it('returns an empty catalog when the remote body fails the schema', async () => {
     mockFetchResolved({ ok: true, json: async () => [{ not: 'a catalog' }] });
-
     expect(await createOnlineSnippetResolver().list()).toEqual({});
-  });
 
-  it('returns an empty catalog when fetch rejects', async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
-
     expect(await createOnlineSnippetResolver().list()).toEqual({});
   });
 });

--- a/src/snippet-engine/online-snippet-resolver.test.ts
+++ b/src/snippet-engine/online-snippet-resolver.test.ts
@@ -1,0 +1,24 @@
+import { deriveSnippetsBaseUrl } from './online-snippet-resolver';
+
+describe('deriveSnippetsBaseUrl', () => {
+  it('swaps a trailing /packages segment for /guides/shared/snippets', () => {
+    expect(deriveSnippetsBaseUrl('https://interactive-learning.grafana.net/packages')).toBe(
+      'https://interactive-learning.grafana.net/guides/shared/snippets'
+    );
+  });
+
+  it('tolerates a trailing slash on the input', () => {
+    expect(deriveSnippetsBaseUrl('https://interactive-learning.grafana.net/packages/')).toBe(
+      'https://interactive-learning.grafana.net/guides/shared/snippets'
+    );
+  });
+
+  it('appends /guides/shared/snippets to non-/packages roots as a defensive fallback', () => {
+    expect(deriveSnippetsBaseUrl('https://example.test')).toBe('https://example.test/guides/shared/snippets');
+  });
+
+  it('returns empty for empty input so callers can short-circuit', () => {
+    expect(deriveSnippetsBaseUrl('')).toBe('');
+    expect(deriveSnippetsBaseUrl('///')).toBe('');
+  });
+});

--- a/src/snippet-engine/online-snippet-resolver.test.ts
+++ b/src/snippet-engine/online-snippet-resolver.test.ts
@@ -1,4 +1,28 @@
-import { deriveSnippetsBaseUrl } from './online-snippet-resolver';
+import { createOnlineSnippetResolver, deriveSnippetsBaseUrl } from './online-snippet-resolver';
+
+jest.mock('../lib/package-recommendations-client', () => ({
+  fetchOnlinePackageRecommendations: jest.fn(),
+}));
+
+import { fetchOnlinePackageRecommendations } from '../lib/package-recommendations-client';
+
+const mockRecommendations = fetchOnlinePackageRecommendations as jest.MockedFunction<
+  typeof fetchOnlinePackageRecommendations
+>;
+
+const PACKAGES_BASE = 'https://interactive-learning.grafana.net/packages';
+const SNIPPETS_BASE = 'https://interactive-learning.grafana.net/guides/shared/snippets';
+
+const validSnippet = {
+  id: 'datasource-picker',
+  title: 'Datasource picker',
+  description: 'Select the datasource.',
+  blocks: [{ type: 'markdown', content: 'Select the datasource.' }],
+};
+
+function mockFetchResolved(value: { ok: boolean; status?: number; json?: () => Promise<unknown> }) {
+  global.fetch = jest.fn().mockResolvedValue(value) as unknown as typeof fetch;
+}
 
 describe('deriveSnippetsBaseUrl', () => {
   it('swaps a trailing /packages segment for /guides/shared/snippets', () => {
@@ -20,5 +44,98 @@ describe('deriveSnippetsBaseUrl', () => {
   it('returns empty for empty input so callers can short-circuit', () => {
     expect(deriveSnippetsBaseUrl('')).toBe('');
     expect(deriveSnippetsBaseUrl('///')).toBe('');
+  });
+});
+
+describe('OnlineCdnSnippetResolver.resolve', () => {
+  beforeEach(() => {
+    mockRecommendations.mockResolvedValue({ baseUrl: PACKAGES_BASE, packages: [] });
+  });
+
+  it('fetches the snippet from the /guides/shared/snippets path and returns the validated body', async () => {
+    mockFetchResolved({ ok: true, json: async () => validSnippet });
+
+    const result = await createOnlineSnippetResolver().resolve('datasource-picker');
+
+    expect(global.fetch).toHaveBeenCalledWith(`${SNIPPETS_BASE}/datasource-picker.json`);
+    expect(result).toMatchObject({ ok: true, id: 'datasource-picker', source: 'online-cdn' });
+  });
+
+  it('encodes the snippet id so a crafted id cannot escape the snippets path', async () => {
+    mockFetchResolved({ ok: false, status: 404 });
+
+    await createOnlineSnippetResolver().resolve('../../etc/passwd');
+
+    expect(global.fetch).toHaveBeenCalledWith(`${SNIPPETS_BASE}/..%2F..%2Fetc%2Fpasswd.json`);
+  });
+
+  it('returns a network-error failure on a non-ok HTTP response (no throw)', async () => {
+    mockFetchResolved({ ok: false, status: 404 });
+
+    const result = await createOnlineSnippetResolver().resolve('missing');
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'network-error' } });
+  });
+
+  it('returns a validation-error failure when the remote body fails the schema (no throw)', async () => {
+    mockFetchResolved({ ok: true, json: async () => ({ id: 'datasource-picker' }) });
+
+    const result = await createOnlineSnippetResolver().resolve('datasource-picker');
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'validation-error' } });
+  });
+
+  it('returns a network-error failure when fetch rejects', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+
+    const result = await createOnlineSnippetResolver().resolve('datasource-picker');
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'network-error' } });
+  });
+
+  it('fails without fetching when no base URL is available', async () => {
+    mockRecommendations.mockResolvedValue({ baseUrl: '', packages: [] });
+    global.fetch = jest.fn() as unknown as typeof fetch;
+
+    const result = await createOnlineSnippetResolver().resolve('datasource-picker');
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ ok: false, error: { code: 'network-error' } });
+  });
+});
+
+describe('OnlineCdnSnippetResolver.list', () => {
+  beforeEach(() => {
+    mockRecommendations.mockResolvedValue({ baseUrl: PACKAGES_BASE, packages: [] });
+  });
+
+  it('fetches and returns the parsed catalog from index.json', async () => {
+    const catalog = {
+      'datasource-picker': { id: 'datasource-picker', title: 'Datasource picker', description: 'Pick a datasource' },
+    };
+    mockFetchResolved({ ok: true, json: async () => catalog });
+
+    const result = await createOnlineSnippetResolver().list();
+
+    expect(global.fetch).toHaveBeenCalledWith(`${SNIPPETS_BASE}/index.json`);
+    expect(result).toEqual(catalog);
+  });
+
+  it('returns an empty catalog on a non-ok HTTP response', async () => {
+    mockFetchResolved({ ok: false, status: 500 });
+
+    expect(await createOnlineSnippetResolver().list()).toEqual({});
+  });
+
+  it('returns an empty catalog when the remote body fails the schema', async () => {
+    mockFetchResolved({ ok: true, json: async () => [{ not: 'a catalog' }] });
+
+    expect(await createOnlineSnippetResolver().list()).toEqual({});
+  });
+
+  it('returns an empty catalog when fetch rejects', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+
+    expect(await createOnlineSnippetResolver().list()).toEqual({});
   });
 });

--- a/src/snippet-engine/online-snippet-resolver.ts
+++ b/src/snippet-engine/online-snippet-resolver.ts
@@ -1,19 +1,10 @@
 /**
  * Online Snippet Resolver
  *
- * Fetches the catalog from `<host>/guides/shared/snippets/index.json`
- * and individual snippets from `<host>/guides/shared/snippets/<id>.json`.
- * The `/guides/shared/` prefix reflects the existing CDN deploy in
- * `grafana/interactive-tutorials`: `.github/workflows/deploy.yml` does
- * `cp -r shared guides/` before pushing to GCS, so everything in the
- * upstream repo's `shared/` directory lands under `guides/shared/` on
- * the CDN. The `shared/` segment reserves space for sibling reusable
- * types (e.g. templates).
- *
- * The host is derived from the existing `/package-recommendations`
- * response by stripping the trailing `/packages` segment off its
- * `baseUrl` field. This keeps the upstream content repo as the
- * single source of truth without adding a new backend endpoint.
+ * Fetches the catalog from `<host>/guides/shared/snippets/index.json` and
+ * snippets from `<host>/guides/shared/snippets/<id>.json`. The host is
+ * derived from the package-recommendations `baseUrl` (see
+ * `deriveSnippetsBaseUrl`).
  */
 
 import { fetchOnlinePackageRecommendations } from '../lib/package-recommendations-client';
@@ -23,26 +14,21 @@ import type { JsonSnippet, SnippetCatalog } from '../types/json-snippet.types';
 import type { SnippetCatalogProvider, SnippetResolution, SnippetResolver } from './types';
 
 /**
- * Derive the snippets directory URL from the package recommendations
- * `baseUrl`. Returns `''` when the input is unusable so callers can
- * short-circuit (a failed lookup renders the inert placeholder).
+ * Snippets directory URL derived from the package-recommendations `baseUrl`.
+ * Returns `''` when unusable so callers can short-circuit.
  */
 export function deriveSnippetsBaseUrl(packagesBaseUrl: string): string {
   const trimmed = packagesBaseUrl.replace(/\/+$/, '');
   if (!trimmed) {
     return '';
   }
-  // The recommendations baseUrl points at the packages directory
-  // (e.g. `https://interactive-learning.grafana.net/packages`). Snippets
-  // are deployed under `/guides/shared/snippets/` because the
-  // interactive-tutorials deploy workflow does `cp -r shared guides/`
-  // before pushing to GCS — drop the `/packages` segment and append
-  // `/guides/shared/snippets`.
+  // Snippets deploy under `/guides/shared/snippets/`: the interactive-tutorials
+  // workflow does `cp -r shared guides/` before pushing to GCS. Swap the
+  // `/packages` segment for it.
   if (trimmed.endsWith('/packages')) {
     return trimmed.slice(0, -'/packages'.length) + '/guides/shared/snippets';
   }
-  // Defensive fallback when upstream changes the convention. A 404 here
-  // is harmless — a failed snippet renders the inert placeholder.
+  // Defensive fallback if upstream changes the convention — a 404 is harmless.
   return `${trimmed}/guides/shared/snippets`;
 }
 

--- a/src/snippet-engine/online-snippet-resolver.ts
+++ b/src/snippet-engine/online-snippet-resolver.ts
@@ -1,0 +1,103 @@
+/**
+ * Online Snippet Resolver
+ *
+ * Fetches the catalog from `<host>/shared/snippets/index.json` and
+ * individual snippets from `<host>/shared/snippets/<id>.json`. The
+ * `/shared/` segment reserves space for sibling reusable types
+ * (e.g. templates) that will live under the same prefix.
+ *
+ * The host is derived from the existing `/package-recommendations`
+ * response by stripping the trailing `/packages` segment off its
+ * `baseUrl` field. This keeps the upstream content repo as the
+ * single source of truth without adding a new backend endpoint.
+ */
+
+import { fetchOnlinePackageRecommendations } from '../lib/package-recommendations-client';
+import { JsonSnippetSchema, SnippetCatalogSchema } from '../types/json-snippet.schema';
+import type { JsonSnippet, SnippetCatalog } from '../types/json-snippet.types';
+
+import type { SnippetCatalogProvider, SnippetResolution, SnippetResolver } from './types';
+
+/**
+ * Derive the snippets directory URL from the package recommendations
+ * `baseUrl`. Returns `''` when the input is unusable so callers can
+ * short-circuit and fall through to the bundled snapshot.
+ */
+export function deriveSnippetsBaseUrl(packagesBaseUrl: string): string {
+  const trimmed = packagesBaseUrl.replace(/\/+$/, '');
+  if (!trimmed) {
+    return '';
+  }
+  // The recommendations baseUrl points at the packages directory
+  // (e.g. `https://interactive-learning.grafana.net/packages`). Snippets
+  // live at the host's `/shared/snippets` path — drop the `/packages`
+  // segment and append `/shared/snippets`.
+  if (trimmed.endsWith('/packages')) {
+    return trimmed.slice(0, -'/packages'.length) + '/shared/snippets';
+  }
+  // Defensive fallback when upstream changes the convention. A 404 here
+  // is harmless — the composite resolver still has the bundled snapshot.
+  return `${trimmed}/shared/snippets`;
+}
+
+export class OnlineCdnSnippetResolver implements SnippetResolver, SnippetCatalogProvider {
+  async resolve(snippetId: string): Promise<SnippetResolution> {
+    const baseUrl = await this.getBaseUrl();
+    if (!baseUrl) {
+      return { ok: false, id: snippetId, error: { code: 'network-error', message: 'No snippets base URL available' } };
+    }
+
+    const url = `${baseUrl}/${encodeURIComponent(snippetId)}.json`;
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        return {
+          ok: false,
+          id: snippetId,
+          error: { code: 'network-error', message: `Snippet fetch failed: HTTP ${response.status}` },
+        };
+      }
+      const raw = await response.json();
+      const parsed = JsonSnippetSchema.safeParse(raw);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          id: snippetId,
+          error: { code: 'validation-error', message: `Online snippet validation failed: ${parsed.error.message}` },
+        };
+      }
+      return { ok: true, id: snippetId, snippet: parsed.data as JsonSnippet, source: 'online-cdn' };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Snippet fetch failed';
+      return { ok: false, id: snippetId, error: { code: 'network-error', message } };
+    }
+  }
+
+  async list(): Promise<SnippetCatalog> {
+    const baseUrl = await this.getBaseUrl();
+    if (!baseUrl) {
+      return {};
+    }
+
+    try {
+      const response = await fetch(`${baseUrl}/index.json`);
+      if (!response.ok) {
+        return {};
+      }
+      const raw = await response.json();
+      const parsed = SnippetCatalogSchema.safeParse(raw);
+      return parsed.success ? parsed.data : {};
+    } catch {
+      return {};
+    }
+  }
+
+  private async getBaseUrl(): Promise<string> {
+    const { baseUrl } = await fetchOnlinePackageRecommendations();
+    return deriveSnippetsBaseUrl(baseUrl);
+  }
+}
+
+export function createOnlineSnippetResolver(): OnlineCdnSnippetResolver {
+  return new OnlineCdnSnippetResolver();
+}

--- a/src/snippet-engine/online-snippet-resolver.ts
+++ b/src/snippet-engine/online-snippet-resolver.ts
@@ -1,10 +1,14 @@
 /**
  * Online Snippet Resolver
  *
- * Fetches the catalog from `<host>/shared/snippets/index.json` and
- * individual snippets from `<host>/shared/snippets/<id>.json`. The
- * `/shared/` segment reserves space for sibling reusable types
- * (e.g. templates) that will live under the same prefix.
+ * Fetches the catalog from `<host>/guides/shared/snippets/index.json`
+ * and individual snippets from `<host>/guides/shared/snippets/<id>.json`.
+ * The `/guides/shared/` prefix reflects the existing CDN deploy in
+ * `grafana/interactive-tutorials`: `.github/workflows/deploy.yml` does
+ * `cp -r shared guides/` before pushing to GCS, so everything in the
+ * upstream repo's `shared/` directory lands under `guides/shared/` on
+ * the CDN. The `shared/` segment reserves space for sibling reusable
+ * types (e.g. templates).
  *
  * The host is derived from the existing `/package-recommendations`
  * response by stripping the trailing `/packages` segment off its
@@ -30,14 +34,16 @@ export function deriveSnippetsBaseUrl(packagesBaseUrl: string): string {
   }
   // The recommendations baseUrl points at the packages directory
   // (e.g. `https://interactive-learning.grafana.net/packages`). Snippets
-  // live at the host's `/shared/snippets` path — drop the `/packages`
-  // segment and append `/shared/snippets`.
+  // are deployed under `/guides/shared/snippets/` because the
+  // interactive-tutorials deploy workflow does `cp -r shared guides/`
+  // before pushing to GCS — drop the `/packages` segment and append
+  // `/guides/shared/snippets`.
   if (trimmed.endsWith('/packages')) {
-    return trimmed.slice(0, -'/packages'.length) + '/shared/snippets';
+    return trimmed.slice(0, -'/packages'.length) + '/guides/shared/snippets';
   }
   // Defensive fallback when upstream changes the convention. A 404 here
-  // is harmless — the composite resolver still has the bundled snapshot.
-  return `${trimmed}/shared/snippets`;
+  // is harmless — a failed snippet renders the inert placeholder.
+  return `${trimmed}/guides/shared/snippets`;
 }
 
 export class OnlineCdnSnippetResolver implements SnippetResolver, SnippetCatalogProvider {

--- a/src/snippet-engine/online-snippet-resolver.ts
+++ b/src/snippet-engine/online-snippet-resolver.ts
@@ -25,7 +25,7 @@ import type { SnippetCatalogProvider, SnippetResolution, SnippetResolver } from 
 /**
  * Derive the snippets directory URL from the package recommendations
  * `baseUrl`. Returns `''` when the input is unusable so callers can
- * short-circuit and fall through to the bundled snapshot.
+ * short-circuit (a failed lookup renders the inert placeholder).
  */
 export function deriveSnippetsBaseUrl(packagesBaseUrl: string): string {
   const trimmed = packagesBaseUrl.replace(/\/+$/, '');

--- a/src/snippet-engine/types.ts
+++ b/src/snippet-engine/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Snippet Engine Types
+ *
+ * Internal shape for the resolver pipeline. The renderer never sees a
+ * `SnippetResolution` — the parser splices the resolved blocks in place.
+ */
+
+import type { JsonSnippet, SnippetCatalog, SnippetCatalogEntry } from '../types/json-snippet.types';
+
+export interface SnippetResolutionSuccess {
+  ok: true;
+  id: string;
+  /** The validated snippet body. */
+  snippet: JsonSnippet;
+  /** Which tier resolved the snippet — 'bundled' or 'online-cdn'. */
+  source: 'bundled' | 'online-cdn';
+}
+
+export type SnippetResolutionErrorCode = 'not-found' | 'network-error' | 'validation-error' | 'parse-error';
+
+export interface SnippetResolutionFailure {
+  ok: false;
+  id: string;
+  error: { code: SnippetResolutionErrorCode; message: string };
+}
+
+export type SnippetResolution = SnippetResolutionSuccess | SnippetResolutionFailure;
+
+/**
+ * A resolver can answer "give me snippet X" — either from a bundled
+ * snapshot or from the live CDN.
+ */
+export interface SnippetResolver {
+  resolve(snippetId: string): Promise<SnippetResolution>;
+}
+
+/**
+ * A catalog provider lists every snippet known to the editor — used to
+ * populate the Snippet Picker without fetching every snippet body.
+ */
+export interface SnippetCatalogProvider {
+  list(): Promise<SnippetCatalog>;
+}
+
+export type { JsonSnippet, SnippetCatalog, SnippetCatalogEntry };

--- a/src/snippet-engine/types.ts
+++ b/src/snippet-engine/types.ts
@@ -12,8 +12,8 @@ export interface SnippetResolutionSuccess {
   id: string;
   /** The validated snippet body. */
   snippet: JsonSnippet;
-  /** Which tier resolved the snippet — 'bundled' or 'online-cdn'. */
-  source: 'bundled' | 'online-cdn';
+  /** Which tier resolved the snippet. */
+  source: 'online-cdn';
 }
 
 export type SnippetResolutionErrorCode = 'not-found' | 'network-error' | 'validation-error' | 'parse-error';
@@ -26,10 +26,7 @@ export interface SnippetResolutionFailure {
 
 export type SnippetResolution = SnippetResolutionSuccess | SnippetResolutionFailure;
 
-/**
- * A resolver can answer "give me snippet X" — either from a bundled
- * snapshot or from the live CDN.
- */
+/** A resolver can answer "give me snippet X" from the live CDN. */
 export interface SnippetResolver {
   resolve(snippetId: string): Promise<SnippetResolution>;
 }

--- a/src/snippet-engine/types.ts
+++ b/src/snippet-engine/types.ts
@@ -1,18 +1,11 @@
-/**
- * Snippet Engine Types
- *
- * Internal shape for the resolver pipeline. The renderer never sees a
- * `SnippetResolution` — the parser splices the resolved blocks in place.
- */
+/** Internal shapes for the resolver pipeline; the renderer never sees these. */
 
 import type { JsonSnippet, SnippetCatalog, SnippetCatalogEntry } from '../types/json-snippet.types';
 
 export interface SnippetResolutionSuccess {
   ok: true;
   id: string;
-  /** The validated snippet body. */
   snippet: JsonSnippet;
-  /** Which tier resolved the snippet. */
   source: 'online-cdn';
 }
 
@@ -26,15 +19,11 @@ export interface SnippetResolutionFailure {
 
 export type SnippetResolution = SnippetResolutionSuccess | SnippetResolutionFailure;
 
-/** A resolver can answer "give me snippet X" from the live CDN. */
 export interface SnippetResolver {
   resolve(snippetId: string): Promise<SnippetResolution>;
 }
 
-/**
- * A catalog provider lists every snippet known to the editor — used to
- * populate the Snippet Picker without fetching every snippet body.
- */
+/** Lists every snippet for the picker without fetching each body. */
 export interface SnippetCatalogProvider {
   list(): Promise<SnippetCatalog>;
 }

--- a/src/types/json-snippet.schema.test.ts
+++ b/src/types/json-snippet.schema.test.ts
@@ -1,0 +1,98 @@
+import { JsonSnippetSchema } from './json-snippet.schema';
+import { JsonGuideSchema } from './json-guide.schema';
+
+describe('JsonSnippetSchema', () => {
+  it('accepts a minimal valid snippet (no schemaVersion — defaults applied)', () => {
+    const result = JsonSnippetSchema.safeParse({
+      id: 'create-prometheus-ds',
+      title: 'Create a Prometheus data source',
+      description: 'Creates and configures a Prometheus data source.',
+      blocks: [{ type: 'markdown', content: 'Hello.' }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.schemaVersion).toBe('1.0.0');
+    }
+  });
+
+  it('rejects a snippet without a description', () => {
+    const result = JsonSnippetSchema.safeParse({
+      id: 'no-desc',
+      title: 'No description',
+      blocks: [{ type: 'markdown', content: 'x' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a snippet whose blocks include a snippet-ref (no nesting)', () => {
+    const result = JsonSnippetSchema.safeParse({
+      id: 'parent',
+      title: 'Parent',
+      description: 'Parent snippet.',
+      blocks: [{ type: 'snippet-ref', snippetId: 'child' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a snippet whose nested section contains a snippet-ref', () => {
+    const result = JsonSnippetSchema.safeParse({
+      id: 'parent',
+      title: 'Parent',
+      description: 'Parent snippet.',
+      blocks: [
+        {
+          type: 'section',
+          title: 'Inside',
+          blocks: [{ type: 'snippet-ref', snippetId: 'nested' }],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a snippet with no blocks', () => {
+    const result = JsonSnippetSchema.safeParse({
+      id: 'empty',
+      title: 'Empty',
+      description: 'Empty snippet.',
+      blocks: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-kebab-case id', () => {
+    const result = JsonSnippetSchema.safeParse({
+      id: 'Not-Kebab',
+      title: 'Bad id',
+      description: 'Bad id snippet.',
+      blocks: [{ type: 'markdown', content: 'x' }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('JsonGuideSchema with snippet-ref blocks', () => {
+  it('accepts a guide that contains a top-level snippet-ref', () => {
+    const result = JsonGuideSchema.safeParse({
+      id: 'guide',
+      title: 'A guide',
+      blocks: [{ type: 'snippet-ref', snippetId: 'open-connections-page' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a guide with a snippet-ref inside a section', () => {
+    const result = JsonGuideSchema.safeParse({
+      id: 'guide',
+      title: 'A guide',
+      blocks: [
+        {
+          type: 'section',
+          title: 'Setup',
+          blocks: [{ type: 'snippet-ref', snippetId: 'open-connections-page' }],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -123,6 +123,10 @@ const ALLOWED_LATERAL_VIOLATIONS = new Set([
   'docs-retrieval/learning-journey-helpers.ts -> learning-paths',
   'requirements-manager/requirements-checker.hook.ts -> context-engine',
   'requirements-manager/step-checker.hook.ts -> context-engine',
+  // Snippet resolution: docs-retrieval invokes snippet-engine to inline
+  // snippet-ref blocks at render time, before parseJsonGuide runs. Keeps
+  // the renderer's resolve→parse pipeline in one place.
+  'docs-retrieval/content-renderer.tsx -> snippet-engine',
 ]);
 
 /**

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -123,10 +123,6 @@ const ALLOWED_LATERAL_VIOLATIONS = new Set([
   'docs-retrieval/learning-journey-helpers.ts -> learning-paths',
   'requirements-manager/requirements-checker.hook.ts -> context-engine',
   'requirements-manager/step-checker.hook.ts -> context-engine',
-  // Snippet resolution: docs-retrieval invokes snippet-engine to inline
-  // snippet-ref blocks at render time, before parseJsonGuide runs. Keeps
-  // the renderer's resolve→parse pipeline in one place.
-  'docs-retrieval/content-renderer.tsx -> snippet-engine',
 ]);
 
 /**

--- a/src/validation/import-graph.ts
+++ b/src/validation/import-graph.ts
@@ -33,6 +33,7 @@ export const TIER_MAP: Record<string, number> = {
   'requirements-manager': 2,
   'learning-paths': 2,
   'package-engine': 2,
+  'snippet-engine': 2,
   hooks: 2,
   integrations: 3,
   components: 4,


### PR DESCRIPTION
<img width="702" height="714" alt="image" src="https://github.com/user-attachments/assets/4ffe6c4c-4fac-458a-a07e-139f43515cc6" />

## What this does

Lets a guide reuse a common set of steps instead of copy-pasting them. An author drops in a **snippet reference** by name, and when the guide loads Pathfinder pulls that snippet's content from the CDN and slots it into place. Improve a snippet once upstream and every guide that uses it picks up the change — no edits to the guides themselves.

In the block editor there's a new "Reusable" group in the block palette with a picker to insert a reference. If a snippet can't be loaded, the guide still renders with a small placeholder where it would have gone, rather than breaking.

**Scope for this first version:** guides consume snippets that are authored upstream (in `grafana/interactive-tutorials`), snippets can't contain other snippets, and guides always get the latest version (no pinning). Authoring snippets and richer editor previews are deliberately left for follow-ups.

## Why this is larger than the 500-line guideline

A snippet reference is only useful when the whole path works end to end, so this lands as one coherent unit: the new reference type, the engine that fetches and inserts snippets, the wiring that resolves references when a guide loads, and the editor UI to add one. Splitting it would ship half-features that can't be exercised on their own — an editor that inserts references nothing can resolve, or an engine with no way to author against it.

It's also test-heavy by design: roughly **40% of the diff (~510 of ~1,300 lines) is tests**. The remaining feature code is genuinely new surface, not padding, and there's no smaller slice of "snippets work" worth reviewing in isolation.

## Testing

- **Automated:** schema validation, resolver caching/dedupe and failure handling, the CDN fetch paths, and the insert-and-splice logic (top level, nested sections, conditional branches, and failure placeholders).
- **Manual:** inserting a snippet reference in the block editor and confirming it renders from the live catalog — in progress.
