### PR TITLE
feat(e2e): add dependency-aware guide execution planner

### DIFF
--- a/src/cli/commands/build-graph.ts
+++ b/src/cli/commands/build-graph.ts
@@ -25,6 +25,7 @@ import type {
 import { RepositoryJsonSchema } from '../../types/package.schema';
 import { readJsonFile } from '../../validation/package-io';
 import { resolveCliPath } from '../utils/file-loader';
+import { detectCycles } from '../utils/graph-cycles';
 
 interface BuildGraphOptions {
   output?: string;
@@ -104,63 +105,6 @@ function buildProvidesMap(
   }
 
   return providesMap;
-}
-
-/**
- * Detect cycles in directed edges using DFS.
- * Returns arrays of IDs forming cycles.
- */
-function detectCycles(nodeIds: Set<string>, edges: GraphEdge[], edgeTypes: Set<GraphEdgeType>): string[][] {
-  const adjacency = new Map<string, string[]>();
-  for (const id of nodeIds) {
-    adjacency.set(id, []);
-  }
-
-  for (const edge of edges) {
-    if (!edgeTypes.has(edge.type)) {
-      continue;
-    }
-    const neighbors = adjacency.get(edge.source);
-    if (neighbors) {
-      neighbors.push(edge.target);
-    }
-  }
-
-  const cycles: string[][] = [];
-  const visited = new Set<string>();
-  const stackPosition = new Map<string, number>();
-  const stack: string[] = [];
-
-  function dfs(node: string): void {
-    if (stackPosition.has(node)) {
-      const cycleStart = stackPosition.get(node)!;
-      cycles.push([...stack.slice(cycleStart), node]);
-      return;
-    }
-    if (visited.has(node)) {
-      return;
-    }
-
-    visited.add(node);
-    stackPosition.set(node, stack.length);
-    stack.push(node);
-
-    const neighbors = adjacency.get(node) ?? [];
-    for (const neighbor of neighbors) {
-      dfs(neighbor);
-    }
-
-    stack.pop();
-    stackPosition.delete(node);
-  }
-
-  for (const id of nodeIds) {
-    if (!visited.has(id)) {
-      dfs(id);
-    }
-  }
-
-  return cycles;
 }
 
 /**

--- a/src/cli/utils/file-loader.test.ts
+++ b/src/cli/utils/file-loader.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for repository-index loading helpers used by the E2E command's
+ * dependency-aware planning. Covers the contract the command relies on to
+ * decide between hard-failing (explicit `--repository`) and degrading
+ * gracefully (default bundled index).
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { bundledRepositoryPath, loadRepositoryIndex } from './file-loader';
+
+function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pathfinder-file-loader-'));
+}
+
+describe('bundledRepositoryPath', () => {
+  it('points at the bundled repository.json', () => {
+    expect(bundledRepositoryPath().endsWith('src/bundled-interactives/repository.json')).toBe(true);
+  });
+});
+
+describe('loadRepositoryIndex', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function write(filename: string, contents: string): string {
+    const filePath = path.join(tmpDir, filename);
+    fs.writeFileSync(filePath, contents, 'utf-8');
+    return filePath;
+  }
+
+  it('loads a valid repository index', () => {
+    const filePath = write(
+      'repository.json',
+      JSON.stringify({ 'guide-a': { path: 'guide-a/', type: 'guide', depends: ['guide-b'] } })
+    );
+
+    const { repository, error } = loadRepositoryIndex(filePath);
+
+    expect(error).toBeUndefined();
+    expect(repository).toEqual({ 'guide-a': { path: 'guide-a/', type: 'guide', depends: ['guide-b'] } });
+  });
+
+  it('returns an error when the file does not exist', () => {
+    const { repository, error } = loadRepositoryIndex(path.join(tmpDir, 'missing.json'));
+
+    expect(repository).toBeNull();
+    expect(error).toMatch(/not found/i);
+  });
+
+  it('returns an error for malformed JSON', () => {
+    const filePath = write('repository.json', '{ not valid json');
+
+    const { repository, error } = loadRepositoryIndex(filePath);
+
+    expect(repository).toBeNull();
+    expect(error).toBeDefined();
+  });
+
+  it('returns a schema-validation error for a structurally invalid index', () => {
+    const filePath = write('repository.json', JSON.stringify({ 'guide-a': 'not-an-entry-object' }));
+
+    const { repository, error } = loadRepositoryIndex(filePath);
+
+    expect(repository).toBeNull();
+    expect(error).toContain('validation failed');
+  });
+});

--- a/src/cli/utils/file-loader.ts
+++ b/src/cli/utils/file-loader.ts
@@ -4,6 +4,9 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import type { RepositoryJson } from '../../types/package.types';
+import { RepositoryJsonSchema } from '../../types/package.schema';
+import { readJsonFile } from '../../validation/package-io';
 
 /**
  * Resolve a user-supplied CLI path to an absolute path. Pass `base` to resolve
@@ -121,4 +124,26 @@ export function loadBundledGuides(): LoadedGuide[] {
   }
 
   return guides;
+}
+
+export function bundledRepositoryPath(): string {
+  return path.resolve(process.cwd(), 'src/bundled-interactives/repository.json');
+}
+
+/**
+ * Load and validate a repository.json index from disk.
+ *
+ * Returns the parsed index on success, or `null` when the file does not
+ * exist or fails schema validation.
+ */
+export function loadRepositoryIndex(filePath: string): { repository: RepositoryJson | null; error?: string } {
+  const result = readJsonFile(filePath, RepositoryJsonSchema);
+  if (!result.ok) {
+    const error =
+      result.code === 'schema_validation'
+        ? `repository.json validation failed: ${result.issues?.map((i) => i.message).join('; ')}`
+        : result.message;
+    return { repository: null, error };
+  }
+  return { repository: result.data };
 }

--- a/src/cli/utils/graph-cycles.ts
+++ b/src/cli/utils/graph-cycles.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure structural cycle detection over typed dependency-graph edges.
+ *
+ * Lives in `utils/` so both the `build-graph` command and the guide-chain
+ * planner can share it without `utils/` importing from `commands/`.
+ */
+
+import type { GraphEdge, GraphEdgeType } from '../../types/package.types';
+
+/**
+ * Detect cycles in directed edges using DFS.
+ * Returns arrays of IDs forming cycles.
+ */
+export function detectCycles(nodeIds: Set<string>, edges: GraphEdge[], edgeTypes: Set<GraphEdgeType>): string[][] {
+  const adjacency = new Map<string, string[]>();
+  for (const id of nodeIds) {
+    adjacency.set(id, []);
+  }
+
+  for (const edge of edges) {
+    if (!edgeTypes.has(edge.type)) {
+      continue;
+    }
+    const neighbors = adjacency.get(edge.source);
+    if (neighbors) {
+      neighbors.push(edge.target);
+    }
+  }
+
+  const cycles: string[][] = [];
+  const visited = new Set<string>();
+  const stackPosition = new Map<string, number>();
+  const stack: string[] = [];
+
+  function dfs(node: string): void {
+    if (stackPosition.has(node)) {
+      const cycleStart = stackPosition.get(node)!;
+      cycles.push([...stack.slice(cycleStart), node]);
+      return;
+    }
+    if (visited.has(node)) {
+      return;
+    }
+
+    visited.add(node);
+    stackPosition.set(node, stack.length);
+    stack.push(node);
+
+    const neighbors = adjacency.get(node) ?? [];
+    for (const neighbor of neighbors) {
+      dfs(neighbor);
+    }
+
+    stack.pop();
+    stackPosition.delete(node);
+  }
+
+  for (const id of nodeIds) {
+    if (!visited.has(id)) {
+      dfs(id);
+    }
+  }
+
+  return cycles;
+}

--- a/src/cli/utils/guide-chains.test.ts
+++ b/src/cli/utils/guide-chains.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Guide chain planner tests.
+ *
+ * Covers ID mapping, dependency ordering, recursive auto-inclusion of missing
+ * prerequisites, virtual-capability resolution, cycle detection, OR-group
+ * handling, and deterministic chain ordering.
+ */
+
+import type { RepositoryJson } from '../../types/package.types';
+import type { LoadedGuide } from './file-loader';
+import { deriveGuideId, planGuideExecution, type GuideChain } from './guide-chains';
+
+function guide(id: string): LoadedGuide {
+  return { path: `${id}/content.json`, content: JSON.stringify({ id, title: id, blocks: [] }) };
+}
+
+function loaderFrom(available: Record<string, LoadedGuide>) {
+  return (id: string): LoadedGuide | null => available[id] ?? null;
+}
+
+function chainIds(chain: GuideChain): string[] {
+  return chain.map((p) => p.id);
+}
+
+describe('deriveGuideId', () => {
+  it('prefers the content.json id field', () => {
+    expect(deriveGuideId({ path: 'some-dir/content.json', content: JSON.stringify({ id: 'real-id' }) })).toBe(
+      'real-id'
+    );
+  });
+
+  it('falls back to the package directory name when content is not parseable', () => {
+    expect(deriveGuideId({ path: 'welcome-to-grafana/content.json', content: 'not json' })).toBe('welcome-to-grafana');
+  });
+
+  it('falls back to a flat file name without extension', () => {
+    expect(deriveGuideId({ path: 'guides/legacy.json', content: 'not json' })).toBe('legacy');
+  });
+});
+
+describe('planGuideExecution', () => {
+  it('orders a prerequisite before its dependent regardless of selection order', () => {
+    const repository: RepositoryJson = {
+      'prometheus-grafana-101': { path: 'prometheus-grafana-101/', type: 'guide', provides: ['prometheus-configured'] },
+      'loki-grafana-101': { path: 'loki-grafana-101/', type: 'guide', depends: ['prometheus-grafana-101'] },
+    };
+
+    // Deliberately reversed selection order.
+    const plan = planGuideExecution({
+      guides: [guide('loki-grafana-101'), guide('prometheus-grafana-101')],
+      repository,
+    });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.chains).toHaveLength(1);
+    expect(chainIds(plan.chains[0]!)).toEqual(['prometheus-grafana-101', 'loki-grafana-101']);
+    expect(plan.autoIncludedIds).toEqual([]);
+    // The dependent records its concrete prerequisite.
+    expect(plan.chains[0]![1]!.dependencies).toEqual(['prometheus-grafana-101']);
+  });
+
+  it('auto-includes a missing prerequisite and runs it first', () => {
+    const repository: RepositoryJson = {
+      'prometheus-grafana-101': { path: 'prometheus-grafana-101/', type: 'guide' },
+      'loki-grafana-101': { path: 'loki-grafana-101/', type: 'guide', depends: ['prometheus-grafana-101'] },
+    };
+
+    const plan = planGuideExecution({
+      guides: [guide('loki-grafana-101')],
+      repository,
+      loadGuideById: loaderFrom({ 'prometheus-grafana-101': guide('prometheus-grafana-101') }),
+    });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.autoIncludedIds).toEqual(['prometheus-grafana-101']);
+    expect(plan.chains).toHaveLength(1);
+    expect(chainIds(plan.chains[0]!)).toEqual(['prometheus-grafana-101', 'loki-grafana-101']);
+    const prometheus = plan.chains[0]![0]!;
+    expect(prometheus.autoIncluded).toBe(true);
+  });
+
+  it('recursively auto-includes transitive prerequisites in dependency order', () => {
+    const repository: RepositoryJson = {
+      a: { path: 'a/', type: 'guide', depends: ['b'] },
+      b: { path: 'b/', type: 'guide', depends: ['c'] },
+      c: { path: 'c/', type: 'guide' },
+    };
+
+    const plan = planGuideExecution({
+      guides: [guide('a')],
+      repository,
+      loadGuideById: loaderFrom({ b: guide('b'), c: guide('c') }),
+    });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.chains).toHaveLength(1);
+    expect(chainIds(plan.chains[0]!)).toEqual(['c', 'b', 'a']);
+    expect(plan.autoIncludedIds).toEqual(['b', 'c']);
+  });
+
+  it('resolves a virtual capability target through provides', () => {
+    const repository: RepositoryJson = {
+      'prometheus-grafana-101': { path: 'prometheus-grafana-101/', type: 'guide', provides: ['prometheus-configured'] },
+      'loki-grafana-101': { path: 'loki-grafana-101/', type: 'guide', depends: ['prometheus-configured'] },
+    };
+
+    const plan = planGuideExecution({
+      guides: [guide('loki-grafana-101')],
+      repository,
+      loadGuideById: loaderFrom({ 'prometheus-grafana-101': guide('prometheus-grafana-101') }),
+    });
+
+    expect(plan.errors).toEqual([]);
+    expect(chainIds(plan.chains[0]!)).toEqual(['prometheus-grafana-101', 'loki-grafana-101']);
+    expect(plan.autoIncludedIds).toEqual(['prometheus-grafana-101']);
+  });
+
+  it('groups unrelated guides into separate singleton chains, ordered deterministically', () => {
+    const repository: RepositoryJson = {
+      zebra: { path: 'zebra/', type: 'guide' },
+      apple: { path: 'apple/', type: 'guide' },
+    };
+
+    const plan = planGuideExecution({
+      guides: [guide('zebra'), guide('apple')],
+      repository,
+    });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.chains).toHaveLength(2);
+    expect(plan.chains.map((c) => chainIds(c))).toEqual([['apple'], ['zebra']]);
+  });
+
+  it('orders multiple chains deterministically by their first guide', () => {
+    const repository: RepositoryJson = {
+      'm-base': { path: 'm-base/', type: 'guide' },
+      'm-dep': { path: 'm-dep/', type: 'guide', depends: ['m-base'] },
+      'a-standalone': { path: 'a-standalone/', type: 'guide' },
+    };
+
+    const plan = planGuideExecution({
+      guides: [guide('m-dep'), guide('m-base'), guide('a-standalone')],
+      repository,
+    });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.chains.map((c) => chainIds(c))).toEqual([['a-standalone'], ['m-base', 'm-dep']]);
+  });
+
+  it('detects depends cycles and fails the plan', () => {
+    const repository: RepositoryJson = {
+      a: { path: 'a/', type: 'guide', depends: ['b'] },
+      b: { path: 'b/', type: 'guide', depends: ['a'] },
+    };
+
+    const plan = planGuideExecution({
+      guides: [guide('a'), guide('b')],
+      repository,
+    });
+
+    expect(plan.chains).toEqual([]);
+    expect(plan.errors.some((e) => e.includes('Cycle in depends chain'))).toBe(true);
+  });
+
+  describe('OR-group dependencies', () => {
+    const repository: RepositoryJson = {
+      dependent: { path: 'dependent/', type: 'guide', depends: [['alt-a', 'alt-b']] },
+      'alt-a': { path: 'alt-a/', type: 'guide' },
+      'alt-b': { path: 'alt-b/', type: 'guide' },
+    };
+
+    it('uses an already-selected alternative without auto-including', () => {
+      const plan = planGuideExecution({
+        guides: [guide('dependent'), guide('alt-b')],
+        repository,
+        loadGuideById: loaderFrom({ 'alt-a': guide('alt-a'), 'alt-b': guide('alt-b') }),
+      });
+
+      expect(plan.errors).toEqual([]);
+      expect(plan.autoIncludedIds).toEqual([]);
+      expect(chainIds(plan.chains[0]!)).toEqual(['alt-b', 'dependent']);
+    });
+
+    it('auto-includes the first resolvable alternative when none are selected', () => {
+      const plan = planGuideExecution({
+        guides: [guide('dependent')],
+        repository,
+        loadGuideById: loaderFrom({ 'alt-a': guide('alt-a'), 'alt-b': guide('alt-b') }),
+      });
+
+      expect(plan.errors).toEqual([]);
+      expect(plan.autoIncludedIds).toEqual(['alt-a']);
+      expect(chainIds(plan.chains[0]!)).toEqual(['alt-a', 'dependent']);
+    });
+  });
+
+  it('treats guides without a repository entry as dependency-free singletons', () => {
+    const plan = planGuideExecution({
+      guides: [guide('unmanaged-1'), guide('unmanaged-2')],
+      repository: {},
+    });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.chains).toHaveLength(2);
+    expect(plan.chains.every((c) => c.length === 1)).toBe(true);
+  });
+
+  it('errors when a prerequisite cannot be loaded for auto-inclusion', () => {
+    const repository: RepositoryJson = {
+      'loki-grafana-101': { path: 'loki-grafana-101/', type: 'guide', depends: ['prometheus-grafana-101'] },
+      'prometheus-grafana-101': { path: 'prometheus-grafana-101/', type: 'guide' },
+    };
+
+    const plan = planGuideExecution({
+      guides: [guide('loki-grafana-101')],
+      repository,
+      loadGuideById: () => null,
+    });
+
+    expect(plan.chains).toEqual([]);
+    expect(plan.errors.some((e) => e.includes('could not load auto-included prerequisite'))).toBe(true);
+  });
+
+  it('fails the plan when a depends target resolves to nothing (hard gate)', () => {
+    const repository: RepositoryJson = {
+      orphan: { path: 'orphan/', type: 'guide', depends: ['does-not-exist'] },
+    };
+
+    const plan = planGuideExecution({
+      guides: [guide('orphan')],
+      repository,
+    });
+
+    expect(plan.chains).toEqual([]);
+    expect(plan.errors.some((e) => e.includes('does-not-exist'))).toBe(true);
+  });
+
+  it('resolves OR-groups as a pure function of the selection set', () => {
+    const repository: RepositoryJson = {
+      x: { path: 'x/', type: 'guide', depends: [['alt-a', 'alt-b']] },
+      y: { path: 'y/', type: 'guide', depends: ['alt-b'] },
+      'alt-a': { path: 'alt-a/', type: 'guide' },
+      'alt-b': { path: 'alt-b/', type: 'guide' },
+    };
+    const loadGuideById = loaderFrom({ 'alt-a': guide('alt-a'), 'alt-b': guide('alt-b') });
+
+    const forward = planGuideExecution({ guides: [guide('x'), guide('y')], repository, loadGuideById });
+    const reverse = planGuideExecution({ guides: [guide('y'), guide('x')], repository, loadGuideById });
+
+    const shape = (plan: ReturnType<typeof planGuideExecution>) => plan.chains.map((c) => chainIds(c));
+    expect(shape(forward)).toEqual(shape(reverse));
+
+    // y's forced alt-b is resolved first, so x's OR-group reuses it: one chain.
+    expect(forward.errors).toEqual([]);
+    expect(forward.autoIncludedIds).toEqual(['alt-b']);
+    expect(forward.chains).toHaveLength(1);
+    expect(chainIds(forward.chains[0]!)).toEqual(['alt-b', 'x', 'y']);
+  });
+
+  it('fails the plan when two selected files derive the same id from different paths', () => {
+    const a: LoadedGuide = {
+      path: 'dir-a/content.json',
+      content: JSON.stringify({ id: 'dup', title: 'dup', blocks: [] }),
+    };
+    const b: LoadedGuide = {
+      path: 'dir-b/content.json',
+      content: JSON.stringify({ id: 'dup', title: 'dup', blocks: [] }),
+    };
+
+    const plan = planGuideExecution({ guides: [a, b], repository: {} });
+
+    expect(plan.chains).toEqual([]);
+    expect(plan.errors.some((e) => e.includes('duplicate guide id'))).toBe(true);
+  });
+});

--- a/src/cli/utils/guide-chains.ts
+++ b/src/cli/utils/guide-chains.ts
@@ -1,0 +1,345 @@
+/**
+ * Dependency-aware guide execution planner.
+ *
+ * Groups guides into chains over their hard `depends` prerequisites and orders
+ * each chain so prerequisites run first. Only `depends` participates;
+ * `recommends`/`suggests` are advisory. Dependency targets may be real package
+ * IDs or virtual capabilities resolved through `provides`.
+ */
+
+import type { GraphEdge, GraphEdgeType, RepositoryEntry, RepositoryJson } from '../../types/package.types';
+import { detectCycles } from './graph-cycles';
+import type { LoadedGuide } from './file-loader';
+
+export interface PlannedGuide {
+  id: string;
+  guide: LoadedGuide;
+  dependencies: string[];
+  autoIncluded: boolean;
+}
+
+/** Guides ordered so prerequisites run before dependents. */
+export type GuideChain = PlannedGuide[];
+
+export interface ExecutionPlan {
+  chains: GuideChain[];
+  autoIncludedIds: string[];
+  errors: string[];
+}
+
+export interface PlanGuideExecutionOptions {
+  guides: LoadedGuide[];
+  repository: RepositoryJson;
+  loadGuideById?: (id: string, entry: RepositoryEntry) => LoadedGuide | null;
+}
+
+/**
+ * Derive a guide's bare package ID. Prefers the `id` field in content.json,
+ * falling back to the directory/file name for legacy guides.
+ */
+export function deriveGuideId(guide: LoadedGuide): string {
+  try {
+    const parsed = JSON.parse(guide.content) as { id?: unknown };
+    if (parsed && typeof parsed.id === 'string' && parsed.id.length > 0) {
+      return parsed.id;
+    }
+  } catch {
+    // Not JSON or no id — fall through to the path-derived name.
+  }
+
+  const segments = guide.path.split('/').filter(Boolean);
+  const last = segments[segments.length - 1] ?? guide.path;
+  const parent = segments[segments.length - 2];
+  if (last === 'content.json' && parent !== undefined) {
+    return parent;
+  }
+  return last.replace(/\.json$/, '');
+}
+
+/**
+ * Build a capability → provider-IDs index from a repository, sorted for
+ * deterministic provider selection.
+ */
+function buildProvidesIndex(repository: RepositoryJson): Map<string, string[]> {
+  const index = new Map<string, string[]>();
+  for (const [id, entry] of Object.entries(repository)) {
+    for (const capability of entry.provides ?? []) {
+      const providers = index.get(capability) ?? [];
+      providers.push(id);
+      index.set(capability, providers);
+    }
+  }
+  for (const providers of index.values()) {
+    providers.sort();
+  }
+  return index;
+}
+
+/**
+ * Resolve a single dependency candidate (a real package ID or virtual
+ * capability) to the concrete provider package IDs that could satisfy it.
+ */
+function resolveCandidateProviders(
+  candidate: string,
+  repository: RepositoryJson,
+  providesIndex: Map<string, string[]>
+): string[] {
+  if (repository[candidate]) {
+    return [candidate];
+  }
+  return providesIndex.get(candidate) ?? [];
+}
+
+function clauseCandidates(clause: string | string[]): string[] {
+  return typeof clause === 'string' ? [clause] : clause;
+}
+
+/**
+ * Plan guide execution: resolve dependencies, auto-include missing
+ * prerequisites, detect cycles, and group guides into topologically ordered
+ * dependency chains.
+ */
+export function planGuideExecution(options: PlanGuideExecutionOptions): ExecutionPlan {
+  const { guides, repository, loadGuideById } = options;
+  const errors: string[] = [];
+
+  const providesIndex = buildProvidesIndex(repository);
+
+  const idToGuide = new Map<string, LoadedGuide>();
+  const directDeps = new Map<string, string[]>();
+  const autoIncluded = new Set<string>();
+  const runSet = new Set<string>();
+
+  for (const guide of guides) {
+    const id = deriveGuideId(guide);
+    const existing = idToGuide.get(id);
+    if (existing) {
+      if (existing.path !== guide.path) {
+        // Fail loudly on duplicate IDs from different paths
+        errors.push(`duplicate guide id "${id}" derived from "${existing.path}" and "${guide.path}"`);
+      }
+      continue;
+    }
+    idToGuide.set(id, guide);
+    runSet.add(id);
+  }
+
+  // Load a prereq into the run set on demand.
+  const ensureLoaded = (requesterId: string, providerId: string): boolean => {
+    if (runSet.has(providerId)) {
+      return true;
+    }
+    const providerEntry = repository[providerId];
+    const loaded = providerEntry ? (loadGuideById?.(providerId, providerEntry) ?? null) : null;
+    if (!loaded) {
+      errors.push(`${requesterId}: could not load auto-included prerequisite "${providerId}"`);
+      return false;
+    }
+    idToGuide.set(providerId, loaded);
+    runSet.add(providerId);
+    autoIncluded.add(providerId);
+    return true;
+  };
+
+  // Resolve one clause to a concrete provider: prefer an alternative already in
+  // the run set (so chains reuse it), otherwise the first resolvable candidate.
+  // Returns null when nothing satisfies the clause.
+  const resolveClauseProvider = (candidates: string[]): string | null => {
+    for (const candidate of candidates) {
+      const reused = resolveCandidateProviders(candidate, repository, providesIndex).find((p) => runSet.has(p));
+      if (reused) {
+        return reused;
+      }
+    }
+    for (const candidate of candidates) {
+      const [provider] = resolveCandidateProviders(candidate, repository, providesIndex);
+      if (provider) {
+        return provider;
+      }
+    }
+    return null;
+  };
+
+  // Resolve a single guide's clauses for one phase: `forced` handles
+  // single-target clauses, `!forced` handles OR-groups. Deps accumulate across
+  // the two phases.
+  const resolvePhase = (id: string, forced: boolean): void => {
+    const deps = directDeps.get(id) ?? [];
+    directDeps.set(id, deps);
+    const entry = repository[id];
+    if (!entry) {
+      return; // Unmanaged guide (no repository entry): dependency-free singleton.
+    }
+    for (const clause of entry.depends ?? []) {
+      const candidates = clauseCandidates(clause);
+      const isForced = candidates.length === 1;
+      if (candidates.length === 0 || isForced !== forced) {
+        continue;
+      }
+      const providerId = resolveClauseProvider(candidates);
+      if (providerId === null) {
+        errors.push(
+          `${id}: depends target "${candidates.join(' | ')}" does not resolve to a known package or capability`
+        );
+        continue;
+      }
+      if (ensureLoaded(id, providerId)) {
+        deps.push(providerId);
+      }
+    }
+  };
+
+  // Make the plan a pure function of the selection set: expand forced
+  // single-target prerequisites to a fixpoint, then resolve OR-group
+  // clauses against that now-stable run set, iterating ids in sorted order.
+  const forcedResolved = new Set<string>();
+  const orResolved = new Set<string>();
+  let progressed = true;
+  while (progressed) {
+    progressed = false;
+
+    let forcedProgress = true;
+    while (forcedProgress) {
+      forcedProgress = false;
+      for (const id of [...runSet].sort()) {
+        if (forcedResolved.has(id)) {
+          continue;
+        }
+        forcedResolved.add(id);
+        const before = runSet.size;
+        resolvePhase(id, true);
+        if (runSet.size !== before) {
+          forcedProgress = true;
+        }
+      }
+    }
+
+    for (const id of [...runSet].sort()) {
+      if (orResolved.has(id)) {
+        continue;
+      }
+      orResolved.add(id);
+      const before = runSet.size;
+      resolvePhase(id, false);
+      if (runSet.size !== before) {
+        progressed = true;
+      }
+    }
+  }
+
+  // Deduplicate accumulated provider ids per guide.
+  for (const [id, deps] of directDeps) {
+    directDeps.set(id, [...new Set(deps)]);
+  }
+
+  const allIds = new Set(runSet);
+  const edges: GraphEdge[] = [];
+  for (const [id, deps] of directDeps) {
+    for (const dep of deps) {
+      edges.push({ source: id, target: dep, type: 'depends' });
+    }
+  }
+
+  // A `depends` cycle is unsatisfiable. Fail the plan.
+  const cycles = detectCycles(allIds, edges, new Set<GraphEdgeType>(['depends']));
+  for (const cycle of cycles) {
+    errors.push(`Cycle in depends chain: ${cycle.join(' → ')}`);
+  }
+
+  const autoIncludedIds = [...autoIncluded].sort();
+  if (errors.length > 0) {
+    return { chains: [], autoIncludedIds, errors };
+  }
+
+  const chains = buildChains(allIds, edges, directDeps, idToGuide, autoIncluded);
+  return { chains, autoIncludedIds, errors };
+}
+
+/**
+ * Group IDs into weakly connected components over `depends` edges, then
+ * topologically sort each component so prerequisites come first.
+ */
+function buildChains(
+  allIds: Set<string>,
+  edges: GraphEdge[],
+  directDeps: Map<string, string[]>,
+  idToGuide: Map<string, LoadedGuide>,
+  autoIncluded: Set<string>
+): GuideChain[] {
+  // Undirected adjacency for component detection.
+  const adjacency = new Map<string, Set<string>>();
+  for (const id of allIds) {
+    adjacency.set(id, new Set());
+  }
+  for (const edge of edges) {
+    adjacency.get(edge.source)?.add(edge.target);
+    adjacency.get(edge.target)?.add(edge.source);
+  }
+
+  const visited = new Set<string>();
+  const components: string[][] = [];
+  for (const start of [...allIds].sort()) {
+    if (visited.has(start)) {
+      continue;
+    }
+    const component: string[] = [];
+    const stack = [start];
+    visited.add(start);
+    while (stack.length > 0) {
+      const node = stack.pop();
+      if (node === undefined) {
+        continue;
+      }
+      component.push(node);
+      for (const neighbor of [...(adjacency.get(node) ?? [])].sort()) {
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor);
+          stack.push(neighbor);
+        }
+      }
+    }
+    components.push(component);
+  }
+
+  const chains = components.map((component) => {
+    const order = topologicalSort(component, directDeps);
+    return order.map<PlannedGuide>((id) => ({
+      id,
+      guide: idToGuide.get(id)!,
+      dependencies: directDeps.get(id) ?? [],
+      autoIncluded: autoIncluded.has(id),
+    }));
+  });
+
+  // Deterministic chain ordering by the first (topologically earliest) guide.
+  chains.sort((a, b) => a[0]!.id.localeCompare(b[0]!.id));
+  return chains;
+}
+
+/**
+ * Topologically sort so prerequisites come before their dependents.
+ * A node is appended only after its prerequisites, and sorted iteration keeps
+ * the result deterministic. The `visited` guard makes this terminate if a
+ * cycle ever slipped through.
+ */
+function topologicalSort(component: string[], directDeps: Map<string, string[]>): string[] {
+  const inComponent = new Set(component);
+  const visited = new Set<string>();
+  const order: string[] = [];
+
+  const visit = (id: string): void => {
+    if (visited.has(id)) {
+      return;
+    }
+    visited.add(id);
+    for (const dep of [...(directDeps.get(id) ?? [])].filter((d) => inComponent.has(d)).sort()) {
+      visit(dep);
+    }
+    order.push(id);
+  };
+
+  for (const id of [...component].sort()) {
+    visit(id);
+  }
+  return order;
+}


### PR DESCRIPTION
## PR Stack Overview

This is the bottom of a 3-PR stack adding dependency-aware guide chaining to the E2E runner:

1. **#1016 — planner core (this PR)**: the `planGuideExecution` planner, repository-index loaders, and a graph-helper export. No runtime wiring.
2. **#1017 — e2e command integration**: builds the plan in `pathfinder-cli e2e`, runs guides in dependency order, resets the `--clean` docker stack once per chain (not between guides in a chain), adds `--repository`, and reports prerequisite-skips.
3. **#1018 — docs**: updates `docs/developer/E2E_TESTING.md` and `docs/design/e2e-test-runner-design.md`.

## Summary

Adds `planGuideExecution`, a planner that turns a set of selected guides plus a `repository.json` index into an ordered list of dependency **chains**. Guides linked by a hard `depends` prerequisite are grouped together and sorted so prerequisites run first. Missing prerequisites are auto-included if available, and `depends` cycles are rejected. 

This is the foundation the e2e runner uses in `#1017` to keep a prerequisite's state alive for its dependents under `--clean`. This PR does not include any runtime calling code.

## What to look at

- [`src/cli/utils/guide-chains.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/765b72c08d0516e90d781f1bbf9c26d1f74f6a76/src/cli/utils/guide-chains.ts) — the planner.
- [`src/cli/utils/file-loader.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/765b72c08d0516e90d781f1bbf9c26d1f74f6a76/src/cli/utils/file-loader.ts) — `loadRepositoryIndex` (schema-validated; returns `{ repository: null, error }` on failure) and `bundledRepositoryPath`. The null-plus-error contract is what #1017 relies on to decide hard-fail vs graceful degradation.
- [`src/cli/commands/build-graph.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/765b72c08d0516e90d781f1bbf9c26d1f74f6a76/src/cli/commands/build-graph.ts) — `detectCycles` is now exported for reuse by the planner.

## Why

Under `--clean`, the e2e runner resets the docker stack between every guide, wiping `grafana-data`. Guides such as `loki-grafana-101` declare `depends: ["prometheus-grafana-101"]` and rely on state the prerequisite created, so they fail on a freshly-reset environment. This planner computes the ordering and grouping needed to run a chain in one environment.

## How to verify

No runtime entrypoint in this PR, just unit tests to verify.

1. Run the specs for this layer: `npx jest src/cli/utils/guide-chains.test.ts src/cli/utils/file-loader.test.ts`
2. Confirm the key planner behaviors hold: `prometheus-grafana-101` is ordered before `loki-grafana-101` regardless of selection order; a missing prerequisite is auto-included and runs first; a `depends` target that is a virtual capability resolves to its `provides` provider; and a `depends` cycle returns a planning error with empty chains.

## Breaking changes

None. This change is purely additive — a new utility module, one newly-exported function, and new tests. No existing signatures, schemas, or contracts change.

