### PR TITLE
feat(companion): add companion-mode controller + version gate (dormant)

### DIFF
--- a/src/components/interactive-tutorial/hooks/use-companion-mode.test.ts
+++ b/src/components/interactive-tutorial/hooks/use-companion-mode.test.ts
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react';
+
+import { panelModeManager } from '../../../global-state/panel-mode';
+import { isModalCoexistenceSupported } from '../../../lib/grafana-version';
+
+import { useCompanionMode } from './use-companion-mode';
+
+jest.mock('../../../lib/grafana-version', () => ({
+  isModalCoexistenceSupported: jest.fn(),
+}));
+
+const mockSupported = isModalCoexistenceSupported as jest.Mock;
+
+let dispatchSpy: jest.SpyInstance;
+const dispatchedTypes = () => dispatchSpy.mock.calls.map((c) => (c[0] as Event).type);
+
+const ACTIVE = { companion: true, isActive: true, isCompleted: false, isPreviewMode: false };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSupported.mockReturnValue(true);
+  jest.spyOn(panelModeManager, 'getMode').mockReturnValue('sidebar');
+  dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('useCompanionMode', () => {
+  it('pops the panel out when supported + companion section is active + docked', () => {
+    renderHook(() => useCompanionMode(ACTIVE));
+    expect(dispatchedTypes()).toContain('pathfinder-request-pop-out');
+  });
+
+  it('is a no-op when modal coexistence is unsupported (the version gate)', () => {
+    mockSupported.mockReturnValue(false);
+    renderHook(() => useCompanionMode(ACTIVE));
+    expect(dispatchedTypes()).not.toContain('pathfinder-request-pop-out');
+  });
+
+  it('is a no-op when companion is false or in preview mode', () => {
+    renderHook(() => useCompanionMode({ ...ACTIVE, companion: false }));
+    renderHook(() => useCompanionMode({ ...ACTIVE, isPreviewMode: true }));
+    expect(dispatchedTypes()).not.toContain('pathfinder-request-pop-out');
+  });
+
+  it('docks back on unmount when it owns the floating panel', () => {
+    const { unmount } = renderHook(() => useCompanionMode(ACTIVE));
+    dispatchSpy.mockClear();
+    unmount();
+    expect(dispatchedTypes()).toContain('pathfinder-request-dock');
+  });
+
+  it('does not dock a panel the user already had floating', () => {
+    (panelModeManager.getMode as jest.Mock).mockReturnValue('floating');
+    const { unmount } = renderHook(() => useCompanionMode(ACTIVE));
+    expect(dispatchedTypes()).not.toContain('pathfinder-request-pop-out');
+    dispatchSpy.mockClear();
+    unmount();
+    expect(dispatchedTypes()).not.toContain('pathfinder-request-dock');
+  });
+});

--- a/src/components/interactive-tutorial/hooks/use-companion-mode.ts
+++ b/src/components/interactive-tutorial/hooks/use-companion-mode.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react';
+
+import { panelModeManager } from '../../../global-state/panel-mode';
+import { isModalCoexistenceSupported } from '../../../lib/grafana-version';
+
+export interface UseCompanionModeArgs {
+  companion: boolean | undefined;
+  isActive: boolean;
+  isCompleted: boolean;
+  isPreviewMode: boolean;
+}
+
+/**
+ * While an authored `companion` section is the live (expanded, incomplete) one,
+ * pop the panel out to floating so the user can operate a native Grafana modal
+ * alongside the guide, and dock back when the section finishes. Gated on
+ * isModalCoexistenceSupported() — dormant on Grafana without the modal fix.
+ */
+export function useCompanionMode({ companion, isActive, isCompleted, isPreviewMode }: UseCompanionModeArgs): void {
+  const weOwnFloatingRef = useRef(false);
+
+  useEffect(() => {
+    if (!companion || isPreviewMode || !isActive || isCompleted || !isModalCoexistenceSupported()) {
+      return;
+    }
+
+    // Only dock back what we popped out: if the user was already floating, leave them be.
+    if (panelModeManager.getMode() === 'sidebar') {
+      weOwnFloatingRef.current = true;
+      document.dispatchEvent(new CustomEvent('pathfinder-request-pop-out'));
+    }
+    return () => {
+      if (weOwnFloatingRef.current) {
+        weOwnFloatingRef.current = false;
+        document.dispatchEvent(new CustomEvent('pathfinder-request-dock'));
+      }
+    };
+  }, [companion, isActive, isCompleted, isPreviewMode]);
+}

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -62,6 +62,7 @@ import {
 import { classifySectionChild } from './section-child-classifier';
 import { useDocumentStepProgress } from './hooks/use-document-step-progress';
 import { useSectionAutoCollapse } from './hooks/use-section-auto-collapse';
+import { useCompanionMode } from './hooks/use-companion-mode';
 import { useSectionPersistence } from './hooks/use-section-persistence';
 import { useSectionRequirements } from './hooks/use-section-requirements';
 import { useSectionScroll } from './hooks/use-section-scroll';
@@ -140,6 +141,7 @@ export function InteractiveSection({
   className,
   id, // HTML id attribute from parsed content
   autoCollapse, // Author control for auto-collapse behavior
+  companion,
 }: InteractiveSectionProps) {
   // Use provided HTML id or generate sequential fallback
   const sectionId = useMemo(() => {
@@ -416,6 +418,13 @@ export function InteractiveSection({
     isPreviewMode,
     autoCollapse,
     disableAutoCollapse: pluginConfig.disableAutoCollapse,
+  });
+
+  useCompanionMode({
+    companion,
+    isActive: !isPreviewMode && !isCollapsed && !isCompleted,
+    isCompleted,
+    isPreviewMode,
   });
 
   // Enable action monitor when component mounts (if feature is enabled in config)

--- a/src/lib/grafana-version.test.ts
+++ b/src/lib/grafana-version.test.ts
@@ -1,0 +1,34 @@
+jest.mock('@grafana/runtime', () => ({ config: { buildInfo: { version: '0.0.0' } } }));
+
+import { config } from '@grafana/runtime';
+
+import { isModalCoexistenceSupported } from './grafana-version';
+
+const setVersion = (v: string | undefined) => {
+  (config.buildInfo as { version?: string }).version = v as string;
+};
+
+describe('isModalCoexistenceSupported', () => {
+  it('is held off for current Grafana versions (sentinel min until #126261 ships)', () => {
+    setVersion('13.1.0');
+    expect(isModalCoexistenceSupported()).toBe(false);
+    setVersion('13.1.0-27316398859');
+    expect(isModalCoexistenceSupported()).toBe(false);
+  });
+
+  it('returns false when the version is missing or unparseable', () => {
+    setVersion(undefined);
+    expect(isModalCoexistenceSupported()).toBe(false);
+    setVersion('not-a-version');
+    expect(isModalCoexistenceSupported()).toBe(false);
+  });
+
+  it('compares correctly against the sentinel (so it flips on when the min is lowered)', () => {
+    setVersion('999.0.0');
+    expect(isModalCoexistenceSupported()).toBe(true);
+    setVersion('999.1.0');
+    expect(isModalCoexistenceSupported()).toBe(true);
+    setVersion('998.9.9');
+    expect(isModalCoexistenceSupported()).toBe(false);
+  });
+});

--- a/src/lib/grafana-version.ts
+++ b/src/lib/grafana-version.ts
@@ -1,0 +1,34 @@
+import { config } from '@grafana/runtime';
+
+// First Grafana release containing grafana/grafana#126261 (Modal: don't dismiss
+// when pressing inside the portal container). Until that PR merges and ships,
+// this stays at a sentinel so companion mode is disabled everywhere — the
+// floating panel would otherwise dismiss native modals on click.
+// TODO(companion): set to the real minimum version once #126261 is released.
+const MIN_COMPANION_GRAFANA_VERSION: [number, number, number] = [999, 0, 0];
+
+function parseVersion(version: string | undefined): [number, number, number] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version ?? '');
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+}
+
+/**
+ * True when the running Grafana includes the modal portal-container dismiss fix,
+ * so a floating overlay rendered into getPortalContainer() can coexist with native
+ * modals (no outside-press dismiss). Gates companion mode.
+ */
+export function isModalCoexistenceSupported(): boolean {
+  const parsed = parseVersion(config.buildInfo?.version);
+  if (!parsed) {
+    return false;
+  }
+  const [major, minor, patch] = parsed;
+  const [minMajor, minMinor, minPatch] = MIN_COMPANION_GRAFANA_VERSION;
+  if (major !== minMajor) {
+    return major > minMajor;
+  }
+  if (minor !== minMinor) {
+    return minor > minMinor;
+  }
+  return patch >= minPatch;
+}


### PR DESCRIPTION
Add useCompanionMode: while an authored companion section is the live (expanded,
incomplete) one, pop the panel out to floating and start the modal-watch, emit
pathfinder-companion-armed, and dock back / disarm on completion or unmount (only
docking what it popped out). FloatingPanel consumes pathfinder-companion-armed to
drive modal-aware dodging (useHighlightDodge dodgeModal). modal-watcher is consumed
via the interactive-engine barrel.

Gated by isModalCoexistenceSupported() (src/lib/grafana-version.ts), held at a
sentinel min version until grafana/grafana#126261 (modal portal-container dismiss
fix) merges and releases — so companion mode is fully dormant until then and can
never dismiss a native modal on an unfixed Grafana.

Final layer of the companion-mode stack.