### PR TITLE
skill:maintain-docs document build-snippets CLI command and /coda/exec endpoint

### DIFF
--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -12,6 +12,12 @@ Persistent tracker for the maintain-docs skill's persistent state across runs.
 
 <!-- Docs checked against source and found accurate. Format: date, doc path. Update date on re-validation. -->
 
+- **2026-06-16**: `docs/developer/CLI_TOOLS.md` — Added a `build-snippets` command section and updated the intro command list/coverage line. Validated against `src/cli/commands/build-snippets.ts` and the `snippets:build` npm script. Supersedes the 2026-03-20 entry.
+- **2026-06-16**: `docs/developer/CODA.md` — Added a Command execution section documenting `POST /coda/exec` (raw/gated modes, active-session auth, 5s default / 120s max timeout, 32 KB output cap, per-user token-bucket rate limit, error statuses). Validated against `pkg/plugin/coda_exec.go`, `coda_exec_ratelimit.go`, and `resources.go`. Supersedes the 2026-03-20 entry.
+- **2026-06-16**: `docs/developer/MCP_SERVER.md` — Confirmed current: no structural changes in `src/cli/mcp/` since the doc's last commit (2026-05-19); already documents the Go MCP retirement (MH5).
+- **2026-06-16**: `docs/developer/package-authoring.md` — Confirmed current: documents the two-file authoring format, not package-engine resolver internals, so the resolver restructure (`dependency-resolver` → `composite-resolver`/`online-cdn-resolver`/`recommender-resolver`) does not affect it.
+- **2026-06-16**: `.cursor/rules/systemPatterns.mdc` — Confirmed current: package-engine entry references `composite-resolver.ts`/`createCompositeResolver` and the bundled → online-CDN → recommender chain; `snippet-engine` is listed in the tier model and subsystem reference. Supersedes the 2026-03-20 entry.
+- **2026-06-16**: Structural scan, no drift since each doc's last commit: `docs/developer/AI_FIX.md`, `docs/developer/STEP_MODEL.md`, `docs/developer/engines/interactive-engine.md`, `docs/developer/engines/requirements-manager.md`, `docs/developer/engines/context-engine.md`, `docs/developer/FEATURE_FLAGS.md`, `docs/developer/EXPERIMENT_TESTING.md`, `docs/developer/LIVE_SESSIONS.md`, `docs/developer/integrations/workshop.md`.
 - **2026-04-27**: `docs/sources/_index.md` — Added Block editor card; refreshed feature bullets for v2.9 (custom guides, floating panel mode).
 - **2026-04-27**: `docs/sources/getting-started/_index.md` — Modernized for v2.9.x: added hover/popout actions, floating panel section, link to block editor doc.
 - **2026-04-27**: `docs/sources/architecture/_index.md` — Rebuilt against current architecture (was 5+ months stale). Added package engine, custom guides backend, floating panel, selector resilience, live sessions, Coda subsystems.
@@ -71,3 +77,7 @@ Persistent tracker for the maintain-docs skill's persistent state across runs.
 - `docs/developer/pages/README.md` — Pages directory README. Very narrow scope (single page definition).
 - `docs/developer/styles/README.md` — Styles directory README. Useful for style work but no agent-level constraints.
 - `.cursor/skills/plugin-bundle-size/SKILL.md` — Discovered automatically by IDE via `.cursor/skills/` glob pattern. No AGENTS.md entry needed.
+- `.cursor/skills/bugfix/SKILL.md` — Workflow skill invoked via `/bugfix`; auto-discovered by the IDE via the `.cursor/skills/` glob. Consistent with the other workflow-skill exclusions; no AGENTS.md entry needed. (Its companion reference `docs/developer/bugfix-patterns.md` is already indexed.)
+- `.cursor/skills/refactor/SKILL.md` — Workflow skill invoked via `/refactor-investigate` / `/refactor-plan` / `/refactor-execute`; auto-discovered by the IDE. No AGENTS.md entry needed.
+- `docs/sources/block-editor/_index.md` — End-user documentation published to Grafana.com. Not agent-relevant for implementation tasks.
+- `docs/sources/terms-and-conditions/_index.md` — End-user data-usage notice published to Grafana.com; auto-generated from `src/components/AppConfig/terms-content.ts` via `npm run docs:sync-terms` (do not hand-edit). Not agent-relevant for implementation tasks.

--- a/docs/developer/CLI_TOOLS.md
+++ b/docs/developer/CLI_TOOLS.md
@@ -5,10 +5,11 @@ The `pathfinder-cli` is a command-line interface for working with interactive JS
 - **validate** — Validates guide definitions and package directories against schemas and best practices
 - **build-repository** — Generates `repository.json` from a package tree
 - **build-graph** — Generates a D3-compatible dependency graph from repository indexes
+- **build-snippets** — Generates a snippet catalog (`index.json`) from a directory of snippet bodies
 - **schema** — Exports Zod validation schemas as JSON Schema for cross-language consumers
 - **e2e** — Runs end-to-end tests on guides in a live Grafana instance (see [E2E testing](./E2E_TESTING.md))
 
-This document covers the `validate`, `build-repository`, `build-graph`, and `schema` commands. For e2e testing, see the dedicated [E2E testing guide](./E2E_TESTING.md). For the package format itself, see the [package authoring guide](./package-authoring.md).
+This document covers the `validate`, `build-repository`, `build-graph`, `build-snippets`, and `schema` commands. For e2e testing, see the dedicated [E2E testing guide](./E2E_TESTING.md). For the package format itself, see the [package authoring guide](./package-authoring.md).
 
 ---
 
@@ -331,6 +332,36 @@ The output is a D3-compatible JSON object with `nodes`, `edges`, and `metadata`:
 - **Nodes** contain full manifest metadata plus `id`, `repository`, and an optional `virtual: true` flag for capability nodes
 - **Edges** have `source`, `target`, and `type` (`depends`, `recommends`, `suggests`, `provides`, `conflicts`, `replaces`, `steps`)
 - **Metadata** includes `generatedAt` timestamp, repository names, and node/edge counts
+
+---
+
+## Build-snippets command
+
+Generates a snippet catalog (`index.json`) from a directory of snippet bodies. Snippet bodies (`<id>.json`) are the source of truth; the catalog is always regenerated, never hand-edited. The catalog is consumed by the snippet engine, which resolves `snippet-ref` blocks by fetching `<id>.json` at parse time.
+
+### Basic syntax
+
+```bash
+node dist/cli/cli/index.js build-snippets <dir> [options]
+```
+
+### Arguments
+
+- `<dir>` (required): Directory containing snippet bodies, one JSON file per snippet named `<id>.json`.
+
+### Options
+
+- `-o, --output <file>`: Output file path. Defaults to `<dir>/index.json`.
+
+### How it works
+
+The command reads every `*.json` file in `<dir>` except `index.json`, validates each against the snippet schema, and builds a catalog mapping each snippet `id` to its `id`, `title`, `description`, and optional `category`, `tags`, and `schemaVersion`. It enforces two rules: each file name must equal the `id` inside it (the resolver fetches `<id>.json`), and ids must be unique. If any body fails validation, a file name does not match its id, or an id is duplicated, no output is written and the command exits non-zero.
+
+Snippet bodies live in the content repository alongside package content, not in this plugin repo. A convenience npm script wraps the command — append the snippet directory:
+
+```bash
+npm run snippets:build -- <dir>
+```
 
 ---
 

--- a/docs/developer/CODA.md
+++ b/docs/developer/CODA.md
@@ -149,7 +149,24 @@ All routes are prefixed by Grafana as `/api/plugins/grafana-pathfinder-app/resou
 | `/vms/{id}`        | DELETE | `handleDeleteVM`       | Destroy VM                                |
 | `/sample-apps`     | GET    | `handleSampleApps`     | Proxy to Coda's sample-apps endpoint      |
 | `/alloy-scenarios` | GET    | `handleAlloyScenarios` | Proxy to Coda's alloy-scenarios endpoint  |
+| `/coda/exec`       | POST   | `handleCodaExec`       | Run one command on the caller's active VM |
 | `/health`          | GET    | `handleHealth`         | Plugin health (includes `codaRegistered`) |
+
+### Command execution (`pkg/plugin/coda_exec.go`)
+
+`POST /coda/exec` runs a single non-interactive shell command against the caller's **active** VM — the one already driving their terminal stream — and returns stdout, stderr, exit code, and duration. Challenge blocks use it to run setup commands and to verify success criteria.
+
+**Auth**: the caller must already own an active streaming session; the endpoint reuses that session's SSH client and never opens a new connection. User identity is taken only from the plugin SDK context (`PluginContext.User`), never the `X-Grafana-User` header (which an unproxied client could spoof to target another user's VM).
+
+**Request** (`CodaExecRequest`): `{ command, timeoutMs?, mode? }`. `timeoutMs` defaults to 5000 and is capped at 120000 (the cap accommodates `setupScript` runs such as `apt-get install`). `mode` is `"raw"` (default) or `"gated"`.
+
+**Gated mode** wraps the command with a `/tmp/pathfinder-ready` sentinel-file precondition so a "Check my work" click cannot evaluate the success criterion before the challenge's setup phase has finished. This is a UI-race guard, **not** a security boundary — the learner has full shell access to the same VM.
+
+**Response** (`CodaExecResponse`): `{ stdout, stderr, exitCode, durationMs, truncated? }`. Output is capped at 32 KB; `truncated` is set when it exceeds the cap.
+
+**Rate limiting** (`pkg/plugin/coda_exec_ratelimit.go`): a per-user token bucket — 10-request burst, 5 req/s sustained refill. On breach the endpoint returns `429` with a `Retry-After` header.
+
+**Error statuses**: `400` (missing command or invalid mode), `401` (no authenticated user), `409` (no active terminal session), `502` (command failed), `503` (session no longer connected — reconnect and retry), `429` (rate limited).
 
 ### Grafana Live streaming (`pkg/plugin/stream.go`)
 


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-06-16. Two confirmed staleness fixes in high-traffic backend/CLI domains, plus orphan triage in the backlog.

### Changes made

- **`docs/developer/CLI_TOOLS.md`** — Added a `build-snippets` command section (the command was added after the doc's last commit) and updated the intro command list + coverage line. Verified against `src/cli/commands/build-snippets.ts` and the `snippets:build` npm script.
- **`docs/developer/CODA.md`** — Added a "Command execution" section documenting `POST /coda/exec`: raw/gated modes, active-session auth (SDK `PluginContext.User`, never `X-Grafana-User`), 5s default / 120s max timeout, 32 KB output cap, per-user token-bucket rate limit, and error statuses. Verified against `pkg/plugin/coda_exec.go`, `coda_exec_ratelimit.go`, and `resources.go`.
- **`docs/_maintenance-backlog.md`** — Recorded this run's validated docs and added exclusions for two orphaned end-user source docs and the `bugfix`/`refactor` workflow skills.

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| HIGH | `CLI_TOOLS.md` missing `build-snippets` command (added after doc's 2026-05-15 commit) | Fixed in this PR |
| HIGH | `CODA.md` missing `POST /coda/exec` endpoint (new `coda_exec.go` + rate limiter) | Fixed in this PR |
| MEDIUM | Orphaned end-user docs `docs/sources/block-editor/_index.md`, `docs/sources/terms-and-conditions/_index.md` | Excluded (backlog) |
| MEDIUM | Orphaned workflow skills `bugfix`, `refactor` | Excluded (backlog) |
| LOW | `MCP_SERVER.md`, `package-authoring.md`, `systemPatterns.mdc` flagged by structural heuristic | Verified current; no change needed |
| MEDIUM | No `CONCERNS.md` concern for `src/snippet-engine/` (carry-forward from 2026-05-21) | Deferred — design doc, human-owned |

### Recommendations for separate work

- `docs/design/CONCERNS.md` lacks a concern entry for the tier-1 `src/snippet-engine/` engine (carried in the backlog since 2026-05-21). Out of scope for this skill — design docs are human-maintained.

### Validation checklist

- [x] All changed files are `.md` or `.mdc` (verified via `git diff --name-only`)
- [x] Phase 2.5 verification passed (claims spot-checked against source)
- [x] `npm run prettier` passed
- [x] No source code files were modified

---
Generated by the maintain-docs skill · [conversation](https://app.warp.dev/conversation/d0535d58-0e21-4d74-8cba-d9db5e4cffae)