### PR TITLE
feat(dom): emit version-stable grafana: selectors from the element picker

### DIFF
--- a/.cursor/rules/techContext.mdc
+++ b/.cursor/rules/techContext.mdc
@@ -40,6 +40,7 @@ globs:
 
 **Frontend Runtime**:
 - `@grafana/data`, `@grafana/ui`, `@grafana/runtime`, `@grafana/scenes` (12.4.0 / 7.0.3)
+- `@grafana/e2e-selectors` — powers `grafana:` reftarget resolution and the picker's reverse lookup (`src/lib/dom/grafana-selector.ts`). Selectors resolve against the running Grafana's `config.buildInfo.version`, but only within the bundled package's version table: Grafanas newer than the bundle resolve to the bundle's latest values. Bump alongside the other pinned `@grafana/*` deps each release cycle to keep `grafana:` selector durability.
 - `react` + `react-dom` (18.3.1), `react-router-dom` (6.28.0)
 - `@emotion/css` (11.13.5) for styling
 - `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` for drag-and-drop

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@emotion/css": "^11.13.5",
         "@grafana/assistant": "^0.1.25",
         "@grafana/data": "13.1.0",
+        "@grafana/e2e-selectors": "13.1.0",
         "@grafana/faro-web-sdk": "^2.8.2",
         "@grafana/i18n": "13.1.0",
         "@grafana/runtime": "13.1.0",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@emotion/css": "^11.13.5",
     "@grafana/assistant": "^0.1.25",
     "@grafana/data": "13.1.0",
+    "@grafana/e2e-selectors": "13.1.0",
     "@grafana/faro-web-sdk": "^2.8.2",
     "@grafana/i18n": "13.1.0",
     "@grafana/runtime": "13.1.0",

--- a/src/interactive-engine/action-handlers/focus-handler.test.ts
+++ b/src/interactive-engine/action-handlers/focus-handler.test.ts
@@ -8,6 +8,12 @@ import * as elementValidator from '../../lib/dom';
 jest.mock('../interactive-state-manager');
 jest.mock('../navigation-manager');
 jest.mock('../../lib/dom');
+// Keep the real @grafana/runtime module graph out of this suite: it transitively
+// loads prismjs, whose auto-highlight callback calls the document.querySelectorAll
+// stubbed below and chokes on the mock elements it returns.
+jest.mock('@grafana/runtime', () => ({
+  config: { buildInfo: { version: '1.0' } },
+}));
 
 const mockStateManager = {
   setState: jest.fn(),

--- a/src/lib/dom/grafana-selector.test.ts
+++ b/src/lib/dom/grafana-selector.test.ts
@@ -4,7 +4,16 @@ import {
   findByGrafanaSelector,
   findOneByGrafanaSelector,
   existsByGrafanaSelector,
+  findGrafanaSelectorPath,
 } from './grafana-selector';
+
+function elementWith(attrs: Record<string, string>): HTMLElement {
+  const el = document.createElement('button');
+  for (const [name, value] of Object.entries(attrs)) {
+    el.setAttribute(name, value);
+  }
+  return el;
+}
 
 describe('grafana-selector', () => {
   beforeEach(() => {
@@ -91,6 +100,52 @@ describe('grafana-selector', () => {
 
     it('should return false if element does not exist', () => {
       expect(existsByGrafanaSelector('components.RefreshPicker.runButtonV2')).toBe(false);
+    });
+  });
+
+  describe('findGrafanaSelectorPath (reverse lookup)', () => {
+    it('maps a component data-testid back to its grafana: components path', () => {
+      const el = elementWith({ 'data-testid': 'data-testid RefreshPicker run button' });
+      const path = findGrafanaSelectorPath(el);
+
+      expect(path).not.toBeNull();
+      expect(path!.startsWith('grafana:components.')).toBe(true);
+      // Round-trips: resolving the returned path yields the element's value.
+      expect(toGrafanaSelector(path!.replace('grafana:', ''))).toContain('data-testid RefreshPicker run button');
+    });
+
+    it('maps a page-level data-testid back to its grafana: pages path', () => {
+      const el = elementWith({ 'data-testid': 'data-testid Username input field' });
+      const path = findGrafanaSelectorPath(el);
+
+      expect(path).not.toBeNull();
+      expect(path!.startsWith('grafana:pages.')).toBe(true);
+      expect(toGrafanaSelector(path!.replace('grafana:', ''))).toContain('data-testid Username input field');
+    });
+
+    it('falls back to aria-label when there is no data-testid', () => {
+      const el = elementWith({ 'aria-label': 'data-testid RefreshPicker run button' });
+      const path = findGrafanaSelectorPath(el);
+
+      expect(path).not.toBeNull();
+      expect(toGrafanaSelector(path!.replace('grafana:', ''))).toContain('data-testid RefreshPicker run button');
+    });
+
+    it('reverses a parameterized selector and extracts the parameter', () => {
+      const el = elementWith({ 'data-testid': 'data-testid Home breadcrumb' });
+      const path = findGrafanaSelectorPath(el);
+
+      expect(path).toBe('grafana:components.Breadcrumbs.breadcrumb:Home');
+    });
+
+    it('returns null for an unknown selector value', () => {
+      const el = elementWith({ 'data-testid': 'totally-not-a-grafana-selector-xyz' });
+      expect(findGrafanaSelectorPath(el)).toBeNull();
+    });
+
+    it('returns null when the element has no testid or aria-label', () => {
+      const el = elementWith({ class: 'plain' });
+      expect(findGrafanaSelectorPath(el)).toBeNull();
     });
   });
 });

--- a/src/lib/dom/grafana-selector.ts
+++ b/src/lib/dom/grafana-selector.ts
@@ -146,8 +146,9 @@ interface ReverseIndex {
   templates: Array<{ regex: RegExp; path: string }>;
 }
 
-// A control character that never appears in a real selector value, used to
-// locate the parameter position inside a parameterized selector's output.
+// Delimited by U+E000 private-use characters that never appear in a real
+// selector value, used to locate the parameter position inside a
+// parameterized selector's output.
 const TEMPLATE_SENTINEL = 'PARAM';
 const TESTID_PREFIX = /^data-testid\s*/;
 

--- a/src/lib/dom/grafana-selector.ts
+++ b/src/lib/dom/grafana-selector.ts
@@ -4,8 +4,27 @@
  * Based on @grafana/plugin-e2e approach for cross-version compatibility
  */
 
-import { selectors as grafanaSelectors } from '@grafana/e2e-selectors';
+import { resolveSelectors, versionedComponents, versionedPages } from '@grafana/e2e-selectors';
+import { config } from '@grafana/runtime';
 import { querySelectorAllEnhanced } from './enhanced-selector';
+
+type SelectorNode = { [key: string]: SelectorNode | string | ((...args: never[]) => unknown) };
+
+let resolvedSelectors: { version: string; tree: SelectorNode } | null = null;
+
+/**
+ * The selector tree resolved for the running Grafana version, so both forward
+ * resolution and reverse lookup use the values this instance actually renders,
+ * not the newest values in the bundled package.
+ */
+function getResolvedSelectors(): SelectorNode {
+  const version = config.buildInfo.version || 'latest';
+  if (resolvedSelectors?.version !== version) {
+    const tree = resolveSelectors({ components: versionedComponents, pages: versionedPages }, version);
+    resolvedSelectors = { version, tree: tree as unknown as SelectorNode };
+  }
+  return resolvedSelectors.tree;
+}
 
 /**
  * Convert a Grafana selector path to a CSS selector string
@@ -31,7 +50,7 @@ export function toGrafanaSelector(selectorPath: string, selectorId?: string): st
 
   // Navigate the selector object path
   const parts = selectorPath.split('.');
-  let current: any = grafanaSelectors;
+  let current: SelectorNode[string] | undefined = getResolvedSelectors();
 
   for (const part of parts) {
     if (!current || typeof current !== 'object') {
@@ -49,7 +68,11 @@ export function toGrafanaSelector(selectorPath: string, selectorId?: string): st
     if (!selectorId) {
       throw new Error(`Selector ${selectorPath} requires an ID parameter`);
     }
-    resolvedValue = current(selectorId);
+    const result = (current as (id: string) => unknown)(selectorId);
+    if (typeof result !== 'string') {
+      throw new Error(`Invalid selector type at ${selectorPath}: ${typeof result}`);
+    }
+    resolvedValue = result;
   } else if (typeof current === 'string') {
     resolvedValue = current;
   } else {
@@ -118,8 +141,6 @@ export function existsByGrafanaSelector(selectorPath: string, selectorId?: strin
 // Reverse lookup: element → grafana: selector path
 // ============================================================================
 
-type SelectorNode = { [key: string]: SelectorNode | string | ((...args: never[]) => unknown) };
-
 interface ReverseIndex {
   exact: Map<string, string>;
   templates: Array<{ regex: RegExp; path: string }>;
@@ -163,13 +184,15 @@ function buildTemplate(fn: (...args: never[]) => unknown): { regex: RegExp; weig
   return { regex: new RegExp(`^${escapeRegExp(prefix)}(.+)${escapeRegExp(suffix)}$`), weight: discriminator.length };
 }
 
-let reverseIndex: ReverseIndex | null = null;
+let reverseIndex: { source: SelectorNode; index: ReverseIndex } | null = null;
 
 function getReverseIndex(): ReverseIndex {
-  if (reverseIndex) {
-    return reverseIndex;
+  const root = getResolvedSelectors();
+  if (reverseIndex?.source === root) {
+    return reverseIndex.index;
   }
   const exact = new Map<string, string>();
+  const ambiguous = new Set<string>();
   const templates: Array<{ regex: RegExp; path: string; weight: number }> = [];
 
   const walk = (node: SelectorNode, path: string): void => {
@@ -177,7 +200,13 @@ function getReverseIndex(): ReverseIndex {
       const value = node[key];
       const childPath = path ? `${path}.${key}` : key;
       if (typeof value === 'string') {
-        if (!exact.has(value)) {
+        if (ambiguous.has(value)) {
+          continue;
+        }
+        if (exact.has(value)) {
+          exact.delete(value);
+          ambiguous.add(value);
+        } else {
           exact.set(value, childPath);
         }
       } else if (typeof value === 'function') {
@@ -191,14 +220,13 @@ function getReverseIndex(): ReverseIndex {
     }
   };
 
-  const root = grafanaSelectors as unknown as SelectorNode;
   walk(root.components as SelectorNode, 'components');
   walk(root.pages as SelectorNode, 'pages');
 
   // Most specific templates first, so a generic pattern never shadows a precise one.
   templates.sort((a, b) => b.weight - a.weight);
-  reverseIndex = { exact, templates: templates.map(({ regex, path }) => ({ regex, path })) };
-  return reverseIndex;
+  reverseIndex = { source: root, index: { exact, templates: templates.map(({ regex, path }) => ({ regex, path })) } };
+  return reverseIndex.index;
 }
 
 /**
@@ -209,6 +237,11 @@ function getReverseIndex(): ReverseIndex {
  * Covers both `components.*` and `pages.*`, matching on `data-testid` first and
  * `aria-label` second, and extracts the parameter for parameterized selectors
  * (e.g. `grafana:components.Breadcrumbs.breadcrumb:Home`).
+ *
+ * Lookups are resolved against the running Grafana version, and any ambiguous
+ * value — one claimed by several selector paths, or matching several templates —
+ * returns null so the picker degrades to its own CSS strategies rather than
+ * emitting a confidently wrong path.
  */
 export function findGrafanaSelectorPath(element: HTMLElement): string | null {
   const index = getReverseIndex();
@@ -224,11 +257,20 @@ export function findGrafanaSelectorPath(element: HTMLElement): string | null {
   }
 
   for (const value of values) {
+    let matched: string | null = null;
     for (const template of index.templates) {
       const match = template.regex.exec(value);
-      if (match && match[1]) {
-        return `grafana:${template.path}:${match[1]}`;
+      if (!match || !match[1]) {
+        continue;
       }
+      if (matched) {
+        matched = null;
+        break;
+      }
+      matched = `grafana:${template.path}:${match[1]}`;
+    }
+    if (matched) {
+      return matched;
     }
   }
 

--- a/src/lib/dom/grafana-selector.ts
+++ b/src/lib/dom/grafana-selector.ts
@@ -113,3 +113,124 @@ export function existsByGrafanaSelector(selectorPath: string, selectorId?: strin
   const elements = findByGrafanaSelector(selectorPath, selectorId);
   return elements.length > 0;
 }
+
+// ============================================================================
+// Reverse lookup: element → grafana: selector path
+// ============================================================================
+
+type SelectorNode = { [key: string]: SelectorNode | string | ((...args: never[]) => unknown) };
+
+interface ReverseIndex {
+  exact: Map<string, string>;
+  templates: Array<{ regex: RegExp; path: string }>;
+}
+
+// A control character that never appears in a real selector value, used to
+// locate the parameter position inside a parameterized selector's output.
+const TEMPLATE_SENTINEL = 'PARAM';
+const TESTID_PREFIX = /^data-testid\s*/;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Turn a parameterized selector function into a matcher. Returns null when the
+ * function ignores its argument, takes several, or is so generic that its only
+ * literal text is the shared `data-testid` prefix (which would match almost any
+ * element — `pages.AddDashboard.itemButton` is the canonical offender).
+ */
+function buildTemplate(fn: (...args: never[]) => unknown): { regex: RegExp; weight: number } | null {
+  let resolved: unknown;
+  try {
+    resolved = (fn as (id: string) => unknown)(TEMPLATE_SENTINEL);
+  } catch {
+    return null;
+  }
+  if (typeof resolved !== 'string') {
+    return null;
+  }
+  const first = resolved.indexOf(TEMPLATE_SENTINEL);
+  if (first === -1 || first !== resolved.lastIndexOf(TEMPLATE_SENTINEL) || resolved.includes('undefined')) {
+    return null;
+  }
+  const prefix = resolved.slice(0, first);
+  const suffix = resolved.slice(first + TEMPLATE_SENTINEL.length);
+  const discriminator = (prefix.replace(TESTID_PREFIX, '') + suffix).trim();
+  if (discriminator.length < 3) {
+    return null;
+  }
+  return { regex: new RegExp(`^${escapeRegExp(prefix)}(.+)${escapeRegExp(suffix)}$`), weight: discriminator.length };
+}
+
+let reverseIndex: ReverseIndex | null = null;
+
+function getReverseIndex(): ReverseIndex {
+  if (reverseIndex) {
+    return reverseIndex;
+  }
+  const exact = new Map<string, string>();
+  const templates: Array<{ regex: RegExp; path: string; weight: number }> = [];
+
+  const walk = (node: SelectorNode, path: string): void => {
+    for (const key of Object.keys(node)) {
+      const value = node[key];
+      const childPath = path ? `${path}.${key}` : key;
+      if (typeof value === 'string') {
+        if (!exact.has(value)) {
+          exact.set(value, childPath);
+        }
+      } else if (typeof value === 'function') {
+        const template = buildTemplate(value);
+        if (template) {
+          templates.push({ regex: template.regex, path: childPath, weight: template.weight });
+        }
+      } else if (value && typeof value === 'object') {
+        walk(value, childPath);
+      }
+    }
+  };
+
+  const root = grafanaSelectors as unknown as SelectorNode;
+  walk(root.components as SelectorNode, 'components');
+  walk(root.pages as SelectorNode, 'pages');
+
+  // Most specific templates first, so a generic pattern never shadows a precise one.
+  templates.sort((a, b) => b.weight - a.weight);
+  reverseIndex = { exact, templates: templates.map(({ regex, path }) => ({ regex, path })) };
+  return reverseIndex;
+}
+
+/**
+ * Reverse of {@link toGrafanaSelector}: given a DOM element, return the
+ * version-stable `grafana:` selector path that targets it, or null when the
+ * element carries no recognized Grafana selector value.
+ *
+ * Covers both `components.*` and `pages.*`, matching on `data-testid` first and
+ * `aria-label` second, and extracts the parameter for parameterized selectors
+ * (e.g. `grafana:components.Breadcrumbs.breadcrumb:Home`).
+ */
+export function findGrafanaSelectorPath(element: HTMLElement): string | null {
+  const index = getReverseIndex();
+  const values = [element.getAttribute('data-testid'), element.getAttribute('aria-label')].filter(
+    (value): value is string => Boolean(value)
+  );
+
+  for (const value of values) {
+    const exactPath = index.exact.get(value);
+    if (exactPath) {
+      return `grafana:${exactPath}`;
+    }
+  }
+
+  for (const value of values) {
+    for (const template of index.templates) {
+      const match = template.regex.exec(value);
+      if (match && match[1]) {
+        return `grafana:${template.path}:${match[1]}`;
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/lib/dom/grafana-selector.versioned.test.ts
+++ b/src/lib/dom/grafana-selector.versioned.test.ts
@@ -30,6 +30,9 @@ jest.mock('@grafana/e2e-selectors', () => {
         row: { '8.5.0': (title: string) => `data-testid thing row ${title}` },
         cell: { '8.5.0': (title: string) => `data-testid thing ${title} end` },
       },
+      Static: {
+        label: { '8.5.0': () => 'data-testid PARAM label' },
+      },
     },
     versionedPages: {
       DupePage: {
@@ -102,5 +105,14 @@ describe('grafana-selector — ambiguity rejection', () => {
   it('returns null when a value matches more than one template', () => {
     config.buildInfo.version = '12.0.0';
     expect(findGrafanaSelectorPath(elementWithTestId('data-testid thing row alpha end'))).toBeNull();
+  });
+
+  it('never treats an argument-ignoring selector function as a template', () => {
+    // Pins the TEMPLATE_SENTINEL contract: the U+E000-delimited sentinel cannot
+    // appear in a probe's output unless the function interpolates its argument,
+    // so Static.label ('data-testid PARAM label') must not become a template
+    // matching unrelated values of the shape 'data-testid ... label'.
+    config.buildInfo.version = '12.0.0';
+    expect(findGrafanaSelectorPath(elementWithTestId('data-testid foo label'))).toBeNull();
   });
 });

--- a/src/lib/dom/grafana-selector.versioned.test.ts
+++ b/src/lib/dom/grafana-selector.versioned.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Version-aware resolution and ambiguity handling for grafana-selector.
+ *
+ * Uses a synthetic versioned selector tree with the package's real
+ * `resolveSelectors`, so the wiring from `config.buildInfo.version` through
+ * forward resolution and the reverse index is exercised end-to-end.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+jest.mock('@grafana/runtime', () => ({
+  config: { buildInfo: { version: 'latest' } },
+}));
+
+jest.mock('@grafana/e2e-selectors', () => {
+  const actual = jest.requireActual('@grafana/e2e-selectors');
+  return {
+    resolveSelectors: actual.resolveSelectors,
+    versionedComponents: {
+      Thing: {
+        button: {
+          '11.0.0': 'data-testid new thing button',
+          '8.5.0': 'old thing button',
+        },
+      },
+      Dupe: {
+        one: { '8.5.0': 'data-testid shared value' },
+      },
+      Tpl: {
+        row: { '8.5.0': (title: string) => `data-testid thing row ${title}` },
+        cell: { '8.5.0': (title: string) => `data-testid thing ${title} end` },
+      },
+    },
+    versionedPages: {
+      DupePage: {
+        two: { '8.5.0': 'data-testid shared value' },
+      },
+    },
+  };
+});
+
+import { config } from '@grafana/runtime';
+import { toGrafanaSelector, findGrafanaSelectorPath } from './grafana-selector';
+
+function elementWithTestId(testId: string): HTMLElement {
+  const el = document.createElement('button');
+  el.setAttribute('data-testid', testId);
+  return el;
+}
+
+describe('grafana-selector — version-aware resolution', () => {
+  it('resolves forward against the running Grafana version, not latest', () => {
+    config.buildInfo.version = '9.0.0';
+    expect(toGrafanaSelector('components.Thing.button')).toContain("[data-testid='old thing button']");
+  });
+
+  it('resolves forward to the newer value once the running version reaches it', () => {
+    config.buildInfo.version = '12.0.0';
+    expect(toGrafanaSelector('components.Thing.button')).toContain("[data-testid='data-testid new thing button']");
+  });
+
+  it('falls back to the latest values when the version is not valid semver', () => {
+    config.buildInfo.version = '1.0';
+    expect(toGrafanaSelector('components.Thing.button')).toContain("[data-testid='data-testid new thing button']");
+  });
+
+  it('reverse-matches the value the running version renders', () => {
+    config.buildInfo.version = '9.0.0';
+    expect(findGrafanaSelectorPath(elementWithTestId('old thing button'))).toBe('grafana:components.Thing.button');
+  });
+
+  it('does not reverse-match a value from a different version', () => {
+    config.buildInfo.version = '9.0.0';
+    expect(findGrafanaSelectorPath(elementWithTestId('data-testid new thing button'))).toBeNull();
+  });
+
+  it('rebuilds the reverse index when the version changes', () => {
+    config.buildInfo.version = '9.0.0';
+    expect(findGrafanaSelectorPath(elementWithTestId('old thing button'))).toBe('grafana:components.Thing.button');
+
+    config.buildInfo.version = '12.0.0';
+    expect(findGrafanaSelectorPath(elementWithTestId('old thing button'))).toBeNull();
+    expect(findGrafanaSelectorPath(elementWithTestId('data-testid new thing button'))).toBe(
+      'grafana:components.Thing.button'
+    );
+  });
+});
+
+describe('grafana-selector — ambiguity rejection', () => {
+  it('returns null for a value claimed by more than one selector path', () => {
+    config.buildInfo.version = '12.0.0';
+    expect(findGrafanaSelectorPath(elementWithTestId('data-testid shared value'))).toBeNull();
+  });
+
+  it('returns a unique template match with its parameter', () => {
+    config.buildInfo.version = '12.0.0';
+    expect(findGrafanaSelectorPath(elementWithTestId('data-testid thing row alpha'))).toBe(
+      'grafana:components.Tpl.row:alpha'
+    );
+  });
+
+  it('returns null when a value matches more than one template', () => {
+    config.buildInfo.version = '12.0.0';
+    expect(findGrafanaSelectorPath(elementWithTestId('data-testid thing row alpha end'))).toBeNull();
+  });
+});

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -529,6 +529,38 @@ describe('Selector Generator — Pipeline', () => {
   });
 
   // ==========================================================================
+  // grafana e2e-selector awareness
+  // ==========================================================================
+
+  describe('grafana e2e-selector awareness', () => {
+    it('prefers a version-stable grafana: selector for a known component testid', () => {
+      const button = document.createElement('button');
+      button.setAttribute('data-testid', 'data-testid RefreshPicker run button');
+      document.body.appendChild(button);
+
+      expect(generateBestSelector(button)).toMatch(/^grafana:components\./);
+    });
+
+    it('keeps the raw testid selector available as a fallback', () => {
+      const button = document.createElement('button');
+      button.setAttribute('data-testid', 'data-testid RefreshPicker run button');
+      document.body.appendChild(button);
+
+      const primary = generateBestSelector(button);
+      const fallbacks = generateFallbackSelectors(button, primary);
+      expect(fallbacks.some((s) => s.includes("[data-testid='data-testid RefreshPicker run button']"))).toBe(true);
+    });
+
+    it('emits a grafana:pages selector as the best selector for a page-level element', () => {
+      const input = document.createElement('input');
+      input.setAttribute('data-testid', 'data-testid Username input field');
+      document.body.appendChild(input);
+
+      expect(generateBestSelector(input)).toMatch(/^grafana:pages\./);
+    });
+  });
+
+  // ==========================================================================
   // Integration
   // ==========================================================================
 

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -11,6 +11,8 @@
 
 import { findButtonByText } from './dom-utils';
 import { querySelectorAllEnhanced, querySelectorAllEnhancedVisible } from './enhanced-selector';
+import { findGrafanaSelectorPath } from './grafana-selector';
+import { resolveSelector } from './selector-resolver';
 
 // ============================================================================
 // Types
@@ -82,6 +84,7 @@ const SELECTOR_CONFIG = {
 } as const;
 
 const CANDIDATE_SCORES = {
+  grafana: 5,
   testId: 10,
   scopedTestId: 15,
   cssId: 50,
@@ -446,6 +449,14 @@ export function retargetElement(element: HTMLElement): HTMLElement {
 // Phase 2: Candidate Generators
 // ============================================================================
 
+function candidateGrafanaSelector(element: HTMLElement): Candidate | null {
+  const path = findGrafanaSelectorPath(element);
+  if (!path) {
+    return null;
+  }
+  return { selector: path, score: CANDIDATE_SCORES.grafana, method: 'grafana' };
+}
+
 function candidateTestId(element: HTMLElement): Candidate | null {
   const testId = getAnyTestId(element);
   if (!testId) {
@@ -719,6 +730,7 @@ function generateCandidates(element: HTMLElement): Candidate[] {
     }
   };
 
+  push(candidateGrafanaSelector(element));
   push(candidateTestId(element));
   push(candidateScopedTestId(element));
   push(candidateTestIdPlusHref(element));
@@ -754,7 +766,7 @@ function testUniqueness(
       return { matchCount: buttons.length, containsTarget: buttons.includes(element as HTMLButtonElement) };
     }
     const matchFn = inOverlay ? querySelectorAllEnhancedVisible : querySelectorAllEnhanced;
-    const matches = matchFn(selector);
+    const matches = matchFn(resolveSelector(selector));
     return { matchCount: matches.elements.length, containsTarget: matches.elements.includes(element) };
   } catch {
     return { matchCount: 0, containsTarget: false };
@@ -931,7 +943,7 @@ function admitCandidate(
   }
 
   if (matchCount === 1) {
-    if (candidate.method === 'button-text' || candidate.method === 'scoped-testid') {
+    if (candidate.method === 'button-text' || candidate.method === 'scoped-testid' || candidate.method === 'grafana') {
       return [{ ...candidate, matchCount }];
     }
     for (const scope of ancestorScopes) {
@@ -955,7 +967,7 @@ function admitCandidate(
     return candidate.method === 'scoped-bare-tag' ? [] : [{ ...candidate, matchCount }];
   }
 
-  if (candidate.method === 'button-text') {
+  if (candidate.method === 'button-text' || candidate.method === 'grafana') {
     return [];
   }
 


### PR DESCRIPTION
Part of grafana/grafana-frontend-platform#194 — selector-logic exploration.

> Originally stacked on #1155 (fallback selector chains), which was closed after discussion. This PR has been rebased onto `main` and reworked to stand alone.

When the picked element (or an ancestor) carries a Grafana `data-testid`, the picker reverse-looks-up the element to a `grafana:` selector path, producing version-stable selectors that don't break on CSS-class churn.

- Reverse-lookup element → `grafana:` selector path (`findGrafanaSelectorPath`): a memoized reverse index over the `components.*` and `pages.*` trees of `@grafana/e2e-selectors`, matching `data-testid` (then `aria-label`) and extracting parameters for parameterized selectors.
- The picker emits the `grafana:` selector as the top-ranked candidate; the raw testid selector remains available as a fallback via `generateFallbackSelectors`. Uniqueness testing resolves `grafana:`/`panel:` prefixes before matching.
- **Version-aware resolution**: both directions resolve the selector tree against the running Grafana's `config.buildInfo.version` — the emitted `grafana:` path is the stable identity, and its CSS value is computed per-version at replay time.
- **Ambiguity rejection**: a value claimed by more than one selector path (8 of 637 values in the current bundle), or matching more than one parameterized template, is never reverse-matched — the picker degrades to its own CSS strategies rather than emitting a confidently wrong path.
- `@grafana/e2e-selectors` is now a direct pinned dependency (previously transitive-only), with the bundle-freshness coupling documented in `.cursor/rules/techContext.mdc`.

## Validation
`npm run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)