### PR TITLE
feat(schema): accept camelCase aliases in JSON guides via a pre-schema normalizer

### DIFF
--- a/src/docs-retrieval/json-parser-aliases.test.ts
+++ b/src/docs-retrieval/json-parser-aliases.test.ts
@@ -1,15 +1,8 @@
 /**
- * Tests for the camelCase ↔ lowercase field aliasing in the JSON parser.
- *
- * `validateGuide` normalizes the camelCase aliases (`targetAction`,
- * `refTarget`, `targetValue`) to their canonical lowercase names before
- * the schema runs, so camelCase-only guides validate. Canonical wins when
- * both are present. The schema itself stays on the canonical names, so the
- * CLI's flag-generation and Commander help-text contracts are unchanged.
- *
- * The parser also plumbs an explicit JSON `id` field into the
- * `ParsedElement.props.stepId` slot so author-stable IDs override the
- * section's positional `${sectionId}-step-N` convention.
+ * camelCase ↔ lowercase field aliasing: `validateGuide` normalizes the
+ * camelCase aliases to canonical lowercase before the schema, so camelCase
+ * guides validate (canonical wins on conflict); the schema and CLI flags stay
+ * canonical. Also covers explicit `id` → `props.stepId` plumbing.
  */
 
 import { parseJsonGuide } from './json-parser';

--- a/src/docs-retrieval/json-parser-aliases.test.ts
+++ b/src/docs-retrieval/json-parser-aliases.test.ts
@@ -1,14 +1,11 @@
 /**
  * Tests for the camelCase ↔ lowercase field aliasing in the JSON parser.
  *
- * The Zod schema (validate-guide) still requires the canonical
- * lowercase form (`action`, `reftarget`, `targetvalue`) so the CLI's
- * flag-generation and Commander help-text contracts stay stable.
- *
- * The runtime parser is a step more lenient: when an authored block
- * contains BOTH the lowercase canonical and a camelCase alias, canonical
- * wins; missing-lowercase + present-camelCase is still rejected at
- * validation time (intentional — schema-level acceptance is a follow-up).
+ * `validateGuide` normalizes the camelCase aliases (`targetAction`,
+ * `refTarget`, `targetValue`) to their canonical lowercase names before
+ * the schema runs, so camelCase-only guides validate. Canonical wins when
+ * both are present. The schema itself stays on the canonical names, so the
+ * CLI's flag-generation and Commander help-text contracts are unchanged.
  *
  * The parser also plumbs an explicit JSON `id` field into the
  * `ParsedElement.props.stepId` slot so author-stable IDs override the
@@ -48,7 +45,7 @@ describe('json-parser — field-name alias acceptance', () => {
     expect(interactive!.props.refTarget).toBe('Save');
   });
 
-  it('interactive block: camelCase-alias-only input is rejected by the schema (canonical required)', () => {
+  it('interactive block: camelCase-alias-only input is accepted and read', () => {
     const guide = makeGuide({
       targetAction: 'highlight',
       refTarget: '.my-element',
@@ -56,11 +53,10 @@ describe('json-parser — field-name alias acceptance', () => {
     });
 
     const result = parseJsonGuide(guide);
-    // Schema-level acceptance of camelCase aliases is a follow-up — for
-    // now the validator rejects guides that omit the lowercase canonical
-    // form. The parser's `?? camelCase` fallback only fires when both
-    // are present (defensive coexistence).
-    expect(result.isValid).toBe(false);
+    expect(result.isValid).toBe(true);
+    const interactive = result.data!.elements.find((el) => el.type === 'interactive-step');
+    expect(interactive!.props.targetAction).toBe('highlight');
+    expect(interactive!.props.refTarget).toBe('.my-element');
   });
 
   it('interactive block: canonical wins when both are present', () => {

--- a/src/validation/normalize-guide-aliases.test.ts
+++ b/src/validation/normalize-guide-aliases.test.ts
@@ -1,0 +1,79 @@
+import { normalizeJsonGuideAliases } from './normalize-guide-aliases';
+
+describe('normalizeJsonGuideAliases', () => {
+  it('renames each camelCase alias to its canonical lowercase name', () => {
+    const out = normalizeJsonGuideAliases({
+      type: 'interactive',
+      targetAction: 'highlight',
+      refTarget: '.my-element',
+      targetValue: 'expected',
+    });
+
+    expect(out).toEqual({
+      type: 'interactive',
+      action: 'highlight',
+      reftarget: '.my-element',
+      targetvalue: 'expected',
+    });
+  });
+
+  it('keeps the canonical value and drops the alias when both are present', () => {
+    const out = normalizeJsonGuideAliases({
+      action: 'button',
+      targetAction: 'highlight',
+      reftarget: 'A',
+      refTarget: 'B',
+    }) as Record<string, unknown>;
+
+    expect(out.action).toBe('button');
+    expect(out.reftarget).toBe('A');
+    expect(out).not.toHaveProperty('targetAction');
+    expect(out).not.toHaveProperty('refTarget');
+  });
+
+  it('recurses into blocks[], multistep steps[], and nested section/conditional branches', () => {
+    const out = normalizeJsonGuideAliases({
+      id: 'g',
+      title: 'g',
+      blocks: [
+        { type: 'interactive', targetAction: 'button', refTarget: 'Save' },
+        { type: 'multistep', steps: [{ targetAction: 'highlight', refTarget: '.a' }] },
+        {
+          type: 'section',
+          blocks: [{ type: 'interactive', targetAction: 'formfill', targetValue: 'x' }],
+        },
+        {
+          type: 'conditional',
+          whenTrue: [{ type: 'interactive', refTarget: '.t' }],
+          whenFalse: [{ type: 'interactive', refTarget: '.f' }],
+        },
+      ],
+    }) as { blocks: Array<Record<string, any>> };
+
+    expect(out.blocks[0]).toMatchObject({ action: 'button', reftarget: 'Save' });
+    expect(out.blocks[1]!.steps[0]).toMatchObject({ action: 'highlight', reftarget: '.a' });
+    expect(out.blocks[2]!.blocks[0]).toMatchObject({ action: 'formfill', targetvalue: 'x' });
+    expect(out.blocks[3]!.whenTrue[0]).toMatchObject({ reftarget: '.t' });
+    expect(out.blocks[3]!.whenFalse[0]).toMatchObject({ reftarget: '.f' });
+  });
+
+  it('is idempotent', () => {
+    const input = { type: 'interactive', targetAction: 'button', refTarget: 'Save' };
+    const once = normalizeJsonGuideAliases(input);
+    const twice = normalizeJsonGuideAliases(once);
+    expect(twice).toEqual(once);
+  });
+
+  it('does not mutate its input', () => {
+    const input = { type: 'interactive', targetAction: 'button' };
+    normalizeJsonGuideAliases(input);
+    expect(input).toEqual({ type: 'interactive', targetAction: 'button' });
+  });
+
+  it('returns non-object input unchanged', () => {
+    expect(normalizeJsonGuideAliases('a string')).toBe('a string');
+    expect(normalizeJsonGuideAliases(42)).toBe(42);
+    expect(normalizeJsonGuideAliases(null)).toBe(null);
+    expect(normalizeJsonGuideAliases(['a', 'b'])).toEqual(['a', 'b']);
+  });
+});

--- a/src/validation/normalize-guide-aliases.ts
+++ b/src/validation/normalize-guide-aliases.ts
@@ -1,0 +1,36 @@
+/**
+ * Pre-schema normalizer: rewrites the camelCase field aliases the runtime
+ * parser tolerates (`targetAction`/`refTarget`/`targetValue`) to their
+ * canonical lowercase schema names, so hand-written camelCase guides pass
+ * `JsonGuideSchema`. Canonical wins when both are present. Pure and
+ * idempotent; runs immediately before the schema in `validateGuide`.
+ */
+
+const FIELD_ALIASES: ReadonlyArray<readonly [alias: string, canonical: string]> = [
+  ['targetAction', 'action'],
+  ['refTarget', 'reftarget'],
+  ['targetValue', 'targetvalue'],
+];
+
+export function normalizeJsonGuideAliases(raw: unknown): unknown {
+  if (Array.isArray(raw)) {
+    return raw.map(normalizeJsonGuideAliases);
+  }
+  if (raw === null || typeof raw !== 'object') {
+    return raw;
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    out[key] = normalizeJsonGuideAliases(value);
+  }
+  for (const [alias, canonical] of FIELD_ALIASES) {
+    if (alias in out) {
+      if (!(canonical in out)) {
+        out[canonical] = out[alias];
+      }
+      delete out[alias];
+    }
+  }
+  return out;
+}

--- a/src/validation/normalize-guide-aliases.ts
+++ b/src/validation/normalize-guide-aliases.ts
@@ -6,11 +6,11 @@
  * idempotent; runs immediately before the schema in `validateGuide`.
  */
 
-const FIELD_ALIASES: ReadonlyArray<readonly [alias: string, canonical: string]> = [
+const FIELD_ALIASES: ReadonlyMap<string, string> = new Map([
   ['targetAction', 'action'],
   ['refTarget', 'reftarget'],
   ['targetValue', 'targetvalue'],
-];
+]);
 
 export function normalizeJsonGuideAliases(raw: unknown): unknown {
   if (Array.isArray(raw)) {
@@ -20,17 +20,13 @@ export function normalizeJsonGuideAliases(raw: unknown): unknown {
     return raw;
   }
 
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
-    out[key] = normalizeJsonGuideAliases(value);
-  }
-  for (const [alias, canonical] of FIELD_ALIASES) {
-    if (alias in out) {
-      if (!(canonical in out)) {
-        out[canonical] = out[alias];
-      }
-      delete out[alias];
-    }
-  }
-  return out;
+  const source = raw as Record<string, unknown>;
+  const entries = Object.entries(source)
+    .filter(([key]) => {
+      const canonical = FIELD_ALIASES.get(key);
+      return canonical === undefined || !Object.hasOwn(source, canonical);
+    })
+    .map(([key, value]) => [FIELD_ALIASES.get(key) ?? key, normalizeJsonGuideAliases(value)] as const);
+
+  return Object.fromEntries(entries);
 }

--- a/src/validation/normalize-guide-aliases.ts
+++ b/src/validation/normalize-guide-aliases.ts
@@ -24,7 +24,7 @@ export function normalizeJsonGuideAliases(raw: unknown): unknown {
   const entries = Object.entries(source)
     .filter(([key]) => {
       const canonical = FIELD_ALIASES.get(key);
-      return canonical === undefined || !Object.hasOwn(source, canonical);
+      return canonical === undefined || !Object.prototype.hasOwnProperty.call(source, canonical);
     })
     .map(([key, value]) => [FIELD_ALIASES.get(key) ?? key, normalizeJsonGuideAliases(value)] as const);
 

--- a/src/validation/validate-guide.ts
+++ b/src/validation/validate-guide.ts
@@ -14,6 +14,7 @@ import {
 import { detectUnknownFields } from './unknown-fields';
 import { validateBlockConditions, type ConditionIssue } from './condition-validator';
 import { customErrorMap } from './error-map';
+import { normalizeJsonGuideAliases } from './normalize-guide-aliases';
 
 export interface ValidationResult {
   isValid: boolean;
@@ -46,15 +47,20 @@ function conditionIssueToWarning(issue: ConditionIssue): ValidationWarning {
 }
 
 export function validateGuide(data: unknown, options: ValidationOptions = {}): ValidationResult {
+  // Accept camelCase field aliases (targetAction/refTarget/targetValue) by
+  // normalizing to canonical lowercase before both the schema and the
+  // unknown-field check see the input.
+  const normalized = normalizeJsonGuideAliases(data);
+
   // 1. Zod parse - validates structure, types, nesting depth and use a custom error map for better messages
-  const result = JsonGuideSchema.safeParse(data, { error: customErrorMap });
+  const result = JsonGuideSchema.safeParse(normalized, { error: customErrorMap });
 
   if (!result.success) {
     return { isValid: false, errors: formatZodErrors(result.error.issues), warnings: [], guide: null };
   }
 
   // 2. Unknown fields check (existing) - single traversal
-  const warnings: ValidationWarning[] = options.skipUnknownFieldCheck ? [] : detectUnknownFields(data);
+  const warnings: ValidationWarning[] = options.skipUnknownFieldCheck ? [] : detectUnknownFields(normalized);
 
   // 3. Condition validation (NEW) - only runs after Zod validates structure
   const conditionIssues = validateBlockConditions(result.data as JsonGuide);

--- a/src/validation/validate-guide.ts
+++ b/src/validation/validate-guide.ts
@@ -47,9 +47,7 @@ function conditionIssueToWarning(issue: ConditionIssue): ValidationWarning {
 }
 
 export function validateGuide(data: unknown, options: ValidationOptions = {}): ValidationResult {
-  // Accept camelCase field aliases (targetAction/refTarget/targetValue) by
-  // normalizing to canonical lowercase before both the schema and the
-  // unknown-field check see the input.
+  // Normalize camelCase aliases before both the schema and the unknown-field check.
   const normalized = normalizeJsonGuideAliases(data);
 
   // 1. Zod parse - validates structure, types, nesting depth and use a custom error map for better messages


### PR DESCRIPTION
## Summary

**P2 (A5)** of the [INTERACTIVE-STATE-CONSOLIDATION breakdown](https://github.com/grafana/pathfinder-rfcs/pull/7) — independent of P1 (#986). Author-facing only.

Hand-written JSON guides that use camelCase field names (`targetAction` / `refTarget` / `targetValue`) previously **failed validation**: the schema requires the canonical lowercase forms (`action` / `reftarget` / `targetvalue`), even though the runtime parser already tolerates the camelCase aliases via `?? block.targetAction` fallbacks. `json-parser-aliases.test.ts` literally documented this gap as "a follow-up" — this is that follow-up.

## What changed

- **New `src/validation/normalize-guide-aliases.ts`** — a pure, idempotent `normalizeJsonGuideAliases(raw)` that deep-clones and recursively rewrites the three camelCase aliases to canonical lowercase (`targetAction→action`, `refTarget→reftarget`, `targetValue→targetvalue`), **canonical wins on conflict**, and removes the alias key.
- **Wired into `validateGuide`** (`src/validation/validate-guide.ts`) — runs once, immediately before `JsonGuideSchema.safeParse` *and* the `detectUnknownFields` traversal (so a both-present guide doesn't draw a spurious "unknown field `targetAction`" warning). This is the single chokepoint all paths converge on (runtime `parseJsonGuide`, content-fetcher, CLI `validate`).
- **Unchanged on purpose:** `json-guide.schema.ts` keeps the canonical field names, and `cli/utils/schema-options.ts` walks the schema's shape — so the emitted CLI flags stay `--action` / `--reftarget` / `--targetvalue` (no `--target-action`). The runtime `?? camelCase` fallbacks in `json-parser.ts` remain as the runtime read path. One validator only.

## Tests

- New `normalize-guide-aliases.test.ts` — rename per alias, canonical-wins, recursion into `blocks[]` / multistep `steps[]` / nested section + conditional branches, idempotency, no-mutation, non-object passthrough.
- Updated `json-parser-aliases.test.ts` — the case that asserted camelCase-only is *rejected* now asserts it **validates** and the props read correctly; refreshed the module docstring. The "canonical wins when both present" case stays green.

## Verification

`npx jest src/validation src/cli` — **38 suites / 854 tests pass** (CLI option-generation suites confirm the flag set is unchanged) · typecheck clean · eslint 0 errors · prettier clean · governance 73/73.
