### PR TITLE
refactor(cli): collapse duplicate file readers and guide-status counts

### DIFF
--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -601,6 +601,26 @@ async function runChains(
   return { results, allPassed, hasAuthExpiry };
 }
 
+interface GuideStatusCounts {
+  passed: number;
+  failed: number;
+  authExpired: number;
+  skippedPrereq: number;
+}
+
+/**
+ * Count guides by terminal status. Computed once and shared by both summary
+ * presentations.
+ */
+function countGuideStatuses(results: GuideRunResult[]): GuideStatusCounts {
+  return {
+    passed: results.filter((r) => r.status === 'passed').length,
+    failed: results.filter((r) => r.status === 'failed').length,
+    authExpired: results.filter((r) => r.status === 'auth_expired').length,
+    skippedPrereq: results.filter((r) => r.status === 'skipped_prereq').length,
+  };
+}
+
 /**
  * Print the run summary: aggregate guide/step counts for multi-guide runs, or a
  * compact pass/fail breakdown for a single guide.
@@ -608,6 +628,7 @@ async function runChains(
 function printSummary(results: GuideRunResult[]): void {
   const resultsWithData = results.filter((r) => r.resultsData).map((r) => r.resultsData!);
   const isMultiGuide = results.length > 1;
+  const counts = countGuideStatuses(results);
 
   console.log('\n' + '─'.repeat(68));
   console.log('📊 Summary');
@@ -615,20 +636,15 @@ function printSummary(results: GuideRunResult[]): void {
 
   if (isMultiGuide) {
     // Multi-guide summary (L3-7B)
-    const passedGuides = results.filter((r) => r.status === 'passed').length;
-    const failedGuides = results.filter((r) => r.status === 'failed').length;
-    const authExpired = results.filter((r) => r.status === 'auth_expired').length;
-    const skippedPrereq = results.filter((r) => r.status === 'skipped_prereq').length;
-
-    console.log(`\n   Guides: ${passedGuides}/${results.length} passed`);
-    if (failedGuides > 0) {
-      console.log(`   ├─ ❌ Failed: ${failedGuides}`);
+    console.log(`\n   Guides: ${counts.passed}/${results.length} passed`);
+    if (counts.failed > 0) {
+      console.log(`   ├─ ❌ Failed: ${counts.failed}`);
     }
-    if (authExpired > 0) {
-      console.log(`   ├─ 🔐 Auth expired: ${authExpired}`);
+    if (counts.authExpired > 0) {
+      console.log(`   ├─ 🔐 Auth expired: ${counts.authExpired}`);
     }
-    if (skippedPrereq > 0) {
-      console.log(`   └─ ⊘ Skipped (prerequisite failed): ${skippedPrereq}`);
+    if (counts.skippedPrereq > 0) {
+      console.log(`   └─ ⊘ Skipped (prerequisite failed): ${counts.skippedPrereq}`);
     }
 
     // Aggregate step statistics across all guides
@@ -687,22 +703,17 @@ function printSummary(results: GuideRunResult[]): void {
     }
   } else {
     // Single guide summary
-    const passed = results.filter((r) => r.status === 'passed').length;
-    const failed = results.filter((r) => r.status === 'failed').length;
-    const authExpired = results.filter((r) => r.status === 'auth_expired').length;
-    const skippedPrereq = results.filter((r) => r.status === 'skipped_prereq').length;
-
-    if (passed > 0) {
-      console.log(`   ✅ Passed: ${passed}`);
+    if (counts.passed > 0) {
+      console.log(`   ✅ Passed: ${counts.passed}`);
     }
-    if (failed > 0) {
-      console.log(`   ❌ Failed: ${failed}`);
+    if (counts.failed > 0) {
+      console.log(`   ❌ Failed: ${counts.failed}`);
     }
-    if (authExpired > 0) {
-      console.log(`   🔐 Auth expired: ${authExpired}`);
+    if (counts.authExpired > 0) {
+      console.log(`   🔐 Auth expired: ${counts.authExpired}`);
     }
-    if (skippedPrereq > 0) {
-      console.log(`   ⊘ Skipped (prerequisite failed): ${skippedPrereq}`);
+    if (counts.skippedPrereq > 0) {
+      console.log(`   ⊘ Skipped (prerequisite failed): ${counts.skippedPrereq}`);
     }
   }
 

--- a/src/cli/utils/playwright-runner.ts
+++ b/src/cli/utils/playwright-runner.ts
@@ -56,48 +56,29 @@ export interface RunGuideOptions {
 }
 
 /**
- * Read abort file content if it exists (L3-3D).
- * Returns undefined if file doesn't exist or is invalid.
+ * Read a file's text if it exists and is readable; undefined otherwise.
  */
-function readAbortFile(abortFilePath: string): AbortFileContent | undefined {
+function readFileIfExists(filePath: string): string | undefined {
   try {
-    if (!existsSync(abortFilePath)) {
+    if (!existsSync(filePath)) {
       return undefined;
     }
-    const content = readFileSync(abortFilePath, 'utf-8');
-    return JSON.parse(content) as AbortFileContent;
+    return readFileSync(filePath, 'utf-8');
   } catch {
     return undefined;
   }
 }
 
 /**
- * Read test results file if it exists (L3-5B).
- * Returns undefined if file doesn't exist or is invalid.
+ * Parse a JSON file's contents if it exists and is valid JSON; undefined otherwise.
  */
-function readResultsFile(resultsFilePath: string): TestResultsData | undefined {
-  try {
-    if (!existsSync(resultsFilePath)) {
-      return undefined;
-    }
-    const content = readFileSync(resultsFilePath, 'utf-8');
-    return JSON.parse(content) as TestResultsData;
-  } catch {
+function readJsonIfExists<T>(filePath: string): T | undefined {
+  const content = readFileIfExists(filePath);
+  if (content === undefined) {
     return undefined;
   }
-}
-
-/**
- * Read the trace file path the runner recorded (see e2e-runner-contract).
- * Returns undefined if the file is missing or empty.
- */
-function readTraceOutputFile(traceOutputFilePath: string): string | undefined {
   try {
-    if (!existsSync(traceOutputFilePath)) {
-      return undefined;
-    }
-    const content = readFileSync(traceOutputFilePath, 'utf-8').trim();
-    return content.length > 0 ? content : undefined;
+    return JSON.parse(content) as T;
   } catch {
     return undefined;
   }
@@ -122,13 +103,13 @@ function processPlaywrightResults(
 
   // Trace location is reported by the runner (see e2e-runner-contract) so the
   // CLI never hardcodes Playwright's per-test output-dir naming.
-  const traceFile = options.trace ? readTraceOutputFile(filePaths.traceOutputFilePath) : undefined;
+  const traceFile = options.trace ? readFileIfExists(filePaths.traceOutputFilePath)?.trim() || undefined : undefined;
 
   // L3-5B: Read results file for JSON reporting
-  const resultsData = readResultsFile(filePaths.resultsFilePath);
+  const resultsData = readJsonIfExists<TestResultsData>(filePaths.resultsFilePath);
 
   // L3-3D: Check abort file for session expiry
-  const abortContent = readAbortFile(filePaths.abortFilePath);
+  const abortContent = readJsonIfExists<AbortFileContent>(filePaths.abortFilePath);
   if (abortContent) {
     // Determine exit code based on abort reason
     const abortExitCode = abortContent.abortReason === 'AUTH_EXPIRED' ? ExitCode.AUTH_FAILURE : ExitCode.TEST_FAILURE;


### PR DESCRIPTION
## Stack Overview
#1076 -> #1077 -> #1078 -> #1079 -> #1080 (this PR) -> #1081

## Summary
Replace the three near-identical readers (readAbortFile, readResultsFile, readTraceOutputFile) with a generic readFileIfExists plus a readJsonIfExists<T> built on top, so the exists/read/parse/catch pattern lives in one place.

In printSummary, compute the per-status guide counts once via a new countGuideStatuses helper and share them across the multi- and single-guide presentations instead of recomputing the same four filters in each branch. Output and behavior are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
