### PR TITLE
feat(dom): anchor identity-less elements via stable ancestors and :has() descendants

### DIFF
--- a/src/components/block-editor/SelectorHealthBadge.test.tsx
+++ b/src/components/block-editor/SelectorHealthBadge.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { SelectorHealthBadge } from './SelectorHealthBadge';
+
+describe('SelectorHealthBadge', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('shows the generator-derived method and stability score for a data-testid selector', async () => {
+    document.body.innerHTML = '<button data-testid="save">Save</button>';
+
+    render(<SelectorHealthBadge reftarget="button[data-testid='save']" />);
+
+    await waitFor(() => expect(screen.getByText('data-testid')).toBeInTheDocument(), { timeout: 2000 });
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('1 match')).toBeInTheDocument();
+  });
+
+  it('rates a bare positional selector with a low stability score', async () => {
+    document.body.innerHTML = '<button>A</button><button id="second">B</button>';
+
+    render(<SelectorHealthBadge reftarget="button:nth-of-type(2)" />);
+
+    await waitFor(() => expect(screen.getByText('nth-of-type')).toBeInTheDocument(), { timeout: 2000 });
+    expect(screen.getByText('20')).toBeInTheDocument();
+  });
+});

--- a/src/components/block-editor/SelectorHealthBadge.tsx
+++ b/src/components/block-editor/SelectorHealthBadge.tsx
@@ -11,59 +11,25 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import { querySelectorAllEnhanced } from '../../lib/dom/enhanced-selector';
 import { resolveSelector } from '../../lib/dom/selector-resolver';
+import { analyzeSelectorString } from '../../lib/dom/selector-generator';
 import { useDebouncedValue } from './useDebouncedValue';
 
 interface SelectorHealthBadgeProps {
   reftarget: string;
 }
 
-interface SelectorInfo {
+const QUALITY_COLORS: Record<string, string> = {
+  good: '#73BF69',
+  medium: '#FF9830',
+  poor: '#F2495C',
+};
+
+interface BadgeInfo {
   method: string;
-  score: number;
+  stabilityScore: number;
+  quality: string;
   matchCount: number;
   warnings: string[];
-}
-
-function analyzeSelectorPattern(reftarget: string): Omit<SelectorInfo, 'matchCount'> {
-  const warnings: string[] = [];
-  let method = 'compound';
-  let score = 40;
-
-  if (reftarget.includes('data-testid')) {
-    method = 'data-testid';
-    score = 100;
-  } else if (reftarget.includes('aria-label')) {
-    method = 'aria-label';
-    score = 85;
-  } else if (reftarget.includes('#')) {
-    method = 'id';
-    score = 90;
-  } else if (reftarget.includes(':text(') || reftarget.includes(':contains(')) {
-    method = 'text';
-    score = reftarget.includes(':text(') ? 65 : 55;
-    warnings.push('Text-based selectors are fragile and may break if the UI text changes');
-  } else if (reftarget.includes(':nth-match') || reftarget.includes(':nth-of-type')) {
-    method = 'positional';
-    score = reftarget.includes(':nth-match') ? 15 : 25;
-    warnings.push('Positional selectors are fragile and may break if the page layout changes');
-  }
-
-  if (reftarget.includes(' > ') && reftarget.split(' > ').length > 3) {
-    warnings.push('Deep nesting makes the selector fragile');
-    score = Math.max(10, score - 15);
-  }
-
-  return { method, score, warnings };
-}
-
-function getQuality(score: number): { label: string; color: string } {
-  if (score >= 80) {
-    return { label: 'good', color: '#73BF69' };
-  }
-  if (score >= 40) {
-    return { label: 'medium', color: '#FF9830' };
-  }
-  return { label: 'poor', color: '#F2495C' };
 }
 
 export function SelectorHealthBadge({ reftarget }: SelectorHealthBadgeProps) {
@@ -72,12 +38,14 @@ export function SelectorHealthBadge({ reftarget }: SelectorHealthBadgeProps) {
   // Debounce the reftarget so DOM queries don't fire on every keystroke
   const debouncedTarget = useDebouncedValue(reftarget, 500);
 
-  const info = useMemo<SelectorInfo | null>(() => {
+  const info = useMemo<BadgeInfo | null>(() => {
     if (!debouncedTarget.trim()) {
       return null;
     }
 
-    const analysis = analyzeSelectorPattern(debouncedTarget);
+    // Quality/flags/score come from the generator's model so the badge agrees
+    // with what the picker would have produced.
+    const analysis = analyzeSelectorString(debouncedTarget);
     const allWarnings = [...analysis.warnings];
 
     let matchCount = 0;
@@ -95,21 +63,27 @@ export function SelectorHealthBadge({ reftarget }: SelectorHealthBadgeProps) {
       allWarnings.push(`Selector matches ${matchCount} elements; consider making it more specific`);
     }
 
-    return { method: analysis.method, score: analysis.score, matchCount, warnings: allWarnings };
+    return {
+      method: analysis.method,
+      stabilityScore: analysis.stabilityScore,
+      quality: analysis.quality,
+      matchCount,
+      warnings: allWarnings,
+    };
   }, [debouncedTarget]);
 
   if (!info) {
     return null;
   }
 
-  const quality = getQuality(info.score);
+  const dotColor = QUALITY_COLORS[info.quality] ?? QUALITY_COLORS.medium;
   const matchColor = info.matchCount === 1 ? '#73BF69' : info.matchCount === 0 ? '#F2495C' : '#FF9830';
 
   return (
     <div className={styles.container}>
-      <span className={styles.dot} style={{ backgroundColor: quality.color }} />
+      <span className={styles.dot} style={{ backgroundColor: dotColor }} />
       <span className={styles.method}>{info.method}</span>
-      <span className={styles.score}>{info.score}</span>
+      <span className={styles.score}>{info.stabilityScore}</span>
       <span className={styles.matches} style={{ color: matchColor }}>
         {info.matchCount === 1 ? '1 match' : `${info.matchCount} matches`}
       </span>

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -561,6 +561,36 @@ describe('Selector Generator — Pipeline', () => {
   });
 
   // ==========================================================================
+  // Automatic stable-ancestor anchoring
+  // ==========================================================================
+
+  describe('ancestor anchoring', () => {
+    it('anchors a structureless element on its nearest stable ancestor instead of a global positional selector', () => {
+      document.body.innerHTML = `
+        <section data-testid="data-source-card">
+          <header>Cards</header>
+          <div><span>one</span><span>two</span></div>
+        </section>
+        <span>outside</span>
+      `;
+      const target = document.querySelectorAll('section[data-testid="data-source-card"] span')[1] as HTMLElement;
+
+      const selector = generateBestSelector(target);
+
+      expect(selector).toContain("data-testid='data-source-card'");
+      expect(selector.startsWith('span:nth-of-type')).toBe(false);
+      expect(querySelectorAllEnhanced(selector).elements).toContain(target);
+    });
+
+    it('does not anchor when the element has a stable intrinsic selector', () => {
+      document.body.innerHTML = `<div><button data-testid="save">Save</button></div>`;
+      const button = document.querySelector("button[data-testid='save']") as HTMLElement;
+
+      expect(generateBestSelector(button)).toBe("button[data-testid='save']");
+    });
+  });
+
+  // ==========================================================================
   // Integration
   // ==========================================================================
 

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -11,6 +11,7 @@ import {
   getSelectorInfo,
   retargetElement,
   generateFallbackSelectors,
+  analyzeSelectorString,
 } from './selector-generator';
 import { querySelectorAllEnhanced } from './enhanced-selector';
 
@@ -557,6 +558,37 @@ describe('Selector Generator — Pipeline', () => {
       document.body.appendChild(input);
 
       expect(generateBestSelector(input)).toMatch(/^grafana:pages\./);
+    });
+  });
+
+  // ==========================================================================
+  // analyzeSelectorString — single source of truth for the health badge
+  // ==========================================================================
+
+  describe('analyzeSelectorString', () => {
+    it('rates a data-testid selector as good with a high stability score', () => {
+      const analysis = analyzeSelectorString("button[data-testid='save']");
+      expect(analysis.method).toBe('data-testid');
+      expect(analysis.quality).toBe('good');
+      expect(analysis.stabilityScore).toBeGreaterThanOrEqual(80);
+    });
+
+    it('rates a bare positional selector as poor and flags it structural', () => {
+      const analysis = analyzeSelectorString('button:nth-of-type(3)');
+      expect(analysis.quality).toBe('poor');
+      expect(analysis.flags).toContain('structural');
+    });
+
+    it('flags an aria-label selector as i18n-sensitive', () => {
+      const analysis = analyzeSelectorString("button[aria-label='Save document']");
+      expect(analysis.flags).toContain('i18n-sensitive');
+      expect(analysis.quality).toBe('medium');
+    });
+
+    it('treats an ancestor-anchored structural selector as medium (testid scope + nth-child)', () => {
+      const analysis = analyzeSelectorString("section[data-testid='card'] > span:nth-child(2)");
+      expect(analysis.flags).toContain('structural');
+      expect(analysis.quality).toBe('medium');
     });
   });
 

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -596,6 +596,31 @@ describe('Selector Generator — Pipeline', () => {
       expect(analysis.method).toBe('has-descendant');
       expect(analysis.quality).toBe('medium');
     });
+
+    it('rates a grafana: reftarget as good with the top stability score', () => {
+      const analysis = analyzeSelectorString('grafana:components.RefreshPicker.runButton');
+      expect(analysis.method).toBe('grafana');
+      expect(analysis.quality).toBe('good');
+      expect(analysis.stabilityScore).toBe(100);
+    });
+
+    it('rates a panel: reftarget as good with the top stability score', () => {
+      const analysis = analyzeSelectorString('panel:CPU Usage');
+      expect(analysis.method).toBe('grafana');
+      expect(analysis.quality).toBe('good');
+      expect(analysis.stabilityScore).toBe(100);
+    });
+
+    it('recognizes a tag-attached id selector as an id method', () => {
+      const analysis = analyzeSelectorString('button#save');
+      expect(analysis.method).toBe('id');
+      expect(analysis.quality).toBe('good');
+    });
+
+    it('does not mistake a fragment href for an id selector', () => {
+      const analysis = analyzeSelectorString("a[href='#section']");
+      expect(analysis.method).toBe('href');
+    });
   });
 
   // ==========================================================================

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -590,6 +590,12 @@ describe('Selector Generator — Pipeline', () => {
       expect(analysis.flags).toContain('structural');
       expect(analysis.quality).toBe('medium');
     });
+
+    it('rates a :has() descendant-anchored selector as medium', () => {
+      const analysis = analyzeSelectorString("li > div:has(a[data-testid='nav'][href='/explore'])");
+      expect(analysis.method).toBe('has-descendant');
+      expect(analysis.quality).toBe('medium');
+    });
   });
 
   // ==========================================================================
@@ -619,6 +625,76 @@ describe('Selector Generator — Pipeline', () => {
       const button = document.querySelector("button[data-testid='save']") as HTMLElement;
 
       expect(generateBestSelector(button)).toBe("button[data-testid='save']");
+    });
+  });
+
+  // ==========================================================================
+  // has-descendant — stable descendant anchoring via :has()
+  // ==========================================================================
+
+  describe('has-descendant selectors', () => {
+    it('selects an identity-less wrapper via a stable descendant using :has()', () => {
+      document.body.innerHTML = `
+        <ul>
+          <li><div class="css-a"><div class="css-b"><a data-testid="nav-item" href="/home">Home</a></div></div></li>
+          <li><div class="css-c"><div class="css-d"><a data-testid="nav-item" href="/explore">Explore</a></div></div></li>
+        </ul>
+      `;
+      const wrapper = document.querySelectorAll('li')[1]!.querySelector('div') as HTMLElement;
+
+      const selector = generateBestSelector(wrapper);
+
+      expect(selector).toContain(':has(');
+      expect(selector).toContain("href='/explore'");
+      expect(querySelectorAllEnhanced(selector).elements).toEqual([wrapper]);
+    });
+
+    it('prefers an interactive descendant over a decorative one', () => {
+      document.body.innerHTML = `
+        <ul><li><div class="css-wrap">
+          <svg data-testid="icon-x"></svg>
+          <a data-testid="link" href="/go">Go</a>
+        </div></li></ul>
+      `;
+      const wrapper = document.querySelector('.css-wrap') as HTMLElement;
+
+      const selector = generateBestSelector(wrapper);
+
+      expect(selector).toContain(':has(');
+      expect(selector).toContain("data-testid='link'");
+      expect(selector).not.toContain('icon-x');
+    });
+
+    it('does not use :has() when the element has its own stable selector', () => {
+      document.body.innerHTML = `<div data-testid="card"><a data-testid="x" href="/y">Y</a></div>`;
+      const card = document.querySelector("[data-testid='card']") as HTMLElement;
+
+      expect(generateBestSelector(card)).toBe("div[data-testid='card']");
+    });
+
+    it('falls back to a positional selector when no stable descendant exists', () => {
+      document.body.innerHTML = `<ul><li><div class="css-wrap"><span>plain</span></div></li></ul>`;
+      const wrapper = document.querySelector('.css-wrap') as HTMLElement;
+
+      const selector = generateBestSelector(wrapper);
+
+      expect(selector).not.toContain(':has(');
+      expect(querySelectorAllEnhanced(selector).elements).toContain(wrapper);
+    });
+
+    it('uses the :has() selector as the primary for an identity-less wrapper', () => {
+      document.body.innerHTML = `
+        <ul>
+          <li><div class="css-wrap"><a data-testid="n" href="/a">A</a></div></li>
+          <li><div class="css-wrap2"><a data-testid="n" href="/b">B</a></div></li>
+        </ul>
+      `;
+      const wrapper = document.querySelector('.css-wrap') as HTMLElement;
+
+      const primary = generateBestSelector(wrapper);
+
+      expect(primary).toContain(':has(');
+      expect(primary).toContain("href='/a'");
     });
   });
 

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -1422,13 +1422,16 @@ export interface SelectorStringAnalysis {
  * selector that also uses `:nth-child` is downgraded via the structural flag).
  */
 function inferMethodAndScore(selector: string): { method: string; score: number } {
+  if (selector.startsWith('grafana:') || selector.startsWith('panel:')) {
+    return { method: 'grafana', score: CANDIDATE_SCORES.grafana };
+  }
   if (selector.includes(':has(')) {
     return { method: 'has-descendant', score: CANDIDATE_SCORES.testId + HAS_DESCENDANT_PENALTY };
   }
   if (SELECTOR_CONFIG.testIdAttrs.some((attr) => selector.includes(attr))) {
     return { method: 'data-testid', score: CANDIDATE_SCORES.testId };
   }
-  if (/(^|[\s>+~])#[\w-]+/.test(selector)) {
+  if (/(^|[\s>+~])[\w-]*#[\w-]+/.test(selector)) {
     return { method: 'id', score: CANDIDATE_SCORES.cssId };
   }
   if (selector.includes('[aria-label')) {

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -1059,8 +1059,7 @@ export function getSelectorInfo(element: HTMLElement): SelectorInfo {
     contextStrategy = 'parent-context';
   }
 
-  const stabilityScore =
-    winner.score <= 20 ? 100 : winner.score <= 60 ? 90 : winner.score <= 150 ? 70 : winner.score <= 500 ? 50 : 20;
+  const stabilityScore = scoreToStability(winner.score);
   const flags = computeStabilityFlags(selector, method);
   const quality = computeQuality(stabilityScore, flags);
 
@@ -1210,4 +1209,94 @@ function computeQuality(stabilityScore: number, flags: StabilityFlag[]): Selecto
     return 'good';
   }
   return 'medium';
+}
+
+/**
+ * Map a candidate's internal score (lower = stronger) onto a 0–100 stability
+ * score (higher = better). Shared by `getSelectorInfo` and `analyzeSelectorString`
+ * so the element-based and string-based paths agree.
+ */
+function scoreToStability(score: number): number {
+  return score <= 20 ? 100 : score <= 60 ? 90 : score <= 150 ? 70 : score <= 500 ? 50 : 20;
+}
+
+export interface SelectorStringAnalysis {
+  method: string;
+  stabilityScore: number;
+  quality: SelectorQuality;
+  flags: StabilityFlag[];
+  warnings: string[];
+}
+
+/**
+ * Infer the method + internal score of a *typed* selector string, in the same
+ * priority order the candidate generators use. The strongest signal present wins;
+ * `computeStabilityFlags` then corrects for fragility (e.g. a testid-scoped
+ * selector that also uses `:nth-child` is downgraded via the structural flag).
+ */
+function inferMethodAndScore(selector: string): { method: string; score: number } {
+  if (SELECTOR_CONFIG.testIdAttrs.some((attr) => selector.includes(attr))) {
+    return { method: 'data-testid', score: CANDIDATE_SCORES.testId };
+  }
+  if (/(^|[\s>+~])#[\w-]+/.test(selector)) {
+    return { method: 'id', score: CANDIDATE_SCORES.cssId };
+  }
+  if (selector.includes('[aria-label')) {
+    return { method: 'aria-label', score: CANDIDATE_SCORES.ariaLabel };
+  }
+  if (selector.includes(':text(')) {
+    return { method: 'role-text', score: CANDIDATE_SCORES.roleText };
+  }
+  if (selector.includes(':contains(')) {
+    return { method: 'role-contains', score: CANDIDATE_SCORES.roleContains };
+  }
+  if (selector.includes('[placeholder')) {
+    return { method: 'placeholder', score: CANDIDATE_SCORES.placeholder };
+  }
+  if (selector.includes('[title')) {
+    return { method: 'title', score: CANDIDATE_SCORES.title };
+  }
+  if (selector.includes('[name')) {
+    return { method: 'name', score: CANDIDATE_SCORES.name };
+  }
+  if (selector.includes('[href')) {
+    return { method: 'href', score: CANDIDATE_SCORES.href };
+  }
+  if (selector.includes(':nth-match')) {
+    return { method: 'nth-match', score: CANDIDATE_SCORES.nthMatch };
+  }
+  if (selector.includes(':nth-of-type') || selector.includes(':nth-child')) {
+    return { method: 'nth-of-type', score: CANDIDATE_SCORES.nthOfType };
+  }
+  return { method: 'compound', score: CANDIDATE_SCORES.compound };
+}
+
+/**
+ * Stability analysis for a selector STRING (no element required), so the block
+ * editor's health badge reflects the generator's own quality model
+ * (`computeStabilityFlags` + `computeQuality` + `scoreToStability`) rather than a
+ * parallel heuristic. Match-count-dependent warnings are added by the caller,
+ * which knows the live DOM.
+ */
+export function analyzeSelectorString(selector: string): SelectorStringAnalysis {
+  const { method, score } = inferMethodAndScore(selector);
+  const stabilityScore = scoreToStability(score);
+  const flags = computeStabilityFlags(selector, method);
+  const quality = computeQuality(stabilityScore, flags);
+
+  const warnings: string[] = [];
+  if (flags.includes('structural')) {
+    warnings.push('Selector depends on element position and may break if the page structure changes');
+  }
+  if (flags.includes('i18n-sensitive')) {
+    warnings.push('Selector uses translatable text — may break in different locales');
+  }
+  if (flags.includes('session-unstable')) {
+    warnings.push('Selector uses framework-generated values — may change between sessions');
+  }
+  if (flags.includes('environment-unstable')) {
+    warnings.push('Selector contains instance-specific data — may not work in different environments');
+  }
+
+  return { method, stabilityScore, quality, flags, warnings };
 }

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -58,6 +58,7 @@ const SELECTOR_CONFIG = {
   maxRetargetDepth: 10,
   maxDisambiguationDepth: 15,
   maxScopingDepth: 8,
+  maxDescendantScan: 50,
   genericButtonWords: [
     'new',
     'add',
@@ -109,6 +110,23 @@ const DISAMBIGUATION_PENALTIES = {
   overlayScope: 75,
   nthMatch: 1000,
 } as const;
+
+// Added to a descendant's own score when that descendant is used to anchor a
+// `:has()` selector on an identity-less ancestor. Keeps has-descendant just
+// below a direct intrinsic selector but far above positional fallbacks.
+const HAS_DESCENDANT_PENALTY = 60;
+
+// Methods that carry no intrinsic identity of the element itself. A bare tag
+// only earns meaning from an ancestor scope, so it belongs here alongside the
+// positional methods: it must neither block :has() anchoring on identity-less
+// elements nor serve as a descendant anchor inside :has(...).
+const STRUCTURAL_METHODS: ReadonlySet<string> = new Set([
+  'compound',
+  'nth-of-type',
+  'nth-match',
+  'fallback',
+  'scoped-bare-tag',
+]);
 
 const OVERLAY_ROLES = ['dialog', 'alertdialog', 'menu', 'listbox', 'tooltip', 'combobox'] as const;
 
@@ -722,7 +740,7 @@ function candidateNthOfType(element: HTMLElement): Candidate | null {
   };
 }
 
-function generateCandidates(element: HTMLElement): Candidate[] {
+function generateIntrinsicCandidates(element: HTMLElement): Candidate[] {
   const candidates: Candidate[] = [];
   const push = (c: Candidate | null) => {
     if (c) {
@@ -746,6 +764,24 @@ function generateCandidates(element: HTMLElement): Candidate[] {
   push(candidateCompound(element));
   push(candidateBareTag(element));
   push(candidateNthOfType(element));
+
+  return candidates;
+}
+
+function generateCandidates(element: HTMLElement): Candidate[] {
+  const candidates = generateIntrinsicCandidates(element);
+
+  // Reach for a descendant-anchored :has() selector only when the element has no
+  // stable identity of its own — i.e. every intrinsic candidate is structural
+  // (compound/nth). This is the identity-less-wrapper case (a styling div around
+  // a nav link); the :has() selector borrows the descendant's identity.
+  const hasStableIntrinsic = candidates.some((c) => !STRUCTURAL_METHODS.has(c.method));
+  if (!hasStableIntrinsic) {
+    const hasDescendant = candidateHasDescendant(element);
+    if (hasDescendant) {
+      candidates.push(hasDescendant);
+    }
+  }
 
   return candidates;
 }
@@ -943,7 +979,12 @@ function admitCandidate(
   }
 
   if (matchCount === 1) {
-    if (candidate.method === 'button-text' || candidate.method === 'scoped-testid' || candidate.method === 'grafana') {
+    if (
+      candidate.method === 'button-text' ||
+      candidate.method === 'scoped-testid' ||
+      candidate.method === 'grafana' ||
+      candidate.method === 'has-descendant'
+    ) {
       return [{ ...candidate, matchCount }];
     }
     for (const scope of ancestorScopes) {
@@ -1005,6 +1046,152 @@ function rankAndSelect(candidates: Candidate[], element: HTMLElement): ScoredCan
 
   scored.sort((a, b) => a.score - b.score);
   return scored[0]!;
+}
+
+// ============================================================================
+// Descendant-anchored :has() selectors
+// ============================================================================
+
+/** Pure-CSS candidate methods that are safe to embed inside `:has(...)`. */
+function isHasUsable(candidate: Candidate): boolean {
+  if (STRUCTURAL_METHODS.has(candidate.method)) {
+    return false;
+  }
+  if (candidate.method === 'grafana' || candidate.method === 'button-text') {
+    return false;
+  }
+  if (candidate.selector.includes(':text(') || candidate.selector.includes(':contains(')) {
+    return false;
+  }
+  return true;
+}
+
+function isInteractiveDescendant(element: HTMLElement): boolean {
+  const tag = element.tagName.toLowerCase();
+  if ((SELECTOR_CONFIG.interactiveTags as readonly string[]).includes(tag)) {
+    return true;
+  }
+  if ((SELECTOR_CONFIG.formControlTags as readonly string[]).includes(tag)) {
+    return true;
+  }
+  const role = element.getAttribute('role');
+  return Boolean(role && (SELECTOR_CONFIG.interactiveRoles as readonly string[]).includes(role));
+}
+
+interface DescendantPick {
+  selector: string;
+  score: number;
+  unique: boolean;
+  interactive: boolean;
+}
+
+function isBetterDescendant(pick: DescendantPick, current: DescendantPick | null): boolean {
+  if (!current) {
+    return true;
+  }
+  if (pick.unique !== current.unique) {
+    return pick.unique;
+  }
+  if (pick.interactive !== current.interactive) {
+    return pick.interactive;
+  }
+  return pick.score < current.score;
+}
+
+/**
+ * Find the strongest stable descendant to anchor a `:has()` selector on.
+ * Prefers globally unique selectors, then interactive/semantic descendants (a
+ * link beats a decorative icon), then the lowest internal score.
+ */
+function bestStableDescendant(element: HTMLElement): DescendantPick | null {
+  const descendants = Array.from(element.querySelectorAll<HTMLElement>('*')).slice(
+    0,
+    SELECTOR_CONFIG.maxDescendantScan
+  );
+  let best: DescendantPick | null = null;
+  for (const descendant of descendants) {
+    const interactive = isInteractiveDescendant(descendant);
+    for (const candidate of generateIntrinsicCandidates(descendant)) {
+      if (!isHasUsable(candidate)) {
+        continue;
+      }
+      const { matchCount, containsTarget } = testUniqueness(candidate.selector, descendant, candidate.method);
+      if (matchCount === 0 || !containsTarget) {
+        continue;
+      }
+      const pick: DescendantPick = {
+        selector: candidate.selector,
+        score: candidate.score,
+        unique: matchCount === 1,
+        interactive,
+      };
+      if (isBetterDescendant(pick, best)) {
+        best = pick;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Make `base` (a `tag:has(descendant)` selector) resolve to exactly `element`.
+ * A bare `:has()` matches every same-tag ancestor that contains the descendant,
+ * so tighten with the parent's child combinator, then escalate to stable
+ * ancestor scopes. Returns null when uniqueness can't be achieved.
+ */
+function tightenHasSelector(base: string, element: HTMLElement): string | null {
+  const isUnique = (selector: string): boolean => {
+    const { matchCount, containsTarget } = testUniqueness(selector, element, 'has-descendant');
+    return matchCount === 1 && containsTarget;
+  };
+
+  if (isUnique(base)) {
+    return base;
+  }
+
+  const parent = element.parentElement;
+  const withParent = parent ? `${parent.tagName.toLowerCase()} > ${base}` : null;
+  if (withParent && isUnique(withParent)) {
+    return withParent;
+  }
+
+  for (const scope of findAllAncestorScopes(element)) {
+    const scoped = `${scope.selector} ${base}`;
+    if (isUnique(scoped)) {
+      return scoped;
+    }
+    if (withParent) {
+      const scopedChild = `${scope.selector} ${withParent}`;
+      if (isUnique(scopedChild)) {
+        return scopedChild;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * For an identity-less element, build a selector that borrows a stable
+ * descendant's identity via `:has()` — e.g. `li > div:has(a[href='/explore'])`.
+ * Keeps the clicked element as the target (no retarget) and degrades far more
+ * gracefully than a positional `:nth-match`. Scored just below the descendant's
+ * own strength, so a direct intrinsic selector always wins when one exists.
+ */
+function candidateHasDescendant(element: HTMLElement): Candidate | null {
+  const descendant = bestStableDescendant(element);
+  if (!descendant) {
+    return null;
+  }
+
+  const tag = element.tagName.toLowerCase();
+  const base = `${tag}:has(${descendant.selector})`;
+  const tightened = tightenHasSelector(base, element);
+  if (!tightened) {
+    return null;
+  }
+
+  return { selector: tightened, score: descendant.score + HAS_DESCENDANT_PENALTY, method: 'has-descendant' };
 }
 
 // ============================================================================
@@ -1235,6 +1422,9 @@ export interface SelectorStringAnalysis {
  * selector that also uses `:nth-child` is downgraded via the structural flag).
  */
 function inferMethodAndScore(selector: string): { method: string; score: number } {
+  if (selector.includes(':has(')) {
+    return { method: 'has-descendant', score: CANDIDATE_SCORES.testId + HAS_DESCENDANT_PENALTY };
+  }
   if (SELECTOR_CONFIG.testIdAttrs.some((attr) => selector.includes(attr))) {
     return { method: 'data-testid', score: CANDIDATE_SCORES.testId };
   }


### PR DESCRIPTION
Part of grafana/grafana-frontend-platform#194 — selector-logic exploration, **Job 3 of 3**.

> **Stacked on Job 1** (#1155). Review/merge that first; GitHub retargets this to `main` once it lands. The diff shown here is scoped to Job 3 only.

Identity-less wrapper elements (no id/testid/stable class) previously produced brittle positional selectors like `div:nth-match(4)`. This job anchors them on stable structure instead:

- **Up** — anchor on the nearest stable ancestor.
- **Down** — borrow a stable descendant's identity via `:has()` *without* retargeting the intent element (e.g. `li>div:has(a[data-testid='...'][href='/explore'])`).

It also unifies the block-editor health-badge scoring with the generator, so the badge reflects the same quality signal the engine uses.

## Validation
`npm run check` green; `:has()` path validated in-browser against the `/explore` nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
