### PR TITLE
feat(e2e): add remote package resolver for --package and --remote

### DIFF
--- a/src/cli/utils/e2e-package.test.ts
+++ b/src/cli/utils/e2e-package.test.ts
@@ -70,6 +70,7 @@ describe('resolveRemotePackage (single, recommender)', () => {
       repository: 'r',
       manifest: { id: 'alerting-101', type: 'guide', testEnvironment: { tier: 'local' } },
     });
+    mockIndex([{ id: 'alerting-101', path: 'alerting-101/', type: 'guide', testEnvironment: { tier: 'local' } }]);
     mockFetch({ ok: true, text: '{"id":"alerting-101"}' });
 
     const result = await resolveRemotePackage('alerting-101', OPTIONS);
@@ -168,6 +169,7 @@ describe('resolveRemotePackage (single, recommender)', () => {
       repository: 'r',
       manifest: undefined,
     });
+    mockIndex([{ id: 'g', path: 'g/', type: 'guide', testEnvironment: { tier: 'local' } }]);
     mockFetch({ ok: true, text: '{"id":"g"}' });
 
     const result = await resolveRemotePackage('g', OPTIONS);
@@ -272,18 +274,21 @@ describe('resolveRemotePackage (dependency resolution)', () => {
     expect(result.prerequisites.map((g) => g.id)).toEqual(['provider']);
   });
 
-  it('runs the target alone when it is absent from the index', async () => {
+  it('skips the target when it is absent from the repository index', async () => {
     mockTargetResolve('orphan');
     mockIndex([{ id: 'other', path: 'other/', type: 'guide', testEnvironment: { tier: 'local' } }]);
     mockFetch({ ok: true, text: '{"id":"orphan"}' });
 
     const result = await resolveRemotePackage('orphan', OPTIONS);
 
-    expect(result.runnable.map((g) => g.id)).toEqual(['orphan']);
+    expect(result.runnable).toHaveLength(0);
     expect(result.prerequisites).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toMatchObject({ id: 'orphan', reason: 'resolution_failed' });
+    expect(result.skipped[0]!.message).toMatch(/not present in the repository index/i);
   });
 
-  it('runs the target alone when the index is unreachable', async () => {
+  it('runs the target alone when the index is unreachable and no prerequisites are declared', async () => {
     mockTargetResolve('loki-101');
     (fetchRepositoryIndex as jest.Mock).mockResolvedValue({ ok: false, code: 'NETWORK_ERROR', message: 'offline' });
     mockFetch({ ok: true, text: '{"id":"loki-101"}' });
@@ -295,7 +300,28 @@ describe('resolveRemotePackage (dependency resolution)', () => {
     expect(result.repository).toEqual({});
   });
 
-  it('reports a prerequisite whose content cannot be fetched', async () => {
+  it('skips the target when the index is unreachable and the manifest declares prerequisites', async () => {
+    mockResolve({
+      ok: true,
+      id: 'loki-101',
+      contentUrl: 'https://cdn.test/loki-101/content.json',
+      manifestUrl: 'https://cdn.test/loki-101/manifest.json',
+      repository: 'r',
+      manifest: { id: 'loki-101', type: 'guide', depends: ['prom-101'], testEnvironment: { tier: 'local' } },
+    });
+    (fetchRepositoryIndex as jest.Mock).mockResolvedValue({ ok: false, code: 'NETWORK_ERROR', message: 'offline' });
+    mockFetch({ ok: true, text: '{"id":"loki-101"}' });
+
+    const result = await resolveRemotePackage('loki-101', OPTIONS);
+
+    expect(result.runnable).toHaveLength(0);
+    expect(result.prerequisites).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toMatchObject({ id: 'loki-101', reason: 'resolution_failed' });
+    expect(result.skipped[0]!.message).toMatch(/unreachable/i);
+  });
+
+  it('cascades the skip to the target when a prerequisite cannot be fetched', async () => {
     mockTargetResolve('loki-101');
     mockIndex([
       { id: 'loki-101', path: 'loki-101/', type: 'guide', depends: ['prom-101'], testEnvironment: { tier: 'local' } },
@@ -312,8 +338,45 @@ describe('resolveRemotePackage (dependency resolution)', () => {
 
     const result = await resolveRemotePackage('loki-101', OPTIONS);
 
-    expect(result.runnable.map((g) => g.id)).toEqual(['loki-101']);
+    expect(result.runnable).toHaveLength(0);
     expect(result.prerequisites).toHaveLength(0);
-    expect(result.skipped[0]).toMatchObject({ id: 'prom-101', reason: 'fetch_failed' });
+    const reasons = Object.fromEntries(result.skipped.map((s) => [s.id, s.reason]));
+    expect(reasons).toEqual({ 'prom-101': 'fetch_failed', 'loki-101': 'prerequisite_failed' });
+    const targetSkip = result.skipped.find((s) => s.id === 'loki-101')!;
+    expect(targetSkip.message).toMatch(/prom-101/);
+  });
+
+  it('cascades the skip to the target when a depends clause cannot be resolved', async () => {
+    mockTargetResolve('loki-101');
+    // "ghost" is neither a known package id nor a known provides capability.
+    mockIndex([
+      { id: 'loki-101', path: 'loki-101/', type: 'guide', depends: ['ghost'], testEnvironment: { tier: 'local' } },
+    ]);
+    mockFetch({ ok: true, text: '{"id":"loki-101"}' });
+
+    const result = await resolveRemotePackage('loki-101', OPTIONS);
+
+    expect(result.runnable).toHaveLength(0);
+    expect(result.prerequisites).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toMatchObject({ id: 'loki-101', reason: 'prerequisite_failed' });
+    expect(result.skipped[0]!.message).toMatch(/ghost/);
+  });
+
+  it('cascades the skip to the target when prerequisites form a cycle', async () => {
+    mockTargetResolve('loki-101');
+    mockIndex([
+      { id: 'loki-101', path: 'loki-101/', type: 'guide', depends: ['prom-101'], testEnvironment: { tier: 'local' } },
+      { id: 'prom-101', path: 'prom-101/', type: 'guide', depends: ['loki-101'], testEnvironment: { tier: 'local' } },
+    ]);
+    mockFetch({ ok: true, text: '{"id":"loki-101"}' });
+
+    const result = await resolveRemotePackage('loki-101', OPTIONS);
+
+    expect(result.runnable).toHaveLength(0);
+    expect(result.prerequisites).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toMatchObject({ id: 'loki-101', reason: 'prerequisite_failed' });
+    expect(result.skipped[0]!.message).toMatch(/[Cc]ycle/);
   });
 });

--- a/src/cli/utils/e2e-package.test.ts
+++ b/src/cli/utils/e2e-package.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Tests for remote package resolution. The recommender resolver, the CDN
+ * repository client, and guide validation are mocked so these tests exercise
+ * the orchestration logic — outcome mapping, target filtering, and graceful
+ * degradation — without real network or schema coupling.
+ */
+
+jest.mock('../../validation', () => ({
+  validateGuideFromString: jest.fn(() => ({ isValid: true, warnings: [], errors: [] })),
+}));
+jest.mock('./recommender-resolver', () => ({
+  resolvePackageById: jest.fn(),
+}));
+jest.mock('../mcp/lib/repository-client', () => ({
+  fetchRepositoryIndex: jest.fn(),
+  buildPackageFileUrl: jest.fn((base: string, path: string, file: string) => `${base}${path}/${file}`),
+}));
+
+import { resolveRemotePackage, resolveRemoteRepository } from './e2e-package';
+import { validateGuideFromString } from '../../validation';
+import { resolvePackageById } from './recommender-resolver';
+import { fetchRepositoryIndex } from '../mcp/lib/repository-client';
+
+const OPTIONS = {
+  grafanaUrl: 'http://localhost:3000',
+  currentTier: 'local' as const,
+  resolverUrl: 'https://recommender.test',
+};
+
+/** Configure the recommender resolver mock to return a fixed resolution. */
+function mockResolve(resolution: unknown): void {
+  (resolvePackageById as jest.Mock).mockResolvedValue(resolution);
+}
+
+/** Configure global fetch to return a text body or an HTTP error. */
+function mockFetch(body: { ok: true; text: string } | { ok: false; status: number }): void {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue(
+      body.ok ? { ok: true, text: async () => body.text } : { ok: false, status: body.status, statusText: 'Error' }
+    ) as unknown as typeof fetch;
+}
+
+/** Configure the CDN index mock with the given packages. */
+function mockIndex(packages: unknown[]): void {
+  (fetchRepositoryIndex as jest.Mock).mockResolvedValue({
+    ok: true,
+    baseUrl: 'https://cdn.test/packages/',
+    packages,
+    rawIndex: {},
+    validation: { isValid: true, issues: [] },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (validateGuideFromString as jest.Mock).mockReturnValue({ isValid: true, warnings: [], errors: [] });
+  // Default to an empty index so single-package runnable tests resolve as
+  // singletons (no dependencies) unless a test sets up an index explicitly.
+  mockIndex([]);
+});
+
+describe('resolveRemotePackage (single, recommender)', () => {
+  it('returns a runnable guide for a local-tier package', async () => {
+    mockResolve({
+      ok: true,
+      id: 'alerting-101',
+      contentUrl: 'https://cdn.test/alerting-101/content.json',
+      manifestUrl: 'https://cdn.test/alerting-101/manifest.json',
+      repository: 'r',
+      manifest: { id: 'alerting-101', type: 'guide', testEnvironment: { tier: 'local' } },
+    });
+    mockFetch({ ok: true, text: '{"id":"alerting-101"}' });
+
+    const result = await resolveRemotePackage('alerting-101', OPTIONS);
+
+    expect(result.skipped).toHaveLength(0);
+    expect(result.runnable).toHaveLength(1);
+    expect(result.runnable[0]).toMatchObject({
+      id: 'alerting-101',
+      tier: 'local',
+      targetUrl: 'http://localhost:3000',
+      sourceUrl: 'https://cdn.test/alerting-101/content.json',
+    });
+    expect(result.runnable[0]!.guide.content).toBe('{"id":"alerting-101"}');
+  });
+
+  it('maps a recommender failure to resolution_failed', async () => {
+    mockResolve({ ok: false, message: 'not-found: package not found' });
+
+    const result = await resolveRemotePackage('missing', OPTIONS);
+
+    expect(result.runnable).toHaveLength(0);
+    expect(result.skipped[0]).toMatchObject({ id: 'missing', reason: 'resolution_failed' });
+  });
+
+  it('skips a non-guide package as unsupported_type', async () => {
+    mockResolve({
+      ok: true,
+      id: 'prometheus-lj',
+      contentUrl: 'https://cdn.test/prometheus-lj/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: { id: 'prometheus-lj', type: 'path', milestones: ['a', 'b'] },
+    });
+
+    const result = await resolveRemotePackage('prometheus-lj', OPTIONS);
+
+    expect(result.runnable).toHaveLength(0);
+    expect(result.skipped[0]).toMatchObject({ id: 'prometheus-lj', reason: 'unsupported_type' });
+  });
+
+  it('skips a cloud-tier package on a local environment', async () => {
+    mockResolve({
+      ok: true,
+      id: 'cloud-guide',
+      contentUrl: 'https://cdn.test/cloud-guide/content.json',
+      manifestUrl: 'https://cdn.test/cloud-guide/manifest.json',
+      repository: 'r',
+      manifest: { id: 'cloud-guide', type: 'guide', testEnvironment: { tier: 'cloud' } },
+    });
+
+    const result = await resolveRemotePackage('cloud-guide', OPTIONS);
+
+    expect(result.runnable).toHaveLength(0);
+    expect(result.skipped[0]).toMatchObject({ id: 'cloud-guide', reason: 'skipped_tier_mismatch' });
+  });
+
+  it('maps a content fetch error to fetch_failed', async () => {
+    mockResolve({
+      ok: true,
+      id: 'g',
+      contentUrl: 'https://cdn.test/g/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: { id: 'g', type: 'guide', testEnvironment: { tier: 'local' } },
+    });
+    mockFetch({ ok: false, status: 503 });
+
+    const result = await resolveRemotePackage('g', OPTIONS);
+
+    expect(result.skipped[0]).toMatchObject({ id: 'g', reason: 'fetch_failed' });
+  });
+
+  it('maps invalid fetched content to validation_failed', async () => {
+    mockResolve({
+      ok: true,
+      id: 'g',
+      contentUrl: 'https://cdn.test/g/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: { id: 'g', type: 'guide', testEnvironment: { tier: 'local' } },
+    });
+    mockFetch({ ok: true, text: '{"not":"a guide"}' });
+    (validateGuideFromString as jest.Mock).mockReturnValue({ isValid: false, warnings: [], errors: ['bad'] });
+
+    const result = await resolveRemotePackage('g', OPTIONS);
+
+    expect(result.skipped[0]).toMatchObject({ id: 'g', reason: 'validation_failed' });
+  });
+
+  it('treats a package with no manifest as a runnable local guide', async () => {
+    mockResolve({
+      ok: true,
+      id: 'g',
+      contentUrl: 'https://cdn.test/g/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: undefined,
+    });
+    mockFetch({ ok: true, text: '{"id":"g"}' });
+
+    const result = await resolveRemotePackage('g', OPTIONS);
+
+    expect(result.runnable).toHaveLength(1);
+    expect(result.runnable[0]).toMatchObject({ id: 'g', tier: 'local' });
+  });
+});
+
+describe('resolveRemoteRepository (batch, CDN index)', () => {
+  it('runs local guides, skips cloud guides, and reconstructs the repository index', async () => {
+    (fetchRepositoryIndex as jest.Mock).mockResolvedValue({
+      ok: true,
+      baseUrl: 'https://cdn.test/packages/',
+      packages: [
+        { id: 'local-a', path: 'local-a/', type: 'guide', testEnvironment: { tier: 'local' }, depends: ['local-b'] },
+        { id: 'local-b', path: 'local-b/', type: 'guide', testEnvironment: { tier: 'local' } },
+        { id: 'cloud-c', path: 'cloud-c/', type: 'guide', testEnvironment: { tier: 'cloud' } },
+        { id: 'path-d', path: 'path-d/', type: 'path', milestones: ['local-a'] },
+      ],
+      rawIndex: {},
+      validation: { isValid: true, issues: [] },
+    });
+    mockFetch({ ok: true, text: '{"id":"x"}' });
+
+    const result = await resolveRemoteRepository(OPTIONS);
+
+    expect(result.runnable.map((g) => g.id).sort()).toEqual(['local-a', 'local-b']);
+
+    const reasons = Object.fromEntries(result.skipped.map((s) => [s.id, s.reason]));
+    expect(reasons).toEqual({ 'cloud-c': 'skipped_tier_mismatch', 'path-d': 'unsupported_type' });
+
+    // Repository index keeps every entry (including the depends edge) for chaining.
+    expect(result.repository['local-a']).toMatchObject({ path: 'local-a/', depends: ['local-b'] });
+    expect(Object.keys(result.repository).sort()).toEqual(['cloud-c', 'local-a', 'local-b', 'path-d']);
+  });
+
+  it('returns an error when the repository index cannot be fetched', async () => {
+    (fetchRepositoryIndex as jest.Mock).mockResolvedValue({ ok: false, code: 'NETWORK_ERROR', message: 'offline' });
+
+    const result = await resolveRemoteRepository(OPTIONS);
+
+    expect(result.error).toMatch(/repository index/i);
+    expect(result.runnable).toHaveLength(0);
+  });
+});
+
+describe('resolveRemotePackage (dependency resolution)', () => {
+  /** Recommender resolves a local-tier guide target by id. */
+  function mockTargetResolve(targetId: string): void {
+    mockResolve({
+      ok: true,
+      id: targetId,
+      contentUrl: `https://cdn.test/${targetId}/content.json`,
+      manifestUrl: `https://cdn.test/${targetId}/manifest.json`,
+      repository: 'r',
+      manifest: { id: targetId, type: 'guide', testEnvironment: { tier: 'local' } },
+    });
+  }
+
+  it('resolves and includes a direct prerequisite, keeping the target as the selected guide', async () => {
+    mockTargetResolve('loki-101');
+    mockIndex([
+      { id: 'loki-101', path: 'loki-101/', type: 'guide', depends: ['prom-101'], testEnvironment: { tier: 'local' } },
+      { id: 'prom-101', path: 'prom-101/', type: 'guide', testEnvironment: { tier: 'local' } },
+    ]);
+    mockFetch({ ok: true, text: '{"id":"loki-101"}' });
+
+    const result = await resolveRemotePackage('loki-101', OPTIONS);
+
+    expect(result.runnable.map((g) => g.id)).toEqual(['loki-101']);
+    expect(result.prerequisites.map((g) => g.id)).toEqual(['prom-101']);
+    expect(result.skipped).toHaveLength(0);
+    expect(Object.keys(result.repository).sort()).toEqual(['loki-101', 'prom-101']);
+  });
+
+  it('resolves transitive prerequisites', async () => {
+    mockTargetResolve('c-guide');
+    mockIndex([
+      { id: 'c-guide', path: 'c/', type: 'guide', depends: ['b-guide'], testEnvironment: { tier: 'local' } },
+      { id: 'b-guide', path: 'b/', type: 'guide', depends: ['a-guide'], testEnvironment: { tier: 'local' } },
+      { id: 'a-guide', path: 'a/', type: 'guide', testEnvironment: { tier: 'local' } },
+    ]);
+    mockFetch({ ok: true, text: '{"id":"c-guide"}' });
+
+    const result = await resolveRemotePackage('c-guide', OPTIONS);
+
+    expect(result.runnable.map((g) => g.id)).toEqual(['c-guide']);
+    expect(result.prerequisites.map((g) => g.id).sort()).toEqual(['a-guide', 'b-guide']);
+  });
+
+  it('resolves a prerequisite advertised via a provides capability', async () => {
+    mockTargetResolve('dependent');
+    mockIndex([
+      { id: 'dependent', path: 'dependent/', type: 'guide', depends: ['db-ready'], testEnvironment: { tier: 'local' } },
+      { id: 'provider', path: 'provider/', type: 'guide', provides: ['db-ready'], testEnvironment: { tier: 'local' } },
+    ]);
+    mockFetch({ ok: true, text: '{"id":"dependent"}' });
+
+    const result = await resolveRemotePackage('dependent', OPTIONS);
+
+    expect(result.prerequisites.map((g) => g.id)).toEqual(['provider']);
+  });
+
+  it('runs the target alone when it is absent from the index', async () => {
+    mockTargetResolve('orphan');
+    mockIndex([{ id: 'other', path: 'other/', type: 'guide', testEnvironment: { tier: 'local' } }]);
+    mockFetch({ ok: true, text: '{"id":"orphan"}' });
+
+    const result = await resolveRemotePackage('orphan', OPTIONS);
+
+    expect(result.runnable.map((g) => g.id)).toEqual(['orphan']);
+    expect(result.prerequisites).toHaveLength(0);
+  });
+
+  it('runs the target alone when the index is unreachable', async () => {
+    mockTargetResolve('loki-101');
+    (fetchRepositoryIndex as jest.Mock).mockResolvedValue({ ok: false, code: 'NETWORK_ERROR', message: 'offline' });
+    mockFetch({ ok: true, text: '{"id":"loki-101"}' });
+
+    const result = await resolveRemotePackage('loki-101', OPTIONS);
+
+    expect(result.runnable.map((g) => g.id)).toEqual(['loki-101']);
+    expect(result.prerequisites).toHaveLength(0);
+    expect(result.repository).toEqual({});
+  });
+
+  it('reports a prerequisite whose content cannot be fetched', async () => {
+    mockTargetResolve('loki-101');
+    mockIndex([
+      { id: 'loki-101', path: 'loki-101/', type: 'guide', depends: ['prom-101'], testEnvironment: { tier: 'local' } },
+      { id: 'prom-101', path: 'prom-101/', type: 'guide', testEnvironment: { tier: 'local' } },
+    ]);
+    // Target content fetches OK; the prerequisite's content fetch fails.
+    global.fetch = jest.fn((url: string) =>
+      Promise.resolve(
+        url.includes('prom-101')
+          ? ({ ok: false, status: 503, statusText: 'Error' } as Response)
+          : ({ ok: true, text: async () => '{"id":"loki-101"}' } as unknown as Response)
+      )
+    ) as unknown as typeof fetch;
+
+    const result = await resolveRemotePackage('loki-101', OPTIONS);
+
+    expect(result.runnable.map((g) => g.id)).toEqual(['loki-101']);
+    expect(result.prerequisites).toHaveLength(0);
+    expect(result.skipped[0]).toMatchObject({ id: 'prom-101', reason: 'fetch_failed' });
+  });
+});

--- a/src/cli/utils/e2e-package.ts
+++ b/src/cli/utils/e2e-package.ts
@@ -36,6 +36,7 @@ export const REMOTE_SKIP_REASONS = [
   'resolution_failed',
   'validation_failed',
   'unsupported_type',
+  'prerequisite_failed',
 ] as const;
 
 /** Why a remote package was skipped instead of run. */
@@ -216,11 +217,74 @@ async function resolveIndexEntry(
  * Enumerate the target's transitive `depends` prerequisites by running the
  * planner as a pure oracle: a throwaway stub loader lets it report
  * `autoIncludedIds` without re-implementing OR-group / `provides` resolution.
- * The stub content is never read, only the discovered ids.
+ * Planner errors (cycles, unresolvable clauses) are surfaced alongside the ids
+ * so callers can cascade them; the stub content is never read.
  */
-function discoverPrerequisiteIds(targetGuide: LoadedGuide, repository: RepositoryJson): string[] {
+function discoverPrerequisites(
+  targetGuide: LoadedGuide,
+  repository: RepositoryJson
+): { ids: string[]; errors: string[] } {
   const stubLoader = (stubId: string): LoadedGuide => ({ path: stubId, content: '{}' });
-  return planGuideExecution({ guides: [targetGuide], repository, loadGuideById: stubLoader }).autoIncludedIds;
+  const plan = planGuideExecution({ guides: [targetGuide], repository, loadGuideById: stubLoader });
+  return { ids: plan.autoIncludedIds, errors: plan.errors };
+}
+
+function prerequisiteFailedSkip(target: ResolvedRemoteGuide, detail: string): SkippedPackage {
+  return {
+    id: target.id,
+    reason: 'prerequisite_failed',
+    message: `Prerequisite(s) did not resolve: ${detail}`,
+    sourceUrl: target.sourceUrl,
+    tier: target.tier,
+  };
+}
+
+function resolutionFailedSkip(target: ResolvedRemoteGuide, message: string): SkippedPackage {
+  return {
+    id: target.id,
+    reason: 'resolution_failed',
+    message,
+    sourceUrl: target.sourceUrl,
+    tier: target.tier,
+  };
+}
+
+function skippedResolution(skipped: SkippedPackage[], repository: RepositoryJson = {}): RemoteResolution {
+  return { runnable: [], prerequisites: [], skipped, repository };
+}
+
+/**
+ * Fetch and classify each discovered prerequisite id against the repository
+ * index, collecting runnable guides and structured skips. A planner-included
+ * id that's missing from the repository becomes a `resolution_failed` skip.
+ */
+async function resolvePrerequisites(
+  ids: string[],
+  repository: RepositoryJson,
+  baseUrl: string,
+  options: RemoteResolveOptions
+): Promise<{ prerequisites: ResolvedRemoteGuide[]; skipped: SkippedPackage[] }> {
+  const prerequisites: ResolvedRemoteGuide[] = [];
+  const skipped: SkippedPackage[] = [];
+  for (const prerequisiteId of ids) {
+    const entry = repository[prerequisiteId];
+    if (!entry) {
+      skipped.push({
+        id: prerequisiteId,
+        reason: 'resolution_failed',
+        message: 'Prerequisite missing from repository index',
+      });
+      continue;
+    }
+    const built = await resolveIndexEntry(prerequisiteId, entry, baseUrl, options);
+    if (built.runnable) {
+      prerequisites.push(built.runnable);
+    }
+    if (built.skipped) {
+      skipped.push(built.skipped);
+    }
+  }
+  return { prerequisites, skipped };
 }
 
 /**
@@ -234,14 +298,8 @@ export async function resolveRemotePackage(id: string, options: RemoteResolveOpt
   // Resolve metadata (URLs + manifest) only; the raw content is fetched in
   // buildGuideOrSkip so the injected guide stays byte-faithful.
   const resolution = await resolvePackageById(options.resolverUrl, id);
-
   if (!resolution.ok) {
-    return {
-      runnable: [],
-      prerequisites: [],
-      skipped: [{ id, reason: 'resolution_failed', message: resolution.message }],
-      repository: {},
-    };
+    return skippedResolution([{ id, reason: 'resolution_failed', message: resolution.message }]);
   }
 
   const built = await buildGuideOrSkip(
@@ -251,30 +309,54 @@ export async function resolveRemotePackage(id: string, options: RemoteResolveOpt
     resolution.contentUrl,
     options
   );
-
-  // Target itself skipped (tier mismatch, unsupported type, fetch/validation): no chain.
   if (!built.runnable) {
-    return { runnable: [], prerequisites: [], skipped: built.skipped ? [built.skipped] : [], repository: {} };
+    return skippedResolution(built.skipped ? [built.skipped] : []);
   }
   const target = built.runnable;
 
-  // Resolve dependencies from the CDN index. Without it fall back to running the target alone.
   const index = await fetchRepositoryIndex(options.repoUrl);
   if (!index.ok) {
+    // Without an index we can only run safely if the manifest declares no prereqs.
+    const declaredDepends = resolution.manifest?.depends ?? [];
+    if (declaredDepends.length > 0) {
+      return skippedResolution([
+        resolutionFailedSkip(
+          target,
+          `Repository index unreachable (${index.message}); target declares prerequisites that cannot be verified`
+        ),
+      ]);
+    }
     return { runnable: [target], prerequisites: [], skipped: [], repository: {} };
   }
 
   const repository = indexToRepository(index.packages);
-  const prerequisites: ResolvedRemoteGuide[] = [];
-  const skipped: SkippedPackage[] = [];
-  for (const prerequisiteId of discoverPrerequisiteIds(target.guide, repository)) {
-    const builtPrereq = await resolveIndexEntry(prerequisiteId, repository[prerequisiteId]!, index.baseUrl, options);
-    if (builtPrereq.runnable) {
-      prerequisites.push(builtPrereq.runnable);
-    }
-    if (builtPrereq.skipped) {
-      skipped.push(builtPrereq.skipped);
-    }
+
+  // The recommender resolves across repos but this CLI checks deps against
+  // one index. If the target's home repo isn't the one we fetched, its
+  // `depends` would be invisible to our planner.
+  if (!repository[target.id]) {
+    return skippedResolution(
+      [
+        resolutionFailedSkip(
+          target,
+          `Target "${target.id}" was resolved via the recommender but is not present in the repository index used for dependency lookup`
+        ),
+      ],
+      repository
+    );
+  }
+
+  // Skip the target when any hard `depends` prereq fails to resolve — the
+  // dependent can't run without its prerequisite state.
+  const discovered = discoverPrerequisites(target.guide, repository);
+  if (discovered.errors.length > 0) {
+    return skippedResolution([prerequisiteFailedSkip(target, discovered.errors.join('; '))], repository);
+  }
+
+  const { prerequisites, skipped } = await resolvePrerequisites(discovered.ids, repository, index.baseUrl, options);
+  if (skipped.length > 0) {
+    const brokenIds = skipped.map((s) => s.id).join(', ');
+    return skippedResolution([...skipped, prerequisiteFailedSkip(target, brokenIds)], repository);
   }
 
   return { runnable: [target], prerequisites, skipped, repository };

--- a/src/cli/utils/e2e-package.ts
+++ b/src/cli/utils/e2e-package.ts
@@ -1,0 +1,315 @@
+/**
+ * Remote package resolution for the e2e CLI.
+ *
+ * Thin orchestration over CLI-local clients:
+ *   - `recommender-resolver` resolves a bare ID via the recommender
+ *     (`GET /api/v1/packages/{id}`) for `--package <id>`; the target's `depends`
+ *     prerequisites are then resolved from the CDN index and chained.
+ *   - `repository-client` fetches the CDN `repository.json` for `--remote` and
+ *     for prerequisite resolution.
+ *
+ * Each resolved package is mapped to either a runnable guide or a structured
+ * skip outcome. Network and validation failures never throw; they become skip
+ * outcomes so a batch run degrades gracefully.
+ */
+
+import { validateGuideFromString } from '../../validation';
+import type { RepositoryEntry, RepositoryJson, TestEnvironment } from '../../types/package.types';
+import { resolvePackageById } from './recommender-resolver';
+import { fetchRepositoryIndex, buildPackageFileUrl, type RepositoryPackage } from '../mcp/lib/repository-client';
+import { planGuideExecution } from './guide-chains';
+import type { LoadedGuide } from './file-loader';
+import { resolveTarget } from './e2e-targets';
+import type { CurrentTier } from './manifest-preflight';
+
+const FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Reasons a remote package is skipped before execution. This is the single
+ * source of truth for the skip vocabulary: the e2e command derives its guide
+ * statuses and its pre-run-skip set from this list, so the two never drift.
+ */
+export const REMOTE_SKIP_REASONS = [
+  'skipped_no_auth',
+  'skipped_tier_mismatch',
+  'fetch_failed',
+  'resolution_failed',
+  'validation_failed',
+  'unsupported_type',
+] as const;
+
+/** Why a remote package was skipped instead of run. */
+export type RemoteSkipReason = (typeof REMOTE_SKIP_REASONS)[number];
+
+/** A remote package resolved to a runnable guide against a local target. */
+export interface ResolvedRemoteGuide {
+  id: string;
+  /** `path` is the source content URL; `content` is the raw JSON text. */
+  guide: LoadedGuide;
+  tier: string;
+  instance?: string;
+  /** Grafana URL the guide will be tested against. */
+  targetUrl: string;
+  /** The content.json URL the guide was fetched from. */
+  sourceUrl: string;
+}
+
+/** A remote package that will not be run, with a structured reason. */
+export interface SkippedPackage {
+  id: string;
+  reason: RemoteSkipReason;
+  message: string;
+  sourceUrl?: string;
+  tier?: string;
+}
+
+/** Result of resolving one or more remote packages. */
+export interface RemoteResolution {
+  /** Guides explicitly selected to run (the target for a package; all guides for a batch). */
+  runnable: ResolvedRemoteGuide[];
+  /**
+   * Prerequisite guides available for the planner to auto-include (single-package mode). */
+  prerequisites: ResolvedRemoteGuide[];
+  /** Packages skipped before execution, with reasons. */
+  skipped: SkippedPackage[];
+  /** Repository index for dependency chaining; empty when no index applies. */
+  repository: RepositoryJson;
+  /** Set when the operation could not start at all (e.g. CDN index unreachable). */
+  error?: string;
+}
+
+export interface RemoteResolveOptions {
+  /** Grafana URL configured for local-tier guides. */
+  grafanaUrl: string;
+  /** Tier of the current test environment (from `--tier`). */
+  currentTier: CurrentTier;
+  /** Recommender base URL for `--package <id>` resolution. */
+  resolverUrl: string;
+  /** CDN base URL override for `--remote` batch resolution. */
+  repoUrl?: string;
+}
+
+/** Fetch a URL as raw text with a timeout. Never throws. */
+async function fetchText(url: string): Promise<{ ok: true; text: string } | { ok: false; message: string }> {
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) {
+      return { ok: false, message: `HTTP ${res.status} ${res.statusText}` };
+    }
+    return { ok: true, text: await res.text() };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : 'Unknown error' };
+  }
+}
+
+/**
+ * Given a resolved package's metadata and content URL, apply target resolution,
+ * fetch the content, and validate it — producing either a runnable guide or a
+ * skip outcome. Shared by single- and batch-resolution paths.
+ */
+async function buildGuideOrSkip(
+  id: string,
+  type: string | undefined,
+  testEnvironment: TestEnvironment,
+  contentUrl: string,
+  options: RemoteResolveOptions
+): Promise<{ runnable?: ResolvedRemoteGuide; skipped?: SkippedPackage }> {
+  // Only single guides are testable; paths/journeys (milestone expansion) are deferred.
+  if (type && type !== 'guide') {
+    return {
+      skipped: {
+        id,
+        reason: 'unsupported_type',
+        message: `Package type "${type}" is not yet testable`,
+        sourceUrl: contentUrl,
+        tier: testEnvironment.tier,
+      },
+    };
+  }
+
+  const target = resolveTarget(testEnvironment, { grafanaUrl: options.grafanaUrl, currentTier: options.currentTier });
+  if (!target.runnable) {
+    return {
+      skipped: {
+        id,
+        reason: target.skipReason!,
+        message: target.message ?? 'Guide skipped',
+        sourceUrl: contentUrl,
+        tier: target.tier,
+      },
+    };
+  }
+
+  const fetched = await fetchText(contentUrl);
+  if (!fetched.ok) {
+    return {
+      skipped: {
+        id,
+        reason: 'fetch_failed',
+        message: `Could not fetch content.json: ${fetched.message}`,
+        sourceUrl: contentUrl,
+        tier: target.tier,
+      },
+    };
+  }
+
+  const validation = validateGuideFromString(fetched.text);
+  if (!validation.isValid) {
+    return {
+      skipped: {
+        id,
+        reason: 'validation_failed',
+        message: 'Fetched content.json failed guide schema validation',
+        sourceUrl: contentUrl,
+        tier: target.tier,
+      },
+    };
+  }
+
+  return {
+    runnable: {
+      id,
+      guide: { path: contentUrl, content: fetched.text },
+      tier: target.tier,
+      instance: target.instance,
+      targetUrl: target.grafanaUrl!,
+      sourceUrl: contentUrl,
+    },
+  };
+}
+
+/** Reconstruct an id-keyed RepositoryJson from a fetched CDN index's packages. */
+function indexToRepository(packages: RepositoryPackage[]): RepositoryJson {
+  const repository: RepositoryJson = {};
+  for (const pkg of packages) {
+    const { id, ...entry } = pkg;
+    repository[id] = entry;
+  }
+  return repository;
+}
+
+/** Fetch + classify a single repository-index entry into a runnable guide or a skip. */
+async function resolveIndexEntry(
+  id: string,
+  entry: RepositoryEntry,
+  baseUrl: string,
+  options: RemoteResolveOptions
+): Promise<{ runnable?: ResolvedRemoteGuide; skipped?: SkippedPackage }> {
+  const contentUrl = buildPackageFileUrl(baseUrl, entry.path, 'content.json');
+  if (!contentUrl) {
+    return {
+      skipped: {
+        id,
+        reason: 'fetch_failed',
+        message: 'Could not construct content.json URL',
+        tier: entry.testEnvironment?.tier,
+      },
+    };
+  }
+  return buildGuideOrSkip(id, entry.type, entry.testEnvironment ?? {}, contentUrl, options);
+}
+
+/**
+ * Enumerate the target's transitive `depends` prerequisites by running the
+ * planner as a pure oracle: a throwaway stub loader lets it report
+ * `autoIncludedIds` without re-implementing OR-group / `provides` resolution.
+ * The stub content is never read, only the discovered ids.
+ */
+function discoverPrerequisiteIds(targetGuide: LoadedGuide, repository: RepositoryJson): string[] {
+  const stubLoader = (stubId: string): LoadedGuide => ({ path: stubId, content: '{}' });
+  return planGuideExecution({ guides: [targetGuide], repository, loadGuideById: stubLoader }).autoIncludedIds;
+}
+
+/**
+ * Resolve a single package by bare ID via the recommender service, then resolve
+ * and fetch the target's `depends` prerequisites from the CDN index so the run
+ * chains them the same way selecting a local guide with dependencies does. When
+ * no index is available (unreachable, or the target is absent from it), the
+ * target runs as its own chain.
+ */
+export async function resolveRemotePackage(id: string, options: RemoteResolveOptions): Promise<RemoteResolution> {
+  // Resolve metadata (URLs + manifest) only; the raw content is fetched in
+  // buildGuideOrSkip so the injected guide stays byte-faithful.
+  const resolution = await resolvePackageById(options.resolverUrl, id);
+
+  if (!resolution.ok) {
+    return {
+      runnable: [],
+      prerequisites: [],
+      skipped: [{ id, reason: 'resolution_failed', message: resolution.message }],
+      repository: {},
+    };
+  }
+
+  const built = await buildGuideOrSkip(
+    resolution.id || id,
+    resolution.manifest?.type,
+    resolution.manifest?.testEnvironment ?? {},
+    resolution.contentUrl,
+    options
+  );
+
+  // Target itself skipped (tier mismatch, unsupported type, fetch/validation): no chain.
+  if (!built.runnable) {
+    return { runnable: [], prerequisites: [], skipped: built.skipped ? [built.skipped] : [], repository: {} };
+  }
+  const target = built.runnable;
+
+  // Resolve dependencies from the CDN index. Without it fall back to running the target alone.
+  const index = await fetchRepositoryIndex(options.repoUrl);
+  if (!index.ok) {
+    return { runnable: [target], prerequisites: [], skipped: [], repository: {} };
+  }
+
+  const repository = indexToRepository(index.packages);
+  const prerequisites: ResolvedRemoteGuide[] = [];
+  const skipped: SkippedPackage[] = [];
+  for (const prerequisiteId of discoverPrerequisiteIds(target.guide, repository)) {
+    const builtPrereq = await resolveIndexEntry(prerequisiteId, repository[prerequisiteId]!, index.baseUrl, options);
+    if (builtPrereq.runnable) {
+      prerequisites.push(builtPrereq.runnable);
+    }
+    if (builtPrereq.skipped) {
+      skipped.push(builtPrereq.skipped);
+    }
+  }
+
+  return { runnable: [target], prerequisites, skipped, repository };
+}
+
+/**
+ * Resolve every package in the CDN `repository.json`, returning runnable
+ * local-tier guides plus structured skips. The repository index is returned so
+ * the caller can drive dependency-aware chaining over the same source.
+ */
+export async function resolveRemoteRepository(options: RemoteResolveOptions): Promise<RemoteResolution> {
+  const index = await fetchRepositoryIndex(options.repoUrl);
+  if (!index.ok) {
+    return {
+      runnable: [],
+      prerequisites: [],
+      skipped: [],
+      repository: {},
+      error: `Could not fetch repository index: ${index.message}`,
+    };
+  }
+
+  const repository = indexToRepository(index.packages);
+  const runnable: ResolvedRemoteGuide[] = [];
+  const skipped: SkippedPackage[] = [];
+
+  for (const pkg of index.packages) {
+    const built = await resolveIndexEntry(pkg.id, pkg, index.baseUrl, options);
+    if (built.runnable) {
+      runnable.push(built.runnable);
+    }
+    if (built.skipped) {
+      skipped.push(built.skipped);
+    }
+  }
+
+  return { runnable, prerequisites: [], skipped, repository };
+}


### PR DESCRIPTION
## Overview

#1103 (recommender client) -> #1104 (this PR) -> reporter/command/docs. Sits on the package-aware e2e testing changes.

## Summary

Adds the remote package resolver behind `--package <id>` and `--remote`. `resolveRemotePackage` resolves a bare id via the CLI-local recommender client (#1103), then resolves and fetches the target's transitive `depends` prerequisites from the CDN index so the run chains them the same way a local selection auto-includes its prerequisites. `resolveRemoteRepository` fetches the whole CDN `repository.json` and resolves every package. Each guide maps to either a runnable guide (target resolved to the local Grafana) or a structured skip — network, validation, tier, and unsupported-type failures become skip outcomes rather than throwing, so a batch degrades gracefully.

## What to look at

- `src/cli/utils/e2e-package.ts`:
  - `discoverPrerequisiteIds` runs the existing planner (`planGuideExecution`) as a pure oracle — a throwaway stub loader lets it report `autoIncludedIds` so OR-group / `provides` resolution isn't re-implemented. Only the ids are used; stub content is discarded.
  - Single-package mode returns the target as `runnable` and its prerequisites as a separate `prerequisites` list (the command auto-includes them via the planner, matching local behavior); batch mode returns all guides as `runnable`.
  - Shared `resolveIndexEntry` + `buildGuideOrSkip` keep the single and batch paths consistent. Fallbacks: if the CDN index is unreachable or the target isn't in it, the target runs as its own chain.
  - It consumes the recommender client from #1103 (`./recommender-resolver`) and the CDN client from `mcp/lib/repository-client` — no `src/package-engine` import, preserving the CLI packaging boundary.

## Why

The point of the stack is to test the published ecosystem, which means resolving guides over the network. Mapping every failure to a structured skip (rather than throwing) is what lets `--remote` test a whole repository without one bad package aborting the batch. Reusing the planner for prerequisite discovery avoids duplicating the dependency-resolution logic that already lives in `guide-chains.ts`.

## How to verify

1. Unit tests (`e2e-package.test.ts`) with mocked recommender/CDN/`fetch`: direct + transitive + `provides` prerequisites, cloud/tier skips, fetch/validation/resolution failures, and the target-absent fallback.
2. End-to-end arrives once the command PR wires the flags: `--package <local-tier-id>` resolves the guide, pulls in its `depends` prerequisite, and runs the prerequisite first; `--remote` runs local-tier guides and skips cloud ones.

## Breaking changes

None. New module; consumed by the command PR next.
