### PR TITLE
test(cross-tab): real-browser adversarial specs for the two-tab controller (#1142)

### DIFF
--- a/tests/two-tab-controller.spec.ts
+++ b/tests/two-tab-controller.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect } from './fixtures';
+import { testIds } from '../src/constants/testIds';
+import { CROSS_TAB_CHANNEL } from '../src/types/cross-tab.types';
+import type { Page } from '@playwright/test';
+
+/**
+ * Real-browser adversarial coverage for the two-tab controller (#1142).
+ *
+ * The security-critical cross-tab tests elsewhere run in jsdom, where
+ * BroadcastChannel is mocked and message delivery is synchronous. These specs
+ * exercise the same trust boundary across real, separate JS contexts where the
+ * channel delivers asynchronously — the conditions the mock can't reproduce.
+ *
+ * SKIPPED (`test.describe.fixme`) until the `enableTwoTabController` admin
+ * setting is turned on (plugin config → Interactive features): the controller
+ * overlay, the live-tab executor, and the "open in interactive window"
+ * affordance are all gated on that setting (default off), so none of this is
+ * reachable on a default instance. To run these, enable the setting (or seed it
+ * in the test instance's plugin jsonData) and remove the `.fixme`.
+ */
+
+const SENTINEL_PATH = '/a/grafana-pathfinder-app/__forged_nav__';
+
+async function postRawCrossTabMessage(page: Page, message: Record<string, unknown>): Promise<void> {
+  await page.evaluate(
+    ({ channel, msg }) => {
+      const ch = new BroadcastChannel(channel);
+      ch.postMessage(msg);
+      ch.close();
+    },
+    { channel: CROSS_TAB_CHANNEL, msg: message }
+  );
+}
+
+async function startCapturingSessionId(page: Page): Promise<void> {
+  await page.evaluate((channel) => {
+    const w = window as unknown as { __pfCapturedSessionId?: string };
+    const ch = new BroadcastChannel(channel);
+    ch.onmessage = (event) => {
+      const data = event.data as { kind?: string; sessionId?: string };
+      if (data?.kind === 'pairing-challenge' && typeof data.sessionId === 'string') {
+        w.__pfCapturedSessionId = data.sessionId;
+        ch.close();
+      }
+    };
+  }, CROSS_TAB_CHANNEL);
+}
+
+async function readCapturedSessionId(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const w = window as unknown as { __pfCapturedSessionId?: string };
+    return w.__pfCapturedSessionId ?? '';
+  });
+}
+
+async function gotoLiveTab(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+}
+
+async function openController(liveTab: Page): Promise<Page> {
+  await liveTab.locator('button[aria-label="Help"]').click();
+  await expect(liveTab.getByTestId(testIds.docsPanel.container)).toBeVisible();
+
+  const openButton = liveTab.getByTestId(testIds.docsPanel.openControllerTabButton);
+  await expect(openButton).toBeVisible();
+
+  const controllerPromise = liveTab.context().waitForEvent('page');
+  await openButton.click();
+  const controller = await controllerPromise;
+  await controller.waitForLoadState('networkidle');
+  return controller;
+}
+
+async function acceptPairing(liveTab: Page): Promise<void> {
+  await liveTab.getByRole('button', { name: 'Accept' }).click();
+}
+
+test.describe.fixme('two-tab controller — real-browser adversarial (pending enableTwoTabController)', () => {
+  test('a forged, unsigned step-command does not drive the live tab', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    const urlBefore = page.url();
+
+    await postRawCrossTabMessage(page, {
+      source: 'pathfinder',
+      senderId: 'attacker-tab',
+      timestamp: Date.now(),
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'forged',
+      runId: 'forged-run',
+      action: { targetAction: 'navigate', refTarget: SENTINEL_PATH },
+    });
+
+    await page.waitForTimeout(500);
+    expect(page.url()).toBe(urlBefore);
+  });
+
+  test('only the paired live tab executes a controller command', async ({ page, context }) => {
+    const liveA = page;
+    await gotoLiveTab(liveA);
+    const controller = await openController(liveA);
+    await acceptPairing(liveA);
+
+    const liveB = await context.newPage();
+    await liveB.goto('/');
+    await liveB.waitForLoadState('networkidle');
+    const liveBUrlBefore = liveB.url();
+
+    await controller.getByRole('button', { name: /do it/i }).first().click();
+
+    await expect.poll(() => liveA.url()).not.toBe(liveBUrlBefore);
+    expect(liveB.url()).toBe(liveBUrlBefore);
+  });
+
+  test('a stale step-complete from a cancelled run does not settle the retried run', async ({ page }) => {
+    const liveA = page;
+    await gotoLiveTab(liveA);
+    const controller = await openController(liveA);
+    await acceptPairing(liveA);
+
+    const composite = controller.getByRole('button', { name: /do section|do it/i }).first();
+    await composite.click();
+    await controller
+      .getByRole('button', { name: /cancel/i })
+      .first()
+      .click();
+
+    await postRawCrossTabMessage(liveA, {
+      source: 'pathfinder',
+      senderId: 'attacker-tab',
+      timestamp: Date.now(),
+      kind: 'step-complete',
+      stepId: 'composite-step',
+      runId: 'stale-run',
+      ok: true,
+    });
+
+    await composite.click();
+    await expect(controller.getByRole('button', { name: /cancel/i }).first()).toBeVisible();
+  });
+
+  test('a forged pairing-accept cannot claim the controller pairing slot', async ({ page, context }) => {
+    const liveA = page;
+    await gotoLiveTab(liveA);
+    await startCapturingSessionId(liveA);
+    const controller = await openController(liveA);
+    await expect.poll(() => readCapturedSessionId(liveA)).not.toBe('');
+    const sessionId = await readCapturedSessionId(liveA);
+    const status = controller.getByTestId(testIds.guideReader.controllerStatus);
+
+    // Attacker reads sessionId off the wire and posts an accept with a bogus
+    // acceptProof (the HMAC field added in #1158, stacked below), then answers
+    // heartbeats as the paired tab. The controller must reject the unprovable
+    // accept and refuse to bind to the attacker.
+    const attacker = await context.newPage();
+    await attacker.goto('/');
+    await postRawCrossTabMessage(attacker, {
+      source: 'pathfinder',
+      senderId: 'attacker-tab',
+      timestamp: Date.now(),
+      kind: 'pairing-accept',
+      sessionId,
+      pairingId: 'guessed',
+      acceptProof: 'forged',
+    });
+    await postRawCrossTabMessage(attacker, {
+      source: 'pathfinder',
+      senderId: 'attacker-tab',
+      timestamp: Date.now(),
+      kind: 'heartbeat',
+      role: 'live',
+    });
+
+    // Forge rejected: the controller does not pair to the attacker.
+    await expect(status).not.toContainText(/connected/i);
+
+    // The genuine gesture-accept still pairs.
+    await acceptPairing(liveA);
+    await expect(status).toContainText(/connected/i);
+  });
+});

--- a/tests/two-tab-controller.spec.ts
+++ b/tests/two-tab-controller.spec.ts
@@ -11,12 +11,15 @@ import type { Page } from '@playwright/test';
  * exercise the same trust boundary across real, separate JS contexts where the
  * channel delivers asynchronously — the conditions the mock can't reproduce.
  *
- * SKIPPED (`test.describe.fixme`) until the `enableTwoTabController` admin
- * setting is turned on (plugin config → Interactive features): the controller
- * overlay, the live-tab executor, and the "open in interactive window"
- * affordance are all gated on that setting (default off), so none of this is
- * reachable on a default instance. To run these, enable the setting (or seed it
- * in the test instance's plugin jsonData) and remove the `.fixme`.
+ * SKIPPED (`test.describe.fixme`): this branch is standalone on `main`, where the
+ * controller overlay, the live-tab executor, and the "open in interactive window"
+ * affordance are gated behind the compile-time `TWOTAB_CONTROLLER_ENABLED` const
+ * (`src/constants/interactive-config.ts`), currently `false` with no runtime
+ * override — so none of this is reachable on any instance this build can produce.
+ * Enabling it needs #1174's `enableTwoTabController` admin toggle, which is not in
+ * this branch. Per the re-enable gate these specs stay registered-but-skipped until
+ * the flag flips; at that point, seed `jsonData.enableTwoTabController = true` (via
+ * `gotoAppConfigPage`, already wired in `tests/fixtures.ts`) and remove the `.fixme`.
  */
 
 const SENTINEL_PATH = '/a/grafana-pathfinder-app/__forged_nav__';
@@ -53,6 +56,27 @@ async function readCapturedSessionId(page: Page): Promise<string> {
   });
 }
 
+async function startCapturingSignedStepCommand(page: Page): Promise<void> {
+  await page.evaluate((channel) => {
+    const w = window as unknown as { __pfCapturedStepCommand?: Record<string, unknown> };
+    const ch = new BroadcastChannel(channel);
+    ch.onmessage = (event) => {
+      const data = event.data as { kind?: string; sig?: string };
+      if (data?.kind === 'step-command' && typeof data.sig === 'string') {
+        w.__pfCapturedStepCommand = data as unknown as Record<string, unknown>;
+        ch.close();
+      }
+    };
+  }, CROSS_TAB_CHANNEL);
+}
+
+async function readCapturedStepCommand(page: Page): Promise<Record<string, unknown> | null> {
+  return page.evaluate(() => {
+    const w = window as unknown as { __pfCapturedStepCommand?: Record<string, unknown> };
+    return w.__pfCapturedStepCommand ?? null;
+  });
+}
+
 async function gotoLiveTab(page: Page): Promise<void> {
   await page.goto('/');
   await page.waitForLoadState('networkidle');
@@ -76,13 +100,15 @@ async function acceptPairing(liveTab: Page): Promise<void> {
   await liveTab.getByRole('button', { name: 'Accept' }).click();
 }
 
-test.describe.fixme('two-tab controller — real-browser adversarial (pending enableTwoTabController)', () => {
-  test('a forged, unsigned step-command does not drive the live tab', async ({ page }) => {
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    const urlBefore = page.url();
+test.describe.fixme('two-tab controller — real-browser adversarial (pending TWOTAB_CONTROLLER_ENABLED)', () => {
+  test('a forged, unsigned step-command does not drive the paired live tab', async ({ page }) => {
+    const liveA = page;
+    await gotoLiveTab(liveA);
+    await openController(liveA);
+    await acceptPairing(liveA);
+    const urlBefore = liveA.url();
 
-    await postRawCrossTabMessage(page, {
+    await postRawCrossTabMessage(liveA, {
       source: 'pathfinder',
       senderId: 'attacker-tab',
       timestamp: Date.now(),
@@ -93,8 +119,11 @@ test.describe.fixme('two-tab controller — real-browser adversarial (pending en
       action: { targetAction: 'navigate', refTarget: SENTINEL_PATH },
     });
 
-    await page.waitForTimeout(500);
-    expect(page.url()).toBe(urlBefore);
+    // The tab is paired and the live-tab executor is installed and listening, so a
+    // stalled URL means the signature gate rejected the unsigned command — not that
+    // nothing was listening.
+    await liveA.waitForTimeout(500);
+    expect(liveA.url()).toBe(urlBefore);
   });
 
   test('only the paired live tab executes a controller command', async ({ page, context }) => {
@@ -106,11 +135,15 @@ test.describe.fixme('two-tab controller — real-browser adversarial (pending en
     const liveB = await context.newPage();
     await liveB.goto('/');
     await liveB.waitForLoadState('networkidle');
+
+    const liveAUrlBefore = liveA.url();
     const liveBUrlBefore = liveB.url();
 
     await controller.getByRole('button', { name: /do it/i }).first().click();
 
-    await expect.poll(() => liveA.url()).not.toBe(liveBUrlBefore);
+    // The command drives the paired tab (A) away from its own baseline; the
+    // unpaired tab (B) never moves from its own baseline.
+    await expect.poll(() => liveA.url()).not.toBe(liveAUrlBefore);
     expect(liveB.url()).toBe(liveBUrlBefore);
   });
 
@@ -151,7 +184,7 @@ test.describe.fixme('two-tab controller — real-browser adversarial (pending en
     const status = controller.getByTestId(testIds.guideReader.controllerStatus);
 
     // Attacker reads sessionId off the wire and posts an accept with a bogus
-    // acceptProof (the HMAC field added in #1158, stacked below), then answers
+    // acceptProof (the HMAC field #1158 adds to pairing-accept), then answers
     // heartbeats as the paired tab. The controller must reject the unprovable
     // accept and refuse to bind to the attacker.
     const attacker = await context.newPage();
@@ -179,5 +212,34 @@ test.describe.fixme('two-tab controller — real-browser adversarial (pending en
     // The genuine gesture-accept still pairs.
     await acceptPairing(liveA);
     await expect(status).toContainText(/connected/i);
+  });
+
+  test('a replayed genuine step-command is ignored by the live tab', async ({ page }) => {
+    const liveA = page;
+    await gotoLiveTab(liveA);
+    // Record the first genuine, signed step-command the controller emits so we can
+    // re-post it verbatim — same {sessionId, sigNonce}, the pair the replay ledger
+    // (seenSignedMessages in pairing-manager) keys on.
+    await startCapturingSignedStepCommand(liveA);
+    const controller = await openController(liveA);
+    await acceptPairing(liveA);
+
+    let navigations = 0;
+    liveA.on('framenavigated', (frame) => {
+      if (frame === liveA.mainFrame()) {
+        navigations += 1;
+      }
+    });
+
+    await controller.getByRole('button', { name: /do it/i }).first().click();
+    await expect.poll(() => readCapturedStepCommand(liveA)).not.toBeNull();
+    const genuine = await readCapturedStepCommand(liveA);
+    const navigationsAfterGenuine = navigations;
+
+    // Re-deliver the once-accepted command. The nonce ledger rejects the second
+    // delivery, so the executor never dispatches it again — no further navigation.
+    await postRawCrossTabMessage(liveA, genuine as Record<string, unknown>);
+    await liveA.waitForTimeout(500);
+    expect(navigations).toBe(navigationsAfterGenuine);
   });
 });


### PR DESCRIPTION
## What

Adds real-browser adversarial Playwright specs for the two-tab controller — `tests/two-tab-controller.spec.ts` — covering the scenarios that jsdom (where `BroadcastChannel` is mocked and synchronous) cannot reproduce.

Closes #1142. Part of #1133.

## Skipped until the flag flips

The specs are a `test.describe.fixme` group, so they are **registered but skipped**. The controller overlay, the live-tab executor, and the "open in interactive window" affordance are all gated on the hardcoded `TWOTAB_CONTROLLER_ENABLED = false`, with no runtime override — so they aren't reachable in a normal build. To run them: build with the flag enabled and remove the `.fixme`. The file header documents this.

This matches the issue framing — these are the gate that must pass *before* the flag is flipped — and lands the concrete scenarios now so they're ready to run at that moment, without shipping a runtime toggle of the security gate (which #1149's concern flags as a one-way door).

## Scenarios

1. **Forged command rejected** — a raw, unsigned `step-command` posted on `pathfinder-cross-tab` does not drive the live tab (asserts no navigation).
2. **Second-tab isolation** — controller paired with live A; a driven command reaches A but not an unpaired live B (the signed `liveTabId` binds the command to the paired tab).
3. **Stale-message safety** — a composite run cancelled then retried is not settled by a stale `step-complete` carrying the old `runId`.
4. **Pairing-slot protection** — a forged `pairing-accept` (correct `sessionId` read off the wire, bogus proof) cannot claim the controller's slot; the genuine accept still pairs (exercises #1158's HMAC-bound accept in a real browser).

Forging is done via `page.evaluate` posting raw messages on a real `BroadcastChannel`, and multi-tab scenarios use multiple pages in one browser context (shared same-origin channel).

## Status / caveat

Because the feature is off in this build, these specs cannot be executed here — they are a faithful scaffold built on the real selectors (`testIds.docsPanel.openControllerTabButton`, `testIds.guideReader.controllerStatus`, the `Accept` pairing button) and the real channel/message contracts. The pairing orchestration (cross-tab `window.open` capture + fragment handoff) should be validated when the flag is enabled and the group is unskipped. Typecheck and prettier are green; `tests/` is outside the eslint config (repo convention); jest (`test:ci`) does not run Playwright specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
