### PR TITLE
fix: patch CVE-2026-41907 and CVE-2026-33750 via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8966,9 +8966,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -22371,9 +22371,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -154,7 +154,13 @@
     "zod": "^4.1.13"
   },
   "overrides": {
-    "dompurify": "^3.3.2"
+    "dompurify": "^3.3.2",
+    "@grafana/ui": {
+      "uuid": "11.1.1"
+    },
+    "minimatch@9": {
+      "brace-expansion": "2.0.3"
+    }
   },
   "lint-staged": {
     "*.{ts,tsx,js,json,yaml,md}": "prettier --config .prettierrc.js --write"


### PR DESCRIPTION
## Summary

- Bumps `uuid` 11.1.0 → 11.1.1 within `@grafana/ui` via scoped npm override (CVE-2026-41907, CVSS 7.5)
- Bumps `brace-expansion` 2.0.2 → 2.0.3 within `minimatch@9` via scoped npm override (CVE-2026-33750, CVSS 6.5)

## What changed

Both changes are expressed as nested entries in the `"overrides"` block of `package.json`, alongside the existing `dompurify` override. No source code changes.

**CVE-2026-41907 — uuid out-of-bounds write (GHSA-w5hq-g745-h8pq)**
`@grafana/ui@13.0.1` pulls in `uuid@11.1.0`. The `v3()`, `v5()`, and `v6()` API methods accept caller-provided output buffers but do not validate bounds, allowing silent partial writes. Fixed in `11.1.1`. The override is scoped to `@grafana/ui` to avoid touching `uuid@9.x` (from `@grafana/scenes`) or `uuid@13.0.2` (from `@grafana/plugin-e2e`, already patched).

**CVE-2026-33750 — brace-expansion DoS (GHSA-f886-m6hf-6m8v)**
`@typescript-eslint/parser` → `minimatch@9.0.9` pulls in `brace-expansion@2.0.2`. A zero-step pattern like `{1..2..0}` triggers an infinite loop (3.5 s hang, ~1.9 GB allocation). Fixed in `2.0.3`. Dev-only dependency. The override is scoped to `minimatch@9` so the already-patched `1.1.15` (via `minimatch@3`) and `5.0.6` (via `minimatch@10`) instances are untouched.

## What this does NOT fix

Two remaining findings require upstream fixes:

| CVE | Package | Blocked on |
|---|---|---|
| CVE-2026-46625 | `js-cookie@2.2.1` via `react-use@17.6.0` | `react-use` has not migrated to js-cookie v3 (major API break) |
| CVE-2026-41907 | `uuid@9.0.1` via `@grafana/scenes@8.2.6` | No 9.x backport exists; fix requires `@grafana/scenes` to upgrade |

## Test plan

- [x] `npm ls uuid` shows `uuid@11.1.1 overridden` under `@grafana/ui`
- [x] `npm ls brace-expansion` shows `brace-expansion@2.0.3 overridden` under `minimatch@9`
- [x] Pre-commit hook: typecheck passed, governance tests passed (73/73)
- [ ] CI passes