### PR TITLE
feat(e2e): add CLI-local recommender client

### DIFF
--- a/src/cli/utils/recommender-resolver.test.ts
+++ b/src/cli/utils/recommender-resolver.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the CLI-local recommender resolver. `fetch` is mocked URL-by-URL so
+ * these exercise the real resolution + manifest-fetch + error-mapping logic
+ * that `e2e-package.test.ts` mocks away.
+ */
+
+import { resolvePackageById } from './recommender-resolver';
+
+interface RouteResponse {
+  ok: boolean;
+  status?: number;
+  body?: string;
+}
+
+/** Route `fetch` by URL substring; unmatched URLs 404. */
+function mockFetch(handler: (url: string) => RouteResponse): void {
+  global.fetch = jest.fn(async (input: unknown) => {
+    const r = handler(String(input));
+    return {
+      ok: r.ok,
+      status: r.status ?? (r.ok ? 200 : 500),
+      statusText: r.ok ? 'OK' : 'Error',
+      json: async () => JSON.parse(r.body ?? '{}'),
+      text: async () => r.body ?? '',
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('resolvePackageById', () => {
+  it('resolves a package and parses its manifest', async () => {
+    mockFetch((url) => {
+      if (url.includes('/api/v1/packages/alerting-101')) {
+        return {
+          ok: true,
+          body: JSON.stringify({
+            id: 'alerting-101',
+            contentUrl: 'https://cdn.test/alerting-101/content.json',
+            manifestUrl: 'https://cdn.test/alerting-101/manifest.json',
+          }),
+        };
+      }
+      if (url.endsWith('manifest.json')) {
+        return {
+          ok: true,
+          body: JSON.stringify({ id: 'alerting-101', type: 'guide', testEnvironment: { tier: 'local' } }),
+        };
+      }
+      return { ok: false, status: 404 };
+    });
+
+    const res = await resolvePackageById('https://recommender.test', 'alerting-101');
+
+    expect(res).toMatchObject({
+      ok: true,
+      id: 'alerting-101',
+      contentUrl: 'https://cdn.test/alerting-101/content.json',
+    });
+    expect(res.ok && res.manifest?.type).toBe('guide');
+    expect(res.ok && res.manifest?.testEnvironment?.tier).toBe('local');
+  });
+
+  it('maps a 404 from the resolver to a failure', async () => {
+    mockFetch(() => ({ ok: false, status: 404 }));
+
+    const res = await resolvePackageById('https://recommender.test', 'missing');
+
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ ok: false, message: expect.stringContaining('404') });
+  });
+
+  it('maps a network error to a failure', async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error('offline');
+    }) as unknown as typeof fetch;
+
+    const res = await resolvePackageById('https://recommender.test', 'x');
+
+    expect(res).toMatchObject({ ok: false, message: 'offline' });
+  });
+
+  it('resolves without a manifest when the manifest fetch fails (non-fatal)', async () => {
+    mockFetch((url) => {
+      if (url.includes('/api/v1/packages/')) {
+        return {
+          ok: true,
+          body: JSON.stringify({
+            id: 'g',
+            contentUrl: 'https://cdn.test/g/content.json',
+            manifestUrl: 'https://cdn.test/g/manifest.json',
+          }),
+        };
+      }
+      return { ok: false, status: 500 }; // manifest fetch fails
+    });
+
+    const res = await resolvePackageById('https://recommender.test', 'g');
+
+    expect(res).toMatchObject({ ok: true, id: 'g', contentUrl: 'https://cdn.test/g/content.json' });
+    expect(res.ok && res.manifest).toBeUndefined();
+  });
+
+  it('resolves without a manifest when the package declares no manifestUrl', async () => {
+    mockFetch(() => ({
+      ok: true,
+      body: JSON.stringify({ id: 'g', contentUrl: 'https://cdn.test/g/content.json', manifestUrl: '' }),
+    }));
+
+    const res = await resolvePackageById('https://recommender.test', 'g');
+
+    expect(res).toMatchObject({ ok: true, id: 'g' });
+    expect(res.ok && res.manifest).toBeUndefined();
+  });
+});

--- a/src/cli/utils/recommender-resolver.test.ts
+++ b/src/cli/utils/recommender-resolver.test.ts
@@ -112,4 +112,63 @@ describe('resolvePackageById', () => {
     expect(res).toMatchObject({ ok: true, id: 'g' });
     expect(res.ok && res.manifest).toBeUndefined();
   });
+
+  it('fails on a 200 with a missing contentUrl', async () => {
+    mockFetch(() => ({ ok: true, body: JSON.stringify({ id: 'g' }) }));
+
+    const res = await resolvePackageById('https://recommender.test', 'g');
+
+    expect(res.ok).toBe(false);
+  });
+
+  it('fails when contentUrl is not an http(s) URL', async () => {
+    mockFetch(() => ({ ok: true, body: JSON.stringify({ id: 'g', contentUrl: 'file:///etc/passwd' }) }));
+
+    const res = await resolvePackageById('https://recommender.test', 'g');
+
+    expect(res.ok).toBe(false);
+  });
+
+  it('preserves a path prefix on the resolver URL', async () => {
+    const calls: string[] = [];
+    global.fetch = jest.fn(async (input: unknown) => {
+      calls.push(String(input));
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ id: 'alerting-101', contentUrl: 'https://cdn.test/c.json', manifestUrl: '' }),
+        text: async () => '',
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await resolvePackageById('https://host/api-prefix', 'alerting-101');
+
+    expect(calls[0]).toBe('https://host/api-prefix/api/v1/packages/alerting-101');
+  });
+
+  it('does not fetch a manifest at a non-http URL', async () => {
+    const calls: string[] = [];
+    global.fetch = jest.fn(async (input: unknown) => {
+      calls.push(String(input));
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          id: 'g',
+          contentUrl: 'https://cdn.test/g/content.json',
+          manifestUrl: 'file:///etc/passwd',
+        }),
+        text: async () => '',
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const res = await resolvePackageById('https://recommender.test', 'g');
+
+    expect(res).toMatchObject({ ok: true, id: 'g' });
+    expect(res.ok && res.manifest).toBeUndefined();
+    // The file: manifest URL must never be requested.
+    expect(calls.some((u) => u.startsWith('file:'))).toBe(false);
+  });
 });

--- a/src/cli/utils/recommender-resolver.ts
+++ b/src/cli/utils/recommender-resolver.ts
@@ -33,7 +33,8 @@ export async function resolvePackageById(resolverUrl: string, id: string): Promi
   let response: Response;
   try {
     // SECURITY: build the URL via the URL API and encode the id (F3).
-    const endpoint = new URL(`/api/v1/packages/${encodeURIComponent(id)}`, resolverUrl);
+    const base = resolverUrl.endsWith('/') ? resolverUrl : `${resolverUrl}/`;
+    const endpoint = new URL(`api/v1/packages/${encodeURIComponent(id)}`, base);
     response = await fetch(endpoint.toString(), {
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       headers: { Accept: 'application/json' },
@@ -46,14 +47,31 @@ export async function resolvePackageById(resolverUrl: string, id: string): Promi
     return { ok: false, message: `HTTP ${response.status} ${response.statusText}` };
   }
 
-  let data: PackageResolutionResponse;
+  let data: Partial<PackageResolutionResponse>;
   try {
-    data = (await response.json()) as PackageResolutionResponse;
+    data = (await response.json()) as Partial<PackageResolutionResponse>;
   } catch (err) {
     return { ok: false, message: err instanceof Error ? err.message : 'Invalid resolution response' };
   }
 
-  return { ok: true, id: data.id, contentUrl: data.contentUrl, manifest: await fetchManifest(data.manifestUrl) };
+  // contentUrl must be be a valid http(s) URL
+  if (typeof data.contentUrl !== 'string' || !isHttpUrl(data.contentUrl)) {
+    return { ok: false, message: 'resolution response did not include a valid contentUrl' };
+  }
+
+  const resolvedId = typeof data.id === 'string' && data.id !== '' ? data.id : id;
+  const manifest = typeof data.manifestUrl === 'string' ? await fetchManifest(data.manifestUrl) : undefined;
+  return { ok: true, id: resolvedId, contentUrl: data.contentUrl, manifest };
+}
+
+/** True only for absolute http(s) URLs; guards against non-http schemes (file:, data:, etc.). */
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -62,7 +80,7 @@ export async function resolvePackageById(resolverUrl: string, id: string): Promi
  * so the guide can still run under default targeting.
  */
 async function fetchManifest(manifestUrl: string): Promise<ManifestJson | undefined> {
-  if (!manifestUrl) {
+  if (!manifestUrl || !isHttpUrl(manifestUrl)) {
     return undefined;
   }
   let raw: unknown;

--- a/src/cli/utils/recommender-resolver.ts
+++ b/src/cli/utils/recommender-resolver.ts
@@ -1,0 +1,83 @@
+/**
+ * CLI recommender client.
+ *
+ * Resolves a bare package id to its CDN content/manifest URLs via the
+ * recommender's `GET /api/v1/packages/{id}` endpoint, returning the parsed
+ * manifest metadata (type, testEnvironment) the e2e runner routes on.
+ */
+
+import { ManifestJsonObjectSchema } from '../../types/package.schema';
+import type { ManifestJson } from '../../types/package.types';
+
+const FETCH_TIMEOUT_MS = 15_000;
+
+/** Subset of the recommender `GET /api/v1/packages/{id}` response we consume. */
+interface PackageResolutionResponse {
+  id: string;
+  contentUrl: string;
+  manifestUrl: string;
+}
+
+/** Outcome of resolving a bare package id. Failures never throw. */
+export type RecommenderResolution =
+  | { ok: true; id: string; contentUrl: string; manifest?: ManifestJson }
+  | { ok: false; message: string };
+
+/**
+ * Resolve a bare package id through the recommender, then fetch its manifest
+ * for routing metadata. Network, HTTP, and parse failures map to
+ * `{ ok: false }` rather than throwing, so the caller can record a structured
+ * skip outcome.
+ */
+export async function resolvePackageById(resolverUrl: string, id: string): Promise<RecommenderResolution> {
+  let response: Response;
+  try {
+    // SECURITY: build the URL via the URL API and encode the id (F3).
+    const endpoint = new URL(`/api/v1/packages/${encodeURIComponent(id)}`, resolverUrl);
+    response = await fetch(endpoint.toString(), {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    });
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : 'Unknown network error' };
+  }
+
+  if (!response.ok) {
+    return { ok: false, message: `HTTP ${response.status} ${response.statusText}` };
+  }
+
+  let data: PackageResolutionResponse;
+  try {
+    data = (await response.json()) as PackageResolutionResponse;
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : 'Invalid resolution response' };
+  }
+
+  return { ok: true, id: data.id, contentUrl: data.contentUrl, manifest: await fetchManifest(data.manifestUrl) };
+}
+
+/**
+ * Fetch and parse a package manifest for routing metadata. Optional and
+ * non-fatal: a missing, unreachable, or malformed manifest yields `undefined`
+ * so the guide can still run under default targeting.
+ */
+async function fetchManifest(manifestUrl: string): Promise<ManifestJson | undefined> {
+  if (!manifestUrl) {
+    return undefined;
+  }
+  let raw: unknown;
+  try {
+    const res = await fetch(manifestUrl, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) {
+      return undefined;
+    }
+    raw = await res.json();
+  } catch {
+    return undefined;
+  }
+  const parsed = ManifestJsonObjectSchema.loose().safeParse(raw);
+  return parsed.success ? (parsed.data as ManifestJson) : undefined;
+}

--- a/src/cli/utils/recommender-resolver.ts
+++ b/src/cli/utils/recommender-resolver.ts
@@ -4,6 +4,12 @@
  * Resolves a bare package id to its CDN content/manifest URLs via the
  * recommender's `GET /api/v1/packages/{id}` endpoint, returning the parsed
  * manifest metadata (type, testEnvironment) the e2e runner routes on.
+ *
+ * @coupling Depends on the recommender's `GET /api/v1/packages/{id}` resolution
+ * endpoint (grafana-recommender; documented in its API docs / openapi.yaml).
+ * This endpoint deliberately separates "what package" from "where it lives" on
+ * the network, so the dependency is intentional, but it is an external API
+ * contract, and changes to its response shape must be reflected here.
  */
 
 import { ManifestJsonObjectSchema } from '../../types/package.schema';


### PR DESCRIPTION
## Overview

Part of the package-aware e2e testing changes. #1086 and #1087 are merged to `main`; this PR adds the CLI recommender client that the package resolver will use.

## Summary

Adds `resolvePackageById(resolverUrl, id)` — a small, CLI-local client for the recommender's `GET /api/v1/packages/{id}` endpoint. It resolves a bare package id to its CDN content URL and fetches the package manifest for routing metadata (type, testEnvironment). Failures never throw: network, HTTP, and parse errors return `{ ok: false, message }`, and a missing/unreachable/malformed manifest is non-fatal. Nothing imports it yet — the package resolver in the next PR consumes it.

## What to look at

- `src/cli/utils/recommender-resolver.ts` — the design boundary is the main review point: this deliberately does **not** reuse `src/package-engine`'s `RecommenderPackageResolver`. The packaged CLI (`Dockerfile.cli`) copies only `src/cli`, `src/types`, and `src/validation`, so importing `src/package-engine` breaks `npm run build:cli`. Keeping a CLI-local client preserves that isolation, mirroring the existing `mcp/lib/repository-client.ts`. Also confirm the URL is built via the `URL` API + `encodeURIComponent` (F3), the request is bounded by `AbortSignal.timeout`, and every failure path returns a structured `{ ok: false }` rather than throwing.

## Why

The e2e runner's upcoming `--package <id>` mode needs recommender resolution, but it must stay inside the CLI's packaging boundary. Rejected alternatives: (1) copy `src/package-engine` into the CLI image — risks dragging its `@grafana/runtime`-coupled siblings (e.g. `online-cdn-resolver`) into a Node-only artifact; (2) invert the dependency so package-engine consumes a CLI module — worse, it pulls CLI code into the browser bundle and inverts the tier order. A small CLI-local client (shared contract types already live at Tier-0 `package.types` / `package.schema`) keeps both the dependency direction and the CLI footprint correct. A future shared package-data module may consolidate these clients; this is the documented interim.

## How to verify

1. `npm run build:cli` succeeds — the new module compiles within the CLI's restricted build (`tsconfig.cli.json`), staying inside the `src/cli` + `src/types` + `src/validation` subtree.
2. Unit tests (`recommender-resolver.test.ts`) cover: successful resolve + manifest parse, resolver 404 → failure, network error → failure, manifest-fetch failure (non-fatal — resolves without a manifest), and a package with no manifestUrl.

## Breaking changes

None. New, currently-unconsumed module; the package resolver wires it in next.
