### PR TITLE
fix(completion-store): persist additive merge from hydration resolve (F-5 follow-up)

### DIFF
--- a/src/global-state/completion-store.test.tsx
+++ b/src/global-state/completion-store.test.tsx
@@ -221,6 +221,15 @@ describe('completion-store', () => {
       expect(screen.getByTestId('completed').textContent).toBe('false');
       expect(storedCompleted.get(`${CONTENT_KEY}-section-x`)).toEqual(new Set(['step-1']));
     });
+
+    it('mark issued during pending hydration survives the resolve', async () => {
+      storedCompleted.set(`${CONTENT_KEY}-section-x`, new Set(['step-a']));
+      render(<StepProbe stepId="step-b" sectionId="section-x" />);
+      // Hydration pending.
+      act(() => markStepCompleted('step-b', 'section-x', 'manual'));
+      await flushMicrotasks();
+      expect(storedCompleted.get(`${CONTENT_KEY}-section-x`)).toEqual(new Set(['step-a', 'step-b']));
+    });
   });
 
   describe('bulk progress events', () => {

--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -181,6 +181,7 @@ function ensureHydrated(contentKey: string, sectionId: string): void {
       if (changed) {
         bumpSectionVersion(contentKey, sectionId);
         notify(contentKey);
+        persistSection(contentKey, sectionId);
       }
       // Reconcile storage with the filtered cache. Without this, the
       // cleared IDs would persist in storage and reappear on next reload.


### PR DESCRIPTION
## Summary

PR #909 deferred F-5 as a "test-only" tripwire — the assumption being that `markStepCompleted`'s additive-merge invariant across the hydration race already held. Writing the tripwire revealed it doesn't.

## Root cause

When `markStepCompleted` fires while a section's hydration read is still in flight:

1. `ensureHydrated` early-returns (the section is already marked hydrated).
2. The synchronous write persists the new in-memory set (e.g. `Set(['step-b'])`) and **overwrites** the on-disk snapshot (`Set(['step-a'])`).
3. The hydration `.then` resolver correctly re-adds the missing IDs to the in-memory cache (skipping anything in the `cleared` set).
4. But the resolver only calls `persistSection` when `hadClears` is true — the additive path silently leaves storage out of sync with memory.
5. On next reload, the previously-stored `step-a` is gone.

## Fix

One-line change in `ensureHydrated`'s `.then` handler: when the resolve adds new IDs (the `changed` branch), call `persistSection` so storage matches the merged in-memory state. The existing `hadClears` reconcile path is preserved; in the rare case both branches fire we eat one redundant write — harmless.

```ts
if (changed) {
  bumpSectionVersion(contentKey, sectionId);
  notify(contentKey);
  persistSection(contentKey, sectionId); // <-- added
}
```

## Test

The F-5 tripwire that surfaced this bug — `'mark issued during pending hydration survives the resolve'` in the existing `hydration race` describe block of `src/global-state/completion-store.test.tsx`:

- Seeds `step-a` in storage.
- Mounts a probe for `step-b` (kicks off hydration).
- Calls `markStepCompleted('step-b', ...)` **before** flushing microtasks.
- Asserts final storage contains BOTH `step-a` AND `step-b`.

Pre-fix: fails (`Set { "step-b" }`, `step-a` dropped).
Post-fix: passes alongside the existing `resetStep` / `resetSection` / `resetSteps` race guards.

## Risk and reversibility

- Single localized change inside the hydration resolver, behind the same `changed` predicate that already exists.
- Existing race-guard tests for reset paths (3 in the same describe block) still pass; the bulk-event, eviction, and reconciliation suites all still pass — `npm run check` clean (231 suites, 3913 tests).
- Reversible by reverting this commit.

Refs PR #909 (F-5 deferred item).
Plan: `pr909-followups-parallel_6f07373c.plan.md`.

## Test plan

- [x] `npx jest src/global-state/completion-store.test.tsx --no-coverage` — 26/26 pass, including the new F-5 tripwire.
- [x] `npm run check` clean (typecheck + lint + prettier + lint:go + test:go + test:ci).

Made with [Cursor](https://cursor.com)