### PR TITLE
feat(ai-fix): render "Fix this" buttons in interactive renderers + requiresDomElement

### DIFF
--- a/src/components/interactive-tutorial/ai-fix-button.test.tsx
+++ b/src/components/interactive-tutorial/ai-fix-button.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import { AiFixButton, dispatchAiFixRequest } from './ai-fix-button';
+import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import { AI_FIX_REQUEST_EVENT, type AiFixRequestDetail } from '../../integrations/assistant-integration/ai-fix-event';
+
+jest.mock('@grafana/ui', () => ({ Icon: () => null }));
+jest.mock('../../lib/analytics', () => ({
+  reportAppInteraction: jest.fn(),
+  UserInteraction: { AiFixAccepted: 'ai_fix_accepted' },
+}));
+
+function captureDetail(fire: () => void): AiFixRequestDetail | null {
+  let captured: AiFixRequestDetail | null = null;
+  const listener = (e: Event) => {
+    captured = (e as CustomEvent<AiFixRequestDetail>).detail;
+  };
+  window.addEventListener(AI_FIX_REQUEST_EVENT, listener);
+  fire();
+  window.removeEventListener(AI_FIX_REQUEST_EVENT, listener);
+  return captured;
+}
+
+const TOP_LEVEL: AiFixRequestDetail = { stepId: 's1', renderedStepId: 'r1', refTarget: '.gone', action: 'button' };
+const SUBSTEP: AiFixRequestDetail = {
+  stepId: 'c1',
+  renderedStepId: 'r1',
+  refTarget: '.gone',
+  action: 'button',
+  containerInfo: { containerId: 'c1', containerKind: 'multistep', subStepIndex: 2 },
+};
+
+describe('dispatchAiFixRequest', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('dispatches the event and reports top-level analytics', () => {
+    const captured = captureDetail(() => dispatchAiFixRequest(TOP_LEVEL));
+    expect(captured).toEqual(TOP_LEVEL);
+    expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.AiFixAccepted, {
+      step_id: 's1',
+      rendered_step_id: 'r1',
+      reftarget: '.gone',
+      target_action: 'button',
+    });
+  });
+
+  it('reports container analytics for a substep patch', () => {
+    const captured = captureDetail(() => dispatchAiFixRequest(SUBSTEP));
+    expect(captured?.containerInfo).toEqual(SUBSTEP.containerInfo);
+    expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.AiFixAccepted, {
+      step_id: 'c1',
+      rendered_step_id: 'r1',
+      container_kind: 'multistep',
+      sub_step_index: 2,
+    });
+  });
+});
+
+describe('AiFixButton', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('dispatches the request on click', () => {
+    const { getByTestId } = render(<AiFixButton detail={TOP_LEVEL} testId="ai-btn" className="c" />);
+    const captured = captureDetail(() => fireEvent.click(getByTestId('ai-btn')));
+    expect(captured).toEqual(TOP_LEVEL);
+    expect(reportAppInteraction).toHaveBeenCalledWith(
+      UserInteraction.AiFixAccepted,
+      expect.objectContaining({ step_id: 's1' })
+    );
+  });
+
+  it('honours the disabled prop', () => {
+    const { getByTestId } = render(<AiFixButton detail={TOP_LEVEL} testId="ai-btn" className="c" disabled />);
+    expect(getByTestId('ai-btn')).toBeDisabled();
+  });
+});

--- a/src/components/interactive-tutorial/ai-fix-button.tsx
+++ b/src/components/interactive-tutorial/ai-fix-button.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { Icon } from '@grafana/ui';
+
+import { AI_FIX_REQUEST_EVENT, type AiFixRequestDetail } from '../../integrations/assistant-integration/ai-fix-event';
+import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+
+export function dispatchAiFixRequest(detail: AiFixRequestDetail): void {
+  const base = { step_id: detail.stepId ?? '', rendered_step_id: detail.renderedStepId ?? '' };
+  const analytics = detail.containerInfo
+    ? { ...base, container_kind: detail.containerInfo.containerKind, sub_step_index: detail.containerInfo.subStepIndex }
+    : { ...base, reftarget: detail.refTarget ?? '', target_action: detail.action ?? '' };
+  reportAppInteraction(UserInteraction.AiFixAccepted, analytics);
+  window.dispatchEvent(new CustomEvent(AI_FIX_REQUEST_EVENT, { detail }));
+}
+
+interface AiFixButtonProps {
+  detail: AiFixRequestDetail;
+  testId: string;
+  className: string;
+  disabled?: boolean;
+}
+
+export function AiFixButton({ detail, testId, className, disabled }: AiFixButtonProps) {
+  return (
+    <button className={className} data-testid={testId} disabled={disabled} onClick={() => dispatchAiFixRequest(detail)}>
+      Fix this <Icon name="ai-sparkle" size="sm" />
+    </button>
+  );
+}

--- a/src/components/interactive-tutorial/interactive-guided.test.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.test.tsx
@@ -11,6 +11,9 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { InteractiveGuided, resetGuidedCounter } from './interactive-guided';
+import { useStepChecker } from '../../requirements-manager';
+import { useAiFixEnabled } from '../../integrations/assistant-integration/use-ai-fix-enabled';
+import { testIds } from '../../constants/testIds';
 
 // ─── Mock @grafana/ui ────────────────────────────────────────────────────────
 jest.mock('@grafana/ui', () => ({
@@ -19,6 +22,7 @@ jest.mock('@grafana/ui', () => ({
       {children}
     </button>
   ),
+  Icon: () => null,
 }));
 
 // ─── Mock @grafana/data ──────────────────────────────────────────────────────
@@ -209,5 +213,51 @@ describe('InteractiveGuided — double skip button (issue #786)', () => {
     const skipButtons = screen.queryAllByTestId(/interactive-skip/);
     expect(skipButtons).toHaveLength(1);
     expect(skipButtons[0]).toHaveTextContent('Skip');
+  });
+});
+
+describe('InteractiveGuided — AI "Fix this" gating vs sequential block', () => {
+  const blockedChecker = {
+    isEnabled: false,
+    isChecking: false,
+    explanation: 'Complete the previous step first',
+    completionReason: 'none',
+    requiresDomElement: true,
+    canFixRequirement: false,
+    markSkipped: jest.fn(),
+    fixRequirement: null,
+    checkStep: jest.fn(),
+    isRetrying: false,
+    retryCount: 0,
+    maxRetries: 3,
+  };
+
+  beforeEach(() => {
+    (useAiFixEnabled as jest.Mock).mockReturnValue(true);
+    (useStepChecker as jest.Mock).mockReturnValue(blockedChecker);
+  });
+
+  it('hides the AI fix button when the step is not eligible (sequential "complete previous step" block)', () => {
+    render(
+      <InteractiveGuided
+        stepId="seq-blocked"
+        isEligibleForChecking={false}
+        requirements="exists-reftarget"
+        internalActions={[{ targetAction: 'highlight', refTarget: '#x' }]}
+      />
+    );
+    expect(screen.queryByTestId(testIds.interactive.guidedAiFixButton('seq-blocked'))).not.toBeInTheDocument();
+  });
+
+  it('shows the AI fix button when eligible and the element requirement fails', () => {
+    render(
+      <InteractiveGuided
+        stepId="elig-failing"
+        isEligibleForChecking={true}
+        requirements="exists-reftarget"
+        internalActions={[{ targetAction: 'highlight', refTarget: '#x' }]}
+      />
+    );
+    expect(screen.getByTestId(testIds.interactive.guidedAiFixButton('elig-failing'))).toBeInTheDocument();
   });
 });

--- a/src/components/interactive-tutorial/interactive-guided.test.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.test.tsx
@@ -26,6 +26,12 @@ jest.mock('@grafana/data', () => ({
   usePluginContext: () => ({ meta: { jsonData: {} } }),
 }));
 
+// ─── Mock useAiFixEnabled (off) — avoids pulling @grafana/assistant, which this
+//     suite's @grafana/ui mock would otherwise leave un-themed and crashing ─────
+jest.mock('../../integrations/assistant-integration/use-ai-fix-enabled', () => ({
+  useAiFixEnabled: jest.fn(() => false),
+}));
+
 // ─── Mock analytics (no-op) ──────────────────────────────────────────────────
 jest.mock('../../lib/analytics', () => ({
   reportAppInteraction: jest.fn(),

--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -757,7 +757,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
               >
                 {checker.canFixRequirement ? 'Fix this' : 'Check again'}
               </button>
-              {aiFixEnabled && checker.requiresDomElement && !checker.canFixRequirement && (
+              {isEligibleForChecking && aiFixEnabled && checker.requiresDomElement && !checker.canFixRequirement && (
                 <AiFixButton
                   className="interactive-guided-ai-fix-btn"
                   testId={testIds.interactive.guidedAiFixButton(renderedStepId)}

--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -17,8 +17,11 @@ import { getConfigWithDefaults } from '../../constants';
 import { findButtonByText, querySelectorAllEnhanced } from '../../lib/dom';
 import { GuidedAction } from '../../types/interactive-actions.types';
 import { testIds } from '../../constants/testIds';
+// Deep import (not the barrel): the barrel re-exports @grafana/assistant, which crashes under jsdom.
+import { useAiFixEnabled } from '../../integrations/assistant-integration/use-ai-fix-enabled';
 import { sanitizeDocumentationHTML } from '../../security';
 import { STEP_STATES } from './step-states';
+import { AiFixButton } from './ai-fix-button';
 import { markStepCompleted, resetStep, useStepCompletion } from '../../global-state/completion-store';
 import type { ProgressReason } from '../../global-state/progress-events';
 
@@ -264,6 +267,8 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
       onStepComplete, // Pass through for objectives auto-completion
       onComplete, // Pass through for objectives auto-completion
     });
+
+    const aiFixEnabled = useAiFixEnabled();
 
     // Combined completion state: objectives always win
     const isCompletedWithObjectives = storedCompleted || checker.completionReason === 'objectives';
@@ -752,6 +757,18 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
               >
                 {checker.canFixRequirement ? 'Fix this' : 'Check again'}
               </button>
+              {aiFixEnabled && checker.requiresDomElement && !checker.canFixRequirement && (
+                <AiFixButton
+                  className="interactive-guided-ai-fix-btn"
+                  testId={testIds.interactive.guidedAiFixButton(renderedStepId)}
+                  detail={{
+                    stepId: stepId ?? renderedStepId,
+                    renderedStepId,
+                    refTarget: firstActionRefTarget,
+                    action: firstActionTargetAction,
+                  }}
+                />
+              )}
             </div>
           )}
 
@@ -837,6 +854,23 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
               >
                 ↻ Try again
               </Button>
+              {aiFixEnabled && currentStepIndex >= 0 && (
+                <AiFixButton
+                  className="interactive-guided-ai-fix-btn"
+                  testId={testIds.interactive.guidedAiFixButton(`${renderedStepId}-runtime`)}
+                  detail={{
+                    stepId: stepId ?? renderedStepId,
+                    renderedStepId,
+                    refTarget: internalActions[currentStepIndex]?.refTarget,
+                    action: internalActions[currentStepIndex]?.targetAction,
+                    containerInfo: {
+                      containerId: stepId ?? renderedStepId,
+                      containerKind: 'guided',
+                      subStepIndex: currentStepIndex,
+                    },
+                  }}
+                />
+              )}
               {skippable && (
                 <Button
                   onClick={handleSkipStep}

--- a/src/components/interactive-tutorial/interactive-multi-step.tsx
+++ b/src/components/interactive-tutorial/interactive-multi-step.tsx
@@ -13,7 +13,10 @@ import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
 import { InternalAction } from '../../types/interactive-actions.types';
 import type { InteractiveElementData } from '../../types/interactive.types';
 import { testIds } from '../../constants/testIds';
+// Deep import (not the barrel): the barrel re-exports @grafana/assistant, which crashes under jsdom.
+import { useAiFixEnabled } from '../../integrations/assistant-integration/use-ai-fix-enabled';
 import { STEP_STATES } from './step-states';
+import { AiFixButton } from './ai-fix-button';
 import { markStepCompleted, resetStep, useStepCompletion } from '../../global-state/completion-store';
 import type { ProgressReason } from '../../global-state/progress-events';
 
@@ -249,6 +252,8 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
       onStepComplete, // Pass through for objectives auto-completion
       onComplete, // Pass through for objectives auto-completion
     });
+
+    const aiFixEnabled = useAiFixEnabled();
 
     // Combined completion state: objectives always win (clarification 1, 2, 18)
     const isCompletedWithObjectives = storedCompleted || checker.completionReason === 'objectives';
@@ -845,6 +850,25 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
               >
                 ↻ Try again
               </Button>
+              {aiFixEnabled &&
+                failedStepIndex >= 0 &&
+                /Element not found|requirements not met/i.test(executionError) && (
+                  <AiFixButton
+                    className="interactive-guided-ai-fix-btn"
+                    testId={testIds.interactive.requirementAiFixButton(renderedStepId)}
+                    detail={{
+                      stepId: stepId ?? renderedStepId,
+                      renderedStepId,
+                      refTarget: internalActions[failedStepIndex]?.refTarget,
+                      action: internalActions[failedStepIndex]?.targetAction,
+                      containerInfo: {
+                        containerId: stepId ?? renderedStepId,
+                        containerKind: 'multistep',
+                        subStepIndex: failedStepIndex,
+                      },
+                    }}
+                  />
+                )}
               {skippable && (
                 <Button
                   onClick={async () => {

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -1147,18 +1147,22 @@ export const InteractiveStep = forwardRef<
                   </button>
                 )}
 
-                {aiFixEnabled && checker.requiresDomElement && !checker.canFixRequirement && !checker.isEnabled && (
-                  <AiFixButton
-                    className="interactive-requirement-ai-fix-btn"
-                    testId={testIds.interactive.requirementAiFixButton(renderedStepId)}
-                    detail={{
-                      stepId: stepId ?? renderedStepId,
-                      renderedStepId,
-                      refTarget,
-                      action: targetAction,
-                    }}
-                  />
-                )}
+                {isEligibleForChecking &&
+                  aiFixEnabled &&
+                  checker.requiresDomElement &&
+                  !checker.canFixRequirement &&
+                  !checker.isEnabled && (
+                    <AiFixButton
+                      className="interactive-requirement-ai-fix-btn"
+                      testId={testIds.interactive.requirementAiFixButton(renderedStepId)}
+                      detail={{
+                        stepId: stepId ?? renderedStepId,
+                        renderedStepId,
+                        refTarget,
+                        action: targetAction,
+                      }}
+                    />
+                  )}
 
                 {/* Skip button only for eligible steps with failed requirements */}
                 {isEligibleForChecking && checker.canSkip && checker.markSkipped && !checker.isEnabled && (

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -19,10 +19,13 @@ import {
 } from '../../interactive-engine';
 import { testIds } from '../../constants/testIds';
 import { AssistantCustomizableProvider, useAssistantBlockValue } from '../../integrations/assistant-integration';
+// Deep import (not the barrel): the barrel re-exports @grafana/assistant, which crashes under jsdom.
+import { useAiFixEnabled } from '../../integrations/assistant-integration/use-ai-fix-enabled';
 import { CodeBlock } from '../../docs-retrieval';
 import { scrollUntilElementFound } from '../../lib/dom';
 import { resolveWithRetry } from '../../lib/dom/selector-retry';
 import { STEP_STATES } from './step-states';
+import { AiFixButton } from './ai-fix-button';
 import { markStepCompleted, resetStep, useStepCompletion } from '../../global-state/completion-store';
 
 /**
@@ -284,6 +287,8 @@ export const InteractiveStep = forwardRef<
       onStepComplete, // Pass through for objectives auto-completion
       onComplete, // Pass through for objectives auto-completion
     });
+
+    const aiFixEnabled = useAiFixEnabled();
 
     // Combined completion state: store-persisted OR checker-derived (objectives
     // / skipped are render-time signals that may not yet have persisted).
@@ -1053,6 +1058,19 @@ export const InteractiveStep = forwardRef<
             >
               Retry
             </button>
+            {aiFixEnabled && /^Element not found/i.test(lazyScrollError) && (
+              <AiFixButton
+                className="interactive-requirement-ai-fix-btn"
+                testId={testIds.interactive.requirementAiFixButton(`${renderedStepId}-lazy`)}
+                disabled={isShowRunning || isDoRunning}
+                detail={{
+                  stepId: stepId ?? renderedStepId,
+                  renderedStepId,
+                  refTarget,
+                  action: targetAction,
+                }}
+              />
+            )}
           </div>
         )}
 
@@ -1121,6 +1139,19 @@ export const InteractiveStep = forwardRef<
                   >
                     {checker.canFixRequirement ? 'Fix this' : 'Retry'}
                   </button>
+                )}
+
+                {aiFixEnabled && checker.requiresDomElement && !checker.canFixRequirement && !checker.isEnabled && (
+                  <AiFixButton
+                    className="interactive-requirement-ai-fix-btn"
+                    testId={testIds.interactive.requirementAiFixButton(renderedStepId)}
+                    detail={{
+                      stepId: stepId ?? renderedStepId,
+                      renderedStepId,
+                      refTarget,
+                      action: targetAction,
+                    }}
+                  />
                 )}
 
                 {/* Skip button only for eligible steps with failed requirements */}

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -290,6 +290,12 @@ export const InteractiveStep = forwardRef<
 
     const aiFixEnabled = useAiFixEnabled();
 
+    // Clear stale runtime errors when an AI patch swaps refTarget (step updates in place).
+    useEffect(() => {
+      setLazyScrollError(null);
+      setPostVerifyError(null);
+    }, [refTarget]);
+
     // Combined completion state: store-persisted OR checker-derived (objectives
     // / skipped are render-time signals that may not yet have persisted).
     const isCompletedWithObjectives =

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -139,6 +139,7 @@ export const testIds = {
     requirementCheck: (requirementId: string) => `interactive-requirement-${requirementId}`,
     requirementFixButton: (stepId: string) => `interactive-requirement-fix-${stepId}`,
     requirementAiFixButton: (stepId: string) => `interactive-requirement-ai-fix-${stepId}`,
+    guidedAiFixButton: (stepId: string) => `interactive-guided-ai-fix-${stepId}`,
     sectionRequirementsBanner: (sectionId: string) => `interactive-section-requirements-banner-${sectionId}`,
     requirementRetryButton: (stepId: string) => `interactive-requirement-retry-${stepId}`,
     requirementSkipButton: (stepId: string) => `interactive-requirement-skip-${stepId}`,

--- a/src/integrations/assistant-integration/index.ts
+++ b/src/integrations/assistant-integration/index.ts
@@ -55,6 +55,8 @@ export {
   useIsAssistantAvailable,
 } from './assistant-dev-mode';
 
+export { useAiFixEnabled } from './use-ai-fix-enabled';
+
 // Custom tools for inline assistant
 export {
   // Tools

--- a/src/integrations/assistant-integration/use-ai-fix-enabled.test.ts
+++ b/src/integrations/assistant-integration/use-ai-fix-enabled.test.ts
@@ -1,0 +1,35 @@
+import { renderHook } from '@testing-library/react';
+
+import { usePluginContext } from '@grafana/data';
+
+import { useAiFixEnabled } from './use-ai-fix-enabled';
+import { useIsAssistantAvailable } from './assistant-dev-mode';
+
+jest.mock('@grafana/data', () => ({ usePluginContext: jest.fn() }));
+jest.mock('./assistant-dev-mode', () => ({ useIsAssistantAvailable: jest.fn() }));
+jest.mock('../../constants', () => ({
+  getConfigWithDefaults: (jsonData: Record<string, unknown> | undefined) => ({
+    enableAiAutoHeal: !!jsonData?.enableAiAutoHeal,
+  }),
+}));
+
+function run(available: boolean, flag: boolean | undefined): boolean {
+  (useIsAssistantAvailable as jest.Mock).mockReturnValue(available);
+  (usePluginContext as jest.Mock).mockReturnValue({ meta: { jsonData: { enableAiAutoHeal: flag } } });
+  return renderHook(() => useAiFixEnabled()).result.current;
+}
+
+describe('useAiFixEnabled', () => {
+  it('is false when the admin flag is off (dark by default)', () => {
+    expect(run(true, false)).toBe(false);
+    expect(run(false, undefined)).toBe(false);
+  });
+
+  it('is false when the assistant is unavailable, even with the flag on', () => {
+    expect(run(false, true)).toBe(false);
+  });
+
+  it('is true only when the flag is on and the assistant is available', () => {
+    expect(run(true, true)).toBe(true);
+  });
+});

--- a/src/integrations/assistant-integration/use-ai-fix-enabled.ts
+++ b/src/integrations/assistant-integration/use-ai-fix-enabled.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+
+import { usePluginContext } from '@grafana/data';
+
+// Deep import (not the barrel): the index re-exports @grafana/assistant, whose runtime
+// init crashes under jsdom — the same chain the docs-panel lazy mount avoids.
+import { useIsAssistantAvailable } from './assistant-dev-mode';
+import { getConfigWithDefaults } from '../../constants';
+
+export function useAiFixEnabled(): boolean {
+  const isAssistantAvailable = useIsAssistantAvailable();
+  const pluginContext = usePluginContext();
+  const enableAiAutoHeal = useMemo(
+    () => getConfigWithDefaults(pluginContext?.meta?.jsonData || {}).enableAiAutoHeal,
+    [pluginContext?.meta?.jsonData]
+  );
+  return isAssistantAvailable && enableAiAutoHeal;
+}

--- a/src/requirements-manager/step-checker.hook.test.ts
+++ b/src/requirements-manager/step-checker.hook.test.ts
@@ -844,3 +844,25 @@ describe('useStepChecker — AlignmentPendingContext gate', () => {
   // suite. The two unit tests above cover the gate's pause/unpause
   // semantics deterministically; an E2E covers the full UX flow.
 });
+
+describe('requiresDomElement', () => {
+  it('is true when requirements include exists-reftarget', async () => {
+    const { result } = await renderStepChecker({ requirements: 'exists-reftarget' });
+    expect(result.current.requiresDomElement).toBe(true);
+  });
+
+  it('is true when exists-reftarget is one of several requirements', async () => {
+    const { result } = await renderStepChecker({ requirements: 'is-admin,exists-reftarget' });
+    expect(result.current.requiresDomElement).toBe(true);
+  });
+
+  it('is false for other requirements', async () => {
+    const { result } = await renderStepChecker({ requirements: 'is-admin' });
+    expect(result.current.requiresDomElement).toBe(false);
+  });
+
+  it('is false when no requirements are set', async () => {
+    const { result } = await renderStepChecker({});
+    expect(result.current.requiresDomElement).toBe(false);
+  });
+});

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -537,7 +537,19 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       safeDispatch(actionFromBaseStepState(errorState));
       updateManager(errorState);
     }
-  }, [objectives, requirements, hints, stepId, isEligibleForChecking, skippable, updateManager, safeDispatch]); // eslint-disable-line react-hooks/exhaustive-deps
+    // refTarget/targetAction: rebuild checkStep when an AI patch swaps the selector.
+  }, [
+    objectives,
+    requirements,
+    hints,
+    stepId,
+    isEligibleForChecking,
+    skippable,
+    updateManager,
+    safeDispatch,
+    refTarget,
+    targetAction,
+  ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /**
    * Attempt to automatically fix failed requirements via the fix-handler registry.

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -796,7 +796,9 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     return undefined;
   }, [stepId]);
 
-  // Check requirements when step eligibility changes (both true and false)
+  // Check requirements when step eligibility OR refTarget changes (both true and false).
+  // refTarget is included so a runtime selector swap (the orchestrator rewriting the guide)
+  // re-runs the check against the new target instead of leaving the step blocked.
   // Note: We removed managerStepState from deps to prevent infinite loops
   // The manager state changes are handled by the registered step checker callback instead
   useEffect(() => {
@@ -805,7 +807,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       // This ensures steps show the correct "blocked" state when they become ineligible
       checkStepRef.current();
     }
-  }, [isEligibleForChecking]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isEligibleForChecking, refTarget]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Listen for section completion events (for `section-completed:` requirements).
   // `step-auto-skipped` was a listener with no dispatcher anywhere in the
@@ -968,6 +970,10 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     };
   }, [requirements, state.isEnabled, state.isCompleted]);
 
+  // A missing DOM element is the only failure the AI "Fix this" affordance can address;
+  // the UI tier ANDs this with assistant availability to decide whether to surface it.
+  const requiresDomElement = (requirements ?? '').includes('exists-reftarget');
+
   return {
     ...state,
     checkStep,
@@ -977,5 +983,6 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     canFixRequirement: state.canFixRequirement,
     fixType: state.fixType,
     fixRequirement: state.canFixRequirement ? fixRequirement : undefined,
+    requiresDomElement,
   };
 }

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -537,7 +537,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       safeDispatch(actionFromBaseStepState(errorState));
       updateManager(errorState);
     }
-    // refTarget/targetAction: rebuild checkStep when an AI patch swaps the selector.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refTarget/targetAction rebuild checkStep when an AI patch swaps the selector; remaining deps intentionally omitted to avoid loops
   }, [
     objectives,
     requirements,
@@ -549,7 +549,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     safeDispatch,
     refTarget,
     targetAction,
-  ]); // eslint-disable-line react-hooks/exhaustive-deps
+  ]);
 
   /**
    * Attempt to automatically fix failed requirements via the fix-handler registry.


### PR DESCRIPTION
## What & why

**PR8 of the PR-886 AI auto-heal breakdown** ([RFC](https://github.com/grafana/pathfinder-rfcs/pull/5)) — the final code PR. Stacks on PR7 ([#996](https://github.com/grafana/grafana-pathfinder-app/pull/996)); depends on PR5 (`useIsAssistantAvailable`) and PR7 (the orchestrator + event contract).

PRs 1–7 landed every part of the AI auto-heal flow except the trigger — **nothing dispatched `pathfinder-ai-fix-request` yet**. This PR completes the wire: the three interactive renderers now render an AI-powered "Fix this ✨" button on a failing step that dispatches the event the PR7 orchestrator consumes.

The RFC framed this as a hard re-base, but `main` already forwards the canonical `stepId` from the section, so dropping the original branch's parallel `sourceStepId` prop means **`interactive-section.tsx`, its registry, and the symmetry tripwire are untouched**.

## What's included

**Shared extractions** (replacing what the original copy-pasted across all 5 sites):
- **`useAiFixEnabled()`** (`src/integrations/assistant-integration/use-ai-fix-enabled.ts`) — the `assistant-available && enableAiAutoHeal` gate. Imported from its **deep module path**, not the barrel (the barrel re-exports `@grafana/assistant`, which crashes under jsdom).
- **`dispatchAiFixRequest()` + `<AiFixButton>`** (`src/components/interactive-tutorial/ai-fix-button.tsx`) — fires the `AiFixAccepted` analytics + the `CustomEvent`.
- **`ai-fix-event.ts`** — single source of truth for the event name + `AiFixRequestDetail` shape; PR7's orchestrator now imports it (its inline interface + the two event-name string literals are gone).

**Five button sites:** interactive-step (lazy-scroll runtime + pre-exec requirement), interactive-multi-step (runtime substep), interactive-guided (pre-exec + runtime substep). Substep sites carry `containerInfo {containerId, containerKind, subStepIndex}`; all dispatch the canonical `stepId`.

**`step-checker`:** derives + returns `requiresDomElement` (the type field shipped in PR1 but was never populated) and adds `refTarget` to the recheck effect deps so a runtime selector swap re-runs the requirements check.

**testId disambiguation (must-fix):** adds `guidedAiFixButton`; the two sibling buttons in step/guided get `-lazy`/`-runtime` suffixes so they're distinguishable.

## Follow-up fixes (found during live E2E)

Two runtime bugs surfaced while testing the end-to-end flow; both are fixed here, in the layer that owns the buttons + the step-checker signal:

- **Patch applied but the step didn't recover** (`fix(ai-fix): re-check + recover…`). After the orchestrator applies a patch, the step's id is stable (apply bakes a derived id into the guide), so the step updates *in place* rather than remounting. `checkStep` didn't list `refTarget`/`targetAction` in its deps → the re-check fired but re-ran the **stale** selector, so the `exists-reftarget` requirement never passed; and the runtime `lazyScrollError` persisted across the in-place update. Fix: add `refTarget`/`targetAction` to `checkStep`'s deps (restores the original #886 behaviour) and clear `lazyScrollError`/`postVerifyError` on `refTarget` change.
- **"Fix this" shown on sequentially-blocked steps** (`fix(ai-fix): don't offer "Fix this" on sequentially-blocked steps`). The pre-execution gate keyed on `requiresDomElement && !isEnabled`, but `requiresDomElement` is derived from the *static* `requirements` string and `!isEnabled` is also true for a "complete previous step" block. Fix: add `isEligibleForChecking` to the gate in interactive-step (Site B) + interactive-guided (Site A), matching the sibling Retry button. The runtime sites are unaffected (they need an execution attempt that can't happen while sequentially blocked).

## It lands dark

`useAiFixEnabled` is false unless an admin sets `enableAiAutoHeal` (default false) **and** the assistant is present; the orchestrator independently re-gates. Verified by grep: the only `pathfinder-ai-fix-request` producer in `src/` is `<AiFixButton>` (behind the gate), plus the orchestrator listener.

The banned multistep "auto-heal watcher" effect the RFC flagged (§5.4) **was never merged to `main`** — nothing to delete. A patch-applied content remount resets the multistep failure state, symmetric with guided (no watcher needed).

## Test plan

- `npm run typecheck` ✅ · `eslint` ✅ 0 errors (changed files) · `prettier --check` ✅ · governance/architecture ✅ (no new tier violations)
- Full frontend suite ✅ **243/243 suites, 4090 passed**
- New tests: `ai-fix-button` (4); `use-ai-fix-enabled` (3); `step-checker` `requiresDomElement` (4); **interactive-guided AI-fix gating** (2 — sequentially-blocked → no button, eligible + failing requirement → button shows)

> Note: `npm run check` is currently blocked at `lint:go` by a **pre-existing** staticcheck issue in `pkg/plugin/package_recommendations_test.go` (byte-identical on the base branch; this PR makes zero Go changes). All frontend gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
