### PR TITLE
feat(companion): add inert companion section flag

### DIFF
--- a/src/components/block-editor/forms/SectionBlockForm.tsx
+++ b/src/components/block-editor/forms/SectionBlockForm.tsx
@@ -66,6 +66,7 @@ export function SectionBlockForm({
   const [requirements, setRequirements] = useState(initial?.requirements?.join(', ') ?? '');
   const [objectives, setObjectives] = useState(initial?.objectives?.join(', ') ?? '');
   const [autoCollapse, setAutoCollapse] = useState(initial?.autoCollapse ?? true);
+  const [companion, setCompanion] = useState(initial?.companion ?? false);
 
   // Preserve nested blocks when editing (but don't display them in the form)
   const nestedBlocks = useRef<JsonBlock[]>(initial?.blocks ?? []);
@@ -90,8 +91,9 @@ export function SectionBlockForm({
       ...(reqArray.length > 0 && { requirements: reqArray }),
       ...(objArray.length > 0 && { objectives: objArray }),
       ...(autoCollapse === false && { autoCollapse: false }),
+      ...(companion === true && { companion: true }),
     };
-  }, [sectionId, title, requirements, objectives, autoCollapse]);
+  }, [sectionId, title, requirements, objectives, autoCollapse, companion]);
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -216,6 +218,18 @@ export function SectionBlockForm({
           value={autoCollapse}
           onChange={(e) => setAutoCollapse(e.currentTarget.checked)}
           data-testid={testIds.blockEditor.sectionAutoCollapseToggle}
+        />
+      </Field>
+
+      {/* Companion mode */}
+      <Field
+        label="Companion mode"
+        description="When the user reaches this section, pop the panel out beside a native Grafana modal so they can operate the dialog while reading the guide. Docks back when the section completes."
+      >
+        <Switch
+          value={companion}
+          onChange={(e) => setCompanion(e.currentTarget.checked)}
+          data-testid={testIds.blockEditor.sectionCompanionToggle}
         />
       </Field>
 

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -1053,6 +1053,7 @@ function renderParsedElement(
           hints={element.props.hints}
           id={element.props.id} // Pass the HTML id attribute
           autoCollapse={element.props.autoCollapse}
+          companion={element.props.companion}
         >
           {renderChildren(element.children)}
         </InteractiveSection>

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -232,6 +232,7 @@ export const testIds = {
     sectionTitleInput: 'block-editor-section-title-input',
     sectionIdInput: 'block-editor-section-id-input',
     sectionAutoCollapseToggle: 'block-editor-section-auto-collapse-toggle',
+    sectionCompanionToggle: 'block-editor-section-companion-toggle',
     addAndRecordButton: 'block-editor-add-and-record-button',
     // Section empty state and nested add button
     sectionEmptyState: 'block-editor-section-empty-state',

--- a/src/docs-retrieval/json-parser-terminal.test.ts
+++ b/src/docs-retrieval/json-parser-terminal.test.ts
@@ -157,4 +157,61 @@ describe('json-parser terminal block', () => {
     expect(sectionEl).toBeDefined();
     expect(sectionEl!.props.autoCollapse).toBeUndefined();
   });
+
+  it('passes companion property to section block', () => {
+    const guide = JSON.stringify({
+      id: 'test-section-companion',
+      title: 'Section with companion',
+      blocks: [
+        {
+          type: 'section',
+          id: 'companion-section',
+          title: 'Beside the modal',
+          companion: true,
+          blocks: [
+            {
+              type: 'terminal',
+              command: 'echo test',
+              content: 'Test command',
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parseJsonGuide(guide);
+    expect(result.isValid).toBe(true);
+
+    const sectionEl = result.data!.elements.find((el) => el.type === 'interactive-section');
+    expect(sectionEl).toBeDefined();
+    expect(sectionEl!.props.companion).toBe(true);
+  });
+
+  it('defaults companion to undefined when not specified', () => {
+    const guide = JSON.stringify({
+      id: 'test-section-companion-default',
+      title: 'Section without companion',
+      blocks: [
+        {
+          type: 'section',
+          id: 'default-companion-section',
+          title: 'Default behavior',
+          blocks: [
+            {
+              type: 'terminal',
+              command: 'echo test',
+              content: 'Test command',
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = parseJsonGuide(guide);
+    expect(result.isValid).toBe(true);
+
+    const sectionEl = result.data!.elements.find((el) => el.type === 'interactive-section');
+    expect(sectionEl).toBeDefined();
+    expect(sectionEl!.props.companion).toBeUndefined();
+  });
 });

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -536,6 +536,7 @@ function convertSectionBlock(block: JsonSectionBlock, path: string, baseUrl?: st
         requirements,
         objectives,
         autoCollapse: block.autoCollapse,
+        companion: block.companion,
       },
       children,
     },

--- a/src/types/component-props.types.ts
+++ b/src/types/component-props.types.ts
@@ -72,6 +72,7 @@ export interface InteractiveSectionProps extends BaseInteractiveProps {
   id?: string; // HTML id attribute for section identification
   skippable?: boolean; // Whether this section can be skipped if requirements fail
   autoCollapse?: boolean; // Whether to auto-collapse on completion (default: true, can be overridden by user preference)
+  companion?: boolean;
 }
 
 /**

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -776,6 +776,10 @@ const SectionProps = {
   requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions'),
   objectives: z.array(z.string()).optional().describe('Learning objectives this section addresses'),
   autoCollapse: z.boolean().optional().describe('Collapse the section after the user completes its contents'),
+  companion: z
+    .boolean()
+    .optional()
+    .describe('Pop the panel out beside a native Grafana modal while this section is active; docks back on completion'),
 };
 
 const AssistantProps = {
@@ -1040,7 +1044,17 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'completeEarly',
     'authorNote',
   ]),
-  section: new Set(['type', 'id', 'title', 'blocks', 'requirements', 'objectives', 'autoCollapse', 'authorNote']),
+  section: new Set([
+    'type',
+    'id',
+    'title',
+    'blocks',
+    'requirements',
+    'objectives',
+    'autoCollapse',
+    'companion',
+    'authorNote',
+  ]),
   conditional: new Set([
     'type',
     'id',

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -183,6 +183,7 @@ export interface JsonSectionBlock extends AuthorAnnotated {
   objectives?: string[];
   /** Whether to auto-collapse this section on completion. Defaults to true. */
   autoCollapse?: boolean;
+  companion?: boolean;
 }
 
 // ============ CONDITIONAL BLOCK ============


### PR DESCRIPTION
Adds an authored `companion?: boolean` flag to section blocks, threaded
through type -> zod schema (+ KNOWN_FIELDS canary) -> parser -> component
props -> content renderer -> block-editor section form (+ test-id).

Inert: nothing consumes it yet. The runtime controller (auto pop-out beside
native modals, dock-back, modal-aware positioning) lands in later layers of
this stack. First layer of the companion-mode stack.
