### PR TITLE
feat(cli): add --clean flag to e2e command for isolated docker-compose runs

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -1,0 +1,20 @@
+# Compose overlay used by `pathfinder-cli e2e --clean` to run the e2e stack
+# in isolation from any local dev `docker compose up` stack on the same machine.
+#
+# Used as:
+#   docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml \
+#                  -p pathfinder-e2e up -d
+services:
+  grafana:
+    container_name: grafana-pathfinder-app-e2e
+    ports: !override
+      - '3010:3000'
+  prometheus:
+    ports: !override
+      - '9091:9090'
+  loki:
+    ports: !override
+      - '3101:3100'
+  alloy:
+    ports: !override
+      - '12346:12345'

--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -24,6 +24,9 @@ npx pathfinder-cli e2e --bundled
 
 # Test a specific bundled guide by name
 npx pathfinder-cli e2e bundled:welcome-to-grafana
+
+# Run against an isolated, clean-slate docker-compose stack (see below)
+npx pathfinder-cli e2e --bundled --clean
 ```
 
 ## CLI reference
@@ -34,16 +37,18 @@ npx pathfinder-cli e2e [options] [files...]
 
 ### Options
 
-| Option                | Description                                                  | Default                      |
-| --------------------- | ------------------------------------------------------------ | ---------------------------- |
-| `--grafana-url <url>` | Grafana instance URL                                         | `http://localhost:3000`      |
-| `--output <path>`     | Path for JSON report output                                  | None                         |
-| `--artifacts <dir>`   | Directory for failure artifacts (screenshots, DOM snapshots) | `/tmp/pathfinder-e2e-{uuid}` |
-| `--verbose`           | Enable detailed logging                                      | `false`                      |
-| `--bundled`           | Test all bundled guides                                      | `false`                      |
-| `--trace`             | Generate Playwright trace files for debugging                | `false`                      |
-| `--headed`            | Run browser visibly (not headless)                           | `false`                      |
-| `--always-screenshot` | Capture screenshots on success and failure                   | `false`                      |
+| Option                          | Description                                                                                                                                   | Default                      |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `--grafana-url <url>`           | Grafana instance URL. Auto-switches to `http://localhost:3010` when `--clean` is set and this flag is not passed.                             | `http://localhost:3000`      |
+| `--output <path>`               | Path for JSON report output                                                                                                                   | None                         |
+| `--artifacts <dir>`             | Directory for failure artifacts (screenshots, DOM snapshots)                                                                                  | `/tmp/pathfinder-e2e-{uuid}` |
+| `--verbose`                     | Enable detailed logging                                                                                                                       | `false`                      |
+| `--bundled`                     | Test all bundled guides                                                                                                                       | `false`                      |
+| `--trace`                       | Generate Playwright trace files for debugging                                                                                                 | `false`                      |
+| `--headed`                      | Run browser visibly (not headless)                                                                                                            | `false`                      |
+| `--always-screenshot`           | Capture screenshots on success and failure                                                                                                    | `false`                      |
+| `--clean`                       | Run against an isolated docker-compose stack (project `pathfinder-e2e`, Grafana on `:3010`). Resets between guides and tears down at the end. | `false`                      |
+| `--clean-ready-timeout-ms <ms>` | How long to wait for the isolated Grafana to become healthy after a `--clean` reset                                                           | `120000`                     |
 
 ### Input formats
 
@@ -208,6 +213,10 @@ Run it to verify your setup:
 ```bash
 npx pathfinder-cli e2e bundled:e2e-framework-test
 ```
+
+## Clean-slate runs (`--clean`)
+
+The `--clean` flag boots a dedicated, isolated docker-compose stack (project `pathfinder-e2e`, Grafana on `:3010`) for the test run, resets it between guides, and tears it down at the end — the normal local dev stack on `:3000` is never touched. Use it when residual state from prior runs is making failures hard to attribute, or when you want clean-slate guarantees across a `--bundled` sweep.
 
 ## Timing and timeouts
 

--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -133,18 +133,25 @@ async function checkGrafanaHealth(grafanaUrl: string): Promise<CliPreflightResul
   }
 }
 
+// Isolated docker-compose project vars used by --clean.
+const CLEAN_COMPOSE_PROJECT = 'pathfinder-e2e';
+const CLEAN_COMPOSE_FILES = ['-f', 'docker-compose.yaml', '-f', 'docker-compose.e2e.yaml'];
+const CLEAN_PROJECT_FLAGS = [...CLEAN_COMPOSE_FILES, '-p', CLEAN_COMPOSE_PROJECT];
+const DEFAULT_GRAFANA_URL = 'http://localhost:3000';
+// Must match `docker-compose.e2e.yaml` (services.grafana.ports → '3010:3000').
+const CLEAN_GRAFANA_URL = 'http://localhost:3010';
+
 /**
- * Run a `docker compose` subcommand and resolve when it exits successfully.
- *
- * Stdio is inherited so the user sees pull / build progress in verbose mode
- * and a single "failed" line in quiet mode.
+ * Run a `docker compose` subcommand against the isolated --clean project and
+ * resolve when it exits successfully.
  */
 async function runDockerCompose(args: string[], options: { verbose: boolean }): Promise<void> {
+  const fullArgs = ['compose', ...CLEAN_PROJECT_FLAGS, ...args];
   return new Promise((resolve, reject) => {
     if (options.verbose) {
-      console.log(`   docker ${['compose', ...args].join(' ')}`);
+      console.log(`   docker ${fullArgs.join(' ')}`);
     }
-    const proc = spawn('docker', ['compose', ...args], {
+    const proc = spawn('docker', fullArgs, {
       stdio: options.verbose ? 'inherit' : ['ignore', 'ignore', 'inherit'],
     });
     proc.on('close', (code) => {
@@ -162,9 +169,6 @@ async function runDockerCompose(args: string[], options: { verbose: boolean }): 
 
 /**
  * Poll Grafana health until it succeeds or `timeoutMs` elapses.
- *
- * Used after `docker compose up` to ensure Grafana is fully booted (database
- * migrated, plugin loaded) before kicking off tests.
  */
 async function waitForGrafanaReady(
   grafanaUrl: string,
@@ -196,9 +200,9 @@ async function waitForGrafanaReady(
 }
 
 /**
- * Bring docker compose down with volumes removed, then back up detached, and
- * wait for Grafana to be reachable. Used by `--clean` to wipe the
- * `grafana-data` SQLite DB between guides.
+ *  Bring docker compose down with volumes removed, then up, and wait for Grafana
+ *  to be reachable. Used by `--clean` to wipe the `grafana-data` DB between
+ *  guides.
  */
 async function cleanResetDocker(grafanaUrl: string, options: E2ECommandOptions): Promise<void> {
   console.log('   docker compose down -v');
@@ -218,14 +222,11 @@ async function cleanResetDocker(grafanaUrl: string, options: E2ECommandOptions):
 /**
  * Synchronously tear down docker compose. Safe to call from `process.on('exit')`
  * and signal handlers since execSync blocks until completion.
- *
- * Failures here are logged but not rethrown — teardown is best-effort cleanup
- * and we don't want to mask the real exit code.
  */
 function teardownDockerSync(verbose: boolean): void {
-  console.log('\n🧹 Tearing down docker compose (down -v)...');
+  console.log(`\n🧹 Tearing down docker compose project ${CLEAN_COMPOSE_PROJECT} (down -v)...`);
   try {
-    execSync('docker compose down -v', {
+    execSync(`docker compose ${CLEAN_PROJECT_FLAGS.join(' ')} down -v`, {
       stdio: verbose ? 'inherit' : ['ignore', 'ignore', 'inherit'],
     });
     console.log('   ✓ Teardown complete');
@@ -576,7 +577,11 @@ const defaultArtifactsDir = `/tmp/pathfinder-e2e-${randomUUID().slice(0, 8)}`;
 export const e2eCommand = new Command('e2e')
   .description('Run E2E tests on JSON guide files')
   .arguments('[files...]')
-  .option('--grafana-url <url>', 'Grafana instance URL', 'http://localhost:3000')
+  .option(
+    '--grafana-url <url>',
+    `Grafana instance URL (default ${DEFAULT_GRAFANA_URL}; ${CLEAN_GRAFANA_URL} when --clean is set and this flag is not passed)`,
+    DEFAULT_GRAFANA_URL
+  )
   .option('--output <path>', 'Path for JSON report output')
   .option('--artifacts <dir>', 'Directory for artifacts', defaultArtifactsDir)
   .option('--verbose', 'Enable verbose logging', false)
@@ -588,19 +593,16 @@ export const e2eCommand = new Command('e2e')
   .option('--always-screenshot', 'Capture screenshots on success and failure', false)
   .option(
     '--clean',
-    'Reset docker compose (down -v + up -d) before tests and between guides, and tear down at the end',
+    `Run tests against an isolated docker-compose stack (project "${CLEAN_COMPOSE_PROJECT}", Grafana on ${CLEAN_GRAFANA_URL}). Resets between guides and tears down at the end.`,
     false
   )
   .option(
     '--clean-ready-timeout-ms <ms>',
-    'How long to wait for Grafana to become healthy after a --clean reset',
+    'How long to wait for the isolated Grafana to become healthy after a --clean reset',
     (v) => parseInt(v, 10),
     120000
   )
   .action(async (files: string[], options: E2ECommandOptions) => {
-    // --clean lifecycle: track whether we've brought docker up so the exit /
-    // signal handlers know whether teardown is needed. execSync is used in
-    // teardown so it runs synchronously inside the 'exit' event listener.
     let dockerStartedByUs = false;
     const installCleanTeardownHandlers = () => {
       const exitHandler = () => {
@@ -624,6 +626,10 @@ export const e2eCommand = new Command('e2e')
     };
     if (options.clean) {
       installCleanTeardownHandlers();
+
+      if (options.grafanaUrl === DEFAULT_GRAFANA_URL) {
+        options.grafanaUrl = CLEAN_GRAFANA_URL;
+      }
     }
 
     try {
@@ -693,11 +699,9 @@ export const e2eCommand = new Command('e2e')
         console.log(`   Screenshots: on success and failure`);
       }
       if (options.clean) {
-        console.log(`   Clean:       enabled (docker compose reset before tests and between guides)`);
+        console.log(`   Clean:       enabled (project "${CLEAN_COMPOSE_PROJECT}", isolated from any dev stack)`);
       }
 
-      // --clean: bring docker up with a clean volume before pre-flight, since
-      // pre-flight checks Grafana health and we want a known-clean state.
       if (options.clean) {
         console.log('\n🧹 Clean start — resetting docker compose before tests...');
         try {
@@ -811,8 +815,6 @@ export const e2eCommand = new Command('e2e')
       }> = [];
 
       for (const [i, guide] of valid.entries()) {
-        // --clean: reset between guides so each guide gets a clean dashboard.
-        // We've already reset before the loop, so skip on the first iteration.
         if (options.clean && i > 0) {
           console.log(`\n🧹 Resetting docker compose between guides...`);
           try {

--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -5,7 +5,7 @@
  * into localStorage and verify they load correctly in the docs panel.
  */
 
-import { spawn } from 'child_process';
+import { execSync, spawn } from 'child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -47,6 +47,8 @@ interface E2ECommandOptions {
   trace: boolean;
   headed: boolean;
   alwaysScreenshot: boolean;
+  clean: boolean;
+  cleanReadyTimeoutMs: number;
 }
 
 /**
@@ -128,6 +130,107 @@ async function checkGrafanaHealth(grafanaUrl: string): Promise<CliPreflightResul
       error: `Grafana not reachable at ${grafanaUrl}: ${errorMessage}`,
       durationMs: Date.now() - startTime,
     };
+  }
+}
+
+/**
+ * Run a `docker compose` subcommand and resolve when it exits successfully.
+ *
+ * Stdio is inherited so the user sees pull / build progress in verbose mode
+ * and a single "failed" line in quiet mode.
+ */
+async function runDockerCompose(args: string[], options: { verbose: boolean }): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (options.verbose) {
+      console.log(`   docker ${['compose', ...args].join(' ')}`);
+    }
+    const proc = spawn('docker', ['compose', ...args], {
+      stdio: options.verbose ? 'inherit' : ['ignore', 'ignore', 'inherit'],
+    });
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`docker compose ${args.join(' ')} exited with code ${code}`));
+      }
+    });
+    proc.on('error', (err) => {
+      reject(new Error(`Failed to run docker compose: ${err.message}`));
+    });
+  });
+}
+
+/**
+ * Poll Grafana health until it succeeds or `timeoutMs` elapses.
+ *
+ * Used after `docker compose up` to ensure Grafana is fully booted (database
+ * migrated, plugin loaded) before kicking off tests.
+ */
+async function waitForGrafanaReady(
+  grafanaUrl: string,
+  options: { verbose: boolean; timeoutMs: number }
+): Promise<void> {
+  const pollIntervalMs = 2000;
+  const startTime = Date.now();
+  let attempts = 0;
+  let lastError = 'unknown error';
+
+  while (Date.now() - startTime < options.timeoutMs) {
+    attempts += 1;
+    const health = await checkGrafanaHealth(grafanaUrl);
+    if (health.passed) {
+      if (options.verbose) {
+        const elapsed = Date.now() - startTime;
+        console.log(
+          `   ✓ Grafana ready after ${attempts} attempt(s) in ${elapsed}ms (version ${health.version ?? 'unknown'})`
+        );
+      }
+      return;
+    }
+    lastError = health.error ?? 'unknown error';
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+
+  const seconds = Math.round(options.timeoutMs / 1000);
+  throw new Error(`Grafana did not become ready within ${seconds}s: ${lastError}`);
+}
+
+/**
+ * Bring docker compose down with volumes removed, then back up detached, and
+ * wait for Grafana to be reachable. Used by `--clean` to wipe the
+ * `grafana-data` SQLite DB between guides.
+ */
+async function cleanResetDocker(grafanaUrl: string, options: E2ECommandOptions): Promise<void> {
+  console.log('   docker compose down -v');
+  await runDockerCompose(['down', '-v'], options);
+
+  console.log('   docker compose up -d');
+  await runDockerCompose(['up', '-d'], options);
+
+  console.log('   Waiting for Grafana to become healthy...');
+  await waitForGrafanaReady(grafanaUrl, {
+    verbose: options.verbose,
+    timeoutMs: options.cleanReadyTimeoutMs,
+  });
+  console.log('   ✓ Grafana ready');
+}
+
+/**
+ * Synchronously tear down docker compose. Safe to call from `process.on('exit')`
+ * and signal handlers since execSync blocks until completion.
+ *
+ * Failures here are logged but not rethrown — teardown is best-effort cleanup
+ * and we don't want to mask the real exit code.
+ */
+function teardownDockerSync(verbose: boolean): void {
+  console.log('\n🧹 Tearing down docker compose (down -v)...');
+  try {
+    execSync('docker compose down -v', {
+      stdio: verbose ? 'inherit' : ['ignore', 'ignore', 'inherit'],
+    });
+    console.log('   ✓ Teardown complete');
+  } catch (err) {
+    console.error(`   ⚠ Failed to tear down docker compose: ${err instanceof Error ? err.message : 'Unknown error'}`);
   }
 }
 
@@ -483,7 +586,46 @@ export const e2eCommand = new Command('e2e')
   .option('--trace', 'Generate Playwright trace file', false)
   .option('--headed', 'Run browser in headed mode (visible)', false)
   .option('--always-screenshot', 'Capture screenshots on success and failure', false)
+  .option(
+    '--clean',
+    'Reset docker compose (down -v + up -d) before tests and between guides, and tear down at the end',
+    false
+  )
+  .option(
+    '--clean-ready-timeout-ms <ms>',
+    'How long to wait for Grafana to become healthy after a --clean reset',
+    (v) => parseInt(v, 10),
+    120000
+  )
   .action(async (files: string[], options: E2ECommandOptions) => {
+    // --clean lifecycle: track whether we've brought docker up so the exit /
+    // signal handlers know whether teardown is needed. execSync is used in
+    // teardown so it runs synchronously inside the 'exit' event listener.
+    let dockerStartedByUs = false;
+    const installCleanTeardownHandlers = () => {
+      const exitHandler = () => {
+        if (dockerStartedByUs) {
+          dockerStartedByUs = false;
+          teardownDockerSync(options.verbose);
+        }
+      };
+      const signalHandler = (signal: NodeJS.Signals) => {
+        if (dockerStartedByUs) {
+          dockerStartedByUs = false;
+          teardownDockerSync(options.verbose);
+        }
+        // Re-raise the signal with the conventional 128 + signal-number exit code
+        const code = signal === 'SIGINT' ? 130 : signal === 'SIGTERM' ? 143 : 1;
+        process.exit(code);
+      };
+      process.on('exit', exitHandler);
+      process.on('SIGINT', signalHandler);
+      process.on('SIGTERM', signalHandler);
+    };
+    if (options.clean) {
+      installCleanTeardownHandlers();
+    }
+
     try {
       // Resolve guides from inputs
       const guides = resolveGuides(files, options);
@@ -549,6 +691,22 @@ export const e2eCommand = new Command('e2e')
       }
       if (options.alwaysScreenshot) {
         console.log(`   Screenshots: on success and failure`);
+      }
+      if (options.clean) {
+        console.log(`   Clean:       enabled (docker compose reset before tests and between guides)`);
+      }
+
+      // --clean: bring docker up with a clean volume before pre-flight, since
+      // pre-flight checks Grafana health and we want a known-clean state.
+      if (options.clean) {
+        console.log('\n🧹 Clean start — resetting docker compose before tests...');
+        try {
+          await cleanResetDocker(options.grafanaUrl, options);
+          dockerStartedByUs = true;
+        } catch (err) {
+          console.error(`\n❌ Failed to reset docker compose: ${err instanceof Error ? err.message : 'Unknown error'}`);
+          process.exit(ExitCode.CONFIGURATION_ERROR);
+        }
       }
 
       // Run CLI-level pre-flight checks
@@ -652,7 +810,23 @@ export const e2eCommand = new Command('e2e')
         resultsData?: TestResultsData;
       }> = [];
 
-      for (const guide of valid) {
+      for (const [i, guide] of valid.entries()) {
+        // --clean: reset between guides so each guide gets a clean dashboard.
+        // We've already reset before the loop, so skip on the first iteration.
+        if (options.clean && i > 0) {
+          console.log(`\n🧹 Resetting docker compose between guides...`);
+          try {
+            await cleanResetDocker(options.grafanaUrl, options);
+            dockerStartedByUs = true;
+          } catch (err) {
+            console.error(
+              `\n❌ Failed to reset docker compose between guides: ${err instanceof Error ? err.message : 'Unknown error'}`
+            );
+            allPassed = false;
+            break;
+          }
+        }
+
         console.log(`\n📚 Testing: ${guide.path}`);
 
         const result = await runPlaywrightTests(guide, options);


### PR DESCRIPTION
## Summary

Adds `--clean` to `pathfinder-cli e2e`. When set, the runner spins up a dedicated `pathfinder-e2e` docker-compose project on host port 3010, resets between guides, and tears it down at the end. Developers can keep their normal dev stack running on port 3000 in parallel. `--clean` never touches it.

## What to look at

- **[`src/cli/commands/e2e.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/db812b8b0858a689b5becc953594809dae100f6a/src/cli/commands/e2e.ts)** — new `--clean` and `--clean-ready-timeout-ms` options. `runDockerCompose` / `teardownDockerSync` always invoke compose with `-f docker-compose.yaml -f docker-compose.e2e.yaml -p pathfinder-e2e`, so `down -v` only nukes `pathfinder-e2e_grafana-data` and never the dev's `grafana-data`. When `--clean` is set and `--grafana-url` is left at the default, the URL auto-switches to `http://localhost:3010` so the pre-flight health check and Playwright runs hit the isolated stack. Teardown is registered via `process.on('exit')` plus `SIGINT`/`SIGTERM` handlers and uses `execSync` so it runs cleanly inside the synchronous exit listener — looks unusual at a glance but is intentional: `process.exit()` does not await async listeners.
- **[`docker-compose.e2e.yaml`](https://github.com/grafana/grafana-pathfinder-app/blob/db812b8b0858a689b5becc953594809dae100f6a/docker-compose.e2e.yaml)** (new) — overlay that overrides the hardcoded `container_name` in `.config/docker-compose-base.yaml` (renamed to `grafana-pathfinder-app-e2e` to avoid the daemon-wide name collision) and remaps host ports (Grafana 3010, Prometheus 9091, Loki 3101, Alloy 12346). Uses Compose's `!override` YAML tag on each `ports:` list so the overlay fully replaces the inherited port mapping instead of appending to it — without `!override`, the resolved config would contain both 3000 and 3010, and the e2e container would fail to bind 3000 whenever a dev stack was up. The `!override` tag requires Docker Compose v2.20+ (Sep 2023); Docker Desktop has shipped with this for ~2 years.

## Why

* For bundled e2e runs across many guides, residual state from one guide (provisioned data sources, dashboards, plugin settings) leaks into the next via the persisted `grafana-data` volume. 
* Testing the same state-mutating guide repeatedly creates different states on repeat runs. 

This can introduce unexpected failures.

The isolated `pathfinder-e2e` project gives clean-slate runs without affecting the local dev environment — both stacks share the same bind-mounted `../dist` plugin code, so an iterative `npm run dev` cycle works transparently across both.

## How to verify

1. **Dev stack survives a `--clean` run.** Start your normal dev stack: `npm run server` (Grafana on `:3000`). In another terminal: `pathfinder-cli e2e bundled:block-editor-tutorial --clean`. While it's running, confirm `docker ps` shows both `grafana-pathfinder-app` (dev) and `grafana-pathfinder-app-e2e` (clean). After it finishes, confirm the dev container is still up and `docker volume ls` shows `grafana-pathfinder-app_grafana-data` but not `pathfinder-e2e_grafana-data` (the latter was wiped on teardown).
2. **Between-guide reset works.** `pathfinder-cli e2e bundled:block-editor-tutorial bundled:welcome-to-grafana --clean --verbose` and watch the output for `🧹 Resetting docker compose between guides...` between each guide.
3. **Ctrl+C still tears down.** Start `pathfinder-cli e2e bundled:block-editor-tutorial --clean`, press Ctrl+C mid-run, confirm `docker ps -a --filter project=pathfinder-e2e` returns no containers and the volume is gone.
4. **Baseline path unchanged.** `pathfinder-cli e2e bundled:block-editor-tutorial` (no `--clean`) runs against the existing local stack on `:3000` like before.

## Breaking changes

None. The flag is opt-in; existing invocations without `--clean` behave exactly as before. Requires Docker Compose v2.20+ for the `!override` YAML tag, but only when `--clean` is actually used — runs without the flag are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
