### PR TITLE
fix(interactive): cross-tab completion-store sync (N-2 follow-up)

### DIFF
--- a/docs/developer/STEP_MODEL.md
+++ b/docs/developer/STEP_MODEL.md
@@ -53,6 +53,23 @@ Known reset sites (each pairs the storage clear with a cache eviction):
 
 Adding a new reset path: pair the storage clear with the corresponding eviction.
 
+## Cross-tab synchronization
+
+The completion store's caches (`entries`, `hydratedSections`, `hydrationVersion`, ...) live in the module instance for the current browser tab. `localStorage` is shared across every tab on the same origin. Without cross-tab sync, tab B's stale cache could silently write back over tab A's authoritative reset.
+
+A module-scope `storage` event listener (installed via `installCrossTabSync` at module init) reacts to cross-tab writes:
+
+1. `event.key === null` — another tab called `localStorage.clear()`; drop every in-memory cache via `evictAllContentCaches`.
+2. `event.key.startsWith(StorageKeys.INTERACTIVE_STEPS_PREFIX)` — another tab wrote a `(contentKey, sectionId)` slot; resolve the contentKey against the live set of active keys (`entries` ∪ `hydratedSections`), then `evictSectionCacheForKey` + `notify` so the subscriber re-hydrates from authoritative storage on the next render.
+
+A per-section monotonic `hydrationVersion` counter closes the in-flight hydration race: every cache-clearing path bumps the version, and `ensureHydrated` snapshots the version at schedule time. When the storage read resolves, a mismatch indicates the cycle was invalidated (by an eviction or a fresh re-hydration kicked off by the listener) and the merge is dropped. This strictly supersedes the `!hydratedSections.has(key)` race guard — the version check also catches the case where a new `ensureHydrated` cycle has already re-added the key before the old `.then` runs.
+
+Limits — best effort, not transactional:
+
+- Last-write-wins. No merge of conflicting changes between tabs.
+- Tab A writing immediately before tab B writes the same key follows browser-defined ordering; the listener fires after-the-fact in each tab.
+- The `completedCountCache` in `lib/user-storage.ts` is also per-tab — the listener invalidates it via `interactiveStepStorage.invalidateCountCache(contentKey)` so the next `getGuideProgress` re-scans storage.
+
 ## Section reducer — minimal state
 
 `section-state.ts` owns one bit: `acknowledged: true | null` (the #842 gate). Cursor is a pure derivation of `(stepIds, completedSet)` via `computeCursor(stepIds, completed)`; the completion set comes from `useSectionCompletion`. Reducer actions:

--- a/src/global-state/completion-store.test.tsx
+++ b/src/global-state/completion-store.test.tsx
@@ -503,6 +503,55 @@ describe('completion-store', () => {
       expect(screen.getByTestId('completed').textContent).toBe('false');
     });
 
+    it('matches exact (contentKey, sectionId) — does not misroute when one content key is a prefix of another', async () => {
+      // Regression for the prefix-collision bug in the original
+      // listener: when one active content key (`bundled:loki-101`)
+      // is a hyphen-delimited string prefix of another
+      // (`bundled:loki-101-extended`), `stripped.startsWith(short + '-')`
+      // matched the shorter key first and evicted the wrong pair,
+      // leaving the longer guide's cache stale until the next mount.
+      const SHORT_KEY = 'bundled:loki-101';
+      const LONG_KEY = 'bundled:loki-101-extended';
+
+      setActiveTabUrl(SHORT_KEY);
+      storedCompleted.set(`${SHORT_KEY}-section-x`, new Set(['step-1']));
+      const short = render(<StepProbe stepId="step-1" sectionId="section-x" />);
+      await flushMicrotasks();
+      expect(short.getByTestId('completed').textContent).toBe('true');
+      short.unmount();
+
+      setActiveTabUrl(LONG_KEY);
+      storedCompleted.set(`${LONG_KEY}-section-y`, new Set(['step-2']));
+      const long = render(<StepProbe stepId="step-2" sectionId="section-y" />);
+      await flushMicrotasks();
+      expect(long.getByTestId('completed').textContent).toBe('true');
+
+      // Tab A clears LONG_KEY's progress; storage event fires here for
+      // the LONG key only. Exact matching evicts the LONG pair; prefix
+      // matching would have evicted a non-existent `(SHORT_KEY, "extended-section-y")`
+      // and left the LONG cache untouched.
+      storedCompleted.delete(`${LONG_KEY}-section-y`);
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${LONG_KEY}-section-y`,
+            newValue: null,
+            oldValue: '["step-2"]',
+          })
+        );
+      });
+      await flushMicrotasks();
+      expect(long.getByTestId('completed').textContent).toBe('false');
+      long.unmount();
+
+      // SHORT_KEY cache must still hold its completion — the exact-match
+      // path never touched it.
+      setActiveTabUrl(SHORT_KEY);
+      const shortAgain = render(<StepProbe stepId="step-1" sectionId="section-x" />);
+      expect(shortAgain.getByTestId('completed').textContent).toBe('true');
+      shortAgain.unmount();
+    });
+
     it('drops stale in-flight hydration when a cross-tab storage event triggers re-hydration', async () => {
       // Race scenario: tab B's `ensureHydrated` has scheduled a storage
       // read with snapshot `{step-1, step-2}`. Tab A clears its progress

--- a/src/global-state/completion-store.test.tsx
+++ b/src/global-state/completion-store.test.tsx
@@ -18,6 +18,7 @@ import {
 } from './completion-store';
 import { setActiveTabUrl, resetContentKeyForTests } from './content-key';
 import { subscribeProgressEvent, type ProgressEventDetail } from './progress-events';
+import { StorageKeys } from '../lib/storage-keys';
 
 // In-memory mocks for the persisted-storage layer so tests are hermetic
 // and synchronous-where-they-can-be.
@@ -44,6 +45,11 @@ jest.mock('../lib/user-storage', () => ({
       });
       return total;
     }),
+    // Cross-tab sync invalidates the per-tab numerator cache without
+    // touching localStorage. Our in-memory mock has no cache to clear,
+    // so this is a no-op stub — present only to satisfy the production
+    // store's call site.
+    invalidateCountCache: jest.fn(),
   },
   interactiveCompletionStorage: {
     set: jest.fn(async (contentKey: string, percentage: number) => {
@@ -420,6 +426,111 @@ describe('completion-store', () => {
       expect(progress.completed).toBe(5);
       expect(progress.total).toBe(3);
       expect(progress.percentage).toBe(100);
+    });
+  });
+
+  // N-2 — cross-tab progress corruption.
+  //
+  // localStorage is shared across browser tabs but the store's caches
+  // live per-tab. Before the storage listener, tab B's stale cache
+  // could silently write back over tab A's authoritative reset (or
+  // vice versa). The listener evicts the affected section's cache +
+  // bumps its hydration version, then notifies subscribers so the
+  // next render re-hydrates from authoritative storage.
+  //
+  // Tests dispatch synthetic StorageEvents (jsdom doesn't fire them
+  // for in-tab localStorage writes — and even if it did, the spec
+  // only fires them in OTHER tabs).
+  describe('cross-tab sync', () => {
+    it('evicts the in-memory section cache when another tab writes to localStorage', async () => {
+      render(<StepProbe stepId="step-1" sectionId="section-x" />);
+      act(() => markStepCompleted('step-1', 'section-x', 'manual'));
+      await flushMicrotasks();
+      expect(screen.getByTestId('completed').textContent).toBe('true');
+
+      // Simulate tab A clearing its progress: localStorage now holds
+      // an empty set for our section, and the storage event fires in
+      // tab B (this test runner). Our listener should evict the cache.
+      storedCompleted.delete(`${CONTENT_KEY}-section-x`);
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${CONTENT_KEY}-section-x`,
+            newValue: '[]',
+            oldValue: '["step-1"]',
+          })
+        );
+      });
+      await flushMicrotasks();
+      // Subscriber re-reads authoritative storage on the next render
+      // and sees the empty set.
+      expect(screen.getByTestId('completed').textContent).toBe('false');
+    });
+
+    it('ignores storage events for unrelated localStorage keys', async () => {
+      render(<StepProbe stepId="step-1" sectionId="section-x" />);
+      act(() => markStepCompleted('step-1', 'section-x', 'manual'));
+      await flushMicrotasks();
+      expect(screen.getByTestId('completed').textContent).toBe('true');
+
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: 'some-other-app-key',
+            newValue: 'irrelevant',
+          })
+        );
+      });
+
+      // Cache untouched — subscriber still sees the completion.
+      expect(screen.getByTestId('completed').textContent).toBe('true');
+    });
+
+    it('treats event.key === null (localStorage.clear from another tab) as a global evict', async () => {
+      render(<StepProbe stepId="step-1" sectionId="section-x" />);
+      act(() => markStepCompleted('step-1', 'section-x', 'manual'));
+      await flushMicrotasks();
+      expect(screen.getByTestId('completed').textContent).toBe('true');
+
+      // Simulate tab A calling `localStorage.clear()` — browsers fire
+      // a `storage` event with key=null in OTHER tabs to signal a
+      // full storage wipe.
+      storedCompleted.clear();
+      act(() => {
+        window.dispatchEvent(new StorageEvent('storage', { key: null }));
+      });
+      await flushMicrotasks();
+      expect(screen.getByTestId('completed').textContent).toBe('false');
+    });
+
+    it('drops stale in-flight hydration when a cross-tab storage event triggers re-hydration', async () => {
+      // Race scenario: tab B's `ensureHydrated` has scheduled a storage
+      // read with snapshot `{step-1, step-2}`. Tab A clears its progress
+      // BEFORE that read resolves. The storage event fires in tab B
+      // (evicts cache + bumps hydration version), the subscriber
+      // re-renders and starts a fresh hydration cycle. The original
+      // in-flight `.then` then resolves — without the version check it
+      // would merge `{step-1, step-2}` back into the now-empty cache,
+      // silently undoing tab A's clear.
+      storedCompleted.set(`${CONTENT_KEY}-section-x`, new Set(['step-1', 'step-2']));
+      render(<StepProbe stepId="step-2" sectionId="section-x" />);
+      // Hydration pending — do NOT flush yet. The original `.then` is
+      // queued with `expectedVersion = 0`.
+      storedCompleted.delete(`${CONTENT_KEY}-section-x`);
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${CONTENT_KEY}-section-x`,
+            newValue: null,
+            oldValue: '["step-1","step-2"]',
+          })
+        );
+      });
+      await flushMicrotasks();
+      // The fresh re-hydration reads the now-empty storage; the stale
+      // in-flight read drops its merge on resolve. Subscriber stays at
+      // not-completed.
+      expect(screen.getByTestId('completed').textContent).toBe('false');
     });
   });
 });

--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -795,29 +795,29 @@ function handleStorageEvent(event: StorageEvent): void {
     return;
   }
   // Key shape: `${INTERACTIVE_STEPS_PREFIX}${contentKey}-${sectionId}`.
-  // `contentKey` may contain hyphens (URLs, bundled paths), so we can't
-  // naively split on '-'. Resolve against the live set of active
-  // content keys: any tab listening for a given content key either has
-  // it in `entries` (post-hydration with at least one step touched) or
-  // in `hydratedSections` (hydration started, possibly still in flight).
-  // We need both — a cross-tab event during an in-flight hydration is
-  // exactly the race the `hydrationVersion` guard exists for, but the
-  // guard never fires if the listener can't even identify the content
-  // key. Content keys we've never seen are not in our cache and need no
-  // eviction; the next render will hydrate fresh.
+  // `contentKey` may contain hyphens (URLs, bundled paths), so naive
+  // prefix matching against a single `contentKey` would misroute when
+  // one active key is a prefix of another (e.g. `bundled:loki-101` and
+  // `bundled:loki-101-extended` both match an event for the longer
+  // key). Disambiguate by reconstructing each known
+  // `(contentKey, sectionId)` pair from `hydratedSections` and
+  // requiring an exact match. Every section with an in-memory cache
+  // passes through `ensureHydrated`, which adds the pair before the
+  // async read fires and keeps it until eviction, so in-flight
+  // hydration (the exact case the `hydrationVersion` guard exists for)
+  // is still represented here. Content keys we've never seen produce
+  // no match; the next render hydrates fresh.
   const stripped = event.key.slice(StorageKeys.INTERACTIVE_STEPS_PREFIX.length);
-  const activeContentKeys = new Set<string>(entries.keys());
   for (const hydratedKey of hydratedSections) {
     const separator = hydratedKey.indexOf('::');
-    if (separator > 0) {
-      activeContentKeys.add(hydratedKey.slice(0, separator));
-    }
-  }
-  for (const contentKey of activeContentKeys) {
-    if (!stripped.startsWith(`${contentKey}-`)) {
+    if (separator <= 0) {
       continue;
     }
-    const sectionId = stripped.slice(contentKey.length + 1);
+    const contentKey = hydratedKey.slice(0, separator);
+    const sectionId = hydratedKey.slice(separator + 2);
+    if (`${contentKey}-${sectionId}` !== stripped) {
+      continue;
+    }
     evictSectionCacheForKey(contentKey, sectionId);
     // `completedCountCache` in `user-storage.ts` is also per-tab and
     // would otherwise return a stale numerator on the next

--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -29,6 +29,7 @@
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
 
 import { interactiveCompletionStorage, interactiveStepStorage } from '../lib/user-storage';
+import { StorageKeys } from '../lib/storage-keys';
 
 import { getContentKey } from './content-key';
 import { getTotalDocumentSteps } from './section-registry';
@@ -77,6 +78,25 @@ const listenersByContent = new Map<string, Set<() => void>>();
  * conflict with hydration's additive merge, so they don't touch this.
  */
 const hydrationClears = new Map<string, Set<string> | 'all'>();
+
+/**
+ * Per-section monotonic hydration version. Snapshotted by `ensureHydrated`
+ * at schedule time and re-checked in the `.then` handler so any storage
+ * read whose cycle has been invalidated (by `evictSectionCache`,
+ * `evictContentCache`, or the cross-tab `storage` listener) drops its
+ * merge instead of resurrecting stale data.
+ *
+ * Strictly stronger than the `!hydratedSections.has(key)` race guard:
+ * if a cache eviction is followed by a fresh `ensureHydrated` cycle
+ * (cross-tab path), the section is re-added to `hydratedSections`
+ * before the old `.then` runs, but the version check still catches the
+ * stale read.
+ */
+const hydrationVersion = new Map<string, number>();
+
+function bumpHydrationVersion(key: string): void {
+  hydrationVersion.set(key, (hydrationVersion.get(key) ?? 0) + 1);
+}
 
 function noteHydrationClear(contentKey: string, sectionId: string, cleared: readonly string[] | 'all'): void {
   const key = `${contentKey}::${sectionId}`;
@@ -143,6 +163,10 @@ function ensureHydrated(contentKey: string, sectionId: string): void {
   }
   hydratedSections.add(key);
   hydrationClears.set(key, new Set());
+  // Snapshot the version at schedule time. If a concurrent eviction
+  // (in-tab or cross-tab) bumps the version before our `.then` runs,
+  // we'll see the mismatch and bail rather than merging stale data.
+  const expectedVersion = hydrationVersion.get(key) ?? 0;
   interactiveStepStorage
     .getCompleted(contentKey, sectionId)
     .then((stored) => {
@@ -152,7 +176,16 @@ function ensureHydrated(contentKey: string, sectionId: string): void {
       // map via `stepsFor(...)` and resurrect cleared progress from the
       // stale snapshot — making "Reset guide" durably ineffective until
       // the next mount.
-      if (!hydratedSections.has(key)) {
+      //
+      // The version check additionally covers the cross-tab path: when
+      // the storage listener evicts AND a new `ensureHydrated` cycle
+      // has started (re-adding the key to `hydratedSections`) before
+      // this `.then` runs, the version mismatch detects the stale read.
+      // Coalesce both sides — a key that has never been bumped reads
+      // back `undefined`, and we want that to compare equal to the
+      // `0` captured at schedule time.
+      const currentVersion = hydrationVersion.get(key) ?? 0;
+      if (!hydratedSections.has(key) || currentVersion !== expectedVersion) {
         hydrationClears.delete(key);
         return;
       }
@@ -517,9 +550,26 @@ export function reconcileSection(sectionId: string, roster: readonly string[]): 
  * on unmount in preview mode so a remount under the same preview key
  * starts from an empty cache rather than inheriting the prior session's
  * in-memory state.
+ *
+ * Thin wrapper over `evictSectionCacheForKey` keyed by the currently
+ * active content key. Cross-tab paths that receive a `storage` event for
+ * a non-active content key must call `evictSectionCacheForKey` directly.
  */
 export function evictSectionCache(sectionId: string): void {
-  const contentKey = getContentKey();
+  evictSectionCacheForKey(getContentKey(), sectionId);
+}
+
+/**
+ * Explicit-content-key variant of `evictSectionCache`. The cross-tab
+ * `storage` listener uses this because the event may carry a key that
+ * isn't the tab's currently-active content key.
+ *
+ * Bumps `hydrationVersion[key]` so any hydration scheduled before this
+ * call drops its merge on resolve — replaces the brittle
+ * `!hydratedSections.has(key)` check (the next `ensureHydrated` cycle
+ * re-adds the key before the old `.then` runs).
+ */
+export function evictSectionCacheForKey(contentKey: string, sectionId: string): void {
   const bySection = entries.get(contentKey);
   if (bySection) {
     bySection.delete(sectionId);
@@ -527,9 +577,11 @@ export function evictSectionCache(sectionId: string): void {
       entries.delete(contentKey);
     }
   }
-  hydratedSections.delete(`${contentKey}::${sectionId}`);
-  hydrationClears.delete(`${contentKey}::${sectionId}`);
-  sectionVersions.delete(`${contentKey}::${sectionId}`);
+  const key = `${contentKey}::${sectionId}`;
+  hydratedSections.delete(key);
+  hydrationClears.delete(key);
+  sectionVersions.delete(key);
+  bumpHydrationVersion(key);
 }
 
 /**
@@ -554,6 +606,10 @@ export function evictContentCache(contentKey: string): void {
   for (const key of Array.from(hydratedSections)) {
     if (key.startsWith(prefix)) {
       hydratedSections.delete(key);
+      // Invalidate any in-flight hydration cycle for this section so
+      // its `.then` handler bails rather than resurrecting the stale
+      // snapshot once the storage read resolves.
+      bumpHydrationVersion(key);
     }
   }
   for (const key of Array.from(hydrationClears.keys())) {
@@ -676,6 +732,14 @@ export function markStepsCompleted(
  */
 export function evictAllContentCaches(): void {
   const contentKeys = Array.from(listenersByContent.keys());
+  // Bump every existing hydration version BEFORE clearing the maps so
+  // any in-flight hydration cycle drops its merge on resolve. Clearing
+  // hydrationVersion outright would reset captured versions to 0, which
+  // would then match a fresh ensureHydrated cycle's snapshot and let
+  // stale data merge.
+  for (const key of Array.from(hydratedSections)) {
+    bumpHydrationVersion(key);
+  }
   entries.clear();
   hydratedSections.clear();
   hydrationClears.clear();
@@ -692,6 +756,83 @@ export function resetCompletionStoreForTests(): void {
   entries.clear();
   hydratedSections.clear();
   hydrationClears.clear();
+  hydrationVersion.clear();
   listenersByContent.clear();
   sectionVersions.clear();
 }
+
+/**
+ * Cross-tab synchronisation — `storage` event listener.
+ *
+ * localStorage is shared across every browser tab on the same origin,
+ * but the completion store's caches (`entries`, `hydratedSections`, ...)
+ * live in this module instance and are therefore per-tab. Without this
+ * listener, tab B's stale cache silently writes back over tab A's
+ * authoritative reset (or vice versa) and the user's progress is
+ * silently corrupted — no error, log, or UI indicator.
+ *
+ * The browser fires a `storage` event in every OTHER tab on the same
+ * origin whenever localStorage is mutated. We react by evicting the
+ * affected section's in-memory cache + bumping its hydration version,
+ * then notifying subscribers so the next render re-reads from the
+ * authoritative storage snapshot.
+ *
+ * Best-effort semantics: a pathological interleaving (tab A writes
+ * immediately before tab B writes the same key) follows last-write-
+ * wins. No merge of conflicting changes.
+ *
+ * See `docs/developer/STEP_MODEL.md` "Cross-tab synchronisation".
+ */
+function handleStorageEvent(event: StorageEvent): void {
+  // `event.key === null` means `localStorage.clear()` was called by
+  // another tab. The interactive-step storage namespace can't survive
+  // a full storage wipe, so drop every in-memory cache.
+  if (event.key === null) {
+    evictAllContentCaches();
+    return;
+  }
+  if (!event.key.startsWith(StorageKeys.INTERACTIVE_STEPS_PREFIX)) {
+    return;
+  }
+  // Key shape: `${INTERACTIVE_STEPS_PREFIX}${contentKey}-${sectionId}`.
+  // `contentKey` may contain hyphens (URLs, bundled paths), so we can't
+  // naively split on '-'. Resolve against the live set of active
+  // content keys: any tab listening for a given content key either has
+  // it in `entries` (post-hydration with at least one step touched) or
+  // in `hydratedSections` (hydration started, possibly still in flight).
+  // We need both — a cross-tab event during an in-flight hydration is
+  // exactly the race the `hydrationVersion` guard exists for, but the
+  // guard never fires if the listener can't even identify the content
+  // key. Content keys we've never seen are not in our cache and need no
+  // eviction; the next render will hydrate fresh.
+  const stripped = event.key.slice(StorageKeys.INTERACTIVE_STEPS_PREFIX.length);
+  const activeContentKeys = new Set<string>(entries.keys());
+  for (const hydratedKey of hydratedSections) {
+    const separator = hydratedKey.indexOf('::');
+    if (separator > 0) {
+      activeContentKeys.add(hydratedKey.slice(0, separator));
+    }
+  }
+  for (const contentKey of activeContentKeys) {
+    if (!stripped.startsWith(`${contentKey}-`)) {
+      continue;
+    }
+    const sectionId = stripped.slice(contentKey.length + 1);
+    evictSectionCacheForKey(contentKey, sectionId);
+    // `completedCountCache` in `user-storage.ts` is also per-tab and
+    // would otherwise return a stale numerator on the next
+    // `getGuideProgress` call.
+    interactiveStepStorage.invalidateCountCache(contentKey);
+    notify(contentKey);
+    return;
+  }
+}
+
+function installCrossTabSync(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.addEventListener('storage', handleStorageEvent);
+}
+
+installCrossTabSync();

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -1024,6 +1024,19 @@ const completedCountCache = new Map<string, number>();
  */
 export const interactiveStepStorage = {
   /**
+   * Drop the cached completion count for a content key without touching
+   * localStorage. Used by the cross-tab `storage` listener in
+   * `completion-store.ts` so the next `countAllCompleted` / `getGuideProgress`
+   * call re-scans from authoritative storage rather than returning a
+   * stale per-tab snapshot.
+   *
+   * Idempotent on unknown keys; safe to call from any tab.
+   */
+  invalidateCountCache(contentKey: string): void {
+    completedCountCache.delete(contentKey);
+  },
+
+  /**
    * Gets completed step IDs for a specific content/section
    */
   async getCompleted(contentKey: string, sectionId: string): Promise<Set<string>> {


### PR DESCRIPTION
## Summary

Follow-up to [#909](https://github.com/grafana/grafana-pathfinder-app/pull/909) closing the N-2 deferred finding: when the same guide is open in two browser tabs, each tab has its own module-scope completion-store cache but they share localStorage. Without cross-tab sync, tab B's stale cache could silently write back over tab A's authoritative reset (or vice versa) with no error, log, or UI indicator.

https://github.com/user-attachments/assets/4cb54c68-719f-43b7-b986-e18c8eaa2c69



## What changed

- **Module-scope `storage` event listener** in `src/global-state/completion-store.ts`. Fires in every OTHER tab on the same origin on localStorage mutation. Handles `event.key === null` (cross-tab `localStorage.clear()`) as a global evict; matches `INTERACTIVE_STEPS_PREFIX` keys against the active set (entries plus hydratedSections), then `evictSectionCacheForKey` + `invalidateCountCache` + `notify`.
- **Hydration-generation counter** (`hydrationVersion`). Snapshotted by `ensureHydrated` at schedule time, re-checked in the `.then` handler. Strictly supersedes the old `!hydratedSections.has(key)` race guard: a cross-tab eviction followed by a fresh re-hydration cycle re-adds the key before the original `.then` runs, so the `has(key)` check alone passes and stale data would merge. The version check catches this.
- **`evictSectionCacheForKey(contentKey, sectionId)`** — extracted explicit-key variant. The cross-tab event may carry a key that isn't the tab's currently active content key. `evictSectionCache(sectionId)` becomes a thin wrapper.
- **`interactiveStepStorage.invalidateCountCache(contentKey)`** export in `src/lib/user-storage.ts`. The per-tab `completedCountCache` was already invalidated inline by `setCompleted` / `clear` / `clearAllForContent` / `clearAll`. Exposed publicly so the cross-tab handler can drop the stale numerator without touching localStorage.

## Tests

Four new tripwires in `src/global-state/completion-store.test.tsx` (\`cross-tab sync\` describe block):

1. Storage event evicts the in-memory section cache; subscriber re-renders against authoritative storage.
2. Storage events for unrelated localStorage keys are ignored (early-return).
3. \`event.key === null\` triggers a global evict.
4. Stale in-flight hydration is dropped when a cross-tab storage event triggers re-hydration (pins the \`hydrationVersion\` contract).

## Docs

New \"Cross-tab synchronization\" subsection in [docs/developer/STEP_MODEL.md](docs/developer/STEP_MODEL.md) documenting the listener, the hydration-version invariant, and the best-effort semantics (last-write-wins; no merge of conflicting changes).

## Test plan

- [x] \`npm run check\` clean: 230 suites / 3902 tests pass (+4 vs base).
- [ ] Manual: open the same guide in two browser tabs, complete a step in tab A, click \"Reset guide\" in tab B, return to tab A, scroll the section, confirm tab A reflects the reset on next render.
- [ ] Manual: complete a step in tab A, then in tab B click reset, complete a different step in tab A, confirm tab B does not silently resurrect tab A's first completion on next render.

## Risk and reversibility

- Storage listener fires on every cross-tab localStorage write including unrelated keys. The early-return on prefix mismatch is O(1).
- Hydration-version check strictly supersedes the prior MF-4 guard; same correctness, broader coverage.
- \`invalidateCountCache\` export is additive; no existing callers affected.
- Reversible by reverting the commit. No storage format changes.

## Deferred follow-ups from PR #909 (remaining)

- N-3 silent QuotaExceededError
- F-1 all-passive guide reads 0%
- F-3 youtube window globals
- F-5 markStepCompleted additive-merge tripwire
- F-6 multi-step \`data: any\` tighten
- F-2 section-child re-render probe
- N-4 STEP_MODEL caveat on type-change orphans
- N-5 evictContentCache locality JSDoc

These will be addressed in subsequent follow-up PRs.