### PR TITLE
fix(cross-tab): two-tab gating PR — add per-run IDs to prevent stale cancel/retry settling

### DIFF
--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -175,6 +175,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
     // Set when the user cancels a controller-mode run, so the awaiting branch
     // distinguishes a deliberate cancel from a disconnect/failure (skips the toast).
     const controllerCancelledRef = useRef(false);
+    const activeRunIdRef = useRef<string>('');
     const [currentStepIndex, setCurrentStepIndex] = useState(0);
     const [failedStepIndex, setFailedStepIndex] = useState(-1);
     const [currentStepStatus, setCurrentStepStatus] = useState<'waiting' | 'timeout' | 'completed'>('waiting');
@@ -575,12 +576,12 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
         // that per click on top of its staged replay, so we keep the entry gate
         // only and let each sub-action fail on the live tab if a prereq regressed.
         controllerCancelledRef.current = false;
-        // Wait for the user to walk through every guided step on the live tab
-        // before marking complete, rather than completing optimistically.
+        const runId = crypto.randomUUID();
+        activeRunIdRef.current = runId;
         setIsExecuting(true);
         // Subscribe before posting so the first progress tick the live tab emits
         // can't arrive before we're listening.
-        const stopProgress = controllerChannel.onStepProgress(renderedStepId, (index) => {
+        const stopProgress = controllerChannel.onStepProgress(renderedStepId, runId, (index) => {
           setCurrentStepIndex(index);
           setCurrentStepStatus('waiting');
         });
@@ -588,6 +589,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
           kind: 'step-command',
           phase: 'do',
           stepId: renderedStepId,
+          runId,
           action: {
             targetAction: 'guided',
             refTarget: '',
@@ -602,7 +604,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
           },
         });
         try {
-          const finished = await controllerChannel.awaitStepComplete(renderedStepId);
+          const finished = await controllerChannel.awaitStepComplete(renderedStepId, runId);
           if (finished) {
             persistCompletion();
             if (onStepComplete && stepId) {
@@ -686,20 +688,17 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
     // Handle cancel during guided execution
     const handleCancel = useCallback(async () => {
       // In controller mode the run is remote: release the awaitStepComplete waiter
-      // (F-1073-1) so the await resolves and the spinner clears, and flag the
-      // cancel so the awaiting branch skips its "not completed" toast.
+      // so the await resolves and the spinner clears, and flag the cancel so the
+      // awaiting branch skips its "not completed" toast.
       controllerCancelledRef.current = true;
-      controllerChannel?.cancelStepComplete(renderedStepId);
-      // Cancel the current guided step
-      // guidedHandler.cancel() already clears highlights via its own navigationManager
+      controllerChannel?.cancelStepComplete(renderedStepId, activeRunIdRef.current);
       guidedHandler.cancel();
 
-      // Reset to initial state - simply revert to "Start guided interaction" button
       setIsExecuting(false);
       setExecutionError(null);
       setCurrentStepIndex(0);
       setCurrentStepStatus('waiting');
-      setWasCancelled(false); // Don't show error state - just return to start
+      setWasCancelled(false);
     }, [guidedHandler, controllerChannel, renderedStepId]);
 
     const isAnyActionRunning = isExecuting || isCurrentlyExecuting;

--- a/src/components/interactive-tutorial/interactive-multi-step.tsx
+++ b/src/components/interactive-tutorial/interactive-multi-step.tsx
@@ -205,6 +205,7 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
     // Set when the user cancels a controller-mode run, so the awaiting branch
     // distinguishes a deliberate cancel from a disconnect/failure (skips the toast).
     const controllerCancelledRef = React.useRef(false);
+    const activeRunIdRef = React.useRef<string>('');
 
     // Handle reset trigger from parent section
     useEffect(() => {
@@ -269,13 +270,12 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
 
     // Create cancellation handler
     const handleMultiStepCancel = useCallback(() => {
-      isCancelledRef.current = true; // Set ref for immediate access
-      // The running loop will detect this and break
+      isCancelledRef.current = true;
       // In controller mode the run is remote: release the awaitStepComplete waiter
-      // (F-1073-1) so the spinner clears, and flag the cancel so the awaiting
-      // branch skips its "not completed" toast.
+      // so the spinner clears, and flag the cancel so the awaiting branch skips
+      // its "not completed" toast.
       controllerCancelledRef.current = true;
-      controllerChannel?.cancelStepComplete(renderedStepId);
+      controllerChannel?.cancelStepComplete(renderedStepId, activeRunIdRef.current);
     }, [controllerChannel, renderedStepId]);
 
     // Main execution logic (similar to InteractiveSection's sequence execution)
@@ -627,16 +627,19 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
         // that per click on top of its staged replay, so we keep the entry gate
         // only and let each sub-action fail on the live tab if a prereq regressed.
         controllerCancelledRef.current = false;
-        // Animate per-step progress from the live tab, and wait for it to finish
-        // before marking complete (the actual execution happens over there).
+        const runId = crypto.randomUUID();
+        activeRunIdRef.current = runId;
         setIsExecuting(true);
         // Subscribe before posting so the first progress tick the live tab emits
         // can't arrive before we're listening.
-        const stopProgress = controllerChannel.onStepProgress(renderedStepId, (index) => setCurrentActionIndex(index));
+        const stopProgress = controllerChannel.onStepProgress(renderedStepId, runId, (index) =>
+          setCurrentActionIndex(index)
+        );
         controllerChannel.post({
           kind: 'step-command',
           phase: 'do',
           stepId: renderedStepId,
+          runId,
           action: {
             targetAction: 'multistep',
             refTarget: '',
@@ -651,7 +654,7 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
           },
         });
         try {
-          const finished = await controllerChannel.awaitStepComplete(renderedStepId);
+          const finished = await controllerChannel.awaitStepComplete(renderedStepId, runId);
           if (finished) {
             persistCompletion();
             if (onStepComplete && stepId) {

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -687,6 +687,7 @@ export const InteractiveStep = forwardRef<
           kind: 'step-command',
           phase: 'show',
           stepId,
+          runId: crypto.randomUUID(),
           action: { targetAction, refTarget, targetValue: currentTargetValue, targetComment },
         });
         if (!doIt) {
@@ -808,6 +809,7 @@ export const InteractiveStep = forwardRef<
           kind: 'step-command',
           phase: 'do',
           stepId,
+          runId: crypto.randomUUID(),
           action: { targetAction, refTarget, targetValue: currentTargetValue, targetComment },
         });
         // F-1063-1 (fix-plan §6.2): simple steps complete optimistically — no live

--- a/src/global-state/controller-channel.test.tsx
+++ b/src/global-state/controller-channel.test.tsx
@@ -48,6 +48,7 @@ function Probe() {
             kind: 'step-command',
             phase: 'do',
             stepId: 's1',
+            runId: 'test-run-id',
             action: { targetAction: 'button', refTarget: '#x' },
           })
         }
@@ -143,6 +144,7 @@ describe('ControllerChannelProvider', () => {
       kind: 'step-command',
       phase: 'do',
       stepId: 's1',
+      runId: 'test-run-id',
       action: { targetAction: 'button', refTarget: '#x' },
     });
   });
@@ -354,7 +356,9 @@ describe('ControllerChannelProvider', () => {
       const [done, setDone] = React.useState('pending');
       return (
         <div>
-          <button onClick={() => channel?.awaitStepComplete('s9').then((ok) => setDone(`ok:${ok}`))}>await</button>
+          <button onClick={() => channel?.awaitStepComplete('s9', 'run-9').then((ok) => setDone(`ok:${ok}`))}>
+            await
+          </button>
           <span data-testid="done">{done}</span>
         </div>
       );
@@ -379,6 +383,7 @@ describe('ControllerChannelProvider', () => {
         timestamp: 0,
         kind: 'step-complete',
         stepId: 's9',
+        runId: 'run-9',
         ok: true,
       })
     );
@@ -386,11 +391,68 @@ describe('ControllerChannelProvider', () => {
     await waitFor(() => expect(screen.getByTestId('done')).toHaveTextContent('ok:true'));
   });
 
+  it('drops a step-complete with a stale runId and does not settle the waiter', async () => {
+    function CompleteProbe() {
+      const channel = useControllerChannel();
+      const [done, setDone] = React.useState('pending');
+      return (
+        <div>
+          <button onClick={() => channel?.awaitStepComplete('s10', 'run-new').then((ok) => setDone(`ok:${ok}`))}>
+            await
+          </button>
+          <span data-testid="done2">{done}</span>
+        </div>
+      );
+    }
+    const transport = new FakeTransport();
+    render(
+      <ControllerChannelProvider transport={transport}>
+        <CompleteProbe />
+      </ControllerChannelProvider>
+    );
+
+    act(() =>
+      transport.emit({ source: 'pathfinder', senderId: 'live-A', timestamp: 0, kind: 'heartbeat', role: 'live' })
+    );
+    fireEvent.click(screen.getByText('await'));
+
+    // A step-complete with the wrong runId (stale from a cancelled run) must not settle.
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'live-A',
+        timestamp: 0,
+        kind: 'step-complete',
+        stepId: 's10',
+        runId: 'run-old',
+        ok: true,
+      })
+    );
+    expect(screen.getByTestId('done2')).toHaveTextContent('pending');
+
+    // The correct runId settles normally.
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'live-A',
+        timestamp: 0,
+        kind: 'step-complete',
+        stepId: 's10',
+        runId: 'run-new',
+        ok: true,
+      })
+    );
+    await waitFor(() => expect(screen.getByTestId('done2')).toHaveTextContent('ok:true'));
+  });
+
   it('forwards step-progress to an onStepProgress subscriber', () => {
     function ProgressProbe() {
       const channel = useControllerChannel();
       const [p, setP] = React.useState('none');
-      React.useEffect(() => channel?.onStepProgress('s9', (index, total) => setP(`${index}/${total}`)), [channel]);
+      React.useEffect(
+        () => channel?.onStepProgress('s9', 'run-9', (index, total) => setP(`${index}/${total}`)),
+        [channel]
+      );
       return <span data-testid="progress">{p}</span>;
     }
     const transport = new FakeTransport();
@@ -401,8 +463,7 @@ describe('ControllerChannelProvider', () => {
     );
 
     // A forged step-progress before any live heartbeat must be dropped — pairing
-    // happens on a heartbeat only, so an unpaired sender can't drive the bar
-    // (F-1084 step-progress spoof, T1 PART C).
+    // happens on a heartbeat only, so an unpaired sender can't drive the bar.
     act(() =>
       transport.emit({
         source: 'pathfinder',
@@ -410,6 +471,7 @@ describe('ControllerChannelProvider', () => {
         timestamp: 0,
         kind: 'step-progress',
         stepId: 's9',
+        runId: 'run-9',
         index: 2,
         total: 3,
       })
@@ -427,6 +489,7 @@ describe('ControllerChannelProvider', () => {
         timestamp: 0,
         kind: 'step-progress',
         stepId: 's9',
+        runId: 'run-9',
         index: 1,
         total: 3,
       })

--- a/src/global-state/controller-channel.tsx
+++ b/src/global-state/controller-channel.tsx
@@ -42,11 +42,11 @@ interface ControllerChannel {
     stepId: string,
     opts: { requirements: string; fixType?: string; targetHref?: string; scrollContainer?: string }
   ) => Promise<FixOutcome>;
-  awaitStepComplete: (stepId: string) => Promise<boolean>;
+  awaitStepComplete: (stepId: string, runId: string) => Promise<boolean>;
   /** Abandon a pending awaitStepComplete waiter (user cancelled); resolves it false. */
-  cancelStepComplete: (stepId: string) => void;
+  cancelStepComplete: (stepId: string, runId: string) => void;
   /** Subscribe to a composite step's per-action progress; returns an unsubscribe. */
-  onStepProgress: (stepId: string, cb: (index: number, total: number) => void) => () => void;
+  onStepProgress: (stepId: string, runId: string, cb: (index: number, total: number) => void) => () => void;
 }
 
 interface PendingRequest {
@@ -113,6 +113,7 @@ export function ControllerChannelProvider({
       pending.clear();
       stepDone.forEach((resolve) => resolve(false));
       stepDone.clear();
+      stepProgressRef.current.clear();
     };
 
     const unsubscribe = active.onMessage((message) => {
@@ -141,8 +142,8 @@ export function ControllerChannelProvider({
           // The initial close above may have been posted before any live tab
           // was listening (controller opened first, or the live tab mounted
           // late). Re-assert it once the first live heartbeat proves a live tab
-          // exists, so the sidebar still hands off (F-1067-1). The flag stops
-          // later reconnects from re-posting on every tick.
+          // exists, so the sidebar still hands off. The flag stops later
+          // reconnects from re-posting on every tick.
           reassertedCloseRef.current = true;
           active.post({ kind: 'sidebar-handoff', action: 'close' });
         }
@@ -158,8 +159,7 @@ export function ControllerChannelProvider({
       }
       // T1 PART C: pairing happens on a heartbeat ONLY (above) — never adopt a
       // sender from a reply, or a forged first reply could claim the pairing slot
-      // before any live tab heartbeats (first-responder spoof, F-1073 / F-1084).
-      // An unpaired or mismatched sender is dropped.
+      // before any live tab heartbeats. An unpaired or mismatched sender is dropped.
       if (pairedLiveIdRef.current === null || message.senderId !== pairedLiveIdRef.current) {
         return;
       }
@@ -168,11 +168,13 @@ export function ControllerChannelProvider({
       } else if (message.kind === 'fix-result') {
         settle(message.requestId, { ok: message.ok, error: message.error });
       } else if (message.kind === 'step-progress') {
-        stepProgressRef.current.get(message.stepId)?.(message.index, message.total);
+        const key = `${message.stepId}:${message.runId}`;
+        stepProgressRef.current.get(key)?.(message.index, message.total);
       } else {
-        const resolve = stepDone.get(message.stepId);
+        const key = `${message.stepId}:${message.runId}`;
+        const resolve = stepDone.get(key);
         if (resolve) {
-          stepDone.delete(message.stepId);
+          stepDone.delete(key);
           resolve(message.ok);
         }
       }
@@ -209,7 +211,7 @@ export function ControllerChannelProvider({
       // Globally unique so a reply can never settle the wrong pending request:
       // a per-instance sequence (`req-1`, `req-2`, …) collides across two
       // controller tabs sharing the channel, and a stray reply would resolve the
-      // other controller's same-numbered request (F-1070-1).
+      // other controller's same-numbered request.
       const requestId = crypto.randomUUID();
       return new Promise<T>((resolve) => {
         const timer = setTimeout(() => {
@@ -256,31 +258,28 @@ export function ControllerChannelProvider({
   );
 
   const awaitStepComplete = useCallback<ControllerChannel['awaitStepComplete']>(
-    (stepId) =>
+    (stepId, runId) =>
       new Promise<boolean>((resolve) => {
-        // A re-run for the same step supersedes any earlier waiter.
-        stepCompletionRef.current.get(stepId)?.(false);
-        stepCompletionRef.current.set(stepId, resolve);
+        stepCompletionRef.current.set(`${stepId}:${runId}`, resolve);
       }),
     []
   );
 
-  const cancelStepComplete = useCallback<ControllerChannel['cancelStepComplete']>((stepId) => {
-    const resolve = stepCompletionRef.current.get(stepId);
+  const cancelStepComplete = useCallback<ControllerChannel['cancelStepComplete']>((stepId, runId) => {
+    const key = `${stepId}:${runId}`;
+    const resolve = stepCompletionRef.current.get(key);
     if (resolve) {
-      stepCompletionRef.current.delete(stepId);
+      stepCompletionRef.current.delete(key);
       resolve(false);
     }
   }, []);
 
-  // One subscriber per stepId (last writer wins). The unsubscribe only deletes
-  // if its own callback is still registered, so a superseding subscriber for the
-  // same step isn't evicted by the previous one's cleanup.
-  const onStepProgress = useCallback<ControllerChannel['onStepProgress']>((stepId, cb) => {
-    stepProgressRef.current.set(stepId, cb);
+  const onStepProgress = useCallback<ControllerChannel['onStepProgress']>((stepId, runId, cb) => {
+    const key = `${stepId}:${runId}`;
+    stepProgressRef.current.set(key, cb);
     return () => {
-      if (stepProgressRef.current.get(stepId) === cb) {
-        stepProgressRef.current.delete(stepId);
+      if (stepProgressRef.current.get(key) === cb) {
+        stepProgressRef.current.delete(key);
       }
     };
   }, []);

--- a/src/integrations/cross-tab/live-tab-executor.test.ts
+++ b/src/integrations/cross-tab/live-tab-executor.test.ts
@@ -78,7 +78,12 @@ function controllerHeartbeat(): CrossTabMessage {
   return { source: 'pathfinder', senderId: 'controller', timestamp: 0, kind: 'heartbeat', role: 'controller' };
 }
 
-function stampStepCommand(phase: 'show' | 'do', targetAction: string, refTarget: string, runId = 'run-1'): CrossTabMessage {
+function stampStepCommand(
+  phase: 'show' | 'do',
+  targetAction: string,
+  refTarget: string,
+  runId = 'run-1'
+): CrossTabMessage {
   return {
     source: 'pathfinder',
     senderId: 'controller',

--- a/src/integrations/cross-tab/live-tab-executor.test.ts
+++ b/src/integrations/cross-tab/live-tab-executor.test.ts
@@ -78,7 +78,7 @@ function controllerHeartbeat(): CrossTabMessage {
   return { source: 'pathfinder', senderId: 'controller', timestamp: 0, kind: 'heartbeat', role: 'controller' };
 }
 
-function stampStepCommand(phase: 'show' | 'do', targetAction: string, refTarget: string): CrossTabMessage {
+function stampStepCommand(phase: 'show' | 'do', targetAction: string, refTarget: string, runId = 'run-1'): CrossTabMessage {
   return {
     source: 'pathfinder',
     senderId: 'controller',
@@ -86,6 +86,7 @@ function stampStepCommand(phase: 'show' | 'do', targetAction: string, refTarget:
     kind: 'step-command',
     phase,
     stepId: 's1',
+    runId,
     action: { targetAction, refTarget },
   };
 }
@@ -168,6 +169,7 @@ describe('installLiveTabExecutor', () => {
       kind: 'step-command',
       phase: 'do',
       stepId: 'ms1',
+      runId: 'run-1',
       action: {
         targetAction: 'multistep',
         refTarget: '',
@@ -194,6 +196,7 @@ describe('installLiveTabExecutor', () => {
       kind: 'step-command',
       phase: 'do',
       stepId: 'ms1',
+      runId: 'run-1',
       action: {
         targetAction: 'multistep',
         refTarget: '',
@@ -218,6 +221,7 @@ describe('installLiveTabExecutor', () => {
       kind: 'step-command',
       phase: 'do',
       stepId: 'g1',
+      runId: 'run-g1',
       action: {
         targetAction: 'guided',
         refTarget: '',
@@ -236,7 +240,7 @@ describe('installLiveTabExecutor', () => {
     // And it reports completion so the controller doesn't mark the step done early.
     await waitFor(() =>
       expect(transport.postedMessages).toContainEqual(
-        expect.objectContaining({ kind: 'step-complete', stepId: 'g1', ok: true })
+        expect.objectContaining({ kind: 'step-complete', stepId: 'g1', runId: 'run-g1', ok: true })
       )
     );
     uninstall();
@@ -253,6 +257,7 @@ describe('installLiveTabExecutor', () => {
       kind: 'step-command',
       phase: 'do',
       stepId: 'ms3',
+      runId: 'run-ms3',
       action: {
         targetAction: 'multistep',
         refTarget: '',
@@ -265,12 +270,44 @@ describe('installLiveTabExecutor', () => {
 
     await waitFor(() =>
       expect(transport.postedMessages).toContainEqual(
-        expect.objectContaining({ kind: 'step-progress', stepId: 'ms3', index: 0, total: 2 })
+        expect.objectContaining({ kind: 'step-progress', stepId: 'ms3', runId: 'run-ms3', index: 0, total: 2 })
       )
     );
     await waitFor(() =>
       expect(transport.postedMessages).toContainEqual(
-        expect.objectContaining({ kind: 'step-progress', stepId: 'ms3', index: 1, total: 2 })
+        expect.objectContaining({ kind: 'step-progress', stepId: 'ms3', runId: 'run-ms3', index: 1, total: 2 })
+      )
+    );
+    uninstall();
+  });
+
+  it('echoes the runId from step-command in step-complete and step-progress replies', async () => {
+    const transport = new FakeTransport();
+    const uninstall = installLiveTabExecutor(transport, { showToDoMs: 0, settleMs: 0, interStepMs: 0 });
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'echo-step',
+      runId: 'echo-run-42',
+      action: {
+        targetAction: 'multistep',
+        refTarget: '',
+        internalActions: [{ targetAction: 'highlight', refTarget: '#a' }],
+      },
+    });
+
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({ kind: 'step-progress', stepId: 'echo-step', runId: 'echo-run-42' })
+      )
+    );
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({ kind: 'step-complete', stepId: 'echo-step', runId: 'echo-run-42', ok: true })
       )
     );
     uninstall();
@@ -287,6 +324,7 @@ describe('installLiveTabExecutor', () => {
       kind: 'step-command',
       phase: 'do',
       stepId: 'ms2',
+      runId: 'run-ms2',
       action: {
         targetAction: 'multistep',
         refTarget: '',
@@ -296,7 +334,7 @@ describe('installLiveTabExecutor', () => {
 
     await waitFor(() =>
       expect(transport.postedMessages).toContainEqual(
-        expect.objectContaining({ kind: 'step-complete', stepId: 'ms2', ok: true })
+        expect.objectContaining({ kind: 'step-complete', stepId: 'ms2', runId: 'run-ms2', ok: true })
       )
     );
     uninstall();

--- a/src/integrations/cross-tab/live-tab-executor.ts
+++ b/src/integrations/cross-tab/live-tab-executor.ts
@@ -225,9 +225,10 @@ export function installLiveTabExecutor(
     if (cancelled) {
       return;
     }
+    const { stepId, runId } = command;
     const internalActions = command.action.internalActions;
     const postProgress = (index: number) =>
-      transport.post({ kind: 'step-progress', stepId: command.stepId, index, total: internalActions?.length ?? 0 });
+      transport.post({ kind: 'step-progress', stepId, runId, index, total: internalActions?.length ?? 0 });
     let ok = false;
     try {
       if (internalActions?.length) {
@@ -245,12 +246,11 @@ export function installLiveTabExecutor(
       console.error('[Pathfinder] cross-tab executor: failed to run remote step', error);
       ok = false;
     }
-    // Reverse error channel (F-1064-1): tell the controller whether a composite
-    // actually finished, so it surfaces failure instead of completing early
-    // (guided waits for the user to click through). Simple steps stay optimistic
-    // by design (F-1063-1) and report nothing back.
+    // Tell the controller whether a composite actually finished, so it surfaces
+    // failure instead of completing early. Simple steps stay optimistic by design
+    // and report nothing back.
     if (internalActions?.length) {
-      transport.post({ kind: 'step-complete', stepId: command.stepId, ok });
+      transport.post({ kind: 'step-complete', stepId, runId, ok });
     }
   };
 

--- a/src/lib/cross-tab-transport.test.ts
+++ b/src/lib/cross-tab-transport.test.ts
@@ -58,7 +58,7 @@ describe('CrossTabTransport', () => {
     const received: CrossTabMessage[] = [];
     live.onMessage((m) => received.push(m));
 
-    controller.post({ kind: 'step-command', phase: 'show', stepId: 's1', action });
+    controller.post({ kind: 'step-command', phase: 'show', stepId: 's1', runId: 'run-1', action });
 
     expect(received).toHaveLength(1);
     expect(received[0]).toMatchObject({

--- a/src/types/cross-tab.types.test.ts
+++ b/src/types/cross-tab.types.test.ts
@@ -47,12 +47,27 @@ describe('validateCrossTabMessage', () => {
   it.each([
     [
       'bad phase',
-      { kind: 'step-command', phase: 'destroy', stepId: 's1', runId: 'r1', action: { targetAction: 'button', refTarget: 'x' } },
+      {
+        kind: 'step-command',
+        phase: 'destroy',
+        stepId: 's1',
+        runId: 'r1',
+        action: { targetAction: 'button', refTarget: 'x' },
+      },
     ],
-    ['missing stepId', { kind: 'step-command', phase: 'do', runId: 'r1', action: { targetAction: 'button', refTarget: 'x' } }],
-    ['missing runId', { kind: 'step-command', phase: 'do', stepId: 's1', action: { targetAction: 'button', refTarget: 'x' } }],
+    [
+      'missing stepId',
+      { kind: 'step-command', phase: 'do', runId: 'r1', action: { targetAction: 'button', refTarget: 'x' } },
+    ],
+    [
+      'missing runId',
+      { kind: 'step-command', phase: 'do', stepId: 's1', action: { targetAction: 'button', refTarget: 'x' } },
+    ],
     ['non-object action', { kind: 'step-command', phase: 'do', stepId: 's1', runId: 'r1', action: 'button' }],
-    ['missing refTarget', { kind: 'step-command', phase: 'do', stepId: 's1', runId: 'r1', action: { targetAction: 'button' } }],
+    [
+      'missing refTarget',
+      { kind: 'step-command', phase: 'do', stepId: 's1', runId: 'r1', action: { targetAction: 'button' } },
+    ],
   ])('rejects a malformed step-command (%s)', (_label, partial) => {
     expect(validateCrossTabMessage(envelope(partial))).toBeNull();
   });

--- a/src/types/cross-tab.types.test.ts
+++ b/src/types/cross-tab.types.test.ts
@@ -10,6 +10,7 @@ describe('validateCrossTabMessage', () => {
       kind: 'step-command',
       phase: 'do',
       stepId: 's1',
+      runId: 'run-1',
       action: { targetAction: 'button', refTarget: 'Save' },
     });
     expect(validateCrossTabMessage(message)).toBe(message);
@@ -37,6 +38,7 @@ describe('validateCrossTabMessage', () => {
       kind: 'step-command',
       phase: 'do',
       stepId: 's1',
+      runId: 'run-1',
       action: { targetAction: 'exec', refTarget: '#x' },
     });
     expect(validateCrossTabMessage(message)).toBeNull();
@@ -45,11 +47,12 @@ describe('validateCrossTabMessage', () => {
   it.each([
     [
       'bad phase',
-      { kind: 'step-command', phase: 'destroy', stepId: 's1', action: { targetAction: 'button', refTarget: 'x' } },
+      { kind: 'step-command', phase: 'destroy', stepId: 's1', runId: 'r1', action: { targetAction: 'button', refTarget: 'x' } },
     ],
-    ['missing stepId', { kind: 'step-command', phase: 'do', action: { targetAction: 'button', refTarget: 'x' } }],
-    ['non-object action', { kind: 'step-command', phase: 'do', stepId: 's1', action: 'button' }],
-    ['missing refTarget', { kind: 'step-command', phase: 'do', stepId: 's1', action: { targetAction: 'button' } }],
+    ['missing stepId', { kind: 'step-command', phase: 'do', runId: 'r1', action: { targetAction: 'button', refTarget: 'x' } }],
+    ['missing runId', { kind: 'step-command', phase: 'do', stepId: 's1', action: { targetAction: 'button', refTarget: 'x' } }],
+    ['non-object action', { kind: 'step-command', phase: 'do', stepId: 's1', runId: 'r1', action: 'button' }],
+    ['missing refTarget', { kind: 'step-command', phase: 'do', stepId: 's1', runId: 'r1', action: { targetAction: 'button' } }],
   ])('rejects a malformed step-command (%s)', (_label, partial) => {
     expect(validateCrossTabMessage(envelope(partial))).toBeNull();
   });
@@ -59,6 +62,7 @@ describe('validateCrossTabMessage', () => {
       kind: 'step-command',
       phase: 'do',
       stepId: 's1',
+      runId: 'run-1',
       action: {
         targetAction: 'guided',
         refTarget: '',
@@ -86,7 +90,9 @@ describe('validateCrossTabMessage', () => {
     ['a non-array internalActions', { targetAction: 'guided', refTarget: '', internalActions: 'highlight' }],
     ['a non-object internal action', { targetAction: 'guided', refTarget: '', internalActions: ['highlight'] }],
   ])('rejects a composite step-command with %s', (_label, action) => {
-    expect(validateCrossTabMessage(envelope({ kind: 'step-command', phase: 'do', stepId: 's1', action }))).toBeNull();
+    expect(
+      validateCrossTabMessage(envelope({ kind: 'step-command', phase: 'do', stepId: 's1', runId: 'run-1', action }))
+    ).toBeNull();
   });
 
   it('rejects a heartbeat with an invalid role', () => {
@@ -98,5 +104,23 @@ describe('validateCrossTabMessage', () => {
     expect(validateCrossTabMessage(envelope({ kind: 'sidebar-handoff', action: 'reopen' }))).not.toBeNull();
     expect(validateCrossTabMessage(envelope({ kind: 'sidebar-handoff', action: 'detonate' }))).toBeNull();
     expect(validateCrossTabMessage(envelope({ kind: 'sidebar-handoff' }))).toBeNull();
+  });
+
+  it('accepts a well-formed step-complete', () => {
+    const message = envelope({ kind: 'step-complete', stepId: 's1', runId: 'run-1', ok: true });
+    expect(validateCrossTabMessage(message)).toBe(message);
+  });
+
+  it('rejects a step-complete missing runId', () => {
+    expect(validateCrossTabMessage(envelope({ kind: 'step-complete', stepId: 's1', ok: true }))).toBeNull();
+  });
+
+  it('accepts a well-formed step-progress', () => {
+    const message = envelope({ kind: 'step-progress', stepId: 's1', runId: 'run-1', index: 0, total: 3 });
+    expect(validateCrossTabMessage(message)).toBe(message);
+  });
+
+  it('rejects a step-progress missing runId', () => {
+    expect(validateCrossTabMessage(envelope({ kind: 'step-progress', stepId: 's1', index: 0, total: 3 }))).toBeNull();
   });
 });

--- a/src/types/cross-tab.types.ts
+++ b/src/types/cross-tab.types.ts
@@ -47,6 +47,7 @@ export interface StepCommandMessage extends CrossTabEnvelope {
   kind: 'step-command';
   phase: 'show' | 'do';
   stepId: string;
+  runId: string;
   action: CrossTabAction;
 }
 
@@ -101,6 +102,7 @@ export interface FixResultMessage extends CrossTabEnvelope {
 export interface StepCompleteMessage extends CrossTabEnvelope {
   kind: 'step-complete';
   stepId: string;
+  runId: string;
   ok: boolean;
 }
 
@@ -109,6 +111,7 @@ export interface StepCompleteMessage extends CrossTabEnvelope {
 export interface StepProgressMessage extends CrossTabEnvelope {
   kind: 'step-progress';
   stepId: string;
+  runId: string;
   index: number;
   total: number;
 }
@@ -169,6 +172,9 @@ function isValidStepCommand(message: Record<string, unknown>): boolean {
     return false;
   }
   if (typeof message.stepId !== 'string') {
+    return false;
+  }
+  if (typeof message.runId !== 'string') {
     return false;
   }
   if (!isRecord(message.action)) {
@@ -256,7 +262,7 @@ function isValidFixResult(message: Record<string, unknown>): boolean {
 // triggers no DOM action, but it resolves a pending awaitStepComplete waiter, so
 // validate the shape to keep a malformed reply from completing the wrong step.
 function isValidStepComplete(message: Record<string, unknown>): boolean {
-  return typeof message.stepId === 'string' && typeof message.ok === 'boolean';
+  return typeof message.stepId === 'string' && typeof message.runId === 'string' && typeof message.ok === 'boolean';
 }
 
 // step-progress is a live → controller reply: the live tab reports which internal
@@ -264,7 +270,12 @@ function isValidStepComplete(message: Record<string, unknown>): boolean {
 // DOM action, but it drives a UI callback keyed by stepId, so validate the shape
 // to keep a malformed reply from advancing the wrong step's progress.
 function isValidStepProgress(message: Record<string, unknown>): boolean {
-  return typeof message.stepId === 'string' && typeof message.index === 'number' && typeof message.total === 'number';
+  return (
+    typeof message.stepId === 'string' &&
+    typeof message.runId === 'string' &&
+    typeof message.index === 'number' &&
+    typeof message.total === 'number'
+  );
 }
 
 // Per-kind validators — the single source of truth shared by the transport


### PR DESCRIPTION
## Summary

Adds a `runId` field to `step-command`, `step-complete`, and `step-progress`
wire messages so the controller can discard replies from cancelled runs. Without
run IDs, a stale `step-complete` from a cancelled composite step could settle
the subsequent retry, completing it incorrectly.

This is gate item 3 of 5 required before the two-tab controller (epic #1133)
can be re-enabled.

## What to look at

- `src/types/cross-tab.types.ts` — `runId: string` added to `StepCommand`,
  `StepComplete`, and `StepProgress`; per-kind validators updated to require it.
- `src/integrations/cross-tab/live-tab-executor.ts` — `runId` is captured from
  the incoming `step-command` and echoed back in `step-progress` and
  `step-complete` replies.
- `src/global-state/controller-channel.tsx` — waiters map key changed from bare
  `stepId` to `${stepId}:${runId}`; incoming replies with a mismatched `runId`
  are silently dropped. `awaitStepComplete` and `cancelStepComplete` now accept
  `(stepId, runId)` so callers register against the right slot. `onStepProgress`
  updated to the same `(stepId, runId, cb)` signature.
- `src/components/interactive-tutorial/interactive-guided.tsx` and
  `interactive-multi-step.tsx` — mint a `runId` via `crypto.randomUUID()` at
  dispatch time, store it in a ref, and pass it through to
  `onStepProgress`/`awaitStepComplete`/`cancelStepComplete`.
- `src/components/interactive-tutorial/interactive-step.tsx` — simple
  (non-composite) step-commands also include a `runId` to satisfy the updated
  wire type.

## Why

`BroadcastChannel` delivers messages asynchronously; a cancelled composite step
leaves in-flight `step-complete` replies in the channel that can arrive after
the retry starts. The existing `cancelled` flag stops a new command from
launching mid-replay but does not filter stale reply messages. Per-run IDs close
this window: the controller simply ignores any reply whose `runId` doesn't match
the active run.

## How to verify

1. Confirm `cross-tab.types.ts` validators reject a `step-complete` message that
   is missing `runId` (the new test in `cross-tab.types.test.ts` covers this).
2. In a manual two-tab session (once the feature is re-enabled): start a
   composite step, cancel it mid-flight, immediately retry, and confirm the retry
   completes correctly without the old run's replies interfering.

## Breaking changes

None. The feature is currently disabled (`TWOTAB_CONTROLLER_ENABLED = false`),
so the wire protocol change has no user-visible effect. The `runId` field is
validated at the transport receive gate, so old messages without `runId` will be
dropped — but there are no persisted or cached messages; all channel state is
ephemeral.

## Out of scope

The remaining 4 gate items (#1139, #1140, #1141, #1142) are tracked separately
and must also be resolved before flipping `TWOTAB_CONTROLLER_ENABLED` to `true`.

Closes #1143
Refs #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
