### PR TITLE
refactor(progress-events): migrate `interactive-progress-cleared` onto unified channel (A3)

### DIFF
--- a/docs/developer/STEP_MODEL.md
+++ b/docs/developer/STEP_MODEL.md
@@ -109,11 +109,11 @@ type ProgressEventDetail =
   | { kind: 'guide'; contentKey; percentage; hasProgress };
 ```
 
-Listeners use `subscribeProgressEvent(detail => ...)`. The store fires `kind: 'step'` from `markStepCompleted` / `resetStep`, `kind: 'guide'` from its `persistSection` writes. `interactive-section.tsx` fires `kind: 'section'` when the section transitions to a terminal state. The four legacy events (`interactive-step-completed`, `section-completed`, `interactive-section-completed`, `interactive-progress-saved`) are gone.
+Listeners use `subscribeProgressEvent(detail => ...)`. The store fires `kind: 'step'` from `markStepCompleted` / `resetStep`, `kind: 'guide'` from its `persistSection` writes. `interactive-section.tsx` fires `kind: 'section'` when the section transitions to a terminal state. The five legacy events (`interactive-step-completed`, `section-completed`, `interactive-section-completed`, `interactive-progress-saved`, `interactive-progress-cleared`) are gone — clears now ride the unified channel as `kind: 'guide'` with `hasProgress: false`.
 
 The orphan `step-auto-skipped` listener at `step-checker.hook.ts:746` was removed in C3 — there were no dispatchers anywhere in the repo.
 
-`interactive-progress-cleared` (dispatched by `handleResetSection` and `useContentReset`) is the one remaining legacy event — it still drives ephemeral preview / alignment UI and will fold into `kind: 'guide'` with `hasProgress: false` once those listeners migrate.
+Per-guide clears use the canonical envelope `{ kind: 'guide', contentKey, percentage: 0, hasProgress: false }`. "Reset all" / per-path resets broadcast with `contentKey: PROGRESS_CONTENT_KEY_WILDCARD` (`'*'`); key-scoped listeners must call `matchesContentKey(detail, expected)` (or the `isGuideClear` type guard) so the wildcard fans out.
 
 ## Tab loader
 

--- a/docs/developer/learning-paths/README.md
+++ b/docs/developer/learning-paths/README.md
@@ -165,7 +165,7 @@ If more than one day has elapsed since the last activity, the streak is reported
 
 **Static paths**: For each guide ID in the path, clears the interactive step storage (`bundled:{guideId}`), interactive completion storage, and journey completion storage. Then removes the guide IDs from `completedGuides`.
 
-**URL-based paths**: Clears milestone tracking (`milestoneCompletionStorage`), journey completion, and `completedGuides` for the fetched guide slugs. Also clears interactive steps and completions for any content key that starts with the path's normalized URL. After clearing, dispatches `CustomEvent('interactive-progress-cleared')` so UI components can refresh.
+**URL-based paths**: Clears milestone tracking (`milestoneCompletionStorage`), journey completion, and `completedGuides` for the fetched guide slugs. Also clears interactive steps and completions for any content key that starts with the path's normalized URL. After clearing, dispatches `pathfinder:progress` with `{ kind: 'guide', contentKey: '*', percentage: 0, hasProgress: false }` (broadcast wildcard) so every key-scoped listener clears its in-memory state and the recommendation panel refreshes.
 
 ## Key hooks and exports
 
@@ -241,10 +241,10 @@ The components consume the hooks exported from this module to render learning pa
 
 ### Events
 
-| Event                          | Dispatched by                  | Listened by                   |
-| ------------------------------ | ------------------------------ | ----------------------------- |
-| `learning-progress-updated`    | Storage layer (`user-storage`) | `useLearningPaths()` hook     |
-| `interactive-progress-cleared` | `resetPath()`                  | UI components needing refresh |
+| Event                                                                            | Dispatched by                  | Listened by                                                                                                 |
+| -------------------------------------------------------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `learning-progress-updated`                                                      | Storage layer (`user-storage`) | `useLearningPaths()` hook                                                                                   |
+| `pathfinder:progress` (`kind: 'guide'`, `contentKey: '*'`, `hasProgress: false`) | `resetPath()`                  | Every per-key progress listener (BlockPreview reset, guide-toolbar progress hooks, context recommendations) |
 
 ## See also
 

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -23,6 +23,7 @@ import {
   interactiveCompletionStorage,
 } from '../../lib/user-storage';
 import { evictAllContentCaches } from '../../global-state/completion-store';
+import { PROGRESS_CONTENT_KEY_WILDCARD, dispatchProgress } from '../../global-state/progress-events';
 import type { EarnedBadge } from '../../types';
 
 // Badge utilities extracted for testability
@@ -370,12 +371,15 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
       // render the prior state until the user closed and reopened the tab.
       evictAllContentCaches();
 
-      // Notify the context engine to refresh recommendations.
-      window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
-          detail: { contentKey: '*' },
-        })
-      );
+      // Broadcast a wildcard clear so the context engine refreshes
+      // recommendations and any open guide tab's per-key listeners
+      // (e.g. `useGuideProgressState`) clear their hasProgress flag.
+      dispatchProgress({
+        kind: 'guide',
+        contentKey: PROGRESS_CONTENT_KEY_WILDCARD,
+        percentage: 0,
+        hasProgress: false,
+      });
     }
   }, []);
 

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -371,9 +371,8 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
       // render the prior state until the user closed and reopened the tab.
       evictAllContentCaches();
 
-      // Broadcast a wildcard clear so the context engine refreshes
-      // recommendations and any open guide tab's per-key listeners
-      // (e.g. `useGuideProgressState`) clear their hasProgress flag.
+      // Wildcard clear → context refresh + every open guide tab's
+      // per-key listeners clear their hasProgress flag.
       dispatchProgress({
         kind: 'guide',
         contentKey: PROGRESS_CONTENT_KEY_WILDCARD,

--- a/src/components/block-editor/BlockPreview.resetKey.test.tsx
+++ b/src/components/block-editor/BlockPreview.resetKey.test.tsx
@@ -1,16 +1,8 @@
 /**
- * Locks the BlockPreview "force remount on guide clear" contract.
- *
- * BlockPreview re-keys ContentRenderer via a local `resetKey` counter
- * that bumps when the unified channel emits `kind: 'guide'` with
- * `hasProgress: false`. Both an exact `contentKey` match AND the
- * wildcard `'*'` sentinel must trigger the bump — the wildcard is
- * what makes "Reset all progress" and "Reset learning path" propagate
- * to any open preview tab.
- *
- * Losing the wildcard branch is the most expensive regression here:
- * the preview would silently render stale interactive state until the
- * user manually toggled the tab.
+ * Locks BlockPreview's force-remount on guide clear. Both an exact
+ * `contentKey` match AND the wildcard `'*'` must bump `resetKey`;
+ * losing the wildcard branch leaves the preview rendering stale
+ * interactive state after "Reset all progress" / path reset.
  */
 
 import * as React from 'react';

--- a/src/components/block-editor/BlockPreview.resetKey.test.tsx
+++ b/src/components/block-editor/BlockPreview.resetKey.test.tsx
@@ -9,6 +9,7 @@ import * as React from 'react';
 import { act, render } from '@testing-library/react';
 
 import { BlockPreview } from './BlockPreview';
+import { PROGRESS_CONTENT_KEY_WILDCARD } from '../../global-state/progress-events';
 import type { JsonGuide } from './types';
 
 // Substitute a probe for ContentRenderer that surfaces its `key` via the
@@ -95,7 +96,12 @@ describe('BlockPreview — resetKey remount', () => {
     act(() => {
       window.dispatchEvent(
         new CustomEvent('pathfinder:progress', {
-          detail: { kind: 'guide', contentKey: '*', percentage: 0, hasProgress: false },
+          detail: {
+            kind: 'guide',
+            contentKey: PROGRESS_CONTENT_KEY_WILDCARD,
+            percentage: 0,
+            hasProgress: false,
+          },
         })
       );
     });
@@ -132,6 +138,39 @@ describe('BlockPreview — resetKey remount', () => {
       window.dispatchEvent(
         new CustomEvent('pathfinder:progress', {
           detail: { kind: 'guide', contentKey: PROGRESS_KEY, percentage: 50, hasProgress: true },
+        })
+      );
+    });
+
+    expect(getByTestId('content-renderer-probe').getAttribute('data-mount-id')).toBe(initialMountId);
+  });
+
+  // Locks the discriminant guard against future re-shuffling: only
+  // `kind: 'guide'` clears bump the key. Step / section completions
+  // on the unified channel must not trigger the expensive remount.
+  it('does NOT bump resetKey on a kind:step event', () => {
+    const { getByTestId } = render(<BlockPreview guide={guide} />);
+    const initialMountId = getByTestId('content-renderer-probe').getAttribute('data-mount-id');
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'step', stepId: 'step-1', sectionId: 'section-a', completed: true, reason: 'manual' },
+        })
+      );
+    });
+
+    expect(getByTestId('content-renderer-probe').getAttribute('data-mount-id')).toBe(initialMountId);
+  });
+
+  it('does NOT bump resetKey on a kind:section event', () => {
+    const { getByTestId } = render(<BlockPreview guide={guide} />);
+    const initialMountId = getByTestId('content-renderer-probe').getAttribute('data-mount-id');
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'section', sectionId: 'section-a', completed: true, percentage: 100 },
         })
       );
     });

--- a/src/components/block-editor/BlockPreview.resetKey.test.tsx
+++ b/src/components/block-editor/BlockPreview.resetKey.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Locks the BlockPreview "force remount on guide clear" contract.
+ *
+ * BlockPreview re-keys ContentRenderer via a local `resetKey` counter
+ * that bumps when the unified channel emits `kind: 'guide'` with
+ * `hasProgress: false`. Both an exact `contentKey` match AND the
+ * wildcard `'*'` sentinel must trigger the bump — the wildcard is
+ * what makes "Reset all progress" and "Reset learning path" propagate
+ * to any open preview tab.
+ *
+ * Losing the wildcard branch is the most expensive regression here:
+ * the preview would silently render stale interactive state until the
+ * user manually toggled the tab.
+ */
+
+import * as React from 'react';
+import { act, render } from '@testing-library/react';
+
+import { BlockPreview } from './BlockPreview';
+import type { JsonGuide } from './types';
+
+// Substitute a probe for ContentRenderer that surfaces its `key` via the
+// DOM. Each `key` change causes a new mount → new probe element with a
+// fresh mount counter, which we read to assert remount.
+let mountCounter = 0;
+jest.mock('../content-renderer/content-renderer', () => ({
+  __esModule: true,
+  ContentRenderer: () => {
+    const id = React.useMemo(() => {
+      mountCounter += 1;
+      return mountCounter;
+    }, []);
+    return <div data-testid="content-renderer-probe" data-mount-id={id} />;
+  },
+}));
+
+// Heavy style helpers — no-op so the probe DOM stays compact.
+jest.mock('./block-editor.styles', () => ({
+  getBlockPreviewStyles: () => ({
+    container: '',
+    resetActions: '',
+    resetButton: '',
+    previewContent: '',
+  }),
+}));
+jest.mock('../../styles/content-html.styles', () => ({ journeyContentHtml: () => '' }));
+jest.mock('../../styles/interactive.styles', () => ({ getInteractiveStyles: () => '' }));
+jest.mock('../../styles/prism.styles', () => ({ getPrismStyles: () => '' }));
+
+// `parseJsonGuide` must succeed on the minimal fixture so BlockPreview
+// reaches the ContentRenderer branch (not the error / empty fallback).
+jest.mock('../../docs-retrieval', () => ({
+  parseJsonGuide: () => ({
+    isValid: true,
+    rawContent: { html: '<div />', metadata: {} },
+    warnings: [],
+  }),
+}));
+
+jest.mock('@grafana/ui', () => ({
+  useStyles2: (factory: () => unknown) => (typeof factory === 'function' ? factory() : factory),
+  Alert: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Icon: () => null,
+  // `@grafana/runtime`'s LocationService reaches for these at module load.
+  createLogger: () => ({ logger: jest.fn() }),
+  attachDebugger: jest.fn(),
+}));
+
+const GUIDE_ID = 'test-guide';
+const PROGRESS_KEY = `block-editor://preview/${GUIDE_ID}`;
+
+const guide: JsonGuide = {
+  id: GUIDE_ID,
+  title: 'Test guide',
+  blocks: [{ type: 'markdown', content: 'hello' }],
+};
+
+beforeEach(() => {
+  mountCounter = 0;
+});
+
+describe('BlockPreview — resetKey remount', () => {
+  it('bumps resetKey on a matching kind:guide clear (hasProgress: false)', () => {
+    const { getByTestId } = render(<BlockPreview guide={guide} />);
+    const initialMountId = getByTestId('content-renderer-probe').getAttribute('data-mount-id');
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'guide', contentKey: PROGRESS_KEY, percentage: 0, hasProgress: false },
+        })
+      );
+    });
+
+    const afterMountId = getByTestId('content-renderer-probe').getAttribute('data-mount-id');
+    expect(afterMountId).not.toBe(initialMountId);
+  });
+
+  it('bumps resetKey on a wildcard clear (contentKey: "*")', () => {
+    const { getByTestId } = render(<BlockPreview guide={guide} />);
+    const initialMountId = getByTestId('content-renderer-probe').getAttribute('data-mount-id');
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'guide', contentKey: '*', percentage: 0, hasProgress: false },
+        })
+      );
+    });
+
+    const afterMountId = getByTestId('content-renderer-probe').getAttribute('data-mount-id');
+    expect(afterMountId).not.toBe(initialMountId);
+  });
+
+  it('does NOT bump resetKey on a clear for a different contentKey', () => {
+    const { getByTestId } = render(<BlockPreview guide={guide} />);
+    const initialMountId = getByTestId('content-renderer-probe').getAttribute('data-mount-id');
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('pathfinder:progress', {
+          detail: {
+            kind: 'guide',
+            contentKey: 'block-editor://preview/some-other-guide',
+            percentage: 0,
+            hasProgress: false,
+          },
+        })
+      );
+    });
+
+    expect(getByTestId('content-renderer-probe').getAttribute('data-mount-id')).toBe(initialMountId);
+  });
+
+  it('does NOT bump resetKey on a kind:guide event with hasProgress: true', () => {
+    const { getByTestId } = render(<BlockPreview guide={guide} />);
+    const initialMountId = getByTestId('content-renderer-probe').getAttribute('data-mount-id');
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'guide', contentKey: PROGRESS_KEY, percentage: 50, hasProgress: true },
+        })
+      );
+    });
+
+    expect(getByTestId('content-renderer-probe').getAttribute('data-mount-id')).toBe(initialMountId);
+  });
+});

--- a/src/components/block-editor/BlockPreview.tsx
+++ b/src/components/block-editor/BlockPreview.tsx
@@ -14,7 +14,7 @@ import { journeyContentHtml } from '../../styles/content-html.styles';
 import { getInteractiveStyles } from '../../styles/interactive.styles';
 import { getPrismStyles } from '../../styles/prism.styles';
 import { useGuidePreviewProgress } from './hooks/useGuidePreviewProgress';
-import { matchesContentKey, subscribeProgressEvent } from '../../global-state/progress-events';
+import { isGuideClear, subscribeProgressEvent } from '../../global-state/progress-events';
 import type { JsonGuide } from './types';
 import type { RawContent } from '../../types/content.types';
 import { testIds } from '../../constants/testIds';
@@ -50,7 +50,7 @@ export function BlockPreview({ guide, showTitle = true, hideResetButton = false 
   const [resetKey, setResetKey] = useState(0);
   useEffect(() => {
     return subscribeProgressEvent((detail) => {
-      if (detail.kind === 'guide' && !detail.hasProgress && matchesContentKey(detail, progressKey)) {
+      if (isGuideClear(detail, progressKey)) {
         setResetKey((prev) => prev + 1);
       }
     });

--- a/src/components/block-editor/BlockPreview.tsx
+++ b/src/components/block-editor/BlockPreview.tsx
@@ -14,6 +14,7 @@ import { journeyContentHtml } from '../../styles/content-html.styles';
 import { getInteractiveStyles } from '../../styles/interactive.styles';
 import { getPrismStyles } from '../../styles/prism.styles';
 import { useGuidePreviewProgress } from './hooks/useGuidePreviewProgress';
+import { matchesContentKey, subscribeProgressEvent } from '../../global-state/progress-events';
 import type { JsonGuide } from './types';
 import type { RawContent } from '../../types/content.types';
 import { testIds } from '../../constants/testIds';
@@ -45,20 +46,17 @@ export function BlockPreview({ guide, showTitle = true, hideResetButton = false 
   const progressKey = `block-editor://preview/${guide.id}`;
   const { hasProgress: hasInteractiveProgress, reset } = useGuidePreviewProgress(progressKey);
 
-  // Force ContentRenderer remount when progress is cleared (locally or by a sibling
-  // surface like BlockEditorHeader). All clears flow through `interactive-progress-cleared`.
+  // Force ContentRenderer remount when progress is cleared (locally or by a
+  // sibling surface like BlockEditorHeader). All clears flow through
+  // `pathfinder:progress` with `kind: 'guide'` and `hasProgress: false`;
+  // wildcard `contentKey: '*'` clears (e.g. "reset all") also bump the key.
   const [resetKey, setResetKey] = useState(0);
   useEffect(() => {
-    const handleCleared = (event: Event) => {
-      const detail = (event as CustomEvent).detail;
-      if (detail?.contentKey === progressKey) {
+    return subscribeProgressEvent((detail) => {
+      if (detail.kind === 'guide' && !detail.hasProgress && matchesContentKey(detail, progressKey)) {
         setResetKey((prev) => prev + 1);
       }
-    };
-    window.addEventListener('interactive-progress-cleared', handleCleared);
-    return () => {
-      window.removeEventListener('interactive-progress-cleared', handleCleared);
-    };
+    });
   }, [progressKey]);
 
   // Validate the guide and prepare for rendering

--- a/src/components/block-editor/BlockPreview.tsx
+++ b/src/components/block-editor/BlockPreview.tsx
@@ -46,10 +46,7 @@ export function BlockPreview({ guide, showTitle = true, hideResetButton = false 
   const progressKey = `block-editor://preview/${guide.id}`;
   const { hasProgress: hasInteractiveProgress, reset } = useGuidePreviewProgress(progressKey);
 
-  // Force ContentRenderer remount when progress is cleared (locally or by a
-  // sibling surface like BlockEditorHeader). All clears flow through
-  // `pathfinder:progress` with `kind: 'guide'` and `hasProgress: false`;
-  // wildcard `contentKey: '*'` clears (e.g. "reset all") also bump the key.
+  // Force ContentRenderer remount on any clear (specific key or wildcard).
   const [resetKey, setResetKey] = useState(0);
   useEffect(() => {
     return subscribeProgressEvent((detail) => {

--- a/src/components/block-editor/hooks/useGuidePreviewProgress.test.ts
+++ b/src/components/block-editor/hooks/useGuidePreviewProgress.test.ts
@@ -11,6 +11,7 @@ import { act, renderHook } from '@testing-library/react';
 
 import { useGuidePreviewProgress } from './useGuidePreviewProgress';
 import { resetContentKeyForTests, setActiveTabUrl } from '../../../global-state/content-key';
+import { PROGRESS_CONTENT_KEY_WILDCARD } from '../../../global-state/progress-events';
 
 jest.mock('../../../lib/user-storage', () => ({
   interactiveStepStorage: {
@@ -181,7 +182,12 @@ describe('useGuidePreviewProgress — listener contract', () => {
     act(() => {
       window.dispatchEvent(
         new CustomEvent('pathfinder:progress', {
-          detail: { kind: 'guide', contentKey: '*', percentage: 0, hasProgress: false },
+          detail: {
+            kind: 'guide',
+            contentKey: PROGRESS_CONTENT_KEY_WILDCARD,
+            percentage: 0,
+            hasProgress: false,
+          },
         })
       );
     });

--- a/src/components/block-editor/hooks/useGuidePreviewProgress.test.ts
+++ b/src/components/block-editor/hooks/useGuidePreviewProgress.test.ts
@@ -2,18 +2,20 @@
  * PERMANENT — seam tripwire for the BlockPreview ↔ InteractiveSection event
  * contract.
  *
- * `useGuidePreviewProgress` is the listener side of two custom events that
- * cross the block-editor preview boundary:
+ * `useGuidePreviewProgress` is the listener side of the unified
+ * `pathfinder:progress` event:
  *
- *   - `interactive-progress-saved`    (producer: persistCompletedSteps in
- *                                      interactive-section.tsx)
- *   - `interactive-progress-cleared`  (producer: BlockPreview reset +, after
- *                                      phase-3 of #842, handleResetSection)
+ *   - `kind: 'guide'` with `hasProgress: true` — guide acquired progress
+ *   - `kind: 'guide'` with `hasProgress: false` — guide was cleared
+ *     (also dispatched by `handleResetSection` and the wildcard "reset all"
+ *     paths in `MyLearningTab` / `learning-paths.hook`)
+ *   - `kind: 'step' | 'section'` with `completed: true` — MF-3 preview
+ *     fallback when the active content key matches the progress key
  *
- * If a refactor of either side breaks the event names, payload shape, or the
- * progressKey filter, the assertions here will fail. The hook also drives
- * BlockPreview's `resetKey` remount mechanism — losing the cleared-listener
- * is the most expensive regression path.
+ * If a refactor breaks the variant names, payload shape, or the progressKey
+ * filter, the assertions here will fail. The hook also drives BlockPreview's
+ * `resetKey` remount mechanism — losing the clear path is the most expensive
+ * regression here.
  */
 
 import { act, renderHook } from '@testing-library/react';
@@ -160,7 +162,7 @@ describe('useGuidePreviewProgress — listener contract', () => {
     expect(result.current.hasProgress).toBe(false);
   });
 
-  it('flips hasProgress to false on a matching "interactive-progress-cleared" event', async () => {
+  it('flips hasProgress to false on a matching kind:guide clear (hasProgress: false)', async () => {
     (interactiveStepStorage.hasProgress as jest.Mock).mockResolvedValue(true);
     const { result } = renderHook(() => useGuidePreviewProgress(PROGRESS_KEY));
     await act(async () => {
@@ -170,8 +172,8 @@ describe('useGuidePreviewProgress — listener contract', () => {
 
     act(() => {
       window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
-          detail: { contentKey: PROGRESS_KEY },
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'guide', contentKey: PROGRESS_KEY, percentage: 0, hasProgress: false },
         })
       );
     });
@@ -179,7 +181,26 @@ describe('useGuidePreviewProgress — listener contract', () => {
     expect(result.current.hasProgress).toBe(false);
   });
 
-  it('ignores a "interactive-progress-cleared" event for a different contentKey', async () => {
+  it('flips hasProgress to false on a wildcard clear (contentKey: "*")', async () => {
+    (interactiveStepStorage.hasProgress as jest.Mock).mockResolvedValue(true);
+    const { result } = renderHook(() => useGuidePreviewProgress(PROGRESS_KEY));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.hasProgress).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'guide', contentKey: '*', percentage: 0, hasProgress: false },
+        })
+      );
+    });
+
+    expect(result.current.hasProgress).toBe(false);
+  });
+
+  it('ignores a kind:guide clear event for a different contentKey', async () => {
     (interactiveStepStorage.hasProgress as jest.Mock).mockResolvedValue(true);
     const { result } = renderHook(() => useGuidePreviewProgress(PROGRESS_KEY));
     await act(async () => {
@@ -188,8 +209,8 @@ describe('useGuidePreviewProgress — listener contract', () => {
 
     act(() => {
       window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
-          detail: { contentKey: OTHER_KEY },
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'guide', contentKey: OTHER_KEY, percentage: 0, hasProgress: false },
         })
       );
     });
@@ -197,7 +218,7 @@ describe('useGuidePreviewProgress — listener contract', () => {
     expect(result.current.hasProgress).toBe(true);
   });
 
-  it('reset() clears storage, sets hasProgress=false, and dispatches "interactive-progress-cleared"', async () => {
+  it('reset() clears storage, sets hasProgress=false, and dispatches kind:guide with hasProgress=false', async () => {
     (interactiveStepStorage.hasProgress as jest.Mock).mockResolvedValue(true);
     const { result } = renderHook(() => useGuidePreviewProgress(PROGRESS_KEY));
     await act(async () => {
@@ -206,7 +227,7 @@ describe('useGuidePreviewProgress — listener contract', () => {
 
     const events: CustomEvent[] = [];
     const handler = (e: Event) => events.push(e as CustomEvent);
-    window.addEventListener('interactive-progress-cleared', handler);
+    window.addEventListener('pathfinder:progress', handler);
 
     try {
       await act(async () => {
@@ -215,10 +236,16 @@ describe('useGuidePreviewProgress — listener contract', () => {
 
       expect(interactiveStepStorage.clearAllForContent).toHaveBeenCalledWith(PROGRESS_KEY);
       expect(result.current.hasProgress).toBe(false);
-      expect(events).toHaveLength(1);
-      expect(events[0]!.detail).toEqual({ contentKey: PROGRESS_KEY });
+      const clearEvent = events.find((e) => e.detail?.kind === 'guide' && e.detail?.hasProgress === false);
+      expect(clearEvent).toBeDefined();
+      expect(clearEvent!.detail).toEqual({
+        kind: 'guide',
+        contentKey: PROGRESS_KEY,
+        percentage: 0,
+        hasProgress: false,
+      });
     } finally {
-      window.removeEventListener('interactive-progress-cleared', handler);
+      window.removeEventListener('pathfinder:progress', handler);
     }
   });
 

--- a/src/components/block-editor/hooks/useGuidePreviewProgress.test.ts
+++ b/src/components/block-editor/hooks/useGuidePreviewProgress.test.ts
@@ -1,21 +1,10 @@
 /**
- * PERMANENT — seam tripwire for the BlockPreview ↔ InteractiveSection event
- * contract.
- *
- * `useGuidePreviewProgress` is the listener side of the unified
- * `pathfinder:progress` event:
- *
- *   - `kind: 'guide'` with `hasProgress: true` — guide acquired progress
- *   - `kind: 'guide'` with `hasProgress: false` — guide was cleared
- *     (also dispatched by `handleResetSection` and the wildcard "reset all"
- *     paths in `MyLearningTab` / `learning-paths.hook`)
- *   - `kind: 'step' | 'section'` with `completed: true` — MF-3 preview
- *     fallback when the active content key matches the progress key
- *
- * If a refactor breaks the variant names, payload shape, or the progressKey
- * filter, the assertions here will fail. The hook also drives BlockPreview's
- * `resetKey` remount mechanism — losing the clear path is the most expensive
- * regression here.
+ * PERMANENT — seam tripwire for the BlockPreview ↔ InteractiveSection
+ * event contract. `useGuidePreviewProgress` listens to
+ * `pathfinder:progress` for `kind:'guide'` (acquire / clear, including
+ * wildcard) plus the MF-3 step/section preview fallback. Losing the
+ * clear path silently breaks BlockPreview's `resetKey` remount — the
+ * most expensive regression here.
  */
 
 import { act, renderHook } from '@testing-library/react';

--- a/src/components/block-editor/hooks/useGuidePreviewProgress.ts
+++ b/src/components/block-editor/hooks/useGuidePreviewProgress.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { interactiveStepStorage, interactiveCompletionStorage } from '../../../lib/user-storage';
 import { evictContentCache } from '../../../global-state/completion-store';
 import { getContentKey } from '../../../global-state/content-key';
-import { subscribeProgressEvent } from '../../../global-state/progress-events';
+import { dispatchProgress, matchesContentKey, subscribeProgressEvent } from '../../../global-state/progress-events';
 
 export interface GuidePreviewProgress {
   hasProgress: boolean;
@@ -16,8 +16,8 @@ export interface GuidePreviewProgress {
  * remounts the renderer on reset) and BlockEditorHeader (which renders the
  * Reset button in preview mode). Both call-sites use this hook with the same
  * `progressKey` and stay in sync via the unified `pathfinder:progress` event
- * (kind === 'guide') plus the legacy `interactive-progress-cleared` event
- * (still dispatched by `handleResetSection` until that path is migrated too).
+ * (kind === 'guide'). `hasProgress: false` is the canonical clear signal;
+ * `contentKey: '*'` broadcasts a clear across every preview.
  */
 export function useGuidePreviewProgress(progressKey: string): GuidePreviewProgress {
   const [hasProgress, setHasProgress] = useState(false);
@@ -35,9 +35,9 @@ export function useGuidePreviewProgress(progressKey: string): GuidePreviewProgre
   }, [progressKey]);
 
   useEffect(() => {
-    const unsubscribeProgress = subscribeProgressEvent((detail) => {
-      if (detail.kind === 'guide' && detail.contentKey === progressKey && detail.hasProgress) {
-        setHasProgress(true);
+    return subscribeProgressEvent((detail) => {
+      if (detail.kind === 'guide' && matchesContentKey(detail, progressKey)) {
+        setHasProgress(detail.hasProgress);
         return;
       }
       // MF-3 — preview mode suppresses `kind: 'guide'` in `persistSection`
@@ -54,17 +54,6 @@ export function useGuidePreviewProgress(progressKey: string): GuidePreviewProgre
         setHasProgress(true);
       }
     });
-    const handleCleared = (event: Event) => {
-      const detail = (event as CustomEvent).detail;
-      if (detail?.contentKey === progressKey) {
-        setHasProgress(false);
-      }
-    };
-    window.addEventListener('interactive-progress-cleared', handleCleared);
-    return () => {
-      unsubscribeProgress();
-      window.removeEventListener('interactive-progress-cleared', handleCleared);
-    };
   }, [progressKey]);
 
   const reset = useCallback(async () => {
@@ -76,11 +65,7 @@ export function useGuidePreviewProgress(progressKey: string): GuidePreviewProgre
       // and the preview keeps showing steps as completed until remount.
       evictContentCache(progressKey);
       setHasProgress(false);
-      window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
-          detail: { contentKey: progressKey },
-        })
-      );
+      dispatchProgress({ kind: 'guide', contentKey: progressKey, percentage: 0, hasProgress: false });
     } catch (error) {
       console.error('[useGuidePreviewProgress] Failed to reset progress:', error);
     }

--- a/src/components/block-editor/hooks/useGuidePreviewProgress.ts
+++ b/src/components/block-editor/hooks/useGuidePreviewProgress.ts
@@ -32,6 +32,13 @@ export function useGuidePreviewProgress(progressKey: string): GuidePreviewProgre
 
   useEffect(() => {
     return subscribeProgressEvent((detail) => {
+      // A `kind: 'guide'` payload for a preview key is authoritative when
+      // it does land. Today the only producer is `reset()` below
+      // (`hasProgress: false`); a `hasProgress: true` arrival would have
+      // to come from a future non-preview producer that already knows
+      // the preview key — in which case skipping the MF-3 fallback is
+      // the correct behaviour, since the guide-level signal supersedes
+      // the per-step inference.
       if (detail.kind === 'guide' && matchesContentKey(detail, progressKey)) {
         setHasProgress(detail.hasProgress);
         return;

--- a/src/components/block-editor/hooks/useGuidePreviewProgress.ts
+++ b/src/components/block-editor/hooks/useGuidePreviewProgress.ts
@@ -11,13 +11,9 @@ export interface GuidePreviewProgress {
 
 /**
  * Tracks interactive progress for a previewed guide and exposes a reset action.
- *
- * The same logical state needs to be observable from both BlockPreview (which
- * remounts the renderer on reset) and BlockEditorHeader (which renders the
- * Reset button in preview mode). Both call-sites use this hook with the same
- * `progressKey` and stay in sync via the unified `pathfinder:progress` event
- * (kind === 'guide'). `hasProgress: false` is the canonical clear signal;
- * `contentKey: '*'` broadcasts a clear across every preview.
+ * Shared by BlockPreview (remounts the renderer on reset) and
+ * BlockEditorHeader (renders the Reset button) — both subscribe to
+ * `pathfinder:progress` with `kind: 'guide'` and stay in sync.
  */
 export function useGuidePreviewProgress(progressKey: string): GuidePreviewProgress {
   const [hasProgress, setHasProgress] = useState(false);
@@ -41,11 +37,8 @@ export function useGuidePreviewProgress(progressKey: string): GuidePreviewProgre
         return;
       }
       // MF-3 — preview mode suppresses `kind: 'guide'` in `persistSection`
-      // (no document total → no percentage), so the Reset button would
-      // otherwise be unreachable in preview. Flip on per-step / per-section
-      // completion events whose active content key matches this preview
-      // hook's progress key. Reads `getContentKey()` lazily because the
-      // hook isn't necessarily mounted under the same active tab.
+      // (no document total → no percentage), so fall back to step / section
+      // events when the active content key matches.
       if (
         (detail.kind === 'step' || detail.kind === 'section') &&
         detail.completed === true &&
@@ -60,9 +53,8 @@ export function useGuidePreviewProgress(progressKey: string): GuidePreviewProgre
     try {
       await interactiveStepStorage.clearAllForContent(progressKey);
       await interactiveCompletionStorage.clear(progressKey);
-      // Drop the completion store's in-memory cache too — otherwise
-      // `useStepCompletion` subscribers still see the prior snapshot
-      // and the preview keeps showing steps as completed until remount.
+      // Otherwise `useStepCompletion` subscribers still see the prior
+      // snapshot until remount.
       evictContentCache(progressKey);
       setHasProgress(false);
       dispatchProgress({ kind: 'guide', contentKey: progressKey, percentage: 0, hasProgress: false });

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -1102,8 +1102,9 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   );
 
   // Content reset hook - handles complex storage/state/reload orchestration.
-  // It dispatches `interactive-progress-cleared`, which `useGuideProgressState`
-  // listens for to clear `hasInteractiveProgress` for this content key.
+  // It dispatches `pathfinder:progress` with `kind: 'guide'` and
+  // `hasProgress: false`, which `useGuideProgressState` listens for to clear
+  // `hasInteractiveProgress` for this content key.
   const handleResetGuide = useContentReset({ model });
 
   // Helper: Reload active tab content (DRY - was duplicated 3x).

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -1101,10 +1101,8 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
     activeTab?.currentUrl
   );
 
-  // Content reset hook - handles complex storage/state/reload orchestration.
-  // It dispatches `pathfinder:progress` with `kind: 'guide'` and
-  // `hasProgress: false`, which `useGuideProgressState` listens for to clear
-  // `hasInteractiveProgress` for this content key.
+  // Dispatches `pathfinder:progress` (kind:'guide', hasProgress:false),
+  // which `useGuideProgressState` listens for.
   const handleResetGuide = useContentReset({ model });
 
   // Helper: Reload active tab content (DRY - was duplicated 3x).

--- a/src/components/docs-panel/hooks/useContentReset.test.ts
+++ b/src/components/docs-panel/hooks/useContentReset.test.ts
@@ -96,11 +96,16 @@ describe('useContentReset', () => {
     expect(mockInteractiveStepStorage.clearAllForContent).toHaveBeenCalledWith('progress-key-123');
     expect(mockInteractiveCompletionStorage.clear).toHaveBeenCalledWith('progress-key-123');
 
-    // Step 3: Event dispatch
+    // Step 3: Event dispatch (unified channel, kind: 'guide' clear)
     expect(mockDispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'interactive-progress-cleared',
-        detail: { contentKey: 'progress-key-123' },
+        type: 'pathfinder:progress',
+        detail: {
+          kind: 'guide',
+          contentKey: 'progress-key-123',
+          percentage: 0,
+          hasProgress: false,
+        },
       })
     );
 

--- a/src/components/docs-panel/hooks/useContentReset.ts
+++ b/src/components/docs-panel/hooks/useContentReset.ts
@@ -64,11 +64,8 @@ export function useContentReset({ model }: UseContentResetOptions) {
         // doesn't invalidate the in-memory state.
         evictContentCache(progressKey);
 
-        // Step 3: Dispatch cross-component event on the unified channel.
-        // Notifies the recommendations panel to refresh and
-        // `useGuideProgressState` to clear its `hasInteractiveProgress`
-        // flag for this contentKey via `kind: 'guide'` with
-        // `hasProgress: false`.
+        // Step 3: Broadcast clear. Refreshes recommendations and clears
+        // `useGuideProgressState.hasInteractiveProgress` for this key.
         dispatchProgress({ kind: 'guide', contentKey: progressKey, percentage: 0, hasProgress: false });
 
         // Step 4: Reload content to reset UI state.

--- a/src/components/docs-panel/hooks/useContentReset.ts
+++ b/src/components/docs-panel/hooks/useContentReset.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../lib/analytics';
 import { interactiveStepStorage, interactiveCompletionStorage } from '../../../lib/user-storage';
 import { evictContentCache } from '../../../global-state/completion-store';
+import { dispatchProgress } from '../../../global-state/progress-events';
 import type { LearningJourneyTab } from '../../../types/content-panel.types';
 import type { DocsPanelModelOperations } from '../types';
 
@@ -63,14 +64,12 @@ export function useContentReset({ model }: UseContentResetOptions) {
         // doesn't invalidate the in-memory state.
         evictContentCache(progressKey);
 
-        // Step 3: Dispatch cross-component event.
-        // Notifies the recommendations panel to refresh and `useGuideProgressState`
-        // to clear its `hasInteractiveProgress` flag for this contentKey.
-        window.dispatchEvent(
-          new CustomEvent('interactive-progress-cleared', {
-            detail: { contentKey: progressKey },
-          })
-        );
+        // Step 3: Dispatch cross-component event on the unified channel.
+        // Notifies the recommendations panel to refresh and
+        // `useGuideProgressState` to clear its `hasInteractiveProgress`
+        // flag for this contentKey via `kind: 'guide'` with
+        // `hasProgress: false`.
+        dispatchProgress({ kind: 'guide', contentKey: progressKey, percentage: 0, hasProgress: false });
 
         // Step 4: Reload content to reset UI state.
         // Tag the loader call as `internal_reload` (aligned-by-construction)

--- a/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
@@ -10,7 +10,7 @@
  *
  * What is pinned:
  *   - `interactive-progress-saved`  : detail `{ contentKey, hasProgress, completionPercentage }`
- *   - `interactive-progress-cleared`: detail `{ contentKey }`
+ *   - `pathfinder:progress` (kind: 'guide', hasProgress: false): detail `{ kind, contentKey, percentage, hasProgress }` (clear signal)
  *   - `section-completed`           : detail `{ sectionId }` (on `document`)
  *   - `interactive-section-completed`: detail `{ sectionId }` (on `window`)
  *   - `interactive-step-completed`  : detail `{ stepId, sectionId }`
@@ -104,11 +104,7 @@ function recordSectionEvents(): { events: CapturedEvent[]; unsubscribe: () => vo
     (target === 'window' ? window : document).addEventListener(name, handler);
     return () => (target === 'window' ? window : document).removeEventListener(name, handler);
   };
-  const offs = [
-    make('pathfinder:progress', 'window'),
-    make('interactive-progress-cleared', 'window'),
-    make('pathfinder-step-progress', 'window'),
-  ];
+  const offs = [make('pathfinder:progress', 'window'), make('pathfinder-step-progress', 'window')];
   return { events, unsubscribe: () => offs.forEach((off) => off()) };
 }
 
@@ -244,7 +240,7 @@ describe('InteractiveSection contracts — Phase 0 tripwire', () => {
       }
     });
 
-    it('dispatches `interactive-progress-cleared` with { contentKey } on section reset', async () => {
+    it('dispatches pathfinder:progress (kind: guide, hasProgress: false) on section reset', async () => {
       const { events, unsubscribe } = recordSectionEvents();
       try {
         renderSingleStepSection();
@@ -261,9 +257,20 @@ describe('InteractiveSection contracts — Phase 0 tripwire', () => {
         });
 
         await waitFor(() => {
-          const evt = events.find((e) => e.name === 'interactive-progress-cleared');
+          const evt = events.find(
+            (e) =>
+              e.name === 'pathfinder:progress' &&
+              e.detail.kind === 'guide' &&
+              e.detail.hasProgress === false &&
+              e.detail.contentKey === NON_PREVIEW_KEY
+          );
           expect(evt).toBeDefined();
-          expect(evt!.detail).toEqual({ contentKey: NON_PREVIEW_KEY });
+          expect(evt!.detail).toEqual({
+            kind: 'guide',
+            contentKey: NON_PREVIEW_KEY,
+            percentage: 0,
+            hasProgress: false,
+          });
         });
       } finally {
         unsubscribe();
@@ -376,16 +383,27 @@ describe('InteractiveSection contracts — Phase 0 tripwire', () => {
         expect(memoryStore.get(`section-steps::${PREVIEW_KEY}::${SECTION_ID}`)).toBeUndefined();
         expect(memoryStore.get(`interactive-completion::${PREVIEW_KEY}`)).toBeUndefined();
 
-        // Now reset and confirm the cleared event still fires.
+        // Now reset and confirm the kind:'guide' clear still fires.
         events.length = 0;
         await waitFor(() => expect(screen.getByTestId(resetButton(SECTION_ID))).toBeInTheDocument());
         act(() => {
           screen.getByTestId(resetButton(SECTION_ID)).click();
         });
         await waitFor(() => {
-          const evt = events.find((e) => e.name === 'interactive-progress-cleared');
+          const evt = events.find(
+            (e) =>
+              e.name === 'pathfinder:progress' &&
+              e.detail.kind === 'guide' &&
+              e.detail.hasProgress === false &&
+              e.detail.contentKey === PREVIEW_KEY
+          );
           expect(evt).toBeDefined();
-          expect(evt!.detail).toEqual({ contentKey: PREVIEW_KEY });
+          expect(evt!.detail).toEqual({
+            kind: 'guide',
+            contentKey: PREVIEW_KEY,
+            percentage: 0,
+            hasProgress: false,
+          });
         });
       } finally {
         unsubscribe();

--- a/src/components/interactive-tutorial/interactive-section.state-machine.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.state-machine.test.tsx
@@ -324,8 +324,13 @@ describe('InteractiveSection state machine — #842 acknowledgement gate', () =>
       renderTrailingGateSection();
 
       const clearedEvents: CustomEvent[] = [];
-      const handler = (e: Event) => clearedEvents.push(e as CustomEvent);
-      window.addEventListener('interactive-progress-cleared', handler);
+      const handler = (e: Event) => {
+        const detail = (e as CustomEvent).detail;
+        if (detail?.kind === 'guide' && detail?.hasProgress === false) {
+          clearedEvents.push(e as CustomEvent);
+        }
+      };
+      window.addEventListener('pathfinder:progress', handler);
 
       try {
         // Mount-restore + migration: completed contains the step, ack
@@ -341,7 +346,7 @@ describe('InteractiveSection state machine — #842 acknowledgement gate', () =>
         expect(memoryStore.get(`section-ack::${NON_PREVIEW_KEY}::${SECTION_GATED}`)).toBeUndefined();
         expect(clearedEvents.length).toBeGreaterThanOrEqual(1);
       } finally {
-        window.removeEventListener('interactive-progress-cleared', handler);
+        window.removeEventListener('pathfinder:progress', handler);
       }
     });
   });

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -1065,24 +1065,18 @@ export function InteractiveSection({
     clearAckAndCollapseStorage();
 
     // Notify listeners that progress for this content was cleared (#842, Bug 2).
-    // Mirrors the dispatch in BlockPreview's reset() so any consumer driving
-    // ephemeral UI off `interactive-progress-cleared` — most importantly
-    // `useGuidePreviewProgress`, which controls the "Reset guide" button
-    // visibility — sees the section-level reset path too. Without this the
-    // block-editor preview's Reset guide button stays visible after a
-    // per-section reset, even when no progress is left.
-    if (typeof window !== 'undefined') {
-      const contentKey = getContentKey();
-      window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
-          detail: { contentKey },
-        })
-      );
-      // All-passive sections bypass `persistSection` on reset too;
-      // recompute so the persisted percentage drops in lockstep.
-      if (!isPreviewMode) {
-        refreshAndNotifyGuideProgress(contentKey);
-      }
+    // Mirrors the dispatch in `useGuidePreviewProgress.reset()` so any consumer
+    // driving ephemeral UI off `kind: 'guide'` with `hasProgress: false` —
+    // most importantly `useGuidePreviewProgress`, which controls the
+    // "Reset guide" button visibility — sees the section-level reset path too.
+    // Without this the block-editor preview's Reset guide button stays visible
+    // after a per-section reset, even when no progress is left.
+    const contentKey = getContentKey();
+    dispatchProgress({ kind: 'guide', contentKey, percentage: 0, hasProgress: false });
+    // All-passive sections bypass `persistSection` on reset too;
+    // recompute so the persisted percentage drops in lockstep.
+    if (!isPreviewMode) {
+      refreshAndNotifyGuideProgress(contentKey);
     }
 
     // Reset all step states in the global manager

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -1064,17 +1064,12 @@ export function InteractiveSection({
     // Clear ack + collapse storage. Hook gates on preview mode internally.
     clearAckAndCollapseStorage();
 
-    // Notify listeners that progress for this content was cleared (#842, Bug 2).
-    // Mirrors the dispatch in `useGuidePreviewProgress.reset()` so any consumer
-    // driving ephemeral UI off `kind: 'guide'` with `hasProgress: false` —
-    // most importantly `useGuidePreviewProgress`, which controls the
-    // "Reset guide" button visibility — sees the section-level reset path too.
-    // Without this the block-editor preview's Reset guide button stays visible
-    // after a per-section reset, even when no progress is left.
+    // #842, Bug 2 — without this the block-editor preview's Reset guide
+    // button stays visible after a per-section reset.
     const contentKey = getContentKey();
     dispatchProgress({ kind: 'guide', contentKey, percentage: 0, hasProgress: false });
-    // All-passive sections bypass `persistSection` on reset too;
-    // recompute so the persisted percentage drops in lockstep.
+    // All-passive sections bypass `persistSection` on reset — recompute
+    // so the persisted percentage drops in lockstep.
     if (!isPreviewMode) {
       refreshAndNotifyGuideProgress(contentKey);
     }

--- a/src/context-engine/context.hook.ts
+++ b/src/context-engine/context.hook.ts
@@ -197,11 +197,7 @@ export function useContextPanel(options: UseContextPanelOptions = {}): UseContex
     return unsubscribe;
   }, [debouncedRefresh]);
 
-  // Listen for guide-level clear signals on the unified channel to
-  // refresh recommendations (completion percentages may have dropped).
-  // Matches the legacy "ignore detail, just refresh" behaviour:
-  // wildcard `contentKey: '*'` and specific keys both qualify, since
-  // `kind: 'guide'` with `hasProgress: false` is the canonical clear.
+  // Any guide clear → refresh recommendations (percentages may have dropped).
   useEffect(() => {
     return subscribeProgressEvent((detail) => {
       if (detail.kind === 'guide' && !detail.hasProgress) {

--- a/src/context-engine/context.hook.ts
+++ b/src/context-engine/context.hook.ts
@@ -6,7 +6,7 @@ import { ContextData, Recommendation, UseContextPanelOptions, UseContextPanelRet
 import type { PackageOpenInfo } from '../types/content-panel.types';
 import { useTimeoutManager } from '../utils/timeout-manager';
 import { suggestionState, SUGGESTIONS_UPDATED_EVENT } from '../global-state/suggestion';
-import { subscribeProgressEvent } from '../global-state/progress-events';
+import { isGuideClear, subscribeProgressEvent } from '../global-state/progress-events';
 
 export function useContextPanel(options: UseContextPanelOptions = {}): UseContextPanelReturn {
   const { onOpenLearningJourney, onOpenDocsPage } = options;
@@ -200,7 +200,7 @@ export function useContextPanel(options: UseContextPanelOptions = {}): UseContex
   // Any guide clear → refresh recommendations (percentages may have dropped).
   useEffect(() => {
     return subscribeProgressEvent((detail) => {
-      if (detail.kind === 'guide' && !detail.hasProgress) {
+      if (isGuideClear(detail)) {
         debouncedRefresh();
       }
     });

--- a/src/context-engine/context.hook.ts
+++ b/src/context-engine/context.hook.ts
@@ -6,6 +6,7 @@ import { ContextData, Recommendation, UseContextPanelOptions, UseContextPanelRet
 import type { PackageOpenInfo } from '../types/content-panel.types';
 import { useTimeoutManager } from '../utils/timeout-manager';
 import { suggestionState, SUGGESTIONS_UPDATED_EVENT } from '../global-state/suggestion';
+import { subscribeProgressEvent } from '../global-state/progress-events';
 
 export function useContextPanel(options: UseContextPanelOptions = {}): UseContextPanelReturn {
   const { onOpenLearningJourney, onOpenDocsPage } = options;
@@ -196,17 +197,17 @@ export function useContextPanel(options: UseContextPanelOptions = {}): UseContex
     return unsubscribe;
   }, [debouncedRefresh]);
 
-  // Listen for progress cleared events to refresh recommendations
+  // Listen for guide-level clear signals on the unified channel to
+  // refresh recommendations (completion percentages may have dropped).
+  // Matches the legacy "ignore detail, just refresh" behaviour:
+  // wildcard `contentKey: '*'` and specific keys both qualify, since
+  // `kind: 'guide'` with `hasProgress: false` is the canonical clear.
   useEffect(() => {
-    const handleProgressCleared = () => {
-      // Refresh recommendations to update completion percentages
-      debouncedRefresh();
-    };
-
-    window.addEventListener('interactive-progress-cleared', handleProgressCleared);
-    return () => {
-      window.removeEventListener('interactive-progress-cleared', handleProgressCleared);
-    };
+    return subscribeProgressEvent((detail) => {
+      if (detail.kind === 'guide' && !detail.hasProgress) {
+        debouncedRefresh();
+      }
+    });
   }, [debouncedRefresh]);
 
   // Merge external suggestions into featuredRecommendations

--- a/src/global-state/completion-store.test.tsx
+++ b/src/global-state/completion-store.test.tsx
@@ -365,6 +365,56 @@ describe('completion-store', () => {
     });
   });
 
+  // Ack-aware "fully cleared" predicate tripwire.
+  //
+  // `persistSection` emits a `kind: 'guide'` clear (`hasProgress: false`)
+  // only when BOTH the interactive-step total AND the section-ack total
+  // are zero. Passive section acknowledgements count as real progress —
+  // clearing the last interactive step in a mixed guide must not fire
+  // "cleared" while acks remain, or the alignment-prompt / preview-reset
+  // consumers would race ahead of the actual storage state.
+  describe('ack-aware guide-cleared dispatch', () => {
+    function captureGuideClearEvents(): { events: ProgressEventDetail[]; unsubscribe: () => void } {
+      const events: ProgressEventDetail[] = [];
+      const unsubscribe = subscribeProgressEvent((detail) => {
+        if (detail.kind === 'guide' && detail.hasProgress === false) {
+          events.push(detail);
+        }
+      });
+      return { events, unsubscribe };
+    }
+
+    it('emits guide-cleared when both step total AND ack total are zero', () => {
+      // Seed a single completed step, then reset it. After reset both
+      // counts are zero so the clear must fire.
+      act(() => {
+        markStepCompleted('step-1', 'section-x', 'manual');
+      });
+      const { events, unsubscribe } = captureGuideClearEvents();
+      act(() => {
+        resetStep('step-1', 'section-x');
+      });
+      expect(events).toEqual([expect.objectContaining({ kind: 'guide', contentKey: CONTENT_KEY, hasProgress: false })]);
+      unsubscribe();
+    });
+
+    it('suppresses guide-cleared while acks remain', () => {
+      // Seed an ack for a sibling section + a completed interactive step
+      // in another section. Resetting the interactive step drops its
+      // section's `completedIds` to zero, but the ack total is still 1.
+      storedAcks.set(`${CONTENT_KEY}-section-passive`, true);
+      act(() => {
+        markStepCompleted('step-1', 'section-x', 'manual');
+      });
+      const { events, unsubscribe } = captureGuideClearEvents();
+      act(() => {
+        resetStep('step-1', 'section-x');
+      });
+      expect(events).toEqual([]);
+      unsubscribe();
+    });
+  });
+
   // Reset guide / "Reset progress" parity tripwire.
   //
   // Storage-clear paths (`useContentReset`, `useGuidePreviewProgress.reset`,

--- a/src/global-state/completion-store.test.tsx
+++ b/src/global-state/completion-store.test.tsx
@@ -365,14 +365,8 @@ describe('completion-store', () => {
     });
   });
 
-  // Ack-aware "fully cleared" predicate tripwire.
-  //
-  // `persistSection` emits a `kind: 'guide'` clear (`hasProgress: false`)
-  // only when BOTH the interactive-step total AND the section-ack total
-  // are zero. Passive section acknowledgements count as real progress —
-  // clearing the last interactive step in a mixed guide must not fire
-  // "cleared" while acks remain, or the alignment-prompt / preview-reset
-  // consumers would race ahead of the actual storage state.
+  // `persistSection` emits a clear only when BOTH step total AND ack
+  // total are zero — passive acks count as real progress.
   describe('ack-aware guide-cleared dispatch', () => {
     function captureGuideClearEvents(): { events: ProgressEventDetail[]; unsubscribe: () => void } {
       const events: ProgressEventDetail[] = [];
@@ -385,8 +379,6 @@ describe('completion-store', () => {
     }
 
     it('emits guide-cleared when both step total AND ack total are zero', () => {
-      // Seed a single completed step, then reset it. After reset both
-      // counts are zero so the clear must fire.
       act(() => {
         markStepCompleted('step-1', 'section-x', 'manual');
       });
@@ -399,9 +391,8 @@ describe('completion-store', () => {
     });
 
     it('suppresses guide-cleared while acks remain', () => {
-      // Seed an ack for a sibling section + a completed interactive step
-      // in another section. Resetting the interactive step drops its
-      // section's `completedIds` to zero, but the ack total is still 1.
+      // Ack on a sibling section keeps the guide-wide ack total at 1
+      // even after resetting the only completed interactive step.
       storedAcks.set(`${CONTENT_KEY}-section-passive`, true);
       act(() => {
         markStepCompleted('step-1', 'section-x', 'manual');

--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -263,20 +263,14 @@ function persistSection(contentKey: string, sectionId: string): void {
   if (completedIds.size > 0 && percentage !== undefined) {
     dispatchProgress({ kind: 'guide', contentKey, percentage, hasProgress: true });
   }
-  // Tail-reset / partial-reset coverage on the unified channel. The
-  // manual reset paths (handleResetSection, useContentReset,
-  // block-editor preview reset) dispatch a `kind: 'guide'` clear
-  // directly; the store also drops to zero progress when the user
-  // redoes the first step or runs a reset path that doesn't go through
-  // one of those manual sites. Fire here whenever the *guide* total
-  // falls to zero so the alignment-prompt and preview-reset-button
-  // consumers see every clear path. Guarded on !isPreview to mirror
-  // persistence; the preview path manages its own dispatch elsewhere.
+  // Tail-reset coverage: catches reset paths that bypass the manual
+  // handlers (e.g. user redoes the first step). Manual reset sites
+  // dispatch their own clear. Preview path manages its dispatch elsewhere.
   if (!isPreview && completedIds.size === 0) {
+    // Passive acks count as real progress — both totals must be zero,
+    // or clearing the last interactive step in a mixed guide fires
+    // "cleared" while acks remain.
     const guideTotal = interactiveStepStorage.countAllCompleted(contentKey);
-    // Both counts must be zero — passive acks are real progress even
-    // when no interactive step is recorded, so clearing the last step
-    // in a mixed guide must not fire "cleared" while acks remain.
     const ackTotal = sectionAcknowledgementStorage.countAllAcknowledged(contentKey);
     if (guideTotal === 0 && ackTotal === 0) {
       dispatchProgress({ kind: 'guide', contentKey, percentage: 0, hasProgress: false });

--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -263,24 +263,23 @@ function persistSection(contentKey: string, sectionId: string): void {
   if (completedIds.size > 0 && percentage !== undefined) {
     dispatchProgress({ kind: 'guide', contentKey, percentage, hasProgress: true });
   }
-  // Tail-reset / partial-reset coverage for the legacy
-  // `interactive-progress-cleared` event. The manual reset paths
-  // (handleResetSection, useContentReset, block-editor preview reset)
-  // dispatch this event directly; the store also drops to zero progress
-  // when the user redoes the first step or runs a reset path that
-  // doesn't go through one of those manual sites. Fire here whenever
-  // the *guide* total falls to zero so the alignment-prompt and
-  // preview-reset-button consumers see every clear path. Guarded on
-  // !isPreview to mirror persistence; the preview path manages its own
-  // dispatch elsewhere.
-  if (!isPreview && completedIds.size === 0 && typeof window !== 'undefined') {
+  // Tail-reset / partial-reset coverage on the unified channel. The
+  // manual reset paths (handleResetSection, useContentReset,
+  // block-editor preview reset) dispatch a `kind: 'guide'` clear
+  // directly; the store also drops to zero progress when the user
+  // redoes the first step or runs a reset path that doesn't go through
+  // one of those manual sites. Fire here whenever the *guide* total
+  // falls to zero so the alignment-prompt and preview-reset-button
+  // consumers see every clear path. Guarded on !isPreview to mirror
+  // persistence; the preview path manages its own dispatch elsewhere.
+  if (!isPreview && completedIds.size === 0) {
     const guideTotal = interactiveStepStorage.countAllCompleted(contentKey);
     // Both counts must be zero — passive acks are real progress even
     // when no interactive step is recorded, so clearing the last step
     // in a mixed guide must not fire "cleared" while acks remain.
     const ackTotal = sectionAcknowledgementStorage.countAllAcknowledged(contentKey);
     if (guideTotal === 0 && ackTotal === 0) {
-      window.dispatchEvent(new CustomEvent('interactive-progress-cleared', { detail: { contentKey } }));
+      dispatchProgress({ kind: 'guide', contentKey, percentage: 0, hasProgress: false });
     }
   }
 }
@@ -530,7 +529,7 @@ export function resetSection(sectionId: string): void {
     notify(contentKey);
     // Symmetric with resetSteps — fire per-step events so reactive
     // listeners (interactive-conditional, requirement re-checks) see
-    // the clear, not just the section-level `interactive-progress-cleared`
+    // the clear, not just the section-level `kind: 'guide'` clear
     // dispatched by the section's own reset handler.
     clearedIds.forEach((id) => {
       dispatchProgress({

--- a/src/global-state/progress-events.ts
+++ b/src/global-state/progress-events.ts
@@ -22,13 +22,7 @@
 
 export type ProgressReason = 'none' | 'objectives' | 'manual' | 'skipped';
 
-/**
- * Sentinel `contentKey` value that means "every guide". Used by
- * "reset all progress" and "reset learning path" flows to broadcast a
- * `kind: 'guide'` clear that any listener (regardless of its tracked
- * key) should react to. Listeners must accept this in addition to an
- * exact `contentKey` match.
- */
+/** Broadcast `contentKey` — every key-scoped listener must accept this. */
 export const PROGRESS_CONTENT_KEY_WILDCARD = '*' as const;
 
 export type ProgressEventDetail =
@@ -46,13 +40,8 @@ export type ProgressEventDetail =
       percentage?: number;
     }
   | {
-      /**
-       * Guide-level aggregate progress. `hasProgress: false` is the
-       * canonical "cleared" signal — supersedes the legacy
-       * `interactive-progress-cleared` window event. `contentKey` may
-       * be `PROGRESS_CONTENT_KEY_WILDCARD` (`'*'`) to broadcast a clear
-       * across every guide (e.g. "reset all progress" / path reset).
-       */
+      // Guide-level aggregate. `hasProgress: false` is the canonical
+      // clear signal; `contentKey: '*'` broadcasts across every guide.
       kind: 'guide';
       contentKey: string;
       percentage: number;
@@ -79,11 +68,7 @@ export function subscribeProgressEvent(listener: (detail: ProgressEventDetail) =
   return () => window.removeEventListener(PROGRESS_EVENT, handler);
 }
 
-/**
- * Returns true when an event's `contentKey` either matches `expected`
- * exactly or is the wildcard sentinel (`'*'`). Use at every
- * key-scoped listener that needs to react to broadcast clears.
- */
+/** Exact match OR the wildcard sentinel. */
 export function matchesContentKey(detail: { contentKey: string }, expected: string): boolean {
   return detail.contentKey === expected || detail.contentKey === PROGRESS_CONTENT_KEY_WILDCARD;
 }

--- a/src/global-state/progress-events.ts
+++ b/src/global-state/progress-events.ts
@@ -25,6 +25,16 @@ export type ProgressReason = 'none' | 'objectives' | 'manual' | 'skipped';
 /** Broadcast `contentKey` — every key-scoped listener must accept this. */
 export const PROGRESS_CONTENT_KEY_WILDCARD = '*' as const;
 
+export interface GuideProgressDetail {
+  kind: 'guide';
+  contentKey: string;
+  percentage: number;
+  hasProgress: boolean;
+}
+
+/** Narrowed shape: the canonical "guide cleared" signal. */
+export type GuideClearDetail = GuideProgressDetail & { hasProgress: false };
+
 export type ProgressEventDetail =
   | {
       kind: 'step';
@@ -39,14 +49,9 @@ export type ProgressEventDetail =
       completed: boolean;
       percentage?: number;
     }
-  | {
-      // Guide-level aggregate. `hasProgress: false` is the canonical
-      // clear signal; `contentKey: '*'` broadcasts across every guide.
-      kind: 'guide';
-      contentKey: string;
-      percentage: number;
-      hasProgress: boolean;
-    };
+  // Guide-level aggregate. `hasProgress: false` is the canonical
+  // clear signal; `contentKey: '*'` broadcasts across every guide.
+  | GuideProgressDetail;
 
 export const PROGRESS_EVENT = 'pathfinder:progress' as const;
 
@@ -71,4 +76,20 @@ export function subscribeProgressEvent(listener: (detail: ProgressEventDetail) =
 /** Exact match OR the wildcard sentinel. */
 export function matchesContentKey(detail: { contentKey: string }, expected: string): boolean {
   return detail.contentKey === expected || detail.contentKey === PROGRESS_CONTENT_KEY_WILDCARD;
+}
+
+/**
+ * Type-guard for clear-only listeners: narrows to `GuideClearDetail` and
+ * — when `expectedKey` is supplied — also accepts the wildcard sentinel.
+ *
+ * Collapses the three checks (`kind === 'guide'` + `!hasProgress` +
+ * `matchesContentKey`) every clear-only subscriber must perform into a
+ * single call so a future site can't forget the `!hasProgress` half and
+ * silently treat a fresh-progress event as a clear.
+ */
+export function isGuideClear(detail: ProgressEventDetail, expectedKey?: string): detail is GuideClearDetail {
+  if (detail.kind !== 'guide' || detail.hasProgress) {
+    return false;
+  }
+  return expectedKey === undefined || matchesContentKey(detail, expectedKey);
 }

--- a/src/global-state/progress-events.ts
+++ b/src/global-state/progress-events.ts
@@ -1,11 +1,12 @@
 /**
  * Unified progress event channel.
  *
- * Replaces four legacy events:
+ * Replaces five legacy events:
  *   - `interactive-step-completed`
  *   - `section-completed`
  *   - `interactive-section-completed`
  *   - `interactive-progress-saved`
+ *   - `interactive-progress-cleared` (`kind: 'guide'` with `hasProgress: false`)
  *
  * The discriminated payload makes intent explicit at the dispatch site
  * and at every listener. Lives in `global-state` (Tier 1) so both the
@@ -20,6 +21,15 @@
  */
 
 export type ProgressReason = 'none' | 'objectives' | 'manual' | 'skipped';
+
+/**
+ * Sentinel `contentKey` value that means "every guide". Used by
+ * "reset all progress" and "reset learning path" flows to broadcast a
+ * `kind: 'guide'` clear that any listener (regardless of its tracked
+ * key) should react to. Listeners must accept this in addition to an
+ * exact `contentKey` match.
+ */
+export const PROGRESS_CONTENT_KEY_WILDCARD = '*' as const;
 
 export type ProgressEventDetail =
   | {
@@ -36,6 +46,13 @@ export type ProgressEventDetail =
       percentage?: number;
     }
   | {
+      /**
+       * Guide-level aggregate progress. `hasProgress: false` is the
+       * canonical "cleared" signal — supersedes the legacy
+       * `interactive-progress-cleared` window event. `contentKey` may
+       * be `PROGRESS_CONTENT_KEY_WILDCARD` (`'*'`) to broadcast a clear
+       * across every guide (e.g. "reset all progress" / path reset).
+       */
       kind: 'guide';
       contentKey: string;
       percentage: number;
@@ -60,4 +77,13 @@ export function subscribeProgressEvent(listener: (detail: ProgressEventDetail) =
   };
   window.addEventListener(PROGRESS_EVENT, handler);
   return () => window.removeEventListener(PROGRESS_EVENT, handler);
+}
+
+/**
+ * Returns true when an event's `contentKey` either matches `expected`
+ * exactly or is the wildcard sentinel (`'*'`). Use at every
+ * key-scoped listener that needs to react to broadcast clears.
+ */
+export function matchesContentKey(detail: { contentKey: string }, expected: string): boolean {
+  return detail.contentKey === expected || detail.contentKey === PROGRESS_CONTENT_KEY_WILDCARD;
 }

--- a/src/hooks/useGuideProgressState.test.ts
+++ b/src/hooks/useGuideProgressState.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { useGuideProgressState } from './useGuideProgressState';
+import { PROGRESS_CONTENT_KEY_WILDCARD } from '../global-state/progress-events';
 
 const mockHasProgress = jest.fn();
 jest.mock('../lib/user-storage', () => ({
@@ -123,7 +124,12 @@ describe('useGuideProgressState', () => {
     act(() => {
       window.dispatchEvent(
         new CustomEvent('pathfinder:progress', {
-          detail: { kind: 'guide', contentKey: '*', percentage: 0, hasProgress: false },
+          detail: {
+            kind: 'guide',
+            contentKey: PROGRESS_CONTENT_KEY_WILDCARD,
+            percentage: 0,
+            hasProgress: false,
+          },
         })
       );
     });

--- a/src/hooks/useGuideProgressState.test.ts
+++ b/src/hooks/useGuideProgressState.test.ts
@@ -91,7 +91,7 @@ describe('useGuideProgressState', () => {
     expect(result.current.hasInteractiveProgress).toBe(true);
   });
 
-  it('flips hasInteractiveProgress false on a matching interactive-progress-cleared event', async () => {
+  it('flips hasInteractiveProgress false on a matching kind:guide clear (hasProgress: false)', async () => {
     mockHasProgress.mockResolvedValue(true);
     const { result } = renderHook(() => useGuideProgressState({ currentUrl: 'guide-a' }));
 
@@ -102,8 +102,8 @@ describe('useGuideProgressState', () => {
 
     act(() => {
       window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
-          detail: { contentKey: 'guide-a' },
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'guide', contentKey: 'guide-a', percentage: 0, hasProgress: false },
         })
       );
     });
@@ -111,7 +111,27 @@ describe('useGuideProgressState', () => {
     expect(result.current.hasInteractiveProgress).toBe(false);
   });
 
-  it('ignores interactive-progress-cleared events for a different content key', async () => {
+  it('flips hasInteractiveProgress false on a wildcard clear (contentKey: "*")', async () => {
+    mockHasProgress.mockResolvedValue(true);
+    const { result } = renderHook(() => useGuideProgressState({ currentUrl: 'guide-a' }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.hasInteractiveProgress).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'guide', contentKey: '*', percentage: 0, hasProgress: false },
+        })
+      );
+    });
+
+    expect(result.current.hasInteractiveProgress).toBe(false);
+  });
+
+  it('ignores kind:guide clear events for a different content key', async () => {
     mockHasProgress.mockResolvedValue(true);
     const { result } = renderHook(() => useGuideProgressState({ currentUrl: 'guide-a' }));
 
@@ -121,8 +141,8 @@ describe('useGuideProgressState', () => {
 
     act(() => {
       window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
-          detail: { contentKey: 'guide-b' },
+        new CustomEvent('pathfinder:progress', {
+          detail: { kind: 'guide', contentKey: 'guide-b', percentage: 0, hasProgress: false },
         })
       );
     });

--- a/src/hooks/useGuideProgressState.ts
+++ b/src/hooks/useGuideProgressState.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { interactiveStepStorage } from '../lib/user-storage';
-import { subscribeProgressEvent } from '../global-state/progress-events';
+import { matchesContentKey, subscribeProgressEvent } from '../global-state/progress-events';
 
 interface ActiveTabSummary {
   currentUrl?: string;
@@ -28,22 +28,14 @@ export function useGuideProgressState(activeTab: ActiveTabSummary | null | undef
   }, [progressKey]);
 
   useEffect(() => {
-    const unsubscribeProgress = subscribeProgressEvent((detail) => {
-      if (detail.kind === 'guide' && detail.contentKey === progressKey && detail.hasProgress) {
-        setHasInteractiveProgress(true);
+    // Single subscription on the unified channel. `hasProgress: false`
+    // is the canonical clear signal, and `contentKey: '*'` broadcasts
+    // a clear across every open guide tab (e.g. "Reset all progress").
+    return subscribeProgressEvent((detail) => {
+      if (detail.kind === 'guide' && matchesContentKey(detail, progressKey)) {
+        setHasInteractiveProgress(detail.hasProgress);
       }
     });
-    const handleProgressCleared = (event: Event) => {
-      const detail = (event as CustomEvent).detail;
-      if (detail?.contentKey === progressKey) {
-        setHasInteractiveProgress(false);
-      }
-    };
-    window.addEventListener('interactive-progress-cleared', handleProgressCleared);
-    return () => {
-      unsubscribeProgress();
-      window.removeEventListener('interactive-progress-cleared', handleProgressCleared);
-    };
   }, [progressKey]);
 
   return { hasInteractiveProgress, progressKey };

--- a/src/hooks/useGuideProgressState.ts
+++ b/src/hooks/useGuideProgressState.ts
@@ -28,9 +28,6 @@ export function useGuideProgressState(activeTab: ActiveTabSummary | null | undef
   }, [progressKey]);
 
   useEffect(() => {
-    // Single subscription on the unified channel. `hasProgress: false`
-    // is the canonical clear signal, and `contentKey: '*'` broadcasts
-    // a clear across every open guide tab (e.g. "Reset all progress").
     return subscribeProgressEvent((detail) => {
       if (detail.kind === 'guide' && matchesContentKey(detail, progressKey)) {
         setHasInteractiveProgress(detail.hasProgress);

--- a/src/learning-paths/learning-paths.hook.ts
+++ b/src/learning-paths/learning-paths.hook.ts
@@ -420,11 +420,9 @@ export function useLearningPaths(): UseLearningPathsReturn {
         await learningProgressStorage.removeCompletedGuides(path.guides);
       }
 
-      // Broadcast a wildcard clear on the unified channel so the
-      // context engine refreshes recommendations and any open guide
-      // tab's per-key listeners clear their hasProgress flag.
-      // (`pathId` was previously included on the legacy event but no
-      // production listener read it; dropped during the migration.)
+      // Wildcard clear → context refresh + every open guide tab's
+      // per-key listeners clear their hasProgress flag. (Legacy event
+      // carried `pathId` but no production listener read it.)
       dispatchProgress({
         kind: 'guide',
         contentKey: PROGRESS_CONTENT_KEY_WILDCARD,

--- a/src/learning-paths/learning-paths.hook.ts
+++ b/src/learning-paths/learning-paths.hook.ts
@@ -25,6 +25,7 @@ import {
   milestoneCompletionStorage,
 } from '../lib/user-storage';
 import { evictContentCache } from '../global-state/completion-store';
+import { PROGRESS_CONTENT_KEY_WILDCARD, dispatchProgress } from '../global-state/progress-events';
 import { BADGES } from './badges';
 import { getStreakInfo } from './streak-tracker';
 import { getPathsData } from './paths-data';
@@ -419,12 +420,17 @@ export function useLearningPaths(): UseLearningPathsReturn {
         await learningProgressStorage.removeCompletedGuides(path.guides);
       }
 
-      // Dispatch event to notify UI components to refresh
-      window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
-          detail: { contentKey: '*', pathId },
-        })
-      );
+      // Broadcast a wildcard clear on the unified channel so the
+      // context engine refreshes recommendations and any open guide
+      // tab's per-key listeners clear their hasProgress flag.
+      // (`pathId` was previously included on the legacy event but no
+      // production listener read it; dropped during the migration.)
+      dispatchProgress({
+        kind: 'guide',
+        contentKey: PROGRESS_CONTENT_KEY_WILDCARD,
+        percentage: 0,
+        hasProgress: false,
+      });
 
       // Reload progress to update UI
       await loadProgress({ current: true });


### PR DESCRIPTION
## Summary

Migration **A3** of the legacy-event consolidation: replace the
`interactive-progress-cleared` window event with `kind: 'guide'`
dispatches carrying `hasProgress: false` on the unified
`pathfinder:progress` channel. Sibling to A2 (#929).

The cutover is **atomic** — all 6 dispatchers and all 4 listeners
move in this commit. The dual-listener pattern in
`useGuideProgressState` and `useGuidePreviewProgress` (unified for
`hasProgress: true`, legacy event for `false`) collapses into a
single subscription per hook.

## Schema

- `kind: 'guide'` with `hasProgress: false` is now the canonical
  clear signal: `{ kind: 'guide', contentKey, percentage: 0,
  hasProgress: false }`.
- New exported constant `PROGRESS_CONTENT_KEY_WILDCARD = '*'` for the
  broadcast sentinel used by "reset all" / "reset learning path".
- New helper `matchesContentKey(detail, expected)` accepts an exact
  match OR the wildcard, so key-scoped listeners can opt in with one
  call.

```ts
// Before
window.dispatchEvent(
  new CustomEvent('interactive-progress-cleared', { detail: { contentKey } })
);
// After
dispatchProgress({ kind: 'guide', contentKey, percentage: 0, hasProgress: false });
```

## Dispatcher migration (6 sites)

| # | Site | Notes |
|---|------|-------|
| D1 | `completion-store.persistSection` | Ack-aware predicate preserved verbatim (only fires when step total AND ack total are zero) |
| D2 | `useContentReset` | Straight swap |
| D3 | `useGuidePreviewProgress.reset()` | Straight swap |
| D4 | `interactive-section.handleResetSection` | Straight swap; stays unconditional (matches today's behaviour) |
| D5 | `MyLearningTab.handleResetProgress` | Uses wildcard |
| D6 | `learning-paths.hook.resetPath` | Uses wildcard. Legacy payload's \`pathId\` had no production listener and was dropped |

## Listener migration (4 sites)

| # | Site | Behaviour change |
|---|------|------------------|
| L1 | \`useGuideProgressState\` | Single subscription; accepts wildcard |
| L2 | \`useGuidePreviewProgress\` | Same; MF-3 step/section fallback retained |
| L3 | \`BlockPreview\` \`resetKey\` remount | Subscribes via unified channel; wildcard now bumps the key too |
| L4 | \`context.hook\` debounced refresh | Subscribes via unified channel; fires on any \`kind: 'guide'\` with \`hasProgress: false\` |

### Behaviour improvement (side effect)

Open guide tabs whose \`LearningJourneyMilestoneToolbar\` showed
stale state after a wildcard clear are implicitly fixed: L1/L2 used
to ignore wildcard events because they did strict-equality on
\`contentKey\`. The shared storage was already cleared by the reset
paths; this catches the in-memory React state up.

## Tests

- Existing assertions rewritten to expect the unified envelope:
  - \`useGuideProgressState.test.ts\`
  - \`useGuidePreviewProgress.test.ts\` (the permanent seam tripwire)
  - \`useContentReset.test.ts\`
  - \`interactive-section.contracts.tripwire.test.tsx\` (both non-preview and preview reset paths)
  - \`interactive-section.state-machine.test.tsx\`
- New focused test in \`completion-store.test.tsx\` pins the
  ack-aware predicate (no clear emitted while acks remain — closes
  the gap flagged by the migration research).
- New \`BlockPreview.resetKey.test.tsx\` locks the wildcard-remount
  path, which is the most expensive regression here per the existing
  tripwire docs.

## Risk and reversibility

Low–medium. Single atomic cutover keeps producers and listeners in
sync. The schema's existing \`hasProgress\` field already supported
this signal — only listeners needed the dual-channel collapse. The
ack-aware predicate in \`persistSection\` is preserved byte-for-byte
(only the dispatch line changed). Fully reversible by reverting
this commit.

## Test plan

- [x] \`npm run check\` (typecheck + lint + prettier + lint:go +
      test:go + test:ci — 231 suites, 3929 tests pass)
- [x] grep \`interactive-progress-cleared\` returns only documentation
      references in \`progress-events.ts\`


Made with [Cursor](https://cursor.com)