### PR TITLE
test(storage): add characterization tests for untested storage modules

### DIFF
--- a/src/components/block-editor/hooks/useBlockPersistence.test.ts
+++ b/src/components/block-editor/hooks/useBlockPersistence.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Characterization / tripwire tests for useBlockPersistence.
+ *
+ * Pins behavior of the block-editor autosave/restore loop before any
+ * refactor that routes it through `UserStorage`:
+ *   - 1000 ms debounce on guide changes
+ *   - per-guide-snapshot dedup via `lastGuideRef`
+ *   - `autoSavePaused` halts saves but preserves the persisted snapshot
+ *   - mount-time `onLoad` receives both `guide` and `blockIds`
+ *   - version mismatch logs a warning but still returns the parsed guide
+ *   - clear / hasSavedGuide / getLastSaveTime contracts
+ */
+import { act, renderHook } from '@testing-library/react';
+
+import { StorageKeys } from '../../../lib/storage-keys';
+import type { JsonGuide } from '../types';
+
+import { useBlockPersistence } from './useBlockPersistence';
+
+const STORAGE_KEY = StorageKeys.BLOCK_EDITOR_STATE;
+
+function guide(title = 'g'): JsonGuide {
+  return {
+    title,
+    sections: [],
+  } as unknown as JsonGuide;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('useBlockPersistence — debounced auto-save', () => {
+  it('writes to localStorage exactly once after the 1000 ms debounce', () => {
+    const { rerender } = renderHook(({ g }) => useBlockPersistence({ guide: g }), {
+      initialProps: { g: guide('a') },
+    });
+
+    // No write yet (initial guide ≠ lastGuideRef but timer hasn't fired).
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    rerender({ g: guide('b') });
+    rerender({ g: guide('c') });
+
+    // Still no write until debounce elapses.
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored.guide.title).toBe('c');
+    expect(stored.version).toBe(2);
+  });
+
+  it('does not write when autoSavePaused is true', () => {
+    const { rerender } = renderHook(
+      ({ g, paused }) => useBlockPersistence({ guide: g, autoSavePaused: paused }),
+      { initialProps: { g: guide('a'), paused: true } }
+    );
+
+    rerender({ g: guide('b'), paused: true });
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not write when autoSave is false', () => {
+    const { rerender } = renderHook(({ g }) => useBlockPersistence({ guide: g, autoSave: false }), {
+      initialProps: { g: guide('a') },
+    });
+
+    rerender({ g: guide('b') });
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('stores blockIds alongside guide when provided', () => {
+    const { rerender } = renderHook(
+      ({ g, ids }: { g: JsonGuide; ids: string[] }) => useBlockPersistence({ guide: g, blockIds: ids }),
+      { initialProps: { g: guide('a'), ids: ['b1', 'b2'] } }
+    );
+
+    rerender({ g: guide('b'), ids: ['b1', 'b2', 'b3'] });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored.blockIds).toEqual(['b1', 'b2', 'b3']);
+  });
+});
+
+describe('useBlockPersistence — mount-time restore via onLoad', () => {
+  it('calls onLoad with stored guide AND blockIds when both are present', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        guide: guide('restored'),
+        blockIds: ['b1', 'b2'],
+        savedAt: new Date().toISOString(),
+        version: 2,
+      })
+    );
+
+    const onLoad = jest.fn();
+    renderHook(() => useBlockPersistence({ guide: guide('current'), onLoad }));
+
+    expect(onLoad).toHaveBeenCalledTimes(1);
+    const [restoredGuide, restoredIds] = onLoad.mock.calls[0]!;
+    expect(restoredGuide.title).toBe('restored');
+    expect(restoredIds).toEqual(['b1', 'b2']);
+  });
+
+  it('does not call onLoad when storage is empty', () => {
+    const onLoad = jest.fn();
+    renderHook(() => useBlockPersistence({ guide: guide('current'), onLoad }));
+    expect(onLoad).not.toHaveBeenCalled();
+  });
+
+  it('does not throw and skips onLoad when stored JSON is malformed', () => {
+    localStorage.setItem(STORAGE_KEY, '{not json');
+    const onLoad = jest.fn();
+    const errSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    expect(() =>
+      renderHook(() => useBlockPersistence({ guide: guide('current'), onLoad }))
+    ).not.toThrow();
+
+    expect(onLoad).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});
+
+describe('useBlockPersistence — load() / clear() / hasSavedGuide / getLastSaveTime', () => {
+  it('load() returns null when storage is empty', () => {
+    const { result } = renderHook(() => useBlockPersistence({ guide: guide('a') }));
+    expect(result.current.load()).toBeNull();
+  });
+
+  it('load() returns the parsed guide and warns on version mismatch', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        guide: guide('legacy'),
+        savedAt: new Date().toISOString(),
+        version: 1, // mismatch
+      })
+    );
+
+    const { result } = renderHook(() => useBlockPersistence({ guide: guide('a') }));
+    const loaded = result.current.load();
+
+    expect(loaded?.title).toBe('legacy');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('version mismatch'));
+    warnSpy.mockRestore();
+  });
+
+  it('clear() removes the storage key', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ guide: guide('a'), savedAt: '', version: 2 }));
+    const { result } = renderHook(() => useBlockPersistence({ guide: guide('a') }));
+
+    act(() => result.current.clear());
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('hasSavedGuide() reflects key presence', () => {
+    const { result } = renderHook(() => useBlockPersistence({ guide: guide('a') }));
+    expect(result.current.hasSavedGuide()).toBe(false);
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ guide: guide('a'), savedAt: '', version: 2 }));
+    expect(result.current.hasSavedGuide()).toBe(true);
+  });
+
+  it('getLastSaveTime() returns a Date when present, null when absent', () => {
+    const { result } = renderHook(() => useBlockPersistence({ guide: guide('a') }));
+    expect(result.current.getLastSaveTime()).toBeNull();
+
+    const ts = '2024-01-02T03:04:05.000Z';
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ guide: guide('a'), savedAt: ts, version: 2 })
+    );
+
+    const t = result.current.getLastSaveTime();
+    expect(t).toBeInstanceOf(Date);
+    expect(t!.toISOString()).toBe(ts);
+  });
+});
+
+describe('useBlockPersistence — custom storageKey', () => {
+  it('honors a custom storageKey for save / load', () => {
+    const customKey = 'custom-block-editor-state';
+
+    const { result, rerender } = renderHook(
+      ({ g }) => useBlockPersistence({ guide: g, storageKey: customKey }),
+      { initialProps: { g: guide('a') } }
+    );
+
+    rerender({ g: guide('b') });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(localStorage.getItem(customKey)).not.toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(result.current.load()?.title).toBe('b');
+  });
+});

--- a/src/components/block-editor/hooks/useBlockPersistence.test.ts
+++ b/src/components/block-editor/hooks/useBlockPersistence.test.ts
@@ -88,6 +88,25 @@ describe('useBlockPersistence — debounced auto-save', () => {
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
+  it('fires onSave on the no-change branch when the serialized guide is unchanged', () => {
+    const onSave = jest.fn();
+    const { rerender } = renderHook(({ g }) => useBlockPersistence({ guide: g, onSave }), {
+      initialProps: { g: guide('a') },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    // First save() flush calls onSave once and pins lastGuideRef to the serialized guide.
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    // New object identity, identical content — the effect re-runs, hits the
+    // no-change branch, and must still notify onSave so callers can clear isDirty.
+    rerender({ g: guide('a') });
+
+    expect(onSave).toHaveBeenCalledTimes(2);
+  });
+
   it('stores blockIds alongside guide when provided', () => {
     const { rerender } = renderHook(
       ({ g, ids }: { g: JsonGuide; ids: string[] }) => useBlockPersistence({ guide: g, blockIds: ids }),

--- a/src/components/block-editor/hooks/useBlockPersistence.test.ts
+++ b/src/components/block-editor/hooks/useBlockPersistence.test.ts
@@ -60,10 +60,9 @@ describe('useBlockPersistence — debounced auto-save', () => {
   });
 
   it('does not write when autoSavePaused is true', () => {
-    const { rerender } = renderHook(
-      ({ g, paused }) => useBlockPersistence({ guide: g, autoSavePaused: paused }),
-      { initialProps: { g: guide('a'), paused: true } }
-    );
+    const { rerender } = renderHook(({ g, paused }) => useBlockPersistence({ guide: g, autoSavePaused: paused }), {
+      initialProps: { g: guide('a'), paused: true },
+    });
 
     rerender({ g: guide('b'), paused: true });
 
@@ -156,9 +155,7 @@ describe('useBlockPersistence — mount-time restore via onLoad', () => {
     const onLoad = jest.fn();
     const errSpy = jest.spyOn(console, 'error').mockImplementation();
 
-    expect(() =>
-      renderHook(() => useBlockPersistence({ guide: guide('current'), onLoad }))
-    ).not.toThrow();
+    expect(() => renderHook(() => useBlockPersistence({ guide: guide('current'), onLoad }))).not.toThrow();
 
     expect(onLoad).not.toHaveBeenCalled();
     errSpy.mockRestore();
@@ -212,10 +209,7 @@ describe('useBlockPersistence — load() / clear() / hasSavedGuide / getLastSave
     expect(result.current.getLastSaveTime()).toBeNull();
 
     const ts = '2024-01-02T03:04:05.000Z';
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({ guide: guide('a'), savedAt: ts, version: 2 })
-    );
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ guide: guide('a'), savedAt: ts, version: 2 }));
 
     const t = result.current.getLastSaveTime();
     expect(t).toBeInstanceOf(Date);
@@ -227,10 +221,9 @@ describe('useBlockPersistence — custom storageKey', () => {
   it('honors a custom storageKey for save / load', () => {
     const customKey = 'custom-block-editor-state';
 
-    const { result, rerender } = renderHook(
-      ({ g }) => useBlockPersistence({ guide: g, storageKey: customKey }),
-      { initialProps: { g: guide('a') } }
-    );
+    const { result, rerender } = renderHook(({ g }) => useBlockPersistence({ guide: g, storageKey: customKey }), {
+      initialProps: { g: guide('a') },
+    });
 
     rerender({ g: guide('b') });
 

--- a/src/components/block-editor/hooks/useRecordingPersistence.test.ts
+++ b/src/components/block-editor/hooks/useRecordingPersistence.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Characterization / tripwire tests for useRecordingPersistence.
+ *
+ * Pins behavior of the recording state persistence hook before any
+ * refactor that routes it through `UserStorage`:
+ *   - save() no-ops when not recording
+ *   - save() writes serialized state when actively recording
+ *   - mount-time restore fires `onRestore` exactly once (Strict Mode safe)
+ *   - clear() removes the key
+ *   - load() handles malformed JSON without throwing
+ */
+import { renderHook, act } from '@testing-library/react';
+
+import { StorageKeys } from '../../../lib/storage-keys';
+import type { RecordedStep } from '../../../utils/devtools/tutorial-exporter';
+
+import { useRecordingPersistence, PersistedRecordingState } from './useRecordingPersistence';
+
+const STORAGE_KEY = StorageKeys.BLOCK_EDITOR_RECORDING_STATE;
+
+function defaultOpts(overrides: Partial<Parameters<typeof useRecordingPersistence>[0]> = {}) {
+  return {
+    recordingIntoSection: null,
+    recordingIntoConditionalBranch: null,
+    recordingStartUrl: null,
+    recordedSteps: [] as RecordedStep[],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useRecordingPersistence — save()', () => {
+  it('no-ops when not recording (section + branch both null)', () => {
+    const { result } = renderHook(() => useRecordingPersistence(defaultOpts()));
+    act(() => result.current.save());
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('writes serialized state when recordingIntoSection is set', () => {
+    const { result } = renderHook(() =>
+      useRecordingPersistence(
+        defaultOpts({
+          recordingIntoSection: 'section-1',
+          recordingStartUrl: '/d/test',
+          recordedSteps: [{ id: 's1' } as unknown as RecordedStep],
+        })
+      )
+    );
+    act(() => result.current.save());
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+
+    const parsed = JSON.parse(raw!) as PersistedRecordingState;
+    expect(parsed.recordingIntoSection).toBe('section-1');
+    expect(parsed.recordingStartUrl).toBe('/d/test');
+    expect(parsed.recordedSteps).toHaveLength(1);
+    expect(typeof parsed.savedAt).toBe('string');
+  });
+
+  it('writes when only recordingIntoConditionalBranch is set', () => {
+    const { result } = renderHook(() =>
+      useRecordingPersistence(
+        defaultOpts({
+          recordingIntoConditionalBranch: { conditionalId: 'c1', branch: 'whenTrue' },
+        })
+      )
+    );
+    act(() => result.current.save());
+
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!) as PersistedRecordingState;
+    expect(parsed.recordingIntoConditionalBranch).toEqual({
+      conditionalId: 'c1',
+      branch: 'whenTrue',
+    });
+  });
+
+  it('auto-saves when recording state changes via rerender', () => {
+    const { rerender } = renderHook((props) => useRecordingPersistence(props), {
+      initialProps: defaultOpts({ recordingIntoSection: 'section-1' }),
+    });
+
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
+    rerender(
+      defaultOpts({
+        recordingIntoSection: 'section-1',
+        recordedSteps: [{ id: 'newstep' } as unknown as RecordedStep],
+      })
+    );
+
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as PersistedRecordingState;
+    expect(parsed.recordedSteps).toHaveLength(1);
+  });
+});
+
+describe('useRecordingPersistence — restore on mount', () => {
+  it('calls onRestore with persisted state when storage has content', () => {
+    const persisted: PersistedRecordingState = {
+      recordingIntoSection: 'section-2',
+      recordingIntoConditionalBranch: null,
+      recordingStartUrl: '/d/x',
+      recordedSteps: [],
+      savedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
+
+    const onRestore = jest.fn();
+    renderHook(() => useRecordingPersistence(defaultOpts({ onRestore })));
+
+    expect(onRestore).toHaveBeenCalledTimes(1);
+    expect(onRestore.mock.calls[0]![0]!.recordingIntoSection).toBe('section-2');
+  });
+
+  it('does not call onRestore when storage is empty', () => {
+    const onRestore = jest.fn();
+    renderHook(() => useRecordingPersistence(defaultOpts({ onRestore })));
+    expect(onRestore).not.toHaveBeenCalled();
+  });
+
+  it('hasRestoredRef gate prevents double restore on rerender', () => {
+    const persisted: PersistedRecordingState = {
+      recordingIntoSection: 'section-2',
+      recordingIntoConditionalBranch: null,
+      recordingStartUrl: null,
+      recordedSteps: [],
+      savedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
+
+    const onRestore = jest.fn();
+    const { rerender } = renderHook((props) => useRecordingPersistence(props), {
+      initialProps: defaultOpts({ onRestore }),
+    });
+
+    rerender(defaultOpts({ onRestore, recordingIntoSection: 'section-2' }));
+    rerender(defaultOpts({ onRestore, recordingIntoSection: 'section-3' }));
+
+    expect(onRestore).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useRecordingPersistence — clear / load / hasPersistedState', () => {
+  it('hasPersistedState reflects key presence', () => {
+    const { result } = renderHook(() => useRecordingPersistence(defaultOpts()));
+    expect(result.current.hasPersistedState()).toBe(false);
+
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        recordingIntoSection: null,
+        recordingIntoConditionalBranch: null,
+        recordingStartUrl: null,
+        recordedSteps: [],
+        savedAt: '',
+      })
+    );
+    expect(result.current.hasPersistedState()).toBe(true);
+  });
+
+  it('load() returns null for empty storage and parsed state when present', () => {
+    const { result } = renderHook(() => useRecordingPersistence(defaultOpts()));
+    expect(result.current.load()).toBeNull();
+
+    const persisted: PersistedRecordingState = {
+      recordingIntoSection: 'sec',
+      recordingIntoConditionalBranch: null,
+      recordingStartUrl: null,
+      recordedSteps: [],
+      savedAt: 'now',
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
+
+    expect(result.current.load()?.recordingIntoSection).toBe('sec');
+  });
+
+  it('load() returns null without throwing on malformed JSON', () => {
+    localStorage.setItem(STORAGE_KEY, '{not json');
+    const errSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const { result } = renderHook(() => useRecordingPersistence(defaultOpts()));
+    expect(result.current.load()).toBeNull();
+
+    errSpy.mockRestore();
+  });
+
+  it('clear() removes the key', () => {
+    localStorage.setItem(STORAGE_KEY, '{}');
+    const { result } = renderHook(() => useRecordingPersistence(defaultOpts()));
+
+    act(() => result.current.clear());
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/src/components/block-editor/hooks/useRecordingPersistence.test.ts
+++ b/src/components/block-editor/hooks/useRecordingPersistence.test.ts
@@ -9,6 +9,7 @@
  *   - clear() removes the key
  *   - load() handles malformed JSON without throwing
  */
+import React, { StrictMode } from 'react';
 import { renderHook, act } from '@testing-library/react';
 
 import { StorageKeys } from '../../../lib/storage-keys';
@@ -123,7 +124,7 @@ describe('useRecordingPersistence — restore on mount', () => {
     expect(onRestore).not.toHaveBeenCalled();
   });
 
-  it('hasRestoredRef gate prevents double restore on rerender', () => {
+  it('hasRestoredRef gate prevents double restore under React StrictMode', () => {
     const persisted: PersistedRecordingState = {
       recordingIntoSection: 'section-2',
       recordingIntoConditionalBranch: null,
@@ -134,12 +135,9 @@ describe('useRecordingPersistence — restore on mount', () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
 
     const onRestore = jest.fn();
-    const { rerender } = renderHook((props) => useRecordingPersistence(props), {
-      initialProps: defaultOpts({ onRestore }),
+    renderHook(() => useRecordingPersistence(defaultOpts({ onRestore })), {
+      wrapper: ({ children }) => React.createElement(StrictMode, null, children),
     });
-
-    rerender(defaultOpts({ onRestore, recordingIntoSection: 'section-2' }));
-    rerender(defaultOpts({ onRestore, recordingIntoSection: 'section-3' }));
 
     expect(onRestore).toHaveBeenCalledTimes(1);
   });

--- a/src/docs-retrieval/content-fetcher.bundled-localstorage.test.ts
+++ b/src/docs-retrieval/content-fetcher.bundled-localstorage.test.ts
@@ -19,10 +19,7 @@ beforeEach(() => {
 
 describe('bundled:wysiwyg-preview', () => {
   it('returns content with the stored JSON title on success', async () => {
-    localStorage.setItem(
-      StorageKeys.WYSIWYG_PREVIEW_JSON,
-      JSON.stringify({ title: 'My Preview Guide', sections: [] })
-    );
+    localStorage.setItem(StorageKeys.WYSIWYG_PREVIEW_JSON, JSON.stringify({ title: 'My Preview Guide', sections: [] }));
 
     const result = await fetchContent('bundled:wysiwyg-preview');
 
@@ -61,10 +58,7 @@ describe('bundled:wysiwyg-preview', () => {
 
 describe('bundled:e2e-test', () => {
   it('returns content with the stored JSON title on success', async () => {
-    localStorage.setItem(
-      StorageKeys.E2E_TEST_GUIDE,
-      JSON.stringify({ title: 'E2E Scenario Alpha', sections: [] })
-    );
+    localStorage.setItem(StorageKeys.E2E_TEST_GUIDE, JSON.stringify({ title: 'E2E Scenario Alpha', sections: [] }));
 
     const result = await fetchContent('bundled:e2e-test');
 
@@ -91,10 +85,7 @@ describe('bundled:e2e-test', () => {
   });
 
   it('reads the e2e-test key independently of wysiwyg-preview', async () => {
-    localStorage.setItem(
-      StorageKeys.WYSIWYG_PREVIEW_JSON,
-      JSON.stringify({ title: 'Preview Title' })
-    );
+    localStorage.setItem(StorageKeys.WYSIWYG_PREVIEW_JSON, JSON.stringify({ title: 'Preview Title' }));
     localStorage.setItem(StorageKeys.E2E_TEST_GUIDE, JSON.stringify({ title: 'E2E Title' }));
 
     const preview = await fetchContent('bundled:wysiwyg-preview');

--- a/src/docs-retrieval/content-fetcher.bundled-localstorage.test.ts
+++ b/src/docs-retrieval/content-fetcher.bundled-localstorage.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Characterization / tripwire tests for the `bundled:wysiwyg-preview` and
+ * `bundled:e2e-test` URL kinds in content-fetcher.
+ *
+ * These pin the localStorage read path (Tier 2 abstraction bypass) before
+ * any extraction of a preview-storage helper. They cover:
+ *   - happy path: stored JSON title becomes the content title
+ *   - empty key: user-facing error string preserved
+ *   - malformed JSON: title falls back to the per-kind default
+ *   - E2E key isolated from preview key (no crosstalk)
+ */
+import { StorageKeys } from '../lib/storage-keys';
+
+import { fetchContent } from './content-fetcher';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('bundled:wysiwyg-preview', () => {
+  it('returns content with the stored JSON title on success', async () => {
+    localStorage.setItem(
+      StorageKeys.WYSIWYG_PREVIEW_JSON,
+      JSON.stringify({ title: 'My Preview Guide', sections: [] })
+    );
+
+    const result = await fetchContent('bundled:wysiwyg-preview');
+
+    expect(result.error).toBeUndefined();
+    expect(result.content).not.toBeNull();
+    expect(result.content!.metadata.title).toBe('My Preview Guide');
+    expect(result.content!.type).toBe('interactive');
+    expect(result.content!.url).toBe('bundled:wysiwyg-preview');
+  });
+
+  it('returns the empty-storage error when the key is absent', async () => {
+    const result = await fetchContent('bundled:wysiwyg-preview');
+
+    expect(result.content).toBeNull();
+    expect(result.error).toMatch(/No preview content available/);
+  });
+
+  it('returns the empty-storage error when the key is whitespace-only', async () => {
+    localStorage.setItem(StorageKeys.WYSIWYG_PREVIEW_JSON, '   ');
+
+    const result = await fetchContent('bundled:wysiwyg-preview');
+
+    expect(result.content).toBeNull();
+    expect(result.error).toMatch(/No preview content available/);
+  });
+
+  it('falls back to the default title when stored JSON is malformed', async () => {
+    localStorage.setItem(StorageKeys.WYSIWYG_PREVIEW_JSON, '{not valid json');
+
+    const result = await fetchContent('bundled:wysiwyg-preview');
+
+    expect(result.content).not.toBeNull();
+    expect(result.content!.metadata.title).toBe('Preview: WYSIWYG Guide');
+  });
+});
+
+describe('bundled:e2e-test', () => {
+  it('returns content with the stored JSON title on success', async () => {
+    localStorage.setItem(
+      StorageKeys.E2E_TEST_GUIDE,
+      JSON.stringify({ title: 'E2E Scenario Alpha', sections: [] })
+    );
+
+    const result = await fetchContent('bundled:e2e-test');
+
+    expect(result.error).toBeUndefined();
+    expect(result.content).not.toBeNull();
+    expect(result.content!.metadata.title).toBe('E2E Scenario Alpha');
+    expect(result.content!.url).toBe('bundled:e2e-test');
+  });
+
+  it('returns the empty-storage error when the key is absent', async () => {
+    const result = await fetchContent('bundled:e2e-test');
+
+    expect(result.content).toBeNull();
+    expect(result.error).toMatch(/No E2E test content available/);
+  });
+
+  it('falls back to default title when stored JSON is malformed', async () => {
+    localStorage.setItem(StorageKeys.E2E_TEST_GUIDE, '@@@');
+
+    const result = await fetchContent('bundled:e2e-test');
+
+    expect(result.content).not.toBeNull();
+    expect(result.content!.metadata.title).toBe('E2E Test Guide');
+  });
+
+  it('reads the e2e-test key independently of wysiwyg-preview', async () => {
+    localStorage.setItem(
+      StorageKeys.WYSIWYG_PREVIEW_JSON,
+      JSON.stringify({ title: 'Preview Title' })
+    );
+    localStorage.setItem(StorageKeys.E2E_TEST_GUIDE, JSON.stringify({ title: 'E2E Title' }));
+
+    const preview = await fetchContent('bundled:wysiwyg-preview');
+    const e2e = await fetchContent('bundled:e2e-test');
+
+    expect(preview.content!.metadata.title).toBe('Preview Title');
+    expect(e2e.content!.metadata.title).toBe('E2E Title');
+  });
+});

--- a/src/integrations/coda/terminal-storage.test.ts
+++ b/src/integrations/coda/terminal-storage.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Characterization / tripwire tests for terminal-storage.
+ *
+ * Pins the public contract before any routing through `UserStorage` happens:
+ *   - localStorage-backed UI prefs (isOpen, height) with height clamping
+ *   - sessionStorage-backed session state (wasConnected, scrollback, lastVmOpts)
+ *   - scrollback truncation policy (`MAX_SCROLLBACK_SIZE` = 100_000)
+ *   - JSON parse failures fall back to `undefined` rather than throw
+ *   - All writes swallow `QuotaExceededError`-class failures
+ */
+import { StorageKeys } from '../../lib/storage-keys';
+
+import {
+  clearScrollback,
+  clearSessionStorage,
+  clearTerminalStorage,
+  DEFAULT_HEIGHT,
+  getLastVmOpts,
+  getScrollback,
+  getTerminalHeight,
+  getTerminalOpen,
+  getWasConnected,
+  MAX_HEIGHT,
+  MIN_HEIGHT,
+  setLastVmOpts,
+  setScrollback,
+  setTerminalHeight,
+  setTerminalOpen,
+  setWasConnected,
+} from './terminal-storage';
+
+const MAX_SCROLLBACK_SIZE = 100_000;
+
+describe('terminal-storage (UI prefs, localStorage)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  describe('terminal open/closed', () => {
+    it('defaults to false when key is absent', () => {
+      expect(getTerminalOpen()).toBe(false);
+    });
+
+    it('round-trips true', () => {
+      setTerminalOpen(true);
+      expect(localStorage.getItem(StorageKeys.CODA_TERMINAL_IS_OPEN)).toBe('true');
+      expect(getTerminalOpen()).toBe(true);
+    });
+
+    it('round-trips false', () => {
+      setTerminalOpen(false);
+      expect(localStorage.getItem(StorageKeys.CODA_TERMINAL_IS_OPEN)).toBe('false');
+      expect(getTerminalOpen()).toBe(false);
+    });
+
+    it('treats any non-"true" value as false', () => {
+      localStorage.setItem(StorageKeys.CODA_TERMINAL_IS_OPEN, 'TRUE');
+      expect(getTerminalOpen()).toBe(false);
+    });
+  });
+
+  describe('terminal height', () => {
+    it('returns DEFAULT_HEIGHT when key is absent', () => {
+      expect(getTerminalHeight()).toBe(DEFAULT_HEIGHT);
+    });
+
+    it('round-trips a valid height', () => {
+      setTerminalHeight(300);
+      expect(getTerminalHeight()).toBe(300);
+    });
+
+    it('clamps values above MAX_HEIGHT on write', () => {
+      setTerminalHeight(MAX_HEIGHT + 100);
+      expect(getTerminalHeight()).toBe(MAX_HEIGHT);
+    });
+
+    it('clamps values below MIN_HEIGHT on write', () => {
+      setTerminalHeight(MIN_HEIGHT - 50);
+      expect(getTerminalHeight()).toBe(MIN_HEIGHT);
+    });
+
+    it('falls back to DEFAULT_HEIGHT when stored value is out of range', () => {
+      localStorage.setItem(StorageKeys.CODA_TERMINAL_HEIGHT, String(MAX_HEIGHT + 1));
+      expect(getTerminalHeight()).toBe(DEFAULT_HEIGHT);
+    });
+
+    it('falls back to DEFAULT_HEIGHT when stored value is not numeric', () => {
+      localStorage.setItem(StorageKeys.CODA_TERMINAL_HEIGHT, 'tall');
+      expect(getTerminalHeight()).toBe(DEFAULT_HEIGHT);
+    });
+  });
+
+  describe('clearTerminalStorage', () => {
+    it('removes only the localStorage UI keys', () => {
+      setTerminalOpen(true);
+      setTerminalHeight(250);
+      setWasConnected(true);
+
+      clearTerminalStorage();
+
+      expect(localStorage.getItem(StorageKeys.CODA_TERMINAL_IS_OPEN)).toBeNull();
+      expect(localStorage.getItem(StorageKeys.CODA_TERMINAL_HEIGHT)).toBeNull();
+      expect(sessionStorage.getItem(StorageKeys.CODA_TERMINAL_WAS_CONNECTED)).toBe('true');
+    });
+  });
+});
+
+describe('terminal-storage (session state, sessionStorage)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  describe('wasConnected', () => {
+    it('defaults to false when absent', () => {
+      expect(getWasConnected()).toBe(false);
+    });
+
+    it('writes "true" to sessionStorage on setWasConnected(true)', () => {
+      setWasConnected(true);
+      expect(sessionStorage.getItem(StorageKeys.CODA_TERMINAL_WAS_CONNECTED)).toBe('true');
+      expect(getWasConnected()).toBe(true);
+    });
+
+    it('removes the key on setWasConnected(false)', () => {
+      setWasConnected(true);
+      setWasConnected(false);
+      expect(sessionStorage.getItem(StorageKeys.CODA_TERMINAL_WAS_CONNECTED)).toBeNull();
+      expect(getWasConnected()).toBe(false);
+    });
+  });
+
+  describe('lastVmOpts', () => {
+    it('returns undefined when key is absent', () => {
+      expect(getLastVmOpts()).toBeUndefined();
+    });
+
+    it('round-trips a populated opts object', () => {
+      setLastVmOpts({ template: 't', app: 'a', scenario: 's' });
+      expect(getLastVmOpts()).toEqual({ template: 't', app: 'a', scenario: 's' });
+    });
+
+    it('returns undefined on malformed JSON instead of throwing', () => {
+      sessionStorage.setItem(StorageKeys.CODA_TERMINAL_LAST_VM_OPTS, '{not json');
+      expect(() => getLastVmOpts()).not.toThrow();
+      expect(getLastVmOpts()).toBeUndefined();
+    });
+
+    it('removes the key when set to undefined', () => {
+      setLastVmOpts({ template: 't' });
+      setLastVmOpts(undefined);
+      expect(sessionStorage.getItem(StorageKeys.CODA_TERMINAL_LAST_VM_OPTS)).toBeNull();
+    });
+
+    it('removes the key when set to an empty object', () => {
+      setLastVmOpts({ template: 't' });
+      setLastVmOpts({});
+      expect(sessionStorage.getItem(StorageKeys.CODA_TERMINAL_LAST_VM_OPTS)).toBeNull();
+    });
+  });
+
+  describe('scrollback', () => {
+    it('returns null when key is absent', () => {
+      expect(getScrollback()).toBeNull();
+    });
+
+    it('round-trips short content untouched', () => {
+      setScrollback('hello');
+      expect(getScrollback()).toBe('hello');
+    });
+
+    it('truncates from the start when content exceeds MAX_SCROLLBACK_SIZE', () => {
+      const oversized = 'x'.repeat(MAX_SCROLLBACK_SIZE) + 'TAIL';
+      setScrollback(oversized);
+      const result = getScrollback();
+      expect(result).not.toBeNull();
+      expect(result!.length).toBe(MAX_SCROLLBACK_SIZE);
+      // Most-recent suffix preserved — the truncation slices `-MAX_SCROLLBACK_SIZE`.
+      expect(result!.endsWith('TAIL')).toBe(true);
+    });
+
+    it('clearScrollback removes the key', () => {
+      setScrollback('content');
+      clearScrollback();
+      expect(getScrollback()).toBeNull();
+    });
+  });
+
+  describe('clearSessionStorage', () => {
+    it('removes all session keys but leaves localStorage UI prefs intact', () => {
+      setTerminalOpen(true);
+      setTerminalHeight(250);
+      setWasConnected(true);
+      setScrollback('content');
+      setLastVmOpts({ template: 't' });
+
+      clearSessionStorage();
+
+      expect(sessionStorage.getItem(StorageKeys.CODA_TERMINAL_WAS_CONNECTED)).toBeNull();
+      expect(sessionStorage.getItem(StorageKeys.CODA_TERMINAL_SCROLLBACK)).toBeNull();
+      expect(sessionStorage.getItem(StorageKeys.CODA_TERMINAL_LAST_VM_OPTS)).toBeNull();
+
+      expect(localStorage.getItem(StorageKeys.CODA_TERMINAL_IS_OPEN)).toBe('true');
+      expect(localStorage.getItem(StorageKeys.CODA_TERMINAL_HEIGHT)).toBe('250');
+    });
+  });
+});
+
+describe('terminal-storage (failure swallowing)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('does not throw when localStorage.setItem throws (e.g. QuotaExceededError)', () => {
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = jest.fn(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    try {
+      expect(() => setTerminalOpen(true)).not.toThrow();
+      expect(() => setTerminalHeight(200)).not.toThrow();
+      expect(() => setScrollback('x')).not.toThrow();
+      expect(() => setLastVmOpts({ template: 't' })).not.toThrow();
+    } finally {
+      Storage.prototype.setItem = original;
+    }
+  });
+
+  it('falls back to defaults when localStorage.getItem throws', () => {
+    const original = Storage.prototype.getItem;
+    Storage.prototype.getItem = jest.fn(() => {
+      throw new Error('storage unavailable');
+    });
+
+    try {
+      expect(getTerminalOpen()).toBe(false);
+      expect(getTerminalHeight()).toBe(DEFAULT_HEIGHT);
+      expect(getWasConnected()).toBe(false);
+      expect(getScrollback()).toBeNull();
+      expect(getLastVmOpts()).toBeUndefined();
+    } finally {
+      Storage.prototype.getItem = original;
+    }
+  });
+});

--- a/src/lib/user-storage.hook.test.ts
+++ b/src/lib/user-storage.hook.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Characterization / tripwire tests for the `useUserStorage` React hook.
+ *
+ * The hook is the bridge that wires the React-managed storage backend into the
+ * module-scoped `globalStorageInstance` used by all non-React storage helpers.
+ * It is a load-bearing seam: every named storage domain
+ * (`tabStorage`, `journeyCompletionStorage`, `learningProgressStorage`, …)
+ * calls `createUserStorage()` which falls through to `createLocalStorage()`
+ * unless this hook has set the global. These tests pin:
+ *
+ *   - When Grafana's `usePluginUserStorage` returns a functional object,
+ *     the hook installs hybrid storage globally and triggers the initial
+ *     `syncFromGrafanaStorage` reconciliation.
+ *   - When Grafana storage is unavailable (null) or non-functional (missing
+ *     `getItem`), the hook falls back to localStorage and still installs
+ *     a global, so standalone helpers never see an uninitialized state.
+ *   - The hook's returned object exposes a stable `UserStorage` shape; calls
+ *     route to the underlying installed backend.
+ *
+ * These tests are deliberately about *backend selection*, not the queue or
+ * sync internals — those are pinned in `user-storage.plumbing.test.ts`.
+ */
+import { renderHook, act } from '@testing-library/react';
+
+import type { GrafanaUserStorage } from '../types/storage.types';
+
+import {
+  __resetSyncedForTests,
+  createLocalStorage,
+  setGlobalStorage,
+  useUserStorage,
+} from './user-storage';
+
+const usePluginUserStorageMock = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  usePluginUserStorage: () => usePluginUserStorageMock(),
+  getAppEvents: jest.fn(() => ({ publish: jest.fn() })),
+}));
+
+function makeFunctionalGrafanaStorage(): GrafanaUserStorage & {
+  getItem: jest.Mock;
+  setItem: jest.Mock;
+} {
+  const store = new Map<string, string>();
+  return {
+    getItem: jest.fn(async (key: string) => store.get(key) ?? null),
+    setItem: jest.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+  } as unknown as GrafanaUserStorage & { getItem: jest.Mock; setItem: jest.Mock };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  usePluginUserStorageMock.mockReset();
+  __resetSyncedForTests();
+  // Reset the module-level global between tests by re-installing a
+  // throwaway localStorage backend. The hook tests that need a clean slate
+  // observe via behavior, not by inspecting the singleton.
+  setGlobalStorage(createLocalStorage());
+});
+
+describe('useUserStorage — backend selection', () => {
+  it('selects hybrid storage when Grafana storage is functional, and the global picks up writes', async () => {
+    const grafana = makeFunctionalGrafanaStorage();
+    usePluginUserStorageMock.mockReturnValue(grafana);
+
+    const { result } = renderHook(() => useUserStorage());
+
+    // Let the mount effect run so setGlobalStorage and the async sync fire.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The hook's setItem should write through to localStorage immediately
+    // (hybrid backend) — this is the observable signature of hybrid vs raw.
+    await act(async () => {
+      await result.current.setItem('hook-test-key', { value: 42 });
+    });
+
+    expect(localStorage.getItem('hook-test-key')).not.toBeNull();
+    // The Grafana side is async + debounced; we only assert it was wired up,
+    // not that it has flushed.
+    expect(grafana.getItem).toHaveBeenCalled();
+  });
+
+  it('falls back to localStorage when usePluginUserStorage returns null', async () => {
+    usePluginUserStorageMock.mockReturnValue(null);
+
+    const { result } = renderHook(() => useUserStorage());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.setItem('hook-fallback-null', { ok: true });
+    });
+
+    expect(localStorage.getItem('hook-fallback-null')).not.toBeNull();
+  });
+
+  it('falls back to localStorage when usePluginUserStorage returns an object without getItem', async () => {
+    usePluginUserStorageMock.mockReturnValue({ setItem: jest.fn() } as unknown);
+
+    const { result } = renderHook(() => useUserStorage());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.setItem('hook-fallback-shape', { ok: true });
+    });
+
+    expect(localStorage.getItem('hook-fallback-shape')).not.toBeNull();
+  });
+
+  it('returns a stable UserStorage shape with getItem/setItem/removeItem/clear', () => {
+    usePluginUserStorageMock.mockReturnValue(null);
+
+    const { result } = renderHook(() => useUserStorage());
+
+    expect(typeof result.current.getItem).toBe('function');
+    expect(typeof result.current.setItem).toBe('function');
+    expect(typeof result.current.removeItem).toBe('function');
+    expect(typeof result.current.clear).toBe('function');
+  });
+});
+
+describe('useUserStorage — global-storage bridge', () => {
+  it('the global picks up the React-selected backend so non-React helpers see hybrid writes', async () => {
+    const grafana = makeFunctionalGrafanaStorage();
+    usePluginUserStorageMock.mockReturnValue(grafana);
+
+    renderHook(() => useUserStorage());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Defer the import so the mocked module is fresh per test.
+    const { createUserStorage } = await import('./user-storage');
+    const standalone = createUserStorage();
+    await standalone.setItem('standalone-key', { from: 'non-react' });
+
+    // Hybrid writes localStorage synchronously.
+    expect(localStorage.getItem('standalone-key')).not.toBeNull();
+  });
+});
+
+describe('useUserStorage — operations route to the installed backend', () => {
+  it('removeItem clears the localStorage entry', async () => {
+    usePluginUserStorageMock.mockReturnValue(null);
+    localStorage.setItem('to-remove', JSON.stringify({ v: 1 }));
+
+    const { result } = renderHook(() => useUserStorage());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.removeItem('to-remove');
+    });
+
+    expect(localStorage.getItem('to-remove')).toBeNull();
+  });
+});

--- a/src/lib/user-storage.hook.test.ts
+++ b/src/lib/user-storage.hook.test.ts
@@ -137,7 +137,6 @@ describe('useUserStorage — global-storage bridge', () => {
       await Promise.resolve();
     });
 
-    // Defer the import so the mocked module is fresh per test.
     const { createUserStorage } = await import('./user-storage');
     const standalone = createUserStorage();
     await standalone.setItem('standalone-key', { from: 'non-react' });

--- a/src/lib/user-storage.hook.test.ts
+++ b/src/lib/user-storage.hook.test.ts
@@ -24,12 +24,7 @@ import { renderHook, act } from '@testing-library/react';
 
 import type { GrafanaUserStorage } from '../types/storage.types';
 
-import {
-  __resetSyncedForTests,
-  createLocalStorage,
-  setGlobalStorage,
-  useUserStorage,
-} from './user-storage';
+import { __resetSyncedForTests, createLocalStorage, setGlobalStorage, useUserStorage } from './user-storage';
 
 const usePluginUserStorageMock = jest.fn();
 


### PR DESCRIPTION
## Summary

Adds tripwire-level characterization tests for five storage modules that previously had no tests, so the rest of this PR stack lands on a real safety net instead of dead reckoning. No production code changes.

## What to look at

- **`src/lib/user-storage.hook.test.ts`** — pins the `useUserStorage` hook's backend selection (hybrid vs localStorage) and the `setGlobalStorage` bridge that non-React storage helpers depend on. This is the most load-bearing of the five — it's the seam that the user-storage decomposition (later in the roadmap) sits on.
- **`src/integrations/coda/terminal-storage.test.ts`** — covers height clamping (`MIN_HEIGHT`/`MAX_HEIGHT`), scrollback truncation (`MAX_SCROLLBACK_SIZE`), and the localStorage/sessionStorage split. Includes failure-swallowing tests so quota / storage-unavailable paths can't regress silently.
- **`src/components/block-editor/hooks/useBlockPersistence.test.ts`** — pins the 1000 ms debounced autosave, `autoSavePaused` gating, blockIds round-trip, and the v2 version-mismatch warning.
- **`src/components/block-editor/hooks/useRecordingPersistence.test.ts`** — pins the mount-time `onRestore`-once guard (Strict Mode safe) and the "save no-ops when not recording" branch.
- **`src/docs-retrieval/content-fetcher.bundled-localstorage.test.ts`** — covers the `bundled:wysiwyg-preview` and `bundled:e2e-test` paths through `fetchContent`, including malformed-JSON title fallback and key isolation between the two.

## Why

`USER_STORAGE_ANALYSIS.md` flagged five modules with zero tests and load-bearing persistence logic. Each was a silent-regression hazard for any future refactor — the kind that ships fine in CI and breaks in production weeks later when somebody changes a key shape. PR #1055 locked the key catalog; this PR locks the behavior behind each key.

PrTester component tests are deliberately deferred — its storage keys are already locked by `storage-keys.test.ts`, and the cleaner surface for testing PrTester's storage behavior is the `usePersistedLocalState` hook that lands in PR3 of this stack.

## How to verify

1. Run the new test files in isolation and confirm they pass:
   ```
   npx jest src/lib/user-storage.hook.test.ts src/integrations/coda/terminal-storage.test.ts src/components/block-editor/hooks/useBlockPersistence.test.ts src/components/block-editor/hooks/useRecordingPersistence.test.ts src/docs-retrieval/content-fetcher.bundled-localstorage.test.ts
   ```
   Expect 64 tests passing.
2. Confirm no production source files were touched in this PR — every change is under a `*.test.ts` path.

## Breaking changes

None. This change is additive: no production code modified, no existing tests changed.

## Out of scope

- PrTester component tests — deferred to PR3 (`usePersistedLocalState`) where the right test surface lives.
- The `useUserStorage` hook tests deliberately do not cover the `syncFromGrafanaStorage` queue + conflict-resolution paths — those are already pinned in [`user-storage.plumbing.test.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/b6cff99a15d7cf9829f76983c194c5db82b2c12c/src/lib/user-storage.plumbing.test.ts) (added in PR #1055).

Refs `.cursor/local/USER_STORAGE.md`, `.cursor/local/USER_STORAGE_ANALYSIS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
