### PR TITLE
feat(e2e): support a base-URL override in the repository client

### DIFF
--- a/src/cli/mcp/lib/repository-client.ts
+++ b/src/cli/mcp/lib/repository-client.ts
@@ -79,12 +79,12 @@ let indexCache: IndexCacheEntry | null = null;
 let indexInFlight: Promise<RepositoryIndexResult> | null = null;
 
 /**
- * Read the configured repository base URL. Always trailing-slash terminated
- * so callers can append `repository.json` directly.
+ * Resolve the repository base URL, always trailing-slash terminated so callers
+ * can append `repository.json` directly. Precedence: explicit `override`, then
+ * the `PATHFINDER_REPOSITORY_URL` env var, then the default CDN.
  */
-export function getRepositoryBaseUrl(): string {
-  const fromEnv = process.env[REPOSITORY_URL_ENV_VAR];
-  const raw = fromEnv && fromEnv.trim() !== '' ? fromEnv.trim() : DEFAULT_REPOSITORY_URL;
+export function getRepositoryBaseUrl(override?: string): string {
+  const raw = override?.trim() || process.env[REPOSITORY_URL_ENV_VAR]?.trim() || DEFAULT_REPOSITORY_URL;
   return raw.endsWith('/') ? raw : `${raw}/`;
 }
 
@@ -109,12 +109,15 @@ export function buildPackageFileUrl(baseUrl: string, entryPath: string, fileName
 /**
  * Fetch and validate `repository.json`. Cached for 60 s by base URL.
  *
+ * Pass `baseUrlOverride` to target a specific repository (e.g. a CLI
+ * `--repo-url`); it falls back to the env var / default CDN when omitted.
+ *
  * Errors are returned, never thrown. Schema drift on the index does not
  * hard-fail — `validation.issues` is populated and `packages` is built
  * best-effort from whatever entries did parse.
  */
-export async function fetchRepositoryIndex(): Promise<RepositoryIndexResult> {
-  const baseUrl = getRepositoryBaseUrl();
+export async function fetchRepositoryIndex(baseUrlOverride?: string): Promise<RepositoryIndexResult> {
+  const baseUrl = getRepositoryBaseUrl(baseUrlOverride);
   const now = Date.now();
   if (indexCache && indexCache.baseUrl === baseUrl && now - indexCache.at < REPOSITORY_INDEX_TTL_MS) {
     return indexCache.result;


### PR DESCRIPTION
## Stack overview

The stack lets `pathfinder-cli e2e` test **published** guides, not just local JSON files. It resolves a guide by bare ID (via the recommender) or the whole published CDN repository, routes each guide to the configured Grafana by its manifest `testEnvironment.tier` (local-tier guides run; cloud-tier guides are skipped until cloud auth is added), and reuses the existing dependency-chaining planner so a resolved guide's `depends` prerequisites run first — matching how selecting a local guide with dependencies behaves today.

- **#1086 `01-repo-client`** (this PR) — make the repository client's base URL configurable (override → env → default).
- **#1087 `02-targets`** — target resolver: maps a guide's `testEnvironment` to a concrete Grafana target or a structured skip (cloud → skipped for now).
- **#1088 `03-package`** — remote package resolver for `--package <id>` (recommender) and `--remote` (CDN index), including fetching a target's `depends` prerequisites; failures become structured skips rather than throwing.
- **#1089 `04-reporter`** — record package metadata and pre-run skip outcomes in the JSON report.
- **#1090 `05-command`** — wire it into the e2e command: `--package`, `--remote`, `--repo-url`, `--resolver-url`; resolve inputs (local or remote) → plan → run → report.
- **#1091 `06-docs`** — document the remote package-aware mode in `E2E_TESTING.md` and the design doc.

## Summary

Adds an optional base-URL override to the CDN repository client (`getRepositoryBaseUrl` / `fetchRepositoryIndex`), resolved with precedence **override → `PATHFINDER_REPOSITORY_URL` → default CDN**. Existing no-arg callers (the MCP authoring tools) are unchanged. This is the bottom of a 6-PR stack that adds package-aware remote testing to the `pathfinder-cli e2e` runner; this PR is the small enabler that lets the runner point at a specific repository.

## What to look at

- `src/cli/mcp/lib/repository-client.ts` — `getRepositoryBaseUrl(override?)` resolves the base URL by precedence (override, then `PATHFINDER_REPOSITORY_URL`, then the default CDN), trailing-slash normalized; `fetchRepositoryIndex(baseUrlOverride?)` threads it through. The index cache is keyed by the **resolved** base URL, so an override never collides with a default-URL cache entry. The key thing to confirm: a no-arg call (`getRepositoryBaseUrl()` / `fetchRepositoryIndex()`) behaves exactly as before — the MCP authoring tools that consume this client are unaffected.

## Why

The e2e runner (later in the stack) needs to target a non-default repository (a dev/staging CDN or a local mirror) via a `--repo-url` flag. The client was environment-only. The rejected alternative was having the command set `process.env[PATHFINDER_REPOSITORY_URL]` to bridge the flag into the env-based client — a process-global side effect and a back-door coupling to the client's env protocol. Passing the override as data keeps the client pure and the command unaware of how the client is configured.

## How to verify

1. Default unchanged: with no override and `PATHFINDER_REPOSITORY_URL` unset, exercise a repo-client consumer (e.g. an MCP authoring tool that lists packages) and confirm requests go to the default CDN (`interactive-learning.grafana.net/packages/`).
2. Env override: set `PATHFINDER_REPOSITORY_URL=https://example.test/packages/`, repeat, and confirm requests target that host.
3. Precedence: confirm an explicit override argument wins over the env var (the `--repo-url` consumer arrives in #1090; in isolation, a direct `fetchRepositoryIndex('https://other.test/packages/')` call demonstrates it).

## Breaking changes

None. Additive optional parameter; default and env-var behavior are preserved.

## Reversibility

Fully reversible. The change is an additive signature enhancement with no persisted state, schema, or contract change. It does alter the repository client's base-URL *resolution*, but back-compatibly — a revert restores prior behavior cleanly with no migration.

## Out of scope

- The `--repo-url` flag that consumes this override — added in #1090.
