### PR TITLE
chore: remove unused custom event listeners ("grafana:location-changed")

### DIFF
--- a/docs/developer/FEATURE_FLAGS.md
+++ b/docs/developer/FEATURE_FLAGS.md
@@ -54,7 +54,7 @@ The plugin uses the [OpenFeature](https://openfeature.dev/) standard with the OF
 
 **Multi-instance support**: Auto-open tracking is scoped per Grafana instance using hostname. This ensures that users with multiple Cloud instances (e.g., `company1.grafana.net` and `company2.grafana.net`) will see the sidebar auto-open independently per instance.
 
-**Onboarding flow integration**: If a user first lands on the setup guide onboarding flow (`/a/grafana-setupguide-app/onboarding-flow`), the plugin defers auto-open. It listens for navigation events (`grafana:location-changed` and `locationService.getHistory().listen()`) and triggers auto-open when the user navigates away from onboarding to normal Grafana pages.
+**Onboarding flow integration**: If a user first lands on the setup guide onboarding flow (`/a/grafana-setupguide-app/onboarding-flow`), the plugin defers auto-open. It listens for navigation events via `locationService.getHistory().listen()` (with a `popstate` fallback) and triggers auto-open when the user navigates away from onboarding to normal Grafana pages.
 
 **Tracking key**: `auto_open_sidebar`
 

--- a/docs/developer/engines/requirements-manager.md
+++ b/docs/developer/engines/requirements-manager.md
@@ -224,7 +224,7 @@ When a requirement check fails, the system may identify an automatic fix. The `f
 
 - **Context monitoring** - Listens to ContextService (EchoSrv) for Grafana state changes
 - **DOM monitoring** - Observes specific DOM changes (plugins, datasources) via MutationObserver
-- **Navigation monitoring** - Tracks URL changes and navigation events (popstate, hashchange, grafana:location-changed)
+- **Navigation monitoring** - Tracks URL changes and navigation events (popstate, hashchange, focus)
 - **Guide response monitoring** - Reacts to guide variable updates (input blocks, user responses)
 - **Heartbeat checking** - Optional periodic rechecking for fragile requirements (configurable)
 

--- a/src/requirements-manager/requirements-checker.hook.ts
+++ b/src/requirements-manager/requirements-checker.hook.ts
@@ -488,17 +488,12 @@ export class SequentialRequirementsManager {
     window.addEventListener('popstate', checkURL);
     window.addEventListener('hashchange', checkURL);
 
-    // Listen for Grafana-specific navigation events if available
-    // These are more reliable than polling for SPA navigation
-    document.addEventListener('grafana:location-changed', checkURL);
-
     // Listen for focus events which can indicate navigation in SPAs
     window.addEventListener('focus', checkURL);
 
     this.navigationUnlisten = () => {
       window.removeEventListener('popstate', checkURL);
       window.removeEventListener('hashchange', checkURL);
-      document.removeEventListener('grafana:location-changed', checkURL);
       window.removeEventListener('focus', checkURL);
     };
   }

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -906,7 +906,6 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     // Listen for navigation events
     window.addEventListener('popstate', handleUrlChange);
     window.addEventListener('hashchange', handleUrlChange);
-    document.addEventListener('grafana:location-changed', handleUrlChange);
 
     // Also check periodically for SPA navigation that doesn't fire events
     const urlCheckInterval = setInterval(handleUrlChange, 2000);
@@ -918,7 +917,6 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       }
       window.removeEventListener('popstate', handleUrlChange);
       window.removeEventListener('hashchange', handleUrlChange);
-      document.removeEventListener('grafana:location-changed', handleUrlChange);
       clearInterval(urlCheckInterval);
     };
   }, [isEligibleForChecking, state.isCompleted, state.fixType, lazyRender, stepId]); // Only re-subscribe when eligibility, completion, or lazy-scroll state changes (objectives tracked via ref)

--- a/src/utils/experiments/experiment-orchestrator.ts
+++ b/src/utils/experiments/experiment-orchestrator.ts
@@ -257,8 +257,6 @@ function setupOnboardingFlowListener(
     }
   };
 
-  document.addEventListener('grafana:location-changed', checkLocationChange);
-
   try {
     const history = locationService.getHistory();
     if (history) {
@@ -290,8 +288,6 @@ function setupTreatmentNavigationListener(hostname: string, targetPages: string[
       }
     }
   };
-
-  document.addEventListener('grafana:location-changed', checkNavigationToTargetPage);
 
   try {
     const history = locationService.getHistory();

--- a/src/utils/experiments/highlighted-guide-orchestrator.ts
+++ b/src/utils/experiments/highlighted-guide-orchestrator.ts
@@ -237,8 +237,6 @@ function installHighlightedGuideNavListener(tryAutoOpen: (path: string) => void)
     tryAutoOpen(newPath);
   };
 
-  document.addEventListener('grafana:location-changed', handler);
-
   try {
     const history = locationService.getHistory();
     if (history) {

--- a/src/utils/pathfinder-deep-link-handler.test.ts
+++ b/src/utils/pathfinder-deep-link-handler.test.ts
@@ -299,19 +299,19 @@ describe('installDeepLinkNavListener', () => {
 
   it('skips the parse + dedup machinery on URL changes that carry no Pathfinder params', () => {
     installDeepLinkNavListener(mkDeps());
-    // The listener captured `handler`; simulate a Grafana SPA navigation to
-    // a page without any pathfinder params and assert findDocPage was not
-    // touched (a strong proxy for "did the handler run").
+    // Simulate a SPA navigation to a page without any pathfinder params.
+    const historyHandler = mockHistoryListen.mock.calls[0][0] as () => void;
     setSearch('?tab=overview');
-    document.dispatchEvent(new CustomEvent('grafana:location-changed'));
+    historyHandler();
     expect(mockFindDocPage).not.toHaveBeenCalled();
   });
 
   it('re-runs the handler when the URL changes to include ?doc=', async () => {
     installDeepLinkNavListener(mkDeps());
+    const historyHandler = mockHistoryListen.mock.calls[0][0] as () => void;
 
     setSearch('?doc=bundled%3Afoo');
-    document.dispatchEvent(new CustomEvent('grafana:location-changed'));
+    historyHandler();
 
     await flushPromises();
     expect(mockFindDocPage).toHaveBeenCalledWith('bundled:foo');

--- a/src/utils/pathfinder-deep-link-handler.test.ts
+++ b/src/utils/pathfinder-deep-link-handler.test.ts
@@ -8,9 +8,8 @@
  *   - `handlePathfinderDeepLink` is a no-op when no Pathfinder params are
  *     present, dedupes same-search re-fires, and routes to the panelMode /
  *     control-group / find-doc-page branches.
- *   - `installDeepLinkNavListener` wires `grafana:location-changed` and
- *     (when available) `history.listen`, falling back to `popstate` only
- *     when `locationService.getHistory()` throws.
+ *   - `installDeepLinkNavListener` wires `history.listen` (primary) and
+ *     falls back to `popstate` when `locationService.getHistory()` throws.
  */
 
 jest.mock('../plugin.json', () => ({
@@ -280,7 +279,7 @@ describe('installDeepLinkNavListener', () => {
     mockGetHistoryImpl = () => ({ listen: mockHistoryListen });
   });
 
-  it('registers grafana:location-changed and history.listen', () => {
+  it('registers history.listen', () => {
     installDeepLinkNavListener(mkDeps());
     expect(mockHistoryListen).toHaveBeenCalledTimes(1);
   });

--- a/src/utils/pathfinder-deep-link-handler.ts
+++ b/src/utils/pathfinder-deep-link-handler.ts
@@ -1,11 +1,12 @@
 /**
  * Centralized `?doc=` / `?panelMode=` / `?kiosk_session=` deep-link handler.
  *
- * `plugin.init` fires only once — when Grafana loads the extension sidebar
- * module, which can happen before the user navigates to a `?doc=` URL.
+ * `plugin.init` fires only once — from `appPluginPostImport` in Grafana's
+ * plugin importer.
+ *
  * `handlePathfinderDeepLink` is idempotent and deduplicated so it can be
  * called on every navigation; `installDeepLinkNavListener` wires it up to
- * `grafana:location-changed` / `history.listen` for SPA navigations.
+ * `locationService.getHistory().listen()` for SPA navigations
  */
 
 import { locationService } from '@grafana/runtime';

--- a/src/utils/pathfinder-deep-link-handler.ts
+++ b/src/utils/pathfinder-deep-link-handler.ts
@@ -177,8 +177,6 @@ export function installDeepLinkNavListener(deps: DeepLinkHandlerDeps): void {
     handlePathfinderDeepLink(deps);
   };
 
-  document.addEventListener('grafana:location-changed', handler);
-
   try {
     const history = locationService.getHistory();
     if (history) {


### PR DESCRIPTION
Follow-up to https://github.com/grafana/grafana-pathfinder-app/pull/904

## Summary

Removes all `grafana:location-changed` custom event listeners from the codebase. I can't find evidence that this event is dispatched anywhere in Grafana. I verified by grepping the full grafana/grafana repo and all installed @grafana/* packages. There's a _super old_ `location-change` (no "d") event, but that predates React, and was removed a long time ago. Every URL change flows through locationService's shared HistoryWrapper history instance, which our existing `history.listen()` handlers use.

