### PR TITLE
fix(e2e): bound step-locator attribute reads to prevent test-timeout hangs

### DIFF
--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -304,8 +304,22 @@ async function waitForSubstepAdvance(
   let lastIndex: string | null = null;
 
   while (Date.now() < deadline) {
-    lastState = await stepLocator.getAttribute('data-test-step-state');
-    lastIndex = await stepLocator.getAttribute('data-test-substep-index');
+    // Unmount mid-wait is a completion signal (section auto-collapse on final substep);
+    // a bare getAttribute on a detached locator blocks until the global test timeout.
+    if ((await stepLocator.count()) === 0) {
+      return;
+    }
+
+    try {
+      lastState = await stepLocator.getAttribute('data-test-step-state', { timeout: 2000 });
+      lastIndex = await stepLocator.getAttribute('data-test-substep-index', { timeout: 2000 });
+    } catch {
+      if ((await stepLocator.count()) === 0) {
+        return;
+      }
+      lastState = null;
+      lastIndex = null;
+    }
 
     if (lastState === 'error') {
       throw new Error('Guided step entered error state');
@@ -352,8 +366,22 @@ async function waitForFormfillSettle(
   const validDeadline = Date.now() + GUIDED_FORMFILL_VALID_TIMEOUT_MS;
   let invalidSince: number | null = null;
 
+  const readFormState = async (): Promise<string | null> => {
+    if ((await stepLocator.count()) === 0) {
+      return null;
+    }
+    try {
+      return await stepLocator.getAttribute('data-test-form-state', { timeout: 2000 });
+    } catch {
+      return null;
+    }
+  };
+
   while (Date.now() < validDeadline) {
-    const formState = await stepLocator.getAttribute('data-test-form-state');
+    if ((await stepLocator.count()) === 0) {
+      return;
+    }
+    const formState = await readFormState();
     if (formState === 'valid') {
       return;
     }
@@ -364,7 +392,7 @@ async function waitForFormfillSettle(
       if (Date.now() - invalidSince >= GUIDED_FORMFILL_INVALID_PERSIST_MS) {
         await target.fill(targetValue);
         await page.waitForTimeout(GUIDED_FORMFILL_DEBOUNCE_MS);
-        const afterRetry = await stepLocator.getAttribute('data-test-form-state');
+        const afterRetry = await readFormState();
         if (afterRetry === 'invalid') {
           throw new Error(
             `Guided step: formfill validation failed (data-test-form-state="invalid" persisted after retry with value "${targetValue}")`


### PR DESCRIPTION
## Summary

This is a follow-on to https://github.com/grafana/grafana-pathfinder-app/pull/982 (i.e., something I missed there).

Guided step elements can unmount mid-iteration (section auto-collapses on completion) between a `count()` guard and a subsequent `getAttribute` call, causing Playwright to auto-wait the full test timeout on the detached locator. This bounds all attribute reads with a 2s timeout and re-checks element presence in the catch handler so a mid-call detach short-circuits instead of hanging.

## What to look at

- **E2E guide runner execution** ([`execution.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/9837ea8cd5ac6b467f769cf7c4775107dc3c4c1c/tests/e2e-runner/utils/guide-runner/execution.ts)): `waitForSubstepAdvance` and `waitForFormfillSettle` both had unbounded `getAttribute` calls that could block on a detached locator. Each now gets a `count() === 0` early-exit at loop top, a `{ timeout: 2000 }` on every `getAttribute`, and a catch handler that re-checks detachment before nulling the value.

## How to verify

1. Test a guide with a section including an interactive-guided step that auto-collapses on completion (e.g., a section whose final substep triggers section collapse). Confirm the runner advances through all substeps without hanging at the test timeout.

## Breaking changes

None. This change is additive and fully reversible — it only tightens timeout behavior in test utilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
