### PR TITLE
refactor(cli): encapsulate CLI<->Playwright e2e env-var protocol

### DIFF
--- a/src/cli/utils/e2e-runner-contract.ts
+++ b/src/cli/utils/e2e-runner-contract.ts
@@ -1,0 +1,47 @@
+/**
+ * Contract between the `pathfinder-cli e2e` command and the Playwright guide
+ * runner it spawns. The CLI (`src/cli/commands/e2e.ts`) sets these environment
+ * variables; the runner (`tests/e2e-runner/guide-runner.spec.ts`) and its
+ * Playwright config (`tests/e2e-runner/playwright.config.ts`) read them.
+ *
+ * Both sides must reference these constants rather than literal strings so a
+ * rename can never silently break the cross-process protocol.
+ */
+
+/**
+ * Environment-variable keys exchanged between the CLI and the Playwright runner.
+ * The property name is the role; the value is the wire key placed in `env`.
+ */
+export const E2E_ENV = {
+  /** Absolute path to the guide JSON the runner should load. */
+  GUIDE_JSON_PATH: 'GUIDE_JSON_PATH',
+  /** Grafana base URL under test. */
+  GRAFANA_URL: 'GRAFANA_URL',
+  /** Flag: enable Playwright tracing. */
+  TRACE: 'E2E_TRACE',
+  /** Flag: enable verbose runner and reporter output. */
+  VERBOSE: 'E2E_VERBOSE',
+  /** Absolute path the runner writes its abort reason to (e.g. session expiry). */
+  ABORT_FILE_PATH: 'ABORT_FILE_PATH',
+  /** Absolute path the runner writes step results to for JSON reporting. */
+  RESULTS_FILE_PATH: 'RESULTS_FILE_PATH',
+  /** Directory the runner collects artifacts (screenshots, etc.) into. */
+  ARTIFACTS_DIR: 'ARTIFACTS_DIR',
+  /** Flag: capture screenshots on success as well as failure. */
+  ALWAYS_SCREENSHOT: 'ALWAYS_SCREENSHOT',
+  /**
+   * Absolute path the runner writes the produced trace's location to, so the CLI
+   * can surface it without hardcoding Playwright's per-test output-dir naming.
+   */
+  TRACE_OUTPUT_FILE: 'E2E_TRACE_OUTPUT_FILE',
+} as const;
+
+/** Encode a boolean for transport through a string environment variable. */
+export function encodeEnvFlag(value: boolean): string {
+  return value ? 'true' : 'false';
+}
+
+/** Decode an environment-variable flag written by {@link encodeEnvFlag}. */
+export function isEnvFlagEnabled(value: string | undefined): boolean {
+  return value === 'true';
+}

--- a/src/cli/utils/playwright-runner.ts
+++ b/src/cli/utils/playwright-runner.ts
@@ -9,6 +9,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 import { ExitCode } from './exit-codes';
+import { E2E_ENV, encodeEnvFlag } from './e2e-runner-contract';
 import type { LoadedGuide } from './file-loader';
 import type { TestResultsData } from './e2e-reporter';
 
@@ -87,6 +88,22 @@ function readResultsFile(resultsFilePath: string): TestResultsData | undefined {
 }
 
 /**
+ * Read the trace file path the runner recorded (see e2e-runner-contract).
+ * Returns undefined if the file is missing or empty.
+ */
+function readTraceOutputFile(traceOutputFilePath: string): string | undefined {
+  try {
+    if (!existsSync(traceOutputFilePath)) {
+      return undefined;
+    }
+    const content = readFileSync(traceOutputFilePath, 'utf-8').trim();
+    return content.length > 0 ? content : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Process Playwright test results from temp files.
  * Reads abort file and results file to determine final outcome.
  *
@@ -98,17 +115,14 @@ function readResultsFile(resultsFilePath: string): TestResultsData | undefined {
 function processPlaywrightResults(
   exitCode: number,
   options: { trace: boolean },
-  filePaths: { abortFilePath: string; resultsFilePath: string }
+  filePaths: { abortFilePath: string; resultsFilePath: string; traceOutputFilePath: string }
 ): PlaywrightResult {
   const playwrightExitCode = exitCode;
   const success = playwrightExitCode === 0;
 
-  // Build trace file path if tracing enabled
-  let traceFile: string | undefined;
-  if (options.trace) {
-    // Playwright stores traces in test-results/ directory
-    traceFile = 'test-results/guide-runner-loads-and-displays-guide-from-JSON-chromium/trace.zip';
-  }
+  // Trace location is reported by the runner (see e2e-runner-contract) so the
+  // CLI never hardcodes Playwright's per-test output-dir naming.
+  const traceFile = options.trace ? readTraceOutputFile(filePaths.traceOutputFilePath) : undefined;
 
   // L3-5B: Read results file for JSON reporting
   const resultsData = readResultsFile(filePaths.resultsFilePath);
@@ -160,6 +174,8 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
   const abortFilePath = join(tempDir, 'abort.json');
   // L3-5B: Create results file path for JSON reporting
   const resultsFilePath = join(tempDir, 'results.json');
+  // Path the runner records the produced trace location to (see e2e-runner-contract).
+  const traceOutputFilePath = join(tempDir, 'trace-path.txt');
 
   try {
     writeFileSync(guidePath, guide.content);
@@ -192,18 +208,15 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
       const proc = spawn('npx', playwrightArgs, {
         env: {
           ...process.env,
-          GUIDE_JSON_PATH: guidePath,
-          GRAFANA_URL: options.grafanaUrl,
-          E2E_TRACE: options.trace ? 'true' : 'false',
-          E2E_VERBOSE: options.verbose ? 'true' : 'false',
-          // L3-3D: Pass abort file path for session validation
-          ABORT_FILE_PATH: abortFilePath,
-          // L3-5B: Pass results file path for JSON reporting
-          RESULTS_FILE_PATH: resultsFilePath,
-          // L3-5D: Pass artifacts directory for artifact collection
-          ARTIFACTS_DIR: options.artifacts,
-          // Capture screenshots on success and failure
-          ALWAYS_SCREENSHOT: options.alwaysScreenshot ? 'true' : 'false',
+          [E2E_ENV.GUIDE_JSON_PATH]: guidePath,
+          [E2E_ENV.GRAFANA_URL]: options.grafanaUrl,
+          [E2E_ENV.TRACE]: encodeEnvFlag(options.trace),
+          [E2E_ENV.VERBOSE]: encodeEnvFlag(options.verbose),
+          [E2E_ENV.ABORT_FILE_PATH]: abortFilePath,
+          [E2E_ENV.RESULTS_FILE_PATH]: resultsFilePath,
+          [E2E_ENV.ARTIFACTS_DIR]: options.artifacts,
+          [E2E_ENV.ALWAYS_SCREENSHOT]: encodeEnvFlag(options.alwaysScreenshot),
+          [E2E_ENV.TRACE_OUTPUT_FILE]: traceOutputFilePath,
           // Prevent Playwright from auto-opening HTML report server in CLI mode
           PLAYWRIGHT_HTML_OPEN: 'never',
         },
@@ -214,7 +227,11 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
         const result = processPlaywrightResults(
           code ?? 1,
           { trace: options.trace },
-          { abortFilePath, resultsFilePath }
+          {
+            abortFilePath,
+            resultsFilePath,
+            traceOutputFilePath,
+          }
         );
         resolve(result);
       });

--- a/tests/e2e-runner/guide-runner.spec.ts
+++ b/tests/e2e-runner/guide-runner.spec.ts
@@ -19,6 +19,7 @@
  */
 
 import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
 
 import { test, expect } from '../fixtures';
 import { testIds } from '../../src/constants/testIds';
@@ -41,6 +42,7 @@ import {
   printDiscoveryResults,
 } from './utils/console-reporter';
 import type { TestResultsData } from '../../src/cli/utils/e2e-reporter';
+import { E2E_ENV, isEnvFlagEnabled } from '../../src/cli/utils/e2e-runner-contract';
 
 /**
  * Write abort reason to file for CLI to read and determine exit code.
@@ -50,7 +52,7 @@ import type { TestResultsData } from '../../src/cli/utils/e2e-reporter';
  * @param message - Human-readable message
  */
 function writeAbortFile(abortReason: AbortReason, message: string): void {
-  const abortFilePath = process.env.ABORT_FILE_PATH;
+  const abortFilePath = process.env[E2E_ENV.ABORT_FILE_PATH];
   if (abortFilePath) {
     const abortData = JSON.stringify({ abortReason, message });
     writeFileSync(abortFilePath, abortData, 'utf-8');
@@ -73,7 +75,7 @@ function writeResultsFile(
   timestamp: string,
   allStepsResult: AllStepsResult
 ): void {
-  const resultsFilePath = process.env.RESULTS_FILE_PATH;
+  const resultsFilePath = process.env[E2E_ENV.RESULTS_FILE_PATH];
   if (!resultsFilePath) {
     return;
   }
@@ -104,8 +106,21 @@ function writeResultsFile(
   writeFileSync(resultsFilePath, JSON.stringify(data), 'utf-8');
 }
 
+/**
+ * Record the produced trace's location for the CLI to surface (see
+ * e2e-runner-contract). Playwright writes the per-test trace to
+ * `<outputDir>/trace.zip` when tracing is on.
+ */
+function writeTracePathFile(outputDir: string): void {
+  const tracePathFile = process.env[E2E_ENV.TRACE_OUTPUT_FILE];
+  if (!tracePathFile || !isEnvFlagEnabled(process.env[E2E_ENV.TRACE])) {
+    return;
+  }
+  writeFileSync(tracePathFile, join(outputDir, 'trace.zip'), 'utf-8');
+}
+
 test.describe('Guide Runner', () => {
-  test('loads and displays guide from JSON', async ({ page }) => {
+  test('loads and displays guide from JSON', async ({ page }, testInfo) => {
     // Guide tests may take longer due to fix button attempts and multi-step execution.
     // Per L3-3C timing design: 30s base + 5s per internal action for multisteps,
     // plus additional time for fix attempts (up to 3 × 10s each).
@@ -116,16 +131,20 @@ test.describe('Guide Runner', () => {
     const testStartTimestamp = new Date().toISOString();
 
     // Read guide JSON from environment variable path
-    const guidePath = process.env.GUIDE_JSON_PATH;
-    const grafanaUrl = process.env.GRAFANA_URL ?? 'http://localhost:3000';
-    const isVerbose = process.env.E2E_VERBOSE === 'true';
+    const guidePath = process.env[E2E_ENV.GUIDE_JSON_PATH];
+    const grafanaUrl = process.env[E2E_ENV.GRAFANA_URL] ?? 'http://localhost:3000';
+    const isVerbose = isEnvFlagEnabled(process.env[E2E_ENV.VERBOSE]);
     // L3-5D: Artifacts directory for artifact collection
-    const artifactsDir = process.env.ARTIFACTS_DIR;
+    const artifactsDir = process.env[E2E_ENV.ARTIFACTS_DIR];
     // Capture screenshots on success and failure
-    const alwaysScreenshot = process.env.ALWAYS_SCREENSHOT === 'true';
+    const alwaysScreenshot = isEnvFlagEnabled(process.env[E2E_ENV.ALWAYS_SCREENSHOT]);
+
+    // Record the trace location up front so the CLI can surface it even when the
+    // test fails (Playwright produces the trace regardless of pass/fail).
+    writeTracePathFile(testInfo.outputDir);
 
     if (!guidePath) {
-      throw new Error('GUIDE_JSON_PATH environment variable is required');
+      throw new Error(`${E2E_ENV.GUIDE_JSON_PATH} environment variable is required`);
     }
 
     const guideJson = readFileSync(guidePath, 'utf-8');

--- a/tests/e2e-runner/playwright.config.ts
+++ b/tests/e2e-runner/playwright.config.ts
@@ -12,6 +12,8 @@ import type { PluginOptions } from '@grafana/plugin-e2e';
 import { defineConfig, devices } from '@playwright/test';
 import { dirname, join } from 'node:path';
 
+import { E2E_ENV, isEnvFlagEnabled } from '../../src/cli/utils/e2e-runner-contract';
+
 const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
 
 // Resolve paths relative to project root (two levels up from this file)
@@ -26,10 +28,10 @@ export default defineConfig<PluginOptions>({
   fullyParallel: false, // Sequential execution for guide tests
   forbidOnly: !!process.env.CI,
   retries: 0, // No retries - failures should be investigated
-  reporter: process.env.E2E_VERBOSE === 'true' ? 'list' : 'line',
+  reporter: isEnvFlagEnabled(process.env[E2E_ENV.VERBOSE]) ? 'list' : 'line',
   use: {
-    baseURL: process.env.GRAFANA_URL || 'http://localhost:3000',
-    trace: process.env.E2E_TRACE === 'true' ? 'on' : 'off',
+    baseURL: process.env[E2E_ENV.GRAFANA_URL] || 'http://localhost:3000',
+    trace: isEnvFlagEnabled(process.env[E2E_ENV.TRACE]) ? 'on' : 'off',
   },
   projects: [
     // 1. Login to Grafana and store the cookie on disk for use in other tests.


### PR DESCRIPTION
## Stack Overview
#1076 -> #1077 -> #1078 -> #1079 (this PR) -> #1080 -> #1081

## Summary
Introduce src/cli/utils/e2e-runner-contract.ts as the single owner of the environment-variable contract between the `pathfinder-cli e2e` command and the Playwright guide runner. Both sides now reference E2E_ENV keys and the encodeEnvFlag/isEnvFlagEnabled helpers instead of duplicating literal env names and the 'true'/'false' convention, so a rename cannot silently break the cross-process protocol.

Also remove the hardcoded Playwright trace slug: the runner records the actual <outputDir>/trace.zip path (E2E_ENV.TRACE_OUTPUT_FILE) and the CLI reads it, so the trace location no longer breaks if the test title or project name changes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
