### PR TITLE
refactor(multi-step): tighten data parameter to InteractiveElementData (F-6 follow-up)

### DIFF
--- a/src/components/interactive-tutorial/interactive-multi-step.tsx
+++ b/src/components/interactive-tutorial/interactive-multi-step.tsx
@@ -11,6 +11,7 @@ import { useStepChecker, validateInteractiveRequirements } from '../../requireme
 import { reportAppInteraction, UserInteraction, buildInteractiveStepProperties } from '../../lib/analytics';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
 import { InternalAction } from '../../types/interactive-actions.types';
+import type { InteractiveElementData } from '../../types/interactive.types';
 import { testIds } from '../../constants/testIds';
 import { STEP_STATES } from './step-states';
 import { markStepCompleted, resetStep, useStepCompletion } from '../../global-state/completion-store';
@@ -63,7 +64,7 @@ interface InteractiveMultiStepProps {
 async function checkActionRequirements(
   action: InternalAction,
   actionIndex: number,
-  checkRequirementsFromData: (data: any) => Promise<any>
+  checkRequirementsFromData: (data: InteractiveElementData) => Promise<any>
 ): Promise<{ pass: boolean; explanation?: string }> {
   if (!action.requirements) {
     return { pass: true };


### PR DESCRIPTION
## Summary

Replaces the `data: any` parameter on `checkRequirementsFromData` inside `checkActionRequirements` (in `src/components/interactive-tutorial/interactive-multi-step.tsx`) with the typed `InteractiveElementData`. This gives us a compile-time guard against future field-casing drift between the legacy snake_case author payload and the camelCase runtime shape produced by the parser introduced in #909.

## Why

This is the deferred F-6 finding from #909. The broader F-6 sweep tightened most call sites during that PR, but a single `data: any` signature in `interactive-multi-step.tsx` was left behind. The parser already emits camelCase, so no caller-side changes are required — `npx tsc --noEmit` and `npm run check` both pass cleanly.

## Scope

- One-line type tightening + one type import.
- Plan: `pr909-followups-parallel_6f07373c.plan.md` — PR 4.
- Refs: #909.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run check` passes (231 suites / 3912 tests)
- [ ] CI green on PR

## Risk and reversibility

Trivial. One-line signature change; revertable with a single commit if it ever surfaces a caller-side regression.

Made with [Cursor](https://cursor.com)