### PR TITLE
feat(e2e): run dependency chains in the e2e command

### DIFF
--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -940,6 +940,16 @@ export const e2eCommand = new Command('e2e')
               exitCode: ExitCode.SUCCESS,
               autoIncluded: planned.autoIncluded,
               failedPrerequisite: blockingDep,
+              // Include a result so the skipped guide is represented in the JSON report
+              resultsData: {
+                guide: { id: planned.id, title: planned.id, path: planned.guide.path },
+                grafanaUrl: options.grafanaUrl,
+                timestamp: new Date().toISOString(),
+                results: [],
+                aborted: true,
+                abortReason: 'SKIPPED_PREREQ',
+                abortMessage: `Prerequisite "${blockingDep}" did not pass`,
+              },
             });
             continue;
           }

--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -7,13 +7,20 @@
 
 import { execSync, spawn } from 'child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { dirname, isAbsolute, join, resolve } from 'path';
 import { tmpdir } from 'os';
 
 import { Command, Option } from 'commander';
 
 import { validateGuideFromString, toLegacyResult } from '../../validation';
-import { loadGuideFiles, loadBundledGuides, type LoadedGuide } from '../utils/file-loader';
+import {
+  loadGuideFiles,
+  loadBundledGuides,
+  loadRepositoryIndex,
+  bundledRepositoryPath,
+  type LoadedGuide,
+} from '../utils/file-loader';
+import { planGuideExecution } from '../utils/guide-chains';
 import {
   generateReport,
   writeReport,
@@ -29,7 +36,7 @@ import {
   type PreflightOutcome,
   type CurrentTier,
 } from '../utils/manifest-preflight';
-import type { ManifestJson } from '../../types/package.types';
+import type { ManifestJson, RepositoryEntry, RepositoryJson } from '../../types/package.types';
 
 import { randomUUID } from 'crypto';
 
@@ -49,6 +56,7 @@ interface E2ECommandOptions {
   alwaysScreenshot: boolean;
   clean: boolean;
   cleanReadyTimeoutMs: number;
+  repository?: string;
 }
 
 /**
@@ -202,7 +210,7 @@ async function waitForGrafanaReady(
 /**
  *  Bring docker compose down with volumes removed, then up, and wait for Grafana
  *  to be reachable. Used by `--clean` to wipe the `grafana-data` DB between
- *  guides.
+ *  dependency chains.
  */
 async function cleanResetDocker(grafanaUrl: string, options: E2ECommandOptions): Promise<void> {
   console.log('   docker compose down -v');
@@ -262,6 +270,21 @@ interface PlaywrightResult {
   abortMessage?: string;
   /** Test results data for JSON report generation (L3-5B) */
   resultsData?: TestResultsData;
+}
+
+type GuideStatus = 'passed' | 'failed' | 'auth_expired' | 'skipped_prereq';
+
+interface GuideRunResult {
+  guide: string;
+  id: string;
+  status: GuideStatus;
+  exitCode: number;
+  traceFile?: string;
+  abortReason?: AbortReason;
+  abortMessage?: string;
+  resultsData?: TestResultsData;
+  autoIncluded: boolean;
+  failedPrerequisite?: string;
 }
 
 /**
@@ -593,7 +616,7 @@ export const e2eCommand = new Command('e2e')
   .option('--always-screenshot', 'Capture screenshots on success and failure', false)
   .option(
     '--clean',
-    `Run tests against an isolated docker-compose stack (project "${CLEAN_COMPOSE_PROJECT}", Grafana on ${CLEAN_GRAFANA_URL}). Resets between guides and tears down at the end.`,
+    `Run tests against an isolated docker-compose stack (project "${CLEAN_COMPOSE_PROJECT}", Grafana on ${CLEAN_GRAFANA_URL}). Resets between dependency chains (not between guides in the same chain) and tears down at the end.`,
     false
   )
   .option(
@@ -601,6 +624,10 @@ export const e2eCommand = new Command('e2e')
     'How long to wait for the isolated Grafana to become healthy after a --clean reset',
     (v) => parseInt(v, 10),
     120000
+  )
+  .option(
+    '--repository <path>',
+    'Path to a repository.json used for dependency-aware ordering (default: the bundled index when present)'
   )
   .action(async (files: string[], options: E2ECommandOptions) => {
     let dockerStartedByUs = false;
@@ -702,6 +729,82 @@ export const e2eCommand = new Command('e2e')
         console.log(`   Clean:       enabled (project "${CLEAN_COMPOSE_PROJECT}", isolated from any dev stack)`);
       }
 
+      // Build a dependency-aware execution plan. Guides linked by `depends` run
+      // in dependency order; under --clean each chain gets a fresh environment.
+      const repositoryPath = options.repository
+        ? isAbsolute(options.repository)
+          ? options.repository
+          : resolve(process.cwd(), options.repository)
+        : bundledRepositoryPath();
+
+      if (options.repository && !existsSync(repositoryPath)) {
+        console.error(`\n❌ Repository index not found: ${repositoryPath}`);
+        process.exit(ExitCode.CONFIGURATION_ERROR);
+      }
+
+      let repository: RepositoryJson = {};
+      if (existsSync(repositoryPath)) {
+        const loaded = loadRepositoryIndex(repositoryPath);
+        if (loaded.error) {
+          // An explicitly requested index that fails to load is a configuration
+          // error; a malformed default (bundled) index degrades to no planning.
+          if (options.repository) {
+            console.error(`\n❌ Failed to load repository index (${repositoryPath}): ${loaded.error}`);
+            process.exit(ExitCode.CONFIGURATION_ERROR);
+          }
+          console.warn(`⚠️  Ignoring default repository index (${repositoryPath}): ${loaded.error}`);
+        }
+        repository = loaded.repository ?? {};
+      }
+
+      const repoBaseDir = dirname(repositoryPath);
+      const loadGuideById = (id: string, entry: RepositoryEntry): LoadedGuide | null => {
+        const rel = entry.path || `${id}/`;
+        const contentPath = rel.endsWith('.json') ? join(repoBaseDir, rel) : join(repoBaseDir, rel, 'content.json');
+        return loadGuideFiles([contentPath])[0] ?? null;
+      };
+
+      const plan = planGuideExecution({ guides: valid, repository, loadGuideById });
+
+      if (plan.errors.length > 0) {
+        console.error('\n❌ Failed to plan guide execution:');
+        for (const planError of plan.errors) {
+          console.error(`   • ${planError}`);
+        }
+        process.exit(ExitCode.CONFIGURATION_ERROR);
+      }
+
+      // Validate prerequisites that were auto-included to satisfy dependencies.
+      const autoIncludedGuides = plan.chains
+        .flat()
+        .filter((p) => p.autoIncluded)
+        .map((p) => p.guide);
+      if (autoIncludedGuides.length > 0) {
+        const { errors: autoErrors } = validateAllGuides(autoIncludedGuides, options);
+        if (autoErrors.length > 0) {
+          console.error('\n❌ Auto-included prerequisite validation failed:\n');
+          for (const { file, errors: fileErrors } of autoErrors) {
+            console.error(`  ${file}:`);
+            for (const error of fileErrors) {
+              console.error(`    - ${error}`);
+            }
+            console.error();
+          }
+          process.exit(ExitCode.CONFIGURATION_ERROR);
+        }
+        console.log(
+          `\n➕ Auto-included ${autoIncludedGuides.length} prerequisite guide(s): ${plan.autoIncludedIds.join(', ')}`
+        );
+      }
+
+      if (options.verbose) {
+        console.log(`\n🔗 Execution plan: ${plan.chains.length} chain(s)`);
+        plan.chains.forEach((chain, idx) => {
+          const names = chain.map((p) => `${p.id}${p.autoIncluded ? ' (auto)' : ''}`).join(' → ');
+          console.log(`   Chain ${idx + 1}: ${names}`);
+        });
+      }
+
       if (options.clean) {
         console.log('\n🧹 Clean start — resetting docker compose before tests...');
         try {
@@ -799,71 +902,94 @@ export const e2eCommand = new Command('e2e')
         console.log('   → Auth and plugin checks will run in Playwright context');
       }
 
-      // Run Playwright tests for each guide
+      // Run Playwright tests chain by chain.
       console.log('\n🎭 Running Playwright tests...\n');
 
       let allPassed = true;
       let hasAuthExpiry = false;
-      const results: Array<{
-        guide: string;
-        success: boolean;
-        exitCode: number;
-        traceFile?: string;
-        abortReason?: AbortReason;
-        abortMessage?: string;
-        resultsData?: TestResultsData;
-      }> = [];
+      const results: GuideRunResult[] = [];
 
-      for (const [i, guide] of valid.entries()) {
-        if (options.clean && i > 0) {
-          console.log(`\n🧹 Resetting docker compose between guides...`);
+      for (const [chainIndex, chain] of plan.chains.entries()) {
+        if (options.clean && chainIndex > 0) {
+          console.log(`\n🧹 Resetting docker compose between chains...`);
           try {
             await cleanResetDocker(options.grafanaUrl, options);
             dockerStartedByUs = true;
           } catch (err) {
             console.error(
-              `\n❌ Failed to reset docker compose between guides: ${err instanceof Error ? err.message : 'Unknown error'}`
+              `\n❌ Failed to reset docker compose between chains: ${err instanceof Error ? err.message : 'Unknown error'}`
             );
             allPassed = false;
             break;
           }
         }
 
-        console.log(`\n📚 Testing: ${guide.path}`);
+        // IDs in this chain that failed or were skipped; their dependents skip.
+        const blocked = new Set<string>();
 
-        const result = await runPlaywrightTests(guide, options);
-        results.push({
-          guide: guide.path,
-          success: result.success,
-          exitCode: result.exitCode,
-          traceFile: result.traceFile,
-          abortReason: result.abortReason,
-          abortMessage: result.abortMessage,
-          resultsData: result.resultsData,
-        });
-
-        if (!result.success) {
-          allPassed = false;
-
-          // L3-3D: Check for auth expiry
-          if (result.abortReason === 'AUTH_EXPIRED') {
-            hasAuthExpiry = true;
-            console.log(`   ❌ Session expired: ${result.abortMessage}`);
-          } else {
-            console.log(`   ❌ Test failed (exit code: ${result.exitCode})`);
+        for (const planned of chain) {
+          const blockingDep = planned.dependencies.find((dep) => blocked.has(dep));
+          if (blockingDep) {
+            blocked.add(planned.id);
+            console.log(`\n📚 ${planned.guide.path}`);
+            console.log(`   ⊘ Skipped: prerequisite "${blockingDep}" did not pass`);
+            results.push({
+              guide: planned.guide.path,
+              id: planned.id,
+              status: 'skipped_prereq',
+              exitCode: ExitCode.SUCCESS,
+              autoIncluded: planned.autoIncluded,
+              failedPrerequisite: blockingDep,
+            });
+            continue;
           }
-        } else {
-          console.log(`   ✅ Test passed`);
-        }
 
-        if (result.traceFile && options.trace) {
-          console.log(`   📊 Trace file: ${result.traceFile}`);
+          const suffix = planned.autoIncluded ? ' (auto-included prerequisite)' : '';
+          console.log(`\n📚 Testing: ${planned.guide.path}${suffix}`);
+
+          const result = await runPlaywrightTests(planned.guide, options);
+          const status: GuideStatus = result.success
+            ? 'passed'
+            : result.abortReason === 'AUTH_EXPIRED'
+              ? 'auth_expired'
+              : 'failed';
+
+          results.push({
+            guide: planned.guide.path,
+            id: planned.id,
+            status,
+            exitCode: result.exitCode,
+            traceFile: result.traceFile,
+            abortReason: result.abortReason,
+            abortMessage: result.abortMessage,
+            resultsData: result.resultsData,
+            autoIncluded: planned.autoIncluded,
+          });
+
+          if (!result.success) {
+            allPassed = false;
+            blocked.add(planned.id);
+
+            // L3-3D: Check for auth expiry
+            if (result.abortReason === 'AUTH_EXPIRED') {
+              hasAuthExpiry = true;
+              console.log(`   ❌ Session expired: ${result.abortMessage}`);
+            } else {
+              console.log(`   ❌ Test failed (exit code: ${result.exitCode})`);
+            }
+          } else {
+            console.log(`   ✅ Test passed`);
+          }
+
+          if (result.traceFile && options.trace) {
+            console.log(`   📊 Trace file: ${result.traceFile}`);
+          }
         }
       }
 
       // Collect results data for reporting
       const resultsWithData = results.filter((r) => r.resultsData).map((r) => r.resultsData!);
-      const isMultiGuide = valid.length > 1;
+      const isMultiGuide = results.length > 1;
 
       // Print summary
       console.log('\n' + '─'.repeat(68));
@@ -872,16 +998,20 @@ export const e2eCommand = new Command('e2e')
 
       if (isMultiGuide) {
         // Multi-guide summary (L3-7B)
-        const passedGuides = results.filter((r) => r.success).length;
-        const failedGuides = results.filter((r) => !r.success && r.abortReason !== 'AUTH_EXPIRED').length;
-        const authExpired = results.filter((r) => r.abortReason === 'AUTH_EXPIRED').length;
+        const passedGuides = results.filter((r) => r.status === 'passed').length;
+        const failedGuides = results.filter((r) => r.status === 'failed').length;
+        const authExpired = results.filter((r) => r.status === 'auth_expired').length;
+        const skippedPrereq = results.filter((r) => r.status === 'skipped_prereq').length;
 
-        console.log(`\n   Guides: ${passedGuides}/${valid.length} passed`);
+        console.log(`\n   Guides: ${passedGuides}/${results.length} passed`);
         if (failedGuides > 0) {
           console.log(`   ├─ ❌ Failed: ${failedGuides}`);
         }
         if (authExpired > 0) {
-          console.log(`   └─ 🔐 Auth expired: ${authExpired}`);
+          console.log(`   ├─ 🔐 Auth expired: ${authExpired}`);
+        }
+        if (skippedPrereq > 0) {
+          console.log(`   └─ ⊘ Skipped (prerequisite failed): ${skippedPrereq}`);
         }
 
         // Aggregate step statistics across all guides
@@ -920,16 +1050,30 @@ export const e2eCommand = new Command('e2e')
         // List individual guide results
         console.log(`\n   Guide results:`);
         for (const result of results) {
-          const status = result.success ? '✅' : result.abortReason === 'AUTH_EXPIRED' ? '🔐' : '❌';
-          const guideName = result.guide.split('/').pop()?.replace('.json', '') ?? result.guide;
-          const reason = result.abortReason === 'AUTH_EXPIRED' ? ' (auth expired)' : '';
-          console.log(`   ${status} ${guideName}${reason}`);
+          const icon =
+            result.status === 'passed'
+              ? '✅'
+              : result.status === 'auth_expired'
+                ? '🔐'
+                : result.status === 'skipped_prereq'
+                  ? '⊘'
+                  : '❌';
+          const guideName = result.id;
+          const suffix = result.autoIncluded ? ' (auto-included)' : '';
+          const reason =
+            result.status === 'auth_expired'
+              ? ' (auth expired)'
+              : result.status === 'skipped_prereq'
+                ? ` (prerequisite "${result.failedPrerequisite}" failed)`
+                : '';
+          console.log(`   ${icon} ${guideName}${suffix}${reason}`);
         }
       } else {
         // Single guide summary
-        const passed = results.filter((r) => r.success).length;
-        const failed = results.filter((r) => !r.success).length;
-        const authExpired = results.filter((r) => r.abortReason === 'AUTH_EXPIRED').length;
+        const passed = results.filter((r) => r.status === 'passed').length;
+        const failed = results.filter((r) => r.status === 'failed').length;
+        const authExpired = results.filter((r) => r.status === 'auth_expired').length;
+        const skippedPrereq = results.filter((r) => r.status === 'skipped_prereq').length;
 
         if (passed > 0) {
           console.log(`   ✅ Passed: ${passed}`);
@@ -939,6 +1083,9 @@ export const e2eCommand = new Command('e2e')
         }
         if (authExpired > 0) {
           console.log(`   🔐 Auth expired: ${authExpired}`);
+        }
+        if (skippedPrereq > 0) {
+          console.log(`   ⊘ Skipped (prerequisite failed): ${skippedPrereq}`);
         }
       }
 

--- a/src/cli/utils/e2e-reporter.test.ts
+++ b/src/cli/utils/e2e-reporter.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Reporter tests for dependency-aware execution outcomes.
+ *
+ * A guide skipped because its prerequisite failed produces no step data, so it
+ * must still be represented in the multi-guide JSON report or the report would
+ * undercount and lose the skip reason relative to the console summary.
+ */
+
+import { generateMultiGuideReport, type TestResultsData } from './e2e-reporter';
+
+function ranGuide(id: string, opts: { failed?: boolean } = {}): TestResultsData {
+  return {
+    guide: { id, title: id, path: `${id}/content.json` },
+    grafanaUrl: 'http://localhost:3000',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    results: [
+      {
+        stepId: 'step-1',
+        status: opts.failed ? 'failed' : 'passed',
+        durationMs: 10,
+        currentUrl: '/',
+        consoleErrors: [],
+        skippable: false,
+      },
+    ],
+    aborted: false,
+  };
+}
+
+/** A guide skipped before execution because its prerequisite failed. */
+function skippedGuide(id: string, failedPrerequisite: string): TestResultsData {
+  return {
+    guide: { id, title: id, path: `${id}/content.json` },
+    grafanaUrl: 'http://localhost:3000',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    results: [],
+    aborted: true,
+    abortReason: 'SKIPPED_PREREQ',
+    abortMessage: `Prerequisite "${failedPrerequisite}" did not pass`,
+  };
+}
+
+describe('generateMultiGuideReport — dependency-skipped guides', () => {
+  it('counts a skipped dependent without treating it as passed', () => {
+    const report = generateMultiGuideReport(
+      [
+        ranGuide('prometheus-grafana-101', { failed: true }),
+        skippedGuide('loki-grafana-101', 'prometheus-grafana-101'),
+      ],
+      'http://localhost:3000'
+    );
+
+    // Both the failed prerequisite and the skipped dependent are represented.
+    expect(report.summary.totalGuides).toBe(2);
+    expect(report.summary.skippedGuides).toBe(1);
+    expect(report.summary.passedGuides).toBe(0);
+
+    const skippedResult = report.guides.find((g) => g.id === 'loki-grafana-101');
+    expect(skippedResult).toMatchObject({ abortReason: 'SKIPPED_PREREQ', success: false });
+  });
+
+  it('reports zero skipped guides when none are skipped', () => {
+    const report = generateMultiGuideReport([ranGuide('a'), ranGuide('b')], 'http://localhost:3000');
+
+    expect(report.summary.totalGuides).toBe(2);
+    expect(report.summary.skippedGuides).toBe(0);
+    expect(report.guides.every((g) => g.abortReason === undefined)).toBe(true);
+  });
+});

--- a/src/cli/utils/e2e-reporter.ts
+++ b/src/cli/utils/e2e-reporter.ts
@@ -146,7 +146,7 @@ export interface E2ETestReport {
   /** Whether test was aborted (L3-3D) */
   aborted?: boolean;
   /** Reason for abort if aborted is true */
-  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE';
+  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE' | 'SKIPPED_PREREQ';
   /** Human-readable abort message */
   abortMessage?: string;
 }
@@ -194,7 +194,7 @@ export interface TestResultsData {
   /** Whether execution was aborted */
   aborted: boolean;
   /** Reason for abort if aborted */
-  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE';
+  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE' | 'SKIPPED_PREREQ';
   /** Abort message */
   abortMessage?: string;
 }
@@ -405,6 +405,8 @@ export interface MultiGuideSummary {
   failedGuides: number;
   /** Number of guides where auth expired during testing */
   authExpiredGuides: number;
+  /** Number of guides skipped because a dependency-chain prerequisite failed */
+  skippedGuides: number;
   /** Aggregated step counts across all guides */
   steps: {
     total: number;
@@ -432,7 +434,7 @@ export interface GuideResult {
   /** Whether this guide passed (no mandatory failures) */
   success: boolean;
   /** Reason for failure/abort if any */
-  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE';
+  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE' | 'SKIPPED_PREREQ';
   /** Summary statistics for this guide */
   summary: ReportSummary;
   /** Duration in milliseconds */
@@ -469,7 +471,8 @@ export interface MultiGuideReport {
  * @returns Aggregated summary statistics
  */
 export function generateMultiGuideSummary(reports: E2ETestReport[]): MultiGuideSummary {
-  const passedGuides = reports.filter((r) => isReportSuccess(r)).length;
+  const skippedGuides = reports.filter((r) => r.abortReason === 'SKIPPED_PREREQ').length;
+  const passedGuides = reports.filter((r) => isReportSuccess(r) && r.abortReason !== 'SKIPPED_PREREQ').length;
   const failedGuides = reports.filter((r) => !isReportSuccess(r) && r.abortReason !== 'AUTH_EXPIRED').length;
   const authExpiredGuides = reports.filter((r) => r.abortReason === 'AUTH_EXPIRED').length;
 
@@ -502,6 +505,7 @@ export function generateMultiGuideSummary(reports: E2ETestReport[]): MultiGuideS
     passedGuides,
     failedGuides,
     authExpiredGuides,
+    skippedGuides,
     steps,
     totalDuration,
   };
@@ -518,7 +522,7 @@ export function toGuideResult(report: E2ETestReport): GuideResult {
     id: report.guide.id,
     title: report.guide.title,
     path: report.guide.path,
-    success: isReportSuccess(report),
+    success: isReportSuccess(report) && report.abortReason !== 'SKIPPED_PREREQ',
     summary: report.summary,
     duration: report.summary.duration,
   };
@@ -607,7 +611,10 @@ export function isMultiGuideReportSuccess(report: MultiGuideReport): boolean {
  */
 export function formatMultiGuideSummary(report: MultiGuideReport): string {
   const { summary } = report;
-  const guideStatus = `${summary.passedGuides}/${summary.totalGuides} guides passed`;
+  let guideStatus = `${summary.passedGuides}/${summary.totalGuides} guides passed`;
+  if (summary.skippedGuides > 0) {
+    guideStatus += `, ${summary.skippedGuides} skipped`;
+  }
 
   const stepParts: string[] = [`${summary.steps.passed} passed`];
   if (summary.steps.failed > 0) {


### PR DESCRIPTION
## PR Stack Overview

Part of the dependency-aware E2E guide-chaining stack: #1016 (planner core) → **#1017 (this PR)** → #1018 (docs). Based on #1016.

## Summary

Wires the planner from #1016 into `pathfinder-cli e2e`. Guides run in dependency order on every run, and under `--clean` the isolated docker stack resets once per dependency chain instead of between every guide, so a prerequisite's state survives for its dependents. Adds an optional `--repository <path>` flag, auto-includes missing prerequisites, and marks dependents of a failed prerequisite as skipped rather than running them against a broken setup.

## What to look at

- [`src/cli/commands/e2e.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8edac4f812982dab8782a227e68f3939d4ad6294/src/cli/commands/e2e.ts) several load-bearing changes to the command execution code.
- [`src/cli/utils/e2e-reporter.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/609047794afd723b0347f9e0c8a2ec8803261a29/src/cli/utils/e2e-reporter.ts) - updates the reporter to ensure guides skipped as a result of a failed prerequisite are documented in the report.

## Why

Under `--clean` the runner reset the docker stack between every guide, wiping `grafana-data`, which broke any guide that `depends` on another (e.g. `loki-grafana-101` needs the Prometheus setup). Resetting per chain keeps prerequisite state available within a chain while still isolating unrelated chains.

## How to verify

Build the CLI first: `npm run build:cli`.

1. Dependency ordering and shared environment: `pathfinder-cli e2e --clean bundled:loki-grafana-101`. Confirm `prometheus-grafana-101` is auto-included and runs first, and that docker resets once at the start — not between the two guides.
2. Explicit bad `--repository` fails fast: `pathfinder-cli e2e --repository /tmp/does-not-exist.json --bundled` exits with code 2 (`CONFIGURATION_ERROR`).
3. Skip propagation: force a prerequisite to fail and confirm dependents in the same chain print "Skipped (prerequisite failed)" and the run exits 1.

## Breaking changes

No flags removed and no exit-code changes. Behavior change to be aware of: dependency-aware ordering now applies to every run (guide execution order can differ when a `depends` relationship exists), and `--clean` resets per chain rather than per guide.

## Reversibility

Reversible — reverting this PR restores the prior per-guide behavior, and nothing persists beyond the ephemeral docker stack. One note for output-parsing consumers: the console now emits a new `skipped_prereq` outcome and resets at chain boundaries, so any tooling that scraped the old per-guide reset cadence or guide-result lines should be re-checked.
