### PR TITLE
feat(companion): add modal-watcher + extend useHighlightDodge to dodge native modals

### DIFF
--- a/src/components/floating-panel/FloatingPanel.tsx
+++ b/src/components/floating-panel/FloatingPanel.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { IconButton, useStyles2, getPortalContainer } from '@grafana/ui';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
 import { buildPathfinderShareUrl } from '../../utils/pathfinder-search-params';
+import { startModalWatch, stopModalWatch } from '../../interactive-engine';
 import { getFloatingPanelStyles } from './floating-panel.styles';
 import { useDragResize } from './useDragResize';
 import { useHighlightDodge } from './useHighlightDodge';
@@ -61,8 +62,13 @@ export function FloatingPanel({
   const [isDodging, setIsDodging] = useState(false);
   const { geometry, setPosition, drag, resize } = useDragResize();
 
-  // Auto-reposition when interactive highlights overlap the panel
-  useHighlightDodge(geometry, panelState === 'minimized');
+  // Auto-reposition to dodge interactive highlights and any open native modal
+  useHighlightDodge(geometry, panelState === 'minimized', true);
+
+  useEffect(() => {
+    startModalWatch();
+    return () => stopModalWatch();
+  }, []);
 
   const handleMinimize = useCallback(() => {
     setPanelState('minimized');

--- a/src/components/floating-panel/useHighlightDodge.test.ts
+++ b/src/components/floating-panel/useHighlightDodge.test.ts
@@ -1,0 +1,87 @@
+import { renderHook } from '@testing-library/react';
+
+import { useHighlightDodge } from './useHighlightDodge';
+
+const GEOMETRY = { x: 50, y: 50, width: 400, height: 400 };
+
+function mockRect(el: HTMLElement, left: number, top: number, width: number, height: number) {
+  el.getBoundingClientRect = () =>
+    ({
+      left,
+      top,
+      right: left + width,
+      bottom: top + height,
+      width,
+      height,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
+
+function addModal(left: number, top: number, width: number, height: number, attrs: Record<string, string> = {}) {
+  const el = document.createElement('div');
+  el.setAttribute('role', 'dialog');
+  el.style.opacity = '1';
+  Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+  document.body.appendChild(el);
+  mockRect(el, left, top, width, height);
+  return el;
+}
+
+function captureEvents() {
+  const events: string[] = [];
+  const dodge = () => events.push('dodge');
+  const compact = () => events.push('compact');
+  document.addEventListener('pathfinder-floating-dodge', dodge);
+  document.addEventListener('pathfinder-floating-compact', compact);
+  return {
+    events,
+    cleanup: () => {
+      document.removeEventListener('pathfinder-floating-dodge', dodge);
+      document.removeEventListener('pathfinder-floating-compact', compact);
+    },
+  };
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+  Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true });
+  document.body.innerHTML = '';
+});
+
+describe('useHighlightDodge — modal dodging', () => {
+  it('dodges to a clear corner when a modal overlaps the panel (dodgeModal=true)', () => {
+    addModal(0, 0, 300, 300); // top-left modal, overlaps the panel at 50,50
+    const cap = captureEvents();
+    renderHook(() => useHighlightDodge(GEOMETRY, false, true));
+    expect(cap.events).toContain('dodge');
+    expect(cap.events).not.toContain('compact');
+    cap.cleanup();
+  });
+
+  it('compacts when a full-viewport modal leaves no clear corner', () => {
+    addModal(0, 0, 1280, 800); // covers everything
+    const cap = captureEvents();
+    renderHook(() => useHighlightDodge(GEOMETRY, false, true));
+    expect(cap.events).toContain('compact');
+    expect(cap.events).not.toContain('dodge');
+    cap.cleanup();
+  });
+
+  it('excludes the Pathfinder panel itself from modal dodging', () => {
+    addModal(0, 0, 300, 300, { 'data-pathfinder-content': 'true' });
+    const cap = captureEvents();
+    renderHook(() => useHighlightDodge(GEOMETRY, false, true));
+    expect(cap.events).toEqual([]);
+    cap.cleanup();
+  });
+
+  it('ignores modals entirely when dodgeModal=false (regression of base behavior)', () => {
+    addModal(0, 0, 300, 300); // overlaps the panel, but dodgeModal is off
+    const cap = captureEvents();
+    renderHook(() => useHighlightDodge(GEOMETRY, false, false));
+    expect(cap.events).toEqual([]);
+    cap.cleanup();
+  });
+});

--- a/src/components/floating-panel/useHighlightDodge.ts
+++ b/src/components/floating-panel/useHighlightDodge.ts
@@ -64,6 +64,40 @@ function findDodgePosition(
   return null;
 }
 
+function toRect(r: DOMRect): Rect {
+  return { left: r.left, top: r.top, right: r.right, bottom: r.bottom, width: r.width, height: r.height };
+}
+
+function unionOfRects(rects: Rect[]): Rect {
+  const left = Math.min(...rects.map((r) => r.left));
+  const top = Math.min(...rects.map((r) => r.top));
+  const right = Math.max(...rects.map((r) => r.right));
+  const bottom = Math.max(...rects.map((r) => r.bottom));
+  return { left, top, right, bottom, width: right - left, height: bottom - top };
+}
+
+/** Largest visible native modal rect, excluding Pathfinder's own floating panel. */
+function largestVisibleModalRect(): Rect | null {
+  let best: Rect | null = null;
+  let bestArea = 0;
+  for (const el of Array.from(document.querySelectorAll('[role="dialog"], [aria-modal="true"]'))) {
+    if (el.closest('[data-pathfinder-content="true"]')) {
+      continue;
+    }
+    const style = window.getComputedStyle(el);
+    if (style.display === 'none' || style.visibility === 'hidden' || parseFloat(style.opacity) === 0) {
+      continue;
+    }
+    const r = el.getBoundingClientRect();
+    const area = r.width * r.height;
+    if (area > bestArea) {
+      bestArea = area;
+      best = toRect(r);
+    }
+  }
+  return best;
+}
+
 /**
  * Hook that watches for interactive highlight overlays and auto-repositions
  * the floating panel to avoid overlapping them.
@@ -72,13 +106,15 @@ function findDodgePosition(
  * are added/removed. Geometry is read from a ref so the observer doesn't
  * need to be recreated when the panel moves.
  */
-export function useHighlightDodge(geometry: FloatingPanelGeometry, isMinimized: boolean) {
+export function useHighlightDodge(geometry: FloatingPanelGeometry, isMinimized: boolean, dodgeModal = false) {
   const previousPositionRef = useRef<{ x: number; y: number } | null>(null);
   // Store geometry in a ref so the observer callback always reads current values
   // without the effect needing to depend on geometry (which changes during drag)
   const geometryRef = useRef(geometry);
+  const dodgeModalRef = useRef(dodgeModal);
   useLayoutEffect(() => {
     geometryRef.current = geometry;
+    dodgeModalRef.current = dodgeModal;
   });
 
   useEffect(() => {
@@ -88,8 +124,16 @@ export function useHighlightDodge(geometry: FloatingPanelGeometry, isMinimized: 
 
     const checkAndDodge = () => {
       const geo = geometryRef.current;
-      const highlights = document.querySelectorAll(HIGHLIGHT_SELECTOR);
-      if (highlights.length === 0) {
+      const obstacles: Rect[] = Array.from(document.querySelectorAll(HIGHLIGHT_SELECTOR)).map((el) =>
+        toRect(el.getBoundingClientRect())
+      );
+      if (dodgeModalRef.current) {
+        const modalRect = largestVisibleModalRect();
+        if (modalRect) {
+          obstacles.push(modalRect);
+        }
+      }
+      if (obstacles.length === 0) {
         if (previousPositionRef.current) {
           document.dispatchEvent(
             new CustomEvent('pathfinder-floating-restore-position', {
@@ -102,32 +146,7 @@ export function useHighlightDodge(geometry: FloatingPanelGeometry, isMinimized: 
         return;
       }
 
-      const highlightArray = Array.from(highlights);
-      const rects = highlightArray.map((el) => el.getBoundingClientRect());
-      const firstRect = rects[0];
-      if (!firstRect) {
-        return;
-      }
-      const union: Rect = {
-        left: firstRect.left,
-        top: firstRect.top,
-        right: firstRect.right,
-        bottom: firstRect.bottom,
-        width: firstRect.width,
-        height: firstRect.height,
-      };
-      for (let i = 1; i < rects.length; i++) {
-        const r = rects[i];
-        if (!r) {
-          continue;
-        }
-        union.left = Math.min(union.left, r.left);
-        union.top = Math.min(union.top, r.top);
-        union.right = Math.max(union.right, r.right);
-        union.bottom = Math.max(union.bottom, r.bottom);
-      }
-      union.width = union.right - union.left;
-      union.height = union.bottom - union.top;
+      const union = unionOfRects(obstacles);
 
       const panelRect: Rect = {
         left: geo.x,
@@ -185,11 +204,15 @@ export function useHighlightDodge(geometry: FloatingPanelGeometry, isMinimized: 
       }
     });
 
+    const handleModalStateChange = () => requestAnimationFrame(checkAndDodge);
+
     observer.observe(document.body, { childList: true, subtree: true });
+    document.addEventListener('pathfinder-modal-state-changed', handleModalStateChange);
     checkAndDodge();
 
     return () => {
       observer.disconnect();
+      document.removeEventListener('pathfinder-modal-state-changed', handleModalStateChange);
       previousPositionRef.current = null;
     };
   }, [isMinimized]); // Stable deps — geometry read from ref

--- a/src/interactive-engine/global-interaction-blocker.ts
+++ b/src/interactive-engine/global-interaction-blocker.ts
@@ -2,6 +2,7 @@ import { InteractiveElementData } from '../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import { INTERACTIVE_Z_INDEX } from '../constants/interactive-z-index';
 import { TimeoutManager } from '../utils/timeout-manager';
+import { detectModalActive } from './modal-watcher';
 
 /**
  * Global interaction blocking state (singleton pattern)
@@ -662,34 +663,7 @@ class GlobalInteractionBlocker {
    * Simple modal detection - if any modal/dialog is active, use full-screen blocking
    */
   private isModalActive(): boolean {
-    // 1. Detect our own image modal (we control this)
-    const ourModal = document.querySelector('.journey-image-modal');
-    if (ourModal) {
-      const style = window.getComputedStyle(ourModal);
-      if (style.display !== 'none' && style.visibility !== 'hidden' && parseFloat(style.opacity) > 0) {
-        return true;
-      }
-    }
-
-    // 2. Detect any ARIA dialogs (role="dialog" OR aria-modal="true")
-    const ariaDialogs = document.querySelectorAll('[role="dialog"], [aria-modal="true"]');
-    for (const dialog of ariaDialogs) {
-      const style = window.getComputedStyle(dialog);
-      if (style.display !== 'none' && style.visibility !== 'hidden' && parseFloat(style.opacity) > 0) {
-        return true;
-      }
-    }
-
-    // 3. Check for overlay containers (common modal pattern)
-    const overlayContainers = document.querySelectorAll('[data-overlay-container="true"]');
-    for (const container of overlayContainers) {
-      const style = window.getComputedStyle(container);
-      if (style.display !== 'none' && style.visibility !== 'hidden' && parseFloat(style.opacity) > 0) {
-        return true;
-      }
-    }
-
-    return false;
+    return detectModalActive();
   }
 
   /**

--- a/src/interactive-engine/index.ts
+++ b/src/interactive-engine/index.ts
@@ -69,3 +69,6 @@ export type {
   FormValidationResult,
   UseFormValidationOptions,
 } from './auto-completion';
+
+// Modal detection + watcher (companion mode)
+export { detectModalActive, startModalWatch, stopModalWatch } from './modal-watcher';

--- a/src/interactive-engine/modal-watcher.test.ts
+++ b/src/interactive-engine/modal-watcher.test.ts
@@ -1,0 +1,109 @@
+import { detectModalActive, startModalWatch, stopModalWatch } from './modal-watcher';
+
+function addDialog(attrs: Record<string, string> = {}, opacity = '1'): HTMLElement {
+  const el = document.createElement('div');
+  el.setAttribute('role', 'dialog');
+  el.style.opacity = opacity;
+  Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  // Drain the refcounted watcher back to zero regardless of what a test left.
+  for (let i = 0; i < 5; i++) {
+    stopModalWatch();
+  }
+  document.body.innerHTML = '';
+});
+
+describe('detectModalActive', () => {
+  it('returns true for a visible role="dialog"', () => {
+    addDialog();
+    expect(detectModalActive()).toBe(true);
+  });
+
+  it('returns true for [aria-modal="true"] and [data-overlay-container="true"]', () => {
+    const m = document.createElement('div');
+    m.setAttribute('aria-modal', 'true');
+    m.style.opacity = '1';
+    document.body.appendChild(m);
+    expect(detectModalActive()).toBe(true);
+
+    document.body.innerHTML = '';
+    const o = document.createElement('div');
+    o.setAttribute('data-overlay-container', 'true');
+    o.style.opacity = '1';
+    document.body.appendChild(o);
+    expect(detectModalActive()).toBe(true);
+  });
+
+  it('excludes the Pathfinder floating panel (role="dialog" + data-pathfinder-content)', () => {
+    addDialog({ 'data-pathfinder-content': 'true' });
+    expect(detectModalActive()).toBe(false);
+  });
+
+  it('excludes dialogs nested inside the Pathfinder panel', () => {
+    const panel = document.createElement('div');
+    panel.setAttribute('data-pathfinder-content', 'true');
+    const nested = document.createElement('div');
+    nested.setAttribute('role', 'dialog');
+    nested.style.opacity = '1';
+    panel.appendChild(nested);
+    document.body.appendChild(panel);
+    expect(detectModalActive()).toBe(false);
+  });
+
+  it('ignores hidden dialogs (display/visibility/opacity)', () => {
+    const d = addDialog();
+    d.style.display = 'none';
+    expect(detectModalActive()).toBe(false);
+    d.style.display = '';
+    d.style.visibility = 'hidden';
+    expect(detectModalActive()).toBe(false);
+    d.style.visibility = '';
+    d.style.opacity = '0';
+    expect(detectModalActive()).toBe(false);
+  });
+
+  it('returns false with no modal present', () => {
+    expect(detectModalActive()).toBe(false);
+  });
+});
+
+describe('startModalWatch / stopModalWatch', () => {
+  const flush = () => new Promise((r) => setTimeout(r, 5));
+
+  it('emits pathfinder-modal-state-changed when a modal opens and closes', async () => {
+    const events: boolean[] = [];
+    const handler = (e: Event) => events.push((e as CustomEvent).detail.isOpen);
+    document.addEventListener('pathfinder-modal-state-changed', handler);
+
+    startModalWatch();
+    const dialog = addDialog();
+    await flush();
+    expect(events).toContain(true);
+
+    dialog.remove();
+    await flush();
+    expect(events).toContain(false);
+
+    document.removeEventListener('pathfinder-modal-state-changed', handler);
+  });
+
+  it('is refcounted — one stop does not tear down while another caller is active', async () => {
+    const events: boolean[] = [];
+    const handler = (e: Event) => events.push((e as CustomEvent).detail.isOpen);
+    document.addEventListener('pathfinder-modal-state-changed', handler);
+
+    startModalWatch();
+    startModalWatch();
+    stopModalWatch(); // one of two — still watching
+
+    addDialog();
+    await flush();
+    expect(events).toContain(true);
+
+    document.removeEventListener('pathfinder-modal-state-changed', handler);
+  });
+});

--- a/src/interactive-engine/modal-watcher.ts
+++ b/src/interactive-engine/modal-watcher.ts
@@ -1,0 +1,89 @@
+const PATHFINDER_PANEL_SELECTOR = '[data-pathfinder-content="true"]';
+const POLL_INTERVAL_MS = 1000;
+
+function isVisible(el: Element): boolean {
+  const style = window.getComputedStyle(el);
+  return style.display !== 'none' && style.visibility !== 'hidden' && parseFloat(style.opacity) > 0;
+}
+
+export function detectModalActive(): boolean {
+  const ourImageModal = document.querySelector('.journey-image-modal');
+  if (ourImageModal && isVisible(ourImageModal)) {
+    return true;
+  }
+
+  const candidates = document.querySelectorAll('[role="dialog"], [aria-modal="true"], [data-overlay-container="true"]');
+  for (const el of Array.from(candidates)) {
+    // Pathfinder's own floating panel is a role="dialog" but is not a native modal.
+    if (el.closest(PATHFINDER_PANEL_SELECTOR)) {
+      continue;
+    }
+    if (isVisible(el)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+let watchCount = 0;
+let observer: MutationObserver | null = null;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let checkPending = false;
+let lastState = false;
+
+function emit(isOpen: boolean): void {
+  document.dispatchEvent(new CustomEvent('pathfinder-modal-state-changed', { detail: { isOpen } }));
+}
+
+function check(): void {
+  const next = detectModalActive();
+  if (next !== lastState) {
+    lastState = next;
+    emit(next);
+  }
+}
+
+function scheduleCheck(): void {
+  if (checkPending) {
+    return;
+  }
+  checkPending = true;
+  // Coalesce bursts of mutations into a single check on the next tick.
+  setTimeout(() => {
+    checkPending = false;
+    check();
+  }, 0);
+}
+
+export function startModalWatch(): void {
+  watchCount += 1;
+  if (watchCount > 1) {
+    return;
+  }
+  lastState = detectModalActive();
+  observer = new MutationObserver(scheduleCheck);
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['class', 'style', 'role', 'aria-hidden', 'aria-modal', 'data-overlay-container'],
+  });
+  pollTimer = setInterval(check, POLL_INTERVAL_MS);
+}
+
+export function stopModalWatch(): void {
+  if (watchCount === 0) {
+    return;
+  }
+  watchCount -= 1;
+  if (watchCount > 0) {
+    return;
+  }
+  observer?.disconnect();
+  observer = null;
+  if (pollTimer !== null) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}


### PR DESCRIPTION
Add src/interactive-engine/modal-watcher.ts: detectModalActive() (shared modal
detection that excludes Pathfinder's own floating panel, which is a role=dialog)
plus refcounted startModalWatch/stopModalWatch that emit pathfinder-modal-state-changed.
GlobalInteractionBlocker.isModalActive now delegates to detectModalActive (single
source; also fixes the panel self-trigger).

Extend useHighlightDodge with a dodgeModal flag: when set, the largest visible
native modal rect is folded into the dodge union and a re-check runs on
pathfinder-modal-state-changed, so the floating panel repositions beside the
modal (or compacts when no corner is clear). Dormant until a consumer passes
dodgeModal / emits pathfinder-companion-armed (the controller, next layer).

Third layer of the companion-mode stack.