### PR TITLE
fix(ci): post e2e results as PR comment instead of pushing to gh-pages

### DIFF
--- a/.github/scripts/build-playwright-comment.js
+++ b/.github/scripts/build-playwright-comment.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const reportsDir = 'all-reports';
+
+function readSummary(file) {
+  const content = fs.readFileSync(file, 'utf8');
+  const value = (key) => (content.match(new RegExp(`^${key}=(.*)$`, 'm')) || [])[1]?.trim() || '';
+  return {
+    image: value('GRAFANA_IMAGE'),
+    version: value('GRAFANA_VERSION'),
+    outcome: value('OUTPUT'),
+  };
+}
+
+function main() {
+  if (!fs.existsSync(reportsDir) || !fs.statSync(reportsDir).isDirectory()) {
+    console.error(`No reports directory found at "${reportsDir}"`);
+    process.exit(1);
+  }
+
+  const rows = fs
+    .readdirSync(reportsDir)
+    .map((entry) => path.join(reportsDir, entry, 'summary.txt'))
+    .filter((file) => fs.existsSync(file))
+    .map(readSummary)
+    .sort((a, b) => b.version.localeCompare(a.version, undefined, { numeric: true }))
+    .map(({ image, version, outcome }) => `| ${image} | ${version} | ${outcome === 'success' ? '✅' : '❌'} |`);
+
+  const table = [
+    '### Playwright test results',
+    '| Image name | Version | Result |',
+    '|:---------- |:------- |:------: |',
+    ...rows,
+  ].join('\n');
+
+  console.log(table);
+}
+
+main();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,18 +414,49 @@ jobs:
       #     path: grafana-server.log
       #     retention-days: 5
 
+  # Aggregates the per-version e2e summaries and posts them as a single PR comment.
+  # We deliberately do NOT deploy to the gh-pages branch: the org-wide "Signed Commits"
+  # ruleset (required_signatures on ~ALL branches) rejects the unsigned commit that the
+  # shared deploy-report-pages action pushes, which reddens every PR. The hosted report
+  # carried no content anyway because upload-report is false in the matrix job above.
   publish-report:
     if: ${{ always() && !cancelled() }}
     needs: [playwright-tests]
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Deploy to GitHub Pages
-      pull-requests: write # Comment on PRs with report links
+      contents: read # Checkout to access the comment-generation script
+      pull-requests: write # Comment on PRs with the e2e results table
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-      - name: Publish report
-        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@4698961fa64137fcac207108397ebe8a738a33d1
+
+      - name: Download report summaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: all-reports
+          pattern: gf-playwright-report-*
+          merge-multiple: true
+
+      - name: Generate results table
+        id: results
+        run: |
+          if [ ! -d all-reports ]; then
+            echo "No report artifacts found; skipping summary."
+            exit 0
+          fi
+          table=$(node .github/scripts/build-playwright-comment.js)
+          {
+            echo "table<<EOF"
+            echo "$table"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "$table" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment PR with results
+        if: ${{ github.event.number != null && steps.results.outputs.table != '' }}
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          comment-tag: gf-playwright-test-results
+          create-if-not-exists: true
+          message: ${{ steps.results.outputs.table }}


### PR DESCRIPTION
## Summary

The `publish-report` e2e job has been failing on every PR. Root cause: the shared `grafana/plugin-actions/.../deploy-report-pages` action pushes an **unsigned** commit to the `gh-pages` branch, and the org-wide "Signed Commits" ruleset rejects it. This PR replaces that action with a self-contained step that posts the per-version results table as a PR comment and creates no git commit, so the signature rule no longer applies.

## Why

The org ruleset "Signed Commits" (`source_type: Organization`) targets `~ALL` branches with the `required_signatures` rule and has **no bypass actors**. Every branch — including `gh-pages` — therefore requires a verified signature on each commit. The shared deploy action commits via plain `git` in a shell step (committer `github-actions[bot]`, then a second cleanup commit as `grafana-plugins-platform-bot[bot]`), neither of which is signed. GitHub rejects the push:

```
remote: error: GH013: Repository rule violations found for refs/heads/gh-pages.
remote: - Commits must have verified signatures.
```

That is the entire failure: every other job (lint, typecheck, build, all e2e legs, CI Gate) passes; only `publish-report` goes red.

Two facts make the fix low-risk:

1. **The hosted report was already empty.** The matrix job calls `upload-report-artifacts` with `upload-report: false`, which strips the HTML report and uploads only a `summary.txt`. So `gh-pages` was only ever receiving empty report folders — the "Report" column in the PR comment was already blank.
2. **The PR comment already worked.** The shared action posts the comment *before* the failing push, so the only deliverable of value was landing regardless; the push failure just reddened the run afterward.

Three fix paths were considered:

- **Deploy via the Pages artifact API** (`upload-pages-artifact` + `deploy-pages`): avoids a commit, but needs a repo Pages-source change and only matters if reports are actually hosted (they aren't).
- **Commit to `gh-pages` through the GitHub API** (auto-signed by GitHub's web-flow key): keeps the branch model, but is the most work and is pointless while `upload-report: false`.
- **Drop the `gh-pages` deploy, keep the comment** (this PR): smallest change, preserves the only real output, removes the failing commit entirely.

The third was chosen because it matches the current reality — no report content is published, and `publish-report` is not a required status check, so the only harm of the failure was red noise that also blocks bots (e.g. Renovate auto-merge) which gate on all-green.

## What to look at

- `.github/workflows/ci.yml` — the rewritten `publish-report` job. It now downloads the `gf-playwright-report-*` artifacts, runs a small script to build the table, writes it to the job summary, and upserts a PR comment tagged `gf-playwright-test-results`. The shared action call and the `contents: write` permission are gone (`contents` is now `read`, only for checkout). Note the comment is now updated in place by tag rather than deleted-and-recreated, so it no longer jumps to the bottom on each run.
- [`.github/scripts/build-playwright-comment.js`](https://github.com/grafana/grafana-pathfinder-app/blob/dacc823e046366b06e3eea9cfdc18279af423add/.github/scripts/build-playwright-comment.js) — reads each artifact's `summary.txt` and emits a sorted `Image name | Version | Result` markdown table. The report-link column was intentionally dropped because no report is hosted anymore.

## How to verify

1. On this PR, confirm the `publish-report` job succeeds (it failed on recent PRs with the `GH013` signature error).
2. Confirm a single "Playwright test results" comment is posted/updated on this PR with a row per Grafana version and a ✅/❌ result.
3. Confirm no new commit lands on the `gh-pages` branch from this run.

## Breaking changes

None functional. The plugin and its build are untouched — this only changes how e2e results are reported. Behavioral notes:

- The `gh-pages` branch no longer receives deploys. Existing (empty) content there is left as-is; it can be cleaned up separately if desired.
- Anyone with a bookmarked `*.github.io/.../<date>/<pr#>/` report URL will no longer get new content — but those pages carried no report to begin with under `upload-report: false`.

## Reversibility

Fully reversible. Reverting this commit restores the `deploy-report-pages` call and the `contents: write` permission. No state migration is involved and the `gh-pages` branch is not modified by this PR, so a revert returns the job to its prior (failing) behavior with nothing to undo.

## Out of scope

- Hosting browsable HTML reports again. If that becomes desirable, it's a separate change: flip `upload-report: true` in the matrix job **and** deploy via a signature-safe mechanism (Pages artifact API, or a GitHub-API commit that GitHub auto-signs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
