### PR TITLE
feat(e2e): run remote-resolved packages from the e2e command

### DIFF
--- a/docs/design/e2e-test-runner-design.md
+++ b/docs/design/e2e-test-runner-design.md
@@ -656,6 +656,8 @@ The sections above describe the core E2E runner: loading a `content.json` from d
 
 This extension can be framed as either "Layer 3 becomes package-aware" or as a new Layer 4 in the [testing strategy](./TESTING_STRATEGY.md) pyramid. If framed as Layer 4, the current "Live Environment Validation" vision (nightly runs, managed environment pools, observability dashboards) would become Layer 5.
 
+> **Implementation status — local-tier slice shipped.** Remote resolution by bare ID and whole-repository batch testing are implemented for `local`-tier guides, which run against the configured Grafana URL. What differs from the design below: batch mode uses a `--remote` flag (not a boolean `--repository`, since `--repository <path>` already denotes the local dependency-ordering index); `cloud`-tier guides are resolved but **skipped** (`skipped_no_auth` / `skipped_tier_mismatch`) because cloud credentials and ephemeral per-guide auth isolation are **not yet implemented**; and path/journey (`milestones`) expansion is **not yet implemented** — `path`/`journey` packages are skipped as `unsupported_type`. The rest of this section describes the full target design. See [`docs/developer/E2E_TESTING.md`](../developer/E2E_TESTING.md#remote-package-aware-testing) for the shipped behavior.
+
 ### Design goals
 
 - **Package-first**: The CLI can test any package by bare ID, resolving content and metadata from the repository ecosystem.

--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -37,27 +37,34 @@ npx pathfinder-cli e2e [options] [files...]
 
 ### Options
 
-| Option                          | Description                                                                                                                                              | Default                      |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
-| `--grafana-url <url>`           | Grafana instance URL. Auto-switches to `http://localhost:3010` when `--clean` is set and this flag is not passed.                                        | `http://localhost:3000`      |
-| `--output <path>`               | Path for JSON report output                                                                                                                              | None                         |
-| `--artifacts <dir>`             | Directory for failure artifacts (screenshots, DOM snapshots)                                                                                             | `/tmp/pathfinder-e2e-{uuid}` |
-| `--verbose`                     | Enable detailed logging                                                                                                                                  | `false`                      |
-| `--bundled`                     | Test all bundled guides                                                                                                                                  | `false`                      |
-| `--trace`                       | Generate Playwright trace files for debugging                                                                                                            | `false`                      |
-| `--headed`                      | Run browser visibly (not headless)                                                                                                                       | `false`                      |
-| `--always-screenshot`           | Capture screenshots on success and failure                                                                                                               | `false`                      |
-| `--clean`                       | Run against an isolated docker-compose stack (project `pathfinder-e2e`, Grafana on `:3010`). Resets between dependency chains and tears down at the end. | `false`                      |
-| `--clean-ready-timeout-ms <ms>` | How long to wait for the isolated Grafana to become healthy after a `--clean` reset                                                                      | `120000`                     |
-| `--repository <path>`           | Path to a `repository.json` used for dependency-aware ordering                                                                                           | Bundled index when present   |
+| Option                          | Description                                                                                                                                   | Default                           |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `--grafana-url <url>`           | Grafana instance URL. Auto-switches to `http://localhost:3010` when `--clean` is set and this flag is not passed.                             | `http://localhost:3000`           |
+| `--output <path>`               | Path for JSON report output                                                                                                                   | None                              |
+| `--artifacts <dir>`             | Directory for failure artifacts (screenshots, DOM snapshots)                                                                                  | `/tmp/pathfinder-e2e-{uuid}`      |
+| `--verbose`                     | Enable detailed logging                                                                                                                       | `false`                           |
+| `--bundled`                     | Test all bundled guides                                                                                                                       | `false`                           |
+| `--trace`                       | Generate Playwright trace files for debugging                                                                                                 | `false`                           |
+| `--headed`                      | Run browser visibly (not headless)                                                                                                            | `false`                           |
+| `--always-screenshot`           | Capture screenshots on success and failure                                                                                                    | `false`                           |
+| `--clean`                       | Run against an isolated docker-compose stack (project `pathfinder-e2e`, Grafana on `:3010`). Resets between guides and tears down at the end. | `false`                           |
+| `--clean-ready-timeout-ms <ms>` | How long to wait for the isolated Grafana to become healthy after a `--clean` reset                                                           | `120000`                          |
+| `--package <dirOrId>`           | Test a local package directory, or — when not an existing directory — a bare package ID resolved remotely via the recommender                 | None                              |
+| `--tier <tier>`                 | Current environment tier (`local` or `cloud`); `cloud` guides are skipped on a `local` environment                                            | `local`                           |
+| `--remote`                      | Resolve and test every package from the CDN repository index                                                                                  | `false`                           |
+| `--repo-url <url>`              | CDN base URL for `--remote`                                                                                                                   | Public package repository         |
+| `--resolver-url <url>`          | Recommender base URL for `--package <id>` resolution                                                                                          | `https://recommender.grafana.com` |
 
 ### Input formats
 
-The CLI accepts three input formats:
+The CLI accepts these input formats:
 
 1. **File paths**: `npx pathfinder-cli e2e ./my-guide.json ./another.json`
 2. **Bundled flag**: `npx pathfinder-cli e2e --bundled` (tests all guides in `src/bundled-interactives/`)
 3. **Bundled by name**: `npx pathfinder-cli e2e bundled:welcome-to-grafana`
+4. **Local package directory**: `npx pathfinder-cli e2e --package ./my-package/` (reads `content.json` + `manifest.json`)
+5. **Remote package ID**: `npx pathfinder-cli e2e --package alerting-101` (resolved via the recommender; see [Remote package-aware testing](#remote-package-aware-testing))
+6. **Remote repository**: `npx pathfinder-cli e2e --remote` (every package in the CDN index)
 
 ## Exit codes
 
@@ -383,9 +390,43 @@ Only `infrastructure` failures are auto-classified. `SELECTOR_NOT_FOUND`, `ACTIO
 
 For the full rationale and validation plan behind this classification approach, see [Error Classification](../design/e2e-test-runner-design.md#error-classification) in the design doc.
 
-## Package-aware testing (upcoming)
+## Remote package-aware testing
 
-A future `--package <id>` and `--repository` mode will allow the CLI to resolve guides from the package repository, route them to the correct Grafana instance based on `manifest.json` metadata, and authenticate independently per guide. This is currently in design. See [Package-Aware Testing](../design/e2e-test-runner-design.md#package-aware-testing) in the design doc for the full specification.
+The CLI can resolve published guides instead of reading local files, then test them against the configured Grafana instance.
+
+- **By ID** (`--package <id>`): when the `--package` value is not an existing local directory, it is treated as a bare package ID and resolved through the recommender (`--resolver-url`, default `https://recommender.grafana.com`). The runner fetches the package's `content.json` and `manifest.json`, validates the content, and runs it.
+- **Whole repository** (`--remote`): fetches the CDN `repository.json` (`--repo-url`, default the public package repository) and tests every package in the index. Dependency-aware chaining still applies, driven by the remote index.
+
+Guides are routed by their manifest's `testEnvironment.tier`:
+
+- `local` (or no tier) guides run against `--grafana-url`.
+- `cloud` guides are **skipped** — cloud authentication is not yet supported, so they are logged and do not fail the run.
+
+This is the local-tier slice of the [Package-Aware Testing](../design/e2e-test-runner-design.md#package-aware-testing) design. Cloud credentials / auth isolation and path/journey (`milestones`) expansion are not yet implemented; `path` and `journey` packages are skipped as an unsupported type.
+
+### Package outcomes
+
+In remote modes a package can end in one of these states. Only `validation_failed` counts as a test failure; the rest are logged and the batch continues:
+
+| Outcome                 | Meaning                                                    | Test failure? |
+| ----------------------- | ---------------------------------------------------------- | ------------- |
+| `passed` / `failed`     | The guide ran (see step results)                           | `failed` only |
+| `skipped_tier_mismatch` | `cloud` guide on a `local` environment                     | No            |
+| `skipped_no_auth`       | `cloud` guide with no credentials (cloud auth deferred)    | No            |
+| `resolution_failed`     | Recommender returned 404 or a network error                | No            |
+| `fetch_failed`          | Could not fetch `content.json` from the CDN                | No            |
+| `unsupported_type`      | Package is a `path` / `journey` (milestone expansion TODO) | No            |
+| `validation_failed`     | Fetched `content.json` failed guide schema validation      | **Yes**       |
+
+With `--output`, pre-run skips are recorded under a `preRunSkipped` array, and each tested guide's report carries package metadata (`packageId`, `tier`, `instance`, `targetUrl`, `sourceUrl`).
+
+```bash
+# Resolve and test a single published guide against local Grafana
+npx pathfinder-cli e2e --package alerting-101
+
+# Test the whole published repository (local-tier guides run, cloud guides skip)
+npx pathfinder-cli e2e --remote --output results.json
+```
 
 ## Related documentation
 

--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -5,7 +5,7 @@
  * into localStorage and verify they load correctly in the docs panel.
  */
 
-import { existsSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import { dirname, isAbsolute, join, resolve } from 'path';
 
 import { Command, Option } from 'commander';
@@ -26,6 +26,7 @@ import {
   writeMultiGuideReport,
   formatMultiGuideSummary,
   type TestResultsData,
+  type PreRunSkip,
 } from '../utils/e2e-reporter';
 import {
   checkTier,
@@ -34,6 +35,15 @@ import {
   type PreflightOutcome,
   type CurrentTier,
 } from '../utils/manifest-preflight';
+import {
+  resolveRemotePackage,
+  resolveRemoteRepository,
+  REMOTE_SKIP_REASONS,
+  type RemoteResolution,
+  type RemoteSkipReason,
+  type ResolvedRemoteGuide,
+  type SkippedPackage,
+} from '../utils/e2e-package';
 import { checkGrafanaHealth } from '../utils/grafana-health';
 import { CleanEnvironment, CLEAN_COMPOSE_PROJECT, CLEAN_GRAFANA_URL } from '../utils/clean-environment';
 import { ExitCode } from '../utils/exit-codes';
@@ -59,11 +69,70 @@ interface E2ECommandOptions {
   clean: boolean;
   cleanReadyTimeoutMs: number;
   repository?: string;
+  /** Resolve and test every package in the CDN repository index. */
+  remote: boolean;
+  /** CDN base URL override for --remote. */
+  repoUrl?: string;
+  /** Recommender base URL for --package <id> resolution. */
+  resolverUrl: string;
 }
 
 const DEFAULT_GRAFANA_URL = 'http://localhost:3000';
+const DEFAULT_RESOLVER_URL = 'https://recommender.grafana.com';
 
-type GuideStatus = 'passed' | 'failed' | 'auth_expired' | 'skipped_prereq';
+/** How guide inputs are resolved for a run. */
+type RunMode = 'local' | 'remote-package' | 'remote-repository';
+
+/** Package metadata attached to a remotely-resolved guide's report. */
+interface PackageMeta {
+  packageId: string;
+  tier?: string;
+  instance?: string;
+  targetUrl?: string;
+  sourceUrl?: string;
+}
+
+/**
+ * A guide's terminal status: either a run outcome (the runner executed or aborted
+ * it) or a remote skip reason (the resolver skipped it before execution). The
+ * skip half is derived from the resolver's `RemoteSkipReason` so the two
+ * vocabularies cannot drift.
+ */
+type GuideStatus = 'passed' | 'failed' | 'auth_expired' | 'skipped_prereq' | RemoteSkipReason;
+
+/** Statuses that count as a test failure (non-zero exit). */
+const FAILURE_STATUSES: ReadonlySet<GuideStatus> = new Set<GuideStatus>(['failed', 'validation_failed']);
+
+/** Pre-run skips (the resolver's skip reasons) recorded in the JSON report; excludes skipped_prereq, which carries step data. */
+const PRE_RUN_SKIP_STATUSES: ReadonlySet<GuideStatus> = new Set<GuideStatus>(REMOTE_SKIP_REASONS);
+
+/** Summary line labels in display order. */
+const GUIDE_STATUS_LABELS: ReadonlyArray<readonly [GuideStatus, string]> = [
+  ['passed', '✅ Passed'],
+  ['failed', '❌ Failed'],
+  ['validation_failed', '❌ Validation failed'],
+  ['auth_expired', '🔐 Auth expired'],
+  ['skipped_prereq', '⊘ Skipped (prerequisite failed)'],
+  ['skipped_tier_mismatch', '⊘ Skipped (tier mismatch)'],
+  ['skipped_no_auth', '⊘ Skipped (no cloud auth)'],
+  ['unsupported_type', '⊘ Skipped (unsupported type)'],
+  ['fetch_failed', '⊘ Skipped (fetch failed)'],
+  ['resolution_failed', '⊘ Skipped (resolution failed)'],
+];
+
+/** Per-guide listing icons. */
+const GUIDE_STATUS_ICONS: Record<GuideStatus, string> = {
+  passed: '✅',
+  failed: '❌',
+  validation_failed: '❌',
+  auth_expired: '🔐',
+  skipped_prereq: '⊘',
+  skipped_tier_mismatch: '⊘',
+  skipped_no_auth: '⊘',
+  unsupported_type: '⊘',
+  fetch_failed: '⊘',
+  resolution_failed: '⊘',
+};
 
 interface GuideRunResult {
   guide: string;
@@ -76,6 +145,34 @@ interface GuideRunResult {
   resultsData?: TestResultsData;
   autoIncluded: boolean;
   failedPrerequisite?: string;
+  /** Declared tier for pre-run skips (for reporting). */
+  tier?: string;
+}
+
+/** Repository source for dependency-aware planning (local index or remote CDN index). */
+interface RepoSource {
+  repository: RepositoryJson;
+  loadGuideById: (id: string, entry: RepositoryEntry) => LoadedGuide | null;
+}
+
+/**
+ * Everything the run pipeline needs, resolved from CLI inputs regardless of
+ * source (local files/bundled, a remote package, or the remote repository).
+ * Hiding the local-vs-remote decision behind this one shape keeps the command
+ * action a straight pipeline.
+ */
+interface RunInputs {
+  mode: RunMode;
+  /** Guides to validate, plan, and run. */
+  guides: LoadedGuide[];
+  /** Dependency-planning source; undefined falls back to the local/bundled index. */
+  repoSource?: RepoSource;
+  /** Packages skipped before execution (remote modes). */
+  preRunSkipped: GuideRunResult[];
+  /** Per-guide package metadata for report enrichment (remote modes). */
+  packageMetaById: Map<string, PackageMeta>;
+  /** Local package directory for manifest pre-flight, when applicable. */
+  localPackageDir?: string;
 }
 
 type GuideValidationError = { file: string; errors: string[] };
@@ -281,13 +378,17 @@ function resolveValidGuides(files: string[], options: E2ECommandOptions): Loaded
 /**
  * Print the validation-passed banner and the resolved run configuration.
  */
-function printRunConfiguration(valid: LoadedGuide[], options: E2ECommandOptions): void {
+function printRunConfiguration(valid: LoadedGuide[], options: E2ECommandOptions, mode: RunMode): void {
   console.log(`\n✅ Guide validation passed for ${valid.length} guide(s).`);
   console.log('\n📋 E2E test configuration:');
   console.log(`   Grafana URL: ${options.grafanaUrl}`);
   console.log(`   Tier:        ${options.tier}`);
   console.log(`   Artifacts:   ${options.artifacts}`);
-  if (options.package) {
+  if (mode === 'remote-package') {
+    console.log(`   Package:     ${options.package} (remote)`);
+  } else if (mode === 'remote-repository') {
+    console.log(`   Source:      remote repository index`);
+  } else if (options.package) {
     console.log(`   Package:     ${options.package}`);
   }
   if (options.output) {
@@ -313,39 +414,49 @@ function printRunConfiguration(valid: LoadedGuide[], options: E2ECommandOptions)
  * the repository index, validates any auto-included prerequisites, and prints
  * the plan in verbose mode. Exits on configuration errors.
  */
-function buildExecutionPlan(valid: LoadedGuide[], options: E2ECommandOptions): ExecutionPlan {
-  const repositoryPath = options.repository
-    ? isAbsolute(options.repository)
-      ? options.repository
-      : resolve(process.cwd(), options.repository)
-    : bundledRepositoryPath();
+function buildExecutionPlan(valid: LoadedGuide[], options: E2ECommandOptions, repoSource?: RepoSource): ExecutionPlan {
+  let repository: RepositoryJson;
+  let loadGuideById: (id: string, entry: RepositoryEntry) => LoadedGuide | null;
 
-  if (options.repository && !existsSync(repositoryPath)) {
-    console.error(`\n❌ Repository index not found: ${repositoryPath}`);
-    process.exit(ExitCode.CONFIGURATION_ERROR);
-  }
+  if (repoSource) {
+    // Remote modes drive chaining from the CDN index and load prerequisites
+    // from already-fetched guides rather than the local filesystem.
+    repository = repoSource.repository;
+    loadGuideById = repoSource.loadGuideById;
+  } else {
+    const repositoryPath = options.repository
+      ? isAbsolute(options.repository)
+        ? options.repository
+        : resolve(process.cwd(), options.repository)
+      : bundledRepositoryPath();
 
-  let repository: RepositoryJson = {};
-  if (existsSync(repositoryPath)) {
-    const loaded = loadRepositoryIndex(repositoryPath);
-    if (loaded.error) {
-      // An explicitly requested index that fails to load is a configuration
-      // error; a malformed default (bundled) index degrades to no planning.
-      if (options.repository) {
-        console.error(`\n❌ Failed to load repository index (${repositoryPath}): ${loaded.error}`);
-        process.exit(ExitCode.CONFIGURATION_ERROR);
-      }
-      console.warn(`⚠️  Ignoring default repository index (${repositoryPath}): ${loaded.error}`);
+    if (options.repository && !existsSync(repositoryPath)) {
+      console.error(`\n❌ Repository index not found: ${repositoryPath}`);
+      process.exit(ExitCode.CONFIGURATION_ERROR);
     }
-    repository = loaded.repository ?? {};
-  }
 
-  const repoBaseDir = dirname(repositoryPath);
-  const loadGuideById = (id: string, entry: RepositoryEntry): LoadedGuide | null => {
-    const rel = entry.path || `${id}/`;
-    const contentPath = rel.endsWith('.json') ? join(repoBaseDir, rel) : join(repoBaseDir, rel, 'content.json');
-    return loadGuideFiles([contentPath])[0] ?? null;
-  };
+    repository = {};
+    if (existsSync(repositoryPath)) {
+      const loaded = loadRepositoryIndex(repositoryPath);
+      if (loaded.error) {
+        // An explicitly requested index that fails to load is a configuration
+        // error; a malformed default (bundled) index degrades to no planning.
+        if (options.repository) {
+          console.error(`\n❌ Failed to load repository index (${repositoryPath}): ${loaded.error}`);
+          process.exit(ExitCode.CONFIGURATION_ERROR);
+        }
+        console.warn(`⚠️  Ignoring default repository index (${repositoryPath}): ${loaded.error}`);
+      }
+      repository = loaded.repository ?? {};
+    }
+
+    const repoBaseDir = dirname(repositoryPath);
+    loadGuideById = (id: string, entry: RepositoryEntry): LoadedGuide | null => {
+      const rel = entry.path || `${id}/`;
+      const contentPath = rel.endsWith('.json') ? join(repoBaseDir, rel) : join(repoBaseDir, rel, 'content.json');
+      return loadGuideFiles([contentPath])[0] ?? null;
+    };
+  }
 
   const plan = planGuideExecution({ guides: valid, repository, loadGuideById });
 
@@ -407,16 +518,19 @@ async function maybeCleanStart(cleanEnv: CleanEnvironment, options: E2ECommandOp
  * apply the tier check, verify Grafana health, then run manifest version/plugin
  * checks. Exits with the appropriate code on any failure or tier skip.
  */
-async function runPreflightChecks(options: E2ECommandOptions): Promise<void> {
+async function runPreflightChecks(options: E2ECommandOptions, packageDir?: string): Promise<void> {
   console.log('\n🔍 Running pre-flight checks...');
 
+  // Manifest pre-flight applies to a local package directory only. Remote modes
+  // resolve tier/target during package resolution, so there is no local manifest
+  // to read here.
   // Load manifest early so the tier check can run before any network I/O.
   // A tier mismatch (e.g. cloud guide on a local env) means the guide should be
   // skipped — we want that message even when Grafana is not reachable.
   let packageManifest: ManifestJson | null = null;
-  if (options.package) {
+  if (packageDir) {
     try {
-      packageManifest = loadManifestFromDir(options.package);
+      packageManifest = loadManifestFromDir(packageDir);
     } catch (err) {
       console.error(`\n❌ Failed to load manifest.json: ${err instanceof Error ? err.message : 'Unknown error'}`);
       process.exit(ExitCode.CONFIGURATION_ERROR);
@@ -452,8 +566,8 @@ async function runPreflightChecks(options: E2ECommandOptions): Promise<void> {
 
   console.log('   ✓ Grafana is reachable');
 
-  // 2. Manifest pre-flight — version and plugin checks (when --package is used)
-  if (options.package) {
+  // 2. Manifest pre-flight — version and plugin checks (local package dir only)
+  if (packageDir) {
     if (packageManifest) {
       console.log('   → Running manifest pre-flight checks...');
       const outcome = await runManifestPreflight(packageManifest, {
@@ -495,6 +609,24 @@ async function runPreflightChecks(options: E2ECommandOptions): Promise<void> {
 }
 
 /**
+ * Merge package metadata into a guide's report data (no-op for local guides,
+ * which have no package metadata).
+ */
+function applyPackageMeta(data: TestResultsData | undefined, meta: PackageMeta | undefined): void {
+  if (!data || !meta) {
+    return;
+  }
+  data.guide = {
+    ...data.guide,
+    packageId: meta.packageId,
+    tier: meta.tier,
+    instance: meta.instance,
+    targetUrl: meta.targetUrl,
+    sourceUrl: meta.sourceUrl,
+  };
+}
+
+/**
  * Execute the planned chains guide-by-guide. Under --clean the environment is
  * reset between chains (not between guides in a chain). Guides whose prerequisite
  * failed within a chain are skipped. Returns per-guide results plus whether
@@ -503,7 +635,8 @@ async function runPreflightChecks(options: E2ECommandOptions): Promise<void> {
 async function runChains(
   plan: ExecutionPlan,
   options: E2ECommandOptions,
-  cleanEnv: CleanEnvironment
+  cleanEnv: CleanEnvironment,
+  packageMetaById: Map<string, PackageMeta> = new Map()
 ): Promise<ChainRunOutcome> {
   console.log('\n🎭 Running Playwright tests...\n');
 
@@ -534,6 +667,16 @@ async function runChains(
         blocked.add(planned.id);
         console.log(`\n📚 ${planned.guide.path}`);
         console.log(`   ⊘ Skipped: prerequisite "${blockingDep}" did not pass`);
+        const prereqResultsData: TestResultsData = {
+          guide: { id: planned.id, title: planned.id, path: planned.guide.path },
+          grafanaUrl: options.grafanaUrl,
+          timestamp: new Date().toISOString(),
+          results: [],
+          aborted: true,
+          abortReason: 'SKIPPED_PREREQ',
+          abortMessage: `Prerequisite "${blockingDep}" did not pass`,
+        };
+        applyPackageMeta(prereqResultsData, packageMetaById.get(planned.id));
         results.push({
           guide: planned.guide.path,
           id: planned.id,
@@ -542,15 +685,7 @@ async function runChains(
           autoIncluded: planned.autoIncluded,
           failedPrerequisite: blockingDep,
           // Include a result so the skipped guide is represented in the JSON report
-          resultsData: {
-            guide: { id: planned.id, title: planned.id, path: planned.guide.path },
-            grafanaUrl: options.grafanaUrl,
-            timestamp: new Date().toISOString(),
-            results: [],
-            aborted: true,
-            abortReason: 'SKIPPED_PREREQ',
-            abortMessage: `Prerequisite "${blockingDep}" did not pass`,
-          },
+          resultsData: prereqResultsData,
         });
         continue;
       }
@@ -559,6 +694,7 @@ async function runChains(
       console.log(`\n📚 Testing: ${planned.guide.path}${suffix}`);
 
       const result = await runPlaywrightTests(planned.guide, options);
+      applyPackageMeta(result.resultsData, packageMetaById.get(planned.id));
       const status: GuideStatus = result.success
         ? 'passed'
         : result.abortReason === 'AUTH_EXPIRED'
@@ -600,24 +736,30 @@ async function runChains(
   return { results, allPassed, hasAuthExpiry };
 }
 
-interface GuideStatusCounts {
-  passed: number;
-  failed: number;
-  authExpired: number;
-  skippedPrereq: number;
-}
-
 /**
  * Count guides by terminal status. Computed once and shared by both summary
  * presentations.
  */
-function countGuideStatuses(results: GuideRunResult[]): GuideStatusCounts {
-  return {
-    passed: results.filter((r) => r.status === 'passed').length,
-    failed: results.filter((r) => r.status === 'failed').length,
-    authExpired: results.filter((r) => r.status === 'auth_expired').length,
-    skippedPrereq: results.filter((r) => r.status === 'skipped_prereq').length,
-  };
+function countGuideStatuses(results: GuideRunResult[]): Record<GuideStatus, number> {
+  const counts = Object.fromEntries(GUIDE_STATUS_LABELS.map(([status]) => [status, 0])) as Record<GuideStatus, number>;
+  for (const result of results) {
+    counts[result.status] += 1;
+  }
+  return counts;
+}
+
+/** Short parenthetical reason for a guide's per-line listing, if any. */
+function guideResultReason(result: GuideRunResult): string {
+  if (result.status === 'skipped_prereq' && result.failedPrerequisite) {
+    return ` (prerequisite "${result.failedPrerequisite}" failed)`;
+  }
+  if (result.status === 'auth_expired') {
+    return ' (auth expired)';
+  }
+  if (result.abortMessage && result.status !== 'passed' && result.status !== 'failed') {
+    return ` (${result.abortMessage})`;
+  }
+  return '';
 }
 
 /**
@@ -634,16 +776,12 @@ function printSummary(results: GuideRunResult[]): void {
   console.log('─'.repeat(68));
 
   if (isMultiGuide) {
-    // Multi-guide summary
+    // Multi-guide summary: passed headline + one line per non-zero status.
     console.log(`\n   Guides: ${counts.passed}/${results.length} passed`);
-    if (counts.failed > 0) {
-      console.log(`   ├─ ❌ Failed: ${counts.failed}`);
-    }
-    if (counts.authExpired > 0) {
-      console.log(`   ├─ 🔐 Auth expired: ${counts.authExpired}`);
-    }
-    if (counts.skippedPrereq > 0) {
-      console.log(`   └─ ⊘ Skipped (prerequisite failed): ${counts.skippedPrereq}`);
+    for (const [status, label] of GUIDE_STATUS_LABELS) {
+      if (status !== 'passed' && counts[status] > 0) {
+        console.log(`   ├─ ${label}: ${counts[status]}`);
+      }
     }
 
     // Aggregate step statistics across all guides
@@ -682,41 +820,27 @@ function printSummary(results: GuideRunResult[]): void {
     // List individual guide results
     console.log(`\n   Guide results:`);
     for (const result of results) {
-      const icon =
-        result.status === 'passed'
-          ? '✅'
-          : result.status === 'auth_expired'
-            ? '🔐'
-            : result.status === 'skipped_prereq'
-              ? '⊘'
-              : '❌';
-      const guideName = result.id;
+      const icon = GUIDE_STATUS_ICONS[result.status];
       const suffix = result.autoIncluded ? ' (auto-included)' : '';
-      const reason =
-        result.status === 'auth_expired'
-          ? ' (auth expired)'
-          : result.status === 'skipped_prereq'
-            ? ` (prerequisite "${result.failedPrerequisite}" failed)`
-            : '';
-      console.log(`   ${icon} ${guideName}${suffix}${reason}`);
+      console.log(`   ${icon} ${result.id}${suffix}${guideResultReason(result)}`);
     }
   } else {
-    // Single guide summary
-    if (counts.passed > 0) {
-      console.log(`   ✅ Passed: ${counts.passed}`);
-    }
-    if (counts.failed > 0) {
-      console.log(`   ❌ Failed: ${counts.failed}`);
-    }
-    if (counts.authExpired > 0) {
-      console.log(`   🔐 Auth expired: ${counts.authExpired}`);
-    }
-    if (counts.skippedPrereq > 0) {
-      console.log(`   ⊘ Skipped (prerequisite failed): ${counts.skippedPrereq}`);
+    // Single guide summary: one line per non-zero status.
+    for (const [status, label] of GUIDE_STATUS_LABELS) {
+      if (counts[status] > 0) {
+        console.log(`   ${label}: ${counts[status]}`);
+      }
     }
   }
 
   console.log('\n' + '─'.repeat(68));
+}
+
+/** Extract pre-run skip outcomes (remote modes) for inclusion in the JSON report. */
+function preRunSkipsFromResults(results: GuideRunResult[]): PreRunSkip[] {
+  return results
+    .filter((r) => PRE_RUN_SKIP_STATUSES.has(r.status))
+    .map((r) => ({ id: r.id, reason: r.status, message: r.abortMessage ?? '', tier: r.tier, sourceUrl: r.guide }));
 }
 
 /**
@@ -730,12 +854,16 @@ function writeJsonReport(results: GuideRunResult[], options: E2ECommandOptions):
 
   const resultsWithData = results.filter((r) => r.resultsData).map((r) => r.resultsData!);
   const isMultiGuide = results.length > 1;
+  const preRunSkipped = preRunSkipsFromResults(results);
 
   if (resultsWithData.length === 0) {
     console.warn(`   ⚠ No test results available for JSON report`);
   } else if (isMultiGuide) {
     try {
       const report = generateMultiGuideReport(resultsWithData, options.grafanaUrl);
+      if (preRunSkipped.length > 0) {
+        report.preRunSkipped = preRunSkipped;
+      }
       writeMultiGuideReport(report, options.output);
       console.log(`\n📄 Multi-guide JSON report written to: ${options.output}`);
       console.log(`   ${formatMultiGuideSummary(report)}`);
@@ -745,6 +873,9 @@ function writeJsonReport(results: GuideRunResult[], options: E2ECommandOptions):
   } else {
     try {
       const report = generateReport(resultsWithData[0]!);
+      if (preRunSkipped.length > 0) {
+        report.preRunSkipped = preRunSkipped;
+      }
       writeReport(report, options.output);
       console.log(`\n📄 JSON report written to: ${options.output}`);
     } catch (err) {
@@ -754,16 +885,149 @@ function writeJsonReport(results: GuideRunResult[], options: E2ECommandOptions):
 }
 
 /**
- * Exit with the code implied by the run outcome: auth failure takes precedence
- * over a generic test failure; a fully passing run returns to the caller.
+ * Exit with the code implied by the final results: auth failure takes precedence
+ * over a generic/validation test failure; a fully passing run returns to the caller.
  */
-function exitFromOutcome(outcome: ChainRunOutcome): void {
-  if (!outcome.allPassed) {
-    if (outcome.hasAuthExpiry) {
-      process.exit(ExitCode.AUTH_FAILURE);
-    }
+function exitFromResults(results: GuideRunResult[]): void {
+  if (results.some((r) => r.status === 'auth_expired')) {
+    process.exit(ExitCode.AUTH_FAILURE);
+  }
+  if (results.some((r) => FAILURE_STATUSES.has(r.status))) {
     process.exit(ExitCode.TEST_FAILURE);
   }
+}
+
+/**
+ * Finalize a run: print the summary, write the JSON report (when requested), and
+ * exit per the results' statuses. Shared by the normal path and the
+ * nothing-to-run path so both report identically.
+ */
+function reportResults(results: GuideRunResult[], options: E2ECommandOptions): void {
+  printSummary(results);
+  writeJsonReport(results, options);
+  exitFromResults(results);
+}
+
+/** True when the value points at an existing local directory (vs. a bare package ID). */
+function isExistingDir(value: string): boolean {
+  try {
+    return existsSync(value) && statSync(value).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Determine how guide inputs should be resolved for this run. */
+function resolveRunMode(options: E2ECommandOptions): RunMode {
+  if (options.remote) {
+    return 'remote-repository';
+  }
+  if (options.package && !isExistingDir(options.package)) {
+    return 'remote-package';
+  }
+  return 'local';
+}
+
+/** Convert a pre-run skipped package into a guide run result. */
+function skipToResult(skip: SkippedPackage): GuideRunResult {
+  return {
+    guide: skip.sourceUrl ?? skip.id,
+    id: skip.id,
+    status: skip.reason,
+    exitCode: skip.reason === 'validation_failed' ? ExitCode.TEST_FAILURE : ExitCode.SUCCESS,
+    autoIncluded: false,
+    abortMessage: skip.message,
+    tier: skip.tier,
+  };
+}
+
+/** Index resolved remote guides by ID for report enrichment. */
+function buildPackageMetaMap(runnable: ResolvedRemoteGuide[]): Map<string, PackageMeta> {
+  return new Map(
+    runnable.map((g) => [
+      g.id,
+      { packageId: g.id, tier: g.tier, instance: g.instance, targetUrl: g.targetUrl, sourceUrl: g.sourceUrl },
+    ])
+  );
+}
+
+/**
+ * Build a synchronous `loadGuideById` backed by already-fetched remote guides.
+ * Used for dependency chaining; prerequisites outside the fetched set (e.g. a
+ * different tier) resolve to null.
+ */
+function remoteLoadGuideById(
+  runnable: ResolvedRemoteGuide[]
+): (id: string, entry: RepositoryEntry) => LoadedGuide | null {
+  const byId = new Map(runnable.map((g) => [g.id, g.guide]));
+  return (id: string) => byId.get(id) ?? null;
+}
+
+/** Print a one-line (or verbose) summary of what remote resolution produced. */
+function printRemoteResolution(resolution: RemoteResolution, mode: RunMode, options: E2ECommandOptions): void {
+  const source = mode === 'remote-package' ? `package "${options.package}"` : 'repository index';
+  console.log(`\n📦 Resolved ${source}: ${resolution.runnable.length} runnable, ${resolution.skipped.length} skipped`);
+  if (options.verbose) {
+    for (const g of resolution.runnable) {
+      console.log(`   ✓ ${g.id} (${g.tier}) → ${g.sourceUrl}`);
+    }
+    for (const s of resolution.skipped) {
+      console.log(`   ⊘ ${s.id}: ${s.reason} — ${s.message}`);
+    }
+  }
+}
+
+/**
+ * Resolve CLI inputs into a uniform, runnable set, hiding whether guides come
+ * from local files/bundled content, a remote package ID, or the remote
+ * repository index. Prints remote-resolution feedback and exits on fatal remote
+ * resolution errors; local validation failures exit inside `resolveValidGuides`.
+ */
+async function resolveRunInputs(files: string[], options: E2ECommandOptions): Promise<RunInputs> {
+  const mode = resolveRunMode(options);
+
+  if (mode === 'local') {
+    return {
+      mode,
+      guides: resolveValidGuides(files, options),
+      preRunSkipped: [],
+      packageMetaById: new Map(),
+      localPackageDir: options.package,
+    };
+  }
+
+  const remoteOptions = {
+    grafanaUrl: options.grafanaUrl,
+    currentTier: options.tier,
+    resolverUrl: options.resolverUrl,
+    repoUrl: options.repoUrl,
+  };
+  const resolution =
+    mode === 'remote-package'
+      ? await resolveRemotePackage(options.package!, remoteOptions)
+      : await resolveRemoteRepository(remoteOptions);
+
+  if (resolution.error) {
+    console.error(`\n❌ ${resolution.error}`);
+    process.exit(ExitCode.CONFIGURATION_ERROR);
+  }
+
+  printRemoteResolution(resolution, mode, options);
+
+  // Only `runnable` guides are selected to run; `prerequisites` are made
+  // available to the planner (loader + metadata) so it auto-includes them the
+  // same way a local selection pulls in its dependencies.
+  const loadable = [...resolution.runnable, ...resolution.prerequisites];
+  return {
+    mode,
+    guides: resolution.runnable.map((g) => g.guide),
+    repoSource: {
+      repository: resolution.repository,
+      loadGuideById: remoteLoadGuideById(loadable),
+    },
+    preRunSkipped: resolution.skipped.map(skipToResult),
+    packageMetaById: buildPackageMetaMap(loadable),
+  };
 }
 
 // Generate unique run ID for default artifacts path
@@ -781,7 +1045,10 @@ export const e2eCommand = new Command('e2e')
   .option('--artifacts <dir>', 'Directory for artifacts', defaultArtifactsDir)
   .option('--verbose', 'Enable verbose logging', false)
   .option('--bundled', 'Test all bundled guides')
-  .option('--package <dir>', 'Load content.json from a package directory; reads manifest.json for pre-flight checks')
+  .option(
+    '--package <dirOrId>',
+    'Test a package: a local directory (content.json + manifest.json), or — when not an existing directory — a bare package ID resolved via the recommender'
+  )
   .addOption(new Option('--tier <tier>', 'Current test environment tier').choices(['local', 'cloud']).default('local'))
   .option('--trace', 'Generate Playwright trace file', false)
   .option('--headed', 'Run browser in headed mode (visible)', false)
@@ -801,6 +1068,9 @@ export const e2eCommand = new Command('e2e')
     '--repository <path>',
     'Path to a repository.json used for dependency-aware ordering (default: the bundled index when present)'
   )
+  .option('--remote', 'Resolve and test every package from the CDN repository index', false)
+  .option('--repo-url <url>', 'CDN base URL for --remote (default: the public Pathfinder package repository)')
+  .option('--resolver-url <url>', 'Recommender base URL for --package <id> resolution', DEFAULT_RESOLVER_URL)
   .action(async (files: string[], options: E2ECommandOptions) => {
     const cleanEnv = new CleanEnvironment(options.verbose);
     if (options.clean) {
@@ -812,23 +1082,26 @@ export const e2eCommand = new Command('e2e')
     }
 
     try {
-      const valid = resolveValidGuides(files, options);
+      const inputs = await resolveRunInputs(files, options);
 
-      printRunConfiguration(valid, options);
+      // Remote runs can resolve to nothing runnable (e.g. all cloud-tier guides):
+      // report the skips and exit without booting Grafana or Playwright.
+      if (inputs.guides.length === 0) {
+        reportResults(inputs.preRunSkipped, options);
+        return;
+      }
 
-      const plan = buildExecutionPlan(valid, options);
+      printRunConfiguration(inputs.guides, options, inputs.mode);
+
+      const plan = buildExecutionPlan(inputs.guides, options, inputs.repoSource);
 
       await maybeCleanStart(cleanEnv, options);
 
-      await runPreflightChecks(options);
+      await runPreflightChecks(options, inputs.localPackageDir);
 
-      const outcome = await runChains(plan, options, cleanEnv);
+      const outcome = await runChains(plan, options, cleanEnv, inputs.packageMetaById);
 
-      printSummary(outcome.results);
-
-      writeJsonReport(outcome.results, options);
-
-      exitFromOutcome(outcome);
+      reportResults([...inputs.preRunSkipped, ...outcome.results], options);
     } catch (error) {
       console.error('❌ Error:', error instanceof Error ? error.message : 'Unknown error');
       process.exit(ExitCode.CONFIGURATION_ERROR);


### PR DESCRIPTION
## Stack overview

#1086 -> #1087 -> #1088 -> #1089 -> #1090 (this PR) -> #1091

## Summary

Wires remote package resolution into `pathfinder-cli e2e`. Adds `--package <id>` (resolve a published guide and its `depends` prerequisites via the recommender), `--remote` (resolve and test every package in the CDN repository), `--repo-url` (CDN base override), and `--resolver-url` (recommender base). Inputs — local files/bundled, a remote package, or the remote repository — are resolved behind one `resolveRunInputs` step, then planned, run, and reported uniformly. `local`-tier guides run against `--grafana-url`; `cloud`-tier guides are skipped.

## What to look at

- `src/cli/commands/e2e.ts`:
  - `resolveRunInputs` hides the local-vs-remote decision behind a single shape (`RunInputs`), keeping the command action a straight pipeline. Remote prerequisites are supplied to the planner as auto-includable (not directly selected), so a `--package <id>` run chains its `depends` exactly like a local selection does.
  - The guide-status vocabulary is extended with the pre-run skip reasons, derived from the resolver's `REMOTE_SKIP_REASONS` so the command and resolver can't drift. `validation_failed` counts as a test failure; the other skips are logged, non-failing outcomes.
  - Summary/exit logic: confirm exit codes still distinguish pass / fail / auth-expired, and that a remote run which resolves to nothing runnable (e.g. all cloud-tier) reports its skips and exits cleanly without booting Grafana/Playwright.

## Why

This is the user-facing payoff of the stack — it turns the resolver and reporter into actual CLI behavior. Routing local and remote inputs through one `resolveRunInputs` keeps the action readable and means dependency chaining, `--clean`, and reporting all work identically regardless of where the guide came from.

## How to verify

1. `npx pathfinder-cli e2e --package <local-tier-id>` — confirm it resolves the guide, auto-includes its `depends` prerequisite, and runs the prerequisite before the target.
2. `npx pathfinder-cli e2e --remote` — confirm local-tier guides run and cloud-tier guides are skipped (logged, not failed); exit code is 0 when only skips/passes occur.
3. `npx pathfinder-cli e2e --package <cloud-tier-id>` — confirm it's skipped with a tier / no-auth reason and exits 0.
4. `--repo-url` / `--resolver-url` point resolution at alternate hosts; `--output report.json` includes the package metadata and `preRunSkipped` entries.
5. Confirm existing local modes (`./guide.json`, `--bundled`, `bundled:name`, `--package <dir>`) are unchanged.

## Breaking changes

None for existing usage. The new flags are additive; local and bundled invocations behave as before.

## Reversibility

Reversible. No persisted state or schema migration — the change adds flags and a resolution branch to the command. It does extend the run's outcome vocabulary (new non-failing skip statuses plus `validation_failed`); reverting restores the prior outcome set cleanly.
