### PR TITLE
fix: remove redundant `dispatchEvents` after combobox fill in `handleDoMode`

### DIFF
--- a/src/interactive-engine/action-handlers/form-fill-handler.ts
+++ b/src/interactive-engine/action-handlers/form-fill-handler.ts
@@ -87,8 +87,6 @@ export class FormFillHandler {
     }
     if (isCombobox) {
       await this.fillComboboxStaged(refinedElement, remainingValue);
-      // Combobox flow handles its own events/enters; still dispatch final blur/change to settle state
-      await this.dispatchEvents(refinedElement, tagName, false);
       await this.markAsCompleted(data);
       return;
     }


### PR DESCRIPTION
## Summary

Combobox fill steps via the "Do It" button were leaving a portal overlay div in `grafana-portal-container` that intercepted pointer events, blocking clicks on adjacent UI. `fillComboboxStaged` already dispatches the input, change, Escape, and blur events the combobox needs; the trailing `dispatchEvents` call was re-focusing the input, re-opening the dropdown, and stranding the overlay. Removing the redundant call lets the staged flow's own events settle the combobox state.

For real users, this is at most annoying, because it requires an extra click to regain control before interacting with grafana/pathfinder again (it's also possibly an a11y issue). 

But the MAIN reason for this change is for our e2e harness: the overlay causes Playwright to timeout for all guides that involve combobox interaction, since it will not try to click through the overlay element with `pointer-events: none`.

## What changed

- `src/interactive-engine/action-handlers/form-fill-handler.ts` — drop the post-`fillComboboxStaged` `dispatchEvents` call so the staged combobox flow owns the final event sequence for that branch.

## Test plan

- [ ] `npm run check`
- [ ] Manual: run an interactive guide containing a combobox fill step, then verify the next step's "Do it" button is immediately clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
