### PR TITLE
review(skill): increase /review depth, aggression

### DIFF
--- a/.cursor/skills/review/SKILL.md
+++ b/.cursor/skills/review/SKILL.md
@@ -63,13 +63,25 @@ Do not suppress `testing-and-verification` for executable changes, including CI 
 
 Run additional reviewers when activated by the routing table in `docs/design/CONCERNS.md`.
 
-Prefer a small reviewer set over speculative breadth.
+**Posture: breadth over economy.** This review is the automated safety net under human review. Run all always-on concerns as independent parallel reviewers, plus every conditional concern the router activates. Do not throttle fan-out to save cost — the goal is to raise the bar on what is caught automatically so human review can focus on novel findings.
 
-- Always-on concerns must always be considered
-- Conditional concerns should only run when activated
-- If many conditional concerns activate, prioritize the highest-signal concerns first and keep the initial reviewer set small
-- Add more conditional reviewers only when the router has strong evidence they are needed
-- If classification suggests a narrow non-runtime class, reduce fan-out conservatively and fail open when uncertain
+- Always-on concerns must always run as dedicated reviewers, not folded into the synthesizer
+- Conditional concerns run whenever activated by the routing table — do not suppress them on classification heuristics alone
+- Dispatch reviewers in parallel where possible
+- The only acceptable reason to skip a routed reviewer is a hard incompatibility with the change class (e.g., `docs-only` PR has no Go backend surface to review)
+- When in doubt, run the reviewer
+
+### Standalone deep-security lens
+
+In addition to the `security` concern reviewer, when the PR touches any of:
+
+- auth, tokens, secrets, or credential refresh paths
+- URL construction, redirect handling, or trust boundaries
+- workflows, publish steps, release tooling, or CI permissions
+- MCP transport, peerjs, or any cross-origin surface
+- dependency manifests (`package.json`, `go.mod`, lockfiles)
+
+…also invoke `.cursor/skills/secure/SKILL.md` as a dedicated lens running alongside the `security` concern. The concern-level reviewer applies the F1–F6 / G1–G7 catalog against the diff; the standalone `secure` skill runs the full audit (frontend F1–F6 + backend allowlists + MCP transport + deps) with deeper context. Both report findings under the `security` concern; the synthesizer dedupes per §5.
 
 ### Reviewer context discipline
 
@@ -118,6 +130,18 @@ Additional instructions for subsystem reviewers:
 ### Shared reviewer output schema
 
 Every reviewer emits the schema defined in `docs/design/PR_REVIEW.md` (Reviewer output schema), including the severity, confidence, and reversibility values.
+
+## 4b. Adversarial verification
+
+Before synthesis, run an adversarial verification pass on the reviewer output:
+
+1. Collect every finding with severity `medium` or higher across all reviewers.
+2. For each such finding, spawn **three independent skeptic sub-agents**, each prompted to **refute** the finding — defaulting to `refuted=true` when uncertain. Skeptics receive only the finding, the relevant diff hunks, and the concern entry — not the original reviewer's reasoning.
+3. Each skeptic returns a structured verdict: `{ refuted: boolean, reason: string }`.
+4. Drop any finding that ≥2 of 3 skeptics mark as refuted. Record dropped findings in a `verification_dropped` list with the skeptics' reasoning, so the synthesizer can surface them if a human wants to inspect.
+5. Findings rated `low` severity or below are passed through without verification — the cost of verifying low-severity items exceeds the value.
+
+This pass exists to kill plausible-but-wrong findings before they reach the human reviewer. False positives erode trust in the automated safety net; spending tokens to suppress them is the right trade.
 
 ## 5. Synthesize and report
 


### PR DESCRIPTION
## Summary

Turn the `/review` orchestrator from a small-fan-out router into an aggressive mega-review. Three changes: §4 flips the posture from "prefer a small reviewer set" to breadth-over-economy, a new standalone deep-security lens runs alongside the `security` concern for high-risk surfaces, and a new §4b adversarial verification pass refutes medium-or-higher findings before synthesis.

## What to look at

- [`.cursor/skills/review/SKILL.md`](https://github.com/grafana/grafana-pathfinder-app/blob/d18a21b3b090f37ca9f1bb3802891320a83aba6a/.cursor/skills/review/SKILL.md) — §4 reviewer-posture rewrite, the new "Standalone deep-security lens" routing block, and the new §4b adversarial verification pass. The synthesizer (§5) is unchanged and still handles dedup; §4b feeds it a filtered finding set plus a `verification_dropped` list.

## Why

This is an intentional choice to spend more tokens to raise the floor on what `/review` catches automatically. The goal is not to replace human PR review — it is to put a more robust safety net under it, so reviewers can focus on novel findings instead of patterns an LLM should have caught.

Three specific gaps the prior posture left open:

1. The "prefer a small reviewer set" rule meant routed concerns sometimes folded into the synthesizer instead of getting their own reviewer pass, which weakens always-on concerns like `correctness-and-reliability` and `testing-and-verification`.
2. The concern-level `security` reviewer applies the F1–F6 / G1–G7 catalog against the diff but does not run the full `.cursor/skills/secure/SKILL.md` audit (frontend F1–F6 + backend allowlists + MCP transport + deps). For PRs touching auth, URLs, trust boundaries, workflows, or secrets, that depth matters.
3. There was no verification gate between reviewers and synthesis. Plausible-but-wrong findings reached the human reviewer, eroding trust in the automated layer. §4b spawns three independent skeptic sub-agents per medium+ finding, defaulting to `refuted=true` when uncertain, and drops findings ≥2 of 3 skeptics refute.

Refs grafana/grafana-pathfinder-app#967 — pre-work for the broader push to raise automated review quality.

## How to verify

1. Run `/review` against a PR with at least one security-sensitive change (token handling, URL construction, or a workflow edit) and confirm the standalone `secure` skill is invoked as a distinct lens alongside the `security` concern reviewer.
2. Run `/review` against a PR where a prior review surfaced a known false positive — confirm §4b's skeptic pass refutes and drops it, and that the dropped finding appears in `verification_dropped` for inspection.
3. Run `/review` against a small `docs-only` PR and confirm the orchestrator still routes narrowly — the breadth-over-economy posture should not fabricate reviewers for surfaces the diff doesn't touch.

## Breaking changes

None. This is an orchestration-skill change only. No code, no contracts, no storage. Reverting the file restores the prior `/review` behavior exactly.

## Out of scope

- Wiring `/review` to call out to external AI CLIs for cross-AI peer review (a future lever; `gsd-review` already exists as a primitive).
- Tuning the skeptic count or refutation threshold in §4b — three skeptics with a 2/3 majority is the starting point; data from real runs will tell us whether to raise or lower it.
- Any change to `docs/design/CONCERNS.md` or `docs/design/PR_REVIEW.md` — the concern registry and pattern catalog are unchanged.

Refs #967

🤖 Generated with [Claude Code](https://claude.com/claude-code)
