### PR TITLE
feat(e2e): add a remote package resolver for --package and --remote

### DIFF
--- a/src/cli/utils/e2e-package.test.ts
+++ b/src/cli/utils/e2e-package.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for remote package resolution. The recommender resolver, the CDN
+ * repository client, and guide validation are mocked so these tests exercise
+ * the orchestration logic — outcome mapping, target filtering, and graceful
+ * degradation — without real network or schema coupling.
+ */
+
+jest.mock('../../validation', () => ({
+  validateGuideFromString: jest.fn(() => ({ isValid: true, warnings: [], errors: [] })),
+}));
+jest.mock('./recommender-resolver', () => ({
+  resolvePackageById: jest.fn(),
+}));
+jest.mock('../mcp/lib/repository-client', () => ({
+  fetchRepositoryIndex: jest.fn(),
+  buildPackageFileUrl: jest.fn((base: string, path: string, file: string) => `${base}${path}/${file}`),
+}));
+
+import { resolveRemotePackage, resolveRemoteRepository } from './e2e-package';
+import { validateGuideFromString } from '../../validation';
+import { resolvePackageById } from './recommender-resolver';
+import { fetchRepositoryIndex } from '../mcp/lib/repository-client';
+
+const OPTIONS = {
+  grafanaUrl: 'http://localhost:3000',
+  currentTier: 'local' as const,
+  resolverUrl: 'https://recommender.test',
+};
+
+/** Configure the recommender resolver mock to return a fixed resolution. */
+function mockResolve(resolution: unknown): void {
+  (resolvePackageById as jest.Mock).mockResolvedValue(resolution);
+}
+
+/** Configure global fetch to return a text body or an HTTP error. */
+function mockFetch(body: { ok: true; text: string } | { ok: false; status: number }): void {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue(
+      body.ok ? { ok: true, text: async () => body.text } : { ok: false, status: body.status, statusText: 'Error' }
+    ) as unknown as typeof fetch;
+}
+
+/** Configure the CDN index mock with the given packages. */
+function mockIndex(packages: unknown[]): void {
+  (fetchRepositoryIndex as jest.Mock).mockResolvedValue({
+    ok: true,
+    baseUrl: 'https://cdn.test/packages/',
+    packages,
+    rawIndex: {},
+    validation: { isValid: true, issues: [] },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (validateGuideFromString as jest.Mock).mockReturnValue({ isValid: true, warnings: [], errors: [] });
+  // Default to an empty index so single-package runnable tests resolve as
+  // singletons (no dependencies) unless a test sets up an index explicitly.
+  mockIndex([]);
+});
+
+describe('resolveRemotePackage (single, recommender)', () => {
+  it('returns a runnable guide for a local-tier package', async () => {
+    mockResolve({
+      ok: true,
+      id: 'alerting-101',
+      contentUrl: 'https://cdn.test/alerting-101/content.json',
+      manifestUrl: 'https://cdn.test/alerting-101/manifest.json',
+      repository: 'r',
+      manifest: { id: 'alerting-101', type: 'guide', testEnvironment: { tier: 'local' } },
+    });
+    mockFetch({ ok: true, text: '{"id":"alerting-101"}' });
+
+    const result = await resolveRemotePackage('alerting-101', OPTIONS);
+
+    expect(result.skipped).toHaveLength(0);
+    expect(result.runnable).toHaveLength(1);
+    expect(result.runnable[0]).toMatchObject({
+      id: 'alerting-101',
+      tier: 'local',
+      targetUrl: 'http://localhost:3000',
+      sourceUrl: 'https://cdn.test/alerting-101/content.json',
+    });
+    expect(result.runnable[0]!.guide.content).toBe('{"id":"alerting-101"}');
+  });
+
+  it('maps a recommender failure to resolution_failed', async () => {
+    mockResolve({ ok: false, message: 'not-found: package not found' });
+
+    const result = await resolveRemotePackage('missing', OPTIONS);
+
+    expect(result.runnable).toHaveLength(0);
+    expect(result.skipped[0]).toMatchObject({ id: 'missing', reason: 'resolution_failed' });
+  });
+
+  it('skips a non-guide package as unsupported_type', async () => {
+    mockResolve({
+      ok: true,
+      id: 'prometheus-lj',
+      contentUrl: 'https://cdn.test/prometheus-lj/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: { id: 'prometheus-lj', type: 'path', milestones: ['a', 'b'] },
+    });
+
+    const result = await resolveRemotePackage('prometheus-lj', OPTIONS);
+
+    expect(result.runnable).toHaveLength(0);
+    expect(result.skipped[0]).toMatchObject({ id: 'prometheus-lj', reason: 'unsupported_type' });
+  });
+
+  it('skips a cloud-tier package on a local environment', async () => {
+    mockResolve({
+      ok: true,
+      id: 'cloud-guide',
+      contentUrl: 'https://cdn.test/cloud-guide/content.json',
+      manifestUrl: 'https://cdn.test/cloud-guide/manifest.json',
+      repository: 'r',
+      manifest: { id: 'cloud-guide', type: 'guide', testEnvironment: { tier: 'cloud' } },
+    });
+
+    const result = await resolveRemotePackage('cloud-guide', OPTIONS);
+
+    expect(result.runnable).toHaveLength(0);
+    expect(result.skipped[0]).toMatchObject({ id: 'cloud-guide', reason: 'skipped_tier_mismatch' });
+  });
+
+  it('maps a content fetch error to fetch_failed', async () => {
+    mockResolve({
+      ok: true,
+      id: 'g',
+      contentUrl: 'https://cdn.test/g/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: { id: 'g', type: 'guide', testEnvironment: { tier: 'local' } },
+    });
+    mockFetch({ ok: false, status: 503 });
+
+    const result = await resolveRemotePackage('g', OPTIONS);
+
+    expect(result.skipped[0]).toMatchObject({ id: 'g', reason: 'fetch_failed' });
+  });
+
+  it('maps invalid fetched content to validation_failed', async () => {
+    mockResolve({
+      ok: true,
+      id: 'g',
+      contentUrl: 'https://cdn.test/g/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: { id: 'g', type: 'guide', testEnvironment: { tier: 'local' } },
+    });
+    mockFetch({ ok: true, text: '{"not":"a guide"}' });
+    (validateGuideFromString as jest.Mock).mockReturnValue({ isValid: false, warnings: [], errors: ['bad'] });
+
+    const result = await resolveRemotePackage('g', OPTIONS);
+
+    expect(result.skipped[0]).toMatchObject({ id: 'g', reason: 'validation_failed' });
+  });
+
+  it('treats a package with no manifest as a runnable local guide', async () => {
+    mockResolve({
+      ok: true,
+      id: 'g',
+      contentUrl: 'https://cdn.test/g/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: undefined,
+    });
+    mockFetch({ ok: true, text: '{"id":"g"}' });
+
+    const result = await resolveRemotePackage('g', OPTIONS);
+
+    expect(result.runnable).toHaveLength(1);
+    expect(result.runnable[0]).toMatchObject({ id: 'g', tier: 'local' });
+  });
+});
+
+describe('resolveRemoteRepository (batch, CDN index)', () => {
+  it('runs local guides, skips cloud guides, and reconstructs the repository index', async () => {
+    (fetchRepositoryIndex as jest.Mock).mockResolvedValue({
+      ok: true,
+      baseUrl: 'https://cdn.test/packages/',
+      packages: [
+        { id: 'local-a', path: 'local-a/', type: 'guide', testEnvironment: { tier: 'local' }, depends: ['local-b'] },
+        { id: 'local-b', path: 'local-b/', type: 'guide', testEnvironment: { tier: 'local' } },
+        { id: 'cloud-c', path: 'cloud-c/', type: 'guide', testEnvironment: { tier: 'cloud' } },
+        { id: 'path-d', path: 'path-d/', type: 'path', milestones: ['local-a'] },
+      ],
+      rawIndex: {},
+      validation: { isValid: true, issues: [] },
+    });
+    mockFetch({ ok: true, text: '{"id":"x"}' });
+
+    const result = await resolveRemoteRepository(OPTIONS);
+
+    expect(result.runnable.map((g) => g.id).sort()).toEqual(['local-a', 'local-b']);
+
+    const reasons = Object.fromEntries(result.skipped.map((s) => [s.id, s.reason]));
+    expect(reasons).toEqual({ 'cloud-c': 'skipped_tier_mismatch', 'path-d': 'unsupported_type' });
+
+    // Repository index keeps every entry (including the depends edge) for chaining.
+    expect(result.repository['local-a']).toMatchObject({ path: 'local-a/', depends: ['local-b'] });
+    expect(Object.keys(result.repository).sort()).toEqual(['cloud-c', 'local-a', 'local-b', 'path-d']);
+  });
+
+  it('returns an error when the repository index cannot be fetched', async () => {
+    (fetchRepositoryIndex as jest.Mock).mockResolvedValue({ ok: false, code: 'NETWORK_ERROR', message: 'offline' });
+
+    const result = await resolveRemoteRepository(OPTIONS);
+
+    expect(result.error).toMatch(/repository index/i);
+    expect(result.runnable).toHaveLength(0);
+  });
+});
+
+describe('resolveRemotePackage (dependency resolution)', () => {
+  /** Recommender resolves a local-tier guide target by id. */
+  function mockTargetResolve(targetId: string): void {
+    mockResolve({
+      ok: true,
+      id: targetId,
+      contentUrl: `https://cdn.test/${targetId}/content.json`,
+      manifestUrl: `https://cdn.test/${targetId}/manifest.json`,
+      repository: 'r',
+      manifest: { id: targetId, type: 'guide', testEnvironment: { tier: 'local' } },
+    });
+  }
+
+  it('resolves and includes a direct prerequisite, keeping the target as the selected guide', async () => {
+    mockTargetResolve('loki-101');
+    mockIndex([
+      { id: 'loki-101', path: 'loki-101/', type: 'guide', depends: ['prom-101'], testEnvironment: { tier: 'local' } },
+      { id: 'prom-101', path: 'prom-101/', type: 'guide', testEnvironment: { tier: 'local' } },
+    ]);
+    mockFetch({ ok: true, text: '{"id":"loki-101"}' });
+
+    const result = await resolveRemotePackage('loki-101', OPTIONS);
+
+    expect(result.runnable.map((g) => g.id)).toEqual(['loki-101']);
+    expect(result.prerequisites.map((g) => g.id)).toEqual(['prom-101']);
+    expect(result.skipped).toHaveLength(0);
+    expect(Object.keys(result.repository).sort()).toEqual(['loki-101', 'prom-101']);
+  });
+
+  it('resolves transitive prerequisites', async () => {
+    mockTargetResolve('c-guide');
+    mockIndex([
+      { id: 'c-guide', path: 'c/', type: 'guide', depends: ['b-guide'], testEnvironment: { tier: 'local' } },
+      { id: 'b-guide', path: 'b/', type: 'guide', depends: ['a-guide'], testEnvironment: { tier: 'local' } },
+      { id: 'a-guide', path: 'a/', type: 'guide', testEnvironment: { tier: 'local' } },
+    ]);
+    mockFetch({ ok: true, text: '{"id":"c-guide"}' });
+
+    const result = await resolveRemotePackage('c-guide', OPTIONS);
+
+    expect(result.runnable.map((g) => g.id)).toEqual(['c-guide']);
+    expect(result.prerequisites.map((g) => g.id).sort()).toEqual(['a-guide', 'b-guide']);
+  });
+
+  it('resolves a prerequisite advertised via a provides capability', async () => {
+    mockTargetResolve('dependent');
+    mockIndex([
+      { id: 'dependent', path: 'dependent/', type: 'guide', depends: ['db-ready'], testEnvironment: { tier: 'local' } },
+      { id: 'provider', path: 'provider/', type: 'guide', provides: ['db-ready'], testEnvironment: { tier: 'local' } },
+    ]);
+    mockFetch({ ok: true, text: '{"id":"dependent"}' });
+
+    const result = await resolveRemotePackage('dependent', OPTIONS);
+
+    expect(result.prerequisites.map((g) => g.id)).toEqual(['provider']);
+  });
+
+  it('runs the target alone when it is absent from the index', async () => {
+    mockTargetResolve('orphan');
+    mockIndex([{ id: 'other', path: 'other/', type: 'guide', testEnvironment: { tier: 'local' } }]);
+    mockFetch({ ok: true, text: '{"id":"orphan"}' });
+
+    const result = await resolveRemotePackage('orphan', OPTIONS);
+
+    expect(result.runnable.map((g) => g.id)).toEqual(['orphan']);
+    expect(result.prerequisites).toHaveLength(0);
+  });
+
+  it('runs the target alone when the index is unreachable', async () => {
+    mockTargetResolve('loki-101');
+    (fetchRepositoryIndex as jest.Mock).mockResolvedValue({ ok: false, code: 'NETWORK_ERROR', message: 'offline' });
+    mockFetch({ ok: true, text: '{"id":"loki-101"}' });
+
+    const result = await resolveRemotePackage('loki-101', OPTIONS);
+
+    expect(result.runnable.map((g) => g.id)).toEqual(['loki-101']);
+    expect(result.prerequisites).toHaveLength(0);
+    expect(result.repository).toEqual({});
+  });
+
+  it('reports a prerequisite whose content cannot be fetched', async () => {
+    mockTargetResolve('loki-101');
+    mockIndex([
+      { id: 'loki-101', path: 'loki-101/', type: 'guide', depends: ['prom-101'], testEnvironment: { tier: 'local' } },
+      { id: 'prom-101', path: 'prom-101/', type: 'guide', testEnvironment: { tier: 'local' } },
+    ]);
+    // Target content fetches OK; the prerequisite's content fetch fails.
+    global.fetch = jest.fn((url: string) =>
+      Promise.resolve(
+        url.includes('prom-101')
+          ? ({ ok: false, status: 503, statusText: 'Error' } as Response)
+          : ({ ok: true, text: async () => '{"id":"loki-101"}' } as unknown as Response)
+      )
+    ) as unknown as typeof fetch;
+
+    const result = await resolveRemotePackage('loki-101', OPTIONS);
+
+    expect(result.runnable.map((g) => g.id)).toEqual(['loki-101']);
+    expect(result.prerequisites).toHaveLength(0);
+    expect(result.skipped[0]).toMatchObject({ id: 'prom-101', reason: 'fetch_failed' });
+  });
+});

--- a/src/cli/utils/e2e-package.ts
+++ b/src/cli/utils/e2e-package.ts
@@ -1,0 +1,315 @@
+/**
+ * Remote package resolution for the e2e CLI.
+ *
+ * Thin orchestration over CLI-local clients:
+ *   - `recommender-resolver` resolves a bare ID via the recommender
+ *     (`GET /api/v1/packages/{id}`) for `--package <id>`; the target's `depends`
+ *     prerequisites are then resolved from the CDN index and chained.
+ *   - `repository-client` fetches the CDN `repository.json` for `--remote` and
+ *     for prerequisite resolution.
+ *
+ * Each resolved package is mapped to either a runnable guide or a structured
+ * skip outcome. Network and validation failures never throw; they become skip
+ * outcomes so a batch run degrades gracefully.
+ */
+
+import { validateGuideFromString } from '../../validation';
+import type { RepositoryEntry, RepositoryJson, TestEnvironment } from '../../types/package.types';
+import { resolvePackageById } from './recommender-resolver';
+import { fetchRepositoryIndex, buildPackageFileUrl, type RepositoryPackage } from '../mcp/lib/repository-client';
+import { planGuideExecution } from './guide-chains';
+import type { LoadedGuide } from './file-loader';
+import { resolveTarget } from './e2e-targets';
+import type { CurrentTier } from './manifest-preflight';
+
+const FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Reasons a remote package is skipped before execution. This is the single
+ * source of truth for the skip vocabulary: the e2e command derives its guide
+ * statuses and its pre-run-skip set from this list, so the two never drift.
+ */
+export const REMOTE_SKIP_REASONS = [
+  'skipped_no_auth',
+  'skipped_tier_mismatch',
+  'fetch_failed',
+  'resolution_failed',
+  'validation_failed',
+  'unsupported_type',
+] as const;
+
+/** Why a remote package was skipped instead of run. */
+export type RemoteSkipReason = (typeof REMOTE_SKIP_REASONS)[number];
+
+/** A remote package resolved to a runnable guide against a local target. */
+export interface ResolvedRemoteGuide {
+  id: string;
+  /** `path` is the source content URL; `content` is the raw JSON text. */
+  guide: LoadedGuide;
+  tier: string;
+  instance?: string;
+  /** Grafana URL the guide will be tested against. */
+  targetUrl: string;
+  /** The content.json URL the guide was fetched from. */
+  sourceUrl: string;
+}
+
+/** A remote package that will not be run, with a structured reason. */
+export interface SkippedPackage {
+  id: string;
+  reason: RemoteSkipReason;
+  message: string;
+  sourceUrl?: string;
+  tier?: string;
+}
+
+/** Result of resolving one or more remote packages. */
+export interface RemoteResolution {
+  /** Guides explicitly selected to run (the target for a package; all guides for a batch). */
+  runnable: ResolvedRemoteGuide[];
+  /**
+   * Prerequisite guides available for the planner to auto-include (single-package mode). */
+  prerequisites: ResolvedRemoteGuide[];
+  /** Packages skipped before execution, with reasons. */
+  skipped: SkippedPackage[];
+  /** Repository index for dependency chaining; empty when no index applies. */
+  repository: RepositoryJson;
+  /** Set when the operation could not start at all (e.g. CDN index unreachable). */
+  error?: string;
+}
+
+export interface RemoteResolveOptions {
+  /** Grafana URL configured for local-tier guides. */
+  grafanaUrl: string;
+  /** Tier of the current test environment (from `--tier`). */
+  currentTier: CurrentTier;
+  /** Recommender base URL for `--package <id>` resolution. */
+  resolverUrl: string;
+  /** CDN base URL override for `--remote` batch resolution. */
+  repoUrl?: string;
+}
+
+/** Fetch a URL as raw text with a timeout. Never throws. */
+async function fetchText(url: string): Promise<{ ok: true; text: string } | { ok: false; message: string }> {
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) {
+      return { ok: false, message: `HTTP ${res.status} ${res.statusText}` };
+    }
+    return { ok: true, text: await res.text() };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : 'Unknown error' };
+  }
+}
+
+/**
+ * Given a resolved package's metadata and content URL, apply target resolution,
+ * fetch the content, and validate it — producing either a runnable guide or a
+ * skip outcome. Shared by single- and batch-resolution paths.
+ */
+async function buildGuideOrSkip(
+  id: string,
+  type: string | undefined,
+  testEnvironment: TestEnvironment,
+  contentUrl: string,
+  options: RemoteResolveOptions
+): Promise<{ runnable?: ResolvedRemoteGuide; skipped?: SkippedPackage }> {
+  // Only single guides are testable; paths/journeys (milestone expansion) are deferred.
+  if (type && type !== 'guide') {
+    return {
+      skipped: {
+        id,
+        reason: 'unsupported_type',
+        message: `Package type "${type}" is not yet testable`,
+        sourceUrl: contentUrl,
+        tier: testEnvironment.tier,
+      },
+    };
+  }
+
+  const target = resolveTarget(testEnvironment, { grafanaUrl: options.grafanaUrl, currentTier: options.currentTier });
+  if (!target.runnable) {
+    return {
+      skipped: {
+        id,
+        reason: target.skipReason!,
+        message: target.message ?? 'Guide skipped',
+        sourceUrl: contentUrl,
+        tier: target.tier,
+      },
+    };
+  }
+
+  const fetched = await fetchText(contentUrl);
+  if (!fetched.ok) {
+    return {
+      skipped: {
+        id,
+        reason: 'fetch_failed',
+        message: `Could not fetch content.json: ${fetched.message}`,
+        sourceUrl: contentUrl,
+        tier: target.tier,
+      },
+    };
+  }
+
+  const validation = validateGuideFromString(fetched.text);
+  if (!validation.isValid) {
+    return {
+      skipped: {
+        id,
+        reason: 'validation_failed',
+        message: 'Fetched content.json failed guide schema validation',
+        sourceUrl: contentUrl,
+        tier: target.tier,
+      },
+    };
+  }
+
+  return {
+    runnable: {
+      id,
+      guide: { path: contentUrl, content: fetched.text },
+      tier: target.tier,
+      instance: target.instance,
+      targetUrl: target.grafanaUrl!,
+      sourceUrl: contentUrl,
+    },
+  };
+}
+
+/** Reconstruct an id-keyed RepositoryJson from a fetched CDN index's packages. */
+function indexToRepository(packages: RepositoryPackage[]): RepositoryJson {
+  const repository: RepositoryJson = {};
+  for (const pkg of packages) {
+    const { id, ...entry } = pkg;
+    repository[id] = entry;
+  }
+  return repository;
+}
+
+/** Fetch + classify a single repository-index entry into a runnable guide or a skip. */
+async function resolveIndexEntry(
+  id: string,
+  entry: RepositoryEntry,
+  baseUrl: string,
+  options: RemoteResolveOptions
+): Promise<{ runnable?: ResolvedRemoteGuide; skipped?: SkippedPackage }> {
+  const contentUrl = buildPackageFileUrl(baseUrl, entry.path, 'content.json');
+  if (!contentUrl) {
+    return {
+      skipped: {
+        id,
+        reason: 'fetch_failed',
+        message: 'Could not construct content.json URL',
+        tier: entry.testEnvironment?.tier,
+      },
+    };
+  }
+  return buildGuideOrSkip(id, entry.type, entry.testEnvironment ?? {}, contentUrl, options);
+}
+
+/**
+ * Enumerate the target's transitive `depends` prerequisites by running the
+ * planner as a pure oracle: a throwaway stub loader lets it report
+ * `autoIncludedIds` without re-implementing OR-group / `provides` resolution.
+ * The stub content is never read, only the discovered ids.
+ */
+function discoverPrerequisiteIds(targetGuide: LoadedGuide, repository: RepositoryJson): string[] {
+  const stubLoader = (stubId: string): LoadedGuide => ({ path: stubId, content: '{}' });
+  return planGuideExecution({ guides: [targetGuide], repository, loadGuideById: stubLoader }).autoIncludedIds;
+}
+
+/**
+ * Resolve a single package by bare ID via the recommender service, then resolve
+ * and fetch the target's `depends` prerequisites from the CDN index so the run
+ * chains them the same way selecting a local guide with dependencies does. When
+ * no index is available (unreachable, or the target is absent from it), the
+ * target runs as its own chain.
+ */
+export async function resolveRemotePackage(id: string, options: RemoteResolveOptions): Promise<RemoteResolution> {
+  // Resolve metadata (URLs + manifest) only; the raw content is fetched in
+  // buildGuideOrSkip so the injected guide stays byte-faithful.
+  const resolution = await resolvePackageById(options.resolverUrl, id);
+
+  if (!resolution.ok) {
+    return {
+      runnable: [],
+      prerequisites: [],
+      skipped: [{ id, reason: 'resolution_failed', message: resolution.message }],
+      repository: {},
+    };
+  }
+
+  const built = await buildGuideOrSkip(
+    resolution.id || id,
+    resolution.manifest?.type,
+    resolution.manifest?.testEnvironment ?? {},
+    resolution.contentUrl,
+    options
+  );
+
+  // Target itself skipped (tier mismatch, unsupported type, fetch/validation): no chain.
+  if (!built.runnable) {
+    return { runnable: [], prerequisites: [], skipped: built.skipped ? [built.skipped] : [], repository: {} };
+  }
+  const target = built.runnable;
+
+  // Resolve dependencies from the CDN index. Without it fall back to running the target alone.
+  const index = await fetchRepositoryIndex(options.repoUrl);
+  if (!index.ok) {
+    return { runnable: [target], prerequisites: [], skipped: [], repository: {} };
+  }
+
+  const repository = indexToRepository(index.packages);
+  const prerequisites: ResolvedRemoteGuide[] = [];
+  const skipped: SkippedPackage[] = [];
+  for (const prerequisiteId of discoverPrerequisiteIds(target.guide, repository)) {
+    const builtPrereq = await resolveIndexEntry(prerequisiteId, repository[prerequisiteId]!, index.baseUrl, options);
+    if (builtPrereq.runnable) {
+      prerequisites.push(builtPrereq.runnable);
+    }
+    if (builtPrereq.skipped) {
+      skipped.push(builtPrereq.skipped);
+    }
+  }
+
+  return { runnable: [target], prerequisites, skipped, repository };
+}
+
+/**
+ * Resolve every package in the CDN `repository.json`, returning runnable
+ * local-tier guides plus structured skips. The repository index is returned so
+ * the caller can drive dependency-aware chaining over the same source.
+ */
+export async function resolveRemoteRepository(options: RemoteResolveOptions): Promise<RemoteResolution> {
+  const index = await fetchRepositoryIndex(options.repoUrl);
+  if (!index.ok) {
+    return {
+      runnable: [],
+      prerequisites: [],
+      skipped: [],
+      repository: {},
+      error: `Could not fetch repository index: ${index.message}`,
+    };
+  }
+
+  const repository = indexToRepository(index.packages);
+  const runnable: ResolvedRemoteGuide[] = [];
+  const skipped: SkippedPackage[] = [];
+
+  for (const pkg of index.packages) {
+    const built = await resolveIndexEntry(pkg.id, pkg, index.baseUrl, options);
+    if (built.runnable) {
+      runnable.push(built.runnable);
+    }
+    if (built.skipped) {
+      skipped.push(built.skipped);
+    }
+  }
+
+  return { runnable, prerequisites: [], skipped, repository };
+}

--- a/src/cli/utils/recommender-resolver.test.ts
+++ b/src/cli/utils/recommender-resolver.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the CLI-local recommender resolver. `fetch` is mocked URL-by-URL so
+ * these exercise the real resolution + manifest-fetch + error-mapping logic
+ * that `e2e-package.test.ts` mocks away.
+ */
+
+import { resolvePackageById } from './recommender-resolver';
+
+interface RouteResponse {
+  ok: boolean;
+  status?: number;
+  body?: string;
+}
+
+/** Route `fetch` by URL substring; unmatched URLs 404. */
+function mockFetch(handler: (url: string) => RouteResponse): void {
+  global.fetch = jest.fn(async (input: unknown) => {
+    const r = handler(String(input));
+    return {
+      ok: r.ok,
+      status: r.status ?? (r.ok ? 200 : 500),
+      statusText: r.ok ? 'OK' : 'Error',
+      json: async () => JSON.parse(r.body ?? '{}'),
+      text: async () => r.body ?? '',
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('resolvePackageById', () => {
+  it('resolves a package and parses its manifest', async () => {
+    mockFetch((url) => {
+      if (url.includes('/api/v1/packages/alerting-101')) {
+        return {
+          ok: true,
+          body: JSON.stringify({
+            id: 'alerting-101',
+            contentUrl: 'https://cdn.test/alerting-101/content.json',
+            manifestUrl: 'https://cdn.test/alerting-101/manifest.json',
+          }),
+        };
+      }
+      if (url.endsWith('manifest.json')) {
+        return {
+          ok: true,
+          body: JSON.stringify({ id: 'alerting-101', type: 'guide', testEnvironment: { tier: 'local' } }),
+        };
+      }
+      return { ok: false, status: 404 };
+    });
+
+    const res = await resolvePackageById('https://recommender.test', 'alerting-101');
+
+    expect(res).toMatchObject({
+      ok: true,
+      id: 'alerting-101',
+      contentUrl: 'https://cdn.test/alerting-101/content.json',
+    });
+    expect(res.ok && res.manifest?.type).toBe('guide');
+    expect(res.ok && res.manifest?.testEnvironment?.tier).toBe('local');
+  });
+
+  it('maps a 404 from the resolver to a failure', async () => {
+    mockFetch(() => ({ ok: false, status: 404 }));
+
+    const res = await resolvePackageById('https://recommender.test', 'missing');
+
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ ok: false, message: expect.stringContaining('404') });
+  });
+
+  it('maps a network error to a failure', async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error('offline');
+    }) as unknown as typeof fetch;
+
+    const res = await resolvePackageById('https://recommender.test', 'x');
+
+    expect(res).toMatchObject({ ok: false, message: 'offline' });
+  });
+
+  it('resolves without a manifest when the manifest fetch fails (non-fatal)', async () => {
+    mockFetch((url) => {
+      if (url.includes('/api/v1/packages/')) {
+        return {
+          ok: true,
+          body: JSON.stringify({
+            id: 'g',
+            contentUrl: 'https://cdn.test/g/content.json',
+            manifestUrl: 'https://cdn.test/g/manifest.json',
+          }),
+        };
+      }
+      return { ok: false, status: 500 }; // manifest fetch fails
+    });
+
+    const res = await resolvePackageById('https://recommender.test', 'g');
+
+    expect(res).toMatchObject({ ok: true, id: 'g', contentUrl: 'https://cdn.test/g/content.json' });
+    expect(res.ok && res.manifest).toBeUndefined();
+  });
+
+  it('resolves without a manifest when the package declares no manifestUrl', async () => {
+    mockFetch(() => ({
+      ok: true,
+      body: JSON.stringify({ id: 'g', contentUrl: 'https://cdn.test/g/content.json', manifestUrl: '' }),
+    }));
+
+    const res = await resolvePackageById('https://recommender.test', 'g');
+
+    expect(res).toMatchObject({ ok: true, id: 'g' });
+    expect(res.ok && res.manifest).toBeUndefined();
+  });
+});

--- a/src/cli/utils/recommender-resolver.ts
+++ b/src/cli/utils/recommender-resolver.ts
@@ -1,0 +1,83 @@
+/**
+ * CLI recommender client.
+ *
+ * Resolves a bare package id to its CDN content/manifest URLs via the
+ * recommender's `GET /api/v1/packages/{id}` endpoint, returning the parsed
+ * manifest metadata (type, testEnvironment) the e2e runner routes on.
+ */
+
+import { ManifestJsonObjectSchema } from '../../types/package.schema';
+import type { ManifestJson } from '../../types/package.types';
+
+const FETCH_TIMEOUT_MS = 15_000;
+
+/** Subset of the recommender `GET /api/v1/packages/{id}` response we consume. */
+interface PackageResolutionResponse {
+  id: string;
+  contentUrl: string;
+  manifestUrl: string;
+}
+
+/** Outcome of resolving a bare package id. Failures never throw. */
+export type RecommenderResolution =
+  | { ok: true; id: string; contentUrl: string; manifest?: ManifestJson }
+  | { ok: false; message: string };
+
+/**
+ * Resolve a bare package id through the recommender, then fetch its manifest
+ * for routing metadata. Network, HTTP, and parse failures map to
+ * `{ ok: false }` rather than throwing, so the caller can record a structured
+ * skip outcome.
+ */
+export async function resolvePackageById(resolverUrl: string, id: string): Promise<RecommenderResolution> {
+  let response: Response;
+  try {
+    // SECURITY: build the URL via the URL API and encode the id (F3).
+    const endpoint = new URL(`/api/v1/packages/${encodeURIComponent(id)}`, resolverUrl);
+    response = await fetch(endpoint.toString(), {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    });
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : 'Unknown network error' };
+  }
+
+  if (!response.ok) {
+    return { ok: false, message: `HTTP ${response.status} ${response.statusText}` };
+  }
+
+  let data: PackageResolutionResponse;
+  try {
+    data = (await response.json()) as PackageResolutionResponse;
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : 'Invalid resolution response' };
+  }
+
+  return { ok: true, id: data.id, contentUrl: data.contentUrl, manifest: await fetchManifest(data.manifestUrl) };
+}
+
+/**
+ * Fetch and parse a package manifest for routing metadata. Optional and
+ * non-fatal: a missing, unreachable, or malformed manifest yields `undefined`
+ * so the guide can still run under default targeting.
+ */
+async function fetchManifest(manifestUrl: string): Promise<ManifestJson | undefined> {
+  if (!manifestUrl) {
+    return undefined;
+  }
+  let raw: unknown;
+  try {
+    const res = await fetch(manifestUrl, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) {
+      return undefined;
+    }
+    raw = await res.json();
+  } catch {
+    return undefined;
+  }
+  const parsed = ManifestJsonObjectSchema.loose().safeParse(raw);
+  return parsed.success ? (parsed.data as ManifestJson) : undefined;
+}


### PR DESCRIPTION
## Stack overview

#1086 -> #1087 -> #1088 (this PR) -> #1089 -> #1090 -> #1091

## Summary

Adds the remote package resolver behind `--package <id>` and `--remote`. `resolveRemotePackage` resolves a bare ID via the recommender, then resolves and fetches the target's transitive `depends` prerequisites from the CDN index so the run chains them the same way a local selection auto-includes its prerequisites. `resolveRemoteRepository` fetches the whole CDN `repository.json` and resolves every package. Each guide is mapped to either a runnable guide (target resolved to the local Grafana) or a structured skip — network, validation, tier, and unsupported-type failures become skip outcomes rather than throwing, so a batch degrades gracefully.

## What to look at

- `src/cli/utils/e2e-package.ts`:
  - `discoverPrerequisiteIds` runs the existing planner (`planGuideExecution`) as a pure oracle — a throwaway stub loader lets it report `autoIncludedIds` so we don't re-implement OR-group / `provides` resolution. Only the IDs are used; stub content is discarded.
  - Single-package mode returns the target as `runnable` and its prerequisites as a separate `prerequisites` list (so the planner auto-includes them in #1090, matching local behavior); batch mode returns all guides as `runnable`.
  - Shared `resolveIndexEntry` + `buildGuideOrSkip` keep the single and batch paths consistent. Fallbacks: if the CDN index is unreachable or the target isn't in it, the target runs as its own chain.

## Why

The point of the stack is to test the published ecosystem, which means resolving guides over the network. Mapping every failure to a structured skip (rather than throwing) is what lets `--remote` test a whole repository without one bad package aborting the batch. Reusing the planner for prerequisite discovery avoids duplicating the dependency-resolution logic that already lives in `guide-chains.ts`.

## How to verify

Behavior is covered by unit tests with mocked recommender/CDN/`fetch` (`e2e-package.test.ts`: direct + transitive + `provides` prerequisites, cloud/tier skips, fetch/validation/resolution failures, target-absent fallback). End-to-end (once #1090 wires the flags): `pathfinder-cli e2e --package <local-tier-id>` resolves the guide, pulls in its `depends` prerequisite, and runs the prerequisite first; `--remote` runs the local-tier guides and skips cloud ones.

## Breaking changes

None. New module; consumed by #1090.

## Out of scope

- Cloud-tier execution (credentials / auth) — cloud guides are skipped here.
- Path/journey (`milestones`) expansion — non-`guide` package types are skipped as `unsupported_type`.
