### PR TITLE
fix(popout): milestone navigation + theme conformance

### DIFF
--- a/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
+++ b/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
@@ -75,6 +75,14 @@ export interface LearningJourneyMilestoneToolbarProps {
    * `<Dropdown>`; the fullscreen surface omits it.
    */
   trailingActions?: React.ReactNode;
+  /**
+   * When true, suppresses the entire `milestoneActions` row (Open + Reset +
+   * `trailingActions`). The arrow nav and progress bar still render. Used
+   * by the floating panel to reclaim vertical space — the popout has a much
+   * smaller content area than the sidebar / fullscreen surfaces and the
+   * secondary actions are still reachable from the docked sidebar.
+   */
+  compact?: boolean;
 }
 
 /**
@@ -92,6 +100,7 @@ export function LearningJourneyMilestoneToolbar({
   progressKey,
   onResetGuide,
   trailingActions,
+  compact = false,
 }: LearningJourneyMilestoneToolbarProps) {
   const styles = useStyles2(getMilestoneStyles);
 
@@ -207,48 +216,50 @@ export function LearningJourneyMilestoneToolbar({
             className={styles.navButton}
           />
         </div>
-        <div className={styles.milestoneActions}>
-          {externalUrl && (
-            <button
-              className={actionButtonClassName}
-              aria-label={t('docsPanel.openInNewTab', 'Open this page in new tab')}
-              onClick={() => {
-                reportAppInteraction(UserInteraction.OpenExtraResource, {
-                  content_url: externalUrl,
-                  content_type: getContentTypeForAnalytics(externalUrl, activeTab.type || 'learning-journey'),
-                  link_text: activeTab.title,
-                  source_page: activeTab.content?.url || activeTab.baseUrl || 'unknown',
-                  link_type: 'external_browser',
-                  interaction_location: openInteractionLocation,
-                  current_milestone: lj.currentMilestone || 0,
-                  total_milestones: lj.totalMilestones || 0,
-                });
-                setTimeout(() => {
-                  window.open(externalUrl, '_blank', 'noopener,noreferrer');
-                }, 100);
-              }}
-            >
-              <Icon name="external-link-alt" size="sm" />
-              <span>{t('docsPanel.open', 'Open')}</span>
-            </button>
-          )}
-          {(hasInteractiveProgress || activeTab.type === 'interactive') && (
-            <button
-              className={actionButtonClassName}
-              aria-label={t('docsPanel.resetGuide', 'Reset guide')}
-              title={t('docsPanel.resetGuideTooltip', 'Resets all interactive steps')}
-              onClick={async () => {
-                if (progressKey) {
-                  await onResetGuide(progressKey, activeTab);
-                }
-              }}
-            >
-              <Icon name="history-alt" size="sm" />
-              <span>{t('docsPanel.resetGuide', 'Reset guide')}</span>
-            </button>
-          )}
-          {trailingActions}
-        </div>
+        {!compact && (
+          <div className={styles.milestoneActions}>
+            {externalUrl && (
+              <button
+                className={actionButtonClassName}
+                aria-label={t('docsPanel.openInNewTab', 'Open this page in new tab')}
+                onClick={() => {
+                  reportAppInteraction(UserInteraction.OpenExtraResource, {
+                    content_url: externalUrl,
+                    content_type: getContentTypeForAnalytics(externalUrl, activeTab.type || 'learning-journey'),
+                    link_text: activeTab.title,
+                    source_page: activeTab.content?.url || activeTab.baseUrl || 'unknown',
+                    link_type: 'external_browser',
+                    interaction_location: openInteractionLocation,
+                    current_milestone: lj.currentMilestone || 0,
+                    total_milestones: lj.totalMilestones || 0,
+                  });
+                  setTimeout(() => {
+                    window.open(externalUrl, '_blank', 'noopener,noreferrer');
+                  }, 100);
+                }}
+              >
+                <Icon name="external-link-alt" size="sm" />
+                <span>{t('docsPanel.open', 'Open')}</span>
+              </button>
+            )}
+            {(hasInteractiveProgress || activeTab.type === 'interactive') && (
+              <button
+                className={actionButtonClassName}
+                aria-label={t('docsPanel.resetGuide', 'Reset guide')}
+                title={t('docsPanel.resetGuideTooltip', 'Resets all interactive steps')}
+                onClick={async () => {
+                  if (progressKey) {
+                    await onResetGuide(progressKey, activeTab);
+                  }
+                }}
+              >
+                <Icon name="history-alt" size="sm" />
+                <span>{t('docsPanel.resetGuide', 'Reset guide')}</span>
+              </button>
+            )}
+            {trailingActions}
+          </div>
+        )}
         <div className={styles.progressBar}>
           <div
             className={styles.progressFill}

--- a/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
+++ b/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
@@ -32,7 +32,7 @@ import type { LearningJourneyTab } from '../../../types/content-panel.types';
 import type { CombinedLearningJourneyPanel } from '../docs-panel';
 import { cleanDocsUrl } from '../utils';
 
-export type MilestoneToolbarSurface = 'sidebar' | 'fullscreen';
+export type MilestoneToolbarSurface = 'sidebar' | 'fullscreen' | 'floating';
 
 export interface LearningJourneyMilestoneToolbarProps {
   panel: CombinedLearningJourneyPanel;
@@ -163,10 +163,14 @@ export function LearningJourneyMilestoneToolbar({
 
   // Distinguish surfaces in analytics for the external-link "Open" button.
   // Arrow-nav analytics intentionally stays on `'milestone_progress_bar'`
-  // for both surfaces — the sidebar / fullscreen split is only meaningful
-  // for the explicit "Open in browser" outbound, not for in-guide nav.
+  // for all surfaces — the per-surface split is only meaningful for the
+  // explicit "Open in browser" outbound, not for in-guide nav.
   const openInteractionLocation =
-    surface === 'fullscreen' ? 'full_screen_milestone_progress_bar' : 'milestone_progress_bar';
+    surface === 'fullscreen'
+      ? 'full_screen_milestone_progress_bar'
+      : surface === 'floating'
+        ? 'floating_panel_milestone_progress_bar'
+        : 'milestone_progress_bar';
 
   return (
     <div className={styles.milestoneProgress}>

--- a/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
+++ b/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
@@ -75,13 +75,6 @@ export interface LearningJourneyMilestoneToolbarProps {
    * `<Dropdown>`; the fullscreen surface omits it.
    */
   trailingActions?: React.ReactNode;
-  /**
-   * When true, suppresses the entire `milestoneActions` row (Open + Reset +
-   * `trailingActions`). The arrow nav and progress bar still render. Used
-   * by the floating panel to reclaim vertical space — the popout has a much
-   * smaller content area than the sidebar / fullscreen surfaces and the
-   * secondary actions are still reachable from the docked sidebar.
-   */
   compact?: boolean;
 }
 
@@ -172,8 +165,8 @@ export function LearningJourneyMilestoneToolbar({
 
   // Distinguish surfaces in analytics for the external-link "Open" button.
   // Arrow-nav analytics intentionally stays on `'milestone_progress_bar'`
-  // for all surfaces — the per-surface split is only meaningful for the
-  // explicit "Open in browser" outbound, not for in-guide nav.
+  // for both surfaces — the sidebar / fullscreen split is only meaningful
+  // for the explicit "Open in browser" outbound, not for in-guide nav.
   const openInteractionLocation =
     surface === 'fullscreen'
       ? 'full_screen_milestone_progress_bar'

--- a/src/components/floating-panel/FloatingPanelContent.tsx
+++ b/src/components/floating-panel/FloatingPanelContent.tsx
@@ -6,29 +6,29 @@ import { getInteractiveStyles } from '../../styles/interactive.styles';
 import { getPrismStyles } from '../../styles/prism.styles';
 import type { RawContent } from '../../types/content.types';
 import type { LearningJourneyTab, PendingAlignment } from '../../types/content-panel.types';
-import { AlignmentPrompt } from '../docs-panel/components';
+import {
+  AlignmentPrompt,
+  LearningJourneyMilestoneToolbar,
+  type MilestoneToolbarSurface,
+} from '../docs-panel/components';
 import { AlignmentPendingContext } from '../../global-state/alignment-pending-context';
 import { useLinkClickHandler } from '../docs-panel/link-handler.hook';
-import type { OpenDocsOptions, OpenLearningJourneyOptions } from '../docs-panel/types';
-
-/**
- * Subset of CombinedLearningJourneyPanel needed by useLinkClickHandler.
- * Mirrors the inline shape the hook declares so we can pass `panel` directly.
- */
-export interface FloatingPanelContentModel {
-  loadTab: (tabId: string, url: string) => Promise<void>;
-  /** @deprecated Internal; routed via `loadTab`. */
-  loadTabContent: (tabId: string, url: string) => void | Promise<void>;
-  openLearningJourney: (url: string, title?: string, options?: OpenLearningJourneyOptions) => void | Promise<string>;
-  openDocsPage?: (url: string, title?: string, options?: OpenDocsOptions) => void | Promise<string>;
-  getActiveTab: () => LearningJourneyTab | null;
-  navigateToNextMilestone: () => void;
-  navigateToPreviousMilestone: () => void;
-  canNavigateNext: () => boolean;
-  canNavigatePrevious: () => boolean;
-}
+import type { CombinedLearningJourneyPanel } from '../docs-panel/docs-panel';
+import { getFloatingPanelStyles } from './floating-panel.styles';
 
 interface FloatingPanelContentProps {
+  /** Toolbar inputs — when omitted (e.g. recommendations tab) the toolbar self-hides. */
+  hasInteractiveProgress?: boolean;
+  progressKey?: string | null;
+  onResetGuide?: (progressKey: string, tab: LearningJourneyTab) => Promise<void> | void;
+  /**
+   * Which surface this content is rendering on — drives the analytics
+   * `interaction_location` for the toolbar's "Open" button. Defaults to
+   * `'floating'` since this component's primary home is the floating panel;
+   * the full-screen surface renders its own toolbar separately and omits the
+   * toolbar props, so the default never leaks into fullscreen analytics.
+   */
+  surface?: MilestoneToolbarSurface;
   /** The guide content to render */
   content: RawContent | null;
   /** Called when a guide completes all interactive sections */
@@ -51,12 +51,11 @@ interface FloatingPanelContentProps {
    */
   activeTab: LearningJourneyTab | null;
   /**
-   * Panel model used by the link click handler for navigation actions
+   * Panel model — used by the link click handler for navigation actions
    * (`loadTabContent`, milestone navigation, opening docs/journeys from
-   * embedded links, etc.). Without this, content links and the
-   * "Ready to Begin" CTA on the cover page have no handler.
+   * embedded links, etc.) AND by the milestone toolbar for prev/next + reset.
    */
-  model: FloatingPanelContentModel;
+  model: CombinedLearningJourneyPanel;
 }
 
 /**
@@ -74,12 +73,17 @@ export function FloatingPanelContent({
   onAlignmentCancel,
   activeTab,
   model,
+  hasInteractiveProgress,
+  progressKey,
+  onResetGuide,
+  surface = 'floating',
 }: FloatingPanelContentProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const journeyStyles = useStyles2(journeyContentHtml);
   const docsStyles = useStyles2(docsContentHtml);
   const interactiveStyles = useStyles2(getInteractiveStyles);
   const prismStyles = useStyles2(getPrismStyles);
+  const floatingStyles = useStyles2(getFloatingPanelStyles);
   // `useTheme2()` is the canonical hook for grabbing the raw theme; the
   // previous `useStyles2((t) => t)` pattern worked but mis-used the
   // CSS-in-JS hook just for theme access.
@@ -119,9 +123,27 @@ export function FloatingPanelContent({
 
   const contentClassName = `${content.type === 'learning-journey' ? journeyStyles : docsStyles} ${interactiveStyles} ${prismStyles}`;
 
+  // Only render the embedded milestone toolbar when the caller passes the
+  // toolbar inputs. The full-screen surface renders its own toolbar in the
+  // layout's sub-header slot and omits these props, which prevents a
+  // double-render of the toolbar on that surface.
+  const showEmbeddedToolbar = onResetGuide !== undefined && progressKey !== undefined && activeTab !== null;
+
   return (
     <AlignmentPendingContext.Provider value={alignmentPendingValue}>
       <div ref={contentRef}>
+        {showEmbeddedToolbar && activeTab && (
+          <LearningJourneyMilestoneToolbar
+            panel={model}
+            activeTab={activeTab}
+            surface={surface}
+            contentRoot={contentRef}
+            actionButtonClassName={floatingStyles.secondaryActionButton}
+            hasInteractiveProgress={!!hasInteractiveProgress}
+            progressKey={progressKey ?? null}
+            onResetGuide={onResetGuide!}
+          />
+        )}
         {pendingAlignment && onAlignmentConfirm && onAlignmentCancel && (
           <div style={{ padding: 16 }}>
             <AlignmentPrompt

--- a/src/components/floating-panel/FloatingPanelContent.tsx
+++ b/src/components/floating-panel/FloatingPanelContent.tsx
@@ -17,17 +17,9 @@ import type { CombinedLearningJourneyPanel } from '../docs-panel/docs-panel';
 import { getFloatingPanelStyles } from './floating-panel.styles';
 
 interface FloatingPanelContentProps {
-  /** Toolbar inputs — when omitted (e.g. recommendations tab) the toolbar self-hides. */
   hasInteractiveProgress?: boolean;
   progressKey?: string | null;
   onResetGuide?: (progressKey: string, tab: LearningJourneyTab) => Promise<void> | void;
-  /**
-   * Which surface this content is rendering on — drives the analytics
-   * `interaction_location` for the toolbar's "Open" button. Defaults to
-   * `'floating'` since this component's primary home is the floating panel;
-   * the full-screen surface renders its own toolbar separately and omits the
-   * toolbar props, so the default never leaks into fullscreen analytics.
-   */
   surface?: MilestoneToolbarSurface;
   /** The guide content to render */
   content: RawContent | null;
@@ -51,9 +43,10 @@ interface FloatingPanelContentProps {
    */
   activeTab: LearningJourneyTab | null;
   /**
-   * Panel model — used by the link click handler for navigation actions
+   * Panel model used by the link click handler for navigation actions
    * (`loadTabContent`, milestone navigation, opening docs/journeys from
-   * embedded links, etc.) AND by the milestone toolbar for prev/next + reset.
+   * embedded links, etc.). Without this, content links and the
+   * "Ready to Begin" CTA on the cover page have no handler.
    */
   model: CombinedLearningJourneyPanel;
 }
@@ -123,10 +116,6 @@ export function FloatingPanelContent({
 
   const contentClassName = `${content.type === 'learning-journey' ? journeyStyles : docsStyles} ${interactiveStyles} ${prismStyles}`;
 
-  // Only render the embedded milestone toolbar when the caller passes the
-  // toolbar inputs. The full-screen surface renders its own toolbar in the
-  // layout's sub-header slot and omits these props, which prevents a
-  // double-render of the toolbar on that surface.
   const showEmbeddedToolbar = onResetGuide !== undefined && progressKey !== undefined && activeTab !== null;
 
   return (

--- a/src/components/floating-panel/FloatingPanelContent.tsx
+++ b/src/components/floating-panel/FloatingPanelContent.tsx
@@ -133,16 +133,19 @@ export function FloatingPanelContent({
     <AlignmentPendingContext.Provider value={alignmentPendingValue}>
       <div ref={contentRef}>
         {showEmbeddedToolbar && activeTab && (
-          <LearningJourneyMilestoneToolbar
-            panel={model}
-            activeTab={activeTab}
-            surface={surface}
-            contentRoot={contentRef}
-            actionButtonClassName={floatingStyles.secondaryActionButton}
-            hasInteractiveProgress={!!hasInteractiveProgress}
-            progressKey={progressKey ?? null}
-            onResetGuide={onResetGuide!}
-          />
+          <div className={floatingStyles.stickyToolbar}>
+            <LearningJourneyMilestoneToolbar
+              panel={model}
+              activeTab={activeTab}
+              surface={surface}
+              contentRoot={contentRef}
+              actionButtonClassName={floatingStyles.secondaryActionButton}
+              hasInteractiveProgress={!!hasInteractiveProgress}
+              progressKey={progressKey ?? null}
+              onResetGuide={onResetGuide!}
+              compact
+            />
+          </div>
         )}
         {pendingAlignment && onAlignmentConfirm && onAlignmentCancel && (
           <div style={{ padding: 16 }}>

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -1,6 +1,9 @@
 import React, { lazy, Suspense, useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { locationService } from '@grafana/runtime';
+import { ThemeContext } from '@grafana/data';
+import { config, locationService } from '@grafana/runtime';
 import { CombinedLearningJourneyPanel } from '../docs-panel/docs-panel';
+import { useContentReset } from '../docs-panel/hooks';
+import { useKeyboardShortcuts } from '../docs-panel/keyboard-shortcuts.hook';
 import { openPendingGuide } from '../docs-panel/pendingGuideRouter';
 import { PERMANENT_TAB_IDS } from '../docs-panel/utils';
 import { PathfinderFeatureProvider } from '../OpenFeatureProvider';
@@ -32,6 +35,7 @@ const EDITOR_FLOATING_TITLE = 'Guide editor';
  */
 export function FloatingPanelManager() {
   const [mode, setMode] = useState<PanelMode>(() => panelModeManager.getMode());
+  const theme = useGrafanaTheme();
 
   // Listen for mode changes
   useEffect(() => {
@@ -49,11 +53,47 @@ export function FloatingPanelManager() {
     return null;
   }
 
+  // Wrap in ThemeContext so `useTheme2` / `useStyles2` inside the popout see
+  // Grafana's current theme. Required because module.tsx mounts this manager
+  // via createCompatRoot, outside Grafana's GrafanaContextProvider tree, so
+  // the default theme context would otherwise apply.
   return (
-    <PathfinderFeatureProvider>
-      <FloatingPanelInner />
-    </PathfinderFeatureProvider>
+    <ThemeContext.Provider value={theme}>
+      <PathfinderFeatureProvider>
+        <FloatingPanelInner />
+      </PathfinderFeatureProvider>
+    </ThemeContext.Provider>
   );
+}
+
+/**
+ * Tracks Grafana's active theme so the standalone floating-panel React root
+ * stays in sync when the user toggles light/dark mode.
+ *
+ * Grafana doesn't expose a public theme-change event for plugins, but it
+ * toggles `theme-dark` / `theme-light` classes on <body> as part of the
+ * switch. Observing that class mutation lets us re-read `config.theme2`
+ * without a page reload.
+ */
+function useGrafanaTheme() {
+  const [theme, setTheme] = useState(() => config.theme2);
+
+  useEffect(() => {
+    const observer = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        if (m.attributeName === 'class') {
+          if (config.theme2 !== theme) {
+            setTheme(config.theme2);
+          }
+          break;
+        }
+      }
+    });
+    observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, [theme]);
+
+  return theme;
 }
 
 /**
@@ -164,7 +204,23 @@ function FloatingPanelInner() {
     }
   }, [restorationDone, hasActiveGuide, isEditorTab]);
 
-  useAlignmentReevaluation(panel, activeTabId, activeTab);
+  const { hasInteractiveProgress, progressKey } = useAlignmentReevaluation(panel, activeTabId, activeTab);
+
+  // Drives the toolbar's "Reset guide" button — same hook the sidebar and
+  // full-screen surfaces use, so reset semantics stay identical across all
+  // three surfaces.
+  const handleResetGuide = useContentReset({ model: panel });
+
+  // Wire Alt+ArrowLeft / Alt+ArrowRight milestone navigation in the popout.
+  // Listeners attach to `document`, so they fire from anywhere — but the hook
+  // already skips text-editable focus targets to preserve native word-jump.
+  useKeyboardShortcuts({
+    tabs,
+    activeTabId,
+    activeTab: activeTab ?? null,
+    isRecommendationsTab: activeTabId === 'recommendations',
+    model: panel,
+  });
   // Prefer `currentUrl` (the milestone the user is reading) so when the user
   // goes from floating → fullscreen via `handleSwitchToFullScreen`, or copies
   // a shareable link, the milestone position carries through. `baseUrl` is
@@ -305,6 +361,9 @@ function FloatingPanelInner() {
           onAlignmentCancel={activeTab ? () => panel.dismissAlignment(activeTab.id) : undefined}
           activeTab={activeTab ?? null}
           model={panel}
+          hasInteractiveProgress={hasInteractiveProgress}
+          progressKey={progressKey}
+          onResetGuide={handleResetGuide}
         />
       )}
     </FloatingPanel>

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -53,10 +53,6 @@ export function FloatingPanelManager() {
     return null;
   }
 
-  // Wrap in ThemeContext so `useTheme2` / `useStyles2` inside the popout see
-  // Grafana's current theme. Required because module.tsx mounts this manager
-  // via createCompatRoot, outside Grafana's GrafanaContextProvider tree, so
-  // the default theme context would otherwise apply.
   return (
     <ThemeContext.Provider value={theme}>
       <PathfinderFeatureProvider>
@@ -66,15 +62,6 @@ export function FloatingPanelManager() {
   );
 }
 
-/**
- * Tracks Grafana's active theme so the standalone floating-panel React root
- * stays in sync when the user toggles light/dark mode.
- *
- * Grafana doesn't expose a public theme-change event for plugins, but it
- * toggles `theme-dark` / `theme-light` classes on <body> as part of the
- * switch. Observing that class mutation lets us re-read `config.theme2`
- * without a page reload.
- */
 function useGrafanaTheme() {
   const [theme, setTheme] = useState(() => config.theme2);
 
@@ -206,14 +193,8 @@ function FloatingPanelInner() {
 
   const { hasInteractiveProgress, progressKey } = useAlignmentReevaluation(panel, activeTabId, activeTab);
 
-  // Drives the toolbar's "Reset guide" button — same hook the sidebar and
-  // full-screen surfaces use, so reset semantics stay identical across all
-  // three surfaces.
   const handleResetGuide = useContentReset({ model: panel });
 
-  // Wire Alt+ArrowLeft / Alt+ArrowRight milestone navigation in the popout.
-  // Listeners attach to `document`, so they fire from anywhere — but the hook
-  // already skips text-editable focus targets to preserve native word-jump.
   useKeyboardShortcuts({
     tabs,
     activeTabId,

--- a/src/components/floating-panel/floating-panel.styles.ts
+++ b/src/components/floating-panel/floating-panel.styles.ts
@@ -155,4 +155,40 @@ export const getFloatingPanelStyles = (theme: GrafanaTheme2) => ({
   pillWrapper: css({
     position: 'relative',
   }),
+
+  // Open / Reset action buttons inside the milestone toolbar. Visual parity
+  // with the sidebar and full-screen `secondaryActionButton`.
+  secondaryActionButton: css({
+    backgroundColor: 'transparent',
+    color: theme.colors.text.primary,
+    border: `1px solid ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+    padding: `${theme.spacing(0.5)} ${theme.spacing(0.75)}`,
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+    cursor: 'pointer',
+    transition: 'all 0.2s ease',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing(0.5),
+    '&:hover:not(:disabled)': {
+      backgroundColor: theme.colors.action.hover,
+      borderColor: theme.colors.border.strong,
+      boxShadow: theme.shadows.z1,
+    },
+    '& svg': {
+      width: '12px',
+      height: '12px',
+      flexShrink: 0,
+    },
+    // Container query mirroring the sidebar's `secondaryActionButton`:
+    // collapse to icon-only when the toolbar gets narrow.
+    '@container (max-width: 360px)': {
+      padding: theme.spacing(0.5),
+      '& > span': {
+        display: 'none',
+      },
+    },
+  }),
 });

--- a/src/components/floating-panel/floating-panel.styles.ts
+++ b/src/components/floating-panel/floating-panel.styles.ts
@@ -156,13 +156,6 @@ export const getFloatingPanelStyles = (theme: GrafanaTheme2) => ({
     position: 'relative',
   }),
 
-  // Wraps the milestone toolbar so it sticks to the top of the scrollable
-  // content area as the user scrolls through the guide. The toolbar's own
-  // `milestoneProgress` style sets `backgroundColor: background.canvas` and
-  // a bottom border, so the sticky stripe reads cleanly over content.
-  // Negative horizontal/top margins cancel the content area's
-  // `padding: theme.spacing(1)` so the toolbar spans the full panel width
-  // and sticks flush against the panel chrome instead of leaving a gap.
   stickyToolbar: css({
     position: 'sticky',
     top: -theme.spacing.gridSize,
@@ -173,8 +166,6 @@ export const getFloatingPanelStyles = (theme: GrafanaTheme2) => ({
     zIndex: 2,
   }),
 
-  // Open / Reset action buttons inside the milestone toolbar. Visual parity
-  // with the sidebar and full-screen `secondaryActionButton`.
   secondaryActionButton: css({
     backgroundColor: 'transparent',
     color: theme.colors.text.primary,
@@ -199,8 +190,6 @@ export const getFloatingPanelStyles = (theme: GrafanaTheme2) => ({
       height: '12px',
       flexShrink: 0,
     },
-    // Container query mirroring the sidebar's `secondaryActionButton`:
-    // collapse to icon-only when the toolbar gets narrow.
     '@container (max-width: 360px)': {
       padding: theme.spacing(0.5),
       '& > span': {

--- a/src/components/floating-panel/floating-panel.styles.ts
+++ b/src/components/floating-panel/floating-panel.styles.ts
@@ -156,6 +156,23 @@ export const getFloatingPanelStyles = (theme: GrafanaTheme2) => ({
     position: 'relative',
   }),
 
+  // Wraps the milestone toolbar so it sticks to the top of the scrollable
+  // content area as the user scrolls through the guide. The toolbar's own
+  // `milestoneProgress` style sets `backgroundColor: background.canvas` and
+  // a bottom border, so the sticky stripe reads cleanly over content.
+  // Negative horizontal/top margins cancel the content area's
+  // `padding: theme.spacing(1)` so the toolbar spans the full panel width
+  // and sticks flush against the panel chrome instead of leaving a gap.
+  stickyToolbar: css({
+    position: 'sticky',
+    top: -theme.spacing.gridSize,
+    marginLeft: -theme.spacing.gridSize,
+    marginRight: -theme.spacing.gridSize,
+    marginTop: -theme.spacing.gridSize,
+    marginBottom: theme.spacing(1),
+    zIndex: 2,
+  }),
+
   // Open / Reset action buttons inside the milestone toolbar. Visual parity
   // with the sidebar and full-screen `secondaryActionButton`.
   secondaryActionButton: css({


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/08a02fb5-26ab-4001-807d-376340522795



- Floating ("popout") panel now mounts the shared `LearningJourneyMilestoneToolbar` (prev/next arrows, "Milestone X of Y" label, progress bar, Open, Reset) and wires `useKeyboardShortcuts`, so users can complete an entire learning path without docking back to the sidebar.
- Wraps the standalone floating React root in `ThemeContext.Provider` driven by `config.theme2` plus a body-class `MutationObserver`, so the popout matches Grafana's light/dark theme and live-updates when the user toggles theme.

## Context

The floating panel was unusable for full learning paths: there was no UI or keyboard handler to advance milestones, and the panel always rendered in the default theme because it mounts via `createCompatRoot` outside Grafana's provider tree.

Implementation notes:
- `LearningJourneyMilestoneToolbar` gains a third `surface` variant `'floating'` (existing `'sidebar'` + `'fullscreen'` were already designed for reuse). Adds `floating_panel_milestone_progress_bar` as the analytics `interaction_location` for the Open button on this surface.
- `FloatingPanelContent` renders the toolbar gated on the toolbar inputs being present — the full-screen surface omits them and renders its own toolbar in the layout's sub-header, so there's no double-toolbar regression.
- New `useGrafanaTheme()` reads `config.theme2` and observes `<body>` class mutations (Grafana toggles `theme-dark` / `theme-light` on body during theme switches; no public theme-change event is exposed for plugins).

## Test plan

- [x] `npm run server` + `npm run dev`, open Pathfinder, start a multi-milestone learning path.
- [x] Pop out the panel: confirm the milestone toolbar (prev arrow, "Milestone X of Y", next arrow, progress bar, Open, Reset) renders above the guide content.
- [x] Click the next/prev arrows — milestone advances/retreats without docking. Disabled states match the sidebar at the start/end milestones.