### PR TITLE
fix(react-compiler): resolve refs rule and remove the disable block

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -116,14 +116,6 @@ export default defineConfig([
   },
   ...baseConfig,
 
-  // eslint-config v10 turns on react-hooks v7's React Compiler ruleset.
-  // react-hooks/refs flags pre-existing call sites; migrated in the top of this stack.
-  {
-    rules: {
-      'react-hooks/refs': 'off',
-    },
-  },
-
   // Phase 6: Security and architecture lint rules (Epic #603)
   // Mechanically enforce security patterns (F1, F5) and architecture patterns.
   // Test files are excluded — they legitimately use innerHTML for DOM setup/teardown.

--- a/src/components/PrTester/PrTester.tsx
+++ b/src/components/PrTester/PrTester.tsx
@@ -203,6 +203,7 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
    * up-to-date file list when it does run.
    */
   const manifestFilesRef = useRef(manifestFiles);
+  // eslint-disable-next-line react-hooks/refs -- intentional latest-value ref read inside the preload effect (see comment above)
   manifestFilesRef.current = manifestFiles;
 
   /**

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -149,6 +149,7 @@ export const ContentRenderer = React.memo(function ContentRenderer({
   // Ref to track the current content URL - updated synchronously before effects run
   // This allows handlers to detect if they're stale (created for different content)
   const currentContentUrlRef = useRef<string | undefined>(content?.url);
+  // eslint-disable-next-line react-hooks/refs -- intentional: updated synchronously so handlers can detect stale content (see comment above)
   currentContentUrlRef.current = content?.url;
 
   // Track interactive section completions for guide-level completion

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -864,16 +864,11 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   });
 
   // Action replay system for attendees
-  const navigationManagerRef = useRef<NavigationManager | null>(null);
+  const [navigationManager] = React.useState(() => new NavigationManager());
   const actionReplayRef = useRef<ActionReplaySystem | null>(null);
 
   // Action capture system for presenters
   const actionCaptureRef = useRef<ActionCaptureSystem | null>(null);
-
-  // Initialize navigation manager once
-  if (!navigationManagerRef.current) {
-    navigationManagerRef.current = new NavigationManager();
-  }
 
   // Hand raise handler for attendees
   const handleHandRaiseToggle = useCallback(
@@ -1086,9 +1081,9 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
 
   // Initialize ActionReplaySystem when joining as attendee
   useEffect(() => {
-    if (sessionRole === 'attendee' && navigationManagerRef.current && attendeeMode && !actionReplayRef.current) {
+    if (sessionRole === 'attendee' && navigationManager && attendeeMode && !actionReplayRef.current) {
       logSession(`[DocsPanel] Initializing ActionReplaySystem for attendee in ${attendeeMode} mode`);
-      actionReplayRef.current = new ActionReplaySystem(attendeeMode, navigationManagerRef.current);
+      actionReplayRef.current = new ActionReplaySystem(attendeeMode, navigationManager);
     }
 
     // Update mode if it changes
@@ -1102,7 +1097,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
       logSession('[DocsPanel] Cleaning up ActionReplaySystem');
       actionReplayRef.current = null;
     }
-  }, [sessionRole, attendeeMode, logSession]);
+  }, [sessionRole, attendeeMode, logSession, navigationManager]);
 
   // Listen for session events and replay them (attendee only)
   useEffect(() => {

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -204,6 +204,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
   // every milestone navigation, which churns the history subscription and
   // risks dropping the very location event that triggered the navigation.
   const dockInputsRef = useRef({ guideUrl, title });
+  // eslint-disable-next-line react-hooks/refs -- intentional latest-value ref so the history listener subscribes once on mount (see comment above)
   dockInputsRef.current = { guideUrl, title };
   useEffect(() => {
     const fullScreenPathname = `${PLUGIN_BASE_URL}/${ROUTES.FullScreen}`;
@@ -307,6 +308,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
   // swapped in), the effect would spuriously fire and kick the user out
   // of full screen.
   const handleExitToSidebarRef = useRef(handleExitToSidebar);
+  // eslint-disable-next-line react-hooks/refs -- intentional latest-callback ref so the empty-state effect's deps stay limited to trigger booleans (see comment above)
   handleExitToSidebarRef.current = handleExitToSidebar;
 
   // Empty-state fallback: if restoration completes with nothing to show

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -1169,6 +1169,7 @@ export function InteractiveSection({
         }
       };
 
+    // eslint-disable-next-line react-hooks/refs -- the stepRefs/multiStepRefs Maps are read inside the ref callback, which runs at commit time, not during render
     return React.Children.map(children, (child) => {
       const schema = lookupStepSchema(child);
       if (!schema) {

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -181,6 +181,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
   // The async checkStep function can be mid-execution when eligibility changes, causing it to
   // use a stale captured value. This ref always has the current value.
   const isEligibleRef = useRef(isEligibleForChecking);
+  // eslint-disable-next-line react-hooks/refs -- intentional latest-value ref read by async checkStep to avoid stale closures
   isEligibleRef.current = isEligibleForChecking;
 
   // Same stale-closure rationale as `isEligibleRef`. Tracked separately so the
@@ -188,6 +189,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
   // eligibility gate alone only blocks Phase 2/3, which lets a coincidentally
   // satisfied objective auto-complete the step out from under the prompt.
   const isAlignmentPausedRef = useRef(isAlignmentPaused);
+  // eslint-disable-next-line react-hooks/refs -- intentional latest-value ref; same stale-closure rationale as isEligibleRef
   isAlignmentPausedRef.current = isAlignmentPaused;
 
   const timeoutManager = useTimeoutManager();
@@ -359,12 +361,14 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
 
   // Import NavigationManager for parent expansion functionality
   const navigationManagerRef = useRef<any>(null);
-  if (!navigationManagerRef.current) {
-    // Lazy import to avoid circular dependencies
-    import('../interactive-engine').then(({ NavigationManager }) => {
-      navigationManagerRef.current = new NavigationManager();
-    });
-  }
+  useEffect(() => {
+    if (!navigationManagerRef.current) {
+      // Lazy import to avoid circular dependencies
+      import('../interactive-engine').then(({ NavigationManager }) => {
+        navigationManagerRef.current = new NavigationManager();
+      });
+    }
+  }, []);
 
   /**
    * Check step conditions with priority logic:
@@ -841,7 +845,8 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     return unsubscribe;
   }, [checkStep, state.isCompleted, requirements]);
 
-  // Track state values in refs to avoid re-subscribing when they change during checks
+  // Track state values in refs to avoid re-subscribing when they change during checks.
+  /* eslint-disable react-hooks/refs -- intentional latest-value refs; read asynchronously by checkStep and event callbacks to avoid stale closures */
   const isCheckingRef = useRef(state.isChecking);
   isCheckingRef.current = state.isChecking;
 
@@ -854,6 +859,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
   // Track objectives in ref to avoid stale closure issues
   const objectivesRef = useRef(objectives);
   objectivesRef.current = objectives;
+  /* eslint-enable react-hooks/refs */
 
   // Subscribe to context changes (EchoSrv events) AND URL changes for blocked steps
   // This ensures steps in "requirements not met" state get rechecked when user performs actions


### PR DESCRIPTION
Top of the React Compiler rule migration, stacked on #1038. **Removes the disable block entirely** — after this PR all four rules (`refs`, `set-state-in-effect`, `immutability`, `globals`) are fully enforced.

**Stack:** #1038 → #1041 → #1042 → **#1043 (this)**

Re-enables `react-hooks/refs` and deletes the React Compiler disable block from `eslint.config.mjs`.

## Restructured (lazy-init refs that don't need to be refs)
- **docs-panel.tsx**: create the attendee `NavigationManager` via a `useState` lazy initializer (stable for the component's life) instead of a render-time lazy-ref write.
- **step-checker.hook.ts**: move the dynamic-import `NavigationManager` init into a mount effect.

## Suppressed inline with justification (intentional latest-value / latest-callback refs whose synchronous update is load-bearing — existing comments already document why)
step-checker eligibility/alignment/check-state/objectives refs, PrTester `manifestFilesRef`, content-renderer `currentContentUrlRef`, FullScreenPanel `dockInputsRef` + `handleExitToSidebarRef`, and the interactive-section `stepRefs`/`multiStepRefs` Maps read inside the ref callback.

> The React Compiler `refs` rule has no clean alternative to the latest-ref pattern without the experimental `useEffectEvent`; these escape hatches are documented and now individually justified rather than blanket-ignored.

## Verification
lint (all four rules enforced, no disable block) ✅ · typecheck ✅ · full suite ✅ (253 suites, 4261 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)