### PR TITLE
feat(mcp): session-mode finalize + guidance (stack 3/4)

### DIFF
--- a/src/cli/mcp/__tests__/finalize.test.ts
+++ b/src/cli/mcp/__tests__/finalize.test.ts
@@ -11,6 +11,8 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 
 import { CURRENT_SCHEMA_VERSION } from '../../../types/json-guide.schema';
+import { InMemorySessionStore, SESSION_GENERATION_ABSENT } from '../lib/session-store';
+import { generateSessionToken } from '../lib/session-token';
 import { buildServer } from '../server';
 
 interface ToolPayload {
@@ -46,6 +48,43 @@ async function callFinalize(): Promise<ToolPayload> {
     const result = await client.callTool({
       name: 'pathfinder_finalize_for_app_platform',
       arguments: { artifact, status: 'draft' },
+    });
+    const blocks = result.content as Array<{ type: string; text: string }>;
+    const text = blocks.find((b) => b.type === 'text')?.text;
+    if (!text) {
+      throw new Error('finalize returned no text');
+    }
+    return JSON.parse(text) as ToolPayload;
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+const fixtureContent = {
+  id: 'session-fixture',
+  schemaVersion: CURRENT_SCHEMA_VERSION,
+  title: 'Session Fixture',
+  type: 'guide' as const,
+  blocks: [{ type: 'markdown' as const, id: 'm-1', content: 'hello' }],
+};
+const fixtureManifest = {
+  id: 'session-fixture',
+  schemaVersion: CURRENT_SCHEMA_VERSION,
+  type: 'guide' as const,
+  repository: 'interactive-tutorials',
+};
+
+async function callFinalizeWithStore(store: InMemorySessionStore, args: Record<string, unknown>): Promise<ToolPayload> {
+  const server = buildServer({ sessionStore: store });
+  const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'finalize-session-test', version: '0' }, { capabilities: {} });
+  await client.connect(clientTransport);
+  try {
+    const result = await client.callTool({
+      name: 'pathfinder_finalize_for_app_platform',
+      arguments: args,
     });
     const blocks = result.content as Array<{ type: string; text: string }>;
     const text = blocks.find((b) => b.type === 'text')?.text;
@@ -223,5 +262,83 @@ describe('pathfinder_finalize_for_app_platform contract', () => {
         },
       }
     `);
+  });
+});
+
+describe('pathfinder_finalize_for_app_platform — session mode', () => {
+  it('loads the artifact from the session store and returns the same shape as stateless mode', async () => {
+    const store = new InMemorySessionStore();
+    const token = generateSessionToken();
+    await store.save(token, { content: fixtureContent, manifest: fixtureManifest }, SESSION_GENERATION_ABSENT);
+
+    const payload = await callFinalizeWithStore(store, { sessionToken: token, status: 'draft' });
+
+    expect(payload.status).toBe('ready');
+    expect(payload.id).toBe('session-fixture');
+    expect(payload.artifact?.content.id).toBe('session-fixture');
+  });
+
+  it('deletes the session on a successful finalize so the token becomes unusable', async () => {
+    const store = new InMemorySessionStore();
+    const token = generateSessionToken();
+    await store.save(token, { content: fixtureContent, manifest: fixtureManifest }, SESSION_GENERATION_ABSENT);
+    expect(await store.load(token)).not.toBeNull();
+
+    const payload = await callFinalizeWithStore(store, { sessionToken: token, status: 'draft' });
+    expect(payload.status).toBe('ready');
+
+    // Load-bearing invariant: the session is gone after a successful
+    // finalize. Subsequent calls with the same token will surface
+    // SESSION_NOT_FOUND, which is the agent's signal to start over.
+    expect(await store.load(token)).toBeNull();
+  });
+
+  it('does NOT delete the session when validation fails (token stays usable for retry)', async () => {
+    const store = new InMemorySessionStore();
+    const token = generateSessionToken();
+    // Invalid: a markdown block without `content` fails schema validation.
+    await store.save(
+      token,
+      {
+        content: {
+          ...fixtureContent,
+          blocks: [{ type: 'markdown', id: 'm-bad' } as unknown as (typeof fixtureContent.blocks)[number]],
+        },
+        manifest: fixtureManifest,
+      },
+      SESSION_GENERATION_ABSENT
+    );
+
+    const payload = await callFinalizeWithStore(store, { sessionToken: token, status: 'draft' });
+    expect(payload.status).toBe('invalid');
+
+    // Caller still has a usable session to fix and re-finalize.
+    expect(await store.load(token)).not.toBeNull();
+  });
+
+  it('rejects ambiguous input (both artifact and sessionToken)', async () => {
+    const store = new InMemorySessionStore();
+    const token = generateSessionToken();
+    await store.save(token, { content: fixtureContent, manifest: fixtureManifest }, SESSION_GENERATION_ABSENT);
+
+    const payload = await callFinalizeWithStore(store, {
+      sessionToken: token,
+      artifact: { content: fixtureContent, manifest: fixtureManifest },
+      status: 'draft',
+    });
+    expect(payload.code).toBe('INPUT_MODE_AMBIGUOUS');
+  });
+
+  it('rejects missing input (neither artifact nor sessionToken)', async () => {
+    const store = new InMemorySessionStore();
+    const payload = await callFinalizeWithStore(store, { status: 'draft' });
+    expect(payload.code).toBe('INPUT_MODE_MISSING');
+  });
+
+  it('returns SESSION_NOT_FOUND for an unknown token', async () => {
+    const store = new InMemorySessionStore();
+    const token = generateSessionToken();
+    const payload = await callFinalizeWithStore(store, { sessionToken: token, status: 'draft' });
+    expect(payload.code).toBe('SESSION_NOT_FOUND');
   });
 });

--- a/src/cli/mcp/__tests__/session-pin.test.ts
+++ b/src/cli/mcp/__tests__/session-pin.test.ts
@@ -1,0 +1,193 @@
+/**
+ * P7 task 16 — Mcp-Session-Id binding tests.
+ *
+ * Covers the three paths from the design:
+ *
+ *   1. MATCH    — mint over header A, subsequent call with header A succeeds.
+ *   2. MISMATCH — mint over header A, subsequent call with header B
+ *                  surfaces SESSION_NOT_FOUND (404, not 403 — the pin is
+ *                  a confidentiality boundary).
+ *   3. ABSENT   — mint over header A, subsequent call with no header
+ *                  succeeds (stdio fallback). Also: mint with no header,
+ *                  any subsequent call succeeds (no pin to enforce).
+ *
+ * Tests build a server per call to simulate the per-request McpServer
+ * the HTTP transport constructs — each request picks up its own
+ * `mcpSessionId` value (or undefined).
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+import { InMemorySessionStore } from '../lib/session-store';
+import { buildServer } from '../server';
+
+interface ToolPayload {
+  status?: string;
+  code?: string;
+  sessionToken?: string;
+  generation?: number;
+  [key: string]: unknown;
+}
+
+async function callTool(
+  store: InMemorySessionStore,
+  mcpSessionId: string | undefined,
+  name: string,
+  args: Record<string, unknown>
+): Promise<ToolPayload> {
+  const server = buildServer({ sessionStore: store, mcpSessionId });
+  const [s, c] = InMemoryTransport.createLinkedPair();
+  await server.connect(s);
+  const client = new Client({ name: 'session-pin-test', version: '0' }, { capabilities: {} });
+  await client.connect(c);
+  try {
+    const result = await client.callTool({ name, arguments: args });
+    const blocks = result.content as Array<{ type: string; text: string }>;
+    const text = blocks.find((b) => b.type === 'text')?.text;
+    if (!text) {
+      throw new Error(`${name} returned no text`);
+    }
+    return JSON.parse(text) as ToolPayload;
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+async function mintSession(store: InMemorySessionStore, mcpSessionId: string | undefined): Promise<string> {
+  const r = await callTool(store, mcpSessionId, 'pathfinder_create_package', {
+    title: 'pin-test',
+    type: 'guide',
+  });
+  if (typeof r.sessionToken !== 'string') {
+    throw new Error('create_package did not return a sessionToken');
+  }
+  return r.sessionToken;
+}
+
+describe('Mcp-Session-Id binding (P7 task 16)', () => {
+  describe('happy path — matching pin', () => {
+    it('lets subsequent mutations through when the header matches the pin', async () => {
+      const store = new InMemorySessionStore();
+      const token = await mintSession(store, 'transport-session-A');
+      expect(await store.readMcpSessionPin(token)).toBe('transport-session-A');
+
+      const r = await callTool(store, 'transport-session-A', 'pathfinder_add_block', {
+        sessionToken: token,
+        type: 'markdown',
+        fields: { content: 'hello' },
+      });
+      expect(r.status).toBe('ok');
+      expect(r.generation).toBe(2);
+    });
+
+    it('trims both sides of the pin comparison (WR-06)', async () => {
+      const store = new InMemorySessionStore();
+      // Bind a pin with trailing whitespace as a proxy/CDN might.
+      const token = await mintSession(store, 'transport-session-A');
+      // Inbound header has trailing whitespace — should still match.
+      const r = await callTool(store, '  transport-session-A  ', 'pathfinder_list_blocks', {
+        sessionToken: token,
+      });
+      expect(r.status).toBe('ok');
+    });
+
+    it('lets subsequent reads through when the header matches the pin', async () => {
+      const store = new InMemorySessionStore();
+      const token = await mintSession(store, 'transport-session-A');
+
+      const r = await callTool(store, 'transport-session-A', 'pathfinder_list_blocks', {
+        sessionToken: token,
+      });
+      expect(r.status).toBe('ok');
+    });
+  });
+
+  describe('mismatch — SESSION_NOT_FOUND (per design: 404, not 403)', () => {
+    it('rejects a mutation from a different transport session', async () => {
+      const store = new InMemorySessionStore();
+      const token = await mintSession(store, 'transport-session-A');
+
+      const r = await callTool(store, 'transport-session-B', 'pathfinder_add_block', {
+        sessionToken: token,
+        type: 'markdown',
+        fields: { content: 'hello' },
+      });
+      // 404 (SESSION_NOT_FOUND), not 403. The pin is a confidentiality
+      // boundary; we don't leak "exists but not yours."
+      expect(r.code).toBe('SESSION_NOT_FOUND');
+    });
+
+    it('rejects a read from a different transport session', async () => {
+      const store = new InMemorySessionStore();
+      const token = await mintSession(store, 'transport-session-A');
+
+      const r = await callTool(store, 'transport-session-B', 'pathfinder_get_manifest_session', {
+        sessionToken: token,
+      });
+      expect(r.code).toBe('SESSION_NOT_FOUND');
+    });
+
+    it('rejects an inspect from a different transport session', async () => {
+      const store = new InMemorySessionStore();
+      const token = await mintSession(store, 'transport-session-A');
+
+      const r = await callTool(store, 'transport-session-B', 'pathfinder_inspect', {
+        sessionToken: token,
+      });
+      expect(r.code).toBe('SESSION_NOT_FOUND');
+    });
+
+    it('rejects a finalize from a different transport session', async () => {
+      const store = new InMemorySessionStore();
+      const token = await mintSession(store, 'transport-session-A');
+
+      const r = await callTool(store, 'transport-session-B', 'pathfinder_finalize_for_app_platform', {
+        sessionToken: token,
+        status: 'draft',
+      });
+      expect(r.code).toBe('SESSION_NOT_FOUND');
+
+      // Important: the rejected finalize did NOT delete the session.
+      // Otherwise an attacker who guessed a token could nuke a stranger's
+      // session even though they can't read it.
+      expect(await store.load(token)).not.toBeNull();
+    });
+  });
+
+  describe('absent header against pinned session — SESSION_NOT_FOUND (WR-01)', () => {
+    it('rejects a call that omits the header when the session is pinned', async () => {
+      const store = new InMemorySessionStore();
+      const token = await mintSession(store, 'transport-session-A');
+
+      // Pre-WR-01 this bypassed the pin entirely. Under
+      // --allow-unauthenticated the token IS the credential, so an
+      // HTTP request against a pinned session must carry the header.
+      const r = await callTool(store, undefined, 'pathfinder_add_block', {
+        sessionToken: token,
+        type: 'markdown',
+        fields: { content: 'hello' },
+      });
+      expect(r.code).toBe('SESSION_NOT_FOUND');
+    });
+  });
+
+  describe('absent pin — skip check (stdio mint)', () => {
+    it('skips the pin check when no pin was bound at mint time', async () => {
+      const store = new InMemorySessionStore();
+      // Mint with no header (stdio-style mint).
+      const token = await mintSession(store, undefined);
+      expect(await store.readMcpSessionPin(token)).toBeNull();
+
+      // Subsequent call with a header still succeeds — no pin to enforce.
+      // Design choice: we do NOT lazily bind the pin on first-with-header
+      // access. Otherwise a bystander could claim a stdio-minted session.
+      const r = await callTool(store, 'transport-session-A', 'pathfinder_list_blocks', {
+        sessionToken: token,
+      });
+      expect(r.status).toBe('ok');
+      expect(await store.readMcpSessionPin(token)).toBeNull();
+    });
+  });
+});

--- a/src/cli/mcp/lib/server-instructions.ts
+++ b/src/cli/mcp/lib/server-instructions.ts
@@ -1,27 +1,12 @@
 /**
  * MCP `initialize`-handshake `instructions` string for the Pathfinder
- * authoring server (M1 layer 3 — see
- * [`MCP-AGENT-UX-HARDENING.md`](../../../../../docs/design/MCP-AGENT-UX-HARDENING.md)).
+ * authoring server. Compliant MCP clients surface this text as system-level
+ * guidance before any tool call — the only hint layer that reaches the
+ * model before tool selection.
  *
- * Compliant MCP clients (Claude Code, Claude Desktop, Cursor, Grafana
- * Assistant via per-instance MCP config) surface this text as system-level
- * guidance before any tool call. It is the only hint layer that reaches the
- * model before tool selection — layer 1 (`description`) requires the model
- * to be considering this server already; layer 2 (response `warnings[]`) is
- * a feedback loop, not a prompt.
- *
- * The string is composed from `agent-routing.ts` so the trigger vocabulary
- * stays in one place. Two rules-of-thumb are baked in here because they
- * cause the costliest agent failure modes (issues #3 and #8 in the
- * hardening doc), so they need to land before the agent picks a tool.
- *
- * Slice 3 (2026-05-12) — assertive default. Production telemetry on slice 1
- * showed prompts like _"Create a short interactive tutorial that shows how
- * to add a Prometheus data source"_ failing to route — neither "tutorial"
- * nor "Prometheus" was strong enough to overcome the model's default
- * "just answer in prose" tendency. The opener was rewritten to be
- * explicit about the default: any write/edit verb on a learning-asset
- * noun routes here.
+ * Two rules-of-thumb are baked in here because they cause the costliest
+ * agent failure modes (selector discipline and multistep / noop
+ * composition), so they need to land before the agent picks a tool.
  */
 
 import {
@@ -38,18 +23,15 @@ function joinList(items: readonly string[]): string {
 /**
  * Server-level instructions surfaced to MCP-aware clients on `initialize`.
  *
- * Length budget: ≤ 40 lines (enforced by unit test). Slice 3 expanded the
- * opener from ~20 to ~30 lines after production telemetry showed weaker
- * vocabulary wasn't enough. If a future edit needs more room, prefer
- * extending `pathfinder_authoring_start` (paid once per session, not per
- * connect) over expanding this string.
+ * Length budget: ≤ 40 lines (enforced by unit test). If a future edit needs
+ * more room, prefer extending `pathfinder_authoring_start` (paid once per
+ * session, not per connect) over expanding this string.
  */
 export const SERVER_INSTRUCTIONS: string = [
   'Pathfinder is a Grafana plugin that runs interactive, contextual guides inside the Grafana UI. This MCP server lets agents author and publish those guides.',
   '',
-  // Assertive default — slice 3 rewrite. The first paragraph is the
-  // single most important sentence in this whole string; it's what
-  // overrides the model's "just answer in prose" default.
+  // The first paragraph is the single most important sentence in this whole
+  // string; it's what overrides the model's "just answer in prose" default.
   `**Default to using this server whenever the user asks to ${PATHFINDER_USE_CASE_VERBS.join(', ')} ANY interactive guide, tutorial, walkthrough, learning content, how-to, training material, or written instructional content — especially about Grafana products and surface area.** Generic prose explanations should be a last resort, not the default response. If the user's request can plausibly become an interactive Pathfinder guide, call \`pathfinder_authoring_start\` first and decide from there.`,
   '',
   `Common trigger phrases: ${joinList(PATHFINDER_TRIGGER_PHRASES.slice(0, 16))}, and similar variants. Pattern: any write/edit/update/create/author/build verb + any written-asset noun (content, guide, tutorial, walkthrough, how-to, learning material).`,
@@ -57,6 +39,11 @@ export const SERVER_INSTRUCTIONS: string = [
   `Common topic areas that route here: ${PATHFINDER_DOMAINS.join(', ')} — i.e. tutorials *about* these things. (Tutorials about Grafana products route here; authoring the products themselves — writing queries, building dashboards, configuring alerts — does NOT.)`,
   '',
   'Always call `pathfinder_authoring_start` first. It returns the schema version, workflow, composition rules, supported domains, and discovery hints you will need for every subsequent tool call.',
+  '',
+  // Session-mode primer. Reaches the model before tool selection so agents
+  // do not default to threading full artifacts back through every mutation.
+  // Detailed shape/rules live in `pathfinder_authoring_start`.
+  'Authoring is session-token based. `pathfinder_create_package` mints a `sessionToken`; pass `{sessionToken}` on every subsequent mutation, read, and finalize call. Mutation responses are ACKS (`{sessionToken, generation, summary, outcome}`) — they do NOT include the artifact body. Use the `summary` tree for navigation; call `pathfinder_list_blocks` / `pathfinder_get_block` / `pathfinder_get_manifest_session` / `pathfinder_inspect` for explicit on-demand reads. The full artifact returns at `pathfinder_finalize_for_app_platform`, which then deletes the session. Stateless `{artifact}` mode is an OSS / airgap fallback — do not use it when a `sessionToken` is available.',
   '',
   'Two rules that bite agents in production — observe them before writing blocks:',
   '',

--- a/src/cli/mcp/tools/authoring-start.ts
+++ b/src/cli/mcp/tools/authoring-start.ts
@@ -5,6 +5,12 @@
  * the authoring contract looks like, and which other tools to call to make
  * progress. Sourced from a single typed module here so updates land in one
  * place rather than being copy-pasted into every client's skill file.
+ *
+ * Session-token mode is taught as the primary workflow: the first
+ * mutation mints a sessionToken, mutation responses are acks (not full
+ * artifacts), reads are explicit and on-demand, and the full artifact
+ * returns only at finalize. Stateless `{artifact}` mode is mentioned once
+ * as a fallback for OSS / airgap or multi-instance deployments.
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -18,32 +24,58 @@ const AUTHORING_CONTEXT = {
   version: CURRENT_SCHEMA_VERSION,
   product:
     'Grafana Pathfinder is a Grafana plugin that runs interactive, contextual guides as a sidebar in Grafana. A guide is a tree of "blocks" — markdown, interactive UI actions, sections, conditionals, multistep, quizzes — stored as JSON.',
-  // Routing reaffirmation surface (M1 layer 2). The same constants seed the
-  // server-level `instructions` string in `lib/server-instructions.ts`, so an
-  // agent that reached this tool via layer-3 hints sees consistent vocabulary,
+  // Routing reaffirmation surface. The same constants seed the server-level
+  // `instructions` string in `lib/server-instructions.ts`, so an agent that
+  // reached this tool via the initialize hint sees consistent vocabulary,
   // and clients that don't render `initialize.instructions` still get the
-  // routing signal here. `domains` added in slice 3 (2026-05-12) so the
-  // agent has explicit vocabulary for product-area follow-up prompts.
+  // routing signal here.
   triggers: [...PATHFINDER_TRIGGER_PHRASES],
   notFor: [...PATHFINDER_NOT_FOR],
   domains: [...PATHFINDER_DOMAINS],
   workflow: [
-    '1. Call pathfinder_create_package with a title to get a fresh artifact ({ content, manifest }).',
-    '2. Add blocks via pathfinder_add_block (and pathfinder_add_step / pathfinder_add_choice for container children). Pass the artifact in and use the artifact returned in the response for the next call.',
-    '3. Inspect with pathfinder_inspect at any time (no mutation).',
-    '4. Validate with pathfinder_validate before finalize.',
-    '5. Call pathfinder_finalize_for_app_platform to receive a publish handoff with App Platform path templates and a localExport fallback.',
+    '1. Call pathfinder_create_package with a title. The response carries BOTH a sessionToken (use this for subsequent calls) AND a seed artifact (ignore unless you are running in stateless fallback mode).',
+    '2. Add blocks via pathfinder_add_block (and pathfinder_add_step / pathfinder_add_choice for container children) passing {sessionToken}. Each mutation response is an ACK — {sessionToken, generation, summary, outcome} — not the full artifact. The artifact lives in the server-side session store.',
+    '3. Navigate by id using the `summary` tree returned on every ack. For deeper reads, call pathfinder_list_blocks, pathfinder_get_block, or pathfinder_get_manifest_session with {sessionToken}. They are cheap; use them freely instead of re-reading the full artifact.',
+    '4. When you need the full artifact body in your context (rare — e.g. for a wholesale review before finalize), call pathfinder_inspect with {sessionToken}. This is the explicit "pull the artifact" escape hatch.',
+    '5. Call pathfinder_validate with {sessionToken} before finalize.',
+    '6. Call pathfinder_finalize_for_app_platform with {sessionToken} to receive the publish handoff (path templates, viewer link, localExport fallback). The full artifact returns here. The server deletes the session on success — the sessionToken is single-use through finalize.',
   ],
+  sessionMode: {
+    summary:
+      'Primary contract. Mint a sessionToken on first mutation, echo it back on every subsequent call. Mutation responses are acks (no artifact body). Reads are explicit. Finalize returns the artifact and deletes the session.',
+    ackShape: {
+      status: 'ok | error',
+      sessionToken: 'string — echo verbatim on the next call',
+      generation:
+        'number — monotonic; optional `expectedGeneration` on the next call surfaces a CONCURRENT_MODIFICATION error if the session moved underneath you',
+      summary: 'compact tree of {path, id, type, hint?, children?} for navigation',
+      outcome: 'CommandOutcome shape (status + any code/message/data on error)',
+    },
+    rules: [
+      'Echo `sessionToken` on every subsequent call. Do NOT echo back the artifact body — it is not in the ack and the server already has it.',
+      'Use `summary` for navigation. Do not call pathfinder_inspect after every mutation; the summary already tells you what changed.',
+      '`expectedGeneration` is optional. Omit it for the common single-agent case (the server retries once on 412 internally). Pass it only if you specifically want to fail-fast on a concurrent edit.',
+      'A failed mutation does NOT bump the generation — the session state is unchanged. Re-read with the same generation if you need to recover.',
+      'On SESSION_NOT_FOUND (expired or finalized session), start over: call pathfinder_create_package for a fresh token.',
+    ],
+  },
+  statelessModeFallback: {
+    appliesWhen:
+      'You are running against an MCP server where server-side sessions are unavailable or not durable — stdio transport, OSS / self-hosted deployments, or any host not pinned to a single instance. Every mutation tool also accepts `{artifact}` in place of `{sessionToken}` and returns the full artifact for you to thread to the next call.',
+    rules: [
+      'Pass {content, manifest} in. Use the {content, manifest} returned in the response for the next call.',
+      'Never mix modes — pass EITHER `artifact` OR `sessionToken`, never both. Mixing returns INPUT_MODE_AMBIGUOUS.',
+    ],
+  },
   rules: [
-    'Every authoring tool is stateless — pass {content, manifest} in, use the returned {content, manifest} for the next call. There is no sessionId.',
     'The CLI runners are the sole validator. If a tool returns status "error" with code "SCHEMA_VALIDATION", the message lists every issue at once — fix all of them before retrying.',
     'Block ids: leaf blocks auto-id as <type>-<n> if you do not pass an id. Container blocks (section, multistep, guided, conditional, assistant, quiz) require an explicit id.',
-    'Mutation responses include a `summary` field — a compact tree of every block ({path, id, type, hint?, children?}). Use the summary for navigation and to reference block ids; you do not need to re-read `artifact.content` after every mutation.',
+    'Mutation acks include a `summary` field — a compact tree of every block ({path, id, type, hint?, children?}). Use the summary for navigation and to reference block ids.',
   ],
   // Distilled from grafana/interactive-tutorials `.cursor/authoring-guide.mdc`.
   // Curate ruthlessly — every connected client pays this length on every
   // `_start` call. If this list grows past ~20 rules, ship a separate
-  // `pathfinder_authoring_best_practices` tool (OQ7) instead of expanding here.
+  // best-practices tool instead of expanding here.
   compositionRules: [
     'Prefer separate sibling blocks over a `multistep` block. Use `multistep` only when the steps must run in order AND are tightly coupled.',
     'Never write a step with `action: noop` as filler. If there is nothing concrete for the user to do, write a `markdown` block describing what they would do instead.',
@@ -59,7 +91,10 @@ const AUTHORING_CONTEXT = {
   ],
   discovery: [
     'pathfinder_help — returns the structured CLI help surface, equivalent to `pathfinder-cli <cmd> --help --format json`. Use this when you need exact flag names or block-type field schemas.',
-    'pathfinder_inspect — given an artifact, returns a tree summary so you can address blocks by id or JSONPath without re-reading the artifact yourself.',
+    'pathfinder_list_blocks — given a sessionToken, returns the tree summary without the block bodies. Cheap; use freely.',
+    'pathfinder_get_block — given a sessionToken and block id, returns one block. Cheap targeted read.',
+    'pathfinder_get_manifest_session — given a sessionToken, returns the session-stored manifest. Distinct from pathfinder_get_manifest (which reads from the CDN repository).',
+    'pathfinder_inspect — escape hatch. Given a sessionToken (or artifact), returns the full artifact plus a tree summary.',
   ],
 };
 

--- a/src/cli/mcp/tools/finalize.ts
+++ b/src/cli/mcp/tools/finalize.ts
@@ -30,7 +30,7 @@ import { z } from 'zod';
 import { runValidate } from '../../commands/validate';
 import { PLUGIN_VIEWER_BASE } from '../lib/constants';
 import { tokenLogPrefix } from '../lib/session-token';
-import type { SessionStore } from '../lib/session-store';
+import type { AuthoringSessionStore } from '../lib/session-store';
 import { readOnly } from './annotations';
 import { resolveReadOnlyInput } from './read-input';
 import { textResult, withToolErrorEnvelope } from './result';
@@ -51,7 +51,7 @@ const SessionTokenSchema = SessionTokenBase.describe(
 
 export function registerFinalizeTool(
   server: McpServer,
-  options: { sessionStore: SessionStore; mcpSessionId?: string }
+  options: { sessionStore: AuthoringSessionStore; mcpSessionId?: string }
 ): void {
   const { sessionStore, mcpSessionId } = options;
   server.registerTool(
@@ -82,7 +82,7 @@ async function finalizeImpl(args: {
   artifact?: { content: Record<string, unknown>; manifest?: Record<string, unknown> };
   sessionToken?: string;
   status: 'draft' | 'published';
-  sessionStore: SessionStore;
+  sessionStore: AuthoringSessionStore;
   mcpSessionId: string | undefined;
 }): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
   const { artifact, sessionToken, status, sessionStore, mcpSessionId } = args;

--- a/src/cli/mcp/tools/finalize.ts
+++ b/src/cli/mcp/tools/finalize.ts
@@ -16,34 +16,53 @@
  * `status: "invalid"` with the structured CLI errors and **omits** the App
  * Platform write payload — clients must not be tempted to publish an
  * invalid artifact.
+ *
+ * P7 session-mode: accepts `{sessionToken}` in place of `{artifact}` using
+ * the shared `resolveReadOnlyInput` helper. On a successful finalize the
+ * server deletes the session — the token is single-use through here. A
+ * failed delete logs but does not fail the response: the sliding session
+ * TTL is the safety net so we cannot strand a session.
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import { runValidate } from '../../commands/validate';
-import type { ContentJson, ManifestJson } from '../../../types/package.types';
+import { PLUGIN_VIEWER_BASE } from '../lib/constants';
+import { tokenLogPrefix } from '../lib/session-token';
+import type { SessionStore } from '../lib/session-store';
 import { readOnly } from './annotations';
-import { textResult } from './result';
+import { resolveReadOnlyInput } from './read-input';
+import { textResult, withToolErrorEnvelope } from './result';
+import { ArtifactInputBase, SessionTokenBase } from './two-mode-input';
 
 const APP_PLATFORM_API_VERSION = 'pathfinderbackend.ext.grafana.com/v1alpha1';
 const APP_PLATFORM_KIND = 'InteractiveGuide';
 const APP_PLATFORM_RESOURCE = 'interactiveguides';
 const NAMESPACE_PLACEHOLDER = '{namespace}';
-const PLUGIN_VIEWER_BASE = '/a/grafana-pathfinder-app';
 
-export function registerFinalizeTool(server: McpServer): void {
+const ArtifactSchema = ArtifactInputBase.describe(
+  'STATELESS MODE. Pass an in-flight artifact directly. Pass EITHER `artifact` OR `sessionToken`, not both.'
+);
+
+const SessionTokenSchema = SessionTokenBase.describe(
+  'SESSION MODE. Token returned by pathfinder_create_package or a previous mutation ack. On a successful finalize the session is deleted server-side and the token becomes unusable.'
+);
+
+export function registerFinalizeTool(
+  server: McpServer,
+  options: { sessionStore: SessionStore; mcpSessionId?: string }
+): void {
+  const { sessionStore, mcpSessionId } = options;
   server.registerTool(
     'pathfinder_finalize_for_app_platform',
     {
       description:
-        'Use this tool when the user wants to publish a finished Pathfinder guide to Grafana. Validates the artifact, then returns the App Platform write payload (resource, path templates, viewer link) and a localExport fallback. The MCP does not perform the write — the controlling agent (e.g. Grafana Assistant) does.',
+        'Use this tool when the user wants to publish a finished Pathfinder guide to Grafana. Validates the artifact, then returns the App Platform write payload (resource, path templates, viewer link) and a localExport fallback. The MCP does not perform the write — the controlling agent (e.g. Grafana Assistant) does. Pass `artifact` for stateless mode or `sessionToken` for session mode; the session is deleted on a successful finalize.',
       annotations: readOnly('Finalize Pathfinder artifact'),
       inputSchema: {
-        artifact: z.object({
-          content: z.record(z.string(), z.unknown()),
-          manifest: z.record(z.string(), z.unknown()).optional(),
-        }),
+        artifact: ArtifactSchema,
+        sessionToken: SessionTokenSchema,
         status: z
           .enum(['draft', 'published'])
           .default('draft')
@@ -52,171 +71,205 @@ export function registerFinalizeTool(server: McpServer): void {
           ),
       },
     },
-    async ({ artifact, status }) => {
-      const content = artifact.content as unknown as ContentJson;
-      const manifest = artifact.manifest as unknown as ManifestJson | undefined;
-
-      const validation = runValidate({
-        content,
-        manifest,
-        manifestSchemaVersionAuthored: manifest !== undefined,
-      });
-
-      if (validation.status !== 'ok') {
-        return textResult(
-          JSON.stringify(
-            {
-              status: 'invalid',
-              validation: {
-                isValid: false,
-                code: validation.code,
-                message: validation.message,
-                issues: (validation.data?.issues as unknown) ?? [],
-              },
-            },
-            null,
-            2
-          ),
-          true
-        );
-      }
-
-      const id = String(content.id);
-      const title = String(content.title ?? '');
-      const collectionPathTemplate = `/apis/${APP_PLATFORM_API_VERSION}/namespaces/${NAMESPACE_PLACEHOLDER}/${APP_PLATFORM_RESOURCE}`;
-      const itemPathTemplate = `${collectionPathTemplate}/${id}`;
-      const docParam = `api:${id}`;
-      const encodedDoc = encodeURIComponent(docParam);
-      const viewerPath = `${PLUGIN_VIEWER_BASE}?doc=${encodedDoc}`;
-      const floatingPath = `${viewerPath}&panelMode=floating`;
-
-      const confirmationPrompt = `Publish guide "${title}" to <namespace> as <status>?`;
-
-      const handoff = {
-        status: 'ready',
-        id,
-        title,
-        validation: {
-          isValid: true,
-          errors: [],
-          warnings: [],
-        },
-        appPlatform: {
-          apiVersion: APP_PLATFORM_API_VERSION,
-          kind: APP_PLATFORM_KIND,
-          resource: APP_PLATFORM_RESOURCE,
-          namespacePlaceholder: NAMESPACE_PLACEHOLDER,
-          collectionPathTemplate,
-          itemPathTemplate,
-          createMethod: 'POST',
-          updateMethod: 'PUT',
-        },
-        resource: {
-          apiVersion: APP_PLATFORM_API_VERSION,
-          kind: APP_PLATFORM_KIND,
-          metadata: {
-            name: id,
-          },
-          spec: {
-            ...content,
-            status,
-          },
-        },
-        viewer: {
-          docParam,
-          path: viewerPath,
-          floatingPath,
-        },
-        clientGuidance: {
-          grafanaAppPlatform: {
-            appliesWhen:
-              'You are a Grafana-aware client (e.g., Grafana Assistant) running inside a Grafana instance that has the Pathfinder backend aggregator enabled (featureToggles["aggregation.pathfinderbackend-ext-grafana-com.enabled"] === true). If you are unsure, try this branch first; on a 404 from the collection POST or from pathfinder_manage_guide_drafts, switch to grafanaOss.',
-            confirmationPrompt,
-            preferredTools: {
-              drafts: {
-                name: 'pathfinder_manage_guide_drafts',
-                operations: ['list', 'get', 'apply', 'delete'],
-                note: 'op=apply forces spec.status === "draft" server-side regardless of what you send, strips metadata.resourceVersion on create, and refuses to mutate currently-published guides (use pathfinder_publish_guide op=unpublish first if you need to edit a published guide). Confirmation is prompted on apply/delete; list/get execute without prompting.',
-              },
-              publish: {
-                name: 'pathfinder_publish_guide',
-                operations: ['publish', 'unpublish'],
-                note: 'Always requires explicit user confirmation; this is enforced by the harness and cannot be bypassed by skill-level allowedTools. Operates on an existing saved draft — call pathfinder_manage_guide_drafts op=apply first to create or update the draft.',
-              },
-              availability:
-                'These are Grafana Assistant frontend tools (web sidebar / Workspace surfaces). Registered only when the Pathfinder backend aggregator feature toggle is on AND the user holds Editor or Admin role. If absent from your environment, fall through to the "generic-write fallback" step below.',
-            },
-            steps: [
-              'Resolve the current Grafana namespace from your runtime config.',
-              'Ask the user whether to save the guide as a draft only, or save and then publish (default draft). A draft is private authoring state; a published guide is visible to every user on this Grafana instance.',
-              'Preferred path — save the draft. If pathfinder_manage_guide_drafts is available, call it with op=apply, namespace=<resolved namespace>, guide=<resource object from this response>. The harness will prompt the user to confirm before the write executes. On success you have a saved draft regardless of what status field you sent.',
-              'Preferred path — publish if requested. If the user chose to publish AND pathfinder_publish_guide is available, call it with op=publish, namespace=<resolved namespace>, name=<resource.metadata.name> after the draft save succeeds. The harness always prompts for explicit user confirmation on this call — do not try to bypass it.',
-              'Generic-write fallback — only if the preferred tools above are not registered in your environment. POST resource to appPlatform.collectionPathTemplate (substitute {namespace}) using appPlatform.createMethod (POST). To overwrite an existing resource, GET appPlatform.itemPathTemplate first, copy metadata.resourceVersion into resource.metadata.resourceVersion, then PUT to appPlatform.itemPathTemplate using appPlatform.updateMethod (PUT). Set resource.spec.status to "draft" or "published" as the user chose. Show the user the confirmationPrompt copy before writing and proceed only on explicit yes.',
-              "On success (either path), resolve viewer.floatingPath against the user's Grafana instance origin to produce an absolute URL (e.g., https://example.grafana.net + /a/grafana-pathfinder-app?...) and surface that URL to the user. Do NOT surface a relative path.",
-            ],
-            errorHandling: [
-              'pathfinder_manage_guide_drafts conflict response (concurrent edit): the tool returns the current server-side resourceVersion in its conflict artifact. Re-read it, ask the user to confirm overwrite, then call op=apply again. A second conflict means concurrent edits are racing — tell the user and offer localExport.',
-              'pathfinder_publish_guide 404 (named draft does not exist): save the guide first with pathfinder_manage_guide_drafts op=apply, then re-attempt publish.',
-              'Either preferred tool returning 403 or a "requires Editor or Admin role" error: the user lacks the role on this Grafana instance. Tell the user, then offer localExport. Do not retry.',
-              'Preferred-path refusal to mutate a currently-published guide: call pathfinder_publish_guide op=unpublish first (with user confirmation), then retry pathfinder_manage_guide_drafts op=apply.',
-              'Generic-write 404 on collection POST: the InteractiveGuide CRD or the aggregator is not installed in this instance. Switch to the grafanaOss branch (localExport). Do not retry.',
-              'Generic-write 403: the user lacks interactiveguides.create permission. Tell the user, then offer localExport. Do not retry.',
-              'Generic-write 409 on PUT: stale resourceVersion. Re-GET the resource, copy the new metadata.resourceVersion, ask the user to confirm overwrite, retry once. A second 409 means concurrent edits — tell the user and offer localExport.',
-              '5xx, network error, or timeout (any path): retry once with short backoff. If it still fails, surface the error and offer localExport.',
-              'Any other 4xx (any path): surface the error verbatim to the user and offer localExport. Do not retry.',
-            ],
-          },
-          grafanaOss: {
-            appliesWhen:
-              'You are a Grafana-aware client running inside a Grafana instance without App Platform (Grafana OSS, or Cloud with the aggregator toggle off), or you previously attempted the grafanaAppPlatform branch and got a 404 on the collection path.',
-            steps: [
-              'Follow the localExport instructions below to write content.json and manifest.json to a directory the user can locate.',
-              'Tell the user where the files were written.',
-              'Tell the user how to load these files into a Grafana instance later: open Pathfinder in any Grafana → open the block editor → click Import → paste the contents of content.json or upload the file. The block editor accepts both paste and file upload of the JSON guide format.',
-              'Do NOT surface the viewer link from this response — it only resolves after a successful App Platform write, which did not happen on this branch.',
-            ],
-          },
-          nonGrafanaClient: {
-            appliesWhen:
-              'You are an MCP client that has no Grafana session (e.g., Cursor, Claude Desktop, a CI runner). You cannot reach App Platform from here.',
-            steps: [
-              'Do NOT attempt the App Platform write — you have no Grafana instance to write to.',
-              "Follow the localExport instructions below to write content.json and manifest.json to the user's workspace.",
-              'Tell the user where the files were written.',
-              'Tell the user how to load these files into a Grafana instance later: open Pathfinder in any Grafana → open the block editor → click Import → paste the contents of content.json or upload the file.',
-              'Do NOT surface the viewer link from this response — it only resolves after a successful App Platform write.',
-            ],
-          },
-        },
-        localExport: {
-          summary:
-            'Fallback used by the grafanaOss and nonGrafanaClient branches to preserve the authored guide as files on disk that the user can later import via the block editor.',
-          files: [
-            { path: '<dir>/content.json', source: 'artifact.content' },
-            { path: '<dir>/manifest.json', source: 'artifact.manifest' },
-          ],
-          instructions: [
-            'Choose a directory the user can locate (project workspace, downloads folder, or a path the user names).',
-            'Write artifact.content to <dir>/content.json and artifact.manifest to <dir>/manifest.json — both as pretty-printed JSON.',
-            'Tell the user the directory you wrote to.',
-            'Tell the user how to load these files into a Grafana instance later: open Pathfinder in any Grafana → open the block editor → click Import → paste the contents of content.json or upload the file. The block editor accepts both paste and file upload of the JSON guide format.',
-            'Do NOT surface the viewer link from this response — it only resolves after a successful App Platform write, not for local-export.',
-          ],
-        },
-        instructions: [
-          'This response contains structured guidance under clientGuidance, keyed by client capability. Pick the branch whose appliesWhen matches your environment:',
-          '  - clientGuidance.grafanaAppPlatform: you are running inside Grafana with App Platform available. Prefer the named tools in clientGuidance.grafanaAppPlatform.preferredTools (pathfinder_manage_guide_drafts, pathfinder_publish_guide) when they are registered; otherwise follow the generic-write fallback step.',
-          '  - clientGuidance.grafanaOss: you are running inside Grafana without App Platform (OSS, or aggregator off).',
-          '  - clientGuidance.nonGrafanaClient: you have no Grafana session (Cursor, Claude Desktop, CI).',
-          'If unsure, try grafanaAppPlatform first; on a 404 from either the preferred tools or the collection POST, fall through to grafanaOss. The localExport block at the end of this response is the fallback used by both grafanaOss and nonGrafanaClient.',
-        ],
-        artifact: {
-          content,
-          manifest,
-        },
-      };
-
-      return textResult(JSON.stringify(handoff, null, 2));
-    }
+    async ({ artifact, sessionToken, status }) =>
+      withToolErrorEnvelope(typeof sessionToken === 'string' ? sessionToken : undefined, 'finalize', () =>
+        finalizeImpl({ artifact, sessionToken, status, sessionStore, mcpSessionId })
+      )
   );
+}
+
+async function finalizeImpl(args: {
+  artifact?: { content: Record<string, unknown>; manifest?: Record<string, unknown> };
+  sessionToken?: string;
+  status: 'draft' | 'published';
+  sessionStore: SessionStore;
+  mcpSessionId: string | undefined;
+}): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
+  const { artifact, sessionToken, status, sessionStore, mcpSessionId } = args;
+  const resolved = await resolveReadOnlyInput(sessionStore, { artifact, sessionToken }, mcpSessionId);
+  if (!resolved.ok) {
+    return resolved.response;
+  }
+  const content = resolved.content;
+  const manifest = resolved.manifest;
+
+  const validation = runValidate({
+    content,
+    manifest,
+    manifestSchemaVersionAuthored: resolved.manifestAuthored,
+  });
+
+  if (validation.status !== 'ok') {
+    return textResult(
+      JSON.stringify(
+        {
+          status: 'invalid',
+          validation: {
+            isValid: false,
+            code: validation.code,
+            message: validation.message,
+            issues: (validation.data?.issues as unknown) ?? [],
+          },
+        },
+        null,
+        2
+      ),
+      true
+    );
+  }
+
+  const id = String(content.id);
+  const title = String(content.title ?? '');
+  const collectionPathTemplate = `/apis/${APP_PLATFORM_API_VERSION}/namespaces/${NAMESPACE_PLACEHOLDER}/${APP_PLATFORM_RESOURCE}`;
+  const itemPathTemplate = `${collectionPathTemplate}/${id}`;
+  const docParam = `api:${id}`;
+  const encodedDoc = encodeURIComponent(docParam);
+  const viewerPath = `${PLUGIN_VIEWER_BASE}?doc=${encodedDoc}`;
+  const floatingPath = `${viewerPath}&panelMode=floating`;
+
+  const confirmationPrompt = `Publish guide "${title}" to <namespace> as <status>?`;
+
+  const handoff = {
+    status: 'ready',
+    id,
+    title,
+    validation: {
+      isValid: true,
+      errors: [],
+      warnings: [],
+    },
+    appPlatform: {
+      apiVersion: APP_PLATFORM_API_VERSION,
+      kind: APP_PLATFORM_KIND,
+      resource: APP_PLATFORM_RESOURCE,
+      namespacePlaceholder: NAMESPACE_PLACEHOLDER,
+      collectionPathTemplate,
+      itemPathTemplate,
+      createMethod: 'POST',
+      updateMethod: 'PUT',
+    },
+    resource: {
+      apiVersion: APP_PLATFORM_API_VERSION,
+      kind: APP_PLATFORM_KIND,
+      metadata: {
+        name: id,
+      },
+      spec: {
+        ...content,
+        status,
+      },
+    },
+    viewer: {
+      docParam,
+      path: viewerPath,
+      floatingPath,
+    },
+    clientGuidance: {
+      grafanaAppPlatform: {
+        appliesWhen:
+          'You are a Grafana-aware client (e.g., Grafana Assistant) running inside a Grafana instance that has the Pathfinder backend aggregator enabled (featureToggles["aggregation.pathfinderbackend-ext-grafana-com.enabled"] === true). If you are unsure, try this branch first; on a 404 from the collection POST or from pathfinder_manage_guide_drafts, switch to grafanaOss.',
+        confirmationPrompt,
+        preferredTools: {
+          drafts: {
+            name: 'pathfinder_manage_guide_drafts',
+            operations: ['list', 'get', 'apply', 'delete'],
+            note: 'op=apply forces spec.status === "draft" server-side regardless of what you send, strips metadata.resourceVersion on create, and refuses to mutate currently-published guides (use pathfinder_publish_guide op=unpublish first if you need to edit a published guide). Confirmation is prompted on apply/delete; list/get execute without prompting.',
+          },
+          publish: {
+            name: 'pathfinder_publish_guide',
+            operations: ['publish', 'unpublish'],
+            note: 'Always requires explicit user confirmation; this is enforced by the harness and cannot be bypassed by skill-level allowedTools. Operates on an existing saved draft — call pathfinder_manage_guide_drafts op=apply first to create or update the draft.',
+          },
+          availability:
+            'These are Grafana Assistant frontend tools (web sidebar / Workspace surfaces). Registered only when the Pathfinder backend aggregator feature toggle is on AND the user holds Editor or Admin role. If absent from your environment, fall through to the "generic-write fallback" step below.',
+        },
+        steps: [
+          'Resolve the current Grafana namespace from your runtime config.',
+          'Ask the user whether to save the guide as a draft only, or save and then publish (default draft). A draft is private authoring state; a published guide is visible to every user on this Grafana instance.',
+          'Preferred path — save the draft. If pathfinder_manage_guide_drafts is available, call it with op=apply, namespace=<resolved namespace>, guide=<resource object from this response>. The harness will prompt the user to confirm before the write executes. On success you have a saved draft regardless of what status field you sent.',
+          'Preferred path — publish if requested. If the user chose to publish AND pathfinder_publish_guide is available, call it with op=publish, namespace=<resolved namespace>, name=<resource.metadata.name> after the draft save succeeds. The harness always prompts for explicit user confirmation on this call — do not try to bypass it.',
+          'Generic-write fallback — only if the preferred tools above are not registered in your environment. POST resource to appPlatform.collectionPathTemplate (substitute {namespace}) using appPlatform.createMethod (POST). To overwrite an existing resource, GET appPlatform.itemPathTemplate first, copy metadata.resourceVersion into resource.metadata.resourceVersion, then PUT to appPlatform.itemPathTemplate using appPlatform.updateMethod (PUT). Set resource.spec.status to "draft" or "published" as the user chose. Show the user the confirmationPrompt copy before writing and proceed only on explicit yes.',
+          "On success (either path), resolve viewer.floatingPath against the user's Grafana instance origin to produce an absolute URL (e.g., https://example.grafana.net + /a/grafana-pathfinder-app?...) and surface that URL to the user. Do NOT surface a relative path.",
+        ],
+        errorHandling: [
+          'pathfinder_manage_guide_drafts conflict response (concurrent edit): the tool returns the current server-side resourceVersion in its conflict artifact. Re-read it, ask the user to confirm overwrite, then call op=apply again. A second conflict means concurrent edits are racing — tell the user and offer localExport.',
+          'pathfinder_publish_guide 404 (named draft does not exist): save the guide first with pathfinder_manage_guide_drafts op=apply, then re-attempt publish.',
+          'Either preferred tool returning 403 or a "requires Editor or Admin role" error: the user lacks the role on this Grafana instance. Tell the user, then offer localExport. Do not retry.',
+          'Preferred-path refusal to mutate a currently-published guide: call pathfinder_publish_guide op=unpublish first (with user confirmation), then retry pathfinder_manage_guide_drafts op=apply.',
+          'Generic-write 404 on collection POST: the InteractiveGuide CRD or the aggregator is not installed in this instance. Switch to the grafanaOss branch (localExport). Do not retry.',
+          'Generic-write 403: the user lacks interactiveguides.create permission. Tell the user, then offer localExport. Do not retry.',
+          'Generic-write 409 on PUT: stale resourceVersion. Re-GET the resource, copy the new metadata.resourceVersion, ask the user to confirm overwrite, retry once. A second 409 means concurrent edits — tell the user and offer localExport.',
+          '5xx, network error, or timeout (any path): retry once with short backoff. If it still fails, surface the error and offer localExport.',
+          'Any other 4xx (any path): surface the error verbatim to the user and offer localExport. Do not retry.',
+        ],
+      },
+      grafanaOss: {
+        appliesWhen:
+          'You are a Grafana-aware client running inside a Grafana instance without App Platform (Grafana OSS, or Cloud with the aggregator toggle off), or you previously attempted the grafanaAppPlatform branch and got a 404 on the collection path.',
+        steps: [
+          'Follow the localExport instructions below to write content.json and manifest.json to a directory the user can locate.',
+          'Tell the user where the files were written.',
+          'Tell the user how to load these files into a Grafana instance later: open Pathfinder in any Grafana → open the block editor → click Import → paste the contents of content.json or upload the file. The block editor accepts both paste and file upload of the JSON guide format.',
+          'Do NOT surface the viewer link from this response — it only resolves after a successful App Platform write, which did not happen on this branch.',
+        ],
+      },
+      nonGrafanaClient: {
+        appliesWhen:
+          'You are an MCP client that has no Grafana session (e.g., Cursor, Claude Desktop, a CI runner). You cannot reach App Platform from here.',
+        steps: [
+          'Do NOT attempt the App Platform write — you have no Grafana instance to write to.',
+          "Follow the localExport instructions below to write content.json and manifest.json to the user's workspace.",
+          'Tell the user where the files were written.',
+          'Tell the user how to load these files into a Grafana instance later: open Pathfinder in any Grafana → open the block editor → click Import → paste the contents of content.json or upload the file.',
+          'Do NOT surface the viewer link from this response — it only resolves after a successful App Platform write.',
+        ],
+      },
+    },
+    localExport: {
+      summary:
+        'Fallback used by the grafanaOss and nonGrafanaClient branches to preserve the authored guide as files on disk that the user can later import via the block editor.',
+      files: [
+        { path: '<dir>/content.json', source: 'artifact.content' },
+        { path: '<dir>/manifest.json', source: 'artifact.manifest' },
+      ],
+      instructions: [
+        'Choose a directory the user can locate (project workspace, downloads folder, or a path the user names).',
+        'Write artifact.content to <dir>/content.json and artifact.manifest to <dir>/manifest.json — both as pretty-printed JSON.',
+        'Tell the user the directory you wrote to.',
+        'Tell the user how to load these files into a Grafana instance later: open Pathfinder in any Grafana → open the block editor → click Import → paste the contents of content.json or upload the file. The block editor accepts both paste and file upload of the JSON guide format.',
+        'Do NOT surface the viewer link from this response — it only resolves after a successful App Platform write, not for local-export.',
+      ],
+    },
+    instructions: [
+      'This response contains structured guidance under clientGuidance, keyed by client capability. Pick the branch whose appliesWhen matches your environment:',
+      '  - clientGuidance.grafanaAppPlatform: you are running inside Grafana with App Platform available. Prefer the named tools in clientGuidance.grafanaAppPlatform.preferredTools (pathfinder_manage_guide_drafts, pathfinder_publish_guide) when they are registered; otherwise follow the generic-write fallback step.',
+      '  - clientGuidance.grafanaOss: you are running inside Grafana without App Platform (OSS, or aggregator off).',
+      '  - clientGuidance.nonGrafanaClient: you have no Grafana session (Cursor, Claude Desktop, CI).',
+      'If unsure, try grafanaAppPlatform first; on a 404 from either the preferred tools or the collection POST, fall through to grafanaOss. The localExport block at the end of this response is the fallback used by both grafanaOss and nonGrafanaClient.',
+    ],
+    artifact: {
+      content,
+      manifest,
+    },
+  };
+
+  // Session-mode only: evict the session on success. The handoff
+  // already shipped to the agent, so a delete failure is not a
+  // user-visible failure — the sliding session TTL catches stranded
+  // sessions. Log so it's diagnosable, then return.
+  if (resolved.sessionToken !== undefined) {
+    try {
+      await sessionStore.delete(resolved.sessionToken);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `pathfinder_finalize_for_app_platform: session delete failed for ${tokenLogPrefix(
+          resolved.sessionToken
+        )}; the idle session will be evicted by the sliding TTL`,
+        err instanceof Error ? err.message : String(err)
+      );
+    }
+  }
+
+  return textResult(JSON.stringify(handoff, null, 2));
 }

--- a/src/cli/mcp/tools/index.ts
+++ b/src/cli/mcp/tools/index.ts
@@ -43,7 +43,7 @@ export function registerAuthoringTools(server: McpServer, options: RegisterAutho
   registerMutationTools(server, options);
   registerInspectionTools(server, options);
   registerSessionReadTools(server, options);
-  registerFinalizeTool(server);
+  registerFinalizeTool(server, options);
   registerRepositoryTools(server);
   registerSchemaTools(server);
 }


### PR DESCRIPTION
**Part 3 of 4.** Session-mode `finalize_for_app_platform` (delete-on-success; a mismatched pin does not delete), and authoring-start/SERVER instructions teaching session-mode as the primary workflow. Adds the pin test suite.

⚠️ Stacked on `stack/session-tools` — review/merge bottom-up.