### PR TITLE
refactor(storage): phase 0-1 groundwork — characterization tests + key inventory

### DIFF
--- a/src/components/PrTester/PrTester.tsx
+++ b/src/components/PrTester/PrTester.tsx
@@ -12,13 +12,14 @@ import {
 import type { ManifestJson } from '../../types/package.types';
 import type { PackageOpenInfo } from '../../types/content-panel.types';
 import { testIds } from '../../constants/testIds';
+import { StorageKeys } from '../../lib/storage-keys';
 
-const PR_URL_STORAGE_KEY = 'pathfinder-pr-tester-url';
-const SELECTED_FILE_STORAGE_KEY = 'pathfinder-pr-tester-selected';
-const SELECTED_PATH_STORAGE_KEY = 'pathfinder-pr-tester-selected-path';
-const TEST_MODE_STORAGE_KEY = 'pathfinder-pr-tester-mode';
-const FETCHED_FILES_STORAGE_KEY = 'pathfinder-pr-tester-files';
-const FETCHED_URL_STORAGE_KEY = 'pathfinder-pr-tester-fetched-url';
+const PR_URL_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_URL;
+const SELECTED_FILE_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_SELECTED_FILE;
+const SELECTED_PATH_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_SELECTED_PATH;
+const TEST_MODE_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_MODE;
+const FETCHED_FILES_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_FETCHED_FILES;
+const FETCHED_URL_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_FETCHED_URL;
 
 export interface PrTesterProps {
   /**

--- a/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
+++ b/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
@@ -4,10 +4,11 @@ import { getDebugPanelStyles } from './debug-panel.styles';
 import { UrlTester } from 'components/UrlTester';
 import { PrTester } from 'components/PrTester';
 import type { PackageOpenInfo } from 'types/content-panel.types';
+import { StorageKeys } from 'lib/storage-keys';
 
 // localStorage keys for section expansion state
-const STORAGE_KEY_PR_TESTER = 'pathfinder-devtools-pr-tester-expanded';
-const STORAGE_KEY_URL_TESTER = 'pathfinder-devtools-url-tester-expanded';
+const STORAGE_KEY_PR_TESTER = StorageKeys.DEVTOOLS_PR_TESTER_EXPANDED;
+const STORAGE_KEY_URL_TESTER = StorageKeys.DEVTOOLS_URL_TESTER_EXPANDED;
 
 /**
  * Get initial expansion state from localStorage with fallback

--- a/src/components/UrlTester/UrlTester.tsx
+++ b/src/components/UrlTester/UrlTester.tsx
@@ -9,8 +9,9 @@ import {
   type UrlValidation,
 } from '../../security';
 import { testIds } from '../../constants/testIds';
+import { StorageKeys } from '../../lib/storage-keys';
 
-const STORAGE_KEY = 'pathfinder-url-tester-url';
+const STORAGE_KEY = StorageKeys.DEVTOOLS_URL_TESTER_URL;
 
 export interface UrlTesterProps {
   onOpenDocsPage: (url: string, title: string) => void;

--- a/src/components/block-editor/HealthStatusBar.test.tsx
+++ b/src/components/block-editor/HealthStatusBar.test.tsx
@@ -11,6 +11,7 @@
 import React from 'react';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { HealthStatusBar } from './HealthStatusBar';
+import { StorageKeys } from '../../lib/storage-keys';
 import type { Diagnostic, GuideLintResult } from './lint';
 import type { EditorBlock } from './types';
 
@@ -21,7 +22,7 @@ jest.mock('./BlockEditorContext', () => ({
   useGuideLintResult: () => mockLint(),
 }));
 
-const STORAGE_KEY = 'pathfinder.blockEditor.healthPanel.open';
+const STORAGE_KEY = StorageKeys.BLOCK_EDITOR_HEALTH_PANEL_OPEN;
 
 function makeLint(diagnostics: Diagnostic[]): GuideLintResult {
   return {

--- a/src/components/block-editor/HealthStatusBar.tsx
+++ b/src/components/block-editor/HealthStatusBar.tsx
@@ -16,6 +16,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Icon, IconButton, Tooltip, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
+import { StorageKeys } from '../../lib/storage-keys';
 import { useGuideLintResult } from './BlockEditorContext';
 import type { Diagnostic, DiagnosticSeverity } from './lint';
 import type { EditorBlock } from './types';
@@ -26,7 +27,7 @@ export interface HealthStatusBarProps {
   blocks: EditorBlock[];
 }
 
-const STORAGE_KEY = 'pathfinder.blockEditor.healthPanel.open';
+const STORAGE_KEY = StorageKeys.BLOCK_EDITOR_HEALTH_PANEL_OPEN;
 
 const SEVERITY_ORDER: DiagnosticSeverity[] = ['error', 'warning', 'info'];
 

--- a/src/components/block-editor/constants.ts
+++ b/src/components/block-editor/constants.ts
@@ -4,6 +4,8 @@
  * Block type metadata and configuration for the block-based editor.
  */
 
+import { StorageKeys } from '../../lib/storage-keys';
+
 import type { BlockType, BlockTypeMetadata } from './types';
 
 /**
@@ -192,21 +194,22 @@ export const BLOCK_TYPE_GROUPS: ReadonlyArray<{
 ] as const;
 
 /**
- * Local storage key for persisting editor state
+ * Local storage key for persisting editor state.
+ * Canonical value lives in the centralized `StorageKeys` registry.
  */
-export const BLOCK_EDITOR_STORAGE_KEY = 'pathfinder-block-editor-state';
+export const BLOCK_EDITOR_STORAGE_KEY = StorageKeys.BLOCK_EDITOR_STATE;
 
 /**
  * Local storage key for persisting recording mode state
  * Allows recording to survive page refreshes (e.g., when saving a dashboard)
  */
-export const RECORDING_STATE_STORAGE_KEY = 'pathfinder-block-editor-recording-state';
+export const RECORDING_STATE_STORAGE_KEY = StorageKeys.BLOCK_EDITOR_RECORDING_STATE;
 
 /**
  * Local storage key for persisting backend tracking state (resource name, status).
  * Ensures the correct save/update button is shown after a page refresh.
  */
-export const BACKEND_TRACKING_STORAGE_KEY = 'pathfinder-block-editor-backend-tracking';
+export const BACKEND_TRACKING_STORAGE_KEY = StorageKeys.BLOCK_EDITOR_BACKEND_TRACKING;
 
 /**
  * Default guide metadata for new guides

--- a/src/components/block-editor/forms/ConditionChipsField.test.tsx
+++ b/src/components/block-editor/forms/ConditionChipsField.test.tsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ConditionChipsField } from './ConditionChipsField';
+import { StorageKeys } from '../../../lib/storage-keys';
 
 // `Combobox` from @grafana/ui uses a virtualized listbox that's awkward to
 // drive from RTL fireEvent. Replace it with a plain <select> for the
@@ -193,15 +194,15 @@ describe('ConditionChipsField — raw mode toggle', () => {
   it('persists the raw-mode preference to localStorage', () => {
     render(<ConditionChipsField value="" onChange={jest.fn()} mode="requirements" />);
 
-    expect(window.localStorage.getItem('pathfinder.blockEditor.conditionField.rawMode')).toBe(null);
+    expect(window.localStorage.getItem(StorageKeys.BLOCK_EDITOR_CONDITION_RAW_MODE)).toBe(null);
     fireEvent.click(screen.getByRole('button', { name: /View raw/i }));
-    expect(window.localStorage.getItem('pathfinder.blockEditor.conditionField.rawMode')).toBe('true');
+    expect(window.localStorage.getItem(StorageKeys.BLOCK_EDITOR_CONDITION_RAW_MODE)).toBe('true');
     fireEvent.click(screen.getByRole('button', { name: /Use chip editor/i }));
-    expect(window.localStorage.getItem('pathfinder.blockEditor.conditionField.rawMode')).toBe('false');
+    expect(window.localStorage.getItem(StorageKeys.BLOCK_EDITOR_CONDITION_RAW_MODE)).toBe('false');
   });
 
   it('initializes raw mode from a previously stored preference', () => {
-    window.localStorage.setItem('pathfinder.blockEditor.conditionField.rawMode', 'true');
+    window.localStorage.setItem(StorageKeys.BLOCK_EDITOR_CONDITION_RAW_MODE, 'true');
     render(<ConditionChipsField value="exists-reftarget" onChange={jest.fn()} mode="requirements" />);
     expect(screen.getByDisplayValue('exists-reftarget')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Use chip editor/i })).toBeInTheDocument();

--- a/src/components/block-editor/forms/ConditionChipsField.tsx
+++ b/src/components/block-editor/forms/ConditionChipsField.tsx
@@ -28,9 +28,10 @@ import {
   isValidRequirement,
 } from '../../../types/requirements.types';
 import { isAutoRecoverableRequirement } from '../../../recovery';
+import { StorageKeys } from '../../../lib/storage-keys';
 import { HELPER_BY_PREFIX } from './condition-helpers';
 
-const RAW_MODE_PREFERENCE_KEY = 'pathfinder.blockEditor.conditionField.rawMode';
+const RAW_MODE_PREFERENCE_KEY = StorageKeys.BLOCK_EDITOR_CONDITION_RAW_MODE;
 
 export type ConditionFieldMode = 'requirements' | 'objectives' | 'conditions' | 'verify';
 

--- a/src/integrations/assistant-integration/AssistantBlockWrapper.tsx
+++ b/src/integrations/assistant-integration/AssistantBlockWrapper.tsx
@@ -11,6 +11,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, Button } from '@grafana/ui';
 import { reportAppInteraction, UserInteraction, buildAssistantCustomizableProperties } from '../../lib/analytics';
+import { buildAssistantStorageKey } from '../../lib/storage-keys';
 import { type DatasourceMetadataArtifact } from './tools';
 import { AssistantBlockValueProvider } from './AssistantBlockValueContext';
 import { parseMarkdownToElements, CodeBlock } from '../../docs-retrieval';
@@ -132,7 +133,7 @@ export function AssistantBlockWrapper({
   // Get initial customized value from localStorage
   const getInitialCustomizedValue = useCallback((): string | null => {
     try {
-      const storageKey = `pathfinder-assistant-${contentKey}-${assistantId}`;
+      const storageKey = buildAssistantStorageKey(contentKey, assistantId);
       return localStorage.getItem(storageKey);
     } catch (error) {
       return null;

--- a/src/integrations/assistant-integration/AssistantCustomizable.tsx
+++ b/src/integrations/assistant-integration/AssistantCustomizable.tsx
@@ -13,6 +13,7 @@ import { getIsAssistantAvailable, useMockInlineAssistant } from './assistant-dev
 import { isAssistantDevModeEnabledGlobal } from '../../utils/dev-mode';
 import { useAssistantCustomizableContext } from './AssistantCustomizableContext';
 import { reportAppInteraction, UserInteraction, buildAssistantCustomizableProperties } from '../../lib/analytics';
+import { buildAssistantStorageKey } from '../../lib/storage-keys';
 import { createDatasourceMetadataTool, type DatasourceMetadataArtifact, isSupportedDatasourceType } from './tools';
 
 export interface AssistantCustomizableProps {
@@ -146,13 +147,13 @@ export function AssistantCustomizable({
 
   // Generate localStorage key
   const getStorageKey = useCallback((): string => {
-    return `pathfinder-assistant-${contentKey}-${assistantId}`;
+    return buildAssistantStorageKey(contentKey, assistantId);
   }, [contentKey, assistantId]);
 
   // Load initial value from localStorage using lazy initialization
   const getInitialValue = useCallback(() => {
     try {
-      const storageKey = `pathfinder-assistant-${contentKey}-${assistantId}`;
+      const storageKey = buildAssistantStorageKey(contentKey, assistantId);
       const storedValue = localStorage.getItem(storageKey);
       return storedValue || defaultValue;
     } catch (error) {
@@ -163,7 +164,7 @@ export function AssistantCustomizable({
 
   const getInitialCustomizedState = useCallback(() => {
     try {
-      const storageKey = `pathfinder-assistant-${contentKey}-${assistantId}`;
+      const storageKey = buildAssistantStorageKey(contentKey, assistantId);
       const storedValue = localStorage.getItem(storageKey);
       return storedValue !== null;
     } catch (error) {

--- a/src/integrations/assistant-integration/useAssistantGeneration.hook.ts
+++ b/src/integrations/assistant-integration/useAssistantGeneration.hook.ts
@@ -20,6 +20,7 @@ import {
 import { getDataSourceSrv, locationService } from '@grafana/runtime';
 import { getIsAssistantAvailable, useMockInlineAssistant } from './assistant-dev-mode';
 import { isAssistantDevModeEnabledGlobal } from '../../utils/dev-mode';
+import { buildAssistantStorageKey } from '../../lib/storage-keys';
 import { createDatasourceMetadataTool, type DatasourceMetadataArtifact, isSupportedDatasourceType } from './tools';
 
 // REACT: Stable array reference to prevent context thrashing (R3)
@@ -96,7 +97,7 @@ export function useAssistantGeneration(options: UseAssistantGenerationOptions): 
 
   // Generate localStorage key
   const getStorageKey = useCallback((): string => {
-    return `pathfinder-assistant-${contentKey}-${assistantId}`;
+    return buildAssistantStorageKey(contentKey, assistantId);
   }, [contentKey, assistantId]);
 
   // Check if assistant is available

--- a/src/integrations/coda/terminal-storage.ts
+++ b/src/integrations/coda/terminal-storage.ts
@@ -5,17 +5,17 @@
  * sessionStorage: Connection state and scrollback - tab-scoped, cleared on close
  */
 
-const STORAGE_PREFIX = 'pathfinder-coda-terminal';
+import { StorageKeys } from '../../lib/storage-keys';
 
 const KEYS = {
-  isOpen: `${STORAGE_PREFIX}-is-open`,
-  height: `${STORAGE_PREFIX}-height`,
+  isOpen: StorageKeys.CODA_TERMINAL_IS_OPEN,
+  height: StorageKeys.CODA_TERMINAL_HEIGHT,
 } as const;
 
 const SESSION_KEYS = {
-  wasConnected: `${STORAGE_PREFIX}-was-connected`,
-  scrollback: `${STORAGE_PREFIX}-scrollback`,
-  lastVmOpts: `${STORAGE_PREFIX}-last-vm-opts`,
+  wasConnected: StorageKeys.CODA_TERMINAL_WAS_CONNECTED,
+  scrollback: StorageKeys.CODA_TERMINAL_SCROLLBACK,
+  lastVmOpts: StorageKeys.CODA_TERMINAL_LAST_VM_OPTS,
 } as const;
 
 const MAX_SCROLLBACK_SIZE = 100_000; // ~100KB limit for sessionStorage

--- a/src/lib/storage-keys.test.ts
+++ b/src/lib/storage-keys.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Contract / stability test for the centralized storage key registry.
+ *
+ * These exact string values are a load-bearing contract: Playwright E2E tests
+ * inject localStorage by key, `experiment-debug` sweeps by prefix, and existing
+ * user data in the wild is addressed by these strings. A rename is a silent,
+ * data-orphaning breaking change — this test makes any change to a key VALUE
+ * fail loudly so it must be a deliberate, reviewed decision (with a migration).
+ *
+ * When ADDING a new key, add it here too. When CHANGING an existing value, stop
+ * and consider the migration implications before updating this test.
+ */
+import { StorageKeys } from './storage-keys';
+
+describe('StorageKeys — stable string contract', () => {
+  it('matches the locked key values exactly', () => {
+    expect(StorageKeys).toEqual({
+      // Core learner / progress state
+      JOURNEY_COMPLETION: 'grafana-pathfinder-app-journey-completion',
+      INTERACTIVE_COMPLETION: 'grafana-pathfinder-app-interactive-completion',
+      TABS: 'grafana-pathfinder-app-tabs',
+      ACTIVE_TAB: 'grafana-pathfinder-app-active-tab',
+      INTERACTIVE_STEPS_PREFIX: 'grafana-pathfinder-app-interactive-steps-',
+      WYSIWYG_PREVIEW: 'grafana-pathfinder-app-wysiwyg-preview',
+      WYSIWYG_PREVIEW_JSON: 'grafana-pathfinder-app-wysiwyg-preview-json',
+      E2E_TEST_GUIDE: 'grafana-pathfinder-app-e2e-test-guide',
+      SECTION_COLLAPSE_PREFIX: 'grafana-pathfinder-app-section-collapse-',
+      SECTION_ACKNOWLEDGED_PREFIX: 'grafana-pathfinder-app-section-acknowledged-',
+      SECTION_DONE_PREFIX: 'grafana-pathfinder-app-section-done-',
+      FULLSCREEN_MODE_STATE: 'grafana-pathfinder-app-fullscreen-mode-state',
+      FULLSCREEN_BUNDLED_STEPS: 'grafana-pathfinder-app-fullscreen-bundled-steps',
+      FULLSCREEN_BUNDLING_ACTION: 'grafana-pathfinder-app-fullscreen-bundling-action',
+      FULLSCREEN_SECTION_INFO: 'grafana-pathfinder-app-fullscreen-section-info',
+      MILESTONE_COMPLETION: 'grafana-pathfinder-app-milestone-completion',
+      LEARNING_PROGRESS: 'grafana-pathfinder-app-learning-progress',
+      GUIDE_RESPONSES: 'grafana-pathfinder-app-guide-responses',
+
+      // Experiment / feature-flag state
+      EXPERIMENT_AUTO_OPEN: 'grafana-pathfinder-app-experiment-auto-open',
+      EXPERIMENT_SESSION_AUTO_OPENED_PREFIX: 'grafana-interactive-learning-panel-auto-opened-',
+      EXPERIMENT_TREATMENT_PAGE_PREFIX: 'grafana-pathfinder-treatment-page-',
+      EXPERIMENT_RESET_PROCESSED_PREFIX: 'grafana-pathfinder-pop-open-reset-processed-',
+      EXPERIMENT_EXPOSURE_REPORTED_PREFIX: 'grafana-pathfinder-experiment-exposure-reported-',
+      EXPERIMENT_TREATMENT_OPENED_LEGACY_PREFIX: 'grafana-pathfinder-experiment-treatment-opened-',
+      HIGHLIGHTED_GUIDE_AUTO_OPEN_PREFIX: 'grafana-pathfinder-highlighted-guide-auto-open-',
+      HIGHLIGHTED_GUIDE_RESET_PROCESSED_PREFIX: 'grafana-pathfinder-highlighted-guide-reset-processed-',
+      FLAG_OVERRIDES: 'grafana-pathfinder-flag-overrides',
+
+      // UI / panel state
+      SUGGESTIONS: 'grafana-pathfinder-app-suggestions',
+      PANEL_MODE: 'grafana-pathfinder-app-panel-mode',
+      FLOATING_PANEL_GEOMETRY: 'grafana-pathfinder-app-floating-panel-geometry',
+
+      // Block editor (centralized from block-editor/constants.ts + UI prefs)
+      BLOCK_EDITOR_STATE: 'pathfinder-block-editor-state',
+      BLOCK_EDITOR_RECORDING_STATE: 'pathfinder-block-editor-recording-state',
+      BLOCK_EDITOR_BACKEND_TRACKING: 'pathfinder-block-editor-backend-tracking',
+      BLOCK_EDITOR_HEALTH_PANEL_OPEN: 'pathfinder.blockEditor.healthPanel.open',
+      BLOCK_EDITOR_CONDITION_RAW_MODE: 'pathfinder.blockEditor.conditionField.rawMode',
+
+      // Coda terminal (centralized from integrations/coda/terminal-storage.ts)
+      CODA_TERMINAL_IS_OPEN: 'pathfinder-coda-terminal-is-open',
+      CODA_TERMINAL_HEIGHT: 'pathfinder-coda-terminal-height',
+      CODA_TERMINAL_WAS_CONNECTED: 'pathfinder-coda-terminal-was-connected',
+      CODA_TERMINAL_SCROLLBACK: 'pathfinder-coda-terminal-scrollback',
+      CODA_TERMINAL_LAST_VM_OPTS: 'pathfinder-coda-terminal-last-vm-opts',
+
+      // Assistant customization (dynamic suffix: `{contentKey}-{assistantId}`)
+      ASSISTANT_CUSTOMIZATION_PREFIX: 'pathfinder-assistant-',
+
+      // Devtools (dev-only panels)
+      DEVTOOLS_PR_TESTER_URL: 'pathfinder-pr-tester-url',
+      DEVTOOLS_PR_TESTER_SELECTED_FILE: 'pathfinder-pr-tester-selected',
+      DEVTOOLS_PR_TESTER_SELECTED_PATH: 'pathfinder-pr-tester-selected-path',
+      DEVTOOLS_PR_TESTER_MODE: 'pathfinder-pr-tester-mode',
+      DEVTOOLS_PR_TESTER_FETCHED_FILES: 'pathfinder-pr-tester-files',
+      DEVTOOLS_PR_TESTER_FETCHED_URL: 'pathfinder-pr-tester-fetched-url',
+      DEVTOOLS_URL_TESTER_URL: 'pathfinder-url-tester-url',
+      DEVTOOLS_PR_TESTER_EXPANDED: 'pathfinder-devtools-pr-tester-expanded',
+      DEVTOOLS_URL_TESTER_EXPANDED: 'pathfinder-devtools-url-tester-expanded',
+    });
+  });
+
+  it('builds the assistant customization key from the prefix', () => {
+    expect(`${StorageKeys.ASSISTANT_CUSTOMIZATION_PREFIX}my-content-asst-1`).toBe(
+      'pathfinder-assistant-my-content-asst-1'
+    );
+  });
+});

--- a/src/lib/storage-keys.test.ts
+++ b/src/lib/storage-keys.test.ts
@@ -10,7 +10,7 @@
  * When ADDING a new key, add it here too. When CHANGING an existing value, stop
  * and consider the migration implications before updating this test.
  */
-import { StorageKeys } from './storage-keys';
+import { StorageKeys, buildAssistantStorageKey } from './storage-keys';
 
 describe('StorageKeys — stable string contract', () => {
   it('matches the locked key values exactly', () => {
@@ -82,8 +82,6 @@ describe('StorageKeys — stable string contract', () => {
   });
 
   it('builds the assistant customization key from the prefix', () => {
-    expect(`${StorageKeys.ASSISTANT_CUSTOMIZATION_PREFIX}my-content-asst-1`).toBe(
-      'pathfinder-assistant-my-content-asst-1'
-    );
+    expect(buildAssistantStorageKey('my-content', 'asst-1')).toBe('pathfinder-assistant-my-content-asst-1');
   });
 });

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -47,13 +47,65 @@ export const StorageKeys = {
   // not session — auto-open fires once per browser, not once per session.
   HIGHLIGHTED_GUIDE_AUTO_OPEN_PREFIX: 'grafana-pathfinder-highlighted-guide-auto-open-',
   HIGHLIGHTED_GUIDE_RESET_PROCESSED_PREFIX: 'grafana-pathfinder-highlighted-guide-reset-processed-',
+  // Legacy global treatment auto-open key (kept for backwards compatibility).
+  // Used with a `{hostname}` suffix. Not migrated — see G5/G10 notes.
+  EXPERIMENT_TREATMENT_OPENED_LEGACY_PREFIX: 'grafana-pathfinder-experiment-treatment-opened-',
+  // Dev/debug feature-flag overrides (localStorage). Read before the MTFF client.
+  FLAG_OVERRIDES: 'grafana-pathfinder-flag-overrides',
   // External app suggestions for the featured zone (sessionStorage)
   SUGGESTIONS: 'grafana-pathfinder-app-suggestions',
   // Floating panel mode preference (sidebar vs floating)
   PANEL_MODE: 'grafana-pathfinder-app-panel-mode',
   // Floating panel position and size
   FLOATING_PANEL_GEOMETRY: 'grafana-pathfinder-app-floating-panel-geometry',
+
+  // ==========================================================================
+  // Block editor (centralized here from block-editor/constants.ts and the
+  // block-editor UI components, which re-export / reference these values).
+  // ==========================================================================
+  BLOCK_EDITOR_STATE: 'pathfinder-block-editor-state',
+  BLOCK_EDITOR_RECORDING_STATE: 'pathfinder-block-editor-recording-state',
+  BLOCK_EDITOR_BACKEND_TRACKING: 'pathfinder-block-editor-backend-tracking',
+  BLOCK_EDITOR_HEALTH_PANEL_OPEN: 'pathfinder.blockEditor.healthPanel.open',
+  BLOCK_EDITOR_CONDITION_RAW_MODE: 'pathfinder.blockEditor.conditionField.rawMode',
+
+  // ==========================================================================
+  // Coda terminal (centralized from integrations/coda/terminal-storage.ts).
+  // is-open / height are localStorage; the rest are sessionStorage.
+  // ==========================================================================
+  CODA_TERMINAL_IS_OPEN: 'pathfinder-coda-terminal-is-open',
+  CODA_TERMINAL_HEIGHT: 'pathfinder-coda-terminal-height',
+  CODA_TERMINAL_WAS_CONNECTED: 'pathfinder-coda-terminal-was-connected',
+  CODA_TERMINAL_SCROLLBACK: 'pathfinder-coda-terminal-scrollback',
+  CODA_TERMINAL_LAST_VM_OPTS: 'pathfinder-coda-terminal-last-vm-opts',
+
+  // ==========================================================================
+  // Assistant customization. Dynamic key: `{PREFIX}{contentKey}-{assistantId}`.
+  // Use `buildAssistantStorageKey()` rather than concatenating inline.
+  // ==========================================================================
+  ASSISTANT_CUSTOMIZATION_PREFIX: 'pathfinder-assistant-',
+
+  // ==========================================================================
+  // Devtools (dev-only panels: PR tester, URL tester, debug panel expansion).
+  // ==========================================================================
+  DEVTOOLS_PR_TESTER_URL: 'pathfinder-pr-tester-url',
+  DEVTOOLS_PR_TESTER_SELECTED_FILE: 'pathfinder-pr-tester-selected',
+  DEVTOOLS_PR_TESTER_SELECTED_PATH: 'pathfinder-pr-tester-selected-path',
+  DEVTOOLS_PR_TESTER_MODE: 'pathfinder-pr-tester-mode',
+  DEVTOOLS_PR_TESTER_FETCHED_FILES: 'pathfinder-pr-tester-files',
+  DEVTOOLS_PR_TESTER_FETCHED_URL: 'pathfinder-pr-tester-fetched-url',
+  DEVTOOLS_URL_TESTER_URL: 'pathfinder-url-tester-url',
+  DEVTOOLS_PR_TESTER_EXPANDED: 'pathfinder-devtools-pr-tester-expanded',
+  DEVTOOLS_URL_TESTER_EXPANDED: 'pathfinder-devtools-url-tester-expanded',
 } as const;
 
 export type StorageKeyName = keyof typeof StorageKeys;
 export type StorageKeyValue = (typeof StorageKeys)[StorageKeyName];
+
+/**
+ * Builds the dynamic localStorage key used to persist a user's assistant-block
+ * customization. Centralized so the key shape lives in exactly one place.
+ */
+export function buildAssistantStorageKey(contentKey: string, assistantId: string): string {
+  return `${StorageKeys.ASSISTANT_CUSTOMIZATION_PREFIX}${contentKey}-${assistantId}`;
+}

--- a/src/lib/user-storage.plumbing.test.ts
+++ b/src/lib/user-storage.plumbing.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Characterization / tripwire tests for the user-storage plumbing layer.
+ *
+ * These pin the behavior of the highest-risk, previously-untested async paths
+ * before any decomposition of `user-storage.ts`:
+ *   - `createHybridStorage` debounced write queue (debounce, per-key dedup,
+ *     synchronous localStorage write, and the anti-stranding re-check drain)
+ *   - `syncFromGrafanaStorage` once-per-lifecycle guard and timestamp-based
+ *     last-write-wins conflict resolution (including deletion tombstones)
+ *   - `createLocalStorage` JSON fallback and plugin-scoped clear
+ *
+ * They are deliberately behavioral: if a future refactor changes any of these
+ * contracts, these tests should fail.
+ */
+import type { GrafanaUserStorage } from '../types/storage.types';
+
+import {
+  __resetSyncedForTests,
+  createHybridStorage,
+  createLocalStorage,
+  syncFromGrafanaStorage,
+  unwrapEnvelope,
+  wrapEnvelope,
+} from './user-storage';
+import { StorageKeys } from './storage-keys';
+
+// user-storage.ts statically imports from `@grafana/runtime`; provide a mock so
+// the module loads under jsdom.
+jest.mock('@grafana/runtime', () => ({
+  usePluginUserStorage: jest.fn(),
+  getAppEvents: jest.fn(() => ({ publish: jest.fn() })),
+}));
+
+const TIMESTAMP_SUFFIX = '__timestamp';
+const tsKey = (key: string) => `${key}${TIMESTAMP_SUFFIX}`;
+
+/** Flush a generous number of microtask ticks so awaited queue work settles. */
+async function flushMicrotasks(times = 8): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
+/** In-memory Grafana user-storage double backed by a Map. */
+function makeGrafanaStorage(seed: Record<string, string> = {}): GrafanaUserStorage & {
+  store: Map<string, string>;
+  getItem: jest.Mock;
+  setItem: jest.Mock;
+} {
+  const store = new Map<string, string>(Object.entries(seed));
+  const getItem = jest.fn(async (key: string) => store.get(key) ?? null);
+  const setItem = jest.fn(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  return { store, getItem, setItem } as unknown as GrafanaUserStorage & {
+    store: Map<string, string>;
+    getItem: jest.Mock;
+    setItem: jest.Mock;
+  };
+}
+
+// ============================================================================
+// createHybridStorage — debounced write queue (Pattern F/G)
+// ============================================================================
+
+describe('createHybridStorage — debounced write queue', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('writes to localStorage synchronously, before the debounce fires', async () => {
+    const grafana = makeGrafanaStorage();
+    const hybrid = createHybridStorage(grafana);
+
+    await hybrid.setItem('k', 'immediate');
+
+    // localStorage holds the value immediately (survives page refresh)…
+    expect(localStorage.getItem('k')).toBe(JSON.stringify('immediate'));
+    expect(localStorage.getItem(tsKey('k'))).not.toBeNull();
+    // …but Grafana has not been touched yet (still debouncing).
+    expect(grafana.setItem).not.toHaveBeenCalled();
+  });
+
+  it('debounces rapid writes to the same key into a single deduped Grafana write (last-write-wins)', async () => {
+    const grafana = makeGrafanaStorage();
+    const hybrid = createHybridStorage(grafana);
+
+    await hybrid.setItem('k', 'a');
+    await hybrid.setItem('k', 'b');
+    await hybrid.setItem('k', 'c');
+
+    expect(grafana.setItem).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(500);
+
+    expect(grafana.setItem).toHaveBeenCalledTimes(1);
+    const [writtenKey, writtenValue] = grafana.setItem.mock.calls[0];
+    expect(writtenKey).toBe('k');
+    // Only the latest value survives dedup.
+    expect(unwrapEnvelope(writtenValue)?.v).toBe(JSON.stringify('c'));
+  });
+
+  it('flushes distinct keys in a single drain', async () => {
+    const grafana = makeGrafanaStorage();
+    const hybrid = createHybridStorage(grafana);
+
+    await hybrid.setItem('k1', 'v1');
+    await hybrid.setItem('k2', 'v2');
+
+    await jest.advanceTimersByTimeAsync(500);
+
+    expect(grafana.setItem).toHaveBeenCalledTimes(2);
+    const keys = grafana.setItem.mock.calls.map((c) => c[0]).sort();
+    expect(keys).toEqual(['k1', 'k2']);
+  });
+
+  it('queues a deletion as an empty-value envelope', async () => {
+    const grafana = makeGrafanaStorage();
+    const hybrid = createHybridStorage(grafana);
+
+    await hybrid.removeItem('k');
+    expect(localStorage.getItem('k')).toBeNull();
+
+    await jest.advanceTimersByTimeAsync(500);
+
+    expect(grafana.setItem).toHaveBeenCalledTimes(1);
+    const [, writtenValue] = grafana.setItem.mock.calls[0];
+    expect(unwrapEnvelope(writtenValue)?.v).toBe('');
+  });
+
+  it('does not strand items pushed while a drain is awaiting (re-check path)', async () => {
+    const grafana = makeGrafanaStorage();
+
+    // Make the FIRST Grafana write hang until we release it, so a second item
+    // can be enqueued while processQueue is mid-await.
+    let releaseFirst: () => void = () => undefined;
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let call = 0;
+    grafana.setItem.mockImplementation(async (key: string, value: string) => {
+      call += 1;
+      grafana.store.set(key, value);
+      if (call === 1) {
+        await firstWrite;
+      }
+    });
+
+    const hybrid = createHybridStorage(grafana);
+
+    await hybrid.setItem('k1', 'v1'); // queue=[k1], debounce timer T1
+    await jest.advanceTimersByTimeAsync(500); // T1 → processQueue begins, awaits firstWrite
+    expect(grafana.setItem).toHaveBeenCalledTimes(1);
+
+    await hybrid.setItem('k2', 'v2'); // queue=[k2], debounce timer T2
+    await jest.advanceTimersByTimeAsync(500); // T2 fires but bails (isProcessingQueue) — k2 now stranded unless re-checked
+
+    expect(grafana.setItem).toHaveBeenCalledTimes(1);
+
+    releaseFirst();
+    await flushMicrotasks();
+
+    // The re-check after the first drain must pick up the stranded k2.
+    expect(grafana.setItem).toHaveBeenCalledTimes(2);
+    expect(grafana.store.has('k2')).toBe(true);
+  });
+});
+
+// ============================================================================
+// syncFromGrafanaStorage — once-per-lifecycle + conflict matrix (Pattern G)
+// ============================================================================
+
+describe('syncFromGrafanaStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    __resetSyncedForTests();
+  });
+
+  it('runs at most once per page lifecycle', async () => {
+    const grafana = makeGrafanaStorage(); // all keys empty
+
+    await syncFromGrafanaStorage(grafana);
+    const callsAfterFirst = grafana.getItem.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    await syncFromGrafanaStorage(grafana);
+    // Second call is a no-op: the guard short-circuits before any reads.
+    expect(grafana.getItem.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('applies Grafana value to localStorage when Grafana is newer', async () => {
+    const key = StorageKeys.LEARNING_PROGRESS;
+    localStorage.setItem(key, '"local-old"');
+    localStorage.setItem(tsKey(key), '100');
+
+    const grafana = makeGrafanaStorage({ [key]: wrapEnvelope('"grafana-new"', 200) });
+
+    await syncFromGrafanaStorage(grafana);
+
+    expect(localStorage.getItem(key)).toBe('"grafana-new"');
+    expect(localStorage.getItem(tsKey(key))).toBe('200');
+  });
+
+  it('pushes localStorage back to Grafana when localStorage is newer', async () => {
+    const key = StorageKeys.TABS;
+    localStorage.setItem(key, '"local-new"');
+    localStorage.setItem(tsKey(key), '300');
+
+    const grafana = makeGrafanaStorage({ [key]: wrapEnvelope('"grafana-old"', 100) });
+
+    await syncFromGrafanaStorage(grafana);
+
+    // localStorage is untouched; Grafana receives the newer local value.
+    expect(localStorage.getItem(key)).toBe('"local-new"');
+    const pushWrite = grafana.setItem.mock.calls.find((c) => c[0] === key);
+    expect(pushWrite).toBeDefined();
+    const envelope = unwrapEnvelope(pushWrite![1]);
+    expect(envelope?.v).toBe('"local-new"');
+    expect(envelope?.t).toBe(300);
+  });
+
+  it('propagates a newer Grafana deletion tombstone to localStorage', async () => {
+    const key = StorageKeys.ACTIVE_TAB;
+    localStorage.setItem(key, '"still-here"');
+    localStorage.setItem(tsKey(key), '100');
+
+    // Deletion is an empty-value envelope with a newer timestamp.
+    const grafana = makeGrafanaStorage({ [key]: wrapEnvelope('', 200) });
+
+    await syncFromGrafanaStorage(grafana);
+
+    expect(localStorage.getItem(key)).toBeNull();
+    expect(localStorage.getItem(tsKey(key))).toBe('200');
+  });
+});
+
+// ============================================================================
+// createLocalStorage — JSON fallback + plugin-scoped clear
+// ============================================================================
+
+describe('createLocalStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('round-trips JSON values', async () => {
+    const storage = createLocalStorage();
+    await storage.setItem('obj', { a: 1, b: [2, 3] });
+    expect(await storage.getItem('obj')).toEqual({ a: 1, b: [2, 3] });
+  });
+
+  it('returns the raw string when the stored value is not JSON', async () => {
+    const storage = createLocalStorage();
+    localStorage.setItem('raw', 'not-json');
+    expect(await storage.getItem<string>('raw')).toBe('not-json');
+  });
+
+  it('returns null for a missing key', async () => {
+    const storage = createLocalStorage();
+    expect(await storage.getItem('absent')).toBeNull();
+  });
+
+  it('clear() only removes plugin-prefixed keys', async () => {
+    const storage = createLocalStorage();
+    localStorage.setItem(StorageKeys.TABS, '[]');
+    localStorage.setItem('unrelated-key', 'keep-me');
+
+    await storage.clear();
+
+    expect(localStorage.getItem(StorageKeys.TABS)).toBeNull();
+    expect(localStorage.getItem('unrelated-key')).toBe('keep-me');
+  });
+});

--- a/src/lib/user-storage.plumbing.test.ts
+++ b/src/lib/user-storage.plumbing.test.ts
@@ -266,14 +266,22 @@ describe('createLocalStorage', () => {
     expect(await storage.getItem('absent')).toBeNull();
   });
 
-  it('clear() only removes plugin-prefixed keys', async () => {
+  it('clear() only removes `grafana-pathfinder-app-` keys, leaving other plugin keys behind', async () => {
     const storage = createLocalStorage();
     localStorage.setItem(StorageKeys.TABS, '[]');
     localStorage.setItem('unrelated-key', 'keep-me');
+    // `clear()` filters on the literal `grafana-pathfinder-app-` prefix, so the
+    // centralized keys that use the bare `pathfinder-*` / dotted `pathfinder.*`
+    // shapes are NOT cleared. Pin that seam rather than implying clear() is
+    // registry-wide.
+    localStorage.setItem(StorageKeys.CODA_TERMINAL_IS_OPEN, '1');
+    localStorage.setItem(StorageKeys.BLOCK_EDITOR_HEALTH_PANEL_OPEN, 'true');
 
     await storage.clear();
 
     expect(localStorage.getItem(StorageKeys.TABS)).toBeNull();
     expect(localStorage.getItem('unrelated-key')).toBe('keep-me');
+    expect(localStorage.getItem(StorageKeys.CODA_TERMINAL_IS_OPEN)).toBe('1');
+    expect(localStorage.getItem(StorageKeys.BLOCK_EDITOR_HEALTH_PANEL_OPEN)).toBe('true');
   });
 });

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -262,8 +262,11 @@ export function createUserStorage(): UserStorage {
  * Creates a storage implementation using browser localStorage
  *
  * This is the fallback for when Grafana user storage is unavailable.
+ *
+ * Exported for characterization tests of the storage plumbing; production
+ * callers should use `createUserStorage()` or `useUserStorage()`.
  */
-function createLocalStorage(): UserStorage {
+export function createLocalStorage(): UserStorage {
   return {
     async getItem<T>(key: string): Promise<T | null> {
       try {
@@ -337,8 +340,11 @@ function createLocalStorage(): UserStorage {
  * 2. Then queued to Grafana storage (async, eventual consistency)
  * 3. Reads come from localStorage (fast, always available)
  * 4. On init, sync from Grafana storage to localStorage (Grafana is source of truth)
+ *
+ * Exported for characterization tests of the debounced write queue; production
+ * callers reach this through `useUserStorage()`.
  */
-function createHybridStorage(grafanaStorage: GrafanaUserStorage): UserStorage {
+export function createHybridStorage(grafanaStorage: GrafanaUserStorage): UserStorage {
   const localStorage = createLocalStorage();
 
   // Queue for async writes to Grafana storage.
@@ -467,6 +473,14 @@ function createHybridStorage(grafanaStorage: GrafanaUserStorage): UserStorage {
 let hasSynced = false;
 
 /**
+ * Test-only reset of the module-level `hasSynced` flag so suites can
+ * exercise the once-per-lifecycle sync contract deterministically.
+ */
+export function __resetSyncedForTests(): void {
+  hasSynced = false;
+}
+
+/**
  * Reads a key from Grafana storage and returns its value and timestamp,
  * handling both the new envelope format and the old separate-timestamp format.
  *
@@ -536,8 +550,11 @@ async function readGrafanaKeyWithMigration(
  * - Deletions are represented by a timestamp without data (value is empty/null)
  * - If a deletion timestamp is newer than existing data, the deletion is applied
  * - This ensures deletions propagate correctly across devices/sessions
+ *
+ * Exported for characterization tests of the once-per-lifecycle sync and
+ * timestamp conflict resolution; production code calls this from `useUserStorage()`.
  */
-async function syncFromGrafanaStorage(grafanaStorage: GrafanaUserStorage): Promise<void> {
+export async function syncFromGrafanaStorage(grafanaStorage: GrafanaUserStorage): Promise<void> {
   // Guard: only sync once per page lifecycle
   if (hasSynced) {
     return;

--- a/src/utils/experiments/experiment-utils.ts
+++ b/src/utils/experiments/experiment-utils.ts
@@ -23,7 +23,7 @@ export const getStorageKeys = (hostname: string) => ({
   // sessionStorage - cleared when browser closes
   autoOpened: `${StorageKeys.EXPERIMENT_SESSION_AUTO_OPENED_PREFIX}${hostname}`,
   // Legacy global treatment key (kept for backwards compatibility)
-  treatmentOpened: `grafana-pathfinder-experiment-treatment-opened-${hostname}`,
+  treatmentOpened: `${StorageKeys.EXPERIMENT_TREATMENT_OPENED_LEGACY_PREFIX}${hostname}`,
   // Per-page treatment prefix
   treatmentPagePrefix: `${StorageKeys.EXPERIMENT_TREATMENT_PAGE_PREFIX}${hostname}-`,
 });

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -4,6 +4,7 @@ import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';
 import { config } from '@grafana/runtime';
 
 import { TrackingHook, reportFeatureFlagExposure } from './openfeature-tracking';
+import { StorageKeys } from '../lib/storage-keys';
 
 // ============================================================================
 // TYPES
@@ -357,7 +358,7 @@ export async function evaluateFeatureFlag<T extends FeatureFlagName>(flagName: T
 // LOCAL OVERRIDES (for browser console testing)
 // ============================================================================
 
-const FLAG_OVERRIDE_STORAGE_KEY = 'grafana-pathfinder-flag-overrides';
+const FLAG_OVERRIDE_STORAGE_KEY = StorageKeys.FLAG_OVERRIDES;
 
 /**
  * Read all flag overrides from localStorage.


### PR DESCRIPTION
## Summary

Groundwork for the user-storage refactor, split into two independently reviewable phases:

- **Phase 0 (tests)** — characterization/tripwire tests that pin the highest-risk, previously-untested async paths in `user-storage.ts` (the hybrid write queue and Grafana sync) before any decomposition begins.
- **Phase 1 (refactor)** — centralize all storage keys so we can see the sprawl of localStorage across the code base.  Lock a contract down so the storage keys can't change.

No production behavior changes, and no stored key-string values change.

## Why

The pre-refactor analysis flagged the hybrid write-queue drain as "the highest-risk path in the entire storage surface" with zero tests, and found ~25 storage keys defined as inline literals outside `StorageKeys` (block editor, Coda terminal, assistant, devtools, feature-flag overrides). Locking that behavior with tests and completing the key inventory are the two lowest-risk, highest-leverage prerequisites for the larger refactor: they de-risk later extractions and give one complete map of every persisted key. Renaming the stored key strings themselves was deliberately excluded — that would orphan existing user data for cosmetic gain.

## What to look at

- [`src/lib/user-storage.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/0be02597744a206f92fbf785f42aec592dae7c2d/src/lib/user-storage.ts) — the only additions are four test-only exports plus `__resetSyncedForTests`, mirroring the existing `__resetQuotaWarningForTests`. Confirm the queue/sync bodies themselves are untouched.
- [`src/lib/user-storage.plumbing.test.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/0be02597744a206f92fbf785f42aec592dae7c2d/src/lib/user-storage.plumbing.test.ts) — the anti-stranding "re-check drain" test is the subtle one: it deliberately lets the second debounce timer fire and bail while the first drain is still awaiting, proving the post-drain re-check rescues the stranded item.
- [`src/lib/storage-keys.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/0be02597744a206f92fbf785f42aec592dae7c2d/src/lib/storage-keys.ts) + [`storage-keys.test.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/0be02597744a206f92fbf785f42aec592dae7c2d/src/lib/storage-keys.test.ts) — new keys carry their exact prior literal values; the contract test asserts the full map so any future rename fails loudly (Playwright E2E injects by key string and stored user data is addressed by these strings, so a rename is a silent, data-orphaning break).
- Call-site repoints — block editor (`constants.ts`, health/condition UI prefs), Coda [`terminal-storage.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/0be02597744a206f92fbf785f42aec592dae7c2d/src/integrations/coda/terminal-storage.ts), assistant integration (removes the triplicated `pathfinder-assistant-` literal via `buildAssistantStorageKey`), devtools panels, `openfeature.ts` flag overrides, and `experiment-utils.ts` legacy key. Each swaps an inline literal for the shared constant; values are byte-identical.

## How to verify

1. With existing guide progress in localStorage, reload Pathfinder and confirm completion / tabs / streaks still load — key strings are unchanged, so prior data must still resolve.
2. Open the Coda terminal, set a height and toggle open/closed, then refresh — confirm open state and height persist (keys now sourced from `StorageKeys.CODA_TERMINAL_*`).
3. In the block editor, toggle the health panel and the condition field's raw-mode toggle, then reload — confirm both preferences persist.
4. Set a feature-flag override through the console flow and confirm it still applies on the next load.

## Breaking changes

None. No key string values changed — this is a literal-to-constant swap plus new tests.

## Reversibility

Fully reversible. No persisted data shape, stored key string, or telemetry payload changes, so a straight revert restores prior state with no migration or manual cleanup.

## Out of scope

- The `module.tsx` entry-point legacy auto-open literal — left as-is to avoid adding an import to the bootstrap path (the refactor bootstrap-contamination gate).
- A highlighted-guide `console.log` hint string that mentions a key prefix — cosmetic, not a functional key.
- Renaming stored key strings to a single prefix, routing raw `localStorage` through named domains, and the badge/analytics dependency inversion — these are later phases of the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
