### PR TITLE
refactor(user-storage): extract experimentAutoOpenStorage to lib/storage/

### DIFF
--- a/src/lib/storage/experiment-auto-open-storage.test.ts
+++ b/src/lib/storage/experiment-auto-open-storage.test.ts
@@ -1,0 +1,103 @@
+import { StorageKeys } from '../storage-keys';
+import { experimentAutoOpenStorage } from './experiment-auto-open-storage';
+
+jest.mock('@grafana/runtime', () => ({
+  usePluginUserStorage: jest.fn(),
+  getAppEvents: jest.fn(),
+}));
+
+describe('experimentAutoOpenStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('get', () => {
+    it('returns defaults when no state has been stored', async () => {
+      const state = await experimentAutoOpenStorage.get();
+      expect(state).toEqual({ pagesAutoOpened: [], globalAutoOpened: false });
+    });
+
+    it('falls back to defaults when stored data fails schema validation', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      localStorage.setItem(StorageKeys.EXPERIMENT_AUTO_OPEN, JSON.stringify({ bogus: true }));
+
+      const state = await experimentAutoOpenStorage.get();
+
+      expect(state).toEqual({ pagesAutoOpened: [], globalAutoOpened: false });
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Experiment auto-open state validation failed, using defaults:',
+        expect.any(Array)
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('markPageAutoOpened / hasPageAutoOpened', () => {
+    it('round-trips a single page pattern through StorageKeys.EXPERIMENT_AUTO_OPEN', async () => {
+      await experimentAutoOpenStorage.markPageAutoOpened('/a/grafana-synthetic-monitoring-app');
+
+      expect(await experimentAutoOpenStorage.hasPageAutoOpened('/a/grafana-synthetic-monitoring-app')).toBe(true);
+      expect(await experimentAutoOpenStorage.hasPageAutoOpened('/a/other-app')).toBe(false);
+
+      const raw = localStorage.getItem(StorageKeys.EXPERIMENT_AUTO_OPEN);
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw!)).toEqual({
+        pagesAutoOpened: ['/a/grafana-synthetic-monitoring-app'],
+        globalAutoOpened: false,
+      });
+    });
+
+    it('does not add duplicate page patterns', async () => {
+      await experimentAutoOpenStorage.markPageAutoOpened('/a/app');
+      await experimentAutoOpenStorage.markPageAutoOpened('/a/app');
+
+      const state = await experimentAutoOpenStorage.get();
+      expect(state.pagesAutoOpened).toEqual(['/a/app']);
+    });
+
+    it('appends additional patterns alongside existing ones', async () => {
+      await experimentAutoOpenStorage.markPageAutoOpened('/a/first');
+      await experimentAutoOpenStorage.markPageAutoOpened('/a/second');
+
+      const state = await experimentAutoOpenStorage.get();
+      expect(state.pagesAutoOpened).toEqual(['/a/first', '/a/second']);
+    });
+  });
+
+  describe('markGlobalAutoOpened / hasGlobalAutoOpened', () => {
+    it('flips and reads the global flag without affecting page patterns', async () => {
+      await experimentAutoOpenStorage.markPageAutoOpened('/a/app');
+      expect(await experimentAutoOpenStorage.hasGlobalAutoOpened()).toBe(false);
+
+      await experimentAutoOpenStorage.markGlobalAutoOpened();
+
+      expect(await experimentAutoOpenStorage.hasGlobalAutoOpened()).toBe(true);
+      const state = await experimentAutoOpenStorage.get();
+      expect(state.pagesAutoOpened).toEqual(['/a/app']);
+    });
+  });
+
+  describe('reset', () => {
+    it('overwrites stored state with defaults but keeps the key present', async () => {
+      await experimentAutoOpenStorage.markPageAutoOpened('/a/app');
+      await experimentAutoOpenStorage.markGlobalAutoOpened();
+
+      await experimentAutoOpenStorage.reset();
+
+      const raw = localStorage.getItem(StorageKeys.EXPERIMENT_AUTO_OPEN);
+      expect(JSON.parse(raw!)).toEqual({ pagesAutoOpened: [], globalAutoOpened: false });
+    });
+  });
+
+  describe('clear', () => {
+    it('removes the storage key entirely', async () => {
+      await experimentAutoOpenStorage.markPageAutoOpened('/a/app');
+      expect(localStorage.getItem(StorageKeys.EXPERIMENT_AUTO_OPEN)).not.toBeNull();
+
+      await experimentAutoOpenStorage.clear();
+
+      expect(localStorage.getItem(StorageKeys.EXPERIMENT_AUTO_OPEN)).toBeNull();
+    });
+  });
+});

--- a/src/lib/storage/experiment-auto-open-storage.ts
+++ b/src/lib/storage/experiment-auto-open-storage.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+
+import { StorageKeys } from '../storage-keys';
+import { createUserStorage } from '../user-storage';
+
+export interface ExperimentAutoOpenState {
+  pagesAutoOpened: string[];
+  globalAutoOpened: boolean;
+}
+
+const defaultState = (): ExperimentAutoOpenState => ({
+  pagesAutoOpened: [],
+  globalAutoOpened: false,
+});
+
+const ExperimentAutoOpenStateSchema = z.object({
+  pagesAutoOpened: z.array(z.string()),
+  globalAutoOpened: z.boolean(),
+});
+
+/**
+ * Experiment auto-open storage operations
+ *
+ * Tracks whether the sidebar has been auto-opened for the experiment.
+ * Persists across browsers via Grafana user storage (when available).
+ *
+ * This replaces sessionStorage-based tracking to ensure:
+ * - State persists across browser sessions
+ * - State syncs across devices (via Grafana user storage)
+ * - State survives cookie/storage clears (if Grafana storage available)
+ */
+export const experimentAutoOpenStorage = {
+  async get(): Promise<ExperimentAutoOpenState> {
+    try {
+      const storage = createUserStorage();
+      const stored = await storage.getItem<unknown>(StorageKeys.EXPERIMENT_AUTO_OPEN);
+
+      if (!stored) {
+        return defaultState();
+      }
+
+      const parsed = ExperimentAutoOpenStateSchema.safeParse(stored);
+      if (parsed.success) {
+        return parsed.data;
+      }
+
+      console.warn('Experiment auto-open state validation failed, using defaults:', parsed.error.issues);
+      return defaultState();
+    } catch {
+      return defaultState();
+    }
+  },
+
+  async hasPageAutoOpened(pagePattern: string): Promise<boolean> {
+    const state = await experimentAutoOpenStorage.get();
+    return state.pagesAutoOpened.includes(pagePattern);
+  },
+
+  async markPageAutoOpened(pagePattern: string): Promise<void> {
+    try {
+      const storage = createUserStorage();
+      const state = await experimentAutoOpenStorage.get();
+
+      if (!state.pagesAutoOpened.includes(pagePattern)) {
+        state.pagesAutoOpened.push(pagePattern);
+        await storage.setItem(StorageKeys.EXPERIMENT_AUTO_OPEN, state);
+      }
+    } catch (error) {
+      console.warn('Failed to mark page as auto-opened:', error);
+    }
+  },
+
+  async hasGlobalAutoOpened(): Promise<boolean> {
+    const state = await experimentAutoOpenStorage.get();
+    return state.globalAutoOpened;
+  },
+
+  async markGlobalAutoOpened(): Promise<void> {
+    try {
+      const storage = createUserStorage();
+      const state = await experimentAutoOpenStorage.get();
+      state.globalAutoOpened = true;
+      await storage.setItem(StorageKeys.EXPERIMENT_AUTO_OPEN, state);
+    } catch (error) {
+      console.warn('Failed to mark global auto-open:', error);
+    }
+  },
+
+  /** Resets auto-open state (called when resetCache flag is toggled in GOFF) */
+  async reset(): Promise<void> {
+    try {
+      const storage = createUserStorage();
+      await storage.setItem(StorageKeys.EXPERIMENT_AUTO_OPEN, defaultState());
+    } catch (error) {
+      console.warn('Failed to reset experiment auto-open state:', error);
+    }
+  },
+
+  async clear(): Promise<void> {
+    try {
+      const storage = createUserStorage();
+      await storage.removeItem(StorageKeys.EXPERIMENT_AUTO_OPEN);
+    } catch (error) {
+      console.warn('Failed to clear experiment auto-open state:', error);
+    }
+  },
+};

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -252,7 +252,7 @@ export function setGlobalStorage(storage: UserStorage): void {
  *
  * @returns UserStorage - Storage interface with async operations
  */
-function createUserStorage(): UserStorage {
+export function createUserStorage(): UserStorage {
   return globalStorageInstance || createLocalStorage();
 }
 
@@ -2029,136 +2029,7 @@ export const guideResponseStorage = {
 
 // ============================================================================
 // EXPERIMENT AUTO-OPEN STORAGE
+// Re-exported from ./storage/experiment-auto-open-storage for backward compatibility.
 // ============================================================================
 
-/**
- * Data structure for experiment auto-open tracking
- *
- * - pagesAutoOpened: Array of page path patterns that have triggered auto-open (treatment variant)
- * - globalAutoOpened: Whether global auto-open has occurred (excluded variant)
- */
-export interface ExperimentAutoOpenState {
-  pagesAutoOpened: string[];
-  globalAutoOpened: boolean;
-}
-
-const DEFAULT_EXPERIMENT_STATE: ExperimentAutoOpenState = {
-  pagesAutoOpened: [],
-  globalAutoOpened: false,
-};
-
-/** Schema for experiment auto-open state validation */
-const ExperimentAutoOpenStateSchema = z.object({
-  pagesAutoOpened: z.array(z.string()),
-  globalAutoOpened: z.boolean(),
-});
-
-/**
- * Experiment auto-open storage operations
- *
- * Tracks whether the sidebar has been auto-opened for the experiment.
- * Persists across browsers via Grafana user storage (when available).
- *
- * This replaces sessionStorage-based tracking to ensure:
- * - State persists across browser sessions
- * - State syncs across devices (via Grafana user storage)
- * - State survives cookie/storage clears (if Grafana storage available)
- */
-export const experimentAutoOpenStorage = {
-  /**
-   * Gets the current experiment auto-open state with Zod validation
-   */
-  async get(): Promise<ExperimentAutoOpenState> {
-    try {
-      const storage = createUserStorage();
-      const stored = await storage.getItem<unknown>(StorageKeys.EXPERIMENT_AUTO_OPEN);
-
-      if (!stored) {
-        return DEFAULT_EXPERIMENT_STATE;
-      }
-
-      // Validate stored data against schema to protect against corruption
-      const parsed = ExperimentAutoOpenStateSchema.safeParse(stored);
-      if (parsed.success) {
-        return parsed.data;
-      }
-
-      console.warn('Experiment auto-open state validation failed, using defaults:', parsed.error.issues);
-      return DEFAULT_EXPERIMENT_STATE;
-    } catch {
-      return DEFAULT_EXPERIMENT_STATE;
-    }
-  },
-
-  /**
-   * Checks if a specific page pattern has been auto-opened (treatment variant)
-   */
-  async hasPageAutoOpened(pagePattern: string): Promise<boolean> {
-    const state = await experimentAutoOpenStorage.get();
-    return state.pagesAutoOpened.includes(pagePattern);
-  },
-
-  /**
-   * Marks a page pattern as auto-opened (treatment variant)
-   * Does not add duplicates
-   */
-  async markPageAutoOpened(pagePattern: string): Promise<void> {
-    try {
-      const storage = createUserStorage();
-      const state = await experimentAutoOpenStorage.get();
-
-      if (!state.pagesAutoOpened.includes(pagePattern)) {
-        state.pagesAutoOpened.push(pagePattern);
-        await storage.setItem(StorageKeys.EXPERIMENT_AUTO_OPEN, state);
-      }
-    } catch (error) {
-      console.warn('Failed to mark page as auto-opened:', error);
-    }
-  },
-
-  /**
-   * Checks if global auto-open has occurred (excluded variant)
-   */
-  async hasGlobalAutoOpened(): Promise<boolean> {
-    const state = await experimentAutoOpenStorage.get();
-    return state.globalAutoOpened;
-  },
-
-  /**
-   * Marks global auto-open as occurred (excluded variant)
-   */
-  async markGlobalAutoOpened(): Promise<void> {
-    try {
-      const storage = createUserStorage();
-      const state = await experimentAutoOpenStorage.get();
-      state.globalAutoOpened = true;
-      await storage.setItem(StorageKeys.EXPERIMENT_AUTO_OPEN, state);
-    } catch (error) {
-      console.warn('Failed to mark global auto-open:', error);
-    }
-  },
-
-  /**
-   * Resets auto-open state (called when resetCache flag is toggled in GOFF)
-   */
-  async reset(): Promise<void> {
-    try {
-      const storage = createUserStorage();
-      await storage.setItem(StorageKeys.EXPERIMENT_AUTO_OPEN, DEFAULT_EXPERIMENT_STATE);
-    } catch (error) {
-      console.warn('Failed to reset experiment auto-open state:', error);
-    }
-  },
-
-  /**
-   * Clears all experiment auto-open state
-   */
-  async clear(): Promise<void> {
-    try {
-      const storage = createUserStorage();
-      await storage.removeItem(StorageKeys.EXPERIMENT_AUTO_OPEN);
-    } catch (error) {
-      console.warn('Failed to clear experiment auto-open state:', error);
-    }
-  },
-};
+export { experimentAutoOpenStorage, type ExperimentAutoOpenState } from './storage/experiment-auto-open-storage';


### PR DESCRIPTION
## Summary

First step in splitting the 2,165-line `src/lib/user-storage.ts` god-module. Moves the `experimentAutoOpenStorage` namespace into its own file under a new `src/lib/storage/` directory and re-exports it from `user-storage.ts`, so no consumer imports change. Behavior is preserved; persisted storage shape and the `StorageKeys.EXPERIMENT_AUTO_OPEN` key are unchanged.

## Why

A combined high-risk-refactor + tech-debt audit of `user-storage.ts` flagged it as a Drift Hub: 10 unrelated storage namespaces, ~19 commits in the last 6 months, and 25+ importers spanning six tier boundaries. Doing a single big-bang split would be hostile to reviewers and dangerous given the file also contains the hybrid-storage write-queue state machine and the cross-system sync logic. The plan is to extract namespaces one at a time, lowest-risk first, so each PR is a localized move with a small characterization-test footprint.

`experimentAutoOpenStorage` is the right namespace to start with:

- Newest code in the file, smallest blast radius (3 production callers, all in `src/utils/experiments/`).
- Self-contained: one storage key, one Zod schema, no `CustomEvent` contract, no module-level mutable state shared with other namespaces.
- Establishes the directory layout and re-export template that subsequent extractions will follow mechanically.

Starting with the harder targets (the hybrid storage engine, the `globalStorageInstance` singleton, namespaces that own `CustomEvent`s) would invert the risk ordering — they need this scaffolding and characterization-test patterns to land safely.

## What to look at

- [`src/lib/storage/experiment-auto-open-storage.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8118724ffb7dfc45985233ee98b817543b9aed86/src/lib/storage/experiment-auto-open-storage.ts) — the extracted namespace. Diff against the old block in `user-storage.ts` should be a pure move *except* for the `defaultState()` factory replacing `DEFAULT_EXPERIMENT_STATE` (see Reversibility for the small bug fix that motivated it).
- [`src/lib/user-storage.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8118724ffb7dfc45985233ee98b817543b9aed86/src/lib/user-storage.ts) — confirm only two things change: `createUserStorage` flips from module-private to `export function`, and the old experiment block is replaced with `export { experimentAutoOpenStorage, type ExperimentAutoOpenState } from './storage/experiment-auto-open-storage';`. No other namespaces touched.
- [`src/lib/storage/experiment-auto-open-storage.test.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8118724ffb7dfc45985233ee98b817543b9aed86/src/lib/storage/experiment-auto-open-storage.test.ts) — 8 characterization tests pinning current behavior through the underlying storage key. These exist because the existing `experiment-utils.test.ts` mocks `experimentAutoOpenStorage` entirely, so until this PR the namespace had no direct test coverage.

## How to verify

1. Confirm the three existing production callers still resolve their imports unchanged: `src/module.tsx:502`, `src/utils/experiments/experiment-utils.ts:9`, and `src/utils/experiments/experiment-debug.ts:13` all import from `'./lib/user-storage'` or `'../../lib/user-storage'` — no path changes required by this PR.
2. Run the affected test suites locally if you want to sanity-check beyond CI: `npx jest src/lib/storage/ src/lib/user-storage.test.ts src/utils/experiments/` — should be 174 tests, all passing.
3. Spot-check the experiment behavior in dev: start Grafana with `npm run server`, visit a treatment page in the GOFF experiment, confirm the sidebar auto-opens on first visit and does not re-open on reload. Then call `experimentAutoOpenStorage.clear()` from the console and confirm a reload re-triggers auto-open.

## Breaking changes

None. Public surface is preserved via re-export; the persisted shape under `StorageKeys.EXPERIMENT_AUTO_OPEN` is unchanged.

## Reversibility

Fully reversible by `git revert`. No storage format or key changes, no migration, no telemetry shape change. One small behavioral fix worth calling out for `reversibility-and-one-way-door` reviewers: while characterizing the namespace, the new tests surfaced a latent bug where `markPageAutoOpened` mutated the module-level `DEFAULT_EXPERIMENT_STATE` constant via `state.pagesAutoOpened.push(...)`. In production this was mostly masked because subsequent reads come from localStorage (a fresh parsed object), but after `experimentAutoOpenStorage.clear()` the mutated defaults would resurface, claiming previously-marked pages were still marked. Fixed in this PR by replacing the shared constant with a `defaultState()` factory that returns a fresh object every call. Revert is safe — the previous buggy behavior was masked in nearly all flows.

## Out of scope

This PR is intentionally narrow. The following are deliberately deferred to follow-up PRs in the same series:

- Other pure namespaces (`fullScreenModeStorage`, `sectionDoneStorage`, `tabStorage`, the section-* family). Will follow the template established here.
- Namespaces that own `CustomEvent` contracts (`guideResponseStorage`, `learningProgressStorage`). Need contract-pin tests before relocation.
- The hybrid storage engine itself — `createHybridStorage`, the write-queue debounce/dedup, `wrapEnvelope`/`unwrapEnvelope`, and `syncFromGrafanaStorage`'s timestamp-based conflict resolution. Highest-risk extraction, will not happen until cheaper namespaces have proven the pattern.
- De-singletonizing `globalStorageInstance`, `hasSynced`, `completedCountCache`, and the quota-warning flag. Touches every importer; held for last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
