### PR TITLE
refactor(security): consolidate duplicated WebCrypto into one audited module (#1159)

### DIFF
--- a/src/integrations/workshop/session-crypto.ts
+++ b/src/integrations/workshop/session-crypto.ts
@@ -1,108 +1,27 @@
 /**
- * Cryptographic utilities for workshop session authentication
- *
- * Implements asymmetric challenge-response presenter verification using ECDSA P-256
- * via the browser-native Web Crypto API. No external dependencies.
- *
- * Security model:
- *   - Presenter generates an ECDSA key pair at session creation
- *   - The PUBLIC key is embedded in the join code (safe to share)
- *   - The PRIVATE key never leaves the presenter's browser session
- *   - Attendees challenge the presenter with a random nonce; only the holder of
- *     the private key can produce a valid signature — knowing the join code
- *     (and therefore the public key) does not allow impersonation
+ * Workshop presenter authentication: ECDSA P-256 challenge-response. The public
+ * key ships in the join code; the non-extractable private key stays in the
+ * presenter's session, so knowing the join code can't impersonate the presenter.
  */
+import { fromBase64url, generateEcdsaKeyPair, signBytes, toBase64url, verifyBytes } from '../../security/webcrypto';
 
-// ============================================================================
-// Base64url helpers
-// ============================================================================
-
-function toBase64url(bytes: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]!);
-  }
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-function fromBase64url(str: string): Uint8Array {
-  const padded = str.replace(/-/g, '+').replace(/_/g, '/');
-  const padLength = (4 - (padded.length % 4)) % 4;
-  const base64 = padded + '='.repeat(padLength);
-  const binary = atob(base64);
-  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
-
-// ============================================================================
-// Public API
-// ============================================================================
-
-const ECDSA_PARAMS = { name: 'ECDSA', namedCurve: 'P-256' } as const;
-const SIGN_PARAMS = { name: 'ECDSA', hash: 'SHA-256' } as const;
-
-/**
- * Generate an ECDSA P-256 key pair for presenter authentication.
- *
- * The public key is returned as a base64url-encoded SPKI buffer — safe to
- * embed in the join code. The private key is a CryptoKey that stays in memory
- * on the presenter's side and is never serialised or transmitted.
- *
- * extractable is set to true so we can export the public key as SPKI.
- * We never call exportKey on the private key.
- */
 export async function generateSessionKeyPair(): Promise<{ publicKeyB64: string; privateKey: CryptoKey }> {
-  const keyPair = await crypto.subtle.generateKey(ECDSA_PARAMS, true, ['sign', 'verify']);
-  const spki = await crypto.subtle.exportKey('spki', keyPair.publicKey);
-  return {
-    publicKeyB64: toBase64url(new Uint8Array(spki)),
-    privateKey: keyPair.privateKey,
-  };
+  return generateEcdsaKeyPair(false);
 }
 
-/**
- * Generate a 16-byte random nonce encoded as base64url.
- * Called by the attendee when sending a presenter challenge.
- */
 export function generateNonce(): string {
   const bytes = new Uint8Array(new ArrayBuffer(16));
   crypto.getRandomValues(bytes);
   return toBase64url(bytes);
 }
 
-/**
- * Sign a nonce with the presenter's ECDSA private key.
- * Returns the signature as base64url.
- */
 export async function signChallenge(privateKey: CryptoKey, nonce: string): Promise<string> {
-  const nonceBytes = fromBase64url(nonce);
-  const sig = await crypto.subtle.sign(SIGN_PARAMS, privateKey, nonceBytes.buffer as ArrayBuffer);
-  return toBase64url(new Uint8Array(sig));
+  return signBytes(privateKey, fromBase64url(nonce));
 }
 
-/**
- * Verify an ECDSA signature against the presenter's public key (from join code).
- * Returns false if the signature is invalid or any argument is malformed.
- */
 export async function verifyChallenge(publicKeyB64: string, nonce: string, signature: string): Promise<boolean> {
   try {
-    const spki = fromBase64url(publicKeyB64);
-    const sigBytes = fromBase64url(signature);
-    const nonceBytes = fromBase64url(nonce);
-
-    const publicKey = await crypto.subtle.importKey('spki', spki.buffer as ArrayBuffer, ECDSA_PARAMS, false, [
-      'verify',
-    ]);
-
-    return await crypto.subtle.verify(
-      SIGN_PARAMS,
-      publicKey,
-      sigBytes.buffer as ArrayBuffer,
-      nonceBytes.buffer as ArrayBuffer
-    );
+    return await verifyBytes(publicKeyB64, fromBase64url(nonce), signature);
   } catch {
     return false;
   }

--- a/src/security/cross-tab-crypto.ts
+++ b/src/security/cross-tab-crypto.ts
@@ -1,62 +1,17 @@
-const ECDSA_PARAMS = { name: 'ECDSA', namedCurve: 'P-256' } as const;
-const SIGN_PARAMS = { name: 'ECDSA', hash: 'SHA-256' } as const;
+import { fromBase64url, generateEcdsaKeyPair, signBytes, toBase64url, verifyBytes } from './webcrypto';
+
 const HMAC_PARAMS = { name: 'HMAC', hash: 'SHA-256' } as const;
 
-function toBase64url(bytes: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]!);
-  }
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-function fromBase64url(str: string): Uint8Array {
-  const padded = str.replace(/-/g, '+').replace(/_/g, '/');
-  const padLength = (4 - (padded.length % 4)) % 4;
-  const base64 = padded + '='.repeat(padLength);
-  const binary = atob(base64);
-  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
-
 export async function generateSessionKeyPair(): Promise<{ publicKeyB64: string; privateKey: CryptoKey }> {
-  // Non-extractable private key: only the public key is exported (spki, below).
-  // The private key material can never be serialized out (exportKey/wrapKey on
-  // it throw); the CryptoKey handle can still be passed around and used to sign.
-  const keyPair = await crypto.subtle.generateKey(ECDSA_PARAMS, false, ['sign', 'verify']);
-  const spki = await crypto.subtle.exportKey('spki', keyPair.publicKey);
-  return {
-    publicKeyB64: toBase64url(new Uint8Array(spki)),
-    privateKey: keyPair.privateKey,
-  };
+  return generateEcdsaKeyPair(false);
 }
 
 export async function signPayload(privateKey: CryptoKey, payload: string): Promise<string> {
-  const bytes = new TextEncoder().encode(payload);
-  const sig = await crypto.subtle.sign(SIGN_PARAMS, privateKey, bytes.buffer as ArrayBuffer);
-  return toBase64url(new Uint8Array(sig));
+  return signBytes(privateKey, new TextEncoder().encode(payload));
 }
 
 export async function verifyPayload(publicKeyB64: string, payload: string, sig: string): Promise<boolean> {
-  try {
-    const spki = fromBase64url(publicKeyB64);
-    const sigBytes = fromBase64url(sig);
-    const payloadBytes = new TextEncoder().encode(payload);
-    const publicKey = await crypto.subtle.importKey('spki', spki.buffer as ArrayBuffer, ECDSA_PARAMS, false, [
-      'verify',
-    ]);
-    return await crypto.subtle.verify(
-      SIGN_PARAMS,
-      publicKey,
-      sigBytes.buffer as ArrayBuffer,
-      payloadBytes.buffer as ArrayBuffer
-    );
-  } catch {
-    return false;
-  }
+  return verifyBytes(publicKeyB64, new TextEncoder().encode(payload), sig);
 }
 
 async function importHmacKey(secret: string, usages: KeyUsage[]): Promise<CryptoKey> {

--- a/src/security/webcrypto.test.ts
+++ b/src/security/webcrypto.test.ts
@@ -1,0 +1,62 @@
+import { fromBase64url, generateEcdsaKeyPair, signBytes, toBase64url, verifyBytes } from './webcrypto';
+
+describe('webcrypto', () => {
+  describe('base64url', () => {
+    it('round-trips arbitrary bytes', () => {
+      const bytes = new Uint8Array([0, 1, 2, 250, 251, 252, 253, 254, 255]);
+      expect(Array.from(fromBase64url(toBase64url(bytes)))).toEqual(Array.from(bytes));
+    });
+
+    it('emits url-safe output with no padding', () => {
+      const encoded = toBase64url(new Uint8Array([251, 255, 191]));
+      expect(encoded).not.toMatch(/[+/=]/);
+    });
+  });
+
+  describe('generateEcdsaKeyPair', () => {
+    it('returns a base64url public key and a private signing key', async () => {
+      const { publicKeyB64, privateKey } = await generateEcdsaKeyPair(false);
+      expect(typeof publicKeyB64).toBe('string');
+      expect(publicKeyB64.length).toBeGreaterThan(0);
+      expect(privateKey.type).toBe('private');
+      expect(privateKey.usages).toContain('sign');
+    });
+
+    it('honors the extractable flag', async () => {
+      const nonExtractable = await generateEcdsaKeyPair(false);
+      const extractable = await generateEcdsaKeyPair(true);
+      expect(nonExtractable.privateKey.extractable).toBe(false);
+      expect(extractable.privateKey.extractable).toBe(true);
+    });
+  });
+
+  describe('signBytes + verifyBytes', () => {
+    const payload = new TextEncoder().encode('hello world');
+
+    it('verifies a valid signature', async () => {
+      const { publicKeyB64, privateKey } = await generateEcdsaKeyPair(false);
+      const sig = await signBytes(privateKey, payload);
+      expect(await verifyBytes(publicKeyB64, payload, sig)).toBe(true);
+    });
+
+    it('rejects a signature over different bytes', async () => {
+      const { publicKeyB64, privateKey } = await generateEcdsaKeyPair(false);
+      const sig = await signBytes(privateKey, payload);
+      expect(await verifyBytes(publicKeyB64, new TextEncoder().encode('tampered'), sig)).toBe(false);
+    });
+
+    it('rejects a signature from a different key pair', async () => {
+      const { privateKey } = await generateEcdsaKeyPair(false);
+      const { publicKeyB64: otherPub } = await generateEcdsaKeyPair(false);
+      const sig = await signBytes(privateKey, payload);
+      expect(await verifyBytes(otherPub, payload, sig)).toBe(false);
+    });
+
+    it('returns false for a garbage public key or signature instead of throwing', async () => {
+      const { publicKeyB64, privateKey } = await generateEcdsaKeyPair(false);
+      const sig = await signBytes(privateKey, payload);
+      expect(await verifyBytes('not-a-key', payload, sig)).toBe(false);
+      expect(await verifyBytes(publicKeyB64, payload, 'not-valid-!!!')).toBe(false);
+    });
+  });
+});

--- a/src/security/webcrypto.ts
+++ b/src/security/webcrypto.ts
@@ -1,0 +1,56 @@
+const ECDSA_PARAMS = { name: 'ECDSA', namedCurve: 'P-256' } as const;
+const SIGN_PARAMS = { name: 'ECDSA', hash: 'SHA-256' } as const;
+
+export function toBase64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function fromBase64url(str: string): Uint8Array {
+  const padded = str.replace(/-/g, '+').replace(/_/g, '/');
+  const padLength = (4 - (padded.length % 4)) % 4;
+  const base64 = padded + '='.repeat(padLength);
+  const binary = atob(base64);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export async function generateEcdsaKeyPair(
+  extractable: boolean
+): Promise<{ publicKeyB64: string; privateKey: CryptoKey }> {
+  const keyPair = await crypto.subtle.generateKey(ECDSA_PARAMS, extractable, ['sign', 'verify']);
+  const spki = await crypto.subtle.exportKey('spki', keyPair.publicKey);
+  return {
+    publicKeyB64: toBase64url(new Uint8Array(spki)),
+    privateKey: keyPair.privateKey,
+  };
+}
+
+export async function signBytes(privateKey: CryptoKey, bytes: Uint8Array): Promise<string> {
+  const sig = await crypto.subtle.sign(SIGN_PARAMS, privateKey, bytes.buffer as ArrayBuffer);
+  return toBase64url(new Uint8Array(sig));
+}
+
+export async function verifyBytes(publicKeyB64: string, bytes: Uint8Array, sig: string): Promise<boolean> {
+  try {
+    const spki = fromBase64url(publicKeyB64);
+    const sigBytes = fromBase64url(sig);
+    const publicKey = await crypto.subtle.importKey('spki', spki.buffer as ArrayBuffer, ECDSA_PARAMS, false, [
+      'verify',
+    ]);
+    return await crypto.subtle.verify(
+      SIGN_PARAMS,
+      publicKey,
+      sigBytes.buffer as ArrayBuffer,
+      bytes.buffer as ArrayBuffer
+    );
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What

Consolidates the duplicated WebCrypto core shared by `src/security/cross-tab-crypto.ts` and `src/integrations/workshop/session-crypto.ts` into one audited Tier-1 module, `src/security/webcrypto.ts`, and resolves the `extractable`-flag divergence the two copies had drifted into.

Closes #1159. Part of #1133.

## The duplication

The two modules carried byte-identical `toBase64url`/`fromBase64url`, identical `ECDSA_PARAMS`/`SIGN_PARAMS`, and near-identical ECDSA keygen/sign/verify. The copies had already drifted on the private-key `extractable` flag: cross-tab minted **non-extractable** keys (`false`), workshop minted **extractable** ones (`true`), justified by an incorrect comment ("extractable is set to true so we can export the public key") — public keys export regardless of the private key's flag, which the cross-tab copy already proves.

## The change

`src/security/webcrypto.ts` (new) owns the shared primitive:

- `toBase64url` / `fromBase64url`
- `generateEcdsaKeyPair(extractable: boolean)` — `extractable` is an **explicit parameter**, no hidden default
- `signBytes(privateKey, bytes)` / `verifyBytes(publicKeyB64, bytes, sig)` — byte-level ECDSA P-256, so each caller prepares its own input

Both consumers now delegate to it:

- `cross-tab-crypto.ts`: `signPayload`/`verifyPayload` wrap `signBytes`/`verifyBytes` over `TextEncoder().encode(payload)`. HMAC helpers (`signHmacPayload`/`verifyHmacPayload`) stay here — cross-tab is their only consumer — and now import the shared base64url helpers.
- `session-crypto.ts`: `signChallenge`/`verifyChallenge` wrap the same primitive over `fromBase64url(nonce)`.

**Extractability decided deliberately:** both call sites now pass `false`. Workshop's private key is hardened to non-extractable — it only ever signs and exports its public key, never the private key, so it never needed extractability (a latent hardening, transparent to behavior).

## Equivalence / behavior

Pure refactor — the bytes signed and verified are unchanged on both sides:

- cross-tab: `sign(encode(payload))` before and after.
- workshop: `sign(fromBase64url(nonce))` before and after.

The crypto is self-consistent and ephemeral (per-session keys, no persisted/cross-version material), so the passing real-WebCrypto suites prove interop. New `src/security/webcrypto.test.ts` covers the shared module directly (base64url round-trip, the `extractable` flag, sign/verify happy-path + cross-key/garbage rejection). `session-crypto.test.ts` and the cross-tab acceptance suite pass unchanged. `npm run test:ci`, typecheck, eslint, prettier, and the import-tier governance tests are green (the new `security/` → consumer edges are legal: cross-tab-crypto stays Tier 1; workshop Tier 3 imports downward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
