### PR TITLE
feat(cross-tab): make the two-tab controller an admin plugin-config toggle (default off)

### DIFF
--- a/src/components/AppConfig/InteractiveFeatures.tsx
+++ b/src/components/AppConfig/InteractiveFeatures.tsx
@@ -12,6 +12,7 @@ import {
   DEFAULT_ENABLE_KIOSK_MODE,
   DEFAULT_KIOSK_RULES_URL,
   DEFAULT_ENABLE_AI_AUTO_HEAL,
+  DEFAULT_ENABLE_TWO_TAB_CONTROLLER,
   getConfigWithDefaults,
 } from '../../constants';
 import { updatePluginSettings } from '../../utils/utils.plugin';
@@ -26,6 +27,7 @@ type State = {
   enableKioskMode: boolean;
   kioskRulesUrl: string;
   enableAiAutoHeal: boolean;
+  enableTwoTabController: boolean;
 };
 
 export interface InteractiveFeaturesProps extends PluginConfigPageProps<AppPluginMeta<JsonData>> {}
@@ -44,6 +46,7 @@ const InteractiveFeatures = ({ plugin }: InteractiveFeaturesProps) => {
     enableKioskMode: jsonData?.enableKioskMode ?? DEFAULT_ENABLE_KIOSK_MODE,
     kioskRulesUrl: jsonData?.kioskRulesUrl ?? DEFAULT_KIOSK_RULES_URL,
     enableAiAutoHeal: jsonData?.enableAiAutoHeal ?? DEFAULT_ENABLE_AI_AUTO_HEAL,
+    enableTwoTabController: jsonData?.enableTwoTabController ?? DEFAULT_ENABLE_TWO_TAB_CONTROLLER,
   }));
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
@@ -100,6 +103,10 @@ const InteractiveFeatures = ({ plugin }: InteractiveFeaturesProps) => {
     setState({ ...state, enableAiAutoHeal: event.target.checked });
   };
 
+  const onToggleEnableTwoTabController = (event: ChangeEvent<HTMLInputElement>) => {
+    setState({ ...state, enableTwoTabController: event.target.checked });
+  };
+
   const onResetDefaults = () => {
     setState({
       enableAutoDetection: DEFAULT_ENABLE_AUTO_DETECTION,
@@ -109,6 +116,7 @@ const InteractiveFeatures = ({ plugin }: InteractiveFeaturesProps) => {
       enableKioskMode: DEFAULT_ENABLE_KIOSK_MODE,
       kioskRulesUrl: DEFAULT_KIOSK_RULES_URL,
       enableAiAutoHeal: DEFAULT_ENABLE_AI_AUTO_HEAL,
+      enableTwoTabController: DEFAULT_ENABLE_TWO_TAB_CONTROLLER,
     });
     setValidationErrors({});
   };
@@ -136,6 +144,7 @@ const InteractiveFeatures = ({ plugin }: InteractiveFeaturesProps) => {
         enableKioskMode: state.enableKioskMode,
         kioskRulesUrl: state.kioskRulesUrl,
         enableAiAutoHeal: state.enableAiAutoHeal,
+        enableTwoTabController: state.enableTwoTabController,
       };
 
       await updatePluginSettings(plugin.meta.id, {
@@ -168,7 +177,8 @@ const InteractiveFeatures = ({ plugin }: InteractiveFeaturesProps) => {
     state.disableAutoCollapse !== (jsonData?.disableAutoCollapse ?? DEFAULT_DISABLE_AUTO_COLLAPSE) ||
     state.enableKioskMode !== (jsonData?.enableKioskMode ?? DEFAULT_ENABLE_KIOSK_MODE) ||
     state.kioskRulesUrl !== (jsonData?.kioskRulesUrl ?? DEFAULT_KIOSK_RULES_URL) ||
-    state.enableAiAutoHeal !== (jsonData?.enableAiAutoHeal ?? DEFAULT_ENABLE_AI_AUTO_HEAL);
+    state.enableAiAutoHeal !== (jsonData?.enableAiAutoHeal ?? DEFAULT_ENABLE_AI_AUTO_HEAL) ||
+    state.enableTwoTabController !== (jsonData?.enableTwoTabController ?? DEFAULT_ENABLE_TWO_TAB_CONTROLLER);
 
   return (
     <form onSubmit={onSubmit}>
@@ -357,6 +367,41 @@ const InteractiveFeatures = ({ plugin }: InteractiveFeaturesProps) => {
               <Text variant="body">
                 Accepted suggestions mutate the in-memory guide JSON for the user&apos;s session. Disable this toggle to
                 hide the AI-powered button entirely; the deterministic &quot;Fix this&quot; recovery path is unaffected.
+              </Text>
+            </Alert>
+          )}
+        </div>
+
+        <div className={styles.divider} />
+
+        <div className={styles.section}>
+          <Text variant="h4" weight="medium">
+            Two-tab interactive controller
+          </Text>
+          <div className={styles.toggleSection}>
+            <Switch
+              data-testid={testIds.appConfig.interactiveFeatures.enableTwoTabController}
+              id="enable-two-tab-controller"
+              value={state.enableTwoTabController}
+              onChange={onToggleEnableTwoTabController}
+            />
+            <div className={styles.toggleLabels}>
+              <Text variant="body" weight="medium">
+                Enable &quot;Open in interactive window&quot;
+              </Text>
+              <Text variant="body" color="secondary">
+                Lets an interactive guide pop out into its own browser tab and drive the original Grafana tab over a
+                same-origin channel. Pairing requires a one-time code and an explicit accept on this tab.
+              </Text>
+            </div>
+          </div>
+
+          {state.enableTwoTabController && (
+            <Alert severity="warning" title="Experimental — drives the authenticated DOM" className={styles.infoAlert}>
+              <Text variant="body">
+                Once paired, the controller tab can run guide actions (navigation, clicks, form fills) against this
+                Grafana session. Enable only on trusted instances. Disable to hide the affordance and the live-tab
+                executor entirely.
               </Text>
             </Alert>
           )}

--- a/src/components/docs-panel/components/DocsPanelContentArea.tsx
+++ b/src/components/docs-panel/components/DocsPanelContentArea.tsx
@@ -24,9 +24,9 @@
 import React, { Suspense, lazy } from 'react';
 import { Button, Icon, IconButton } from '@grafana/ui';
 import { t } from '@grafana/i18n';
-import { PLUGIN_BASE_URL } from '../../../constants';
+import { usePluginContext } from '@grafana/data';
+import { PLUGIN_BASE_URL, getConfigWithDefaults } from '../../../constants';
 import { testIds } from '../../../constants/testIds';
-import { TWOTAB_CONTROLLER_ENABLED } from '../../../constants/interactive-config';
 import type { LearningJourneyTab, PackageOpenInfo, ContextPanelState } from '../../../types/content-panel.types';
 import type { getStyles as getDocsPanelStyles } from '../../../styles/docs-panel.styles';
 import { isDocsLikeTab, pickGrafanaDocsOpenAction, pickControllerTabOpenAction } from '../utils';
@@ -117,6 +117,9 @@ export function DocsPanelContentArea(props: DocsPanelContentAreaProps): React.Re
     reloadActiveTab,
     restoreScrollPosition,
   } = props;
+
+  const pluginContext = usePluginContext();
+  const twoTabControllerEnabled = getConfigWithDefaults(pluginContext?.meta?.jsonData || {}).enableTwoTabController;
 
   return (
     <div className={styles.content} data-testid={testIds.docsPanel.content}>
@@ -316,7 +319,7 @@ export function DocsPanelContentArea(props: DocsPanelContentAreaProps): React.Re
                       );
                     })()}
                     {(() => {
-                      if (!TWOTAB_CONTROLLER_ENABLED) {
+                      if (!twoTabControllerEnabled) {
                         return null;
                       }
                       const guideUrl = activeTab.content?.url || activeTab.baseUrl;

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -76,4 +76,12 @@ describe('getConfigWithDefaults feature flags', () => {
   it('defaults enableAiAutoHeal to false when jsonData is absent', () => {
     expect(getConfigWithDefaults({}).enableAiAutoHeal).toBe(false);
   });
+
+  it('defaults enableTwoTabController to false when jsonData is absent', () => {
+    expect(getConfigWithDefaults({}).enableTwoTabController).toBe(false);
+  });
+
+  it('honors an explicit enableTwoTabController override', () => {
+    expect(getConfigWithDefaults({ enableTwoTabController: true }).enableTwoTabController).toBe(true);
+  });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,6 +70,10 @@ export const DEFAULT_KIOSK_RULES_URL = '';
 // AI auto-heal: default OFF — the AI write path requires explicit admin opt-in
 export const DEFAULT_ENABLE_AI_AUTO_HEAL = false;
 
+// Two-tab controller: default OFF — the live-tab executor drives the user's
+// authenticated Grafana DOM, so it requires explicit admin opt-in
+export const DEFAULT_ENABLE_TWO_TAB_CONTROLLER = false;
+
 // PeerJS Server defaults (for live sessions)
 export const DEFAULT_PEERJS_HOST = 'localhost';
 export const DEFAULT_PEERJS_PORT = 9000;
@@ -141,6 +145,8 @@ export interface DocsPluginConfig {
   kioskRulesUrl?: string;
   // AI auto-heal
   enableAiAutoHeal?: boolean;
+  // Two-tab interactive controller (admin opt-in; drives the authenticated DOM)
+  enableTwoTabController?: boolean;
 }
 
 // Helper functions to get configuration values with defaults
@@ -187,6 +193,8 @@ export const getConfigWithDefaults = (
   kioskRulesUrl: config.kioskRulesUrl ?? DEFAULT_KIOSK_RULES_URL,
   // AI auto-heal
   enableAiAutoHeal: config.enableAiAutoHeal ?? DEFAULT_ENABLE_AI_AUTO_HEAL,
+  // Two-tab interactive controller
+  enableTwoTabController: config.enableTwoTabController ?? DEFAULT_ENABLE_TWO_TAB_CONTROLLER,
 });
 
 /**

--- a/src/constants/interactive-config.ts
+++ b/src/constants/interactive-config.ts
@@ -346,10 +346,3 @@ export interface ActionMetadata {
 export type ActionType = (typeof ACTION_TYPES)[keyof typeof ACTION_TYPES];
 export type CommonRequirement = (typeof COMMON_REQUIREMENTS)[number];
 export type DataAttribute = (typeof DATA_ATTRIBUTES)[keyof typeof DATA_ATTRIBUTES];
-
-// Two-tab interactive controller feature flag.
-// Set to false to ship the feature dark — all three gates (controller overlay
-// entry, live-tab executor install, and the docs-panel UI affordance) check
-// this constant. Flip to true once the follow-up security/correctness items
-// are resolved (see epic #1133).
-export const TWOTAB_CONTROLLER_ENABLED = false;

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -200,6 +200,7 @@ export const testIds = {
       guidedTimeout: 'config-interactive-guided-timeout',
       disableAutoCollapse: 'config-interactive-disable-auto-collapse',
       enableAiAutoHeal: 'config-interactive-enable-ai-auto-heal',
+      enableTwoTabController: 'config-interactive-enable-two-tab-controller',
       reset: 'config-interactive-reset-defaults',
       submit: 'config-interactive-submit',
     },

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -8,7 +8,6 @@ import { reportAppInteraction, UserInteraction } from './lib/analytics';
 import { initPluginTranslations } from '@grafana/i18n';
 import pluginJson from './plugin.json';
 import { getConfigWithDefaults, DocsPluginConfig } from './constants';
-import { TWOTAB_CONTROLLER_ENABLED } from './constants/interactive-config';
 import { linkInterceptionState } from './global-state/link-interception';
 import { sidebarState } from 'global-state/sidebar';
 import { panelModeManager } from './global-state/panel-mode';
@@ -138,9 +137,10 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
 
   // Interactive controller (?doc=<guide>&controller=1): the same overlay, but
   // step actions stay visible so this tab can drive the originating Grafana tab.
-  // Gated on pathfinder.enabled — the controller drives the user's authenticated
-  // Grafana, so it must not mount when the plugin is disabled.
-  if (TWOTAB_CONTROLLER_ENABLED && docsParam && controllerParam && controllerPairing && pathfinderEnabled) {
+  // Gated on the enableTwoTabController admin setting and pathfinder.enabled — the
+  // controller drives the user's authenticated Grafana, so it must not mount when
+  // the plugin is disabled or the instance hasn't opted in.
+  if (config.enableTwoTabController && docsParam && controllerParam && controllerPairing && pathfinderEnabled) {
     if (!document.getElementById('pathfinder-controller-root')) {
       // Claim the id synchronously, before the dynamic import, so a second
       // plugin.init can't race past the guard and double-mount.
@@ -166,7 +166,7 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   // Live tab only (the controller tab returned early above): load the cross-tab
   // executor so a controller tab can drive this Grafana DOM. Mount the pairing
   // banner first so its challenge listener is live before the transport starts.
-  if (TWOTAB_CONTROLLER_ENABLED && pathfinderEnabled) {
+  if (config.enableTwoTabController && pathfinderEnabled) {
     if (!document.getElementById('pathfinder-pairing-banner-root')) {
       const bannerContainer = document.createElement('div');
       bannerContainer.id = 'pathfinder-pairing-banner-root';


### PR DESCRIPTION
## What

Replaces the compile-time `TWOTAB_CONTROLLER_ENABLED` constant with an admin-controlled plugin-config setting, `enableTwoTabController` (default **off**), so an instance admin can enable the two-tab interactive controller without a custom build. Mirrors the existing `enableAiAutoHeal` opt-in.

Part of #1133.

## Why

The gate was a hardcoded `const = false` with no runtime override — the feature could only be enabled by editing source and rebuilding. Moving it to `jsonData` (plugin config → **Interactive features**) lets admins opt in per-instance while the feature still ships dark by default.

## Changes

- **`src/constants.ts`** — `DEFAULT_ENABLE_TWO_TAB_CONTROLLER = false`, `enableTwoTabController?: boolean` on `DocsPluginConfig`, and the `getConfigWithDefaults` resolution (exactly the `enableAiAutoHeal` shape).
- **`src/components/AppConfig/InteractiveFeatures.tsx`** — a "Two-tab interactive controller" toggle with a warning Alert (it drives the authenticated DOM), wired through draft state / reset / save / `hasChanges` like the other toggles.
- **`src/constants/testIds.ts`** — `interactiveFeatures.enableTwoTabController`.
- **Gate sites now read `config.enableTwoTabController`:** `module.tsx` (controller-overlay entry + live-tab-executor install — `config` is already computed there from `meta.jsonData`) and `DocsPanelContentArea.tsx` (the "Open in interactive window" affordance, via `usePluginContext()` + `getConfigWithDefaults`, the same pattern other in-panel components use — no `as any` global).
- **`src/constants/interactive-config.ts`** — the `TWOTAB_CONTROLLER_ENABLED` const removed.
- **`docs/developer/CROSS_TAB_CONTROLLER.md`** — gating sections updated: both mount sites now require the admin setting **and** `shouldMountSidebar(...)`.

## Default & security

Default is **off** — enabling is an explicit admin action. Note this changes the nature of the re-enable one-way door: instead of a code flip, any admin who toggles this makes the live-tab executor reachable in production. The trust-boundary work this gate protects (authenticated pairing #1153/#1158, deeper validation #1144, and the real-browser adversarial tests #1142) should be landed before admins are encouraged to turn it on. The config UI carries an experimental/security warning to that effect.

## Cross-PR note

The `cross-tab-controller` concern (#1149 / PR #1165) and the E2E specs (#1142 / PR #1173) reference `TWOTAB_CONTROLLER_ENABLED` by name; whichever merges after this should update those references to the `enableTwoTabController` config setting.

## Verification

`npm run test:ci` (incl. new `getConfigWithDefaults` coverage for the flag), typecheck, eslint, prettier, and `npm run build` all green. No dangling references to the removed const.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
