### PR TITLE
feat(ai-fix): add AI-fix patch wire-format schema

### DIFF
--- a/src/integrations/assistant-integration/ai-fix-patch.schema.test.ts
+++ b/src/integrations/assistant-integration/ai-fix-patch.schema.test.ts
@@ -11,6 +11,15 @@ describe('AiFixPatchSchema', () => {
       expect(result.success).toBe(true);
     });
 
+    it('accepts an attribute selector matching a javascript: href prefix', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: 'a[href^="javascript:"]',
+      });
+      expect(result.success).toBe(true);
+    });
+
     it('rejects an empty targetStepId', () => {
       const result = AiFixPatchSchema.safeParse({
         type: 'selector-patch',
@@ -66,6 +75,56 @@ describe('AiFixPatchSchema', () => {
         newReftarget: '[data-testid="run-query"]',
       });
       expect(result.success).toBe(true);
+    });
+
+    it('rejects a negative subStepIndex', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'substep-selector-patch',
+        containerId: 'multi-1',
+        subStepIndex: -1,
+        newReftarget: '[data-testid="run-query"]',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a null subStepIndex', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'substep-selector-patch',
+        containerId: 'multi-1',
+        subStepIndex: null,
+        newReftarget: '[data-testid="run-query"]',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an empty containerId', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'substep-selector-patch',
+        containerId: '',
+        subStepIndex: 0,
+        newReftarget: '[data-testid="run-query"]',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a null containerId', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'substep-selector-patch',
+        containerId: null,
+        subStepIndex: 0,
+        newReftarget: '[data-testid="run-query"]',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a dangerous newReftarget (SafeSelectorSchema applies to substeps)', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'substep-selector-patch',
+        containerId: 'multi-1',
+        subStepIndex: 0,
+        newReftarget: 'javascript:alert(1)',
+      });
+      expect(result.success).toBe(false);
     });
   });
 

--- a/src/integrations/assistant-integration/ai-fix-patch.schema.test.ts
+++ b/src/integrations/assistant-integration/ai-fix-patch.schema.test.ts
@@ -1,0 +1,137 @@
+import { AiFixPatchSchema } from './ai-fix-patch.schema';
+
+describe('AiFixPatchSchema', () => {
+  describe('selector-patch', () => {
+    it('accepts a well-formed selector patch', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: '[data-testid="save-button"]',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty targetStepId', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'selector-patch',
+        targetStepId: '',
+        newReftarget: '.save',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects an HTML-shaped selector', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: '<script>alert(1)</script>',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a javascript: URL selector', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: 'javascript:alert(1)',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a template-literal interpolation', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: '${process.env.SECRET}',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a selector longer than 512 chars', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: '.x'.repeat(300),
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('substep-selector-patch', () => {
+    it('accepts a well-formed substep selector patch', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'substep-selector-patch',
+        containerId: 'multi-1',
+        subStepIndex: 0,
+        newReftarget: '[data-testid="run-query"]',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('prepend-step', () => {
+    it('accepts a well-formed prepend-step', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'prepend-step',
+        beforeStepId: 'step-1',
+        newStep: {
+          type: 'interactive',
+          action: 'highlight',
+          reftarget: '[data-testid="nav-dashboards"]',
+          content: 'Open dashboards',
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a newStep whose reftarget fails the safe-selector check', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'prepend-step',
+        beforeStepId: 'step-1',
+        newStep: {
+          type: 'interactive',
+          action: 'highlight',
+          reftarget: '<img src=x onerror=alert(1)>',
+          content: 'bad',
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a newStep that fails JsonInteractiveBlockSchema (non-noop with no reftarget)', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'prepend-step',
+        beforeStepId: 'step-1',
+        newStep: {
+          type: 'interactive',
+          action: 'highlight',
+          content: 'missing reftarget',
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts a noop newStep without reftarget', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'prepend-step',
+        beforeStepId: 'step-1',
+        newStep: {
+          type: 'interactive',
+          action: 'noop',
+          content: 'informational',
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('discriminator', () => {
+    it('rejects a payload with an unknown type', () => {
+      const result = AiFixPatchSchema.safeParse({
+        type: 'replace-everything',
+        targetStepId: 'step-1',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/integrations/assistant-integration/ai-fix-patch.schema.ts
+++ b/src/integrations/assistant-integration/ai-fix-patch.schema.ts
@@ -2,16 +2,25 @@ import { z } from 'zod';
 
 import { JsonInteractiveBlockSchema } from '../../types/json-guide.schema';
 
-// Deny-list: reject HTML, template interpolation, and unsafe URL schemes (XSS guard); 512-char cap bounds querySelector cost.
-const DANGEROUS_SELECTOR_PATTERNS = ['<', '>', '`', '${', 'javascript:', 'data:', 'vbscript:'] as const;
+// XSS guard for strings flowing into querySelector: HTML/template chars are blocked
+// anywhere; URL schemes are blocked only as a prefix, so attribute matches like
+// a[href^="javascript:"] pass. 512-char cap bounds querySelector cost.
+const DANGEROUS_URL_SCHEMES = ['javascript:', 'data:', 'vbscript:'] as const;
+const DANGEROUS_SUBSTRINGS = ['<', '>', '`', '${'] as const;
 
 const SafeSelectorSchema = z
   .string()
   .min(1)
   .max(512, 'Selector exceeds 512-character cap')
-  .refine((sel) => !DANGEROUS_SELECTOR_PATTERNS.some((p) => sel.toLowerCase().includes(p)), {
-    error: 'Selector contains a disallowed substring (HTML, template, or unsafe URL scheme)',
-  });
+  .refine(
+    (sel) => {
+      const normalized = sel.trim().toLowerCase();
+      const startsWithUnsafeScheme = DANGEROUS_URL_SCHEMES.some((scheme) => normalized.startsWith(scheme));
+      const containsUnsafeSubstring = DANGEROUS_SUBSTRINGS.some((p) => sel.includes(p));
+      return !startsWithUnsafeScheme && !containsUnsafeSubstring;
+    },
+    { error: 'Selector contains a disallowed substring (HTML, template, or unsafe URL scheme)' }
+  );
 
 const SelectorPatchSchema = z.object({
   type: z.literal('selector-patch'),

--- a/src/integrations/assistant-integration/ai-fix-patch.schema.ts
+++ b/src/integrations/assistant-integration/ai-fix-patch.schema.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+
+import { JsonInteractiveBlockSchema } from '../../types/json-guide.schema';
+
+// Deny-list: reject HTML, template interpolation, and unsafe URL schemes (XSS guard); 512-char cap bounds querySelector cost.
+const DANGEROUS_SELECTOR_PATTERNS = ['<', '>', '`', '${', 'javascript:', 'data:', 'vbscript:'] as const;
+
+const SafeSelectorSchema = z
+  .string()
+  .min(1)
+  .max(512, 'Selector exceeds 512-character cap')
+  .refine((sel) => !DANGEROUS_SELECTOR_PATTERNS.some((p) => sel.toLowerCase().includes(p)), {
+    error: 'Selector contains a disallowed substring (HTML, template, or unsafe URL scheme)',
+  });
+
+const SelectorPatchSchema = z.object({
+  type: z.literal('selector-patch'),
+  targetStepId: z.string().min(1),
+  newReftarget: SafeSelectorSchema,
+  rationale: z.string().max(500).optional(),
+});
+
+const PrependStepSchema = z.object({
+  type: z.literal('prepend-step'),
+  beforeStepId: z.string().min(1),
+  newStep: JsonInteractiveBlockSchema.superRefine((step, ctx) => {
+    if (step.reftarget !== undefined) {
+      const result = SafeSelectorSchema.safeParse(step.reftarget);
+      if (!result.success) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['reftarget'],
+          message: result.error.issues[0]?.message ?? 'Unsafe selector',
+        });
+      }
+    }
+  }),
+  rationale: z.string().max(500).optional(),
+});
+
+const SubstepSelectorPatchSchema = z.object({
+  type: z.literal('substep-selector-patch'),
+  containerId: z.string().min(1),
+  subStepIndex: z.number().int().min(0),
+  newReftarget: SafeSelectorSchema,
+  rationale: z.string().max(500).optional(),
+});
+
+export const AiFixPatchSchema = z.discriminatedUnion('type', [
+  SelectorPatchSchema,
+  PrependStepSchema,
+  SubstepSelectorPatchSchema,
+]);
+
+export type AiFixPatch = z.infer<typeof AiFixPatchSchema>;
+export type SelectorPatch = z.infer<typeof SelectorPatchSchema>;
+export type PrependStepPatch = z.infer<typeof PrependStepSchema>;
+export type SubstepSelectorPatch = z.infer<typeof SubstepSelectorPatchSchema>;


### PR DESCRIPTION
## What & why

**PR3 of the PR-886 AI auto-heal breakdown** ([RFC](https://github.com/grafana/pathfinder-rfcs/blob/208096ae619519c32ff2f56aca84685bd4a2414d/plans/PR-886-AI-AUTOHEAL-BREAKDOWN.md)). PR1 ([#980](https://github.com/grafana/grafana-pathfinder-app/pull/980)) is merged. PR2 (id-space reconciliation) was **folded into PR4** — `main` already settles the id space (`deriveStepId` + id-keyed completion + `reconcileSection` orphan self-heal), so the canonical-id/block-finder work moves into PR4 where `applyPatchToGuide` lives.

This PR adds the **AI-fix patch wire-format schema** — the Zod contract for what the Grafana Assistant is allowed to return when a user clicks the AI "Fix this" button on a failing interactive step.

## What's included

Two net-new files under `src/integrations/assistant-integration/`:
- `ai-fix-patch.schema.ts` — a `discriminatedUnion('type')` of:
  - `selector-patch` — replace a failing step's `reftarget`
  - `substep-selector-patch` — replace a `reftarget` inside a multistep/guided container (addressed by container id + positional index)
  - `prepend-step` — insert a new interactive step before the failing one; `newStep` round-trips through the authoritative `JsonInteractiveBlockSchema`
- `ai-fix-patch.schema.test.ts` — boundary tests

Every selector field passes `SafeSelectorSchema`: a deny-list (`<`, `>`, `` ` ``, `${`, `javascript:`, `data:`, `vbscript:`) + a 512-char cap. This is the security core — these strings flow into `querySelector`, so anything HTML/URL/template-shaped is rejected at the boundary.

## It lands dark

Net-new and inert — nothing imports `AiFixPatchSchema` until PR4 (`applyPatchToGuide`) and PR5 (the generation hook). No barrel export added yet (those PRs import the module directly). Zero behavior change for existing users.

## Test plan

- `npm run typecheck` ✅ — confirms `prepend-step`'s `JsonInteractiveBlockSchema.superRefine(...)` compiles against `main`'s Zod-4 schema
- `npm run lint` ✅ 0 errors · `prettier` ✅
- `jest ai-fix-patch.schema.test.ts` ✅ 12/12 — deny-list rejects HTML / `javascript:` / `${…}` / >512-char; `prepend-step` delegates to `JsonInteractiveBlockSchema` (non-`noop`-without-`reftarget` rejects, `noop`-without-`reftarget` accepts); unknown discriminator rejects
- governance/architecture (Tier 3 → Tier 0 import) ✅ 73/73
