### PR TITLE
fix(cross-tab): authenticate pairing-accept to prevent forged-accept DoS (#1158)

### DIFF
--- a/docs/developer/CROSS_TAB_CONTROLLER.md
+++ b/docs/developer/CROSS_TAB_CONTROLLER.md
@@ -81,9 +81,16 @@ DOM sink and is **not** unconditionally safe to install — see the trust model.
 
 ## Entry gate and mount policy
 
-Both the controller overlay (`?controller=1` path) and the live-tab executor install are gated on `pathfinderEnabled` (the `pathfinder.enabled` kill-switch) — the same policy that controls whether the main Pathfinder sidebar mounts. Because the executor drives the user's authenticated Grafana DOM, it must follow the same mount gate as the rest of the plugin.
+Both the controller overlay (`?controller=1` path) and the live-tab executor install are gated on two conditions: the `enableTwoTabController` admin setting (plugin config → Interactive features, default **off**), and `pathfinderEnabled` (the `pathfinder.enabled` kill-switch) — the same policy that controls whether the main Pathfinder sidebar mounts. The admin setting ships the feature dark until an instance opts in; the kill-switch keeps it aligned with the rest of the plugin. Because the executor drives the user's authenticated Grafana DOM, it must follow the same mount gate as the rest of the plugin.
 
 ## Security / trust model
+
+> **Reviewing a change in this subsystem?** The `cross-tab-controller` concern in
+> [`docs/design/CONCERNS.md`](../design/CONCERNS.md) is the canonical review checklist
+> for these files. It fires on any single touch of the cross-tab files and enumerates
+> the trust invariants below — signed commands, gesture-to-accept pairing, the per-kind
+> validation gate, and the `enableTwoTabController` re-enable one-way door — that a
+> reviewer must confirm before merge.
 
 `BroadcastChannel` is shared by every script running on the same origin, so a
 message on `pathfinder-cross-tab` is **not** proof it came from a Pathfinder
@@ -133,8 +140,9 @@ Defense in depth on top of authentication:
   set — at the transport receive gate _and_ again at the executor sink. Malformed
   or unknown-kind messages are dropped before the auth gate is even consulted.
 - **Install/entry gating.** The executor is installed, and the controller
-  overlay mounted, only when `pathfinderEnabled` is true — a disabled plugin
-  exposes neither the sink nor the driver.
+  overlay mounted, only when the `enableTwoTabController` admin setting is on
+  _and_ `pathfinderEnabled` is true — a disabled plugin, or an instance that
+  hasn't opted in, exposes neither the sink nor the driver.
 - **Same-build / same-origin / one-session assumption.** Controller and live
   tabs are the same plugin build in the same browser profile and session; there
   is no protocol-version negotiation and cross-version compatibility is not a

--- a/docs/developer/CROSS_TAB_CONTROLLER.md
+++ b/docs/developer/CROSS_TAB_CONTROLLER.md
@@ -101,7 +101,11 @@ drive that Grafana. The controller→live command path is therefore
   an HMAC over the canonical challenge `{pairingId, publicKeyB64, sessionId}`.
   The live tab accepts a challenge only when it matches a registered, unexpired
   launch — a wrong secret, a mutated `sessionId`/`publicKeyB64`, or an unknown
-  `pairingId` is dropped (`pairing-manager.ts`).
+  `pairingId` is dropped (`pairing-manager.ts`). The reverse `pairing-accept`
+  carries an HMAC over `{pairingId, sessionId, liveTabId}` keyed by the same
+  launch secret, so the controller binds its pairing slot only to an accept it
+  can attribute to the launched tab — a forged accept (`sessionId` is readable
+  off the wire) can't take the slot.
 - **Per-session keypair.** The controller generates a **non-extractable** ECDSA
   P-256 keypair per session; only the public key crosses the wire
   (`cross-tab-crypto.ts`). Authority to drive the live tab _is_ possession of
@@ -116,8 +120,9 @@ drive that Grafana. The controller→live command path is therefore
   `check-requirements`, `fix-requirement`, `sidebar-handoff` — is ECDSA-signed
   and bound to `sessionId`, `liveTabId`, the command body, a fresh `sigNonce`,
   and a `sigTs`. The executor's auth gate (`verifySignedMessage`) checks the
-  accepted session, the `sessionId`/`liveTabId` match, a ±30s timestamp window,
-  the signature against the accepted public key, and a session-wide
+  accepted session, the `sessionId`/`liveTabId` match, the timestamp window (up
+  to 30s old, at most 1s future-dated since both tabs share a clock), the
+  signature against the accepted public key, and a session-wide
   `(sessionId:sigNonce)` replay ledger before any action runs.
 
 Defense in depth on top of authentication:

--- a/docs/developer/CROSS_TAB_CONTROLLER.md
+++ b/docs/developer/CROSS_TAB_CONTROLLER.md
@@ -167,8 +167,15 @@ window plus the replay ledger kill any captured in-flight message.
 **Out of scope: same-origin code execution.** XSS or a malicious script running
 _inside_ the controller or live tab is out of scope — it already holds the
 session (and, in the controller, the signing key), so the cross-tab boundary is
-not the relevant control. Non-extractable keys and per-kind validation are
-hardening, not a defense against an already-compromised origin.
+not the relevant control. This includes capturing the launch secret: it reaches
+the controller through a `window.open` URL fragment, so a same-page script
+(panel/datasource XSS) or an extension content script with page access can read
+it and forge a valid challenge or accept proof. The authenticated pairing path
+therefore defends specifically against a **separate same-origin tab that only
+observes the channel** — it can post forged messages but cannot read the secret,
+so it can neither pair as the controller nor claim the live tab's pairing slot.
+Non-extractable keys and per-kind validation are hardening, not a defense
+against an already-compromised origin.
 
 ## Tab pairing
 

--- a/src/components/interactive-tutorial/interactive-step.test.tsx
+++ b/src/components/interactive-tutorial/interactive-step.test.tsx
@@ -4,6 +4,7 @@ import { InteractiveStep } from './interactive-step';
 import { InteractiveModeContext } from '../../global-state/interactive-mode-context';
 import { ControllerChannelProvider } from '../../global-state/controller-channel';
 import { TEST_PAIRING } from '../../test-utils/fake-cross-tab-transport';
+import { createPairingAcceptProof } from '../../lib/pairing-manager';
 
 describe('InteractiveStep: showMeText label override', () => {
   it('renders custom Show me label when showMeText is provided', () => {
@@ -198,6 +199,11 @@ describe('InteractiveStep: controller mode emits over the channel instead of exe
     );
     const challenges = transport.post.mock.calls.map((c) => c[0]).filter((p: any) => p.kind === 'pairing-challenge');
     const challenge = challenges[challenges.length - 1];
+    const acceptProof = await createPairingAcceptProof(TEST_PAIRING.pairingSecret, {
+      pairingId: TEST_PAIRING.pairingId,
+      sessionId: challenge.sessionId,
+      liveTabId: liveId,
+    });
     act(() =>
       transport.emit({
         source: 'pathfinder',
@@ -205,7 +211,12 @@ describe('InteractiveStep: controller mode emits over the channel instead of exe
         timestamp: 0,
         kind: 'pairing-accept',
         sessionId: challenge.sessionId,
+        pairingId: TEST_PAIRING.pairingId,
+        acceptProof,
       })
+    );
+    await waitFor(() =>
+      expect(transport.post).toHaveBeenCalledWith(expect.objectContaining({ kind: 'sidebar-handoff' }))
     );
   }
 

--- a/src/global-state/controller-channel.test.tsx
+++ b/src/global-state/controller-channel.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { ControllerChannelProvider, useControllerChannel, useControllerConnected } from './controller-channel';
 import { FakeCrossTabTransport, TEST_PAIRING } from '../test-utils/fake-cross-tab-transport';
+import { createPairingAcceptProof } from '../lib/pairing-manager';
 import type { CrossTabMessage } from '../types/cross-tab.types';
 
 function liveHeartbeat(): CrossTabMessage {
@@ -70,6 +71,11 @@ async function waitForPostedOfKind(transport: FakeCrossTabTransport, kind: strin
 
 async function pairWithLive(transport: FakeCrossTabTransport, liveId = 'live'): Promise<void> {
   const challenge = await waitForPostedOfKind(transport, 'pairing-challenge');
+  const acceptProof = await createPairingAcceptProof(TEST_PAIRING.pairingSecret, {
+    pairingId: TEST_PAIRING.pairingId,
+    sessionId: challenge.sessionId,
+    liveTabId: liveId,
+  });
   act(() =>
     transport.emit({
       source: 'pathfinder',
@@ -77,8 +83,11 @@ async function pairWithLive(transport: FakeCrossTabTransport, liveId = 'live'): 
       timestamp: 0,
       kind: 'pairing-accept',
       sessionId: challenge.sessionId,
+      pairingId: TEST_PAIRING.pairingId,
+      acceptProof,
     })
   );
+  await waitForPostedOfKind(transport, 'sidebar-handoff');
 }
 
 function signedFieldsFor(liveId: string) {
@@ -213,13 +222,52 @@ describe('ControllerChannelProvider', () => {
     );
 
     act(() =>
-      transport.emit({ source: 'pathfinder', senderId: 'live', timestamp: 0, kind: 'pairing-accept', sessionId: 'x' })
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'live',
+        timestamp: 0,
+        kind: 'pairing-accept',
+        sessionId: 'x',
+        pairingId: TEST_PAIRING.pairingId,
+        acceptProof: 'ignored-already-paired',
+      })
     );
     act(() => transport.emit(liveHeartbeat()));
 
     expect(
       transport.postedMessages.filter((m) => (m as any)?.kind === 'sidebar-handoff' && (m as any)?.action === 'close')
     ).toHaveLength(1);
+  });
+
+  it('ignores a forged pairing-accept and still pairs with the genuine live tab', async () => {
+    const transport = new FakeCrossTabTransport();
+    render(
+      <ControllerChannelProvider transport={transport} pairing={TEST_PAIRING}>
+        <Probe />
+      </ControllerChannelProvider>
+    );
+
+    const challenge = await waitForPostedOfKind(transport, 'pairing-challenge');
+    act(() =>
+      transport.emit({
+        source: 'pathfinder',
+        senderId: 'attacker',
+        timestamp: 0,
+        kind: 'pairing-accept',
+        sessionId: challenge.sessionId,
+        pairingId: TEST_PAIRING.pairingId,
+        acceptProof: 'forged',
+      })
+    );
+
+    await pairWithLive(transport, 'live');
+
+    fireEvent.click(screen.getByText('post'));
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({ ...signedFieldsFor('live'), kind: 'step-command' })
+      )
+    );
   });
 
   it('drops heartbeat-only pairing attempts', () => {

--- a/src/global-state/controller-channel.tsx
+++ b/src/global-state/controller-channel.tsx
@@ -5,6 +5,7 @@ import {
   createSignatureNonce,
   SIGNED_MESSAGE_STALE_MS,
   signSignedMessage,
+  verifyPairingAcceptProof,
   type ControllerPairingLaunch,
 } from '../lib/pairing-manager';
 import { generateSessionKeyPair } from '../security/cross-tab-crypto';
@@ -205,13 +206,21 @@ export function ControllerChannelProvider({
 
     const unsubscribe = active.onMessage((message) => {
       if (message.kind === 'pairing-accept') {
-        if (message.sessionId !== sessionId) {
+        if (message.sessionId !== sessionId || pairedLiveIdRef.current !== null || !pairing) {
           return;
         }
-        if (pairedLiveIdRef.current === null) {
-          pairedLiveIdRef.current = message.senderId;
-          void refreshPreparedHandBack().finally(() => post({ kind: 'sidebar-handoff', action: 'close' }));
+        if (message.pairingId !== pairing.pairingId) {
+          return;
         }
+        const liveTabId = message.senderId;
+        const binding = { pairingId: message.pairingId, sessionId, liveTabId };
+        void verifyPairingAcceptProof(pairing.pairingSecret, binding, message.acceptProof).then((ok) => {
+          if (!ok || pairedLiveIdRef.current !== null) {
+            return;
+          }
+          pairedLiveIdRef.current = liveTabId;
+          void refreshPreparedHandBack().finally(() => post({ kind: 'sidebar-handoff', action: 'close' }));
+        });
         return;
       }
 
@@ -298,7 +307,7 @@ export function ControllerChannelProvider({
         active.stop();
       }
     };
-  }, [active, post, postPayload, postPreparedHandBack, refreshPreparedHandBack, sessionId]);
+  }, [active, pairing, post, postPayload, postPreparedHandBack, refreshPreparedHandBack, sessionId]);
 
   const request = useCallback(
     <T extends RemoteRequirementResult | FixOutcome | null>(payload: RequestPayload, fallback: T): Promise<T> => {

--- a/src/integrations/cross-tab/cross-tab-protocol.acceptance.test.tsx
+++ b/src/integrations/cross-tab/cross-tab-protocol.acceptance.test.tsx
@@ -687,6 +687,12 @@ describe('cross-tab pairing protocol acceptance', () => {
       const signed = await sign(ctrl.privateKey, COMMAND_FAMILIES[0]!.body, { sigTs: Date.now() + 60_000 });
       expect(await verifySignedMessage(signed, LIVE_TAB_ID)).toBe(false);
     });
+
+    it('rejects a future-dated sigTs within the stale window but past the tightened skew', async () => {
+      const ctrl = await acceptControllerInManager();
+      const signed = await sign(ctrl.privateKey, COMMAND_FAMILIES[0]!.body, { sigTs: Date.now() + 5_000 });
+      expect(await verifySignedMessage(signed, LIVE_TAB_ID)).toBe(false);
+    });
   });
 
   // ========================================================================

--- a/src/integrations/cross-tab/cross-tab-protocol.acceptance.test.tsx
+++ b/src/integrations/cross-tab/cross-tab-protocol.acceptance.test.tsx
@@ -510,6 +510,29 @@ describe('cross-tab pairing protocol acceptance', () => {
       acceptSession({ ...b, pairingProof: proofB }, true);
       expect(getAcceptedSession()).toBeNull();
     });
+
+    it('ignores a verbatim challenge replay under a different senderId and stays acceptable', async () => {
+      const launch = createControllerPairingLaunch();
+      const valid: PendingChallenge = {
+        sessionId: 'session-1',
+        publicKeyB64: 'pk-1',
+        senderTabId: 'ctrl-1',
+        pairingId: launch.pairingId,
+      };
+      const proof = await createPairingChallengeProof(launch.pairingSecret, valid);
+      setOwnLiveTabId(LIVE_TAB_ID);
+
+      const seen: Array<PendingChallenge | null> = [];
+      const unsub = onPendingChallenge((c) => seen.push(c));
+      await setPendingChallenge({ ...valid, pairingProof: proof });
+      await setPendingChallenge({ ...valid, senderTabId: 'attacker', pairingProof: proof });
+      unsub();
+
+      expect(seen).toEqual([expect.objectContaining({ sessionId: 'session-1' })]);
+
+      acceptSession({ ...valid, pairingProof: proof }, true);
+      expect(getAcceptedSession()).toMatchObject({ sessionId: 'session-1', liveTabId: LIVE_TAB_ID });
+    });
   });
 
   // ========================================================================

--- a/src/integrations/cross-tab/live-tab-executor.ts
+++ b/src/integrations/cross-tab/live-tab-executor.ts
@@ -128,12 +128,19 @@ export function installLiveTabExecutor(
 
   // When the user accepts pairing, post pairing-accept so the controller can
   // bind its liveTabId and start signing commands.
-  const unsubscribeAccepted = authGate.onSessionAccepted((liveTabId) => {
-    const accepted = pairingManager.getAcceptedSession();
-    if (accepted) {
-      transport.post({ kind: 'pairing-accept', sessionId: accepted.sessionId });
-    }
-    void liveTabId;
+  const unsubscribeAccepted = authGate.onSessionAccepted(() => {
+    void (async () => {
+      const accept = await pairingManager.createPairingAcceptForSession();
+      const accepted = pairingManager.getAcceptedSession();
+      if (accepted && accept) {
+        transport.post({
+          kind: 'pairing-accept',
+          sessionId: accepted.sessionId,
+          pairingId: accept.pairingId,
+          acceptProof: accept.acceptProof,
+        });
+      }
+    })();
   });
 
   // Teardown flag: a replay in flight (or queued) must not touch the DOM after

--- a/src/lib/pairing-manager.test.ts
+++ b/src/lib/pairing-manager.test.ts
@@ -10,6 +10,7 @@
 
 import {
   acceptSession,
+  createPairingAcceptForSession,
   createPairingChallengeProof,
   getAcceptedSession,
   registerExpectedPairingLaunch,
@@ -17,6 +18,7 @@ import {
   setOwnLiveTabId,
   setPendingChallenge,
   signSignedMessage,
+  verifyPairingAcceptProof,
   verifySignedMessage,
   type ControllerPairingLaunch,
   type PendingChallenge,
@@ -121,5 +123,46 @@ describe('pairing-manager challenge acceptance (smoke)', () => {
 
     acceptSession(challenge, true);
     expect(getAcceptedSession()).not.toBeNull();
+  });
+});
+
+describe('pairing-manager launch TTL race (smoke)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    resetPairingManagerForTests();
+    setOwnLiveTabId('live-1');
+  });
+
+  afterEach(() => {
+    resetPairingManagerForTests();
+    jest.useRealTimers();
+  });
+
+  it('still posts an authenticated accept when the launch is pruned while the prompt is fresh', async () => {
+    const FIVE_MIN = 5 * 60_000;
+    const challenge = await trustedChallenge(); // launch registered at t=0, expires at +5min
+
+    // Prompt armed just before the launch TTL → fresh for ~30s past it.
+    jest.setSystemTime(FIVE_MIN - 10_000);
+    await setPendingChallenge(challenge);
+
+    // A rebroadcast after the TTL prunes the expired launch; the prompt is still fresh.
+    jest.setSystemTime(FIVE_MIN + 1_000);
+    await setPendingChallenge(challenge);
+
+    acceptSession(challenge, true);
+    expect(getAcceptedSession()).not.toBeNull();
+
+    // The secret captured at verify time means an authenticated accept is still produced.
+    const accept = await createPairingAcceptForSession();
+    expect(accept).not.toBeNull();
+    expect(
+      await verifyPairingAcceptProof(
+        'secret-1',
+        { pairingId: 'pairing-1', sessionId: 'session-1', liveTabId: 'live-1' },
+        accept!.acceptProof
+      )
+    ).toBe(true);
   });
 });

--- a/src/lib/pairing-manager.test.ts
+++ b/src/lib/pairing-manager.test.ts
@@ -11,6 +11,7 @@
 import {
   acceptSession,
   createPairingAcceptForSession,
+  createPairingAcceptProof,
   createPairingChallengeProof,
   getAcceptedSession,
   registerExpectedPairingLaunch,
@@ -164,5 +165,22 @@ describe('pairing-manager launch TTL race (smoke)', () => {
         accept!.acceptProof
       )
     ).toBe(true);
+  });
+
+  it('rejects a challenge proof presented as an accept proof (cross-protocol domain separation)', async () => {
+    const launch = pairingLaunch();
+    const challenge = pendingChallenge({ pairingId: launch.pairingId });
+    const acceptBinding = { pairingId: launch.pairingId, sessionId: challenge.sessionId, liveTabId: 'live-1' };
+
+    // Challenge proof binds {pairingId, publicKeyB64, sessionId}; accept binds
+    // {pairingId, sessionId, liveTabId}. Same secret + shared pairingId/sessionId,
+    // but the distinct field sets must keep the two proofs non-interchangeable.
+    const challengeProof = await createPairingChallengeProof(launch.pairingSecret, challenge);
+    expect(await verifyPairingAcceptProof(launch.pairingSecret, acceptBinding, challengeProof)).toBe(false);
+
+    // Positive control: a genuine accept proof over the same binding still validates,
+    // so the rejection above is domain separation, not a blanket failure.
+    const acceptProof = await createPairingAcceptProof(launch.pairingSecret, acceptBinding);
+    expect(await verifyPairingAcceptProof(launch.pairingSecret, acceptBinding, acceptProof)).toBe(true);
   });
 });

--- a/src/lib/pairing-manager.ts
+++ b/src/lib/pairing-manager.ts
@@ -152,6 +152,8 @@ export async function verifyPairingAcceptProof(
 }
 
 let pendingChallenge: PendingChallenge | null = null;
+// Captured at verify time so a launch pruned by its TTL while the prompt is still fresh can't strand the accept (#1170).
+let pendingChallengeSecret: string | null = null;
 let pendingChallengeExpiresAt = 0;
 let pendingChallengeTimer: ReturnType<typeof setTimeout> | null = null;
 let acceptedSession: AcceptedSession | null = null;
@@ -182,6 +184,7 @@ function clearPendingChallenge(): void {
     pendingChallengeTimer = null;
   }
   pendingChallenge = null;
+  pendingChallengeSecret = null;
   pendingChallengeExpiresAt = 0;
   notifyPendingChallenge(null);
 }
@@ -293,6 +296,7 @@ export async function setPendingChallenge(challenge: PendingChallenge): Promise<
     clearPendingChallenge();
   }
   pendingChallenge = verifiedChallenge;
+  pendingChallengeSecret = verifiedLaunch.pairingSecret;
   pendingChallengeExpiresAt = now + PENDING_CHALLENGE_TTL_MS;
   schedulePendingChallengeExpiration();
   notifyPendingChallenge(verifiedChallenge);
@@ -324,14 +328,13 @@ export function acceptSession(challenge: PendingChallenge, trustedGesture: boole
     }
     return;
   }
-  const launch = expectedLaunches.get(pendingChallenge.pairingId);
   acceptedSession = {
     sessionId: pendingChallenge.sessionId,
     publicKeyB64: pendingChallenge.publicKeyB64,
     liveTabId: liveId,
     pairingId: pendingChallenge.pairingId,
   };
-  acceptedLaunchSecret = launch?.pairingSecret ?? null;
+  acceptedLaunchSecret = pendingChallengeSecret;
   expectedLaunches.delete(pendingChallenge.pairingId);
   seenSignedMessages.clear();
   clearPendingChallenge();
@@ -425,6 +428,7 @@ export function resetPairingManagerForTests(): void {
     pendingChallengeTimer = null;
   }
   pendingChallenge = null;
+  pendingChallengeSecret = null;
   pendingChallengeExpiresAt = 0;
   acceptedSession = null;
   acceptedLaunchSecret = null;

--- a/src/lib/pairing-manager.ts
+++ b/src/lib/pairing-manager.ts
@@ -13,6 +13,7 @@ export interface AcceptedSession {
   sessionId: string;
   publicKeyB64: string;
   liveTabId: string;
+  pairingId: string;
 }
 
 export interface SignedMessageFields {
@@ -32,6 +33,7 @@ export interface ControllerPairingLaunch {
 
 export const SIGNED_MESSAGE_STALE_MS = 30_000;
 const STALE_THRESHOLD_MS = SIGNED_MESSAGE_STALE_MS;
+const FUTURE_SKEW_MS = 1_000;
 const PAIRING_LAUNCH_TTL_MS = 5 * 60_000;
 const PENDING_CHALLENGE_TTL_MS = 30_000;
 const REJECTED_CHALLENGE_TTL_MS = 5 * 60_000;
@@ -123,10 +125,37 @@ export async function createPairingChallengeProof(
   return signHmacPayload(pairingSecret, canonicalPairingChallengePayload(challenge));
 }
 
+export interface PairingAcceptBinding {
+  pairingId: string;
+  sessionId: string;
+  liveTabId: string;
+}
+
+export function canonicalPairingAcceptPayload(binding: PairingAcceptBinding): string {
+  return stableJson({
+    liveTabId: binding.liveTabId,
+    pairingId: binding.pairingId,
+    sessionId: binding.sessionId,
+  });
+}
+
+export async function createPairingAcceptProof(pairingSecret: string, binding: PairingAcceptBinding): Promise<string> {
+  return signHmacPayload(pairingSecret, canonicalPairingAcceptPayload(binding));
+}
+
+export async function verifyPairingAcceptProof(
+  pairingSecret: string,
+  binding: PairingAcceptBinding,
+  acceptProof: string
+): Promise<boolean> {
+  return verifyHmacPayload(pairingSecret, canonicalPairingAcceptPayload(binding), acceptProof);
+}
+
 let pendingChallenge: PendingChallenge | null = null;
 let pendingChallengeExpiresAt = 0;
 let pendingChallengeTimer: ReturnType<typeof setTimeout> | null = null;
 let acceptedSession: AcceptedSession | null = null;
+let acceptedLaunchSecret: string | null = null;
 let ownLiveTabId: string | null = null;
 let seenSignedMessages = new Map<string, number>();
 let rejectedChallenges = new Map<string, number>();
@@ -287,20 +316,28 @@ export function acceptSession(challenge: PendingChallenge, trustedGesture: boole
   const liveId = ownLiveTabId;
   const now = Date.now();
   const pendingFresh = pendingChallengeIsFresh(now);
-  if (!trustedGesture || !pendingChallenge || !pendingFresh || !liveId || !sameChallenge(pendingChallenge, challenge)) {
+  if (
+    !trustedGesture ||
+    !pendingChallenge ||
+    !pendingFresh ||
+    !liveId ||
+    !pendingChallenge.pairingId ||
+    !sameChallenge(pendingChallenge, challenge)
+  ) {
     if (pendingChallenge && !pendingFresh) {
       clearPendingChallenge();
     }
     return;
   }
+  const launch = expectedLaunches.get(pendingChallenge.pairingId);
   acceptedSession = {
     sessionId: pendingChallenge.sessionId,
     publicKeyB64: pendingChallenge.publicKeyB64,
     liveTabId: liveId,
+    pairingId: pendingChallenge.pairingId,
   };
-  if (pendingChallenge.pairingId) {
-    expectedLaunches.delete(pendingChallenge.pairingId);
-  }
+  acceptedLaunchSecret = launch?.pairingSecret ?? null;
+  expectedLaunches.delete(pendingChallenge.pairingId);
   seenSignedMessages.clear();
   clearPendingChallenge();
   acceptedListeners.forEach((l) => l(liveId));
@@ -324,6 +361,20 @@ export function rejectSession(challenge: PendingChallenge): void {
 
 export function getAcceptedSession(): AcceptedSession | null {
   return acceptedSession;
+}
+
+export async function createPairingAcceptForSession(): Promise<{ pairingId: string; acceptProof: string } | null> {
+  const session = acceptedSession;
+  const secret = acceptedLaunchSecret;
+  if (!session || !secret) {
+    return null;
+  }
+  const acceptProof = await createPairingAcceptProof(secret, {
+    pairingId: session.pairingId,
+    sessionId: session.sessionId,
+    liveTabId: session.liveTabId,
+  });
+  return { pairingId: session.pairingId, acceptProof };
 }
 
 export function onSessionAccepted(listener: (liveTabId: string) => void): () => void {
@@ -355,7 +406,7 @@ export async function verifySignedMessage(message: SignedMessageFields, ownTabId
     return false;
   }
   const now = Date.now();
-  if (Math.abs(now - sigTs) > STALE_THRESHOLD_MS) {
+  if (sigTs - now > FUTURE_SKEW_MS || now - sigTs > STALE_THRESHOLD_MS) {
     return false;
   }
   const canonical = canonicalSignedPayload(message);
@@ -381,6 +432,7 @@ export function resetPairingManagerForTests(): void {
   pendingChallenge = null;
   pendingChallengeExpiresAt = 0;
   acceptedSession = null;
+  acceptedLaunchSecret = null;
   ownLiveTabId = null;
   seenSignedMessages = new Map();
   rejectedChallenges = new Map();

--- a/src/lib/pairing-manager.ts
+++ b/src/lib/pairing-manager.ts
@@ -166,6 +166,10 @@ let expectedLaunches = new Map<string, ControllerPairingLaunch & { expiresAt: nu
 const challengeListeners = new Set<(challenge: PendingChallenge | null) => void>();
 const acceptedListeners = new Set<(liveTabId: string) => void>();
 
+// The rejected-ledger key is scoped per originating tab, so it includes
+// senderTabId; sameChallenge deliberately omits it — challenge identity is the
+// crypto triple (sessionId/publicKeyB64/pairingId), not the sender. The
+// divergence is intentional; don't align them.
 function challengeKey(challenge: PendingChallenge): string {
   return `${challenge.senderTabId}:${challenge.sessionId}`;
 }

--- a/src/lib/pairing-manager.ts
+++ b/src/lib/pairing-manager.ts
@@ -169,12 +169,7 @@ function challengeKey(challenge: PendingChallenge): string {
 }
 
 function sameChallenge(a: PendingChallenge, b: PendingChallenge): boolean {
-  return (
-    a.sessionId === b.sessionId &&
-    a.publicKeyB64 === b.publicKeyB64 &&
-    a.senderTabId === b.senderTabId &&
-    a.pairingId === b.pairingId
-  );
+  return a.sessionId === b.sessionId && a.publicKeyB64 === b.publicKeyB64 && a.pairingId === b.pairingId;
 }
 
 function notifyPendingChallenge(challenge: PendingChallenge | null): void {

--- a/src/types/cross-tab.types.ts
+++ b/src/types/cross-tab.types.ts
@@ -264,6 +264,12 @@ function isOptionalString(value: unknown): boolean {
   return value === undefined || typeof value === 'string';
 }
 
+const MAX_PAIRING_FIELD_LENGTH = 512;
+
+function isBoundedString(value: unknown, maxLength: number): boolean {
+  return typeof value === 'string' && value.length <= maxLength;
+}
+
 // check-requirements / fix-requirement are SIDE-EFFECTING on the live tab —
 // the executor runs checkRequirements (DOM/URL probes) and dispatchFix
 // (navigation / DOM mutation) against the authenticated document. They are the
@@ -347,18 +353,18 @@ function isValidStepProgress(message: Record<string, unknown>): boolean {
 
 function isValidPairingChallenge(message: Record<string, unknown>): boolean {
   return (
-    typeof message.sessionId === 'string' &&
-    typeof message.publicKeyB64 === 'string' &&
-    typeof message.pairingId === 'string' &&
-    typeof message.pairingProof === 'string'
+    isBoundedString(message.sessionId, MAX_PAIRING_FIELD_LENGTH) &&
+    isBoundedString(message.publicKeyB64, MAX_PAIRING_FIELD_LENGTH) &&
+    isBoundedString(message.pairingId, MAX_PAIRING_FIELD_LENGTH) &&
+    isBoundedString(message.pairingProof, MAX_PAIRING_FIELD_LENGTH)
   );
 }
 
 function isValidPairingAccept(message: Record<string, unknown>): boolean {
   return (
-    typeof message.sessionId === 'string' &&
-    typeof message.pairingId === 'string' &&
-    typeof message.acceptProof === 'string'
+    isBoundedString(message.sessionId, MAX_PAIRING_FIELD_LENGTH) &&
+    isBoundedString(message.pairingId, MAX_PAIRING_FIELD_LENGTH) &&
+    isBoundedString(message.acceptProof, MAX_PAIRING_FIELD_LENGTH)
   );
 }
 

--- a/src/types/cross-tab.types.ts
+++ b/src/types/cross-tab.types.ts
@@ -77,6 +77,8 @@ export interface PairingChallengeMessage extends CrossTabEnvelope {
 export interface PairingAcceptMessage extends CrossTabEnvelope {
   kind: 'pairing-accept';
   sessionId: string;
+  pairingId: string;
+  acceptProof: string;
 }
 
 export interface HeartbeatMessage extends CrossTabEnvelope {
@@ -353,7 +355,11 @@ function isValidPairingChallenge(message: Record<string, unknown>): boolean {
 }
 
 function isValidPairingAccept(message: Record<string, unknown>): boolean {
-  return typeof message.sessionId === 'string';
+  return (
+    typeof message.sessionId === 'string' &&
+    typeof message.pairingId === 'string' &&
+    typeof message.acceptProof === 'string'
+  );
 }
 
 // Per-kind validators — the single source of truth shared by the transport


### PR DESCRIPTION
## What

Authenticates the `pairing-accept` message so a same-origin script can no longer forge one and dead-lock the two-tab controller (a forged-accept availability DoS), and tightens the signed-message timestamp window against future-dated `sigTs`. Both are "before re-enable" items for `TWOTAB_CONTROLLER_ENABLED`.

Closes #1158. Part of #1133.

## The problem

Before this change the controller bound its pairing slot on a bare `sessionId` match:

```ts
if (message.kind === 'pairing-accept') {
  if (message.sessionId !== sessionId) return;
  if (pairedLiveIdRef.current === null) {
    pairedLiveIdRef.current = message.senderId;   // first-writer-wins, never rebinds
    ...
  }
}
```

`sessionId` travels in cleartext inside the broadcast `pairing-challenge`, so a co-plugin / panel-XSS / extension script that reads `BroadcastChannel('pathfinder-cross-tab')` can post a forged `pairing-accept` faster than the user clicks Accept. The controller latches `pairedLiveIdRef` to the attacker's `senderId` and never rebinds, so the genuine session can never drive the live tab — a dead controller. (Integrity was already safe: the attacker lacks the controller's private key and the live tab gates commands on `liveTabId`. This is availability-only — but it blocks the feature.)

## The fix

`pairing-accept` now carries an HMAC proof keyed by the **launch secret** — the same `pairingSecret` already used for the challenge proof, delivered to the controller via its URL fragment and **never broadcast**:

- **Live tab** (`pairing-manager.createPairingAcceptForSession` → `live-tab-executor`): emits `{ pairingId, acceptProof = HMAC(pairingSecret, {pairingId, sessionId, liveTabId}) }`. The launch secret is captured into the accepted session at `acceptSession` time (and persists for reconnect re-emits); it never leaves the live tab's memory and is not exposed by `getAcceptedSession`.
- **Controller** (`controller-channel`): verifies `pairingId` matches its own launch and `verifyPairingAcceptProof(...)` passes **before** binding `pairedLiveIdRef`. Without a launch it has no secret to verify against, so it **fails closed** and never pairs.

A forger lacks the secret, so it cannot produce a valid proof for any `liveTabId` — it can neither take the slot nor bind the controller to a tab of its choosing. Replaying a genuine accept only re-confirms the genuine pairing. The accept proof binds `{pairingId, sessionId, liveTabId}` while the challenge proof binds `{pairingId, publicKeyB64, sessionId}`, so the two HMACs are domain-separated and non-interchangeable.

### Future-dated `sigTs`

`verifySignedMessage` previously accepted `sigTs` up to 30 s in the **future** (symmetric `Math.abs(now - sigTs) > 30s`). Both tabs share one clock, so a future timestamp is jitter or forgery; the window is now asymmetric — up to 30 s old, at most 1 s future skew — which shrinks the replay-validity window an attacker could claim.

## Tests

- `controller-channel.test.tsx`: new `ignores a forged pairing-accept and still pairs with the genuine live tab`; existing `pairWithLive` helper now produces a valid proof and awaits the (now-async) binding.
- `cross-tab-protocol.acceptance.test.tsx`: new boundary case for the tightened skew (a `now + 5s` sigTs that the old 30 s window accepted is now rejected); the real-flow suite exercises the new accept proof end-to-end with real WebCrypto.
- `interactive-step.test.tsx`: controller-mode pairing helper updated to the authenticated accept.
- `npm run test:ci` green; typecheck, eslint, prettier clean.

## Review

Ran an adversarial review (crypto-attacker, correctness/lifecycle, regression/contract lenses). The crypto and regression lenses found nothing; the one correctness note (a cosmetic symmetric-vs-asymmetric timestamp check in the controller's own prepared-handback self-guard) was verified to be structurally unreachable — `sigTs` is always in the past at verify time — and left unchanged to keep scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
