### PR TITLE
hardening(cross-tab): deepen wire validation for nested message fields (#1144)

### DIFF
--- a/src/types/cross-tab.types.test.ts
+++ b/src/types/cross-tab.types.test.ts
@@ -115,6 +115,18 @@ describe('validateCrossTabMessage', () => {
     ],
     ['a non-array internalActions', { targetAction: 'guided', refTarget: '', internalActions: 'highlight' }],
     ['a non-object internal action', { targetAction: 'guided', refTarget: '', internalActions: ['highlight'] }],
+    [
+      'an internal action with a non-string refTarget',
+      { targetAction: 'guided', refTarget: '', internalActions: [{ targetAction: 'highlight', refTarget: 123 }] },
+    ],
+    [
+      'an internal action with a non-string targetValue',
+      {
+        targetAction: 'multistep',
+        refTarget: '',
+        internalActions: [{ targetAction: 'formfill', refTarget: '#a', targetValue: 5 }],
+      },
+    ],
   ])('rejects a composite step-command with %s', (_label, action) => {
     expect(
       validateCrossTabMessage(envelope({ kind: 'step-command', phase: 'do', stepId: 's1', runId: 'run-1', action }))
@@ -154,5 +166,38 @@ describe('validateCrossTabMessage', () => {
 
   it('rejects a step-progress missing runId', () => {
     expect(validateCrossTabMessage(envelope({ kind: 'step-progress', stepId: 's1', index: 0, total: 3 }))).toBeNull();
+  });
+
+  it.each([
+    ['index below zero', { index: -1, total: 3 }],
+    ['total below one', { index: 0, total: 0 }],
+    ['index past total', { index: 4, total: 3 }],
+  ])('rejects a step-progress with %s', (_label, bounds) => {
+    expect(
+      validateCrossTabMessage(envelope({ kind: 'step-progress', stepId: 's1', runId: 'run-1', ...bounds }))
+    ).toBeNull();
+  });
+
+  it('accepts a well-formed requirement-result', () => {
+    const message = envelope({
+      kind: 'requirement-result',
+      requestId: 'req-1',
+      stepId: 's1',
+      result: { requirements: 'navmenu-open', pass: false, error: [{ requirement: 'navmenu-open', pass: false }] },
+    });
+    expect(validateCrossTabMessage(message)).toBe(message);
+  });
+
+  it.each([
+    ['a non-object error element', { requirements: 'x', pass: false, error: ['boom'] }],
+    ['an error element missing pass', { requirements: 'x', pass: false, error: [{ requirement: 'x' }] }],
+    [
+      'an error element with a non-string fixType',
+      { requirements: 'x', pass: false, error: [{ requirement: 'x', pass: false, fixType: 7 }] },
+    ],
+  ])('rejects a requirement-result with %s', (_label, result) => {
+    expect(
+      validateCrossTabMessage(envelope({ kind: 'requirement-result', requestId: 'req-1', stepId: 's1', result }))
+    ).toBeNull();
   });
 });

--- a/src/types/cross-tab.types.ts
+++ b/src/types/cross-tab.types.ts
@@ -237,7 +237,13 @@ function isValidStepCommand(message: Record<string, unknown>): boolean {
     return (
       Array.isArray(action.internalActions) &&
       action.internalActions.every(
-        (sub) => isRecord(sub) && typeof sub.targetAction === 'string' && KNOWN_TARGET_ACTIONS.has(sub.targetAction)
+        (sub) =>
+          isRecord(sub) &&
+          typeof sub.targetAction === 'string' &&
+          KNOWN_TARGET_ACTIONS.has(sub.targetAction) &&
+          isOptionalString(sub.refTarget) &&
+          isOptionalString(sub.targetValue) &&
+          isOptionalString(sub.targetComment)
       )
     );
   }
@@ -291,7 +297,22 @@ function isValidRequirementResult(message: Record<string, unknown>): boolean {
     return false;
   }
   const result = message.result;
-  return typeof result.requirements === 'string' && typeof result.pass === 'boolean' && Array.isArray(result.error);
+  return (
+    typeof result.requirements === 'string' &&
+    typeof result.pass === 'boolean' &&
+    Array.isArray(result.error) &&
+    result.error.every(
+      (e) =>
+        isRecord(e) &&
+        typeof e.requirement === 'string' &&
+        typeof e.pass === 'boolean' &&
+        isOptionalString(e.error) &&
+        isOptionalString(e.fixType) &&
+        isOptionalString(e.targetHref) &&
+        isOptionalString(e.scrollContainer) &&
+        (e.canFix === undefined || typeof e.canFix === 'boolean')
+    )
+  );
 }
 
 function isValidFixResult(message: Record<string, unknown>): boolean {
@@ -315,7 +336,10 @@ function isValidStepProgress(message: Record<string, unknown>): boolean {
     typeof message.stepId === 'string' &&
     typeof message.runId === 'string' &&
     typeof message.index === 'number' &&
-    typeof message.total === 'number'
+    typeof message.total === 'number' &&
+    message.index >= 0 &&
+    message.total >= 1 &&
+    message.index <= message.total
   );
 }
 


### PR DESCRIPTION
## What

Deepens the cross-tab `KIND_VALIDATORS` so the per-kind gate validates nested fields, not just top-level shape. Post-re-enable hardening (not a gate) for the two-tab controller.

Closes #1144. Part of #1133.

## Changes (`src/types/cross-tab.types.ts`)

1. **`step-command` → `internalActions[]` elements.** Each composite sub-action is replayed as a DOM action on the live tab. The gate already checked each element's `targetAction` against `KNOWN_TARGET_ACTIONS`; it now also validates `refTarget`, `targetValue`, and `targetComment` are optional strings, so a malformed element can't slip through to the executor.
2. **`requirement-result` → `error[]` elements.** Previously only `Array.isArray(error)` was checked. Each element is now validated to the `RemoteRequirementError` shape — required `requirement: string` + `pass: boolean`, and optional-string `error`/`fixType`/`targetHref`/`scrollContainer` plus optional-boolean `canFix` — so a forged error array can't reach the controller's requirements-state consumer with unexpected types.
3. **`step-progress` bounds.** `index`/`total` were type-checked but unbounded. Now also enforces `index >= 0`, `total >= 1`, `index <= total`, so an out-of-range progress message can't drive the UI progress display.

### Note on the issue's `phase` item

The issue also asked to validate a `phase` field on `internalActions` elements, but `CrossTabInternalAction` has no `phase` field (`phase` lives on the `step-command` envelope, not its sub-actions) — so that part was a stale premise and is intentionally omitted.

## Tests

`cross-tab.types.test.ts` gains cases for each tightening: internal actions with a non-string `refTarget`/`targetValue`; a well-formed `requirement-result` plus rejection of a non-object / `pass`-less / wrong-typed error element; and `step-progress` rejection for index-below-zero, total-below-one, and index-past-total. `npm run test:ci`, typecheck, eslint, prettier green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
