### PR TITLE
refactor(security): extract isTrustedFinalUrl trust-gate helper

### DIFF
--- a/src/docs-retrieval/content-fetcher.ts
+++ b/src/docs-retrieval/content-fetcher.ts
@@ -23,7 +23,7 @@ import {
   isGrafanaDocsUrl,
   isLocalhostUrl,
   isInteractiveLearningUrl,
-  isGitHubRawUrl,
+  isTrustedFinalUrl,
   sanitizeHtmlUrl,
 } from '../security';
 import { isDevModeEnabledGlobal } from '../utils/dev-mode';
@@ -130,7 +130,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
     // In production: Only Grafana docs, interactive learning domains, and bundled content
     // In dev mode: Also allows localhost and GitHub raw URLs for testing
     const isDevMode = isDevModeEnabledGlobal();
-    const isTrustedSource = isAllowedContentUrl(url) || (isDevMode && (isLocalhostUrl(url) || isGitHubRawUrl(url)));
+    const isTrustedSource = isTrustedFinalUrl(url);
 
     if (!isTrustedSource) {
       const errorMessage = isDevMode
@@ -673,11 +673,7 @@ async function tryUrlVariations(urls: string[], options: ContentFetchOptions): P
           // (e.g., Grafana Cloud). Fall back to the requested URL which was
           // already validated before entering this function.
           const finalUrl = response.url || urlVariation;
-          const isDevMode = isDevModeEnabledGlobal();
-          const isFinalUrlTrusted =
-            isAllowedContentUrl(finalUrl) ||
-            (isDevMode && isLocalhostUrl(finalUrl)) ||
-            (isDevMode && isGitHubRawUrl(finalUrl));
+          const isFinalUrlTrusted = isTrustedFinalUrl(finalUrl);
 
           if (!isFinalUrlTrusted) {
             console.warn(`URL variation ${urlVariation} redirected to untrusted URL: ${finalUrl}`);
@@ -761,11 +757,7 @@ async function fetchRawHtml(url: string, options: ContentFetchOptions): Promise<
         // When empty, fall back to the original request URL which was already
         // validated at the initial trust gate in fetchContent().
         const finalUrl = response.url || url;
-        const isDevMode = isDevModeEnabledGlobal();
-        const isFinalUrlTrusted =
-          isAllowedContentUrl(finalUrl) ||
-          (isDevMode && isLocalhostUrl(finalUrl)) ||
-          (isDevMode && isGitHubRawUrl(finalUrl));
+        const isFinalUrlTrusted = isTrustedFinalUrl(finalUrl);
 
         if (!isFinalUrlTrusted) {
           console.warn(
@@ -895,11 +887,7 @@ async function fetchRawHtml(url: string, options: ContentFetchOptions): Promise<
                 errorType: 'other',
               };
             } else {
-              const isDevMode = isDevModeEnabledGlobal();
-              const isRedirectTrusted =
-                isAllowedContentUrl(redirectUrl.href) ||
-                (isDevMode && isLocalhostUrl(redirectUrl.href)) ||
-                (isDevMode && isGitHubRawUrl(redirectUrl.href));
+              const isRedirectTrusted = isTrustedFinalUrl(redirectUrl.href);
 
               if (!isRedirectTrusted) {
                 console.warn(`Redirect target not in trusted domain list: ${redirectUrl.href}`);

--- a/src/docs-retrieval/validation-integration.test.ts
+++ b/src/docs-retrieval/validation-integration.test.ts
@@ -11,6 +11,7 @@ global.fetch = jest.fn();
 jest.mock('../security', () => ({
   ...jest.requireActual('../security'),
   isAllowedContentUrl: jest.fn().mockReturnValue(true),
+  isTrustedFinalUrl: jest.fn().mockReturnValue(true),
   isInteractiveLearningUrl: jest.fn().mockReturnValue(false),
   isGrafanaDocsUrl: jest.fn().mockReturnValue(false),
   isLocalhostUrl: jest.fn().mockReturnValue(false),

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -17,6 +17,7 @@ export {
   isGitHubRawUrl,
   isLocalhostUrl,
   isAllowedContentUrl,
+  isTrustedFinalUrl,
   validateTutorialUrl,
   validateRedirectPath,
   isYouTubeDomain,

--- a/src/security/url-validator.test.ts
+++ b/src/security/url-validator.test.ts
@@ -10,6 +10,7 @@ import {
   validateTutorialUrl,
   validateRedirectPath,
   isGitHubRawUrl,
+  isTrustedFinalUrl,
 } from './url-validator';
 
 // Mock the dev-mode module
@@ -457,6 +458,39 @@ describe('GitHub URL validators', () => {
     it('should reject invalid URLs', () => {
       expect(isGitHubRawUrl('not a url')).toBe(false);
       expect(isGitHubRawUrl('')).toBe(false);
+    });
+  });
+
+  describe('isTrustedFinalUrl', () => {
+    beforeEach(() => {
+      jest.mocked(isDevModeEnabledGlobal).mockReturnValue(false);
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should trust allowed content URLs regardless of dev mode', () => {
+      expect(isTrustedFinalUrl('https://grafana.com/docs/grafana/latest/')).toBe(true);
+      expect(isTrustedFinalUrl('https://interactive-learning.grafana.net/guide/')).toBe(true);
+      expect(isTrustedFinalUrl('bundled:welcome-to-grafana')).toBe(true);
+    });
+
+    it('should reject localhost and GitHub raw URLs in production mode', () => {
+      expect(isTrustedFinalUrl('http://localhost:3000/docs')).toBe(false);
+      expect(isTrustedFinalUrl('https://raw.githubusercontent.com/grafana/repo/main/file.json')).toBe(false);
+    });
+
+    it('should trust localhost and GitHub raw URLs only in dev mode', () => {
+      jest.mocked(isDevModeEnabledGlobal).mockReturnValue(true);
+      expect(isTrustedFinalUrl('http://localhost:3000/anything')).toBe(true);
+      expect(isTrustedFinalUrl('https://raw.githubusercontent.com/grafana/repo/main/file.json')).toBe(true);
+    });
+
+    it('should reject untrusted domains even in dev mode', () => {
+      jest.mocked(isDevModeEnabledGlobal).mockReturnValue(true);
+      expect(isTrustedFinalUrl('https://evil.com/fake-docs')).toBe(false);
+      expect(isTrustedFinalUrl('https://grafana.com.evil.com/docs')).toBe(false);
     });
   });
 });

--- a/src/security/url-validator.ts
+++ b/src/security/url-validator.ts
@@ -333,6 +333,21 @@ export function isGitHubRawUrl(urlString: string): boolean {
 }
 
 /**
+ * Single source of truth for the content-fetch trust gate: a URL is trusted if
+ * it is an allowed content URL, or — in dev mode only — a localhost or GitHub
+ * raw URL. Used by the fetcher before fetching and after every redirect.
+ */
+export function isTrustedFinalUrl(urlString: string): boolean {
+  if (isAllowedContentUrl(urlString)) {
+    return true;
+  }
+  if (isDevModeEnabledGlobal()) {
+    return isLocalhostUrl(urlString) || isGitHubRawUrl(urlString);
+  }
+  return false;
+}
+
+/**
  * Default redirect path used when validation fails or input is missing.
  * Always redirects to Grafana home page as a safe fallback.
  */


### PR DESCRIPTION
## Summary

Extracts the content-fetch trust predicate into a single `isTrustedFinalUrl(url)` helper in the security tier. The check — *allowed content URL, or (in dev mode only) localhost / GitHub-raw* — was inlined in four places and is now defined once. Behavior is identical; this is a structural change only.

First PR of the content-fetcher modularization stack ([plan supersedes the closed monolithic #800](https://github.com/grafana/grafana-pathfinder-app/pull/800)). It lands the shared security helper that the later transport-extraction PRs depend on.

## Why

Four copies of a security predicate is a convergent re-bugging risk: a fix to the trust logic has to be applied to all four or they silently diverge. The duplication sat across the initial gate in `fetchContent` plus the post-fetch and post-redirect re-validations in `tryUrlVariations` and `fetchRawHtml`. Centralizing the boolean removes that hazard without touching any call site's surrounding warn / continue / error handling.

## What to look at

- **[`src/security/url-validator.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8969d265f2a6390ca398ab73895ff46eec17ce5c/src/security/url-validator.ts)** — the new `isTrustedFinalUrl`. It already had `isDevModeEnabledGlobal` imported, so this stays a Tier-1 module with no new dependency. Confirm the dev-mode branch (`isLocalhostUrl || isGitHubRawUrl`) matches the original inlined predicate exactly.
- **[`src/docs-retrieval/content-fetcher.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8969d265f2a6390ca398ab73895ff46eec17ce5c/src/docs-retrieval/content-fetcher.ts)** — four sites now call the helper. Each keeps its own logging/error shape; only the boolean was replaced. Note `fetchContent` still computes `isDevMode` locally because the error *message* (not the gate) branches on it.
- **[`validation-integration.test.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8969d265f2a6390ca398ab73895ff46eec17ce5c/src/docs-retrieval/validation-integration.test.ts)** — the security mock previously stubbed `isAllowedContentUrl → true` to bypass the gate. The gate decision moved to `isTrustedFinalUrl`, so the mock now overrides *that* seam. Assertions and intent are unchanged — this looks like a behavior edit but is only the mock tracking the moved seam.

## How to verify

1. With the panel open, load a real Grafana docs guide — content renders as before (trusted path still accepted).
2. Attempt to load an untrusted URL (e.g. `https://example.com/x`) — still rejected with the "Only Grafana.com documentation…" message.
3. In dev mode, confirm a `localhost` docs URL and a `raw.githubusercontent.com` URL still load; in production mode, confirm both are rejected.

## Breaking changes

None. This change is structural and fully reversible — no contract surfaces (error-type enum, fallback order, storage keys, URL grammar) are touched.

## Out of scope

- Extraction of the transport, metadata, bundled-loader, cover-page, backend-guide, and package-content modules — handled in the subsequent PRs of this stack.
- Consolidating the duplicated `content.json → unstyled.html` fallback ladder — its own later PR; `unstyled.html` removal is deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
