### PR TITLE
fix(react-compiler): resolve globals + immutability rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -117,13 +117,11 @@ export default defineConfig([
   ...baseConfig,
 
   // eslint-config v10 turns on react-hooks v7's React Compiler ruleset. These
-  // four flag pre-existing call sites; deferred to a follow-up. Other new rules stay on.
+  // two flag pre-existing call sites; migrated progressively in the rest of this stack.
   {
     rules: {
       'react-hooks/refs': 'off',
       'react-hooks/set-state-in-effect': 'off',
-      'react-hooks/immutability': 'off',
-      'react-hooks/globals': 'off',
     },
   },
 

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -811,7 +811,9 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   const logSession = useDevModeLogger(isDevMode);
 
   // Set global config for utility functions that can't access React context
-  (window as any).__pathfinderPluginConfig = pluginConfig;
+  React.useEffect(() => {
+    (window as any).__pathfinderPluginConfig = pluginConfig;
+  }, [pluginConfig]);
 
   const { tabs, activeTabId, contextPanel } = model.useState();
   React.useEffect(() => {

--- a/src/components/interactive-tutorial/interactive-guided.test.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.test.tsx
@@ -10,7 +10,7 @@
 
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { InteractiveGuided, resetGuidedCounter } from './interactive-guided';
+import { InteractiveGuided } from './interactive-guided';
 import { useStepChecker } from '../../requirements-manager';
 import { useAiFixEnabled } from '../../integrations/assistant-integration/use-ai-fix-enabled';
 import { testIds } from '../../constants/testIds';
@@ -135,7 +135,6 @@ describe('InteractiveGuided — double skip button (issue #786)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     callOrder = [];
-    resetGuidedCounter();
 
     // Default: executeGuidedStep hangs (simulates waiting for user interaction)
     mockExecuteGuidedStep.mockImplementation(() => {

--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useCallback, forwardRef, useId, useImperativeHandle, useEffect, useMemo } from 'react';
 import { Button } from '@grafana/ui';
 import { usePluginContext } from '@grafana/data';
 
@@ -80,13 +80,6 @@ function SafeHTML({ html, className }: { html: string; className?: string }) {
   return <span className={className}>{elements}</span>;
 }
 
-let anonymousGuidedCounter = 0;
-
-/** Reset the anonymous guided step counter (called by resetInteractiveCounters). */
-export function resetGuidedCounter(): void {
-  anonymousGuidedCounter = 0;
-}
-
 interface InteractiveGuidedProps {
   internalActions: GuidedAction[];
 
@@ -148,12 +141,8 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
     },
     ref
   ) => {
-    const generatedStepIdRef = useRef<string | undefined>(undefined);
-    if (!generatedStepIdRef.current) {
-      anonymousGuidedCounter += 1;
-      generatedStepIdRef.current = `guided-step-${anonymousGuidedCounter}`;
-    }
-    const renderedStepId = stepId ?? generatedStepIdRef.current;
+    const generatedStepId = `guided-step-${useId().replace(/:/g, '')}`;
+    const renderedStepId = stepId ?? generatedStepId;
     const analyticsStepMeta = useMemo(
       () => ({
         stepId: stepId ?? renderedStepId,

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -7,7 +7,7 @@ import { useStepChecker } from '../../requirements-manager';
 import { useIsAlignmentPaused, useAlignmentStartingLocation } from '../../global-state/alignment-pending-context';
 import { InteractiveStep, resetStepCounter } from './interactive-step';
 import { InteractiveMultiStep, resetMultiStepCounter } from './interactive-multi-step';
-import { InteractiveGuided, resetGuidedCounter } from './interactive-guided';
+import { InteractiveGuided } from './interactive-guided';
 import { InteractiveQuiz, resetQuizCounter } from './interactive-quiz';
 import { TerminalStep, resetTerminalStepCounter } from './terminal-step';
 import { TerminalConnectStep, resetTerminalConnectStepCounter } from './terminal-connect-step';
@@ -119,7 +119,6 @@ export function resetInteractiveCounters() {
   // Reset anonymous step ID counters across all step types
   resetStepCounter();
   resetMultiStepCounter();
-  resetGuidedCounter();
   resetQuizCounter();
   resetTerminalStepCounter();
   resetTerminalConnectStepCounter();

--- a/src/components/interactive-tutorial/terminal-connect-step.tsx
+++ b/src/components/interactive-tutorial/terminal-connect-step.tsx
@@ -111,7 +111,6 @@ export const TerminalConnectStep = forwardRef<
 
     const generatedStepIdRef = useRef<string | undefined>(undefined);
     if (!generatedStepIdRef.current) {
-      // eslint-disable-next-line react-hooks/globals -- counter pattern used across all step components
       terminalConnectStepCounter += 1;
       generatedStepIdRef.current = `terminal-connect-step-${terminalConnectStepCounter}`;
     }

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -756,7 +756,10 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
    * Stable reference to checkStep function for event-driven triggers
    */
   const checkStepRef = useRef(checkStep);
-  checkStepRef.current = checkStep;
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/immutability -- latest-callback ref: event-driven triggers invoke the current checkStep without re-subscribing on its identity change
+    checkStepRef.current = checkStep;
+  });
 
   // Initial requirements check for first steps when component mounts
   useEffect(() => {


### PR DESCRIPTION
Part of the React Compiler rule migration, stacked on #1038 (which adopted `@grafana/eslint-config` v10 and temporarily deferred react-hooks v7's React Compiler ruleset).

**Stack:** #1038 → **#1041 (this)** → #1042 → #1043

Re-enables `react-hooks/globals` and `react-hooks/immutability` after migrating the call sites they flag.

## Changes
- **interactive-guided.tsx**: replace the module-counter + lazy-ref anonymous step-id generation with `useId()`, preserving the `guided-step-` prefix (E2E `data-step-id` contract) by stripping colons. Removes the now-dead `anonymousGuidedCounter` / `resetGuidedCounter` and their wiring in `interactive-section.tsx` and the test.
- **docs-panel.tsx**: move the `window.__pathfinderPluginConfig` assignment out of render into an effect (App/module already set it at plugin init).
- **step-checker.hook.ts**: move the `checkStep` latest-ref write into an effect; the `immutability` flag on the intentional latest-callback-ref escape hatch is suppressed inline with justification.
- **terminal-connect-step.tsx**: drop a dangling `react-hooks/globals` disable that no longer corresponds to a fired diagnostic.

## Verification
lint (globals + immutability enforced) ✅ · typecheck ✅ · full suite ✅ (253 suites, 4261 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)