### PR TITLE
fix(e2e): treat step unmount as completion in guided substep loop

### DIFF
--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -206,22 +206,26 @@ export async function waitForCompletionWithObjectivePolling(
   const startTime = Date.now();
   const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
   const urlBeforeClick = options?.urlBeforeClick;
+  let seenAlive = false;
 
   while (Date.now() - startTime < timeout) {
-    // If step element was detached (e.g. after formfill that changed URL), treat as completed
     const count = await stepLocator.count();
-    if (count === 0 && urlBeforeClick != null) {
-      const currentUrl = page.url();
-      if (currentUrl !== urlBeforeClick) {
-        return { completedViaObjectives: false };
-      }
+    if (count > 0) {
+      seenAlive = true;
+    }
+
+    // Unmount after the element was observed alive is a completion signal
+    if (count === 0 && seenAlive) {
+      return { completedViaObjectives: false };
+    }
+    if (count === 0 && urlBeforeClick != null && page.url() !== urlBeforeClick) {
+      return { completedViaObjectives: false };
     }
 
     let state: string | null = null;
     try {
       state = await stepLocator.getAttribute('data-test-step-state', { timeout: 2000 });
     } catch {
-      // Element may have detached (e.g. formfill closed overlay); check URL change
       if (urlBeforeClick != null && page.url() !== urlBeforeClick) {
         return { completedViaObjectives: false };
       }
@@ -234,7 +238,6 @@ export async function waitForCompletionWithObjectivePolling(
     await page.waitForTimeout(COMPLETION_POLL_INTERVAL_MS);
   }
 
-  // Final check: step may have detached after URL change (e.g. formfill into command palette)
   if (urlBeforeClick != null) {
     const count = await stepLocator.count();
     if (count === 0 && page.url() !== urlBeforeClick) {
@@ -242,7 +245,6 @@ export async function waitForCompletionWithObjectivePolling(
     }
   }
 
-  // Final fallback: assert contract completion with short timeout
   await expect(stepLocator).toHaveAttribute('data-test-step-state', 'completed', { timeout: 1000 });
   return { completedViaObjectives: false };
 }
@@ -394,7 +396,7 @@ async function runGuidedSubstepLoop(
     verbose?: boolean;
     artifactsDir?: string;
   }
-): Promise<void> {
+): Promise<{ completed: boolean }> {
   let stepLocator = options.stepLocator;
   const { perSubstepTimeoutMs, verbose = false, artifactsDir } = options;
   const guidedStepCount = step.guidedStepCount ?? 1;
@@ -405,10 +407,20 @@ async function runGuidedSubstepLoop(
     }
   };
 
+  // Step unmount mid-loop is a completion signal
+  const stepDetached = async (): Promise<boolean> => {
+    stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
+    return (await stepLocator.count()) === 0;
+  };
+
   while (true) {
+    if (await stepDetached()) {
+      return { completed: true };
+    }
+
     const state = await stepLocator.getAttribute('data-test-step-state');
     if (state === 'completed') {
-      break;
+      return { completed: true };
     }
     if (state === 'error') {
       await captureLoopArtifacts('error-state');
@@ -427,7 +439,7 @@ async function runGuidedSubstepLoop(
     const currentIndex = indexStr != null ? parseInt(indexStr, 10) : 0;
     const safeIndex = Number.isNaN(currentIndex) ? 0 : currentIndex;
     if (safeIndex >= guidedStepCount) {
-      break;
+      return { completed: false };
     }
 
     const commentBox = page.locator('.interactive-comment-box').first();
@@ -457,18 +469,8 @@ async function runGuidedSubstepLoop(
         await target.scrollIntoViewIfNeeded();
         await target.click();
         await page.waitForTimeout(100);
-        const urlAfter = page.url();
-        if (urlBefore !== urlAfter) {
+        if (urlBefore !== page.url()) {
           await page.waitForLoadState('domcontentloaded');
-          stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
-          const count = await stepLocator.count();
-          if (count === 0) {
-            break;
-          }
-          const newState = await stepLocator.getAttribute('data-test-step-state');
-          if (newState === 'completed') {
-            break;
-          }
         }
       } else if (action === 'hover') {
         if (!reftarget) {
@@ -492,6 +494,10 @@ async function runGuidedSubstepLoop(
     } catch (err) {
       await captureLoopArtifacts(`substep-${safeIndex}-${action}`);
       throw err;
+    }
+
+    if (await stepDetached()) {
+      return { completed: true };
     }
 
     await waitForSubstepAdvance(page, stepLocator, safeIndex, perSubstepTimeoutMs, { commentBox });
@@ -739,7 +745,6 @@ export async function executeStep(
     const doItButton = page.getByTestId(testIds.interactive.doItButton(step.stepId));
     const urlBeforeClick = page.url();
     await doItButton.click();
-    const urlAfterClick = page.url();
 
     if (verbose) {
       console.log(`   → Clicked "Do it" for step ${step.stepId}`);
@@ -758,13 +763,15 @@ export async function executeStep(
       await expect(stepLocator).toHaveAttribute('data-test-step-state', 'executing', {
         timeout: GUIDED_WAIT_EXECUTING_MS,
       });
-      await runGuidedSubstepLoop(page, step, {
+      const { completed } = await runGuidedSubstepLoop(page, step, {
         stepLocator,
         perSubstepTimeoutMs: TIMEOUT_PER_GUIDED_SUBSTEP_MS,
         verbose,
         artifactsDir,
       });
-      await waitForCompletionWithObjectivePolling(page, step.stepId, timeout);
+      if (!completed) {
+        await waitForCompletionWithObjectivePolling(page, step.stepId, timeout);
+      }
 
       let guidedArtifacts: ArtifactPaths | undefined;
       if (artifactsDir && alwaysScreenshot) {


### PR DESCRIPTION
## Summary

The guide-runner hung on the final substep of multistep-guided steps when the substep's action caused the parent section to auto-collapse, unmounting the step element from the DOM. The runner then polled a detached locator until the global timeout fired. The substep loop now treats mid-flight unmount as a terminal completion signal, and the completion poller short-circuits once the step has been observed alive and is later detached.

## What changed

- `tests/e2e-runner/utils/guide-runner/execution.ts`
  - `runGuidedSubstepLoop` now returns `{ completed: boolean }`. A new `stepDetached()` helper runs at the top of each iteration and immediately after every substep action; either detection point returns `{ completed: true }`. The previous URL-change-specific inline re-query is removed — both the URL-change and the no-nav section-collapse cases are now handled uniformly.
  - `executeStep`'s guided branch captures the loop result and skips the post-loop `waitForCompletionWithObjectivePolling` when the loop already observed completion.
  - `waitForCompletionWithObjectivePolling` tracks `seenAlive`. A `count === 0` observation after the element was seen alive returns success regardless of `urlBeforeClick`. This retroactively fixes the same class of bug for non-guided multisteps whose final internal action triggers section auto-collapse without navigation.

## Test plan

- [ ] `npm run check`
- [ ] `npm run e2e -- --package <block-editor-tutorial-package>` — confirm the previously hanging multistep-guided section now completes
- [ ] Run a sample of other bundled guides via `npm run e2e -- --bundled` to confirm no regressions on happy-path guided steps (state-based completion still wins on the top-of-loop check)
- [ ] Manual: a guide whose final non-guided multistep action triggers section auto-collapse — verify it no longer hangs

## Risk and reversibility

Contained to the e2e runner; no product code changes. Reversible — revert the single commit. Behavioural change is "unmount counts as completion", which trusts a Pathfinder invariant (steps never re-mount under the same id within a run). If that invariant were ever violated by product code, the runner would falsely pass a step rather than hang — failure mode shifts from "hang on a real bug" to "miss a real bug", so monitor for unexpectedly green guides in CI after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
