### PR TITLE
fix(react-compiler): resolve set-state-in-effect rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -116,12 +116,11 @@ export default defineConfig([
   },
   ...baseConfig,
 
-  // eslint-config v10 turns on react-hooks v7's React Compiler ruleset. These
-  // two flag pre-existing call sites; migrated progressively in the rest of this stack.
+  // eslint-config v10 turns on react-hooks v7's React Compiler ruleset.
+  // react-hooks/refs flags pre-existing call sites; migrated in the top of this stack.
   {
     rules: {
       'react-hooks/refs': 'off',
-      'react-hooks/set-state-in-effect': 'off',
     },
   },
 

--- a/src/components/LiveSession/AttendeeJoin.tsx
+++ b/src/components/LiveSession/AttendeeJoin.tsx
@@ -122,6 +122,7 @@ export function AttendeeJoin({ isOpen, onClose, onJoined }: AttendeeJoinProps) {
   useEffect(() => {
     if (!isOpen) {
       // Reset all state when modal is closed
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- modal lifecycle: clear fields when the modal is dismissed
       setJoinCode('');
       setSessionOffer(null);
       setError(null);
@@ -137,6 +138,7 @@ export function AttendeeJoin({ isOpen, onClose, onJoined }: AttendeeJoinProps) {
       try {
         const offerFromUrl = parseSessionFromUrl();
         if (offerFromUrl) {
+          // eslint-disable-next-line react-hooks/set-state-in-effect -- modal lifecycle: hydrate from the join URL when the modal opens
           setSessionOffer(offerFromUrl);
         } else {
           // No session in URL - ensure we're at the join code input screen

--- a/src/components/PrTester/PrTester.tsx
+++ b/src/components/PrTester/PrTester.tsx
@@ -62,7 +62,6 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
     }
   });
 
-  const [fetchState, setFetchState] = useState<FetchState>('idle');
   const [files, setFiles] = useState<PrJsonFile[]>(() => {
     try {
       const storedFiles = localStorage.getItem(FETCHED_FILES_STORAGE_KEY);
@@ -76,6 +75,9 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
     }
     return [];
   });
+
+  // Initial fetch state reflects whether files were restored from storage.
+  const [fetchState, setFetchState] = useState<FetchState>(() => (files.length > 0 ? 'fetched' : 'idle'));
 
   const [error, setError] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
@@ -161,16 +163,6 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
       // Ignore localStorage errors
     }
   }, [userSelectedPath]);
-
-  // Set initial fetch state based on restored files
-  const initialFetchState = useMemo(() => (files.length > 0 ? 'fetched' : 'idle') as FetchState, [files.length]);
-
-  useEffect(() => {
-    if (fetchState === 'idle' && initialFetchState === 'fetched') {
-      setFetchState('fetched');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only run once on mount
 
   useEffect(() => {
     try {

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -267,6 +267,13 @@ export function BlockEditorHeader({
 
   // Inline title editing
   const [titleDraft, setTitleDraft] = useState(guideTitle);
+  // Keep the draft in sync when the title changes externally (e.g. guide loaded
+  // from library) — the "adjust state during render" pattern, no effect needed.
+  const [lastSyncedTitle, setLastSyncedTitle] = useState(guideTitle);
+  if (guideTitle !== lastSyncedTitle) {
+    setLastSyncedTitle(guideTitle);
+    setTitleDraft(guideTitle);
+  }
   const titleInputRef = useRef<HTMLInputElement>(null);
 
   // Track the current panel mode so the Pop out button can swap between
@@ -298,11 +305,6 @@ export function BlockEditorHeader({
   const handleGoFullScreen = useCallback(() => {
     document.dispatchEvent(new CustomEvent('pathfinder-request-full-screen'));
   }, []);
-
-  // Keep draft in sync when title changes externally (e.g. guide loaded from library)
-  useEffect(() => {
-    setTitleDraft(guideTitle);
-  }, [guideTitle]);
 
   const commitTitle = () => {
     const trimmed = titleDraft.trim();

--- a/src/components/block-editor/GitHubPRModal.tsx
+++ b/src/components/block-editor/GitHubPRModal.tsx
@@ -194,6 +194,7 @@ export function GitHubPRModal({ isOpen, guide, onClose }: GitHubPRModalProps) {
     }
 
     let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset to preparing each time the modal (re)opens, before the async prepare resolves
     setState({ status: 'preparing' });
 
     prepareGitHubPR(guide)

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -821,13 +821,8 @@ function TabsWrapper({ element }: { element: ParsedElement }) {
     label: tabEl.props?.['data-label'] || '',
   }));
 
-  const [activeTab, setActiveTab] = React.useState(tabsData[0]?.key || '');
-
-  React.useEffect(() => {
-    if (tabsData.length > 0 && !activeTab) {
-      setActiveTab(tabsData[0]!.key);
-    }
-  }, [tabsData, activeTab]);
+  const [selectedTab, setSelectedTab] = React.useState('');
+  const activeTab = selectedTab || tabsData[0]?.key || '';
 
   if (!tabsBarElement || !tabContentElement) {
     console.warn('Missing required tabs elements');
@@ -846,7 +841,7 @@ function TabsWrapper({ element }: { element: ParsedElement }) {
             key={tab.key}
             label={tab.label}
             active={activeTab === tab.key}
-            onChangeTab={() => setActiveTab(tab.key)}
+            onChangeTab={() => setSelectedTab(tab.key)}
           />
         ))}
       </TabsBar>

--- a/src/components/docs-panel/hooks/usePanelMode.ts
+++ b/src/components/docs-panel/hooks/usePanelMode.ts
@@ -46,6 +46,7 @@ export function usePanelMode(): UsePanelModeResult {
     const onFullScreenRoute = window.location.pathname.startsWith(`${PLUGIN_BASE_URL}/${ROUTES.FullScreen}`);
     if (!onFullScreenRoute) {
       panelModeManager.setMode('sidebar');
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- self-heal: correct stale persisted fullscreen mode when not on the fullscreen route
       setPanelMode('sidebar');
     }
   }, [panelMode]);

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -139,13 +139,8 @@ function FloatingPanelInner() {
     // sidebar's gate at `docs-panel.tsx` so all three surfaces agree on
     // when "the panel is empty".
     const hasOnlyDefaultTabs = tabs.every((t) => PERMANENT_TAB_IDS.has(t.id));
-    if (hasOnlyDefaultTabs) {
-      panel.restoreTabsAsync().then(() => {
-        setRestorationDone(true);
-      });
-    } else {
-      setRestorationDone(true);
-    }
+    const restore = hasOnlyDefaultTabs ? panel.restoreTabsAsync() : Promise.resolve();
+    restore.then(() => setRestorationDone(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run once on mount
 

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -128,11 +128,8 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     // when "the panel is empty".
     const liveTabs = panel.state.tabs;
     const hasOnlyDefaultTabs = liveTabs.every((t) => PERMANENT_TAB_IDS.has(t.id));
-    if (hasOnlyDefaultTabs) {
-      panel.restoreTabsAsync().then(() => setRestorationDone(true));
-    } else {
-      setRestorationDone(true);
-    }
+    const restore = hasOnlyDefaultTabs ? panel.restoreTabsAsync() : Promise.resolve();
+    restore.then(() => setRestorationDone(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -214,6 +214,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
     useEffect(() => {
       if (resetTrigger && resetTrigger > 0) {
         persistReset();
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- reset local UI state when the parent bumps resetTrigger, alongside the persistReset store write
         setExecutionError(null);
         setCurrentStepIndex(0);
         setCurrentStepStatus('waiting');

--- a/src/context-engine/context.hook.ts
+++ b/src/context-engine/context.hook.ts
@@ -229,6 +229,7 @@ export function useContextPanel(options: UseContextPanelOptions = {}): UseContex
 
   // Apply suggestions on mount and when they change
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- apply persisted suggestions on mount; re-applied on the SUGGESTIONS_UPDATED event subscribed below
     applySuggestions();
 
     const handler = () => applySuggestions();
@@ -240,6 +241,7 @@ export function useContextPanel(options: UseContextPanelOptions = {}): UseContex
   const tagsString = contextData.tags?.join(',') || '';
   useEffect(() => {
     if (!contextData.isLoading && contextData.currentPath) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- data fetch when the active context changes
       fetchRecommendations(contextData);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- contextData would cause infinite loop

--- a/src/integrations/coda/TerminalPanel.tsx
+++ b/src/integrations/coda/TerminalPanel.tsx
@@ -76,6 +76,7 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
   // show the expanded terminal.
   useEffect(() => {
     if (terminalCtx?.isExpanded && !isExpanded) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- mirror the shared terminal context's expanded flag into local state and notify the parent
       setIsExpanded(true);
       setTerminalOpen(true);
     }

--- a/src/learning-paths/learning-paths.hook.ts
+++ b/src/learning-paths/learning-paths.hook.ts
@@ -85,7 +85,7 @@ export function useLearningPaths(): UseLearningPathsReturn {
 
   // Dynamic guide data fetched from index.json for URL-based paths
   const [dynamicGuideData, setDynamicGuideData] = useState<Record<string, FetchedPathGuides>>({});
-  const [isDynamicLoading, setIsDynamicLoading] = useState(false);
+  const [isDynamicLoading, setIsDynamicLoading] = useState<boolean>(() => getPathsData().paths.some((p) => p.url));
 
   // Get raw paths for the current platform (OSS or Cloud)
   const rawPaths = useMemo(() => {
@@ -100,7 +100,6 @@ export function useLearningPaths(): UseLearningPathsReturn {
     }
 
     const abortController = new AbortController();
-    setIsDynamicLoading(true);
 
     void (async () => {
       const results: Record<string, FetchedPathGuides> = {};


### PR DESCRIPTION
Part of the React Compiler rule migration, stacked on #1038.

**Stack:** #1038 → #1041 → **#1042 (this)** → #1043

Re-enables `react-hooks/set-state-in-effect` after migrating the 14 call sites it flags.

## Restructured (derivable / init-from-props / async-orchestration)
- **content-renderer.tsx**: derive the active tab during render instead of an effect.
- **PrTester.tsx**: seed `fetchState` from restored files via a lazy `useState` initializer.
- **FloatingPanelManager.tsx** / **FullScreenPanel.tsx**: fold the synchronous restoration-done set-state into the shared async continuation.
- **BlockEditorHeader.tsx**: sync `titleDraft` to the external title with the "adjust state during render" pattern.
- **learning-paths.hook.ts**: seed `isDynamicLoading` from whether any URL paths exist.

## Suppressed inline with justification (genuinely effect-appropriate, matching the existing convention in this codebase)
AttendeeJoin (modal lifecycle), GitHubPRModal (reset on reopen), usePanelMode (fullscreen self-heal), interactive-guided (reset on `resetTrigger` with a store write), context.hook (apply suggestions / fetch on context change), TerminalPanel (mirror shared terminal-context expand flag).

## Verification
lint (set-state-in-effect enforced) ✅ · typecheck ✅ · full suite ✅ (253 suites, 4261 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)