### PR TITLE
refactor(cli): address five tech debt findings in validate and build-graph

### DIFF
--- a/src/cli/__tests__/validate-stdin.test.ts
+++ b/src/cli/__tests__/validate-stdin.test.ts
@@ -143,6 +143,18 @@ describe('validate --stdin', () => {
       expect(Object.keys(parsed).sort()).toEqual(['errors', 'isValid', 'warnings']);
     });
 
+    it('honors --format json placed before the subcommand (global position)', () => {
+      const input = JSON.stringify({
+        id: 'json-guide',
+        title: 'JSON guide',
+        blocks: [{ type: 'markdown', content: '# Hello' }],
+      });
+      const stdout = runCli(['--format', 'json', 'validate', '--stdin'], input);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.isValid).toBe(true);
+      expect(Object.keys(parsed).sort()).toEqual(['errors', 'isValid', 'warnings']);
+    });
+
     it('emits JSON for an auto-detected package directory', () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'validate-json-package-'));
       try {

--- a/src/cli/__tests__/validator-parity.test.ts
+++ b/src/cli/__tests__/validator-parity.test.ts
@@ -29,7 +29,9 @@ function listPackages(): Array<{ name: string; dir: string }> {
     .readdirSync(BUNDLED_DIR, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => ({ name: entry.name, dir: path.join(BUNDLED_DIR, entry.name) }))
-    .filter(({ dir }) => fs.existsSync(path.join(dir, 'content.json')) && fs.existsSync(path.join(dir, 'manifest.json')));
+    .filter(
+      ({ dir }) => fs.existsSync(path.join(dir, 'content.json')) && fs.existsSync(path.join(dir, 'manifest.json'))
+    );
 }
 
 describe('validator parity on bundled corpus', () => {

--- a/src/cli/__tests__/validator-parity.test.ts
+++ b/src/cli/__tests__/validator-parity.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Validator parity test.
+ *
+ * The CLI has two validation surfaces that overlap by design:
+ *  - `validatePackage(dir)` (src/validation/validate-package.ts) — disk
+ *    validator used by the CLI `validate` command. Adds asset-reference and
+ *    testEnvironment checks the in-memory variant doesn't perform.
+ *  - `validatePackageState(content, manifest)` (src/cli/utils/package-io/
+ *    state-validation.ts) — in-memory validator that every authoring write
+ *    and the MCP `pathfinder_validate` tool route through.
+ *
+ * The team accepts that these have different scopes. What this test pins is
+ * the overlap: on the bundled corpus, the two validators must agree on the
+ * top-level validity verdict and on id mismatches. If one starts rejecting a
+ * package the other accepts, this fails and forces a deliberate decision.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { ContentJson, ManifestJson } from '../../types/package.types';
+import { validatePackage } from '../../validation/validate-package';
+import { validatePackageState } from '../utils/package-io';
+
+const BUNDLED_DIR = path.resolve(__dirname, '../../bundled-interactives');
+
+function listPackages(): Array<{ name: string; dir: string }> {
+  return fs
+    .readdirSync(BUNDLED_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({ name: entry.name, dir: path.join(BUNDLED_DIR, entry.name) }))
+    .filter(({ dir }) => fs.existsSync(path.join(dir, 'content.json')) && fs.existsSync(path.join(dir, 'manifest.json')));
+}
+
+describe('validator parity on bundled corpus', () => {
+  const packages = listPackages();
+
+  it('finds at least one bundled package to compare against', () => {
+    expect(packages.length).toBeGreaterThan(0);
+  });
+
+  for (const { name, dir } of packages) {
+    describe(name, () => {
+      const diskResult = validatePackage(dir);
+      const content = JSON.parse(fs.readFileSync(path.join(dir, 'content.json'), 'utf-8')) as ContentJson;
+      const manifest = JSON.parse(fs.readFileSync(path.join(dir, 'manifest.json'), 'utf-8')) as ManifestJson;
+      const stateOutcome = validatePackageState(content, manifest);
+
+      it('disk validator and in-memory validator agree on top-level validity', () => {
+        expect(stateOutcome.ok).toBe(diskResult.isValid);
+      });
+
+      it('both validators agree on id mismatch detection', () => {
+        const diskHasIdMismatch = diskResult.errors.some((e) => e.code === 'id_mismatch');
+        const stateHasIdMismatch = stateOutcome.issues.some((i) => i.code === 'ID_MISMATCH');
+        expect(stateHasIdMismatch).toBe(diskHasIdMismatch);
+      });
+    });
+  }
+});
+
+describe('validator parity — synthetic divergence cases', () => {
+  it('both reject a package whose manifest id differs from content id', () => {
+    const content: ContentJson = {
+      id: 'real-id',
+      title: 'Test',
+      blocks: [{ type: 'markdown', content: '# Hello' }],
+    } as ContentJson;
+    const manifest = {
+      id: 'wrong-id',
+      type: 'guide',
+      description: 'd',
+      category: 'c',
+      targeting: { match: { urlPrefix: '/' } },
+    } as ManifestJson;
+
+    const stateOutcome = validatePackageState(content, manifest);
+    expect(stateOutcome.ok).toBe(false);
+    expect(stateOutcome.issues.some((i) => i.code === 'ID_MISMATCH')).toBe(true);
+
+    // Mirror on disk for the disk validator.
+    const tmpDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'parity-mismatch-'));
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'content.json'), JSON.stringify(content));
+      fs.writeFileSync(path.join(tmpDir, 'manifest.json'), JSON.stringify(manifest));
+      const diskResult = validatePackage(tmpDir);
+      expect(diskResult.isValid).toBe(false);
+      expect(diskResult.errors.some((e) => e.code === 'id_mismatch')).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/commands/build-graph.ts
+++ b/src/cli/commands/build-graph.ts
@@ -12,7 +12,6 @@
 
 import { Command } from 'commander';
 import * as fs from 'fs';
-import * as path from 'path';
 
 import type {
   DependencyGraph,
@@ -25,6 +24,7 @@ import type {
 } from '../../types/package.types';
 import { RepositoryJsonSchema } from '../../types/package.schema';
 import { readJsonFile } from '../../validation/package-io';
+import { resolveCliPath } from '../utils/file-loader';
 
 interface BuildGraphOptions {
   output?: string;
@@ -372,8 +372,7 @@ export const buildGraphCommand = new Command('build-graph')
       }
       const name = entry.slice(0, colonIndex);
       const repoPath = entry.slice(colonIndex + 1);
-      const absolutePath = path.isAbsolute(repoPath) ? repoPath : path.resolve(process.cwd(), repoPath);
-      return { name, path: absolutePath };
+      return { name, path: resolveCliPath(repoPath) };
     });
 
     const { graph, lintMessages, errors } = buildGraph(repoPaths);
@@ -398,7 +397,7 @@ export const buildGraphCommand = new Command('build-graph')
     const json = JSON.stringify(graph, null, 2);
 
     if (options.output) {
-      const outputPath = path.isAbsolute(options.output) ? options.output : path.resolve(process.cwd(), options.output);
+      const outputPath = resolveCliPath(options.output);
       fs.writeFileSync(outputPath, json + '\n', 'utf-8');
       console.error(
         `✅ Wrote graph to ${outputPath} (${graph.metadata.nodeCount} nodes, ${graph.metadata.edgeCount} edges)`

--- a/src/cli/commands/build-repository.ts
+++ b/src/cli/commands/build-repository.ts
@@ -17,6 +17,7 @@ import type { RepositoryEntry, RepositoryJson } from '../../types/package.types'
 // refinement (ManifestJsonSchema) for strict correctness checking.
 import { ContentJsonSchema, ManifestJsonObjectSchema, RepositoryJsonSchema } from '../../types/package.schema';
 import { readJsonFile } from '../../validation/package-io';
+import { resolveCliPath } from '../utils/file-loader';
 import { formatJsonWithPrettier } from '../utils/output';
 
 interface BuildRepositoryOptions {
@@ -215,7 +216,7 @@ export const buildRepositoryCommand = new Command('build-repository')
     'Path(s) to exclude from scan (relative to root); excluded trees are not descended into'
   )
   .action(async (root: string, options: BuildRepositoryOptions) => {
-    const absoluteRoot = path.isAbsolute(root) ? root : path.resolve(process.cwd(), root);
+    const absoluteRoot = resolveCliPath(root);
 
     if (!fs.existsSync(absoluteRoot)) {
       console.error(`Directory not found: ${absoluteRoot}`);
@@ -241,7 +242,7 @@ export const buildRepositoryCommand = new Command('build-repository')
     const json = await formatJsonWithPrettier(JSON.stringify(repository, null, 2));
 
     if (options.output) {
-      const outputPath = path.isAbsolute(options.output) ? options.output : path.resolve(process.cwd(), options.output);
+      const outputPath = resolveCliPath(options.output);
       fs.writeFileSync(outputPath, json, 'utf-8');
       console.log(`✅ Wrote repository.json to ${outputPath} (${Object.keys(repository).length} packages)`);
     } else {

--- a/src/cli/commands/build-snippets.ts
+++ b/src/cli/commands/build-snippets.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { JsonSnippetSchema, SnippetCatalogSchema } from '../../types/json-snippet.schema';
 import type { SnippetCatalog, SnippetCatalogEntry } from '../../types/json-snippet.types';
 import { readJsonFile } from '../../validation/package-io';
+import { resolveCliPath } from '../utils/file-loader';
 import { formatJsonWithPrettier } from '../utils/output';
 
 const CATALOG_FILENAME = 'index.json';
@@ -104,7 +105,7 @@ export const buildSnippetsCommand = new Command('build-snippets')
   .argument('<dir>', 'Directory containing snippet bodies (<id>.json)')
   .option('-o, --output <file>', 'Output file path (default: <dir>/index.json)')
   .action(async (dir: string, options: BuildSnippetsOptions) => {
-    const absoluteDir = path.isAbsolute(dir) ? dir : path.resolve(process.cwd(), dir);
+    const absoluteDir = resolveCliPath(dir);
     const { catalog, warnings, errors } = buildSnippetCatalog(absoluteDir);
 
     for (const warning of warnings) {
@@ -119,11 +120,7 @@ export const buildSnippetsCommand = new Command('build-snippets')
     }
 
     const json = await formatJsonWithPrettier(JSON.stringify(catalog, null, 2));
-    const outputPath = options.output
-      ? path.isAbsolute(options.output)
-        ? options.output
-        : path.resolve(process.cwd(), options.output)
-      : path.join(absoluteDir, CATALOG_FILENAME);
+    const outputPath = options.output ? resolveCliPath(options.output) : path.join(absoluteDir, CATALOG_FILENAME);
 
     fs.writeFileSync(outputPath, json, 'utf-8');
     console.log(`✅ Wrote ${outputPath} (${Object.keys(catalog).length} snippets)`);

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -26,12 +26,12 @@ interface ValidateOptions {
 }
 
 /**
- * Stable regexes for default-array INFO messages emitted by
- * `validatePackage`. Used to collapse the six "depends/recommends/.../replaces
- * defaulting to []" lines that fire on every fresh package into a single
- * summary line, freeing screen budget for real WARN/ERROR signals.
+ * Stable message code (defined in `validate-package.ts`) for the six
+ * "depends/recommends/.../replaces defaulting to []" INFO lines that fire on
+ * every fresh package. The collapse below folds them into a single summary
+ * line so real WARN/ERROR signals stay scannable.
  */
-const DEFAULT_ARRAY_INFO_REGEX = /^manifest\.json: "([a-zA-Z]+)" not specified, defaulting to \[\]/;
+const DEFAULT_DEP_FIELD_INFO_CODE = 'manifest_dep_field_defaulted';
 
 interface ValidationSummary {
   totalFiles: number;
@@ -134,15 +134,17 @@ function formatPackageResult(dirName: string, result: PackageValidationResult, s
   // Collapse the default-array INFO messages into a single summary line
   // unless --verbose. Six identical-shape "defaulting to []" lines on every
   // fresh package drown out real warnings; one summary keeps validate output
-  // scannable without losing information for authors who want it.
+  // scannable without losing information for authors who want it. The
+  // producer tags each line with a stable `code` so we match on that rather
+  // than the message text.
   const defaultArrayFields: string[] = [];
   for (const msg of result.messages) {
-    if (msg.severity === 'info' && !verbose) {
-      const m = DEFAULT_ARRAY_INFO_REGEX.exec(msg.message);
-      if (m) {
-        defaultArrayFields.push(m[1]!);
-        continue;
-      }
+    if (msg.code === DEFAULT_DEP_FIELD_INFO_CODE && !verbose) {
+      // The field name is the last path segment (e.g. ['manifest.json',
+      // 'depends'] → 'depends'). Producer always sets the 2-segment path;
+      // fall back to '?' if a future variant doesn't, to avoid a crash.
+      defaultArrayFields.push(msg.path?.[msg.path.length - 1] ?? '?');
+      continue;
     }
     const icon = msg.severity === 'error' ? '❌' : msg.severity === 'warn' ? '⚠️ ' : 'ℹ️ ';
     console.log(`  ${icon} ${msg.severity.toUpperCase()}: ${msg.message}`);

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -242,6 +242,18 @@ export function readStdin(): Promise<string> {
   });
 }
 
+function runFileValidation(guides: LoadedGuide[], options: ValidateOptions): void {
+  const summary = validateGuides(guides, options);
+  if (options.format === 'json') {
+    formatJsonOutput(summary);
+  } else {
+    formatTextOutput(summary, options);
+  }
+  if (summary.invalidFiles > 0) {
+    process.exit(1);
+  }
+}
+
 function runStdinValidation(input: string, options: ValidateOptions): void {
   const result = validateGuideFromString(input, { strict: options.strict });
   const legacy = toLegacyResult(result);
@@ -316,6 +328,56 @@ function autoDetectPositionals(files: string[]): { kind: 'package' | 'packages';
   return null;
 }
 
+/**
+ * Tagged dispatch result for the `validate` command. Each variant maps to
+ * exactly one runner. `error` carries a user-facing message for invalid flag
+ * combinations the action prints to stderr before exiting non-zero.
+ */
+type ValidateMode =
+  | { kind: 'stdin' }
+  | { kind: 'package'; path: string }
+  | { kind: 'packages'; path: string }
+  | { kind: 'bundled' }
+  | { kind: 'files'; paths: string[] }
+  | { kind: 'error'; message: string };
+
+function resolveMode(options: ValidateOptions, files: string[]): ValidateMode {
+  if (options.stdin) {
+    if (files.length > 0 || options.bundled || options.package || options.packages) {
+      return {
+        kind: 'error',
+        message: '--stdin is mutually exclusive with file arguments, --bundled, --package, and --packages',
+      };
+    }
+    return { kind: 'stdin' };
+  }
+  if (options.package) {
+    return { kind: 'package', path: options.package };
+  }
+  if (options.packages) {
+    return { kind: 'packages', path: options.packages };
+  }
+  // Auto-detect: a single positional directory argument is interpreted as a
+  // package (if it has content.json) or a tree (if its children do). The
+  // top-level command description promises "JSON guide files or package
+  // directories" so a bare positional dir should Just Work without forcing
+  // the user to discover --package via help text.
+  const autoDetected = autoDetectPositionals(files);
+  if (autoDetected) {
+    return autoDetected;
+  }
+  if (options.bundled) {
+    return { kind: 'bundled' };
+  }
+  if (files.length > 0) {
+    return { kind: 'files', paths: files };
+  }
+  return {
+    kind: 'error',
+    message: 'Please specify files to validate, use --bundled, --package, or --packages flag',
+  };
+}
+
 export interface ValidateArgs {
   content: ContentJson;
   manifest?: ManifestJson;
@@ -376,66 +438,33 @@ export const validateCommand = new Command('validate')
       options.format = readOutputOptions(this).format;
     }
     try {
-      if (options.stdin) {
-        if (files.length > 0 || options.bundled || options.package || options.packages) {
-          console.error('--stdin is mutually exclusive with file arguments, --bundled, --package, and --packages');
+      const mode = resolveMode(options, files);
+      switch (mode.kind) {
+        case 'error':
+          console.error(mode.message);
           process.exit(1);
+          return;
+        case 'stdin': {
+          const input = await readStdin();
+          return runStdinValidation(input, options);
         }
-        const input = await readStdin();
-        return runStdinValidation(input, options);
-      }
-
-      if (options.package) {
-        return runPackageValidation(options.package, options);
-      }
-
-      if (options.packages) {
-        return runPackagesValidation(options.packages, options);
-      }
-
-      // Auto-detect when a positional path is a directory: the top-level
-      // command description promises "JSON guide files or package
-      // directories", so a bare positional dir should Just Work without
-      // forcing the user to discover --package via help text.
-      const autoDetected = autoDetectPositionals(files);
-      if (autoDetected) {
-        if (autoDetected.kind === 'package') {
-          return runPackageValidation(autoDetected.path, options);
+        case 'package':
+          return runPackageValidation(mode.path, options);
+        case 'packages':
+          return runPackagesValidation(mode.path, options);
+        case 'bundled':
+        case 'files': {
+          const guides = mode.kind === 'bundled' ? loadBundledGuides() : loadGuideFiles(mode.paths);
+          if (guides.length === 0) {
+            console.error(
+              mode.kind === 'bundled'
+                ? 'No bundled guides found in src/bundled-interactives/'
+                : 'No valid JSON guide files found in the specified paths'
+            );
+            process.exit(1);
+          }
+          return runFileValidation(guides, options);
         }
-        if (autoDetected.kind === 'packages') {
-          return runPackagesValidation(autoDetected.path, options);
-        }
-      }
-
-      let guides: LoadedGuide[] = [];
-
-      if (options.bundled) {
-        guides = loadBundledGuides();
-        if (guides.length === 0) {
-          console.error('No bundled guides found in src/bundled-interactives/');
-          process.exit(1);
-        }
-      } else if (files.length > 0) {
-        guides = loadGuideFiles(files);
-        if (guides.length === 0) {
-          console.error('No valid JSON guide files found in the specified paths');
-          process.exit(1);
-        }
-      } else {
-        console.error('Please specify files to validate, use --bundled, --package, or --packages flag');
-        process.exit(1);
-      }
-
-      const summary = validateGuides(guides, options);
-
-      if (options.format === 'json') {
-        formatJsonOutput(summary);
-      } else {
-        formatTextOutput(summary, options);
-      }
-
-      if (summary.invalidFiles > 0) {
-        process.exit(1);
       }
     } catch (error) {
       console.error('Error:', error instanceof Error ? error.message : 'Unknown error');

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -13,7 +13,7 @@ import { validateGuideFromString, toLegacyResult } from '../../validation';
 import { validatePackage, validatePackageTree, type PackageValidationResult } from '../../validation/validate-package';
 import { loadGuideFiles, loadBundledGuides, type LoadedGuide } from '../utils/file-loader';
 import { validatePackageState } from '../utils/package-io';
-import { manyIssuesOutcome, type CommandOutcome } from '../utils/output';
+import { manyIssuesOutcome, readOutputOptions, type CommandOutcome } from '../utils/output';
 
 interface ValidateOptions {
   bundled?: boolean;
@@ -354,12 +354,25 @@ export const validateCommand = new Command('validate')
   .option('--bundled', 'Validate all bundled guides in src/bundled-interactives/')
   .option('--stdin', 'Read a single JSON guide from stdin instead of files')
   .option('--strict', 'Treat warnings as errors')
-  .option('--format <format>', 'Output format: text or json', 'text')
+  // No `.default('text')` here — the action falls back to the root program's
+  // --format via `readOutputOptions` when the local flag isn't set. A local
+  // default would shadow the global because Commander's `optsWithGlobals`
+  // gives child opts precedence over parent opts when both define the same
+  // flag name.
+  .option('--format <format>', 'Output format: text or json')
   .option('--package <dir>', 'Validate a single package directory (expects content.json)')
   .option('--packages <dir>', 'Validate a tree of package directories')
   .option('--verbose', 'Show every INFO message individually (default: collapse default-array INFOs)')
   .action(async function (this: Command, files: string[]) {
     const options = this.optsWithGlobals<ValidateOptions>();
+    // Fall back to the root program's --format when the local flag wasn't
+    // passed. Without this, a root-level `pathfinder-cli --format json
+    // validate ...` would be silently dropped by Commander's child-precedence
+    // merge. `readOutputOptions` is what every other CLI command uses to read
+    // the global output contract.
+    if (!options.format) {
+      options.format = readOutputOptions(this).format;
+    }
     try {
       if (options.stdin) {
         if (files.length > 0 || options.bundled || options.package || options.packages) {

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import type { ContentJson, ManifestJson } from '../../types/package.types';
 import { validateGuideFromString, toLegacyResult } from '../../validation';
 import { validatePackage, validatePackageTree, type PackageValidationResult } from '../../validation/validate-package';
-import { loadGuideFiles, loadBundledGuides, type LoadedGuide } from '../utils/file-loader';
+import { loadGuideFiles, loadBundledGuides, resolveCliPath, type LoadedGuide } from '../utils/file-loader';
 import { validatePackageState } from '../utils/package-io';
 import { manyIssuesOutcome, readOutputOptions, type CommandOutcome } from '../utils/output';
 
@@ -167,7 +167,7 @@ function formatPackageResult(dirName: string, result: PackageValidationResult, s
 }
 
 function runPackageValidation(packageDir: string, options: ValidateOptions): void {
-  const absoluteDir = path.isAbsolute(packageDir) ? packageDir : path.resolve(process.cwd(), packageDir);
+  const absoluteDir = resolveCliPath(packageDir);
   const result = validatePackage(absoluteDir, { strict: options.strict });
 
   if (options.format === 'json') {
@@ -182,7 +182,7 @@ function runPackageValidation(packageDir: string, options: ValidateOptions): voi
 }
 
 function runPackagesValidation(rootDir: string, options: ValidateOptions): void {
-  const absoluteRoot = path.isAbsolute(rootDir) ? rootDir : path.resolve(process.cwd(), rootDir);
+  const absoluteRoot = resolveCliPath(rootDir);
   const results = validatePackageTree(absoluteRoot, { strict: options.strict });
 
   if (results.size === 0) {

--- a/src/cli/utils/file-loader.ts
+++ b/src/cli/utils/file-loader.ts
@@ -5,6 +5,16 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+/**
+ * Resolve a user-supplied CLI path to an absolute path. Pass `base` to resolve
+ * against something other than `process.cwd()` (e.g., a configured project
+ * root). The base only kicks in for relative inputs — absolute paths pass
+ * through unchanged.
+ */
+export function resolveCliPath(input: string, base: string = process.cwd()): string {
+  return path.isAbsolute(input) ? input : path.resolve(base, input);
+}
+
 export interface LoadedGuide {
   path: string;
   content: string;
@@ -31,7 +41,7 @@ export function loadGuideFiles(filePaths: string[]): LoadedGuide[] {
  */
 function loadGuideFile(filePath: string): LoadedGuide | null {
   try {
-    const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(process.cwd(), filePath);
+    const absolutePath = resolveCliPath(filePath);
 
     if (!fs.existsSync(absolutePath)) {
       console.warn(`File not found: ${filePath}`);

--- a/src/validation/validate-package.test.ts
+++ b/src/validation/validate-package.test.ts
@@ -485,3 +485,41 @@ describe('validatePackageTree', () => {
     expect(bad?.isValid).toBe(false);
   });
 });
+
+// Stable-code contract: the `validate` CLI command's INFO collapse pass
+// matches on `msg.code === 'manifest_dep_field_defaulted'`. If that code
+// ever changes here, this test breaks and the consumer needs updating in
+// the same change. Keeps producer and consumer pinned to the same string.
+describe('validatePackage — stable message codes', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('tags every defaulted dependency-list field with manifest_dep_field_defaulted', () => {
+    const pkgDir = path.join(tmpDir, 'bare-package');
+    writeJson(path.join(pkgDir, 'content.json'), {
+      id: 'bare-package',
+      title: 'Bare',
+      blocks: [{ type: 'markdown', content: '# Hello' }],
+    });
+    // Manifest with no dep-list fields set — all six should be tagged.
+    writeJson(path.join(pkgDir, 'manifest.json'), {
+      id: 'bare-package',
+      type: 'guide',
+      description: 'Bare manifest to trigger every defaulted-dep INFO',
+      category: 'test',
+      targeting: { match: { urlPrefix: '/' } },
+    });
+
+    const result = validatePackage(pkgDir);
+    const tagged = result.messages.filter((m) => m.code === 'manifest_dep_field_defaulted');
+    const taggedFields = tagged.map((m) => m.path?.[m.path.length - 1]).sort();
+    expect(taggedFields).toEqual(['conflicts', 'depends', 'provides', 'recommends', 'replaces', 'suggests']);
+  });
+});

--- a/src/validation/validate-package.ts
+++ b/src/validation/validate-package.ts
@@ -45,7 +45,7 @@ export interface PackageValidationMessage {
  */
 export type PackageValidationMessageCode =
   /** A dependency-list field (depends/recommends/etc) on the manifest is unset and defaulted to []. */
-  | 'manifest_dep_field_defaulted';
+  'manifest_dep_field_defaulted';
 
 export interface PackageValidationResult {
   isValid: boolean;

--- a/src/validation/validate-package.ts
+++ b/src/validation/validate-package.ts
@@ -29,7 +29,23 @@ export interface PackageValidationMessage {
    * renderer prints this as a `Fix:` line under the message.
    */
   remediation?: string;
+  /**
+   * Optional stable code identifying the class of message. Consumers (e.g.
+   * the `validate` CLI command's INFO-collapse pass) match on this rather
+   * than on `message` text to avoid coupling to wording. See
+   * `PackageValidationMessageCode` for the registered codes.
+   */
+  code?: PackageValidationMessageCode;
 }
+
+/**
+ * Stable codes for `PackageValidationMessage.code`. Added as we identify
+ * messages that downstream consumers need to match on programmatically.
+ * Codes are stable strings — rename here means a wire break.
+ */
+export type PackageValidationMessageCode =
+  /** A dependency-list field (depends/recommends/etc) on the manifest is unset and defaulted to []. */
+  | 'manifest_dep_field_defaulted';
 
 export interface PackageValidationResult {
   isValid: boolean;
@@ -281,6 +297,7 @@ function emitManifestMessages(
         message: `manifest.json: "${field}" not specified, defaulting to []`,
         path: ['manifest.json', field],
         remediation: `pathfinder-cli set-manifest <dir> --${field} <package-id> [--${field} <package-id> ...]`,
+        code: 'manifest_dep_field_defaulted',
       });
     }
   }


### PR DESCRIPTION
## Summary

Implements findings from a `/techdebt` audit of `src/cli`. Five focused fixes across the `validate` and `build-graph` subcommand surfaces, plus shared helper extraction. Implementation behavior is unchanged except for one bug: `pathfinder-cli --format json validate ...` (global-position `--format`) was silently dropping the flag and emitting text — now it honors the global like every other CLI command does.

## What to look at

- **`src/cli/commands/validate.ts`** — the load-bearing change is the new `resolveMode(options, files)` router and the `--format` precedence fallback. The fallback only kicks in when the local flag wasn't passed; tests pin both positional and global placement. The mutual-exclusion check for `--stdin` is now a tagged-union variant rather than an inline `if` chain.
- **`src/validation/validate-package.ts`** — new optional `code` field on `PackageValidationMessage` with a stable type union `PackageValidationMessageCode`. The six "depends/recommends/.../replaces defaulting to []" INFO lines are tagged with `'manifest_dep_field_defaulted'`. This is additive — existing consumers that ignore `code` are unaffected.
- **`src/cli/utils/file-loader.ts`** — new `resolveCliPath(input, base?)` helper. The `base` parameter exists so the one call site that legitimately resolves against a non-cwd root (excludes in `build-repository.ts:174`) is *not* migrated; that line stays as-is on purpose.
- **`src/cli/__tests__/validator-parity.test.ts`** — new test pinning the deliberate-by-design split between `validatePackage(dir)` (disk) and `validatePackageState(content, manifest)` (in-memory). They have different scopes — only the disk variant runs asset and testEnvironment checks — but they must agree on top-level validity and id-mismatch detection across the 10 bundled packages. If one starts rejecting what the other accepts, this fails and forces an explicit decision.

## Why

Five issues surfaced from `/techdebt src/cli` audit, in order of user impact:

1. **`--format` precedence bug in `validate`** — `pathfinder-cli --format json validate file.json` (the agent/MCP-friendly global position) was silently emitting text because Commander's `optsWithGlobals` resolves the child's `.default('text')` ahead of the parent's user-set `'json'`. Drop the local default and fall back to `readOutputOptions(this)` when the local flag isn't passed. Both positions now work.
2. **9 copies of `path.isAbsolute(x) ? x : path.resolve(cwd, x)`** scattered across the CLI surface. Extracted to `resolveCliPath`. Pure deduplication; behavior unchanged.
3. **`validatePackage` ↔ `validatePackageState` drift risk.** The team documents the two validators as deliberately scoped differently, but nothing pins their overlap — both should agree on the top-level verdict and id-mismatch detection for any well-formed package. Parity test on the bundled corpus pins that.
4. **Fragile string-match coupling in the INFO-collapse pass.** `validate.ts` was matching a regex against producer-side message text in `validate-package.ts`. If the producer ever rewords those lines, the collapse silently degrades and no test catches it. Replaced with a stable `code` field; producer-side contract test asserts every defaulted dep-field gets tagged.
5. **`validate` action's 5-mode dispatch** was 60 lines of inline if/else-if with scattered `process.exit(1)` calls and hand-rolled mutual-exclusion checks. Collapsed into a `resolveMode` tagged-union router; the action becomes a switch with one obvious arm per mode.

## How to verify

The implementation is covered by 866 unit tests passing locally; CI will run them again. PR-specific manual verification:

1. **`--format` precedence (the one behavior change).** Run both positions against a bundled package and confirm both emit JSON:

   ```bash
   npx pathfinder-cli@... --format json validate src/bundled-interactives/welcome-to-grafana
   npx pathfinder-cli@... validate src/bundled-interactives/welcome-to-grafana --format json
   ```

   Before this PR, the first command silently emitted text. Both should now emit JSON.

2. **INFO-collapse behavior preserved.** Run `validate` on a freshly-created package (or any of the bundled ones whose manifest doesn't set every dep-list field) and confirm you see the one-line summary "X optional manifest field(s) not set (depends, recommends, …) — run with --verbose for details." rather than six individual INFO lines. `--verbose` should still expand them.

3. **Parity test catches synthetic divergence.** Locally introduce an id mismatch in one of the bundled packages and confirm both `validatePackage` and `validatePackageState` reject it (the parity test should fail loudly). Revert.

## Breaking changes

None. The wire shapes emitted by `validate` are unchanged. The new `PackageValidationMessage.code` field is optional and additive; existing consumers that ignore it are unaffected. The `--format` precedence fix only makes the global position start *working* — no consumer was relying on it silently failing.

## Out of scope

- `build-graph` does not yet produce a `CommandOutcome`-shaped response. It emits raw JSON to stdout — by design, since its product *is* JSON and there is no text mode to switch into. The `/techdebt` audit initially flagged this and the user correctly pushed back that it was a misframing; not a debt.
- `validate`'s three legacy JSON shapes (`{ isValid, errors, warnings }` for stdin, `{ totalFiles, validFiles, ... }` for files, `PackageValidationResult` for packages) are intentionally preserved. Migrating them to the unified `CommandOutcome` shape would be a wire-format break that consumers (including MCP tooling) depend on; out of scope for a pure techdebt sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
