### PR TITLE
test(interactive-section): pin sibling re-render on completion-store flip (F-2 follow-up)

### DIFF
--- a/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
@@ -392,4 +392,96 @@ describe('InteractiveSection contracts — Phase 0 tripwire', () => {
       }
     });
   });
+
+  // F-2 tripwire — pin the cross-step re-render contract introduced by
+  // PR #909. The store relocation moved completion state out of the
+  // section's reducer and into the global `completion-store`; the section
+  // now subscribes via `useSyncExternalStore(useSectionCompletion)`. If
+  // that wiring regresses (missing listener, stale snapshot, dep-array
+  // gap on the version bump), an external `markStepCompleted` call will
+  // silently fail to trigger a re-render — sibling steps keep rendering
+  // against the pre-flip completion set and section-level derivations
+  // (`stepsCompleted`, `isCompleted`, the Reset button gate) never reflect
+  // the new state. PR #909 deferred this probe as follow-up F-2; this
+  // test pins the contract so the wiring can't quietly regress.
+  describe('cross-step re-render on store flips (F-2)', () => {
+    it('re-renders sibling step + section when markStepCompleted flips from outside React', async () => {
+      const { markStepCompleted } = require('../../global-state/completion-store');
+
+      const flushMicrotasks = async () => {
+        await act(async () => {
+          await Promise.resolve();
+        });
+      };
+
+      const { events, unsubscribe } = recordSectionEvents();
+      try {
+        render(
+          <InteractiveSection id="contracts" title="Contracts section" autoCollapse={false}>
+            <InteractiveStep stepId="step-1" targetAction="highlight" refTarget=".a">
+              Step one
+            </InteractiveStep>
+            <InteractiveStep stepId="step-2" targetAction="highlight" refTarget=".b">
+              Step two
+            </InteractiveStep>
+          </InteractiveSection>
+        );
+
+        // Both children mount with their author-supplied stepIds.
+        await waitFor(() => {
+          expect(screen.getByTestId(`harness-complete-step-1`)).toBeInTheDocument();
+          expect(screen.getByTestId(`harness-complete-step-2`)).toBeInTheDocument();
+        });
+
+        // Drain the initial mount's `useDocumentStepProgress` dispatch so
+        // the post-flip event is unambiguously attributable to a
+        // store-driven re-render rather than the mount-time effect.
+        await waitFor(() => {
+          expect(events.find((e) => e.name === 'pathfinder-step-progress')).toBeDefined();
+        });
+        events.length = 0;
+
+        // Flip completion from outside React. The section must re-render
+        // via its `useSyncExternalStore` subscription to pick this up.
+        await act(async () => {
+          markStepCompleted('step-1', SECTION_ID, 'manual');
+          await Promise.resolve();
+        });
+
+        // Sibling addressability: the store flip didn't unmount or
+        // re-key the unrelated child. Step-1's harness is still in the
+        // DOM too — completed steps are not torn down by the section.
+        expect(screen.getByTestId(`harness-complete-step-2`)).toBeInTheDocument();
+        expect(screen.getByTestId(`harness-complete-step-1`)).toBeInTheDocument();
+
+        // `useDocumentStepProgress` lives inside the section and has
+        // `completedSteps` in its effect deps. A re-fire of
+        // `pathfinder-step-progress` proves the section re-rendered with
+        // the new `completedSteps` reference returned by the store.
+        // Without the `useSyncExternalStore` wiring, this dispatch never
+        // happens because the effect never re-runs.
+        await waitFor(() => {
+          const evt = events.find((e) => e.name === 'pathfinder-step-progress' && e.detail.sectionId === SECTION_ID);
+          expect(evt).toBeDefined();
+        });
+
+        // Drive step-2's harness button. The section's
+        // `handleStepComplete` closure captures `completedSteps` from the
+        // most recent commit; if the prior store flip didn't refresh that
+        // snapshot, the section would still see only step-2 completed and
+        // `stepsCompleted` would stay false (Do Section, not Reset). The
+        // appearance of `resetSectionButton` is the visible-DOM
+        // confirmation that the cross-step re-render contract holds.
+        act(() => {
+          screen.getByTestId(`harness-complete-step-2`).click();
+        });
+        await flushMicrotasks();
+        await waitFor(() => {
+          expect(screen.getByTestId(resetButton(SECTION_ID))).toBeInTheDocument();
+        });
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
 });

--- a/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
@@ -455,11 +455,14 @@ describe('InteractiveSection contracts — Phase 0 tripwire', () => {
         expect(screen.getByTestId(`harness-complete-step-1`)).toBeInTheDocument();
 
         // `useDocumentStepProgress` lives inside the section and has
-        // `completedSteps` in its effect deps. A re-fire of
-        // `pathfinder-step-progress` proves the section re-rendered with
-        // the new `completedSteps` reference returned by the store.
-        // Without the `useSyncExternalStore` wiring, this dispatch never
-        // happens because the effect never re-runs.
+        // `completedSteps` in its effect deps. The dispatched payload is
+        // `{ sectionId, totalSteps, documentStepIndex, completedCount }`
+        // — no `completedSteps` field. A re-fire of
+        // `pathfinder-step-progress` for this `sectionId` proves the
+        // section re-committed with a new `completedSteps` reference
+        // (the only dep in the effect that could have changed).
+        // Without the `useSyncExternalStore` wiring, this dispatch
+        // never happens because the effect never re-runs.
         await waitFor(() => {
           const evt = events.find((e) => e.name === 'pathfinder-step-progress' && e.detail.sectionId === SECTION_ID);
           expect(evt).toBeDefined();

--- a/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
@@ -454,15 +454,10 @@ describe('InteractiveSection contracts — Phase 0 tripwire', () => {
         expect(screen.getByTestId(`harness-complete-step-2`)).toBeInTheDocument();
         expect(screen.getByTestId(`harness-complete-step-1`)).toBeInTheDocument();
 
-        // `useDocumentStepProgress` lives inside the section and has
-        // `completedSteps` in its effect deps. The dispatched payload is
-        // `{ sectionId, totalSteps, documentStepIndex, completedCount }`
-        // — no `completedSteps` field. A re-fire of
-        // `pathfinder-step-progress` for this `sectionId` proves the
-        // section re-committed with a new `completedSteps` reference
-        // (the only dep in the effect that could have changed).
-        // Without the `useSyncExternalStore` wiring, this dispatch
-        // never happens because the effect never re-runs.
+        // Regression probe: this event only re-fires when `completedSteps`
+        // changes in `useDocumentStepProgress`'s deps — which requires
+        // the `useSyncExternalStore` subscription to land the flip in
+        // the section's render commit.
         await waitFor(() => {
           const evt = events.find((e) => e.name === 'pathfinder-step-progress' && e.detail.sectionId === SECTION_ID);
           expect(evt).toBeDefined();


### PR DESCRIPTION
## Summary

PR #909 collapsed `InteractiveSection`'s completion state into the global `completion-store` and re-wired the section to subscribe via `useSyncExternalStore(useSectionCompletion)`. Review surfaced **F-2**: there was no test pinning the cross-step re-render contract. If the store wiring ever regresses (missing listener, stale snapshot, or a dep-array gap on the version bump), an external `markStepCompleted` call would silently fail to refresh sibling steps, and section-level derivations (`stepsCompleted`, `isCompleted`, the Reset button gate) would never reflect the new state. That probe was deferred from #909 as follow-up **F-2**; this PR lands it.

## What changed

Appends one tripwire test to `src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx`:

- Mounts an `InteractiveSection` with two `InteractiveStep` children (explicit `stepId`s `step-1`, `step-2`).
- Drains the initial mount-time `pathfinder-step-progress` so the post-flip event is unambiguously store-driven.
- Calls `markStepCompleted('step-1', SECTION_ID, 'manual')` from outside React.
- Asserts the sibling harness stays addressable (no unmount / re-key).
- Asserts the section's `useDocumentStepProgress` effect re-fires `pathfinder-step-progress` for this `sectionId` — proving the section re-committed with a new `completedSteps` reference and the effect's dep array saw the change.
- Clicks `step-2`'s harness to confirm `handleStepComplete` captured the refreshed `completedSteps` snapshot (the Reset button appears, not Do Section).

Test-only — no production code touched.

## Why

Pins the `useSyncExternalStore(useSectionCompletion)` wiring introduced by #909 against silent regressions. Without this, a dep-array gap or missed subscription would compile, type-check, lint, and pass every existing test — but break the Reset / progress UX in production. The tripwire fails loudly the moment the wiring breaks.

## Test plan

- [x] `npx jest src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx --no-coverage` — 11/11 pass (including the new F-2 test, 8 ms).
- [x] `npm run check` — clean (231 suites / 3913 tests pass; typecheck + lint + prettier + Go lint + Go tests + frontend CI all green).

## Risk and reversibility

Test-only file; no runtime, no public API, no migration. Two-way door — revert by deleting the appended `describe` block.

## Refs

- Deferred follow-up **F-2** from #909.
- PR #909 follow-up batch, PR 6 (F-2).

Made with [Cursor](https://cursor.com)