### PR TITLE
fix(pr-tester): clamp stale persisted test mode to a mode the PR supports

### DIFF
--- a/src/components/PrTester/PrTester.tsx
+++ b/src/components/PrTester/PrTester.tsx
@@ -9,6 +9,7 @@ import {
   indexPrFiles,
   type PathPackageBuildResult,
 } from './pr-path-package';
+import { resolveEffectiveTestMode, type TestMode } from './pr-tester-mode';
 import type { ManifestJson } from '../../types/package.types';
 import type { PackageOpenInfo } from '../../types/content-panel.types';
 import { testIds } from '../../constants/testIds';
@@ -32,7 +33,6 @@ export interface PrTesterProps {
 }
 
 type FetchState = 'idle' | 'fetching' | 'fetched' | 'error';
-type TestMode = 'single' | 'all' | 'path';
 
 /**
  * PR Tester — load JSON files from a GitHub PR and test them locally.
@@ -370,6 +370,18 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
     });
   }, [contentByDir, pathManifests, selectedPath, contentByPackageId]);
 
+  // testMode is restored from localStorage and can outlive the PR it was
+  // chosen for. A single-guide PR hides the mode selector, so a stale 'path'
+  // would strand the panel with no way back to 'single'.
+  const effectiveTestMode: TestMode = useMemo(
+    () =>
+      resolveEffectiveTestMode(testMode, {
+        manifestsLoading,
+        hasAnyPathPackage: pathManifestEntries.length > 0,
+      }),
+    [manifestsLoading, testMode, pathManifestEntries.length]
+  );
+
   const handleFetchPr = useCallback(async () => {
     const cleanedUrl = prUrl.trim();
 
@@ -405,18 +417,18 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
   }, [prUrl]);
 
   const handleTestGuide = useCallback(() => {
-    if (testMode === 'single') {
+    if (effectiveTestMode === 'single') {
       if (!currentFile) {
         return;
       }
       onOpenDocsPage(currentFile.rawUrl, currentFile.directoryName);
       setTestSuccess(true);
-    } else if (testMode === 'all') {
+    } else if (effectiveTestMode === 'all') {
       contentFiles.forEach((file) => {
         onOpenDocsPage(file.rawUrl, file.directoryName);
       });
       setTestSuccess(true);
-    } else if (testMode === 'path') {
+    } else if (effectiveTestMode === 'path') {
       if (!pathBuild || !pathBuild.ok) {
         return;
       }
@@ -425,7 +437,7 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
     }
 
     successTimeoutRef.current = setTimeout(() => setTestSuccess(false), 2000);
-  }, [contentFiles, currentFile, onOpenDocsPage, pathBuild, testMode]);
+  }, [contentFiles, currentFile, onOpenDocsPage, pathBuild, effectiveTestMode]);
 
   const handleUrlChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const newUrl = e.currentTarget.value;
@@ -493,9 +505,9 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
   ];
 
   const getActionButtonText = () => {
-    if (testMode === 'single') {
+    if (effectiveTestMode === 'single') {
       return 'Test guide';
-    } else if (testMode === 'all') {
+    } else if (effectiveTestMode === 'all') {
       return `Open all ${contentFiles.length} guides`;
     } else {
       return 'Test as learning path';
@@ -503,10 +515,10 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
   };
 
   const isActionDisabled = (() => {
-    if (testMode === 'single') {
+    if (effectiveTestMode === 'single') {
       return !currentFile;
     }
-    if (testMode === 'all') {
+    if (effectiveTestMode === 'all') {
       return contentFiles.length === 0;
     }
     return !pathBuild || !pathBuild.ok;
@@ -517,7 +529,7 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
    * warning box so the author knows why "Test as learning path" is disabled.
    */
   const pathErrorMessage = useMemo(() => {
-    if (!hasFetched || testMode !== 'path') {
+    if (!hasFetched || effectiveTestMode !== 'path') {
       return null;
     }
     if (manifestsLoading) {
@@ -542,7 +554,7 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
       return `Missing milestone content in this PR: ${pathBuild.missingMilestones.join(', ')}. Include each milestone's content.json in the PR.`;
     }
     return null;
-  }, [hasFetched, testMode, manifestsLoading, hasAnyPathPackage, pathBuild]);
+  }, [hasFetched, effectiveTestMode, manifestsLoading, hasAnyPathPackage, pathBuild]);
 
   return (
     <div className={styles.formGroup} data-testid={testIds.prTester.form}>
@@ -578,11 +590,11 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
       {hasFetched && (hasMultipleContentFiles || hasAnyPathPackage) && (
         <div className={styles.modeContainer}>
           <label className={styles.label}>Test mode</label>
-          <RadioButtonGroup options={modeOptions} value={testMode} onChange={handleTestModeChange} fullWidth />
+          <RadioButtonGroup options={modeOptions} value={effectiveTestMode} onChange={handleTestModeChange} fullWidth />
         </div>
       )}
 
-      {hasFetched && hasMultipleContentFiles && testMode === 'single' && (
+      {hasFetched && hasMultipleContentFiles && effectiveTestMode === 'single' && (
         <div className={styles.selectContainer}>
           <label className={styles.label}>Guide to test</label>
           <Combobox
@@ -595,7 +607,7 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
       )}
 
       {/* Path mode: pick a manifest + show its milestones in manifest order */}
-      {hasFetched && testMode === 'path' && (
+      {hasFetched && effectiveTestMode === 'path' && (
         <div className={styles.pathOrderContainer}>
           {manifestsLoading && (
             <p className={styles.helpText}>
@@ -649,7 +661,7 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
         </div>
       )}
 
-      {hasFetched && testMode === 'all' && (
+      {hasFetched && effectiveTestMode === 'all' && (
         <div className={styles.allGuidesPreview}>
           <label className={styles.label}>Will open {contentFiles.length} guides:</label>
           <ul className={styles.guidesList}>
@@ -664,7 +676,7 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
         </div>
       )}
 
-      {hasFetched && hasSingleContentFile && testMode === 'single' && currentFile && (
+      {hasFetched && hasSingleContentFile && effectiveTestMode === 'single' && currentFile && (
         <div className={styles.readyText}>
           <Icon name="check" />
           Ready: {currentFile.directoryName}

--- a/src/components/PrTester/pr-tester-mode.test.ts
+++ b/src/components/PrTester/pr-tester-mode.test.ts
@@ -1,0 +1,23 @@
+import { resolveEffectiveTestMode } from './pr-tester-mode';
+
+describe('resolveEffectiveTestMode', () => {
+  it('clamps a stale path mode to single when the PR has no path package', () => {
+    expect(resolveEffectiveTestMode('path', { manifestsLoading: false, hasAnyPathPackage: false })).toBe('single');
+  });
+
+  it('keeps path mode when the PR actually has a path package', () => {
+    expect(resolveEffectiveTestMode('path', { manifestsLoading: false, hasAnyPathPackage: true })).toBe('path');
+  });
+
+  it('does not clamp while manifests are still loading', () => {
+    expect(resolveEffectiveTestMode('path', { manifestsLoading: true, hasAnyPathPackage: false })).toBe('path');
+  });
+
+  it('leaves single mode untouched', () => {
+    expect(resolveEffectiveTestMode('single', { manifestsLoading: false, hasAnyPathPackage: false })).toBe('single');
+  });
+
+  it('leaves all mode untouched even without a path package', () => {
+    expect(resolveEffectiveTestMode('all', { manifestsLoading: false, hasAnyPathPackage: false })).toBe('all');
+  });
+});

--- a/src/components/PrTester/pr-tester-mode.ts
+++ b/src/components/PrTester/pr-tester-mode.ts
@@ -1,0 +1,20 @@
+export type TestMode = 'single' | 'all' | 'path';
+
+export interface TestModeContext {
+  /** Manifests are still being fetched, so path availability is not yet known. */
+  manifestsLoading: boolean;
+  /** The PR contains at least one path/journey manifest. */
+  hasAnyPathPackage: boolean;
+}
+
+/**
+ * Clamp a persisted test mode to one the current PR can honor. The skip while
+ * manifests load is load-bearing: `hasAnyPathPackage` is still false mid-fetch
+ * for a genuine path PR, so clamping then would drop a valid 'path' selection.
+ */
+export function resolveEffectiveTestMode(testMode: TestMode, ctx: TestModeContext): TestMode {
+  if (!ctx.manifestsLoading && testMode === 'path' && !ctx.hasAnyPathPackage) {
+    return 'single';
+  }
+  return testMode;
+}


### PR DESCRIPTION
## Summary

The PR tester (dev mode) could get stranded in **Learning path** mode for a single-guide PR. **Problem:** `testMode` is restored from `localStorage` and outlives the PR it was chosen for. **Root cause:** the mode selector only renders when the PR has multiple content files or a path/journey manifest, so a single-`content.json` PR with a stale `'path'` value showed the "No path or journey manifest found" warning with no control to switch back to `'single'`. **Fix:** derive an `effectiveTestMode` that clamps `'path'` to `'single'` when the PR has no path package, and drive the whole panel off it.

## What to look at

- `src/components/PrTester/pr-tester-mode.ts` — the new pure `resolveEffectiveTestMode` rule. Note the `manifestsLoading` guard looks like it could be dropped but is load-bearing: `hasAnyPathPackage` is still `false` mid-fetch for a genuine path PR, so clamping during load would discard a valid `'path'` selection. The persisted `testMode` (the user's raw choice) is intentionally left untouched, so reloading a real path PR restores `'path'`.
- `src/components/PrTester/PrTester.tsx` — every render branch, the action button, the selector `value`, and the path warning now read `effectiveTestMode` instead of `testMode`. `setTestMode`/persistence still use the raw value.

## How to verify

1. In dev mode, open the **PR tester**, paste a PR that has a `path`/`journey` manifest, and test it as a **Learning path** (this persists `'path'`).
2. Now paste a single-guide PR (one `content.json`, no manifest), e.g. `https://github.com/grafana/interactive-tutorials/pull/394`, and fetch it.
3. Confirm the panel falls back to single-guide testing — the action button reads **Test guide**, the "Ready: …" line shows, and the "No path or journey manifest found" dead-end is gone.
4. Paste the path PR again and confirm it still opens as a learning path (the clamp did not permanently overwrite the persisted mode).

## Breaking changes

None. Storage keys, persisted values, and their semantics are unchanged — `testMode` is still persisted as the user's raw choice; only the *rendered* mode is clamped.

Fixes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
