### PR TITLE
feat(reftarget): support ordered fallback selector chains for interactive blocks

### DIFF
--- a/src/cli/__tests__/authoring-integration.test.ts
+++ b/src/cli/__tests__/authoring-integration.test.ts
@@ -27,6 +27,7 @@ import { runCreate } from '../commands/create';
 import { runInspect } from '../commands/inspect';
 import { runSetManifest } from '../commands/set-manifest';
 import { readPackage } from '../utils/package-io';
+import { findBlockById } from '../utils/package-io/tree';
 import { validatePackage } from '../../validation/validate-package';
 
 function tempDir(): string {
@@ -179,5 +180,53 @@ describe('agent authoring round-trip (full multi-block guide)', () => {
     expect(state.content.id).toBe('getting-started-with-loki');
     expect(state.manifest?.id).toBe('getting-started-with-loki');
     expect(state.manifest?.provides).toEqual(['loki-basics']);
+  });
+});
+
+describe('reftarget fallback arrays round-trip via the CLI', () => {
+  const root = tempDir();
+  const dir = path.join(root, 'fallback-guide');
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('persists multiple --reftarget as an ordered array and a single one as a string', async () => {
+    const created = await runCreate({
+      dir,
+      id: 'fallback-guide',
+      title: 'Fallback guide',
+      type: 'guide',
+      description: 'Exercises reftarget fallback chains',
+    });
+    expect(created.status).toBe('ok');
+
+    // Repeated --reftarget (Commander accumulates into an array) → ordered fallback chain.
+    let r = await runAddBlock({
+      dir,
+      type: 'interactive',
+      explicitId: 'multi',
+      flagValues: {
+        action: 'button',
+        content: 'Save the dashboard',
+        reftarget: ['Save dashboard', "button[data-testid='save-dashboard']"],
+      },
+    });
+    expect(r.status).toBe('ok');
+
+    // A single --reftarget → plain string (byte-identical to legacy guides).
+    r = await runAddBlock({
+      dir,
+      type: 'interactive',
+      explicitId: 'single',
+      flagValues: { action: 'button', content: 'Open the menu', reftarget: ['Open menu'] },
+    });
+    expect(r.status).toBe('ok');
+
+    const state = readPackage(dir);
+    const multi = findBlockById(state.content, 'multi') as { reftarget?: unknown } | null;
+    const single = findBlockById(state.content, 'single') as { reftarget?: unknown } | null;
+    expect(multi?.reftarget).toEqual(['Save dashboard', "button[data-testid='save-dashboard']"]);
+    expect(single?.reftarget).toBe('Open menu');
   });
 });

--- a/src/cli/__tests__/schema-options.test.ts
+++ b/src/cli/__tests__/schema-options.test.ts
@@ -60,6 +60,11 @@ describe('describeField', () => {
     });
   });
 
+  it('detects a string | string[] union as string-or-array-string', () => {
+    const field = z.union([z.string(), z.array(z.string())]).optional();
+    expect(describeField(field)).toMatchObject({ kind: 'string-or-array-string', optional: true });
+  });
+
   it('detects literal as literal', () => {
     expect(describeField(z.literal('markdown'))).toMatchObject({ kind: 'literal', optional: false });
   });
@@ -241,6 +246,29 @@ describe('parseOptionValues', () => {
   });
 });
 
+describe('parseOptionValues — reftarget fallback arrays', () => {
+  const Schema = z.object({
+    type: z.literal('interactive'),
+    action: z.enum(['button', 'navigate']),
+    reftarget: z.union([z.string(), z.array(z.string())]).optional(),
+  });
+
+  it('collapses a single repeated --reftarget to a plain string', () => {
+    const result = parseOptionValues(Schema, { action: 'button', reftarget: ['#only'] });
+    expect(result).toEqual({ action: 'button', reftarget: '#only' });
+  });
+
+  it('keeps multiple repeated --reftarget as an ordered array', () => {
+    const result = parseOptionValues(Schema, { action: 'button', reftarget: ['#a', '#b'] });
+    expect(result).toEqual({ action: 'button', reftarget: ['#a', '#b'] });
+  });
+
+  it('omits an unset reftarget (empty repeatable default)', () => {
+    const result = parseOptionValues(Schema, { action: 'button', reftarget: [] });
+    expect(result).toEqual({ action: 'button' });
+  });
+});
+
 describe('integration with the live JsonInteractiveBlockSchema', () => {
   it('registers exactly the production interactive-block flags', () => {
     const cmd = new Command('interactive');
@@ -250,7 +278,7 @@ describe('integration with the live JsonInteractiveBlockSchema', () => {
       [
         '--id <string>',
         '--action <highlight|button|formfill|navigate|hover|noop|popout>',
-        '--reftarget <string>',
+        '--reftarget <selector>',
         '--targetvalue <string>',
         '--content <string>',
         '--tooltip <string>',

--- a/src/cli/utils/cli-validators.ts
+++ b/src/cli/utils/cli-validators.ts
@@ -142,6 +142,21 @@ export function assertCssSelector(value: unknown, fieldPath: string): void {
   }
 }
 
+/**
+ * A reftarget: a single selector or an ordered fallback array (strongest first).
+ * Every entry is validated as a CSS selector; an empty array is rejected.
+ */
+export function assertCssSelectorOrArray(value: unknown, fieldPath: string): void {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      fail(fieldPath, 'reftarget array must contain at least one selector');
+    }
+    value.forEach((element, index) => assertCssSelector(element, `${fieldPath}[${index}]`));
+    return;
+  }
+  assertCssSelector(value, fieldPath);
+}
+
 export function assertPackageIdRef(value: unknown, fieldPath: string): void {
   if (typeof value !== 'string') {
     fail(fieldPath, 'must be a package id string');
@@ -243,7 +258,7 @@ export const BLOCK_FIELD_VALIDATORS: Record<string, Record<string, FieldValidato
     end: [assertNonNegativeInt],
   },
   interactive: {
-    reftarget: [assertCssSelector],
+    reftarget: [assertCssSelectorOrArray],
     verify: [assertCssSelector],
     scrollContainer: [assertCssSelector],
   },
@@ -259,7 +274,7 @@ export const BLOCK_FIELD_VALIDATORS: Record<string, Record<string, FieldValidato
 };
 
 export const STEP_FIELD_VALIDATORS: Record<string, FieldValidator[]> = {
-  reftarget: [assertCssSelector],
+  reftarget: [assertCssSelectorOrArray],
   scrollContainer: [assertCssSelector],
 };
 

--- a/src/cli/utils/schema-options.ts
+++ b/src/cli/utils/schema-options.ts
@@ -39,6 +39,7 @@ export type FieldShape =
   | { kind: 'boolean'; optional: boolean; description: string | undefined }
   | { kind: 'enum'; optional: boolean; values: readonly string[]; description: string | undefined }
   | { kind: 'array-string'; optional: boolean; description: string | undefined }
+  | { kind: 'string-or-array-string'; optional: boolean; description: string | undefined }
   | { kind: 'literal'; optional: boolean }
   | { kind: 'unsupported'; reason: string; optional: boolean };
 
@@ -118,6 +119,20 @@ export function describeField(field: z.ZodType): FieldShape {
     }
     return { kind: 'unsupported', reason: `array of ${elementType ?? 'unknown'}`, optional };
   }
+  if (t === 'union') {
+    // `reftarget` is `z.union([z.string(), z.array(z.string())])` — a single
+    // selector or an ordered fallback chain. Expose it as a repeatable flag;
+    // parseOptionValues collapses a single value to a string.
+    const branches: Array<{ def?: { type?: string; element?: { def?: { type?: string } } } }> =
+      (def as any).options ?? [];
+    const hasString = branches.some((branch) => branch?.def?.type === 'string');
+    const hasStringArray = branches.some(
+      (branch) => branch?.def?.type === 'array' && branch?.def?.element?.def?.type === 'string'
+    );
+    if (hasString && hasStringArray) {
+      return { kind: 'string-or-array-string', optional, description };
+    }
+  }
 
   return { kind: 'unsupported', reason: t ?? 'unknown', optional };
 }
@@ -189,6 +204,19 @@ export function zodFieldToOption(name: string, field: z.ZodType): Option | null 
   if (shape.kind === 'array-string') {
     // Repeatable: each --flag <item> appends to the accumulated array.
     const option = new Option(`--${flag} <item>`, description);
+    option.argParser((value: string, previous: string[] | undefined) => [...(previous ?? []), value]);
+    option.default([] as string[]);
+    if (!shape.optional) {
+      option.makeOptionMandatory();
+    }
+    return option;
+  }
+
+  if (shape.kind === 'string-or-array-string') {
+    // Repeatable: pass --flag once for a single selector, or multiple times to
+    // build an ordered fallback chain (strongest first). parseOptionValues
+    // collapses a single value back to a plain string.
+    const option = new Option(`--${flag} <selector>`, description);
     option.argParser((value: string, previous: string[] | undefined) => [...(previous ?? []), value]);
     option.default([] as string[]);
     if (!shape.optional) {
@@ -357,6 +385,18 @@ export function parseOptionValues<T extends z.ZodObject>(
         continue;
       }
       out[name] = raw;
+      continue;
+    }
+    if (description.kind === 'string-or-array-string') {
+      const collected = Array.isArray(raw) ? raw : [raw];
+      if (collected.length === 0) {
+        // Flag never provided — leave absent so optional/required handling in the
+        // schema applies cleanly.
+        continue;
+      }
+      // One selector → plain string (byte-identical to single-selector guides);
+      // multiple → ordered fallback array.
+      out[name] = collected.length === 1 ? collected[0] : collected;
       continue;
     }
     out[name] = raw;

--- a/src/cli/utils/warnings.ts
+++ b/src/cli/utils/warnings.ts
@@ -69,10 +69,14 @@ export function unverifiedSelectorWarning(path: string): OutcomeWarning {
 
 /**
  * Internal predicate: a value is a "non-empty selector" when it is a string
- * with at least one non-whitespace character. Centralized so the three
- * `runX` consumers all decide the same way.
+ * with a non-whitespace character, or a non-empty array containing such a
+ * string (a reftarget fallback chain). Centralized so the three `runX`
+ * consumers all decide the same way.
  */
-export function isNonEmptySelector(value: unknown): value is string {
+export function isNonEmptySelector(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some((entry) => typeof entry === 'string' && entry.trim().length > 0);
+  }
   return typeof value === 'string' && value.trim().length > 0;
 }
 

--- a/src/components/block-editor/BlockFormModal.tsx
+++ b/src/components/block-editor/BlockFormModal.tsx
@@ -163,7 +163,7 @@ export function BlockFormModal({
   } | null>(null);
 
   // Store a callback to receive the selected element
-  const pickerCallbackRef = useRef<((selector: string) => void) | null>(null);
+  const pickerCallbackRef = useRef<((selector: string, fallbacks?: string[]) => void) | null>(null);
 
   // Store callbacks for record mode
   const recordStopCallbackRef = useRef<(() => void) | null>(null);
@@ -322,19 +322,22 @@ export function BlockFormModal({
   }, []);
 
   // Called by forms when they want to start the picker
-  const handlePickerModeChange = useCallback((isActive: boolean, onSelect?: (selector: string) => void) => {
-    setIsPickerActive(isActive);
-    if (isActive && onSelect) {
-      pickerCallbackRef.current = onSelect;
-    } else if (!isActive) {
-      pickerCallbackRef.current = null;
-    }
-  }, []);
+  const handlePickerModeChange = useCallback(
+    (isActive: boolean, onSelect?: (selector: string, fallbacks?: string[]) => void) => {
+      setIsPickerActive(isActive);
+      if (isActive && onSelect) {
+        pickerCallbackRef.current = onSelect;
+      } else if (!isActive) {
+        pickerCallbackRef.current = null;
+      }
+    },
+    []
+  );
 
   // Called when user selects an element
-  const handleElementSelect = useCallback((selector: string) => {
+  const handleElementSelect = useCallback((selector: string, fallbacks?: string[]) => {
     if (pickerCallbackRef.current) {
-      pickerCallbackRef.current(selector);
+      pickerCallbackRef.current(selector, fallbacks);
     }
     setIsPickerActive(false);
     pickerCallbackRef.current = null;

--- a/src/components/block-editor/ElementPicker.tsx
+++ b/src/components/block-editor/ElementPicker.tsx
@@ -74,7 +74,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
 export interface ElementPickerProps {
   /** Called when an element is selected */
-  onSelect: (selector: string) => void;
+  onSelect: (selector: string, fallbacks?: string[]) => void;
   /** Called when picker is cancelled */
   onCancel: () => void;
 }
@@ -175,7 +175,7 @@ export function ElementPicker({ onSelect, onCancel }: ElementPickerProps) {
         console.warn('[ElementPicker] Selector warnings:', result.warnings);
       }
 
-      onSelect(result.selector);
+      onSelect(result.selector, result.fallbacks);
     },
     [onSelect, getElementUnderCursor]
   );

--- a/src/components/block-editor/forms/BranchBlocksEditor.tsx
+++ b/src/components/block-editor/forms/BranchBlocksEditor.tsx
@@ -47,6 +47,7 @@ import {
   isVideoBlock,
   isInputBlock,
 } from '../../../types/json-guide.types';
+import { primaryRefTarget } from '../../../lib/dom';
 import { getBlockPreview } from '../utils';
 
 // ============================================================================
@@ -396,7 +397,7 @@ export function BranchBlocksEditor({ label, variant, blocks, onChange, onPickerM
       } else if (isInteractiveBlock(block)) {
         setFormContent(block.content);
         setFormAction(block.action ?? block.targetAction ?? 'highlight');
-        setFormReftarget(block.reftarget ?? block.refTarget ?? '');
+        setFormReftarget(primaryRefTarget(block.reftarget ?? block.refTarget ?? ''));
         setFormTargetvalue(block.targetvalue ?? block.targetValue ?? '');
         setFormRequirements(block.requirements?.join(', ') || '');
       } else if (isImageBlock(block)) {

--- a/src/components/block-editor/forms/CodeBlockForm.tsx
+++ b/src/components/block-editor/forms/CodeBlockForm.tsx
@@ -15,6 +15,7 @@ import { TypeSwitchDropdown } from './TypeSwitchDropdown';
 import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock } from '../types';
 import type { JsonCodeBlockBlock } from '../../../types/json-guide.types';
+import { primaryRefTarget } from '../../../lib/dom';
 
 function isCodeBlockBlock(block: JsonBlock): block is JsonCodeBlockBlock {
   return block.type === 'code-block';
@@ -60,7 +61,9 @@ export function CodeBlockForm({
 
   const [code, setCode] = useState(initial?.code ?? '');
   const [language, setLanguage] = useState(initial?.language ?? 'javascript');
-  const [reftarget, setReftarget] = useState(initial?.reftarget ?? DEFAULT_REFTARGET);
+  // Visual editor edits a single primary selector; fallback arrays are authored
+  // via JSON/CLI. Collapse to the primary here so the field stays a string.
+  const [reftarget, setReftarget] = useState(primaryRefTarget(initial?.reftarget ?? DEFAULT_REFTARGET));
   const [content, setContent] = useState(initial?.content ?? '');
   const [requirements, setRequirements] = useState(initial?.requirements?.join(', ') ?? '');
   const [skippable, setSkippable] = useState(initial?.skippable ?? false);

--- a/src/components/block-editor/forms/ConditionalBlockForm.tsx
+++ b/src/components/block-editor/forms/ConditionalBlockForm.tsx
@@ -26,6 +26,7 @@ import type {
   ConditionalDisplayMode,
   ConditionalSectionConfig,
 } from '../../../types/json-guide.types';
+import { primaryRefTarget } from '../../../lib/dom';
 
 /** Options for display mode radio buttons */
 const DISPLAY_MODE_OPTIONS = [
@@ -110,7 +111,7 @@ export function ConditionalBlockForm({
   const [conditions, setConditions] = useState(initial?.conditions?.join(', ') ?? '');
   const [description, setDescription] = useState(initial?.description ?? '');
   const [displayMode, setDisplayMode] = useState<ConditionalDisplayMode>(initial?.display ?? 'inline');
-  const [reftarget, setReftarget] = useState(initial?.reftarget ?? '');
+  const [reftarget, setReftarget] = useState(primaryRefTarget(initial?.reftarget ?? ''));
 
   // Per-branch section config state
   const [whenTrueTitle, setWhenTrueTitle] = useState(initial?.whenTrueSectionConfig?.title ?? '');

--- a/src/components/block-editor/forms/InteractiveBlockForm.test.tsx
+++ b/src/components/block-editor/forms/InteractiveBlockForm.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { InteractiveBlockForm } from './InteractiveBlockForm';
 import type { JsonBlock } from '../types';
@@ -25,6 +25,35 @@ const primaryInput = () => screen.getByPlaceholderText("e.g., button[data-testid
 const fallbackInputs = () => screen.getAllByPlaceholderText(FALLBACK_PLACEHOLDER);
 const descriptionInput = () => screen.getByPlaceholderText('Click the **Save** button to save your changes.');
 const submitButton = () => screen.getByRole('button', { name: 'Add block' });
+
+describe('InteractiveBlockForm — element picker', () => {
+  it('populates the primary and fallback chain from the picker selection', () => {
+    let captured: ((selector: string, fallbacks?: string[]) => void) | undefined;
+    const onPickerModeChange = jest.fn(
+      (_active: boolean, onSelect?: (selector: string, fallbacks?: string[]) => void) => {
+        captured = onSelect;
+      }
+    );
+    const onSubmit = jest.fn();
+    render(<InteractiveBlockForm onSubmit={onSubmit} onCancel={jest.fn()} onPickerModeChange={onPickerModeChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pick element' }));
+    expect(captured).toBeDefined();
+
+    act(() => {
+      captured!("button[data-testid='save']", ["button:contains('Save')"]);
+    });
+
+    fireEvent.change(descriptionInput(), { target: { value: 'Save your work' } });
+    fireEvent.click(submitButton());
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reftarget: ["button[data-testid='save']", "button:contains('Save')"],
+      })
+    );
+  });
+});
 
 describe('InteractiveBlockForm — fallback selectors', () => {
   it('serializes the primary plus fallbacks as an ordered array', () => {

--- a/src/components/block-editor/forms/InteractiveBlockForm.test.tsx
+++ b/src/components/block-editor/forms/InteractiveBlockForm.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { InteractiveBlockForm } from './InteractiveBlockForm';
+import type { JsonBlock } from '../types';
+import type { JsonInteractiveBlock } from '../../../types/json-guide.types';
+
+// Grafana's Combobox (Action Type picker) measures text via a <canvas> 2d
+// context, which jsdom doesn't implement. Stub the methods it calls.
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+    measureText: () => ({ width: 0 }),
+    font: '',
+  })) as unknown as HTMLCanvasElement['getContext'];
+});
+
+function renderForm(opts: { onSubmit?: (block: JsonBlock) => void; initialData?: JsonInteractiveBlock } = {}) {
+  const onSubmit = opts.onSubmit ?? jest.fn();
+  render(<InteractiveBlockForm onSubmit={onSubmit} onCancel={jest.fn()} initialData={opts.initialData} />);
+  return { onSubmit };
+}
+
+const FALLBACK_PLACEHOLDER = "e.g., button[data-testid='save-dashboard']";
+const primaryInput = () => screen.getByPlaceholderText("e.g., button[data-testid='save'], .my-class");
+const fallbackInputs = () => screen.getAllByPlaceholderText(FALLBACK_PLACEHOLDER);
+const descriptionInput = () => screen.getByPlaceholderText('Click the **Save** button to save your changes.');
+const submitButton = () => screen.getByRole('button', { name: 'Add block' });
+
+describe('InteractiveBlockForm — fallback selectors', () => {
+  it('serializes the primary plus fallbacks as an ordered array', () => {
+    const { onSubmit } = renderForm();
+
+    fireEvent.change(primaryInput(), { target: { value: 'Save dashboard' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add fallback selector' }));
+    fireEvent.change(fallbackInputs()[0]!, { target: { value: "button[data-testid='save']" } });
+    fireEvent.change(descriptionInput(), { target: { value: 'Save your work' } });
+    fireEvent.click(submitButton());
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ reftarget: ['Save dashboard', "button[data-testid='save']"] })
+    );
+  });
+
+  it('serializes a primary-only selector as a plain string', () => {
+    const { onSubmit } = renderForm();
+
+    fireEvent.change(primaryInput(), { target: { value: '#only' } });
+    fireEvent.change(descriptionInput(), { target: { value: 'Do it' } });
+    fireEvent.click(submitButton());
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ reftarget: '#only' }));
+  });
+
+  it('drops empty fallback rows on submit', () => {
+    const { onSubmit } = renderForm();
+
+    fireEvent.change(primaryInput(), { target: { value: '#primary' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add fallback selector' }));
+    // Leave the new fallback row blank.
+    fireEvent.change(descriptionInput(), { target: { value: 'Do it' } });
+    fireEvent.click(submitButton());
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ reftarget: '#primary' }));
+  });
+
+  it('loads an existing array into the primary field plus fallback rows', () => {
+    renderForm({
+      initialData: { type: 'interactive', action: 'highlight', content: 'c', reftarget: ['#a', '#b', '#c'] },
+    });
+
+    expect(primaryInput()).toHaveValue('#a');
+    const rows = fallbackInputs();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveValue('#b');
+    expect(rows[1]).toHaveValue('#c');
+  });
+
+  it('removes a fallback row', () => {
+    renderForm({
+      initialData: { type: 'interactive', action: 'highlight', content: 'c', reftarget: ['#a', '#b'] },
+    });
+
+    expect(fallbackInputs()).toHaveLength(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove fallback' }));
+    expect(screen.queryAllByPlaceholderText(FALLBACK_PLACEHOLDER)).toHaveLength(0);
+  });
+});

--- a/src/components/block-editor/forms/InteractiveBlockForm.test.tsx
+++ b/src/components/block-editor/forms/InteractiveBlockForm.test.tsx
@@ -20,9 +20,7 @@ function renderForm(opts: { onSubmit?: (block: JsonBlock) => void; initialData?:
   return { onSubmit };
 }
 
-const FALLBACK_PLACEHOLDER = "e.g., button[data-testid='save-dashboard']";
 const primaryInput = () => screen.getByPlaceholderText("e.g., button[data-testid='save'], .my-class");
-const fallbackInputs = () => screen.getAllByPlaceholderText(FALLBACK_PLACEHOLDER);
 const descriptionInput = () => screen.getByPlaceholderText('Click the **Save** button to save your changes.');
 const submitButton = () => screen.getByRole('button', { name: 'Add block' });
 
@@ -55,21 +53,7 @@ describe('InteractiveBlockForm — element picker', () => {
   });
 });
 
-describe('InteractiveBlockForm — fallback selectors', () => {
-  it('serializes the primary plus fallbacks as an ordered array', () => {
-    const { onSubmit } = renderForm();
-
-    fireEvent.change(primaryInput(), { target: { value: 'Save dashboard' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Add fallback selector' }));
-    fireEvent.change(fallbackInputs()[0]!, { target: { value: "button[data-testid='save']" } });
-    fireEvent.change(descriptionInput(), { target: { value: 'Save your work' } });
-    fireEvent.click(submitButton());
-
-    expect(onSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({ reftarget: ['Save dashboard', "button[data-testid='save']"] })
-    );
-  });
-
+describe('InteractiveBlockForm — fallback chain serialization', () => {
   it('serializes a primary-only selector as a plain string', () => {
     const { onSubmit } = renderForm();
 
@@ -80,37 +64,15 @@ describe('InteractiveBlockForm — fallback selectors', () => {
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ reftarget: '#only' }));
   });
 
-  it('drops empty fallback rows on submit', () => {
-    const { onSubmit } = renderForm();
-
-    fireEvent.change(primaryInput(), { target: { value: '#primary' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Add fallback selector' }));
-    // Leave the new fallback row blank.
-    fireEvent.change(descriptionInput(), { target: { value: 'Do it' } });
-    fireEvent.click(submitButton());
-
-    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ reftarget: '#primary' }));
-  });
-
-  it('loads an existing array into the primary field plus fallback rows', () => {
-    renderForm({
+  it('preserves an existing fallback chain through edit + submit (no manual editor)', () => {
+    const { onSubmit } = renderForm({
       initialData: { type: 'interactive', action: 'highlight', content: 'c', reftarget: ['#a', '#b', '#c'] },
     });
 
+    // The primary is editable; the auto-generated fallback chain is carried through silently.
     expect(primaryInput()).toHaveValue('#a');
-    const rows = fallbackInputs();
-    expect(rows).toHaveLength(2);
-    expect(rows[0]).toHaveValue('#b');
-    expect(rows[1]).toHaveValue('#c');
-  });
+    fireEvent.click(submitButton());
 
-  it('removes a fallback row', () => {
-    renderForm({
-      initialData: { type: 'interactive', action: 'highlight', content: 'c', reftarget: ['#a', '#b'] },
-    });
-
-    expect(fallbackInputs()).toHaveLength(1);
-    fireEvent.click(screen.getByRole('button', { name: 'Remove fallback' }));
-    expect(screen.queryAllByPlaceholderText(FALLBACK_PLACEHOLDER)).toHaveLength(0);
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ reftarget: ['#a', '#b', '#c'] }));
   });
 });

--- a/src/components/block-editor/forms/InteractiveBlockForm.tsx
+++ b/src/components/block-editor/forms/InteractiveBlockForm.tsx
@@ -31,7 +31,12 @@ import {
   removeTokenFromConditionField,
 } from '../lint';
 import { testIds } from '../../../constants/testIds';
-import { generateFallbackSelectors, querySelectorAllEnhanced, resolveSelector, primaryRefTarget } from '../../../lib/dom';
+import {
+  generateFallbackSelectors,
+  querySelectorAllEnhanced,
+  resolveSelector,
+  primaryRefTarget,
+} from '../../../lib/dom';
 import { SelectorHealthBadge } from '../SelectorHealthBadge';
 import { SelectorTestOverlay } from '../SelectorTestOverlay';
 import { useSelectorTest } from '../useSelectorTest';
@@ -135,10 +140,7 @@ export function InteractiveBlockForm({
   }, [onPickerModeChange, action]);
 
   const addFallback = useCallback(() => setFallbacks((prev) => [...prev, '']), []);
-  const removeFallback = useCallback(
-    (index: number) => setFallbacks((prev) => prev.filter((_, i) => i !== index)),
-    []
-  );
+  const removeFallback = useCallback((index: number) => setFallbacks((prev) => prev.filter((_, i) => i !== index)), []);
   const updateFallback = useCallback(
     (index: number, value: string) => setFallbacks((prev) => prev.map((fb, i) => (i === index ? value : fb))),
     []
@@ -477,7 +479,12 @@ export function InteractiveBlockForm({
                       placeholder="e.g., button[data-testid='save-dashboard']"
                       className={styles.selectorInput}
                     />
-                    <IconButton name="arrow-up" tooltip="Move up" disabled={i === 0} onClick={() => moveFallback(i, -1)} />
+                    <IconButton
+                      name="arrow-up"
+                      tooltip="Move up"
+                      disabled={i === 0}
+                      onClick={() => moveFallback(i, -1)}
+                    />
                     <IconButton
                       name="arrow-down"
                       tooltip="Move down"

--- a/src/components/block-editor/forms/InteractiveBlockForm.tsx
+++ b/src/components/block-editor/forms/InteractiveBlockForm.tsx
@@ -30,7 +30,7 @@ import {
   removeTokenFromConditionField,
 } from '../lint';
 import { testIds } from '../../../constants/testIds';
-import { generateFallbackSelectors, querySelectorAllEnhanced, resolveSelector } from '../../../lib/dom';
+import { generateFallbackSelectors, querySelectorAllEnhanced, resolveSelector, primaryRefTarget } from '../../../lib/dom';
 import { SelectorHealthBadge } from '../SelectorHealthBadge';
 import { SelectorTestOverlay } from '../SelectorTestOverlay';
 import { useSelectorTest } from '../useSelectorTest';
@@ -85,7 +85,7 @@ export function InteractiveBlockForm({
   // Initialize from existing data or defaults
   const initial = initialData && isInteractiveBlock(initialData) ? initialData : null;
   const [action, setAction] = useState<JsonInteractiveAction>(initial?.action ?? 'highlight');
-  const [reftarget, setReftarget] = useState(initial?.reftarget ?? '');
+  const [reftarget, setReftarget] = useState(primaryRefTarget(initial?.reftarget ?? ''));
   const [targetvalue, setTargetvalue] = useState(initial?.targetvalue ?? '');
   const [content, setContent] = useState(initial?.content ?? '');
   const [tooltip, setTooltip] = useState(initial?.tooltip ?? '');

--- a/src/components/block-editor/forms/InteractiveBlockForm.tsx
+++ b/src/components/block-editor/forms/InteractiveBlockForm.tsx
@@ -8,6 +8,7 @@ import React, { useState, useCallback } from 'react';
 import {
   Button,
   Field,
+  IconButton,
   Input,
   TextArea,
   Combobox,
@@ -85,7 +86,12 @@ export function InteractiveBlockForm({
   // Initialize from existing data or defaults
   const initial = initialData && isInteractiveBlock(initialData) ? initialData : null;
   const [action, setAction] = useState<JsonInteractiveAction>(initial?.action ?? 'highlight');
+  // The "Target selector" field holds the primary (strongest) selector; the
+  // optional fallback chain (weaker selectors, tried in order) is edited below.
   const [reftarget, setReftarget] = useState(primaryRefTarget(initial?.reftarget ?? ''));
+  const [fallbacks, setFallbacks] = useState<string[]>(() =>
+    Array.isArray(initial?.reftarget) ? initial.reftarget.slice(1) : []
+  );
   const [targetvalue, setTargetvalue] = useState(initial?.targetvalue ?? '');
   const [content, setContent] = useState(initial?.content ?? '');
   const [tooltip, setTooltip] = useState(initial?.tooltip ?? '');
@@ -128,6 +134,27 @@ export function InteractiveBlockForm({
     });
   }, [onPickerModeChange, action]);
 
+  const addFallback = useCallback(() => setFallbacks((prev) => [...prev, '']), []);
+  const removeFallback = useCallback(
+    (index: number) => setFallbacks((prev) => prev.filter((_, i) => i !== index)),
+    []
+  );
+  const updateFallback = useCallback(
+    (index: number, value: string) => setFallbacks((prev) => prev.map((fb, i) => (i === index ? value : fb))),
+    []
+  );
+  const moveFallback = useCallback((index: number, direction: -1 | 1) => {
+    setFallbacks((prev) => {
+      const target = index + direction;
+      if (target < 0 || target >= prev.length) {
+        return prev;
+      }
+      const next = [...prev];
+      [next[index], next[target]] = [next[target]!, next[index]!];
+      return next;
+    });
+  }, []);
+
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
@@ -152,11 +179,18 @@ export function InteractiveBlockForm({
       // Treat both actions like noop for the bulk of the optional-field gating below.
       const isStateOnlyAction = isNoopAction || isPopoutAction;
 
+      // The primary selector plus any non-empty fallbacks become an ordered array;
+      // with no fallbacks the value stays a plain string (legacy-identical).
+      const primarySelector = reftarget.trim();
+      const cleanedFallbacks = fallbacks.map((fb) => fb.trim()).filter(Boolean);
+      const reftargetValue: string | string[] =
+        cleanedFallbacks.length > 0 ? [primarySelector, ...cleanedFallbacks] : primarySelector;
+
       const block: JsonInteractiveBlock = {
         type: 'interactive',
         action,
         // Only include reftarget for actions that operate on DOM elements
-        ...(!isStateOnlyAction && reftarget.trim() && { reftarget: reftarget.trim() }),
+        ...(!isStateOnlyAction && primarySelector && { reftarget: reftargetValue }),
         content: content.trim(),
         // formfill stores the value to fill; popout stores the target panel mode.
         ...(!isStateOnlyAction && targetvalue.trim() && { targetvalue: targetvalue.trim() }),
@@ -187,6 +221,7 @@ export function InteractiveBlockForm({
     [
       action,
       reftarget,
+      fallbacks,
       targetvalue,
       content,
       tooltip,
@@ -426,6 +461,39 @@ export function InteractiveBlockForm({
           {showAlternatives && alternatives.length === 0 && (
             <span style={{ fontSize: 12, color: '#8e8e8e' }}>No alternative selectors found for this element.</span>
           )}
+
+          {/* Fallback selectors — tried in order (strongest first) if the target selector above isn't found */}
+          <Field
+            label="Fallback selectors"
+            description="Optional. Tried in order if the target selector above can't be found — e.g. a stable data-testid to fall back to when matching by visible text fails in another language."
+          >
+            <Stack direction="column" gap={1}>
+              {fallbacks.map((fb, i) => (
+                <div key={i}>
+                  <div className={styles.selectorField}>
+                    <Input
+                      value={fb}
+                      onChange={(e) => updateFallback(i, e.currentTarget.value)}
+                      placeholder="e.g., button[data-testid='save-dashboard']"
+                      className={styles.selectorInput}
+                    />
+                    <IconButton name="arrow-up" tooltip="Move up" disabled={i === 0} onClick={() => moveFallback(i, -1)} />
+                    <IconButton
+                      name="arrow-down"
+                      tooltip="Move down"
+                      disabled={i === fallbacks.length - 1}
+                      onClick={() => moveFallback(i, 1)}
+                    />
+                    <IconButton name="trash-alt" tooltip="Remove fallback" onClick={() => removeFallback(i)} />
+                  </div>
+                  {fb.trim() && <SelectorHealthBadge reftarget={fb} />}
+                </div>
+              ))}
+              <Button size="sm" variant="secondary" icon="plus" type="button" onClick={addFallback}>
+                Add fallback selector
+              </Button>
+            </Stack>
+          </Field>
         </>
       )}
 

--- a/src/components/block-editor/forms/InteractiveBlockForm.tsx
+++ b/src/components/block-editor/forms/InteractiveBlockForm.tsx
@@ -8,7 +8,6 @@ import React, { useState, useCallback } from 'react';
 import {
   Button,
   Field,
-  IconButton,
   Input,
   TextArea,
   Combobox,
@@ -139,24 +138,6 @@ export function InteractiveBlockForm({
       }
     });
   }, [onPickerModeChange, action]);
-
-  const addFallback = useCallback(() => setFallbacks((prev) => [...prev, '']), []);
-  const removeFallback = useCallback((index: number) => setFallbacks((prev) => prev.filter((_, i) => i !== index)), []);
-  const updateFallback = useCallback(
-    (index: number, value: string) => setFallbacks((prev) => prev.map((fb, i) => (i === index ? value : fb))),
-    []
-  );
-  const moveFallback = useCallback((index: number, direction: -1 | 1) => {
-    setFallbacks((prev) => {
-      const target = index + direction;
-      if (target < 0 || target >= prev.length) {
-        return prev;
-      }
-      const next = [...prev];
-      [next[index], next[target]] = [next[target]!, next[index]!];
-      return next;
-    });
-  }, []);
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -464,44 +445,6 @@ export function InteractiveBlockForm({
           {showAlternatives && alternatives.length === 0 && (
             <span style={{ fontSize: 12, color: '#8e8e8e' }}>No alternative selectors found for this element.</span>
           )}
-
-          {/* Fallback selectors — tried in order (strongest first) if the target selector above isn't found */}
-          <Field
-            label="Fallback selectors"
-            description="Optional. Tried in order if the target selector above can't be found — e.g. a stable data-testid to fall back to when matching by visible text fails in another language."
-          >
-            <Stack direction="column" gap={1}>
-              {fallbacks.map((fb, i) => (
-                <div key={i}>
-                  <div className={styles.selectorField}>
-                    <Input
-                      value={fb}
-                      onChange={(e) => updateFallback(i, e.currentTarget.value)}
-                      placeholder="e.g., button[data-testid='save-dashboard']"
-                      className={styles.selectorInput}
-                    />
-                    <IconButton
-                      name="arrow-up"
-                      tooltip="Move up"
-                      disabled={i === 0}
-                      onClick={() => moveFallback(i, -1)}
-                    />
-                    <IconButton
-                      name="arrow-down"
-                      tooltip="Move down"
-                      disabled={i === fallbacks.length - 1}
-                      onClick={() => moveFallback(i, 1)}
-                    />
-                    <IconButton name="trash-alt" tooltip="Remove fallback" onClick={() => removeFallback(i)} />
-                  </div>
-                  {fb.trim() && <SelectorHealthBadge reftarget={fb} />}
-                </div>
-              ))}
-              <Button size="sm" variant="secondary" icon="plus" type="button" onClick={addFallback}>
-                Add fallback selector
-              </Button>
-            </Stack>
-          </Field>
         </>
       )}
 

--- a/src/components/block-editor/forms/InteractiveBlockForm.tsx
+++ b/src/components/block-editor/forms/InteractiveBlockForm.tsx
@@ -129,8 +129,9 @@ export function InteractiveBlockForm({
 
   // Start element picker - pass callback to receive selected element
   const startPicker = useCallback(() => {
-    onPickerModeChange?.(true, (selector: string) => {
+    onPickerModeChange?.(true, (selector: string, pickedFallbacks: string[] = []) => {
       setReftarget(selector);
+      setFallbacks(pickedFallbacks);
       // Auto-add default requirements based on selector pattern
       const suggestions = suggestDefaultRequirements(action, selector);
       if (suggestions.length > 0) {

--- a/src/components/block-editor/forms/StepEditor.tsx
+++ b/src/components/block-editor/forms/StepEditor.tsx
@@ -229,7 +229,7 @@ export interface StepEditorProps {
   /** Whether this is for a guided block (uses description instead of tooltip) */
   isGuided?: boolean;
   /** Called to start/stop the element picker with a callback for receiving the selector */
-  onPickerModeChange?: (isActive: boolean, onSelect?: (selector: string) => void) => void;
+  onPickerModeChange?: (isActive: boolean, onSelect?: (selector: string, fallbacks?: string[]) => void) => void;
   /**
    * Called when record mode starts/stops.
    * When starting (isActive=true), provides callbacks so parent can control the overlay.

--- a/src/components/block-editor/forms/StepEditor.tsx
+++ b/src/components/block-editor/forms/StepEditor.tsx
@@ -40,6 +40,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { INTERACTIVE_ACTIONS, POPOUT_TARGET_MODES } from '../constants';
 import { useActionRecorder } from '../../../utils/devtools';
+import { primaryRefTarget } from '../../../lib/dom';
 import { suggestDefaultRequirements, mergeRequirements } from './requirements-suggester';
 import { ConditionChipsField } from './ConditionChipsField';
 import {
@@ -421,7 +422,7 @@ export function StepEditor({
       }
       setEditingStepIndex(index);
       setEditAction(step.action ?? step.targetAction ?? 'highlight');
-      setEditReftarget(step.reftarget ?? step.refTarget ?? '');
+      setEditReftarget(primaryRefTarget(step.reftarget ?? step.refTarget ?? ''));
       setEditTargetvalue(step.targetvalue ?? step.targetValue ?? '');
       setEditFormHint(step.formHint ?? '');
       setEditValidateInput(step.validateInput ?? false);
@@ -938,7 +939,7 @@ export function StepEditor({
                           )}
                         </div>
                         {/* Show description/tooltip if available, otherwise show selector (or "Info step" for noop, "Dock"/"Undock" for popout) */}
-                        <div className={styles.stepSelector} title={step.reftarget}>
+                        <div className={styles.stepSelector} title={step.reftarget ? primaryRefTarget(step.reftarget) : undefined}>
                           {step.action === 'noop'
                             ? isGuided
                               ? step.description || 'Informational step'

--- a/src/components/block-editor/forms/StepEditor.tsx
+++ b/src/components/block-editor/forms/StepEditor.tsx
@@ -939,7 +939,10 @@ export function StepEditor({
                           )}
                         </div>
                         {/* Show description/tooltip if available, otherwise show selector (or "Info step" for noop, "Dock"/"Undock" for popout) */}
-                        <div className={styles.stepSelector} title={step.reftarget ? primaryRefTarget(step.reftarget) : undefined}>
+                        <div
+                          className={styles.stepSelector}
+                          title={step.reftarget ? primaryRefTarget(step.reftarget) : undefined}
+                        >
                           {step.action === 'noop'
                             ? isGuided
                               ? step.description || 'Informational step'

--- a/src/components/block-editor/lint/cross-block-checks.ts
+++ b/src/components/block-editor/lint/cross-block-checks.ts
@@ -217,7 +217,11 @@ export function destructiveActionWithoutObjective(guide: JsonGuide): Diagnostic[
     let actionLabel = '';
 
     if (isInteractiveBlock(block)) {
-      if (block.action === 'button' && block.reftarget && DESTRUCTIVE_REFTARGET_PATTERN.test(primaryRefTarget(block.reftarget))) {
+      if (
+        block.action === 'button' &&
+        block.reftarget &&
+        DESTRUCTIVE_REFTARGET_PATTERN.test(primaryRefTarget(block.reftarget))
+      ) {
         isDestructive = true;
         actionLabel = `button "${primaryRefTarget(block.reftarget)}"`;
       }
@@ -347,11 +351,15 @@ export function requirementsImpliedByActionButNotDeclared(guide: JsonGuide): Dia
       continue;
     }
 
-    const expected = suggestRequirementsFromContext(action, primaryRefTarget(block.reftarget ?? block.refTarget ?? ''), {
-      isFirstStepInGuide: isFirstStep,
-      isInsideMultistep: false,
-      currentPath: typeof window !== 'undefined' ? window.location.pathname : undefined,
-    });
+    const expected = suggestRequirementsFromContext(
+      action,
+      primaryRefTarget(block.reftarget ?? block.refTarget ?? ''),
+      {
+        isFirstStepInGuide: isFirstStep,
+        isInsideMultistep: false,
+        currentPath: typeof window !== 'undefined' ? window.location.pathname : undefined,
+      }
+    );
     if (expected.length === 0) {
       continue;
     }

--- a/src/components/block-editor/lint/cross-block-checks.ts
+++ b/src/components/block-editor/lint/cross-block-checks.ts
@@ -34,6 +34,7 @@ import {
 } from '../../../types/json-guide.types';
 import { ParameterizedRequirementPrefix } from '../../../types/requirements.types';
 import { suggestRequirementsFromContext } from '../forms/requirements-suggester';
+import { primaryRefTarget } from '../../../lib/dom';
 import type { Diagnostic } from './types';
 
 // ---------------------------------------------------------------------------
@@ -216,9 +217,9 @@ export function destructiveActionWithoutObjective(guide: JsonGuide): Diagnostic[
     let actionLabel = '';
 
     if (isInteractiveBlock(block)) {
-      if (block.action === 'button' && block.reftarget && DESTRUCTIVE_REFTARGET_PATTERN.test(block.reftarget)) {
+      if (block.action === 'button' && block.reftarget && DESTRUCTIVE_REFTARGET_PATTERN.test(primaryRefTarget(block.reftarget))) {
         isDestructive = true;
-        actionLabel = `button "${block.reftarget}"`;
+        actionLabel = `button "${primaryRefTarget(block.reftarget)}"`;
       }
     } else {
       // multistep / guided — check if any step is destructive.
@@ -227,11 +228,11 @@ export function destructiveActionWithoutObjective(guide: JsonGuide): Diagnostic[
         continue;
       }
       const destructiveStep = steps.find(
-        (s) => s.action === 'button' && s.reftarget && DESTRUCTIVE_REFTARGET_PATTERN.test(s.reftarget)
+        (s) => s.action === 'button' && s.reftarget && DESTRUCTIVE_REFTARGET_PATTERN.test(primaryRefTarget(s.reftarget))
       );
       if (destructiveStep) {
         isDestructive = true;
-        actionLabel = `step "${destructiveStep.reftarget}"`;
+        actionLabel = `step "${primaryRefTarget(destructiveStep.reftarget!)}"`;
       }
     }
 
@@ -346,7 +347,7 @@ export function requirementsImpliedByActionButNotDeclared(guide: JsonGuide): Dia
       continue;
     }
 
-    const expected = suggestRequirementsFromContext(action, block.reftarget ?? block.refTarget ?? '', {
+    const expected = suggestRequirementsFromContext(action, primaryRefTarget(block.reftarget ?? block.refTarget ?? ''), {
       isFirstStepInGuide: isFirstStep,
       isInsideMultistep: false,
       currentPath: typeof window !== 'undefined' ? window.location.pathname : undefined,

--- a/src/components/block-editor/types.ts
+++ b/src/components/block-editor/types.ts
@@ -107,7 +107,7 @@ export interface BlockFormProps<T extends JsonBlock = JsonBlock> {
    * When starting (isActive=true), provide a callback to receive the selected element.
    * The modal will render the picker and call the callback with the selector.
    */
-  onPickerModeChange?: (isActive: boolean, onSelect?: (selector: string) => void) => void;
+  onPickerModeChange?: (isActive: boolean, onSelect?: (selector: string, fallbacks?: string[]) => void) => void;
   /**
    * Called to start/stop record mode.
    * When starting (isActive=true), provides callbacks so parent can control the overlay.

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -1014,10 +1014,14 @@ function renderParsedElement(
 
   // Helper to substitute variables in internal actions (for multistep/guided blocks)
   // Uses generic to preserve the input array type (InternalAction[], GuidedAction[], etc.)
-  const subInternalActions = <T extends { refTarget?: string; targetValue?: string }>(actions: T[]): T[] => {
+  const subInternalActions = <T extends { refTarget?: string | string[]; targetValue?: string }>(
+    actions: T[]
+  ): T[] => {
     return actions.map((action) => ({
       ...action,
-      refTarget: sub(action.refTarget) ?? action.refTarget,
+      refTarget: Array.isArray(action.refTarget)
+        ? action.refTarget.map((target) => sub(target) ?? target)
+        : sub(action.refTarget) ?? action.refTarget,
       targetValue: sub(action.targetValue),
     }));
   };

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -1014,14 +1014,12 @@ function renderParsedElement(
 
   // Helper to substitute variables in internal actions (for multistep/guided blocks)
   // Uses generic to preserve the input array type (InternalAction[], GuidedAction[], etc.)
-  const subInternalActions = <T extends { refTarget?: string | string[]; targetValue?: string }>(
-    actions: T[]
-  ): T[] => {
+  const subInternalActions = <T extends { refTarget?: string | string[]; targetValue?: string }>(actions: T[]): T[] => {
     return actions.map((action) => ({
       ...action,
       refTarget: Array.isArray(action.refTarget)
         ? action.refTarget.map((target) => sub(target) ?? target)
-        : sub(action.refTarget) ?? action.refTarget,
+        : (sub(action.refTarget) ?? action.refTarget),
       targetValue: sub(action.targetValue),
     }));
   };

--- a/src/components/interactive-tutorial/interactive-guided.test.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.test.tsx
@@ -68,6 +68,7 @@ jest.mock('../../constants/interactive-config', () => ({
 jest.mock('../../lib/dom', () => ({
   findButtonByText: jest.fn().mockReturnValue([]),
   querySelectorAllEnhanced: jest.fn().mockReturnValue({ elements: [], usedFallback: false }),
+  primaryRefTarget: (rt: string | string[]) => (Array.isArray(rt) ? (rt[0] ?? '') : rt),
 }));
 
 // ─── Mock security ───────────────────────────────────────────────────────────

--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -15,7 +15,7 @@ import { waitForReactUpdates } from '../../lib/async-utils';
 import { useStepChecker, validateInteractiveRequirements } from '../../requirements-manager';
 import { getInteractiveConfig } from '../../constants/interactive-config';
 import { getConfigWithDefaults } from '../../constants';
-import { findButtonByText, querySelectorAllEnhanced } from '../../lib/dom';
+import { findButtonByText, querySelectorAllEnhanced, primaryRefTarget } from '../../lib/dom';
 import { GuidedAction } from '../../types/interactive-actions.types';
 import { testIds } from '../../constants/testIds';
 // Deep import (not the barrel): the barrel re-exports @grafana/assistant, which crashes under jsdom.
@@ -247,7 +247,8 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
 
     // For exists-reftarget requirement, use the first internal action's target
     // This ensures the requirement checker knows which element to look for
-    const firstActionRefTarget = internalActions.length > 0 ? internalActions[0]!.refTarget : undefined;
+    const firstActionRefTarget =
+      internalActions[0]?.refTarget === undefined ? undefined : primaryRefTarget(internalActions[0].refTarget);
     const firstActionTargetAction = internalActions.length > 0 ? internalActions[0]!.targetAction : undefined;
 
     // Runtime validation: check for impossible requirement configurations
@@ -430,8 +431,9 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
           return;
         }
 
-        // Non-noop actions require refTarget
-        const selector = currentAction.refTarget;
+        // Non-noop actions require refTarget. Coordinate-matching detection keys
+        // off the primary selector; the execute path keeps the full fallback chain.
+        const selector = currentAction.refTarget === undefined ? undefined : primaryRefTarget(currentAction.refTarget);
         if (!selector) {
           return;
         }
@@ -951,7 +953,10 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
                   detail={{
                     stepId: stepId ?? renderedStepId,
                     renderedStepId,
-                    refTarget: internalActions[failedStepIndex]?.refTarget,
+                    refTarget:
+                      internalActions[failedStepIndex]?.refTarget === undefined
+                        ? undefined
+                        : primaryRefTarget(internalActions[failedStepIndex]!.refTarget),
                     action: internalActions[failedStepIndex]?.targetAction,
                     containerInfo: {
                       containerId: stepId ?? renderedStepId,

--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -247,8 +247,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
 
     // For exists-reftarget requirement, use the first internal action's target
     // This ensures the requirement checker knows which element to look for
-    const firstActionRefTarget =
-      internalActions[0]?.refTarget === undefined ? undefined : primaryRefTarget(internalActions[0].refTarget);
+    const firstActionRefTarget = internalActions[0]?.refTarget;
     const firstActionTargetAction = internalActions.length > 0 ? internalActions[0]!.targetAction : undefined;
 
     // Runtime validation: check for impossible requirement configurations
@@ -856,7 +855,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
                   detail={{
                     stepId: stepId ?? renderedStepId,
                     renderedStepId,
-                    refTarget: firstActionRefTarget,
+                    refTarget: firstActionRefTarget === undefined ? undefined : primaryRefTarget(firstActionRefTarget),
                     action: firstActionTargetAction,
                   }}
                 />

--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -597,7 +597,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
             internalActions: internalActions.map(
               (a): CrossTabInternalAction => ({
                 targetAction: a.targetAction,
-                refTarget: a.refTarget,
+                refTarget: a.refTarget === undefined ? undefined : primaryRefTarget(a.refTarget),
                 targetValue: a.targetValue,
                 targetComment: a.targetComment,
               })

--- a/src/components/interactive-tutorial/interactive-multi-step.tsx
+++ b/src/components/interactive-tutorial/interactive-multi-step.tsx
@@ -647,7 +647,7 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
             internalActions: internalActions.map(
               (a): CrossTabInternalAction => ({
                 targetAction: a.targetAction,
-                refTarget: a.refTarget,
+                refTarget: a.refTarget === undefined ? undefined : primaryRefTarget(a.refTarget),
                 targetValue: a.targetValue,
                 targetComment: a.targetComment,
               })

--- a/src/components/interactive-tutorial/interactive-multi-step.tsx
+++ b/src/components/interactive-tutorial/interactive-multi-step.tsx
@@ -224,8 +224,7 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
 
     // For exists-reftarget requirement, use the first internal action's target
     // This ensures the requirement checker knows which element to look for
-    const firstActionRefTarget =
-      internalActions[0]?.refTarget === undefined ? undefined : primaryRefTarget(internalActions[0].refTarget);
+    const firstActionRefTarget = internalActions[0]?.refTarget;
     const firstActionTargetAction = internalActions.length > 0 ? internalActions[0]!.targetAction : undefined;
 
     // Get the interactive functions from the hook

--- a/src/components/interactive-tutorial/interactive-multi-step.tsx
+++ b/src/components/interactive-tutorial/interactive-multi-step.tsx
@@ -13,6 +13,7 @@ import { reportAppInteraction, UserInteraction, buildInteractiveStepProperties }
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
 import { InternalAction } from '../../types/interactive-actions.types';
 import type { InteractiveElementData } from '../../types/interactive.types';
+import { primaryRefTarget } from '../../lib/dom/dom-utils';
 import { testIds } from '../../constants/testIds';
 // Deep import (not the barrel): the barrel re-exports @grafana/assistant, which crashes under jsdom.
 import { useAiFixEnabled } from '../../integrations/assistant-integration/use-ai-fix-enabled';
@@ -223,7 +224,8 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
 
     // For exists-reftarget requirement, use the first internal action's target
     // This ensures the requirement checker knows which element to look for
-    const firstActionRefTarget = internalActions.length > 0 ? internalActions[0]!.refTarget : undefined;
+    const firstActionRefTarget =
+      internalActions[0]?.refTarget === undefined ? undefined : primaryRefTarget(internalActions[0].refTarget);
     const firstActionTargetAction = internalActions.length > 0 ? internalActions[0]!.targetAction : undefined;
 
     // Get the interactive functions from the hook
@@ -498,7 +500,7 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
       () =>
         internalActions.map((action) => ({
           targetAction: action.targetAction,
-          refTarget: action.refTarget || '',
+          refTarget: action.refTarget === undefined ? '' : primaryRefTarget(action.refTarget),
           targetValue: action.targetValue,
         })),
       [internalActions]
@@ -947,7 +949,10 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
                     detail={{
                       stepId: stepId ?? renderedStepId,
                       renderedStepId,
-                      refTarget: internalActions[failedStepIndex]?.refTarget,
+                      refTarget:
+                        internalActions[failedStepIndex]?.refTarget === undefined
+                          ? undefined
+                          : primaryRefTarget(internalActions[failedStepIndex]!.refTarget),
                       action: internalActions[failedStepIndex]?.targetAction,
                       containerInfo: {
                         containerId: stepId ?? renderedStepId,

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -22,7 +22,7 @@ import { AssistantCustomizableProvider, useAssistantBlockValue } from '../../int
 // Deep import (not the barrel): the barrel re-exports @grafana/assistant, which crashes under jsdom.
 import { useAiFixEnabled } from '../../integrations/assistant-integration/use-ai-fix-enabled';
 import { CodeBlock } from '../../docs-retrieval';
-import { scrollUntilElementFound } from '../../lib/dom';
+import { scrollUntilElementFound, primaryRefTarget } from '../../lib/dom';
 import { resolveWithRetry } from '../../lib/dom/selector-retry';
 import { STEP_STATES } from './step-states';
 import { AiFixButton } from './ai-fix-button';
@@ -51,7 +51,7 @@ interface LazyScrollResult {
  * @returns Result indicating success/failure
  */
 async function executeWithLazyScroll(
-  refTarget: string,
+  refTarget: string | string[],
   lazyRender: boolean,
   scrollContainer: string | undefined,
   action: () => Promise<void>,
@@ -78,7 +78,7 @@ async function executeWithLazyScroll(
   // Element not found - try lazy scroll discovery only if enabled
   if (lazyRender) {
     console.log(`[LazyScroll] Element not found, attempting scroll discovery: ${refTarget}`);
-    const foundElement = await scrollUntilElementFound(refTarget, {
+    const foundElement = await scrollUntilElementFound(primaryRefTarget(refTarget), {
       scrollContainerSelector: scrollContainer,
     });
 
@@ -261,7 +261,7 @@ export const InteractiveStep = forwardRef<
       validateInteractiveRequirements(
         {
           requirements,
-          refTarget,
+          refTarget: primaryRefTarget(refTarget),
           stepId: renderedStepId,
         },
         'InteractiveStep'
@@ -279,7 +279,7 @@ export const InteractiveStep = forwardRef<
       requirements,
       hints,
       targetAction,
-      refTarget,
+      refTarget: primaryRefTarget(refTarget),
       stepId: stepId || renderedStepId, // Fallback if no stepId provided
       isEligibleForChecking: isPartOfSection ? isEligibleForChecking : isEligibleForChecking && !isCompleted,
       skippable,
@@ -373,7 +373,7 @@ export const InteractiveStep = forwardRef<
       if (targetAction !== 'formfill' || !refTarget) {
         return null;
       }
-      return resolveTargetElement({ targetAction, refTarget, targetValue: currentTargetValue });
+      return resolveTargetElement({ targetAction, refTarget: primaryRefTarget(refTarget), targetValue: currentTargetValue });
     }, [targetAction, refTarget, currentTargetValue]);
 
     // Handle form validation completion
@@ -551,7 +551,7 @@ export const InteractiveStep = forwardRef<
             const result = await checkPostconditions({
               requirements: postVerify,
               targetAction,
-              refTarget,
+              refTarget: primaryRefTarget(refTarget),
               targetValue: currentTargetValue,
               stepId: stepId || renderedStepId,
             });
@@ -564,7 +564,7 @@ export const InteractiveStep = forwardRef<
                 buildInteractiveStepProperties(
                   {
                     target_action: targetAction,
-                    ref_target: refTarget,
+                    ref_target: primaryRefTarget(refTarget),
                     interaction_location: 'interactive_step_auto',
                     failure_reason: 'post_verification_failed',
                   },
@@ -581,7 +581,7 @@ export const InteractiveStep = forwardRef<
               buildInteractiveStepProperties(
                 {
                   target_action: targetAction,
-                  ref_target: refTarget,
+                  ref_target: primaryRefTarget(refTarget),
                   interaction_location: 'interactive_step_auto',
                   failure_reason: 'post_verification_error',
                 },
@@ -610,7 +610,7 @@ export const InteractiveStep = forwardRef<
           buildInteractiveStepProperties(
             {
               target_action: targetAction,
-              ref_target: refTarget,
+              ref_target: primaryRefTarget(refTarget),
               ...(currentTargetValue && { target_value: currentTargetValue }),
               interaction_location: 'interactive_step_auto',
               completion_method: 'auto_detected',
@@ -636,7 +636,7 @@ export const InteractiveStep = forwardRef<
     // Use the shared auto-detection hook
     useSingleActionDetection({
       targetAction,
-      refTarget,
+      refTarget: primaryRefTarget(refTarget),
       targetValue: currentTargetValue,
       isEnabled: finalIsEnabled,
       isCompleted: isCompletedWithObjectives,
@@ -661,7 +661,7 @@ export const InteractiveStep = forwardRef<
         buildInteractiveStepProperties(
           {
             target_action: targetAction,
-            ref_target: refTarget,
+            ref_target: primaryRefTarget(refTarget),
             ...(currentTargetValue && { target_value: currentTargetValue }),
             interaction_location: 'interactive_step',
           },
@@ -783,7 +783,7 @@ export const InteractiveStep = forwardRef<
         buildInteractiveStepProperties(
           {
             target_action: targetAction,
-            ref_target: refTarget,
+            ref_target: primaryRefTarget(refTarget),
             ...(currentTargetValue && { target_value: currentTargetValue }),
             interaction_location: 'interactive_step',
           },
@@ -911,13 +911,13 @@ export const InteractiveStep = forwardRef<
     const getActionDescription = () => {
       switch (targetAction) {
         case 'button':
-          return `Click "${refTarget}"`;
+          return `Click "${primaryRefTarget(refTarget)}"`;
         case 'highlight':
           return `Highlight element`;
         case 'formfill':
           return `Fill form with "${currentTargetValue || 'value'}"`;
         case 'navigate':
-          return `Navigate to ${refTarget}`;
+          return `Navigate to ${primaryRefTarget(refTarget)}`;
         case 'hover':
           return `Hover over element`;
         case 'sequence':
@@ -953,7 +953,7 @@ export const InteractiveStep = forwardRef<
       <div
         className={`interactive-step${className ? ` ${className}` : ''}${completedClass}${isCurrentlyExecuting ? ' executing' : ''}`}
         data-targetaction={targetAction}
-        data-reftarget={refTarget}
+        data-reftarget={primaryRefTarget(refTarget)}
         data-targetvalue={currentTargetValue}
         data-targetcomment={targetComment}
         data-openguide={openGuide}
@@ -1162,7 +1162,7 @@ export const InteractiveStep = forwardRef<
                 detail={{
                   stepId: stepId ?? renderedStepId,
                   renderedStepId,
-                  refTarget,
+                  refTarget: primaryRefTarget(refTarget),
                   action: targetAction,
                 }}
               />
@@ -1248,7 +1248,7 @@ export const InteractiveStep = forwardRef<
                       detail={{
                         stepId: stepId ?? renderedStepId,
                         renderedStepId,
-                        refTarget,
+                        refTarget: primaryRefTarget(refTarget),
                         action: targetAction,
                       }}
                     />

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -261,7 +261,7 @@ export const InteractiveStep = forwardRef<
       validateInteractiveRequirements(
         {
           requirements,
-          refTarget: primaryRefTarget(refTarget),
+          refTarget,
           stepId: renderedStepId,
         },
         'InteractiveStep'
@@ -279,7 +279,7 @@ export const InteractiveStep = forwardRef<
       requirements,
       hints,
       targetAction,
-      refTarget: primaryRefTarget(refTarget),
+      refTarget,
       stepId: stepId || renderedStepId, // Fallback if no stepId provided
       isEligibleForChecking: isPartOfSection ? isEligibleForChecking : isEligibleForChecking && !isCompleted,
       skippable,
@@ -551,7 +551,7 @@ export const InteractiveStep = forwardRef<
             const result = await checkPostconditions({
               requirements: postVerify,
               targetAction,
-              refTarget: primaryRefTarget(refTarget),
+              refTarget,
               targetValue: currentTargetValue,
               stepId: stepId || renderedStepId,
             });

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -692,7 +692,12 @@ export const InteractiveStep = forwardRef<
           phase: 'show',
           stepId,
           runId: crypto.randomUUID(),
-          action: { targetAction, refTarget, targetValue: currentTargetValue, targetComment },
+          action: {
+            targetAction,
+            refTarget: primaryRefTarget(refTarget),
+            targetValue: currentTargetValue,
+            targetComment,
+          },
         });
         if (!doIt) {
           // F-1063-1 (fix-plan §6.2): simple steps complete optimistically — no
@@ -814,7 +819,12 @@ export const InteractiveStep = forwardRef<
           phase: 'do',
           stepId,
           runId: crypto.randomUUID(),
-          action: { targetAction, refTarget, targetValue: currentTargetValue, targetComment },
+          action: {
+            targetAction,
+            refTarget: primaryRefTarget(refTarget),
+            targetValue: currentTargetValue,
+            targetComment,
+          },
         });
         // F-1063-1 (fix-plan §6.2): simple steps complete optimistically — no live
         // ack, and they complete even with no live tab connected. Accepted by

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -373,7 +373,11 @@ export const InteractiveStep = forwardRef<
       if (targetAction !== 'formfill' || !refTarget) {
         return null;
       }
-      return resolveTargetElement({ targetAction, refTarget: primaryRefTarget(refTarget), targetValue: currentTargetValue });
+      return resolveTargetElement({
+        targetAction,
+        refTarget: primaryRefTarget(refTarget),
+        targetValue: currentTargetValue,
+      });
     }, [targetAction, refTarget, currentTargetValue]);
 
     // Handle form validation completion

--- a/src/docs-retrieval/json-parser-aliases.test.ts
+++ b/src/docs-retrieval/json-parser-aliases.test.ts
@@ -22,6 +22,38 @@ function makeGuide(blockOverrides: Record<string, unknown>): JsonGuide {
   };
 }
 
+describe('json-parser — reftarget fallback arrays', () => {
+  function refTargetOf(guide: JsonGuide) {
+    const result = parseJsonGuide(guide);
+    return result.data!.elements.find((el) => el.type === 'interactive-step')!.props.refTarget;
+  }
+
+  it('passes a multi-selector array through as an ordered array', () => {
+    const guide = makeGuide({ action: 'button', reftarget: ['Save dashboard', "button[data-testid='save']"] });
+    expect(refTargetOf(guide)).toEqual(['Save dashboard', "button[data-testid='save']"]);
+  });
+
+  it('collapses a single-element array to a plain string', () => {
+    const guide = makeGuide({ action: 'highlight', reftarget: ['#only'] });
+    expect(refTargetOf(guide)).toBe('#only');
+  });
+
+  it('trims entries and drops whitespace-only ones', () => {
+    const guide = makeGuide({ action: 'highlight', reftarget: ['  #a  ', '   ', '#b'] });
+    expect(refTargetOf(guide)).toEqual(['#a', '#b']);
+  });
+
+  it('leaves a single string unchanged', () => {
+    const guide = makeGuide({ action: 'button', reftarget: 'Save' });
+    expect(refTargetOf(guide)).toBe('Save');
+  });
+
+  it('normalizes the camelCase alias array', () => {
+    const guide = makeGuide({ targetAction: 'highlight', refTarget: ['#a', '#b'] });
+    expect(refTargetOf(guide)).toEqual(['#a', '#b']);
+  });
+});
+
 describe('json-parser — field-name alias acceptance', () => {
   it('interactive block: reads canonical lowercase fields', () => {
     const guide = makeGuide({

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -244,7 +244,7 @@ function resolveStepId(
   authorId: string | undefined,
   stepContext: StepContext | undefined,
   action: string | undefined,
-  refTarget: string | undefined,
+  refTarget: string | string[] | undefined,
   variant?: string
 ): string | undefined {
   if (authorId) {
@@ -257,7 +257,8 @@ function resolveStepId(
     sectionId: stepContext.parentSectionId,
     index: stepContext.index,
     action,
-    refTarget,
+    // The id is derived from the strongest selector; fallbacks don't change identity.
+    refTarget: Array.isArray(refTarget) ? refTarget[0] : refTarget,
     variant,
   });
 }
@@ -580,7 +581,7 @@ function convertConditionalBlock(block: JsonConditionalBlock, path: string, base
         conditions: block.conditions,
         description: block.description,
         display: block.display ?? 'inline',
-        refTarget: block.reftarget,
+        refTarget: normalizeRefTarget(block.reftarget),
         // Per-branch section configs (each branch has its own title, requirements, objectives)
         whenTrueSectionConfig: block.whenTrueSectionConfig,
         whenFalseSectionConfig: block.whenFalseSectionConfig,
@@ -594,6 +595,23 @@ function convertConditionalBlock(block: JsonConditionalBlock, path: string, base
   };
 }
 
+/**
+ * Normalize an authored reftarget. Arrays are trimmed, empty entries dropped,
+ * and a single-entry array collapsed to a plain string so the common case
+ * serializes identically to a single-selector guide. Single strings pass
+ * through unchanged.
+ */
+function normalizeRefTarget(value: string | string[] | undefined): string | string[] | undefined {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  const cleaned = value.map((selector) => selector.trim()).filter(Boolean);
+  if (cleaned.length === 0) {
+    return undefined;
+  }
+  return cleaned.length === 1 ? cleaned[0] : cleaned;
+}
+
 function convertInteractiveBlock(
   block: JsonInteractiveBlock,
   path: string,
@@ -604,7 +622,7 @@ function convertInteractiveBlock(
   // form. Prefer the lowercase slot when present (canonical wins) and
   // fall back to the camelCase alias.
   const targetAction = block.action ?? block.targetAction;
-  const refTargetValue = block.reftarget ?? block.refTarget;
+  const refTargetValue = normalizeRefTarget(block.reftarget ?? block.refTarget);
   const targetValue = block.targetvalue ?? block.targetValue;
   const stepId = resolveStepId(block.id, stepContext, targetAction, refTargetValue);
 
@@ -666,7 +684,7 @@ function convertMultistepBlock(block: JsonMultistepBlock, path: string, stepCont
   // Accept either the lowercase canonical or the camelCase alias on each step.
   const internalActions = block.steps.map((step: JsonStep) => ({
     targetAction: step.action ?? step.targetAction,
-    refTarget: step.reftarget ?? step.refTarget,
+    refTarget: normalizeRefTarget(step.reftarget ?? step.refTarget),
     targetValue: step.targetvalue ?? step.targetValue,
     requirements: step.requirements?.join(','),
     targetComment: step.tooltip ? markdownToHtml(step.tooltip) : undefined,
@@ -710,7 +728,7 @@ function convertGuidedBlock(block: JsonGuidedBlock, path: string, stepContext?: 
   // Accept either the lowercase canonical or the camelCase alias on each step.
   const internalActions = block.steps.map((step: JsonStep) => ({
     targetAction: step.action ?? step.targetAction,
-    refTarget: step.reftarget ?? step.refTarget,
+    refTarget: normalizeRefTarget(step.reftarget ?? step.refTarget),
     targetValue: step.targetvalue ?? step.targetValue,
     requirements: step.requirements?.join(','),
     // For guided blocks, prefer description (shown in steps panel), fall back to tooltip for backward compatibility

--- a/src/docs-retrieval/reftarget-fallback.integration.test.ts
+++ b/src/docs-retrieval/reftarget-fallback.integration.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Cross-layer end-to-end test for reftarget fallback chains: author a guide with
+ * an ordered `reftarget` array, parse it, and resolve it against the DOM through
+ * the real selector pipeline. Proves the full path (schema/parser → runtime
+ * union → selector-major resolver) without a browser.
+ *
+ * The motivating scenario: a guide authored in English targets a button by
+ * visible text ("Save dashboard"), but the user runs Grafana in German so the
+ * button reads "Speichern". The primary (visible-text) selector misses; the
+ * stable `data-testid` fallback wins.
+ */
+
+import { parseJsonGuide } from './json-parser';
+import { resolveWithRetry } from '../lib/dom/selector-retry';
+import type { JsonGuide } from '../types/json-guide.types';
+
+function refTargetFromGuide(guide: JsonGuide): string | string[] {
+  const result = parseJsonGuide(guide);
+  const step = result.data!.elements.find((el) => el.type === 'interactive-step');
+  return step!.props.refTarget as string | string[];
+}
+
+describe('reftarget fallback chain — parse + resolve end to end', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('falls back from a locale-broken visible-text selector to a stable data-testid', async () => {
+    // German locale: the button text is "Speichern", not "Save dashboard".
+    document.body.innerHTML = '<button data-testid="save-dashboard">Speichern</button>';
+
+    const guide: JsonGuide = {
+      id: 'fallback-e2e',
+      title: 'Fallback e2e',
+      blocks: [
+        {
+          type: 'interactive',
+          action: 'button',
+          content: 'Save the dashboard',
+          reftarget: ['Save dashboard', 'button[data-testid="save-dashboard"]'],
+        },
+      ],
+    };
+
+    const refTarget = refTargetFromGuide(guide);
+    expect(refTarget).toEqual(['Save dashboard', 'button[data-testid="save-dashboard"]']);
+
+    const resolved = await resolveWithRetry(refTarget, 'button', { delays: [] });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.selectedIndex).toBe(1);
+    expect(resolved!.element.getAttribute('data-testid')).toBe('save-dashboard');
+  });
+
+  it('uses the primary selector when it does resolve (English locale)', async () => {
+    // English locale: the visible-text primary matches, so the fallback is never used.
+    document.body.innerHTML = '<button data-testid="save-dashboard">Save dashboard</button>';
+
+    const guide: JsonGuide = {
+      id: 'fallback-e2e',
+      title: 'Fallback e2e',
+      blocks: [
+        {
+          type: 'interactive',
+          action: 'button',
+          content: 'Save the dashboard',
+          reftarget: ['Save dashboard', 'button[data-testid="save-dashboard"]'],
+        },
+      ],
+    };
+
+    const resolved = await resolveWithRetry(refTargetFromGuide(guide), 'button', { delays: [] });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.selectedIndex).toBe(0);
+  });
+
+  it('returns null when no selector in the chain resolves', async () => {
+    document.body.innerHTML = '<button data-testid="something-else">Other</button>';
+
+    const guide: JsonGuide = {
+      id: 'fallback-e2e',
+      title: 'Fallback e2e',
+      blocks: [
+        {
+          type: 'interactive',
+          action: 'button',
+          content: 'Save the dashboard',
+          reftarget: ['Save dashboard', 'button[data-testid="save-dashboard"]'],
+        },
+      ],
+    };
+
+    const resolved = await resolveWithRetry(refTargetFromGuide(guide), 'button', { delays: [] });
+    expect(resolved).toBeNull();
+  });
+});

--- a/src/global-state/step-id.ts
+++ b/src/global-state/step-id.ts
@@ -43,8 +43,8 @@ export interface DeriveStepIdInput {
   index: number;
   /** The `targetAction` value when present. */
   action?: string;
-  /** The `refTarget` value when present. */
-  refTarget?: string;
+  /** The `refTarget` value when present (the strongest selector is used for a fallback array). */
+  refTarget?: string | string[];
   /** Optional discriminant for sub-step blocks (e.g. multistep children). */
   variant?: string;
 }
@@ -59,7 +59,7 @@ export function deriveStepId(input: DeriveStepIdInput): string {
     input.sectionId,
     String(input.index),
     input.action ?? '',
-    input.refTarget ?? '',
+    (Array.isArray(input.refTarget) ? input.refTarget[0] : input.refTarget) ?? '',
     input.variant ?? '',
   ].join('|');
   const hash = djb2Hash(seed).toString(36);

--- a/src/integrations/assistant-integration/ai-fix-confidence.test.ts
+++ b/src/integrations/assistant-integration/ai-fix-confidence.test.ts
@@ -1,4 +1,5 @@
 jest.mock('../../lib/dom', () => ({
+  primaryRefTarget: (rt: string | string[]) => (Array.isArray(rt) ? (rt[0] ?? '') : rt),
   resolveSelector: (selector: string) => selector,
   querySelectorAllEnhanced: (selector: string) => {
     try {

--- a/src/integrations/assistant-integration/ai-fix-confidence.ts
+++ b/src/integrations/assistant-integration/ai-fix-confidence.ts
@@ -1,4 +1,4 @@
-import { querySelectorAllEnhanced, resolveSelector } from '../../lib/dom';
+import { querySelectorAllEnhanced, resolveSelector, primaryRefTarget } from '../../lib/dom';
 import type { AiFixPatch } from './ai-fix-patch.schema';
 
 export type ConfidenceResult = { ok: true } | { ok: false; reason: string };
@@ -12,7 +12,9 @@ export type ConfidenceResult = { ok: true } | { ok: false; reason: string };
  * failing selector.
  */
 export function evaluatePatchConfidence(patch: AiFixPatch): ConfidenceResult {
-  const proposedSelector = patch.type === 'prepend-step' ? (patch.newStep.reftarget ?? '') : patch.newReftarget;
+  const proposedSelector = primaryRefTarget(
+    patch.type === 'prepend-step' ? (patch.newStep.reftarget ?? '') : patch.newReftarget
+  );
 
   // A prepend-step without a reftarget is purely instructional — no DOM target to verify.
   if (patch.type === 'prepend-step' && !proposedSelector) {

--- a/src/interactive-engine/action-handlers/button-handler.test.ts
+++ b/src/interactive-engine/action-handlers/button-handler.test.ts
@@ -21,6 +21,7 @@ const makeResolved = (buttons: HTMLElement[]) => ({
   resolvedSelector: '#mock',
   usedFallback: false,
   retryCount: 0,
+  selectedIndex: 0,
 });
 
 const mockStateManager = {

--- a/src/interactive-engine/action-handlers/button-handler.ts
+++ b/src/interactive-engine/action-handlers/button-handler.ts
@@ -32,10 +32,26 @@ export class ButtonHandler {
   }
 
   /**
-   * Find buttons using intelligent selector/text detection with retry support
-   * Uses resolveWithRetry for resilience against timing issues
+   * Find buttons using intelligent selector/text detection with retry support.
+   * Accepts an ordered fallback chain; each candidate runs its full resolution
+   * before the next is tried (selector-major).
    */
-  private async findButtons(refTarget: string): Promise<HTMLElement[]> {
+  private async findButtons(refTarget: string | string[]): Promise<HTMLElement[]> {
+    const candidates = Array.isArray(refTarget) ? refTarget : [refTarget];
+    for (const candidate of candidates) {
+      const buttons = await this.findButtonsForSelector(candidate);
+      if (buttons.length > 0) {
+        return buttons;
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Resolve a single selector or button-text value to button elements.
+   * Uses resolveWithRetry for resilience against timing issues.
+   */
+  private async findButtonsForSelector(refTarget: string): Promise<HTMLElement[]> {
     // For CSS selectors, use resolveWithRetry then filter to buttons
     if (isCssSelector(refTarget)) {
       const resolved = await resolveWithRetry(refTarget, 'button');

--- a/src/interactive-engine/action-handlers/code-block-handler.ts
+++ b/src/interactive-engine/action-handlers/code-block-handler.ts
@@ -31,7 +31,10 @@ export interface CodeBlockInsertResult {
   error?: string;
 }
 
-export async function clearAndInsertCode(refTarget: string, code: string): Promise<CodeBlockInsertResult> {
+export async function clearAndInsertCode(
+  refTarget: string | string[],
+  code: string
+): Promise<CodeBlockInsertResult> {
   try {
     const resolved = await resolveWithRetry(refTarget, 'codeblock');
 

--- a/src/interactive-engine/action-handlers/code-block-handler.ts
+++ b/src/interactive-engine/action-handlers/code-block-handler.ts
@@ -31,10 +31,7 @@ export interface CodeBlockInsertResult {
   error?: string;
 }
 
-export async function clearAndInsertCode(
-  refTarget: string | string[],
-  code: string
-): Promise<CodeBlockInsertResult> {
+export async function clearAndInsertCode(refTarget: string | string[], code: string): Promise<CodeBlockInsertResult> {
   try {
     const resolved = await resolveWithRetry(refTarget, 'codeblock');
 

--- a/src/interactive-engine/action-handlers/form-fill-handler.ts
+++ b/src/interactive-engine/action-handlers/form-fill-handler.ts
@@ -32,7 +32,7 @@ export class FormFillHandler {
     }
   }
 
-  private async findTargetElement(selector: string): Promise<HTMLElement> {
+  private async findTargetElement(selector: string | string[]): Promise<HTMLElement> {
     const resolved = await resolveWithRetry(selector, 'formfill');
 
     if (!resolved) {

--- a/src/interactive-engine/action-handlers/guided-handler.test.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.test.ts
@@ -11,6 +11,7 @@ jest.mock('../../lib/dom', () => ({
   findButtonByText: jest.fn().mockReturnValue([]),
   isElementVisible: jest.fn().mockReturnValue(true),
   resolveSelector: jest.fn((selector: string) => selector),
+  primaryRefTarget: (rt: string | string[]) => (Array.isArray(rt) ? (rt[0] ?? '') : rt),
 }));
 jest.mock('../../lib/dom/selector-detector', () => ({
   isCssSelector: jest.fn().mockReturnValue(false),

--- a/src/interactive-engine/action-handlers/guided-handler.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.ts
@@ -1,7 +1,13 @@
 import { InteractiveStateManager } from '../interactive-state-manager';
 import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
-import { querySelectorAllEnhanced, findButtonByText, isElementVisible, resolveSelector } from '../../lib/dom';
+import {
+  querySelectorAllEnhanced,
+  findButtonByText,
+  isElementVisible,
+  resolveSelector,
+  primaryRefTarget,
+} from '../../lib/dom';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 import { GuidedAction } from '../../types/interactive-actions.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
@@ -148,7 +154,7 @@ export class GuidedHandler {
         action.isSkippable,
         action.formHint, // Pass form hint for formfill validation feedback
         action.targetValue, // Pass target value for data-test-target-value attribute
-        action.refTarget! // E2E contract: selector for current target (data-test-refTarget)
+        primaryRefTarget(refTarget) // E2E contract: selector for current target (data-test-refTarget)
       );
 
       // Wait for user to complete the action, skip, cancel, or timeout
@@ -340,7 +346,7 @@ export class GuidedHandler {
    * @param skipRetryOnFailure - If true, throw immediately on first failure (for skippable steps)
    */
   private async findTargetElementWithRetry(
-    selector: string,
+    selector: string | string[],
     actionType: 'hover' | 'button' | 'highlight' | 'formfill',
     timeout: number,
     retryInterval: number,
@@ -375,8 +381,9 @@ export class GuidedHandler {
     throw new Error(`Timeout finding element: ${selector}`);
   }
 
-  private async expandNavigationParentIfNeeded(selector: string): Promise<void> {
-    const targetHref = this.getNavigationTargetHref(selector);
+  private async expandNavigationParentIfNeeded(selector: string | string[]): Promise<void> {
+    // Nav expansion is a best-effort pre-step keyed off the primary selector.
+    const targetHref = this.getNavigationTargetHref(primaryRefTarget(selector));
     if (!targetHref) {
       return;
     }
@@ -399,9 +406,27 @@ export class GuidedHandler {
    * Formfill targets form elements (input, textarea, select)
    */
   private async findTargetElement(
-    selector: string,
+    selector: string | string[],
     actionType: 'hover' | 'button' | 'highlight' | 'formfill'
   ): Promise<HTMLElement> {
+    const candidates = Array.isArray(selector) ? selector : [selector];
+    for (const candidate of candidates) {
+      const element = this.findTargetElementForSelector(candidate, actionType);
+      if (element) {
+        return element;
+      }
+    }
+    throw new Error(`No elements found matching selector: ${selector}`);
+  }
+
+  /**
+   * Resolve a single selector to an element using action-specific detection.
+   * Returns null when nothing matches so the caller can try the next candidate.
+   */
+  private findTargetElementForSelector(
+    selector: string,
+    actionType: 'hover' | 'button' | 'highlight' | 'formfill'
+  ): HTMLElement | null {
     let targetElements: HTMLElement[];
 
     // Resolve grafana: prefix if present
@@ -473,7 +498,7 @@ export class GuidedHandler {
     targetElements = enhancedResult.elements;
 
     if (targetElements.length === 0) {
-      throw new Error(`No elements found matching selector: ${resolvedSelector}`);
+      return null;
     }
 
     if (targetElements.length > 1) {

--- a/src/interactive-engine/action-handlers/hover-handler.test.ts
+++ b/src/interactive-engine/action-handlers/hover-handler.test.ts
@@ -20,6 +20,7 @@ const makeResolved = (el: HTMLElement, extras?: { elements?: HTMLElement[] }) =>
   resolvedSelector: '#mock',
   usedFallback: false,
   retryCount: 0,
+  selectedIndex: 0,
 });
 
 describe('HoverHandler', () => {

--- a/src/interactive-engine/action-handlers/hover-handler.ts
+++ b/src/interactive-engine/action-handlers/hover-handler.ts
@@ -36,7 +36,7 @@ export class HoverHandler {
     }
   }
 
-  private async findTargetElement(selector: string): Promise<HTMLElement> {
+  private async findTargetElement(selector: string | string[]): Promise<HTMLElement> {
     const resolved = await resolveWithRetry(selector, 'hover');
 
     if (!resolved) {

--- a/src/interactive-engine/action-handlers/navigate-handler.ts
+++ b/src/interactive-engine/action-handlers/navigate-handler.ts
@@ -3,6 +3,7 @@ import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
 import { config, locationService } from '@grafana/runtime';
 import { parseUrlSafely, validateRedirectPath } from '../../security/url-validator';
+import { primaryRefTarget } from '../../lib/dom';
 
 export class NavigateHandler {
   constructor(
@@ -40,42 +41,46 @@ export class NavigateHandler {
     // Note: No need to clear highlights for navigate - user is leaving the page
     // The page navigation will naturally clean up all DOM elements
 
+    // navigate targets are always a single URL/route (the schema rejects arrays
+    // for the navigate action); primaryRefTarget narrows the union to that string.
+    const refTarget = primaryRefTarget(data.refTarget);
+
     // Do mode: actually navigate to the target URL
     // Use Grafana's idiomatic navigation pattern via locationService
     // This handles both internal Grafana routes and external URLs appropriately
-    if (data.refTarget.startsWith('http://') || data.refTarget.startsWith('https://')) {
+    if (refTarget.startsWith('http://') || refTarget.startsWith('https://')) {
       // SECURITY: Validate external URL scheme to prevent javascript:/data: injection
-      const parsed = parseUrlSafely(data.refTarget);
+      const parsed = parseUrlSafely(refTarget);
       if (!parsed || !['http:', 'https:'].includes(parsed.protocol)) {
-        console.warn(`[NavigateHandler] Blocked navigation to invalid URL: ${data.refTarget.slice(0, 100)}`);
+        console.warn(`[NavigateHandler] Blocked navigation to invalid URL: ${refTarget.slice(0, 100)}`);
         return;
       }
       // External URL - open in new tab to preserve current Grafana session
-      window.open(data.refTarget, '_blank', 'noopener,noreferrer');
+      window.open(refTarget, '_blank', 'noopener,noreferrer');
     } else {
       // SECURITY: Reject protocol-relative URLs before URL parsing.
       // '//evil.com' parses via new URL() as cross-origin with pathname '/', which
       // collides with validateRedirectPath's rejection sentinel and bypasses the check.
-      if (!data.refTarget.startsWith('/') || data.refTarget.startsWith('//')) {
-        console.warn(`[NavigateHandler] Blocked navigation to invalid path: ${data.refTarget.slice(0, 100)}`);
+      if (!refTarget.startsWith('/') || refTarget.startsWith('//')) {
+        console.warn(`[NavigateHandler] Blocked navigation to invalid path: ${refTarget.slice(0, 100)}`);
         return;
       }
 
       // SECURITY: Validate internal path against denied routes (F-1 / ASE26016)
       const user = config.bootData?.user;
       const isAdmin = user?.isGrafanaAdmin === true || user?.orgRole === 'Admin';
-      const safePath = validateRedirectPath(data.refTarget, isAdmin);
+      const safePath = validateRedirectPath(refTarget, isAdmin);
 
       let parsed: URL;
       try {
-        parsed = new URL(data.refTarget, window.location.origin);
+        parsed = new URL(refTarget, window.location.origin);
       } catch {
-        console.warn(`[NavigateHandler] Blocked navigation to unparseable path: ${data.refTarget.slice(0, 100)}`);
+        console.warn(`[NavigateHandler] Blocked navigation to unparseable path: ${refTarget.slice(0, 100)}`);
         return;
       }
 
       if (safePath !== parsed.pathname) {
-        console.warn(`[NavigateHandler] Blocked navigation to restricted path: ${data.refTarget.slice(0, 100)}`);
+        console.warn(`[NavigateHandler] Blocked navigation to restricted path: ${refTarget.slice(0, 100)}`);
         return;
       }
 

--- a/src/interactive-engine/interactive.hook.test.ts
+++ b/src/interactive-engine/interactive.hook.test.ts
@@ -82,6 +82,7 @@ jest.mock('../lib/dom', () => ({
   findButtonByText: jest.fn().mockReturnValue([]),
   querySelectorAllEnhanced: jest.fn().mockReturnValue({ elements: [], usedFallback: false, originalSelector: '' }),
   resolveSelector: jest.fn((selector: string) => selector), // Pass through selector as-is for tests
+  primaryRefTarget: (rt: string | string[]) => (Array.isArray(rt) ? (rt[0] ?? '') : rt),
 }));
 
 describe('useInteractiveElements', () => {

--- a/src/interactive-engine/interactive.hook.ts
+++ b/src/interactive-engine/interactive.hook.ts
@@ -4,7 +4,7 @@ import { addGlobalInteractiveStyles, updateInteractiveThemeColors } from '../sty
 import { waitForReactUpdates } from '../lib/async-utils';
 // eslint-disable-next-line no-restricted-imports -- [ratchet] ALLOWED_LATERAL_VIOLATIONS: interactive-engine -> requirements-manager
 import { checkRequirements, checkPostconditions, RequirementsCheckOptions } from '../requirements-manager';
-import { extractInteractiveDataFromElement } from '../lib/dom';
+import { extractInteractiveDataFromElement, primaryRefTarget } from '../lib/dom';
 import { InteractiveElementData } from '../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import { InteractiveStateManager } from './interactive-state-manager';
@@ -215,7 +215,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
       const options: RequirementsCheckOptions = {
         requirements: data.requirements || '',
         targetAction: data.targetAction,
-        refTarget: data.refTarget,
+        refTarget: primaryRefTarget(data.refTarget),
         targetValue: data.targetValue,
         stepId: data.textContent || 'unknown',
       };
@@ -248,14 +248,14 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
     async (
       verifyString: string,
       targetAction?: string,
-      refTarget?: string,
+      refTarget?: string | string[],
       targetValue?: string,
       stepId?: string
     ): Promise<InteractiveRequirementsCheck> => {
       const options: RequirementsCheckOptions = {
         requirements: verifyString || '',
         targetAction,
-        refTarget,
+        refTarget: refTarget === undefined ? undefined : primaryRefTarget(refTarget),
         targetValue,
         stepId,
       };
@@ -295,9 +295,13 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
 
   const interactiveSequence = useCallback(
     async (data: InteractiveElementData, showOnly: boolean): Promise<string> => {
+      // Sequence containers are addressed by a single selector (the legacy path
+      // does not support fallback chains); narrow the union to that string.
+      const refTarget = primaryRefTarget(data.refTarget);
+
       // This is here so recursion cannot happen
-      if (activeRefsRef.current.has(data.refTarget)) {
-        return data.refTarget;
+      if (activeRefsRef.current.has(refTarget)) {
+        return refTarget;
       }
 
       stateManager.setState(data, 'running');
@@ -305,7 +309,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
       try {
         // Resolve grafana: prefix if present
         const { resolveSelector } = await import('../lib/dom');
-        const resolvedSelector = resolveSelector(data.refTarget);
+        const resolvedSelector = resolveSelector(refTarget);
 
         const searchContainer = containerRef?.current || document;
         const targetElements = searchContainer.querySelectorAll(resolvedSelector);
@@ -320,7 +324,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
           stateManager.handleError(msg, 'interactiveSequence', data, true);
         }
 
-        activeRefsRef.current.add(data.refTarget);
+        activeRefsRef.current.add(refTarget);
 
         // Find all interactive elements within the sequence container
         const interactiveElements = Array.from(
@@ -328,7 +332,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
         );
 
         if (interactiveElements.length === 0) {
-          const msg = `No interactive elements found within sequence container: ${data.refTarget}`;
+          const msg = `No interactive elements found within sequence container: ${refTarget}`;
           stateManager.handleError(msg, 'interactiveSequence', data, true);
         }
 
@@ -343,14 +347,14 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
         // Mark as completed after successful execution
         stateManager.setState(data, 'completed');
 
-        activeRefsRef.current.delete(data.refTarget);
-        return data.refTarget;
+        activeRefsRef.current.delete(refTarget);
+        return refTarget;
       } catch (error) {
         stateManager.handleError(error as Error, 'interactiveSequence', data, false);
-        activeRefsRef.current.delete(data.refTarget);
+        activeRefsRef.current.delete(refTarget);
       }
 
-      return data.refTarget;
+      return refTarget;
     },
     [containerRef, activeRefsRef, sequenceManager, stateManager]
   );
@@ -375,7 +379,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
   const executeInteractiveAction = useCallback(
     async (
       targetAction: string,
-      refTarget: string,
+      refTarget: string | string[],
       targetValue?: string,
       buttonType: 'show' | 'do' = 'do',
       targetComment?: string
@@ -388,7 +392,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
         targetComment: targetComment,
         requirements: undefined,
         tagName: 'button', // Simulated for React components
-        textContent: `${buttonType === 'show' ? 'Show me' : 'Do'}: ${refTarget}`,
+        textContent: `${buttonType === 'show' ? 'Show me' : 'Do'}: ${primaryRefTarget(refTarget)}`,
         timestamp: Date.now(),
       };
 

--- a/src/interactive-engine/interactive.hook.ts
+++ b/src/interactive-engine/interactive.hook.ts
@@ -215,7 +215,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
       const options: RequirementsCheckOptions = {
         requirements: data.requirements || '',
         targetAction: data.targetAction,
-        refTarget: primaryRefTarget(data.refTarget),
+        refTarget: data.refTarget,
         targetValue: data.targetValue,
         stepId: data.textContent || 'unknown',
       };
@@ -255,7 +255,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
       const options: RequirementsCheckOptions = {
         requirements: verifyString || '',
         targetAction,
-        refTarget: refTarget === undefined ? undefined : primaryRefTarget(refTarget),
+        refTarget,
         targetValue,
         stepId,
       };

--- a/src/lib/dom/dom-utils.test.ts
+++ b/src/lib/dom/dom-utils.test.ts
@@ -4,6 +4,7 @@ import {
   findButtonByText,
   resetValueTracker,
   reftargetExistsCheck,
+  primaryRefTarget,
   navmenuOpenCheck,
   getVisibleHighlightTarget,
 } from './dom-utils';
@@ -325,6 +326,65 @@ describe('reftargetExistsCheck', () => {
       requirement: 'exists-reftarget',
       pass: true,
     });
+  });
+});
+
+describe('reftargetExistsCheck with selector arrays', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body = document.createElement('body');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (document.body) {
+      document.body.innerHTML = '';
+    }
+  });
+
+  it('passes when any candidate exists', async () => {
+    const div = document.createElement('div');
+    div.id = 'present';
+    container.appendChild(div);
+
+    const result = await reftargetExistsCheck(['#missing', '#present'], 'highlight');
+
+    expect(result.pass).toBe(true);
+  });
+
+  it('fails when no candidate exists', async () => {
+    const result = await reftargetExistsCheck(['#missing-a', '#missing-b'], 'highlight');
+
+    expect(result.pass).toBe(false);
+  });
+
+  it('returns a fixable failure when all candidates fail but a fix is available', async () => {
+    const toggle = document.createElement('button');
+    toggle.setAttribute('data-testid', 'data-testid Options group X toggle');
+    toggle.setAttribute('aria-expanded', 'false');
+    container.appendChild(toggle);
+
+    const result = await reftargetExistsCheck(['#missing-a', '#missing-b'], 'highlight');
+
+    expect(result.pass).toBe(false);
+    expect(result.canFix).toBe(true);
+    expect(result.fixType).toBe('expand-options-group');
+  });
+});
+
+describe('primaryRefTarget', () => {
+  it('returns a string unchanged', () => {
+    expect(primaryRefTarget('#a')).toBe('#a');
+  });
+
+  it('returns the first element of an array', () => {
+    expect(primaryRefTarget(['#a', '#b'])).toBe('#a');
+  });
+
+  it('returns an empty string for an empty array', () => {
+    expect(primaryRefTarget([])).toBe('');
   });
 });
 

--- a/src/lib/dom/dom-utils.ts
+++ b/src/lib/dom/dom-utils.ts
@@ -153,18 +153,15 @@ export interface ReftargetExistsOptions {
 }
 
 /**
- * Check if a target element exists based on the action type
- * For button actions, checks if buttons with matching text exist
- * For other actions, checks if the CSS selector matches an element
- * Includes retry logic for elements that might not exist immediately
- * Enhanced with parent section expansion detection for navigation menu items
- * Supports lazy render fallback for virtualized containers (e.g., Grafana dashboards)
+ * The strongest selector from a reftarget value, for the call sites that need a
+ * single string (analytics, the data-reftarget attribute, display text, the
+ * navigate URL). Index 0 is the primary; an empty array yields ''.
  */
-export async function reftargetExistsCheck(
-  reftarget: string,
-  targetAction: string,
-  options?: ReftargetExistsOptions
-): Promise<{
+export function primaryRefTarget(reftarget: string | string[]): string {
+  return Array.isArray(reftarget) ? (reftarget[0] ?? '') : reftarget;
+}
+
+interface ReftargetCheckResult {
   requirement: string;
   pass: boolean;
   error?: string;
@@ -172,7 +169,49 @@ export async function reftargetExistsCheck(
   fixType?: string;
   targetHref?: string;
   scrollContainer?: string;
-}> {
+}
+
+/**
+ * Check if a target element exists based on the action type.
+ *
+ * `reftarget` may be a single selector or an ordered fallback array (strongest
+ * first); the check passes if ANY candidate currently exists. This is a fast,
+ * synchronous existence probe (no retry) — the action-time resolver does the
+ * selector-major retry-with-backoff. When all candidates fail, the richest
+ * fixable failure is returned so recovery (lazy-scroll, expand-nav) still fires.
+ *
+ * For button actions, checks if buttons with matching text exist; for other
+ * actions, checks if the CSS selector matches an element. Enhanced with parent
+ * section expansion detection for navigation menu items and lazy render fallback
+ * for virtualized containers (e.g., Grafana dashboards).
+ */
+export async function reftargetExistsCheck(
+  reftarget: string | string[],
+  targetAction: string,
+  options?: ReftargetExistsOptions
+): Promise<ReftargetCheckResult> {
+  const candidates = (Array.isArray(reftarget) ? reftarget : [reftarget]).map((s) => s.trim()).filter(Boolean);
+  if (candidates.length === 0) {
+    return { requirement: 'exists-reftarget', pass: false, error: 'No reftarget provided' };
+  }
+
+  const failures: ReftargetCheckResult[] = [];
+  for (const candidate of candidates) {
+    const result = await checkSingleReftarget(candidate, targetAction, options);
+    if (result.pass) {
+      return result;
+    }
+    failures.push(result);
+  }
+
+  return failures.find((failure) => failure.canFix) ?? failures[0]!;
+}
+
+async function checkSingleReftarget(
+  reftarget: string,
+  targetAction: string,
+  options?: ReftargetExistsOptions
+): Promise<ReftargetCheckResult> {
   // Resolve grafana: selectors first
   const resolvedSelector = resolveSelector(reftarget);
 

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -11,6 +11,7 @@ import {
   getSelectorInfo,
   retargetElement,
   generateFallbackSelectors,
+  generateSelectorChain,
 } from './selector-generator';
 import { querySelectorAllEnhanced } from './enhanced-selector';
 
@@ -497,6 +498,72 @@ describe('Selector Generator — Pipeline', () => {
       const primary = generateBestSelector(button);
       const fallbacks = generateFallbackSelectors(button, primary);
       expect(fallbacks.length).toBeLessThanOrEqual(4);
+    });
+  });
+
+  // ==========================================================================
+  // generateSelectorChain — strategy-diverse fallback chain
+  // ==========================================================================
+
+  describe('generateSelectorChain', () => {
+    it('returns the strongest selector as primary with a strategy-diverse fallback', () => {
+      const button = document.createElement('button');
+      button.setAttribute('data-testid', 'save');
+      button.setAttribute('aria-label', 'Save document');
+      document.body.appendChild(button);
+
+      const chain = generateSelectorChain(button);
+
+      expect(chain[0]).toBe(generateBestSelector(button));
+      expect(chain[0]).toContain("data-testid='save'");
+      expect(chain.length).toBeGreaterThanOrEqual(2);
+      // A different (text/aria) family is represented among the fallbacks.
+      expect(chain.slice(1).some((s) => s.includes('aria-label'))).toBe(true);
+    });
+
+    it('caps the chain at three entries', () => {
+      const button = document.createElement('button');
+      button.setAttribute('data-testid', 'publish');
+      button.id = 'publish-btn';
+      button.setAttribute('aria-label', 'Publish the report');
+      button.setAttribute('title', 'Publish');
+      button.textContent = 'Publish report';
+      document.body.appendChild(button);
+
+      const chain = generateSelectorChain(button);
+      expect(chain.length).toBeLessThanOrEqual(3);
+    });
+
+    it('never repeats a selector', () => {
+      const button = document.createElement('button');
+      button.setAttribute('data-testid', 'publish');
+      button.setAttribute('aria-label', 'Publish the report');
+      button.textContent = 'Publish report';
+      document.body.appendChild(button);
+
+      const chain = generateSelectorChain(button);
+      expect(new Set(chain).size).toBe(chain.length);
+    });
+
+    it('omits fragile structural selectors when a diverse fallback exists', () => {
+      const button = document.createElement('button');
+      button.setAttribute('data-testid', 'publish');
+      button.setAttribute('aria-label', 'Publish the report');
+      document.body.appendChild(button);
+
+      const chain = generateSelectorChain(button);
+      expect(chain.some((s) => s.includes(':nth-of-type') || s.includes(':nth-match'))).toBe(false);
+    });
+
+    it('includes a structural fallback only when nothing more stable remains', () => {
+      const button = document.createElement('button');
+      button.setAttribute('data-testid', 'lonely');
+      document.body.appendChild(button);
+
+      const chain = generateSelectorChain(button);
+      expect(chain[0]).toContain("data-testid='lonely'");
+      expect(chain.length).toBe(2);
+      expect(chain[1]).toContain(':nth-of-type');
     });
   });
 

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -1102,6 +1102,103 @@ export function generateFallbackSelectors(element: HTMLElement, primarySelector:
   return result;
 }
 
+const MAX_CHAIN = 3;
+
+const TESTID_METHODS: ReadonlySet<string> = new Set(['data-testid', 'scoped-testid', 'testid-href']);
+const TEXT_METHODS: ReadonlySet<string> = new Set([
+  'role',
+  'role-text',
+  'role-contains',
+  'aria-label',
+  'button-text',
+  'button-css-text',
+  'button-css-contains',
+  'label-text',
+]);
+const STRUCTURAL_METHODS: ReadonlySet<string> = new Set(['compound', 'nth-of-type', 'nth-match', 'fallback']);
+
+/**
+ * Group a candidate's method into a stability family. Diversity across families is
+ * what makes a fallback chain resilient: a single DOM change rarely breaks two
+ * different families at once (e.g. a testid rename does not also change the
+ * visible text). Everything that is neither testid, text/aria nor structural
+ * (id, name, placeholder, title, href) is a stable non-text attribute: 'attr'.
+ */
+function strategyFamily(method: string): string {
+  if (TESTID_METHODS.has(method)) {
+    return 'testid';
+  }
+  if (TEXT_METHODS.has(method)) {
+    return 'text';
+  }
+  if (STRUCTURAL_METHODS.has(method)) {
+    return 'structural';
+  }
+  return 'attr';
+}
+
+/**
+ * Build an ordered, strategy-diverse fallback chain for an element.
+ *
+ * The primary is the single best selector (same as `generateBestSelector`). The
+ * fallbacks are the best-scoring candidate from each *different* family, so the
+ * chain degrades across independent failure modes rather than stacking variants
+ * of the same fragile idea. Fragile structural selectors (`nth-*`/compound) are
+ * excluded unless they are the only survivor. Capped at `MAX_CHAIN`.
+ */
+export function generateSelectorChain(element: HTMLElement): string[] {
+  const target = retargetElement(element);
+  const candidates = generateCandidates(target);
+  const primary = rankAndSelect(candidates, target);
+
+  const ancestorScopes = findAllAncestorScopes(target);
+  const inOverlay = findOverlayContext(target) !== null;
+  const scored: ScoredCandidate[] = [];
+  for (const candidate of candidates) {
+    const { matchCount, containsTarget } = testUniqueness(candidate.selector, target, candidate.method, inOverlay);
+    if (matchCount === 0 || !containsTarget) {
+      continue;
+    }
+    if (matchCount === 1) {
+      scored.push({ ...candidate, matchCount });
+      continue;
+    }
+    if (candidate.method === 'button-text') {
+      continue;
+    }
+    for (const d of disambiguate(candidate, target, ancestorScopes, inOverlay)) {
+      scored.push({ ...d, matchCount: 1 });
+    }
+  }
+  scored.sort((a, b) => a.score - b.score);
+
+  const chain: string[] = [primary.selector];
+  const seen = new Set<string>([primary.selector]);
+  const usedFamilies = new Set<string>([strategyFamily(primary.method)]);
+
+  for (const candidate of scored) {
+    if (chain.length >= MAX_CHAIN) {
+      break;
+    }
+    const family = strategyFamily(candidate.method);
+    if (family === 'structural' || usedFamilies.has(family) || seen.has(candidate.selector)) {
+      continue;
+    }
+    chain.push(candidate.selector);
+    seen.add(candidate.selector);
+    usedFamilies.add(family);
+  }
+
+  if (chain.length === 1) {
+    const structural = scored.find((c) => strategyFamily(c.method) === 'structural' && !seen.has(c.selector));
+    if (structural) {
+      chain.push(structural.selector);
+    }
+  }
+
+  return chain.slice(0, MAX_CHAIN);
+}
+
 /**
  * @deprecated Caching has been removed — this is a no-op for backward compatibility.
  */

--- a/src/lib/dom/selector-pipeline.test.ts
+++ b/src/lib/dom/selector-pipeline.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { resolveSelectorPipeline } from './selector-pipeline';
+
+describe('resolveSelectorPipeline', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('resolves a single string selector with selectedIndex 0', async () => {
+    document.body.innerHTML = '<div id="a"></div>';
+    const result = await resolveSelectorPipeline({ reftarget: '#a', delays: [] });
+    expect(result?.element.id).toBe('a');
+    expect(result?.selectedIndex).toBe(0);
+    expect(result?.strategy).toBe('exact');
+  });
+
+  it('uses the first matching candidate in an array', async () => {
+    document.body.innerHTML = '<div id="a"></div><div id="b"></div>';
+    const result = await resolveSelectorPipeline({ reftarget: ['#a', '#b'], delays: [] });
+    expect(result?.element.id).toBe('a');
+    expect(result?.selectedIndex).toBe(0);
+  });
+
+  it('prefers the primary even when a fallback also matches', async () => {
+    document.body.innerHTML = '<div id="primary"></div><div id="fallback"></div>';
+    const result = await resolveSelectorPipeline({ reftarget: ['#primary', '#fallback'], delays: [] });
+    expect(result?.element.id).toBe('primary');
+    expect(result?.selectedIndex).toBe(0);
+  });
+
+  it('falls back to a later candidate when earlier ones miss', async () => {
+    document.body.innerHTML = '<div id="fallback"></div>';
+    const result = await resolveSelectorPipeline({ reftarget: ['#missing', '#fallback'], delays: [] });
+    expect(result?.element.id).toBe('fallback');
+    expect(result?.selectedIndex).toBe(1);
+  });
+
+  it('supports a mixed button-text + CSS fallback chain', async () => {
+    document.body.innerHTML = '<div id="real"></div>';
+    const result = await resolveSelectorPipeline({
+      reftarget: ['Nonexistent label', '#real'],
+      action: 'button',
+      delays: [],
+    });
+    expect(result?.element.id).toBe('real');
+    expect(result?.selectedIndex).toBe(1);
+  });
+
+  it('returns null for empty or whitespace-only input', async () => {
+    expect(await resolveSelectorPipeline({ reftarget: '', delays: [] })).toBeNull();
+    expect(await resolveSelectorPipeline({ reftarget: [], delays: [] })).toBeNull();
+    expect(await resolveSelectorPipeline({ reftarget: ['', '   '], delays: [] })).toBeNull();
+  });
+
+  it('returns null when no candidate matches', async () => {
+    const result = await resolveSelectorPipeline({ reftarget: ['#nope1', '#nope2'], delays: [] });
+    expect(result).toBeNull();
+  });
+
+  it('exhausts the primary full retry budget before trying a fallback (selector-major)', async () => {
+    jest.useFakeTimers();
+    try {
+      // Fallback is present from the start; primary never appears.
+      document.body.innerHTML = '<div id="fallback"></div>';
+      const promise = resolveSelectorPipeline({ reftarget: ['#missing', '#fallback'], delays: [50] });
+
+      let settled = false;
+      void promise.then(() => {
+        settled = true;
+      });
+
+      // Parked at the primary's retry sleep — the already-present fallback must not win yet.
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      await jest.advanceTimersByTimeAsync(50);
+      const result = await promise;
+      expect(result?.selectedIndex).toBe(1);
+      expect(result?.element.id).toBe('fallback');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/lib/dom/selector-pipeline.ts
+++ b/src/lib/dom/selector-pipeline.ts
@@ -17,7 +17,7 @@ import { findButtonByText } from './dom-utils';
 import { isCssSelector } from './selector-detector';
 
 export interface PipelineConfig {
-  reftarget: string;
+  reftarget: string | string[];
   action?: string;
   delays?: number[];
   relaxOnRetry?: boolean;
@@ -30,22 +30,56 @@ export interface PipelineResult {
   strategy: 'exact' | 'retry';
   confidence: number;
   retryCount: number;
+  /** Index of the candidate that resolved; 0 is the primary (strongest) selector. */
+  selectedIndex: number;
 }
 
 /**
- * Unified selector resolution pipeline with strategy escalation.
+ * Unified selector resolution pipeline with strategy escalation and an ordered
+ * fallback chain.
  *
- * Stage 1: Exact match (confidence 1.0)
- * Stage 2: Wait + retry with exponential backoff (confidence 0.95)
+ * `reftarget` may be a single selector or an ordered array (strongest first).
+ * Resolution is selector-major: each candidate runs the complete exact + retry
+ * pipeline (its full retry budget) before the next candidate is tried, so the
+ * primary is never skipped in favor of a weaker selector.
  *
- * Note: prefix matching and combinator relaxation are already handled internally
- * by querySelectorAllEnhanced/handleTestIdSelector, so they fire automatically
- * during Stage 1 and Stage 2.
+ * Per candidate — Stage 1: exact match (confidence 1.0); Stage 2: wait + retry
+ * with exponential backoff (confidence 0.95). Prefix matching and combinator
+ * relaxation are handled internally by querySelectorAllEnhanced, so they fire
+ * automatically during both stages.
  */
 export async function resolveSelectorPipeline(config: PipelineConfig): Promise<PipelineResult | null> {
   const { reftarget, action, delays = [200, 600, 1800], relaxOnRetry = true } = config;
+  const candidates = (Array.isArray(reftarget) ? reftarget : [reftarget]).map((s) => s.trim()).filter(Boolean);
+  if (candidates.length === 0) {
+    return null;
+  }
+
   const effectiveAction = action ?? 'highlight';
 
+  for (let index = 0; index < candidates.length; index++) {
+    const result = await resolveSingleCandidate(candidates[index]!, effectiveAction, delays, relaxOnRetry);
+    if (result) {
+      if (index > 0) {
+        console.log(`[SelectorFallback] resolved via fallback selector #${index}: ${candidates[index]}`);
+      }
+      return { ...result, selectedIndex: index };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a single selector through the full exact + retry pipeline.
+ * Returns the result without a `selectedIndex` (the caller stamps it).
+ */
+async function resolveSingleCandidate(
+  reftarget: string,
+  effectiveAction: string,
+  delays: number[],
+  relaxOnRetry: boolean
+): Promise<Omit<PipelineResult, 'selectedIndex'> | null> {
   // Resolve any prefixes (grafana:, panel:, etc.)
   const resolvedSelector = resolveSelector(reftarget);
 
@@ -106,7 +140,7 @@ export async function resolveSelectorPipeline(config: PipelineConfig): Promise<P
     }
   }
 
-  // All strategies exhausted
+  // All strategies exhausted for this candidate
   return null;
 }
 

--- a/src/lib/dom/selector-retry.test.ts
+++ b/src/lib/dom/selector-retry.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { resolveWithRetry } from './selector-retry';
+
+describe('resolveWithRetry', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('resolves a single string and reports selectedIndex 0', async () => {
+    document.body.innerHTML = '<div id="a"></div>';
+    const resolved = await resolveWithRetry('#a', 'highlight', { delays: [] });
+    expect(resolved?.element.id).toBe('a');
+    expect(resolved?.selectedIndex).toBe(0);
+    expect(resolved?.usedFallback).toBe(false);
+  });
+
+  it('falls back to a later selector and surfaces selectedIndex', async () => {
+    document.body.innerHTML = '<div id="fallback"></div>';
+    const resolved = await resolveWithRetry(['#missing', '#fallback'], 'highlight', { delays: [] });
+    expect(resolved?.element.id).toBe('fallback');
+    expect(resolved?.selectedIndex).toBe(1);
+  });
+
+  it('returns null when nothing matches', async () => {
+    const resolved = await resolveWithRetry(['#x', '#y'], 'highlight', { delays: [] });
+    expect(resolved).toBeNull();
+  });
+});

--- a/src/lib/dom/selector-retry.ts
+++ b/src/lib/dom/selector-retry.ts
@@ -24,6 +24,8 @@ export interface ResolvedElement {
   resolvedSelector: string;
   usedFallback: boolean;
   retryCount: number;
+  /** Index of the candidate that resolved; 0 is the primary (strongest) selector. */
+  selectedIndex: number;
 }
 
 /**
@@ -36,13 +38,15 @@ export interface ResolvedElement {
  * 5. On retry 2+ with `relaxOnRetry`: relaxes child combinators (`>` -> space)
  * 6. After all strategies exhausted, returns null
  *
- * @param reftarget - The selector or button text to resolve
+ * @param reftarget - The selector or button text to resolve. May be an ordered
+ *   array of fallback selectors (strongest first); each is tried in full before
+ *   the next.
  * @param action - The action type (e.g. 'button', 'highlight', 'formfill'). Defaults to 'highlight'.
  * @param config - Retry configuration. Defaults to DEFAULT_RETRY_CONFIG.
  * @returns ResolvedElement on success, null if element not found after all retries
  */
 export async function resolveWithRetry(
-  reftarget: string,
+  reftarget: string | string[],
   action?: string,
   config?: Partial<RetryConfig>
 ): Promise<ResolvedElement | null> {
@@ -65,5 +69,6 @@ export async function resolveWithRetry(
     resolvedSelector: pipelineResult.resolvedSelector,
     usedFallback: pipelineResult.strategy !== 'exact',
     retryCount: pipelineResult.retryCount,
+    selectedIndex: pipelineResult.selectedIndex,
   };
 }

--- a/src/requirements-manager/requirements-checker.utils.test.ts
+++ b/src/requirements-manager/requirements-checker.utils.test.ts
@@ -111,6 +111,22 @@ describe('requirements-checker.utils', () => {
         scrollContainer: undefined,
       });
     });
+
+    it('passes a refTarget fallback array through to the existence check intact', async () => {
+      const options: RequirementsCheckOptions = {
+        requirements: 'exists-reftarget',
+        refTarget: ['button[data-testid="save"]', 'Save dashboard'],
+        targetAction: 'button',
+      };
+
+      const result = await checkRequirements(options);
+      expect(result.pass).toBe(true);
+      expect(mockReftargetExistsCheck).toHaveBeenCalledWith(
+        ['button[data-testid="save"]', 'Save dashboard'],
+        'button',
+        { lazyRender: undefined, scrollContainer: undefined }
+      );
+    });
   });
 
   describe('hasPermissionCHECK', () => {

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -64,7 +64,7 @@ export interface CheckResultError {
 export interface RequirementsCheckOptions {
   requirements: string;
   targetAction?: string;
-  refTarget?: string;
+  refTarget?: string | string[];
   targetValue?: string;
   stepId?: string;
   retryCount?: number; // Current retry attempt (internal use)
@@ -79,7 +79,7 @@ type CheckMode = 'pre' | 'post';
 
 interface CheckContext {
   targetAction?: string;
-  refTarget?: string;
+  refTarget?: string | string[];
   /** Enable progressive scroll discovery for virtualized containers */
   lazyRender?: boolean;
   /** CSS selector for scroll container when lazyRender is enabled */
@@ -314,13 +314,14 @@ export async function checkPostconditions(options: RequirementsCheckOptions): Pr
 export function validateInteractiveRequirements(
   props: {
     requirements?: string;
-    refTarget?: string;
+    refTarget?: string | string[];
     stepId?: string;
     originalHTML?: string;
   },
   elementType: string
 ): boolean {
   const { requirements, refTarget, stepId, originalHTML } = props;
+  const hasRefTarget = Array.isArray(refTarget) ? refTarget.length > 0 : !!refTarget && refTarget.trim() !== '';
 
   // If no requirements, nothing to validate
   if (!requirements) {
@@ -332,7 +333,7 @@ export function validateInteractiveRequirements(
   const hasExistsReftarget = requirementList.includes('exists-reftarget');
 
   // If 'exists-reftarget' is present but no refTarget, this is an impossible configuration
-  if (hasExistsReftarget && !refTarget) {
+  if (hasExistsReftarget && !hasRefTarget) {
     const errorMessage = [
       `[${elementType}] Invalid requirement configuration:`,
       `  - Element has 'exists-reftarget' requirement but no refTarget`,

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -35,6 +35,7 @@ import { INTERACTIVE_CONFIG, isFirstStep } from '../constants/interactive-config
 import { useTimeoutManager } from '../utils/timeout-manager';
 import { useIsAlignmentPaused } from '../global-state/alignment-pending-context';
 import { checkRequirements, type RequirementsCheckResult } from './requirements-checker.utils';
+import { primaryRefTarget } from '../lib/dom';
 import { stripTabLocalRequirements } from './controller-requirements';
 import { useInteractiveMode } from '../global-state/interactive-mode-context';
 import { useControllerChannel } from '../global-state/controller-channel';
@@ -270,7 +271,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
           const result = isRemote
             ? ((await controllerChannel?.requestRequirementCheck(optionsStepId ?? stepId, requirements, {
                 targetAction,
-                refTarget,
+                refTarget: primaryRefTarget(refTarget),
               })) ??
               (await checkRequirements({
                 requirements: stripTabLocalRequirements(requirements) ?? '',

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -217,7 +217,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       options: {
         requirements: string;
         targetAction?: string;
-        refTarget?: string;
+        refTarget?: string | string[];
         stepId?: string;
         /** Force a specific retry count (0 disables retries entirely). */
         maxRetriesOverride?: number;

--- a/src/types/component-props.types.ts
+++ b/src/types/component-props.types.ts
@@ -27,7 +27,7 @@ export interface BaseInteractiveProps {
  */
 export interface InteractiveStepProps extends BaseInteractiveProps {
   targetAction: 'button' | 'highlight' | 'formfill' | 'navigate' | 'sequence' | 'hover' | 'noop' | 'popout';
-  refTarget: string;
+  refTarget: string | string[]; // Single selector or ordered fallback chain (strongest first)
   targetValue?: string;
   postVerify?: string;
   targetComment?: string;
@@ -83,7 +83,7 @@ export interface StepInfo {
   element: React.ReactElement<InteractiveStepProps> | React.ReactElement<any>;
   index: number;
   targetAction?: string; // Optional for multi-step and guided
-  refTarget?: string; // Optional for multi-step and guided
+  refTarget?: string | string[]; // Optional for multi-step and guided; single selector or fallback chain
   targetValue?: string;
   targetComment?: string; // Optional comment to show during execution
   requirements?: string;

--- a/src/types/hooks.types.ts
+++ b/src/types/hooks.types.ts
@@ -17,7 +17,7 @@ export interface UseStepCheckerProps {
   hints?: string;
   stepId: string;
   targetAction?: string; // Pass through to requirements checking
-  refTarget?: string; // Pass through to requirements checking
+  refTarget?: string | string[]; // Pass through to requirements checking (single selector or fallback chain)
   isEligibleForChecking: boolean;
   skippable?: boolean; // Whether this step can be skipped if requirements fail
   stepIndex?: number; // Document-wide step index for sequence awareness

--- a/src/types/interactive-actions.types.ts
+++ b/src/types/interactive-actions.types.ts
@@ -9,7 +9,7 @@
  */
 export interface InternalAction {
   targetAction: string;
-  refTarget?: string;
+  refTarget?: string | string[]; // Single selector or ordered fallback chain (strongest first)
   targetValue?: string;
   requirements?: string;
   targetComment?: string; // Optional comment to display during this step
@@ -22,7 +22,7 @@ export interface InternalAction {
  */
 export interface GuidedAction extends InternalAction {
   targetAction: 'hover' | 'button' | 'highlight' | 'noop' | 'formfill';
-  refTarget?: string; // Required for hover/button/highlight/formfill, optional for noop
+  refTarget?: string | string[]; // Required for hover/button/highlight/formfill, optional for noop
   targetValue?: string; // Value for formfill actions (supports regex patterns)
   targetComment?: string; // Optional comment to display in tooltip during this step
   isSkippable?: boolean; // Whether this specific step can be skipped

--- a/src/types/interactive.types.ts
+++ b/src/types/interactive.types.ts
@@ -10,8 +10,10 @@ export type InteractiveActionType =
   | 'popout'; // Toggle the docs panel between sidebar and floating modes
 
 export interface InteractiveElementData {
-  // Core interactive attributes
-  refTarget: string;
+  // Core interactive attributes.
+  // A single selector, or an ordered fallback chain (strongest first) that the
+  // resolver tries in order. Use primaryRefTarget() for sites that need one string.
+  refTarget: string | string[];
   targetAction: string;
   targetValue?: string;
   targetComment?: string;

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -82,6 +82,26 @@ export const JsonInteractiveActionSchema = z.enum([
 ]);
 
 /**
+ * Schema for a reftarget value: a single selector or an ordered array of
+ * fallback selectors (strongest first). Every entry must be non-empty; an empty
+ * array is rejected. The `navigate` action is restricted to a single string by a
+ * per-block refinement (its value is a URL, not a selector chain).
+ * @coupling Type: `string | string[]` on reftarget fields in json-guide.types.ts
+ */
+const ReftargetSchema = z.union([
+  z.string().min(1),
+  z.array(z.string().min(1)).min(1, 'reftarget array must contain at least one selector'),
+]);
+
+/** True when a reftarget value is present and non-empty (string or array). */
+function hasReftarget(value: string | string[] | undefined): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  return value !== undefined && value.trim() !== '';
+}
+
+/**
  * Allowed targetvalue values for the `popout` action.
  * - 'sidebar' docks the panel back into the Grafana sidebar.
  * - 'floating' undocks the panel into a floating window.
@@ -129,12 +149,9 @@ export const JsonStepSchema = z
     id: z.string().optional().describe('Stable identifier for this step (used for cross-step references)'),
     action: JsonInteractiveActionSchema.describe('Action to perform on target element'),
     // reftarget is optional for noop actions (informational steps)
-    reftarget: z
-      .string()
-      .optional()
-      .describe(
-        'Verified Grafana DOM selector (CSS or data-testid) for the target element. Required for non-noop actions. Do NOT invent or guess. If you do not have an explicit, verified selector, do one of: (a) use `action: button` with the visible button text, (b) drop the step and write a markdown block describing what the user would do, (c) ask the user. A wrong selector silently breaks the guide at runtime — the validator cannot catch this.'
-      ),
+    reftarget: ReftargetSchema.optional().describe(
+      'Verified Grafana DOM selector (CSS or data-testid) for the target element. Required for non-noop actions. Do NOT invent or guess. If you do not have an explicit, verified selector, do one of: (a) use `action: button` with the visible button text, (b) drop the step and write a markdown block describing what the user would do, (c) ask the user. A wrong selector silently breaks the guide at runtime — the validator cannot catch this. May be an ordered array of fallback selectors (strongest first); navigate must be a single string.'
+    ),
 
     targetvalue: z
       .string()
@@ -155,10 +172,13 @@ export const JsonStepSchema = z
       if (step.action === 'noop' || step.action === 'popout') {
         return true;
       }
-      return step.reftarget !== undefined && step.reftarget.trim() !== '';
+      return hasReftarget(step.reftarget);
     },
     { error: "Non-noop actions require 'reftarget'" }
   )
+  .refine((step) => step.action !== 'navigate' || !Array.isArray(step.reftarget), {
+    error: 'navigate actions require a single string reftarget (a URL), not an array',
+  })
   .refine(
     (step) => {
       if (step.action === 'formfill' && step.validateInput === true) {
@@ -275,12 +295,9 @@ export const JsonInteractiveBlockSchema = z
     id: z.string().optional().describe('Stable identifier for edit-block / remove-block addressing'),
     action: JsonInteractiveActionSchema.describe('Action to perform on target element'),
     // reftarget is optional for noop actions (informational steps)
-    reftarget: z
-      .string()
-      .optional()
-      .describe(
-        'Verified Grafana DOM selector (CSS or data-testid) for the target element. Required for non-noop actions. Do NOT invent or guess. If you do not have an explicit, verified selector, do one of: (a) use `action: button` with the visible button text, (b) drop the step and write a markdown block describing what the user would do, (c) ask the user. A wrong selector silently breaks the guide at runtime — the validator cannot catch this.'
-      ),
+    reftarget: ReftargetSchema.optional().describe(
+      'Verified Grafana DOM selector (CSS or data-testid) for the target element. Required for non-noop actions. Do NOT invent or guess. If you do not have an explicit, verified selector, do one of: (a) use `action: button` with the visible button text, (b) drop the step and write a markdown block describing what the user would do, (c) ask the user. A wrong selector silently breaks the guide at runtime — the validator cannot catch this. May be an ordered array of fallback selectors (strongest first); navigate must be a single string.'
+    ),
 
     targetvalue: z
       .string()
@@ -317,10 +334,13 @@ export const JsonInteractiveBlockSchema = z
       if (block.action === 'noop' || block.action === 'popout') {
         return true;
       }
-      return block.reftarget !== undefined && block.reftarget.trim() !== '';
+      return hasReftarget(block.reftarget);
     },
     { error: "Non-noop actions require 'reftarget'" }
   )
+  .refine((block) => block.action !== 'navigate' || !Array.isArray(block.reftarget), {
+    error: 'navigate actions require a single string reftarget (a URL), not an array',
+  })
   .refine(
     (block) => {
       if (block.action === 'formfill' && block.validateInput === true) {
@@ -569,12 +589,9 @@ export const JsonChallengeBlockSchema = z.object({
 export const JsonCodeBlockBlockSchema = z.object({
   type: z.literal('code-block'),
   id: z.string().optional().describe('Stable identifier for edit-block / remove-block addressing'),
-  reftarget: z
-    .string()
-    .min(1, 'Code block reftarget is required')
-    .describe(
-      'Verified Grafana DOM selector for the target Monaco editor. Do NOT invent or guess. Confirm against the live Grafana DOM or ask the user for the selector — Monaco editors have stable data-testid attributes in Grafana. A wrong selector silently breaks the guide at runtime; the validator cannot catch this.'
-    ),
+  reftarget: ReftargetSchema.describe(
+    'Verified Grafana DOM selector for the target Monaco editor. Do NOT invent or guess. Confirm against the live Grafana DOM or ask the user for the selector — Monaco editors have stable data-testid attributes in Grafana. A wrong selector silently breaks the guide at runtime; the validator cannot catch this. May be an ordered array of fallback selectors (strongest first).'
+  ),
   language: z.string().optional().describe('Source language hint (e.g., promql, logql, sql)'),
   code: z.string().min(1, 'Code is required').describe('Code to insert into the editor'),
   content: z.string().optional().describe('Optional instructional text shown above the code'),
@@ -817,12 +834,9 @@ const ConditionalProps = {
     .enum(['inline', 'section'])
     .optional()
     .describe('Render the conditional inline or as a collapsible section'),
-  reftarget: z
-    .string()
-    .optional()
-    .describe(
-      'Verified Grafana DOM selector consumed by certain conditional styles. Do NOT invent or guess; confirm against the live Grafana DOM. A wrong selector silently fails at runtime — the validator cannot catch this.'
-    ),
+  reftarget: ReftargetSchema.optional().describe(
+    'Verified Grafana DOM selector consumed by certain conditional styles. Do NOT invent or guess; confirm against the live Grafana DOM. A wrong selector silently fails at runtime — the validator cannot catch this. May be an ordered array of fallback selectors (strongest first).'
+  ),
   whenTrueSectionConfig: ConditionalSectionConfigSchema.optional().describe(
     'Section config applied to the whenTrue branch'
   ),

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -226,8 +226,8 @@ export interface JsonConditionalBlock extends AuthorAnnotated {
   description?: string;
   /** Display mode: 'inline' (default) or 'section' for section-styled rendering */
   display?: ConditionalDisplayMode;
-  /** Target element for exists-reftarget condition (CSS selector or button text) */
-  reftarget?: string;
+  /** Target element for exists-reftarget condition (CSS selector or button text; may be a fallback array) */
+  reftarget?: string | string[];
   /** Section config for the 'pass' branch (only used when display is 'section') */
   whenTrueSectionConfig?: ConditionalSectionConfig;
   /** Section config for the 'fail' branch (only used when display is 'section') */
@@ -264,10 +264,13 @@ export interface JsonInteractiveBlock extends AssistantProps, AuthorAnnotated {
    * present so authors who prefer camelCase still get a working guide.
    */
   targetAction?: JsonInteractiveAction;
-  /** CSS selector or Grafana selector for the target element (optional for noop actions) */
-  reftarget?: string;
+  /**
+   * CSS selector or Grafana selector for the target element (optional for noop actions).
+   * May be an ordered array of fallback selectors (strongest first). `navigate` must be a single string.
+   */
+  reftarget?: string | string[];
   /** camelCase alias for `reftarget`. Tolerated by the runtime parser. */
-  refTarget?: string;
+  refTarget?: string | string[];
   /**
    * Value for formfill actions (supports regex patterns starting with ^ or $ or enclosed in /pattern/).
    * For popout actions, must be 'sidebar' (dock) or 'floating' (undock).
@@ -374,10 +377,13 @@ export interface JsonStep {
   action: JsonInteractiveAction;
   /** camelCase alias for `action`. Tolerated by the runtime parser. */
   targetAction?: JsonInteractiveAction;
-  /** CSS selector or Grafana selector for the target element (optional for noop actions) */
-  reftarget?: string;
+  /**
+   * CSS selector or Grafana selector for the target element (optional for noop actions).
+   * May be an ordered array of fallback selectors (strongest first). `navigate` must be a single string.
+   */
+  reftarget?: string | string[];
   /** camelCase alias for `reftarget`. Tolerated by the runtime parser. */
-  refTarget?: string;
+  refTarget?: string | string[];
   /**
    * Value for formfill actions (supports regex patterns starting with ^ or $ or enclosed in /pattern/).
    * For popout actions, must be 'sidebar' (dock) or 'floating' (undock).
@@ -653,8 +659,8 @@ export interface JsonCodeBlockBlock extends AuthorAnnotated {
   type: 'code-block';
   /** Stable identifier for edit-block / remove-block addressing (auto-assigned by the CLI when omitted) */
   id?: string;
-  /** CSS selector for the Monaco editor container */
-  reftarget: string;
+  /** CSS selector for the Monaco editor container (may be a fallback array, strongest first) */
+  reftarget: string | string[];
   /** Programming language for syntax highlighting (e.g., 'javascript', 'typescript', 'python') */
   language?: string;
   /** The code to display and insert */

--- a/src/utils/devtools/selector-generator.util.test.ts
+++ b/src/utils/devtools/selector-generator.util.test.ts
@@ -1,0 +1,32 @@
+import { generateSelectorFromEvent } from './selector-generator.util';
+
+describe('generateSelectorFromEvent — fallback chain', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns a strategy-diverse fallback chain that excludes the primary selector', () => {
+    const button = document.createElement('button');
+    button.setAttribute('data-testid', 'save');
+    button.setAttribute('aria-label', 'Save document');
+    document.body.appendChild(button);
+
+    const result = generateSelectorFromEvent(button, new MouseEvent('click'));
+
+    expect(Array.isArray(result.fallbacks)).toBe(true);
+    expect(result.fallbacks.length).toBeGreaterThan(0);
+    expect(result.fallbacks).not.toContain(result.selector);
+  });
+
+  it('returns an empty fallback chain when the element has only one viable selector', () => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+
+    const result = generateSelectorFromEvent(div, new MouseEvent('click'));
+
+    expect(result.fallbacks).toEqual([]);
+  });
+});

--- a/src/utils/devtools/selector-generator.util.ts
+++ b/src/utils/devtools/selector-generator.util.ts
@@ -5,12 +5,13 @@
  * the useActionRecorder hook and block editor components.
  */
 
-import { generateBestSelector, getSelectorInfo, validateAndCleanSelector } from '../../lib/dom';
+import { generateBestSelector, generateSelectorChain, getSelectorInfo, validateAndCleanSelector } from '../../lib/dom';
 import { detectActionType, type DetectedAction } from '../../lib/dom/action-detector';
 import type { SelectorInfo } from './dev-tools.types';
 
 export interface SelectorGenerationResult {
   selector: string;
+  fallbacks: string[];
   action: DetectedAction;
   selectorInfo: SelectorInfo;
   warnings: string[];
@@ -65,8 +66,15 @@ export function generateSelectorFromEvent(
     contextStrategy: info.contextStrategy,
   };
 
+  // The chain's first entry is the primary; keep only the weaker, strategy-diverse
+  // fallbacks, and drop any that collapse onto the validated primary.
+  const fallbacks = generateSelectorChain(target)
+    .slice(1)
+    .filter((candidate) => candidate !== selector);
+
   return {
     selector,
+    fallbacks,
     action,
     selectorInfo,
     warnings: validated.warnings,

--- a/src/validation/validate-guide.test.ts
+++ b/src/validation/validate-guide.test.ts
@@ -712,8 +712,7 @@ describe('JsonGuideSchema', () => {
   });
 
   describe('reftarget fallback arrays', () => {
-    const guideWith = (block: Record<string, unknown>) =>
-      JSON.stringify({ id: 'g', title: 'T', blocks: [block] });
+    const guideWith = (block: Record<string, unknown>) => JSON.stringify({ id: 'g', title: 'T', blocks: [block] });
 
     it('accepts an interactive block with an ordered reftarget array', () => {
       const result = validateGuideFromString(

--- a/src/validation/validate-guide.test.ts
+++ b/src/validation/validate-guide.test.ts
@@ -710,4 +710,63 @@ describe('JsonGuideSchema', () => {
       expect(result.isValid).toBe(false);
     });
   });
+
+  describe('reftarget fallback arrays', () => {
+    const guideWith = (block: Record<string, unknown>) =>
+      JSON.stringify({ id: 'g', title: 'T', blocks: [block] });
+
+    it('accepts an interactive block with an ordered reftarget array', () => {
+      const result = validateGuideFromString(
+        guideWith({
+          type: 'interactive',
+          action: 'button',
+          content: 'Click',
+          reftarget: ['Save', "button[data-testid='save']"],
+        })
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('accepts a multistep step with a reftarget array', () => {
+      const result = validateGuideFromString(
+        guideWith({ type: 'multistep', content: 'X', steps: [{ action: 'highlight', reftarget: ['#a', '#b'] }] })
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('accepts a code-block with a reftarget array', () => {
+      const result = validateGuideFromString(
+        guideWith({ type: 'code-block', code: 'up', reftarget: ['.monaco', "[data-testid='editor']"] })
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('rejects an empty reftarget array', () => {
+      const result = validateGuideFromString(
+        guideWith({ type: 'interactive', action: 'button', content: 'Click', reftarget: [] })
+      );
+      expect(result.isValid).toBe(false);
+    });
+
+    it('rejects a reftarget array containing an empty selector', () => {
+      const result = validateGuideFromString(
+        guideWith({ type: 'interactive', action: 'button', content: 'Click', reftarget: ['#a', ''] })
+      );
+      expect(result.isValid).toBe(false);
+    });
+
+    it('accepts navigate with a single string reftarget', () => {
+      const result = validateGuideFromString(
+        guideWith({ type: 'interactive', action: 'navigate', content: 'Go', reftarget: '/dashboards' })
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it('rejects navigate with a reftarget array', () => {
+      const result = validateGuideFromString(
+        guideWith({ type: 'interactive', action: 'navigate', content: 'Go', reftarget: ['/dashboards', '/home'] })
+      );
+      expect(result.isValid).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Part of grafana/grafana-frontend-platform#194 — selector-logic exploration, **Job 1 of 3**.

`refTarget` now accepts an ordered array of selectors and resolves them selector-major, so an interactive step survives UI churn by falling back to the next candidate. The element picker generates a strategy-diverse fallback chain automatically and the block editor carries it into the step form.

## What's in here
- **Schema + runtime** — guide JSON accepts `refTarget` arrays; the union is carried through the interactive runtime.
- **Resolution** — selector-major fallback resolution; `exists-reftarget` passes if *any* candidate resolves.
- **Picker → form** — `generateSelectorChain` produces a strategy-diverse chain; `generateSelectorFromEvent` returns it; the block editor authors the chain into the form and the manual fallback editor is removed in favor of it.
- **CLI** — repeated `--reftarget` builds a fallback chain.
- **Tests** — end-to-end parse + resolve coverage for chains.

## Validation
`npm run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
