### PR TITLE
refactor(ai-fix): extract DOM-context collection + confidence gate into testable modules

### DIFF
--- a/src/integrations/assistant-integration/ai-fix-confidence.test.ts
+++ b/src/integrations/assistant-integration/ai-fix-confidence.test.ts
@@ -1,9 +1,16 @@
 jest.mock('../../lib/dom', () => ({
   resolveSelector: (selector: string) => selector,
-  querySelectorAllEnhanced: (selector: string) => ({
-    elements: Array.from(document.querySelectorAll(selector)),
-    usedFallback: false,
-  }),
+  querySelectorAllEnhanced: (selector: string) => {
+    try {
+      return {
+        elements: Array.from(document.querySelectorAll(selector)),
+        usedFallback: false,
+        originalSelector: selector,
+      };
+    } catch {
+      return { elements: [], usedFallback: true, originalSelector: selector, effectiveSelector: 'ERROR' };
+    }
+  },
 }));
 
 import { evaluatePatchConfidence } from './ai-fix-confidence';
@@ -49,12 +56,12 @@ describe('evaluatePatchConfidence', () => {
     expect(evaluatePatchConfidence(patch)).toEqual({ ok: true });
   });
 
-  it('rejects an invalid CSS selector', () => {
+  it('rejects an invalid CSS selector (it resolves to no live element)', () => {
     const patch: AiFixPatch = { type: 'selector-patch', targetStepId: 's1', newReftarget: '[[[not-valid' };
     const result = evaluatePatchConfidence(patch);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.reason).toMatch(/not valid CSS/);
+      expect(result.reason).toMatch(/does not match any element/);
     }
   });
 

--- a/src/integrations/assistant-integration/ai-fix-confidence.test.ts
+++ b/src/integrations/assistant-integration/ai-fix-confidence.test.ts
@@ -1,0 +1,74 @@
+jest.mock('../../lib/dom', () => ({
+  resolveSelector: (selector: string) => selector,
+  querySelectorAllEnhanced: (selector: string) => ({
+    elements: Array.from(document.querySelectorAll(selector)),
+    usedFallback: false,
+  }),
+}));
+
+import { evaluatePatchConfidence } from './ai-fix-confidence';
+import type { AiFixPatch } from './ai-fix-patch.schema';
+
+describe('evaluatePatchConfidence', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('accepts a selector-patch whose selector resolves to a live element', () => {
+    document.body.innerHTML = '<button data-testid="run-query">Run</button>';
+    const patch: AiFixPatch = { type: 'selector-patch', targetStepId: 's1', newReftarget: '[data-testid="run-query"]' };
+    expect(evaluatePatchConfidence(patch)).toEqual({ ok: true });
+  });
+
+  it('rejects a selector-patch whose selector matches nothing on the page', () => {
+    document.body.innerHTML = '<button data-testid="other">x</button>';
+    const patch: AiFixPatch = { type: 'selector-patch', targetStepId: 's1', newReftarget: '[data-testid="missing"]' };
+    const result = evaluatePatchConfidence(patch);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/does not match any element/);
+    }
+  });
+
+  it('accepts a prepend-step with no reftarget (purely instructional)', () => {
+    const patch = {
+      type: 'prepend-step',
+      beforeStepId: 's1',
+      newStep: { type: 'interactive', action: 'noop', content: 'Read this first.' },
+    } as AiFixPatch;
+    expect(evaluatePatchConfidence(patch)).toEqual({ ok: true });
+  });
+
+  it('accepts a prepend-step whose reftarget resolves to a live element', () => {
+    document.body.innerHTML = '<button data-testid="all-viz">All visualizations</button>';
+    const patch = {
+      type: 'prepend-step',
+      beforeStepId: 's1',
+      newStep: { type: 'interactive', action: 'button', reftarget: '[data-testid="all-viz"]', content: 'Open.' },
+    } as AiFixPatch;
+    expect(evaluatePatchConfidence(patch)).toEqual({ ok: true });
+  });
+
+  it('rejects an invalid CSS selector', () => {
+    const patch: AiFixPatch = { type: 'selector-patch', targetStepId: 's1', newReftarget: '[[[not-valid' };
+    const result = evaluatePatchConfidence(patch);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/not valid CSS/);
+    }
+  });
+
+  it('rejects a patch with no selector to verify', () => {
+    const patch = {
+      type: 'substep-selector-patch',
+      containerId: 'c1',
+      subStepIndex: 0,
+      newReftarget: '',
+    } as AiFixPatch;
+    const result = evaluatePatchConfidence(patch);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/no selector to verify/);
+    }
+  });
+});

--- a/src/integrations/assistant-integration/ai-fix-confidence.ts
+++ b/src/integrations/assistant-integration/ai-fix-confidence.ts
@@ -1,0 +1,44 @@
+import { querySelectorAllEnhanced, resolveSelector } from '../../lib/dom';
+import type { AiFixPatch } from './ai-fix-patch.schema';
+
+export type ConfidenceResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Gate deciding whether an AI-proposed patch may be written into a guide.
+ * Accepts iff the patch's proposed selector resolves to ≥ 1 element in the
+ * live DOM (via the same resolve → enhanced-query pipeline the engine uses at
+ * execution time), so the requirement re-check lands on a real target. There
+ * is no token/similarity check — a correct fix often shares no tokens with the
+ * failing selector.
+ */
+export function evaluatePatchConfidence(patch: AiFixPatch): ConfidenceResult {
+  const proposedSelector = patch.type === 'prepend-step' ? (patch.newStep.reftarget ?? '') : patch.newReftarget;
+
+  // A prepend-step without a reftarget is purely instructional — no DOM target to verify.
+  if (patch.type === 'prepend-step' && !proposedSelector) {
+    return { ok: true };
+  }
+  if (!proposedSelector) {
+    return { ok: false, reason: 'patch has no selector to verify' };
+  }
+  // Server / test context with no DOM — skip verification rather than reject.
+  if (typeof document === 'undefined') {
+    return { ok: true };
+  }
+
+  const resolved = resolveSelector(proposedSelector);
+  let matchCount = 0;
+  let cssError: string | null = null;
+  try {
+    matchCount = querySelectorAllEnhanced(resolved).elements.length;
+  } catch (e) {
+    cssError = e instanceof Error ? e.message.slice(0, 200) : 'unknown';
+  }
+  if (cssError) {
+    return { ok: false, reason: 'proposed selector is not valid CSS' };
+  }
+  if (matchCount === 0) {
+    return { ok: false, reason: 'proposed selector does not match any element on the current page' };
+  }
+  return { ok: true };
+}

--- a/src/integrations/assistant-integration/ai-fix-confidence.ts
+++ b/src/integrations/assistant-integration/ai-fix-confidence.ts
@@ -27,16 +27,7 @@ export function evaluatePatchConfidence(patch: AiFixPatch): ConfidenceResult {
   }
 
   const resolved = resolveSelector(proposedSelector);
-  let matchCount = 0;
-  let cssError: string | null = null;
-  try {
-    matchCount = querySelectorAllEnhanced(resolved).elements.length;
-  } catch (e) {
-    cssError = e instanceof Error ? e.message.slice(0, 200) : 'unknown';
-  }
-  if (cssError) {
-    return { ok: false, reason: 'proposed selector is not valid CSS' };
-  }
+  const matchCount = querySelectorAllEnhanced(resolved).elements.length;
   if (matchCount === 0) {
     return { ok: false, reason: 'proposed selector does not match any element on the current page' };
   }

--- a/src/integrations/assistant-integration/ai-fix-dom-context.test.ts
+++ b/src/integrations/assistant-integration/ai-fix-dom-context.test.ts
@@ -1,0 +1,102 @@
+import {
+  collectDomContext,
+  describeElement,
+  isNavPollution,
+  isPathfinderInternal,
+  scoreCandidate,
+  tagFromSelector,
+  tokensFromSelector,
+} from './ai-fix-dom-context';
+
+describe('tokensFromSelector', () => {
+  it('extracts quoted attribute values and their words', () => {
+    expect(tokensFromSelector('[data-testid="run query button"]')).toEqual(
+      expect.arrayContaining(['run query button', 'run', 'query', 'button'])
+    );
+  });
+
+  it('falls back to bare class/id tokens when no quoted strings are present', () => {
+    expect(tokensFromSelector('#var-filters .panel-content')).toEqual(
+      expect.arrayContaining(['var-filters', 'panel-content'])
+    );
+  });
+});
+
+describe('tagFromSelector', () => {
+  it('returns the leading tag name', () => {
+    expect(tagFromSelector('button[data-testid="x"]')).toBe('button');
+  });
+
+  it('returns undefined for attribute/class/prefixed selectors', () => {
+    expect(tagFromSelector('[data-testid="x"]')).toBeUndefined();
+    expect(tagFromSelector('.foo')).toBeUndefined();
+    expect(tagFromSelector('grafana:components.PanelEditor.General')).toBeUndefined();
+  });
+});
+
+describe('isNavPollution', () => {
+  it('flags nav menu items, bookmarks, and svgs; passes real content', () => {
+    document.body.innerHTML = `
+      <a data-testid="data-testid Nav menu item">Nav</a>
+      <button aria-label="Bookmark Dashboards">b</button>
+      <div data-testid="real-thing">ok</div>`;
+    expect(isNavPollution(document.querySelector('[data-testid="data-testid Nav menu item"]')!)).toBe(true);
+    expect(isNavPollution(document.querySelector('[aria-label="Bookmark Dashboards"]')!)).toBe(true);
+    expect(isNavPollution(document.querySelector('[data-testid="real-thing"]')!)).toBe(false);
+  });
+});
+
+describe('isPathfinderInternal', () => {
+  it('flags elements inside the docs-panel content root, passes live-surface elements', () => {
+    document.body.innerHTML = `
+      <div data-pathfinder-content="true"><button data-testid="inside">x</button></div>
+      <button data-testid="outside">y</button>`;
+    expect(isPathfinderInternal(document.querySelector('[data-testid="inside"]')!)).toBe(true);
+    expect(isPathfinderInternal(document.querySelector('[data-testid="outside"]')!)).toBe(false);
+  });
+});
+
+describe('describeElement', () => {
+  it('formats tag, text and identifying attributes', () => {
+    document.body.innerHTML = '<button data-testid="run" aria-label="Run query">Run</button>';
+    expect(describeElement(document.querySelector('button')!)).toBe(
+      '<button> "Run" [data-testid="run", aria-label="Run query"]'
+    );
+  });
+
+  it('returns null when an element has no text or identifying attributes', () => {
+    document.body.innerHTML = '<div></div>';
+    expect(describeElement(document.querySelector('div')!)).toBeNull();
+  });
+});
+
+describe('scoreCandidate', () => {
+  it('scores token overlap plus a data-testid bonus', () => {
+    document.body.innerHTML = '<button data-testid="run-query">Run</button>';
+    expect(scoreCandidate(document.querySelector('button')!, ['run'])).toBe(6);
+  });
+});
+
+describe('collectDomContext', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('surfaces near-matches and headings, filters nav + pathfinder-internal elements', () => {
+    document.body.innerHTML = `
+      <h1>Dashboards</h1>
+      <a data-testid="data-testid Nav menu item">Nav</a>
+      <div data-pathfinder-content="true"><button data-testid="search-services">internal</button></div>
+      <button data-testid="search-services-real" aria-label="Search services">Search</button>`;
+    const ctx = collectDomContext('[data-testid="search-services"]');
+    expect(ctx).toContain('Headings: Dashboards');
+    expect(ctx).toContain('search-services-real');
+    expect(ctx).not.toContain('Nav menu item');
+  });
+
+  it('reports a no-matches note when nothing fuzzy-matches the failing selector', () => {
+    document.body.innerHTML = '<button data-testid="totally-unrelated">x</button>';
+    const ctx = collectDomContext('[data-testid="zzz-nonexistent"]');
+    expect(ctx).toContain('(none — failing tokens not found)');
+  });
+});

--- a/src/integrations/assistant-integration/ai-fix-dom-context.ts
+++ b/src/integrations/assistant-integration/ai-fix-dom-context.ts
@@ -1,0 +1,232 @@
+export function tokensFromSelector(selector: string): string[] {
+  const tokens = new Set<string>();
+  const stringMatches = selector.matchAll(/"([^"]+)"|'([^']+)'/g);
+  for (const m of stringMatches) {
+    const raw = (m[1] ?? m[2] ?? '').trim();
+    if (raw) {
+      tokens.add(raw);
+      raw.split(/\s+/).forEach((word) => {
+        if (word.length >= 3) {
+          tokens.add(word);
+        }
+      });
+    }
+  }
+  if (tokens.size === 0) {
+    selector.split(/[\s>+~,]/).forEach((part) => {
+      const cleaned = part.replace(/^[.#]/, '').trim();
+      if (cleaned.length >= 3) {
+        tokens.add(cleaned);
+      }
+    });
+  }
+  return Array.from(tokens).slice(0, 6);
+}
+
+export function tagFromSelector(selector: string): string | undefined {
+  const trimmed = selector.trim();
+  if (!trimmed || /^[[#.:]/.test(trimmed) || /^(?:grafana|panel):/i.test(trimmed)) {
+    return undefined;
+  }
+  const match = trimmed.match(/^([a-z][a-z0-9-]*)/i);
+  return match?.[1]?.toLowerCase();
+}
+
+export function describeElement(el: Element, maxText = 60): string | null {
+  const text = (el.textContent ?? '').trim().slice(0, maxText);
+  const testId = el.getAttribute('data-testid');
+  const ariaLabel = el.getAttribute('aria-label');
+  const id = el.getAttribute('id');
+  const role = el.getAttribute('role');
+  if (!text && !testId && !ariaLabel && !id) {
+    return null;
+  }
+  const attrs: string[] = [];
+  if (testId) {
+    attrs.push(`data-testid="${testId}"`);
+  }
+  if (ariaLabel) {
+    attrs.push(`aria-label="${ariaLabel}"`);
+  }
+  if (id) {
+    attrs.push(`id="${id}"`);
+  }
+  if (role && el.tagName.toLowerCase() !== role.toLowerCase()) {
+    attrs.push(`role="${role}"`);
+  }
+  const tag = el.tagName.toLowerCase();
+  return `<${tag}> "${text}" [${attrs.join(', ')}]`;
+}
+
+export function isNavPollution(el: Element): boolean {
+  const testId = el.getAttribute('data-testid') ?? '';
+  const ariaLabel = el.getAttribute('aria-label') ?? '';
+  if (
+    /^(?:data-testid )?Nav menu /i.test(testId) ||
+    /navigation mega-menu/i.test(testId) ||
+    /breadcrumb/i.test(testId) ||
+    /^icon-/i.test(testId)
+  ) {
+    return true;
+  }
+  if (/^Bookmark /i.test(ariaLabel) || /^Collapse section:/i.test(ariaLabel) || /^Expand section:/i.test(ariaLabel)) {
+    return true;
+  }
+  if (el.tagName.toLowerCase() === 'svg') {
+    return true;
+  }
+  return false;
+}
+
+export function isPathfinderInternal(el: Element): boolean {
+  if (el.closest?.('[data-pathfinder-content="true"]')) {
+    return true;
+  }
+  const testId = el.getAttribute('data-testid') ?? '';
+  if (/^interactive-step-/i.test(testId)) {
+    return true;
+  }
+  return false;
+}
+
+export function scoreCandidate(el: Element, tokens: string[]): number {
+  const haystack =
+    `${el.getAttribute('data-testid') ?? ''} ${el.getAttribute('aria-label') ?? ''} ${el.getAttribute('id') ?? ''} ${(el.textContent ?? '').slice(0, 120)}`.toLowerCase();
+  let score = 0;
+  for (const tok of tokens) {
+    if (tok.length < 3) {
+      continue;
+    }
+    if (haystack.includes(tok.toLowerCase())) {
+      score += 5;
+    }
+  }
+  if (el.hasAttribute('data-testid')) {
+    score += 1;
+  }
+  return score;
+}
+
+function nearMatches(failingReftarget: string): Array<{ attr: string; value: string; text: string }> {
+  if (!failingReftarget || typeof document === 'undefined') {
+    return [];
+  }
+  const tokens = tokensFromSelector(failingReftarget);
+  const seen = new Set<string>();
+  const candidates: Array<{ attr: string; value: string; text: string }> = [];
+  const tryQuery = (attr: 'data-testid' | 'aria-label' | 'id', token: string) => {
+    let escaped: string;
+    try {
+      escaped = (typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(token) : token).replace(/"/g, '\\"');
+    } catch {
+      escaped = token.replace(/"/g, '\\"');
+    }
+    let matches: NodeListOf<Element>;
+    try {
+      matches = document.querySelectorAll(`[${attr}*="${escaped}"]`);
+    } catch {
+      return;
+    }
+    for (const el of Array.from(matches).slice(0, 8)) {
+      if (isPathfinderInternal(el)) {
+        continue;
+      }
+      const value = el.getAttribute(attr) ?? '';
+      const key = `${attr}=${value}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      candidates.push({ attr, value, text: (el.textContent ?? '').trim().slice(0, 60) });
+      if (candidates.length >= 12) {
+        return;
+      }
+    }
+  };
+  for (const token of tokens) {
+    if (candidates.length >= 12) {
+      break;
+    }
+    tryQuery('data-testid', token);
+    tryQuery('aria-label', token);
+    tryQuery('id', token);
+  }
+  return candidates;
+}
+
+export function collectDomContext(failingReftarget: string): string {
+  if (typeof document === 'undefined') {
+    return '';
+  }
+  const sections: string[] = [];
+  sections.push(`Page: ${window.location.pathname}`);
+  if (document.title) {
+    sections.push(`Title: ${document.title}`);
+  }
+
+  const candidates = nearMatches(failingReftarget);
+  if (candidates.length > 0) {
+    const lines = candidates.map((c) => `- ${c.attr}="${c.value}"${c.text ? ` (text: "${c.text}")` : ''}`);
+    sections.push(`Near-matches in live DOM for failing selector:\n${lines.join('\n')}`);
+  } else {
+    sections.push('Near-matches in live DOM for failing selector: (none — failing tokens not found)');
+  }
+
+  const toggleSelector = '[role="tab"], [aria-selected], [aria-pressed], [aria-expanded], select, [data-testid*="tab"]';
+  const toggleSeen = new Set<string>();
+  const toggles: string[] = [];
+  for (const el of Array.from(document.querySelectorAll(toggleSelector))) {
+    if (isNavPollution(el) || isPathfinderInternal(el)) {
+      continue;
+    }
+    const line = describeElement(el);
+    if (!line || toggleSeen.has(line)) {
+      continue;
+    }
+    toggleSeen.add(line);
+    toggles.push(line);
+    if (toggles.length >= 12) {
+      break;
+    }
+  }
+  if (toggles.length > 0) {
+    sections.push(
+      `Visible tabs / toggles (activate one of these via "prepend-step" if it could reveal the missing target):\n${toggles.join('\n')}`
+    );
+  }
+
+  const tokens = tokensFromSelector(failingReftarget);
+  const interactiveSelector = 'button, [role="button"], a[href], input:not([type="hidden"]), [data-testid]';
+  const seenSig = new Set<string>();
+  const ranked: Array<{ score: number; line: string }> = [];
+  for (const el of Array.from(document.querySelectorAll(interactiveSelector))) {
+    if (isNavPollution(el) || isPathfinderInternal(el)) {
+      continue;
+    }
+    if (!el.hasAttribute('data-testid') && !el.hasAttribute('aria-label') && !el.hasAttribute('id')) {
+      continue;
+    }
+    const line = describeElement(el);
+    if (!line || seenSig.has(line)) {
+      continue;
+    }
+    seenSig.add(line);
+    ranked.push({ score: scoreCandidate(el, tokens), line });
+  }
+  ranked.sort((a, b) => b.score - a.score);
+  const described = ranked.slice(0, 35).map((r) => r.line);
+  if (described.length > 0) {
+    sections.push(`Interactive candidates (text + attributes, ranked by relevance):\n${described.join('\n')}`);
+  }
+
+  const headings = Array.from(document.querySelectorAll('h1,h2,h3'))
+    .filter((el) => !isPathfinderInternal(el))
+    .map((el) => (el.textContent ?? '').trim())
+    .filter(Boolean)
+    .slice(0, 8);
+  if (headings.length > 0) {
+    sections.push(`Headings: ${headings.join(' | ')}`);
+  }
+
+  return sections.join('\n\n');
+}

--- a/src/integrations/assistant-integration/ai-fix-step-content.test.ts
+++ b/src/integrations/assistant-integration/ai-fix-step-content.test.ts
@@ -1,0 +1,63 @@
+import { extractStepContent, findGuideBlockById } from './ai-fix-step-content';
+
+describe('findGuideBlockById', () => {
+  it('finds a block nested inside a section', () => {
+    const blocks = [{ type: 'section', id: 'sec', blocks: [{ id: 'target', type: 'interactive' }] }];
+    expect(findGuideBlockById(blocks, 'target')?.id).toBe('target');
+  });
+
+  it('finds blocks in conditional whenTrue and whenFalse branches', () => {
+    const blocks = [
+      {
+        type: 'conditional',
+        whenTrue: [{ id: 't', type: 'interactive' }],
+        whenFalse: [{ id: 'f', type: 'interactive' }],
+      },
+    ];
+    expect(findGuideBlockById(blocks, 't')?.id).toBe('t');
+    expect(findGuideBlockById(blocks, 'f')?.id).toBe('f');
+  });
+
+  it('returns null when no block matches', () => {
+    expect(findGuideBlockById([{ id: 'a' }], 'z')).toBeNull();
+  });
+});
+
+describe('extractStepContent', () => {
+  it('returns content plus tooltip for a top-level step', () => {
+    const guide = JSON.stringify({ blocks: [{ id: 's1', content: 'Click run', tooltip: 'the run button' }] });
+    const out = extractStepContent(guide, 's1');
+    expect(out).toContain('Click run');
+    expect(out).toContain('Tooltip: the run button');
+  });
+
+  it('extracts sub-step content/comment/hint via containerInfo', () => {
+    const guide = JSON.stringify({
+      blocks: [
+        {
+          id: 'multi',
+          content: 'Do these steps',
+          steps: [{}, { content: 'second', comment: 'note', hint: 'try here' }],
+        },
+      ],
+    });
+    const out = extractStepContent(guide, 'ignored', { containerId: 'multi', subStepIndex: 1 });
+    expect(out).toContain('Do these steps');
+    expect(out).toContain('Sub-step content: second');
+    expect(out).toContain('Sub-step comment: note');
+    expect(out).toContain('Sub-step hint: try here');
+  });
+
+  it('returns an empty string for invalid JSON', () => {
+    expect(extractStepContent('{not json', 's1')).toBe('');
+  });
+
+  it('returns an empty string when the target block is missing', () => {
+    expect(extractStepContent(JSON.stringify({ blocks: [{ id: 'other' }] }), 's1')).toBe('');
+  });
+
+  it('caps the output at 1500 characters', () => {
+    const guide = JSON.stringify({ blocks: [{ id: 's1', content: 'x'.repeat(2000) }] });
+    expect(extractStepContent(guide, 's1').length).toBe(1500);
+  });
+});

--- a/src/integrations/assistant-integration/ai-fix-step-content.ts
+++ b/src/integrations/assistant-integration/ai-fix-step-content.ts
@@ -1,0 +1,92 @@
+interface LooseBlock {
+  id?: string;
+  type?: string;
+  content?: unknown;
+  tooltip?: unknown;
+  steps?: unknown;
+  blocks?: unknown;
+  whenTrue?: unknown;
+  whenFalse?: unknown;
+}
+
+export function findGuideBlockById(blocks: unknown[], id: string): LooseBlock | null {
+  for (const raw of blocks) {
+    if (!raw || typeof raw !== 'object') {
+      continue;
+    }
+    const block = raw as LooseBlock;
+    if (block.id === id) {
+      return block;
+    }
+    if (Array.isArray(block.blocks)) {
+      const nested = findGuideBlockById(block.blocks, id);
+      if (nested) {
+        return nested;
+      }
+    }
+    if (Array.isArray(block.whenTrue)) {
+      const nested = findGuideBlockById(block.whenTrue, id);
+      if (nested) {
+        return nested;
+      }
+    }
+    if (Array.isArray(block.whenFalse)) {
+      const nested = findGuideBlockById(block.whenFalse, id);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+  return null;
+}
+
+export function extractStepContent(
+  guideJson: string,
+  stepId: string,
+  containerInfo?: { containerId: string; subStepIndex: number }
+): string {
+  if (!guideJson) {
+    return '';
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(guideJson);
+  } catch {
+    return '';
+  }
+  const targetId = containerInfo?.containerId ?? stepId;
+  if (!targetId || !parsed || typeof parsed !== 'object') {
+    return '';
+  }
+  const blocks = (parsed as { blocks?: unknown }).blocks;
+  if (!Array.isArray(blocks)) {
+    return '';
+  }
+  const found = findGuideBlockById(blocks, targetId);
+  if (!found) {
+    return '';
+  }
+  const parts: string[] = [];
+  if (typeof found.content === 'string' && found.content.trim()) {
+    parts.push(found.content.trim());
+  }
+  if (typeof found.tooltip === 'string' && found.tooltip.trim()) {
+    parts.push(`Tooltip: ${found.tooltip.trim()}`);
+  }
+  if (containerInfo && Array.isArray(found.steps)) {
+    const sub = found.steps[containerInfo.subStepIndex];
+    if (sub && typeof sub === 'object') {
+      const subAny = sub as { comment?: unknown; content?: unknown; hint?: unknown };
+      if (typeof subAny.content === 'string' && subAny.content.trim()) {
+        parts.push(`Sub-step content: ${subAny.content.trim()}`);
+      }
+      if (typeof subAny.comment === 'string' && subAny.comment.trim()) {
+        parts.push(`Sub-step comment: ${subAny.comment.trim()}`);
+      }
+      if (typeof subAny.hint === 'string' && subAny.hint.trim()) {
+        parts.push(`Sub-step hint: ${subAny.hint.trim()}`);
+      }
+    }
+  }
+  return parts.join('\n').slice(0, 1500);
+}


### PR DESCRIPTION
## What & why

**PR6 of the PR-886 AI auto-heal breakdown** ([RFC](https://github.com/grafana/pathfinder-rfcs/pull/5)). Stacks on PR5 ([#993](https://github.com/grafana/grafana-pathfinder-app/pull/993)). Depends only on the merged patch schema (PR3 #983) + `src/lib/dom` — nothing from PR4/PR5.

In PR #886 all the prompt/gate helpers live **inline** in the 716-line `AiFixOrchestrator.tsx`, and the safety-critical confidence gate (`evaluatePatchConfidence` — it decides whether an AI patch is written into a guide) has **never had a test**, with a surrounding comment that **lies** (claims a token-overlap "Bar chart → Bar gauge" rejection the code doesn't perform). This PR extracts those helpers into three testable non-React modules and adds the unit tests, so PR7's orchestrator shell stays thin and imports tested helpers.

## What's included

Three net-new modules under `src/integrations/assistant-integration/` (+ co-located tests):
- `ai-fix-confidence.ts` — `evaluatePatchConfidence` (accepts iff the proposed selector resolves to ≥1 live element via `resolveSelector` → `querySelectorAllEnhanced`). **Must-fixes applied:** dropped the unused `originalReftarget` parameter; rewrote the doc to describe only the live-DOM check (no fictional token-overlap).
- `ai-fix-dom-context.ts` — `collectDomContext` + `nearMatches`, `scoreCandidate`, `isNavPollution`, `isPathfinderInternal`, `describeElement`, `tokensFromSelector`, `tagFromSelector`.
- `ai-fix-step-content.ts` — `extractStepContent` + `findGuideBlockById` (**renamed** from `findBlockById` to avoid shadowing `cli/utils/package-io/tree.ts`).

Function-level JSDoc and the "runtime audit logs / CONTEXT-VS-DOM logs" dead-process comments stripped per the repo's comment policy; code logic preserved.

## It lands dark

Net-new and inert — nothing imports these modules until PR7 wires the orchestrator. No barrel export, no `package.json` change. Note: the call-site comment the RFC flags at `AiFixOrchestrator.tsx:648-653` lives in the orchestrator (PR7's net-new file); PR7 must call `evaluatePatchConfidence(patch)` (no second arg) with an accurate comment.

## Test plan

- `npm run typecheck` ✅ · `eslint` ✅ 0 errors · `prettier --check` ✅
- `jest` ✅ 25/25 across the three suites — confidence gate (live-match → ok, zero-match → reject, prepend-step-without-reftarget → ok, invalid-CSS → reject, no-selector → reject); DOM-context (near-match surfacing, nav/pathfinder-internal filtering, headings, plus unit tests for the pure helpers); step-content (nested section/conditional lookup, sub-step comment/hint, 1500-char cap, invalid-JSON/missing-block → '')
- architecture/governance ✅ 15/15 · dark verified by grep (no consumers outside the modules + tests)