### PR TITLE
chore(deps): bump @openfeature/ofrep-web-provider from 0.3.5 to 0.4.1

### DIFF
--- a/docs/developer/FEATURE_FLAGS.md
+++ b/docs/developer/FEATURE_FLAGS.md
@@ -171,7 +171,8 @@ await OpenFeature.setProviderAndWait(
   OPENFEATURE_DOMAIN,
   new OFREPWebProvider({
     baseUrl: `/apis/features.grafana.app/v0alpha1/namespaces/${namespace}`,
-    pollInterval: -1, // Flags fetched once on init, no polling
+    disableVisibilityRefresh: true, // Do not refresh
+    cacheMode: 'disabled', // Do not write to localStorage
     timeoutMs: 10_000,
   }),
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@grafana/schema": "^13.0.0",
         "@grafana/ui": "^13.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openfeature/ofrep-web-provider": "^0.3.5",
+        "@openfeature/ofrep-web-provider": "^0.4.1",
         "@openfeature/react-sdk": "^1.0.0",
         "@openfeature/web-sdk": "^1.7.2",
         "@tiptap/extension-link": "^3.10.4",
@@ -2149,6 +2149,18 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@grafana/runtime/node_modules/@openfeature/ofrep-web-provider": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@openfeature/ofrep-web-provider/-/ofrep-web-provider-0.3.6.tgz",
+      "integrity": "sha512-fV4BHab6gg0IMPeJJZ3lxtyfStSpea7N81sHJeBjgf7wYrU/SIYmdWV9Vy5HwlONjcsV58EKtOndV3WdkCqnAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openfeature/ofrep-core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@openfeature/web-sdk": "^1.4.0"
       }
     },
     "node_modules/@grafana/scenes": {
@@ -4281,21 +4293,21 @@
       "peer": true
     },
     "node_modules/@openfeature/ofrep-core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@openfeature/ofrep-core/-/ofrep-core-2.1.0.tgz",
-      "integrity": "sha512-UVRb7IS4c9i2kQrSO1yKLIMFBjEBLgHFaOhhcSXc4E2Q93SjUPspcoWMx+Qf5yyjuW6i93d6ynSQ3+KzB3evTw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/ofrep-core/-/ofrep-core-2.2.0.tgz",
+      "integrity": "sha512-YbeT8mYS4Ggo/JFcYY1IzN0O0UvsCx7RPk1m40TFc4ip0gJdFVpYc5a8WDwZC2v/YqxreJ7NWBDxHxP5SOevsA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@openfeature/core": "^1.6.0"
       }
     },
     "node_modules/@openfeature/ofrep-web-provider": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@openfeature/ofrep-web-provider/-/ofrep-web-provider-0.3.6.tgz",
-      "integrity": "sha512-fV4BHab6gg0IMPeJJZ3lxtyfStSpea7N81sHJeBjgf7wYrU/SIYmdWV9Vy5HwlONjcsV58EKtOndV3WdkCqnAQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@openfeature/ofrep-web-provider/-/ofrep-web-provider-0.4.1.tgz",
+      "integrity": "sha512-DoWFtDT+9r+KyqvOYLPTgPgZLKIlUejaUkM++y/VSmVwWZiuKuJP3c8bqBMV+Mi8GSQ9ihJETLzk/BLNXWChpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openfeature/ofrep-core": "^2.1.0"
+        "@openfeature/ofrep-core": "^2.2.0"
       },
       "peerDependencies": {
         "@openfeature/web-sdk": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@grafana/schema": "^13.0.0",
     "@grafana/ui": "^13.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openfeature/ofrep-web-provider": "^0.3.5",
+    "@openfeature/ofrep-web-provider": "^0.4.1",
     "@openfeature/react-sdk": "^1.0.0",
     "@openfeature/web-sdk": "^1.7.2",
     "@tiptap/extension-link": "^3.10.4",

--- a/src/utils/openfeature.test.ts
+++ b/src/utils/openfeature.test.ts
@@ -144,7 +144,8 @@ describe('openfeature', () => {
             name: 'ofrep',
             config: expect.objectContaining({
               baseUrl: '/apis/features.grafana.app/v0alpha1/namespaces/stacks-12345',
-              pollInterval: -1,
+              disableVisibilityRefresh: true,
+              cacheMode: 'disabled',
               timeoutMs: 10_000,
             }),
           }),

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -245,7 +245,8 @@ export async function initializeOpenFeature(): Promise<void> {
     OPENFEATURE_DOMAIN,
     new OFREPWebProvider({
       baseUrl: `/apis/features.grafana.app/v0alpha1/namespaces/${namespace}`,
-      pollInterval: -1, // Do not poll - flags are fetched once on init
+      disableVisibilityRefresh: true, // Do not refresh
+      cacheMode: 'disabled', // Do not write to localStorage
       timeoutMs: 10_000, // Timeout after 10 seconds
     }),
     {


### PR DESCRIPTION
Updates the OFREP Web Provider for OpenFeature across a breaking change, disabling the new refresh on window focus functionality, disabling the localStorage caching functionality, and removing the polling disable (as it is now disabled by default).

cc https://github.com/grafana/grafana-backend-services-squad/pull/16 https://github.com/open-feature/js-sdk-contrib/pull/1535