### PR TITLE
feat(ai-fix): add pure applyPatchToGuide with pre/post schema validation

### DIFF
--- a/src/integrations/assistant-integration/ai-fix-step-id.ts
+++ b/src/integrations/assistant-integration/ai-fix-step-id.ts
@@ -1,0 +1,80 @@
+import { deriveStepId } from '../../global-state/step-id';
+import {
+  isConditionalBlock,
+  isSectionBlock,
+  type JsonBlock,
+  type JsonGuide,
+  type JsonGuidedBlock,
+  type JsonInteractiveBlock,
+  type JsonMultistepBlock,
+} from '../../types/json-guide.types';
+
+const STANDALONE_PARENT_ID = '__standalone__';
+
+// Canonical step id for an addressable block — identical to the value json-parser.ts
+// assigns to props.stepId (author id else deriveStepId). The apply test's parity case
+// pins this to the parser; keep the per-type extraction in sync.
+function resolveStepIdForBlock(block: JsonBlock, parentSectionId: string, index: number): string | undefined {
+  if (block.id) {
+    return block.id;
+  }
+  switch (block.type) {
+    case 'interactive': {
+      const b = block as JsonInteractiveBlock;
+      return deriveStepId({
+        sectionId: parentSectionId,
+        index,
+        action: b.action ?? b.targetAction,
+        refTarget: b.reftarget ?? b.refTarget,
+      });
+    }
+    case 'multistep': {
+      const first = (block as JsonMultistepBlock).steps[0];
+      return deriveStepId({
+        sectionId: parentSectionId,
+        index,
+        action: first?.action ?? first?.targetAction,
+        refTarget: first?.reftarget ?? first?.refTarget,
+        variant: 'multistep',
+      });
+    }
+    case 'guided': {
+      const first = (block as JsonGuidedBlock).steps[0];
+      return deriveStepId({
+        sectionId: parentSectionId,
+        index,
+        action: first?.action ?? first?.targetAction,
+        refTarget: first?.reftarget ?? first?.refTarget,
+        variant: 'guided',
+      });
+    }
+    default:
+      return undefined;
+  }
+}
+
+// Write a canonical id onto every addressable block lacking an author id, matching the
+// parser's walk so a block resolves by the same stepId a component dispatched. Mutates in
+// place (pass a clone); recurses sections + conditional branches — the containers the apply reaches.
+export function materializeStepIds(guide: JsonGuide): JsonGuide {
+  const walk = (blocks: JsonBlock[], parentSectionId: string, parentPath: string): void => {
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i]!;
+      const path = `${parentPath}[${i}]`;
+      if (!block.id) {
+        const derived = resolveStepIdForBlock(block, parentSectionId, i);
+        if (derived) {
+          block.id = derived;
+        }
+      }
+      if (isSectionBlock(block)) {
+        walk(block.blocks, block.id ? `section-${block.id}` : `section:${path}`, `${path}.blocks`);
+      } else if (isConditionalBlock(block)) {
+        walk(block.whenTrue, `conditional-true:${path}`, `${path}.whenTrue`);
+        walk(block.whenFalse, `conditional-false:${path}`, `${path}.whenFalse`);
+      }
+    }
+  };
+  walk(guide.blocks, STANDALONE_PARENT_ID, 'blocks');
+  return guide;
+}

--- a/src/integrations/assistant-integration/apply-ai-fix-patch.test.ts
+++ b/src/integrations/assistant-integration/apply-ai-fix-patch.test.ts
@@ -1,0 +1,383 @@
+import { applyPatchToGuide } from './apply-ai-fix-patch';
+import type { AiFixPatch } from './ai-fix-patch.schema';
+import { parseJsonGuide } from '../../docs-retrieval';
+import type { ParsedElement } from '../../types/content.types';
+
+function makeGuide(blocks: unknown[]): string {
+  return JSON.stringify({ schemaVersion: '1.1.0', id: 'test-guide', title: 'Test guide', blocks });
+}
+
+// Collect every props.stepId the parser assigns — used to drive the "addressable by the
+// parser's stepId" contract tests below.
+function collectStepIds(elements: Array<ParsedElement | string>): string[] {
+  const ids: string[] = [];
+  for (const el of elements) {
+    if (typeof el === 'string') {
+      continue;
+    }
+    const stepId = el.props?.stepId;
+    if (typeof stepId === 'string' && stepId.length > 0) {
+      ids.push(stepId);
+    }
+    ids.push(...collectStepIds(el.children));
+  }
+  return ids;
+}
+
+const validStep = {
+  type: 'interactive',
+  id: 'step-1',
+  action: 'button',
+  reftarget: '[data-testid="old-selector"]',
+  content: 'Click me',
+};
+
+describe('applyPatchToGuide', () => {
+  describe('selector-patch', () => {
+    it('replaces the reftarget on the matching interactive block', () => {
+      const result = applyPatchToGuide(makeGuide([validStep]), {
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: '[data-testid="new-selector"]',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(JSON.parse(result.newGuideJson).blocks[0].reftarget).toBe('[data-testid="new-selector"]');
+      }
+    });
+
+    it('reaches a step nested in a section block', () => {
+      const guideJson = makeGuide([{ type: 'section', title: 'Outer', blocks: [validStep] }]);
+      const result = applyPatchToGuide(guideJson, {
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: '[data-testid="found-in-section"]',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(JSON.parse(result.newGuideJson).blocks[0].blocks[0].reftarget).toBe('[data-testid="found-in-section"]');
+      }
+    });
+
+    it('fails when no block matches the target id', () => {
+      const result = applyPatchToGuide(makeGuide([validStep]), {
+        type: 'selector-patch',
+        targetStepId: 'step-missing',
+        newReftarget: '[data-testid="x"]',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/No interactive block found/);
+      }
+    });
+
+    it('reaches a step nested in a conditional whenTrue branch', () => {
+      const conditional = {
+        type: 'conditional',
+        conditions: ['has-datasource:prometheus'],
+        whenTrue: [validStep],
+        whenFalse: [],
+      };
+      const result = applyPatchToGuide(makeGuide([conditional]), {
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: '[data-testid="found-in-whenTrue"]',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(JSON.parse(result.newGuideJson).blocks[0].whenTrue[0].reftarget).toBe(
+          '[data-testid="found-in-whenTrue"]'
+        );
+      }
+    });
+
+    it('reaches a step nested in a conditional whenFalse branch', () => {
+      const conditional = {
+        type: 'conditional',
+        conditions: ['has-datasource:prometheus'],
+        whenTrue: [],
+        whenFalse: [validStep],
+      };
+      const result = applyPatchToGuide(makeGuide([conditional]), {
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: '[data-testid="found-in-whenFalse"]',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(JSON.parse(result.newGuideJson).blocks[0].whenFalse[0].reftarget).toBe(
+          '[data-testid="found-in-whenFalse"]'
+        );
+      }
+    });
+
+    it('does not crash when a sibling conditional has no matching step', () => {
+      const conditional = {
+        type: 'conditional',
+        conditions: ['has-datasource:prometheus'],
+        whenTrue: [{ ...validStep, id: 'unrelated-a' }],
+        whenFalse: [{ ...validStep, id: 'unrelated-b' }],
+      };
+      const result = applyPatchToGuide(makeGuide([conditional, validStep]), {
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: '[data-testid="found-after-conditional"]',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(JSON.parse(result.newGuideJson).blocks[1].reftarget).toBe('[data-testid="found-after-conditional"]');
+      }
+    });
+  });
+
+  describe('prepend-step', () => {
+    it('inserts the new step immediately before the target', () => {
+      const result = applyPatchToGuide(makeGuide([validStep]), {
+        type: 'prepend-step',
+        beforeStepId: 'step-1',
+        newStep: {
+          type: 'interactive',
+          action: 'button',
+          reftarget: '[data-testid="setup-step"]',
+          content: 'Open the menu first',
+        } as never,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const parsed = JSON.parse(result.newGuideJson);
+        expect(parsed.blocks).toHaveLength(2);
+        expect(parsed.blocks[0].reftarget).toBe('[data-testid="setup-step"]');
+        expect(parsed.blocks[1].id).toBe('step-1');
+      }
+    });
+
+    it('inserts inside a container at the correct position', () => {
+      const other = { ...validStep, id: 'step-other', reftarget: '[data-testid="other"]' };
+      const guideJson = makeGuide([{ type: 'section', title: 'Outer', blocks: [other, validStep] }]);
+      const result = applyPatchToGuide(guideJson, {
+        type: 'prepend-step',
+        beforeStepId: 'step-1',
+        newStep: {
+          type: 'interactive',
+          action: 'button',
+          reftarget: '[data-testid="setup"]',
+          content: 'Setup',
+        } as never,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const sectionBlocks = JSON.parse(result.newGuideJson).blocks[0].blocks;
+        expect(sectionBlocks).toHaveLength(3);
+        expect(sectionBlocks[0].id).toBe('step-other');
+        expect(sectionBlocks[1].reftarget).toBe('[data-testid="setup"]');
+        expect(sectionBlocks[2].id).toBe('step-1');
+      }
+    });
+  });
+
+  describe('substep-selector-patch', () => {
+    const multistepWithTwoSteps = {
+      type: 'multistep',
+      id: 'multi-1',
+      content: 'Do two things',
+      steps: [
+        { action: 'button', reftarget: '[data-testid="first"]' },
+        { action: 'button', reftarget: '[data-testid="second-stale"]' },
+      ],
+    };
+
+    it('replaces the reftarget on the targeted sub-step inside a multistep block', () => {
+      const result = applyPatchToGuide(makeGuide([multistepWithTwoSteps]), {
+        type: 'substep-selector-patch',
+        containerId: 'multi-1',
+        subStepIndex: 1,
+        newReftarget: '[data-testid="second-fixed"]',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const parsed = JSON.parse(result.newGuideJson);
+        expect(parsed.blocks[0].steps[0].reftarget).toBe('[data-testid="first"]');
+        expect(parsed.blocks[0].steps[1].reftarget).toBe('[data-testid="second-fixed"]');
+      }
+    });
+
+    it('reaches a container nested in a section', () => {
+      const result = applyPatchToGuide(
+        makeGuide([{ type: 'section', title: 'Outer', blocks: [multistepWithTwoSteps] }]),
+        {
+          type: 'substep-selector-patch',
+          containerId: 'multi-1',
+          subStepIndex: 0,
+          newReftarget: '[data-testid="first-fixed"]',
+        }
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    it('fails when the container id is not found', () => {
+      const result = applyPatchToGuide(makeGuide([multistepWithTwoSteps]), {
+        type: 'substep-selector-patch',
+        containerId: 'missing',
+        subStepIndex: 0,
+        newReftarget: '[data-testid="x"]',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/No multistep\/guided container/);
+      }
+    });
+
+    it('fails with a range error when subStepIndex is out of bounds', () => {
+      const result = applyPatchToGuide(makeGuide([multistepWithTwoSteps]), {
+        type: 'substep-selector-patch',
+        containerId: 'multi-1',
+        subStepIndex: 99,
+        newReftarget: '[data-testid="x"]',
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/out of range/);
+      }
+    });
+
+    it('works for guided containers too', () => {
+      const guided = {
+        type: 'guided',
+        id: 'guided-1',
+        content: 'Guided sequence',
+        steps: [{ action: 'button', reftarget: '[data-testid="g-step"]' }],
+      };
+      const result = applyPatchToGuide(makeGuide([guided]), {
+        type: 'substep-selector-patch',
+        containerId: 'guided-1',
+        subStepIndex: 0,
+        newReftarget: '[data-testid="g-step-fixed"]',
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('reaches a multistep container nested in a conditional branch', () => {
+      const conditional = {
+        type: 'conditional',
+        conditions: ['has-datasource:prometheus'],
+        whenTrue: [multistepWithTwoSteps],
+        whenFalse: [],
+      };
+      const result = applyPatchToGuide(makeGuide([conditional]), {
+        type: 'substep-selector-patch',
+        containerId: 'multi-1',
+        subStepIndex: 1,
+        newReftarget: '[data-testid="patched-via-conditional"]',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(JSON.parse(result.newGuideJson).blocks[0].whenTrue[0].steps[1].reftarget).toBe(
+          '[data-testid="patched-via-conditional"]'
+        );
+      }
+    });
+  });
+
+  // The folded-in id reconciliation: an anonymous block (no author id) must be addressable by
+  // the exact stepId the parser hands the component (props.stepId === materialized block.id).
+  describe('addresses anonymous blocks by the parser-derived stepId', () => {
+    it('selector-patch on an anonymous top-level interactive block', () => {
+      const guideJson = makeGuide([
+        { type: 'interactive', action: 'button', reftarget: '[data-testid="old"]', content: 'Click' },
+      ]);
+      const stepIds = collectStepIds(parseJsonGuide(guideJson).data?.elements ?? []);
+      expect(stepIds).toHaveLength(1);
+      const result = applyPatchToGuide(guideJson, {
+        type: 'selector-patch',
+        targetStepId: stepIds[0]!,
+        newReftarget: '[data-testid="new"]',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(JSON.parse(result.newGuideJson).blocks[0].reftarget).toBe('[data-testid="new"]');
+      }
+    });
+
+    it('selector-patch on an anonymous interactive nested in a section', () => {
+      const guideJson = makeGuide([
+        {
+          type: 'section',
+          title: 'S',
+          blocks: [{ type: 'interactive', action: 'button', reftarget: '[data-testid="old"]', content: 'Click' }],
+        },
+      ]);
+      const stepIds = collectStepIds(parseJsonGuide(guideJson).data?.elements ?? []);
+      expect(stepIds).toHaveLength(1);
+      const result = applyPatchToGuide(guideJson, {
+        type: 'selector-patch',
+        targetStepId: stepIds[0]!,
+        newReftarget: '[data-testid="new"]',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(JSON.parse(result.newGuideJson).blocks[0].blocks[0].reftarget).toBe('[data-testid="new"]');
+      }
+    });
+
+    it('substep-selector-patch on an anonymous multistep container', () => {
+      const guideJson = makeGuide([
+        {
+          type: 'multistep',
+          content: 'Do',
+          steps: [
+            { action: 'button', reftarget: '[data-testid="a"]' },
+            { action: 'button', reftarget: '[data-testid="b-stale"]' },
+          ],
+        },
+      ]);
+      const stepIds = collectStepIds(parseJsonGuide(guideJson).data?.elements ?? []);
+      expect(stepIds).toHaveLength(1);
+      const result = applyPatchToGuide(guideJson, {
+        type: 'substep-selector-patch',
+        containerId: stepIds[0]!,
+        subStepIndex: 1,
+        newReftarget: '[data-testid="b-fixed"]',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(JSON.parse(result.newGuideJson).blocks[0].steps[1].reftarget).toBe('[data-testid="b-fixed"]');
+      }
+    });
+  });
+
+  describe('error paths', () => {
+    it('rejects unparseable JSON', () => {
+      const result = applyPatchToGuide('not-json', { type: 'selector-patch', targetStepId: 'x', newReftarget: '.btn' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/Failed to parse/);
+      }
+    });
+
+    it('rejects a guide that fails schema validation before the patch', () => {
+      const malformed = JSON.stringify({ id: 'g', title: 't', blocks: 'not-an-array' });
+      const result = applyPatchToGuide(malformed, { type: 'selector-patch', targetStepId: 'x', newReftarget: '.btn' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/schema validation/);
+      }
+    });
+
+    it('discards a mutation that produces a schema-invalid guide (post-validation)', () => {
+      const guideJson = makeGuide([validStep]);
+      // Bypass the patch schema to inject a newStep missing required `content`.
+      const badPatch = {
+        type: 'prepend-step',
+        beforeStepId: 'step-1',
+        newStep: { type: 'interactive', action: 'button', reftarget: '[data-testid="x"]' },
+      } as unknown as AiFixPatch;
+      const result = applyPatchToGuide(guideJson, badPatch);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/failed schema check/);
+      }
+      // Caller's input string is untouched.
+      expect(JSON.parse(guideJson).blocks).toHaveLength(1);
+    });
+  });
+});

--- a/src/integrations/assistant-integration/apply-ai-fix-patch.test.ts
+++ b/src/integrations/assistant-integration/apply-ai-fix-patch.test.ts
@@ -111,6 +111,19 @@ describe('applyPatchToGuide', () => {
       }
     });
 
+    it('rejects an unsafe selector patch even when called directly with a typed patch', () => {
+      const result = applyPatchToGuide(makeGuide([validStep]), {
+        type: 'selector-patch',
+        targetStepId: 'step-1',
+        newReftarget: '<script>alert(1)</script>',
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toMatch(/patch/i);
+      }
+    });
+
     it('does not crash when a sibling conditional has no matching step', () => {
       const conditional = {
         type: 'conditional',
@@ -363,18 +376,17 @@ describe('applyPatchToGuide', () => {
       }
     });
 
-    it('discards a mutation that produces a schema-invalid guide (post-validation)', () => {
+    it('rejects a structurally-invalid patch that bypassed schema validation at the call site', () => {
       const guideJson = makeGuide([validStep]);
-      // Bypass the patch schema to inject a newStep missing required `content`.
       const badPatch = {
         type: 'prepend-step',
         beforeStepId: 'step-1',
-        newStep: { type: 'interactive', action: 'button', reftarget: '[data-testid="x"]' },
+        newStep: { type: 'interactive', action: 'button', reftarget: '[data-testid="x"]' }, // missing required content
       } as unknown as AiFixPatch;
       const result = applyPatchToGuide(guideJson, badPatch);
       expect(result.ok).toBe(false);
       if (!result.ok) {
-        expect(result.error).toMatch(/failed schema check/);
+        expect(result.error).toMatch(/patch failed schema validation/);
       }
       // Caller's input string is untouched.
       expect(JSON.parse(guideJson).blocks).toHaveLength(1);

--- a/src/integrations/assistant-integration/apply-ai-fix-patch.ts
+++ b/src/integrations/assistant-integration/apply-ai-fix-patch.ts
@@ -1,4 +1,4 @@
-import type { AiFixPatch } from './ai-fix-patch.schema';
+import { AiFixPatchSchema, type AiFixPatch } from './ai-fix-patch.schema';
 import { materializeStepIds } from './ai-fix-step-id';
 import { JsonGuideSchema } from '../../types/json-guide.schema';
 import {
@@ -90,6 +90,10 @@ function mutateSubstepReftarget(
 }
 
 export function applyPatchToGuide(guideJson: string, patch: AiFixPatch): ApplyResult {
+  if (!AiFixPatchSchema.safeParse(patch).success) {
+    return { ok: false, error: 'AI fix patch failed schema validation; cannot safely patch' };
+  }
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(guideJson);

--- a/src/integrations/assistant-integration/apply-ai-fix-patch.ts
+++ b/src/integrations/assistant-integration/apply-ai-fix-patch.ts
@@ -1,0 +1,146 @@
+import type { AiFixPatch } from './ai-fix-patch.schema';
+import { materializeStepIds } from './ai-fix-step-id';
+import { JsonGuideSchema } from '../../types/json-guide.schema';
+import {
+  isConditionalBlock,
+  isSectionBlock,
+  type JsonBlock,
+  type JsonGuide,
+  type JsonGuidedBlock,
+  type JsonInteractiveBlock,
+  type JsonMultistepBlock,
+  type JsonStep,
+} from '../../types/json-guide.types';
+
+export type ApplyResult = { ok: true; newGuideJson: string } | { ok: false; error: string };
+
+function isInteractiveWithId(block: JsonBlock, id: string): block is JsonInteractiveBlock {
+  return block.type === 'interactive' && (block as JsonInteractiveBlock).id === id;
+}
+
+function isStepContainerWithId(block: JsonBlock, id: string): block is JsonMultistepBlock | JsonGuidedBlock {
+  return (block.type === 'multistep' || block.type === 'guided') && block.id === id;
+}
+
+function mutateMatchingBlock(
+  blocks: JsonBlock[],
+  matchId: string,
+  mutator: (parent: JsonBlock[], index: number) => void
+): boolean {
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i]!;
+    if (isInteractiveWithId(block, matchId)) {
+      mutator(blocks, i);
+      return true;
+    }
+    if (isSectionBlock(block)) {
+      if (mutateMatchingBlock(block.blocks, matchId, mutator)) {
+        return true;
+      }
+    } else if (isConditionalBlock(block)) {
+      if (mutateMatchingBlock(block.whenTrue, matchId, mutator)) {
+        return true;
+      }
+      if (mutateMatchingBlock(block.whenFalse, matchId, mutator)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+type SubstepMutateOutcome =
+  | { outcome: 'patched' }
+  | { outcome: 'out-of-range'; stepCount: number }
+  | { outcome: 'not-found' };
+
+// Split outcomes keep the recursion clean: a not-found inner branch must not mask a sibling that matches.
+function mutateSubstepReftarget(
+  blocks: JsonBlock[],
+  containerId: string,
+  subStepIndex: number,
+  newReftarget: string
+): SubstepMutateOutcome {
+  for (const block of blocks) {
+    if (isStepContainerWithId(block, containerId)) {
+      if (subStepIndex < 0 || subStepIndex >= block.steps.length) {
+        return { outcome: 'out-of-range', stepCount: block.steps.length };
+      }
+      const step = block.steps[subStepIndex] as JsonStep;
+      step.reftarget = newReftarget;
+      return { outcome: 'patched' };
+    }
+    if (isSectionBlock(block)) {
+      const nested = mutateSubstepReftarget(block.blocks, containerId, subStepIndex, newReftarget);
+      if (nested.outcome !== 'not-found') {
+        return nested;
+      }
+    } else if (isConditionalBlock(block)) {
+      const nestedTrue = mutateSubstepReftarget(block.whenTrue, containerId, subStepIndex, newReftarget);
+      if (nestedTrue.outcome !== 'not-found') {
+        return nestedTrue;
+      }
+      const nestedFalse = mutateSubstepReftarget(block.whenFalse, containerId, subStepIndex, newReftarget);
+      if (nestedFalse.outcome !== 'not-found') {
+        return nestedFalse;
+      }
+    }
+  }
+  return { outcome: 'not-found' };
+}
+
+export function applyPatchToGuide(guideJson: string, patch: AiFixPatch): ApplyResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(guideJson);
+  } catch (e) {
+    return { ok: false, error: `Failed to parse guide JSON: ${e instanceof Error ? e.message : 'unknown'}` };
+  }
+
+  const beforeCheck = JsonGuideSchema.safeParse(parsed);
+  if (!beforeCheck.success) {
+    return { ok: false, error: 'Current guide failed schema validation; cannot safely patch' };
+  }
+
+  // Deep clone so a failed mutation never leaks into the caller's guide; materialize
+  // canonical ids so anonymous blocks resolve by the same stepId a component dispatched.
+  const guide = materializeStepIds(JSON.parse(JSON.stringify(beforeCheck.data)) as JsonGuide);
+
+  if (patch.type === 'selector-patch') {
+    const didMutate = mutateMatchingBlock(guide.blocks, patch.targetStepId, (parent, index) => {
+      (parent[index] as JsonInteractiveBlock).reftarget = patch.newReftarget;
+    });
+    if (!didMutate) {
+      return { ok: false, error: `No interactive block found with id "${patch.targetStepId}"` };
+    }
+  } else if (patch.type === 'prepend-step') {
+    const didMutate = mutateMatchingBlock(guide.blocks, patch.beforeStepId, (parent, index) => {
+      parent.splice(index, 0, patch.newStep as JsonBlock);
+    });
+    if (!didMutate) {
+      return { ok: false, error: `No interactive block found with id "${patch.beforeStepId}"` };
+    }
+  } else {
+    const result = mutateSubstepReftarget(guide.blocks, patch.containerId, patch.subStepIndex, patch.newReftarget);
+    if (result.outcome === 'not-found') {
+      return { ok: false, error: `No multistep/guided container found with id "${patch.containerId}"` };
+    }
+    if (result.outcome === 'out-of-range') {
+      return {
+        ok: false,
+        error: `Container "${patch.containerId}" has ${result.stepCount} steps; index ${patch.subStepIndex} is out of range`,
+      };
+    }
+  }
+
+  // A mutation that breaks the guide is discarded here — an invalid guide must never reach the renderer.
+  const afterCheck = JsonGuideSchema.safeParse(guide);
+  if (!afterCheck.success) {
+    return {
+      ok: false,
+      error: `Patched guide failed schema check: ${afterCheck.error.issues[0]?.message ?? 'unknown'}`,
+    };
+  }
+
+  return { ok: true, newGuideJson: JSON.stringify(afterCheck.data) };
+}


### PR DESCRIPTION
## What & why

**PR4 of the PR-886 AI auto-heal breakdown.** Stacked on **PR3 (#983)** — this PR's base is `feat/ai-fix-patch-schema`; GitHub auto-retargets it to `main` once PR3 merges (a quick rebase may be needed if PR3 squash-merges).

Adds the pure **`applyPatchToGuide(guideJson, patch)`** — given a validated `AiFixPatch`, it locates the target block, applies the mutation, and re-validates, returning the new guide JSON or an error. No DOM, no React; **lands dark** (only PR7's orchestrator will call it).

## What's included

Three net-new files under `src/integrations/assistant-integration/`:
- **`apply-ai-fix-patch.ts`** — pipeline: `JSON.parse` → pre-validate (`JsonGuideSchema`) → deep-clone → materialize ids → mutate by patch type → post-validate → re-stringify. Mutators recurse sections + conditional branches; `selector-patch` rewrites `reftarget`, `substep-selector-patch` rewrites `steps[i].reftarget`, `prepend-step` splices a new block before the target. A post-validation failure discards the mutation — an invalid guide never reaches the renderer.
- **`ai-fix-step-id.ts`** — the folded-in **PR2** reconciliation. `materializeStepIds` reproduces the parser's `deriveStepId` walk so an **anonymous** block (no author id) is addressable by the same `stepId` a component dispatches. Reuses `main`'s `deriveStepId`; no parser change, no new dependency.
- **`apply-ai-fix-patch.test.ts`** — 20 cases.

## The id reconciliation (folded-in PR2), verified

`main` stores the derived `stepId` only on `props.stepId`, never on `block.id`, so the apply re-derives it. The risk is the materializer drifting from the parser — pinned by **contract tests** that parse a guide with anonymous blocks, read the real `props.stepId`, and assert `applyPatchToGuide` finds the block by it (top-level, section-nested, and multistep container). No `block.id` mutation is persisted to source; materialization happens on the apply's local clone only.

## Test plan

- `npm run typecheck` ✅
- `npm run lint` ✅ 0 errors · prettier ✅
- `jest apply-ai-fix-patch.test.ts` ✅ 20/20 — all patch types + section/conditional recursion + error paths + **anonymous-block re-derive contract tests** + post-validation-rejects
- governance/architecture (Tier-3 → Tier 0/1 imports) ✅ 73/73
- dark-landing grep: no production consumer of `applyPatchToGuide`/`materializeStepIds` (only the test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)