### PR TITLE
refactor(storage): promote interactive-progress-cleared into StorageEvents

### DIFF
--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -16,6 +16,7 @@ import { BadgeIcon } from './BadgeIcon';
 import { SkeletonLoader } from '../SkeletonLoader';
 import { FeedbackButton } from '../FeedbackButton/FeedbackButton';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import { StorageEvents } from '../../lib/event-names';
 import {
   learningProgressStorage,
   journeyCompletionStorage,
@@ -372,7 +373,7 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
 
       // Notify the context engine to refresh recommendations.
       window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
+        new CustomEvent(StorageEvents.InteractiveProgressCleared, {
           detail: { contentKey: '*' },
         })
       );

--- a/src/components/block-editor/BlockPreview.tsx
+++ b/src/components/block-editor/BlockPreview.tsx
@@ -18,6 +18,7 @@ import { useGuidePreviewProgress } from './hooks/useGuidePreviewProgress';
 import type { JsonGuide } from './types';
 import type { ContentParseResult, RawContent } from '../../types/content.types';
 import { testIds } from '../../constants/testIds';
+import { StorageEvents } from '../../lib/event-names';
 
 export interface BlockPreviewProps {
   /** The guide to preview */
@@ -56,9 +57,9 @@ export function BlockPreview({ guide, showTitle = true, hideResetButton = false 
         setResetKey((prev) => prev + 1);
       }
     };
-    window.addEventListener('interactive-progress-cleared', handleCleared);
+    window.addEventListener(StorageEvents.InteractiveProgressCleared, handleCleared);
     return () => {
-      window.removeEventListener('interactive-progress-cleared', handleCleared);
+      window.removeEventListener(StorageEvents.InteractiveProgressCleared, handleCleared);
     };
   }, [progressKey]);
 

--- a/src/components/block-editor/hooks/useGuidePreviewProgress.ts
+++ b/src/components/block-editor/hooks/useGuidePreviewProgress.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { interactiveStepStorage, interactiveCompletionStorage } from '../../../lib/user-storage';
+import { StorageEvents } from '../../../lib/event-names';
 import { evictContentCache } from '../../../global-state/completion-store';
 import { getContentKey } from '../../../global-state/content-key';
 import { subscribeProgressEvent } from '../../../global-state/progress-events';
@@ -60,10 +61,10 @@ export function useGuidePreviewProgress(progressKey: string): GuidePreviewProgre
         setHasProgress(false);
       }
     };
-    window.addEventListener('interactive-progress-cleared', handleCleared);
+    window.addEventListener(StorageEvents.InteractiveProgressCleared, handleCleared);
     return () => {
       unsubscribeProgress();
-      window.removeEventListener('interactive-progress-cleared', handleCleared);
+      window.removeEventListener(StorageEvents.InteractiveProgressCleared, handleCleared);
     };
   }, [progressKey]);
 
@@ -77,7 +78,7 @@ export function useGuidePreviewProgress(progressKey: string): GuidePreviewProgre
       evictContentCache(progressKey);
       setHasProgress(false);
       window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
+        new CustomEvent(StorageEvents.InteractiveProgressCleared, {
           detail: { contentKey: progressKey },
         })
       );

--- a/src/components/docs-panel/hooks/useContentReset.ts
+++ b/src/components/docs-panel/hooks/useContentReset.ts
@@ -17,6 +17,7 @@ import {
   enrichWithStepContext,
 } from '../../../lib/analytics';
 import { interactiveStepStorage, interactiveCompletionStorage } from '../../../lib/user-storage';
+import { StorageEvents } from '../../../lib/event-names';
 import { evictContentCache } from '../../../global-state/completion-store';
 import type { LearningJourneyTab } from '../../../types/content-panel.types';
 import type { DocsPanelModelOperations } from '../types';
@@ -67,7 +68,7 @@ export function useContentReset({ model }: UseContentResetOptions) {
         // Notifies the recommendations panel to refresh and `useGuideProgressState`
         // to clear its `hasInteractiveProgress` flag for this contentKey.
         window.dispatchEvent(
-          new CustomEvent('interactive-progress-cleared', {
+          new CustomEvent(StorageEvents.InteractiveProgressCleared, {
             detail: { contentKey: progressKey },
           })
         );

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -47,6 +47,7 @@ function lookupStepSchema(child: React.ReactNode): StepTypeSchema | undefined {
   return STEP_TYPE_LOOKUP.get(child.type as React.ComponentType<any>);
 }
 import { reportAppInteraction, UserInteraction, getSourceDocument, calculateStepCompletion } from '../../lib/analytics';
+import { StorageEvents } from '../../lib/event-names';
 import { sectionDoneStorage } from '../../lib/user-storage';
 import { INTERACTIVE_CONFIG, getInteractiveConfig } from '../../constants/interactive-config';
 import { getConfigWithDefaults } from '../../constants';
@@ -1073,7 +1074,7 @@ export function InteractiveSection({
     if (typeof window !== 'undefined') {
       const contentKey = getContentKey();
       window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
+        new CustomEvent(StorageEvents.InteractiveProgressCleared, {
           detail: { contentKey },
         })
       );

--- a/src/context-engine/context.hook.ts
+++ b/src/context-engine/context.hook.ts
@@ -6,6 +6,7 @@ import { getDetectedDatasourceType, getDetectedVisualizationType, onContextChang
 import { ContextData, Recommendation, UseContextPanelOptions, UseContextPanelReturn } from '../types/context.types';
 import type { PackageOpenInfo } from '../types/content-panel.types';
 import { useTimeoutManager } from '../utils/timeout-manager';
+import { StorageEvents } from '../lib/event-names';
 import { suggestionState, SUGGESTIONS_UPDATED_EVENT } from '../global-state/suggestion';
 
 export function useContextPanel(options: UseContextPanelOptions = {}): UseContextPanelReturn {
@@ -204,9 +205,9 @@ export function useContextPanel(options: UseContextPanelOptions = {}): UseContex
       debouncedRefresh();
     };
 
-    window.addEventListener('interactive-progress-cleared', handleProgressCleared);
+    window.addEventListener(StorageEvents.InteractiveProgressCleared, handleProgressCleared);
     return () => {
-      window.removeEventListener('interactive-progress-cleared', handleProgressCleared);
+      window.removeEventListener(StorageEvents.InteractiveProgressCleared, handleProgressCleared);
     };
   }, [debouncedRefresh]);
 

--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -33,6 +33,7 @@ import {
   interactiveStepStorage,
   sectionAcknowledgementStorage,
 } from '../lib/user-storage';
+import { StorageEvents } from '../lib/event-names';
 import { StorageKeys } from '../lib/storage-keys';
 
 import { getContentKey } from './content-key';
@@ -280,7 +281,7 @@ function persistSection(contentKey: string, sectionId: string): void {
     // in a mixed guide must not fire "cleared" while acks remain.
     const ackTotal = sectionAcknowledgementStorage.countAllAcknowledged(contentKey);
     if (guideTotal === 0 && ackTotal === 0) {
-      window.dispatchEvent(new CustomEvent('interactive-progress-cleared', { detail: { contentKey } }));
+      window.dispatchEvent(new CustomEvent(StorageEvents.InteractiveProgressCleared, { detail: { contentKey } }));
     }
   }
 }

--- a/src/hooks/useGuideProgressState.ts
+++ b/src/hooks/useGuideProgressState.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { StorageEvents } from '../lib/event-names';
 import { interactiveStepStorage } from '../lib/user-storage';
 import { subscribeProgressEvent } from '../global-state/progress-events';
 
@@ -39,10 +40,10 @@ export function useGuideProgressState(activeTab: ActiveTabSummary | null | undef
         setHasInteractiveProgress(false);
       }
     };
-    window.addEventListener('interactive-progress-cleared', handleProgressCleared);
+    window.addEventListener(StorageEvents.InteractiveProgressCleared, handleProgressCleared);
     return () => {
       unsubscribeProgress();
-      window.removeEventListener('interactive-progress-cleared', handleProgressCleared);
+      window.removeEventListener(StorageEvents.InteractiveProgressCleared, handleProgressCleared);
     };
   }, [progressKey]);
 

--- a/src/learning-paths/learning-paths.hook.ts
+++ b/src/learning-paths/learning-paths.hook.ts
@@ -421,7 +421,7 @@ export function useLearningPaths(): UseLearningPathsReturn {
 
       // Dispatch event to notify UI components to refresh
       window.dispatchEvent(
-        new CustomEvent('interactive-progress-cleared', {
+        new CustomEvent(StorageEvents.InteractiveProgressCleared, {
           detail: { contentKey: '*', pathId },
         })
       );

--- a/src/lib/event-names.ts
+++ b/src/lib/event-names.ts
@@ -1,6 +1,7 @@
 export const StorageEvents = {
   LearningProgressUpdated: 'learning-progress-updated',
   GuideResponseChanged: 'guide-response-changed',
+  InteractiveProgressCleared: 'interactive-progress-cleared',
 } as const;
 
 export type StorageEventName = (typeof StorageEvents)[keyof typeof StorageEvents];


### PR DESCRIPTION
## Summary

Promotes the `'interactive-progress-cleared'` event name into `StorageEvents.InteractiveProgressCleared`. Production code now references a typed constant; test files keep the literal string as the wire-level contract value. Closes the last cross-cutting event-name scatter that lived outside `event-names.ts`.

## What to look at

- **[`src/lib/event-names.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/ed9e8792598b0e9e5741f37fcbe3fcf5e7ffb1b8/src/lib/event-names.ts)** — adds `InteractiveProgressCleared: 'interactive-progress-cleared'`. Single-line addition; this is the canonical definition site.
- **9 production producers and listeners migrated** to import the constant:
  - Dispatchers: `completion-store.ts`, `MyLearningTab.tsx`, `interactive-section.tsx`
  - Dual dispatch + listen at progressKey scope: `BlockPreview.tsx`, `useGuidePreviewProgress.ts`, `useContentReset.ts`
  - Listeners: `useGuideProgressState.ts`, `context.hook.ts`, `learning-paths.hook.ts`
- **Test files deliberately keep the string literal.** `interactive-section.contracts.tripwire.test.tsx` documents this explicitly: the literal *is* the contract value the constant must resolve to. Same logic for the other event-touching test files — they pin the wire-level value, production references the constant.

## Why

`USER_STORAGE_ANALYSIS.md` flagged `'interactive-progress-cleared'` as the last E5 (contract-surface scatter) finding for events — every other cross-cutting event name already lived in `StorageEvents`. PR #1055 established this pattern for storage *keys*; this PR finishes the symmetry for storage *events*. The value of doing it now is that PR4's badge-eviction coordinator dispatches related progress events, and consolidating before then keeps that PR's diff focused on the structural change rather than event-name plumbing.

## How to verify

1. Grep for the literal string outside `event-names.ts`:
   ```
   grep -rn "'interactive-progress-cleared'" src/ --include="*.ts" --include="*.tsx" | grep -v event-names.ts
   ```
   Expect only test files (`interactive-section.contracts.tripwire.test.tsx`, `interactive-section.state-machine.test.tsx`, `useGuidePreviewProgress.test.ts`, `useContentReset.test.ts`, `useGuideProgressState.test.ts`).
2. Open the docs panel, complete one step of any guide, then click "Reset guide". Confirm the recommendations panel refreshes and the `hasInteractiveProgress` flag clears — the event still fires end-to-end.
3. Trigger a learning-path reset from `MyLearningTab` and confirm context-engine recommendations refresh.

## Breaking changes

None. The event name string value is unchanged — `StorageEvents.InteractiveProgressCleared === 'interactive-progress-cleared'`. Any external listener that subscribed to the literal string continues to receive events.

## Reversibility

Fully reversible. The event payload shape (`{ contentKey }`) and dispatch semantics are unchanged. A revert restores the literal-string call sites without any data-shape concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
