### PR TITLE
fix(interactive): add title and aria-describedby to requirement buttons

### DIFF
--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -704,7 +704,9 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
             <div className={`interactive-guided-requirements${checker.isChecking ? ' rechecking' : ''}`}>
               <div className="interactive-guided-requirement-box">
                 <span className="interactive-guided-requirement-icon">👣</span>
-                <span className="interactive-guided-requirement-text">{checker.explanation}</span>
+                <span id={`requirement-explanation-${renderedStepId}`} className="interactive-guided-requirement-text">
+                  {checker.explanation}
+                </span>
                 {checker.isChecking && <span className="interactive-requirement-spinner">⟳</span>}
               </div>
               <button
@@ -714,6 +716,12 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
                     ? testIds.interactive.requirementFixButton(renderedStepId)
                     : testIds.interactive.requirementRetryButton(renderedStepId)
                 }
+                title={
+                  checker.canFixRequirement
+                    ? 'Apply the automatic fix for this requirement'
+                    : 'Check whether this requirement is now met'
+                }
+                aria-describedby={`requirement-explanation-${renderedStepId}`}
                 onClick={async () => {
                   if (checker.canFixRequirement && checker.fixRequirement) {
                     await checker.fixRequirement();

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -1066,7 +1066,7 @@ export const InteractiveStep = forwardRef<
               className={`interactive-step-requirement-explanation${checker.isChecking ? ' rechecking' : ''}`}
               data-testid={testIds.interactive.requirementCheck(renderedStepId)}
             >
-              {explanationText}
+              <span id={`requirement-explanation-${renderedStepId}`}>{explanationText}</span>
               {checker.isChecking && <span className="interactive-requirement-spinner">⟳</span>}
               <div className="interactive-step-requirement-buttons">
                 {/* Retry button for eligible steps or fixable requirements */}
@@ -1078,6 +1078,12 @@ export const InteractiveStep = forwardRef<
                         ? testIds.interactive.requirementFixButton(renderedStepId)
                         : testIds.interactive.requirementRetryButton(renderedStepId)
                     }
+                    title={
+                      checker.canFixRequirement
+                        ? 'Apply the automatic fix for this requirement'
+                        : 'Check whether this requirement is now met'
+                    }
+                    aria-describedby={`requirement-explanation-${renderedStepId}`}
                     onClick={async () => {
                       if (checker.canFixRequirement && checker.fixRequirement) {
                         await checker.fixRequirement();


### PR DESCRIPTION
## Summary

These buttons appear when a guide step's requirements aren't met — exactly the moment when a learner needs context for what to do next. Currently they have no tooltip and no semantic link to their adjacent explanation text. This PR adds:

- `title` for sighted hover users on the requirement "Fix this" / "Retry" / "Check again" buttons
- `aria-describedby` linking each button to its adjacent explanation `<span>` so screen-reader users hear the context when focus reaches the button
- A small structural change in `interactive-step.tsx`: wraps the bare `explanationText` in a `<span id={...}>` so the description scopes to just the explanation, not the spinner or button

## Why this shape

`aria-label` was deliberately not used. Overriding the visible button text ("Fix this") with the longer description would mean screen-reader users hear "Apply the automatic fix for this requirement" instead of "Fix this" — the antipattern WAI-ARIA warns against when surrounding context already provides what's missing. `aria-describedby` keeps the visible text as the accessible name and adds the explanation as a separately announced description.

## Test Plan

- Trigger any guide step where requirements aren't met (for example Prometheus & Grafana 101) — hover the button and confirm the native tooltip appears with the expected copy ("Apply the automatic fix for this requirement" or "Check whether this requirement is now met")
- Inspect the rendered DOM: the `<button>` carries `title` and `aria-describedby="requirement-explanation-<step-id>"`, and the adjacent `<span id="requirement-explanation-<step-id>">` exists wrapping the explanation text (ids match exactly)
- Tab to the button via keyboard and confirm focus behavior is unchanged