### PR TITLE
ci: cache node_modules by package-lock hash, drop run_id handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,30 +20,9 @@ env:
   NODE_VERSION: '22'
 
 jobs:
-  # Setup job installs dependencies and caches node_modules for parallel jobs
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm' # Cross-run npm cache (speeds up npm ci)
-      - run: npm ci
-      - uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: node_modules
-          key: node-modules-${{ github.run_id }} # Intra-run sharing
-
   # Parallel quality check jobs
   lint:
     name: Lint
-    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -55,16 +34,18 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+          cache: 'npm'
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: node-modules
         with:
           path: node_modules
-          key: node-modules-${{ github.run_id }}
-          fail-on-cache-miss: true
+          key: node-modules-${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npm run lint
 
   typecheck:
     name: Typecheck
-    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -76,16 +57,18 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+          cache: 'npm'
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: node-modules
         with:
           path: node_modules
-          key: node-modules-${{ github.run_id }}
-          fail-on-cache-miss: true
+          key: node-modules-${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npm run typecheck
 
   prettier:
     name: Prettier
-    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -97,16 +80,18 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+          cache: 'npm'
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: node-modules
         with:
           path: node_modules
-          key: node-modules-${{ github.run_id }}
-          fail-on-cache-miss: true
+          key: node-modules-${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npm run prettier-test
 
   test:
     name: Test
-    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -118,11 +103,14 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+          cache: 'npm'
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: node-modules
         with:
           path: node_modules
-          key: node-modules-${{ github.run_id }}
-          fail-on-cache-miss: true
+          key: node-modules-${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npm run test:ci
       - name: Upload coverage reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -133,7 +121,6 @@ jobs:
 
   validate-packages:
     name: Validate packages
-    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -145,11 +132,14 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+          cache: 'npm'
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: node-modules
         with:
           path: node_modules
-          key: node-modules-${{ github.run_id }}
-          fail-on-cache-miss: true
+          key: node-modules-${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - name: Build CLI
         run: npm run build:cli
       - name: Validate bundled packages
@@ -193,7 +183,6 @@ jobs:
   # Build job runs in parallel with quality checks
   build:
     name: Build
-    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -211,11 +200,14 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+          cache: 'npm'
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: node-modules
         with:
           path: node_modules
-          key: node-modules-${{ github.run_id }}
-          fail-on-cache-miss: true
+          key: node-modules-${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
+      - if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Build frontend
         run: npm run build


### PR DESCRIPTION
## What

Replaces the `node-modules-${{ github.run_id }}` Actions-cache handoff between the `setup` job and the six parallel jobs (lint, typecheck, prettier, test, validate-packages, build) with the conventional per-job pattern: each job restores `node_modules` from a cache keyed on `runner.os` + node version + `hashFiles('package-lock.json')`, and runs `npm ci` only on a cache miss. The `setup` job is removed entirely, along with `fail-on-cache-miss` and the `needs: setup` serialization.

## Why

CI was failing intermittently — most visibly right after stacked-PR rebases — with every downstream job dying before running anything:

```
Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: node-modules-<run_id>
```

Root cause is the cache key, not any code change:

- The key was `github.run_id` — **unique per run, never reused** — so every run left a ~120 MB `node_modules` cache behind that just accumulated. (Verified: the repo had **73 orphaned `node-modules-<run_id>` caches totalling ~8.6 GB**, since cleared.)
- GitHub enforces a **10 GB per-repo cache budget** with LRU eviction. Over budget, a cache can be evicted **within minutes of being written** — so `setup` saves it, and ~5 min later (the parallel jobs gate behind e2e-image resolution) it is already gone.
- `fail-on-cache-miss: true` turns that eviction into a hard job failure.
- **Stacked-PR rebases are the accelerant**: a stack rebase force-pushes every branch at once → a burst of simultaneous runs → a flood of new caches → budget blows → aggressive eviction.

A `run_id` key is the worst of both worlds: it pays the storage cost but gets **zero cross-run reuse** (a unique key can never hit on a later run).

## The fix

Key the cache on `package-lock.json` instead — the conventional pattern, and exactly what `actions/setup-node`'s own `cache: 'npm'` already does for `~/.npm` in this same workflow. This:

- **Collapses cardinality** from one cache per run to one per dependency change.
- **Reuses `node_modules` across runs** — most PRs do not touch `package-lock.json`, so they restore an existing cache and skip install entirely.
- **Self-heals on eviction**: a miss falls back to `npm ci` (slower-but-green) instead of hard-failing. No more `fail-on-cache-miss`.
- **Removes the `setup` serialization**: jobs no longer wait for a setup job before starting; each self-serves `node_modules`.

`runner.os` + node version are in the key because a cached `node_modules` is ABI-sensitive.

## Notes

- Reuses the `actions/cache` SHA already pinned in this workflow (`27d5ce7` / v5.0.5) so zizmor's pinning check stays happy.
- On a cold dependency bump, the parallel jobs may each run `npm ci` and try to save the same key; the first save wins and the rest no-op with a harmless "cache already exists" warning. There is no native postinstall here, so a cold install is cheap.
- The orphaned `node-modules-<run_id>` caches (73 / ~8.6 GB) have been deleted via the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
