### PR TITLE
chore(security): enforce F5 DOM sinks mechanically

### DIFF
--- a/.cursor/rules/frontend-security.mdc
+++ b/.cursor/rules/frontend-security.mdc
@@ -2,168 +2,43 @@
 title: Frontend Security Rule
 description: Unified frontend security rule covering frontend code and AI agent behavior.
 globs:
-  - "**/*.ts"
-  - "**/*.tsx"
-  - "**/*.js"
-  - "**/*.jsx"
+  - '**/*.ts'
+  - '**/*.tsx'
+  - '**/*.js'
+  - '**/*.jsx'
 alwaysApply: false
 ---
 
-# Frontend Security Rules
+# Frontend security rules
 
-## F1 — Avoid Untrusted SVGs
-Do **not** use dynamically generated or user-supplied SVGs directly, as they can cause XSS vulnerabilities.  
-If you must render a non-static SVG, sanitize it first using **DOMPurify**.
+These rules describe review intent. Repeatable syntax checks, including F5 DOM sinks, are enforced in `eslint.config.mjs`; run lint before calling frontend security clean. Do not bypass a security lint rule without a narrow local justification.
 
-**Do**
-```tsx
-import DOMPurify from 'dompurify';
-const clean = DOMPurify.sanitize(untrustedSvg, { USE_PROFILES: { svg: true } });
-return <div dangerouslySetInnerHTML={{ __html: clean }} />;
-```
+## F1 — Avoid untrusted SVGs
 
-**Don't**
-```tsx
-return <div dangerouslySetInnerHTML={{ __html: untrustedSvg }} />;
-```
+Prefer static React icons/components. If SVG data comes from user input, remote content, uploads, or generated text, sanitize it with DOMPurify's SVG profile before rendering.
 
-**Agent behavior**  
-If SVG data originates from user input, remote URLs, or uploads, **always** sanitize with DOMPurify or prefer a React-based icon component instead.
+## F2 — Use safe React data bindings
 
----
+Prefer JSX text bindings (`{value}`) for dynamic text. Use raw HTML rendering only when the value is already sanitized and structure must be preserved.
 
-## F2 — Use Safe React Data Bindings
-React data bindings (`{}`) automatically escape values and prevent XSS.  
-Always prefer these for inserting dynamic text.
+## F3 — Don't treat URLs as strings
 
-**Do**
-```tsx
-return <li>{data}</li>;
-```
-
-**Don't**
-```tsx
-return <li dangerouslySetInnerHTML={{ __html: data }} />;
-```
-
-**Agent behavior**  
-Prefer `{}` over `dangerouslySetInnerHTML`. Only allow `dangerouslySetInnerHTML` when absolutely required **and** when properly sanitized (see F4).
-
----
-
-## F3 — Don't Treat URLs as Strings
-Always use a proper URL parsing/handling API — e.g., the native **`URL`** constructor, **`URLSearchParams`**, or safe utilities provided by your framework.  
-Prefer the URL Web API directly instead of string concatenation.
-
-**Don't**
-```ts
-// Unsafe string concatenation
-const endpoint = apiBase + '/users?id=' + userId;
-fetch(endpoint);
-
-const redirectUrl = '/redirect?target=' + location.href;
-window.location.href = redirectUrl;
-```
-
-**Do**
-```ts
-// Safe construction with URL and URLSearchParams
-const url = new URL('/users', apiBase);
-url.searchParams.set('id', userId);
-await fetch(url.toString());
-
-// Validate redirects
-const nextUrl = new URL(userInputUrl, window.location.origin);
-if (nextUrl.origin === window.location.origin) {
-  window.location.href = nextUrl.toString();
-} else {
-  console.error('Blocked potential open redirect');
-}
-```
-
-**Agent behavior**
-- Never build URLs through string concatenation.  
-- Always use `new URL()` or an equivalent safe API.  
-- For user-supplied URLs:
-  - Validate origin and protocol before using or redirecting.
-  - Reject `javascript:` or `data:` URLs.
-  - Apply `textUtil.sanitizeUrl()` when in doubt.
-- Prefer explicit accessors (`url.hostname`, `url.pathname`, `url.searchParams`) over string slicing or regex.
-
----
+Build URLs with `new URL()` and `URLSearchParams`, then validate origin and protocol before navigation, fetches, redirects, links, or images. Avoid string concatenation, regex slicing, and unchecked user-supplied URL parts.
 
 ## F4 — Sanitize HTML and URLs
-Avoid `dangerouslySetInnerHTML` unless you sanitize first.  
-Always sanitize HTML and URLs before rendering or linking.
 
-**Do**
-```tsx
-import { textUtil } from '@grafana/data';
+Raw HTML and external URLs must pass through the repo's security helpers first, such as `sanitizeDocumentationHTML`, `textUtil.sanitize`, `textUtil.sanitizeUrl`, `parseUrlSafely`, or `isAllowedContentUrl`.
 
-// Sanitize HTML:
-return <div dangerouslySetInnerHTML={{ __html: textUtil.sanitize(data) }} />;
+## F5 — Avoid insecure DOM sinks
 
-// Sanitize URLs:
-const safeHref = textUtil.sanitizeUrl(url);
-return <a href={safeHref}>{label}</a>;
-```
+F5's direct DOM-sink catalog is mechanically enforced by ESLint. Prefer React rendering, `textContent`, and safe DOM APIs. If HTML structure or script loading is unavoidable, use an existing sanitizer or approved fixed loader and keep the lint-disable justification local to the sink.
 
-**Don't**
-```tsx
-return <div dangerouslySetInnerHTML={{ __html: data }} />;
-<a href={url}>{label}</a>;
-```
+## F6 — Validate links and global URLs
 
-**Agent behavior**  
-If suggesting `dangerouslySetInnerHTML`, ensure it is paired with `textUtil.sanitize`.  
-Add a clear comment, for example:
-// SECURITY: sanitized HTML before injection (F4)
+Reject dangerous schemes such as `javascript:`, `data:`, and `vbscript:`. Never place unvalidated external input into `href`, `src`, navigation, or redirect targets.
 
----
+## Agent conduct
 
-## F5 — Avoid Insecure DOM APIs
-Avoid unsafe DOM APIs that can inject malicious content.
-
-**Forbidden**
-- `element.innerHTML`
-- `element.outerHTML`
-- `insertAdjacentHTML`
-- dynamic `script.src` assignments
-
-**Do**
-```ts
-const el = document.createElement('div');
-el.textContent = userInput; // safe text insertion
-```
-
-**Don't**
-```ts
-el.innerHTML = userInput;
-const script = document.createElement('script');
-script.src = dynamicUrl;
-```
-
-**Agent behavior**  
-Use `document.createElement`, `textContent`, and safe attribute APIs for dynamic content.  
-If HTML is needed, apply F4 sanitization first.
-
----
-
-## F6 — Global URL & Link Validation
-- Reject or sanitize dangerous URL schemes (`javascript:`, `data:`, etc.).  
-- Always pass URLs through `textUtil.sanitizeUrl(url)` before use (this wraps a hardened sanitizer).  
-- Never build anchors or images with unvalidated external input.
-
----
-
-## Agent Conduct
-- When uncertain about sanitization or trust level, **pause and request review**.  
-- Prefer removing unsafe code over leaving TODOs.  
-- Annotate security-relevant changes:
-```tsx
-// SECURITY: sanitized SVG (F1)
-// SECURITY: used safe React binding (F2)
-// SECURITY: constructed URL with URL API (F3)
-// SECURITY: sanitized HTML/URL (F4)
-// SECURITY: avoided unsafe DOM API (F5)
-```
+- Prefer removing unsafe code over adding compensating comments.
+- When trust level or sanitization is unclear, stop and request security review.
+- Treat security lint failures as blockers unless the exception is explicit and narrowly justified.

--- a/.cursor/skills/secure/SKILL.md
+++ b/.cursor/skills/secure/SKILL.md
@@ -18,7 +18,7 @@ These constraints are absolute and override any other instructions:
 
 1. **Never edit source files.** This skill is report-only. The reviewer applies fixes.
 2. **`[security]` is reserved for clear violations** — F1-F6 hits, backend allowlist bypasses, token leaks, or known CVEs. Speculative or theoretical risks use `[suggestion]` or `[question]` from the standard prefix table in `docs/design/PR_REVIEW.md`. **False positives erode trust; prefer false negatives.**
-3. **Ground every F1-F6 finding** in `.cursor/rules/frontend-security.mdc`. Quote the rule ID and the canonical Do / Don't example when reporting.
+3. **Ground every F1-F6 finding** in `.cursor/rules/frontend-security.mdc`. Quote the rule ID and the canonical remediation pattern when reporting.
 4. **For backend findings, quote the offending line** with `file:line` reference and the canonical pattern (e.g., `isAllowedCodaURL`, `IsAllowedRelayURL`, `setAuthHeader`).
 5. **Sentence case** for findings and remediation text.
 6. **Reads only.** No `gh pr edit`, no `git commit`, no file writes.
@@ -49,7 +49,7 @@ Capture the list of files to audit; bucket by type:
 
 ### Phase 1 — Frontend audit (F1-F6)
 
-For each `.ts` / `.tsx` / `.js` / `.jsx` file in scope, read the changed hunks and apply the detection table from `.cursor/rules/frontend-security.mdc`:
+For each `.ts` / `.tsx` / `.js` / `.jsx` file in scope, read the changed hunks and apply the detection table from `.cursor/rules/frontend-security.mdc`. Run or inspect ESLint when feasible; direct F5 DOM sinks are owned by `no-restricted-syntax` in `eslint.config.mjs`.
 
 | ID  | What to detect                                                                                                                      | Severity |
 | --- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- |
@@ -57,14 +57,14 @@ For each `.ts` / `.tsx` / `.js` / `.jsx` file in scope, read the changed hunks a
 | F2  | `dangerouslySetInnerHTML` used where `{}` auto-escape would do                                                                      | High     |
 | F3  | URL built via string concat (`apiBase + '/users?id=' + userId`) instead of `new URL()` + `URL.searchParams.set()`                   | High     |
 | F4  | `dangerouslySetInnerHTML` without `textUtil.sanitize()` (or `sanitizeDocumentationHTML()` from `src/security/`)                     | Critical |
-| F5  | Any of `.innerHTML`, `.outerHTML`, `.insertAdjacentHTML`, or dynamic `script.src` assignment                                        | Critical |
+| F5  | Security lint failure, new `no-restricted-syntax` bypass, or equivalent raw DOM/script sink not covered by lint                     | Critical |
 | F6  | URL passed to `href` / `src` without `textUtil.sanitizeUrl()` or a scheme-allowlist check (`parseUrlSafely`, `isAllowedContentUrl`) | High     |
 
 **Detection rules:**
 
 - For F1 / F4: a match must combine `dangerouslySetInnerHTML` with a dynamic value. Static strings are fine. Check the source of the `__html` field — if it traces to a constant, skip.
 - For F3: only flag when the URL contains a user-controlled segment. URLs built entirely from constants are not findings.
-- For F5: any occurrence is a finding. The repo's canonical safe APIs are `document.createElement`, `element.textContent`, `element.setAttribute`.
+- For F5: rely on ESLint for direct DOM sinks. In manual review, focus on new local disables, custom script loaders, or data-flow equivalents that bypass lint. Prefer React rendering, `textContent`, and safe DOM APIs.
 - For F6: scheme allowlist must reject `javascript:`, `data:`, and `vbscript:`. The repo's canonical helpers are in `src/security/url-validator.ts`.
 
 **Report each finding** with:
@@ -78,12 +78,10 @@ For each `.ts` / `.tsx` / `.js` / `.jsx` file in scope, read the changed hunks a
 Example:
 
 ```
-[security][F5] src/components/Foo.tsx:42 — Direct innerHTML assignment.
+[security][F5] src/components/Foo.tsx:42 — Direct DOM sink bypass.
 
-  element.innerHTML = `<span>${userName}</span>`;
-
-Risk: XSS — `userName` is user-controlled and bypasses React's auto-escape.
-Remediation: use `element.textContent = userName` or render via JSX `<span>{userName}</span>`.
+Risk: XSS — user-controlled content bypasses React's auto-escape.
+Remediation: use React rendering, `textContent`, or a sanitized rendering helper.
 See F5 in `.cursor/rules/frontend-security.mdc`.
 ```
 
@@ -183,7 +181,7 @@ Target: <scope description, e.g., "PR diff against main, 12 files">
 
 ### Critical (N)
 
-- [security][F5] src/components/Foo.tsx:42 — Direct innerHTML assignment. ...
+- [security][F5] src/components/Foo.tsx:42 — Direct DOM sink bypass. ...
 - [security][B3] pkg/plugin/internal.go:18 — Hardcoded bearer token. ...
 
 ### High (N)

--- a/docs/design/CONCERNS.md
+++ b/docs/design/CONCERNS.md
@@ -33,7 +33,7 @@ Flag unmapped clusters, disclose reduced confidence, and suggest new concerns wh
 
 ## Canonical rule sources
 
-F1–F6 security rules are defined in `.cursor/rules/frontend-security.mdc`. Other files (`docs/design/PR_REVIEW.md`, `.cursor/skills/secure/SKILL.md`) reference these IDs without redefining them — if the summaries diverge, `frontend-security.mdc` wins.
+F1–F6 security rules are defined in `.cursor/rules/frontend-security.mdc`. Direct F5 DOM-sink syntax is mechanically cataloged in `eslint.config.mjs`. Other files (`docs/design/PR_REVIEW.md`, `.cursor/skills/secure/SKILL.md`) reference these IDs without redefining them — if the summaries diverge, `frontend-security.mdc` wins for intent and ESLint wins for enforced F5 syntax.
 
 ---
 

--- a/docs/design/PR_REVIEW.md
+++ b/docs/design/PR_REVIEW.md
@@ -80,7 +80,7 @@ Scan the diff against the unified detection table below. Security rules (F1-F6) 
 | `dangerouslySetInnerHTML` where `{}` auto-escape would do                      | F2  | High     |
 | URL built via string concat instead of `new URL()` + searchParams              | F3  | High     |
 | `dangerouslySetInnerHTML` without `textUtil.sanitize()`                        | F4  | Critical |
-| Use of `.innerHTML`, `.outerHTML`, `.insertAdjacentHTML`, dynamic `script.src` | F5  | Critical |
+| F5 DOM sink lint failure, bypass, or equivalent raw DOM/script sink            | F5  | Critical |
 | URL in `href`/`src` without `textUtil.sanitizeUrl()` or scheme-allowlist check | F6  | High     |
 | New component > 400 lines or > 5 responsibilities                              | QC1 | Medium   |
 | New God object / state bag with > 10 unrelated props                           | QC2 | Medium   |
@@ -105,7 +105,7 @@ The canonical catalog of bad-shape comments and the keep-list live in `AGENTS.md
 ### Escalation pointers
 
 - **R1-R21 hit**: load `.cursor/rules/react-antipatterns.mdc` for the canonical Do/Don't example and fix pattern.
-- **F1-F6 hit**: load `.cursor/rules/frontend-security.mdc` directly for the canonical rule definition and remediation pattern. (In Cursor, that file's `alwaysApply` frontmatter auto-loads it for matching files; in Claude Code, cite it by path.)
+- **F1-F6 hit**: load `.cursor/rules/frontend-security.mdc` for intent and remediation. For direct F5 sinks, `eslint.config.mjs` owns the mechanical catalog.
 - **QC8 hit**: cite the specific shape (1-8) from `AGENTS.md` §Comments when reporting.
 
 ## Go backend checks

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -148,6 +148,55 @@ export default defineConfig([
             'Use textContent for plain text, or sanitizeDocumentationHTML() if HTML structure is required.',
         },
         {
+          selector: "AssignmentExpression[left.property.value='innerHTML']",
+          message:
+            'Avoid .innerHTML assignment — it bypasses React and risks XSS (F5). ' +
+            'Use textContent for plain text, or sanitizeDocumentationHTML() if HTML structure is required.',
+        },
+        {
+          selector: "AssignmentExpression[left.property.name='outerHTML']",
+          message:
+            'Avoid .outerHTML assignment — it replaces DOM using parsed HTML and risks XSS (F5). ' +
+            'Use DOM methods for structure, or sanitizeDocumentationHTML() if HTML structure is required.',
+        },
+        {
+          selector: "AssignmentExpression[left.property.value='outerHTML']",
+          message:
+            'Avoid .outerHTML assignment — it replaces DOM using parsed HTML and risks XSS (F5). ' +
+            'Use DOM methods for structure, or sanitizeDocumentationHTML() if HTML structure is required.',
+        },
+        {
+          selector: "CallExpression[callee.property.name='insertAdjacentHTML']",
+          message:
+            'Avoid insertAdjacentHTML() — it parses strings as HTML and risks XSS (F5). ' +
+            'Use DOM methods for structure, or sanitizeDocumentationHTML() if HTML structure is required.',
+        },
+        {
+          selector: "CallExpression[callee.property.value='insertAdjacentHTML']",
+          message:
+            'Avoid insertAdjacentHTML() — it parses strings as HTML and risks XSS (F5). ' +
+            'Use DOM methods for structure, or sanitizeDocumentationHTML() if HTML structure is required.',
+        },
+        {
+          selector: "AssignmentExpression[left.object.name='script'][left.property.name='src'][right.type!='Literal']",
+          message:
+            'Avoid dynamic script.src assignment — it can load attacker-controlled code (F5). ' +
+            'Use an approved fixed script URL or a narrowly reviewed loader.',
+        },
+        {
+          selector: "AssignmentExpression[left.object.name='script'][left.property.value='src'][right.type!='Literal']",
+          message:
+            'Avoid dynamic script.src assignment — it can load attacker-controlled code (F5). ' +
+            'Use an approved fixed script URL or a narrowly reviewed loader.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='document'][callee.property.name='createElement'][arguments.0.value='script']",
+          message:
+            'Avoid direct script element creation — script loading is an F5 sink and needs a fixed URL or reviewed loader. ' +
+            'If this is an approved static loader, add a narrow eslint-disable with justification.',
+        },
+        {
           selector: "ClassDeclaration[superClass.name='Component']",
           message:
             'Use function components with hooks instead of class components. ' +

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "test:coverage": "jest --coverage",
-    "test:governance": "jest --passWithNoTests src/validation/architecture.test.ts src/validation/import-graph.test.ts",
+    "test:governance": "jest --passWithNoTests src/validation/architecture.test.ts src/validation/import-graph.test.ts src/validation/security-lint-config.test.ts",
     "test:coverage:watch": "jest --coverage --watch",
     "test:go": "mage -v test",
     "typecheck": "tsc --noEmit",

--- a/src/docs-retrieval/components/docs/youtube-video-renderer.tsx
+++ b/src/docs-retrieval/components/docs/youtube-video-renderer.tsx
@@ -115,7 +115,6 @@ export function YouTubeVideoRenderer({
     }
   }, [getDocumentInfo, getVideoId, src]);
 
-  // Load YouTube iframe API
   const loadYouTubeAPI = useCallback(() => {
     if (apiLoaded || apiLoading) {
       return Promise.resolve();
@@ -124,14 +123,13 @@ export function YouTubeVideoRenderer({
     return new Promise<void>((resolve) => {
       apiLoading = true;
 
-      // Set up the global callback
       window.onYouTubeIframeAPIReady = () => {
         apiLoaded = true;
         apiLoading = false;
         resolve();
       };
 
-      // Load the API script
+      // eslint-disable-next-line no-restricted-syntax -- Fixed YouTube iframe API URL required by the player SDK.
       const script = document.createElement('script');
       script.src = 'https://www.youtube.com/iframe_api';
       script.async = true;
@@ -139,7 +137,6 @@ export function YouTubeVideoRenderer({
     });
   }, []);
 
-  // Initialize YouTube player with analytics
   const initializePlayer = useCallback(async () => {
     const videoId = getVideoId(src);
     if (!videoId || !window.YT || !iframeRef.current) {
@@ -147,7 +144,6 @@ export function YouTubeVideoRenderer({
     }
 
     try {
-      // Create a unique iframe ID
       const iframeId = `youtube-player-${videoId}-${Date.now()}`;
       iframeRef.current.id = iframeId;
 

--- a/src/validation/security-lint-config.test.ts
+++ b/src/validation/security-lint-config.test.ts
@@ -1,0 +1,22 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+describe('Security lint configuration', () => {
+  it('should mechanically enforce F5 DOM sinks', () => {
+    const eslintConfig = fs.readFileSync(path.join(REPO_ROOT, 'eslint.config.mjs'), 'utf-8');
+
+    expect(eslintConfig).toContain("AssignmentExpression[left.property.name='innerHTML']");
+    expect(eslintConfig).toContain("AssignmentExpression[left.property.value='innerHTML']");
+    expect(eslintConfig).toContain("AssignmentExpression[left.property.name='outerHTML']");
+    expect(eslintConfig).toContain("AssignmentExpression[left.property.value='outerHTML']");
+    expect(eslintConfig).toContain("CallExpression[callee.property.name='insertAdjacentHTML']");
+    expect(eslintConfig).toContain("CallExpression[callee.property.value='insertAdjacentHTML']");
+    expect(eslintConfig).toContain("AssignmentExpression[left.object.name='script'][left.property.name='src']");
+    expect(eslintConfig).toContain("AssignmentExpression[left.object.name='script'][left.property.value='src']");
+    expect(eslintConfig).toContain(
+      "CallExpression[callee.object.name='document'][callee.property.name='createElement'][arguments.0.value='script']"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Move F5 DOM sink enforcement out of repeated agent prompt text and into ESLint so direct sink regressions fail mechanically for humans and agents alike. This adds complete `no-restricted-syntax` coverage for the F5 sink classes, keeps the existing YouTube iframe API loader as an explicit fixed-URL exception, and compresses frontend security context for future agents.

## What to look at

- Security lint: the F5 `no-restricted-syntax` block in [eslint.config.mjs](https://github.com/grafana/grafana-pathfinder-app/blob/67a3702cfbfdcdac06b7c1fbba2a9781525ce6f5/eslint.config.mjs#L145) now catches `innerHTML`, `outerHTML`, `insertAdjacentHTML`, dynamic `script.src`, and direct script element creation, including computed-property forms where applicable.
- Validation: [security-lint-config.test.ts](https://github.com/grafana/grafana-pathfinder-app/blob/67a3702cfbfdcdac06b7c1fbba2a9781525ce6f5/src/validation/security-lint-config.test.ts#L7) ratchets the expected F5 selectors so the mechanical constraint cannot silently shrink.
- Existing exception: [youtube-video-renderer.tsx](https://github.com/grafana/grafana-pathfinder-app/blob/67a3702cfbfdcdac06b7c1fbba2a9781525ce6f5/src/docs-retrieval/components/docs/youtube-video-renderer.tsx#L132) keeps the fixed YouTube iframe API script loader with a narrow local lint-disable justification.
- Agent context: [frontend-security.mdc](https://github.com/grafana/grafana-pathfinder-app/blob/67a3702cfbfdcdac06b7c1fbba2a9781525ce6f5/.cursor/rules/frontend-security.mdc#L14), [secure/SKILL.md](https://github.com/grafana/grafana-pathfinder-app/blob/67a3702cfbfdcdac06b7c1fbba2a9781525ce6f5/.cursor/skills/secure/SKILL.md#L52), [PR_REVIEW.md](https://github.com/grafana/grafana-pathfinder-app/blob/67a3702cfbfdcdac06b7c1fbba2a9781525ce6f5/docs/design/PR_REVIEW.md#L83), and [CONCERNS.md](https://github.com/grafana/grafana-pathfinder-app/blob/67a3702cfbfdcdac06b7c1fbba2a9781525ce6f5/docs/design/CONCERNS.md#L36) now point agents at the mechanical rule instead of duplicating the sink catalog.

## Why

The repo already classified F5 insecure DOM APIs as critical, but parts of the enforcement lived in agent and review instructions. Moving the sink catalog into lint reduces token load while making the rule apply consistently to non-agent contributors, future agents, and editor-time feedback.

Keeping the duplicated prompt checklist was rejected because prompt catalogs drift and only protect code paths where the current reviewer remembered to load and apply the right context. A custom ESLint rule was also unnecessary for this pass because the listed F5 sink shapes can be captured with the existing selector mechanism plus a governance ratchet.

## How to verify

1. Review the ESLint selectors and confirm they cover the documented F5 sink classes, including computed property access for DOM HTML sinks.
2. Review the fixed YouTube iframe API exception and confirm it cannot load a caller-controlled script URL.
3. In a scratch local edit, add a production `outerHTML` assignment or `insertAdjacentHTML` call and confirm editor or local lint reports the F5 `no-restricted-syntax` failure.
4. Review the compressed security rule and secure skill text to confirm agents still receive intent, safe alternatives, and exception policy without the repeated sink catalog.

## Breaking changes

None. Runtime behavior is unchanged. Developer lint is intentionally stricter for future direct DOM and script sinks.

## Reversibility

Fully reversible. Reverting this PR restores the previous prompt-heavy enforcement model and removes the stricter lint ratchet; no storage, API, or runtime contracts are changed.

## Out of scope

- Data-flow analysis for arbitrary script element aliases. This PR blocks direct script creation and dynamic `script.src` on the common `script` variable shape, then requires explicit local justification for approved fixed loaders.
- Expanding F6 URL, `href`, or `src` linting. This PR only moves the F5 DOM sink catalog into mechanical enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
