### PR TITLE
test(interactive): tripwire that the section step-type map matches the registry

### DIFF
--- a/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
@@ -84,7 +84,9 @@ jest.mock('./interactive-conditional', () => {
 
 import { testIds } from '../../constants/testIds';
 import { InteractiveStep } from './interactive-step';
-import { InteractiveSection, resetInteractiveCounters } from './interactive-section';
+import { InteractiveSection, resetInteractiveCounters, STEP_TYPE_LOOKUP } from './interactive-section';
+import { STEP_TYPE_SCHEMAS } from './step-type-registry';
+import { INTERACTIVE_STEP_COMPONENT_TYPES } from './section-child-classifier';
 import { memoryStore, resetSectionHarness, silenceSectionWarnings } from '../../test-utils/interactive-section-harness';
 
 const NON_PREVIEW_KEY = '/';
@@ -146,6 +148,26 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+});
+
+// Tracked step-type registry parity (B4). Adding a step type to one site but
+// not the others is a silent-drift bug (historically: ChallengeBlock landed in
+// only two of the sites). These pin all three tracked sites against each other.
+// See .cursor/rules/tracked-step-types.mdc.
+describe('step-type registry parity', () => {
+  it('STEP_TYPE_LOOKUP holds exactly the registry schemas (both directions)', () => {
+    expect(new Set(STEP_TYPE_LOOKUP.values())).toEqual(new Set(STEP_TYPE_SCHEMAS));
+    expect(STEP_TYPE_LOOKUP.size).toBe(STEP_TYPE_SCHEMAS.length);
+  });
+
+  it('every tracked step component except InteractiveStep is in the classifier set', () => {
+    for (const component of STEP_TYPE_LOOKUP.keys()) {
+      if (component === InteractiveStep) {
+        continue;
+      }
+      expect(INTERACTIVE_STEP_COMPONENT_TYPES.has(component)).toBe(true);
+    }
+  });
 });
 
 describe('InteractiveSection contracts — Phase 0 tripwire', () => {

--- a/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
@@ -150,10 +150,7 @@ afterEach(() => {
   cleanup();
 });
 
-// Tracked step-type registry parity (B4). Adding a step type to one site but
-// not the others is a silent-drift bug (historically: ChallengeBlock landed in
-// only two of the sites). These pin all three tracked sites against each other.
-// See .cursor/rules/tracked-step-types.mdc.
+// Parity across the three tracked step-type sites; see .cursor/rules/tracked-step-types.mdc.
 describe('step-type registry parity', () => {
   it('STEP_TYPE_LOOKUP holds exactly the registry schemas (both directions)', () => {
     expect(new Set(STEP_TYPE_LOOKUP.values())).toEqual(new Set(STEP_TYPE_SCHEMAS));

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -24,7 +24,7 @@ export { shouldNumberSectionChild, wrapSectionChildrenForNumbering } from './sec
 // of 2). The other site that must be edited when adding a step type is
 // `section-child-classifier.ts` `INTERACTIVE_STEP_COMPONENT_TYPES`.
 // See .cursor/rules/tracked-step-types.mdc for the full checklist.
-const STEP_TYPE_LOOKUP: ReadonlyMap<React.ComponentType<any>, StepTypeSchema> = new Map<
+export const STEP_TYPE_LOOKUP: ReadonlyMap<React.ComponentType<any>, StepTypeSchema> = new Map<
   React.ComponentType<any>,
   StepTypeSchema
 >([

--- a/src/components/interactive-tutorial/section-child-classifier.ts
+++ b/src/components/interactive-tutorial/section-child-classifier.ts
@@ -30,7 +30,7 @@ import type { ChildKind } from './step-section-utils';
  * `classifySectionChild` because its `targetAction` prop subdivides it
  * into interactive vs informational variants.
  */
-const INTERACTIVE_STEP_COMPONENT_TYPES: ReadonlySet<unknown> = new Set<unknown>([
+export const INTERACTIVE_STEP_COMPONENT_TYPES: ReadonlySet<unknown> = new Set<unknown>([
   InteractiveMultiStep,
   InteractiveGuided,
   InteractiveQuiz,


### PR DESCRIPTION
## Summary

**P3 (B4)** of the [INTERACTIVE-STATE-CONSOLIDATION breakdown](https://github.com/grafana/pathfinder-rfcs/pull/7)

The tracked step-type registry lives in three sites that must stay in sync:
- `STEP_TYPE_LOOKUP` (`interactive-section.tsx`) — component → schema, the orchestration map
- `STEP_TYPE_SCHEMAS` (`step-type-registry.ts`) — the canonical schema list
- `INTERACTIVE_STEP_COMPONENT_TYPES` (`section-child-classifier.ts`) — the #842 acknowledgement-gate set

Adding a step type to a subset fails **silently** — the documented "ChallengeBlock-in-only-two-of-the-sites" bug, where a step renders but is misclassified as passive (forcing a spurious "Mark section as complete"). There was no test pinning these together.

## What changed

- **Extend `interactive-section.contracts.tripwire.test.tsx`** with a `step-type registry parity` block:
  - `STEP_TYPE_LOOKUP`'s schemas equal `STEP_TYPE_SCHEMAS` **both directions** (set equality) + size match — adding to either side alone fails CI.
  - every component in `STEP_TYPE_LOOKUP` except `InteractiveStep` (special-cased in the classifier) is present in `INTERACTIVE_STEP_COMPONENT_TYPES`.
- **Export `STEP_TYPE_LOOKUP`** and **`INTERACTIVE_STEP_COMPONENT_TYPES`** so the test can read them. The registry (`step-type-registry.ts`) is deliberately left importing no components — not re-plumbed (D2).

The mock harness already loads `InteractiveSection`; the registry is unmocked, so schema references compare directly and component identities match across sites via jest's module cache.

## Verification

- `npx jest src/components/interactive-tutorial src/validation/architecture.test.ts src/validation/import-graph.test.ts` — **23 suites / 389 tests pass**, governance 73/73.
- **Confirmed the tripwire bites:** temporarily removed `ChallengeBlock` from `STEP_TYPE_LOOKUP` → the parity test failed; restored → green.
- typecheck clean · eslint 0 errors · prettier clean.
