### PR TITLE
chore(lint): scope golangci-lint to exclude node_modules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,6 @@
+version: '2'
+
+linters:
+  exclusions:
+    paths:
+      - node_modules


### PR DESCRIPTION
## What

Adds a root `.golangci.yaml` (golangci-lint v2 schema) that excludes `node_modules` from linting.

## Why

`lint:go` runs `mage -v lint` → `golangci-lint run ./...`. Because `node_modules` sits under the Go module root with no `go.mod` boundary, `go list ./...` resolves `node_modules/flatted/golang/pkg/flatted` as part of `github.com/grafana/grafana-pathfinder-app`. The linter then flagged `govet` issues in that third-party file:

```
node_modules/flatted/golang/pkg/flatted/flatted.go:55:67: inline: Constant reflect.String should be inlined (govet)
node_modules/flatted/golang/pkg/flatted/flatted.go:62:20: inline: Constant reflect.Ptr should be inlined (govet)
```

These are not our code. The exclusion scopes `lint:go` to packages we own (`pkg/...`).

## Result

`mage -v lint` now reports `0 issues`, and `pkg/` is still linted (the standard linter set is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)