### PR TITLE
feat(ai-fix): add AiFixOrchestrator shell + lazy mount in docs-panel

### DIFF
--- a/src/components/docs-panel/AiFixOrchestrator.test.tsx
+++ b/src/components/docs-panel/AiFixOrchestrator.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { render, act, waitFor } from '@testing-library/react';
+
+import { usePluginContext } from '@grafana/data';
+import { getAppEvents } from '@grafana/runtime';
+
+import AiFixOrchestrator from './AiFixOrchestrator';
+import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import { useAiFixGeneration } from '../../integrations/assistant-integration/useAiFixGeneration.hook';
+import { evaluatePatchConfidence } from '../../integrations/assistant-integration/ai-fix-confidence';
+import { applyPatchToGuide } from '../../integrations/assistant-integration/apply-ai-fix-patch';
+import { AI_FIX_REQUEST_EVENT } from '../../integrations/assistant-integration/ai-fix-event';
+import type { LearningJourneyTab } from '../../types/content-panel.types';
+
+jest.mock('@grafana/data', () => ({
+  usePluginContext: jest.fn(),
+  AppEvents: { alertSuccess: { name: 'alert-success' }, alertWarning: { name: 'alert-warning' } },
+}));
+jest.mock('@grafana/runtime', () => ({ getAppEvents: jest.fn() }));
+jest.mock('../../lib/analytics', () => ({
+  reportAppInteraction: jest.fn(),
+  UserInteraction: {
+    AiFixOffered: 'ai_fix_offered',
+    AiFixApplied: 'ai_fix_applied',
+    AiFixFailed: 'ai_fix_failed',
+  },
+}));
+jest.mock('../../constants', () => ({
+  getConfigWithDefaults: (jsonData: Record<string, unknown> | undefined) => ({
+    enableAiAutoHeal: !!jsonData?.enableAiAutoHeal,
+  }),
+}));
+jest.mock('../../interactive-engine', () => ({
+  GlobalInteractionBlocker: {
+    getInstance: () => ({ startAdHocBlocking: jest.fn(), stopAdHocBlocking: jest.fn() }),
+  },
+}));
+jest.mock('../../integrations/assistant-integration/ai-fix-dom-context', () => ({
+  collectDomContext: jest.fn(() => ''),
+  tagFromSelector: jest.fn(() => undefined),
+}));
+jest.mock('../../integrations/assistant-integration/ai-fix-step-content', () => ({
+  extractStepContent: jest.fn(() => ''),
+}));
+jest.mock('../../integrations/assistant-integration/ai-fix-step-id', () => ({
+  materializeStepIdsInJson: (json: string) => json,
+}));
+jest.mock('../../integrations/assistant-integration/ai-fix-confidence', () => ({
+  evaluatePatchConfidence: jest.fn(() => ({ ok: true })),
+}));
+jest.mock('../../integrations/assistant-integration/apply-ai-fix-patch', () => ({
+  applyPatchToGuide: jest.fn(() => ({ ok: true, newGuideJson: '{"blocks":[],"patched":true}' })),
+}));
+jest.mock('../../integrations/assistant-integration/useAiFixGeneration.hook', () => ({
+  useAiFixGeneration: jest.fn(),
+}));
+
+const TAB = { id: 'tab1', content: { content: '{"blocks":[]}' } } as unknown as LearningJourneyTab;
+const OTHER_TAB = { id: 'tab2', content: { content: '{"blocks":["other"]}' } } as unknown as LearningJourneyTab;
+const SELECTOR_PATCH = {
+  type: 'selector-patch',
+  targetStepId: 's1',
+  newReftarget: '[data-testid="ok"]',
+  rationale: 'use the live testid',
+} as const;
+
+const publish = jest.fn();
+const generate = jest.fn();
+const reset = jest.fn();
+let hookReturn: ReturnType<typeof useAiFixGeneration>;
+
+function dispatchRequest(detail: Record<string, unknown> = { stepId: 's1', refTarget: '.gone', action: 'button' }) {
+  return act(async () => {
+    window.dispatchEvent(new CustomEvent(AI_FIX_REQUEST_EVENT, { detail }));
+  });
+}
+
+function setFlag(enabled: boolean) {
+  (usePluginContext as jest.Mock).mockReturnValue({ meta: { jsonData: { enableAiAutoHeal: enabled } } });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getAppEvents as jest.Mock).mockReturnValue({ publish });
+  setFlag(true);
+  hookReturn = { isAssistantAvailable: true, generate, isGenerating: false, patch: null, error: null, reset };
+  (useAiFixGeneration as jest.Mock).mockImplementation(() => hookReturn);
+  (evaluatePatchConfidence as jest.Mock).mockReturnValue({ ok: true });
+  (applyPatchToGuide as jest.Mock).mockReturnValue({ ok: true, newGuideJson: '{"blocks":[],"patched":true}' });
+});
+
+describe('AiFixOrchestrator', () => {
+  it('renders nothing', () => {
+    const { container } = render(<AiFixOrchestrator activeTab={TAB} onPatchApplied={jest.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('drops the request when the admin flag is off (dark landing)', async () => {
+    setFlag(false);
+    render(<AiFixOrchestrator activeTab={TAB} onPatchApplied={jest.fn()} />);
+    await dispatchRequest();
+    expect(generate).not.toHaveBeenCalled();
+    expect(reportAppInteraction).toHaveBeenCalledWith(
+      UserInteraction.AiFixFailed,
+      expect.objectContaining({ reason: 'feature_flag_disabled' })
+    );
+  });
+
+  it('drops the request when the assistant is unavailable', async () => {
+    hookReturn = { ...hookReturn, isAssistantAvailable: false };
+    render(<AiFixOrchestrator activeTab={TAB} onPatchApplied={jest.fn()} />);
+    await dispatchRequest();
+    expect(generate).not.toHaveBeenCalled();
+    expect(reportAppInteraction).toHaveBeenCalledWith(
+      UserInteraction.AiFixFailed,
+      expect.objectContaining({ reason: 'assistant_unavailable' })
+    );
+  });
+
+  it('calls generate with the failing step details when enabled and available', async () => {
+    render(<AiFixOrchestrator activeTab={TAB} onPatchApplied={jest.fn()} />);
+    await dispatchRequest({ stepId: 's1', refTarget: '.gone', action: 'button' });
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guideJson: TAB.content!.content,
+        failingStepId: 's1',
+        failingReftarget: '.gone',
+        failingAction: 'button',
+      })
+    );
+    expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.AiFixOffered, expect.any(Object));
+  });
+
+  it('applies a confident patch back into the tab and reports success', async () => {
+    const onPatchApplied = jest.fn();
+    const { rerender } = render(<AiFixOrchestrator activeTab={TAB} onPatchApplied={onPatchApplied} />);
+    await dispatchRequest();
+
+    hookReturn = { ...hookReturn, patch: SELECTOR_PATCH };
+    rerender(<AiFixOrchestrator activeTab={TAB} onPatchApplied={onPatchApplied} />);
+
+    await waitFor(() => expect(onPatchApplied).toHaveBeenCalledWith('tab1', '{"blocks":[],"patched":true}'));
+    expect(reportAppInteraction).toHaveBeenCalledWith(
+      UserInteraction.AiFixApplied,
+      expect.objectContaining({ patch_type: 'selector-patch' })
+    );
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ type: 'alert-success' }));
+  });
+
+  it('rejects a low-confidence patch without writing it back', async () => {
+    (evaluatePatchConfidence as jest.Mock).mockReturnValue({ ok: false, reason: 'no live match' });
+    const onPatchApplied = jest.fn();
+    const { rerender } = render(<AiFixOrchestrator activeTab={TAB} onPatchApplied={onPatchApplied} />);
+    await dispatchRequest();
+
+    hookReturn = { ...hookReturn, patch: SELECTOR_PATCH };
+    rerender(<AiFixOrchestrator activeTab={TAB} onPatchApplied={onPatchApplied} />);
+
+    await waitFor(() =>
+      expect(reportAppInteraction).toHaveBeenCalledWith(
+        UserInteraction.AiFixFailed,
+        expect.objectContaining({ reason: 'low-confidence: no live match' })
+      )
+    );
+    expect(onPatchApplied).not.toHaveBeenCalled();
+    expect(applyPatchToGuide).not.toHaveBeenCalled();
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ type: 'alert-warning' }));
+  });
+
+  it('surfaces a generation error as a warning toast', async () => {
+    const { rerender } = render(<AiFixOrchestrator activeTab={TAB} onPatchApplied={jest.fn()} />);
+    await dispatchRequest();
+
+    hookReturn = { ...hookReturn, error: new Error('assistant exploded') };
+    rerender(<AiFixOrchestrator activeTab={TAB} onPatchApplied={jest.fn()} />);
+
+    await waitFor(() =>
+      expect(reportAppInteraction).toHaveBeenCalledWith(
+        UserInteraction.AiFixFailed,
+        expect.objectContaining({ reason: 'assistant exploded' })
+      )
+    );
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ type: 'alert-warning' }));
+  });
+
+  it('applies the patch to the originating tab even after a tab switch', async () => {
+    const onPatchApplied = jest.fn();
+    const { rerender } = render(<AiFixOrchestrator activeTab={TAB} onPatchApplied={onPatchApplied} />);
+    await dispatchRequest();
+
+    // User switches to another tab while the assistant is still thinking.
+    hookReturn = { ...hookReturn, patch: SELECTOR_PATCH };
+    rerender(<AiFixOrchestrator activeTab={OTHER_TAB} onPatchApplied={onPatchApplied} />);
+
+    await waitFor(() => expect(onPatchApplied).toHaveBeenCalledTimes(1));
+    expect(onPatchApplied).toHaveBeenCalledWith('tab1', expect.any(String));
+    expect(applyPatchToGuide).toHaveBeenCalledWith(TAB.content!.content, SELECTOR_PATCH);
+  });
+
+  it('self-heals the in-flight gate when generation never resolves', async () => {
+    jest.useFakeTimers();
+    try {
+      render(<AiFixOrchestrator activeTab={TAB} onPatchApplied={jest.fn()} />);
+      await dispatchRequest();
+      expect(generate).toHaveBeenCalledTimes(1);
+
+      // A second request is dropped while the first is still in flight.
+      await dispatchRequest();
+      expect(generate).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
+      expect(reportAppInteraction).toHaveBeenCalledWith(
+        UserInteraction.AiFixFailed,
+        expect.objectContaining({ reason: 'timeout' })
+      );
+
+      // Gate is clear again — a fresh request goes through.
+      await dispatchRequest();
+      expect(generate).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/components/docs-panel/AiFixOrchestrator.tsx
+++ b/src/components/docs-panel/AiFixOrchestrator.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import { AppEvents, usePluginContext } from '@grafana/data';
+import { getAppEvents } from '@grafana/runtime';
+
+import { getConfigWithDefaults } from '../../constants';
+import { evaluatePatchConfidence } from '../../integrations/assistant-integration/ai-fix-confidence';
+import { collectDomContext, tagFromSelector } from '../../integrations/assistant-integration/ai-fix-dom-context';
+import { AI_FIX_REQUEST_EVENT, type AiFixRequestDetail } from '../../integrations/assistant-integration/ai-fix-event';
+import { materializeStepIdsInJson } from '../../integrations/assistant-integration/ai-fix-step-id';
+import { extractStepContent } from '../../integrations/assistant-integration/ai-fix-step-content';
+import { applyPatchToGuide } from '../../integrations/assistant-integration/apply-ai-fix-patch';
+import { useAiFixGeneration } from '../../integrations/assistant-integration/useAiFixGeneration.hook';
+import { GlobalInteractionBlocker } from '../../interactive-engine';
+import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import type { LearningJourneyTab } from '../../types/content-panel.types';
+
+// Safety net: the assistant can resolve without a patch or error, which would wedge the gate forever.
+const AI_FIX_REQUEST_TIMEOUT_MS = 30_000;
+
+function publishToast(severity: 'success' | 'warning', title: string, body?: string) {
+  try {
+    const event = severity === 'success' ? AppEvents.alertSuccess : AppEvents.alertWarning;
+    getAppEvents().publish({ type: event.name, payload: body ? [title, body] : [title] });
+  } catch {
+    // Non-Grafana host (jsdom): a missing toast is harmless.
+  }
+}
+
+interface PendingAiFixRequest {
+  detail: AiFixRequestDetail;
+  tabId: string;
+  guideJson: string;
+}
+
+interface AiFixOrchestratorProps {
+  activeTab: LearningJourneyTab | null;
+  onPatchApplied: (tabId: string, newGuideJson: string) => void;
+}
+
+function AiFixOrchestrator({ activeTab, onPatchApplied }: AiFixOrchestratorProps): null {
+  const contentKey = activeTab?.id ?? 'pathfinder-ai-fix-orchestrator';
+  const { generate, patch, error, reset, isAssistantAvailable } = useAiFixGeneration(contentKey);
+
+  const pluginContext = usePluginContext();
+  const aiAutoHealEnabled = useMemo(
+    () => getConfigWithDefaults(pluginContext?.meta?.jsonData || {}).enableAiAutoHeal,
+    [pluginContext?.meta?.jsonData]
+  );
+
+  const pendingRequestRef = useRef<PendingAiFixRequest | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Latest tab via ref so the listener isn't re-bound each render (would drop in-flight requests).
+  const activeTabRef = useRef<LearningJourneyTab | null>(activeTab);
+  useEffect(() => {
+    activeTabRef.current = activeTab;
+  }, [activeTab]);
+
+  const clearPending = useCallback(() => {
+    pendingRequestRef.current = null;
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    GlobalInteractionBlocker.getInstance().stopAdHocBlocking();
+    reset();
+  }, [reset]);
+
+  useEffect(() => () => clearPending(), [clearPending]);
+
+  useEffect(() => {
+    const handler = async (e: Event) => {
+      const detail = (e as CustomEvent<AiFixRequestDetail>).detail;
+      const tab = activeTabRef.current;
+      if (!tab?.content?.content) {
+        return;
+      }
+      if (!aiAutoHealEnabled) {
+        reportAppInteraction(UserInteraction.AiFixFailed, { reason: 'feature_flag_disabled' });
+        return;
+      }
+      if (!isAssistantAvailable) {
+        reportAppInteraction(UserInteraction.AiFixFailed, { reason: 'assistant_unavailable' });
+        return;
+      }
+      if (pendingRequestRef.current) {
+        return;
+      }
+      pendingRequestRef.current = { detail, tabId: tab.id, guideJson: tab.content.content };
+      reportAppInteraction(UserInteraction.AiFixOffered, {
+        step_id: detail.stepId ?? '',
+        rendered_step_id: detail.renderedStepId ?? '',
+      });
+
+      GlobalInteractionBlocker.getInstance().startAdHocBlocking('Asking Grafana Assistant for a fix…');
+      timeoutRef.current = setTimeout(() => {
+        if (!pendingRequestRef.current) {
+          return;
+        }
+        reportAppInteraction(UserInteraction.AiFixFailed, { step_id: detail.stepId ?? '', reason: 'timeout' });
+        publishToast('warning', "AI couldn't fix this step", 'The request timed out.');
+        clearPending();
+      }, AI_FIX_REQUEST_TIMEOUT_MS);
+
+      // Materialize canonical ids so the assistant + extraction see the ids a component dispatched.
+      const augmentedJson = materializeStepIdsInJson(tab.content.content);
+      const domHint = collectDomContext(detail.refTarget ?? '');
+      const failingStepContent = extractStepContent(augmentedJson, detail.stepId ?? '', detail.containerInfo);
+      const failingTag = tagFromSelector(detail.refTarget ?? '');
+
+      await generate({
+        guideJson: augmentedJson,
+        failingStepId: detail.stepId ?? '',
+        failingReftarget: detail.refTarget ?? '',
+        failingAction: detail.action ?? '',
+        failingStepContent: failingStepContent || undefined,
+        failingTag,
+        domHint,
+        containerInfo: detail.containerInfo,
+      });
+    };
+
+    window.addEventListener(AI_FIX_REQUEST_EVENT, handler);
+    return () => window.removeEventListener(AI_FIX_REQUEST_EVENT, handler);
+  }, [generate, isAssistantAvailable, aiAutoHealEnabled, clearPending]);
+
+  useEffect(() => {
+    if (!patch) {
+      return;
+    }
+    // Use the tab/guide captured at acceptance — the user may have switched tabs mid-flight.
+    const request = pendingRequestRef.current;
+    if (!request) {
+      clearPending();
+      return;
+    }
+
+    const confidence = evaluatePatchConfidence(patch);
+    if (!confidence.ok) {
+      reportAppInteraction(UserInteraction.AiFixFailed, {
+        step_id: request.detail.stepId ?? '',
+        reason: `low-confidence: ${confidence.reason}`,
+      });
+      publishToast('warning', "AI couldn't find a confident fix", confidence.reason);
+      clearPending();
+      return;
+    }
+
+    // applyPatchToGuide materializes ids internally — pass the raw guide string.
+    const result = applyPatchToGuide(request.guideJson, patch);
+    if (result.ok) {
+      onPatchApplied(request.tabId, result.newGuideJson);
+      reportAppInteraction(UserInteraction.AiFixApplied, {
+        step_id: request.detail.stepId ?? '',
+        patch_type: patch.type,
+      });
+      publishToast(
+        'success',
+        'AI updated this step',
+        patch.rationale ? patch.rationale : 'A new selector was applied; the requirement will re-check now.'
+      );
+    } else {
+      reportAppInteraction(UserInteraction.AiFixFailed, {
+        step_id: request.detail.stepId ?? '',
+        reason: result.error,
+      });
+      publishToast('warning', "AI couldn't update this step", result.error);
+    }
+
+    clearPending();
+  }, [patch, onPatchApplied, clearPending]);
+
+  useEffect(() => {
+    if (!error) {
+      return;
+    }
+    const request = pendingRequestRef.current;
+    reportAppInteraction(UserInteraction.AiFixFailed, {
+      step_id: request?.detail.stepId ?? '',
+      reason: error.message.slice(0, 200),
+    });
+    publishToast('warning', "AI couldn't fix this step", error.message.slice(0, 200));
+    clearPending();
+  }, [error, clearPending]);
+
+  return null;
+}
+
+// Lazy default export keeps @grafana/assistant out of the docs-panel init chain
+// (its runtime init throws "Class extends value undefined" under jest).
+export default AiFixOrchestrator;

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -19,6 +19,8 @@ const TerminalProviderLazy = lazy(() =>
     default: module.TerminalProvider,
   }))
 );
+// Lazy so @grafana/assistant stays out of the docs-panel init chain (see AiFixOrchestrator).
+const AiFixOrchestrator = lazy(() => import('./AiFixOrchestrator'));
 import { usePluginContext } from '@grafana/data';
 import { DocsPluginConfig, getConfigWithDefaults } from '../../constants';
 
@@ -1198,6 +1200,16 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   // scroll container (DOM id pinned by docs-panel.contract.test.tsx).
   useScrollTracking({ activeTab, isRecommendationsTab });
 
+  const handleAiFixPatchApplied = useCallback(
+    (tabId: string, newGuideJson: string) => {
+      const updatedTabs = model.state.tabs.map((t) =>
+        t.id === tabId && t.content ? { ...t, content: { ...t.content, content: newGuideJson } } : t
+      );
+      model.setState({ tabs: updatedTabs });
+    },
+    [model]
+  );
+
   // ContentRenderer renders the content with styling applied via CSS classes
 
   return (
@@ -1207,6 +1219,9 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
       data-pathfinder-content="true"
       data-testid={testIds.docsPanel.container}
     >
+      <Suspense fallback={null}>
+        <AiFixOrchestrator activeTab={activeTab} onPatchApplied={handleAiFixPatchApplied} />
+      </Suspense>
       {/* Live session controls - only render when there's session content.
           The component returns null when both flags are off, preserving the
           original surface gate. */}

--- a/src/integrations/assistant-integration/ai-fix-event.ts
+++ b/src/integrations/assistant-integration/ai-fix-event.ts
@@ -1,0 +1,13 @@
+export const AI_FIX_REQUEST_EVENT = 'pathfinder-ai-fix-request';
+
+export interface AiFixRequestDetail {
+  stepId?: string;
+  renderedStepId?: string;
+  refTarget?: string;
+  action?: string;
+  containerInfo?: {
+    containerId: string;
+    containerKind: 'multistep' | 'guided';
+    subStepIndex: number;
+  };
+}

--- a/src/integrations/assistant-integration/ai-fix-step-id.test.ts
+++ b/src/integrations/assistant-integration/ai-fix-step-id.test.ts
@@ -1,0 +1,28 @@
+import { materializeStepIdsInJson } from './ai-fix-step-id';
+
+describe('materializeStepIdsInJson', () => {
+  it('writes a canonical id onto an anonymous addressable block', () => {
+    const out = materializeStepIdsInJson(
+      JSON.stringify({ blocks: [{ type: 'interactive', action: 'button', reftarget: '.x' }] })
+    );
+    const block = JSON.parse(out).blocks[0];
+    expect(typeof block.id).toBe('string');
+    expect(block.id.length).toBeGreaterThan(0);
+  });
+
+  it('preserves an author-provided id', () => {
+    const out = materializeStepIdsInJson(
+      JSON.stringify({ blocks: [{ id: 'author-step', type: 'interactive', action: 'button', reftarget: '.x' }] })
+    );
+    expect(JSON.parse(out).blocks[0].id).toBe('author-step');
+  });
+
+  it('returns the input unchanged when it is not valid JSON', () => {
+    expect(materializeStepIdsInJson('not json {')).toBe('not json {');
+  });
+
+  it('returns the input unchanged when it is not a guide-shaped object', () => {
+    expect(materializeStepIdsInJson('{"nope":true}')).toBe('{"nope":true}');
+    expect(materializeStepIdsInJson('[]')).toBe('[]');
+  });
+});

--- a/src/integrations/assistant-integration/ai-fix-step-id.ts
+++ b/src/integrations/assistant-integration/ai-fix-step-id.ts
@@ -78,3 +78,19 @@ export function materializeStepIds(guide: JsonGuide): JsonGuide {
   walk(guide.blocks, STANDALONE_PARENT_ID, 'blocks');
   return guide;
 }
+
+// String entry point for callers holding raw guide JSON (the orchestrator feeds the
+// id-augmented form to the assistant + content extraction). Returns the input unchanged
+// when it is not parseable guide-shaped JSON.
+export function materializeStepIdsInJson(guideJson: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(guideJson);
+  } catch {
+    return guideJson;
+  }
+  if (!parsed || typeof parsed !== 'object' || !Array.isArray((parsed as Partial<JsonGuide>).blocks)) {
+    return guideJson;
+  }
+  return JSON.stringify(materializeStepIds(parsed as JsonGuide));
+}


### PR DESCRIPTION
## What & why

**PR7 of the PR-886 AI auto-heal breakdown** ([RFC](https://github.com/grafana/pathfinder-rfcs/pull/5)). Stacks on PR6 ([#995](https://github.com/grafana/grafana-pathfinder-app/pull/995)); depends on PR4 (apply), PR5 (hook), and PR6 (extracted helpers).

This is the thin React shell that glues the AI-powered "Fix this" affordance to the docs-panel Scene model, plus the docs-panel lazy mount. In PR #886 the orchestrator was a 716-line file with all the DOM-context / confidence / step-content helpers inline; PR6 extracted and unit-tested those ~510 lines, so this shell just imports them.


## What's included

- **`src/components/docs-panel/AiFixOrchestrator.tsx`** — thin shell (3 effects: request listener, apply, error) consuming PR6's helpers, PR5's `useAiFixGeneration`, and PR4's `applyPatchToGuide`. Renders nothing.
- **`docs-panel.tsx`** — `lazy()` import + `handleAiFixPatchApplied` tab-content writer + `<Suspense>` mount as the first child of the `data-pathfinder-content` container.
- **`ai-fix-step-id.ts`** — adds `materializeStepIdsInJson` (a string entry point on PR2's id module) so the shell can feed the assistant + content extraction the same canonical ids a component dispatched. The id-augmented form drives `extractStepContent` (whose `findGuideBlockById` resolves anonymous blocks by their derived id) and the assistant prompt.
- Co-located unit tests for the orchestrator and for `materializeStepIdsInJson`.

### Must-fixes applied (from §5.4 PR7)

- Call `evaluatePatchConfidence(patch)` with **no second arg** and an **accurate** one-line comment (the old code carried a comment claiming a token-overlap "Bar chart → Bar gauge" rejection that never existed; PR6 fixed the helper, this fixes the call site).
- **Dropped** the outer `synthesizeStepIdsInJson(...)` wrap on the apply path — `applyPatchToGuide` materializes ids internally, so the apply effect passes the raw guide string directly.
- **Deleted** the screenshot `NOTE` (defends a v1-disabled feature with no code left).
- **Trimmed** the 22-line file docstring / numbered runbook (moved to the commit body); kept one copy of the `lazy()`/jest-init-crash workaround note.

## It lands dark

- Nothing dispatches `pathfinder-ai-fix-request` yet — the button sites land in PR8. The orchestrator only mounts a listener.
- Even if an event fired, the handler early-returns while `enableAiAutoHeal` is false (default) — defense-in-depth alongside the (future) button-site gate.
- The `lazy()` import keeps `@grafana/assistant` out of the docs-panel init chain.

Verified dark by grep: the only `dispatchEvent('pathfinder-ai-fix-request')` in `src/` is in the orchestrator's own test.

## Test plan

- `npm run typecheck` ✅ · `eslint` ✅ 0 errors · `prettier --check` ✅
- Governance/architecture tests ✅ (no new tier violations; imports flow Tier 3 → Tier 4 downward)
- `jest` ✅ — new `AiFixOrchestrator` suite (7): renders-nothing, flag-off drop, assistant-unavailable drop, generate wiring, confident-patch apply + success toast, low-confidence rejection, error→warning toast; `materializeStepIdsInJson` suite (4): anonymous-block id, author-id preserved, invalid-JSON passthrough, non-guide passthrough
- Full frontend suite ✅ 240/240 suites, 4039 passed