### PR TITLE
docs(completion-store): document evictContentCache subscriber locality (N-5 follow-up)

### DIFF
--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -547,6 +547,15 @@ export function evictSectionCache(sectionId: string): void {
  * Safe to call with any contentKey, including ones the store hasn't
  * seen — entries / hydration markers / version counters are all
  * Map-keyed by exact string and unknown keys are no-ops.
+ *
+ * Subscribers via `useStepCompletion` / `useSectionCompletion` capture
+ * `getContentKey()` at hook-render time. Eviction by a content key
+ * that differs from the active hook's captured key will NOT trigger
+ * a re-render for those subscribers — they continue to read from the
+ * old cache slot. In practice this is fine: a user only interacts with
+ * one active content key at a time, and evictions are scoped to that
+ * key. If you need to evict a different content key while subscribers
+ * remain mounted under it, use `evictAllContentCaches()` instead.
  */
 export function evictContentCache(contentKey: string): void {
   entries.delete(contentKey);


### PR DESCRIPTION
## Summary

Adds a JSDoc paragraph to `evictContentCache` in `src/global-state/completion-store.ts` documenting a subtle subscriber-locality property of the cache.

- Subscribers via `useStepCompletion` / `useSectionCompletion` capture `getContentKey()` at hook-render time.
- Evicting under a content key that differs from the active hook's captured key will **not** re-render those subscribers — they continue to read the old cache slot.
- In practice this is fine: a user only interacts with one active content key at a time, and evictions are scoped to that key.
- If a caller ever needs to evict a different key while subscribers remain mounted under it, they should use `evictAllContentCaches()` instead.

Pure documentation change — no runtime behavior is altered.

## Why

Closes out the **N-5** finding deferred from #909 (`refactor(interactive): collapse state ownership, restore tier hygiene`). The reviewer flagged that the subscriber-locality property of `evictContentCache` was non-obvious and worth recording inline so future callers don't reach for it expecting cross-key invalidation.

Tracked in the PR #909 follow-ups plan at `/Users/jayclifford/.cursor/plans/pr909-followups-parallel_6f07373c.plan.md` as PR 8.

## Test plan

- [x] `npm run check` (typecheck + lint + prettier + lint:go + test:go + test:ci) — 231 suites, 3912 tests passing.
- [x] `git diff origin/main -- src/global-state/completion-store.ts` shows only the JSDoc paragraph addition (no executable code changes).

## Risk and reversibility

Zero runtime risk — JSDoc-only. Trivially revertible.

Made with [Cursor](https://cursor.com)