### PR TITLE
Agent hardening Phase B: close the ratchet loopholes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
 npx lint-staged
+npm run typecheck
+npm run test:governance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,9 +165,10 @@ Do NOT create summary `.md` files unless explicitly requested by the user. No `I
 npm install              # Install dependencies (requires Node.js 22+)
 npm run dev              # Frontend watch mode
 npm run server           # Run Grafana locally with Docker
-npm run test:ci          # Frontend tests (agents should use this, not `npm test`)
+npm run test:ci          # Frontend tests, no coverage (agents should use this, not `npm test`)
+npm run test:coverage    # Frontend tests with coverage + thresholds (used by `npm run check`)
 npm run lint:fix         # Lint + autofix
-npm run check            # Full pre-merge gate: typecheck + lint + prettier + lint:go + test:go + test:ci
+npm run check            # Full pre-merge gate: typecheck + lint + prettier + lint:go + test:go + test:coverage
 ```
 
 Dev server runs at http://localhost:3000 (admin/admin). For the complete command reference (build targets, mage tasks, validation, i18n, peerjs, etc.), see `docs/developer/COMMANDS.md` or read `package.json#scripts` directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,5 +36,5 @@ Treat them as complementary: prevent-doc-drift handles _new_ drift introduced by
 
 ### Other Claude Code specifics
 
-- **Full pre-merge check**: `npm run check` runs typecheck + lint + prettier + lint:go + test:go + test:ci in one command.
+- **Full pre-merge check**: `npm run check` runs typecheck + lint + prettier + lint:go + test:go + test:coverage in one command.
 - **Memory system**: Long-lived user / project / feedback notes live under `~/.claude/projects/<project-slug>/memory/`, where `<project-slug>` is the absolute path to this repo with `/` replaced by `-` (for example, a clone at `/Users/alice/code/grafana-pathfinder-app` resolves to `-Users-alice-code-grafana-pathfinder-app`). See the `auto memory` section in the system prompt for the file format.

--- a/docs/developer/COMMANDS.md
+++ b/docs/developer/COMMANDS.md
@@ -21,13 +21,13 @@ npm run dev
 # Run Grafana locally with Docker
 npm run server
 
-# Run all tests (CI mode - agents should use this)
+# Run all tests, no coverage (CI mode - agents should use this for focused runs)
 npm run test:ci
 
 # Run tests in watch mode (for local development)
 npm test
 
-# Run tests with coverage
+# Run tests with coverage + threshold enforcement (used by `npm run check`)
 npm run test:coverage
 ```
 
@@ -52,7 +52,7 @@ npm run lint:go
 
 ## Pre-merge check
 
-`npm run check` runs typecheck + lint + prettier + lint:go + test:go + test:ci in one command.
+`npm run check` runs typecheck + lint + prettier + lint:go + test:go + test:coverage in one command.
 
 ## Building and testing
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,7 @@ const TIER_2_ENGINES = [
   'requirements-manager',
   'learning-paths',
   'package-engine',
+  'hooks',
 ];
 const TIER_1_PLUS = [
   'lib',
@@ -23,6 +24,7 @@ const TIER_1_PLUS = [
   'global-state',
   'utils',
   'validation',
+  'recovery',
   ...TIER_2_ENGINES,
   'integrations',
   'components',
@@ -186,14 +188,14 @@ export default defineConfig([
     ]
   ),
 
-  // Tier 1 (lib/, security/, styles/, global-state/, utils/, validation/) — no imports from Tier 2+
+  // Tier 1 (lib/, security/, styles/, global-state/, utils/, validation/, recovery/) — no imports from Tier 2+
   tierBoundaryConfig(
-    ['lib', 'security', 'styles', 'global-state', 'utils', 'validation'],
+    ['lib', 'security', 'styles', 'global-state', 'utils', 'validation', 'recovery'],
     [
       {
         regex: bannedDirRegex(TIER_2_PLUS),
         message:
-          'Tier 1 (lib/, security/, styles/, utils/) must not import from Tier 2+ modules. ' +
+          'Tier 1 (lib/, security/, styles/, global-state/, utils/, validation/, recovery/) must not import from Tier 2+ modules. ' +
           'Move shared logic to types/ or lib/. See TIER_MAP in src/validation/import-graph.ts.',
       },
     ]

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,12 @@ module.exports = {
   ],
 
   // Coverage configuration
-  collectCoverage: true,
+  // Default off: `npm run test:ci` (and focused subsets via `--`) skip coverage
+  // entirely, so agents and developers don't get false-failures from threshold
+  // checks on partial test runs. The full pre-merge gate (`npm run check`) calls
+  // `npm run test:coverage`, which passes `--coverage` on the CLI and overrides
+  // this default — that's where the threshold enforcement lives.
+  collectCoverage: false,
   coverageReporters: ['text', 'html', 'lcov'],
   coverageDirectory: 'coverage',
   collectCoverageFrom: [

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "test:coverage": "jest --coverage",
+    "test:governance": "jest --passWithNoTests src/validation/architecture.test.ts src/validation/import-graph.test.ts",
     "test:coverage:watch": "jest --coverage --watch",
     "test:go": "mage -v test",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "repository:build": "node dist/cli/cli/index.js build-repository src/bundled-interactives -o src/bundled-interactives/repository.json",
     "repository:check": "node dist/cli/cli/index.js build-repository src/bundled-interactives -o /tmp/repository-check.json && diff -q src/bundled-interactives/repository.json /tmp/repository-check.json",
     "schema:export": "node dist/cli/cli/index.js schema --all",
-    "check": "npm run typecheck && npm run lint && npm run prettier-test && npm run docs:sync-terms:check && npm run lint:go && npm run test:go && npm run test:ci",
+    "check": "npm run typecheck && npm run lint && npm run prettier-test && npm run docs:sync-terms:check && npm run lint:go && npm run test:go && npm run test:coverage",
     "prepare": "husky"
   },
   "author": "Grafanalabs",

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -58,18 +58,7 @@ function collectViolations(getViolationKey: (ctx: ResolvedImportContext) => stri
   const allFiles = getAllFileImports();
   const violations = new Set<string>();
 
-  const processResolved = (relPath: string, topLevelDir: string | null, resolved: string): void => {
-    const targetTopLevel = getTargetTopLevel(resolved);
-    if (!targetTopLevel) {
-      return;
-    }
-    const violationKey = getViolationKey({ relPath, topLevelDir, resolved, targetTopLevel });
-    if (violationKey) {
-      violations.add(violationKey);
-    }
-  };
-
-  for (const { file, relPath, topLevelDir, imports, resolvedAliasImports } of allFiles) {
+  for (const { file, relPath, topLevelDir, imports } of allFiles) {
     if (isTestFile(file)) {
       continue;
     }
@@ -77,12 +66,19 @@ function collectViolations(getViolationKey: (ctx: ResolvedImportContext) => stri
     const fileDir = path.dirname(file);
     for (const imp of imports) {
       const resolved = resolveImportToRelative(fileDir, imp);
-      if (resolved) {
-        processResolved(relPath, topLevelDir, resolved);
+      if (!resolved) {
+        continue;
       }
-    }
-    for (const resolved of resolvedAliasImports) {
-      processResolved(relPath, topLevelDir, resolved);
+
+      const targetTopLevel = getTargetTopLevel(resolved);
+      if (!targetTopLevel) {
+        continue;
+      }
+
+      const violationKey = getViolationKey({ relPath, topLevelDir, resolved, targetTopLevel });
+      if (violationKey) {
+        violations.add(violationKey);
+      }
     }
   }
 
@@ -453,17 +449,12 @@ function diffExcludedSets(label: string, docExcluded: Set<string>): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// ESLint / TIER_MAP sync (B5 — prevents F-5 regression)
+// ESLint / TIER_MAP sync
 // ---------------------------------------------------------------------------
 //
-// eslint.config.mjs hand-mirrors TIER_MAP via const arrays (TIER_2_ENGINES,
-// TIER_1_PLUS, …). The mirror provides faster editor-time feedback than the
-// Jest ratchet — but two sources of truth drift. This test parses the
-// const-array literals out of eslint.config.mjs and compares them against
-// TIER_MAP. Any divergence fails CI with a directional diff.
-//
-// Implementation: text-parse rather than dynamic-import to avoid pulling in
-// the full ESLint plugin chain at test time.
+// eslint.config.mjs hand-mirrors TIER_MAP via const arrays for faster
+// editor-time feedback. Two sources of truth drift; these tests text-parse
+// the eslint config and assert it matches TIER_MAP.
 
 const ESLINT_CONFIG_PATH = path.join(REPO_ROOT, 'eslint.config.mjs');
 
@@ -598,26 +589,6 @@ describe('ESLint config sync with TIER_MAP', () => {
       );
     }
   });
-
-  it('flags a divergent set when the parser is fed a doctored constant', () => {
-    const fakeConfig = `
-      const TIER_2_ENGINES = ['context-engine', 'docs-retrieval'];
-      const TIER_1_PLUS = ['lib', ...TIER_2_ENGINES];
-    `;
-    const defs = new Map<string, string[]>();
-    defs.set('TIER_2_ENGINES', parseConstantTokens(fakeConfig, 'TIER_2_ENGINES'));
-    defs.set('TIER_1_PLUS', parseConstantTokens(fakeConfig, 'TIER_1_PLUS'));
-
-    const actual = expandTokens('TIER_2_ENGINES', defs);
-    const errors = diffSets(
-      'TIER_2_ENGINES',
-      tierDirs((t) => t === 2),
-      actual
-    );
-    // Real TIER_MAP has 7 engines, fake config has 2 → expect errors mentioning the missing ones
-    expect(errors.length).toBeGreaterThan(0);
-    expect(errors.some((e) => e.includes('`hooks`'))).toBe(true);
-  });
 });
 
 describe('Tier documentation sync', () => {
@@ -673,5 +644,34 @@ describe('Tier documentation sync', () => {
     const parsed = parseTierDoc(fakeDoc, 'fake.md');
     const errors = diffTierMaps('fake.md', parsed.tiers);
     expect(errors.some((e) => e.includes('`phantom-module`') && e.includes('not in TIER_MAP'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TS path-alias tripwire
+// ---------------------------------------------------------------------------
+//
+// The import-graph scanner only resolves relative specifiers. If
+// tsconfig.compilerOptions.paths is ever populated, aliased imports would
+// silently bypass tier enforcement. Fail loudly the moment paths appears
+// so whoever introduces it extends the scanner first.
+
+describe('TS path-alias tripwire', () => {
+  const tsconfigs = [path.join(REPO_ROOT, 'tsconfig.json'), path.join(REPO_ROOT, '.config', 'tsconfig.json')];
+
+  it.each(tsconfigs)('%s declares no compilerOptions.paths', (tsconfigPath) => {
+    const text = fs.readFileSync(tsconfigPath, 'utf-8');
+    const stripped = text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    const parsed = JSON.parse(stripped) as { compilerOptions?: { paths?: Record<string, unknown> } };
+    const paths = parsed.compilerOptions?.paths ?? {};
+
+    if (Object.keys(paths).length > 0) {
+      throw new Error(
+        `${path.relative(REPO_ROOT, tsconfigPath)} declares compilerOptions.paths, but the ` +
+          `import-graph scanner in src/validation/import-graph.ts only resolves relative ` +
+          `specifiers. Aliased imports would silently bypass tier enforcement. Extend the ` +
+          `scanner to resolve tsconfig.paths before merging this change.`
+      );
+    }
   });
 });

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -58,7 +58,18 @@ function collectViolations(getViolationKey: (ctx: ResolvedImportContext) => stri
   const allFiles = getAllFileImports();
   const violations = new Set<string>();
 
-  for (const { file, relPath, topLevelDir, imports } of allFiles) {
+  const processResolved = (relPath: string, topLevelDir: string | null, resolved: string): void => {
+    const targetTopLevel = getTargetTopLevel(resolved);
+    if (!targetTopLevel) {
+      return;
+    }
+    const violationKey = getViolationKey({ relPath, topLevelDir, resolved, targetTopLevel });
+    if (violationKey) {
+      violations.add(violationKey);
+    }
+  };
+
+  for (const { file, relPath, topLevelDir, imports, resolvedAliasImports } of allFiles) {
     if (isTestFile(file)) {
       continue;
     }
@@ -66,19 +77,12 @@ function collectViolations(getViolationKey: (ctx: ResolvedImportContext) => stri
     const fileDir = path.dirname(file);
     for (const imp of imports) {
       const resolved = resolveImportToRelative(fileDir, imp);
-      if (!resolved) {
-        continue;
+      if (resolved) {
+        processResolved(relPath, topLevelDir, resolved);
       }
-
-      const targetTopLevel = getTargetTopLevel(resolved);
-      if (!targetTopLevel) {
-        continue;
-      }
-
-      const violationKey = getViolationKey({ relPath, topLevelDir, resolved, targetTopLevel });
-      if (violationKey) {
-        violations.add(violationKey);
-      }
+    }
+    for (const resolved of resolvedAliasImports) {
+      processResolved(relPath, topLevelDir, resolved);
     }
   }
 
@@ -605,7 +609,11 @@ describe('ESLint config sync with TIER_MAP', () => {
     defs.set('TIER_1_PLUS', parseConstantTokens(fakeConfig, 'TIER_1_PLUS'));
 
     const actual = expandTokens('TIER_2_ENGINES', defs);
-    const errors = diffSets('TIER_2_ENGINES', tierDirs((t) => t === 2), actual);
+    const errors = diffSets(
+      'TIER_2_ENGINES',
+      tierDirs((t) => t === 2),
+      actual
+    );
     // Real TIER_MAP has 7 engines, fake config has 2 → expect errors mentioning the missing ones
     expect(errors.length).toBeGreaterThan(0);
     expect(errors.some((e) => e.includes('`hooks`'))).toBe(true);

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -448,6 +448,170 @@ function diffExcludedSets(label: string, docExcluded: Set<string>): string[] {
   return errors;
 }
 
+// ---------------------------------------------------------------------------
+// ESLint / TIER_MAP sync (B5 — prevents F-5 regression)
+// ---------------------------------------------------------------------------
+//
+// eslint.config.mjs hand-mirrors TIER_MAP via const arrays (TIER_2_ENGINES,
+// TIER_1_PLUS, …). The mirror provides faster editor-time feedback than the
+// Jest ratchet — but two sources of truth drift. This test parses the
+// const-array literals out of eslint.config.mjs and compares them against
+// TIER_MAP. Any divergence fails CI with a directional diff.
+//
+// Implementation: text-parse rather than dynamic-import to avoid pulling in
+// the full ESLint plugin chain at test time.
+
+const ESLINT_CONFIG_PATH = path.join(REPO_ROOT, 'eslint.config.mjs');
+
+function parseConstantTokens(text: string, varName: string): string[] {
+  const blockRe = new RegExp(`const\\s+${varName}\\s*=\\s*\\[([\\s\\S]*?)\\];`);
+  const match = blockRe.exec(text);
+  if (!match) {
+    throw new Error(`Could not find \`const ${varName} = [...]\` in eslint.config.mjs.`);
+  }
+  const body = match[1]!;
+  const tokens: string[] = [];
+  const tokenRe = /(['"])([^'"]+)\1|\.\.\.(\w+)/g;
+  let tokenMatch: RegExpExecArray | null;
+  while ((tokenMatch = tokenRe.exec(body)) !== null) {
+    if (tokenMatch[2] !== undefined) {
+      tokens.push(tokenMatch[2]);
+    } else if (tokenMatch[3] !== undefined) {
+      tokens.push(`...${tokenMatch[3]}`);
+    }
+  }
+  return tokens;
+}
+
+function expandTokens(name: string, defs: Map<string, string[]>, seen = new Set<string>()): string[] {
+  if (seen.has(name)) {
+    throw new Error(`Circular reference detected expanding ${name} in eslint.config.mjs.`);
+  }
+  const tokens = defs.get(name);
+  if (!tokens) {
+    throw new Error(`Unknown constant referenced: ${name}.`);
+  }
+  const nextSeen = new Set(seen).add(name);
+  const expanded: string[] = [];
+  for (const token of tokens) {
+    if (token.startsWith('...')) {
+      expanded.push(...expandTokens(token.slice(3), defs, nextSeen));
+    } else {
+      expanded.push(token);
+    }
+  }
+  return expanded;
+}
+
+function tierDirs(predicate: (tier: number) => boolean): string[] {
+  return Object.entries(TIER_MAP)
+    .filter(([, tier]) => predicate(tier))
+    .map(([dir]) => dir);
+}
+
+function diffSets(label: string, expected: string[], actual: string[]): string[] {
+  const expectedSet = new Set(expected);
+  const actualSet = new Set(actual);
+  const errors: string[] = [];
+  for (const dir of expectedSet) {
+    if (!actualSet.has(dir)) {
+      errors.push(`${label}: TIER_MAP includes \`${dir}\` but eslint.config.mjs does not`);
+    }
+  }
+  for (const dir of actualSet) {
+    if (!expectedSet.has(dir)) {
+      errors.push(`${label}: eslint.config.mjs includes \`${dir}\` but TIER_MAP does not`);
+    }
+  }
+  return errors;
+}
+
+describe('ESLint config sync with TIER_MAP', () => {
+  it('TIER_2_ENGINES, TIER_1_PLUS, TIER_2_PLUS, TIER_3_PLUS, TIER_4 mirror TIER_MAP', () => {
+    const text = fs.readFileSync(ESLINT_CONFIG_PATH, 'utf8');
+    const names = ['TIER_2_ENGINES', 'TIER_1_PLUS', 'TIER_2_PLUS', 'TIER_3_PLUS', 'TIER_4'] as const;
+    const defs = new Map<string, string[]>();
+    for (const name of names) {
+      defs.set(name, parseConstantTokens(text, name));
+    }
+
+    const expectations: Array<[string, string[]]> = [
+      ['TIER_2_ENGINES', tierDirs((t) => t === 2)],
+      ['TIER_1_PLUS', tierDirs((t) => t >= 1)],
+      ['TIER_2_PLUS', tierDirs((t) => t >= 2)],
+      ['TIER_3_PLUS', tierDirs((t) => t >= 3)],
+      ['TIER_4', tierDirs((t) => t === 4)],
+    ];
+
+    const errors: string[] = [];
+    for (const [name, expected] of expectations) {
+      const actual = expandTokens(name, defs);
+      errors.push(...diffSets(name, expected, actual));
+    }
+
+    if (errors.length > 0) {
+      throw new Error(
+        `eslint.config.mjs tier constants are out of sync with TIER_MAP ` +
+          `(defined in src/validation/import-graph.ts):\n\n` +
+          errors.map((e) => `  - ${e}`).join('\n') +
+          `\n\nUpdate eslint.config.mjs to mirror TIER_MAP exactly, or update TIER_MAP if ` +
+          `the architecture intentionally changed. The architecture ratchet is the source of ` +
+          `truth; eslint provides faster editor-time feedback on the same boundaries.`
+      );
+    }
+  });
+
+  it('tierBoundaryConfig source-dir lists collectively cover every TIER_MAP directory', () => {
+    const text = fs.readFileSync(ESLINT_CONFIG_PATH, 'utf8');
+    // Capture the first argument array of each tierBoundaryConfig call.
+    // The TIER_2_ENGINES.map(...) call has `[engine]` (an identifier, no
+    // string literals), so it contributes nothing here — TIER_2_ENGINES
+    // sync is verified separately.
+    const callRe = /tierBoundaryConfig\(\s*\[([^\]]*)\]/g;
+    const directDirs = new Set<string>();
+    let callMatch: RegExpExecArray | null;
+    while ((callMatch = callRe.exec(text)) !== null) {
+      const body = callMatch[1]!;
+      const stringRe = /['"]([^'"]+)['"]/g;
+      let sm: RegExpExecArray | null;
+      while ((sm = stringRe.exec(body)) !== null) {
+        directDirs.add(sm[1]!);
+      }
+    }
+
+    // What we expect those calls to cover, in total: every TIER_MAP dir
+    // that isn't a Tier 2 engine (those are spread in via .map).
+    const expectedDirect = tierDirs((t) => t !== 2);
+    const errors = diffSets('tierBoundaryConfig source dirs', expectedDirect, [...directDirs]);
+
+    if (errors.length > 0) {
+      throw new Error(
+        `eslint.config.mjs tierBoundaryConfig calls do not cover every TIER_MAP directory:\n\n` +
+          errors.map((e) => `  - ${e}`).join('\n') +
+          `\n\nEach directory in TIER_MAP must be the source of a tierBoundaryConfig call at ` +
+          `its tier level (Tier 2 engines come from TIER_2_ENGINES.map). A missing entry means ` +
+          `files in that directory get no ESLint tier enforcement.`
+      );
+    }
+  });
+
+  it('flags a divergent set when the parser is fed a doctored constant', () => {
+    const fakeConfig = `
+      const TIER_2_ENGINES = ['context-engine', 'docs-retrieval'];
+      const TIER_1_PLUS = ['lib', ...TIER_2_ENGINES];
+    `;
+    const defs = new Map<string, string[]>();
+    defs.set('TIER_2_ENGINES', parseConstantTokens(fakeConfig, 'TIER_2_ENGINES'));
+    defs.set('TIER_1_PLUS', parseConstantTokens(fakeConfig, 'TIER_1_PLUS'));
+
+    const actual = expandTokens('TIER_2_ENGINES', defs);
+    const errors = diffSets('TIER_2_ENGINES', tierDirs((t) => t === 2), actual);
+    // Real TIER_MAP has 7 engines, fake config has 2 → expect errors mentioning the missing ones
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => e.includes('`hooks`'))).toBe(true);
+  });
+});
+
 describe('Tier documentation sync', () => {
   const docs: Array<[string, string]> = [
     ['AGENTS.md', path.join(REPO_ROOT, 'AGENTS.md')],

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -24,6 +24,7 @@ import {
   assertRatchet,
   getAllFileImports,
   getRootLevelSourceFiles,
+  getSourceTier,
   getTargetTopLevel,
   isTestFile,
   resolveImportToRelative,
@@ -48,13 +49,10 @@ interface ResolvedImportContext {
  * - Imports whose resolved path has no extractable top-level directory
  *
  * Root-level files (e.g. module.tsx) are included but have
- * topLevelDir=null, so callbacks must handle that case.
- *
- * Known limitation: root-level files' imports are invisible to tier
- * enforcement because all three constraint callbacks return null when
- * topLevelDir is null. Today only module.tsx and constants.ts live at
- * root, so the practical risk is low. If root-level files proliferate,
- * consider assigning them explicit tiers via a parallel map.
+ * topLevelDir=null. The vertical-tier callback uses getSourceTier() to
+ * resolve the source tier via ROOT_LEVEL_TIER_MAP for those files; the
+ * lateral and barrel callbacks remain a no-op for root files because
+ * those constraints don't apply to non-engine source files.
  */
 function collectViolations(getViolationKey: (ctx: ResolvedImportContext) => string | null): Set<string> {
   const allFiles = getAllFileImports();
@@ -175,16 +173,18 @@ describe('Tier map completeness', () => {
     if (unaccounted.length > 0) {
       throw new Error(
         `Unaccounted root-level source files in src/: ${unaccounted.join(', ')}\n\n` +
-          `Root-level files are a deliberate exception and must be explicitly reviewed. ` +
-          `Add new root-level files to ROOT_LEVEL_ALLOWED_FILES in src/validation/import-graph.ts ` +
-          `with a comment describing why they are allowed to live at src root.`
+          `Root-level files bypass top-level tier enforcement, so each one must be explicitly ` +
+          `tiered. Add an entry to ROOT_LEVEL_TIER_MAP in src/validation/import-graph.ts mapping ` +
+          `the file to its tier number (matching the TIER_MAP scale: 0 = types/constants, ` +
+          `1 = support, 2 = engines, 3 = integrations, 4 = UI). ROOT_LEVEL_ALLOWED_FILES is ` +
+          `derived from that map, so a single tier assignment covers both checks.`
       );
     }
 
     const staleEntries = [...ROOT_LEVEL_ALLOWED_FILES].filter((entry) => !rootLevelSourceFiles.includes(entry));
     if (staleEntries.length > 0) {
       throw new Error(
-        `Stale entries in ROOT_LEVEL_ALLOWED_FILES (file no longer exists — remove the entry):\n` +
+        `Stale entries in ROOT_LEVEL_TIER_MAP (file no longer exists — remove the entry):\n` +
           staleEntries.map((entry) => `  - ${entry}`).join('\n')
       );
     }
@@ -194,11 +194,7 @@ describe('Tier map completeness', () => {
 describe('Import graph: vertical tier enforcement', () => {
   it('should not contain upward-tier imports beyond the ratchet allowlist', () => {
     const violations = collectViolations(({ relPath, topLevelDir, targetTopLevel }) => {
-      if (!topLevelDir) {
-        return null;
-      }
-
-      const sourceTier = TIER_MAP[topLevelDir];
+      const sourceTier = getSourceTier(relPath, topLevelDir);
       const targetTier = TIER_MAP[targetTopLevel];
       if (sourceTier === undefined || targetTier === undefined || targetTier <= sourceTier) {
         return null;

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -458,6 +458,8 @@ function diffExcludedSets(label: string, docExcluded: Set<string>): string[] {
 
 const ESLINT_CONFIG_PATH = path.join(REPO_ROOT, 'eslint.config.mjs');
 
+// Assumes flat string arrays — `[ 'a', 'b', ...OTHER ]`. Trailing `];` inside a
+// comment or a nested bracket would derail the non-greedy match.
 function parseConstantTokens(text: string, varName: string): string[] {
   const blockRe = new RegExp(`const\\s+${varName}\\s*=\\s*\\[([\\s\\S]*?)\\];`);
   const match = blockRe.exec(text);
@@ -652,25 +654,56 @@ describe('Tier documentation sync', () => {
 // ---------------------------------------------------------------------------
 //
 // The import-graph scanner only resolves relative specifiers. If
-// tsconfig.compilerOptions.paths is ever populated, aliased imports would
-// silently bypass tier enforcement. Fail loudly the moment paths appears
-// so whoever introduces it extends the scanner first.
+// tsconfig.compilerOptions.paths is ever populated — or if baseUrl is
+// widened beyond the scaffolded baseline — aliased / bare-rooted imports
+// would silently bypass tier enforcement. Fail loudly the moment either
+// appears so whoever introduces it extends the scanner first.
+//
+// KNOWN_BASELINE_BASE_URL documents the pre-existing blind spot: the
+// scaffolded `.config/tsconfig.json` sets baseUrl="../src", which lets
+// bare specifiers like `import x from 'lib/foo'` resolve against src/.
+// These are already invisible to extractRelativeImports. Treating the
+// baseline as known (rather than failing now) keeps the tripwire shippable
+// while still catching any further widening.
+
+const KNOWN_BASELINE_BASE_URL: Record<string, string> = {
+  '.config/tsconfig.json': '../src',
+};
 
 describe('TS path-alias tripwire', () => {
   const tsconfigs = [path.join(REPO_ROOT, 'tsconfig.json'), path.join(REPO_ROOT, '.config', 'tsconfig.json')];
 
-  it.each(tsconfigs)('%s declares no compilerOptions.paths', (tsconfigPath) => {
+  it.each(tsconfigs)('%s declares no compilerOptions.paths or new baseUrl', (tsconfigPath) => {
     const text = fs.readFileSync(tsconfigPath, 'utf-8');
     const stripped = text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
-    const parsed = JSON.parse(stripped) as { compilerOptions?: { paths?: Record<string, unknown> } };
+    const parsed = JSON.parse(stripped) as {
+      compilerOptions?: { paths?: Record<string, unknown>; baseUrl?: string };
+    };
+    const relPath = toPosixPath(path.relative(REPO_ROOT, tsconfigPath));
     const paths = parsed.compilerOptions?.paths ?? {};
+    const baseUrl = parsed.compilerOptions?.baseUrl;
 
     if (Object.keys(paths).length > 0) {
       throw new Error(
-        `${path.relative(REPO_ROOT, tsconfigPath)} declares compilerOptions.paths, but the ` +
+        `${relPath} declares compilerOptions.paths, but the ` +
           `import-graph scanner in src/validation/import-graph.ts only resolves relative ` +
           `specifiers. Aliased imports would silently bypass tier enforcement. Extend the ` +
           `scanner to resolve tsconfig.paths before merging this change.`
+      );
+    }
+
+    if (baseUrl !== undefined && baseUrl !== KNOWN_BASELINE_BASE_URL[relPath]) {
+      const baseline = KNOWN_BASELINE_BASE_URL[relPath];
+      const baselineNote = baseline
+        ? `Known baseline for ${relPath} is "${baseline}"; this file declares "${baseUrl}".`
+        : `No baseline is registered for ${relPath}.`;
+      throw new Error(
+        `${relPath} declares compilerOptions.baseUrl="${baseUrl}", which lets bare specifiers ` +
+          `like \`import x from 'lib/foo'\` resolve against the baseUrl root. The import-graph ` +
+          `scanner in src/validation/import-graph.ts only resolves relative specifiers, so these ` +
+          `imports would silently bypass tier enforcement. ${baselineNote} Either extend the ` +
+          `scanner to resolve baseUrl-rooted specifiers, or update KNOWN_BASELINE_BASE_URL in ` +
+          `architecture.test.ts if this change is deliberate.`
       );
     }
   });

--- a/src/validation/import-graph.test.ts
+++ b/src/validation/import-graph.test.ts
@@ -5,19 +5,15 @@
  * ensuring the boundary enforcement logic itself is correct.
  */
 
-import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 
 import {
-  AliasConfig,
   ROOT_LEVEL_ALLOWED_FILES,
   ROOT_LEVEL_TIER_MAP,
   SRC_DIR,
   TIER_MAP,
   TIER_2_ENGINES,
   EXCLUDED_TOP_LEVEL,
-  extractBareImports,
   extractRelativeImports,
   getNewViolations,
   getRootLevelSourceFiles,
@@ -28,9 +24,6 @@ import {
   isTestFile,
   assertRatchet,
   collectSourceFiles,
-  loadAliasConfig,
-  resetCache,
-  resolveAliasedSpecifierWithConfig,
   resolveImportToRelative,
   toPosixPath,
 } from './import-graph';
@@ -109,172 +102,6 @@ describe('extractRelativeImports', () => {
       `import { real } from './actual';`,
     ].join('\n');
     expect(extractRelativeImports(content)).toEqual(['./actual']);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// extractBareImports
-// ---------------------------------------------------------------------------
-
-describe('extractBareImports', () => {
-  it('extracts node_modules specifiers', () => {
-    const content = `import React from 'react';\nimport { css } from '@emotion/css';`;
-    const result = extractBareImports(content);
-    expect(result).toContain('react');
-    expect(result).toContain('@emotion/css');
-  });
-
-  it('extracts alias-style specifiers', () => {
-    const content = `import x from '@components/foo';\nimport y from '@/lib/bar';`;
-    const result = extractBareImports(content);
-    expect(result).toContain('@components/foo');
-    expect(result).toContain('@/lib/bar');
-  });
-
-  it('ignores relative imports', () => {
-    const content = [`import { a } from './local';`, `import { b } from '../parent';`, `import c from 'react';`].join(
-      '\n'
-    );
-    expect(extractBareImports(content)).toEqual(['react']);
-  });
-
-  it('extracts bare require() and dynamic import() specifiers', () => {
-    const content = [`const x = require('rxjs');`, `const y = await import('lodash');`].join('\n');
-    const result = extractBareImports(content);
-    expect(result).toContain('rxjs');
-    expect(result).toContain('lodash');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// TypeScript path-alias resolution
-// ---------------------------------------------------------------------------
-
-describe('resolveAliasedSpecifierWithConfig', () => {
-  const config: AliasConfig = {
-    baseDir: SRC_DIR,
-    patterns: [
-      {
-        prefix: '@components/',
-        suffix: '',
-        hasWildcard: true,
-        replacements: [{ prefix: 'components/', suffix: '' }],
-      },
-      {
-        prefix: '@lib/',
-        suffix: '',
-        hasWildcard: true,
-        replacements: [{ prefix: 'lib/', suffix: '' }],
-      },
-      {
-        prefix: '@types-root',
-        suffix: '',
-        hasWildcard: false,
-        replacements: [{ prefix: 'types/index', suffix: '' }],
-      },
-    ],
-  };
-
-  it('resolves a wildcard alias to a src-relative path', () => {
-    expect(resolveAliasedSpecifierWithConfig('@components/foo/bar', config)).toBe('components/foo/bar');
-  });
-
-  it('returns posix-separator paths even with nested wildcard values', () => {
-    expect(resolveAliasedSpecifierWithConfig('@lib/analytics/events', config)).toBe('lib/analytics/events');
-  });
-
-  it('resolves an exact (non-wildcard) alias', () => {
-    expect(resolveAliasedSpecifierWithConfig('@types-root', config)).toBe('types/index');
-  });
-
-  it('returns null for specifiers that match no alias pattern', () => {
-    expect(resolveAliasedSpecifierWithConfig('react', config)).toBeNull();
-    expect(resolveAliasedSpecifierWithConfig('@grafana/data', config)).toBeNull();
-  });
-
-  it('returns null when the resolved path escapes SRC_DIR', () => {
-    const escapingConfig: AliasConfig = {
-      baseDir: SRC_DIR,
-      patterns: [
-        {
-          prefix: '@external/',
-          suffix: '',
-          hasWildcard: true,
-          replacements: [{ prefix: '../node_modules/', suffix: '' }],
-        },
-      ],
-    };
-    expect(resolveAliasedSpecifierWithConfig('@external/some-pkg', escapingConfig)).toBeNull();
-  });
-
-  it('requires the wildcard portion to be non-empty', () => {
-    // "@components/" is the prefix; "@components/" alone has nothing in the * slot.
-    expect(resolveAliasedSpecifierWithConfig('@components/', config)).toBeNull();
-  });
-});
-
-describe('loadAliasConfig', () => {
-  let tmpDir: string;
-
-  beforeEach(() => {
-    resetCache();
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pathfinder-alias-'));
-  });
-
-  afterEach(() => {
-    resetCache();
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  function writeTsconfig(contents: object | string): string {
-    const filePath = path.join(tmpDir, 'tsconfig.json');
-    fs.writeFileSync(filePath, typeof contents === 'string' ? contents : JSON.stringify(contents));
-    return filePath;
-  }
-
-  it('returns null when tsconfig has no paths field', () => {
-    const filePath = writeTsconfig({ compilerOptions: { baseUrl: '.' } });
-    expect(loadAliasConfig(filePath)).toBeNull();
-  });
-
-  it('returns null when paths is empty', () => {
-    const filePath = writeTsconfig({ compilerOptions: { baseUrl: '.', paths: {} } });
-    expect(loadAliasConfig(filePath)).toBeNull();
-  });
-
-  it('parses wildcard alias patterns', () => {
-    const filePath = writeTsconfig({
-      compilerOptions: {
-        baseUrl: '../src',
-        paths: { '@components/*': ['components/*'] },
-      },
-    });
-    const config = loadAliasConfig(filePath);
-    expect(config).not.toBeNull();
-    expect(config!.patterns).toHaveLength(1);
-    const pattern = config!.patterns[0]!;
-    expect(pattern.hasWildcard).toBe(true);
-    expect(pattern.prefix).toBe('@components/');
-    expect(pattern.suffix).toBe('');
-    expect(pattern.replacements).toEqual([{ prefix: 'components/', suffix: '' }]);
-  });
-
-  it('tolerates JSONC (comments) in tsconfig files', () => {
-    const filePath = writeTsconfig(`{
-      // a leading line comment
-      "compilerOptions": {
-        /* block comment */
-        "baseUrl": ".",
-        "paths": { "@x/*": ["x/*"] }
-      }
-    }`);
-    const config = loadAliasConfig(filePath);
-    expect(config).not.toBeNull();
-    expect(config!.patterns[0]!.prefix).toBe('@x/');
-  });
-
-  it('returns null when the tsconfig file is missing', () => {
-    expect(loadAliasConfig(path.join(tmpDir, 'missing.json'))).toBeNull();
   });
 });
 

--- a/src/validation/import-graph.test.ts
+++ b/src/validation/import-graph.test.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 
 import {
   ROOT_LEVEL_ALLOWED_FILES,
+  ROOT_LEVEL_TIER_MAP,
   SRC_DIR,
   TIER_MAP,
   TIER_2_ENGINES,
@@ -18,6 +19,7 @@ import {
   extractRelativeImports,
   resolveImportToRelative,
   getTargetTopLevel,
+  getSourceTier,
   collectSourceFiles,
   getRootLevelSourceFiles,
   toPosixPath,
@@ -206,6 +208,33 @@ describe('getTargetTopLevel', () => {
 });
 
 // ---------------------------------------------------------------------------
+// getSourceTier
+// ---------------------------------------------------------------------------
+
+describe('getSourceTier', () => {
+  it('returns the TIER_MAP tier for a file in a known top-level directory', () => {
+    expect(getSourceTier('lib/foo.ts', 'lib')).toBe(TIER_MAP['lib']);
+  });
+
+  it('returns the TIER_MAP tier regardless of file path depth', () => {
+    expect(getSourceTier('components/nested/deeply/widget.tsx', 'components')).toBe(TIER_MAP['components']);
+  });
+
+  it('returns the ROOT_LEVEL_TIER_MAP tier for a root-level file', () => {
+    expect(getSourceTier('module.tsx', null)).toBe(ROOT_LEVEL_TIER_MAP['module.tsx']);
+    expect(getSourceTier('constants.ts', null)).toBe(ROOT_LEVEL_TIER_MAP['constants.ts']);
+  });
+
+  it('returns undefined for an unknown top-level directory', () => {
+    expect(getSourceTier('phantom/foo.ts', 'phantom')).toBeUndefined();
+  });
+
+  it('returns undefined for an unknown root-level file', () => {
+    expect(getSourceTier('helpers.ts', null)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // TIER_MAP / TIER_2_ENGINES / EXCLUDED_TOP_LEVEL consistency
 // ---------------------------------------------------------------------------
 
@@ -226,6 +255,17 @@ describe('architecture constants', () => {
     const rootLevelSourceFiles = getRootLevelSourceFiles();
     const invalidEntries = [...ROOT_LEVEL_ALLOWED_FILES].filter((file) => !rootLevelSourceFiles.includes(file));
     expect(invalidEntries).toEqual([]);
+  });
+
+  it('ROOT_LEVEL_ALLOWED_FILES is derived from ROOT_LEVEL_TIER_MAP (single source of truth)', () => {
+    expect([...ROOT_LEVEL_ALLOWED_FILES].sort()).toEqual(Object.keys(ROOT_LEVEL_TIER_MAP).sort());
+  });
+
+  it('every ROOT_LEVEL_TIER_MAP tier is a valid tier in TIER_MAP', () => {
+    const validTiers = new Set(Object.values(TIER_MAP));
+    for (const [file, tier] of Object.entries(ROOT_LEVEL_TIER_MAP)) {
+      expect({ file, tier, isValid: validTiers.has(tier) }).toEqual({ file, tier, isValid: true });
+    }
   });
 });
 

--- a/src/validation/import-graph.test.ts
+++ b/src/validation/import-graph.test.ts
@@ -132,11 +132,9 @@ describe('extractBareImports', () => {
   });
 
   it('ignores relative imports', () => {
-    const content = [
-      `import { a } from './local';`,
-      `import { b } from '../parent';`,
-      `import c from 'react';`,
-    ].join('\n');
+    const content = [`import { a } from './local';`, `import { b } from '../parent';`, `import c from 'react';`].join(
+      '\n'
+    );
     expect(extractBareImports(content)).toEqual(['react']);
   });
 

--- a/src/validation/import-graph.test.ts
+++ b/src/validation/import-graph.test.ts
@@ -5,27 +5,34 @@
  * ensuring the boundary enforcement logic itself is correct.
  */
 
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 import {
+  AliasConfig,
   ROOT_LEVEL_ALLOWED_FILES,
   ROOT_LEVEL_TIER_MAP,
   SRC_DIR,
   TIER_MAP,
   TIER_2_ENGINES,
   EXCLUDED_TOP_LEVEL,
-  isTestFile,
-  getTopLevelDir,
+  extractBareImports,
   extractRelativeImports,
-  resolveImportToRelative,
-  getTargetTopLevel,
-  getSourceTier,
-  collectSourceFiles,
-  getRootLevelSourceFiles,
-  toPosixPath,
   getNewViolations,
+  getRootLevelSourceFiles,
+  getSourceTier,
   getStaleEntries,
+  getTargetTopLevel,
+  getTopLevelDir,
+  isTestFile,
   assertRatchet,
+  collectSourceFiles,
+  loadAliasConfig,
+  resetCache,
+  resolveAliasedSpecifierWithConfig,
+  resolveImportToRelative,
+  toPosixPath,
 } from './import-graph';
 
 // ---------------------------------------------------------------------------
@@ -102,6 +109,174 @@ describe('extractRelativeImports', () => {
       `import { real } from './actual';`,
     ].join('\n');
     expect(extractRelativeImports(content)).toEqual(['./actual']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractBareImports
+// ---------------------------------------------------------------------------
+
+describe('extractBareImports', () => {
+  it('extracts node_modules specifiers', () => {
+    const content = `import React from 'react';\nimport { css } from '@emotion/css';`;
+    const result = extractBareImports(content);
+    expect(result).toContain('react');
+    expect(result).toContain('@emotion/css');
+  });
+
+  it('extracts alias-style specifiers', () => {
+    const content = `import x from '@components/foo';\nimport y from '@/lib/bar';`;
+    const result = extractBareImports(content);
+    expect(result).toContain('@components/foo');
+    expect(result).toContain('@/lib/bar');
+  });
+
+  it('ignores relative imports', () => {
+    const content = [
+      `import { a } from './local';`,
+      `import { b } from '../parent';`,
+      `import c from 'react';`,
+    ].join('\n');
+    expect(extractBareImports(content)).toEqual(['react']);
+  });
+
+  it('extracts bare require() and dynamic import() specifiers', () => {
+    const content = [`const x = require('rxjs');`, `const y = await import('lodash');`].join('\n');
+    const result = extractBareImports(content);
+    expect(result).toContain('rxjs');
+    expect(result).toContain('lodash');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TypeScript path-alias resolution
+// ---------------------------------------------------------------------------
+
+describe('resolveAliasedSpecifierWithConfig', () => {
+  const config: AliasConfig = {
+    baseDir: SRC_DIR,
+    patterns: [
+      {
+        prefix: '@components/',
+        suffix: '',
+        hasWildcard: true,
+        replacements: [{ prefix: 'components/', suffix: '' }],
+      },
+      {
+        prefix: '@lib/',
+        suffix: '',
+        hasWildcard: true,
+        replacements: [{ prefix: 'lib/', suffix: '' }],
+      },
+      {
+        prefix: '@types-root',
+        suffix: '',
+        hasWildcard: false,
+        replacements: [{ prefix: 'types/index', suffix: '' }],
+      },
+    ],
+  };
+
+  it('resolves a wildcard alias to a src-relative path', () => {
+    expect(resolveAliasedSpecifierWithConfig('@components/foo/bar', config)).toBe('components/foo/bar');
+  });
+
+  it('returns posix-separator paths even with nested wildcard values', () => {
+    expect(resolveAliasedSpecifierWithConfig('@lib/analytics/events', config)).toBe('lib/analytics/events');
+  });
+
+  it('resolves an exact (non-wildcard) alias', () => {
+    expect(resolveAliasedSpecifierWithConfig('@types-root', config)).toBe('types/index');
+  });
+
+  it('returns null for specifiers that match no alias pattern', () => {
+    expect(resolveAliasedSpecifierWithConfig('react', config)).toBeNull();
+    expect(resolveAliasedSpecifierWithConfig('@grafana/data', config)).toBeNull();
+  });
+
+  it('returns null when the resolved path escapes SRC_DIR', () => {
+    const escapingConfig: AliasConfig = {
+      baseDir: SRC_DIR,
+      patterns: [
+        {
+          prefix: '@external/',
+          suffix: '',
+          hasWildcard: true,
+          replacements: [{ prefix: '../node_modules/', suffix: '' }],
+        },
+      ],
+    };
+    expect(resolveAliasedSpecifierWithConfig('@external/some-pkg', escapingConfig)).toBeNull();
+  });
+
+  it('requires the wildcard portion to be non-empty', () => {
+    // "@components/" is the prefix; "@components/" alone has nothing in the * slot.
+    expect(resolveAliasedSpecifierWithConfig('@components/', config)).toBeNull();
+  });
+});
+
+describe('loadAliasConfig', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    resetCache();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pathfinder-alias-'));
+  });
+
+  afterEach(() => {
+    resetCache();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeTsconfig(contents: object | string): string {
+    const filePath = path.join(tmpDir, 'tsconfig.json');
+    fs.writeFileSync(filePath, typeof contents === 'string' ? contents : JSON.stringify(contents));
+    return filePath;
+  }
+
+  it('returns null when tsconfig has no paths field', () => {
+    const filePath = writeTsconfig({ compilerOptions: { baseUrl: '.' } });
+    expect(loadAliasConfig(filePath)).toBeNull();
+  });
+
+  it('returns null when paths is empty', () => {
+    const filePath = writeTsconfig({ compilerOptions: { baseUrl: '.', paths: {} } });
+    expect(loadAliasConfig(filePath)).toBeNull();
+  });
+
+  it('parses wildcard alias patterns', () => {
+    const filePath = writeTsconfig({
+      compilerOptions: {
+        baseUrl: '../src',
+        paths: { '@components/*': ['components/*'] },
+      },
+    });
+    const config = loadAliasConfig(filePath);
+    expect(config).not.toBeNull();
+    expect(config!.patterns).toHaveLength(1);
+    const pattern = config!.patterns[0]!;
+    expect(pattern.hasWildcard).toBe(true);
+    expect(pattern.prefix).toBe('@components/');
+    expect(pattern.suffix).toBe('');
+    expect(pattern.replacements).toEqual([{ prefix: 'components/', suffix: '' }]);
+  });
+
+  it('tolerates JSONC (comments) in tsconfig files', () => {
+    const filePath = writeTsconfig(`{
+      // a leading line comment
+      "compilerOptions": {
+        /* block comment */
+        "baseUrl": ".",
+        "paths": { "@x/*": ["x/*"] }
+      }
+    }`);
+    const config = loadAliasConfig(filePath);
+    expect(config).not.toBeNull();
+    expect(config!.patterns[0]!.prefix).toBe('@x/');
+  });
+
+  it('returns null when the tsconfig file is missing', () => {
+    expect(loadAliasConfig(path.join(tmpDir, 'missing.json'))).toBeNull();
   });
 });
 

--- a/src/validation/import-graph.ts
+++ b/src/validation/import-graph.ts
@@ -46,17 +46,10 @@ export const TIER_2_ENGINES = Object.entries(TIER_MAP)
 export const EXCLUDED_TOP_LEVEL = new Set(['test-utils', 'cli', 'bundled-interactives', 'img', 'locales']);
 
 /**
- * Root-level src/ files with their assigned tiers.
- *
- * Files in src root have `topLevelDir === null` and would otherwise bypass
- * tier enforcement. Assigning each an explicit tier closes that gap (F-6).
- * Every entry must also appear in ROOT_LEVEL_ALLOWED_FILES — the sync is
- * locked by a unit test in import-graph.test.ts.
- *
- * Tier assignments here follow the same semantics as TIER_MAP: a file may
- * import from its own tier or lower. `module.tsx` is the plugin entrypoint
- * and legitimately reaches into pages/integrations (Tier 3/4), so it gets
- * Tier 4. `constants.ts` is pure data and lives at Tier 0.
+ * Root-level src/ files have `topLevelDir === null` and would otherwise
+ * bypass tier enforcement. Each entry gets an explicit tier so the vertical
+ * check can resolve a source tier for them. `module.tsx` is the plugin
+ * entrypoint and legitimately reaches into pages/integrations, so Tier 4.
  */
 export const ROOT_LEVEL_TIER_MAP: Record<string, number> = {
   'constants.ts': 0,
@@ -111,15 +104,7 @@ export interface FileImports {
   file: string;
   relPath: string;
   topLevelDir: string | null;
-  /** Raw relative specifiers (e.g. "./foo", "../lib/bar"). Resolve with resolveImportToRelative(). */
   imports: string[];
-  /**
-   * Bare/aliased specifiers (e.g. "@components/foo") already resolved to
-   * src-relative paths via tsconfig.paths. Empty when no aliases are
-   * configured. Downstream callers treat these identically to resolved
-   * relative imports.
-   */
-  resolvedAliasImports: string[];
 }
 
 /**
@@ -136,9 +121,7 @@ export function getTopLevelDir(relPath: string): string | null {
   return segments[0] ?? null;
 }
 
-const isRelativeSpecifier = (value: string): boolean => value.startsWith('./') || value.startsWith('../');
-
-function extractImportSpecifiers(content: string, filter: (specifier: string) => boolean): string[] {
+export function extractRelativeImports(content: string): string[] {
   const specifiers = new Set<string>();
   const sourceFile = ts.createSourceFile(
     'import-graph-input.tsx',
@@ -148,8 +131,9 @@ function extractImportSpecifiers(content: string, filter: (specifier: string) =>
     ts.ScriptKind.TSX
   );
 
-  const addIfMatch = (value: string): void => {
-    if (filter(value)) {
+  const isRelativeSpecifier = (value: string): boolean => value.startsWith('./') || value.startsWith('../');
+  const addIfRelative = (value: string): void => {
+    if (isRelativeSpecifier(value)) {
       specifiers.add(value);
     }
   };
@@ -160,7 +144,7 @@ function extractImportSpecifiers(content: string, filter: (specifier: string) =>
       node.moduleSpecifier &&
       ts.isStringLiteralLike(node.moduleSpecifier)
     ) {
-      addIfMatch(node.moduleSpecifier.text);
+      addIfRelative(node.moduleSpecifier.text);
     }
 
     if (ts.isCallExpression(node)) {
@@ -171,9 +155,9 @@ function extractImportSpecifiers(content: string, filter: (specifier: string) =>
       }
 
       if (ts.isIdentifier(node.expression) && node.expression.text === 'require') {
-        addIfMatch(firstArg.text);
+        addIfRelative(firstArg.text);
       } else if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
-        addIfMatch(firstArg.text);
+        addIfRelative(firstArg.text);
       }
     }
 
@@ -183,14 +167,6 @@ function extractImportSpecifiers(content: string, filter: (specifier: string) =>
   visit(sourceFile);
 
   return [...specifiers];
-}
-
-export function extractRelativeImports(content: string): string[] {
-  return extractImportSpecifiers(content, isRelativeSpecifier);
-}
-
-export function extractBareImports(content: string): string[] {
-  return extractImportSpecifiers(content, (s) => !isRelativeSpecifier(s));
 }
 
 export function resolveImportToRelative(fileDir: string, importPath: string): string | null {
@@ -208,20 +184,11 @@ export function getTargetTopLevel(resolvedRelative: string): string | null {
   return segments[0] ?? null;
 }
 
-/**
- * Returns the tier number for an import-graph source file.
- *
- * For files inside a top-level directory, looks up TIER_MAP[topLevelDir].
- * For root-level files (topLevelDir === null), looks up ROOT_LEVEL_TIER_MAP
- * by the file's basename (e.g. "module.tsx"). Returns undefined when no
- * tier is assigned — callers should treat that as "skip this file".
- */
 export function getSourceTier(relPath: string, topLevelDir: string | null): number | undefined {
   if (topLevelDir !== null) {
     return TIER_MAP[topLevelDir];
   }
-  const basename = toPosixPath(relPath);
-  return ROOT_LEVEL_TIER_MAP[basename];
+  return ROOT_LEVEL_TIER_MAP[toPosixPath(relPath)];
 }
 
 let cachedFileImports: FileImports[] | undefined;
@@ -230,19 +197,13 @@ export function getAllFileImports(): FileImports[] {
   if (cachedFileImports) {
     return cachedFileImports;
   }
-  const aliasConfig = loadAliasConfig();
   const files = collectSourceFiles();
   cachedFileImports = files.map((file) => {
     const relPath = toPosixPath(path.relative(SRC_DIR, file));
     const topLevelDir = getTopLevelDir(relPath);
     const content = fs.readFileSync(file, 'utf-8');
     const imports = extractRelativeImports(content);
-    const resolvedAliasImports = aliasConfig
-      ? extractBareImports(content)
-          .map((spec) => resolveAliasedSpecifierWithConfig(spec, aliasConfig))
-          .filter((v): v is string => v !== null)
-      : [];
-    return { file, relPath, topLevelDir, imports, resolvedAliasImports };
+    return { file, relPath, topLevelDir, imports };
   });
   return cachedFileImports;
 }
@@ -250,137 +211,6 @@ export function getAllFileImports(): FileImports[] {
 /** Reset the cached file imports. Useful for testing. */
 export function resetCache(): void {
   cachedFileImports = undefined;
-  aliasConfigCache = undefined;
-}
-
-// ---------------------------------------------------------------------------
-// TypeScript path-alias resolution (B6 — closes F-7)
-// ---------------------------------------------------------------------------
-//
-// The repo's tsconfig has baseUrl set but no `paths` today. If aliases are
-// later added (e.g. `@/components/*` → `components/*`), the relative-only
-// scanner above would silently miss those edges. This block reads
-// tsconfig.compilerOptions.paths and resolves alias specifiers to src-
-// relative paths, the same format the relative resolver produces, so
-// downstream callers (collectViolations) treat both edge sources
-// identically.
-
-interface AliasReplacement {
-  prefix: string;
-  suffix: string;
-}
-
-interface AliasPattern {
-  prefix: string;
-  suffix: string;
-  hasWildcard: boolean;
-  replacements: AliasReplacement[];
-}
-
-export interface AliasConfig {
-  baseDir: string;
-  patterns: AliasPattern[];
-}
-
-const TSCONFIG_PATH = path.resolve(SRC_DIR, '..', '.config', 'tsconfig.json');
-
-let aliasConfigCache: { value: AliasConfig | null } | undefined;
-
-/**
- * Strip C-style and line comments from JSONC content so JSON.parse can
- * read it. Naive but sufficient for tsconfig files, which don't use
- * comment-like sequences inside string literals.
- */
-function stripJsonComments(text: string): string {
-  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
-}
-
-export function loadAliasConfig(tsconfigPath: string = TSCONFIG_PATH): AliasConfig | null {
-  if (aliasConfigCache) {
-    return aliasConfigCache.value;
-  }
-  let parsed: { compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> } };
-  try {
-    parsed = JSON.parse(stripJsonComments(fs.readFileSync(tsconfigPath, 'utf-8')));
-  } catch (err) {
-    aliasConfigCache = { value: null };
-    return null;
-  }
-  const co = parsed.compilerOptions ?? {};
-  const paths = co.paths;
-  if (!paths || Object.keys(paths).length === 0) {
-    aliasConfigCache = { value: null };
-    return null;
-  }
-  const baseUrl = co.baseUrl ?? '.';
-  const baseDir = path.resolve(path.dirname(tsconfigPath), baseUrl);
-  const patterns: AliasPattern[] = Object.entries(paths).map(([pattern, replacements]) => {
-    const hasWildcard = pattern.includes('*');
-    const [prefix, suffix = ''] = pattern.split('*');
-    return {
-      prefix: prefix ?? '',
-      suffix,
-      hasWildcard,
-      replacements: replacements.map((r) => {
-        const [rPrefix, rSuffix = ''] = r.split('*');
-        return { prefix: rPrefix ?? '', suffix: rSuffix };
-      }),
-    };
-  });
-  const config: AliasConfig = { baseDir, patterns };
-  aliasConfigCache = { value: config };
-  return config;
-}
-
-/**
- * Resolve a bare module specifier against an alias config. Returns a
- * src-relative path (POSIX separators) if the specifier matches an
- * alias pattern AND the resolution lands inside SRC_DIR. Returns null
- * otherwise — including when the specifier matches but resolves to a
- * node_modules path (e.g. `@grafana/data`) or escapes SRC_DIR.
- *
- * Pure function suitable for unit tests with synthetic configs.
- */
-export function resolveAliasedSpecifierWithConfig(specifier: string, config: AliasConfig): string | null {
-  for (const pat of config.patterns) {
-    if (pat.hasWildcard) {
-      if (!specifier.startsWith(pat.prefix) || !specifier.endsWith(pat.suffix)) {
-        continue;
-      }
-      if (specifier.length <= pat.prefix.length + pat.suffix.length) {
-        continue;
-      }
-      const wildcardValue = specifier.slice(pat.prefix.length, specifier.length - pat.suffix.length);
-      for (const replacement of pat.replacements) {
-        const resolvedRelative = replacement.prefix + wildcardValue + replacement.suffix;
-        const srcRelative = resolveInsideSrcDir(config.baseDir, resolvedRelative);
-        if (srcRelative !== null) {
-          return srcRelative;
-        }
-      }
-      return null;
-    }
-
-    if (specifier === pat.prefix) {
-      for (const replacement of pat.replacements) {
-        const srcRelative = resolveInsideSrcDir(config.baseDir, replacement.prefix);
-        if (srcRelative !== null) {
-          return srcRelative;
-        }
-      }
-      return null;
-    }
-  }
-  return null;
-}
-
-function resolveInsideSrcDir(baseDir: string, relativeFromBase: string): string | null {
-  const absolute = path.resolve(baseDir, relativeFromBase);
-  const srcRelative = path.relative(SRC_DIR, absolute);
-  if (srcRelative.startsWith('..') || path.isAbsolute(srcRelative)) {
-    return null;
-  }
-  return toPosixPath(srcRelative);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/validation/import-graph.ts
+++ b/src/validation/import-graph.ts
@@ -44,7 +44,27 @@ export const TIER_2_ENGINES = Object.entries(TIER_MAP)
   .map(([dir]) => dir);
 
 export const EXCLUDED_TOP_LEVEL = new Set(['test-utils', 'cli', 'bundled-interactives', 'img', 'locales']);
-export const ROOT_LEVEL_ALLOWED_FILES = new Set(['constants.ts', 'constants.test.ts', 'module.tsx']);
+
+/**
+ * Root-level src/ files with their assigned tiers.
+ *
+ * Files in src root have `topLevelDir === null` and would otherwise bypass
+ * tier enforcement. Assigning each an explicit tier closes that gap (F-6).
+ * Every entry must also appear in ROOT_LEVEL_ALLOWED_FILES — the sync is
+ * locked by a unit test in import-graph.test.ts.
+ *
+ * Tier assignments here follow the same semantics as TIER_MAP: a file may
+ * import from its own tier or lower. `module.tsx` is the plugin entrypoint
+ * and legitimately reaches into pages/integrations (Tier 3/4), so it gets
+ * Tier 4. `constants.ts` is pure data and lives at Tier 0.
+ */
+export const ROOT_LEVEL_TIER_MAP: Record<string, number> = {
+  'constants.ts': 0,
+  'constants.test.ts': 0,
+  'module.tsx': 4,
+};
+
+export const ROOT_LEVEL_ALLOWED_FILES = new Set(Object.keys(ROOT_LEVEL_TIER_MAP));
 
 export function toPosixPath(filePath: string): string {
   return filePath.replace(/\\/g, '/');
@@ -169,6 +189,22 @@ export function getTargetTopLevel(resolvedRelative: string): string | null {
   const segments = toPosixPath(resolvedRelative).split('/');
   // ?? null satisfies noUncheckedIndexedAccess; split() always returns at least one element
   return segments[0] ?? null;
+}
+
+/**
+ * Returns the tier number for an import-graph source file.
+ *
+ * For files inside a top-level directory, looks up TIER_MAP[topLevelDir].
+ * For root-level files (topLevelDir === null), looks up ROOT_LEVEL_TIER_MAP
+ * by the file's basename (e.g. "module.tsx"). Returns undefined when no
+ * tier is assigned — callers should treat that as "skip this file".
+ */
+export function getSourceTier(relPath: string, topLevelDir: string | null): number | undefined {
+  if (topLevelDir !== null) {
+    return TIER_MAP[topLevelDir];
+  }
+  const basename = toPosixPath(relPath);
+  return ROOT_LEVEL_TIER_MAP[basename];
 }
 
 let cachedFileImports: FileImports[] | undefined;

--- a/src/validation/import-graph.ts
+++ b/src/validation/import-graph.ts
@@ -111,7 +111,15 @@ export interface FileImports {
   file: string;
   relPath: string;
   topLevelDir: string | null;
+  /** Raw relative specifiers (e.g. "./foo", "../lib/bar"). Resolve with resolveImportToRelative(). */
   imports: string[];
+  /**
+   * Bare/aliased specifiers (e.g. "@components/foo") already resolved to
+   * src-relative paths via tsconfig.paths. Empty when no aliases are
+   * configured. Downstream callers treat these identically to resolved
+   * relative imports.
+   */
+  resolvedAliasImports: string[];
 }
 
 /**
@@ -128,7 +136,9 @@ export function getTopLevelDir(relPath: string): string | null {
   return segments[0] ?? null;
 }
 
-export function extractRelativeImports(content: string): string[] {
+const isRelativeSpecifier = (value: string): boolean => value.startsWith('./') || value.startsWith('../');
+
+function extractImportSpecifiers(content: string, filter: (specifier: string) => boolean): string[] {
   const specifiers = new Set<string>();
   const sourceFile = ts.createSourceFile(
     'import-graph-input.tsx',
@@ -138,9 +148,8 @@ export function extractRelativeImports(content: string): string[] {
     ts.ScriptKind.TSX
   );
 
-  const isRelativeSpecifier = (value: string): boolean => value.startsWith('./') || value.startsWith('../');
-  const addIfRelative = (value: string): void => {
-    if (isRelativeSpecifier(value)) {
+  const addIfMatch = (value: string): void => {
+    if (filter(value)) {
       specifiers.add(value);
     }
   };
@@ -151,7 +160,7 @@ export function extractRelativeImports(content: string): string[] {
       node.moduleSpecifier &&
       ts.isStringLiteralLike(node.moduleSpecifier)
     ) {
-      addIfRelative(node.moduleSpecifier.text);
+      addIfMatch(node.moduleSpecifier.text);
     }
 
     if (ts.isCallExpression(node)) {
@@ -162,9 +171,9 @@ export function extractRelativeImports(content: string): string[] {
       }
 
       if (ts.isIdentifier(node.expression) && node.expression.text === 'require') {
-        addIfRelative(firstArg.text);
+        addIfMatch(firstArg.text);
       } else if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
-        addIfRelative(firstArg.text);
+        addIfMatch(firstArg.text);
       }
     }
 
@@ -174,6 +183,14 @@ export function extractRelativeImports(content: string): string[] {
   visit(sourceFile);
 
   return [...specifiers];
+}
+
+export function extractRelativeImports(content: string): string[] {
+  return extractImportSpecifiers(content, isRelativeSpecifier);
+}
+
+export function extractBareImports(content: string): string[] {
+  return extractImportSpecifiers(content, (s) => !isRelativeSpecifier(s));
 }
 
 export function resolveImportToRelative(fileDir: string, importPath: string): string | null {
@@ -213,13 +230,19 @@ export function getAllFileImports(): FileImports[] {
   if (cachedFileImports) {
     return cachedFileImports;
   }
+  const aliasConfig = loadAliasConfig();
   const files = collectSourceFiles();
   cachedFileImports = files.map((file) => {
     const relPath = toPosixPath(path.relative(SRC_DIR, file));
     const topLevelDir = getTopLevelDir(relPath);
     const content = fs.readFileSync(file, 'utf-8');
     const imports = extractRelativeImports(content);
-    return { file, relPath, topLevelDir, imports };
+    const resolvedAliasImports = aliasConfig
+      ? extractBareImports(content)
+          .map((spec) => resolveAliasedSpecifierWithConfig(spec, aliasConfig))
+          .filter((v): v is string => v !== null)
+      : [];
+    return { file, relPath, topLevelDir, imports, resolvedAliasImports };
   });
   return cachedFileImports;
 }
@@ -227,6 +250,137 @@ export function getAllFileImports(): FileImports[] {
 /** Reset the cached file imports. Useful for testing. */
 export function resetCache(): void {
   cachedFileImports = undefined;
+  aliasConfigCache = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// TypeScript path-alias resolution (B6 — closes F-7)
+// ---------------------------------------------------------------------------
+//
+// The repo's tsconfig has baseUrl set but no `paths` today. If aliases are
+// later added (e.g. `@/components/*` → `components/*`), the relative-only
+// scanner above would silently miss those edges. This block reads
+// tsconfig.compilerOptions.paths and resolves alias specifiers to src-
+// relative paths, the same format the relative resolver produces, so
+// downstream callers (collectViolations) treat both edge sources
+// identically.
+
+interface AliasReplacement {
+  prefix: string;
+  suffix: string;
+}
+
+interface AliasPattern {
+  prefix: string;
+  suffix: string;
+  hasWildcard: boolean;
+  replacements: AliasReplacement[];
+}
+
+export interface AliasConfig {
+  baseDir: string;
+  patterns: AliasPattern[];
+}
+
+const TSCONFIG_PATH = path.resolve(SRC_DIR, '..', '.config', 'tsconfig.json');
+
+let aliasConfigCache: { value: AliasConfig | null } | undefined;
+
+/**
+ * Strip C-style and line comments from JSONC content so JSON.parse can
+ * read it. Naive but sufficient for tsconfig files, which don't use
+ * comment-like sequences inside string literals.
+ */
+function stripJsonComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+export function loadAliasConfig(tsconfigPath: string = TSCONFIG_PATH): AliasConfig | null {
+  if (aliasConfigCache) {
+    return aliasConfigCache.value;
+  }
+  let parsed: { compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> } };
+  try {
+    parsed = JSON.parse(stripJsonComments(fs.readFileSync(tsconfigPath, 'utf-8')));
+  } catch (err) {
+    aliasConfigCache = { value: null };
+    return null;
+  }
+  const co = parsed.compilerOptions ?? {};
+  const paths = co.paths;
+  if (!paths || Object.keys(paths).length === 0) {
+    aliasConfigCache = { value: null };
+    return null;
+  }
+  const baseUrl = co.baseUrl ?? '.';
+  const baseDir = path.resolve(path.dirname(tsconfigPath), baseUrl);
+  const patterns: AliasPattern[] = Object.entries(paths).map(([pattern, replacements]) => {
+    const hasWildcard = pattern.includes('*');
+    const [prefix, suffix = ''] = pattern.split('*');
+    return {
+      prefix: prefix ?? '',
+      suffix,
+      hasWildcard,
+      replacements: replacements.map((r) => {
+        const [rPrefix, rSuffix = ''] = r.split('*');
+        return { prefix: rPrefix ?? '', suffix: rSuffix };
+      }),
+    };
+  });
+  const config: AliasConfig = { baseDir, patterns };
+  aliasConfigCache = { value: config };
+  return config;
+}
+
+/**
+ * Resolve a bare module specifier against an alias config. Returns a
+ * src-relative path (POSIX separators) if the specifier matches an
+ * alias pattern AND the resolution lands inside SRC_DIR. Returns null
+ * otherwise — including when the specifier matches but resolves to a
+ * node_modules path (e.g. `@grafana/data`) or escapes SRC_DIR.
+ *
+ * Pure function suitable for unit tests with synthetic configs.
+ */
+export function resolveAliasedSpecifierWithConfig(specifier: string, config: AliasConfig): string | null {
+  for (const pat of config.patterns) {
+    if (pat.hasWildcard) {
+      if (!specifier.startsWith(pat.prefix) || !specifier.endsWith(pat.suffix)) {
+        continue;
+      }
+      if (specifier.length <= pat.prefix.length + pat.suffix.length) {
+        continue;
+      }
+      const wildcardValue = specifier.slice(pat.prefix.length, specifier.length - pat.suffix.length);
+      for (const replacement of pat.replacements) {
+        const resolvedRelative = replacement.prefix + wildcardValue + replacement.suffix;
+        const srcRelative = resolveInsideSrcDir(config.baseDir, resolvedRelative);
+        if (srcRelative !== null) {
+          return srcRelative;
+        }
+      }
+      return null;
+    }
+
+    if (specifier === pat.prefix) {
+      for (const replacement of pat.replacements) {
+        const srcRelative = resolveInsideSrcDir(config.baseDir, replacement.prefix);
+        if (srcRelative !== null) {
+          return srcRelative;
+        }
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+function resolveInsideSrcDir(baseDir: string, relativeFromBase: string): string | null {
+  const absolute = path.resolve(baseDir, relativeFromBase);
+  const srcRelative = path.relative(SRC_DIR, absolute);
+  if (srcRelative.startsWith('..') || path.isAbsolute(srcRelative)) {
+    return null;
+  }
+  return toPosixPath(srcRelative);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second PR in the agent-hardening sequence (`docs/design/AGENT_HARDENING.md`). Phase A — "stop lying to the agent" (#903) — made the prose accurate. This PR closes five known gaps in the existing tier ratchet so the boundaries it claims to enforce are actually enforced everywhere.

Deferred per the design doc: **B1 + B2** (mechanical `/review` + `prevent-doc-drift` Stop-hooks — open design questions per the doc), and **B3** (concentration ratchet — wants B5's sync infrastructure first).

## Per-commit map

| Commit | Item | Finding | What it closes |
| ------ | ---- | ------- | -------------- |
| `dd248565` | **B4** | F-6 | Root-level `src/` files (`module.tsx`, `constants.ts`, …) now have explicit tier assignments via `ROOT_LEVEL_TIER_MAP`. A new `helpers.ts` at root without a tier entry fails CI. `ROOT_LEVEL_ALLOWED_FILES` is now derived from the map (one source of truth). |
| `60d73ac3` | **B5** | F-5 | New `architecture.test.ts` describe-block parses `eslint.config.mjs` and asserts the tier-constant arrays + `tierBoundaryConfig` source-dir lists match `TIER_MAP`. The test caught pre-existing drift: `hooks` missing from `TIER_2_ENGINES`, `recovery` missing from `TIER_1_PLUS` and the Tier 1 source list — all fixed in the same commit. |
| `c9ae837f` | **B6** | F-7 | Import scanner now reads `tsconfig.compilerOptions.paths` and resolves aliased specifiers to src-relative paths via `resolveAliasedSpecifierWithConfig`. Repo has no aliases today so the behavior is unchanged; the first PR to add one will get ratchet coverage automatically. |
| `77590775` | — | — | Prettier formatting trailing from B6's lint-staged hook. |
| `18fa5fc6` | **B8** | F-12 | `jest.config.js` flipped to `collectCoverage: false`. `npm run test:ci -- <focused>` no longer trips the global threshold; `npm run check` now routes through `test:coverage`, which keeps threshold enforcement intact on the full gate. |
| `98b9fcba` | **B7** | F-9 (partial) | `.husky/pre-commit` now runs `typecheck` + a new `test:governance` subset (architecture + import-graph) after lint-staged. Measured ~8s total on a clean tree. |

## Test plan

- [x] `npm run test:ci -- src/validation/` — 12 suites, 417 tests pass without the `--coverage=false` workaround
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (14 pre-existing warnings about unused eslint-disable directives, unchanged)
- [x] Negative test for B4: `touch src/helpers.ts` → architecture test fails with a message pointing at `ROOT_LEVEL_TIER_MAP`
- [x] Negative test for B5: removing an entry from `TIER_2_ENGINES` in `eslint.config.mjs` → sync test fails with directional diff
- [x] Negative test for B6: unit tests cover wildcard, exact, no-match, src-escape, empty-wildcard, JSONC, missing file
- [x] Negative test for B8: `npm run test:coverage -- src/validation/architecture.test.ts` still fails the 1% threshold (reproducing F-12 against the new `test:coverage` script — proving thresholds still apply where they should)
- [x] B7 hook self-exercised by the B7 commit landing through the new pre-commit chain
- [ ] Reviewer: run `npm run check` end-to-end to confirm the full pre-merge gate still passes with `test:coverage` instead of `test:ci`

## Files touched

| Area | Files |
| ---- | ----- |
| Validation infrastructure | `src/validation/import-graph.ts`, `src/validation/import-graph.test.ts`, `src/validation/architecture.test.ts` |
| ESLint mirror | `eslint.config.mjs` |
| Test config | `jest.config.js`, `package.json` (scripts) |
| Hooks | `.husky/pre-commit` |
| Docs | `AGENTS.md`, `CLAUDE.md`, `docs/developer/COMMANDS.md` |

No product code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
