### PR TITLE
fix(floating): preserve milestone on dock-back by sharing tabStorage

### DIFF
--- a/src/components/App/ContextPanel.tsx
+++ b/src/components/App/ContextPanel.tsx
@@ -25,7 +25,6 @@ export default function MemoizedContextPanel() {
   // mode. The user opened the sidebar so they want it — don't fight it.
   useEffect(() => {
     if (mode === 'floating') {
-      panelModeManager.restoreSidebarTabSnapshot();
       panelModeManager.setMode('sidebar');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/docs-panel/docs-panel.alignment.test.ts
+++ b/src/components/docs-panel/docs-panel.alignment.test.ts
@@ -137,7 +137,7 @@ jest.mock('../../global-state/link-interception', () => ({
 }));
 
 jest.mock('../../global-state/panel-mode', () => ({
-  panelModeManager: { getMode: jest.fn(() => 'sidebar'), setMode: jest.fn(), snapshotSidebarTabs: jest.fn() },
+  panelModeManager: { getMode: jest.fn(() => 'sidebar'), setMode: jest.fn() },
 }));
 
 jest.mock('../LearningPaths', () => ({

--- a/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
+++ b/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
@@ -126,7 +126,7 @@ jest.mock('../../global-state/link-interception', () => ({
 }));
 
 jest.mock('../../global-state/panel-mode', () => ({
-  panelModeManager: { getMode: jest.fn(() => 'sidebar'), setMode: jest.fn(), snapshotSidebarTabs: jest.fn() },
+  panelModeManager: { getMode: jest.fn(() => 'sidebar'), setMode: jest.fn() },
 }));
 
 jest.mock('../LearningPaths', () => ({

--- a/src/components/docs-panel/hooks/useFullScreenHandoff.test.ts
+++ b/src/components/docs-panel/hooks/useFullScreenHandoff.test.ts
@@ -41,14 +41,12 @@ function dispatchFullScreen() {
 describe('useFullScreenHandoff', () => {
   let setModeSpy: jest.SpyInstance;
   let setPendingGuideSpy: jest.SpyInstance;
-  let snapshotSpy: jest.SpyInstance;
   let capturePriorPathSpy: jest.SpyInstance;
   let publishMock: jest.Mock;
 
   beforeEach(() => {
     setModeSpy = jest.spyOn(panelModeManager, 'setMode').mockImplementation(() => {});
     setPendingGuideSpy = jest.spyOn(panelModeManager, 'setPendingGuide').mockImplementation(() => {});
-    snapshotSpy = jest.spyOn(panelModeManager, 'snapshotSidebarTabs').mockImplementation(() => {});
     capturePriorPathSpy = jest.spyOn(panelModeManager, 'capturePriorPath').mockImplementation(() => {});
     publishMock = jest.fn();
     (getAppEvents as jest.Mock).mockReturnValue({ publish: publishMock });
@@ -84,7 +82,7 @@ describe('useFullScreenHandoff', () => {
     expect(locationService.push).not.toHaveBeenCalled();
   });
 
-  it('editor branch: pushes the bare full-screen route with no doc query, no snapshot', () => {
+  it('editor branch: pushes the bare full-screen route with no doc query', () => {
     const { model } = makeModel({
       tabs: [{ id: 'editor', type: 'editor', title: 'Block editor', baseUrl: 'bundled:editor' }],
       activeTabId: 'editor',
@@ -95,7 +93,6 @@ describe('useFullScreenHandoff', () => {
     expect(setPendingGuideSpy).toHaveBeenCalledWith({ title: 'Block editor', type: 'editor' });
     expect(capturePriorPathSpy).toHaveBeenCalledTimes(1);
     expect(setModeSpy).toHaveBeenCalledWith('fullscreen');
-    expect(snapshotSpy).not.toHaveBeenCalled();
     expect(locationService.push).toHaveBeenCalledWith(expect.stringContaining('/fullscreen'));
     expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.FullScreenEnter, {
       guide_url: '',
@@ -159,7 +156,6 @@ describe('useFullScreenHandoff', () => {
     });
     expect(capturePriorPathSpy).toHaveBeenCalledTimes(1);
     expect(setModeSpy).toHaveBeenCalledWith('fullscreen');
-    expect(snapshotSpy).not.toHaveBeenCalled();
     const pushedUrl = (locationService.push as jest.Mock).mock.calls[0][0];
     expect(pushedUrl).toContain('doc=');
     expect(pushedUrl).toContain('type=learning-journey');

--- a/src/components/docs-panel/hooks/useFullScreenHandoff.ts
+++ b/src/components/docs-panel/hooks/useFullScreenHandoff.ts
@@ -5,17 +5,13 @@
  * surface lands on the user's current milestone.
  *
  * Mirrors usePopOutHandoff's structure (editor branch, refusal branch,
- * active-guide handoff) with three full-screen-specific differences:
+ * active-guide handoff) with two full-screen-specific differences:
  *   1. Live session block: when a session is active, surface an alert and
  *      return without switching. A fresh SessionProvider on the new page
  *      would disconnect the session, which is worse than refusing.
  *   2. devtools tabs are refused alongside `recommendations` (not popped
  *      out). Pop-out has no equivalent block because devtools has its
  *      own UX in the floating mode.
- *   3. *No* `snapshotSidebarTabs()` — the sidebar and full-screen surfaces
- *      share intent (same tabs, same active guide), so snapshot/restore
- *      would clobber milestone progress full-screen wrote back to
- *      tabStorage. The forward handoff keeps tab state shared.
  *
  * Critical closure rule (addresses pre-mortem H1):
  *   Reads `model.state.tabs` and `model.state.activeTabId` *inside* the
@@ -84,12 +80,6 @@ export function useFullScreenHandoff(model: FullScreenModel, isSessionActive: bo
         });
         // Remember where we came from so explicit Exit can land back on the
         // user's prior Grafana page instead of the plugin home.
-        //
-        // Intentionally NO `snapshotSidebarTabs()` here: the sidebar and
-        // full-screen surfaces share intent (same tabs, same active guide),
-        // so the snapshot/restore would clobber the milestone progress
-        // full-screen wrote back to tabStorage and the user would land at
-        // the prior milestone on dock-back.
         panelModeManager.capturePriorPath(window.location.pathname + window.location.search);
         panelModeManager.setPendingGuide({ title: activeTab.title, type: 'editor' });
         panelModeManager.setMode('fullscreen');
@@ -132,12 +122,6 @@ export function useFullScreenHandoff(model: FullScreenModel, isSessionActive: bo
 
       // Remember where we came from so explicit Exit can land back on the
       // user's prior Grafana page instead of the plugin home.
-      //
-      // Intentionally NO `snapshotSidebarTabs()` here: the sidebar and
-      // full-screen surfaces share intent (same tabs, same active guide),
-      // so the snapshot/restore would clobber the milestone progress
-      // full-screen wrote back to tabStorage and the user would land at
-      // the prior milestone on dock-back.
       panelModeManager.capturePriorPath(window.location.pathname + window.location.search);
       panelModeManager.setMode('fullscreen');
       // Encode the tab type in the URL so a refresh / shared link rehydrates

--- a/src/components/docs-panel/hooks/usePopOutHandoff.test.ts
+++ b/src/components/docs-panel/hooks/usePopOutHandoff.test.ts
@@ -24,35 +24,37 @@ function makeModel(initial: { tabs: any[]; activeTabId: string }) {
   // Mutable state container so we can flip activeTabId between mount and
   // event dispatch — characterizes the H1 closure-capture safety property.
   const state = { ...initial };
+  const saveTabsToStorage = jest.fn().mockResolvedValue(undefined);
   const model = {
     get state() {
       return state;
     },
+    saveTabsToStorage,
   };
   return {
     model: model as any,
+    saveTabsToStorage,
     setActive(id: string) {
       state.activeTabId = id;
     },
   };
 }
 
-function dispatchPopOut() {
-  act(() => {
+async function dispatchPopOut() {
+  await act(async () => {
     document.dispatchEvent(new CustomEvent('pathfinder-request-pop-out'));
+    // Let the async handler's await chain settle.
+    await Promise.resolve();
+    await Promise.resolve();
   });
 }
 
 describe('usePopOutHandoff', () => {
   let setModeSpy: jest.SpyInstance;
-  let setPendingGuideSpy: jest.SpyInstance;
-  let snapshotSpy: jest.SpyInstance;
   let publishMock: jest.Mock;
 
   beforeEach(() => {
     setModeSpy = jest.spyOn(panelModeManager, 'setMode').mockImplementation(() => {});
-    setPendingGuideSpy = jest.spyOn(panelModeManager, 'setPendingGuide').mockImplementation(() => {});
-    snapshotSpy = jest.spyOn(panelModeManager, 'snapshotSidebarTabs').mockImplementation(() => {});
     publishMock = jest.fn();
     (getAppEvents as jest.Mock).mockReturnValue({ publish: publishMock });
     (reportAppInteraction as jest.Mock).mockClear();
@@ -62,8 +64,8 @@ describe('usePopOutHandoff', () => {
     jest.restoreAllMocks();
   });
 
-  it('hands off the active learning-journey tab using currentUrl, then switches to floating', () => {
-    const { model } = makeModel({
+  it('flushes tabs to storage and switches to floating for an active learning-journey tab', async () => {
+    const { model, saveTabsToStorage } = makeModel({
       tabs: [
         {
           id: 'tab-a',
@@ -78,15 +80,9 @@ describe('usePopOutHandoff', () => {
     });
 
     renderHook(() => usePopOutHandoff(model));
-    dispatchPopOut();
+    await dispatchPopOut();
 
-    expect(setPendingGuideSpy).toHaveBeenCalledWith({
-      url: 'https://example.com/a/milestone-3',
-      title: 'Journey A',
-      type: 'learning-journey',
-      packageInfo: { packageId: 'pkg-x' },
-    });
-    expect(snapshotSpy).toHaveBeenCalledTimes(1);
+    expect(saveTabsToStorage).toHaveBeenCalledTimes(1);
     expect(setModeSpy).toHaveBeenCalledWith('floating');
     expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.FloatingPanelPopOut, {
       guide_url: 'https://example.com/a/milestone-3',
@@ -94,37 +90,54 @@ describe('usePopOutHandoff', () => {
     });
   });
 
-  it('treats docs tabs as type "docs" in the handoff payload', () => {
+  it('awaits saveTabsToStorage before flipping the mode (closes the in-task milestone race)', async () => {
     const { model } = makeModel({
       tabs: [
         {
-          id: 'tab-d',
-          type: 'docs',
-          title: 'Docs page',
-          baseUrl: 'https://example.com/d',
-          currentUrl: 'https://example.com/d',
+          id: 'tab-a',
+          type: 'learning-journey',
+          title: 'Journey A',
+          baseUrl: 'https://example.com/a',
+          currentUrl: 'https://example.com/a/milestone-3',
         },
       ],
-      activeTabId: 'tab-d',
+      activeTabId: 'tab-a',
     });
+    // Replace the resolved save with a deferred one so we can assert ordering.
+    let resolveSave!: () => void;
+    const savePromise = new Promise<void>((r) => {
+      resolveSave = r;
+    });
+    (model.saveTabsToStorage as jest.Mock).mockReturnValue(savePromise);
 
     renderHook(() => usePopOutHandoff(model));
-    dispatchPopOut();
+    act(() => {
+      document.dispatchEvent(new CustomEvent('pathfinder-request-pop-out'));
+    });
 
-    expect(setPendingGuideSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'docs' }));
+    // Without resolving the save, setMode must not have fired.
+    await Promise.resolve();
+    expect(setModeSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveSave();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(setModeSpy).toHaveBeenCalledWith('floating');
   });
 
-  it('editor branch: snapshot + setMode("floating") with empty guide_url, no setPendingGuide', () => {
-    const { model } = makeModel({
+  it('editor branch: flushes storage and switches to floating with empty guide_url', async () => {
+    const { model, saveTabsToStorage } = makeModel({
       tabs: [{ id: 'editor', type: 'editor', title: 'Block editor', baseUrl: 'bundled:editor' }],
       activeTabId: 'editor',
     });
 
     renderHook(() => usePopOutHandoff(model));
-    dispatchPopOut();
+    await dispatchPopOut();
 
-    expect(setPendingGuideSpy).not.toHaveBeenCalled();
-    expect(snapshotSpy).toHaveBeenCalledTimes(1);
+    expect(saveTabsToStorage).toHaveBeenCalledTimes(1);
     expect(setModeSpy).toHaveBeenCalledWith('floating');
     expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.FloatingPanelPopOut, {
       guide_url: '',
@@ -132,28 +145,28 @@ describe('usePopOutHandoff', () => {
     });
   });
 
-  it('refuses pop-out from the recommendations tab and emits alert-info', () => {
-    const { model } = makeModel({
+  it('refuses pop-out from the recommendations tab and emits alert-info', async () => {
+    const { model, saveTabsToStorage } = makeModel({
       tabs: [{ id: 'recommendations', type: 'docs', title: 'Recs', baseUrl: '' }],
       activeTabId: 'recommendations',
     });
 
     renderHook(() => usePopOutHandoff(model));
-    dispatchPopOut();
+    await dispatchPopOut();
 
     expect(publishMock).toHaveBeenCalledWith({
       type: 'alert-info',
       payload: ['Open a guide before popping out the panel.'],
     });
-    expect(setPendingGuideSpy).not.toHaveBeenCalled();
+    expect(saveTabsToStorage).not.toHaveBeenCalled();
     expect(setModeSpy).not.toHaveBeenCalled();
   });
 
-  it('refuses pop-out when there is no active tab', () => {
+  it('refuses pop-out when there is no active tab', async () => {
     const { model } = makeModel({ tabs: [], activeTabId: 'missing' });
 
     renderHook(() => usePopOutHandoff(model));
-    dispatchPopOut();
+    await dispatchPopOut();
 
     expect(publishMock).toHaveBeenCalledWith({
       type: 'alert-info',
@@ -162,7 +175,7 @@ describe('usePopOutHandoff', () => {
     expect(setModeSpy).not.toHaveBeenCalled();
   });
 
-  it('H1 — re-reads model.state inside the handler (tab switched after mount)', () => {
+  it('H1 — re-reads model.state inside the handler (tab switched after mount)', async () => {
     // Mount with tab A active, then switch to tab B, then dispatch.
     // If the handler captured `state` at mount time (closure-over-snapshot
     // bug), tab A would still be the source. The handler MUST re-read.
@@ -188,17 +201,15 @@ describe('usePopOutHandoff', () => {
 
     renderHook(() => usePopOutHandoff(model));
     setActive('tab-b');
-    dispatchPopOut();
+    await dispatchPopOut();
 
-    expect(setPendingGuideSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        url: 'https://example.com/b',
-        title: 'Journey B',
-      })
-    );
+    expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.FloatingPanelPopOut, {
+      guide_url: 'https://example.com/b',
+      guide_title: 'Journey B',
+    });
   });
 
-  it('falls back to baseUrl when currentUrl is missing', () => {
+  it('falls back to baseUrl when currentUrl is missing', async () => {
     const { model } = makeModel({
       tabs: [
         {
@@ -213,9 +224,12 @@ describe('usePopOutHandoff', () => {
     });
 
     renderHook(() => usePopOutHandoff(model));
-    dispatchPopOut();
+    await dispatchPopOut();
 
-    expect(setPendingGuideSpy).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://example.com/c' }));
+    expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.FloatingPanelPopOut, {
+      guide_url: 'https://example.com/c',
+      guide_title: 'Journey C',
+    });
   });
 
   it('removes the listener on unmount', () => {

--- a/src/components/docs-panel/hooks/usePopOutHandoff.ts
+++ b/src/components/docs-panel/hooks/usePopOutHandoff.ts
@@ -1,8 +1,9 @@
 /**
  * Owns the `pathfinder-request-pop-out` CustomEvent — the contract by which
  * the panel-mode action buttons request the docs panel switch from
- * `sidebar` to `floating`, handing off the active guide so the floating
- * instance lands on the user's current milestone instead of the cover page.
+ * `sidebar` to `floating`. The floating panel restores tabs (including
+ * the active guide's `currentUrl`) from the shared `tabStorage`, so the
+ * handoff is just: flush tabs to storage, then flip the mode.
  *
  * Critical closure rule (addresses pre-mortem H1):
  *   The handler reads `model.state.tabs` and `model.state.activeTabId`
@@ -13,16 +14,15 @@
  *   handoff on whatever tab was active at mount.
  *
  * Behavior matrix preserved verbatim:
- *   - Editor tab: snapshot sidebar tabs, switch mode to `floating`. The
- *     floating instance detects the editor tab and renders the BlockEditor
- *     directly — no `setPendingGuide` payload needed.
+ *   - Editor tab: flush tabs to storage, switch mode to `floating`. The
+ *     floating instance detects the editor tab on restore and renders
+ *     the BlockEditor directly.
  *   - No active guide (no active tab, recommendations tab, or no URL):
  *     publish an alert-info ("Open a guide before popping out the panel.")
  *     and return without changing modes.
- *   - Active guide: set `pendingGuide` ({ url, title, type, packageInfo }),
- *     snapshot sidebar tabs, switch mode to `floating`. `currentUrl` is
- *     preferred over `baseUrl` so the floating instance opens at the
- *     user's milestone, not the cover.
+ *   - Active guide: flush tabs to storage, switch mode to `floating`.
+ *     The floating instance restores from `tabStorage` and lands on the
+ *     active tab at its current milestone (`currentUrl`).
  *
  * Analytics: emits `UserInteraction.FloatingPanelPopOut` with `guide_url`
  * + `guide_title`, both branches (editor and guide). Editor branch sends
@@ -31,8 +31,7 @@
  * Contract surfaces preserved (Pattern J):
  *   - CustomEvent name: `pathfinder-request-pop-out`
  *   - `panelModeManager.setMode('floating')`
- *   - `panelModeManager.setPendingGuide(...)` payload shape
- *   - `panelModeManager.snapshotSidebarTabs()`
+ *   - `model.saveTabsToStorage()` awaited before the mode flip
  */
 import * as React from 'react';
 import { getAppEvents } from '@grafana/runtime';
@@ -40,46 +39,28 @@ import { reportAppInteraction, UserInteraction } from '../../../lib/analytics';
 import { panelModeManager } from '../../../global-state/panel-mode';
 import type { CombinedPanelState } from '../../../types/content-panel.types';
 
-/**
- * Structural type for the hook's model parameter. Defined here (not imported
- * from `../docs-panel`) to avoid a `hooks/ → docs-panel.tsx → hooks/` import
- * cycle. The real model is `CombinedLearningJourneyPanel`, which satisfies
- * this shape by virtue of extending `SceneObjectBase<CombinedPanelState>`.
- */
 interface PopOutModel {
   state: CombinedPanelState;
+  saveTabsToStorage(): Promise<void>;
 }
 
 export function usePopOutHandoff(model: PopOutModel): void {
   React.useEffect(() => {
-    const handlePopOut = () => {
-      // Read inside the closure — see "Critical closure rule" in the file header.
+    const handlePopOut = async () => {
       const { tabs: currentTabs, activeTabId: currentActiveTabId } = model.state;
       const activeTab = currentTabs.find((tab) => tab.id === currentActiveTabId);
-      // Prefer `currentUrl` so a popped-out learning journey lands on the
-      // user's current milestone, not the cover page. For non-journey tabs
-      // the two fields are equal.
       const guideUrl = activeTab?.currentUrl || activeTab?.baseUrl;
 
-      // Editor tab popout: the block editor itself moves into the floating panel.
-      // No pendingGuide handoff — the floating panel detects the editor tab and
-      // renders <BlockEditor /> directly (see FloatingPanelManager).
       if (activeTab?.type === 'editor') {
         reportAppInteraction(UserInteraction.FloatingPanelPopOut, {
           guide_url: '',
           guide_title: activeTab.title,
         });
-        panelModeManager.snapshotSidebarTabs();
-        // The floating panel creates a new CombinedLearningJourneyPanel instance
-        // with its own per-instance `_hasRestoredTabs` guard, so it can rehydrate
-        // the editor tab from localStorage without any cross-instance reset.
+        await model.saveTabsToStorage();
         panelModeManager.setMode('floating');
         return;
       }
 
-      // Refuse to pop out when there's no guide context — without this guard the
-      // sidebar would close and the floating panel would have nothing to show.
-      // Surface a notification so the user understands why nothing happened.
       if (!activeTab || activeTab.id === 'recommendations' || !guideUrl) {
         getAppEvents().publish({
           type: 'alert-info',
@@ -88,24 +69,12 @@ export function usePopOutHandoff(model: PopOutModel): void {
         return;
       }
 
-      panelModeManager.setPendingGuide({
-        url: guideUrl,
-        title: activeTab.title,
-        type: activeTab.type === 'learning-journey' ? 'learning-journey' : 'docs',
-        // Forward synthetic packageInfo (e.g. PR-tester journeys whose URL
-        // is a raw GitHub URL, not a recognised package URL) so the floating
-        // panel rebuilds the milestone toolbar after the handoff.
-        packageInfo: activeTab.packageInfo,
-      });
-
       reportAppInteraction(UserInteraction.FloatingPanelPopOut, {
         guide_url: guideUrl,
         guide_title: activeTab.title,
       });
 
-      // Snapshot sidebar tabs before switching — the floating panel's model
-      // will overwrite tabStorage via openDocsPage → saveTabsToStorage
-      panelModeManager.snapshotSidebarTabs();
+      await model.saveTabsToStorage();
       panelModeManager.setMode('floating');
     };
 

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -4,7 +4,6 @@ import { config, locationService } from '@grafana/runtime';
 import { CombinedLearningJourneyPanel } from '../docs-panel/docs-panel';
 import { useContentReset } from '../docs-panel/hooks';
 import { useKeyboardShortcuts } from '../docs-panel/keyboard-shortcuts.hook';
-import { openPendingGuide } from '../docs-panel/pendingGuideRouter';
 import { PERMANENT_TAB_IDS } from '../docs-panel/utils';
 import { PathfinderFeatureProvider } from '../OpenFeatureProvider';
 import { useGuideProgressState, useAutoLaunchTutorial, useStepProgressFromEvents } from '../../hooks';
@@ -117,16 +116,6 @@ function FloatingPanelInner() {
     document.dispatchEvent(new CustomEvent('pathfinder-panel-mounted', { detail: { timestamp: Date.now() } }));
     sidebarState.setIsSidebarMounted(true);
 
-    // If a guide was handed off from the sidebar (pop-out), open it now.
-    // Tag the source as `floating_panel_dock` (aligned-by-construction) so
-    // the implied-0th-step evaluator doesn't second-guess a guide the user
-    // is already viewing.
-    const pendingGuide = panelModeManager.consumePendingGuide();
-    if (pendingGuide) {
-      guideOpenInFlightRef.current = true;
-      openPendingGuide(panel, pendingGuide, 'floating_panel_dock');
-    }
-
     return () => {
       document.removeEventListener('pathfinder-auto-launch-pending', handlePending);
       // Only clear if we're still the active owner — during dock-back the
@@ -213,9 +202,6 @@ function FloatingPanelInner() {
       guide_url: guideUrl || '',
       guide_title: title,
     });
-    // Restore the sidebar's original tab state (snapshotted before pop-out)
-    // so the floating panel's tabStorage writes don't wipe the user's tabs
-    panelModeManager.restoreSidebarTabSnapshot();
     panelModeManager.setMode('sidebar');
     sidebarState.setPendingOpenSource('floating_panel_dock', 'open');
     sidebarState.openSidebar('Interactive learning');
@@ -235,7 +221,6 @@ function FloatingPanelInner() {
   }, [handleSwitchToSidebar]);
 
   const handleClose = useCallback(() => {
-    panelModeManager.restoreSidebarTabSnapshot();
     panelModeManager.setMode('sidebar');
   }, []);
 

--- a/src/components/floating-panel/floating-panel.shared-tabstorage.test.ts
+++ b/src/components/floating-panel/floating-panel.shared-tabstorage.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tripwire (Pattern J — contract-surface preservation)
+ *
+ * Pins the "floating panel shares `tabStorage` with the sidebar" contract,
+ * which fixes the milestone-reset-on-dock-back bug by removing the
+ * snapshot/restore mechanism. If a future change reintroduces
+ * `snapshotSidebarTabs` / `restoreSidebarTabSnapshot` on the floating
+ * surface, the bug returns: the snapshot taken at pop-out time gets
+ * written back to `tabStorage` at dock, clobbering whatever milestone
+ * position the user advanced through in the floating panel.
+ *
+ * Why a tripwire (not a runtime mount test):
+ *   `@grafana/scenes` + `@grafana/ui` require a theme provider that is
+ *   not available in the Jest environment. Source-assertion tripwires
+ *   are the established shape for the docs-panel + floating-panel
+ *   surfaces in this repo (see `docs-panel.panel-mode.test.tsx`).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+function read(rel: string): string {
+  return fs.readFileSync(path.resolve(__dirname, '..', '..', rel), 'utf-8');
+}
+
+const SNAPSHOT_METHODS = ['snapshotSidebarTabs', 'restoreSidebarTabSnapshot'];
+
+describe('floating panel shares tabStorage with the sidebar', () => {
+  it('panelModeManager no longer exposes the snapshot API', () => {
+    const src = read('global-state/panel-mode.ts');
+    for (const method of SNAPSHOT_METHODS) {
+      expect(src).not.toContain(method);
+    }
+  });
+
+  it('FloatingPanelManager does not snapshot or restore', () => {
+    const src = read('components/floating-panel/FloatingPanelManager.tsx');
+    for (const method of SNAPSHOT_METHODS) {
+      expect(src).not.toContain(method);
+    }
+  });
+
+  it('usePopOutHandoff awaits saveTabsToStorage before flipping the mode', () => {
+    const src = read('components/docs-panel/hooks/usePopOutHandoff.ts');
+    for (const method of SNAPSHOT_METHODS) {
+      expect(src).not.toContain(method);
+    }
+    expect(src).toMatch(/await\s+model\.saveTabsToStorage\(\)/);
+    expect(src).toContain("setMode('floating')");
+  });
+
+  it('full-screen-autodock does not snapshot or set a pending guide for the floating branch', () => {
+    const src = read('components/full-screen/full-screen-autodock.ts');
+    for (const method of SNAPSHOT_METHODS) {
+      expect(src).not.toContain(method);
+    }
+    expect(src).not.toContain('setPendingGuide');
+  });
+});

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -174,6 +174,13 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     onIncoming: () => {
       guideOpenInFlightRef.current = true;
     },
+    // The floating→fullscreen handoff pushes a `?doc=` URL, which makes
+    // `handlePathfinderDeepLink` schedule a delayed auto-launch ~500ms later.
+    // By then the pending-guide mount effect has already opened the guide
+    // (with packageInfo). Without this skip, the duplicate open goes through
+    // `openLearningJourney` without packageInfo and replaces the journey
+    // content with a flat single-doc — the milestone arrows disappear.
+    skipLaunch: () => guideOpenInFlightRef.current,
   });
 
   // Active tab projection.

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -194,25 +194,23 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
   // that took them there. Decision logic (sidebar vs floating fallback) is
   // factored out into `dockOnLeavingFullScreen` for unit testability.
   //
-  // Latest tab/title/url are read through a ref so the listener subscribes
+  // Latest title/url are read through a ref so the listener subscribes
   // exactly once on mount. Without the ref the effect re-subscribes on
-  // every milestone navigation (`activeTab` is a fresh `find()` reference
-  // per render), which churns the history subscription and risks dropping
-  // the very location event that triggered the navigation.
-  const dockInputsRef = useRef({ guideUrl, title, activeTab });
-  dockInputsRef.current = { guideUrl, title, activeTab };
+  // every milestone navigation, which churns the history subscription and
+  // risks dropping the very location event that triggered the navigation.
+  const dockInputsRef = useRef({ guideUrl, title });
+  dockInputsRef.current = { guideUrl, title };
   useEffect(() => {
     const fullScreenPathname = `${PLUGIN_BASE_URL}/${ROUTES.FullScreen}`;
     const history = locationService.getHistory();
     const unlisten = history.listen((location: { pathname: string }) => {
-      const { guideUrl: latestGuideUrl, title: latestTitle, activeTab: latestActiveTab } = dockInputsRef.current;
+      const { guideUrl: latestGuideUrl, title: latestTitle } = dockInputsRef.current;
       dockOnLeavingFullScreen({
         pathname: location.pathname,
         fullScreenPathname,
         myPluginId: pluginJson.id,
         guideUrl: latestGuideUrl,
         title: latestTitle,
-        activeTab: latestActiveTab,
       });
     });
     return unlisten;

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -5,6 +5,7 @@ import { useStyles2 } from '@grafana/ui';
 
 import { CombinedLearningJourneyPanel } from '../docs-panel/docs-panel';
 import { useContentReset } from '../docs-panel/hooks';
+import { useKeyboardShortcuts } from '../docs-panel/keyboard-shortcuts.hook';
 import { openPendingGuide } from '../docs-panel/pendingGuideRouter';
 import { LearningJourneyMilestoneToolbar } from '../docs-panel/components';
 import { PERMANENT_TAB_IDS } from '../docs-panel/utils';
@@ -223,6 +224,14 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
   const { hasInteractiveProgress, progressKey } = useGuideProgressState(activeTab);
 
   const handleResetGuide = useContentReset({ model: panel });
+
+  useKeyboardShortcuts({
+    tabs,
+    activeTabId,
+    activeTab: activeTab ?? null,
+    isRecommendationsTab: activeTabId === 'recommendations',
+    model: panel,
+  });
 
   const handleExitToSidebar = useCallback(() => {
     reportAppInteraction(UserInteraction.FullScreenExit, {

--- a/src/components/full-screen/full-screen-autodock.test.ts
+++ b/src/components/full-screen/full-screen-autodock.test.ts
@@ -9,14 +9,12 @@ import { panelModeManager } from '../../global-state/panel-mode';
 import { sidebarState } from '../../global-state/sidebar';
 import { isExtensionSidebarOwnedByOther } from '../../utils/experiments/experiment-utils';
 import { reportAppInteraction } from '../../lib/analytics';
-import type { LearningJourneyTab } from '../../types/content-panel.types';
 
 jest.mock('../../global-state/panel-mode', () => ({
   panelModeManager: {
     getMode: jest.fn(),
     setMode: jest.fn(),
     setPendingGuide: jest.fn(),
-    restoreSidebarTabSnapshot: jest.fn(),
   },
 }));
 
@@ -39,20 +37,9 @@ jest.mock('../../lib/analytics', () => ({
 const FULL_SCREEN_PATHNAME = '/a/grafana-pathfinder-app/fullscreen';
 const PLUGIN_ID = 'grafana-pathfinder-app';
 
-const baseTab: LearningJourneyTab = {
-  id: 'tab-1',
-  title: 'My journey',
+const baseTab = {
   baseUrl: 'https://raw.githubusercontent.com/x/y/z/cover/content.json',
-  currentUrl: 'https://raw.githubusercontent.com/x/y/z/cover/content.json',
-  content: null,
-  isLoading: false,
-  error: null,
-  type: 'learning-journey',
-  packageInfo: {
-    packageId: 'my-path',
-    packageManifest: { id: 'my-path', type: 'path', milestones: ['m1', 'm2'] },
-    resolvedMilestones: [],
-  },
+  title: 'My journey',
 };
 
 function defaultInputs(overrides: Partial<Parameters<typeof dockOnLeavingFullScreen>[0]> = {}) {
@@ -62,7 +49,6 @@ function defaultInputs(overrides: Partial<Parameters<typeof dockOnLeavingFullScr
     myPluginId: PLUGIN_ID,
     guideUrl: baseTab.baseUrl,
     title: baseTab.title,
-    activeTab: baseTab,
     ...overrides,
   };
 }
@@ -125,17 +111,6 @@ describe('dockOnLeavingFullScreen', () => {
       expect(panelModeManager.setPendingGuide).not.toHaveBeenCalled();
     });
 
-    it('does NOT call restoreSidebarTabSnapshot — fullscreen and sidebar share intent, the latest tabStorage state must win', () => {
-      // Regression: the snapshot/restore mechanism overwrote the milestone
-      // position fullscreen wrote during the user's session (e.g. step
-      // navigation) with the stale "before-fullscreen" snapshot, dumping
-      // the user back at page 1 of the journey on dock.
-      dockOnLeavingFullScreen(defaultInputs());
-      jest.runAllTimers();
-
-      expect(panelModeManager.restoreSidebarTabSnapshot).not.toHaveBeenCalled();
-    });
-
     it('reports analytics with destination=sidebar and reason=navigation_away', () => {
       dockOnLeavingFullScreen(defaultInputs());
 
@@ -171,20 +146,13 @@ describe('dockOnLeavingFullScreen', () => {
       expect(outcome).toBe('floating');
       expect(panelModeManager.setMode).toHaveBeenCalledWith('floating');
       expect(sidebarState.openSidebar).not.toHaveBeenCalled();
-      expect(panelModeManager.restoreSidebarTabSnapshot).not.toHaveBeenCalled();
     });
 
-    it('hands off the active tab via setPendingGuide so the floating panel rebuilds the journey', () => {
+    it('does not set a pending guide — the floating panel restores from tabStorage', () => {
       dockOnLeavingFullScreen(defaultInputs());
+      jest.runAllTimers();
 
-      // setPendingGuide fires synchronously so the consumer (floating
-      // panel mount) sees the handoff data the moment it mounts.
-      expect(panelModeManager.setPendingGuide).toHaveBeenCalledWith({
-        url: baseTab.baseUrl,
-        title: baseTab.title,
-        type: 'learning-journey',
-        packageInfo: baseTab.packageInfo,
-      });
+      expect(panelModeManager.setPendingGuide).not.toHaveBeenCalled();
     });
 
     it('reports analytics with destination=floating and reason=navigation_away_sidebar_occupied', () => {
@@ -196,26 +164,6 @@ describe('dockOnLeavingFullScreen', () => {
         guide_title: baseTab.title,
         reason: 'navigation_away_sidebar_occupied',
       });
-    });
-
-    it('downgrades non-journey tabs to type=docs in the pending guide', () => {
-      const docsTab: LearningJourneyTab = { ...baseTab, type: 'docs', packageInfo: undefined };
-
-      dockOnLeavingFullScreen(defaultInputs({ activeTab: docsTab }));
-
-      expect(panelModeManager.setPendingGuide).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'docs', packageInfo: undefined })
-      );
-    });
-
-    it('skips setPendingGuide when there is no guideUrl or activeTab', () => {
-      dockOnLeavingFullScreen(defaultInputs({ guideUrl: undefined, activeTab: undefined }));
-      jest.runAllTimers();
-
-      expect(panelModeManager.setPendingGuide).not.toHaveBeenCalled();
-      // Mode change still fires so the floating panel mounts (it can fall
-      // back to tabStorage restoration when no pending guide is set).
-      expect(panelModeManager.setMode).toHaveBeenCalledWith('floating');
     });
   });
 });

--- a/src/components/full-screen/full-screen-autodock.ts
+++ b/src/components/full-screen/full-screen-autodock.ts
@@ -21,7 +21,6 @@ import { panelModeManager } from '../../global-state/panel-mode';
 import { sidebarState } from '../../global-state/sidebar';
 import { isExtensionSidebarOwnedByOther } from '../../utils/experiments/experiment-utils';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
-import type { LearningJourneyTab } from '../../types/content-panel.types';
 
 export type AutoDockOutcome = 'sidebar' | 'floating' | 'noop';
 
@@ -32,10 +31,9 @@ export interface AutoDockInputs {
   fullScreenPathname: string;
   /** Pathfinder's plugin id, used for the sidebar-ownership comparison. */
   myPluginId: string;
-  /** Captured from `FullScreenPanel`'s active tab — used for the floating handoff. */
+  /** Captured from `FullScreenPanel`'s active tab — reported as analytics context. */
   guideUrl: string | undefined;
   title: string;
-  activeTab: LearningJourneyTab | undefined;
 }
 
 /**
@@ -59,7 +57,7 @@ export function dockOnLeavingFullScreen(inputs: AutoDockInputs): AutoDockOutcome
     return 'noop';
   }
 
-  const { guideUrl, title, activeTab, myPluginId } = inputs;
+  const { guideUrl, title, myPluginId } = inputs;
 
   // Defer the actual mode/sidebar side effects to the next macrotask.
   // The history listener fires synchronously on `locationService.push`,
@@ -80,17 +78,6 @@ export function dockOnLeavingFullScreen(inputs: AutoDockInputs): AutoDockOutcome
       guide_title: title,
       reason: 'navigation_away_sidebar_occupied',
     });
-    // Hand off the journey + packageInfo so the floating panel rebuilds
-    // the milestone toolbar without round-tripping through tabStorage.
-    if (guideUrl && activeTab) {
-      const tabType = activeTab.type === 'learning-journey' ? 'learning-journey' : 'docs';
-      panelModeManager.setPendingGuide({
-        url: guideUrl,
-        title,
-        type: tabType,
-        packageInfo: activeTab.packageInfo,
-      });
-    }
     deferred(() => panelModeManager.setMode('floating'));
     return 'floating';
   }
@@ -102,12 +89,9 @@ export function dockOnLeavingFullScreen(inputs: AutoDockInputs): AutoDockOutcome
     reason: 'navigation_away',
   });
 
-  // No `restoreSidebarTabSnapshot()`: we intentionally keep the latest
-  // tabStorage state full-screen wrote (active milestone URL, completion,
-  // etc.) so the docking sidebar restores the user where they left off,
-  // not where they started. Sidebar and full-screen share intent — the
-  // snapshot mechanism is only useful when surfaces have separate tab
-  // sets (i.e. floating).
+  // All surfaces share `tabStorage` — the docking sidebar restores the
+  // latest milestone URL full-screen wrote during the session, not the
+  // pre-fullscreen position.
   deferred(() => {
     panelModeManager.setMode('sidebar');
     sidebarState.setPendingOpenSource('fullscreen_handoff', 'open');

--- a/src/global-state/panel-mode.test.ts
+++ b/src/global-state/panel-mode.test.ts
@@ -3,8 +3,7 @@
  *
  * Covers the third "fullscreen" mode added alongside sidebar/floating: it must
  * persist, parse back from storage, fire the same close-extension-sidebar
- * event as floating, and not interfere with the existing snapshot/handoff
- * helpers.
+ * event as floating, and round-trip pendingGuide / priorPath handoffs.
  */
 
 import { panelModeManager } from './panel-mode';
@@ -85,25 +84,6 @@ describe('panelModeManager', () => {
       } finally {
         document.removeEventListener('pathfinder-panel-mode-change', handler);
       }
-    });
-  });
-
-  describe('snapshot/restore handoff', () => {
-    it('snapshots sidebar tabs and restores them after a fullscreen round trip', () => {
-      const tabsSnapshot = JSON.stringify([{ id: 'tab-1', title: 'Original' }]);
-      localStorage.setItem(StorageKeys.TABS, tabsSnapshot);
-      localStorage.setItem(StorageKeys.ACTIVE_TAB, 'tab-1');
-
-      panelModeManager.snapshotSidebarTabs();
-
-      // Simulate the fullscreen panel writing different tabs
-      localStorage.setItem(StorageKeys.TABS, JSON.stringify([{ id: 'tab-2', title: 'Other' }]));
-      localStorage.setItem(StorageKeys.ACTIVE_TAB, 'tab-2');
-
-      panelModeManager.restoreSidebarTabSnapshot();
-
-      expect(localStorage.getItem(StorageKeys.TABS)).toBe(tabsSnapshot);
-      expect(localStorage.getItem(StorageKeys.ACTIVE_TAB)).toBe('tab-1');
     });
   });
 

--- a/src/global-state/panel-mode.ts
+++ b/src/global-state/panel-mode.ts
@@ -41,8 +41,6 @@ export interface PendingGuide {
  */
 class PanelModeManager {
   private _pendingGuide: PendingGuide | null = null;
-  private _sidebarTabSnapshot: string | null = null;
-  private _sidebarActiveTabSnapshot: string | null = null;
   private _priorPath: string | null = null;
   /**
    * Get the current panel mode from localStorage.
@@ -140,40 +138,12 @@ class PanelModeManager {
   }
 
   /**
-   * Snapshot the current sidebar tab state from localStorage.
-   * Called before switching to floating mode so the floating panel's
-   * model writes (via openDocsPage → saveTabsToStorage) don't
-   * permanently overwrite the sidebar's tab state.
-   */
-  public snapshotSidebarTabs(): void {
-    this._sidebarTabSnapshot = localStorage.getItem(StorageKeys.TABS) ?? null;
-    this._sidebarActiveTabSnapshot = localStorage.getItem(StorageKeys.ACTIVE_TAB) ?? null;
-  }
-
-  /**
-   * Restore the sidebar tab snapshot to localStorage.
-   * Called before switching back to sidebar mode so the sidebar's
-   * model restores the original tabs, not the floating panel's.
-   */
-  public restoreSidebarTabSnapshot(): void {
-    if (this._sidebarTabSnapshot !== null) {
-      localStorage.setItem(StorageKeys.TABS, this._sidebarTabSnapshot);
-    }
-    if (this._sidebarActiveTabSnapshot !== null) {
-      localStorage.setItem(StorageKeys.ACTIVE_TAB, this._sidebarActiveTabSnapshot);
-    }
-    this._sidebarTabSnapshot = null;
-    this._sidebarActiveTabSnapshot = null;
-  }
-
-  /**
    * Capture the Grafana route the user was on right before entering full
    * screen, so the explicit "Return to sidebar" button can land them back
    * where they came from instead of the plugin home (My Learning).
    *
-   * Captured at the same call sites as {@link snapshotSidebarTabs}: the
-   * sidebar / floating "switch to full screen" handlers, immediately
-   * before the route push to `/fullscreen`.
+   * Called from the sidebar / floating "switch to full screen" handlers,
+   * immediately before the route push to `/fullscreen`.
    */
   public capturePriorPath(path: string): void {
     this._priorPath = path;

--- a/src/hooks/useAutoLaunchTutorial.test.ts
+++ b/src/hooks/useAutoLaunchTutorial.test.ts
@@ -154,6 +154,23 @@ describe('useAutoLaunchTutorial', () => {
     expect(onLaunched).not.toHaveBeenCalled();
   });
 
+  it('skips the panel call when skipLaunch returns true but still fires onIncoming', () => {
+    const panel = makePanel();
+    const onIncoming = jest.fn();
+    renderHook(() =>
+      useAutoLaunchTutorial(asPanel(panel), {
+        onIncoming,
+        skipLaunch: () => true,
+      })
+    );
+
+    dispatchAutoLaunch({ url: 'bundled:foo', title: 'Foo', type: 'learning-journey' });
+
+    expect(onIncoming).toHaveBeenCalledTimes(1);
+    expect(panel.openLearningJourney).not.toHaveBeenCalled();
+    expect(panel.openDocsPage).not.toHaveBeenCalled();
+  });
+
   it('unsubscribes on unmount so re-mounts do not double-route', () => {
     const panel = makePanel();
     const { unmount } = renderHook(() => useAutoLaunchTutorial(asPanel(panel)));

--- a/src/hooks/useAutoLaunchTutorial.ts
+++ b/src/hooks/useAutoLaunchTutorial.ts
@@ -61,11 +61,18 @@ export interface UseAutoLaunchTutorialOptions {
    * can wait for completion.
    */
   onLaunched?: (detail: AutoLaunchTutorialDetail, openedAsLearningJourney: boolean) => void;
+  /**
+   * When true, the auto-launch event is ignored. Fullscreen uses this to
+   * skip the deep-link handler's delayed `auto-launch-tutorial` dispatch
+   * when a pending-guide handoff already opened the guide on mount.
+   */
+  skipLaunch?: () => boolean;
 }
 
 export function useAutoLaunchTutorial(panel: AutoLaunchPanel, options?: UseAutoLaunchTutorialOptions): void {
   const onIncoming = options?.onIncoming;
   const onLaunched = options?.onLaunched;
+  const skipLaunch = options?.skipLaunch;
 
   useEffect(() => {
     const handleAutoLaunch = (event: Event) => {
@@ -74,6 +81,10 @@ export function useAutoLaunchTutorial(panel: AutoLaunchPanel, options?: UseAutoL
         return;
       }
       onIncoming?.(detail);
+
+      if (skipLaunch?.()) {
+        return;
+      }
 
       const { url, title, type, source } = detail;
       if (!url || !title) {
@@ -98,5 +109,5 @@ export function useAutoLaunchTutorial(panel: AutoLaunchPanel, options?: UseAutoL
     return () => {
       document.removeEventListener('auto-launch-tutorial', handleAutoLaunch);
     };
-  }, [panel, onIncoming, onLaunched]);
+  }, [panel, onIncoming, onLaunched, skipLaunch]);
 }


### PR DESCRIPTION
## Summary

- Floating mode reset the journey to milestone 1 on dock-back because it snapshotted `localStorage` at pop-out and restored it verbatim, overwriting whatever milestone the user advanced to in the floating panel.
- Consolidate the floating surface onto the fullscreen pattern: all surfaces share `tabStorage` and the latest `currentUrl` wins on every mount. The dedicated snapshot mechanism is removed.
- Closes the in-task pop-out race by awaiting `saveTabsToStorage()` in `usePopOutHandoff` before flipping the mode.
- Full screen: skip the deep-link handler's delayed `auto-launch-tutorial` when a pending-guide handoff already opened the journey, so floating → full screen no longer replaces journey content with a flat single-doc and hides the milestone arrows.


https://github.com/user-attachments/assets/a86feac7-6acf-49b0-ae47-a477b77ba401



## Notable changes

- `panel-mode.ts`: deleted `snapshotSidebarTabs` / `restoreSidebarTabSnapshot` (and the two backing fields).
- `usePopOutHandoff.ts`: dropped snapshot + `setPendingGuide`; awaits `saveTabsToStorage()` before `setMode('floating')`.
- `FloatingPanelManager.tsx`: dropped `consumePendingGuide` on mount and `restoreSidebarTabSnapshot` from `handleSwitchToSidebar` / `handleClose`.
- `full-screen-autodock.ts`: dropped `setPendingGuide` from the floating branch (`tabStorage` already carries the latest position).
- `ContextPanel.tsx`: dropped `restoreSidebarTabSnapshot` from the floating-mode self-heal.
- `useAutoLaunchTutorial.ts` + `FullScreenPanel.tsx`: added `skipLaunch` so a pending-guide handoff is not overwritten by the ~500ms delayed auto-launch from `?doc=` navigation.
- Added a Pattern J tripwire pinning the new contract; updated existing tests for the removed methods.
- Net: -114 lines (prior commits) + fullscreen handoff fix.

## Test plan

- [x] `npm run check` — 231 frontend suites pass, Go tests pass, typecheck + lint + prettier clean.
- [x] Manual: in `npm run server`, open a learning journey in the sidebar.
- [x] Pop the journey out into the floating panel.
- [x] Navigate forward through milestones (Alt+Right or the milestone toolbar) — verify two or more milestones.
- [x] Click "Dock to sidebar" — the sidebar should reopen on the same milestone you reached in the floating panel.
