### PR TITLE
refactor(progress-events): migrate `pathfinder-step-progress` onto unified channel (A2)

### DIFF
--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -178,9 +178,7 @@ function FloatingPanelInner() {
   // tab is its own kind of "active content" but isn't a guide, so leave it false.
   const hasActiveGuide = activeTab != null && activeTab.id !== 'recommendations' && !isEditorTab;
 
-  // Track interactive step progress via the unified `pathfinder:progress`
-  // event (variant `kind: 'document'`) — shared subscription with
-  // FullScreenPanel via the hook.
+  // Shared with FullScreenPanel via the hook.
   const stepProgress = useStepProgressFromEvents(hasActiveGuide);
 
   // After restoration completes, if there's no guide to show and none

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -178,8 +178,9 @@ function FloatingPanelInner() {
   // tab is its own kind of "active content" but isn't a guide, so leave it false.
   const hasActiveGuide = activeTab != null && activeTab.id !== 'recommendations' && !isEditorTab;
 
-  // Track interactive step progress via the `pathfinder-step-progress`
-  // event — shared subscription with FullScreenPanel via the hook.
+  // Track interactive step progress via the unified `pathfinder:progress`
+  // event (variant `kind: 'document'`) — shared subscription with
+  // FullScreenPanel via the hook.
   const stepProgress = useStepProgressFromEvents(hasActiveGuide);
 
   // After restoration completes, if there's no guide to show and none

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -178,7 +178,6 @@ function FloatingPanelInner() {
   // tab is its own kind of "active content" but isn't a guide, so leave it false.
   const hasActiveGuide = activeTab != null && activeTab.id !== 'recommendations' && !isEditorTab;
 
-  // Shared with FullScreenPanel via the hook.
   const stepProgress = useStepProgressFromEvents(hasActiveGuide);
 
   // After restoration completes, if there's no guide to show and none

--- a/src/components/interactive-tutorial/hooks/use-document-step-progress.ts
+++ b/src/components/interactive-tutorial/hooks/use-document-step-progress.ts
@@ -65,8 +65,11 @@ export function useDocumentStepProgress({
         documentStepIndex,
         completedCount: completedDocumentCount,
       });
-    } catch {
-      // no-op
+    } catch (err) {
+      // Surface the failure instead of silently dropping it — the chip
+      // will simply stay stale, but the I/O failure now leaves a
+      // diagnostic breadcrumb in the console.
+      console.warn('[useDocumentStepProgress] failed to publish document progress:', err);
     }
   }, [currentlyExecutingStep, stepComponents, sectionId, completedSteps]);
 }

--- a/src/components/interactive-tutorial/hooks/use-document-step-progress.ts
+++ b/src/components/interactive-tutorial/hooks/use-document-step-progress.ts
@@ -3,18 +3,19 @@
  * publishing side-effect.
  *
  * Pattern J (contract surface) per the High-Risk Refactor Guidelines:
- * this hook owns two window globals and one CustomEvent that the
- * rest of the plugin reads.
+ * this hook owns two window globals and one unified-channel event
+ * that the rest of the plugin reads.
  *
  *   - `window.__DocsPluginTotalSteps` — total step count across the
  *     document. Read by `src/lib/analytics.ts`.
  *   - `window.__DocsPluginCurrentStepIndex` — currently-executing
  *     step's document-wide index. Read by `src/lib/analytics.ts`.
- *   - `pathfinder-step-progress` CustomEvent — published whenever
- *     execution state or completion changes. Detail:
- *     `{ sectionId, totalSteps, documentStepIndex, completedCount }`.
- *     Consumed by `src/hooks/useStepProgressFromEvents.ts` to drive
- *     the FullScreenLayout / FloatingPanel progress chip.
+ *   - `pathfinder:progress` event with `kind: 'document'` — published
+ *     whenever execution state or completion changes. Payload:
+ *     `{ kind: 'document', contentKey, sectionId, totalSteps,
+ *        documentStepIndex?, completedCount }`. Consumed by
+ *     `src/hooks/useStepProgressFromEvents.ts` to drive the
+ *     FullScreenLayout / FloatingPanel progress chip.
  *
  * The hook performs a pure side-effect: no return value.
  * Behaviour and payload shapes match the pre-extraction effect
@@ -27,6 +28,7 @@ import { interactiveStepStorage } from '../../../lib/user-storage';
 import type { StepInfo } from '../../../types/component-props.types';
 import { getContentKey } from '../get-content-key';
 import { getDocumentStepPosition, getTotalDocumentSteps } from '../../../global-state/section-registry';
+import { dispatchProgress } from '../../../global-state/progress-events';
 
 export interface UseDocumentStepProgressArgs {
   sectionId: string;
@@ -69,16 +71,14 @@ export function useDocumentStepProgress({
       const contentKey = getContentKey();
       const completedDocumentCount = interactiveStepStorage.countAllCompleted(contentKey);
 
-      window.dispatchEvent(
-        new CustomEvent('pathfinder-step-progress', {
-          detail: {
-            sectionId,
-            totalSteps,
-            documentStepIndex,
-            completedCount: completedDocumentCount,
-          },
-        })
-      );
+      dispatchProgress({
+        kind: 'document',
+        contentKey,
+        sectionId,
+        totalSteps,
+        documentStepIndex,
+        completedCount: completedDocumentCount,
+      });
     } catch {
       // no-op
     }

--- a/src/components/interactive-tutorial/hooks/use-document-step-progress.ts
+++ b/src/components/interactive-tutorial/hooks/use-document-step-progress.ts
@@ -1,25 +1,11 @@
 /**
- * `useDocumentStepProgress` — owns the document-wide step-progress
- * publishing side-effect.
+ * Owns document-wide step-progress publishing (Pattern J contract surface).
  *
- * Pattern J (contract surface) per the High-Risk Refactor Guidelines:
- * this hook owns two window globals and one unified-channel event
- * that the rest of the plugin reads.
- *
- *   - `window.__DocsPluginTotalSteps` — total step count across the
- *     document. Read by `src/lib/analytics.ts`.
- *   - `window.__DocsPluginCurrentStepIndex` — currently-executing
- *     step's document-wide index. Read by `src/lib/analytics.ts`.
- *   - `pathfinder:progress` event with `kind: 'document'` — published
- *     whenever execution state or completion changes. Payload:
- *     `{ kind: 'document', contentKey, sectionId, totalSteps,
- *        documentStepIndex?, completedCount }`. Consumed by
- *     `src/hooks/useStepProgressFromEvents.ts` to drive the
- *     FullScreenLayout / FloatingPanel progress chip.
- *
- * The hook performs a pure side-effect: no return value.
- * Behaviour and payload shapes match the pre-extraction effect
- * exactly — pinned by the contracts tripwire.
+ * Writes two window globals read by `lib/analytics`
+ * (`__DocsPluginTotalSteps`, `__DocsPluginCurrentStepIndex`) and emits
+ * `pathfinder:progress` with `kind: 'document'`, consumed by
+ * `useStepProgressFromEvents` to drive the panel progress chip.
+ * Payload shape pinned by the contracts tripwire.
  */
 
 import { useEffect } from 'react';

--- a/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
@@ -229,13 +229,16 @@ describe('InteractiveSection contracts — Phase 0 tripwire', () => {
         await waitFor(() => {
           const evt = events.find((e) => e.name === 'pathfinder:progress' && e.detail.kind === 'document');
           expect(evt).toBeDefined();
-          // `documentStepIndex` is optional in the unified schema and is
-          // only present while a step is executing; the post-completion
-          // dispatch can omit it.
-          const keys = Object.keys(evt!.detail);
-          expect(keys).toEqual(
-            expect.arrayContaining(['kind', 'contentKey', 'sectionId', 'totalSteps', 'completedCount'])
-          );
+          // Exact key-set pin: stray keys MUST fail the tripwire. The
+          // schema marks `documentStepIndex` as optional (omitted when
+          // no step is executing), so the only permitted shapes are the
+          // required keys alone or required + that single optional key.
+          const REQUIRED = ['completedCount', 'contentKey', 'kind', 'sectionId', 'totalSteps'];
+          const OPTIONAL = ['documentStepIndex'];
+          const keys = Object.keys(evt!.detail).sort();
+          const requiredOnly = [...REQUIRED].sort();
+          const requiredPlusOptional = [...REQUIRED, ...OPTIONAL].sort();
+          expect([requiredOnly, requiredPlusOptional]).toContainEqual(keys);
           expect(evt!.detail.kind).toBe('document');
           expect(evt!.detail.sectionId).toBe(SECTION_ID);
           expect(typeof evt!.detail.contentKey).toBe('string');

--- a/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
@@ -14,7 +14,7 @@
  *   - `section-completed`           : detail `{ sectionId }` (on `document`)
  *   - `interactive-section-completed`: detail `{ sectionId }` (on `window`)
  *   - `interactive-step-completed`  : detail `{ stepId, sectionId }`
- *   - `pathfinder-step-progress`    : detail `{ sectionId, totalSteps, documentStepIndex, completedCount }`
+ *   - `pathfinder:progress` (kind: 'document'): detail `{ kind, contentKey, sectionId, totalSteps, documentStepIndex?, completedCount }`
  *   - `window.__DocsPluginCurrentStepIndex` + `__DocsPluginTotalSteps`
  *   - Preview-mode write-suppression for the four storage namespaces,
  *     with the `interactive-progress-saved` event still firing.
@@ -104,11 +104,7 @@ function recordSectionEvents(): { events: CapturedEvent[]; unsubscribe: () => vo
     (target === 'window' ? window : document).addEventListener(name, handler);
     return () => (target === 'window' ? window : document).removeEventListener(name, handler);
   };
-  const offs = [
-    make('pathfinder:progress', 'window'),
-    make('interactive-progress-cleared', 'window'),
-    make('pathfinder-step-progress', 'window'),
-  ];
+  const offs = [make('pathfinder:progress', 'window'), make('interactive-progress-cleared', 'window')];
   return { events, unsubscribe: () => offs.forEach((off) => off()) };
 }
 
@@ -221,7 +217,7 @@ describe('InteractiveSection contracts — Phase 0 tripwire', () => {
       }
     });
 
-    it('dispatches `pathfinder-step-progress` with the documented detail shape', async () => {
+    it('dispatches pathfinder:progress (kind: document) with the documented detail shape', async () => {
       const { events, unsubscribe } = recordSectionEvents();
       try {
         renderSingleStepSection();
@@ -231,13 +227,20 @@ describe('InteractiveSection contracts — Phase 0 tripwire', () => {
         });
 
         await waitFor(() => {
-          const evt = events.find((e) => e.name === 'pathfinder-step-progress');
+          const evt = events.find((e) => e.name === 'pathfinder:progress' && e.detail.kind === 'document');
           expect(evt).toBeDefined();
-          expect(Object.keys(evt!.detail).sort()).toEqual(
-            ['completedCount', 'documentStepIndex', 'sectionId', 'totalSteps'].sort()
+          // `documentStepIndex` is optional in the unified schema and is
+          // only present while a step is executing; the post-completion
+          // dispatch can omit it.
+          const keys = Object.keys(evt!.detail);
+          expect(keys).toEqual(
+            expect.arrayContaining(['kind', 'contentKey', 'sectionId', 'totalSteps', 'completedCount'])
           );
+          expect(evt!.detail.kind).toBe('document');
           expect(evt!.detail.sectionId).toBe(SECTION_ID);
+          expect(typeof evt!.detail.contentKey).toBe('string');
           expect(typeof evt!.detail.totalSteps).toBe('number');
+          expect(typeof evt!.detail.completedCount).toBe('number');
         });
       } finally {
         unsubscribe();
@@ -437,7 +440,7 @@ describe('InteractiveSection contracts — Phase 0 tripwire', () => {
         // the post-flip event is unambiguously attributable to a
         // store-driven re-render rather than the mount-time effect.
         await waitFor(() => {
-          expect(events.find((e) => e.name === 'pathfinder-step-progress')).toBeDefined();
+          expect(events.find((e) => e.name === 'pathfinder:progress' && e.detail.kind === 'document')).toBeDefined();
         });
         events.length = 0;
 
@@ -459,7 +462,9 @@ describe('InteractiveSection contracts — Phase 0 tripwire', () => {
         // the `useSyncExternalStore` subscription to land the flip in
         // the section's render commit.
         await waitFor(() => {
-          const evt = events.find((e) => e.name === 'pathfinder-step-progress' && e.detail.sectionId === SECTION_ID);
+          const evt = events.find(
+            (e) => e.name === 'pathfinder:progress' && e.detail.kind === 'document' && e.detail.sectionId === SECTION_ID
+          );
           expect(evt).toBeDefined();
         });
 

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -1140,10 +1140,10 @@ export function InteractiveSection({
     registerSectionSteps(sectionId, stepComponents.length);
   }, [sectionId, stepComponents.length]);
 
-  // Document-wide step progress (window globals + `pathfinder-step-progress`
-  // CustomEvent) is owned by `useDocumentStepProgress`. Pattern J:
-  // contract-surface ownership move; the contracts tripwire pins the
-  // payload shape across the seam.
+  // Document-wide step progress (window globals + `pathfinder:progress`
+  // `kind: 'document'` payload) is owned by `useDocumentStepProgress`.
+  // Pattern J: contract-surface ownership move; the contracts tripwire
+  // pins the payload shape across the seam.
   useDocumentStepProgress({
     sectionId,
     currentlyExecutingStep,

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -1141,9 +1141,8 @@ export function InteractiveSection({
   }, [sectionId, stepComponents.length]);
 
   // Document-wide step progress (window globals + `pathfinder:progress`
-  // `kind: 'document'` payload) is owned by `useDocumentStepProgress`.
-  // Pattern J: contract-surface ownership move; the contracts tripwire
-  // pins the payload shape across the seam.
+  // kind:'document') is owned by `useDocumentStepProgress`. Pattern J
+  // contract surface — payload shape pinned by the contracts tripwire.
   useDocumentStepProgress({
     sectionId,
     currentlyExecutingStep,

--- a/src/global-state/progress-events.ts
+++ b/src/global-state/progress-events.ts
@@ -43,10 +43,8 @@ export type ProgressEventDetail =
       hasProgress: boolean;
     }
   | {
-      // Document-wide aggregate progress for the "X of Y steps" panel chip.
-      // Emitted by `use-document-step-progress` on section mount, step
-      // start/stop, and step completion. `documentStepIndex` is omitted
-      // while no step is currently executing.
+      // Document-wide aggregate for the "X of Y steps" panel chip.
+      // `documentStepIndex` is omitted when no step is executing.
       kind: 'document';
       contentKey: string;
       sectionId: string;

--- a/src/global-state/progress-events.ts
+++ b/src/global-state/progress-events.ts
@@ -1,11 +1,12 @@
 /**
  * Unified progress event channel.
  *
- * Replaces four legacy events:
+ * Replaces five legacy events:
  *   - `interactive-step-completed`
  *   - `section-completed`
  *   - `interactive-section-completed`
  *   - `interactive-progress-saved`
+ *   - `pathfinder-step-progress` (document-wide aggregate)
  *
  * The discriminated payload makes intent explicit at the dispatch site
  * and at every listener. Lives in `global-state` (Tier 1) so both the
@@ -40,6 +41,18 @@ export type ProgressEventDetail =
       contentKey: string;
       percentage: number;
       hasProgress: boolean;
+    }
+  | {
+      // Document-wide aggregate progress for the "X of Y steps" panel chip.
+      // Emitted by `use-document-step-progress` on section mount, step
+      // start/stop, and step completion. `documentStepIndex` is omitted
+      // while no step is currently executing.
+      kind: 'document';
+      contentKey: string;
+      sectionId: string;
+      totalSteps: number;
+      completedCount: number;
+      documentStepIndex?: number;
     };
 
 export const PROGRESS_EVENT = 'pathfinder:progress' as const;

--- a/src/hooks/useStepProgressFromEvents.test.ts
+++ b/src/hooks/useStepProgressFromEvents.test.ts
@@ -1,13 +1,31 @@
 /**
- * Tests for the shared `pathfinder-step-progress` listener used by the
- * floating and fullscreen panels for the header progress chip.
+ * Tests for the shared `pathfinder:progress` (variant `kind: 'document'`)
+ * listener used by the floating and fullscreen panels for the header
+ * progress chip.
  */
 
 import { act, renderHook } from '@testing-library/react';
 import { useStepProgressFromEvents } from './useStepProgressFromEvents';
 
-function dispatchProgress(detail: { totalSteps?: number; completedCount?: number }) {
-  window.dispatchEvent(new CustomEvent('pathfinder-step-progress', { detail }));
+function dispatchDocumentProgress(detail: {
+  totalSteps?: number;
+  completedCount?: number;
+  contentKey?: string;
+  sectionId?: string;
+  documentStepIndex?: number;
+}) {
+  window.dispatchEvent(
+    new CustomEvent('pathfinder:progress', {
+      detail: {
+        kind: 'document',
+        contentKey: detail.contentKey ?? 'test-guide',
+        sectionId: detail.sectionId ?? 'section-1',
+        totalSteps: detail.totalSteps ?? 0,
+        completedCount: detail.completedCount ?? 0,
+        documentStepIndex: detail.documentStepIndex,
+      },
+    })
+  );
 }
 
 describe('useStepProgressFromEvents', () => {
@@ -20,7 +38,7 @@ describe('useStepProgressFromEvents', () => {
     const { result } = renderHook(() => useStepProgressFromEvents(true));
 
     act(() => {
-      dispatchProgress({ totalSteps: 7, completedCount: 3 });
+      dispatchDocumentProgress({ totalSteps: 7, completedCount: 3 });
     });
 
     expect(result.current).toBe('3/7');
@@ -30,12 +48,12 @@ describe('useStepProgressFromEvents', () => {
     const { result } = renderHook(() => useStepProgressFromEvents(true));
 
     act(() => {
-      dispatchProgress({ totalSteps: 7, completedCount: 0 });
+      dispatchDocumentProgress({ totalSteps: 7, completedCount: 0 });
     });
     expect(result.current).toBe('0/7');
 
     act(() => {
-      dispatchProgress({ totalSteps: 7, completedCount: 7 });
+      dispatchDocumentProgress({ totalSteps: 7, completedCount: 7 });
     });
     expect(result.current).toBe('7/7');
   });
@@ -44,12 +62,12 @@ describe('useStepProgressFromEvents', () => {
     const { result } = renderHook(() => useStepProgressFromEvents(true));
 
     act(() => {
-      dispatchProgress({ totalSteps: 5, completedCount: 2 });
+      dispatchDocumentProgress({ totalSteps: 5, completedCount: 2 });
     });
     expect(result.current).toBe('2/5');
 
     act(() => {
-      dispatchProgress({ totalSteps: 0, completedCount: 0 });
+      dispatchDocumentProgress({ totalSteps: 0, completedCount: 0 });
     });
     expect(result.current).toBeUndefined();
   });
@@ -58,7 +76,7 @@ describe('useStepProgressFromEvents', () => {
     const { result } = renderHook(() => useStepProgressFromEvents(false));
 
     act(() => {
-      dispatchProgress({ totalSteps: 7, completedCount: 3 });
+      dispatchDocumentProgress({ totalSteps: 7, completedCount: 3 });
     });
 
     expect(result.current).toBeUndefined();
@@ -70,11 +88,35 @@ describe('useStepProgressFromEvents', () => {
     });
 
     act(() => {
-      dispatchProgress({ totalSteps: 7, completedCount: 3 });
+      dispatchDocumentProgress({ totalSteps: 7, completedCount: 3 });
     });
     expect(result.current).toBe('3/7');
 
     rerender({ active: false });
+    expect(result.current).toBeUndefined();
+  });
+
+  it('ignores non-document variants of the unified progress event', () => {
+    const { result } = renderHook(() => useStepProgressFromEvents(true));
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'guide', contentKey: 'test-guide', percentage: 50, hasProgress: true },
+        })
+      );
+      window.dispatchEvent(
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'step', stepId: 's1', completed: true, reason: 'manual' },
+        })
+      );
+      window.dispatchEvent(
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'section', sectionId: 'section-1', completed: true },
+        })
+      );
+    });
+
     expect(result.current).toBeUndefined();
   });
 
@@ -84,7 +126,7 @@ describe('useStepProgressFromEvents', () => {
     const { unmount } = renderHook(() => useStepProgressFromEvents(true));
     unmount();
 
-    expect(removeSpy).toHaveBeenCalledWith('pathfinder-step-progress', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('pathfinder:progress', expect.any(Function));
     removeSpy.mockRestore();
   });
 });

--- a/src/hooks/useStepProgressFromEvents.ts
+++ b/src/hooks/useStepProgressFromEvents.ts
@@ -1,6 +1,7 @@
 /**
- * Subscribe to the `pathfinder-step-progress` window event and project the
- * detail into a "done/total" string for the panel header chip.
+ * Subscribe to the unified `pathfinder:progress` window event (variant
+ * `kind: 'document'`) and project the detail into a "done/total" string
+ * for the panel header chip.
  *
  * Why this exists: identical 20-line subscription used to live in both
  * `FullScreenPanel` and `FloatingPanelManager`. The previous polling on
@@ -18,10 +19,7 @@
 
 import { useEffect, useState } from 'react';
 
-interface StepProgressDetail {
-  totalSteps?: number;
-  completedCount?: number;
-}
+import { subscribeProgressEvent } from '../global-state/progress-events';
 
 export function useStepProgressFromEvents(hasActiveGuide: boolean): string | undefined {
   const [stepProgress, setStepProgress] = useState<string | undefined>();
@@ -31,21 +29,18 @@ export function useStepProgressFromEvents(hasActiveGuide: boolean): string | und
       return;
     }
 
-    const handle = (e: Event) => {
-      const detail = (e as CustomEvent<StepProgressDetail>).detail;
-      const total = detail?.totalSteps ?? 0;
-      const done = detail?.completedCount ?? 0;
+    return subscribeProgressEvent((detail) => {
+      if (detail.kind !== 'document') {
+        return;
+      }
+      const total = detail.totalSteps ?? 0;
+      const done = detail.completedCount ?? 0;
       if (total > 0) {
         setStepProgress(`${done}/${total}`);
       } else {
         setStepProgress(undefined);
       }
-    };
-
-    window.addEventListener('pathfinder-step-progress', handle);
-    return () => {
-      window.removeEventListener('pathfinder-step-progress', handle);
-    };
+    });
   }, [hasActiveGuide]);
 
   // Derived in render rather than via setState in the effect so the

--- a/src/hooks/useStepProgressFromEvents.ts
+++ b/src/hooks/useStepProgressFromEvents.ts
@@ -1,20 +1,9 @@
 /**
- * Subscribe to the unified `pathfinder:progress` window event (variant
- * `kind: 'document'`) and project the detail into a "done/total" string
- * for the panel header chip.
- *
- * Why this exists: identical 20-line subscription used to live in both
- * `FullScreenPanel` and `FloatingPanelManager`. The previous polling on
- * `__DocsPluginCurrentStepIndex` only updated while a step was *executing*,
- * so the chip went stale immediately after each step finished. The event
- * is published by `interactive-section` whenever execution OR completion
- * state changes, so listening for it gives us a counter that reflects
- * "completed / total" instead of a moving cursor.
- *
- * The hook returns `undefined` when no progress has been observed yet, or
- * when `hasActiveGuide` flips to false (the chip is meaningless without an
- * active guide and we don't want a stale value lingering on the recommendations
- * tab).
+ * Project `pathfinder:progress` events (`kind: 'document'`) into a
+ * "done/total" string for the shared panel header chip. The event refires
+ * on completion changes, not just step execution, so the counter stays
+ * fresh between steps. Returns `undefined` when no event has arrived or
+ * `hasActiveGuide` is false (no stale chip on the recommendations tab).
  */
 
 import { useEffect, useState } from 'react';
@@ -43,9 +32,6 @@ export function useStepProgressFromEvents(hasActiveGuide: boolean): string | und
     });
   }, [hasActiveGuide]);
 
-  // Derived in render rather than via setState in the effect so the
-  // `react-hooks/set-state-in-effect` rule stays clean. Stale state from a
-  // prior active session is hidden until the next event arrives — the chip
-  // is meaningless without an active guide anyway.
+  // Derive in render so `react-hooks/set-state-in-effect` stays clean.
   return hasActiveGuide ? stepProgress : undefined;
 }


### PR DESCRIPTION
## Summary

Migration **A2** of the legacy-event consolidation: replace the standalone
`pathfinder-step-progress` window event with a new `kind: 'document'`
variant on the unified `pathfinder:progress` channel. The panel header
chip ("X of Y steps") now reads from the unified channel like every
other progress consumer.

This is one of two siblings; **A3** (`interactive-progress-cleared`) will
follow as a separate PR.

## What changed

- `ProgressEventDetail` (`src/global-state/progress-events.ts`) gains a
  fourth variant:
  ```ts
  | { kind: 'document'; contentKey: string; sectionId: string;
      totalSteps: number; completedCount: number;
      documentStepIndex?: number }
  ```
  Field set matches the legacy payload verbatim. `contentKey` is **new**
  to the envelope — it isn't read by the existing listener, but it
  closes a latent cross-guide-contamination gap (cheap to include,
  harmless if unused).
- `useDocumentStepProgress` (the single producer) now calls
  `dispatchProgress({ kind: 'document', ... })`.
- `useStepProgressFromEvents` (the single listener) now subscribes via
  `subscribeProgressEvent` and filters on `kind === 'document'`.
- Tests:
  - `useStepProgressFromEvents.test.ts` — rewrote dispatch helper to
    use the unified envelope; added an explicit probe that the listener
    ignores `step` / `section` / `guide` variants; unsubscribe assertion
    now expects `'pathfinder:progress'`.
  - `interactive-section.contracts.tripwire.test.tsx` — dropped the
    legacy listener, replaced the `pathfinder-step-progress` payload
    assertion with a `kind: 'document'` shape assertion (key set + types).

## Why

The unified `pathfinder:progress` channel was introduced to consolidate
five legacy custom events behind a single discriminated dispatch /
subscribe pair (`dispatchProgress` / `subscribeProgressEvent`). A2
removes one of the two remaining stragglers, leaving the codebase with
one canonical event channel for progress + a single tier-safe entry
point for it.

## Out of scope

- Window globals `__DocsPluginTotalSteps` and
  `__DocsPluginCurrentStepIndex` are intentionally untouched (deferred
  to A4). They are read by analytics and are a separate contract surface.
- `interactive-progress-cleared` migration is **A3**, opening as a
  sibling PR.

## Risk and reversibility

Low. Single producer + single listener seam, both in the same conceptual
component pair (`InteractiveSection` ↔ panel chip). The contracts
tripwire pins the payload shape across the seam. Fully reversible by
reverting this commit.

## Test plan

- [x] `npm run check` (typecheck + lint + prettier + lint:go + test:go +
      test:ci — 3922 tests pass)
- [x] grep `pathfinder-step-progress` returns only the documentation
      reference in `progress-events.ts` header