### PR TITLE
fix(progress): treat all-passive guide as 100% when acknowledged (F-1 follow-up)

### DIFF
--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -450,11 +450,9 @@ export function InteractiveSection({
   }, [isCompleted, isPreviewMode, sectionId]);
 
   // Trigger reactive checks when section completion status changes.
-  // The `stepComponents.length > 0 || gateAnalysis.isAllPassive` guard
-  // lets all-passive sections (which register zero interactive steps)
-  // still flow through this effect so their "section done" bit is
-  // persisted and the guide-level progress percentage refreshes — see
-  // F-1 follow-up to PR #909.
+  // The `gateAnalysis.isAllPassive` branch lets sections with zero
+  // interactive steps still persist `sectionDoneStorage` + refresh
+  // guide progress (F-1, #909 follow-up).
   useEffect(() => {
     if (isCompleted && (stepComponents.length > 0 || gateAnalysis.isAllPassive)) {
       // Single unified event — replaces the two legacy CustomEvents
@@ -472,10 +470,8 @@ export function InteractiveSection({
         // Preview mode is sandboxed — keep the ephemeral check DOM-only.
         if (!isPreviewMode) {
           sectionDoneStorage.set(getContentKey(), sectionId, true);
-          // All-passive sections never write to `interactiveStepStorage`,
-          // so `persistSection` never runs for them and the guide
-          // percentage would otherwise never update. Refresh here so
-          // My Learning + the progress chip reflect the ack.
+          // All-passive sections bypass `persistSection`, so refresh
+          // the guide percentage explicitly.
           if (gateAnalysis.isAllPassive) {
             refreshAndNotifyGuideProgress(getContentKey());
           }
@@ -1082,11 +1078,8 @@ export function InteractiveSection({
           detail: { contentKey },
         })
       );
-      // For all-passive sections the store-based reset doesn't update
-      // the persisted guide percentage (no step writes → no
-      // `persistSection`). Recompute now so My Learning / the chip
-      // catch the drop. Safe for all sections — it's a no-op when
-      // there's nothing to recalculate.
+      // All-passive sections bypass `persistSection` on reset too;
+      // recompute so the persisted percentage drops in lockstep.
       if (!isPreviewMode) {
         refreshAndNotifyGuideProgress(contentKey);
       }

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -70,6 +70,7 @@ import {
   markStepCompleted,
   markStepsCompleted,
   reconcileSection,
+  refreshAndNotifyGuideProgress,
   resetSection as resetSectionStore,
   resetSteps,
   useSectionCompletion,
@@ -448,9 +449,14 @@ export function InteractiveSection({
     }
   }, [isCompleted, isPreviewMode, sectionId]);
 
-  // Trigger reactive checks when section completion status changes
+  // Trigger reactive checks when section completion status changes.
+  // The `stepComponents.length > 0 || gateAnalysis.isAllPassive` guard
+  // lets all-passive sections (which register zero interactive steps)
+  // still flow through this effect so their "section done" bit is
+  // persisted and the guide-level progress percentage refreshes — see
+  // F-1 follow-up to PR #909.
   useEffect(() => {
-    if (isCompleted && stepComponents.length > 0) {
+    if (isCompleted && (stepComponents.length > 0 || gateAnalysis.isAllPassive)) {
       // Single unified event — replaces the two legacy CustomEvents
       // (`section-completed` on document + `interactive-section-completed`
       // on window). The `!hasEmittedGuideCompletionRef.current` guard
@@ -466,6 +472,13 @@ export function InteractiveSection({
         // Preview mode is sandboxed — keep the ephemeral check DOM-only.
         if (!isPreviewMode) {
           sectionDoneStorage.set(getContentKey(), sectionId, true);
+          // All-passive sections never write to `interactiveStepStorage`,
+          // so `persistSection` never runs for them and the guide
+          // percentage would otherwise never update. Refresh here so
+          // My Learning + the progress chip reflect the ack.
+          if (gateAnalysis.isAllPassive) {
+            refreshAndNotifyGuideProgress(getContentKey());
+          }
         }
       }
 
@@ -476,7 +489,7 @@ export function InteractiveSection({
         SequentialRequirementsManager.getInstance().watchNextStep(3000); // Watch for 3 seconds
       });
     }
-  }, [isCompleted, sectionId, stepComponents.length, isPreviewMode]);
+  }, [isCompleted, sectionId, stepComponents.length, isPreviewMode, gateAnalysis.isAllPassive]);
 
   // PRE-COMPUTE eligibility for ALL steps once (React best practice)
   // This prevents expensive recalculation on every render
@@ -1069,6 +1082,14 @@ export function InteractiveSection({
           detail: { contentKey },
         })
       );
+      // For all-passive sections the store-based reset doesn't update
+      // the persisted guide percentage (no step writes → no
+      // `persistSection`). Recompute now so My Learning / the chip
+      // catch the drop. Safe for all sections — it's a no-op when
+      // there's nothing to recalculate.
+      if (!isPreviewMode) {
+        refreshAndNotifyGuideProgress(contentKey);
+      }
     }
 
     // Reset all step states in the global manager
@@ -1099,7 +1120,7 @@ export function InteractiveSection({
         }, 100);
       }, 200);
     });
-  }, [disabled, isRunning, stepComponents, resetCollapse, clearAckAndCollapseStorage, sectionId]);
+  }, [disabled, isRunning, stepComponents, resetCollapse, clearAckAndCollapseStorage, sectionId, isPreviewMode]);
 
   /**
    * Mark the section as acknowledged (issue #842).

--- a/src/global-state/completion-store.test.tsx
+++ b/src/global-state/completion-store.test.tsx
@@ -9,6 +9,7 @@ import {
   markStepCompleted,
   markStepsCompleted,
   reconcileSection,
+  refreshAndNotifyGuideProgress,
   resetCompletionStoreForTests,
   resetSection,
   resetStep,
@@ -22,6 +23,7 @@ import { subscribeProgressEvent, type ProgressEventDetail } from './progress-eve
 // In-memory mocks for the persisted-storage layer so tests are hermetic
 // and synchronous-where-they-can-be.
 const storedCompleted = new Map<string, Set<string>>(); // `${contentKey}-${sectionId}` -> ids
+const storedAcks = new Map<string, true>(); // `${contentKey}-${sectionId}` -> true
 const guidePercentages = new Map<string, number>();
 
 jest.mock('../lib/user-storage', () => ({
@@ -50,19 +52,34 @@ jest.mock('../lib/user-storage', () => ({
       guidePercentages.set(contentKey, percentage);
     }),
   },
+  sectionAcknowledgementStorage: {
+    countAllAcknowledged: jest.fn((contentKey: string) => {
+      let count = 0;
+      storedAcks.forEach((_value, key) => {
+        if (key.startsWith(`${contentKey}-`)) {
+          count++;
+        }
+      });
+      return count;
+    }),
+  },
 }));
 
 let mockTotalDocumentSteps = 0;
+let mockRegisteredSectionCount = 0;
 jest.mock('./section-registry', () => ({
   getTotalDocumentSteps: () => mockTotalDocumentSteps,
+  getRegisteredSectionCount: () => mockRegisteredSectionCount,
 }));
 
 const CONTENT_KEY = 'bundled:test-guide';
 
 beforeEach(() => {
   storedCompleted.clear();
+  storedAcks.clear();
   guidePercentages.clear();
   mockTotalDocumentSteps = 0;
+  mockRegisteredSectionCount = 0;
   resetCompletionStoreForTests();
   resetContentKeyForTests();
   setActiveTabUrl(CONTENT_KEY);
@@ -169,15 +186,48 @@ describe('completion-store', () => {
 
   // F-1 follow-up to PR #909. A guide whose sections are entirely
   // passive registers no interactive steps, so `getTotalDocumentSteps()`
-  // is 0. The passive ack still persists an ack-marker that
-  // `countAllCompleted` sees, so the numerator is > 0 while the
-  // denominator is 0. Before the fix this 0/0 divided into 0% and the
-  // progress chip / My Learning row stayed at 0 forever; the fix
-  // treats "acknowledged with no interactive total" as 100%.
-  it('getGuideProgress returns 100% for an all-passive guide once an ack-marker is present', () => {
-    storedCompleted.set(`${CONTENT_KEY}-section-passive`, new Set(['__ack-marker__']));
-    mockTotalDocumentSteps = 0;
-    expect(getGuideProgress(CONTENT_KEY)).toEqual({ completed: 1, total: 0, percentage: 100 });
+  // is 0. The user's "Mark section complete" click persists an entry in
+  // `sectionAcknowledgementStorage` (not `interactiveStepStorage`), so
+  // the percentage must come from the ack-count divided by the number
+  // of registered sections. Before the fix this 0/0 divided into 0% and
+  // the progress chip / My Learning row stayed at 0 forever.
+  describe('all-passive guide progress (F-1)', () => {
+    it('returns 100% once every registered section is acknowledged', () => {
+      mockTotalDocumentSteps = 0;
+      mockRegisteredSectionCount = 1;
+      storedAcks.set(`${CONTENT_KEY}-section-passive`, true);
+      expect(getGuideProgress(CONTENT_KEY)).toEqual({ completed: 1, total: 1, percentage: 100 });
+    });
+
+    it('returns a partial percentage for multi-section guides with one ack', () => {
+      mockTotalDocumentSteps = 0;
+      mockRegisteredSectionCount = 4;
+      storedAcks.set(`${CONTENT_KEY}-section-1`, true);
+      expect(getGuideProgress(CONTENT_KEY)).toEqual({ completed: 1, total: 4, percentage: 25 });
+    });
+
+    it('returns 0% when no sections are acknowledged yet', () => {
+      mockTotalDocumentSteps = 0;
+      mockRegisteredSectionCount = 3;
+      expect(getGuideProgress(CONTENT_KEY)).toEqual({ completed: 0, total: 3, percentage: 0 });
+    });
+
+    it('returns 0% when no sections are registered yet (guide not mounted)', () => {
+      mockTotalDocumentSteps = 0;
+      mockRegisteredSectionCount = 0;
+      expect(getGuideProgress(CONTENT_KEY)).toEqual({ completed: 0, total: 0, percentage: 0 });
+    });
+
+    it('refreshAndNotifyGuideProgress persists the percentage to interactiveCompletionStorage', () => {
+      mockTotalDocumentSteps = 0;
+      mockRegisteredSectionCount = 2;
+      storedAcks.set(`${CONTENT_KEY}-section-1`, true);
+      storedAcks.set(`${CONTENT_KEY}-section-2`, true);
+
+      refreshAndNotifyGuideProgress(CONTENT_KEY);
+
+      expect(guidePercentages.get(CONTENT_KEY)).toBe(100);
+    });
   });
 
   it('getGuideProgress computes percentage when total steps is known', () => {

--- a/src/global-state/completion-store.test.tsx
+++ b/src/global-state/completion-store.test.tsx
@@ -190,13 +190,11 @@ describe('completion-store', () => {
     expect(getGuideProgress(CONTENT_KEY)).toEqual({ completed: 0, total: 0, percentage: 0 });
   });
 
-  // F-1 follow-up to PR #909. A guide whose sections are entirely
-  // passive registers no interactive steps, so `getTotalDocumentSteps()`
-  // is 0. The user's "Mark section complete" click persists an entry in
-  // `sectionAcknowledgementStorage` (not `interactiveStepStorage`), so
-  // the percentage must come from the ack-count divided by the number
-  // of registered sections. Before the fix this 0/0 divided into 0% and
-  // the progress chip / My Learning row stayed at 0 forever.
+  // F-1 (#909 follow-up): all-passive guides have no interactive
+  // steps, so `getGuideProgress` must derive the percentage from
+  // `sectionAcknowledgementStorage` (where the production ack writer
+  // persists) divided by `getRegisteredSectionCount()`, not from the
+  // 0/0 step-count division the pre-fix code did.
   describe('all-passive guide progress (F-1)', () => {
     it('returns 100% once every registered section is acknowledged', () => {
       mockTotalDocumentSteps = 0;

--- a/src/global-state/completion-store.test.tsx
+++ b/src/global-state/completion-store.test.tsx
@@ -162,10 +162,22 @@ describe('completion-store', () => {
     expect(screen.getByTestId('reason').textContent).toBe('skipped');
   });
 
-  it('getGuideProgress returns 0% when total steps is unknown', () => {
-    storedCompleted.set(`${CONTENT_KEY}-section-x`, new Set(['step-1']));
+  it('getGuideProgress returns 0% when total is unknown and nothing has been completed', () => {
     mockTotalDocumentSteps = 0;
-    expect(getGuideProgress(CONTENT_KEY)).toEqual({ completed: 1, total: 0, percentage: 0 });
+    expect(getGuideProgress(CONTENT_KEY)).toEqual({ completed: 0, total: 0, percentage: 0 });
+  });
+
+  // F-1 follow-up to PR #909. A guide whose sections are entirely
+  // passive registers no interactive steps, so `getTotalDocumentSteps()`
+  // is 0. The passive ack still persists an ack-marker that
+  // `countAllCompleted` sees, so the numerator is > 0 while the
+  // denominator is 0. Before the fix this 0/0 divided into 0% and the
+  // progress chip / My Learning row stayed at 0 forever; the fix
+  // treats "acknowledged with no interactive total" as 100%.
+  it('getGuideProgress returns 100% for an all-passive guide once an ack-marker is present', () => {
+    storedCompleted.set(`${CONTENT_KEY}-section-passive`, new Set(['__ack-marker__']));
+    mockTotalDocumentSteps = 0;
+    expect(getGuideProgress(CONTENT_KEY)).toEqual({ completed: 1, total: 0, percentage: 100 });
   });
 
   it('getGuideProgress computes percentage when total steps is known', () => {

--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -245,10 +245,22 @@ function persistSection(contentKey: string, sectionId: string): void {
 
 function refreshGuidePercentage(contentKey: string): number | undefined {
   const docTotal = getTotalDocumentSteps();
+  const allCompleted = interactiveStepStorage.countAllCompleted(contentKey);
   if (docTotal < 1) {
+    // All-passive guide: `registerSectionSteps` only counts non-passive
+    // steps, so a guide whose sections are entirely passive reports
+    // docTotal === 0 even after the user acknowledges every section.
+    // The passive ack still writes an ack-marker entry that
+    // `countAllCompleted` sees, so when `allCompleted > 0` the guide
+    // is effectively 100% complete. Without this branch the persisted
+    // percentage stays unset and My Learning shows 0% for a fully-done
+    // guide (F-1 follow-up to PR #909).
+    if (allCompleted > 0) {
+      interactiveCompletionStorage.set(contentKey, 100);
+      return 100;
+    }
     return undefined;
   }
-  const allCompleted = interactiveStepStorage.countAllCompleted(contentKey);
   const percentage = Math.round((allCompleted / docTotal) * 100);
   interactiveCompletionStorage.set(contentKey, percentage);
   return percentage;
@@ -335,7 +347,12 @@ export function getGuideProgress(contentKey: string): GuideProgress {
   const completedRaw = interactiveStepStorage.countAllCompleted(contentKey);
   const completed = completedRaw < 0 ? 0 : completedRaw;
   if (total < 1) {
-    return { completed, total, percentage: 0 };
+    // All-passive guide: the only persisted entry is an ack-marker from
+    // a passive section the user acknowledged, so `completed > 0` while
+    // `total === 0`. Treat that 0/0 as 100% instead of dividing into the
+    // 0% NaN trap — without this the progress chip reads 0% even after
+    // the user finishes the guide (F-1 follow-up to PR #909).
+    return { completed, total, percentage: completed > 0 ? 100 : 0 };
   }
   // Defensive ceiling. `countAllCompleted` reads roster-blind from
   // storage; if a guide ships a v2 schema that renames or removes a

--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -275,12 +275,9 @@ function persistSection(contentKey: string, sectionId: string): void {
   // dispatch elsewhere.
   if (!isPreview && completedIds.size === 0 && typeof window !== 'undefined') {
     const guideTotal = interactiveStepStorage.countAllCompleted(contentKey);
-    // Don't fire the cleared event while passive acks still exist —
-    // the user has visible progress on this guide even though no
-    // interactive steps are recorded. Without this guard, clearing
-    // the last interactive step in a mixed guide would falsely tell
-    // the alignment / preview-reset consumers that the guide is
-    // back to zero progress.
+    // Both counts must be zero — passive acks are real progress even
+    // when no interactive step is recorded, so clearing the last step
+    // in a mixed guide must not fire "cleared" while acks remain.
     const ackTotal = sectionAcknowledgementStorage.countAllAcknowledged(contentKey);
     if (guideTotal === 0 && ackTotal === 0) {
       window.dispatchEvent(new CustomEvent('interactive-progress-cleared', { detail: { contentKey } }));
@@ -291,15 +288,10 @@ function persistSection(contentKey: string, sectionId: string): void {
 function refreshGuidePercentage(contentKey: string): number | undefined {
   const docTotal = getTotalDocumentSteps();
   if (docTotal < 1) {
-    // All-passive guide: `registerSectionSteps` only counts non-passive
-    // steps, so a guide whose sections are entirely passive reports
-    // docTotal === 0 even after the user acknowledges every section.
-    // Derive the percentage from `sectionAcknowledgementStorage`
-    // (the production ack writer) against the count of registered
-    // sections so multi-section all-passive guides report partial
-    // progress correctly. Without this branch the persisted
-    // percentage stays unset and My Learning shows 0% for a fully
-    // acknowledged guide (F-1 follow-up to PR #909).
+    // All-passive guide (F-1, #909 follow-up): no interactive steps
+    // means no `interactiveStepStorage` writes, so derive the
+    // percentage from `sectionAcknowledgementStorage` — the namespace
+    // the production ack writer actually persists to.
     const sectionCount = getRegisteredSectionCount();
     if (sectionCount < 1) {
       return undefined;
@@ -316,11 +308,9 @@ function refreshGuidePercentage(contentKey: string): number | undefined {
 }
 
 /**
- * Recompute and persist the guide percentage for `contentKey`, then
- * notify subscribers. Public entry point for callers (notably the
- * all-passive section ack handler) that update progress outside the
- * step-write path, where `persistSection` would otherwise refresh
- * automatically.
+ * Public entry point for callers that update progress outside the
+ * step-write path (e.g. all-passive section ack), where `persistSection`
+ * is never called and would otherwise leave the percentage stale.
  */
 export function refreshAndNotifyGuideProgress(contentKey: string): void {
   if (isPreviewContentKey(contentKey)) {
@@ -414,12 +404,9 @@ export function getGuideProgress(contentKey: string): GuideProgress {
   const completedRaw = interactiveStepStorage.countAllCompleted(contentKey);
   const completed = completedRaw < 0 ? 0 : completedRaw;
   if (total < 1) {
-    // All-passive guide: nothing to divide by from the interactive step
-    // count. Derive the percentage from acknowledged sections vs the
-    // registered section count instead. `completed` and `total` here
-    // refer to sections, not steps, so the UI reads as
-    // "acknowledged / registered sections" — without this the chip
-    // would divide 0/0 and report 0% forever (F-1 follow-up to #909).
+    // All-passive branch (F-1, #909 follow-up): `completed` / `total`
+    // here count sections, not steps, since there are no interactive
+    // steps to divide by.
     const sectionCount = getRegisteredSectionCount();
     const ackCount = sectionAcknowledgementStorage.countAllAcknowledged(contentKey);
     if (sectionCount < 1) {

--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -28,10 +28,14 @@
 
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
 
-import { interactiveCompletionStorage, interactiveStepStorage } from '../lib/user-storage';
+import {
+  interactiveCompletionStorage,
+  interactiveStepStorage,
+  sectionAcknowledgementStorage,
+} from '../lib/user-storage';
 
 import { getContentKey } from './content-key';
-import { getTotalDocumentSteps } from './section-registry';
+import { getRegisteredSectionCount, getTotalDocumentSteps } from './section-registry';
 import { dispatchProgress, type ProgressReason } from './progress-events';
 
 /** Synthetic section ID for steps that are not inside an `<InteractiveSection>`. */
@@ -237,7 +241,14 @@ function persistSection(contentKey: string, sectionId: string): void {
   // dispatch elsewhere.
   if (!isPreview && completedIds.size === 0 && typeof window !== 'undefined') {
     const guideTotal = interactiveStepStorage.countAllCompleted(contentKey);
-    if (guideTotal === 0) {
+    // Don't fire the cleared event while passive acks still exist —
+    // the user has visible progress on this guide even though no
+    // interactive steps are recorded. Without this guard, clearing
+    // the last interactive step in a mixed guide would falsely tell
+    // the alignment / preview-reset consumers that the guide is
+    // back to zero progress.
+    const ackTotal = sectionAcknowledgementStorage.countAllAcknowledged(contentKey);
+    if (guideTotal === 0 && ackTotal === 0) {
       window.dispatchEvent(new CustomEvent('interactive-progress-cleared', { detail: { contentKey } }));
     }
   }
@@ -245,25 +256,47 @@ function persistSection(contentKey: string, sectionId: string): void {
 
 function refreshGuidePercentage(contentKey: string): number | undefined {
   const docTotal = getTotalDocumentSteps();
-  const allCompleted = interactiveStepStorage.countAllCompleted(contentKey);
   if (docTotal < 1) {
     // All-passive guide: `registerSectionSteps` only counts non-passive
     // steps, so a guide whose sections are entirely passive reports
     // docTotal === 0 even after the user acknowledges every section.
-    // The passive ack still writes an ack-marker entry that
-    // `countAllCompleted` sees, so when `allCompleted > 0` the guide
-    // is effectively 100% complete. Without this branch the persisted
-    // percentage stays unset and My Learning shows 0% for a fully-done
-    // guide (F-1 follow-up to PR #909).
-    if (allCompleted > 0) {
-      interactiveCompletionStorage.set(contentKey, 100);
-      return 100;
+    // Derive the percentage from `sectionAcknowledgementStorage`
+    // (the production ack writer) against the count of registered
+    // sections so multi-section all-passive guides report partial
+    // progress correctly. Without this branch the persisted
+    // percentage stays unset and My Learning shows 0% for a fully
+    // acknowledged guide (F-1 follow-up to PR #909).
+    const sectionCount = getRegisteredSectionCount();
+    if (sectionCount < 1) {
+      return undefined;
     }
-    return undefined;
+    const ackCount = sectionAcknowledgementStorage.countAllAcknowledged(contentKey);
+    const percentage = Math.min(100, Math.round((ackCount / sectionCount) * 100));
+    interactiveCompletionStorage.set(contentKey, percentage);
+    return percentage;
   }
+  const allCompleted = interactiveStepStorage.countAllCompleted(contentKey);
   const percentage = Math.round((allCompleted / docTotal) * 100);
   interactiveCompletionStorage.set(contentKey, percentage);
   return percentage;
+}
+
+/**
+ * Recompute and persist the guide percentage for `contentKey`, then
+ * notify subscribers. Public entry point for callers (notably the
+ * all-passive section ack handler) that update progress outside the
+ * step-write path, where `persistSection` would otherwise refresh
+ * automatically.
+ */
+export function refreshAndNotifyGuideProgress(contentKey: string): void {
+  if (isPreviewContentKey(contentKey)) {
+    return;
+  }
+  const percentage = refreshGuidePercentage(contentKey);
+  if (percentage !== undefined) {
+    dispatchProgress({ kind: 'guide', contentKey, percentage, hasProgress: percentage > 0 });
+  }
+  notify(contentKey);
 }
 
 export interface UseStepCompletionResult {
@@ -347,12 +380,19 @@ export function getGuideProgress(contentKey: string): GuideProgress {
   const completedRaw = interactiveStepStorage.countAllCompleted(contentKey);
   const completed = completedRaw < 0 ? 0 : completedRaw;
   if (total < 1) {
-    // All-passive guide: the only persisted entry is an ack-marker from
-    // a passive section the user acknowledged, so `completed > 0` while
-    // `total === 0`. Treat that 0/0 as 100% instead of dividing into the
-    // 0% NaN trap — without this the progress chip reads 0% even after
-    // the user finishes the guide (F-1 follow-up to PR #909).
-    return { completed, total, percentage: completed > 0 ? 100 : 0 };
+    // All-passive guide: nothing to divide by from the interactive step
+    // count. Derive the percentage from acknowledged sections vs the
+    // registered section count instead. `completed` and `total` here
+    // refer to sections, not steps, so the UI reads as
+    // "acknowledged / registered sections" — without this the chip
+    // would divide 0/0 and report 0% forever (F-1 follow-up to #909).
+    const sectionCount = getRegisteredSectionCount();
+    const ackCount = sectionAcknowledgementStorage.countAllAcknowledged(contentKey);
+    if (sectionCount < 1) {
+      return { completed: 0, total: 0, percentage: 0 };
+    }
+    const percentage = Math.min(100, Math.round((ackCount / sectionCount) * 100));
+    return { completed: ackCount, total: sectionCount, percentage };
   }
   // Defensive ceiling. `countAllCompleted` reads roster-blind from
   // storage; if a guide ships a v2 schema that renames or removes a

--- a/src/global-state/section-registry.ts
+++ b/src/global-state/section-registry.ts
@@ -109,6 +109,14 @@ export function getTotalDocumentSteps(): number {
   return totalDocumentSteps;
 }
 
+/** Number of distinct sections currently registered for this document.
+ *  Used by the completion store to compute a guide percentage for the
+ *  all-passive case (`getTotalDocumentSteps() === 0`), where there is
+ *  nothing to divide by other than the section count. */
+export function getRegisteredSectionCount(): number {
+  return globalStepRegistry.size;
+}
+
 /** Document-wide position of a step within a section.
  *  Returns `{ stepIndex: offset + sectionStepIndex, totalSteps: totalDocumentSteps }`.
  *  For unknown sectionIds, offset defaults to 0 (preserving the

--- a/src/global-state/section-registry.ts
+++ b/src/global-state/section-registry.ts
@@ -109,10 +109,9 @@ export function getTotalDocumentSteps(): number {
   return totalDocumentSteps;
 }
 
-/** Number of distinct sections currently registered for this document.
- *  Used by the completion store to compute a guide percentage for the
- *  all-passive case (`getTotalDocumentSteps() === 0`), where there is
- *  nothing to divide by other than the section count. */
+/** Denominator for the all-passive guide percentage in the completion
+ *  store — when `getTotalDocumentSteps() === 0`, sections are the only
+ *  thing left to divide by. */
 export function getRegisteredSectionCount(): number {
   return globalStepRegistry.size;
 }

--- a/src/lib/user-storage.test.ts
+++ b/src/lib/user-storage.test.ts
@@ -291,6 +291,40 @@ describe('sectionAcknowledgementStorage', () => {
 });
 
 // ============================================================================
+// sectionAcknowledgementStorage.countAllAcknowledged (F-1 follow-up to #909)
+// ============================================================================
+
+describe('sectionAcknowledgementStorage.countAllAcknowledged', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns 0 when no acknowledgement entries exist', () => {
+    expect(sectionAcknowledgementStorage.countAllAcknowledged('guide-a')).toBe(0);
+  });
+
+  it('counts each acknowledged section for the given content key', async () => {
+    await sectionAcknowledgementStorage.set('guide-a', 'section-1', true);
+    await sectionAcknowledgementStorage.set('guide-a', 'section-2', true);
+    expect(sectionAcknowledgementStorage.countAllAcknowledged('guide-a')).toBe(2);
+  });
+
+  it('ignores acknowledgement entries belonging to other content keys', async () => {
+    await sectionAcknowledgementStorage.set('guide-a', 'section-1', true);
+    await sectionAcknowledgementStorage.set('guide-b', 'section-1', true);
+    expect(sectionAcknowledgementStorage.countAllAcknowledged('guide-a')).toBe(1);
+    expect(sectionAcknowledgementStorage.countAllAcknowledged('guide-b')).toBe(1);
+  });
+
+  it('drops cleared entries from the count', async () => {
+    await sectionAcknowledgementStorage.set('guide-a', 'section-1', true);
+    await sectionAcknowledgementStorage.set('guide-a', 'section-2', true);
+    await sectionAcknowledgementStorage.clear('guide-a', 'section-1');
+    expect(sectionAcknowledgementStorage.countAllAcknowledged('guide-a')).toBe(1);
+  });
+});
+
+// ============================================================================
 // interactiveStepStorage.clearAllForContent — ack-prefix sweep TESTS
 // ============================================================================
 

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -1319,6 +1319,37 @@ export const sectionAcknowledgementStorage = {
       console.warn('Failed to clear section acknowledgement state:', error);
     }
   },
+
+  /**
+   * Synchronously count how many sections under `contentKey` have been
+   * acknowledged. Scans the localStorage namespace directly (mirrors
+   * `interactiveStepStorage.countAllCompleted`) so the completion store
+   * can derive a guide percentage for all-passive guides — which
+   * register zero interactive steps and therefore never write to
+   * `INTERACTIVE_STEPS_PREFIX`.
+   *
+   * Reads from `localStorage` only; Grafana user-storage entries land in
+   * localStorage first via the hybrid-storage writer, so this count is
+   * always in sync with what the user just did.
+   */
+  countAllAcknowledged(contentKey: string): number {
+    try {
+      const prefix = `${StorageKeys.SECTION_ACKNOWLEDGED_PREFIX}${contentKey}-`;
+      let count = 0;
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith(prefix)) {
+          const value = localStorage.getItem(key);
+          if (value === 'true') {
+            count++;
+          }
+        }
+      }
+      return count;
+    } catch {
+      return 0;
+    }
+  },
 };
 
 /**

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -1334,16 +1334,10 @@ export const sectionAcknowledgementStorage = {
   },
 
   /**
-   * Synchronously count how many sections under `contentKey` have been
-   * acknowledged. Scans the localStorage namespace directly (mirrors
-   * `interactiveStepStorage.countAllCompleted`) so the completion store
-   * can derive a guide percentage for all-passive guides — which
-   * register zero interactive steps and therefore never write to
-   * `INTERACTIVE_STEPS_PREFIX`.
-   *
-   * Reads from `localStorage` only; Grafana user-storage entries land in
-   * localStorage first via the hybrid-storage writer, so this count is
-   * always in sync with what the user just did.
+   * Synchronously count acknowledged sections under `contentKey`.
+   * Mirrors `interactiveStepStorage.countAllCompleted`; required so
+   * the completion store can derive an all-passive guide percentage
+   * without an async read.
    */
   countAllAcknowledged(contentKey: string): number {
     try {

--- a/src/test-utils/interactive-section-harness.tsx
+++ b/src/test-utils/interactive-section-harness.tsx
@@ -130,6 +130,16 @@ export function createUserStorageMock() {
       clear: jest.fn(async (contentKey: string, sectionId: string) => {
         memoryStore.delete(ackKey(contentKey, sectionId));
       }),
+      countAllAcknowledged: jest.fn((contentKey: string) => {
+        let count = 0;
+        const prefix = ackKey(contentKey, '');
+        memoryStore.forEach((value, key) => {
+          if (key.startsWith(prefix) && value === true) {
+            count++;
+          }
+        });
+        return count;
+      }),
     },
     /** Mount-free `section-completed:` requirement storage (Phase 2 follow-up
      *  for issue #13). Mirrors the two-state shape of


### PR DESCRIPTION
## Summary

Deferred **F-1** follow-up to #909 (*refactor(interactive): collapse state ownership, restore tier hygiene*). A guide whose sections are entirely passive registers no interactive steps, so the user's "Mark section complete" click never reaches `persistSection` — and the persisted `interactiveCompletionStorage` percentage stayed at 0% even after the user acknowledged every section. The progress chip and the My Learning row silently lied about a real terminal state.

This PR routes the all-passive percentage through `sectionAcknowledgementStorage` — the storage namespace the production ack writer actually writes to — instead of inventing an ack-marker entry in `interactiveStepStorage` (which `countAllCompleted` deliberately filters out).

## What changed

**`src/lib/user-storage.ts`**

- Add `sectionAcknowledgementStorage.countAllAcknowledged(contentKey)` — a synchronous localStorage scan that mirrors `interactiveStepStorage.countAllCompleted` and returns the number of acknowledged sections under `contentKey`. The completion store needs a sync read to compute progress on every change.

**`src/global-state/section-registry.ts`**

- Export `getRegisteredSectionCount()` — the denominator the completion store needs when `getTotalDocumentSteps() === 0`. Every `<InteractiveSection>` registers itself (even passive-only) so this is the canonical "how many sections is this guide?" answer.

**`src/global-state/completion-store.ts`**

- `refreshGuidePercentage` and `getGuideProgress` — when `getTotalDocumentSteps() < 1`, derive the percentage from `countAllAcknowledged / getRegisteredSectionCount` instead of returning 0. Persist via `interactiveCompletionStorage.set` so cross-tab reads + My Learning see the same value. `getGuideProgress` reports `{ completed: ackCount, total: sectionCount }` in this branch so the numbers make sense to UI consumers ("3 / 5 sections acknowledged").
- Export `refreshAndNotifyGuideProgress(contentKey)` — a public entry point that recomputes the percentage, fires `kind: 'guide'`, and notifies subscribers. Used by the section's ack handler (which doesn't go through `persistSection`).
- Extend the `interactive-progress-cleared` guard inside `persistSection` to require **both** `countAllCompleted === 0` **and** `countAllAcknowledged === 0`, so resetting the last interactive step in a mixed guide doesn't falsely tell consumers the guide is back to zero progress while passive acks remain.

**`src/components/interactive-tutorial/interactive-section.tsx`**

- Relax the `isCompleted` effect guard from `stepComponents.length > 0` to `stepComponents.length > 0 || gateAnalysis.isAllPassive`. All-passive sections now also persist `sectionDoneStorage` (so `section-completed:` requirement checks work for them) and dispatch `kind: 'section'`.
- After the section dispatch, all-passive sections call `refreshAndNotifyGuideProgress(getContentKey())` so the guide percentage gets recomputed and persisted.
- Mirror the recompute on the reset path so My Learning + the chip drop back down when the user resets an all-passive section.

**`src/test-utils/interactive-section-harness.tsx`**

- Mock `sectionAcknowledgementStorage.countAllAcknowledged` for the section-state-machine and tripwire test suites.

**`src/lib/user-storage.test.ts`** and **`src/global-state/completion-store.test.tsx`**

- Cover the new ack-count read, the four all-passive branches in `getGuideProgress` (full ack, partial ack, no ack, no sections registered), and `refreshAndNotifyGuideProgress` persistence.

## Why

PR #909 collapsed step state into the canonical completion store and moved passive acks into their own storage namespace. The original F-1 fix proposed in this PR's earlier revision reached for a synthetic ack-marker entry in `interactiveStepStorage` that no post-#909 code path actually writes (and that `countAllCompleted` deliberately filters out). Reviewer flagged it as a passing-test-broken-in-prod regression — this revision wires the fix through the storage the production ack writer uses, so it actually fires in the running app.

## Test plan

- [x] `npx jest src/global-state/completion-store.test.tsx --no-coverage` — 30/30 pass (5 new F-1 cases + 25 existing).
- [x] `npx jest src/lib/user-storage.test.ts --no-coverage` — 40/40 pass (4 new `countAllAcknowledged` cases).
- [x] `npx jest src/components/interactive-tutorial src/global-state --no-coverage` — 390 pass / 12 skipped / 5 todo.
- [x] `npm run check` — clean.

## Risk and reversibility

Low-to-moderate. The change touches three production code paths (`refreshGuidePercentage`, `getGuideProgress`, the cleared-event guard) and adds two effect branches in the section component, but every branch is gated on `getTotalDocumentSteps() < 1` (or `gateAnalysis.isAllPassive`), so guides with any interactive steps are bit-for-bit identical to pre-PR. Reversible by reverting the commit; the new `countAllAcknowledged` reader is additive.

## References

- Parent PR: #909
- PR #909 follow-up batch, PR 2 (F-1).

Made with [Cursor](https://cursor.com)