### PR TITLE
fix(module): two-tab gating PR - align controller/executor entry gates with production mount policy

### DIFF
--- a/docs/developer/CROSS_TAB_CONTROLLER.md
+++ b/docs/developer/CROSS_TAB_CONTROLLER.md
@@ -79,6 +79,10 @@ The transport degrades to a no-op where `BroadcastChannel` is unavailable. The
 provider is inert until a tab actually drives one; the executor, however, is a
 DOM sink and is **not** unconditionally safe to install — see the trust model.
 
+## Entry gate and mount policy
+
+Both the controller overlay (`?controller=1` path) and the live-tab executor install are gated on `shouldMountSidebar(pathfinderEnabled, mainVariant, after24hVariant)` — the same policy that controls whether the main Pathfinder sidebar mounts. Using only `pathfinderEnabled` would allow the controller and executor to appear for users in the experiment control group, where no Pathfinder surface exists. Because the executor drives the user's authenticated Grafana DOM, it must follow the same exclusion logic as the rest of the plugin.
+
 ## Security / trust model
 
 `BroadcastChannel` is shared by every script running on the same origin, so a

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -135,12 +135,12 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
 
   // Interactive controller (?doc=<guide>&controller=1): the same overlay, but
   // step actions stay visible so this tab can drive the originating Grafana tab.
-  // Gated on pathfinderEnabled — the controller drives the user's authenticated
-  // Grafana, so it must not mount when the plugin is disabled (F-1062-1).
-  if (TWOTAB_CONTROLLER_ENABLED && docsParam && controllerParam && pathfinderEnabled) {
+  // Gated on shouldMountSidebar — the controller drives the user's authenticated
+  // Grafana, so it must not mount when the plugin is disabled.
+  if (TWOTAB_CONTROLLER_ENABLED && docsParam && controllerParam && shouldMountSidebar(pathfinderEnabled, mainVariant, after24hVariant)) {
     if (!document.getElementById('pathfinder-controller-root')) {
       // Claim the id synchronously, before the dynamic import, so a second
-      // plugin.init can't race past the guard and double-mount (F-1062-2).
+      // plugin.init can't race past the guard and double-mount.
       const container = document.createElement('div');
       container.id = 'pathfinder-controller-root';
       document.body.appendChild(container);
@@ -160,10 +160,10 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
 
   // Live tab only (the controller tab returned early above): load the cross-tab
   // executor so a controller tab can drive this Grafana DOM. Gated on
-  // pathfinderEnabled (T1 PART B) — the executor is a same-origin DOM sink and
-  // must not be installed for disabled users. Lazy import keeps the interactive
-  // engine out of the entry bundle.
-  if (TWOTAB_CONTROLLER_ENABLED && pathfinderEnabled) {
+  // shouldMountSidebar — the executor is a same-origin DOM sink and must not be
+  // installed for users the experiment has excluded. Lazy import keeps the
+  // interactive engine out of the entry bundle.
+  if (TWOTAB_CONTROLLER_ENABLED && shouldMountSidebar(pathfinderEnabled, mainVariant, after24hVariant)) {
     import('./integrations/cross-tab/live-tab-executor')
       .then(({ installLiveTabExecutor }) => installLiveTabExecutor())
       .catch((err) => console.error('[Pathfinder] Failed to load cross-tab executor:', err));

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -137,7 +137,12 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   // step actions stay visible so this tab can drive the originating Grafana tab.
   // Gated on shouldMountSidebar — the controller drives the user's authenticated
   // Grafana, so it must not mount when the plugin is disabled.
-  if (TWOTAB_CONTROLLER_ENABLED && docsParam && controllerParam && shouldMountSidebar(pathfinderEnabled, mainVariant, after24hVariant)) {
+  if (
+    TWOTAB_CONTROLLER_ENABLED &&
+    docsParam &&
+    controllerParam &&
+    shouldMountSidebar(pathfinderEnabled, mainVariant, after24hVariant)
+  ) {
     if (!document.getElementById('pathfinder-controller-root')) {
       // Claim the id synchronously, before the dynamic import, so a second
       // plugin.init can't race past the guard and double-mount.


### PR DESCRIPTION
## Summary

Gates the two-tab controller overlay and live-tab executor install on the same
`shouldMountSidebar()` policy as the rest of Pathfinder, rather than only on
`pathfinderEnabled`. This ensures the controller and executor never mount in
sessions where the main sidebar is suppressed by experiment variant or 24h
conditions.

This is gate item 4 of 5 required before the two-tab controller (epic #1133)
can be re-enabled.

## What to look at

- `src/module.tsx` — two gate conditions updated: the controller overlay entry
  (the `?controller=1` early-return path) and the live-tab executor install.
  Both now use `shouldMountSidebar(pathfinderEnabled, mainVariant, after24hVariant)`
  instead of bare `pathfinderEnabled`.
- `docs/developer/CROSS_TAB_CONTROLLER.md` — new note documenting the gate
  policy rationale.

## Why

`shouldMountSidebar` enforces the production experiment rollout logic: it checks
`pathfinderEnabled`, `mainVariant`, and `after24hVariant`. Using only
`pathfinderEnabled` meant the controller and executor could mount for users in
the experiment control group — sessions where no Pathfinder surface would appear.
The controller drives the user's authenticated Grafana DOM, so it must follow
the same exclusion policy as the rest of the plugin.

## How to verify

1. Open `src/module.tsx` and confirm both `TWOTAB_CONTROLLER_ENABLED` gate
   conditions use `shouldMountSidebar(...)` as the innermost check rather than
   bare `pathfinderEnabled`.
2. In a local dev build, confirm the plugin still loads and the sidebar mounts
   normally (the flag is dark, so the controller code path is unreachable, but
   the non-controller path must be unaffected).

## Breaking changes

None. The feature is currently disabled (`TWOTAB_CONTROLLER_ENABLED = false`),
so the gate change has no user-visible effect until the feature is re-enabled.

## Out of scope

The remaining 4 gate items (#1139, #1140, #1143, #1142) are tracked separately
and must also be resolved before flipping `TWOTAB_CONTROLLER_ENABLED` to `true`.

Closes #1141
Refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
