### PR TITLE
docs(step-model): document type-change orphan caveat for stable step IDs (N-4 follow-up)

### DIFF
--- a/docs/developer/STEP_MODEL.md
+++ b/docs/developer/STEP_MODEL.md
@@ -18,6 +18,12 @@ The canonical JSON form is lowercase (`action`, `reftarget`, `targetvalue`). The
 
 Authors can also write an explicit `id` on an interactive block; the parser plumbs it through to `ParsedElement.props.stepId`, overriding the section's positional `${sectionId}-step-N` convention. This is the recommended path for stable `section-completed:` requirement targets.
 
+### Step ID stability — type-change caveat
+
+Stable IDs survive position and content edits. They do NOT survive a block-type change (e.g. `interactive-step` → `interactive-multi-step` without an explicit `id`), because `deriveStepId(...)` doesn't include the block's `type` in its hash input — by design, since the type can flip during authoring without the author considering it identity-changing. Authors who want type-change resilience must set an explicit `id` on the block.
+
+The hash inputs are documented at `src/global-state/step-id.ts` (`deriveStepId(...)`): `sectionId`, zero-based `index`, `action`, `refTarget`, and an optional `variant` — notably no `type`. Audit that file to confirm which authoring edits do and do not orphan prior completion state in `interactiveStepStorage`.
+
 ## Completion store — canonical persistence
 
 Step completion lives in `src/global-state/completion-store.ts`. The store is the canonical persistence layer — `SectionState` no longer carries a parallel `completed` set, and step components no longer maintain a local `isLocallyCompleted` flag. The store backs the existing `interactiveStepStorage` namespace so localStorage shape is preserved.


### PR DESCRIPTION
## Summary

Closes the **N-4** finding from the PR #909 code review that was deferred out of the original docs sweep. Adds a short subsection to `docs/developer/STEP_MODEL.md` documenting that stable step IDs survive position and content edits but **NOT** a block-type change (for example, `interactive-step` -> `interactive-multi-step` without an explicit `id`), because `deriveStepId(...)` in `src/global-state/step-id.ts` intentionally omits `type` from its hash input.

Authors who want type-change resilience must set an explicit `id` on the block.

## Why

PR #909 introduced the stable step-ID derivation and updated `STEP_MODEL.md`, but the type-change caveat was flagged during review (N-4) and parked for a follow-up. Without this note, an author flipping a block's type will silently orphan prior completion state in `interactiveStepStorage` with no in-tree explanation of the cause.

## What changed

- `docs/developer/STEP_MODEL.md`: new "Step ID stability - type-change caveat" subsection under the existing stable-ID guidance, with a pointer to `src/global-state/step-id.ts` for the actual hash inputs.

No code changes.

## Plan reference

This is PR 7 of the `pr909-followups-parallel` plan (N-4 STEP_MODEL caveat).

## Test plan

- [x] `npx prettier --check docs/developer/STEP_MODEL.md` passes
- [x] `npm run check` passes (typecheck + lint + prettier + lint:go + test:go + test:ci)
- [ ] Reviewer skim: caveat reads correctly and the `src/global-state/step-id.ts` pointer matches `deriveStepId(...)`'s actual inputs (`sectionId`, `index`, `action`, `refTarget`, optional `variant` - no `type`)

Made with [Cursor](https://cursor.com)