### PR TITLE
feat(agents): add techdebt skill and wire it into /review

### DIFF
--- a/.cursor/skills/review/SKILL.md
+++ b/.cursor/skills/review/SKILL.md
@@ -158,7 +158,24 @@ If `coverage_confidence` is not `high`, include a short coverage note such as:
 
 > Coverage note: this PR appears to center on an area that is only lightly modeled by `docs/design/CONCERNS.md`. I reviewed it with general concerns and adjacent subsystem logic, but review confidence is reduced there. If this area is important long-term, consider refining or adding a concern entry.
 
-## 6. Documentation drift check
+## 6. Tech-debt scan
+
+After synthesis, spawn a sub-agent scoped to **only the files changed in this PR** to detect tech-debt patterns. The sub-agent reads `.cursor/skills/techdebt/SKILL.md` and runs all categories (A–E) against the changed file set.
+
+Instructions for the sub-agent:
+
+1. Resolve the target to the PR's changed file list — do not expand scope to the full subsystem.
+2. Run `SKILL.md` workflow steps 1–6 against that file list exactly.
+3. Suppress findings on files that the diff only touches in tests (D2 is still relevant there).
+4. Return only **high-confidence findings**; do not emit suggestive findings unless the overall change classification is `mixed` or `product-runtime` and the router has flagged correctness risk.
+
+Include the tech-debt report in the final review output under a **Tech debt** section. If the sub-agent returns no findings, emit:
+
+> Tech debt: no high-confidence patterns found in the changed files.
+
+The tech-debt scan is **non-blocking** — findings do not block merge, but they are included in the review for the author's awareness. If a finding overlaps with a correctness or architecture finding already raised by another reviewer, prefer the primary concern's finding and add a note that it also represents accrued debt.
+
+## 7. Documentation drift check
 
 After synthesis, invoke `.cursor/skills/prevent-doc-drift/SKILL.md` in **review mode** to detect whether this PR introduces new subsystems, scripts, skills, docs, plugin routes, feature flags, or architecture changes that require updates to agent guidance (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules/`).
 

--- a/.cursor/skills/review/SKILL.md
+++ b/.cursor/skills/review/SKILL.md
@@ -5,7 +5,7 @@ description: Routed PR review orchestrator. Load for `/review` command or any PR
 
 # PR review orchestrator
 
-Conduct a **Principal Engineer level** review in six phases.
+Conduct a **Principal Engineer level** review in seven phases.
 
 ## 1. Read the concern registry
 
@@ -173,7 +173,7 @@ Include the tech-debt report in the final review output under a **Tech debt** se
 
 > Tech debt: no high-confidence patterns found in the changed files.
 
-The tech-debt scan is **non-blocking** — findings do not block merge, but they are included in the review for the author's awareness. If a finding overlaps with a correctness or architecture finding already raised by another reviewer, prefer the primary concern's finding and add a note that it also represents accrued debt.
+The tech-debt scan is **non-blocking** — findings do not block merge, but they are included in the review for the author's awareness. Dedupe against synthesis findings per §5.
 
 ## 7. Documentation drift check
 

--- a/.cursor/skills/techdebt/PATTERNS.md
+++ b/.cursor/skills/techdebt/PATTERNS.md
@@ -1,0 +1,346 @@
+# techdebt — Pattern Catalog
+
+Each pattern entry has:
+
+- **Definition** — one sentence
+- **Severity** — 1 (cosmetic), 2 (maintenance hazard), 3 (correctness or compounding risk). Used in `hotspot_score = churn_90d × severity`.
+- **High-confidence signature** — emit by default when all bullets apply
+- **Suggestive signature** — partial match; emit only with `--suggestive`
+- **Disqualifiers** — hard filters. If any disqualifier applies, drop the candidate or demote to suggestive.
+
+The skill MUST check disqualifiers before emitting a finding. See `SKILL.md` for the protocol.
+
+---
+
+## Category A — Local syntactic (single-file, AST-detectable)
+
+### A1 — Cargo-Cult Commentary
+
+- **Definition**: Comments that restate what the code says rather than explaining why, creating a second source of truth that drifts.
+- **Severity**: 1
+- **High-confidence signature**:
+  - Comment line above a statement whose text paraphrases the statement's identifiers (e.g., `// Set the user name` above `user.name = input.value`).
+  - JSDoc/docstring on a function whose `@param` descriptions only restate parameter types and names.
+  - Comment density (comment lines ÷ LOC) > 30% in a file that is not a public library API surface.
+- **Suggestive signature**:
+  - Multiple block comments inside a single function narrating each step.
+  - Comment refers to behavior absent from the code below it (requires `git blame` to confirm drift).
+- **Disqualifiers**:
+  - File is a documented public API surface (exported types in a library package, OpenAPI schemas, generated docs source).
+  - Comment references external context: ticket ID, RFC, bug ID, browser/runtime quirk, regulatory requirement.
+  - Comment explains *why* a non-obvious choice was made — test: does it contain "because" or contrast with an alternative?
+
+### A2 — God Component / Large Component
+
+- **Definition**: A single component owning too many responsibilities — too many hooks, props, state slices, or rendering branches.
+- **Severity**: 3
+- **High-confidence signature** (two or more must apply):
+  - LOC > 300 in a single component file.
+  - Props count > 10 on a single component.
+  - Hook calls > 8 inside a single function component.
+  - Separate `useState` / `useReducer` calls > 6 with low referential overlap between slices.
+- **Suggestive signature**:
+  - Component returns JSX from multiple internal `renderHeader` / `renderBody` / `renderFooter`-style helpers.
+  - Generic component name (`Container`, `Wrapper`, `Page`, `Manager`) — naming itself signals diffuse responsibility.
+- **Disqualifiers**:
+  - Top-level route/page component legitimately composing multiple concerns. (Flag with softer threshold if at all.)
+  - Form with many genuine fields — count fields, not just props.
+  - Generated code (codegen, GraphQL types, OpenAPI clients).
+
+### A3 — Over-Specified Defense
+
+- **Definition**: Guard clauses, null checks, or error handling for cases that cannot occur given the types or call sites.
+- **Severity**: 2
+- **High-confidence signature**:
+  - Null/undefined check on a parameter whose TypeScript type is non-nullable.
+  - `try`/`catch` wrapping code that cannot throw (pure synchronous computation, no I/O).
+  - `default` branch on a `switch` over an exhaustive union type, especially one that throws "unreachable."
+  - Hypothetical features beyond stated requirements (e.g., OAuth wiring with no auth requirement; retry logic on an in-process function call).
+- **Suggestive signature**:
+  - Optional-chain ladders (`if (x && x.y && x.y.z)`) against fully-typed objects.
+  - Re-validation of input shapes already validated upstream (requires call-site tracing).
+- **Disqualifiers**:
+  - Public API boundary: network, file I/O, IPC, user input, third-party callbacks.
+  - Defending against documented bugs in a third-party library.
+  - Type assertion or guard added because TypeScript's flow analysis cannot prove safety (look for `// eslint-disable` or comments to this effect).
+
+### A4 — Multiple Booleans for State
+
+- **Definition**: Two or more boolean state variables in the same component where only certain combinations are valid — a discriminated union or enum would be clearer.
+- **Severity**: 2
+- **High-confidence signature**:
+  - Single component has ≥ 3 boolean state variables (`isLoading`, `isError`, `isSuccess`, `isIdle`, ...) that are mutually exclusive in practice.
+  - JSX contains conditions like `!isLoading && !isError && data` — implicit state machine encoded in `&&` chains.
+- **Suggestive signature**:
+  - Two booleans where one is the negation of a derived value of the other.
+- **Disqualifiers**:
+  - Booleans are genuinely orthogonal (e.g., `isExpanded` + `isSelected` on a tree node — they vary independently).
+
+### A5 — Any-Type / Non-Null Assertion Cluster
+
+- **Definition**: Concentrated use of `any`, `as unknown as`, or `!` non-null assertions, especially in recently-added code.
+- **Severity**: 2
+- **High-confidence signature**:
+  - More than 2 of (`any`, `as unknown as`, `!` non-null assertion) per 100 LOC in a single file.
+  - A cluster of these in a single recent commit (use `git log -p` to confirm).
+- **Suggestive signature**:
+  - A function whose return type is `any` because the body lost type narrowing partway through.
+- **Disqualifiers**:
+  - Test files (looser typing is conventional).
+  - Interop layer with an untyped library (look for the import).
+  - Type assertion with an adjacent comment justifying why TypeScript flow analysis cannot prove the narrowing.
+
+---
+
+## Category B — Cross-file structural (corpus-similarity)
+
+> No embedding service is assumed. The agent is the similarity engine. In `Evidence`, state the explicit comparison: which symbols, what's structurally identical, what's cosmetically different (variable names, statement order, equivalent control flow). Normalize bodies before judging — strip imports, JSX scaffolding, and comments.
+
+### B1 — Near-Duplicate Function
+
+- **Definition**: Two or more functions implementing the same logic with cosmetic differences (renamed variables, reordered statements, equivalent control flow).
+- **Severity**: 3
+- **High-confidence signature**:
+  - Two functions in different files have structurally identical bodies after normalization (rename variables, ignore JSX scaffolding, sort independent statements).
+  - Signatures are compatible (same arity, parameter types substitutable).
+  - Neither function imports the other (rules out delegation).
+- **Suggestive signature**:
+  - Functions whose bodies share the same algorithm shape but diverge on one branch.
+  - Differently-named functions implementing the same data transformation.
+- **Disqualifiers**:
+  - Similarity is in trivial boilerplate (React component shells around different JSX content). Re-normalize stripping JSX entirely; if what remains is small, drop.
+  - Intentional variant — adjacent files with names that signal variation (`Button.tsx` and `IconButton.tsx`), or one explicitly extends the other.
+  - Generated code, fixtures, examples, test snapshots.
+
+### B2 — Reinvented Hook
+
+- **Definition**: A custom hook (or inline hook composition in a component) that duplicates the structure of an exported hook elsewhere in the project.
+- **Severity**: 2
+- **High-confidence signature**:
+  - Component contains a sequence of hook calls (e.g., `useState` + `useEffect` + `useCallback`) whose data flow matches an exported hook in the project.
+  - The component's file does not import the existing hook.
+- **Suggestive signature**:
+  - Inline `useEffect`-with-`fetch`-and-loading-state when the project has a data-fetching hook (`useQuery`, `useFetch`, etc.).
+- **Disqualifiers**:
+  - The existing hook lives in a package boundary the component genuinely can't import.
+  - The inline version has materially different behavior (different cache key strategy, different error-handling contract, different cleanup semantics).
+
+### B3 — Reinvented Library Function
+
+- **Definition**: A function whose signature and body match a well-known utility from a library already in `package.json`.
+- **Severity**: 2
+- **High-confidence signature**:
+  - Function body matches the normalized shape of a known utility (`debounce`, `throttle`, `groupBy`, `pick`, `omit`, `chunk`, `uniq`, `flatten`, `deepClone`, `isEqual`, date math, etc.).
+  - That library is in `package.json` dependencies.
+- **Suggestive signature**:
+  - Function name matches a well-known utility name regardless of whether the library is installed — surface as "consider adopting the library version."
+- **Disqualifiers**:
+  - The reimplementation is materially different (type-safe variant the library lacks, different edge-case behavior).
+  - The library version has a known cost in this context (e.g., full `lodash` in a client bundle without per-method imports).
+  - The implementation predates the dependency being added — check `git log -L` if churn is low.
+
+### B4 — Convergent Re-Bugging
+
+- **Definition**: The same latent bug appearing in multiple places where the same logic was independently reimplemented.
+- **Severity**: 3
+- **High-confidence signature**:
+  - A B1 hit (near-duplicate functions) where the duplicates share an anti-pattern: missing null check on the same field, same off-by-one, same race-condition shape, same forgotten edge case.
+- **Suggestive signature**:
+  - Two functions implement the same task and both lack a check the codebase performs elsewhere for similar inputs.
+- **Disqualifiers**:
+  - None. When B4 hits, always surface it — fixing it fixes multiple latent bugs at once.
+
+---
+
+## Category C — Delegation and architectural (graph-level)
+
+### C1 — Prop Drilling
+
+- **Definition**: A prop passed through N consecutive components in the render tree without being read or transformed by intermediate components.
+- **Severity**: 2
+- **High-confidence signature**:
+  - Named prop appears in the props interface of ≥ 3 consecutive components along a render path.
+  - Intermediate components only forward the prop — no read, no transform, no conditional logic on it.
+- **Suggestive signature**:
+  - Prop drilled through 2 levels with the third level imminent (look at recent diffs).
+- **Disqualifiers**:
+  - Theming, locale, auth, or other context-like values where the pattern is intentional and context API was deliberately avoided. Check for comments or ADRs explaining the choice.
+  - Render-prop wrappers or higher-order components whose contract is forwarding.
+
+### C2 — Pass-Through Delegation (Middle Man)
+
+- **Definition**: A function whose entire body is a single call to another function with the same arguments — Fowler's Middle Man at function granularity.
+- **Severity**: 1
+- **High-confidence signature**:
+  - Function body is exactly `return otherFn(...args)` (or near-equivalent allowing only argument renaming).
+  - No transformation, validation, logging, or side effect occurs in the wrapper.
+- **Suggestive signature**:
+  - Class or module whose exported surface is predominantly thin pass-throughs to a single delegate.
+- **Disqualifiers**:
+  - The wrapper is the public API boundary that intentionally hides the inner function. (In that case, the *inner* should be internal — flag the visibility mismatch instead.)
+  - The wrapper exists to apply a type narrowing or generic constraint that adds real safety. Verify by checking the signatures differ in a load-bearing way.
+
+### C3 — Drift Hub
+
+- **Definition**: A file with high churn, high incoming dependency count, and monotonic growth — the place where compounding debt accumulates.
+- **Severity**: 3
+- **High-confidence signature**:
+  - File is in the top 5% of churn over the last 90 days (`git log --since="90 days ago" --pretty=format:"%H" -- <file> | wc -l` ranked against the subsystem).
+  - Incoming imports above a subsystem-relative threshold (rule of thumb: > 8 importers in subsystems of < 100 files; scale up for larger subsystems).
+  - Average lines-added-per-commit exceeds lines-removed (`git log --shortstat --since="90 days ago" -- <file>`).
+- **Suggestive signature**:
+  - High churn but moderate fan-in.
+  - High fan-in but moderate churn.
+- **Disqualifiers**:
+  - None. C3 is a prioritization signal — when it fires alongside other patterns, those patterns should be ranked first.
+
+### C4 — Orphan Cluster
+
+- **Definition**: A set of files that import each other heavily but are rarely imported by the rest of the codebase — a dead or near-dead subsystem.
+- **Severity**: 2
+- **High-confidence signature**:
+  - Strongly connected component in the import graph with low external in-degree (the cluster's external in-degree summed across files is less than its internal edge count).
+  - The cluster's only external callers are its own tests.
+- **Suggestive signature**:
+  - A cluster reachable only via one entry-point file that is itself rarely imported.
+- **Disqualifiers**:
+  - Feature-flagged code intentionally dormant (look for flag references).
+  - Code reachable only via dynamic import (`await import(...)`) — grep for dynamic imports targeting the cluster.
+  - CLI entry points / scripts that are invoked by build tooling, not imported.
+
+---
+
+## Category D — Process debt
+
+### D1 — Stale Memory Drift
+
+- **Definition**: Agent-facing memory files (`CLAUDE.md`, `AGENTS.md`, `.cursor/rules/*`) describe an architecture or constraint that the current code no longer reflects.
+- **Severity**: 2
+- **High-confidence signature**:
+  - A memory/doc file claims a specific file path, symbol, or import edge that no longer exists. Verify by `grep` against current code.
+  - A memory/doc file states a constraint ("X must not depend on Y", "always use Z for W") that the current code violates.
+- **Suggestive signature**:
+  - Memory file last modified > 90 days before files it describes (`git log -1 --format=%ct`); content references symbols that have churned heavily since.
+- **Disqualifiers**:
+  - Doc is dated/scoped to a milestone (e.g., header says "as of v2.x") and the current version differs.
+  - Constraint is documented as aspirational future state, not current.
+
+### D2 — Test-Generation Debt
+
+- **Definition**: Tests that exercise code without asserting meaningful behavior — generated to satisfy coverage rather than verify correctness.
+- **Severity**: 3
+- **High-confidence signature**:
+  - Test file has assertions-per-test ratio < 1 on average (count `expect(` / `assert*` / `should.` per `it(` or `test(`).
+  - Multiple tests whose only assertions are `toBeDefined`, `toBeTruthy`, `not.toThrow`, or equivalent existence checks.
+  - Mock-heavy tests where the mocks are the only thing being verified (test asserts a mock was called, but the mock has no contract that ties it to real behavior).
+- **Suggestive signature**:
+  - Snapshot-only tests on logic-bearing functions (snapshots ratify whatever the code does today).
+  - Tests with identical `arrange` blocks differing only in trivial parameter values, all asserting the same shape.
+- **Disqualifiers**:
+  - Smoke tests explicitly intended to verify wiring / module loading. Check filename or describe-block name.
+  - Type-only tests (e.g., `tsd` test suites) that legitimately use existence assertions.
+  - Tests for code whose only contract is "does not throw" (e.g., logger initializers).
+
+---
+
+## Category E — Operational debt (extraction-seam patterns)
+
+These detect the high-risk seams that resist refactoring: imperative resource managers, ad-hoc async state machines, module-level mutable state, and scattered contract surfaces. Agentic engineering amplifies all of them — agents extend existing files rather than introduce new modules, so these patterns accrete in place.
+
+Each E-pattern is intentionally scoped small so that one finding = one chip-away session.
+
+### E1 — Imperative Resource Manager Mixed with Logic
+
+- **Definition**: A file or class owns timers, observers, or external subscriptions AND also contains business logic, with no clear separation between resource lifecycle and behavior.
+- **Severity**: 2
+- **High-confidence signature**:
+  - File contains 2+ of: `setInterval`, `setTimeout` (long-lived), `addEventListener`, `MutationObserver`, `IntersectionObserver`, `ResizeObserver`, `requestAnimationFrame` loops, external subscriptions (`.subscribe(`).
+  - Same file contains business logic functions (transformations, decisions, validation, content shaping) that are NOT the resource's direct callback.
+  - Resource cleanup (`removeEventListener` / `clearInterval` / `disconnect` / `.unsubscribe()`) is scattered across multiple methods or absent.
+- **Suggestive signature**:
+  - Resource setup and cleanup are >100 LOC apart in the same file.
+  - Resource managed via `useRef` for the handle and `useEffect` for setup, with cleanup logic that has grown beyond the effect's return.
+- **Disqualifiers**:
+  - File is explicitly a resource wrapper (name like `useEventListener`, `*Manager`, `*Subscription`) — its purpose IS resource management.
+  - Framework integration boundary where this is conventional (`useEffect`-based DOM listener attachment for a single event with paired cleanup is fine).
+
+### E2 — Inline Async State Machine
+
+- **Definition**: Ad-hoc async coordination (debounce + retry + cancellation + in-flight tracking) embedded in a component method or hook body instead of a named state-machine helper.
+- **Severity**: 3
+- **High-confidence signature**:
+  - A single function or hook body contains 3+ of: `setTimeout` for debounce, `AbortController`, `Promise.race`, retry loop with backoff (recursive or `for` with sleep), `useRef` for "is this the latest call" tracking, manual cancellation tokens.
+  - Stale-result guarding via `if (ref.current !== thisCallId) return;` or equivalent.
+- **Suggestive signature**:
+  - Inline debounce-and-fetch pattern when another file in the project has the same pattern (suggests both should adopt a shared machine).
+  - `useEffect` with cleanup that cancels an in-flight async — usually the seed of a state machine that hasn't been extracted.
+- **Disqualifiers**:
+  - Genuinely one-off async with no concurrency concerns (single event, no cancellation needed).
+  - Framework-provided coordination (`react-query`, `SWR`, RTK Query) in use — inline code is just configuration.
+
+### E3 — Singleton Used Outside Boundary
+
+- **Definition**: A module-level singleton instance (not a class) is imported by deep business logic where dependency injection would let tests substitute it.
+- **Severity**: 2
+- **High-confidence signature**:
+  - File exports a pre-constructed instance (`export const fooManager = new FooManager()` or `export const x = createX()`).
+  - That export is imported by ≥ 3 non-test files.
+  - At least one consumer is inside a React component, hook, or pure business function (not just a boundary like an entry point or framework integration).
+  - Tests for the consumers contain `jest.mock(...)` or equivalent targeting this module — direct evidence the singleton is a test-friction point.
+- **Suggestive signature**:
+  - Singleton holds mutable state that varies the consumer's behavior across calls (not just a function bag).
+- **Disqualifiers**:
+  - Singleton IS the boundary (analytics, logger, telemetry, feature-flag client, error reporter) — global is intentional.
+  - Singleton has no mutable state and exposes only pure functions — it's a namespace, not a singleton in the load-bearing sense.
+
+### E4 — Module-Level Mutable Registry
+
+- **Definition**: A file-level `let`, `Map`, `Set`, or array declared outside any function or class, mutated by exported functions in the file — a hidden project singleton with no named lifecycle owner.
+- **Severity**: 3
+- **High-confidence signature**:
+  - Top-level declaration: `let foo`, `const bar = new Map()`, `const baz = new Set()`, or `const xs: T[] = []` outside any function/class scope.
+  - Mutation observed in ≥ 2 exported functions of the file (`.set(`, `.add(`, `.push(`, reassignment).
+  - No paired init/dispose, no React provider hosting it, no service that owns its lifecycle.
+- **Suggestive signature**:
+  - Module-level cache without TTL, eviction, or explicit clear.
+  - Module-level array used as an event bus or queue.
+  - Test files clear the registry in `beforeEach` / `afterEach` — strong signal the lifecycle is implicit and tests are working around it.
+- **Disqualifiers**:
+  - Read-only constants table (frozen, no mutations after first assignment).
+  - Memoization cache with a documented eviction strategy or explicit `clear()` exported.
+  - Module-level state that IS the framework's intended pattern (e.g., a Redux store, a Zustand store) — the lifecycle owner is the framework.
+
+### E5 — Contract Surface Scatter
+
+- **Definition**: An external contract value (CustomEvent name, storage key, URL query param, test ID, feature-flag identifier) appears as a string literal in multiple files instead of a single shared constant.
+- **Severity**: 2
+- **High-confidence signature**:
+  - Identical string literal appears in ≥ 3 files; the literal is one of:
+    - A CustomEvent type (used with `dispatchEvent` / `addEventListener` / `new CustomEvent`)
+    - A storage key (`localStorage.{get,set,remove}Item`, `sessionStorage.*`, IndexedDB store/object name)
+    - A URL query parameter (`searchParams.get`/`set`/`has`/`delete`)
+    - A `data-testid` attribute value
+    - A feature-flag key (project-conventional pattern: `getFlag('...')`, `isEnabled('...')`)
+  - At least one consumer is in a different package boundary than the producer (different top-level subdirectory).
+- **Suggestive signature**:
+  - Same literal in exactly 2 production files.
+  - A shared constant exists for this value AND the raw literal also appears elsewhere — bypass-in-progress.
+- **Disqualifiers**:
+  - The literal IS the shared constant: declared once and re-exported / imported elsewhere — grep confirms the other occurrences are imports of the constant, not duplicate literals.
+  - Test fixtures intentionally re-stating the contract for documentation.
+  - Migration window where old and new keys coexist intentionally — look for a comment or ADR.
+
+### E6 — Bootstrap Orchestration at Root
+
+- **Definition**: A designated entry-point file accumulates multiple subsystem setup concerns whose ordering matters, instead of delegating to focused bootstrap modules.
+- **Severity**: 3
+- **High-confidence signature**:
+  - File is the project's designated entry point (matches `package.json` `main` / `module` / `exports` field, or follows convention: `src/index.*`, `src/main.*`, `src/module.*`, `src/App.*`, `src/server.*`).
+  - File exceeds 150 LOC and contains ≥ 3 distinct setup concerns at top level (e.g., feature-flag init + routing registration + storage init + telemetry boot + i18n config + service registration).
+  - Setup ordering matters and is encoded by source-line order rather than explicit dependency declarations (no init graph; reorder = breakage).
+- **Suggestive signature**:
+  - Entry-point file with 5+ side-effectful imports (imports invoked for their side effects, not for symbols).
+  - Top-level `await` or IIFE pattern doing multi-step boot.
+- **Disqualifiers**:
+  - Framework-conventional thin boilerplate (e.g., Vite `main.tsx` with `<App />` mount; Next.js `_app.tsx`).
+  - Entry file delegates to focused modules and the orchestration itself is thin (count actual logic lines, not import lines).

--- a/.cursor/skills/techdebt/PATTERNS.md
+++ b/.cursor/skills/techdebt/PATTERNS.md
@@ -245,9 +245,7 @@ The skill MUST check disqualifiers before emitting a finding. See `SKILL.md` for
 
 ## Category E — Operational debt (extraction-seam patterns)
 
-These detect the high-risk seams that resist refactoring: imperative resource managers, ad-hoc async state machines, module-level mutable state, and scattered contract surfaces. Agentic engineering amplifies all of them — agents extend existing files rather than introduce new modules, so these patterns accrete in place.
-
-Each E-pattern is intentionally scoped small so that one finding = one chip-away session.
+E-patterns are extraction seams — high-risk refactor targets. Each is scoped to a single chip-away session.
 
 ### E1 — Imperative Resource Manager Mixed with Logic
 

--- a/.cursor/skills/techdebt/PATTERNS.md
+++ b/.cursor/skills/techdebt/PATTERNS.md
@@ -28,7 +28,7 @@ The skill MUST check disqualifiers before emitting a finding. See `SKILL.md` for
 - **Disqualifiers**:
   - File is a documented public API surface (exported types in a library package, OpenAPI schemas, generated docs source).
   - Comment references external context: ticket ID, RFC, bug ID, browser/runtime quirk, regulatory requirement.
-  - Comment explains *why* a non-obvious choice was made — test: does it contain "because" or contrast with an alternative?
+  - Comment explains _why_ a non-obvious choice was made — test: does it contain "because" or contrast with an alternative?
 
 ### A2 — God Component / Large Component
 
@@ -177,7 +177,7 @@ The skill MUST check disqualifiers before emitting a finding. See `SKILL.md` for
 - **Suggestive signature**:
   - Class or module whose exported surface is predominantly thin pass-throughs to a single delegate.
 - **Disqualifiers**:
-  - The wrapper is the public API boundary that intentionally hides the inner function. (In that case, the *inner* should be internal — flag the visibility mismatch instead.)
+  - The wrapper is the public API boundary that intentionally hides the inner function. (In that case, the _inner_ should be internal — flag the visibility mismatch instead.)
   - The wrapper exists to apply a type narrowing or generic constraint that adds real safety. Verify by checking the signatures differ in a load-bearing way.
 
 ### C3 — Drift Hub

--- a/.cursor/skills/techdebt/SKILL.md
+++ b/.cursor/skills/techdebt/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: techdebt
+description: "Locate technical debt in a subsystem or architectural component of a codebase. Use when the user runs `/techdebt <subsystem>` or asks to audit a module for smells, duplication, prop drilling, dead code, or other debt patterns. Examples: \"/techdebt src/auth\", \"find tech debt in components/docs-panel\", \"audit the interactive-engine for smells\"."
+---
+
+# techdebt — Locate Technical Debt in a Subsystem
+
+A confidence-tiered audit skill. Every pattern has a high-confidence signature, a suggestive signature, and **disqualifiers that act as hard filters**. The disqualifier protocol is what makes the skill usable rather than noisy.
+
+## When to Use
+
+- `/techdebt <subsystem>` — explicit invocation, always with a target
+- "find tech debt in X" / "audit Y for smells" / "what's wrong with this module"
+- Pre-refactor due diligence on a single subsystem
+- Sub-agent invocation from `/review` to scan changed files for debt patterns
+
+The skill **requires a concrete target**. If the user gives none, ask for one — do not audit the whole repo.
+
+## Invocation
+
+```
+/techdebt <subsystem>                    # all categories, high-confidence only
+/techdebt <subsystem> --category A       # one category
+/techdebt <subsystem> --category A,B     # subset
+/techdebt <subsystem> --pattern B1       # single pattern
+/techdebt <subsystem> --suggestive       # also emit suggestive-tier findings
+```
+
+Categories:
+
+- **A** — Local syntactic (A1–A5). Single-file, fast.
+- **B** — Cross-file structural / corpus similarity (B1–B4). Slowest — agent acts as similarity judge.
+- **C** — Delegation and architectural / graph-level (C1–C4). Uses import graph + churn.
+- **D** — Process debt (D1 Stale Memory Drift, D2 Test-Generation Debt).
+- **E** — Operational debt / extraction seams (E1–E6). High-risk refactor targets: imperative resource managers, async state machines, singletons, module-level registries, contract-surface scatter, bootstrap orchestration. Each E finding is scoped small enough to act on in one session.
+
+## Workflow
+
+1. **Resolve target** → concrete file set. Accept directory, glob, or named subsystem (consult repo's `AGENTS.md` / architecture docs if the term is symbolic). Print resolved file count before continuing.
+2. **Build inventory** in one pass:
+   - File list with LOC
+   - Exported symbols per file
+   - Per-file churn: `git log --since="90 days ago" --pretty=format:"%H" -- <file> | wc -l`
+   - Project dependencies: read `package.json` (for B3)
+3. **Load [`PATTERNS.md`](PATTERNS.md)** from this skill directory. Re-read every invocation — do not rely on memory.
+4. **Run each pattern** against the inventory:
+   - **Category A**: read each file; scan for the signature.
+   - **Category B**: agent is the similarity engine. Normalize bodies (strip imports, JSX scaffolding, comments) before comparing. Emit the explicit similarity claim in `Evidence` so it can be audited.
+   - **Category C**: build a minimal import graph via `grep -rn "from ['\"]" <subsystem>`. Use `git log` for churn (C3).
+   - **Category D**: D1 diffs `CLAUDE.md` / `AGENTS.md` / `.cursor/rules/` docs against current code; D2 reads test files and counts meaningful assertions.
+   - **Category E**: targeted grep + read. E1 looks for paired resource APIs (`setInterval`/`addEventListener`/`*Observer`) with cleanup distance; E2 looks for `AbortController` + debounce + retry in the same function; E3 looks for `export const … = new X()` then traces importers; E4 looks for top-level `let` / `new Map()` / `new Set()` outside any function; E5 looks for repeated string literals matching CustomEvent / storage / testid / query-param patterns; E6 inspects the project's designated entry-point file(s).
+5. **Check disqualifiers BEFORE emitting**. For every candidate hit, walk the pattern's disqualifier list. If any matches → drop the candidate. If a disqualifier cannot be verified, demote to **suggestive** rather than emit a high-confidence flag. Record what was checked.
+6. **Emit findings** grouped by confidence tier, ordered by hotspot score (`churn_90d × pattern_severity`) within each tier.
+
+## Disqualifier Protocol
+
+Disqualifiers are **hard filters**, not soft considerations.
+
+- Walk the list before flagging.
+- Cannot rule out a disqualifier → demote to suggestive. Never emit high-confidence with an unchecked disqualifier.
+- `Disqualifiers checked` field on each finding is the audit trail.
+
+## Confidence Tiers
+
+- **High** — signature matched AND all disqualifiers ruled out. Default emit.
+- **Suggestive** — signature partially matched, OR one or more disqualifiers couldn't be verified. Emit only with `--suggestive`.
+
+## Output Format
+
+Group findings by tier (High first, then Suggestive if requested). Within each tier, order by hotspot score descending.
+
+### Per finding
+
+```markdown
+### [Pattern ID] — [pattern name]
+
+- **Confidence**: high | suggestive
+- **Locations**:
+  - `path/to/file.ts:12-34` — `symbolName`
+  - `path/to/other.ts:8-29` — `otherSymbol`
+- **Evidence**: One paragraph: what was observed and why it matches the signature. For B-category, include the explicit similarity claim and what convinced you.
+- **Disqualifiers checked**:
+  - Not generated code (no `**/*.generated.*` match)
+  - Functions have semantically distinct names — flagged anyway because behavior is identical
+- **Hotspot**: churn 12 commits/90d (top 8%) — prioritize
+- **Suggested action**: One or two sentences. Concrete: "Extract X into Y", "Replace with `lodash/debounce`", "Hoist this prop to context".
+```
+
+### Patterns with no findings
+
+End the report with a compact line, **not** per-pattern sections:
+
+```markdown
+## No evidence found
+
+A1, A3, A5 · B2, B4 · C1, C4 · D1
+```
+
+Do not spend output explaining what wasn't found.
+
+### When nothing is found at all
+
+> No tech debt found above the confidence threshold in `<subsystem>`. Run with `--suggestive` to include lower-confidence candidates.
+
+## Example: `/techdebt src/context-engine`
+
+```
+Resolved → 14 files, 2,341 LOC
+Inventory:
+  - 38 exported symbols
+  - Hottest files (90d): contextEngine.ts (18 commits), useContextEngine.ts (11)
+  - Deps relevant to B3: lodash, date-fns, zod
+Running A1–E6…
+
+High-confidence findings (3):
+  A2 — ContextProvider.tsx (LOC 412, hooks 11, churn 18)
+  C1 — currentUserId drilled 4 levels (churn 11)
+  B3 — src/context-engine/utils/debounce.ts reimplements lodash/debounce (churn 3)
+
+No evidence found: A1, A3, A4, A5 · B1, B2, B4 · C2, C3, C4 · D1, D2
+```
+
+## Notes on detection fidelity
+
+- **No embedding service is assumed.** Category B uses the agent as similarity judge. The skill compensates by demanding explicit reasoning in `Evidence` — every B finding states what the agent compared and what convinced it.
+- **Churn is the only quantitative prioritization signal.** Hotspot = `churn_90d × pattern_severity` (severity in `PATTERNS.md`). No code-complexity metric is computed.
+- **Patterns are intentionally narrow.** When in doubt between flagging and not, prefer not. False positives erode trust faster than missed findings.

--- a/.cursor/skills/techdebt/SKILL.md
+++ b/.cursor/skills/techdebt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: techdebt
-description: "Locate technical debt in a subsystem or architectural component of a codebase. Use when the user runs `/techdebt <subsystem>` or asks to audit a module for smells, duplication, prop drilling, dead code, or other debt patterns. Examples: \"/techdebt src/auth\", \"find tech debt in components/docs-panel\", \"audit the interactive-engine for smells\"."
+description: 'Locate technical debt in a subsystem or architectural component of a codebase. Use when the user runs `/techdebt <subsystem>` or asks to audit a module for smells, duplication, prop drilling, dead code, or other debt patterns. Examples: "/techdebt src/auth", "find tech debt in components/docs-panel", "audit the interactive-engine for smells".'
 ---
 
 # techdebt — Locate Technical Debt in a Subsystem

--- a/.cursor/skills/techdebt/SKILL.md
+++ b/.cursor/skills/techdebt/SKILL.md
@@ -5,16 +5,11 @@ description: 'Locate technical debt in a subsystem or architectural component of
 
 # techdebt — Locate Technical Debt in a Subsystem
 
-A confidence-tiered audit skill. Every pattern has a high-confidence signature, a suggestive signature, and **disqualifiers that act as hard filters**. The disqualifier protocol is what makes the skill usable rather than noisy.
+Confidence-tiered audit. Disqualifiers are hard filters, not soft considerations — they are what keeps the skill useful rather than noisy.
 
 ## When to Use
 
-- `/techdebt <subsystem>` — explicit invocation, always with a target
-- "find tech debt in X" / "audit Y for smells" / "what's wrong with this module"
-- Pre-refactor due diligence on a single subsystem
-- Sub-agent invocation from `/review` to scan changed files for debt patterns
-
-The skill **requires a concrete target**. If the user gives none, ask for one — do not audit the whole repo.
+Triggered by `/techdebt <subsystem>`, by phrases like "find tech debt in X" / "audit Y for smells", as pre-refactor due diligence, or as a sub-agent from `/review` against a PR's changed files. **Requires a concrete target** — if the user gives none, ask for one; do not audit the whole repo.
 
 ## Invocation
 
@@ -49,16 +44,8 @@ Categories:
    - **Category C**: build a minimal import graph via `grep -rn "from ['\"]" <subsystem>`. Use `git log` for churn (C3).
    - **Category D**: D1 diffs `CLAUDE.md` / `AGENTS.md` / `.cursor/rules/` docs against current code; D2 reads test files and counts meaningful assertions.
    - **Category E**: targeted grep + read. E1 looks for paired resource APIs (`setInterval`/`addEventListener`/`*Observer`) with cleanup distance; E2 looks for `AbortController` + debounce + retry in the same function; E3 looks for `export const … = new X()` then traces importers; E4 looks for top-level `let` / `new Map()` / `new Set()` outside any function; E5 looks for repeated string literals matching CustomEvent / storage / testid / query-param patterns; E6 inspects the project's designated entry-point file(s).
-5. **Check disqualifiers BEFORE emitting**. For every candidate hit, walk the pattern's disqualifier list. If any matches → drop the candidate. If a disqualifier cannot be verified, demote to **suggestive** rather than emit a high-confidence flag. Record what was checked.
-6. **Emit findings** grouped by confidence tier, ordered by hotspot score (`churn_90d × pattern_severity`) within each tier.
-
-## Disqualifier Protocol
-
-Disqualifiers are **hard filters**, not soft considerations.
-
-- Walk the list before flagging.
-- Cannot rule out a disqualifier → demote to suggestive. Never emit high-confidence with an unchecked disqualifier.
-- `Disqualifiers checked` field on each finding is the audit trail.
+5. **Check disqualifiers BEFORE emitting**. For every candidate hit, walk the pattern's disqualifier list. If any matches → drop the candidate. If a disqualifier cannot be verified, demote to **suggestive**. Never emit high-confidence with an unchecked disqualifier. The `Disqualifiers checked` field on each finding is the audit trail.
+6. **Emit findings** grouped by confidence tier, ordered by hotspot score (`churn_90d × pattern_severity`) within each tier. Cap output at **10 high-confidence findings**; if more exist, emit a trailing `## Additional candidates (truncated)` line with counts per pattern ID. Prefer not-flagging when uncertain — false positives erode trust faster than missed findings.
 
 ## Confidence Tiers
 
@@ -102,26 +89,23 @@ Do not spend output explaining what wasn't found.
 
 > No tech debt found above the confidence threshold in `<subsystem>`. Run with `--suggestive` to include lower-confidence candidates.
 
-## Example: `/techdebt src/context-engine`
+## Example header
 
 ```
-Resolved → 14 files, 2,341 LOC
+Resolved → <N> files, <LOC> LOC in <subsystem>
 Inventory:
-  - 38 exported symbols
-  - Hottest files (90d): contextEngine.ts (18 commits), useContextEngine.ts (11)
-  - Deps relevant to B3: lodash, date-fns, zod
+  - <N> exported symbols
+  - Hottest files (90d): <file> (<commits>), …
+  - Deps relevant to B3: <library list from package.json>
 Running A1–E6…
 
-High-confidence findings (3):
-  A2 — ContextProvider.tsx (LOC 412, hooks 11, churn 18)
-  C1 — currentUserId drilled 4 levels (churn 11)
-  B3 — src/context-engine/utils/debounce.ts reimplements lodash/debounce (churn 3)
+High-confidence findings (<N>):
+  <pattern ID> — <path>:<lines> (churn <N>)
+  …
 
-No evidence found: A1, A3, A4, A5 · B1, B2, B4 · C2, C3, C4 · D1, D2
+No evidence found: A1, A3 · B2, B4 · C2, C4 · D1
 ```
 
-## Notes on detection fidelity
+## Shallow-clone fallback
 
-- **No embedding service is assumed.** Category B uses the agent as similarity judge. The skill compensates by demanding explicit reasoning in `Evidence` — every B finding states what the agent compared and what convinced it.
-- **Churn is the only quantitative prioritization signal.** Hotspot = `churn_90d × pattern_severity` (severity in `PATTERNS.md`). No code-complexity metric is computed.
-- **Patterns are intentionally narrow.** When in doubt between flagging and not, prefer not. False positives erode trust faster than missed findings.
+If `git log --since="90 days ago"` returns no history (shallow CI clones), set churn=1 for all files and note `Hotspot scoring degraded: shallow clone, no churn signal` in the output header. Findings remain valid; only the ordering loses fidelity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,9 +226,13 @@ Frequently-needed entries:
 
 ## PR reviews
 
-Use `/review`. It invokes `.cursor/skills/review/SKILL.md` (orchestration workflow) which loads `docs/design/CONCERNS.md` (concern routing) and `docs/design/PR_REVIEW.md` (pattern catalog for R1-R21, F1-F6, QC1-QC7, G1-G7); `react-antipatterns.mdc` loads on hit. For Go PRs touching `pkg/**/*.go`, also verify `npm run lint:go`, `npm run test:go`, and `go build ./...` pass.
+Use `/review`. It invokes `.cursor/skills/review/SKILL.md` (orchestration workflow) which loads `docs/design/CONCERNS.md` (concern routing) and `docs/design/PR_REVIEW.md` (pattern catalog for R1-R21, F1-F6, QC1-QC7, G1-G7); `react-antipatterns.mdc` loads on hit. The review skill also spawns a tech-debt sub-agent (`.cursor/skills/techdebt/SKILL.md`) scoped to the PR's changed files. For Go PRs touching `pkg/**/*.go`, also verify `npm run lint:go`, `npm run test:go`, and `go build ./...` pass.
 
 Use `CONCERNS.md` alone for impact analysis, change risk classification, and subsystem-aware debugging.
+
+## Tech-debt audits
+
+Use `/techdebt <subsystem>` to run a confidence-tiered debt audit on a concrete target (directory, glob, or named subsystem). The skill reads `.cursor/skills/techdebt/SKILL.md` and its `PATTERNS.md` catalog (categories A–E: local syntactic, cross-file structural, architectural, process debt, operational seams). Findings are ordered by hotspot score (`churn × severity`) so the highest-risk items surface first. Run with `--suggestive` to include lower-confidence candidates.
 
 ## `npx` examples
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,23 +8,23 @@
 
 Reusable agent workflows. Read a skill's `SKILL.md` before invoking it.
 
-| Skill                | Trigger                          | Purpose                                                                                                                                 |
-| -------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `bugfix`             | `/bugfix [issue-#]`              | Two-commit failing-test → fix workflow in a worktree                                                                                    |
-| `changelog`          | `/changelog [version]`           | Draft CHANGELOG entry from merged PRs since the last release tag                                                                        |
-| `design-review`      | conversation request             | Principal-engineer design partner; never writes code                                                                                    |
-| `e2e-guide-analysis` | run E2E on a guide               | Diagnose E2E failures, write a learning report                                                                                          |
-| `i18n-sync`          | `/i18n-sync`                     | Stub missing keys across 21 locales; emit a translation gap report                                                                      |
-| `maintain-docs`      | conversation request, periodic   | Whole-repo doc audit: orphans, drift, staleness — opens a PR                                                                            |
-| `plugin-bundle-size` | conversation request             | Reduce plugin bundle size via React.lazy + webpack code splitting                                                                       |
-| `pr-summary`         | `/pr-summary`                    | Draft structured PR description from the diff via `CONCERNS.md` routing                                                                 |
-| `prevent-doc-drift`  | `/review`, pre-merge             | **Per-PR** drift prevention: detects new features / architecture in a PR and updates AGENTS.md, CLAUDE.md, `.cursor/rules/` in same PR  |
-| `refactor`           | `/refactor-investigate <target>` | High-risk refactor with pre / extract / post-test gates                                                                                 |
-| `release-prep`       | `/release-prep [version]`        | Bump version + draft changelog + run check; user creates the tag                                                                        |
-| `review`             | `/review`                        | Principal-engineer PR review: routes via `CONCERNS.md`, grounds findings in `docs/design/PR_REVIEW.md` catalog, invokes doc-drift check |
-| `secure`             | `/secure`                        | Security audit: F1-F6 frontend + backend allowlists + MCP transport + deps                                                              |
+| Skill                | Trigger                          | Purpose                                                                                                                                     |
+| -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bugfix`             | `/bugfix [issue-#]`              | Two-commit failing-test → fix workflow in a worktree                                                                                        |
+| `changelog`          | `/changelog [version]`           | Draft CHANGELOG entry from merged PRs since the last release tag                                                                            |
+| `design-review`      | conversation request             | Principal-engineer design partner; never writes code                                                                                        |
+| `e2e-guide-analysis` | run E2E on a guide               | Diagnose E2E failures, write a learning report                                                                                              |
+| `i18n-sync`          | `/i18n-sync`                     | Stub missing keys across 21 locales; emit a translation gap report                                                                          |
+| `maintain-docs`      | conversation request, periodic   | Whole-repo doc audit: orphans, drift, staleness — opens a PR                                                                                |
+| `plugin-bundle-size` | conversation request             | Reduce plugin bundle size via React.lazy + webpack code splitting                                                                           |
+| `pr-summary`         | `/pr-summary`                    | Draft structured PR description from the diff via `CONCERNS.md` routing                                                                     |
+| `prevent-doc-drift`  | `/review`, pre-merge             | **Per-PR** drift prevention: detects new features / architecture in a PR and updates AGENTS.md, CLAUDE.md, `.cursor/rules/` in same PR      |
+| `refactor`           | `/refactor-investigate <target>` | High-risk refactor with pre / extract / post-test gates                                                                                     |
+| `release-prep`       | `/release-prep [version]`        | Bump version + draft changelog + run check; user creates the tag                                                                            |
+| `review`             | `/review`                        | Principal-engineer PR review: routes via `CONCERNS.md`, grounds findings in `docs/design/PR_REVIEW.md` catalog, invokes doc-drift check     |
+| `secure`             | `/secure`                        | Security audit: F1-F6 frontend + backend allowlists + MCP transport + deps                                                                  |
 | `techdebt`           | `/techdebt <subsystem>`          | Confidence-tiered tech-debt audit: smells, duplication, prop drilling, dead code, extraction seams; also runs as sub-agent inside `/review` |
-| `tidy-up`            | `/tidy-up`                       | Pre-commit gate (typecheck + lint + prettier + Go)                                                                                      |
+| `tidy-up`            | `/tidy-up`                       | Pre-commit gate (typecheck + lint + prettier + Go)                                                                                          |
 
 ### Doc-quality skill pairing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Reusable agent workflows. Read a skill's `SKILL.md` before invoking it.
 | `release-prep`       | `/release-prep [version]`        | Bump version + draft changelog + run check; user creates the tag                                                                        |
 | `review`             | `/review`                        | Principal-engineer PR review: routes via `CONCERNS.md`, grounds findings in `docs/design/PR_REVIEW.md` catalog, invokes doc-drift check |
 | `secure`             | `/secure`                        | Security audit: F1-F6 frontend + backend allowlists + MCP transport + deps                                                              |
+| `techdebt`           | `/techdebt <subsystem>`          | Confidence-tiered tech-debt audit: smells, duplication, prop drilling, dead code, extraction seams; also runs as sub-agent inside `/review` |
 | `tidy-up`            | `/tidy-up`                       | Pre-commit gate (typecheck + lint + prettier + Go)                                                                                      |
 
 ### Doc-quality skill pairing


### PR DESCRIPTION
## Summary

Add a new `/techdebt` skill and integrate it into the `/review` workflow as a non-blocking, changed-files-only tech-debt scan.

## What changed

- Added `.cursor/skills/techdebt/SKILL.md` with the confidence-tiered audit workflow and reporting format.
- Added `.cursor/skills/techdebt/PATTERNS.md` with A-E debt pattern categories and disqualifiers.
- Updated `.cursor/skills/review/SKILL.md` to add a dedicated tech-debt scan phase before the existing doc-drift check.
- Updated `AGENTS.md` and `CLAUDE.md` to document the new `/techdebt` command and its use as a `/review` sub-agent.

## Why

This makes debt discovery explicit and repeatable during reviews while keeping it scoped and non-blocking, so reviewers get higher-signal architectural maintenance feedback without slowing merge flow.

## Test plan

- [ ] `npm run check`
- [ ] Run `/review` on this branch and verify the output includes a **Tech debt** section before doc-drift reporting.
- [ ] Run `/techdebt <target>` on a concrete target and verify the new workflow/pattern catalog is used.

## Risk and reversibility

Low risk and reversible. The change is limited to agent-facing guidance and skill orchestration; reverting this PR restores prior review behavior and does not change runtime plugin behavior or persisted data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)