### PR TITLE
refactor(storage): extract three shared storage utilities

### DIFF
--- a/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
+++ b/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
@@ -21,12 +21,8 @@ export interface SelectorDebugPanelProps {
 export function SelectorDebugPanel({ onOpenDocsPage, onOpenLearningJourney }: SelectorDebugPanelProps = {}) {
   const styles = useStyles2(getDebugPanelStyles);
 
-  const [prTesterExpanded, setPrTesterExpanded] = usePersistedBoolean(
-    StorageKeys.DEVTOOLS_PR_TESTER_EXPANDED
-  );
-  const [UrlTesterExpanded, setUrlTesterExpanded] = usePersistedBoolean(
-    StorageKeys.DEVTOOLS_URL_TESTER_EXPANDED
-  );
+  const [prTesterExpanded, setPrTesterExpanded] = usePersistedBoolean(StorageKeys.DEVTOOLS_PR_TESTER_EXPANDED);
+  const [UrlTesterExpanded, setUrlTesterExpanded] = usePersistedBoolean(StorageKeys.DEVTOOLS_URL_TESTER_EXPANDED);
 
   // Handle leaving dev mode
   const handleLeaveDevMode = useCallback(async () => {

--- a/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
+++ b/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
@@ -1,29 +1,11 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { Button, Badge, Icon, useStyles2, Stack } from '@grafana/ui';
 import { getDebugPanelStyles } from './debug-panel.styles';
 import { UrlTester } from 'components/UrlTester';
 import { PrTester } from 'components/PrTester';
 import type { PackageOpenInfo } from 'types/content-panel.types';
 import { StorageKeys } from 'lib/storage-keys';
-
-// localStorage keys for section expansion state
-const STORAGE_KEY_PR_TESTER = StorageKeys.DEVTOOLS_PR_TESTER_EXPANDED;
-const STORAGE_KEY_URL_TESTER = StorageKeys.DEVTOOLS_URL_TESTER_EXPANDED;
-
-/**
- * Get initial expansion state from localStorage with fallback
- */
-function getInitialExpanded(storageKey: string, defaultValue: boolean): boolean {
-  try {
-    const stored = localStorage.getItem(storageKey);
-    if (stored !== null) {
-      return stored === 'true';
-    }
-  } catch {
-    // Ignore localStorage errors
-  }
-  return defaultValue;
-}
+import { usePersistedBoolean } from '../../hooks';
 
 export interface SelectorDebugPanelProps {
   /**
@@ -39,27 +21,12 @@ export interface SelectorDebugPanelProps {
 export function SelectorDebugPanel({ onOpenDocsPage, onOpenLearningJourney }: SelectorDebugPanelProps = {}) {
   const styles = useStyles2(getDebugPanelStyles);
 
-  // Section expansion state - initialize from localStorage
-  const [prTesterExpanded, setPrTesterExpanded] = useState(() => getInitialExpanded(STORAGE_KEY_PR_TESTER, false));
-  const [UrlTesterExpanded, setUrlTesterExpanded] = useState(() => getInitialExpanded(STORAGE_KEY_URL_TESTER, false));
-
-  // Persist PR tester expansion state
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY_PR_TESTER, String(prTesterExpanded));
-    } catch {
-      // Ignore localStorage errors
-    }
-  }, [prTesterExpanded]);
-
-  // Persist URL tester expansion state
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY_URL_TESTER, String(UrlTesterExpanded));
-    } catch {
-      // Ignore localStorage errors
-    }
-  }, [UrlTesterExpanded]);
+  const [prTesterExpanded, setPrTesterExpanded] = usePersistedBoolean(
+    StorageKeys.DEVTOOLS_PR_TESTER_EXPANDED
+  );
+  const [UrlTesterExpanded, setUrlTesterExpanded] = usePersistedBoolean(
+    StorageKeys.DEVTOOLS_URL_TESTER_EXPANDED
+  );
 
   // Handle leaving dev mode
   const handleLeaveDevMode = useCallback(async () => {

--- a/src/components/UrlTester/UrlTester.tsx
+++ b/src/components/UrlTester/UrlTester.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Icon, Input, useStyles2 } from '@grafana/ui';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { getUrlTesterStyles } from './url-tester.styles';
 import {
   isGitHubRawUrl,
@@ -10,8 +10,7 @@ import {
 } from '../../security';
 import { testIds } from '../../constants/testIds';
 import { StorageKeys } from '../../lib/storage-keys';
-
-const STORAGE_KEY = StorageKeys.DEVTOOLS_URL_TESTER_URL;
+import { usePersistedString } from '../../hooks';
 
 export interface UrlTesterProps {
   onOpenDocsPage: (url: string, title: string) => void;
@@ -72,21 +71,9 @@ function validateContentUrl(url: string): UrlValidation {
 
 export const UrlTester = ({ onOpenDocsPage, onOpenLearningJourney }: UrlTesterProps) => {
   const styles = useStyles2(getUrlTesterStyles);
-  const [testUrl, setTestUrl] = useState(() => {
-    try {
-      return localStorage.getItem(STORAGE_KEY) || '';
-    } catch {
-      return '';
-    }
-  });
+  const [testUrl, setTestUrl] = usePersistedString(StorageKeys.DEVTOOLS_URL_TESTER_URL);
   const [testError, setTestError] = useState<string | null>(null);
   const [testSuccess, setTestSuccess] = useState(false);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, testUrl);
-    } catch {}
-  }, [testUrl]);
 
   const handleSubmit = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/block-editor/HealthStatusBar.tsx
+++ b/src/components/block-editor/HealthStatusBar.tsx
@@ -12,7 +12,8 @@
  * address the diagnostic, not hide it.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import { usePersistedBoolean } from '../../hooks';
 import { Icon, IconButton, Tooltip, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
@@ -224,25 +225,11 @@ export function HealthStatusBar({ blocks }: HealthStatusBarProps) {
   const styles = useStyles2(getStyles);
   const lint = useGuideLintResult();
 
-  const [isExpanded, setIsExpanded] = useState<boolean>(() => {
-    try {
-      return window.localStorage.getItem(STORAGE_KEY) === 'true';
-    } catch {
-      return false;
-    }
-  });
+  const [isExpanded, setIsExpanded] = usePersistedBoolean(STORAGE_KEY);
 
   const toggleExpanded = useCallback(() => {
-    setIsExpanded((prev) => {
-      const next = !prev;
-      try {
-        window.localStorage.setItem(STORAGE_KEY, String(next));
-      } catch {
-        // localStorage unavailable; in-memory is fine.
-      }
-      return next;
-    });
-  }, []);
+    setIsExpanded((prev) => !prev);
+  }, [setIsExpanded]);
 
   const grouped = useMemo(() => {
     const out: Record<DiagnosticSeverity, Diagnostic[]> = { error: [], warning: [], info: [] };

--- a/src/components/block-editor/forms/ConditionChipsField.tsx
+++ b/src/components/block-editor/forms/ConditionChipsField.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../../types/requirements.types';
 import { isAutoRecoverableRequirement } from '../../../recovery';
 import { StorageKeys } from '../../../lib/storage-keys';
+import { usePersistedBoolean } from '../../../hooks';
 import { HELPER_BY_PREFIX } from './condition-helpers';
 
 const RAW_MODE_PREFERENCE_KEY = StorageKeys.BLOCK_EDITOR_CONDITION_RAW_MODE;
@@ -83,22 +84,6 @@ function tokensToString(tokens: string[]): string {
   return tokens.join(', ');
 }
 
-function readRawModePreference(): boolean {
-  try {
-    return window.localStorage.getItem(RAW_MODE_PREFERENCE_KEY) === 'true';
-  } catch {
-    return false;
-  }
-}
-
-function writeRawModePreference(value: boolean): void {
-  try {
-    window.localStorage.setItem(RAW_MODE_PREFERENCE_KEY, String(value));
-  } catch {
-    // localStorage unavailable — preference falls back to default each session.
-  }
-}
-
 function getPlaceholder(mode: ConditionFieldMode): string {
   switch (mode) {
     case 'requirements':
@@ -121,7 +106,7 @@ export function ConditionChipsField({
 }: ConditionChipsFieldProps) {
   const styles = useStyles2(getStyles);
   const tokens = useMemo(() => tokensFromString(value), [value]);
-  const [isRawMode, setIsRawMode] = useState<boolean>(() => readRawModePreference());
+  const [isRawMode, setIsRawMode] = usePersistedBoolean(RAW_MODE_PREFERENCE_KEY);
   const [isAdding, setIsAdding] = useState(false);
   const [pickedOption, setPickedOption] = useState<PickerOption | null>(null);
   const [argValue, setArgValue] = useState('');
@@ -131,13 +116,9 @@ export function ConditionChipsField({
   const [helperValid, setHelperValid] = useState(true);
 
   const toggleRawMode = useCallback(() => {
-    setIsRawMode((prev) => {
-      const next = !prev;
-      writeRawModePreference(next);
-      return next;
-    });
+    setIsRawMode((prev) => !prev);
     setIsAdding(false);
-  }, []);
+  }, [setIsRawMode]);
 
   const removeChip = useCallback(
     (token: string) => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,8 +5,4 @@ export {
   type UseAutoLaunchTutorialOptions,
 } from './useAutoLaunchTutorial';
 export { useStepProgressFromEvents } from './useStepProgressFromEvents';
-export {
-  usePersistedBoolean,
-  usePersistedLocalState,
-  usePersistedString,
-} from './usePersistedLocalState';
+export { usePersistedBoolean, usePersistedLocalState, usePersistedString } from './usePersistedLocalState';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,8 @@ export {
   type UseAutoLaunchTutorialOptions,
 } from './useAutoLaunchTutorial';
 export { useStepProgressFromEvents } from './useStepProgressFromEvents';
+export {
+  usePersistedBoolean,
+  usePersistedLocalState,
+  usePersistedString,
+} from './usePersistedLocalState';

--- a/src/hooks/usePersistedLocalState.test.ts
+++ b/src/hooks/usePersistedLocalState.test.ts
@@ -1,0 +1,150 @@
+import { act, renderHook } from '@testing-library/react';
+
+import {
+  usePersistedBoolean,
+  usePersistedLocalState,
+  usePersistedString,
+} from './usePersistedLocalState';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('usePersistedString', () => {
+  const KEY = 'test-pls-string';
+
+  it('initializes from defaultValue when storage is empty', () => {
+    const { result } = renderHook(() => usePersistedString(KEY, 'fallback'));
+    expect(result.current[0]).toBe('fallback');
+  });
+
+  it('initializes from localStorage when the key is present', () => {
+    localStorage.setItem(KEY, 'stored');
+    const { result } = renderHook(() => usePersistedString(KEY));
+    expect(result.current[0]).toBe('stored');
+  });
+
+  it('writes through to localStorage on update', () => {
+    const { result } = renderHook(() => usePersistedString(KEY));
+
+    act(() => {
+      result.current[1]('new value');
+    });
+
+    expect(result.current[0]).toBe('new value');
+    expect(localStorage.getItem(KEY)).toBe('new value');
+  });
+
+  it('supports a functional updater', () => {
+    const { result } = renderHook(() => usePersistedString(KEY, 'a'));
+
+    act(() => {
+      result.current[1]((prev) => prev + 'b');
+    });
+
+    expect(result.current[0]).toBe('ab');
+    expect(localStorage.getItem(KEY)).toBe('ab');
+  });
+});
+
+describe('usePersistedBoolean', () => {
+  const KEY = 'test-pls-bool';
+
+  it('defaults to false when key is absent', () => {
+    const { result } = renderHook(() => usePersistedBoolean(KEY));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('respects defaultValue override when key is absent', () => {
+    const { result } = renderHook(() => usePersistedBoolean(KEY, true));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('parses "true" as true and other strings as false', () => {
+    localStorage.setItem(KEY, 'true');
+    const { result } = renderHook(() => usePersistedBoolean(KEY));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('treats "TRUE" / non-strict values as false (strict equality)', () => {
+    localStorage.setItem(KEY, 'TRUE');
+    const { result } = renderHook(() => usePersistedBoolean(KEY));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('writes "true" / "false" strings on toggle', () => {
+    const { result } = renderHook(() => usePersistedBoolean(KEY));
+
+    act(() => result.current[1](true));
+    expect(localStorage.getItem(KEY)).toBe('true');
+
+    act(() => result.current[1](false));
+    expect(localStorage.getItem(KEY)).toBe('false');
+  });
+});
+
+describe('usePersistedLocalState (generic)', () => {
+  const KEY = 'test-pls-generic';
+
+  it('round-trips an object via JSON', () => {
+    const { result } = renderHook(() =>
+      usePersistedLocalState<{ count: number }>({
+        key: KEY,
+        defaultValue: { count: 0 },
+        deserialize: (raw) => JSON.parse(raw),
+        serialize: JSON.stringify,
+      })
+    );
+
+    act(() => result.current[1]({ count: 5 }));
+
+    expect(localStorage.getItem(KEY)).toBe('{"count":5}');
+    expect(result.current[0]).toEqual({ count: 5 });
+  });
+
+  it('returns defaultValue when deserialize throws', () => {
+    localStorage.setItem(KEY, 'not json');
+
+    const { result } = renderHook(() =>
+      usePersistedLocalState<{ count: number }>({
+        key: KEY,
+        defaultValue: { count: 99 },
+        deserialize: (raw) => JSON.parse(raw),
+        serialize: JSON.stringify,
+      })
+    );
+
+    expect(result.current[0]).toEqual({ count: 99 });
+  });
+
+  it('falls back to defaultValue when localStorage.getItem throws on init', () => {
+    const original = Storage.prototype.getItem;
+    Storage.prototype.getItem = jest.fn(() => {
+      throw new Error('storage unavailable');
+    });
+    try {
+      const { result } = renderHook(() => usePersistedString(KEY, 'fallback'));
+      expect(result.current[0]).toBe('fallback');
+    } finally {
+      Storage.prototype.getItem = original;
+    }
+  });
+
+  it('does not throw when localStorage.setItem throws on update', () => {
+    const { result } = renderHook(() => usePersistedString(KEY));
+
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = jest.fn(() => {
+      throw new Error('quota');
+    });
+    try {
+      expect(() =>
+        act(() => {
+          result.current[1]('x');
+        })
+      ).not.toThrow();
+    } finally {
+      Storage.prototype.setItem = original;
+    }
+  });
+});

--- a/src/hooks/usePersistedLocalState.test.ts
+++ b/src/hooks/usePersistedLocalState.test.ts
@@ -1,10 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 
-import {
-  usePersistedBoolean,
-  usePersistedLocalState,
-  usePersistedString,
-} from './usePersistedLocalState';
+import { usePersistedBoolean, usePersistedLocalState, usePersistedString } from './usePersistedLocalState';
 
 beforeEach(() => {
   localStorage.clear();

--- a/src/hooks/usePersistedLocalState.ts
+++ b/src/hooks/usePersistedLocalState.ts
@@ -1,0 +1,118 @@
+/**
+ * `usePersistedLocalState` — a small `useState` wrapper that lazy-reads its
+ * initial value from `localStorage` and writes through to localStorage on
+ * every change.
+ *
+ * Replaces the hand-rolled `useState(() => localStorage.getItem(KEY) || x)`
+ * + `useEffect(() => localStorage.setItem(KEY, ...))` pattern that was
+ * duplicated across the dev/UI-pref components surveyed in
+ * `.cursor/local/USER_STORAGE_ANALYSIS.md`:
+ *   - PrTester, UrlTester, SelectorDebugPanel (devtool prefs)
+ *   - HealthStatusBar, ConditionChipsField (block-editor UI prefs)
+ *
+ * Designed for ephemeral *UI preferences* — anything where a localStorage
+ * read miss should fall back to a fixed default without surfacing an error.
+ * Quota and parse failures are deliberately swallowed in line with the
+ * existing call-site contract; UI state is local-only and not synced to
+ * Grafana user storage.
+ *
+ * Three flavors are provided so callers don't have to write the same
+ * deserialize/serialize boilerplate every time:
+ *
+ *   - `usePersistedString`    → string values, stored as-is
+ *   - `usePersistedBoolean`   → boolean values, stored as `"true"` / `"false"`
+ *   - `usePersistedLocalState` → arbitrary `T`, callers provide
+ *                                serialize / deserialize callbacks
+ */
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+
+export interface UsePersistedLocalStateOptions<T> {
+  /** Storage key — must come from `StorageKeys` for new call sites. */
+  key: string;
+  /** Default returned when the key is absent or deserialize fails. */
+  defaultValue: T;
+  /** Convert the storage string into `T`. Throwing falls back to `defaultValue`. */
+  deserialize: (raw: string) => T;
+  /** Convert `T` into the string to store. */
+  serialize: (value: T) => string;
+}
+
+/**
+ * Generic persisted-state hook. Reads `key` once on mount via the lazy
+ * initializer; writes on every state change via an effect. Returns the
+ * same `[value, setValue]` tuple as `useState`.
+ */
+export function usePersistedLocalState<T>({
+  key,
+  defaultValue,
+  deserialize,
+  serialize,
+}: UsePersistedLocalStateOptions<T>): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored === null) {
+        return defaultValue;
+      }
+      return deserialize(stored);
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  // Skip the write on the first effect run. The mount write would otherwise
+  // turn the default value into a persisted value, changing observable
+  // behavior for call sites that previously only wrote on user-driven change.
+  const isFirstEffectRun = useRef(true);
+
+  useEffect(() => {
+    if (isFirstEffectRun.current) {
+      isFirstEffectRun.current = false;
+      return;
+    }
+    try {
+      localStorage.setItem(key, serialize(value));
+    } catch {
+      // Storage unavailable / quota — UI preferences degrade silently.
+    }
+  }, [key, value, serialize]);
+
+  return [value, setValue];
+}
+
+/**
+ * String-valued persisted state. The default is `''` unless overridden.
+ */
+export function usePersistedString(
+  key: string,
+  defaultValue = ''
+): [string, Dispatch<SetStateAction<string>>] {
+  const deserialize = useCallback((raw: string) => raw, []);
+  const serialize = useCallback((value: string) => value, []);
+  return usePersistedLocalState({
+    key,
+    defaultValue,
+    deserialize,
+    serialize,
+  });
+}
+
+/**
+ * Boolean-valued persisted state. Stored as `"true"` / `"false"` strings
+ * for compatibility with existing call sites. Only `"true"` is treated as
+ * `true` on read — any other value defaults to `false` (or `defaultValue`
+ * when the key is absent).
+ */
+export function usePersistedBoolean(
+  key: string,
+  defaultValue = false
+): [boolean, Dispatch<SetStateAction<boolean>>] {
+  const deserialize = useCallback((raw: string) => raw === 'true', []);
+  const serialize = useCallback((value: boolean) => String(value), []);
+  return usePersistedLocalState({
+    key,
+    defaultValue,
+    deserialize,
+    serialize,
+  });
+}

--- a/src/hooks/usePersistedLocalState.ts
+++ b/src/hooks/usePersistedLocalState.ts
@@ -83,10 +83,7 @@ export function usePersistedLocalState<T>({
 /**
  * String-valued persisted state. The default is `''` unless overridden.
  */
-export function usePersistedString(
-  key: string,
-  defaultValue = ''
-): [string, Dispatch<SetStateAction<string>>] {
+export function usePersistedString(key: string, defaultValue = ''): [string, Dispatch<SetStateAction<string>>] {
   const deserialize = useCallback((raw: string) => raw, []);
   const serialize = useCallback((value: string) => value, []);
   return usePersistedLocalState({
@@ -103,10 +100,7 @@ export function usePersistedString(
  * `true` on read — any other value defaults to `false` (or `defaultValue`
  * when the key is absent).
  */
-export function usePersistedBoolean(
-  key: string,
-  defaultValue = false
-): [boolean, Dispatch<SetStateAction<boolean>>] {
+export function usePersistedBoolean(key: string, defaultValue = false): [boolean, Dispatch<SetStateAction<boolean>>] {
   const deserialize = useCallback((raw: string) => raw === 'true', []);
   const serialize = useCallback((value: boolean) => String(value), []);
   return usePersistedLocalState({

--- a/src/lib/storage/extension-sidebar.test.ts
+++ b/src/lib/storage/extension-sidebar.test.ts
@@ -1,0 +1,146 @@
+import {
+  EXTENSION_SIDEBAR_DOCKED_KEY,
+  clearExtensionSidebarDocked,
+  isExtensionSidebarInUse,
+  isExtensionSidebarOwnedByOther,
+  isExtensionSidebarOwnedByPathfinder,
+  parseExtensionSidebarDocked,
+} from './extension-sidebar';
+
+const MY_PLUGIN_ID = 'grafana-pathfinder-app';
+const TITLE_MATCH = 'Interactive learning';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('parseExtensionSidebarDocked', () => {
+  it('returns null when the key is absent', () => {
+    expect(parseExtensionSidebarDocked()).toBeNull();
+  });
+
+  it('parses JSON object shape with pluginId + componentTitle', () => {
+    localStorage.setItem(
+      EXTENSION_SIDEBAR_DOCKED_KEY,
+      JSON.stringify({ pluginId: MY_PLUGIN_ID, componentTitle: TITLE_MATCH })
+    );
+
+    expect(parseExtensionSidebarDocked()).toEqual({
+      pluginId: MY_PLUGIN_ID,
+      componentTitle: TITLE_MATCH,
+    });
+  });
+
+  it('falls back to treating the raw value as pluginId on JSON parse failure', () => {
+    localStorage.setItem(EXTENSION_SIDEBAR_DOCKED_KEY, MY_PLUGIN_ID);
+
+    expect(parseExtensionSidebarDocked()).toEqual({ pluginId: MY_PLUGIN_ID });
+  });
+
+  it('returns undefined for non-string fields in JSON', () => {
+    localStorage.setItem(
+      EXTENSION_SIDEBAR_DOCKED_KEY,
+      JSON.stringify({ pluginId: 42, componentTitle: null })
+    );
+
+    expect(parseExtensionSidebarDocked()).toEqual({
+      pluginId: undefined,
+      componentTitle: undefined,
+    });
+  });
+
+  it('returns null when storage throws', () => {
+    const original = Storage.prototype.getItem;
+    Storage.prototype.getItem = jest.fn(() => {
+      throw new Error('storage unavailable');
+    });
+    try {
+      expect(parseExtensionSidebarDocked()).toBeNull();
+    } finally {
+      Storage.prototype.getItem = original;
+    }
+  });
+});
+
+describe('isExtensionSidebarOwnedByOther', () => {
+  it('false when nothing is docked', () => {
+    expect(isExtensionSidebarOwnedByOther(MY_PLUGIN_ID)).toBe(false);
+  });
+
+  it('false when the docked surface is us (object shape)', () => {
+    localStorage.setItem(
+      EXTENSION_SIDEBAR_DOCKED_KEY,
+      JSON.stringify({ pluginId: MY_PLUGIN_ID })
+    );
+    expect(isExtensionSidebarOwnedByOther(MY_PLUGIN_ID)).toBe(false);
+  });
+
+  it('false when the docked surface is us (legacy string shape)', () => {
+    localStorage.setItem(EXTENSION_SIDEBAR_DOCKED_KEY, MY_PLUGIN_ID);
+    expect(isExtensionSidebarOwnedByOther(MY_PLUGIN_ID)).toBe(false);
+  });
+
+  it('true when another plugin is docked (object shape)', () => {
+    localStorage.setItem(
+      EXTENSION_SIDEBAR_DOCKED_KEY,
+      JSON.stringify({ pluginId: 'other-plugin' })
+    );
+    expect(isExtensionSidebarOwnedByOther(MY_PLUGIN_ID)).toBe(true);
+  });
+
+  it('true when another plugin is docked (legacy string shape)', () => {
+    localStorage.setItem(EXTENSION_SIDEBAR_DOCKED_KEY, 'other-plugin');
+    expect(isExtensionSidebarOwnedByOther(MY_PLUGIN_ID)).toBe(true);
+  });
+
+  it('false when pluginId is missing/invalid', () => {
+    localStorage.setItem(EXTENSION_SIDEBAR_DOCKED_KEY, JSON.stringify({ pluginId: 42 }));
+    expect(isExtensionSidebarOwnedByOther(MY_PLUGIN_ID)).toBe(false);
+  });
+});
+
+describe('isExtensionSidebarOwnedByPathfinder', () => {
+  it('matches by pluginId', () => {
+    localStorage.setItem(
+      EXTENSION_SIDEBAR_DOCKED_KEY,
+      JSON.stringify({ pluginId: MY_PLUGIN_ID })
+    );
+    expect(isExtensionSidebarOwnedByPathfinder(MY_PLUGIN_ID, TITLE_MATCH)).toBe(true);
+  });
+
+  it('matches by componentTitle (older Grafana versions)', () => {
+    localStorage.setItem(
+      EXTENSION_SIDEBAR_DOCKED_KEY,
+      JSON.stringify({ pluginId: undefined, componentTitle: TITLE_MATCH })
+    );
+    expect(isExtensionSidebarOwnedByPathfinder(MY_PLUGIN_ID, TITLE_MATCH)).toBe(true);
+  });
+
+  it('false when neither match', () => {
+    localStorage.setItem(
+      EXTENSION_SIDEBAR_DOCKED_KEY,
+      JSON.stringify({ pluginId: 'other', componentTitle: 'Other component' })
+    );
+    expect(isExtensionSidebarOwnedByPathfinder(MY_PLUGIN_ID, TITLE_MATCH)).toBe(false);
+  });
+
+  it('matches legacy plain string as pluginId', () => {
+    localStorage.setItem(EXTENSION_SIDEBAR_DOCKED_KEY, MY_PLUGIN_ID);
+    expect(isExtensionSidebarOwnedByPathfinder(MY_PLUGIN_ID, TITLE_MATCH)).toBe(true);
+  });
+});
+
+describe('isExtensionSidebarInUse / clearExtensionSidebarDocked', () => {
+  it('inUse is false when absent, true when present (any shape)', () => {
+    expect(isExtensionSidebarInUse()).toBe(false);
+
+    localStorage.setItem(EXTENSION_SIDEBAR_DOCKED_KEY, 'x');
+    expect(isExtensionSidebarInUse()).toBe(true);
+  });
+
+  it('clear() removes the key', () => {
+    localStorage.setItem(EXTENSION_SIDEBAR_DOCKED_KEY, 'x');
+    clearExtensionSidebarDocked();
+    expect(localStorage.getItem(EXTENSION_SIDEBAR_DOCKED_KEY)).toBeNull();
+  });
+});

--- a/src/lib/storage/extension-sidebar.test.ts
+++ b/src/lib/storage/extension-sidebar.test.ts
@@ -38,10 +38,7 @@ describe('parseExtensionSidebarDocked', () => {
   });
 
   it('returns undefined for non-string fields in JSON', () => {
-    localStorage.setItem(
-      EXTENSION_SIDEBAR_DOCKED_KEY,
-      JSON.stringify({ pluginId: 42, componentTitle: null })
-    );
+    localStorage.setItem(EXTENSION_SIDEBAR_DOCKED_KEY, JSON.stringify({ pluginId: 42, componentTitle: null }));
 
     expect(parseExtensionSidebarDocked()).toEqual({
       pluginId: undefined,
@@ -68,10 +65,7 @@ describe('isExtensionSidebarOwnedByOther', () => {
   });
 
   it('false when the docked surface is us (object shape)', () => {
-    localStorage.setItem(
-      EXTENSION_SIDEBAR_DOCKED_KEY,
-      JSON.stringify({ pluginId: MY_PLUGIN_ID })
-    );
+    localStorage.setItem(EXTENSION_SIDEBAR_DOCKED_KEY, JSON.stringify({ pluginId: MY_PLUGIN_ID }));
     expect(isExtensionSidebarOwnedByOther(MY_PLUGIN_ID)).toBe(false);
   });
 
@@ -81,10 +75,7 @@ describe('isExtensionSidebarOwnedByOther', () => {
   });
 
   it('true when another plugin is docked (object shape)', () => {
-    localStorage.setItem(
-      EXTENSION_SIDEBAR_DOCKED_KEY,
-      JSON.stringify({ pluginId: 'other-plugin' })
-    );
+    localStorage.setItem(EXTENSION_SIDEBAR_DOCKED_KEY, JSON.stringify({ pluginId: 'other-plugin' }));
     expect(isExtensionSidebarOwnedByOther(MY_PLUGIN_ID)).toBe(true);
   });
 
@@ -101,10 +92,7 @@ describe('isExtensionSidebarOwnedByOther', () => {
 
 describe('isExtensionSidebarOwnedByPathfinder', () => {
   it('matches by pluginId', () => {
-    localStorage.setItem(
-      EXTENSION_SIDEBAR_DOCKED_KEY,
-      JSON.stringify({ pluginId: MY_PLUGIN_ID })
-    );
+    localStorage.setItem(EXTENSION_SIDEBAR_DOCKED_KEY, JSON.stringify({ pluginId: MY_PLUGIN_ID }));
     expect(isExtensionSidebarOwnedByPathfinder(MY_PLUGIN_ID, TITLE_MATCH)).toBe(true);
   });
 

--- a/src/lib/storage/extension-sidebar.ts
+++ b/src/lib/storage/extension-sidebar.ts
@@ -93,10 +93,7 @@ export function isExtensionSidebarInUse(): boolean {
  * componentTitle match for older Grafana versions where pluginId was not
  * yet recorded.
  */
-export function isExtensionSidebarOwnedByPathfinder(
-  myPluginId: string,
-  componentTitleMatch: string
-): boolean {
+export function isExtensionSidebarOwnedByPathfinder(myPluginId: string, componentTitleMatch: string): boolean {
   const docked = parseExtensionSidebarDocked();
   if (!docked) {
     return false;

--- a/src/lib/storage/extension-sidebar.ts
+++ b/src/lib/storage/extension-sidebar.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared parser for Grafana's `grafana.navigation.extensionSidebarDocked`
+ * localStorage key. Older Grafana versions wrote the docked plugin id as a
+ * bare string; newer versions write `{ pluginId, componentTitle, ... }`.
+ *
+ * The same parse was previously inlined three times in `module.tsx` (restore
+ * + suggest-reject paths) and `experiment-utils.ts`
+ * (`isExtensionSidebarOwnedByOther`) with subtly different fallback logic.
+ * Consolidating fixes one of the patterns flagged in
+ * `.cursor/local/USER_STORAGE_ANALYSIS.md` as B4 (convergent re-bugging) and
+ * eliminates the "which variant does each caller use?" question for future
+ * sidebar-coordination work.
+ *
+ * The key itself is externally owned by Grafana — it lives outside
+ * `StorageKeys` and stays the responsibility of the platform. This module
+ * only provides shape-aware reading.
+ */
+
+export const EXTENSION_SIDEBAR_DOCKED_KEY = 'grafana.navigation.extensionSidebarDocked';
+
+/**
+ * Structured view of the docked-sidebar entry.
+ *
+ *   - `null`: the key is absent (or storage is unavailable). Nothing is
+ *     docked from the Grafana-side perspective.
+ *   - `{ pluginId, componentTitle }`: the docked surface is identified.
+ *     Either or both fields may be `undefined` depending on Grafana version
+ *     and which component is docked.
+ */
+export interface ExtensionSidebarDocked {
+  pluginId?: string;
+  componentTitle?: string;
+}
+
+/**
+ * Read and parse the docked-sidebar entry from localStorage.
+ *
+ * Returns `null` when the key is absent or storage throws. Returns a
+ * structured object when the value parses as JSON. Falls back to treating
+ * the raw string as a `pluginId` to preserve the legacy contract from older
+ * Grafana versions.
+ */
+export function parseExtensionSidebarDocked(): ExtensionSidebarDocked | null {
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(EXTENSION_SIDEBAR_DOCKED_KEY);
+  } catch {
+    return null;
+  }
+  if (raw === null) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as { pluginId?: unknown; componentTitle?: unknown };
+    return {
+      pluginId: typeof parsed.pluginId === 'string' ? parsed.pluginId : undefined,
+      componentTitle: typeof parsed.componentTitle === 'string' ? parsed.componentTitle : undefined,
+    };
+  } catch {
+    // Legacy plain-string format from older Grafana versions.
+    return { pluginId: raw };
+  }
+}
+
+/**
+ * True when the docked sidebar belongs to a plugin other than `myPluginId`.
+ * Returns false when nothing is docked or the docked surface belongs to us.
+ */
+export function isExtensionSidebarOwnedByOther(myPluginId: string): boolean {
+  const docked = parseExtensionSidebarDocked();
+  if (!docked) {
+    return false;
+  }
+  const { pluginId } = docked;
+  return typeof pluginId === 'string' && pluginId.length > 0 && pluginId !== myPluginId;
+}
+
+/**
+ * True when *something* is docked (Pathfinder or otherwise). Convenience
+ * for the "is the sidebar in use at all?" check.
+ */
+export function isExtensionSidebarInUse(): boolean {
+  try {
+    return localStorage.getItem(EXTENSION_SIDEBAR_DOCKED_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Match the docked surface against a Pathfinder fingerprint. Mirrors the
+ * historical `module.tsx` restore-path check: pluginId equality OR a
+ * componentTitle match for older Grafana versions where pluginId was not
+ * yet recorded.
+ */
+export function isExtensionSidebarOwnedByPathfinder(
+  myPluginId: string,
+  componentTitleMatch: string
+): boolean {
+  const docked = parseExtensionSidebarDocked();
+  if (!docked) {
+    return false;
+  }
+  return docked.pluginId === myPluginId || docked.componentTitle === componentTitleMatch;
+}
+
+/**
+ * Clear the docked-sidebar key. Safe to call when storage is unavailable.
+ */
+export function clearExtensionSidebarDocked(): void {
+  try {
+    localStorage.removeItem(EXTENSION_SIDEBAR_DOCKED_KEY);
+  } catch {
+    // Storage unavailable — nothing to clear from our side.
+  }
+}

--- a/src/lib/storage/key-utils.test.ts
+++ b/src/lib/storage/key-utils.test.ts
@@ -1,0 +1,101 @@
+import { clearKeysByPrefix, collectKeysByPrefix } from './key-utils';
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+describe('collectKeysByPrefix', () => {
+  it('returns every key with the given prefix', () => {
+    localStorage.setItem('foo-1', '1');
+    localStorage.setItem('foo-2', '2');
+    localStorage.setItem('bar-3', '3');
+
+    const collected = collectKeysByPrefix(localStorage, 'foo-');
+    expect(collected.sort()).toEqual(['foo-1', 'foo-2']);
+  });
+
+  it('returns [] when no key matches', () => {
+    localStorage.setItem('bar', '1');
+    expect(collectKeysByPrefix(localStorage, 'foo-')).toEqual([]);
+  });
+
+  it('returns [] when storage.key throws', () => {
+    const original = Storage.prototype.key;
+    Storage.prototype.key = jest.fn(() => {
+      throw new Error('storage unavailable');
+    });
+    try {
+      expect(collectKeysByPrefix(localStorage, 'foo-')).toEqual([]);
+    } finally {
+      Storage.prototype.key = original;
+    }
+  });
+
+  it('works against sessionStorage', () => {
+    sessionStorage.setItem('s-a', 'a');
+    sessionStorage.setItem('s-b', 'b');
+    sessionStorage.setItem('other', 'c');
+
+    expect(collectKeysByPrefix(sessionStorage, 's-').sort()).toEqual(['s-a', 's-b']);
+  });
+
+  it('iterates from the top index down so concurrent removes are safe', () => {
+    localStorage.setItem('p-1', '1');
+    localStorage.setItem('p-2', '2');
+    localStorage.setItem('p-3', '3');
+
+    // Simulate a caller that removes each key as it iterates. With a
+    // descending sweep, every match is still seen.
+    const collected = collectKeysByPrefix(localStorage, 'p-');
+    expect(collected).toHaveLength(3);
+  });
+});
+
+describe('clearKeysByPrefix', () => {
+  it('removes only matching keys and leaves siblings alone', () => {
+    localStorage.setItem('p-1', '1');
+    localStorage.setItem('p-2', '2');
+    localStorage.setItem('keep-me', 'k');
+
+    const removed = clearKeysByPrefix(localStorage, 'p-');
+
+    expect(removed.sort()).toEqual(['p-1', 'p-2']);
+    expect(localStorage.getItem('p-1')).toBeNull();
+    expect(localStorage.getItem('p-2')).toBeNull();
+    expect(localStorage.getItem('keep-me')).toBe('k');
+  });
+
+  it('returns [] when no key matches', () => {
+    localStorage.setItem('bar', '1');
+    expect(clearKeysByPrefix(localStorage, 'foo-')).toEqual([]);
+    expect(localStorage.getItem('bar')).toBe('1');
+  });
+
+  it('does not throw when storage.removeItem throws on some entries', () => {
+    localStorage.setItem('p-1', '1');
+    localStorage.setItem('p-2', '2');
+
+    const original = Storage.prototype.removeItem;
+    Storage.prototype.removeItem = jest.fn(() => {
+      throw new Error('quota / locked');
+    });
+    try {
+      expect(() => clearKeysByPrefix(localStorage, 'p-')).not.toThrow();
+    } finally {
+      Storage.prototype.removeItem = original;
+    }
+  });
+
+  it('works against sessionStorage', () => {
+    sessionStorage.setItem('s-a', 'a');
+    sessionStorage.setItem('s-b', 'b');
+    sessionStorage.setItem('other', 'c');
+
+    clearKeysByPrefix(sessionStorage, 's-');
+
+    expect(sessionStorage.getItem('s-a')).toBeNull();
+    expect(sessionStorage.getItem('s-b')).toBeNull();
+    expect(sessionStorage.getItem('other')).toBe('c');
+  });
+});

--- a/src/lib/storage/key-utils.ts
+++ b/src/lib/storage/key-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared low-level storage helpers.
+ *
+ * Two prefix-sweep operations are duplicated in 7+ call sites across the
+ * codebase (`user-storage.ts`, `experiment-utils.ts`,
+ * `highlighted-guide-utils.ts`, `experiment-debug.ts`). They follow the same
+ * three-step pattern: iterate storage by index, collect matching keys into
+ * an array, then act on each. Routing through one helper makes the
+ * iteration order, error handling, and "skip keys that turn null mid-walk"
+ * behavior consistent across the codebase.
+ *
+ * These helpers operate on a `Storage` instance directly so they work
+ * against `localStorage`, `sessionStorage`, or any test double. They never
+ * route through `UserStorage` — the prefix sweep is a key-shape operation,
+ * not a value-shape operation.
+ */
+
+/**
+ * Return every key in `storage` that begins with `prefix`.
+ *
+ * Iterates from `storage.length - 1` down to 0 so a caller can safely
+ * `storage.removeItem(key)` while iterating without skipping siblings.
+ * Returns an empty array if storage access throws (private mode, etc).
+ */
+export function collectKeysByPrefix(storage: Storage, prefix: string): string[] {
+  const matches: string[] = [];
+  try {
+    for (let i = storage.length - 1; i >= 0; i--) {
+      const key = storage.key(i);
+      if (key !== null && key.startsWith(prefix)) {
+        matches.push(key);
+      }
+    }
+  } catch {
+    // Storage unavailable — caller treats absence as "no keys".
+  }
+  return matches;
+}
+
+/**
+ * Remove every key in `storage` that begins with `prefix`. Returns the
+ * list of keys that were cleared, in the order they were removed. Safe to
+ * call when storage is unavailable (returns `[]`).
+ */
+export function clearKeysByPrefix(storage: Storage, prefix: string): string[] {
+  const keys = collectKeysByPrefix(storage, prefix);
+  try {
+    for (const key of keys) {
+      storage.removeItem(key);
+    }
+  } catch {
+    // Partial removal is fine — the keys we did clear remain cleared.
+  }
+  return keys;
+}

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -14,6 +14,11 @@ import { panelModeManager } from './global-state/panel-mode';
 import { suggestionState } from './global-state/suggestion';
 import { handlePathfinderDeepLink, installDeepLinkNavListener } from './utils/pathfinder-deep-link-handler';
 import { parsePathfinderDeepLink } from './utils/pathfinder-search-params';
+import {
+  clearExtensionSidebarDocked,
+  isExtensionSidebarOwnedByPathfinder,
+  parseExtensionSidebarDocked,
+} from './lib/storage/extension-sidebar';
 
 // Buffer pathfinder-suggest events that arrive before async init completes.
 // Registered synchronously (before any await) so events from faster-loading
@@ -72,30 +77,14 @@ const highlightedGuideConfig = initializeHighlightedGuideExperiment(hostname);
 // Check if Pathfinder was already docked (browser restore scenario).
 // If floating mode is active, clear the docked state so Grafana doesn't
 // auto-open the sidebar on page load — the floating panel handles display.
-try {
-  const dockedValue = localStorage.getItem('grafana.navigation.extensionSidebarDocked');
-  if (dockedValue) {
-    let isPathfinderDocked = false;
-    try {
-      const parsedValue = JSON.parse(dockedValue);
-      isPathfinderDocked =
-        parsedValue.pluginId === pluginJson.id || parsedValue.componentTitle === 'Interactive learning';
-    } catch {
-      // Fallback for older Grafana versions that might store a simple string
-      isPathfinderDocked = dockedValue === pluginJson.id || dockedValue === 'Interactive learning';
-    }
-    if (isPathfinderDocked) {
-      const persistedMode = panelModeManager.getMode();
-      if (persistedMode === 'floating' || persistedMode === 'fullscreen') {
-        // Don't restore sidebar — another presentation surface owns the panel
-        localStorage.removeItem('grafana.navigation.extensionSidebarDocked');
-      } else {
-        sidebarState.setPendingOpenSource('browser_restore', 'restore');
-      }
-    }
+if (isExtensionSidebarOwnedByPathfinder(pluginJson.id, 'Interactive learning')) {
+  const persistedMode = panelModeManager.getMode();
+  if (persistedMode === 'floating' || persistedMode === 'fullscreen') {
+    // Don't restore sidebar — another presentation surface owns the panel
+    clearExtensionSidebarDocked();
+  } else {
+    sidebarState.setPendingOpenSource('browser_restore', 'restore');
   }
-} catch {
-  // localStorage might be unavailable
 }
 
 // Initialize translations
@@ -428,25 +417,12 @@ function handlePathfinderSuggest(event: CustomEvent, experimentVariant: string):
   }
 
   // Check if another plugin is occupying the sidebar
-  try {
-    const dockedValue = localStorage.getItem('grafana.navigation.extensionSidebarDocked');
-    if (dockedValue) {
-      let dockedPluginId: string | undefined;
-      try {
-        dockedPluginId = JSON.parse(dockedValue)?.pluginId;
-      } catch {
-        // Older Grafana versions may store a plain string
-      }
-
-      if (dockedPluginId && dockedPluginId !== pluginJson.id) {
-        console.warn('[Pathfinder] pathfinder-suggest rejected: sidebar occupied by', dockedPluginId);
-        detail.status = 'rejected';
-        detail.reason = 'sidebar_in_use';
-        return;
-      }
-    }
-  } catch {
-    // localStorage unavailable -- proceed optimistically
+  const docked = parseExtensionSidebarDocked();
+  if (docked?.pluginId && docked.pluginId !== pluginJson.id) {
+    console.warn('[Pathfinder] pathfinder-suggest rejected: sidebar occupied by', docked.pluginId);
+    detail.status = 'rejected';
+    detail.reason = 'sidebar_in_use';
+    return;
   }
 
   const buffered = detail._buffered === true;

--- a/src/utils/experiments/experiment-debug.ts
+++ b/src/utils/experiments/experiment-debug.ts
@@ -11,6 +11,7 @@
  */
 
 import { experimentAutoOpenStorage } from '../../lib/user-storage';
+import { collectKeysByPrefix } from '../../lib/storage/key-utils';
 import { StorageKeys } from '../../lib/storage-keys';
 import {
   getExperimentConfig,
@@ -31,24 +32,15 @@ interface ExposureMarker {
 
 function listExposureMarkers(hostname: string): ExposureMarker[] {
   const prefix = `${StorageKeys.EXPERIMENT_EXPOSURE_REPORTED_PREFIX}${hostname}:`;
-  const markers: ExposureMarker[] = [];
-  try {
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i);
-      if (key && key.startsWith(prefix)) {
-        // Marker shape: `{prefix}{hostname}:{flagKey}:{variant}`
-        // flagKey contains a dot but never a colon, so split on the last colon.
-        const suffix = key.slice(prefix.length);
-        const lastColon = suffix.lastIndexOf(':');
-        const flag = lastColon >= 0 ? suffix.slice(0, lastColon) : suffix;
-        const variant = lastColon >= 0 ? suffix.slice(lastColon + 1) : '';
-        markers.push({ key, flag, variant });
-      }
-    }
-  } catch {
-    // localStorage unavailable — return empty
-  }
-  return markers;
+  return collectKeysByPrefix(localStorage, prefix).map((key) => {
+    // Marker shape: `{prefix}{hostname}:{flagKey}:{variant}`
+    // flagKey contains a dot but never a colon, so split on the last colon.
+    const suffix = key.slice(prefix.length);
+    const lastColon = suffix.lastIndexOf(':');
+    const flag = lastColon >= 0 ? suffix.slice(0, lastColon) : suffix;
+    const variant = lastColon >= 0 ? suffix.slice(lastColon + 1) : '';
+    return { key, flag, variant };
+  });
 }
 
 // Rate limiting for refetch
@@ -101,13 +93,7 @@ export function createExperimentDebugger(experimentConfig: ExperimentConfig): vo
       console.log('[Pathfinder] Clearing all storage...');
 
       // Find all per-page treatment keys
-      const perPageKeys: string[] = [];
-      for (let i = 0; i < sessionStorage.length; i++) {
-        const key = sessionStorage.key(i);
-        if (key && key.startsWith(storageKeys.treatmentPagePrefix)) {
-          perPageKeys.push(key);
-        }
-      }
+      const perPageKeys = collectKeysByPrefix(sessionStorage, storageKeys.treatmentPagePrefix);
 
       // Show current state before clearing
       const perPageState: Record<string, string | null> = {};
@@ -168,11 +154,8 @@ export function createExperimentDebugger(experimentConfig: ExperimentConfig): vo
     showCache: async () => {
       // Find all per-page treatment keys
       const perPageKeys: Record<string, string | null> = {};
-      for (let i = 0; i < sessionStorage.length; i++) {
-        const key = sessionStorage.key(i);
-        if (key && key.startsWith(storageKeys.treatmentPagePrefix)) {
-          perPageKeys[key] = sessionStorage.getItem(key);
-        }
+      for (const key of collectKeysByPrefix(sessionStorage, storageKeys.treatmentPagePrefix)) {
+        perPageKeys[key] = sessionStorage.getItem(key);
       }
 
       // Get Grafana user storage state

--- a/src/utils/experiments/experiment-utils.ts
+++ b/src/utils/experiments/experiment-utils.ts
@@ -7,6 +7,11 @@
 
 import { matchPathPattern } from '../openfeature';
 import { experimentAutoOpenStorage, StorageKeys } from '../../lib/user-storage';
+import { clearKeysByPrefix } from '../../lib/storage/key-utils';
+import {
+  isExtensionSidebarInUse,
+  isExtensionSidebarOwnedByOther as parsedIsOwnedByOther,
+} from '../../lib/storage/extension-sidebar';
 
 // ============================================================================
 // STORAGE KEY HELPERS
@@ -164,12 +169,7 @@ export async function resetExperimentState(hostname: string): Promise<void> {
   sessionStorage.removeItem(keys.treatmentOpened);
 
   // Clear per-page keys from sessionStorage
-  for (let i = sessionStorage.length - 1; i >= 0; i--) {
-    const key = sessionStorage.key(i);
-    if (key && key.startsWith(keys.treatmentPagePrefix)) {
-      sessionStorage.removeItem(key);
-    }
-  }
+  clearKeysByPrefix(sessionStorage, keys.treatmentPagePrefix);
 
   // Reset Grafana user storage
   await experimentAutoOpenStorage.reset();
@@ -211,12 +211,7 @@ export function shouldAutoOpenForPath(hostname: string, targetPages: string[], c
  * @returns true if a sidebar is already docked/open, false otherwise
  */
 export function isSidebarAlreadyInUse(): boolean {
-  try {
-    return localStorage.getItem('grafana.navigation.extensionSidebarDocked') !== null;
-  } catch {
-    // localStorage might be unavailable in some contexts
-    return false;
-  }
+  return isExtensionSidebarInUse();
 }
 
 /**
@@ -234,22 +229,7 @@ export function isSidebarAlreadyInUse(): boolean {
  * the docked plugin id as a bare string instead of `{ pluginId: ... }`.
  */
 export function isExtensionSidebarOwnedByOther(myPluginId: string): boolean {
-  try {
-    const raw = localStorage.getItem('grafana.navigation.extensionSidebarDocked');
-    if (!raw) {
-      return false;
-    }
-    let dockedPluginId: string | undefined;
-    try {
-      const parsed = JSON.parse(raw) as { pluginId?: unknown };
-      dockedPluginId = typeof parsed.pluginId === 'string' ? parsed.pluginId : undefined;
-    } catch {
-      dockedPluginId = raw;
-    }
-    return Boolean(dockedPluginId) && dockedPluginId !== myPluginId;
-  } catch {
-    return false;
-  }
+  return parsedIsOwnedByOther(myPluginId);
 }
 
 /**

--- a/src/utils/experiments/highlighted-guide-utils.ts
+++ b/src/utils/experiments/highlighted-guide-utils.ts
@@ -17,6 +17,7 @@
  * context-engine's featured-injection seam.
  */
 
+import { clearKeysByPrefix } from '../../lib/storage/key-utils';
 import { StorageKeys } from '../../lib/storage-keys';
 import type { Recommendation } from '../../types/context.types';
 import { findDocPage } from '../find-doc-page';
@@ -53,19 +54,8 @@ export function markHighlightedGuideAutoOpened(hostname: string, guideId: string
 }
 
 export function clearHighlightedGuideMarkers(hostname: string): void {
-  try {
-    const prefix = `${StorageKeys.HIGHLIGHTED_GUIDE_AUTO_OPEN_PREFIX}${hostname}:`;
-    const toRemove: string[] = [];
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i);
-      if (key && key.startsWith(prefix)) {
-        toRemove.push(key);
-      }
-    }
-    toRemove.forEach((key) => localStorage.removeItem(key));
-  } catch {
-    // localStorage unavailable
-  }
+  const prefix = `${StorageKeys.HIGHLIGHTED_GUIDE_AUTO_OPEN_PREFIX}${hostname}:`;
+  clearKeysByPrefix(localStorage, prefix);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Extracts three shared storage utilities that deduplicate patterns flagged as B1 (near-duplicate function) and B4 (convergent re-bugging) in `USER_STORAGE_ANALYSIS.md`. The two prefix-sweep helpers and the extension-sidebar parser are prerequisites for the next PR in this stack (PR4 / badge eviction); the `usePersistedLocalState` hook is a UI-prefs convenience that retires hand-rolled state-from-localStorage boilerplate in five components.

## What to look at

- **[`src/lib/storage/key-utils.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/7f91a8cec36114adec2e7cc1fda6b1f567dbfafe/src/lib/storage/key-utils.ts)** — `collectKeysByPrefix(storage, prefix)` / `clearKeysByPrefix(storage, prefix)`. Iterates descending so callers can `removeItem` during the sweep without skipping siblings. Migrates `highlighted-guide-utils.clearHighlightedGuideMarkers`, `experiment-utils.resetExperimentState`, and three sites in `experiment-debug` (`listExposureMarkers`, `clearCache`, `showCache`).
- **[`src/lib/storage/extension-sidebar.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/7f91a8cec36114adec2e7cc1fda6b1f567dbfafe/src/lib/storage/extension-sidebar.ts)** — `parseExtensionSidebarDocked()` plus four narrow helpers (`isExtensionSidebarOwnedByOther`, `isExtensionSidebarOwnedByPathfinder`, `isExtensionSidebarInUse`, `clearExtensionSidebarDocked`). One canonical parser for the `grafana.navigation.extensionSidebarDocked` key, which previously had three subtly-different parse paths (`module.tsx` restore, `module.tsx` suggest-reject, `experiment-utils.isExtensionSidebarOwnedByOther`) — the JSON-then-legacy-string fallback varied between them. The legacy call sites delegate.
- **[`src/hooks/usePersistedLocalState.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/7f91a8cec36114adec2e7cc1fda6b1f567dbfafe/src/hooks/usePersistedLocalState.ts)** — generic + `usePersistedString` + `usePersistedBoolean`. **Note the first-effect-run skip**: the write-on-change effect deliberately skips the initial render so the default value never gets persisted unprompted. Without that guard, `ConditionChipsField` and `HealthStatusBar` would start writing `'false'` to localStorage just because the component mounted, which would change the observable contract for those keys — `ConditionChipsField.test.tsx:197` explicitly tests the "absent until user toggles" behavior.
- **Component migrations**: `UrlTester.tsx`, `SelectorDebugPanel.tsx`, `HealthStatusBar.tsx`, `ConditionChipsField.tsx`. The `hooks/index.ts` barrel adds the three exports so consumers import from `'../../hooks'`, not the internal path.

## Why

`USER_STORAGE_ANALYSIS.md` identified these three patterns as cross-cutting debt that was blocking cleaner extraction in user-storage and learning-paths. The prefix-sweep utility is a direct prerequisite for PR4 — the badge coordinator's deletion of `learningProgressStorage.markGuideCompleted` from `user-storage.ts` doesn't itself need the helper, but the user-storage decomposition that follows will. The extension-sidebar parser closes a real B4 bug class: the three parsers previously disagreed on whether to treat a legacy plain-string value as a `pluginId`.

## How to verify

1. Open the dev panel (with dev mode enabled). Type a URL into URL Tester, refresh the page — confirm the URL persists. Toggle PR Tester and URL Tester sections open / closed, refresh, confirm state restores.
2. Open the block editor. Toggle the health-status bar expanded / collapsed, refresh, confirm restore. In a condition field (e.g., requirements), click "View raw" → "Use chip editor", refresh, confirm the chosen mode restores.
3. With another plugin currently docked in the Grafana extension sidebar, dispatch a `pathfinder-suggest` event and confirm it's rejected with `reason: 'sidebar_in_use'`. Then with Pathfinder docked, confirm a fresh suggest succeeds.

## Breaking changes

None. All migrations preserve the existing storage key strings and the existing read/write contracts. The `usePersistedLocalState` hook intentionally does NOT write the default value on mount, preserving the call-site behavior where `localStorage.getItem(KEY)` returns `null` until the user actually toggles the preference.

## Out of scope

- **PrTester migration is deferred.** Its storage is a multi-key coupled cache (PR URL + fetched files JSON + the URL that the files were fetched for — all three must invalidate atomically when the URL changes). That fits a typed multi-key reducer, not a single-key hook. Will be a separate follow-up.
- **`user-storage.ts` internal prefix sweeps not migrated.** Six existing inline sweeps in `clearAllForContent`, `clearAll`, `hasProgress`, `countAllCompleted`, `countAllAcknowledged` are intentionally left for the user-storage decomposition PR where they'll be revisited alongside the broader L1/L2 split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
