### PR TITLE
feat(twotab): open an interactive guide in a controller tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,19 +189,21 @@ Excluded from tier analysis (not tiered): `test-utils/`, `cli/`, `bundled-intera
 
 **Key dependency edges** (where the load-bearing wiring lives):
 
-| Edge                                           | Why                                                            |
-| ---------------------------------------------- | -------------------------------------------------------------- |
-| `context-engine` → `docs-retrieval`            | Fetches content for the recommendations it surfaces            |
-| `docs-retrieval` → `bundled-interactives`      | Fallback when the online CDN is unavailable                    |
-| `docs-retrieval` → `package-engine`            | Resolves package manifests + content                           |
-| `docs-retrieval` → `snippet-engine`            | Inlines `snippet-ref` blocks against the CDN at parse time     |
-| `components/docs-panel` → `interactive-engine` | Executes step actions when the user clicks "Show me" / "Do it" |
-| `interactive-engine` → `requirements-manager`  | Checks prereqs before enabling / executing a step              |
-| `interactive-engine` → `lib/dom`               | Selector resolution + element detection                        |
-| `components/docs-panel` → `context-engine`     | Reads and renders recommendations                              |
-| `components/docs-panel` → `global-state`       | Sidebar, panel-mode, tab persistence                           |
-| `learning-paths` → `lib/user-storage`          | Persists progress + streak data                                |
-| `recovery` → `requirements-manager`            | Decides whether a failed requirement is auto-recoverable       |
+| Edge                                                          | Why                                                                                |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `context-engine` → `docs-retrieval`                           | Fetches content for the recommendations it surfaces                                |
+| `docs-retrieval` → `bundled-interactives`                     | Fallback when the online CDN is unavailable                                        |
+| `docs-retrieval` → `package-engine`                           | Resolves package manifests + content                                               |
+| `docs-retrieval` → `snippet-engine`                           | Inlines `snippet-ref` blocks against the CDN at parse time                         |
+| `components/docs-panel` → `interactive-engine`                | Executes step actions when the user clicks "Show me" / "Do it"                     |
+| `interactive-engine` → `requirements-manager`                 | Checks prereqs before enabling / executing a step                                  |
+| `interactive-engine` → `lib/dom`                              | Selector resolution + element detection                                            |
+| `components/docs-panel` → `context-engine`                    | Reads and renders recommendations                                                  |
+| `components/docs-panel` → `global-state`                      | Sidebar, panel-mode, tab persistence                                               |
+| `learning-paths` → `lib/user-storage`                         | Persists progress + streak data                                                    |
+| `recovery` → `requirements-manager`                           | Decides whether a failed requirement is auto-recoverable                           |
+| `global-state/controller-channel` → `lib/cross-tab-transport` | BroadcastChannel link between a popped-out controller tab and the live Grafana tab |
+| `integrations/cross-tab` → `interactive-engine`               | Live tab replays a controller tab's step commands against its own DOM              |
 
 For per-subsystem entry points, public surfaces, and key files, load `.cursor/rules/systemPatterns.mdc`.
 

--- a/docs/developer/CONTEXT_INDEX.md
+++ b/docs/developer/CONTEXT_INDEX.md
@@ -56,14 +56,15 @@ Load these files **only when working in the relevant domain**.
 
 ## Dev mode, local dev, live sessions
 
-| File                       | When to load                                            | Auto-triggered by globs        |
-| -------------------------- | ------------------------------------------------------- | ------------------------------ |
-| `DEV_MODE.md`              | Dev mode configuration and debugging tools              | `src/utils/dev-mode.ts`        |
-| `LOCAL_DEV.md`             | Local development setup, prerequisites, Docker workflow | --                             |
-| `LIVE_SESSIONS.md`         | Live sessions feature (WebRTC, PeerJS)                  | `src/components/LiveSession/*` |
-| `KNOWN_ISSUES.md`          | Known bugs and workarounds                              | --                             |
-| `integrations/workshop.md` | Workshop mode, action capture and replay                | `src/integrations/workshop/*`  |
-| `SCALE_TESTING.md`         | Live session scale testing procedures                   | --                             |
+| File                       | When to load                                                                                          | Auto-triggered by globs                                                   |
+| -------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `DEV_MODE.md`              | Dev mode configuration and debugging tools                                                            | `src/utils/dev-mode.ts`                                                   |
+| `LOCAL_DEV.md`             | Local development setup, prerequisites, Docker workflow                                               | --                                                                        |
+| `LIVE_SESSIONS.md`         | Live sessions feature (WebRTC, PeerJS)                                                                | `src/components/LiveSession/*`                                            |
+| `KNOWN_ISSUES.md`          | Known bugs and workarounds                                                                            | --                                                                        |
+| `integrations/workshop.md` | Workshop mode, action capture and replay                                                              | `src/integrations/workshop/*`                                             |
+| `CROSS_TAB_CONTROLLER.md`  | Two-tab interactive controller — a popped-out guide drives the live Grafana tab over BroadcastChannel | `src/integrations/cross-tab/*`, `src/global-state/controller-channel.tsx` |
+| `SCALE_TESTING.md`         | Live session scale testing procedures                                                                 | --                                                                        |
 
 ## Subsystem references
 

--- a/docs/developer/CROSS_TAB_CONTROLLER.md
+++ b/docs/developer/CROSS_TAB_CONTROLLER.md
@@ -1,0 +1,209 @@
+# Two-tab interactive controller
+
+The interactive controller lets a guide popped out into its own browser tab
+**drive interactivity in the original Grafana tab**. You read the guide on (say)
+a second monitor and click "Show me" / "Do it" there; the highlight or action
+runs against the live Grafana in the first tab.
+
+It reuses the full-screen guide-reader overlay: same overlay, but in controller
+mode the step controls stay visible and route their actions over a cross-tab
+channel instead of executing locally. (The overlay defaults to a non-driving
+`interactive` mode; controller mode is an explicit opt-in via `?controller=1`.)
+
+## How a user reaches it
+
+The docs content-meta toolbar shows an **Interactive** button for guides with no
+public doc page (`backend-guide:` / `api:` / interactive-learning packages —
+`pickControllerTabOpenAction`). It opens a same-origin tab at
+`/?doc=<guide>&controller=1`. Being same-origin, the new tab inherits the Grafana
+session via cookies.
+
+## Data flow
+
+```
+Controller tab (?controller=1)                Live Grafana tab (normal load)
+──────────────────────────────                ──────────────────────────────
+GuideReaderOverlay mode="controller"          module.tsx normal path
+  └ ControllerChannelProvider                   └ installLiveTabExecutor()
+      step click → emit step-command ───►  BroadcastChannel  ───► run via interactive-engine
+      heartbeat (controller)  ───────────► 'pathfinder-cross-tab' ──► ack heartbeat (live)
+      connection badge  ◄──────────────────────────────────────────┘
+```
+
+- **Same browser, same profile only.** `BroadcastChannel` is scoped to one
+  browser profile. A different browser, profile, or device would need the WebRTC
+  transport used by Workshop / Live Sessions, not this one.
+- The controller tab short-circuits in `module.tsx` and never installs the
+  executor; only the normal (live) load does.
+
+## Key files by layer
+
+| Concern                        | File                                                                                                                        |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| Deep-link param `controller=1` | `src/utils/pathfinder-search-params.ts`                                                                                     |
+| Mount the controller overlay   | `src/module.tsx` (`?controller=1` short-circuit)                                                                            |
+| Overlay + status badge         | `src/components/guide-reader/GuideReaderOverlay.tsx`                                                                        |
+| "Interactive" affordance       | `src/components/docs-panel/utils/controller-tab-open-action.ts` (`pickControllerTabOpenAction`), `DocsPanelContentArea.tsx` |
+| Interactive mode enum          | `src/global-state/interactive-mode-context.ts` (`InteractiveMode`, `useInteractiveMode`)                                    |
+| Transport                      | `src/lib/cross-tab-transport.ts` (`CrossTabTransport`)                                                                      |
+| Message protocol               | `src/types/cross-tab.types.ts`                                                                                              |
+| Controller emit + presence     | `src/global-state/controller-channel.tsx` (`ControllerChannelProvider`, `useControllerChannel`)                             |
+| Per-step emit                  | `interactive-step.tsx`, `interactive-multi-step.tsx`, `interactive-guided.tsx` (handlers branch on `useInteractiveMode()`)  |
+| Requirement round-trip         | `src/requirements-manager/step-checker.hook.ts` (controller branch), `controller-requirements.ts` (tab-local set)           |
+| Live-tab executor              | `src/integrations/cross-tab/live-tab-executor.ts` (`installLiveTabExecutor`: replay, requirement eval, remote fix)          |
+
+## Message protocol
+
+`CrossTabMessage` (`types/cross-tab.types.ts`) is a discriminated union sent over
+the `pathfinder-cross-tab` channel. Every message carries an envelope
+(`source: 'pathfinder'`, a per-tab `senderId` used to drop self-echoes, and a
+`timestamp`):
+
+- `step-command` — `{ phase: 'show' | 'do', stepId, action: { targetAction, refTarget, targetValue?, targetComment?, internalActions? } }`.
+  Composite steps carry their ordered sub-actions in `internalActions`. A
+  `multistep` replays with staged pacing (see [Replay pacing](#replay-pacing));
+  a `guided` step runs through the live tab's `GuidedHandler` instead — it
+  highlights each target and waits for the user.
+- `step-complete` — `{ stepId, ok }`, live → controller, signals a composite
+  actually finished so the controller marks completion only then.
+- `step-progress` — `{ stepId, index, total }`, live → controller, reports which
+  internal action a composite is replaying so the controller can animate per-step
+  progress while it runs on the live tab.
+- `heartbeat` — `{ role: 'controller' | 'live' }`
+- `check-requirements` / `requirement-result` — the requirement round-trip
+  (controller → live → controller), correlated by `requestId`.
+- `fix-requirement` / `fix-result` — a "Fix this" routed to the live tab,
+  correlated by `requestId`.
+
+The transport degrades to a no-op where `BroadcastChannel` is unavailable. The
+provider is inert until a tab actually drives one; the executor, however, is a
+DOM sink and is **not** unconditionally safe to install — see the trust model.
+
+## Security / trust model
+
+`BroadcastChannel` is shared by every script running on the same origin, so a
+message on `pathfinder-cross-tab` is **not** proof it came from a Pathfinder
+controller — a compromised co-plugin, a panel/datasource XSS, or a browser
+extension content script could forge one. The live-tab executor turns messages
+into real actions (navigate, button clicks, form fills) against the user's
+authenticated Grafana, so the channel is treated as untrusted input:
+
+- **Per-kind validation.** Every inbound message is checked against
+  `validateCrossTabMessage` (`types/cross-tab.types.ts`) — envelope plus the
+  kind-specific shape, with `step-command` actions restricted to a known verb
+  set — at the transport receive gate _and_ again at the executor sink, before
+  any action runs. Malformed or unknown-kind messages are dropped.
+- **Install/entry gating.** The executor is installed, and the controller
+  overlay mounted, only when `pathfinderEnabled` is true — a disabled plugin
+  exposes neither the sink nor the driver.
+- **Same-build / same-origin / one-session assumption.** Controller and live
+  tabs are the same plugin build in the same browser profile and session; there
+  is no protocol-version negotiation and cross-version compatibility is not a
+  goal.
+
+This is a same-origin trust posture, not authentication: validation constrains
+_what_ a forged message can ask for, and gating limits _when_ the sink exists.
+
+### Known limitations / future work
+
+**No sender authentication (v1).** The controller binds to the first live tab
+that answers its heartbeat (see [Tab pairing](#tab-pairing)) — there is no
+handshake proving the responder is a genuine Pathfinder live tab. Any same-origin
+script that learns the channel name can claim the pairing slot with a forged
+`live` heartbeat; once paired it can drive `check-requirements` /
+`fix-requirement`, which run navigation and DOM mutation against the
+authenticated live tab — the highest-risk surface. Per-kind validation constrains
+message _shape_, not _authorization_. Candidate mitigations for a future version:
+a gesture-to-accept on the live tab, or an out-of-band nonce exchanged when the
+controller opens the tab. (Mirrored by the `TODO(twotab)` at the pairing site in
+`controller-channel.tsx`.)
+
+## Tab pairing
+
+A controller binds to the **first live tab that answers** its heartbeat and
+records that tab's `senderId` (`controller-channel.tsx`). It then ignores
+replies — `requirement-result`, `fix-result`, `step-complete` — from any other
+tab, so a second Grafana tab can't answer a requirement check with a different
+DOM state. It re-pairs if the bound tab goes stale. Commands themselves are still
+broadcast (every live tab executes them); only the replies the controller trusts
+are scoped to the paired tab.
+
+## Replay pacing
+
+A `multistep` posts a single `step-command` (`phase: 'do'`) carrying its
+`internalActions`. The live-tab executor replays each action the way a normal
+multi-step paces itself — highlight (show) → pause → perform (do) → settle →
+inter-step pause — so the user watches the same staged sequence in the live tab
+rather than an instant burst. Pacing constants come from
+`INTERACTIVE_CONFIG.delays.multiStep` and are injectable for tests. A `guided`
+step is **not** auto-replayed: the executor runs each action through
+`GuidedHandler` so the user performs it on the live tab. Either way the executor
+posts `step-complete` when the sequence finishes, and the controller waits for
+that before marking the step done (so a guided step isn't completed on click).
+
+## Requirement evaluation (round-trip)
+
+A controller tab drives a _different_ Grafana tab, so requirements that probe
+the live tab's DOM / URL (`exists-reftarget`, `navmenu-open`, `on-page:`,
+`form-valid`) can't be evaluated locally. Rather than strip and ignore them, the
+controller asks the live tab:
+
+```
+Controller (useStepChecker, controller mode)        Live tab (installLiveTabExecutor)
+  requestRequirementCheck ─ check-requirements ─►  checkRequirements() against real DOM
+  createRequirementsState ◄─ requirement-result ──  reply { pass, error[] (canFix/fixType) }
+  "Fix this" → requestFix ─ fix-requirement ────►  dispatchFix() against real DOM
+  recheck                 ◄─ fix-result ──────────  reply { ok, error? }
+```
+
+- The reply is a plain `RequirementsCheckResult`; it flows through the **same**
+  `createRequirementsState` path the in-tab checker uses, so the warning and
+  "Fix this" affordance render identically — no controller-specific UI.
+- Evaluation and fixes run on the **live** side (tier 3 → requirements-manager,
+  a legal downward import). `controller-channel.tsx` (tier 1) only correlates
+  replies by `requestId` and carries the result as a tier-0 type — it must not
+  import requirements-manager (upward).
+- A controller-mode heartbeat polls while a fragile step is **blocked** (the
+  in-tab watchdog only polls while enabled), so the warning clears once the
+  prerequisite is met on the live tab.
+- The round-trip does not depend on the `connected` heartbeat badge:
+  `requestRequirementCheck` posts regardless of connection state (the channel
+  value omits `connected`), so the check fires the moment a step renders;
+  `connected` only drives the presence badge.
+- If no live tab answers within the timeout, the check falls back to stripping
+  the tab-local tokens and evaluating the rest locally — session/permission
+  requirements still gate, and a disconnected controller never hangs.
+
+## Presence
+
+The controller pings a `controller` heartbeat on an interval; the live executor
+replies with a `live` heartbeat for each ping it receives. The controller marks
+itself connected on the first reply and stale (back to "waiting") if none arrives
+within the timeout — so closing or navigating away from the live tab flips the
+badge.
+
+## Scope and limitations
+
+- **Routed:** `interactive-step` (Show me / Do it), multi-step (staged replay),
+  and guided (runs through `GuidedHandler` on the live tab). Requirements —
+  including tab-local ones — are evaluated and fixed on the live tab, re-checked
+  at click time so a regressed prerequisite gates, and composites complete only
+  once the live tab reports `step-complete`.
+- **Replies scoped to one live tab:** a controller trusts requirement/fix/
+  completion replies from a single paired tab; see [Tab pairing](#tab-pairing).
+  Commands are still broadcast, so multiple live tabs all execute them.
+- **Not yet routed:** a section's aggregate "Do section" runs its child steps
+  directly rather than emitting one command; quiz grading is local (so it still
+  works in the controller); terminal / challenge need a shared VM session and are
+  out of scope.
+- Completion sync rides the existing `completion-store` cross-tab storage event
+  when the same guide is open in the live tab; otherwise it is not yet propagated.
+
+## Extending to more step types
+
+1. In the step component's click handler, branch on `useInteractiveMode() === 'controller'`
+   and call `useControllerChannel()?.post(...)` with a `step-command` (mirror
+   `interactive-step.tsx`) instead of executing locally.
+2. If the action shape differs (e.g. `internalActions` for multi-step / guided),
+   extend `CrossTabAction` / `CrossTabMessage` and handle the new shape in
+   `live-tab-executor.ts`.

--- a/src/components/docs-panel/components/DocsPanelContentArea.tsx
+++ b/src/components/docs-panel/components/DocsPanelContentArea.tsx
@@ -28,7 +28,7 @@ import { PLUGIN_BASE_URL } from '../../../constants';
 import { testIds } from '../../../constants/testIds';
 import type { LearningJourneyTab, PackageOpenInfo, ContextPanelState } from '../../../types/content-panel.types';
 import type { getStyles as getDocsPanelStyles } from '../../../styles/docs-panel.styles';
-import { isDocsLikeTab, pickGrafanaDocsOpenAction } from '../utils';
+import { isDocsLikeTab, pickGrafanaDocsOpenAction, pickControllerTabOpenAction } from '../utils';
 import { reportAppInteraction, UserInteraction, getContentTypeForAnalytics } from '../../../lib/analytics';
 import { getMilestoneSlug, markMilestoneDone, setJourneyCompletionPercentage } from '../../../docs-retrieval';
 import { ContentRenderer } from '../../content-renderer/content-renderer';
@@ -307,6 +307,36 @@ export function DocsPanelContentArea(props: DocsPanelContentAreaProps): React.Re
                             setTimeout(() => {
                               window.open(cleanUrl, '_blank', 'noopener,noreferrer');
                             }, 100);
+                          }}
+                        >
+                          <Icon name="external-link-alt" size="sm" />
+                          <span>{t('docsPanel.open', 'Open')}</span>
+                        </button>
+                      );
+                    })()}
+                    {(() => {
+                      const guideUrl = activeTab.content?.url || activeTab.baseUrl;
+                      const action = pickControllerTabOpenAction(guideUrl, activeTab.type);
+                      if (!action.shouldShow || !action.controllerUrl) {
+                        return null;
+                      }
+                      const controllerUrl = action.controllerUrl;
+                      return (
+                        <button
+                          className={styles.secondaryActionButton}
+                          aria-label={t('docsPanel.openControllerInNewTab', 'Open in interactive window')}
+                          title={t('docsPanel.openControllerInNewTab', 'Open in interactive window')}
+                          data-testid={testIds.docsPanel.openControllerTabButton}
+                          onClick={() => {
+                            reportAppInteraction(UserInteraction.OpenExtraResource, {
+                              content_url: guideUrl || 'unknown',
+                              content_type: getContentTypeForAnalytics(guideUrl, activeTab.type || 'interactive'),
+                              link_text: activeTab.title,
+                              source_page: 'docs_content_meta_right',
+                              link_type: 'external_browser',
+                              interaction_location: 'docs_content_meta_right',
+                            });
+                            window.open(controllerUrl, '_blank', 'noopener,noreferrer');
                           }}
                         >
                           <Icon name="external-link-alt" size="sm" />

--- a/src/components/docs-panel/components/DocsPanelContentArea.tsx
+++ b/src/components/docs-panel/components/DocsPanelContentArea.tsx
@@ -26,6 +26,7 @@ import { Button, Icon, IconButton } from '@grafana/ui';
 import { t } from '@grafana/i18n';
 import { PLUGIN_BASE_URL } from '../../../constants';
 import { testIds } from '../../../constants/testIds';
+import { TWOTAB_CONTROLLER_ENABLED } from '../../../constants/interactive-config';
 import type { LearningJourneyTab, PackageOpenInfo, ContextPanelState } from '../../../types/content-panel.types';
 import type { getStyles as getDocsPanelStyles } from '../../../styles/docs-panel.styles';
 import { isDocsLikeTab, pickGrafanaDocsOpenAction, pickControllerTabOpenAction } from '../utils';
@@ -315,6 +316,9 @@ export function DocsPanelContentArea(props: DocsPanelContentAreaProps): React.Re
                       );
                     })()}
                     {(() => {
+                      if (!TWOTAB_CONTROLLER_ENABLED) {
+                        return null;
+                      }
                       const guideUrl = activeTab.content?.url || activeTab.baseUrl;
                       const action = pickControllerTabOpenAction(guideUrl, activeTab.type);
                       if (!action.shouldShow || !action.controllerUrl) {

--- a/src/components/docs-panel/docs-panel.contract.test.tsx
+++ b/src/components/docs-panel/docs-panel.contract.test.tsx
@@ -119,6 +119,7 @@ const SOURCE_CONTRACT: Array<{ file: string; references: string[] }> = [
     file: 'components/DocsPanelContentArea.tsx',
     references: [
       'testIds.docsPanel.content',
+      'testIds.docsPanel.openControllerTabButton',
       'testIds.devTools.previewBanner',
       'testIds.devTools.previewModeIndicator',
       'testIds.devTools.returnToEditorButton',

--- a/src/components/docs-panel/utils/controller-tab-open-action.test.ts
+++ b/src/components/docs-panel/utils/controller-tab-open-action.test.ts
@@ -1,0 +1,26 @@
+import { pickControllerTabOpenAction } from './controller-tab-open-action';
+
+describe('pickControllerTabOpenAction', () => {
+  it('returns shouldShow=false without a url', () => {
+    expect(pickControllerTabOpenAction(undefined, 'interactive')).toEqual({ shouldShow: false });
+  });
+
+  it('returns shouldShow=false for non-interactive tab types', () => {
+    expect(pickControllerTabOpenAction('backend-guide:x', 'docs')).toEqual({ shouldShow: false });
+    expect(pickControllerTabOpenAction('backend-guide:x', undefined)).toEqual({ shouldShow: false });
+  });
+
+  it('builds a same-origin controller URL for an interactive tab', () => {
+    const result = pickControllerTabOpenAction('backend-guide:my-guide', 'interactive');
+    expect(result.shouldShow).toBe(true);
+    const url = new URL(result.controllerUrl!, 'http://localhost');
+    expect(url.pathname).toBe('/');
+    expect(url.searchParams.get('doc')).toBe('backend-guide:my-guide');
+    expect(url.searchParams.get('controller')).toBe('1');
+    expect(url.searchParams.get('readonly')).toBeNull();
+  });
+
+  it('shows for an interactive guide regardless of url scheme (e.g. bundled)', () => {
+    expect(pickControllerTabOpenAction('bundled:alerting-101', 'interactive').shouldShow).toBe(true);
+  });
+});

--- a/src/components/docs-panel/utils/controller-tab-open-action.ts
+++ b/src/components/docs-panel/utils/controller-tab-open-action.ts
@@ -1,0 +1,17 @@
+export interface ControllerTabOpenAction {
+  shouldShow: boolean;
+  controllerUrl?: string;
+}
+
+export function pickControllerTabOpenAction(
+  url: string | undefined,
+  tabType: string | undefined
+): ControllerTabOpenAction {
+  if (!url || tabType !== 'interactive') {
+    return { shouldShow: false };
+  }
+  const params = new URLSearchParams();
+  params.set('doc', url);
+  params.set('controller', '1');
+  return { shouldShow: true, controllerUrl: `/?${params.toString()}` };
+}

--- a/src/components/docs-panel/utils/controller-tab-open-action.ts
+++ b/src/components/docs-panel/utils/controller-tab-open-action.ts
@@ -1,3 +1,5 @@
+import type { LearningJourneyTab } from '../../../types/content-panel.types';
+
 export interface ControllerTabOpenAction {
   shouldShow: boolean;
   controllerUrl?: string;
@@ -5,7 +7,7 @@ export interface ControllerTabOpenAction {
 
 export function pickControllerTabOpenAction(
   url: string | undefined,
-  tabType: string | undefined
+  tabType: LearningJourneyTab['type']
 ): ControllerTabOpenAction {
   if (!url || tabType !== 'interactive') {
     return { shouldShow: false };

--- a/src/components/docs-panel/utils/index.ts
+++ b/src/components/docs-panel/utils/index.ts
@@ -13,3 +13,5 @@ export { loadDocsTabContentResult, UNRESOLVED_PACKAGE_ERROR } from './docs-tab-l
 export { findCurrentMilestoneIndex } from './milestone-index';
 export { pickGrafanaDocsOpenAction } from './grafana-docs-open-action';
 export type { GrafanaDocsOpenAction } from './grafana-docs-open-action';
+export { pickControllerTabOpenAction } from './controller-tab-open-action';
+export type { ControllerTabOpenAction } from './controller-tab-open-action';

--- a/src/components/guide-reader/GuideReaderOverlay.test.tsx
+++ b/src/components/guide-reader/GuideReaderOverlay.test.tsx
@@ -17,7 +17,10 @@ jest.mock('../OpenFeatureProvider', () => ({
 // responsibilities (fetch → render, close, error) rather than ContentRenderer
 // internals (covered by its own suite).
 jest.mock('../content-renderer/content-renderer', () => ({
-  ContentRenderer: () => <div data-testid="mock-content">content</div>,
+  ContentRenderer: () => {
+    const { useInteractiveMode } = require('../../global-state/interactive-readonly-context');
+    return <div data-testid="mock-content">mode:{useInteractiveMode()}</div>;
+  },
 }));
 
 const mockFetchContent = fetchUnifiedContent as jest.MockedFunction<typeof fetchUnifiedContent>;
@@ -42,6 +45,15 @@ describe('GuideReaderOverlay', () => {
     expect(mockFetchContent).toHaveBeenCalledWith('backend-guide:x');
     expect(screen.getByTestId(testIds.guideReader.overlay)).toBeInTheDocument();
     expect(await screen.findByTestId('mock-content')).toBeInTheDocument();
+  });
+
+  it('provides controller mode to the rendered content', async () => {
+    mockFetchContent.mockResolvedValue({ content: { url: 'backend-guide:x', type: 'interactive' } } as any);
+
+    render(<GuideReaderOverlay doc="backend-guide:x" mode="controller" />);
+
+    const content = await screen.findByTestId('mock-content');
+    expect(content).toHaveTextContent('mode:controller');
   });
 
   it('closes the tab when the close button is clicked', async () => {

--- a/src/components/guide-reader/GuideReaderOverlay.test.tsx
+++ b/src/components/guide-reader/GuideReaderOverlay.test.tsx
@@ -18,7 +18,7 @@ jest.mock('../OpenFeatureProvider', () => ({
 // internals (covered by its own suite).
 jest.mock('../content-renderer/content-renderer', () => ({
   ContentRenderer: () => {
-    const { useInteractiveMode } = require('../../global-state/interactive-readonly-context');
+    const { useInteractiveMode } = require('../../global-state/interactive-mode-context');
     return <div data-testid="mock-content">mode:{useInteractiveMode()}</div>;
   },
 }));
@@ -54,6 +54,15 @@ describe('GuideReaderOverlay', () => {
 
     const content = await screen.findByTestId('mock-content');
     expect(content).toHaveTextContent('mode:controller');
+  });
+
+  it('defaults to interactive mode (not the privileged controller) when none is passed', async () => {
+    mockFetchContent.mockResolvedValue({ content: { url: 'backend-guide:x', type: 'interactive' } } as any);
+
+    render(<GuideReaderOverlay doc="backend-guide:x" />);
+
+    const content = await screen.findByTestId('mock-content');
+    expect(content).toHaveTextContent('mode:interactive');
   });
 
   it('closes the tab when the close button is clicked', async () => {

--- a/src/components/guide-reader/GuideReaderOverlay.tsx
+++ b/src/components/guide-reader/GuideReaderOverlay.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { cx } from '@emotion/css';
 import { ThemeContext } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { Icon, useStyles2 } from '@grafana/ui';
@@ -10,13 +11,13 @@ import { journeyContentHtml, docsContentHtml } from '../../styles/content-html.s
 import { getInteractiveStyles } from '../../styles/interactive.styles';
 import { getPrismStyles } from '../../styles/prism.styles';
 import { InteractiveModeContext, type InteractiveMode } from '../../global-state/interactive-mode-context';
+import { ControllerChannelProvider, useControllerConnected } from '../../global-state/controller-channel';
 import { PathfinderFeatureProvider } from '../OpenFeatureProvider';
 import { testIds } from '../../constants/testIds';
 import type { RawContent } from '../../types/content.types';
 import { getGuideReaderStyles } from './guide-reader.styles';
 
 interface GuideReaderOverlayProps {
-  /** The `?doc=` value to render (e.g. `backend-guide:<id>`). */
   doc: string;
   mode?: InteractiveMode;
 }
@@ -41,6 +42,22 @@ function useGrafanaTheme() {
   }, []);
 
   return theme;
+}
+
+function ControllerStatusBadge() {
+  const styles = useStyles2(getGuideReaderStyles);
+  const connected = useControllerConnected();
+  return (
+    <div className={styles.controllerStatus} data-testid={testIds.guideReader.controllerStatus}>
+      <span
+        className={cx(
+          styles.controllerStatusDot,
+          connected ? styles.controllerStatusConnected : styles.controllerStatusWaiting
+        )}
+      />
+      {connected ? 'Connected to your Grafana tab' : 'Waiting for your Grafana tab…'}
+    </div>
+  );
 }
 
 /**
@@ -127,6 +144,12 @@ function GuideReaderInner({ doc, mode }: { doc: string; mode: InteractiveMode })
     ? `${content.type === 'learning-journey' ? journeyStyles : docsStyles} ${interactiveStyles} ${prismStyles}`
     : '';
 
+  const body = content ? (
+    <div ref={contentRef}>
+      <ContentRenderer content={content} containerRef={contentRef} className={contentClassName} />
+    </div>
+  ) : null;
+
   return createPortal(
     <div
       className={styles.backdrop}
@@ -159,11 +182,16 @@ function GuideReaderInner({ doc, mode }: { doc: string; mode: InteractiveMode })
             Loading guide...
           </div>
         )}
-        {content && (
+        {body && (
           <InteractiveModeContext.Provider value={mode}>
-            <div ref={contentRef}>
-              <ContentRenderer content={content} containerRef={contentRef} className={contentClassName} />
-            </div>
+            {mode === 'controller' ? (
+              <ControllerChannelProvider>
+                <ControllerStatusBadge />
+                {body}
+              </ControllerChannelProvider>
+            ) : (
+              body
+            )}
           </InteractiveModeContext.Provider>
         )}
       </div>

--- a/src/components/guide-reader/GuideReaderOverlay.tsx
+++ b/src/components/guide-reader/GuideReaderOverlay.tsx
@@ -9,7 +9,7 @@ import { fetchUnifiedContent } from '../../docs-retrieval';
 import { journeyContentHtml, docsContentHtml } from '../../styles/content-html.styles';
 import { getInteractiveStyles } from '../../styles/interactive.styles';
 import { getPrismStyles } from '../../styles/prism.styles';
-import { InteractiveModeContext, type InteractiveMode } from '../../global-state/interactive-readonly-context';
+import { InteractiveModeContext, type InteractiveMode } from '../../global-state/interactive-mode-context';
 import { PathfinderFeatureProvider } from '../OpenFeatureProvider';
 import { testIds } from '../../constants/testIds';
 import type { RawContent } from '../../types/content.types';
@@ -49,7 +49,7 @@ function useGrafanaTheme() {
  * dedicated viewer. `mode` drives InteractiveModeContext: 'controller' keeps
  * step actions visible so this tab can drive the originating Grafana tab.
  */
-export const GuideReaderOverlay: React.FC<GuideReaderOverlayProps> = ({ doc, mode = 'controller' }) => {
+export const GuideReaderOverlay: React.FC<GuideReaderOverlayProps> = ({ doc, mode = 'interactive' }) => {
   const theme = useGrafanaTheme();
   return (
     <ThemeContext.Provider value={theme}>
@@ -60,7 +60,7 @@ export const GuideReaderOverlay: React.FC<GuideReaderOverlayProps> = ({ doc, mod
   );
 };
 
-function GuideReaderInner({ doc, mode = 'controller' }: GuideReaderOverlayProps) {
+function GuideReaderInner({ doc, mode }: { doc: string; mode: InteractiveMode }) {
   const styles = useStyles2(getGuideReaderStyles);
   const journeyStyles = useStyles2(journeyContentHtml);
   const docsStyles = useStyles2(docsContentHtml);

--- a/src/components/guide-reader/GuideReaderOverlay.tsx
+++ b/src/components/guide-reader/GuideReaderOverlay.tsx
@@ -9,6 +9,7 @@ import { fetchUnifiedContent } from '../../docs-retrieval';
 import { journeyContentHtml, docsContentHtml } from '../../styles/content-html.styles';
 import { getInteractiveStyles } from '../../styles/interactive.styles';
 import { getPrismStyles } from '../../styles/prism.styles';
+import { InteractiveModeContext, type InteractiveMode } from '../../global-state/interactive-readonly-context';
 import { PathfinderFeatureProvider } from '../OpenFeatureProvider';
 import { testIds } from '../../constants/testIds';
 import type { RawContent } from '../../types/content.types';
@@ -17,6 +18,7 @@ import { getGuideReaderStyles } from './guide-reader.styles';
 interface GuideReaderOverlayProps {
   /** The `?doc=` value to render (e.g. `backend-guide:<id>`). */
   doc: string;
+  mode?: InteractiveMode;
 }
 
 // Mirrors FloatingPanelManager: this tree is mounted in a standalone root
@@ -43,21 +45,22 @@ function useGrafanaTheme() {
 
 /**
  * Full-screen viewer for a single guide, mounted in a new tab as a portal over
- * `document.body` at a high z-index so it covers all of Grafana's chrome — the
- * tab is a dedicated reader, not a second live Grafana to wander into.
+ * `document.body` at a high z-index so it covers all of Grafana's chrome — a
+ * dedicated viewer. `mode` drives InteractiveModeContext: 'controller' keeps
+ * step actions visible so this tab can drive the originating Grafana tab.
  */
-export const GuideReaderOverlay: React.FC<GuideReaderOverlayProps> = ({ doc }) => {
+export const GuideReaderOverlay: React.FC<GuideReaderOverlayProps> = ({ doc, mode = 'controller' }) => {
   const theme = useGrafanaTheme();
   return (
     <ThemeContext.Provider value={theme}>
       <PathfinderFeatureProvider>
-        <GuideReaderInner doc={doc} />
+        <GuideReaderInner doc={doc} mode={mode} />
       </PathfinderFeatureProvider>
     </ThemeContext.Provider>
   );
 };
 
-function GuideReaderInner({ doc }: GuideReaderOverlayProps) {
+function GuideReaderInner({ doc, mode = 'controller' }: GuideReaderOverlayProps) {
   const styles = useStyles2(getGuideReaderStyles);
   const journeyStyles = useStyles2(journeyContentHtml);
   const docsStyles = useStyles2(docsContentHtml);
@@ -157,9 +160,11 @@ function GuideReaderInner({ doc }: GuideReaderOverlayProps) {
           </div>
         )}
         {content && (
-          <div ref={contentRef}>
-            <ContentRenderer content={content} containerRef={contentRef} className={contentClassName} />
-          </div>
+          <InteractiveModeContext.Provider value={mode}>
+            <div ref={contentRef}>
+              <ContentRenderer content={content} containerRef={contentRef} className={contentClassName} />
+            </div>
+          </InteractiveModeContext.Provider>
         )}
       </div>
     </div>,

--- a/src/components/guide-reader/guide-reader.styles.ts
+++ b/src/components/guide-reader/guide-reader.styles.ts
@@ -48,4 +48,31 @@ export const getGuideReaderStyles = (theme: GrafanaTheme2) => ({
     textAlign: 'center',
     color: theme.colors.text.secondary,
   }),
+  controllerStatus: css({
+    position: 'fixed',
+    top: theme.spacing(2),
+    left: theme.spacing(2),
+    zIndex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(0.5, 1.5),
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: '999px',
+    background: theme.colors.background.secondary,
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+  controllerStatusDot: css({
+    width: '8px',
+    height: '8px',
+    borderRadius: '50%',
+    flexShrink: 0,
+  }),
+  controllerStatusConnected: css({
+    background: theme.colors.success.text,
+  }),
+  controllerStatusWaiting: css({
+    background: theme.colors.warning.text,
+  }),
 });

--- a/src/components/interactive-tutorial/interactive-guided.test.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.test.tsx
@@ -30,6 +30,14 @@ jest.mock('@grafana/data', () => ({
   usePluginContext: () => ({ meta: { jsonData: {} } }),
 }));
 
+// ─── Mock @grafana/runtime ───────────────────────────────────────────────────
+// The component publishes app-event toasts via getAppEvents(); importing the
+// real module pulls in config/LocationService, which needs @grafana/data's
+// getThemeById (not provided by the mock above).
+jest.mock('@grafana/runtime', () => ({
+  getAppEvents: () => ({ publish: jest.fn() }),
+}));
+
 // ─── Mock useAiFixEnabled (off) — avoids pulling @grafana/assistant, which this
 //     suite's @grafana/ui mock would otherwise leave un-themed and crashing ─────
 jest.mock('../../integrations/assistant-integration/use-ai-fix-enabled', () => ({

--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo, useRef } from 'react';
 import { Button } from '@grafana/ui';
 import { usePluginContext } from '@grafana/data';
+import { getAppEvents } from '@grafana/runtime';
 
 import { reportAppInteraction, UserInteraction, buildInteractiveStepProperties } from '../../lib/analytics';
 import {
@@ -23,6 +24,9 @@ import { sanitizeDocumentationHTML } from '../../security';
 import { STEP_STATES } from './step-states';
 import { AiFixButton } from './ai-fix-button';
 import { markStepCompleted, resetStep, useStepCompletion } from '../../global-state/completion-store';
+import { useInteractiveMode } from '../../global-state/interactive-mode-context';
+import { useControllerChannel } from '../../global-state/controller-channel';
+import type { CrossTabInternalAction } from '../../types/cross-tab.types';
 import type { ProgressReason } from '../../global-state/progress-events';
 
 /**
@@ -165,7 +169,12 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
     );
 
     // Local UI state
+    const mode = useInteractiveMode();
+    const controllerChannel = useControllerChannel();
     const [isExecuting, setIsExecuting] = useState(false);
+    // Set when the user cancels a controller-mode run, so the awaiting branch
+    // distinguishes a deliberate cancel from a disconnect/failure (skips the toast).
+    const controllerCancelledRef = useRef(false);
     const [currentStepIndex, setCurrentStepIndex] = useState(0);
     const [failedStepIndex, setFailedStepIndex] = useState(-1);
     const [currentStepStatus, setCurrentStepStatus] = useState<'waiting' | 'timeout' | 'completed'>('waiting');
@@ -550,6 +559,74 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
         )
       );
 
+      if (mode === 'controller') {
+        if (!controllerChannel) {
+          // No live tab connected (NEW-1073-1): tell the user instead of toggling
+          // a spinner that resolves to nothing.
+          getAppEvents().publish({
+            type: 'alert-info',
+            payload: ['No live tab connected', 'Open a live Grafana tab to run this step there.'],
+          });
+          return;
+        }
+        // §6.4 (entry-only): composites are NOT re-gated at click time the way a
+        // simple step is (which calls checker.revalidate() before posting). A
+        // requirement round-trip can cost up to ~4s, and a composite would pay
+        // that per click on top of its staged replay, so we keep the entry gate
+        // only and let each sub-action fail on the live tab if a prereq regressed.
+        controllerCancelledRef.current = false;
+        // Wait for the user to walk through every guided step on the live tab
+        // before marking complete, rather than completing optimistically.
+        setIsExecuting(true);
+        // Subscribe before posting so the first progress tick the live tab emits
+        // can't arrive before we're listening.
+        const stopProgress = controllerChannel.onStepProgress(renderedStepId, (index) => {
+          setCurrentStepIndex(index);
+          setCurrentStepStatus('waiting');
+        });
+        controllerChannel.post({
+          kind: 'step-command',
+          phase: 'do',
+          stepId: renderedStepId,
+          action: {
+            targetAction: 'guided',
+            refTarget: '',
+            internalActions: internalActions.map(
+              (a): CrossTabInternalAction => ({
+                targetAction: a.targetAction,
+                refTarget: a.refTarget,
+                targetValue: a.targetValue,
+                targetComment: a.targetComment,
+              })
+            ),
+          },
+        });
+        try {
+          const finished = await controllerChannel.awaitStepComplete(renderedStepId);
+          if (finished) {
+            persistCompletion();
+            if (onStepComplete && stepId) {
+              onStepComplete(stepId);
+            }
+            if (onComplete) {
+              onComplete();
+            }
+          } else if (!controllerCancelledRef.current) {
+            // NEW-1073-3: the live tab didn't finish (it disconnected or the step
+            // failed there) and the user didn't cancel — surface a retry hint
+            // rather than silently leaving the step incomplete.
+            getAppEvents().publish({
+              type: 'alert-warning',
+              payload: ['Step not completed', 'The live tab did not finish this step — please retry.'],
+            });
+          }
+        } finally {
+          stopProgress?.();
+          setIsExecuting(false);
+        }
+        return;
+      }
+
       await executeStep();
     }, [
       disabled,
@@ -557,9 +634,15 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
       isCompletedWithObjectives,
       checker.isEnabled,
       executeStep,
-      internalActions.length,
+      internalActions,
       renderedStepId,
       analyticsStepMeta,
+      mode,
+      controllerChannel,
+      persistCompletion,
+      onStepComplete,
+      onComplete,
+      stepId,
     ]);
 
     // Handle step reset (redo functionality)
@@ -602,6 +685,11 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
 
     // Handle cancel during guided execution
     const handleCancel = useCallback(async () => {
+      // In controller mode the run is remote: release the awaitStepComplete waiter
+      // (F-1073-1) so the await resolves and the spinner clears, and flag the
+      // cancel so the awaiting branch skips its "not completed" toast.
+      controllerCancelledRef.current = true;
+      controllerChannel?.cancelStepComplete(renderedStepId);
       // Cancel the current guided step
       // guidedHandler.cancel() already clears highlights via its own navigationManager
       guidedHandler.cancel();
@@ -612,7 +700,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
       setCurrentStepIndex(0);
       setCurrentStepStatus('waiting');
       setWasCancelled(false); // Don't show error state - just return to start
-    }, [guidedHandler]);
+    }, [guidedHandler, controllerChannel, renderedStepId]);
 
     const isAnyActionRunning = isExecuting || isCurrentlyExecuting;
 

--- a/src/components/interactive-tutorial/interactive-multi-step.tsx
+++ b/src/components/interactive-tutorial/interactive-multi-step.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo, useRef } from 'react';
 import { Button } from '@grafana/ui';
+import { getAppEvents } from '@grafana/runtime';
 
 import {
   useInteractiveElements,
@@ -18,6 +19,9 @@ import { useAiFixEnabled } from '../../integrations/assistant-integration/use-ai
 import { STEP_STATES } from './step-states';
 import { AiFixButton } from './ai-fix-button';
 import { markStepCompleted, resetStep, useStepCompletion } from '../../global-state/completion-store';
+import { useInteractiveMode } from '../../global-state/interactive-mode-context';
+import { useControllerChannel } from '../../global-state/controller-channel';
+import type { CrossTabInternalAction } from '../../types/cross-tab.types';
 import type { ProgressReason } from '../../global-state/progress-events';
 
 let anonymousMultiStepCounter = 0;
@@ -163,6 +167,8 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
     );
 
     // Local UI state (similar to InteractiveStep)
+    const mode = useInteractiveMode();
+    const controllerChannel = useControllerChannel();
     const [isExecuting, setIsExecuting] = useState(false);
 
     // Completion lives in the store.
@@ -196,6 +202,9 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
 
     // Use ref for cancellation to avoid closure issues
     const isCancelledRef = React.useRef(false);
+    // Set when the user cancels a controller-mode run, so the awaiting branch
+    // distinguishes a deliberate cancel from a disconnect/failure (skips the toast).
+    const controllerCancelledRef = React.useRef(false);
 
     // Handle reset trigger from parent section
     useEffect(() => {
@@ -262,7 +271,12 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
     const handleMultiStepCancel = useCallback(() => {
       isCancelledRef.current = true; // Set ref for immediate access
       // The running loop will detect this and break
-    }, []);
+      // In controller mode the run is remote: release the awaitStepComplete waiter
+      // (F-1073-1) so the spinner clears, and flag the cancel so the awaiting
+      // branch skips its "not completed" toast.
+      controllerCancelledRef.current = true;
+      controllerChannel?.cancelStepComplete(renderedStepId);
+    }, [controllerChannel, renderedStepId]);
 
     // Main execution logic (similar to InteractiveSection's sequence execution)
     const executeStep = useCallback(async (): Promise<boolean> => {
@@ -597,6 +611,71 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
         )
       );
 
+      if (mode === 'controller') {
+        if (!controllerChannel) {
+          // No live tab connected (NEW-1073-1): tell the user instead of toggling
+          // a spinner that resolves to nothing.
+          getAppEvents().publish({
+            type: 'alert-info',
+            payload: ['No live tab connected', 'Open a live Grafana tab to run this step there.'],
+          });
+          return;
+        }
+        // §6.4 (entry-only): composites are NOT re-gated at click time the way a
+        // simple step is (which calls checker.revalidate() before posting). A
+        // requirement round-trip can cost up to ~4s, and a composite would pay
+        // that per click on top of its staged replay, so we keep the entry gate
+        // only and let each sub-action fail on the live tab if a prereq regressed.
+        controllerCancelledRef.current = false;
+        // Animate per-step progress from the live tab, and wait for it to finish
+        // before marking complete (the actual execution happens over there).
+        setIsExecuting(true);
+        // Subscribe before posting so the first progress tick the live tab emits
+        // can't arrive before we're listening.
+        const stopProgress = controllerChannel.onStepProgress(renderedStepId, (index) => setCurrentActionIndex(index));
+        controllerChannel.post({
+          kind: 'step-command',
+          phase: 'do',
+          stepId: renderedStepId,
+          action: {
+            targetAction: 'multistep',
+            refTarget: '',
+            internalActions: internalActions.map(
+              (a): CrossTabInternalAction => ({
+                targetAction: a.targetAction,
+                refTarget: a.refTarget,
+                targetValue: a.targetValue,
+                targetComment: a.targetComment,
+              })
+            ),
+          },
+        });
+        try {
+          const finished = await controllerChannel.awaitStepComplete(renderedStepId);
+          if (finished) {
+            persistCompletion();
+            if (onStepComplete && stepId) {
+              onStepComplete(stepId);
+            }
+            if (onComplete) {
+              onComplete();
+            }
+          } else if (!controllerCancelledRef.current) {
+            // NEW-1073-3: the live tab didn't finish (it disconnected or the
+            // replay failed there) and the user didn't cancel — surface a retry
+            // hint rather than silently leaving the step incomplete.
+            getAppEvents().publish({
+              type: 'alert-warning',
+              payload: ['Step not completed', 'The live tab did not finish this step — please retry.'],
+            });
+          }
+        } finally {
+          stopProgress?.();
+          setIsExecuting(false);
+        }
+        return;
+      }
+
       await executeStep();
     }, [
       disabled,
@@ -604,9 +683,15 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
       isCompletedWithObjectives,
       checker.isEnabled,
       executeStep,
-      internalActions.length,
+      internalActions,
       renderedStepId,
       analyticsStepMeta,
+      mode,
+      controllerChannel,
+      persistCompletion,
+      onStepComplete,
+      onComplete,
+      stepId,
     ]);
 
     // Handle individual step reset (redo functionality)

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -3,8 +3,9 @@ import { Button } from '@grafana/ui';
 import { usePluginContext } from '@grafana/data';
 
 import { useInteractiveElements, ActionMonitor } from '../../interactive-engine';
-import { useStepChecker } from '../../requirements-manager';
+import { useStepChecker, stripTabLocalRequirements } from '../../requirements-manager';
 import { useIsAlignmentPaused, useAlignmentStartingLocation } from '../../global-state/alignment-pending-context';
+import { useInteractiveMode } from '../../global-state/interactive-mode-context';
 import { InteractiveStep, resetStepCounter } from './interactive-step';
 import { InteractiveMultiStep, resetMultiStepCounter } from './interactive-multi-step';
 import { InteractiveGuided, resetGuidedCounter } from './interactive-guided';
@@ -160,6 +161,19 @@ export function InteractiveSection({
   // `useSectionCompletion`); the cursor is a pure derivation of the
   // step roster + the completed set.
   const [sectionState, dispatch] = useReducer(sectionReducer, initialSectionState);
+  const mode = useInteractiveMode();
+  // In controller mode, drop requirements that probe this tab (nav menu, current
+  // page, ...) — the live tab enforces them; session requirements still gate.
+  // Deliberately strip-only, NOT round-tripped (NEW-1068-1): this is the coarse
+  // section-level "can this section run" gate, and each step still round-trips
+  // its own tab-local requirements to the live tab when it executes
+  // (see `attemptCheck` in step-checker.hook.ts). Round-tripping the whole
+  // section here would add per-section latency for a gate the per-step checks
+  // already enforce precisely.
+  const controllerRequirements = useMemo(
+    () => (mode === 'controller' ? stripTabLocalRequirements(requirements) : requirements),
+    [mode, requirements]
+  );
   const [currentlyExecutingStep, setCurrentlyExecutingStep] = useState<string | null>(null);
   const [isRunning, setIsRunning] = useState(false);
   const [executingStepNumber, setExecutingStepNumber] = useState(0); // Track which step is being executed (1-indexed for display)
@@ -203,7 +217,7 @@ export function InteractiveSection({
   // timing contract — the 5s cadence is load-bearing for "auto-pickup of
   // out-of-band state changes that don't fire one of the 4 events".
   const { status: sectionRequirementsStatus, fix: fixSectionRequirements } = useSectionRequirements({
-    requirements,
+    requirements: controllerRequirements,
     sectionId,
     title,
     hints,
@@ -674,9 +688,9 @@ export function InteractiveSection({
     }
 
     // Check section-level requirements first and apply same priority logic
-    if (requirements) {
+    if (controllerRequirements) {
       const sectionRequirementsData = {
-        requirements: requirements,
+        requirements: controllerRequirements,
         targetAction: 'section',
         refTarget: `section-${sectionId}`,
         targetValue: undefined,
@@ -700,7 +714,7 @@ export function InteractiveSection({
                 await navigationManager.expandParentNavigationSection(fixableError.targetHref);
               } else if (fixableError?.fixType === 'location' && fixableError.targetHref) {
                 await navigationManager.fixLocationRequirement(fixableError.targetHref);
-              } else if (requirements.includes('navmenu-open')) {
+              } else if (controllerRequirements.includes('navmenu-open')) {
                 await navigationManager.fixNavigationRequirements();
               }
 
@@ -1031,7 +1045,7 @@ export function InteractiveSection({
     title,
     handleSectionCancel,
     currentStepIndex,
-    requirements,
+    controllerRequirements,
     checkRequirementsFromData,
     scrollToStep,
     beginProgrammaticScroll,

--- a/src/components/interactive-tutorial/interactive-step.test.tsx
+++ b/src/components/interactive-tutorial/interactive-step.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { InteractiveStep } from './interactive-step';
+import { InteractiveModeContext } from '../../global-state/interactive-mode-context';
+import { ControllerChannelProvider } from '../../global-state/controller-channel';
 
 describe('InteractiveStep: showMeText label override', () => {
   it('renders custom Show me label when showMeText is provided', () => {
@@ -165,5 +167,272 @@ describe('InteractiveStep: popout action type', () => {
     } finally {
       dispatchSpy.mockRestore();
     }
+  });
+});
+
+describe('InteractiveStep: controller mode emits over the channel instead of executing', () => {
+  function makeTransport() {
+    let listener: ((message: any) => void) | null = null;
+    return {
+      start: jest.fn(),
+      stop: jest.fn(),
+      post: jest.fn(),
+      onMessage: jest.fn((l: (message: any) => void) => {
+        listener = l;
+        return () => {
+          listener = null;
+        };
+      }),
+      emit: (message: any) => listener?.(message),
+    };
+  }
+
+  function countRequirementChecks(transport: ReturnType<typeof makeTransport>): number {
+    return transport.post.mock.calls.map((c) => c[0]).filter((p: any) => p.kind === 'check-requirements').length;
+  }
+
+  // The controller posts a `check-requirements` request with a generated
+  // requestId; reply to the latest one with a matching `requirement-result` so
+  // the awaiting step resolves instead of waiting out the round-trip timeout.
+  function replyToRequirementCheck(transport: ReturnType<typeof makeTransport>, pass: boolean, extra = {}) {
+    const requests = transport.post.mock.calls.map((c) => c[0]).filter((p: any) => p.kind === 'check-requirements');
+    const request = requests[requests.length - 1];
+    if (!request) {
+      return false;
+    }
+    // Pairing happens on a heartbeat (T1 PART C); a reply is only honored from
+    // the paired tab. Emit one from the same sender so the result is accepted
+    // (binds once, harmless to repeat).
+    transport.emit({ source: 'pathfinder', senderId: 'live', timestamp: 0, kind: 'heartbeat', role: 'live' });
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'live',
+      timestamp: 0,
+      kind: 'requirement-result',
+      requestId: request.requestId,
+      stepId: request.stepId,
+      result: {
+        requirements: request.requirements,
+        pass,
+        error: pass ? [] : [{ requirement: request.requirements, pass: false, ...extra }],
+      },
+    });
+    return true;
+  }
+
+  it('emits a "show" step-command when Show me is clicked', async () => {
+    const transport = makeTransport();
+    render(
+      <InteractiveModeContext.Provider value="controller">
+        <ControllerChannelProvider transport={transport}>
+          <InteractiveStep targetAction="highlight" refTarget="#panel-add" stepId="ctrl-show" showMe doIt={false}>
+            Step
+          </InteractiveStep>
+        </ControllerChannelProvider>
+      </InteractiveModeContext.Provider>
+    );
+
+    const button = await screen.findByRole('button', { name: /show me/i });
+    await waitFor(() => expect(button).not.toBeDisabled());
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(transport.post).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'step-command',
+          phase: 'show',
+          stepId: 'ctrl-show',
+          action: expect.objectContaining({ targetAction: 'highlight', refTarget: '#panel-add' }),
+        })
+      )
+    );
+  });
+
+  it('emits a "do" step-command when Do it is clicked', async () => {
+    const transport = makeTransport();
+    render(
+      <InteractiveModeContext.Provider value="controller">
+        <ControllerChannelProvider transport={transport}>
+          <InteractiveStep targetAction="button" refTarget="button[type='submit']" stepId="ctrl-do">
+            Step
+          </InteractiveStep>
+        </ControllerChannelProvider>
+      </InteractiveModeContext.Provider>
+    );
+
+    const button = await screen.findByRole('button', { name: /do it/i });
+    await waitFor(() => expect(button).not.toBeDisabled());
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(transport.post).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'step-command', phase: 'do', stepId: 'ctrl-do' })
+      )
+    );
+  });
+
+  it('round-trips tab-local requirements to the live tab instead of stripping them', async () => {
+    const transport = makeTransport();
+    render(
+      <InteractiveModeContext.Provider value="controller">
+        <ControllerChannelProvider transport={transport}>
+          <InteractiveStep
+            targetAction="button"
+            refTarget="#not-on-this-tab"
+            requirements="exists-reftarget"
+            stepId="ctrl-req"
+          >
+            Step
+          </InteractiveStep>
+        </ControllerChannelProvider>
+      </InteractiveModeContext.Provider>
+    );
+
+    await waitFor(() =>
+      expect(transport.post).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'check-requirements', stepId: 'ctrl-req', requirements: 'exists-reftarget' })
+      )
+    );
+  });
+
+  it('enables a step once the live tab reports its requirements pass', async () => {
+    const transport = makeTransport();
+    render(
+      <InteractiveModeContext.Provider value="controller">
+        <ControllerChannelProvider transport={transport}>
+          <InteractiveStep targetAction="button" refTarget="#ok" requirements="exists-reftarget" stepId="ctrl-pass">
+            Step
+          </InteractiveStep>
+        </ControllerChannelProvider>
+      </InteractiveModeContext.Provider>
+    );
+
+    await waitFor(() => expect(replyToRequirementCheck(transport, true)).toBe(true));
+
+    const button = await screen.findByRole('button', { name: /do it/i });
+    await waitFor(() => expect(button).not.toBeDisabled());
+
+    // Clicking re-verifies against the live tab before acting; answer that
+    // second round-trip with a pass so the command is emitted.
+    const before = countRequirementChecks(transport);
+    fireEvent.click(button);
+    await waitFor(() => expect(countRequirementChecks(transport)).toBeGreaterThan(before));
+    replyToRequirementCheck(transport, true);
+
+    await waitFor(() =>
+      expect(transport.post).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'step-command', phase: 'do', stepId: 'ctrl-pass' })
+      )
+    );
+  });
+
+  it('gates the action when a re-check at click time reports the requirement failed', async () => {
+    const transport = makeTransport();
+    render(
+      <InteractiveModeContext.Provider value="controller">
+        <ControllerChannelProvider transport={transport}>
+          <InteractiveStep targetAction="button" refTarget="#ok" requirements="navmenu-open" stepId="ctrl-regress">
+            Step
+          </InteractiveStep>
+        </ControllerChannelProvider>
+      </InteractiveModeContext.Provider>
+    );
+
+    // Step starts satisfied, so it enables and Do it is clickable.
+    await waitFor(() => expect(replyToRequirementCheck(transport, true)).toBe(true));
+    const button = await screen.findByRole('button', { name: /do it/i });
+    await waitFor(() => expect(button).not.toBeDisabled());
+
+    // The prerequisite regressed by click time: the re-check fails, so no
+    // command is emitted and the fix affordance surfaces instead.
+    const before = countRequirementChecks(transport);
+    fireEvent.click(button);
+    await waitFor(() => expect(countRequirementChecks(transport)).toBeGreaterThan(before));
+    replyToRequirementCheck(transport, false, { canFix: true, fixType: 'navigation' });
+
+    expect(await screen.findByRole('button', { name: /fix this/i })).toBeInTheDocument();
+    expect(transport.post).not.toHaveBeenCalledWith(expect.objectContaining({ kind: 'step-command' }));
+  });
+
+  it('surfaces a failing requirement and a fix affordance reported by the live tab', async () => {
+    const transport = makeTransport();
+    render(
+      <InteractiveModeContext.Provider value="controller">
+        <ControllerChannelProvider transport={transport}>
+          <InteractiveStep targetAction="button" refTarget="#nav" requirements="navmenu-open" stepId="ctrl-fail">
+            Step
+          </InteractiveStep>
+        </ControllerChannelProvider>
+      </InteractiveModeContext.Provider>
+    );
+
+    await waitFor(() =>
+      expect(replyToRequirementCheck(transport, false, { canFix: true, fixType: 'navigation' })).toBe(true)
+    );
+
+    expect(await screen.findByRole('button', { name: /fix this/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /do it/i })).not.toBeInTheDocument();
+  });
+
+  it('fails open to a stripped local check when the live tab never answers (§6.5)', async () => {
+    jest.useFakeTimers();
+    try {
+      const transport = makeTransport();
+      render(
+        <InteractiveModeContext.Provider value="controller">
+          <ControllerChannelProvider transport={transport}>
+            <InteractiveStep
+              targetAction="button"
+              refTarget="#ok"
+              requirements="exists-reftarget"
+              stepId="ctrl-timeout"
+            >
+              Step
+            </InteractiveStep>
+          </ControllerChannelProvider>
+        </InteractiveModeContext.Provider>
+      );
+
+      // The controller posts the check, but no live tab ever replies. After the
+      // round-trip timeout the step must fail OPEN: strip the tab-local
+      // `exists-reftarget` token and evaluate the (now empty) remainder locally,
+      // which passes — so a disconnected driver stays usable instead of blocked
+      // forever on a silent live tab.
+      await waitFor(() =>
+        expect(transport.post).toHaveBeenCalledWith(expect.objectContaining({ kind: 'check-requirements' }))
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      const button = await screen.findByRole('button', { name: /do it/i });
+      await waitFor(() => expect(button).not.toBeDisabled());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('fails loud instead of dispatching a controller step with no stepId (F-1063-3)', async () => {
+    const transport = makeTransport();
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <InteractiveModeContext.Provider value="controller">
+        <ControllerChannelProvider transport={transport}>
+          <InteractiveStep targetAction="highlight" refTarget="#panel-add" showMe doIt={false}>
+            Step
+          </InteractiveStep>
+        </ControllerChannelProvider>
+      </InteractiveModeContext.Provider>
+    );
+
+    const button = await screen.findByRole('button', { name: /show me/i });
+    await waitFor(() => expect(button).not.toBeDisabled());
+    fireEvent.click(button);
+
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    // The provider still posts heartbeats; assert no step-command was dispatched.
+    expect(transport.post).not.toHaveBeenCalledWith(expect.objectContaining({ kind: 'step-command' }));
+    warn.mockRestore();
   });
 });

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -27,6 +27,8 @@ import { resolveWithRetry } from '../../lib/dom/selector-retry';
 import { STEP_STATES } from './step-states';
 import { AiFixButton } from './ai-fix-button';
 import { markStepCompleted, resetStep, useStepCompletion } from '../../global-state/completion-store';
+import { useInteractiveMode } from '../../global-state/interactive-mode-context';
+import { useControllerChannel } from '../../global-state/controller-channel';
 
 /**
  * Result type for lazy scroll execution wrapper
@@ -202,6 +204,8 @@ export const InteractiveStep = forwardRef<
     );
 
     // Local UI state
+    const mode = useInteractiveMode();
+    const controllerChannel = useControllerChannel();
     const [isShowRunning, setIsShowRunning] = useState(false);
     const [isDoRunning, setIsDoRunning] = useState(false);
     const [postVerifyError, setPostVerifyError] = useState<string | null>(null);
@@ -287,6 +291,11 @@ export const InteractiveStep = forwardRef<
       onStepComplete, // Pass through for objectives auto-completion
       onComplete, // Pass through for objectives auto-completion
     });
+
+    // `checker` is a fresh object every render, but `revalidate` is a stable
+    // useCallback — pull it out so the click handlers can depend on it without
+    // rebuilding every render (which depending on the whole `checker` would force).
+    const { revalidate } = checker;
 
     const aiFixEnabled = useAiFixEnabled();
 
@@ -660,6 +669,41 @@ export const InteractiveStep = forwardRef<
         )
       );
 
+      if (mode === 'controller') {
+        if (!stepId) {
+          // F-1063-3: a controller-mode step must carry an author/parser-assigned
+          // stepId. The anonymous fallback is mount-instance-derived and would
+          // mis-address the live tab, so fail loud rather than dispatch a guess.
+          console.warn('[Pathfinder] controller "show" skipped: step has no stepId');
+          return;
+        }
+        // Cross-tab state can be stale; re-verify against the live tab and gate.
+        // revalidate() fails OPEN when no live tab answers (§6.5), so a
+        // disconnected controller proceeds rather than being silently blocked.
+        if (!(await revalidate())) {
+          return;
+        }
+        controllerChannel?.post({
+          kind: 'step-command',
+          phase: 'show',
+          stepId,
+          action: { targetAction, refTarget, targetValue: currentTargetValue, targetComment },
+        });
+        if (!doIt) {
+          // F-1063-1 (fix-plan §6.2): simple steps complete optimistically — no
+          // live ack, and they complete even with no live tab connected. Accepted
+          // by design; composite steps are ack-gated separately (#1073).
+          persistCompletion();
+          if (onStepComplete) {
+            onStepComplete(stepId);
+          }
+          if (onComplete) {
+            onComplete();
+          }
+        }
+        return;
+      }
+
       setIsShowRunning(true);
       try {
         // Use lazy scroll wrapper to ensure element is found before executing
@@ -717,6 +761,9 @@ export const InteractiveStep = forwardRef<
       stepId,
       analyticsStepMeta,
       persistCompletion,
+      mode,
+      controllerChannel,
+      revalidate,
     ]);
 
     // Handle individual "Do it" action (delegates to executeStep)
@@ -742,6 +789,39 @@ export const InteractiveStep = forwardRef<
           analyticsStepMeta
         )
       );
+
+      if (mode === 'controller') {
+        if (!stepId) {
+          // F-1063-3: a controller-mode step must carry an author/parser-assigned
+          // stepId. The anonymous fallback is mount-instance-derived and would
+          // mis-address the live tab, so fail loud rather than dispatch a guess.
+          console.warn('[Pathfinder] controller "do" skipped: step has no stepId');
+          return;
+        }
+        // Cross-tab state can be stale; re-verify against the live tab and gate.
+        // revalidate() fails OPEN when no live tab answers (§6.5), so a
+        // disconnected controller proceeds rather than being silently blocked.
+        if (!(await revalidate())) {
+          return;
+        }
+        controllerChannel?.post({
+          kind: 'step-command',
+          phase: 'do',
+          stepId,
+          action: { targetAction, refTarget, targetValue: currentTargetValue, targetComment },
+        });
+        // F-1063-1 (fix-plan §6.2): simple steps complete optimistically — no live
+        // ack, and they complete even with no live tab connected. Accepted by
+        // design; composite steps are ack-gated separately (#1073).
+        persistCompletion();
+        if (onStepComplete) {
+          onStepComplete(stepId);
+        }
+        if (onComplete) {
+          onComplete();
+        }
+        return;
+      }
 
       setIsDoRunning(true);
       try {
@@ -778,6 +858,14 @@ export const InteractiveStep = forwardRef<
       targetAction,
       currentTargetValue,
       analyticsStepMeta,
+      mode,
+      controllerChannel,
+      persistCompletion,
+      onStepComplete,
+      onComplete,
+      stepId,
+      targetComment,
+      revalidate,
     ]);
 
     // Handle individual step reset (redo functionality)

--- a/src/constants/interactive-config.ts
+++ b/src/constants/interactive-config.ts
@@ -45,6 +45,7 @@ export const INTERACTIVE_CONFIG_DEFAULTS = {
       defaultStepDelay: 1800, // Default delay between internal actions in multi-step
       showToDoIterations: 18, // 18 * 100ms = 1800ms delay between show and do
       baseInterval: 100, // Base 100ms interval for cancellation-safe delays
+      settleAfterActionMs: 200, // Pause after a 'do' action settles the DOM before the next internal action
     },
     // Navigation manager timing
     navigation: {
@@ -345,3 +346,10 @@ export interface ActionMetadata {
 export type ActionType = (typeof ACTION_TYPES)[keyof typeof ACTION_TYPES];
 export type CommonRequirement = (typeof COMMON_REQUIREMENTS)[number];
 export type DataAttribute = (typeof DATA_ATTRIBUTES)[keyof typeof DATA_ATTRIBUTES];
+
+// Two-tab interactive controller feature flag.
+// Set to false to ship the feature dark — all three gates (controller overlay
+// entry, live-tab executor install, and the docs-panel UI affordance) check
+// this constant. Flip to true once the follow-up security/correctness items
+// are resolved (see epic #1133).
+export const TWOTAB_CONTROLLER_ENABLED = false;

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -41,6 +41,7 @@ export const testIds = {
     retryButton: 'docs-panel-retry-button',
     popOutButton: 'docs-panel-pop-out-button',
     fullScreenButton: 'docs-panel-full-screen-button',
+    openControllerTabButton: 'docs-panel-open-controller-tab-button',
   },
 
   // Full screen mode page (sibling of the sidebar / floating panel)

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -396,5 +396,6 @@ export const testIds = {
     loading: 'guide-reader-loading',
     error: 'guide-reader-error',
     closeHint: 'guide-reader-close-hint',
+    controllerStatus: 'guide-reader-controller-status',
   },
 };

--- a/src/global-state/controller-channel.test.tsx
+++ b/src/global-state/controller-channel.test.tsx
@@ -1,0 +1,445 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { ControllerChannelProvider, useControllerChannel, useControllerConnected } from './controller-channel';
+import type { CrossTabMessage } from '../types/cross-tab.types';
+
+class FakeTransport {
+  started = false;
+  stopped = false;
+  postedMessages: unknown[] = [];
+  private listener: ((message: CrossTabMessage) => void) | null = null;
+
+  start(): void {
+    this.started = true;
+  }
+
+  stop(): void {
+    this.stopped = true;
+  }
+
+  post(payload: unknown): void {
+    this.postedMessages.push(payload);
+  }
+
+  onMessage(listener: (message: CrossTabMessage) => void): () => void {
+    this.listener = listener;
+    return () => {
+      this.listener = null;
+    };
+  }
+
+  emit(message: CrossTabMessage): void {
+    this.listener?.(message);
+  }
+}
+
+function liveHeartbeat(): CrossTabMessage {
+  return { source: 'pathfinder', senderId: 'live', timestamp: 0, kind: 'heartbeat', role: 'live' };
+}
+
+function Probe() {
+  const channel = useControllerChannel();
+  const connected = useControllerConnected();
+  return (
+    <div>
+      <button
+        onClick={() =>
+          channel?.post({
+            kind: 'step-command',
+            phase: 'do',
+            stepId: 's1',
+            action: { targetAction: 'button', refTarget: '#x' },
+          })
+        }
+      >
+        post
+      </button>
+      <span data-testid="connected">{String(connected)}</span>
+    </div>
+  );
+}
+
+function RequestProbe() {
+  const channel = useControllerChannel();
+  const [check, setCheck] = React.useState('pending');
+  const [fix, setFix] = React.useState('pending');
+  return (
+    <div>
+      <button
+        onClick={() =>
+          channel?.requestRequirementCheck('s1', 'navmenu-open').then((r) => setCheck(r ? `pass:${r.pass}` : 'null'))
+        }
+      >
+        check
+      </button>
+      <button
+        onClick={() =>
+          channel
+            ?.requestFix('s1', { requirements: 'navmenu-open', fixType: 'navigation' })
+            .then((r) => setFix(`ok:${r.ok}`))
+        }
+      >
+        fix
+      </button>
+      <span data-testid="check">{check}</span>
+      <span data-testid="fix">{fix}</span>
+    </div>
+  );
+}
+
+function postedOfKind(transport: FakeTransport, kind: string): any {
+  return (transport.postedMessages as any[]).find((m) => m.kind === kind);
+}
+
+describe('ControllerChannelProvider', () => {
+  it('starts the transport on mount and stops it on unmount', () => {
+    const transport = new FakeTransport();
+    const { unmount } = render(
+      <ControllerChannelProvider transport={transport}>
+        <Probe />
+      </ControllerChannelProvider>
+    );
+
+    expect(transport.started).toBe(true);
+    expect(transport.stopped).toBe(false);
+
+    unmount();
+    expect(transport.stopped).toBe(true);
+  });
+
+  it('posts a controller heartbeat on mount', () => {
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <Probe />
+      </ControllerChannelProvider>
+    );
+
+    expect(transport.postedMessages).toContainEqual({ kind: 'heartbeat', role: 'controller' });
+  });
+
+  it('hands the sidebar off (close) on mount', () => {
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <Probe />
+      </ControllerChannelProvider>
+    );
+
+    expect(transport.postedMessages).toContainEqual({ kind: 'sidebar-handoff', action: 'close' });
+  });
+
+  it('forwards channel.post to the transport', () => {
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <Probe />
+      </ControllerChannelProvider>
+    );
+
+    fireEvent.click(screen.getByText('post'));
+
+    expect(transport.postedMessages).toContainEqual({
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 's1',
+      action: { targetAction: 'button', refTarget: '#x' },
+    });
+  });
+
+  it('reports connected once a live heartbeat arrives', () => {
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <Probe />
+      </ControllerChannelProvider>
+    );
+
+    expect(screen.getByTestId('connected')).toHaveTextContent('false');
+    act(() => transport.emit(liveHeartbeat()));
+    expect(screen.getByTestId('connected')).toHaveTextContent('true');
+  });
+
+  it('re-asserts sidebar-handoff:close once the first live heartbeat arrives (F-1067-1)', () => {
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <Probe />
+      </ControllerChannelProvider>
+    );
+
+    const closes = () =>
+      transport.postedMessages.filter((m) => (m as any)?.kind === 'sidebar-handoff' && (m as any)?.action === 'close');
+    expect(closes()).toHaveLength(1); // initial close at mount
+
+    act(() => transport.emit(liveHeartbeat()));
+    expect(closes()).toHaveLength(2); // re-asserted now a live tab is present
+
+    // A second/third live heartbeat must not keep re-posting.
+    act(() => transport.emit(liveHeartbeat()));
+    expect(closes()).toHaveLength(2);
+  });
+
+  it('resolves requestRequirementCheck with the live tab reply', async () => {
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <RequestProbe />
+      </ControllerChannelProvider>
+    );
+
+    // Pair with the live tab first — replies are only honored from the paired
+    // tab, and pairing happens on a heartbeat (T1 PART C).
+    act(() => transport.emit(liveHeartbeat()));
+    fireEvent.click(screen.getByText('check'));
+    const request = postedOfKind(transport, 'check-requirements');
+    expect(request.requestId).toBeTruthy();
+
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'live',
+        timestamp: 0,
+        kind: 'requirement-result',
+        requestId: request.requestId,
+        stepId: 's1',
+        result: { requirements: 'navmenu-open', pass: true, error: [] },
+      })
+    );
+
+    await waitFor(() => expect(screen.getByTestId('check')).toHaveTextContent('pass:true'));
+  });
+
+  it('resolves requestFix with the live tab outcome', async () => {
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <RequestProbe />
+      </ControllerChannelProvider>
+    );
+
+    // Pair with the live tab first (T1 PART C: replies need an established pair).
+    act(() => transport.emit(liveHeartbeat()));
+    fireEvent.click(screen.getByText('fix'));
+    const request = postedOfKind(transport, 'fix-requirement');
+    expect(request.requestId).toBeTruthy();
+
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'live',
+        timestamp: 0,
+        kind: 'fix-result',
+        requestId: request.requestId,
+        stepId: 's1',
+        ok: true,
+      })
+    );
+
+    await waitFor(() => expect(screen.getByTestId('fix')).toHaveTextContent('ok:true'));
+  });
+
+  it('falls back to null when no live tab answers within the timeout', async () => {
+    jest.useFakeTimers();
+    try {
+      const transport = new FakeTransport();
+      render(
+        <ControllerChannelProvider transport={transport}>
+          <RequestProbe />
+        </ControllerChannelProvider>
+      );
+
+      fireEvent.click(screen.getByText('check'));
+      await act(async () => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      expect(screen.getByTestId('check')).toHaveTextContent('null');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('drops a reply from an unpaired tab and never lets it claim the pairing slot (T1 PART C)', async () => {
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <RequestProbe />
+      </ControllerChannelProvider>
+    );
+
+    fireEvent.click(screen.getByText('check'));
+    const request = postedOfKind(transport, 'check-requirements');
+
+    // A forged reply arrives before any live heartbeat. It must be ignored AND
+    // must not bind the pairing slot — pairing happens on a heartbeat only.
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'attacker',
+        timestamp: 0,
+        kind: 'requirement-result',
+        requestId: request.requestId,
+        stepId: 's1',
+        result: { requirements: 'navmenu-open', pass: true, error: [] },
+      })
+    );
+    expect(screen.getByTestId('check')).toHaveTextContent('pending');
+
+    // The real live tab heartbeats and pairs; its reply is then honored — proving
+    // the attacker never claimed the slot.
+    act(() => transport.emit(liveHeartbeat()));
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'live',
+        timestamp: 0,
+        kind: 'requirement-result',
+        requestId: request.requestId,
+        stepId: 's1',
+        result: { requirements: 'navmenu-open', pass: false, error: [] },
+      })
+    );
+    await waitFor(() => expect(screen.getByTestId('check')).toHaveTextContent('pass:false'));
+  });
+
+  it('binds to the first live tab and ignores replies from others', async () => {
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <RequestProbe />
+      </ControllerChannelProvider>
+    );
+
+    // Pair with live tab A via its heartbeat.
+    act(() =>
+      transport.emit({ source: 'pathfinder', senderId: 'live-A', timestamp: 0, kind: 'heartbeat', role: 'live' })
+    );
+
+    fireEvent.click(screen.getByText('check'));
+    const request = postedOfKind(transport, 'check-requirements');
+
+    // A different tab answering the same requestId must be ignored.
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'live-B',
+        timestamp: 0,
+        kind: 'requirement-result',
+        requestId: request.requestId,
+        stepId: 's1',
+        result: { requirements: 'navmenu-open', pass: false, error: [] },
+      })
+    );
+    expect(screen.getByTestId('check')).toHaveTextContent('pending');
+
+    // The paired tab's reply is honored.
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'live-A',
+        timestamp: 0,
+        kind: 'requirement-result',
+        requestId: request.requestId,
+        stepId: 's1',
+        result: { requirements: 'navmenu-open', pass: true, error: [] },
+      })
+    );
+    await waitFor(() => expect(screen.getByTestId('check')).toHaveTextContent('pass:true'));
+  });
+
+  it('resolves awaitStepComplete when the live tab reports completion', async () => {
+    function CompleteProbe() {
+      const channel = useControllerChannel();
+      const [done, setDone] = React.useState('pending');
+      return (
+        <div>
+          <button onClick={() => channel?.awaitStepComplete('s9').then((ok) => setDone(`ok:${ok}`))}>await</button>
+          <span data-testid="done">{done}</span>
+        </div>
+      );
+    }
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <CompleteProbe />
+      </ControllerChannelProvider>
+    );
+
+    // Pair with live-A first; a step-complete is only honored from the paired
+    // tab (T1 PART C), and pairing happens on a heartbeat.
+    act(() =>
+      transport.emit({ source: 'pathfinder', senderId: 'live-A', timestamp: 0, kind: 'heartbeat', role: 'live' })
+    );
+    fireEvent.click(screen.getByText('await'));
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'live-A',
+        timestamp: 0,
+        kind: 'step-complete',
+        stepId: 's9',
+        ok: true,
+      })
+    );
+
+    await waitFor(() => expect(screen.getByTestId('done')).toHaveTextContent('ok:true'));
+  });
+
+  it('forwards step-progress to an onStepProgress subscriber', () => {
+    function ProgressProbe() {
+      const channel = useControllerChannel();
+      const [p, setP] = React.useState('none');
+      React.useEffect(() => channel?.onStepProgress('s9', (index, total) => setP(`${index}/${total}`)), [channel]);
+      return <span data-testid="progress">{p}</span>;
+    }
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <ProgressProbe />
+      </ControllerChannelProvider>
+    );
+
+    // A forged step-progress before any live heartbeat must be dropped — pairing
+    // happens on a heartbeat only, so an unpaired sender can't drive the bar
+    // (F-1084 step-progress spoof, T1 PART C).
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'attacker',
+        timestamp: 0,
+        kind: 'step-progress',
+        stepId: 's9',
+        index: 2,
+        total: 3,
+      })
+    );
+    expect(screen.getByTestId('progress')).toHaveTextContent('none');
+
+    // Pair with live-A via a heartbeat; its step-progress is then honored.
+    act(() =>
+      transport.emit({ source: 'pathfinder', senderId: 'live-A', timestamp: 0, kind: 'heartbeat', role: 'live' })
+    );
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'live-A',
+        timestamp: 0,
+        kind: 'step-progress',
+        stepId: 's9',
+        index: 1,
+        total: 3,
+      })
+    );
+    expect(screen.getByTestId('progress')).toHaveTextContent('1/3');
+  });
+
+  it('returns null outside a provider', () => {
+    function Peek() {
+      const channel = useControllerChannel();
+      return <span data-testid="outside">{channel === null ? 'null' : 'present'}</span>;
+    }
+    render(<Peek />);
+    expect(screen.getByTestId('outside')).toHaveTextContent('null');
+  });
+});

--- a/src/global-state/controller-channel.tsx
+++ b/src/global-state/controller-channel.tsx
@@ -1,0 +1,302 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { CrossTabTransport, createSenderId } from '../lib/cross-tab-transport';
+import type {
+  CheckRequirementsMessage,
+  CrossTabMessage,
+  CrossTabPayload,
+  FixRequirementMessage,
+  RemoteRequirementResult,
+} from '../types/cross-tab.types';
+
+const HEARTBEAT_INTERVAL_MS = 2000;
+const HEARTBEAT_STALE_MS = 5000;
+// Requirement/fix round-trips fall back after this; step-run completion is
+// unbounded (guided is human-paced) and fails only when the paired tab goes stale.
+const REQUEST_TIMEOUT_MS = 4000;
+
+interface ChannelTransport {
+  start(): void;
+  stop(): void;
+  post(payload: CrossTabPayload): void;
+  onMessage(listener: (message: CrossTabMessage) => void): () => void;
+}
+
+interface FixOutcome {
+  ok: boolean;
+  error?: string;
+}
+
+type RequestPayload =
+  | Omit<CheckRequirementsMessage, 'source' | 'senderId' | 'timestamp' | 'requestId'>
+  | Omit<FixRequirementMessage, 'source' | 'senderId' | 'timestamp' | 'requestId'>;
+
+interface ControllerChannel {
+  post: (payload: CrossTabPayload) => void;
+  /** Ask the live tab to evaluate a step's requirements; resolves null on timeout. */
+  requestRequirementCheck: (
+    stepId: string,
+    requirements: string,
+    opts?: { targetAction?: string; refTarget?: string; targetValue?: string }
+  ) => Promise<RemoteRequirementResult | null>;
+  requestFix: (
+    stepId: string,
+    opts: { requirements: string; fixType?: string; targetHref?: string; scrollContainer?: string }
+  ) => Promise<FixOutcome>;
+  awaitStepComplete: (stepId: string) => Promise<boolean>;
+  /** Abandon a pending awaitStepComplete waiter (user cancelled); resolves it false. */
+  cancelStepComplete: (stepId: string) => void;
+  /** Subscribe to a composite step's per-action progress; returns an unsubscribe. */
+  onStepProgress: (stepId: string, cb: (index: number, total: number) => void) => () => void;
+}
+
+interface PendingRequest {
+  resolve: (value: RemoteRequirementResult | FixOutcome | null) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const ControllerChannelContext = createContext<ControllerChannel | null>(null);
+// Connection state lives in its own context: the heartbeat flips `connected`
+// every few seconds, and folding it into the channel value would re-render
+// every InteractiveStep that only needs `post`. The status badge is the sole
+// consumer of this context (NEW-1065-1).
+const ControllerConnectionContext = createContext<boolean>(false);
+
+export function useControllerChannel(): ControllerChannel | null {
+  return useContext(ControllerChannelContext);
+}
+
+export function useControllerConnected(): boolean {
+  return useContext(ControllerConnectionContext);
+}
+
+export function ControllerChannelProvider({
+  children,
+  transport,
+}: {
+  children: React.ReactNode;
+  transport?: ChannelTransport;
+}) {
+  const [active] = useState<ChannelTransport>(() => transport ?? new CrossTabTransport(createSenderId()));
+  const [connected, setConnected] = useState(false);
+  const lastLiveSeenRef = useRef(0);
+  const reassertedCloseRef = useRef(false);
+  // The one live tab this controller is bound to (first to send a `live`
+  // heartbeat); replies from any other tab are ignored.
+  const pairedLiveIdRef = useRef<string | null>(null);
+  const pendingRef = useRef<Map<string, PendingRequest>>(new Map());
+  const stepCompletionRef = useRef<Map<string, (ok: boolean) => void>>(new Map());
+  const stepProgressRef = useRef<Map<string, (index: number, total: number) => void>>(new Map());
+
+  const post = useCallback((payload: CrossTabPayload) => active.post(payload), [active]);
+
+  useEffect(() => {
+    active.start();
+    // Hand the main window's sidebar off to this controller tab while it drives.
+    active.post({ kind: 'sidebar-handoff', action: 'close' });
+
+    const pending = pendingRef.current;
+    const stepDone = stepCompletionRef.current;
+    const settle = (requestId: string, value: RemoteRequirementResult | FixOutcome | null) => {
+      const entry = pending.get(requestId);
+      if (!entry) {
+        return;
+      }
+      clearTimeout(entry.timer);
+      pending.delete(requestId);
+      entry.resolve(value);
+    };
+    const failAllPending = () => {
+      pending.forEach((entry) => {
+        clearTimeout(entry.timer);
+        entry.resolve(null);
+      });
+      pending.clear();
+      stepDone.forEach((resolve) => resolve(false));
+      stepDone.clear();
+    };
+
+    const unsubscribe = active.onMessage((message) => {
+      if (message.kind === 'heartbeat') {
+        if (message.role !== 'live') {
+          return;
+        }
+        // PAIRING SITE. TODO(twotab): v1 ships without a sender handshake — the
+        // controller binds to the first live tab that sends a `live` heartbeat,
+        // so any same-origin script that learns the channel name can claim this
+        // slot with a forged heartbeat. Once paired it can drive check-requirements
+        // / fix-requirement, which run navigation + DOM mutation against the
+        // authenticated live tab (the highest-risk surface, #1070). Per-kind
+        // validation gates message SHAPE, not AUTHORIZATION. Future work: a
+        // gesture-to-accept on the live tab or an out-of-band nonce at controller
+        // open. See CROSS_TAB_CONTROLLER.md "Known limitations".
+        if (pairedLiveIdRef.current === null) {
+          pairedLiveIdRef.current = message.senderId;
+        }
+        if (message.senderId !== pairedLiveIdRef.current) {
+          return;
+        }
+        lastLiveSeenRef.current = Date.now();
+        setConnected(true);
+        if (!reassertedCloseRef.current) {
+          // The initial close above may have been posted before any live tab
+          // was listening (controller opened first, or the live tab mounted
+          // late). Re-assert it once the first live heartbeat proves a live tab
+          // exists, so the sidebar still hands off (F-1067-1). The flag stops
+          // later reconnects from re-posting on every tick.
+          reassertedCloseRef.current = true;
+          active.post({ kind: 'sidebar-handoff', action: 'close' });
+        }
+        return;
+      }
+      if (
+        message.kind !== 'requirement-result' &&
+        message.kind !== 'fix-result' &&
+        message.kind !== 'step-complete' &&
+        message.kind !== 'step-progress'
+      ) {
+        return;
+      }
+      // T1 PART C: pairing happens on a heartbeat ONLY (above) — never adopt a
+      // sender from a reply, or a forged first reply could claim the pairing slot
+      // before any live tab heartbeats (first-responder spoof, F-1073 / F-1084).
+      // An unpaired or mismatched sender is dropped.
+      if (pairedLiveIdRef.current === null || message.senderId !== pairedLiveIdRef.current) {
+        return;
+      }
+      if (message.kind === 'requirement-result') {
+        settle(message.requestId, message.result);
+      } else if (message.kind === 'fix-result') {
+        settle(message.requestId, { ok: message.ok, error: message.error });
+      } else if (message.kind === 'step-progress') {
+        stepProgressRef.current.get(message.stepId)?.(message.index, message.total);
+      } else {
+        const resolve = stepDone.get(message.stepId);
+        if (resolve) {
+          stepDone.delete(message.stepId);
+          resolve(message.ok);
+        }
+      }
+    });
+
+    const tick = () => {
+      active.post({ kind: 'heartbeat', role: 'controller' });
+      if (lastLiveSeenRef.current > 0 && Date.now() - lastLiveSeenRef.current > HEARTBEAT_STALE_MS) {
+        setConnected(false);
+        // Paired tab gone: drop the binding to allow re-pairing and fail waiters.
+        pairedLiveIdRef.current = null;
+        failAllPending();
+      }
+    };
+    tick();
+    const intervalId = setInterval(tick, HEARTBEAT_INTERVAL_MS);
+
+    // Closing the controller tab (or unmounting) hands the sidebar back.
+    const handBack = () => active.post({ kind: 'sidebar-handoff', action: 'reopen' });
+    window.addEventListener('pagehide', handBack);
+
+    return () => {
+      window.removeEventListener('pagehide', handBack);
+      handBack();
+      clearInterval(intervalId);
+      unsubscribe();
+      active.stop();
+      failAllPending();
+    };
+  }, [active]);
+
+  const request = useCallback(
+    <T extends RemoteRequirementResult | FixOutcome | null>(payload: RequestPayload, fallback: T): Promise<T> => {
+      // Globally unique so a reply can never settle the wrong pending request:
+      // a per-instance sequence (`req-1`, `req-2`, …) collides across two
+      // controller tabs sharing the channel, and a stray reply would resolve the
+      // other controller's same-numbered request (F-1070-1).
+      const requestId = crypto.randomUUID();
+      return new Promise<T>((resolve) => {
+        const timer = setTimeout(() => {
+          pendingRef.current.delete(requestId);
+          resolve(fallback);
+        }, REQUEST_TIMEOUT_MS);
+        pendingRef.current.set(requestId, { resolve: resolve as PendingRequest['resolve'], timer });
+        post({ ...payload, requestId });
+      });
+    },
+    [post]
+  );
+
+  const requestRequirementCheck = useCallback<ControllerChannel['requestRequirementCheck']>(
+    (stepId, requirements, opts) =>
+      request(
+        {
+          kind: 'check-requirements',
+          stepId,
+          requirements,
+          targetAction: opts?.targetAction,
+          refTarget: opts?.refTarget,
+          targetValue: opts?.targetValue,
+        },
+        null
+      ),
+    [request]
+  );
+
+  const requestFix = useCallback<ControllerChannel['requestFix']>(
+    (stepId, opts) =>
+      request(
+        {
+          kind: 'fix-requirement',
+          stepId,
+          requirements: opts.requirements,
+          fixType: opts.fixType,
+          targetHref: opts.targetHref,
+          scrollContainer: opts.scrollContainer,
+        },
+        { ok: false, error: 'No live tab responded' }
+      ),
+    [request]
+  );
+
+  const awaitStepComplete = useCallback<ControllerChannel['awaitStepComplete']>(
+    (stepId) =>
+      new Promise<boolean>((resolve) => {
+        // A re-run for the same step supersedes any earlier waiter.
+        stepCompletionRef.current.get(stepId)?.(false);
+        stepCompletionRef.current.set(stepId, resolve);
+      }),
+    []
+  );
+
+  const cancelStepComplete = useCallback<ControllerChannel['cancelStepComplete']>((stepId) => {
+    const resolve = stepCompletionRef.current.get(stepId);
+    if (resolve) {
+      stepCompletionRef.current.delete(stepId);
+      resolve(false);
+    }
+  }, []);
+
+  // One subscriber per stepId (last writer wins). The unsubscribe only deletes
+  // if its own callback is still registered, so a superseding subscriber for the
+  // same step isn't evicted by the previous one's cleanup.
+  const onStepProgress = useCallback<ControllerChannel['onStepProgress']>((stepId, cb) => {
+    stepProgressRef.current.set(stepId, cb);
+    return () => {
+      if (stepProgressRef.current.get(stepId) === cb) {
+        stepProgressRef.current.delete(stepId);
+      }
+    };
+  }, []);
+
+  // The channel value omits `connected` (it lives in ControllerConnectionContext)
+  // and depends only on the useCallback-stable post + round-trip helpers, so it
+  // stays referentially stable across heartbeat ticks — step consumers don't
+  // re-render (NEW-1065-1).
+  const channel = useMemo<ControllerChannel>(
+    () => ({ post, requestRequirementCheck, requestFix, awaitStepComplete, cancelStepComplete, onStepProgress }),
+    [post, requestRequirementCheck, requestFix, awaitStepComplete, cancelStepComplete, onStepProgress]
+  );
+
+  return (
+    <ControllerChannelContext.Provider value={channel}>
+      <ControllerConnectionContext.Provider value={connected}>{children}</ControllerConnectionContext.Provider>
+    </ControllerChannelContext.Provider>
+  );
+}

--- a/src/integrations/cross-tab/live-tab-executor.test.ts
+++ b/src/integrations/cross-tab/live-tab-executor.test.ts
@@ -1,0 +1,543 @@
+import { waitFor } from '@testing-library/react';
+import { getAppEvents } from '@grafana/runtime';
+import { installLiveTabExecutor, resetLiveTabExecutorForTests } from './live-tab-executor';
+import { FocusHandler, ButtonHandler, NavigateHandler, GuidedHandler } from '../../interactive-engine/action-handlers';
+import { checkRequirements, dispatchFix } from '../../requirements-manager';
+import { sidebarState } from '../../global-state/sidebar';
+import { isExtensionSidebarOwnedByOther } from '../../utils/experiments/experiment-utils';
+import type { CrossTabMessage } from '../../types/cross-tab.types';
+
+jest.mock('../../requirements-manager', () => {
+  const actual = jest.requireActual('../../requirements-manager');
+  return { ...actual, checkRequirements: jest.fn(), dispatchFix: jest.fn() };
+});
+
+jest.mock('../../interactive-engine/action-handlers', () => {
+  const makeHandler = () => ({ execute: jest.fn().mockResolvedValue(undefined) });
+  const makeGuided = () => ({
+    resetProgress: jest.fn(),
+    executeGuidedStep: jest.fn().mockResolvedValue('completed'),
+  });
+  return {
+    FocusHandler: jest.fn(makeHandler),
+    ButtonHandler: jest.fn(makeHandler),
+    FormFillHandler: jest.fn(makeHandler),
+    HoverHandler: jest.fn(makeHandler),
+    NavigateHandler: jest.fn(makeHandler),
+    GuidedHandler: jest.fn(makeGuided),
+  };
+});
+
+jest.mock('@grafana/runtime', () => {
+  const actual = jest.requireActual('@grafana/runtime');
+  const publish = jest.fn();
+  return { ...actual, getAppEvents: jest.fn(() => ({ publish })) };
+});
+
+jest.mock('../../global-state/sidebar', () => ({
+  sidebarState: { getIsSidebarMounted: jest.fn(() => true), openSidebar: jest.fn() },
+}));
+
+jest.mock('../../utils/experiments/experiment-utils', () => {
+  const actual = jest.requireActual('../../utils/experiments/experiment-utils');
+  return { ...actual, isExtensionSidebarOwnedByOther: jest.fn(() => false) };
+});
+
+class FakeTransport {
+  started = false;
+  stopped = false;
+  senderId = 'live-self';
+  postedMessages: unknown[] = [];
+  private listener: ((message: CrossTabMessage) => void) | null = null;
+
+  start(): void {
+    this.started = true;
+  }
+
+  stop(): void {
+    this.stopped = true;
+  }
+
+  post(payload: unknown): void {
+    this.postedMessages.push(payload);
+  }
+
+  onMessage(listener: (message: CrossTabMessage) => void): () => void {
+    this.listener = listener;
+    return () => {
+      this.listener = null;
+    };
+  }
+
+  emit(message: CrossTabMessage): void {
+    this.listener?.(message);
+  }
+}
+
+function controllerHeartbeat(): CrossTabMessage {
+  return { source: 'pathfinder', senderId: 'controller', timestamp: 0, kind: 'heartbeat', role: 'controller' };
+}
+
+function stampStepCommand(phase: 'show' | 'do', targetAction: string, refTarget: string): CrossTabMessage {
+  return {
+    source: 'pathfinder',
+    senderId: 'controller',
+    timestamp: 0,
+    kind: 'step-command',
+    phase,
+    stepId: 's1',
+    action: { targetAction, refTarget },
+  };
+}
+
+function stampSidebarHandoff(action: 'close' | 'reopen'): CrossTabMessage {
+  return { source: 'pathfinder', senderId: 'controller', timestamp: 0, kind: 'sidebar-handoff', action };
+}
+
+function executeOf(handler: unknown): jest.Mock {
+  const ctor = handler as jest.Mock;
+  return (ctor.mock.results[0]?.value as { execute: jest.Mock }).execute;
+}
+
+describe('installLiveTabExecutor', () => {
+  beforeEach(() => {
+    resetLiveTabExecutorForTests();
+    jest.clearAllMocks();
+    (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
+    (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(false);
+    (checkRequirements as jest.Mock).mockResolvedValue({ requirements: '', pass: true, error: [] });
+    (dispatchFix as jest.Mock).mockResolvedValue({ ok: true });
+  });
+
+  it('starts the transport on install and stops it on uninstall', () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    expect(transport.started).toBe(true);
+    expect(transport.stopped).toBe(false);
+
+    uninstall();
+    expect(transport.stopped).toBe(true);
+  });
+
+  it('routes a "do" highlight command to FocusHandler.execute with click=true', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    transport.emit(stampStepCommand('do', 'highlight', '#target'));
+
+    await waitFor(() => expect(executeOf(FocusHandler)).toHaveBeenCalled());
+    expect(executeOf(FocusHandler)).toHaveBeenCalledWith(
+      expect.objectContaining({ refTarget: '#target', targetAction: 'highlight' }),
+      true
+    );
+    uninstall();
+  });
+
+  it('routes a "show" command to the handler with click=false', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    transport.emit(stampStepCommand('show', 'highlight', '#target'));
+
+    await waitFor(() => expect(executeOf(FocusHandler)).toHaveBeenCalled());
+    expect(executeOf(FocusHandler)).toHaveBeenCalledWith(expect.objectContaining({ refTarget: '#target' }), false);
+    uninstall();
+  });
+
+  it('routes button and navigate actions to their handlers', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    transport.emit(stampStepCommand('do', 'button', "button[type='submit']"));
+    transport.emit(stampStepCommand('do', 'navigate', '/dashboards'));
+
+    await waitFor(() => expect(executeOf(ButtonHandler)).toHaveBeenCalled());
+    await waitFor(() => expect(executeOf(NavigateHandler)).toHaveBeenCalled());
+    uninstall();
+  });
+
+  it('replays a multi-step internalActions sequence in order', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport, { showToDoMs: 0, settleMs: 0, interStepMs: 0 });
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'ms1',
+      action: {
+        targetAction: 'multistep',
+        refTarget: '',
+        internalActions: [
+          { targetAction: 'highlight', refTarget: '#a' },
+          { targetAction: 'button', refTarget: '#b' },
+        ],
+      },
+    });
+
+    await waitFor(() => expect(executeOf(FocusHandler)).toHaveBeenCalled());
+    await waitFor(() => expect(executeOf(ButtonHandler)).toHaveBeenCalled());
+    uninstall();
+  });
+
+  it('paces each composite action through show then do', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport, { showToDoMs: 0, settleMs: 0, interStepMs: 0 });
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'ms1',
+      action: {
+        targetAction: 'multistep',
+        refTarget: '',
+        internalActions: [{ targetAction: 'highlight', refTarget: '#a' }],
+      },
+    });
+
+    await waitFor(() => expect(executeOf(FocusHandler)).toHaveBeenCalledTimes(2));
+    expect(executeOf(FocusHandler)).toHaveBeenNthCalledWith(1, expect.objectContaining({ refTarget: '#a' }), false);
+    expect(executeOf(FocusHandler)).toHaveBeenNthCalledWith(2, expect.objectContaining({ refTarget: '#a' }), true);
+    uninstall();
+  });
+
+  it('runs a guided command through the guided handler, not the auto replay', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'g1',
+      action: {
+        targetAction: 'guided',
+        refTarget: '',
+        internalActions: [
+          { targetAction: 'highlight', refTarget: '#a' },
+          { targetAction: 'button', refTarget: '#b' },
+        ],
+      },
+    });
+
+    const executeGuidedStep = (GuidedHandler as jest.Mock).mock.results[0]?.value.executeGuidedStep as jest.Mock;
+    await waitFor(() => expect(executeGuidedStep).toHaveBeenCalledTimes(2));
+    // Guided waits for the user — it must NOT auto-perform via the action handlers.
+    expect(executeOf(FocusHandler)).not.toHaveBeenCalled();
+    expect(executeOf(ButtonHandler)).not.toHaveBeenCalled();
+    // And it reports completion so the controller doesn't mark the step done early.
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({ kind: 'step-complete', stepId: 'g1', ok: true })
+      )
+    );
+    uninstall();
+  });
+
+  it('posts step-progress for each action during a multi-step replay', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport, { showToDoMs: 0, settleMs: 0, interStepMs: 0 });
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'ms3',
+      action: {
+        targetAction: 'multistep',
+        refTarget: '',
+        internalActions: [
+          { targetAction: 'highlight', refTarget: '#a' },
+          { targetAction: 'button', refTarget: '#b' },
+        ],
+      },
+    });
+
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({ kind: 'step-progress', stepId: 'ms3', index: 0, total: 2 })
+      )
+    );
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({ kind: 'step-progress', stepId: 'ms3', index: 1, total: 2 })
+      )
+    );
+    uninstall();
+  });
+
+  it('posts step-complete after a multi-step replay finishes', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport, { showToDoMs: 0, settleMs: 0, interStepMs: 0 });
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'ms2',
+      action: {
+        targetAction: 'multistep',
+        refTarget: '',
+        internalActions: [{ targetAction: 'highlight', refTarget: '#a' }],
+      },
+    });
+
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({ kind: 'step-complete', stepId: 'ms2', ok: true })
+      )
+    );
+    uninstall();
+  });
+
+  it('ignores unsupported actions without throwing or routing', () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    expect(() => transport.emit(stampStepCommand('do', 'multistep', '#x'))).not.toThrow();
+    expect(executeOf(FocusHandler)).not.toHaveBeenCalled();
+    expect(executeOf(ButtonHandler)).not.toHaveBeenCalled();
+    uninstall();
+  });
+
+  it('responds to a controller heartbeat with a live heartbeat', () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    transport.emit(controllerHeartbeat());
+
+    expect(transport.postedMessages).toContainEqual({ kind: 'heartbeat', role: 'live' });
+    uninstall();
+  });
+
+  it('closes the live-tab sidebar when a controller takes over', () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    transport.emit(stampSidebarHandoff('close'));
+
+    expect(getAppEvents().publish).toHaveBeenCalledWith(expect.objectContaining({ type: 'close-extension-sidebar' }));
+    uninstall();
+  });
+
+  it('reopens the sidebar when the controller leaves and the slot is free', () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    transport.emit(stampSidebarHandoff('close'));
+    transport.emit(stampSidebarHandoff('reopen'));
+
+    expect(sidebarState.openSidebar).toHaveBeenCalled();
+    uninstall();
+  });
+
+  it('does not reopen when another plugin occupies the sidebar', () => {
+    (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(true);
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    transport.emit(stampSidebarHandoff('close'));
+    transport.emit(stampSidebarHandoff('reopen'));
+
+    expect(sidebarState.openSidebar).not.toHaveBeenCalled();
+    uninstall();
+  });
+
+  it('evaluates a check-requirements request against the live tab and replies', async () => {
+    (checkRequirements as jest.Mock).mockResolvedValue({
+      requirements: 'navmenu-open',
+      pass: false,
+      error: [{ requirement: 'navmenu-open', pass: false, canFix: true, fixType: 'navigation' }],
+    });
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'check-requirements',
+      requestId: 'r1',
+      stepId: 's1',
+      requirements: 'navmenu-open',
+    });
+
+    await waitFor(() =>
+      expect(checkRequirements).toHaveBeenCalledWith(expect.objectContaining({ requirements: 'navmenu-open' }))
+    );
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({
+          kind: 'requirement-result',
+          requestId: 'r1',
+          stepId: 's1',
+          result: expect.objectContaining({ pass: false }),
+        })
+      )
+    );
+    uninstall();
+  });
+
+  it('runs a fix-requirement against the live tab and replies with the outcome', async () => {
+    (dispatchFix as jest.Mock).mockResolvedValue({ ok: true });
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'fix-requirement',
+      requestId: 'f1',
+      stepId: 's1',
+      requirements: 'navmenu-open',
+      fixType: 'navigation',
+    });
+
+    await waitFor(() =>
+      expect(dispatchFix).toHaveBeenCalledWith(
+        expect.objectContaining({ fixType: 'navigation', requirements: 'navmenu-open' })
+      )
+    );
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({ kind: 'fix-result', requestId: 'f1', stepId: 's1', ok: true })
+      )
+    );
+    uninstall();
+  });
+
+  it('replies with a failed fix-result when the live-tab fix throws', async () => {
+    (dispatchFix as jest.Mock).mockRejectedValue(new Error('boom'));
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'fix-requirement',
+      requestId: 'f2',
+      stepId: 's1',
+      requirements: 'navmenu-open',
+      fixType: 'navigation',
+    });
+
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({ kind: 'fix-result', requestId: 'f2', ok: false })
+      )
+    );
+    uninstall();
+  });
+
+  it('only installs once until uninstalled', () => {
+    const first = new FakeTransport();
+    const second = new FakeTransport();
+    const uninstall = installLiveTabExecutor(first);
+    installLiveTabExecutor(second);
+
+    expect(first.started).toBe(true);
+    expect(second.started).toBe(false);
+    uninstall();
+  });
+
+  it('does not brick the executor if a handler constructor throws (NEW-1064-1)', () => {
+    (ButtonHandler as unknown as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('constructor boom');
+    });
+    const first = new FakeTransport();
+    expect(() => installLiveTabExecutor(first)).toThrow('constructor boom');
+    expect(first.started).toBe(false);
+
+    // installed stayed false, so a later init installs cleanly rather than
+    // being permanently blocked by the failed attempt.
+    const second = new FakeTransport();
+    const uninstall = installLiveTabExecutor(second);
+    expect(second.started).toBe(true);
+    uninstall();
+  });
+
+  it('does not execute commands delivered after uninstall (NEW-1064-2)', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+    uninstall();
+
+    transport.emit(stampStepCommand('do', 'highlight', '#target'));
+    await Promise.resolve();
+
+    expect(executeOf(FocusHandler)).not.toHaveBeenCalled();
+  });
+
+  it('drops a command with an unrecognized action at the sink (T1 defense in depth)', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    const forged = {
+      ...stampStepCommand('do', 'highlight', '#t'),
+      action: { targetAction: 'exec', refTarget: '#t' },
+    } as CrossTabMessage;
+    transport.emit(forged);
+    await Promise.resolve();
+
+    expect(executeOf(FocusHandler)).not.toHaveBeenCalled();
+    uninstall();
+  });
+
+  it('drops a forged fix-requirement missing required fields without dispatching a fix (T1 / security gate)', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    // fix-requirement is the highest-risk kind — runRemoteFix → dispatchFix
+    // performs navigation / DOM mutation on the authenticated live tab. A message
+    // missing the required `requirements` string must be dropped at the gate, so
+    // dispatchFix is never reached and no fix-result is posted back.
+    const forged = {
+      source: 'pathfinder',
+      senderId: 'attacker',
+      timestamp: 0,
+      kind: 'fix-requirement',
+      requestId: 'x1',
+      stepId: 's1',
+      fixType: 'navigation',
+    } as unknown as CrossTabMessage;
+    transport.emit(forged);
+    await Promise.resolve();
+
+    expect(dispatchFix).not.toHaveBeenCalled();
+    expect(transport.postedMessages).not.toContainEqual(expect.objectContaining({ kind: 'fix-result' }));
+    uninstall();
+  });
+
+  it('drops a forged check-requirements missing required fields without probing the DOM (T1 / security gate)', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport);
+
+    const forged = {
+      source: 'pathfinder',
+      senderId: 'attacker',
+      timestamp: 0,
+      kind: 'check-requirements',
+      requestId: 'x2',
+      stepId: 's1',
+    } as unknown as CrossTabMessage;
+    transport.emit(forged);
+    await Promise.resolve();
+
+    expect(checkRequirements).not.toHaveBeenCalled();
+    expect(transport.postedMessages).not.toContainEqual(expect.objectContaining({ kind: 'requirement-result' }));
+    uninstall();
+  });
+});

--- a/src/integrations/cross-tab/live-tab-executor.ts
+++ b/src/integrations/cross-tab/live-tab-executor.ts
@@ -1,0 +1,348 @@
+import { config, getAppEvents } from '@grafana/runtime';
+import { addGlobalInteractiveStyles, updateInteractiveThemeColors } from '../../styles/interactive.styles';
+import { waitForReactUpdates } from '../../lib/async-utils';
+import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
+import type { InteractiveElementData } from '../../types/interactive.types';
+import {
+  ButtonHandler,
+  FocusHandler,
+  FormFillHandler,
+  GuidedHandler,
+  HoverHandler,
+  InteractiveStateManager,
+  NavigateHandler,
+  NavigationManager,
+} from '../../interactive-engine';
+import type { GuidedAction } from '../../types/interactive-actions.types';
+import { CrossTabTransport, createSenderId } from '../../lib/cross-tab-transport';
+import { checkRequirements, dispatchFix, type RequirementsCheckResult } from '../../requirements-manager';
+import {
+  validateCrossTabMessage,
+  type CheckRequirementsMessage,
+  type CrossTabInternalAction,
+  type CrossTabMessage,
+  type CrossTabPayload,
+  type FixRequirementMessage,
+  type RemoteRequirementResult,
+  type StepCommandMessage,
+} from '../../types/cross-tab.types';
+import { sidebarState } from '../../global-state/sidebar';
+import { isExtensionSidebarOwnedByOther } from '../../utils/experiments/experiment-utils';
+import pluginJson from '../../plugin.json';
+
+// The verbs the guided handler can actually drive — narrower than the receive
+// gate's KNOWN_TARGET_ACTIONS, so runGuided checks against this before casting.
+const GUIDED_VERBS: ReadonlySet<GuidedAction['targetAction']> = new Set([
+  'hover',
+  'button',
+  'highlight',
+  'noop',
+  'formfill',
+]);
+
+interface ExecutorTransport {
+  start(): void;
+  stop(): void;
+  post(payload: CrossTabPayload): void;
+  onMessage(listener: (message: CrossTabMessage) => void): () => void;
+}
+
+interface ExecutorPacing {
+  showToDoMs: number;
+  settleMs: number;
+  interStepMs: number;
+}
+
+const DEFAULT_PACING: ExecutorPacing = {
+  showToDoMs: INTERACTIVE_CONFIG.delays.multiStep.showToDoIterations * INTERACTIVE_CONFIG.delays.multiStep.baseInterval,
+  settleMs: INTERACTIVE_CONFIG.delays.multiStep.settleAfterActionMs,
+  interStepMs: INTERACTIVE_CONFIG.delays.multiStep.defaultStepDelay,
+};
+
+// F-1056-4: the tier-0 wire mirror (RemoteRequirementResult) and the tier-2 real
+// result (RequirementsCheckResult) must stay structurally interchangeable in BOTH
+// directions — evaluateRequirements posts the real type as the mirror, and the
+// controller reads the mirror back as the real type. Drift in either type makes
+// this assignment fail to compile.
+type MutuallyAssignable<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never;
+const _resultMirrorIsExact: MutuallyAssignable<RemoteRequirementResult, RequirementsCheckResult> = true;
+void _resultMirrorIsExact;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Double rAF: one frame to flush the action's state update, a second to let the
+// browser paint it, so the next internal action sees a settled DOM.
+const settleDom = (): Promise<void> =>
+  new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+
+let installed = false;
+
+/** @internal Test-only reset of the install-once guard. */
+export function resetLiveTabExecutorForTests(): void {
+  installed = false;
+}
+
+export function installLiveTabExecutor(
+  transport: ExecutorTransport = new CrossTabTransport(createSenderId()),
+  pacing: ExecutorPacing = DEFAULT_PACING
+): () => void {
+  if (installed || typeof window === 'undefined') {
+    return () => undefined;
+  }
+
+  try {
+    addGlobalInteractiveStyles();
+    updateInteractiveThemeColors(config.theme2);
+  } catch (error) {
+    console.warn('[Pathfinder] cross-tab executor: style init failed', error);
+  }
+
+  const stateManager = new InteractiveStateManager();
+  const navigationManager = new NavigationManager();
+  const focusHandler = new FocusHandler(stateManager, navigationManager, waitForReactUpdates);
+  const buttonHandler = new ButtonHandler(stateManager, navigationManager, waitForReactUpdates);
+  const formFillHandler = new FormFillHandler(stateManager, navigationManager, waitForReactUpdates);
+  const navigateHandler = new NavigateHandler(stateManager, waitForReactUpdates);
+  const hoverHandler = new HoverHandler(stateManager, navigationManager, waitForReactUpdates);
+  const guidedHandler = new GuidedHandler(stateManager, navigationManager, waitForReactUpdates);
+
+  // Claim the install slot only after every handler is constructed, so a
+  // throwing constructor leaves installed=false and a later init can retry
+  // instead of permanently bricking the executor for the session (NEW-1064-1).
+  installed = true;
+
+  // Teardown flag: a replay in flight (or queued) must not touch the DOM after
+  // uninstall (NEW-1064-2).
+  let cancelled = false;
+  // Serialize replays onto a single chain so a slow paced replay finishes (or
+  // is cancelled) before the next command starts — commands cannot interleave
+  // and race on shared highlight state (F-1069-1).
+  let queue: Promise<void> = Promise.resolve();
+
+  const runAction = async (action: CrossTabInternalAction, isShow: boolean): Promise<void> => {
+    const data: InteractiveElementData = {
+      refTarget: action.refTarget ?? '',
+      targetAction: action.targetAction,
+      targetValue: action.targetValue,
+      targetComment: action.targetComment,
+      tagName: 'button',
+      textContent: `${isShow ? 'Show me' : 'Do'}: ${action.refTarget ?? ''}`,
+      timestamp: Date.now(),
+    };
+
+    switch (action.targetAction) {
+      case 'highlight':
+        await focusHandler.execute(data, !isShow);
+        break;
+      case 'button':
+        await buttonHandler.execute(data, !isShow);
+        break;
+      case 'formfill':
+        await formFillHandler.execute(data, !isShow);
+        break;
+      case 'navigate':
+        await navigateHandler.execute(data, !isShow);
+        break;
+      case 'hover':
+        await hoverHandler.execute(data, !isShow);
+        break;
+      case 'noop':
+        break;
+      case 'guided':
+      case 'multistep':
+        // A composite verb reaching runAction means its internalActions were
+        // empty/absent — runStepCommand expands them before dispatch, so this
+        // is a malformed command, not a directly-executable action.
+        console.warn(
+          `[Pathfinder] cross-tab executor: composite action "${action.targetAction}" carried no internalActions to replay`
+        );
+        break;
+      default:
+        console.warn(`[Pathfinder] cross-tab executor: unsupported action "${action.targetAction}"`);
+    }
+  };
+
+  type ActionList = NonNullable<StepCommandMessage['action']['internalActions']>;
+  type OnProgress = (index: number) => void;
+
+  // multi-step / guided replay each internal action the way a live tab paces a
+  // normal multi-step: highlight (show) → pause → perform (do) → settle → pause,
+  // so the user watches the same staged sequence rather than an instant burst.
+  // Composites always run the full show→do sequence; the command's wire `phase`
+  // is not consulted (controllers only ever post composites as a 'do').
+  const runComposite = async (actions: ActionList, onProgress: OnProgress): Promise<void> => {
+    for (let i = 0; i < actions.length; i++) {
+      // Paced replay holds the loop open for seconds; bail between actions if a
+      // teardown set cancelled so we never touch the DOM post-uninstall (NEW-1064-2).
+      if (cancelled) {
+        return;
+      }
+      onProgress(i);
+      const action = actions[i]!;
+      await runAction(action, true);
+      await sleep(pacing.showToDoMs);
+      await runAction(action, false);
+      await settleDom();
+      await sleep(pacing.settleMs);
+      if (i < actions.length - 1) {
+        await sleep(pacing.interStepMs);
+      }
+    }
+  };
+
+  // Guided is human-driven: highlight each target and wait for the user to perform
+  // it on the live tab, rather than the auto replay a multi-step uses.
+  const runGuided = async (actions: ActionList, onProgress: OnProgress): Promise<boolean> => {
+    guidedHandler.resetProgress();
+    for (let i = 0; i < actions.length; i++) {
+      onProgress(i);
+      const action = actions[i]!;
+      // The receive gate accepts any KNOWN_TARGET_ACTIONS verb, which is wider than
+      // the guided verb set — guard the cast so a non-guided verb (e.g. navigate)
+      // fails loud instead of being mistyped into the guided handler (F-1073-nit-cast).
+      if (!GUIDED_VERBS.has(action.targetAction as GuidedAction['targetAction'])) {
+        console.warn(`[Pathfinder] cross-tab executor: guided step has non-guided verb "${action.targetAction}"`);
+        return false;
+      }
+      const result = await guidedHandler.executeGuidedStep(
+        {
+          targetAction: action.targetAction as GuidedAction['targetAction'],
+          refTarget: action.refTarget,
+          targetValue: action.targetValue,
+          targetComment: action.targetComment,
+        },
+        i,
+        actions.length
+      );
+      if (result !== 'completed' && result !== 'skipped') {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const runStepCommand = async (command: StepCommandMessage): Promise<void> => {
+    if (cancelled) {
+      return;
+    }
+    const internalActions = command.action.internalActions;
+    const postProgress = (index: number) =>
+      transport.post({ kind: 'step-progress', stepId: command.stepId, index, total: internalActions?.length ?? 0 });
+    let ok = false;
+    try {
+      if (internalActions?.length) {
+        if (command.action.targetAction === 'guided') {
+          ok = await runGuided(internalActions, postProgress);
+        } else {
+          await runComposite(internalActions, postProgress);
+          ok = true;
+        }
+      } else {
+        await runAction(command.action, command.phase === 'show');
+        ok = true;
+      }
+    } catch (error) {
+      console.error('[Pathfinder] cross-tab executor: failed to run remote step', error);
+      ok = false;
+    }
+    // Reverse error channel (F-1064-1): tell the controller whether a composite
+    // actually finished, so it surfaces failure instead of completing early
+    // (guided waits for the user to click through). Simple steps stay optimistic
+    // by design (F-1063-1) and report nothing back.
+    if (internalActions?.length) {
+      transport.post({ kind: 'step-complete', stepId: command.stepId, ok });
+    }
+  };
+
+  // Evaluate the controller's tab-local requirements against this tab's DOM.
+  const evaluateRequirements = async (message: CheckRequirementsMessage): Promise<void> => {
+    try {
+      const result = await checkRequirements({
+        requirements: message.requirements,
+        targetAction: message.targetAction ?? 'button',
+        refTarget: message.refTarget ?? '',
+        targetValue: message.targetValue,
+        stepId: message.stepId,
+      });
+      transport.post({ kind: 'requirement-result', requestId: message.requestId, stepId: message.stepId, result });
+    } catch (error) {
+      transport.post({
+        kind: 'requirement-result',
+        requestId: message.requestId,
+        stepId: message.stepId,
+        result: {
+          requirements: message.requirements,
+          pass: false,
+          error: [{ requirement: message.requirements, pass: false, error: `${error}` }],
+        },
+      });
+    }
+  };
+
+  // Run the controller's "Fix this" against this tab's DOM, not the controller's.
+  const runRemoteFix = async (message: FixRequirementMessage): Promise<void> => {
+    let ok = false;
+    let error: string | undefined;
+    try {
+      const result = await dispatchFix({
+        fixType: message.fixType,
+        targetHref: message.targetHref,
+        scrollContainer: message.scrollContainer,
+        requirements: message.requirements,
+        stepId: message.stepId,
+        navigationManager,
+        fixNavigationRequirements: () => navigationManager.fixNavigationRequirements(),
+      });
+      ok = result.ok;
+      error = result.ok ? undefined : result.error;
+    } catch (caught) {
+      error = `${caught}`;
+    }
+    transport.post({ kind: 'fix-result', requestId: message.requestId, stepId: message.stepId, ok, error });
+  };
+
+  // Only restore a sidebar this tab actually gave up to a controller.
+  let handedOffSidebar = false;
+
+  const unsubscribe = transport.onMessage((message) => {
+    // Defense in depth: re-validate at the DOM sink before dispatch, so the
+    // executor never trusts a message that bypassed the transport gate (T1).
+    // check-requirements and fix-requirement are the highest-risk kinds here —
+    // they drive DOM probes and navigation/DOM mutation — so they MUST dispatch
+    // off `validated`, never the raw message.
+    const validated = validateCrossTabMessage(message);
+    if (!validated) {
+      return;
+    }
+    if (validated.kind === 'step-command') {
+      queue = queue.then(() => runStepCommand(validated));
+    } else if (validated.kind === 'check-requirements') {
+      void evaluateRequirements(validated);
+    } else if (validated.kind === 'fix-requirement') {
+      void runRemoteFix(validated);
+    } else if (validated.kind === 'heartbeat' && validated.role === 'controller') {
+      transport.post({ kind: 'heartbeat', role: 'live' });
+    } else if (validated.kind === 'sidebar-handoff') {
+      if (validated.action === 'close') {
+        if (sidebarState.getIsSidebarMounted()) {
+          getAppEvents().publish({ type: 'close-extension-sidebar', payload: {} });
+          handedOffSidebar = true;
+        }
+      } else if (validated.action === 'reopen') {
+        if (handedOffSidebar && !isExtensionSidebarOwnedByOther(pluginJson.id)) {
+          sidebarState.openSidebar('Interactive learning');
+        }
+        handedOffSidebar = false;
+      }
+    }
+  });
+  transport.start();
+
+  return () => {
+    cancelled = true;
+    unsubscribe();
+    transport.stop();
+    navigationManager.clearAllHighlights();
+    installed = false;
+  };
+}

--- a/src/interactive-engine/index.ts
+++ b/src/interactive-engine/index.ts
@@ -26,7 +26,15 @@ export { default as GlobalInteractionBlocker } from './global-interaction-blocke
 export { useSequentialStepState } from './use-sequential-step-state.hook';
 
 // Action handlers (re-export only handlers used externally)
-export { GuidedHandler, clearAndInsertCode } from './action-handlers';
+export {
+  GuidedHandler,
+  clearAndInsertCode,
+  FocusHandler,
+  ButtonHandler,
+  FormFillHandler,
+  HoverHandler,
+  NavigateHandler,
+} from './action-handlers';
 export type { CodeBlockInsertResult } from './action-handlers';
 
 // Auto-completion (re-export from auto-completion index)

--- a/src/lib/cross-tab-transport.test.ts
+++ b/src/lib/cross-tab-transport.test.ts
@@ -221,6 +221,13 @@ describe('CrossTabTransport', () => {
     controller.post({ kind: 'heartbeat', role: 'controller' });
     expect(received).toHaveLength(0);
   });
+
+  it('stays inactive (no throw) when no channel is available', () => {
+    const transport = new CrossTabTransport('id', () => null);
+    transport.start();
+    expect(transport.isActive()).toBe(false);
+    expect(() => transport.post({ kind: 'heartbeat', role: 'controller' })).not.toThrow();
+  });
 });
 
 describe('createSenderId', () => {

--- a/src/locales/cs-CZ/grafana-pathfinder-app.json
+++ b/src/locales/cs-CZ/grafana-pathfinder-app.json
@@ -41,6 +41,7 @@
     "nextMilestone": "Další mílník",
     "nextMilestoneTooltip": "Další mílník (Alt + →)",
     "open": "Otevřít",
+    "openControllerInNewTab": "",
     "openInNewTab": "Otevřít tuto stránku v nové kartě",
     "previousMilestone": "Předchozí mílník",
     "previousMilestoneTooltip": "Předchozí mílník (Alt + ←)",

--- a/src/locales/de-DE/grafana-pathfinder-app.json
+++ b/src/locales/de-DE/grafana-pathfinder-app.json
@@ -35,6 +35,7 @@
     "nextMilestone": "Nächster Meilenstein",
     "nextMilestoneTooltip": "Nächster Meilenstein (Alt + →)",
     "open": "Öffnen",
+    "openControllerInNewTab": "",
     "openInNewTab": "Diese Seite in neuem Tab öffnen",
     "previousMilestone": "Vorheriger Meilenstein",
     "previousMilestoneTooltip": "Vorheriger Meilenstein (Alt + ←)",

--- a/src/locales/en-US/grafana-pathfinder-app.json
+++ b/src/locales/en-US/grafana-pathfinder-app.json
@@ -38,6 +38,7 @@
     "nextMilestone": "Next milestone",
     "nextMilestoneTooltip": "Next milestone (Alt + →)",
     "open": "Open",
+    "openControllerInNewTab": "Open in interactive window",
     "openInNewTab": "Open this page in new tab",
     "previousMilestone": "Previous milestone",
     "previousMilestoneTooltip": "Previous milestone (Alt + ←)",

--- a/src/locales/es-ES/grafana-pathfinder-app.json
+++ b/src/locales/es-ES/grafana-pathfinder-app.json
@@ -38,6 +38,7 @@
     "nextMilestone": "Siguiente hito",
     "nextMilestoneTooltip": "Siguiente hito (Alt + →)",
     "open": "Abrir",
+    "openControllerInNewTab": "",
     "openInNewTab": "Abrir esta página en nueva pestaña",
     "previousMilestone": "Hito anterior",
     "previousMilestoneTooltip": "Hito anterior (Alt + ←)",

--- a/src/locales/fr-FR/grafana-pathfinder-app.json
+++ b/src/locales/fr-FR/grafana-pathfinder-app.json
@@ -38,6 +38,7 @@
     "nextMilestone": "Étape suivante",
     "nextMilestoneTooltip": "Étape suivante (Alt + →)",
     "open": "Ouvrir",
+    "openControllerInNewTab": "",
     "openInNewTab": "Ouvrir cette page dans un nouvel onglet",
     "previousMilestone": "Étape précédente",
     "previousMilestoneTooltip": "Étape précédente (Alt + ←)",

--- a/src/locales/hu-HU/grafana-pathfinder-app.json
+++ b/src/locales/hu-HU/grafana-pathfinder-app.json
@@ -35,6 +35,7 @@
     "nextMilestone": "Következő mérföldkő",
     "nextMilestoneTooltip": "Következő mérföldkő (Alt + →)",
     "open": "Megnyitás",
+    "openControllerInNewTab": "",
     "openInNewTab": "Oldal megnyitása új fülben",
     "previousMilestone": "Előző mérföldkő",
     "previousMilestoneTooltip": "Előző mérföldkő (Alt + ←)",

--- a/src/locales/id-ID/grafana-pathfinder-app.json
+++ b/src/locales/id-ID/grafana-pathfinder-app.json
@@ -32,6 +32,7 @@
     "nextMilestone": "Pencapaian berikutnya",
     "nextMilestoneTooltip": "Pencapaian berikutnya (Alt + →)",
     "open": "Buka",
+    "openControllerInNewTab": "",
     "openInNewTab": "Buka halaman ini di tab baru",
     "previousMilestone": "Pencapaian sebelumnya",
     "previousMilestoneTooltip": "Pencapaian sebelumnya (Alt + ←)",

--- a/src/locales/it-IT/grafana-pathfinder-app.json
+++ b/src/locales/it-IT/grafana-pathfinder-app.json
@@ -38,6 +38,7 @@
     "nextMilestone": "Traguardo successivo",
     "nextMilestoneTooltip": "Traguardo successivo (Alt + →)",
     "open": "Apri",
+    "openControllerInNewTab": "",
     "openInNewTab": "Apri questa pagina in una nuova scheda",
     "previousMilestone": "Traguardo precedente",
     "previousMilestoneTooltip": "Traguardo precedente (Alt + ←)",

--- a/src/locales/ja-JP/grafana-pathfinder-app.json
+++ b/src/locales/ja-JP/grafana-pathfinder-app.json
@@ -32,6 +32,7 @@
     "nextMilestone": "次のマイルストーン",
     "nextMilestoneTooltip": "次のマイルストーン (Alt + →)",
     "open": "開く",
+    "openControllerInNewTab": "",
     "openInNewTab": "このページを新しいタブで開く",
     "previousMilestone": "前のマイルストーン",
     "previousMilestoneTooltip": "前のマイルストーン (Alt + ←)",

--- a/src/locales/ko-KR/grafana-pathfinder-app.json
+++ b/src/locales/ko-KR/grafana-pathfinder-app.json
@@ -32,6 +32,7 @@
     "nextMilestone": "다음 마일스톤",
     "nextMilestoneTooltip": "다음 마일스톤 (Alt + →)",
     "open": "열기",
+    "openControllerInNewTab": "",
     "openInNewTab": "이 페이지를 새 탭에서 열기",
     "previousMilestone": "이전 마일스톤",
     "previousMilestoneTooltip": "이전 마일스톤 (Alt + ←)",

--- a/src/locales/nl-NL/grafana-pathfinder-app.json
+++ b/src/locales/nl-NL/grafana-pathfinder-app.json
@@ -35,6 +35,7 @@
     "nextMilestone": "Volgende mijlpaal",
     "nextMilestoneTooltip": "Volgende mijlpaal (Alt + →)",
     "open": "Openen",
+    "openControllerInNewTab": "",
     "openInNewTab": "Deze pagina openen in nieuw tabblad",
     "previousMilestone": "Vorige mijlpaal",
     "previousMilestoneTooltip": "Vorige mijlpaal (Alt + ←)",

--- a/src/locales/pl-PL/grafana-pathfinder-app.json
+++ b/src/locales/pl-PL/grafana-pathfinder-app.json
@@ -41,6 +41,7 @@
     "nextMilestone": "Następny kamień milowy",
     "nextMilestoneTooltip": "Następny kamień milowy (Alt + →)",
     "open": "Otwórz",
+    "openControllerInNewTab": "",
     "openInNewTab": "Otwórz tę stronę w nowej karcie",
     "previousMilestone": "Poprzedni kamień milowy",
     "previousMilestoneTooltip": "Poprzedni kamień milowy (Alt + ←)",

--- a/src/locales/pt-BR/grafana-pathfinder-app.json
+++ b/src/locales/pt-BR/grafana-pathfinder-app.json
@@ -38,6 +38,7 @@
     "nextMilestone": "Próximo marco",
     "nextMilestoneTooltip": "Próximo marco (Alt + →)",
     "open": "Abrir",
+    "openControllerInNewTab": "",
     "openInNewTab": "Abrir esta página em nova aba",
     "previousMilestone": "Marco anterior",
     "previousMilestoneTooltip": "Marco anterior (Alt + ←)",

--- a/src/locales/pt-PT/grafana-pathfinder-app.json
+++ b/src/locales/pt-PT/grafana-pathfinder-app.json
@@ -38,6 +38,7 @@
     "nextMilestone": "Próximo marco",
     "nextMilestoneTooltip": "Próximo marco (Alt + →)",
     "open": "Abrir",
+    "openControllerInNewTab": "",
     "openInNewTab": "Abrir esta página em novo separador",
     "previousMilestone": "Marco anterior",
     "previousMilestoneTooltip": "Marco anterior (Alt + ←)",

--- a/src/locales/ru-RU/grafana-pathfinder-app.json
+++ b/src/locales/ru-RU/grafana-pathfinder-app.json
@@ -41,6 +41,7 @@
     "nextMilestone": "Следующий этап",
     "nextMilestoneTooltip": "Следующий этап (Alt + →)",
     "open": "Открыть",
+    "openControllerInNewTab": "",
     "openInNewTab": "Открыть эту страницу в новой вкладке",
     "previousMilestone": "Предыдущий этап",
     "previousMilestoneTooltip": "Предыдущий этап (Alt + ←)",

--- a/src/locales/sv-SE/grafana-pathfinder-app.json
+++ b/src/locales/sv-SE/grafana-pathfinder-app.json
@@ -35,6 +35,7 @@
     "nextMilestone": "Nästa milstolpe",
     "nextMilestoneTooltip": "Nästa milstolpe (Alt + →)",
     "open": "Öppna",
+    "openControllerInNewTab": "",
     "openInNewTab": "Öppna denna sida i ny flik",
     "previousMilestone": "Föregående milstolpe",
     "previousMilestoneTooltip": "Föregående milstolpe (Alt + ←)",

--- a/src/locales/zh-CN/grafana-pathfinder-app.json
+++ b/src/locales/zh-CN/grafana-pathfinder-app.json
@@ -32,6 +32,7 @@
     "nextMilestone": "下一个里程碑",
     "nextMilestoneTooltip": "下一个里程碑 (Alt + →)",
     "open": "打开",
+    "openControllerInNewTab": "",
     "openInNewTab": "在新标签页中打开此页面",
     "previousMilestone": "上一个里程碑",
     "previousMilestoneTooltip": "上一个里程碑 (Alt + ←)",

--- a/src/locales/zh-Hans/grafana-pathfinder-app.json
+++ b/src/locales/zh-Hans/grafana-pathfinder-app.json
@@ -32,6 +32,7 @@
     "nextMilestone": "下一个里程碑",
     "nextMilestoneTooltip": "下一个里程碑 (Alt + →)",
     "open": "打开",
+    "openControllerInNewTab": "",
     "openInNewTab": "在新标签页中打开此页面",
     "previousMilestone": "上一个里程碑",
     "previousMilestoneTooltip": "上一个里程碑 (Alt + ←)",

--- a/src/locales/zh-Hant/grafana-pathfinder-app.json
+++ b/src/locales/zh-Hant/grafana-pathfinder-app.json
@@ -32,6 +32,7 @@
     "nextMilestone": "下一個里程碑",
     "nextMilestoneTooltip": "下一個里程碑 (Alt + →)",
     "open": "打開",
+    "openControllerInNewTab": "",
     "openInNewTab": "在新標籤頁中打開此頁面",
     "previousMilestone": "上一個里程碑",
     "previousMilestoneTooltip": "上一個里程碑 (Alt + ←)",

--- a/src/locales/zh-TW/grafana-pathfinder-app.json
+++ b/src/locales/zh-TW/grafana-pathfinder-app.json
@@ -32,6 +32,7 @@
     "nextMilestone": "下一個里程碑",
     "nextMilestoneTooltip": "下一個里程碑 (Alt + →)",
     "open": "打開",
+    "openControllerInNewTab": "",
     "openInNewTab": "在新標籤頁中打開此頁面",
     "previousMilestone": "上一個里程碑",
     "previousMilestoneTooltip": "上一個里程碑 (Alt + ←)",

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -8,6 +8,7 @@ import { reportAppInteraction, UserInteraction } from './lib/analytics';
 import { initPluginTranslations } from '@grafana/i18n';
 import pluginJson from './plugin.json';
 import { getConfigWithDefaults, DocsPluginConfig } from './constants';
+import { TWOTAB_CONTROLLER_ENABLED } from './constants/interactive-config';
 import { linkInterceptionState } from './global-state/link-interception';
 import { sidebarState } from 'global-state/sidebar';
 import { panelModeManager } from './global-state/panel-mode';
@@ -147,7 +148,7 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   // step actions stay visible so this tab can drive the originating Grafana tab.
   // Gated on pathfinderEnabled — the controller drives the user's authenticated
   // Grafana, so it must not mount when the plugin is disabled (F-1062-1).
-  if (docsParam && controllerParam && pathfinderEnabled) {
+  if (TWOTAB_CONTROLLER_ENABLED && docsParam && controllerParam && pathfinderEnabled) {
     if (!document.getElementById('pathfinder-controller-root')) {
       // Claim the id synchronously, before the dynamic import, so a second
       // plugin.init can't race past the guard and double-mount (F-1062-2).
@@ -166,6 +167,17 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
         });
     }
     return;
+  }
+
+  // Live tab only (the controller tab returned early above): load the cross-tab
+  // executor so a controller tab can drive this Grafana DOM. Gated on
+  // pathfinderEnabled (T1 PART B) — the executor is a same-origin DOM sink and
+  // must not be installed for disabled users. Lazy import keeps the interactive
+  // engine out of the entry bundle.
+  if (TWOTAB_CONTROLLER_ENABLED && pathfinderEnabled) {
+    import('./integrations/cross-tab/live-tab-executor')
+      .then(({ installLiveTabExecutor }) => installLiveTabExecutor())
+      .catch((err) => console.error('[Pathfinder] Failed to load cross-tab executor:', err));
   }
 
   const sidebarMountable = shouldMountSidebar(pathfinderEnabled, mainVariant, after24hVariant);

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -145,22 +145,24 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
 
   // Interactive controller (?doc=<guide>&controller=1): the same overlay, but
   // step actions stay visible so this tab can drive the originating Grafana tab.
-  if (docsParam && controllerParam) {
+  // Gated on pathfinderEnabled — the controller drives the user's authenticated
+  // Grafana, so it must not mount when the plugin is disabled (F-1062-1).
+  if (docsParam && controllerParam && pathfinderEnabled) {
     if (!document.getElementById('pathfinder-controller-root')) {
+      // Claim the id synchronously, before the dynamic import, so a second
+      // plugin.init can't race past the guard and double-mount (F-1062-2).
+      const container = document.createElement('div');
+      container.id = 'pathfinder-controller-root';
+      document.body.appendChild(container);
       import('./components/guide-reader/GuideReaderOverlay')
         .then(async ({ GuideReaderOverlay }) => {
-          if (document.getElementById('pathfinder-controller-root')) {
-            return;
-          }
           const { createCompatRoot } = await import('./lib/create-root-compat');
-          const container = document.createElement('div');
-          container.id = 'pathfinder-controller-root';
-          document.body.appendChild(container);
           const root = await createCompatRoot(container);
           root.render(React.createElement(GuideReaderOverlay, { doc: docsParam, mode: 'controller' }));
         })
         .catch((err) => {
           console.error('[Pathfinder] Failed to load interactive controller:', err);
+          container.remove();
         });
     }
     return;

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -141,7 +141,30 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   (window as any).__pathfinderPluginConfig = config;
 
   // Snapshotted before handlePathfinderDeepLink strips it from the URL.
-  const docsParam = parsePathfinderDeepLink(window.location.search).doc;
+  const { doc: docsParam, controller: controllerParam } = parsePathfinderDeepLink(window.location.search);
+
+  // Interactive controller (?doc=<guide>&controller=1): the same overlay, but
+  // step actions stay visible so this tab can drive the originating Grafana tab.
+  if (docsParam && controllerParam) {
+    if (!document.getElementById('pathfinder-controller-root')) {
+      import('./components/guide-reader/GuideReaderOverlay')
+        .then(async ({ GuideReaderOverlay }) => {
+          if (document.getElementById('pathfinder-controller-root')) {
+            return;
+          }
+          const { createCompatRoot } = await import('./lib/create-root-compat');
+          const container = document.createElement('div');
+          container.id = 'pathfinder-controller-root';
+          document.body.appendChild(container);
+          const root = await createCompatRoot(container);
+          root.render(React.createElement(GuideReaderOverlay, { doc: docsParam, mode: 'controller' }));
+        })
+        .catch((err) => {
+          console.error('[Pathfinder] Failed to load interactive controller:', err);
+        });
+    }
+    return;
+  }
 
   const sidebarMountable = shouldMountSidebar(pathfinderEnabled, mainVariant, after24hVariant);
   const deepLinkDeps = {

--- a/src/requirements-manager/controller-requirements.test.ts
+++ b/src/requirements-manager/controller-requirements.test.ts
@@ -1,0 +1,48 @@
+import { stripTabLocalRequirements, TAB_LOCAL_REQUIREMENTS } from './controller-requirements';
+
+describe('TAB_LOCAL_REQUIREMENTS drift guard (F-1063-2)', () => {
+  // Pins the allowlist of tab-local (DOM/URL/nav-probing) requirement kinds.
+  // If a new such requirement is added to the requirements checker, this list
+  // must grow to match — otherwise it would be evaluated against the controller
+  // tab instead of stripped. Update both together; this test is the reminder.
+  it('contains exactly the known DOM/URL/navigation-probing requirements', () => {
+    expect([...TAB_LOCAL_REQUIREMENTS].sort()).toEqual(
+      ['exists-reftarget', 'form-valid', 'navmenu-open', 'on-page'].sort()
+    );
+  });
+
+  it('strips every listed requirement (bare and parameterized forms)', () => {
+    for (const id of TAB_LOCAL_REQUIREMENTS) {
+      expect(stripTabLocalRequirements(id)).toBe('');
+      expect(stripTabLocalRequirements(`${id}:some-arg`)).toBe('');
+    }
+  });
+});
+
+describe('stripTabLocalRequirements', () => {
+  it('drops requirements that probe this tab (DOM / URL / nav)', () => {
+    expect(stripTabLocalRequirements('exists-reftarget')).toBe('');
+    expect(stripTabLocalRequirements('navmenu-open')).toBe('');
+    expect(stripTabLocalRequirements('on-page:/explore')).toBe('');
+    expect(stripTabLocalRequirements('form-valid')).toBe('');
+  });
+
+  it('keeps session / permission requirements so genuine failures still surface', () => {
+    expect(stripTabLocalRequirements('is-admin')).toBe('is-admin');
+    expect(stripTabLocalRequirements('has-datasources')).toBe('has-datasources');
+    expect(stripTabLocalRequirements('has-datasource:prometheus')).toBe('has-datasource:prometheus');
+    expect(stripTabLocalRequirements('dashboard-exists')).toBe('dashboard-exists');
+    expect(stripTabLocalRequirements('section-completed:intro')).toBe('section-completed:intro');
+  });
+
+  it('keeps only the session requirements from a mixed list', () => {
+    expect(stripTabLocalRequirements('exists-reftarget, is-admin, on-page:/explore, has-datasources')).toBe(
+      'is-admin,has-datasources'
+    );
+  });
+
+  it('passes empty / undefined through unchanged', () => {
+    expect(stripTabLocalRequirements(undefined)).toBeUndefined();
+    expect(stripTabLocalRequirements('')).toBe('');
+  });
+});

--- a/src/requirements-manager/controller-requirements.ts
+++ b/src/requirements-manager/controller-requirements.ts
@@ -1,0 +1,26 @@
+// Requirements that probe THIS tab's live DOM / URL / navigation and therefore
+// cannot be evaluated from a controller tab driving a different Grafana tab.
+// Session / permission requirements (is-admin, has-datasources, dashboard-exists,
+// ...) are deliberately NOT listed — they reflect the user's Grafana, are valid
+// from any tab, and must still gate so genuine failures surface to the user.
+// Exported for the drift tripwire in controller-requirements.test.ts. When a new
+// DOM/URL/navigation-probing requirement is added to the requirements checker,
+// add its id here too, or it will be (wrongly) evaluated against the controller
+// tab instead of stripped (F-1063-2).
+export const TAB_LOCAL_REQUIREMENTS = ['exists-reftarget', 'navmenu-open', 'on-page', 'form-valid'];
+
+function isTabLocal(token: string): boolean {
+  return TAB_LOCAL_REQUIREMENTS.some((id) => token === id || token.startsWith(`${id}:`));
+}
+
+export function stripTabLocalRequirements(requirements: string | undefined): string | undefined {
+  if (!requirements) {
+    return requirements;
+  }
+  return requirements
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean)
+    .filter((token) => !isTabLocal(token))
+    .join(',');
+}

--- a/src/requirements-manager/index.ts
+++ b/src/requirements-manager/index.ts
@@ -21,6 +21,7 @@ export {
 
 // Step checker hook (unified requirements + objectives)
 export { useStepChecker } from './step-checker.hook';
+export { stripTabLocalRequirements } from './controller-requirements';
 
 export type { UseStepCheckerProps, UseStepCheckerReturn } from '../types/hooks.types';
 

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -34,7 +34,10 @@ import { useInteractiveElements, useSequentialStepState } from '../interactive-e
 import { INTERACTIVE_CONFIG, isFirstStep } from '../constants/interactive-config';
 import { useTimeoutManager } from '../utils/timeout-manager';
 import { useIsAlignmentPaused } from '../global-state/alignment-pending-context';
-import { checkRequirements } from './requirements-checker.utils';
+import { checkRequirements, type RequirementsCheckResult } from './requirements-checker.utils';
+import { stripTabLocalRequirements } from './controller-requirements';
+import { useInteractiveMode } from '../global-state/interactive-mode-context';
+import { useControllerChannel } from '../global-state/controller-channel';
 import type { UseStepCheckerProps, UseStepCheckerReturn } from '../types/hooks.types';
 
 // Re-export for convenience
@@ -88,7 +91,7 @@ function actionFromBaseStepState(s: LegacyStateShape): StepAction {
  */
 export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn {
   const {
-    requirements,
+    requirements: rawRequirements,
     objectives,
     hints,
     stepId,
@@ -104,6 +107,12 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     onStepComplete,
     onComplete,
   } = props;
+
+  const mode = useInteractiveMode();
+  const controllerChannel = useControllerChannel();
+  // Keep the full requirements string in controller mode; tab-local ones are
+  // evaluated on the live tab via the round-trip in `attemptCheck`.
+  const requirements = rawRequirements;
 
   /**
    * Resolve the store-write target for this checker.
@@ -214,6 +223,8 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
         maxRetriesOverride?: number;
         /** Wrap the entire call in Promise.race with this timeout. Reject propagates to caller. */
         timeoutMs?: number;
+        /** In controller mode, evaluate against the live tab instead of this tab's DOM. */
+        remote?: boolean;
       },
       onStateUpdate: (retryCount: number, maxRetries: number, isRetrying: boolean) => void
     ) => {
@@ -224,12 +235,22 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
         stepId: optionsStepId,
         maxRetriesOverride,
         timeoutMs,
+        remote,
       } = options;
+      // The live tab runs its own retry loop, so a remote check must not retry
+      // here — each attempt would post a fresh round-trip and stall the warning.
+      const isRemote = remote === true && mode === 'controller' && controllerChannel != null;
       // When lazyRender is enabled, don't do automatic retries - let the button handle lazy scroll.
       // The explicit override (passed by the objectives path) takes precedence.
-      const maxRetries = maxRetriesOverride ?? (lazyRender ? 0 : INTERACTIVE_CONFIG.delays.requirements.maxRetries);
+      const maxRetries = isRemote
+        ? 0
+        : (maxRetriesOverride ?? (lazyRender ? 0 : INTERACTIVE_CONFIG.delays.requirements.maxRetries));
 
-      const attemptCheck = async (retryCount: number): Promise<any> => {
+      // Typed (not `any`) so the live-tab RemoteRequirementResult and the local
+      // RequirementsCheckResult must stay structurally interchangeable — a future
+      // drift between the wire mirror and the real type becomes a compile error
+      // here rather than a silent runtime mismatch (NEW-1070-1).
+      const attemptCheck = async (retryCount: number): Promise<RequirementsCheckResult> => {
         // REACT: Check mounted before state updates to prevent updates after unmount (R4)
         if (!isMountedRef.current) {
           return { requirements: requirements || '', pass: false, error: [] };
@@ -239,16 +260,38 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
         onStateUpdate(retryCount, maxRetries, retryCount > 0);
 
         try {
-          const result = await checkRequirements({
-            requirements,
-            targetAction,
-            refTarget,
-            stepId: optionsStepId,
-            retryCount: 0, // Disable internal retry since we're handling it here
-            maxRetries: 0,
-            lazyRender,
-            scrollContainer,
-          });
+          // In controller mode the live tab is the source of truth for DOM/URL
+          // requirements; round-trip the check there. When no live tab answers
+          // within the timeout we deliberately fail OPEN, not closed: strip the
+          // tab-local DOM/URL tokens and evaluate the rest locally (§6.5). A
+          // fail-closed block would strand the two-monitor driver whenever the
+          // live tab briefly disconnects; session/permission/role requirements
+          // are NOT stripped, so genuine authorization failures still gate.
+          const result = isRemote
+            ? ((await controllerChannel?.requestRequirementCheck(optionsStepId ?? stepId, requirements, {
+                targetAction,
+                refTarget,
+              })) ??
+              (await checkRequirements({
+                requirements: stripTabLocalRequirements(requirements) ?? '',
+                targetAction,
+                refTarget,
+                stepId: optionsStepId,
+                retryCount: 0,
+                maxRetries: 0,
+                lazyRender,
+                scrollContainer,
+              })))
+            : await checkRequirements({
+                requirements,
+                targetAction,
+                refTarget,
+                stepId: optionsStepId,
+                retryCount: 0, // Disable internal retry since we're handling it here
+                maxRetries: 0,
+                lazyRender,
+                scrollContainer,
+              });
 
           // REACT: Check mounted before continuing recursive calls (R4)
           if (!isMountedRef.current) {
@@ -320,7 +363,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
         }
       });
     },
-    [lazyRender, scrollContainer] // checkRequirements is an imported function but lazyRender/scrollContainer are props
+    [lazyRender, scrollContainer, mode, controllerChannel, stepId] // checkRequirements is imported; the rest gate the controller round-trip
   );
 
   // Manager integration for state propagation
@@ -486,6 +529,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
             targetAction: targetAction || 'button',
             refTarget: refTarget || stepId,
             stepId,
+            remote: true,
           },
           (retryCount, _maxRetries, isRetrying) => {
             safeDispatch({ type: 'UPDATE_RETRY', retryCount, isRetrying });
@@ -555,6 +599,48 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     targetAction,
   ]);
 
+  // Re-check requirements at click time (cross-tab state can be stale), fold the
+  // result into the FSM so a regressed prerequisite re-surfaces, and return
+  // whether the action may proceed.
+  const revalidate = useCallback(async (): Promise<boolean> => {
+    if (!requirements || requirements.trim() === '') {
+      return true;
+    }
+    const result = await checkRequirementsWithStateUpdates(
+      {
+        requirements,
+        targetAction: targetAction || 'button',
+        refTarget: refTarget || stepId,
+        stepId,
+        remote: true,
+      },
+      (retryCount, _maxRetries, isRetrying) => {
+        safeDispatch({ type: 'UPDATE_RETRY', retryCount, isRetrying });
+      }
+    );
+    if (!isMountedRef.current) {
+      return result.pass;
+    }
+    const requirementsState = createRequirementsState(result, requirements, hints, skippable);
+    safeDispatch(actionFromBaseStepState(requirementsState));
+    updateManager(requirementsState);
+    prevIsEnabledRef.current = result.pass;
+    if (result.pass) {
+      enabledTimestampRef.current = Date.now();
+    }
+    return result.pass;
+  }, [
+    requirements,
+    targetAction,
+    refTarget,
+    stepId,
+    hints,
+    skippable,
+    checkRequirementsWithStateUpdates,
+    safeDispatch,
+    updateManager,
+  ]);
+
   /**
    * Attempt to automatically fix failed requirements via the fix-handler registry.
    * Wraps `dispatchFix` with mount-safety, the post-fix recheck, and error reporting.
@@ -583,15 +669,24 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     try {
       safeDispatch({ type: 'START_CHECK' });
 
-      const result = await dispatchFix({
-        fixType: state.fixType,
-        targetHref: state.targetHref,
-        scrollContainer: state.scrollContainer,
-        requirements,
-        stepId,
-        navigationManager: navigationManagerRef.current,
-        fixNavigationRequirements,
-      });
+      // A controller's fix must run on the live tab's DOM, not this tab's.
+      const result =
+        mode === 'controller' && controllerChannel != null
+          ? await controllerChannel.requestFix(stepId, {
+              requirements: requirements ?? '',
+              fixType: state.fixType,
+              targetHref: state.targetHref,
+              scrollContainer: state.scrollContainer,
+            })
+          : await dispatchFix({
+              fixType: state.fixType,
+              targetHref: state.targetHref,
+              scrollContainer: state.scrollContainer,
+              requirements,
+              stepId,
+              navigationManager: navigationManagerRef.current,
+              fixNavigationRequirements,
+            });
 
       if (!result.ok) {
         console.warn('Fix failed:', result.error);
@@ -604,7 +699,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
           // these fields via spread.)
           safeDispatch({
             type: 'SET_ERROR',
-            error: result.error,
+            error: result.error ?? 'Failed to fix requirements',
             canFix: state.canFixRequirement,
             fixType: state.fixType,
             targetHref: state.targetHref,
@@ -651,6 +746,8 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     stepId,
     timeoutManager,
     safeDispatch,
+    mode,
+    controllerChannel,
   ]);
 
   /**
@@ -753,7 +850,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
         50
       );
     },
-    [skippable, updateManager, stepId, timeoutManager, writeStoreReset] // eslint-disable-line react-hooks/exhaustive-deps -- checkStep intentionally excluded to prevent infinite loops
+    [skippable, updateManager, stepId, timeoutManager, writeStoreReset] // checkStep intentionally excluded (called via ref) to prevent infinite loops
   );
 
   /**
@@ -951,13 +1048,17 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       return;
     }
 
-    // Only run when step is enabled, not completed, and requirements are fragile
+    // Only run when not completed and requirements are fragile.
     const req = requirements || '';
     const isFragile = INTERACTIVE_CONFIG.requirements.heartbeat.onlyForFragile
       ? req.includes('navmenu-open') || req.includes('exists-reftarget') || req.includes('on-page:')
       : !!req;
 
-    if (!isFragile || state.isCompleted || !state.isEnabled) {
+    // A controller's fragile step often starts blocked; poll the live tab while
+    // blocked too so the warning surfaces and later clears. In-tab keeps the
+    // original enabled-only watchdog.
+    const watchWhileBlocked = mode === 'controller';
+    if (!isFragile || state.isCompleted || (!state.isEnabled && !watchWhileBlocked)) {
       return;
     }
 
@@ -989,7 +1090,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       stopped = true;
       clearTimeout(timeoutId);
     };
-  }, [requirements, state.isEnabled, state.isCompleted]);
+  }, [requirements, state.isEnabled, state.isCompleted, mode]);
 
   // A missing DOM element is the only failure the AI "Fix this" affordance can address;
   // the UI tier ANDs this with assistant availability to decide whether to surface it.
@@ -998,6 +1099,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
   return {
     ...state,
     checkStep,
+    revalidate,
     markCompleted,
     markSkipped: skippable ? markSkipped : undefined,
     resetStep,

--- a/src/types/cross-tab.types.test.ts
+++ b/src/types/cross-tab.types.test.ts
@@ -54,7 +54,49 @@ describe('validateCrossTabMessage', () => {
     expect(validateCrossTabMessage(envelope(partial))).toBeNull();
   });
 
+  it('accepts a composite step-command whose internalActions are all recognized', () => {
+    const message = envelope({
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 's1',
+      action: {
+        targetAction: 'guided',
+        refTarget: '',
+        internalActions: [
+          { targetAction: 'highlight', refTarget: '#a' },
+          { targetAction: 'button', refTarget: 'Save' },
+        ],
+      },
+    });
+    expect(validateCrossTabMessage(message)).toBe(message);
+  });
+
+  it.each([
+    [
+      'an internal action with an unrecognized verb',
+      {
+        targetAction: 'multistep',
+        refTarget: '',
+        internalActions: [
+          { targetAction: 'highlight', refTarget: '#a' },
+          { targetAction: 'exec', refTarget: '#x' },
+        ],
+      },
+    ],
+    ['a non-array internalActions', { targetAction: 'guided', refTarget: '', internalActions: 'highlight' }],
+    ['a non-object internal action', { targetAction: 'guided', refTarget: '', internalActions: ['highlight'] }],
+  ])('rejects a composite step-command with %s', (_label, action) => {
+    expect(validateCrossTabMessage(envelope({ kind: 'step-command', phase: 'do', stepId: 's1', action }))).toBeNull();
+  });
+
   it('rejects a heartbeat with an invalid role', () => {
     expect(validateCrossTabMessage(envelope({ kind: 'heartbeat', role: 'admin' }))).toBeNull();
+  });
+
+  it('accepts a sidebar-handoff with a known action and rejects others', () => {
+    expect(validateCrossTabMessage(envelope({ kind: 'sidebar-handoff', action: 'close' }))).not.toBeNull();
+    expect(validateCrossTabMessage(envelope({ kind: 'sidebar-handoff', action: 'reopen' }))).not.toBeNull();
+    expect(validateCrossTabMessage(envelope({ kind: 'sidebar-handoff', action: 'detonate' }))).toBeNull();
+    expect(validateCrossTabMessage(envelope({ kind: 'sidebar-handoff' }))).toBeNull();
   });
 });

--- a/src/types/cross-tab.types.ts
+++ b/src/types/cross-tab.types.ts
@@ -1,8 +1,21 @@
-import type { InteractiveAction } from './collaboration.types';
-
 export const CROSS_TAB_CHANNEL = 'pathfinder-cross-tab';
 
 export type CrossTabRole = 'controller' | 'live';
+
+export interface CrossTabInternalAction {
+  targetAction: string;
+  refTarget?: string;
+  targetValue?: string;
+  targetComment?: string;
+}
+
+export interface CrossTabAction {
+  targetAction: string;
+  refTarget: string;
+  targetValue?: string;
+  targetComment?: string;
+  internalActions?: CrossTabInternalAction[];
+}
 
 interface CrossTabEnvelope {
   source: 'pathfinder';
@@ -10,11 +23,31 @@ interface CrossTabEnvelope {
   timestamp: number;
 }
 
+// Tier-0 structural mirror of requirements-manager's CheckResultError /
+// RequirementsCheckResult, so a live-tab result crosses the channel without an
+// upward import.
+export interface RemoteRequirementError {
+  requirement: string;
+  pass: boolean;
+  error?: string;
+  context?: Record<string, unknown> | null;
+  canFix?: boolean;
+  fixType?: string;
+  targetHref?: string;
+  scrollContainer?: string;
+}
+
+export interface RemoteRequirementResult {
+  requirements: string;
+  pass: boolean;
+  error: RemoteRequirementError[];
+}
+
 export interface StepCommandMessage extends CrossTabEnvelope {
   kind: 'step-command';
   phase: 'show' | 'do';
   stepId: string;
-  action: InteractiveAction;
+  action: CrossTabAction;
 }
 
 export interface HeartbeatMessage extends CrossTabEnvelope {
@@ -22,7 +55,74 @@ export interface HeartbeatMessage extends CrossTabEnvelope {
   role: CrossTabRole;
 }
 
-export type CrossTabMessage = StepCommandMessage | HeartbeatMessage;
+export interface SidebarHandoffMessage extends CrossTabEnvelope {
+  kind: 'sidebar-handoff';
+  action: 'close' | 'reopen';
+}
+
+// Requirement round-trip (controller → live → controller); requestId correlates
+// each reply to its request since several steps may be in flight.
+export interface CheckRequirementsMessage extends CrossTabEnvelope {
+  kind: 'check-requirements';
+  requestId: string;
+  stepId: string;
+  requirements: string;
+  targetAction?: string;
+  refTarget?: string;
+  targetValue?: string;
+}
+
+export interface RequirementResultMessage extends CrossTabEnvelope {
+  kind: 'requirement-result';
+  requestId: string;
+  stepId: string;
+  result: RemoteRequirementResult;
+}
+
+export interface FixRequirementMessage extends CrossTabEnvelope {
+  kind: 'fix-requirement';
+  requestId: string;
+  stepId: string;
+  requirements: string;
+  fixType?: string;
+  targetHref?: string;
+  scrollContainer?: string;
+}
+
+export interface FixResultMessage extends CrossTabEnvelope {
+  kind: 'fix-result';
+  requestId: string;
+  stepId: string;
+  ok: boolean;
+  error?: string;
+}
+
+// Live → controller: a composite finished; the controller marks completion only then.
+export interface StepCompleteMessage extends CrossTabEnvelope {
+  kind: 'step-complete';
+  stepId: string;
+  ok: boolean;
+}
+
+// Live → controller: which internal action a composite is on, so the controller
+// can animate per-step progress while the replay runs on the live tab.
+export interface StepProgressMessage extends CrossTabEnvelope {
+  kind: 'step-progress';
+  stepId: string;
+  index: number;
+  total: number;
+}
+
+export type CrossTabMessage =
+  | StepCommandMessage
+  | HeartbeatMessage
+  | SidebarHandoffMessage
+  | CheckRequirementsMessage
+  | RequirementResultMessage
+  | FixRequirementMessage
+  | FixResultMessage
+  | StepCompleteMessage
+  | StepProgressMessage;
 
 // Distributively strip the envelope from every message kind, so the
 // post() payload type stays derived from CrossTabMessage instead of a
@@ -47,6 +147,7 @@ const KNOWN_TARGET_ACTIONS: ReadonlySet<string> = new Set([
   'formfill',
   'navigate',
   'hover',
+  'guided',
   'multistep',
 ]);
 
@@ -74,15 +175,96 @@ function isValidStepCommand(message: Record<string, unknown>): boolean {
     return false;
   }
   const action = message.action;
-  return (
-    typeof action.refTarget === 'string' &&
-    typeof action.targetAction === 'string' &&
-    KNOWN_TARGET_ACTIONS.has(action.targetAction)
-  );
+  if (
+    typeof action.refTarget !== 'string' ||
+    typeof action.targetAction !== 'string' ||
+    !KNOWN_TARGET_ACTIONS.has(action.targetAction)
+  ) {
+    return false;
+  }
+  // Composite (guided/multistep) steps carry an ordered internalActions
+  // sequence; every element is replayed as a DOM action on the live tab, so
+  // each must itself carry a recognized verb — validate the whole array, not
+  // just the composite envelope (T1 / #1068).
+  if (action.internalActions !== undefined) {
+    return (
+      Array.isArray(action.internalActions) &&
+      action.internalActions.every(
+        (sub) => isRecord(sub) && typeof sub.targetAction === 'string' && KNOWN_TARGET_ACTIONS.has(sub.targetAction)
+      )
+    );
+  }
+  return true;
 }
 
 function isValidHeartbeat(message: Record<string, unknown>): boolean {
   return message.role === 'controller' || message.role === 'live';
+}
+
+function isValidSidebarHandoff(message: Record<string, unknown>): boolean {
+  return message.action === 'close' || message.action === 'reopen';
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string';
+}
+
+// check-requirements / fix-requirement are SIDE-EFFECTING on the live tab —
+// the executor runs checkRequirements (DOM/URL probes) and dispatchFix
+// (navigation / DOM mutation) against the authenticated document. They are the
+// highest-risk surface in the protocol, so the controller-supplied fields that
+// flow into those calls are validated field-by-field before dispatch.
+function isValidCheckRequirements(message: Record<string, unknown>): boolean {
+  return (
+    typeof message.requestId === 'string' &&
+    typeof message.stepId === 'string' &&
+    typeof message.requirements === 'string' &&
+    isOptionalString(message.targetAction) &&
+    isOptionalString(message.refTarget) &&
+    isOptionalString(message.targetValue)
+  );
+}
+
+function isValidFixRequirement(message: Record<string, unknown>): boolean {
+  return (
+    typeof message.requestId === 'string' &&
+    typeof message.stepId === 'string' &&
+    typeof message.requirements === 'string' &&
+    isOptionalString(message.fixType) &&
+    isOptionalString(message.targetHref) &&
+    isOptionalString(message.scrollContainer)
+  );
+}
+
+// requirement-result / fix-result are replies the controller feeds into its
+// requirements-state path; validate the reply shape so a malformed result can't
+// resolve a pending request with garbage.
+function isValidRequirementResult(message: Record<string, unknown>): boolean {
+  if (typeof message.requestId !== 'string' || typeof message.stepId !== 'string' || !isRecord(message.result)) {
+    return false;
+  }
+  const result = message.result;
+  return typeof result.requirements === 'string' && typeof result.pass === 'boolean' && Array.isArray(result.error);
+}
+
+function isValidFixResult(message: Record<string, unknown>): boolean {
+  return typeof message.requestId === 'string' && typeof message.stepId === 'string' && typeof message.ok === 'boolean';
+}
+
+// step-complete is a live → controller reply: the live tab reports a composite
+// finished so the controller can mark completion only when it actually ran. It
+// triggers no DOM action, but it resolves a pending awaitStepComplete waiter, so
+// validate the shape to keep a malformed reply from completing the wrong step.
+function isValidStepComplete(message: Record<string, unknown>): boolean {
+  return typeof message.stepId === 'string' && typeof message.ok === 'boolean';
+}
+
+// step-progress is a live → controller reply: the live tab reports which internal
+// action a composite is on so the controller can animate progress. It triggers no
+// DOM action, but it drives a UI callback keyed by stepId, so validate the shape
+// to keep a malformed reply from advancing the wrong step's progress.
+function isValidStepProgress(message: Record<string, unknown>): boolean {
+  return typeof message.stepId === 'string' && typeof message.index === 'number' && typeof message.total === 'number';
 }
 
 // Per-kind validators — the single source of truth shared by the transport
@@ -94,6 +276,13 @@ function isValidHeartbeat(message: Record<string, unknown>): boolean {
 const KIND_VALIDATORS: Record<CrossTabMessage['kind'], (message: Record<string, unknown>) => boolean> = {
   'step-command': isValidStepCommand,
   heartbeat: isValidHeartbeat,
+  'sidebar-handoff': isValidSidebarHandoff,
+  'check-requirements': isValidCheckRequirements,
+  'requirement-result': isValidRequirementResult,
+  'fix-requirement': isValidFixRequirement,
+  'fix-result': isValidFixResult,
+  'step-complete': isValidStepComplete,
+  'step-progress': isValidStepProgress,
 };
 
 /**

--- a/src/types/hooks.types.ts
+++ b/src/types/hooks.types.ts
@@ -83,6 +83,7 @@ export interface UseStepCheckerReturn {
 
   // Actions
   checkStep: () => Promise<void>;
+  revalidate: () => Promise<boolean>; // re-checks at action time; true = the step may proceed
   markCompleted: () => void;
   markSkipped?: () => void; // Function to skip this step
   // Reset all step state including skipped. Pass `{ skipStoreWrite: true }`

--- a/src/utils/pathfinder-search-params.test.ts
+++ b/src/utils/pathfinder-search-params.test.ts
@@ -18,9 +18,9 @@ import {
 } from './pathfinder-search-params';
 
 describe('PATHFINDER_PARAMS', () => {
-  it('contains the documented six params (kept in lock-step with parse + strip)', () => {
+  it('contains the documented seven params (kept in lock-step with parse + strip)', () => {
     expect([...PATHFINDER_PARAMS].sort()).toEqual(
-      ['doc', 'kiosk_session', 'page', 'panelMode', 'source', 'type'].sort()
+      ['controller', 'doc', 'kiosk_session', 'page', 'panelMode', 'source', 'type'].sort()
     );
   });
 });
@@ -34,12 +34,13 @@ describe('parsePathfinderDeepLink', () => {
       page: undefined,
       kioskSession: undefined,
       panelMode: undefined,
+      controller: false,
     });
   });
 
   it('parses every supported param, including the renamed kiosk_session → kioskSession', () => {
     const search =
-      '?doc=https%3A%2F%2Fgrafana.com%2Fdocs%2Ffoo&type=learning-journey&source=learning-hub&page=%2Fexplore&kiosk_session=abc123&panelMode=fullscreen';
+      '?doc=https%3A%2F%2Fgrafana.com%2Fdocs%2Ffoo&type=learning-journey&source=learning-hub&page=%2Fexplore&kiosk_session=abc123&panelMode=fullscreen&controller=1';
     expect(parsePathfinderDeepLink(search)).toEqual({
       doc: 'https://grafana.com/docs/foo',
       type: 'learning-journey',
@@ -47,7 +48,14 @@ describe('parsePathfinderDeepLink', () => {
       page: '/explore',
       kioskSession: 'abc123',
       panelMode: 'fullscreen',
+      controller: true,
     });
+  });
+
+  it('parses controller=1 as true and anything else as false', () => {
+    expect(parsePathfinderDeepLink('?controller=1').controller).toBe(true);
+    expect(parsePathfinderDeepLink('?controller=0').controller).toBe(false);
+    expect(parsePathfinderDeepLink('').controller).toBe(false);
   });
 
   it('rejects unknown `type` values (typos drop to undefined rather than poisoning consumers)', () => {
@@ -77,7 +85,7 @@ describe('parsePathfinderDeepLink', () => {
 describe('stripPathfinderParams', () => {
   it('removes every Pathfinder-controlled param while preserving foreign params', () => {
     const url = new URL(
-      'https://example.com/foo?doc=bar&type=learning-journey&source=hub&page=/explore&kiosk_session=xyz&panelMode=floating&keep=this'
+      'https://example.com/foo?doc=bar&type=learning-journey&source=hub&page=/explore&kiosk_session=xyz&panelMode=floating&controller=1&keep=this'
     );
 
     stripPathfinderParams(url);
@@ -88,6 +96,7 @@ describe('stripPathfinderParams', () => {
     expect(url.searchParams.get('page')).toBeNull();
     expect(url.searchParams.get('kiosk_session')).toBeNull();
     expect(url.searchParams.get('panelMode')).toBeNull();
+    expect(url.searchParams.get('controller')).toBeNull();
     expect(url.searchParams.get('keep')).toBe('this');
   });
 

--- a/src/utils/pathfinder-search-params.ts
+++ b/src/utils/pathfinder-search-params.ts
@@ -19,7 +19,7 @@
  * `searchParams.set` — no user-controlled keys are ever set.
  */
 
-export const PATHFINDER_PARAMS = ['doc', 'type', 'source', 'page', 'kiosk_session', 'panelMode'] as const;
+export const PATHFINDER_PARAMS = ['doc', 'type', 'source', 'page', 'kiosk_session', 'panelMode', 'controller'] as const;
 export type PathfinderParam = (typeof PATHFINDER_PARAMS)[number];
 
 // Subset of PATHFINDER_PARAMS that activate the deep-link handler
@@ -55,6 +55,7 @@ export interface DeepLinkParams {
   kioskSession?: string;
   /** Surface mode from `?panelMode=`. Strict whitelist; unknowns drop to undefined. */
   panelMode?: PathfinderDeepLinkPanelMode;
+  controller?: boolean;
 }
 
 const ALLOWED_TYPES: ReadonlySet<PathfinderDeepLinkType> = new Set(['learning-journey', 'docs', 'interactive']);
@@ -81,6 +82,7 @@ export function parsePathfinderDeepLink(search: string): DeepLinkParams {
     page: params.get('page') ?? undefined,
     kioskSession: params.get('kiosk_session') ?? undefined,
     panelMode,
+    controller: params.get('controller') === '1',
   };
 }
 


### PR DESCRIPTION
Stacked on #1056.

Adds an **"Open in interactive window"** button to the docs content-meta toolbar (sibling of the docs / learning-journey open buttons), shown only for guides of type `interactive` (`pickControllerTabOpenAction`). It opens a same-origin `?doc=<guide>&controller=1` tab; `module.tsx` gains a matching short-circuit that mounts `GuideReaderOverlay` in controller mode.

`GuideReaderOverlay` gains a `mode` prop and `InteractiveMode` gains `'controller'`; `controller` joins the `PATHFINDER_PARAMS` parse/strip set. Clicking the visible step actions doesn't drive the live tab yet — the cross-tab emit wiring lands in the next layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)