### PR TITLE
refactor(block-editor): extract helpers and dedupe merge logic in useBlockEditor

### DIFF
--- a/src/components/block-editor/hooks/useBlockEditor.helpers.test.ts
+++ b/src/components/block-editor/hooks/useBlockEditor.helpers.test.ts
@@ -1,0 +1,96 @@
+import type { EditorBlock } from '../types';
+import type { JsonSectionBlock } from '../../../types/json-guide.types';
+import {
+  generateBlockId,
+  isConditionalBlock,
+  isGuidedBlock,
+  isInteractiveBlock,
+  isMultistepBlock,
+  isSectionBlock,
+  parseBlockId,
+} from './useBlockEditor.helpers';
+
+const makeSection = (id: string, nested: JsonSectionBlock['blocks']): EditorBlock => ({
+  id,
+  block: { type: 'section', title: 'Section', blocks: nested },
+});
+
+describe('type guards', () => {
+  it('identifies each block kind', () => {
+    expect(isSectionBlock({ type: 'section', title: 's', blocks: [] })).toBe(true);
+    expect(isConditionalBlock({ type: 'conditional', conditions: [], whenTrue: [], whenFalse: [] })).toBe(true);
+    expect(isInteractiveBlock({ type: 'interactive', action: 'button', reftarget: '#x', content: 'go' })).toBe(true);
+    expect(isMultistepBlock({ type: 'multistep', content: '', steps: [] })).toBe(true);
+    expect(isGuidedBlock({ type: 'guided', content: '', steps: [] })).toBe(true);
+
+    expect(isSectionBlock({ type: 'markdown', content: '' })).toBe(false);
+    expect(isInteractiveBlock({ type: 'markdown', content: '' })).toBe(false);
+  });
+});
+
+describe('generateBlockId', () => {
+  it('produces ids with the block- prefix', () => {
+    expect(generateBlockId()).toMatch(/^block-\d+-[a-z0-9]+$/);
+  });
+
+  it('produces distinct ids on consecutive calls', () => {
+    const ids = new Set([generateBlockId(), generateBlockId(), generateBlockId(), generateBlockId()]);
+    expect(ids.size).toBe(4);
+  });
+});
+
+describe('parseBlockId', () => {
+  const sectionA = makeSection('section-a', [
+    { type: 'markdown', content: 'first' },
+    { type: 'markdown', content: 'second' },
+  ]);
+  const rootMarkdown: EditorBlock = { id: 'block-root-1', block: { type: 'markdown', content: 'top' } };
+  const blocks: EditorBlock[] = [sectionA, rootMarkdown];
+
+  it('resolves a root-level block by id', () => {
+    const parsed = parseBlockId('block-root-1', blocks);
+    expect(parsed.isNested).toBe(false);
+    expect(parsed.rootIndex).toBe(1);
+    expect(parsed.block).toEqual({ type: 'markdown', content: 'top' });
+  });
+
+  it('returns an empty result when a root id is unknown', () => {
+    expect(parseBlockId('does-not-exist', blocks)).toEqual({ isNested: false });
+  });
+
+  it('resolves a nested block by composite id', () => {
+    const parsed = parseBlockId('section-a-nested-1', blocks);
+    expect(parsed.isNested).toBe(true);
+    expect(parsed.sectionId).toBe('section-a');
+    expect(parsed.nestedIndex).toBe(1);
+    expect(parsed.sectionRootIndex).toBe(0);
+    expect(parsed.block).toEqual({ type: 'markdown', content: 'second' });
+  });
+
+  it('reports nested with no block when the index is out of range', () => {
+    const parsed = parseBlockId('section-a-nested-9', blocks);
+    expect(parsed.isNested).toBe(true);
+    expect(parsed.sectionRootIndex).toBe(0);
+    expect(parsed.block).toBeUndefined();
+  });
+
+  it('reports nested with no sectionRootIndex when the section id is unknown', () => {
+    const parsed = parseBlockId('ghost-section-nested-0', blocks);
+    expect(parsed.isNested).toBe(true);
+    expect(parsed.sectionRootIndex).toBeUndefined();
+    expect(parsed.block).toBeUndefined();
+  });
+
+  it('treats a non-numeric suffix after -nested- as not a nested id, falling back to root lookup', () => {
+    expect(parseBlockId('section-a-nested-foo', blocks)).toEqual({ isNested: false });
+  });
+
+  it('uses the last -nested- marker so section ids containing -nested- still parse', () => {
+    const trickySection = makeSection('weird-nested-name', [{ type: 'markdown', content: 'hi' }]);
+    const parsed = parseBlockId('weird-nested-name-nested-0', [trickySection]);
+    expect(parsed.isNested).toBe(true);
+    expect(parsed.sectionId).toBe('weird-nested-name');
+    expect(parsed.nestedIndex).toBe(0);
+    expect(parsed.block).toEqual({ type: 'markdown', content: 'hi' });
+  });
+});

--- a/src/components/block-editor/hooks/useBlockEditor.helpers.ts
+++ b/src/components/block-editor/hooks/useBlockEditor.helpers.ts
@@ -1,0 +1,59 @@
+import type { EditorBlock, JsonBlock } from '../types';
+import type {
+  JsonSectionBlock,
+  JsonConditionalBlock,
+  JsonInteractiveBlock,
+  JsonMultistepBlock,
+  JsonGuidedBlock,
+} from '../../../types/json-guide.types';
+
+export const isSectionBlock = (block: JsonBlock): block is JsonSectionBlock => block.type === 'section';
+export const isConditionalBlock = (block: JsonBlock): block is JsonConditionalBlock => block.type === 'conditional';
+export const isInteractiveBlock = (block: JsonBlock): block is JsonInteractiveBlock => block.type === 'interactive';
+export const isMultistepBlock = (block: JsonBlock): block is JsonMultistepBlock => block.type === 'multistep';
+export const isGuidedBlock = (block: JsonBlock): block is JsonGuidedBlock => block.type === 'guided';
+
+export const generateBlockId = (): string => `block-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+
+const NESTED_MARKER = '-nested-';
+
+export interface ParsedBlockId {
+  isNested: boolean;
+  sectionId?: string;
+  nestedIndex?: number;
+  block?: JsonBlock;
+  rootIndex?: number;
+  sectionRootIndex?: number;
+}
+
+/**
+ * Parse a block ID to determine whether it addresses a root block or a nested block.
+ * Nested block IDs have the form `${sectionId}-nested-${nestedIndex}`.
+ */
+export const parseBlockId = (id: string, blocks: EditorBlock[]): ParsedBlockId => {
+  const markerIndex = id.lastIndexOf(NESTED_MARKER);
+
+  if (markerIndex !== -1) {
+    const sectionId = id.slice(0, markerIndex);
+    const nestedIndexStr = id.slice(markerIndex + NESTED_MARKER.length);
+    const nestedIndex = parseInt(nestedIndexStr, 10);
+
+    if (!isNaN(nestedIndex) && nestedIndexStr === String(nestedIndex)) {
+      const sectionRootIndex = blocks.findIndex((b) => b.id === sectionId);
+      const section = sectionRootIndex >= 0 ? blocks[sectionRootIndex] : undefined;
+      if (section && isSectionBlock(section.block)) {
+        const nestedBlock = section.block.blocks[nestedIndex];
+        if (nestedBlock) {
+          return { isNested: true, sectionId, nestedIndex, block: nestedBlock, sectionRootIndex };
+        }
+      }
+      return { isNested: true, sectionRootIndex: sectionRootIndex >= 0 ? sectionRootIndex : undefined };
+    }
+  }
+
+  const rootIndex = blocks.findIndex((b) => b.id === id);
+  if (rootIndex >= 0) {
+    return { isNested: false, block: blocks[rootIndex]!.block, rootIndex };
+  }
+  return { isNested: false };
+};

--- a/src/components/block-editor/hooks/useBlockEditor.merge.test.ts
+++ b/src/components/block-editor/hooks/useBlockEditor.merge.test.ts
@@ -1,0 +1,160 @@
+import type { EditorBlock } from '../types';
+import type {
+  JsonGuidedBlock,
+  JsonInteractiveBlock,
+  JsonMultistepBlock,
+  JsonSectionBlock,
+} from '../../../types/json-guide.types';
+import { mergeBlocks } from './useBlockEditor.merge';
+
+const interactive = (id: string, overrides: Partial<JsonInteractiveBlock> = {}): EditorBlock => ({
+  id,
+  block: {
+    type: 'interactive',
+    action: 'button',
+    reftarget: `#btn-${id}`,
+    content: `do ${id}`,
+    ...overrides,
+  },
+});
+
+const markdown = (id: string, content = 'note'): EditorBlock => ({
+  id,
+  block: { type: 'markdown', content },
+});
+
+const section = (id: string, nested: JsonSectionBlock['blocks']): EditorBlock => ({
+  id,
+  block: { type: 'section', title: 'Section', blocks: nested },
+});
+
+describe('mergeBlocks', () => {
+  it('returns null when fewer than two mergeable blocks are selected', () => {
+    const prev = [interactive('a'), markdown('b')];
+    expect(mergeBlocks(prev, ['a'], 'multistep')).toBeNull();
+    expect(mergeBlocks(prev, ['a', 'b'], 'multistep')).toBeNull(); // markdown isn't mergeable
+  });
+
+  it('returns null when no ids match', () => {
+    const prev = [interactive('a'), interactive('b')];
+    expect(mergeBlocks(prev, ['x', 'y'], 'guided')).toBeNull();
+  });
+
+  it('merges two root-level interactive blocks into a multistep at the first position', () => {
+    const prev = [markdown('top'), interactive('a'), interactive('b'), markdown('tail')];
+    const result = mergeBlocks(prev, ['a', 'b'], 'multistep');
+    expect(result).not.toBeNull();
+    expect(result!.map((b) => b.block.type)).toEqual(['markdown', 'multistep', 'markdown']);
+
+    const merged = result![1]!.block as JsonMultistepBlock;
+    expect(merged.type).toBe('multistep');
+    expect(merged.content).toBe('Complete the following steps:');
+    expect(merged.steps).toEqual([
+      { action: 'button', reftarget: '#btn-a', tooltip: 'do a' },
+      { action: 'button', reftarget: '#btn-b', tooltip: 'do b' },
+    ]);
+  });
+
+  it('orders steps by document position even when selection ids are passed out of order', () => {
+    const prev = [interactive('first'), interactive('middle'), interactive('last')];
+    const result = mergeBlocks(prev, ['last', 'first'], 'guided')!;
+    const merged = result.find((b) => b.block.type === 'guided')!.block as JsonGuidedBlock;
+    expect(merged.steps.map((s) => s.reftarget)).toEqual(['#btn-first', '#btn-last']);
+  });
+
+  it('prefers tooltip over content when producing multistep steps', () => {
+    const prev = [
+      interactive('a', { tooltip: 'tip-a', content: 'content-a' }),
+      interactive('b', { content: 'content-b' }), // no tooltip → fall back to content
+      interactive('c', { tooltip: '', content: 'content-c' }), // empty tooltip → fall back to content
+    ];
+    const result = mergeBlocks(prev, ['a', 'b', 'c'], 'multistep')!;
+    const merged = result.find((b) => b.block.type === 'multistep')!.block as JsonMultistepBlock;
+    expect(merged.steps.map((s) => s.tooltip)).toEqual(['tip-a', 'content-b', 'content-c']);
+  });
+
+  it('maps interactive content to description when merging into a guided block', () => {
+    const prev = [interactive('a', { content: 'first' }), interactive('b', { content: 'second' })];
+    const result = mergeBlocks(prev, ['a', 'b'], 'guided')!;
+    const merged = result.find((b) => b.block.type === 'guided')!.block as JsonGuidedBlock;
+    expect(merged.content).toBe('Follow the steps below:');
+    expect(merged.steps).toEqual([
+      { action: 'button', reftarget: '#btn-a', description: 'first' },
+      { action: 'button', reftarget: '#btn-b', description: 'second' },
+    ]);
+  });
+
+  it('expands a selected multistep block into its individual steps', () => {
+    const existingMultistep: EditorBlock = {
+      id: 'm',
+      block: {
+        type: 'multistep',
+        content: 'old multistep',
+        steps: [
+          { action: 'button', reftarget: '#x', tooltip: 'x' },
+          { action: 'button', reftarget: '#y', tooltip: 'y' },
+        ],
+      } satisfies JsonMultistepBlock,
+    };
+    const prev = [existingMultistep, interactive('after', { tooltip: 'after' })];
+    const result = mergeBlocks(prev, ['m', 'after'], 'multistep')!;
+    const merged = result.find((b) => b.block.type === 'multistep')!.block as JsonMultistepBlock;
+    expect(merged.steps).toEqual([
+      { action: 'button', reftarget: '#x', tooltip: 'x' },
+      { action: 'button', reftarget: '#y', tooltip: 'y' },
+      { action: 'button', reftarget: '#btn-after', tooltip: 'after' },
+    ]);
+  });
+
+  it('merges nested blocks inside their section and places the merged block at the first nested index', () => {
+    const nestedInteractives = [
+      { type: 'interactive', action: 'button', reftarget: '#n-a', content: 'na' },
+      { type: 'markdown', content: 'spacer' },
+      { type: 'interactive', action: 'button', reftarget: '#n-b', content: 'nb' },
+    ] as JsonSectionBlock['blocks'];
+    const prev = [section('s1', nestedInteractives), markdown('after-section')];
+
+    const result = mergeBlocks(prev, ['s1-nested-0', 's1-nested-2'], 'multistep')!;
+    expect(result).toHaveLength(2); // section + markdown — no new root block
+    const updatedSection = result[0]!.block as JsonSectionBlock;
+    expect(updatedSection.blocks.map((b) => b.type)).toEqual(['multistep', 'markdown']);
+    const merged = updatedSection.blocks[0] as JsonMultistepBlock;
+    expect(merged.steps.map((s) => s.reftarget)).toEqual(['#n-a', '#n-b']);
+  });
+
+  it('leaves the root list intact (no surplus block) when merging nested blocks', () => {
+    const prev = [
+      section('s1', [
+        { type: 'interactive', action: 'button', reftarget: '#n-a', content: 'a' },
+        { type: 'interactive', action: 'button', reftarget: '#n-b', content: 'b' },
+      ] as JsonSectionBlock['blocks']),
+    ];
+    const result = mergeBlocks(prev, ['s1-nested-0', 's1-nested-1'], 'guided')!;
+    expect(result).toHaveLength(1);
+    const updatedSection = result[0]!.block as JsonSectionBlock;
+    expect(updatedSection.blocks).toHaveLength(1);
+    expect(updatedSection.blocks[0]!.type).toBe('guided');
+  });
+
+  it('inserts the merged block at the first selected root position, accounting for removed blocks before it', () => {
+    const prev = [
+      markdown('top'),
+      interactive('a'),
+      markdown('mid'),
+      interactive('b'),
+      interactive('c'),
+      markdown('tail'),
+    ];
+    const result = mergeBlocks(prev, ['a', 'b', 'c'], 'multistep')!;
+    // Layout: top kept at 0, merged block lands at index 1 (where 'a' lived),
+    // mid kept (now at 2), tail kept (now at 3). 'b' and 'c' are absorbed.
+    expect(result).toHaveLength(4);
+    expect(result.map((b) => b.block.type)).toEqual(['markdown', 'multistep', 'markdown', 'markdown']);
+    expect(result[0]!.id).toBe('top');
+    expect(result[2]!.id).toBe('mid');
+    expect(result[3]!.id).toBe('tail');
+    const merged = result[1]!.block as JsonMultistepBlock;
+    expect(merged.steps).toHaveLength(3);
+    expect(merged.steps.map((s) => s.reftarget)).toEqual(['#btn-a', '#btn-b', '#btn-c']);
+  });
+});

--- a/src/components/block-editor/hooks/useBlockEditor.merge.ts
+++ b/src/components/block-editor/hooks/useBlockEditor.merge.ts
@@ -1,0 +1,153 @@
+import type { EditorBlock, JsonBlock } from '../types';
+import type {
+  JsonGuidedBlock,
+  JsonInteractiveBlock,
+  JsonMultistepBlock,
+  JsonStep,
+} from '../../../types/json-guide.types';
+import {
+  generateBlockId,
+  isGuidedBlock,
+  isInteractiveBlock,
+  isMultistepBlock,
+  isSectionBlock,
+  parseBlockId,
+  type ParsedBlockId,
+} from './useBlockEditor.helpers';
+
+export type MergeKind = 'multistep' | 'guided';
+
+interface MergeSpec {
+  defaultContent: string;
+  interactiveToStep: (interactive: JsonInteractiveBlock) => JsonStep;
+}
+
+const MERGE_SPECS: Record<MergeKind, MergeSpec> = {
+  multistep: {
+    defaultContent: 'Complete the following steps:',
+    interactiveToStep: (interactive) => ({
+      action: interactive.action,
+      reftarget: interactive.reftarget,
+      ...(interactive.targetvalue && { targetvalue: interactive.targetvalue }),
+      ...(interactive.tooltip && { tooltip: interactive.tooltip }),
+      ...(!interactive.tooltip && interactive.content && { tooltip: interactive.content }),
+    }),
+  },
+  guided: {
+    defaultContent: 'Follow the steps below:',
+    interactiveToStep: (interactive) => ({
+      action: interactive.action,
+      reftarget: interactive.reftarget,
+      ...(interactive.targetvalue && { targetvalue: interactive.targetvalue }),
+      ...(interactive.content && { description: interactive.content }),
+    }),
+  },
+};
+
+const isMergeable = (
+  block: JsonBlock | undefined
+): block is JsonInteractiveBlock | JsonMultistepBlock | JsonGuidedBlock =>
+  !!block && (isInteractiveBlock(block) || isMultistepBlock(block) || isGuidedBlock(block));
+
+/**
+ * Position weight for sorting parsed blocks in document order. Root blocks use
+ * their root index; nested blocks fall under their section's root index and
+ * sort by nested index within that section.
+ *
+ * The 10000 multiplier assumes sections hold fewer than 10000 children — true
+ * for any realistic guide. If that ever stops being true, switch to a tuple
+ * comparator.
+ */
+const positionWeight = (p: ParsedBlockId): number => {
+  const SECTION_STRIDE = 10000;
+  if (p.isNested) {
+    return (p.sectionRootIndex ?? 0) * SECTION_STRIDE + (p.nestedIndex ?? 0);
+  }
+  return (p.rootIndex ?? 0) * SECTION_STRIDE;
+};
+
+type ParsedWithId = ParsedBlockId & { id: string };
+
+/**
+ * Merge interactive/multistep/guided blocks identified by `blockIds` into a
+ * single multistep or guided block (per `kind`). Returns the new block list,
+ * or `null` if there is nothing to merge (fewer than two mergeable inputs).
+ *
+ * The merged block is inserted at the position of the first selected block in
+ * document order. If that first block is nested inside a section, the merged
+ * block is placed inside that section; otherwise it is placed at root level.
+ */
+export const mergeBlocks = (prev: EditorBlock[], blockIds: string[], kind: MergeKind): EditorBlock[] | null => {
+  const parsedBlocks: ParsedWithId[] = blockIds
+    .map((id) => ({ id, ...parseBlockId(id, prev) }))
+    .filter((p): p is ParsedWithId => isMergeable(p.block));
+
+  if (parsedBlocks.length < 2) {
+    return null;
+  }
+
+  parsedBlocks.sort((a, b) => positionWeight(a) - positionWeight(b));
+
+  const spec = MERGE_SPECS[kind];
+  const steps: JsonStep[] = parsedBlocks.flatMap((p) => {
+    const block = p.block!;
+    if (isInteractiveBlock(block)) {
+      return [spec.interactiveToStep(block)];
+    }
+    return (block as JsonMultistepBlock | JsonGuidedBlock).steps;
+  });
+
+  const mergedBlock: JsonMultistepBlock | JsonGuidedBlock = {
+    type: kind,
+    content: spec.defaultContent,
+    steps,
+  };
+
+  const firstParsed = parsedBlocks[0]!;
+  const insertIntoSection = firstParsed.isNested && firstParsed.sectionId !== undefined;
+
+  const rootIdsToRemove = new Set(parsedBlocks.filter((p) => !p.isNested).map((p) => p.id));
+
+  const nestedToRemove = new Map<string, number[]>();
+  for (const p of parsedBlocks) {
+    if (p.isNested && p.sectionId !== undefined && p.nestedIndex !== undefined) {
+      const existing = nestedToRemove.get(p.sectionId) ?? [];
+      existing.push(p.nestedIndex);
+      nestedToRemove.set(p.sectionId, existing);
+    }
+  }
+
+  const newBlocks = prev
+    .filter((b) => !rootIdsToRemove.has(b.id))
+    .map((b) => {
+      if (!isSectionBlock(b.block)) {
+        return b;
+      }
+      const isInsertionSection = insertIntoSection && b.id === firstParsed.sectionId;
+      if (!nestedToRemove.has(b.id) && !isInsertionSection) {
+        return b;
+      }
+
+      const indicesToRemove = new Set(nestedToRemove.get(b.id) ?? []);
+      const newSectionBlocks = b.block.blocks.filter((_, i) => !indicesToRemove.has(i));
+
+      if (isInsertionSection) {
+        const insertIdx = firstParsed.nestedIndex!;
+        const removedBefore = Array.from(indicesToRemove).filter((i) => i < insertIdx).length;
+        const adjustedIdx = insertIdx - removedBefore;
+        newSectionBlocks.splice(adjustedIdx, 0, mergedBlock);
+      }
+
+      return { ...b, block: { ...b.block, blocks: newSectionBlocks } };
+    });
+
+  if (!insertIntoSection) {
+    const newEditorBlock: EditorBlock = { id: generateBlockId(), block: mergedBlock };
+    const originalIndex = prev.findIndex((b) => b.id === firstParsed.id);
+    const removedBeforeInsert = prev.filter((b, i) => i < originalIndex && rootIdsToRemove.has(b.id)).length;
+    const insertIndex = originalIndex - removedBeforeInsert;
+    newBlocks.splice(insertIndex, 0, newEditorBlock);
+  }
+
+  return newBlocks;
+};

--- a/src/components/block-editor/hooks/useBlockEditor.ts
+++ b/src/components/block-editor/hooks/useBlockEditor.ts
@@ -8,7 +8,6 @@
 import { useCallback, useMemo } from 'react';
 import type { EditorBlock, BlockEditorState, JsonBlock, JsonGuide, ViewMode } from '../types';
 import type {
-  JsonSectionBlock,
   JsonConditionalBlock,
   JsonInteractiveBlock,
   JsonMultistepBlock,
@@ -18,48 +17,15 @@ import type {
 import { DEFAULT_GUIDE_METADATA } from '../constants';
 import { copyNestedInstanceId } from '../nestedBlockInstanceId';
 import { useGuideHistory } from './useGuideHistory';
-
-/**
- * Type guard for section blocks
- */
-const isSectionBlock = (block: JsonBlock): block is JsonSectionBlock => {
-  return block.type === 'section';
-};
-
-/**
- * Type guard for conditional blocks
- */
-const isConditionalBlock = (block: JsonBlock): block is JsonConditionalBlock => {
-  return block.type === 'conditional';
-};
-
-/**
- * Type guard for interactive blocks
- */
-const isInteractiveBlock = (block: JsonBlock): block is JsonInteractiveBlock => {
-  return block.type === 'interactive';
-};
-
-/**
- * Type guard for multistep blocks
- */
-const isMultistepBlock = (block: JsonBlock): block is JsonMultistepBlock => {
-  return block.type === 'multistep';
-};
-
-/**
- * Type guard for guided blocks
- */
-const isGuidedBlock = (block: JsonBlock): block is JsonGuidedBlock => {
-  return block.type === 'guided';
-};
-
-/**
- * Generate a unique ID for a block
- */
-const generateBlockId = (): string => {
-  return `block-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-};
+import {
+  generateBlockId,
+  isConditionalBlock,
+  isGuidedBlock,
+  isInteractiveBlock,
+  isMultistepBlock,
+  isSectionBlock,
+  parseBlockId,
+} from './useBlockEditor.helpers';
 
 /**
  * Hook options
@@ -1252,53 +1218,6 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
       { skipHistory: true }
     );
   }, [setState]);
-
-  /**
-   * Parse a block ID to determine if it's a nested block.
-   * Nested block IDs have format: `${sectionId}-nested-${nestedIndex}`.
-   * Uses string operations instead of regex for better performance and clarity.
-   */
-  const parseBlockId = (
-    id: string,
-    blocks: EditorBlock[]
-  ): {
-    isNested: boolean;
-    sectionId?: string;
-    nestedIndex?: number;
-    block?: JsonBlock;
-    rootIndex?: number;
-    sectionRootIndex?: number;
-  } => {
-    const NESTED_MARKER = '-nested-';
-    const markerIndex = id.lastIndexOf(NESTED_MARKER);
-
-    // Check if it's a nested block ID
-    if (markerIndex !== -1) {
-      const sectionId = id.slice(0, markerIndex);
-      const nestedIndexStr = id.slice(markerIndex + NESTED_MARKER.length);
-      const nestedIndex = parseInt(nestedIndexStr, 10);
-
-      // Validate the index is a valid number
-      if (!isNaN(nestedIndex) && nestedIndexStr === String(nestedIndex)) {
-        const sectionRootIndex = blocks.findIndex((b) => b.id === sectionId);
-        const section = sectionRootIndex >= 0 ? blocks[sectionRootIndex] : undefined;
-        if (section && isSectionBlock(section.block)) {
-          const nestedBlock = section.block.blocks[nestedIndex];
-          if (nestedBlock) {
-            return { isNested: true, sectionId, nestedIndex, block: nestedBlock, sectionRootIndex };
-          }
-        }
-        return { isNested: true, sectionRootIndex: sectionRootIndex >= 0 ? sectionRootIndex : undefined };
-      }
-    }
-
-    // It's a root-level block
-    const rootIndex = blocks.findIndex((b) => b.id === id);
-    if (rootIndex >= 0) {
-      return { isNested: false, block: blocks[rootIndex]!.block, rootIndex };
-    }
-    return { isNested: false };
-  };
 
   // Merge interactive/multistep/guided blocks into a Multistep block
   const mergeBlocksToMultistep = useCallback(

--- a/src/components/block-editor/hooks/useBlockEditor.ts
+++ b/src/components/block-editor/hooks/useBlockEditor.ts
@@ -7,25 +7,12 @@
 
 import { useCallback, useMemo } from 'react';
 import type { EditorBlock, BlockEditorState, JsonBlock, JsonGuide, ViewMode } from '../types';
-import type {
-  JsonConditionalBlock,
-  JsonInteractiveBlock,
-  JsonMultistepBlock,
-  JsonGuidedBlock,
-  JsonStep,
-} from '../../../types/json-guide.types';
+import type { JsonConditionalBlock } from '../../../types/json-guide.types';
 import { DEFAULT_GUIDE_METADATA } from '../constants';
 import { copyNestedInstanceId } from '../nestedBlockInstanceId';
 import { useGuideHistory } from './useGuideHistory';
-import {
-  generateBlockId,
-  isConditionalBlock,
-  isGuidedBlock,
-  isInteractiveBlock,
-  isMultistepBlock,
-  isSectionBlock,
-  parseBlockId,
-} from './useBlockEditor.helpers';
+import { generateBlockId, isConditionalBlock, isSectionBlock } from './useBlockEditor.helpers';
+import { mergeBlocks } from './useBlockEditor.merge';
 
 /**
  * Hook options
@@ -1219,117 +1206,14 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
     );
   }, [setState]);
 
-  // Merge interactive/multistep/guided blocks into a Multistep block
   const mergeBlocksToMultistep = useCallback(
     (blockIds: string[]) => {
       setState((prev) => {
-        // Parse all block IDs and collect mergeable blocks (interactive, multistep, guided)
-        const parsedBlocks = blockIds
-          .map((id) => ({ id, ...parseBlockId(id, prev.blocks) }))
-          .filter(
-            (p) => p.block && (isInteractiveBlock(p.block) || isMultistepBlock(p.block) || isGuidedBlock(p.block))
-          );
-
-        if (parsedBlocks.length < 2) {
+        const newBlocks = mergeBlocks(prev.blocks, blockIds, 'multistep');
+        if (!newBlocks) {
           return prev;
         }
-
-        // Sort by document position: root blocks by index, nested by section position + nested index
-        parsedBlocks.sort((a, b) => {
-          // Get effective position for sorting
-          const aPos = a.isNested
-            ? (a.sectionRootIndex ?? 0) * 10000 + (a.nestedIndex ?? 0)
-            : (a.rootIndex ?? 0) * 10000;
-          const bPos = b.isNested
-            ? (b.sectionRootIndex ?? 0) * 10000 + (b.nestedIndex ?? 0)
-            : (b.rootIndex ?? 0) * 10000;
-          return aPos - bPos;
-        });
-
-        // Convert blocks to steps, extracting steps from multistep/guided blocks
-        const steps: JsonStep[] = parsedBlocks.flatMap((p) => {
-          if (isInteractiveBlock(p.block!)) {
-            const interactive = p.block as JsonInteractiveBlock;
-            return [
-              {
-                action: interactive.action,
-                reftarget: interactive.reftarget,
-                ...(interactive.targetvalue && { targetvalue: interactive.targetvalue }),
-                // Use tooltip if available, otherwise use content
-                ...(interactive.tooltip && { tooltip: interactive.tooltip }),
-                ...(!interactive.tooltip && interactive.content && { tooltip: interactive.content }),
-              },
-            ];
-          }
-          // For multistep/guided blocks, extract their steps
-          const stepsBlock = p.block as JsonMultistepBlock | JsonGuidedBlock;
-          return stepsBlock.steps;
-        });
-
-        // Create the multistep block
-        const multistepBlock: JsonMultistepBlock = {
-          type: 'multistep',
-          content: 'Complete the following steps:',
-          steps,
-        };
-
-        const firstParsed = parsedBlocks[0]!;
-        const insertIntoSection = firstParsed.isNested && firstParsed.sectionId;
-
-        const rootIdsToRemove = new Set(parsedBlocks.filter((p) => !p.isNested).map((p) => p.id));
-
-        const nestedToRemove = new Map<string, number[]>();
-        parsedBlocks
-          .filter((p) => p.isNested && p.sectionId !== undefined && p.nestedIndex !== undefined)
-          .forEach((p) => {
-            const existing = nestedToRemove.get(p.sectionId!) || [];
-            existing.push(p.nestedIndex!);
-            nestedToRemove.set(p.sectionId!, existing);
-          });
-
-        let newBlocks = prev.blocks
-          .filter((b) => !rootIdsToRemove.has(b.id))
-          .map((b) => {
-            if (
-              isSectionBlock(b.block) &&
-              (nestedToRemove.has(b.id) || (insertIntoSection && b.id === firstParsed.sectionId))
-            ) {
-              const indicesToRemove = new Set(nestedToRemove.get(b.id) || []);
-              let newSectionBlocks = b.block.blocks.filter((_, i) => !indicesToRemove.has(i));
-
-              if (insertIntoSection && b.id === firstParsed.sectionId) {
-                const insertIdx = firstParsed.nestedIndex!;
-                const removedBefore = Array.from(indicesToRemove).filter((i) => i < insertIdx).length;
-                const adjustedIdx = insertIdx - removedBefore;
-                newSectionBlocks.splice(adjustedIdx, 0, multistepBlock);
-              }
-
-              return {
-                ...b,
-                block: { ...b.block, blocks: newSectionBlocks },
-              };
-            }
-            return b;
-          });
-
-        if (!insertIntoSection) {
-          const newEditorBlock: EditorBlock = {
-            id: generateBlockId(),
-            block: multistepBlock,
-          };
-
-          let insertIndex = prev.blocks.findIndex((b) => b.id === firstParsed.id);
-          const removedBeforeInsert = prev.blocks.filter((b, i) => i < insertIndex && rootIdsToRemove.has(b.id)).length;
-          insertIndex -= removedBeforeInsert;
-
-          newBlocks.splice(insertIndex, 0, newEditorBlock);
-        }
-
-        const newState = {
-          ...prev,
-          blocks: newBlocks,
-          isDirty: true,
-        };
+        const newState = { ...prev, blocks: newBlocks, isDirty: true };
         notifyChange(newState);
         return newState;
       });
@@ -1337,115 +1221,14 @@ export function useBlockEditor(options: UseBlockEditorOptions = {}): UseBlockEdi
     [notifyChange, setState]
   );
 
-  // Merge interactive/multistep/guided blocks into a Guided block
   const mergeBlocksToGuided = useCallback(
     (blockIds: string[]) => {
       setState((prev) => {
-        // Parse all block IDs and collect mergeable blocks (interactive, multistep, guided)
-        const parsedBlocks = blockIds
-          .map((id) => ({ id, ...parseBlockId(id, prev.blocks) }))
-          .filter(
-            (p) => p.block && (isInteractiveBlock(p.block) || isMultistepBlock(p.block) || isGuidedBlock(p.block))
-          );
-
-        if (parsedBlocks.length < 2) {
+        const newBlocks = mergeBlocks(prev.blocks, blockIds, 'guided');
+        if (!newBlocks) {
           return prev;
         }
-
-        // Sort by document position: root blocks by index, nested by section position + nested index
-        parsedBlocks.sort((a, b) => {
-          // Get effective position for sorting
-          const aPos = a.isNested
-            ? (a.sectionRootIndex ?? 0) * 10000 + (a.nestedIndex ?? 0)
-            : (a.rootIndex ?? 0) * 10000;
-          const bPos = b.isNested
-            ? (b.sectionRootIndex ?? 0) * 10000 + (b.nestedIndex ?? 0)
-            : (b.rootIndex ?? 0) * 10000;
-          return aPos - bPos;
-        });
-
-        // Convert blocks to steps, extracting steps from multistep/guided blocks
-        const steps: JsonStep[] = parsedBlocks.flatMap((p) => {
-          if (isInteractiveBlock(p.block!)) {
-            const interactive = p.block as JsonInteractiveBlock;
-            return [
-              {
-                action: interactive.action,
-                reftarget: interactive.reftarget,
-                ...(interactive.targetvalue && { targetvalue: interactive.targetvalue }),
-                ...(interactive.content && { description: interactive.content }),
-              },
-            ];
-          }
-          // For multistep/guided blocks, extract their steps
-          const stepsBlock = p.block as JsonMultistepBlock | JsonGuidedBlock;
-          return stepsBlock.steps;
-        });
-
-        // Create the guided block
-        const guidedBlock: JsonGuidedBlock = {
-          type: 'guided',
-          content: 'Follow the steps below:',
-          steps,
-        };
-
-        const firstParsed = parsedBlocks[0]!;
-        const insertIntoSection = firstParsed.isNested && firstParsed.sectionId;
-
-        const rootIdsToRemove = new Set(parsedBlocks.filter((p) => !p.isNested).map((p) => p.id));
-
-        const nestedToRemove = new Map<string, number[]>();
-        parsedBlocks
-          .filter((p) => p.isNested && p.sectionId !== undefined && p.nestedIndex !== undefined)
-          .forEach((p) => {
-            const existing = nestedToRemove.get(p.sectionId!) || [];
-            existing.push(p.nestedIndex!);
-            nestedToRemove.set(p.sectionId!, existing);
-          });
-
-        let newBlocks = prev.blocks
-          .filter((b) => !rootIdsToRemove.has(b.id))
-          .map((b) => {
-            if (
-              isSectionBlock(b.block) &&
-              (nestedToRemove.has(b.id) || (insertIntoSection && b.id === firstParsed.sectionId))
-            ) {
-              const indicesToRemove = new Set(nestedToRemove.get(b.id) || []);
-              let newSectionBlocks = b.block.blocks.filter((_, i) => !indicesToRemove.has(i));
-
-              if (insertIntoSection && b.id === firstParsed.sectionId) {
-                const insertIdx = firstParsed.nestedIndex!;
-                const removedBefore = Array.from(indicesToRemove).filter((i) => i < insertIdx).length;
-                const adjustedIdx = insertIdx - removedBefore;
-                newSectionBlocks.splice(adjustedIdx, 0, guidedBlock);
-              }
-
-              return {
-                ...b,
-                block: { ...b.block, blocks: newSectionBlocks },
-              };
-            }
-            return b;
-          });
-
-        if (!insertIntoSection) {
-          const newEditorBlock: EditorBlock = {
-            id: generateBlockId(),
-            block: guidedBlock,
-          };
-
-          let insertIndex = prev.blocks.findIndex((b) => b.id === firstParsed.id);
-          const removedBeforeInsert = prev.blocks.filter((b, i) => i < insertIndex && rootIdsToRemove.has(b.id)).length;
-          insertIndex -= removedBeforeInsert;
-
-          newBlocks.splice(insertIndex, 0, newEditorBlock);
-        }
-
-        const newState = {
-          ...prev,
-          blocks: newBlocks,
-          isDirty: true,
-        };
+        const newState = { ...prev, blocks: newBlocks, isDirty: true };
         notifyChange(newState);
         return newState;
       });


### PR DESCRIPTION
## Summary

Trim `useBlockEditor.ts` by extracting two cohesive, pure pieces into their own files: (1) the type guards / id helpers / `parseBlockId` already-pure utilities, and (2) the shared algorithm behind `mergeBlocksToMultistep` and `mergeBlocksToGuided`. The hook's public return shape (`UseBlockEditorReturn`) and observable behavior are unchanged; the file shrinks from 1617 to 1319 lines and the two merge functions collapse from ~230 lines of near-duplicate code to thin setState wrappers around a single shared helper.

Implements findings from a `/techdebt` + high-risk-refactor-guideline analysis of `src/components/block-editor/hooks/useBlockEditor.ts`.

## Why

`useBlockEditor.ts` had two refactor-resistant accretion patterns:

1. **B1 / B4 — Near-duplicate merge functions.** `mergeBlocksToMultistep` and `mergeBlocksToGuided` were structurally identical (~95%): same parse → mergeable-filter → document-position sort → split into root removals + per-section nested removals → rebuild via filter+map → conditional re-insert with removed-before index adjustment. They differed only in (a) the per-step shape produced from an interactive block, (b) the merged block type literal, and (c) the default content string. Any latent bug in the sort key, the index-adjustment math, or the section-vs-root insertion path lived in both copies (a "convergent re-bugging" risk per the techdebt catalog).
2. **Pure helpers buried in the hook body.** `parseBlockId` was declared inside the hook function but closed over nothing — it was a pure function with no direct test coverage, and the `-nested-` suffix parsing is subtle enough to deserve independent tests. Type guards and `generateBlockId` were similarly out-of-place.

Rejected alternatives (left out per the high-risk-refactor guidelines):

- Sub-hooking the section-vs-conditional-branch operation families together. That's the next-most-promising target but would push past the safe-PR size and risks restructuring code with thin unit coverage in the same PR as this dedup.
- Replacing `JSON.parse(JSON.stringify(...))` deep clones with `structuredClone`. Behavior change; not bundled.
- Touching the `setState`/`notifyChange` repetition or `{ skipHistory: true }` overload usage. Those involve `useGuideHistory` coupling and belong in a follow-up.

## What to look at

- `src/components/block-editor/hooks/useBlockEditor.merge.ts` — the new pure `mergeBlocks(prev, ids, kind)` helper. The two divergence points between multistep and guided are isolated as `MERGE_SPECS[kind]` (default content + `interactiveToStep`); everything else is shared. Trace the `positionWeight` function — it is the same `* 10000` stride the old code used inline, kept identical so document-order sort behavior is preserved. Returns `null` when there is nothing to merge so the hook callback can `return prev` without constructing a new state object.
- `src/components/block-editor/hooks/useBlockEditor.ts` — `mergeBlocksToMultistep` and `mergeBlocksToGuided` are now ~13-line wrappers that delegate to `mergeBlocks` and apply the standard `setState` + `notifyChange` envelope. The `UseBlockEditorReturn` shape, dependency arrays, and `useMemo` exports are unchanged.
- `src/components/block-editor/hooks/useBlockEditor.helpers.ts` — `parseBlockId` is now top-level with an exported `ParsedBlockId` type. The implementation is line-for-line the same as the original inline version.
- `src/components/block-editor/hooks/useBlockEditor.helpers.test.ts` and `useBlockEditor.merge.test.ts` — these tests are net-new coverage. Previously the only direct hook test was 51 lines covering `updateNestedBlock`; the merge logic had zero direct coverage.

## How to verify

1. Open the block editor in the dev server, drop in two interactive blocks at root level, multi-select them, and click "Merge into multistep". Confirm the resulting multistep block lands where the first selection was and contains both steps with `tooltip` (falling back to `content` when no tooltip is set on the source interactive).
2. Repeat with "Merge into guided" — confirm the resulting block has `description` populated from interactive `content`.
3. Build a section containing two interactive blocks plus a non-interactive block between them. Multi-select only the two interactives and merge. Confirm the merged block ends up nested inside the section at the first selected index, the section's other contents are intact, and no new root-level block appears.
4. Multi-select an existing multistep block alongside a fresh interactive and merge. Confirm the existing multistep is unrolled into its component steps in the result (not nested as a sub-block).
5. Confirm undo restores the pre-merge state and that the dirty indicator behaves the same as before this PR.

## Breaking changes

None. This change is purely internal: no schema, no DOM contracts (`data-test-*`), no storage keys, no public TypeScript surface, and no behavior change observable from outside the hook. Fully reversible by reverting the two commits.

## Out of scope

- Extracting section-block operations and conditional-branch operations into sibling sub-hooks. The B1 duplication between those two families is real but the right abstraction is easier to see after the merge dedup lands.
- Replacing the `JSON.parse(JSON.stringify(...))` deep clones at the duplicate-block call sites.
- Reviewing the stale-`state.blocks` read inside `duplicateBlock` — looks suspicious, may be load-bearing, deserves its own bug-fix PR with a regression test.
- Touching the `setState` / `notifyChange` repetition (~20 occurrences) — wait until the file is decomposed further before picking the abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
