### PR TITLE
refactor(docs-panel): extract shared loadTab helpers; route openDocsPage through loadTab

### DIFF
--- a/src/components/docs-panel/docs-panel.alignment.test.ts
+++ b/src/components/docs-panel/docs-panel.alignment.test.ts
@@ -292,6 +292,8 @@ describe('CombinedLearningJourneyPanel — implied-0th-step alignment', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetLocation.mockReturnValue({ pathname: '/explore', search: '' });
+    // openDocsPage routes through loadTab → shouldUseDocsLoader; force the docs loader.
+    jest.requireMock('./utils').shouldUseDocsLoader.mockReturnValue(true);
   });
 
   describe('loadDocsTabContent — pendingAlignment decision', () => {
@@ -723,6 +725,47 @@ describe('CombinedLearningJourneyPanel — implied-0th-step alignment', () => {
       await new Promise((r) => setTimeout(r, 0));
 
       expect(getTab(panel, tabId).pendingAlignment).toBeUndefined();
+    });
+  });
+
+  describe('openDocsPage — routes the content load through loadTab', () => {
+    it('reaches the docs loader and transitions loading → success', async () => {
+      let resolveLoad: (value: unknown) => void = () => {};
+      mockLoadDocsTabContentResult.mockReturnValue(
+        new Promise((resolve) => {
+          resolveLoad = resolve;
+        })
+      );
+      const panel = new CombinedLearningJourneyPanel();
+
+      const tabId = await panel.openDocsPage('bundled:connections-guide', 'Test Guide');
+
+      // Dispatched through loadTab, still in flight.
+      expect(mockLoadDocsTabContentResult).toHaveBeenCalled();
+      const loadingTab = getTab(panel, tabId);
+      expect(loadingTab.isLoading).toBe(true);
+      expect(loadingTab.error).toBe(null);
+      expect(loadingTab.content).toBe(null);
+
+      resolveLoad(makeContentResult());
+      await new Promise((r) => setTimeout(r, 0));
+
+      const loadedTab = getTab(panel, tabId);
+      expect(loadedTab.isLoading).toBe(false);
+      expect(loadedTab.error).toBe(null);
+      expect(loadedTab.content).toBeDefined();
+    });
+
+    it('transitions loading → error when the docs loader returns an error', async () => {
+      mockLoadDocsTabContentResult.mockResolvedValue({ content: null, error: 'Failed to load documentation' });
+      const panel = new CombinedLearningJourneyPanel();
+
+      const tabId = await panel.openDocsPage('bundled:connections-guide', 'Test Guide');
+      await new Promise((r) => setTimeout(r, 0));
+
+      const tab = getTab(panel, tabId);
+      expect(tab.isLoading).toBe(false);
+      expect(tab.error).toBe('Failed to load documentation');
     });
   });
 });

--- a/src/components/docs-panel/docs-panel.alignment.test.ts
+++ b/src/components/docs-panel/docs-panel.alignment.test.ts
@@ -766,5 +766,27 @@ describe('CombinedLearningJourneyPanel — implied-0th-step alignment', () => {
       expect(tab.isLoading).toBe(false);
       expect(tab.error).toBe('Failed to load documentation');
     });
+
+    it('reaches the docs loader via the packageInfo trigger when shouldUseDocsLoader is false', async () => {
+      // Isolate loadTab's second dispatch arm: with shouldUseDocsLoader false,
+      // reaching the docs loader proves `options.packageInfo != null` alone
+      // routed it — openDocsPage is that arm's primary call site.
+      jest.requireMock('./utils').shouldUseDocsLoader.mockReturnValue(false);
+      mockLoadDocsTabContentResult.mockResolvedValue(makeContentResult());
+      const panel = new CombinedLearningJourneyPanel();
+
+      const tabId = await panel.openDocsPage('bundled:connections-guide', 'Test Guide', {
+        packageInfo: { packageManifest: { startingLocation: '/connections' } } as any,
+      });
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(mockLoadDocsTabContentResult).toHaveBeenCalledWith(
+        'bundled:connections-guide',
+        expect.objectContaining({ packageInfo: { packageManifest: { startingLocation: '/connections' } } })
+      );
+      const tab = getTab(panel, tabId);
+      expect(tab.isLoading).toBe(false);
+      expect(tab.content).toBeDefined();
+    });
   });
 });

--- a/src/components/docs-panel/docs-panel.alignment.test.ts
+++ b/src/components/docs-panel/docs-panel.alignment.test.ts
@@ -740,7 +740,6 @@ describe('CombinedLearningJourneyPanel — implied-0th-step alignment', () => {
 
       const tabId = await panel.openDocsPage('bundled:connections-guide', 'Test Guide');
 
-      // Dispatched through loadTab, still in flight.
       expect(mockLoadDocsTabContentResult).toHaveBeenCalled();
       const loadingTab = getTab(panel, tabId);
       expect(loadingTab.isLoading).toBe(true);

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -363,14 +363,9 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
   }
 
   /**
-   * Unified tab-loader entry point. Dispatches to the right content
-   * pipeline based on the tab's shape (and the optional `packageInfo`
-   * input).
-   *
-   * Callers should use this instead of branching on `shouldUseDocsLoader`
-   * + the legacy `loadTabContent` / `loadDocsTabContent` pair directly.
-   * The two internal methods remain available as the underlying
-   * implementations; future work can fold them together.
+   * Unified tab-loader entry point. Dispatches to the docs/package pipeline
+   * or the guide pipeline based on the tab's shape and the optional
+   * `packageInfo` input.
    */
   public async loadTab(
     tabId: string,
@@ -380,20 +375,13 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     const tab = this.state.tabs.find((t) => t.id === tabId);
     const needsDocsLoader = options?.packageInfo != null || (tab ? shouldUseDocsLoader(tab) : false);
     if (needsDocsLoader) {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- delegating to internal implementation
       await this.loadDocsTabContent(tabId, url, options?.skipReadyToBegin, options?.packageInfo);
       return;
     }
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- delegating to internal implementation
     await this.loadTabContent(tabId, url);
   }
 
-  /**
-   * @deprecated Prefer {@link loadTab}. Internal implementation kept for
-   * the unified dispatcher to route into; will fold into `loadTab` once
-   * the content-fetcher split is removed.
-   */
-  public async loadTabContent(tabId: string, url: string) {
+  private async loadTabContent(tabId: string, url: string) {
     // Skip loading if URL is empty
     if (!url || url.trim() === '') {
       return;
@@ -710,12 +698,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     return tabId;
   }
 
-  /**
-   * @deprecated Prefer {@link loadTab}. Internal implementation kept for
-   * the unified dispatcher to route into; will fold into `loadTab` once
-   * the content-fetcher split is removed.
-   */
-  public async loadDocsTabContent(
+  private async loadDocsTabContent(
     tabId: string,
     url: string,
     skipReadyToBegin?: boolean,
@@ -778,8 +761,6 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
               : fetchedContent.type === 'interactive'
                 ? 'interactive'
                 : t.type,
-          // Persist auto-derived packageInfo so subsequent reloads/restores
-          // skip the manifest fetch and render with the milestone toolbar.
           packageInfo: packageInfo ?? t.packageInfo,
           pathContext,
           pendingAlignment,

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -337,6 +337,31 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     return tabId;
   }
 
+  private setTabLoading(tabId: string): void {
+    const updatedTabs = this.state.tabs.map((t) => (t.id === tabId ? { ...t, isLoading: true, error: null } : t));
+    this.setState({ tabs: updatedTabs });
+  }
+
+  private finishTabSuccess(
+    tabId: string,
+    buildPatch: (tab: LearningJourneyTab) => Partial<LearningJourneyTab>
+  ): LearningJourneyTab | undefined {
+    const finalUpdatedTabs = this.state.tabs.map((t) =>
+      t.id === tabId ? { ...t, ...buildPatch(t), isLoading: false, error: null } : t
+    );
+    this.setState({ tabs: finalUpdatedTabs });
+    this.saveTabsToStorage();
+    return finalUpdatedTabs.find((t) => t.id === tabId);
+  }
+
+  private failTab(tabId: string, message: string): void {
+    const errorUpdatedTabs = this.state.tabs.map((t) =>
+      t.id === tabId ? { ...t, isLoading: false, error: message } : t
+    );
+    this.setState({ tabs: errorUpdatedTabs });
+    this.saveTabsToStorage();
+  }
+
   /**
    * Unified tab-loader entry point. Dispatches to the right content
    * pipeline based on the tab's shape (and the optional `packageInfo`
@@ -374,17 +399,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       return;
     }
 
-    // Update tab to loading state
-    const updatedTabs = this.state.tabs.map((t) =>
-      t.id === tabId
-        ? {
-            ...t,
-            isLoading: true,
-            error: null,
-          }
-        : t
-    );
-    this.setState({ tabs: updatedTabs });
+    this.setTabLoading(tabId);
 
     try {
       const tab = this.state.tabs.find((t) => t.id === tabId);
@@ -421,65 +436,22 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
           };
         }
 
-        // Success: set content and clear error
-        const finalUpdatedTabs = this.state.tabs.map((t) =>
-          t.id === tabId
-            ? {
-                ...t,
-                content,
-                isLoading: false,
-                error: null,
-                currentUrl: url,
-              }
-            : t
-        );
-        this.setState({ tabs: finalUpdatedTabs });
+        const updatedTab = this.finishTabSuccess(tabId, () => ({ content, currentUrl: url }));
 
-        // Save tabs to storage after content is loaded
-        this.saveTabsToStorage();
-
-        // Update completion percentage for learning journeys.
         // Use learningJourney.baseUrl (the path's cover page URL) as the storage
         // key so it matches the key used by context.service.ts when reading
         // completion via getJourneyCompletionPercentageAsync(rec.contentUrl).
-        const updatedTab = finalUpdatedTabs.find((t) => t.id === tabId);
         if (updatedTab?.type === 'learning-journey' && updatedTab.content) {
           const progress = getJourneyProgress(updatedTab.content);
           const completionKey = updatedTab.content.metadata.learningJourney?.baseUrl || updatedTab.baseUrl;
           setJourneyCompletionPercentage(completionKey, progress);
         }
       } else {
-        // Fetch failed: set error from result
-        const errorUpdatedTabs = this.state.tabs.map((t) =>
-          t.id === tabId
-            ? {
-                ...t,
-                isLoading: false,
-                error: result.error || 'Failed to load content',
-              }
-            : t
-        );
-        this.setState({ tabs: errorUpdatedTabs });
-
-        // Save tabs to storage even when there's an error
-        this.saveTabsToStorage();
+        this.failTab(tabId, result.error || 'Failed to load content');
       }
     } catch (error) {
       console.error(`Failed to load journey content for tab ${tabId}:`, error);
-
-      const errorUpdatedTabs = this.state.tabs.map((t) =>
-        t.id === tabId
-          ? {
-              ...t,
-              isLoading: false,
-              error: error instanceof Error ? error.message : 'Failed to load content',
-            }
-          : t
-      );
-      this.setState({ tabs: errorUpdatedTabs });
-
-      // Save tabs to storage even when there's an error
-      this.saveTabsToStorage();
+      this.failTab(tabId, error instanceof Error ? error.message : 'Failed to load content');
     }
   }
 
@@ -733,8 +705,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     // Save tabs to storage immediately after creating
     this.saveTabsToStorage();
 
-    // Load docs content for the tab
-    this.loadDocsTabContent(tabId, url, skipReadyToBegin, packageInfo);
+    this.loadTab(tabId, url, { skipReadyToBegin, packageInfo });
 
     return tabId;
   }
@@ -755,17 +726,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     // empty URL without packageInfo returns a visible error). Surfacing errors
     // is preferable to the old silent no-op for corrupted/restored tabs.
 
-    // Update tab to loading state
-    const updatedTabs = this.state.tabs.map((t) =>
-      t.id === tabId
-        ? {
-            ...t,
-            isLoading: true,
-            error: null,
-          }
-        : t
-    );
-    this.setState({ tabs: updatedTabs });
+    this.setTabLoading(tabId);
 
     try {
       const launchSource = this._consumeAutoLaunchSource();
@@ -781,7 +742,6 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
 
       // Check if fetch succeeded or failed
       if (result.content) {
-        // Success: set content and clear error
         const fetchedContent = result.content;
 
         const pathContext = fetchedContent.metadata.learningJourney
@@ -808,34 +768,22 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
               }
             : undefined;
 
-        const finalUpdatedTabs = this.state.tabs.map((t) =>
-          t.id === tabId
-            ? {
-                ...t,
-                content: fetchedContent,
-                isLoading: false,
-                error: null,
-                baseUrl: t.baseUrl || fetchedContent.url,
-                currentUrl: fetchedContent.url || url,
-                type:
-                  packageInfo != null
-                    ? getPackageRenderType(packageInfo.packageManifest)
-                    : fetchedContent.type === 'interactive'
-                      ? 'interactive'
-                      : t.type,
-                // Persist auto-derived packageInfo so subsequent reloads/restores
-                // skip the manifest fetch and render with the milestone toolbar.
-                packageInfo: packageInfo ?? t.packageInfo,
-                pathContext,
-                pendingAlignment,
-              }
-            : t
-        );
-        // Capture the title from the freshly-built tab BEFORE setState so the
-        // telemetry payload doesn't depend on the post-setState state shape
-        // (defensive against future async/batched setState behaviour).
-        const finalTab = finalUpdatedTabs.find((t) => t.id === tabId);
-        this.setState({ tabs: finalUpdatedTabs });
+        const finalTab = this.finishTabSuccess(tabId, (t) => ({
+          content: fetchedContent,
+          baseUrl: t.baseUrl || fetchedContent.url,
+          currentUrl: fetchedContent.url || url,
+          type:
+            packageInfo != null
+              ? getPackageRenderType(packageInfo.packageManifest)
+              : fetchedContent.type === 'interactive'
+                ? 'interactive'
+                : t.type,
+          // Persist auto-derived packageInfo so subsequent reloads/restores
+          // skip the manifest fetch and render with the milestone toolbar.
+          packageInfo: packageInfo ?? t.packageInfo,
+          pathContext,
+          pendingAlignment,
+        }));
 
         if (pendingAlignment) {
           reportAppInteraction(UserInteraction.AlignmentPromptShown, {
@@ -846,41 +794,12 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
             starting_location: pendingAlignment.startingLocation,
           });
         }
-
-        // Save tabs to storage after content is loaded
-        this.saveTabsToStorage();
       } else {
-        // Fetch failed: set error from result
-        const errorUpdatedTabs = this.state.tabs.map((t) =>
-          t.id === tabId
-            ? {
-                ...t,
-                isLoading: false,
-                error: result.error || 'Failed to load documentation',
-              }
-            : t
-        );
-        this.setState({ tabs: errorUpdatedTabs });
-
-        // Save tabs to storage even when there's an error
-        this.saveTabsToStorage();
+        this.failTab(tabId, result.error || 'Failed to load documentation');
       }
     } catch (error) {
       console.error(`Failed to load docs content for tab ${tabId}:`, error);
-
-      const errorUpdatedTabs = this.state.tabs.map((t) =>
-        t.id === tabId
-          ? {
-              ...t,
-              isLoading: false,
-              error: error instanceof Error ? error.message : 'Failed to load documentation',
-            }
-          : t
-      );
-      this.setState({ tabs: errorUpdatedTabs });
-
-      // Save tabs to storage even when there's an error
-      this.saveTabsToStorage();
+      this.failTab(tabId, error instanceof Error ? error.message : 'Failed to load documentation');
     }
   }
 }

--- a/src/components/docs-panel/hooks/useContentReset.test.ts
+++ b/src/components/docs-panel/hooks/useContentReset.test.ts
@@ -60,8 +60,6 @@ describe('useContentReset', () => {
   beforeEach(() => {
     mockModel = {
       loadTab: jest.fn().mockResolvedValue(undefined),
-      loadDocsTabContent: jest.fn().mockResolvedValue(undefined),
-      loadTabContent: jest.fn().mockResolvedValue(undefined),
       _recordAutoLaunchSource: jest.fn(),
     };
     mockDispatchEvent = jest.spyOn(window, 'dispatchEvent');

--- a/src/components/docs-panel/link-handler.hook.test.ts
+++ b/src/components/docs-panel/link-handler.hook.test.ts
@@ -24,7 +24,6 @@ describe('useLinkClickHandler', () => {
   // Mock model with all required functions
   const mockModel = {
     loadTab: jest.fn().mockResolvedValue(undefined),
-    loadTabContent: jest.fn(),
     openLearningJourney: jest.fn(),
     openDocsPage: jest.fn(),
     getActiveTab: jest.fn(),

--- a/src/components/docs-panel/link-handler.hook.ts
+++ b/src/components/docs-panel/link-handler.hook.ts
@@ -26,8 +26,6 @@ interface UseLinkClickHandlerProps {
   theme: GrafanaTheme2;
   model: {
     loadTab: (tabId: string, url: string) => Promise<void>;
-    /** @deprecated Internal; routed via `loadTab`. Retained for older callers. */
-    loadTabContent: (tabId: string, url: string) => void;
     openLearningJourney: (url: string, title: string, options?: OpenLearningJourneyOptions) => void;
     openDocsPage?: (url: string, title: string, options?: OpenDocsOptions) => void;
     getActiveTab: () => LearningJourneyTab | null;

--- a/src/components/docs-panel/types.ts
+++ b/src/components/docs-panel/types.ts
@@ -52,25 +52,13 @@ export interface DocsPanelModelOperations {
   openDocsPage(url: string, title?: string, options?: OpenDocsOptions): Promise<string>;
 
   /**
-   * Unified tab loader. Dispatches to the right content pipeline based on
-   * the tab's shape (and the optional `packageInfo` input). Prefer this
-   * over the legacy `loadTabContent` / `loadDocsTabContent` pair.
+   * Unified tab loader. Dispatches to the docs/package pipeline or the guide
+   * pipeline based on the tab's shape and the optional `packageInfo` input.
    */
   loadTab(
     tabId: string,
     url: string,
     options?: { skipReadyToBegin?: boolean; packageInfo?: PackageOpenInfo }
-  ): Promise<void>;
-
-  /** @deprecated Internal implementation routed via `loadTab`. */
-  loadTabContent(tabId: string, url: string): Promise<void>;
-
-  /** @deprecated Internal implementation routed via `loadTab`. */
-  loadDocsTabContent(
-    tabId: string,
-    url: string,
-    skipReadyToBegin?: boolean,
-    packageInfo?: PackageOpenInfo
   ): Promise<void>;
 
   /** Close a tab by ID */


### PR DESCRIPTION
## Summary

**P1 (A1)** of the [INTERACTIVE-STATE-CONSOLIDATION breakdown](https://github.com/grafana/pathfinder-rfcs/pull/7)

`docs-panel.tsx` had two near-parallel content loaders — `loadTabContent` (guide path) and `loadDocsTabContent` (docs/package path) — duplicating the same loading / success / failure / save-tabs boilerplate 4+ times. Separately, `openDocsPage` still called the deprecated `loadDocsTabContent` **directly**, bypassing the unified `loadTab` dispatcher.

## What changed

- **Extract three private helpers** adjacent to `loadTab`:
  - `setTabLoading(tabId)` — the loading-state map + `setState` (was textually identical in both loaders).
  - `finishTabSuccess(tabId, buildPatch)` — applies a per-tab patch, sets `isLoading:false/error:null`, persists, and **returns the freshly-built tab**. The callback form preserves the docs path's reads of the existing tab (`t.baseUrl`/`t.packageInfo`/`t.type`); the return value lets the docs path read the telemetry title from the pre-`setState` array (the invariant the old inline comment defended is now structural).
  - `failTab(tabId, message)` — the error map + `setState` + persist (was duplicated 4×: each loader's `else` and `catch`).
- **Route `openDocsPage` through `loadTab`** instead of calling `loadDocsTabContent` directly. `loadTab`'s `shouldUseDocsLoader`/`packageInfo` routing re-enters the docs loader with the same args, so `loadTab` is now the single entry point and the deprecated internals are reached only from there.
- **Guardrail honored:** the two loaders are *not* folded — their divergent guide-journey vs docs-alignment work stays in two purpose-named functions sharing the helpers.

Net **−130/+92** in `docs-panel.tsx`.

## Tests

- New `openDocsPage` routing tests in `docs-panel.alignment.test.ts`: loading → success and loading → error transitions, asserting the docs loader is reached through `loadTab`.
- Made the alignment harness's `shouldUseDocsLoader` mock realistic (returns `true`) now that `openDocsPage` consults it via `loadTab` — previously the bare `jest.fn()` returned `undefined`, which would mis-route `packageInfo`-less opens to the guide loader.

## Verification

- `npm run typecheck` — clean
- frontend `eslint` — 0 errors (2 pre-existing `_recordAutoLaunchSource` deprecation warnings, untouched lines)
- `prettier --check` — clean
- `npm run test:ci` — **232 suites / 3958 tests pass** (no regressions outside docs-panel from the routing change)
- governance (`architecture` / `import-graph`) — 73/73

> `npm run check`'s `lint:go` step fails on a vendored `node_modules/flatted/golang` file unrelated to this PR (zero Go files changed); all frontend gates pass.