### PR TITLE
refactor(cli): drop requirement-ID comment tags in e2e command and modules

### DIFF
--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -581,7 +581,6 @@ async function runChains(
         allPassed = false;
         blocked.add(planned.id);
 
-        // L3-3D: Check for auth expiry
         if (result.abortReason === 'AUTH_EXPIRED') {
           hasAuthExpiry = true;
           console.log(`   ❌ Session expired: ${result.abortMessage}`);
@@ -635,7 +634,7 @@ function printSummary(results: GuideRunResult[]): void {
   console.log('─'.repeat(68));
 
   if (isMultiGuide) {
-    // Multi-guide summary (L3-7B)
+    // Multi-guide summary
     console.log(`\n   Guides: ${counts.passed}/${results.length} passed`);
     if (counts.failed > 0) {
       console.log(`   ├─ ❌ Failed: ${counts.failed}`);
@@ -760,7 +759,6 @@ function writeJsonReport(results: GuideRunResult[], options: E2ECommandOptions):
  */
 function exitFromOutcome(outcome: ChainRunOutcome): void {
   if (!outcome.allPassed) {
-    // L3-3D: Use exit code 4 for auth expiry
     if (outcome.hasAuthExpiry) {
       process.exit(ExitCode.AUTH_FAILURE);
     }

--- a/src/cli/utils/exit-codes.ts
+++ b/src/cli/utils/exit-codes.ts
@@ -1,5 +1,5 @@
 /**
- * Exit codes per design spec
+ * Process exit codes returned by the e2e command.
  */
 export const ExitCode = {
   SUCCESS: 0,

--- a/src/cli/utils/playwright-runner.ts
+++ b/src/cli/utils/playwright-runner.ts
@@ -14,13 +14,13 @@ import type { LoadedGuide } from './file-loader';
 import type { TestResultsData } from './e2e-reporter';
 
 /**
- * Abort reason from test execution (L3-3D).
+ * Abort reason from test execution.
  * Written to abort file by test, read by CLI to determine exit code.
  */
 export type AbortReason = 'AUTH_EXPIRED' | 'MANDATORY_FAILURE';
 
 /**
- * Abort file content structure (L3-3D).
+ * Abort file content structure.
  */
 interface AbortFileContent {
   abortReason: AbortReason;
@@ -34,11 +34,11 @@ export interface PlaywrightResult {
   success: boolean;
   exitCode: number;
   traceFile?: string;
-  /** Abort reason if test was aborted (L3-3D) */
+  /** Abort reason if test was aborted */
   abortReason?: AbortReason;
-  /** Abort message if test was aborted (L3-3D) */
+  /** Abort message if test was aborted */
   abortMessage?: string;
-  /** Test results data for JSON report generation (L3-5B) */
+  /** Test results data for JSON report generation */
   resultsData?: TestResultsData;
 }
 
@@ -105,10 +105,9 @@ function processPlaywrightResults(
   // CLI never hardcodes Playwright's per-test output-dir naming.
   const traceFile = options.trace ? readFileIfExists(filePaths.traceOutputFilePath)?.trim() || undefined : undefined;
 
-  // L3-5B: Read results file for JSON reporting
   const resultsData = readJsonIfExists<TestResultsData>(filePaths.resultsFilePath);
 
-  // L3-3D: Check abort file for session expiry
+  // An abort file means the runner stopped early (e.g. session expiry).
   const abortContent = readJsonIfExists<AbortFileContent>(filePaths.abortFilePath);
   if (abortContent) {
     // Determine exit code based on abort reason
@@ -137,12 +136,12 @@ function processPlaywrightResults(
  * Writes guide JSON to temp file, spawns Playwright with environment variables,
  * and cleans up temp file after completion.
  *
- * Session validation (L3-3D):
+ * Session validation:
  * - Creates abort file path for test to write abort reason
  * - Reads abort file after test completes to determine exit code
  * - Returns AUTH_EXPIRED abort reason if session expired
  *
- * JSON reporting (L3-5B):
+ * JSON reporting:
  * - Creates results file path for test to write step results
  * - Reads results file after test completes
  * - Returns results data for JSON report generation
@@ -151,9 +150,9 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
   // Write guide to temp file
   const tempDir = mkdtempSync(join(tmpdir(), 'pathfinder-e2e-'));
   const guidePath = join(tempDir, 'guide.json');
-  // L3-3D: Create abort file path for session validation
+  // Abort file path for session validation
   const abortFilePath = join(tempDir, 'abort.json');
-  // L3-5B: Create results file path for JSON reporting
+  // Results file path for JSON reporting
   const resultsFilePath = join(tempDir, 'results.json');
   // Path the runner records the produced trace location to (see e2e-runner-contract).
   const traceOutputFilePath = join(tempDir, 'trace-path.txt');


### PR DESCRIPTION
## Stack Overview
#1076 -> #1077 -> #1078 -> #1079 -> #1080 -> #1081 (this PR)

## Summary
Remove the L3-* design-requirement tags (and the 'per design spec' note) from the e2e command and the modules it was split into (playwright-runner, exit-codes) per the QC8 comment guidance: these reference dead process artifacts that mean nothing months later. Pure-narration comments are deleted; where a comment carried intent the substantive text is kept without the tag.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
