### PR TITLE
chore(ci): bump plugin-ci-workflows CD to v8.0.1 (GATB)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

- Bumps the shared CD workflow in [`.github/workflows/publish.yml`](.github/workflows/publish.yml) from ` ci-cd-workflows/v7.3.1` → ` v8.0.1`, switching GitHub App authentication to the GitHub App Token Broker (GATB) with short-lived tokens per the v8.0.0 migration guide.


