### PR TITLE
fix(analytics): include all enrolled experiments in event enrichment

### DIFF
--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,4 +1,4 @@
-import { reportAppInteraction, UserInteraction } from './analytics';
+import { reportAppInteraction, UserInteraction, bindExperimentsProvider } from './analytics';
 import { reportInteraction } from '@grafana/runtime';
 
 jest.mock('@grafana/runtime', () => ({
@@ -66,5 +66,70 @@ describe('reportAppInteraction', () => {
     expect(properties.step_id).toBe('step-1');
     expect(properties.content_type).toBe('interactive_guide');
     expect(properties.plugin_version).toBe('1.0.0-test');
+  });
+});
+
+describe('reportAppInteraction experiment enrichment', () => {
+  const HIGHLIGHTED = 'pathfinder.highlighted-guide-experiment';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete (window as any).__pathfinderKioskSessionId;
+  });
+
+  // Runs first, while the module-level provider is still unbound (nothing has
+  // called bindExperimentsProvider yet), so it exercises the graceful no-op path.
+  it('reports without variant/experiments when no provider is bound', () => {
+    reportAppInteraction(UserInteraction.SummaryClick, { content_url: 'u' });
+
+    const props = mockReportInteraction.mock.calls[0][1];
+    expect(props).not.toHaveProperty('experiments');
+    expect(props).not.toHaveProperty('variant');
+    expect(props.plugin_version).toBe('1.0.0-test');
+  });
+
+  it('passes the enrolled experiments through and rolls variant up to treatment', () => {
+    bindExperimentsProvider(() => [
+      { flag: 'pathfinder.experiment-variant', variant: 'control', pages: [] },
+      { flag: HIGHLIGHTED, variant: 'treatment', pages: [], guideId: 'g', docType: 'learning-journey' },
+    ]);
+
+    reportAppInteraction(UserInteraction.SummaryClick, {});
+
+    const props = mockReportInteraction.mock.calls[0][1];
+    expect(props.variant).toBe('treatment');
+    expect(props.experiments).toEqual([
+      expect.objectContaining({ flag: 'pathfinder.experiment-variant', variant: 'control' }),
+      expect.objectContaining({ flag: HIGHLIGHTED, variant: 'treatment', guideId: 'g', docType: 'learning-journey' }),
+    ]);
+  });
+
+  it('rolls variant up to control when no enrolled experiment is treatment', () => {
+    bindExperimentsProvider(() => [{ flag: HIGHLIGHTED, variant: 'control', pages: [], guideId: 'g' }]);
+
+    reportAppInteraction(UserInteraction.SummaryClick, {});
+
+    expect(mockReportInteraction.mock.calls[0][1].variant).toBe('control');
+  });
+
+  it('omits variant/experiments when the user is enrolled in nothing', () => {
+    bindExperimentsProvider(() => []);
+
+    reportAppInteraction(UserInteraction.SummaryClick, {});
+
+    const props = mockReportInteraction.mock.calls[0][1];
+    expect(props).not.toHaveProperty('experiments');
+    expect(props).not.toHaveProperty('variant');
+  });
+
+  it('does not enrich FeatureFlagEvaluated events (recursion guard)', () => {
+    bindExperimentsProvider(() => [{ flag: HIGHLIGHTED, variant: 'treatment', pages: [], guideId: 'g' }]);
+
+    reportAppInteraction(UserInteraction.FeatureFlagEvaluated, { flag_key: HIGHLIGHTED });
+
+    const props = mockReportInteraction.mock.calls[0][1];
+    expect(props).not.toHaveProperty('experiments');
+    expect(props).not.toHaveProperty('variant');
+    expect(props.flag_key).toBe(HIGHLIGHTED);
   });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -8,18 +8,18 @@
 import { reportInteraction } from '@grafana/runtime';
 import packageJson from '../../package.json';
 import { isInteractiveLearningUrl } from '../security/url-validator';
-import type { ExperimentConfig } from '../utils/openfeature';
+import type { ExperimentConfig, ExperimentAnalyticsEntry } from '../utils/openfeature';
 
-type GetExperimentConfigFn = (flag: string) => ExperimentConfig;
-let _getExperimentConfig: GetExperimentConfigFn | null = null;
+type GetActiveExperimentsFn = () => ExperimentAnalyticsEntry[];
+let _getActiveExperiments: GetActiveExperimentsFn | null = null;
 
 /**
- * Late-binds the getExperimentConfig function after OpenFeature initializes.
+ * Late-binds the active-experiments provider after OpenFeature initializes.
  * Called from module.tsx to break the static import chain that would otherwise
  * pull the entire OpenFeature SDK into the entry-point bundle.
  */
-export function bindExperimentConfig(fn: GetExperimentConfigFn): void {
-  _getExperimentConfig = fn;
+export function bindExperimentsProvider(fn: GetActiveExperimentsFn): void {
+  _getActiveExperiments = fn;
 }
 
 // ============================================================================
@@ -113,76 +113,25 @@ const createInteractionName = (type: UserInteraction): string => {
   return `pathfinder_${type}`;
 };
 
-/**
- * Experiment entry for analytics enrichment
- * Each experiment includes its flag name and the raw config from GOFF
- */
-interface ExperimentAnalyticsEntry {
-  flag: string;
-  [key: string]: unknown; // Allow any additional properties from GOFF
-}
-
-/**
- * Gets the current experiment variant for analytics enrichment.
- *
- * Returns 'treatment' if the user is in treatment for any experiment,
- * 'control' if in control for any (and not treatment for another),
- * otherwise 'excluded'.
- */
-function getExperimentVariant(): ExperimentConfig['variant'] | null {
-  if (!_getExperimentConfig) {
+function getExperimentsForAnalytics(): ExperimentAnalyticsEntry[] | null {
+  if (!_getActiveExperiments) {
     return null;
   }
   try {
-    const mainVariant = _getExperimentConfig('pathfinder.experiment-variant').variant;
-    const after24hVariant = _getExperimentConfig('pathfinder.after-24h-experiment').variant;
-
-    if (mainVariant === 'treatment' || after24hVariant === 'treatment') {
-      return 'treatment';
-    }
-    if (mainVariant === 'control' || after24hVariant === 'control') {
-      return 'control';
-    }
-    return 'excluded';
+    return _getActiveExperiments();
   } catch {
     return null;
   }
 }
 
-/**
- * Gets the current experiments state as an array for analytics enrichment
- *
- * This captures all active experiments at the time of the analytics event,
- * enabling analysis of experiment impact on user behavior.
- *
- * Each experiment config is included as-is from GOFF, allowing flexibility for any
- * experiment structure without requiring code changes.
- *
- * @returns Array of experiment configs, or null if experiments cannot be retrieved
- */
-function getExperimentsForAnalytics(): ExperimentAnalyticsEntry[] | null {
-  if (!_getExperimentConfig) {
-    return null;
+function rollUpVariant(experiments: ExperimentAnalyticsEntry[]): ExperimentConfig['variant'] {
+  if (experiments.some((experiment) => experiment.variant === 'treatment')) {
+    return 'treatment';
   }
-  try {
-    const experiments: ExperimentAnalyticsEntry[] = [];
-
-    const experimentVariantConfig = _getExperimentConfig('pathfinder.experiment-variant');
-    experiments.push({
-      flag: 'pathfinder.experiment-variant',
-      ...experimentVariantConfig,
-    });
-
-    const after24hConfig = _getExperimentConfig('pathfinder.after-24h-experiment');
-    experiments.push({
-      flag: 'pathfinder.after-24h-experiment',
-      ...after24hConfig,
-    });
-
-    return experiments;
-  } catch (error) {
-    return null;
+  if (experiments.some((experiment) => experiment.variant === 'control')) {
+    return 'control';
   }
+  return 'excluded';
 }
 
 /**
@@ -232,18 +181,16 @@ export function reportAppInteraction(
     // Skip experiment enrichment for FeatureFlagEvaluated events to avoid recursion
     // (those events already contain the flag info in their properties)
     const shouldEnrichWithExperiments = type !== UserInteraction.FeatureFlagEvaluated;
-    const experiments = shouldEnrichWithExperiments ? getExperimentsForAnalytics() : null;
-    const variant = shouldEnrichWithExperiments ? getExperimentVariant() : null;
+    const activeExperiments = shouldEnrichWithExperiments ? getExperimentsForAnalytics() : null;
+    const experiments = activeExperiments && activeExperiments.length > 0 ? activeExperiments : null;
+    const variant = experiments ? rollUpVariant(experiments) : null;
 
     const kioskSessionId = (window as any).__pathfinderKioskSessionId as string | undefined;
 
-    // Add global attributes to all events
     const enrichedProperties: Record<string, unknown> = {
       plugin_version: packageJson.version,
       ...properties,
-      // Include variant for easy filtering/segmentation in analytics
       ...(variant && { variant }),
-      // Include experiments array if available (null check for graceful degradation)
       ...(experiments && { experiments }),
       ...(kioskSessionId && { kiosk_session_id: kioskSessionId }),
     };

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -37,12 +37,12 @@ document.addEventListener('pathfinder-suggest', earlySuggestListener);
 // This connects to the Multi-Tenant Feature Flag Service (MTFF) in Grafana Cloud
 // Uses dynamic import so the SDK stays out of the entry-point bundle
 try {
-  const { initializeOpenFeature, getExperimentConfig } = await import('./utils/openfeature');
+  const { initializeOpenFeature, getActiveExperiments } = await import('./utils/openfeature');
   await initializeOpenFeature();
 
-  // Late-bind experiment config to analytics (breaks the static import chain)
-  const { bindExperimentConfig } = await import('./lib/analytics');
-  bindExperimentConfig(getExperimentConfig);
+  // Late-bind the active-experiments provider to analytics (breaks the static import chain)
+  const { bindExperimentsProvider } = await import('./lib/analytics');
+  bindExperimentsProvider(getActiveExperiments);
 } catch (e) {
   console.error('[OpenFeature] Error initializing feature flags:', e);
 }

--- a/src/utils/openfeature.test.ts
+++ b/src/utils/openfeature.test.ts
@@ -491,6 +491,115 @@ describe('openfeature', () => {
     });
   });
 
+  describe('getActiveExperiments', () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it('returns only the enrolled experiment, dropping excluded arms', () => {
+      jest.isolateModules(() => {
+        const mockOF = createMockOpenFeature();
+        const mockReact = createMockReactSdk();
+        mockOF.mockClient.getObjectValue.mockImplementation((flagName: string) => {
+          if (flagName === 'pathfinder.highlighted-guide-experiment') {
+            return {
+              variant: 'treatment',
+              pages: ['/a/grafana-irm-app*'],
+              guideId: 'https://interactive-learning.grafana.net/packages/grafana-irm-configuration-lj/content.json',
+              autoOpen: true,
+              docType: 'learning-journey',
+            };
+          }
+          return { variant: 'excluded', pages: [] };
+        });
+        jest.doMock('@openfeature/web-sdk', () => mockOF);
+        jest.doMock('@openfeature/react-sdk', () => mockReact);
+
+        const { getActiveExperiments } = require('./openfeature');
+        const result = getActiveExperiments();
+
+        expect(result).toEqual([
+          {
+            flag: 'pathfinder.highlighted-guide-experiment',
+            variant: 'treatment',
+            pages: ['/a/grafana-irm-app*'],
+            guideId: 'https://interactive-learning.grafana.net/packages/grafana-irm-configuration-lj/content.json',
+            autoOpen: true,
+            docType: 'learning-journey',
+            resetCache: false,
+          },
+        ]);
+      });
+    });
+
+    it('includes every enrolled experiment and drops excluded + boolean flags', () => {
+      jest.isolateModules(() => {
+        const mockOF = createMockOpenFeature();
+        const mockReact = createMockReactSdk();
+        mockOF.mockClient.getObjectValue.mockImplementation((flagName: string) => {
+          if (flagName === 'pathfinder.experiment-variant') {
+            return { variant: 'control', pages: [] };
+          }
+          if (flagName === 'pathfinder.highlighted-guide-experiment') {
+            return { variant: 'treatment', pages: ['/a/grafana-irm-app*'], guideId: 'bundled:g', autoOpen: true };
+          }
+          return { variant: 'excluded', pages: [] };
+        });
+        jest.doMock('@openfeature/web-sdk', () => mockOF);
+        jest.doMock('@openfeature/react-sdk', () => mockReact);
+
+        const { getActiveExperiments } = require('./openfeature');
+        const flags = getActiveExperiments().map((entry: { flag: string }) => entry.flag);
+
+        expect(flags).toEqual(['pathfinder.experiment-variant', 'pathfinder.highlighted-guide-experiment']);
+      });
+    });
+
+    it('returns an empty array when no experiment is enrolled', () => {
+      jest.isolateModules(() => {
+        const mockOF = createMockOpenFeature();
+        const mockReact = createMockReactSdk();
+        mockOF.mockClient.getObjectValue.mockReturnValue({ variant: 'excluded', pages: [] });
+        jest.doMock('@openfeature/web-sdk', () => mockOF);
+        jest.doMock('@openfeature/react-sdk', () => mockReact);
+
+        const { getActiveExperiments } = require('./openfeature');
+        expect(getActiveExperiments()).toEqual([]);
+      });
+    });
+
+    it('reflects a localStorage override for the highlighted-guide flag (incl. guideId/docType)', () => {
+      jest.isolateModules(() => {
+        const mockOF = createMockOpenFeature();
+        const mockReact = createMockReactSdk();
+        mockOF.mockClient.getObjectValue.mockReturnValue({ variant: 'excluded', pages: [] });
+        jest.doMock('@openfeature/web-sdk', () => mockOF);
+        jest.doMock('@openfeature/react-sdk', () => mockReact);
+
+        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+        const { setFlagOverride, getActiveExperiments } = require('./openfeature');
+        setFlagOverride('pathfinder.highlighted-guide-experiment', {
+          variant: 'treatment',
+          pages: ['/a/grafana-irm-app*'],
+          guideId: 'bundled:my-guide',
+          autoOpen: true,
+          docType: 'interactive',
+        });
+
+        const highlighted = getActiveExperiments().find(
+          (entry: { flag: string }) => entry.flag === 'pathfinder.highlighted-guide-experiment'
+        );
+
+        expect(highlighted).toEqual(
+          expect.objectContaining({ variant: 'treatment', guideId: 'bundled:my-guide', docType: 'interactive' })
+        );
+
+        consoleSpy.mockRestore();
+      });
+    });
+  });
+
   describe('evaluateFeatureFlag', () => {
     it('should evaluate boolean flag (tracking happens via hook added at init)', async () => {
       await jest.isolateModulesAsync(async () => {

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -182,6 +182,14 @@ export type FlagTrackingKey = (typeof pathfinderFeatureFlags)[keyof typeof pathf
     : never
   : never;
 
+export interface ExperimentAnalyticsEntry {
+  flag: FeatureFlagName;
+  variant: ExperimentConfig['variant'];
+  pages: string[];
+  resetCache?: boolean;
+  [key: string]: unknown;
+}
+
 /**
  * Map of flag names to their tracking keys (only for flags with trackingKey defined)
  */
@@ -594,6 +602,28 @@ function validateHighlightedGuideValue(value: unknown): HighlightedGuideConfig |
     ...(docType ? { docType } : {}),
   };
 }
+
+// ============================================================================
+// EXPERIMENT ANALYTICS
+// ============================================================================
+
+const HIGHLIGHTED_GUIDE_FLAG: FeatureFlagName = 'pathfinder.highlighted-guide-experiment';
+
+const getExperimentFlagNames = (): FeatureFlagName[] =>
+  featureFlagNames.filter((name) => pathfinderFeatureFlags[name].valueType === 'object');
+
+// Enumerated from pathfinderFeatureFlags (single source of truth) so a new experiment
+// is captured automatically. Excluded arms are dropped — 'excluded' means the user
+// isn't enrolled, matching the exposure-event convention (openfeature-tracking.ts).
+export const getActiveExperiments = (): ExperimentAnalyticsEntry[] =>
+  getExperimentFlagNames()
+    .map((flag) =>
+      // highlighted-guide carries extra fields (guideId/docType) that getExperimentConfig strips
+      flag === HIGHLIGHTED_GUIDE_FLAG
+        ? { flag, ...getHighlightedGuideConfig() }
+        : { flag, ...getExperimentConfig(flag) }
+    )
+    .filter((entry) => entry.variant !== 'excluded');
 
 // ============================================================================
 // URL PATTERN MATCHING


### PR DESCRIPTION
## What & why

`reportAppInteraction` enriches every engagement event with a top-level `variant` and an `experiments[]` array. Both were **hardcoded** to read only `pathfinder.experiment-variant` and `pathfinder.after-24h-experiment`, so the currently-active `pathfinder.highlighted-guide-experiment` never appeared in analytics — a user in its `treatment` arm reported `variant: "excluded"` on every engagement event, making the guide-vs-guide comparison impossible to segment without joining back to the exposure event.

Root cause: when `highlighted-guide-experiment` was added, `analytics.ts` was never updated.

## Change

Enrichment is now **data-driven** over the single `pathfinderFeatureFlags` source of truth:

- `getActiveExperiments()` (new, in `openfeature.ts`) enumerates experiment flags (`valueType: 'object'`) and returns only **enrolled** (non-`excluded`) arms — matching the exposure-event convention in `openfeature-tracking.ts`. The highlighted-guide flag is read via its own accessor so `guideId`/`docType` survive.
- `reportAppInteraction` calls the provider **once** and derives both `experiments[]` and the rolled-up `variant` from it. The two hardcoded helpers are deleted.
- Late-binding + type-only import preserved, so the OpenFeature SDK stays out of the entry bundle (verified: 0 `OFREPWebProvider` refs in `dist/module.js`).

A newly added experiment is now picked up automatically — no `analytics.ts` change needed.

## Behaviour change (heads-up for analytics / dashboard owners)

This changes **live** analytics:
- A `highlighted-guide` treatment user now emits `variant: "treatment"` + the experiment inside `experiments[]` (previously `variant: "excluded"`, experiment absent).
- `experiments[]` now contains **only enrolled** experiments (was: every defined flag, including `excluded` ones).
- A user enrolled in **no** experiment now emits **no** `variant`/`experiments` keys (was: `variant: "excluded"`).

No in-repo code reads these fields, but external RudderStack dashboards/funnels that segment by the top-level `variant` or assume the old 2-element array will shift.

## Testing

- `getActiveExperiments`: enrolled-only filtering, multi-enrollment, empty case, override path (incl. `guideId`/`docType`).
- `reportAppInteraction`: `experiments[]` passthrough, variant roll-up precedence, `FeatureFlagEvaluated` recursion guard, graceful no-op when unbound / no enrollment.
- typecheck, lint, prettier, build all green; 50/50 tests across the two suites; governance (architecture + import-graph) unchanged.