### PR TITLE
feat(e2e): add a test-target resolver for package-aware runs

### DIFF
--- a/src/cli/utils/e2e-targets.test.ts
+++ b/src/cli/utils/e2e-targets.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the e2e target resolver. Covers tier → target mapping and the two
+ * skip reasons, including the forward-looking cloud-on-cloud skip that the
+ * cloud-auth follow-on will turn into a runnable target.
+ */
+
+import { resolveTarget } from './e2e-targets';
+
+const LOCAL_URL = 'http://localhost:3000';
+
+describe('resolveTarget', () => {
+  it('runs local-tier guides against the configured Grafana URL', () => {
+    const target = resolveTarget({ tier: 'local' }, { grafanaUrl: LOCAL_URL, currentTier: 'local' });
+
+    expect(target.runnable).toBe(true);
+    expect(target.grafanaUrl).toBe(LOCAL_URL);
+    expect(target.tier).toBe('local');
+    expect(target.skipReason).toBeUndefined();
+  });
+
+  it('treats a missing tier as local (runnable)', () => {
+    const target = resolveTarget({}, { grafanaUrl: LOCAL_URL, currentTier: 'local' });
+
+    expect(target.runnable).toBe(true);
+    expect(target.tier).toBe('local');
+    expect(target.grafanaUrl).toBe(LOCAL_URL);
+  });
+
+  it('runs an unknown tier (forward-compatible) against the configured URL', () => {
+    const target = resolveTarget({ tier: 'enterprise' }, { grafanaUrl: LOCAL_URL, currentTier: 'local' });
+
+    expect(target.runnable).toBe(true);
+    expect(target.tier).toBe('enterprise');
+    expect(target.grafanaUrl).toBe(LOCAL_URL);
+  });
+
+  it('skips a cloud guide on a local environment with tier-mismatch', () => {
+    const target = resolveTarget({ tier: 'cloud' }, { grafanaUrl: LOCAL_URL, currentTier: 'local' });
+
+    expect(target.runnable).toBe(false);
+    expect(target.skipReason).toBe('skipped_tier_mismatch');
+    expect(target.grafanaUrl).toBeUndefined();
+    expect(target.message).toBeDefined();
+  });
+
+  it('skips a cloud guide on a cloud environment with no-auth (credentials deferred)', () => {
+    const target = resolveTarget({ tier: 'cloud' }, { grafanaUrl: LOCAL_URL, currentTier: 'cloud' });
+
+    expect(target.runnable).toBe(false);
+    expect(target.skipReason).toBe('skipped_no_auth');
+  });
+
+  it('carries the requested instance through on both run and skip', () => {
+    const runnable = resolveTarget(
+      { tier: 'local', instance: 'play.grafana.org' },
+      { grafanaUrl: LOCAL_URL, currentTier: 'local' }
+    );
+    expect(runnable.instance).toBe('play.grafana.org');
+
+    const skipped = resolveTarget(
+      { tier: 'cloud', instance: 'myslug.grafana.net' },
+      { grafanaUrl: LOCAL_URL, currentTier: 'local' }
+    );
+    expect(skipped.instance).toBe('myslug.grafana.net');
+  });
+});

--- a/src/cli/utils/e2e-targets.ts
+++ b/src/cli/utils/e2e-targets.ts
@@ -1,0 +1,69 @@
+/**
+ * Test-target resolution for the e2e CLI.
+ *
+ * Maps a guide's `testEnvironment` (from its manifest) to a concrete Grafana
+ * target, or to a reason the guide cannot be tested in the current environment.
+ * Tier rules are delegated to `checkTier` so there is a single source of truth.
+ */
+
+import type { TestEnvironment } from '../../types/package.types';
+import { checkTier, type CurrentTier } from './manifest-preflight';
+
+/** Why a guide cannot be tested in the current environment. */
+export type TargetSkipReason = 'skipped_no_auth' | 'skipped_tier_mismatch';
+
+/** Resolution of a guide's `testEnvironment` to a concrete test target. */
+export interface ResolvedTarget {
+  /** True when the guide can run against the resolved target in this environment. */
+  runnable: boolean;
+  /** Declared tier, or `"local"` when the manifest omits one. */
+  tier: string;
+  /** Specific instance hostname the guide requested, if any. */
+  instance?: string;
+  /** Grafana base URL to test against. Present only when `runnable`. */
+  grafanaUrl?: string;
+  /** Why the guide is not runnable. Present only when not `runnable`. */
+  skipReason?: TargetSkipReason;
+  /** Human-readable explanation for logging. */
+  message?: string;
+  /** Cloud credentials. */
+  username?: string;
+  password?: string;
+}
+
+export interface ResolveTargetOptions {
+  /** Grafana URL configured for local-tier guides. */
+  grafanaUrl: string;
+  /** Tier of the current test environment (from `--tier`). */
+  currentTier: CurrentTier;
+}
+
+/**
+ * Resolve a guide's `testEnvironment` to a concrete test target.
+ *
+ * - `local` / absent / unknown tier → runnable against `options.grafanaUrl`
+ * - `cloud` tier on a `local` environment → `skipped_tier_mismatch`
+ * - `cloud` tier on a `cloud` environment → `skipped_no_auth` (auth not yet supported)
+ */
+export function resolveTarget(testEnvironment: TestEnvironment, options: ResolveTargetOptions): ResolvedTarget {
+  const tier = testEnvironment.tier ?? 'local';
+  const instance = testEnvironment.instance;
+  const tierResult = checkTier(testEnvironment, options.currentTier);
+
+  if (tierResult.status === 'skip' && tierResult.code === 'tier-mismatch') {
+    return { runnable: false, tier, instance, skipReason: 'skipped_tier_mismatch', message: tierResult.reason };
+  }
+
+  // Credentials not yet supported for cloud-tier guides; skip with "skipped_no_auth" reason.
+  if (tier === 'cloud') {
+    return {
+      runnable: false,
+      tier,
+      instance,
+      skipReason: 'skipped_no_auth',
+      message: 'Cloud-tier guide requires credentials that are not yet supported',
+    };
+  }
+
+  return { runnable: true, tier, instance, grafanaUrl: options.grafanaUrl };
+}


### PR DESCRIPTION
## Stack overview

#1086 -> #1087 (this PR) -> #1088 -> #1089 -> #1090 -> #1091

## Summary

Adds `resolveTarget(testEnvironment, { grafanaUrl, currentTier })`, which maps a guide's manifest `testEnvironment` to a concrete Grafana target or a structured skip. Tier rules are delegated to the existing `checkTier` so there's one source of truth: `local`/absent/unknown tier runs against the configured Grafana URL; `cloud` is skipped (`skipped_tier_mismatch` on a local environment, `skipped_no_auth` on a cloud one). Pure function, no I/O — consumed by the remote resolver in #1088.

## What to look at

- `src/cli/utils/e2e-targets.ts` — `resolveTarget` reuses `checkTier` rather than re-deriving tier logic. The cloud branches always skip for now (no credentials), but the returned `ResolvedTarget` keeps optional `username`/`password` fields so the shape is stable when cloud auth is added.

## Why

Routing a guide to the right Grafana (and skipping what can't run here) is a distinct decision from *fetching* the guide. Isolating it as a pure resolver keeps the remote resolver (#1088) and command (#1090) simple, and reusing `checkTier` avoids a second copy of the tier rules drifting from the manifest-preflight path.

## How to verify

Behavior is covered by unit tests (`e2e-targets.test.ts`: local/cloud/unknown tiers, both skip reasons, instance passthrough). The end-to-end effect is observable once #1090 wires it in: run `pathfinder-cli e2e --remote` against a local Grafana and confirm `local`-tier guides run while `cloud`-tier guides are skipped (not failed).

## Breaking changes

None. New module; nothing else changes.
