### PR TITLE
fix(cross-tab): write formfill via Monaco model API so it lands on a backgrounded live tab

### DIFF
--- a/src/interactive-engine/action-handlers/code-block-handler.test.ts
+++ b/src/interactive-engine/action-handlers/code-block-handler.test.ts
@@ -46,12 +46,18 @@ describe('trySetMonacoModelValue', () => {
     expect(focus).toHaveBeenCalled();
   });
 
-  it('falls back to the matching model when no editor matches', () => {
+  it('falls back to the matching model when no editor matches, without touching the wrong editor', () => {
     const modelSetValue = jest.fn();
+    const wrongEditorSetValue = jest.fn();
+    const wrongEditorFocus = jest.fn();
     const monaco: MonacoMock = {
       editor: {
         getEditors: () => [
-          { getModel: () => ({ uri: { toString: () => 'other' } }), setValue: jest.fn(), focus: jest.fn() },
+          {
+            getModel: () => ({ uri: { toString: () => 'other' } }),
+            setValue: wrongEditorSetValue,
+            focus: wrongEditorFocus,
+          },
         ],
         getModels: () => [{ uri: { toString: () => URI }, setValue: modelSetValue }],
       },
@@ -60,5 +66,8 @@ describe('trySetMonacoModelValue', () => {
 
     expect(trySetMonacoModelValue(textareaUnder(URI), 'v')).toBe(true);
     expect(modelSetValue).toHaveBeenCalledWith('v');
+    // The non-matching editor is left alone, and the model-fallback path never focuses.
+    expect(wrongEditorSetValue).not.toHaveBeenCalled();
+    expect(wrongEditorFocus).not.toHaveBeenCalled();
   });
 });

--- a/src/interactive-engine/action-handlers/code-block-handler.test.ts
+++ b/src/interactive-engine/action-handlers/code-block-handler.test.ts
@@ -1,0 +1,64 @@
+import { trySetMonacoModelValue } from './code-block-handler';
+
+type MonacoMock = NonNullable<Window['monaco']>;
+
+describe('trySetMonacoModelValue', () => {
+  const URI = 'inmemory://model/1';
+
+  function textareaUnder(uri: string): HTMLElement {
+    const root = document.createElement('div');
+    root.setAttribute('data-uri', uri);
+    const textarea = document.createElement('textarea');
+    root.appendChild(textarea);
+    document.body.appendChild(root);
+    return textarea;
+  }
+
+  afterEach(() => {
+    window.monaco = undefined;
+    document.body.innerHTML = '';
+  });
+
+  it('returns false when the Monaco API is unavailable', () => {
+    expect(trySetMonacoModelValue(textareaUnder(URI), 'x')).toBe(false);
+  });
+
+  it('returns false when the element has no [data-uri] editor', () => {
+    window.monaco = { editor: { getEditors: () => [], getModels: () => [] } };
+    const orphan = document.createElement('textarea');
+    document.body.appendChild(orphan);
+    expect(trySetMonacoModelValue(orphan, 'x')).toBe(false);
+  });
+
+  it('writes via the matching editor and focuses it', () => {
+    const setValue = jest.fn();
+    const focus = jest.fn();
+    const monaco: MonacoMock = {
+      editor: {
+        getEditors: () => [{ getModel: () => ({ uri: { toString: () => URI } }), setValue, focus }],
+        getModels: () => [],
+      },
+    };
+    window.monaco = monaco;
+
+    expect(trySetMonacoModelValue(textareaUnder(URI), 'sum(rate(x[5m]))')).toBe(true);
+    expect(setValue).toHaveBeenCalledWith('sum(rate(x[5m]))');
+    expect(focus).toHaveBeenCalled();
+  });
+
+  it('falls back to the matching model when no editor matches', () => {
+    const modelSetValue = jest.fn();
+    const monaco: MonacoMock = {
+      editor: {
+        getEditors: () => [
+          { getModel: () => ({ uri: { toString: () => 'other' } }), setValue: jest.fn(), focus: jest.fn() },
+        ],
+        getModels: () => [{ uri: { toString: () => URI }, setValue: modelSetValue }],
+      },
+    };
+    window.monaco = monaco;
+
+    expect(trySetMonacoModelValue(textareaUnder(URI), 'v')).toBe(true);
+    expect(modelSetValue).toHaveBeenCalledWith('v');
+  });
+});

--- a/src/interactive-engine/action-handlers/code-block-handler.ts
+++ b/src/interactive-engine/action-handlers/code-block-handler.ts
@@ -89,42 +89,9 @@ export function trySetMonacoModelValue(element: HTMLElement, value: string): boo
 }
 
 async function tryMonacoApi(container: HTMLElement, code: string): Promise<CodeBlockInsertResult> {
-  if (!window.monaco?.editor) {
-    return { success: false, error: 'Monaco API not available' };
-  }
-
-  // Find the Monaco editor element with data-uri
-  const monacoEl = container.querySelector('[data-uri]') as HTMLElement | null;
-  if (!monacoEl) {
-    return { success: false, error: 'Monaco editor element not found' };
-  }
-
-  const dataUri = monacoEl.getAttribute('data-uri');
-  if (!dataUri) {
-    return { success: false, error: 'Monaco data-uri not found' };
-  }
-
-  // Try to find the editor instance by URI
-  const editors = window.monaco.editor.getEditors();
-  for (const editor of editors) {
-    const model = editor.getModel();
-    if (model && model.uri.toString() === dataUri) {
-      editor.setValue(code);
-      editor.focus();
-      return { success: true };
-    }
-  }
-
-  // Try model-based approach
-  const models = window.monaco.editor.getModels();
-  for (const model of models) {
-    if (model.uri.toString() === dataUri) {
-      model.setValue(code);
-      return { success: true };
-    }
-  }
-
-  return { success: false, error: 'Monaco editor instance not found' };
+  return trySetMonacoModelValue(container, code)
+    ? { success: true }
+    : { success: false, error: 'Monaco editor instance not found' };
 }
 
 async function tryTextareaApproach(container: HTMLElement, code: string): Promise<CodeBlockInsertResult> {

--- a/src/interactive-engine/action-handlers/code-block-handler.ts
+++ b/src/interactive-engine/action-handlers/code-block-handler.ts
@@ -58,6 +58,36 @@ export async function clearAndInsertCode(refTarget: string, code: string): Promi
   }
 }
 
+// Writes `value` via the Monaco model API (not the hidden textarea) for the
+// editor owning `element`, so it lands even on a backgrounded tab — e.g. the
+// two-tab controller driving a non-focused live tab. Returns false when the
+// API/model isn't found so callers fall back to synthetic textarea events.
+export function trySetMonacoModelValue(element: HTMLElement, value: string): boolean {
+  if (!window.monaco?.editor) {
+    return false;
+  }
+  const monacoEl = element.closest('[data-uri]') ?? element.querySelector('[data-uri]');
+  const dataUri = monacoEl?.getAttribute('data-uri');
+  if (!dataUri) {
+    return false;
+  }
+  for (const editor of window.monaco.editor.getEditors()) {
+    const model = editor.getModel();
+    if (model && model.uri.toString() === dataUri) {
+      editor.setValue(value);
+      editor.focus();
+      return true;
+    }
+  }
+  for (const model of window.monaco.editor.getModels()) {
+    if (model.uri.toString() === dataUri) {
+      model.setValue(value);
+      return true;
+    }
+  }
+  return false;
+}
+
 async function tryMonacoApi(container: HTMLElement, code: string): Promise<CodeBlockInsertResult> {
   if (!window.monaco?.editor) {
     return { success: false, error: 'Monaco API not available' };

--- a/src/interactive-engine/action-handlers/form-fill-handler.ts
+++ b/src/interactive-engine/action-handlers/form-fill-handler.ts
@@ -4,6 +4,7 @@ import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG, CLEAR_COMMAND } from '../../constants/interactive-config';
 import { resetValueTracker, isElementVisible } from '../../lib/dom';
 import { resolveWithRetry } from '../../lib/dom/selector-retry';
+import { trySetMonacoModelValue } from './code-block-handler';
 
 export class FormFillHandler {
   constructor(
@@ -410,6 +411,9 @@ export class FormFillHandler {
   }
 
   private async setMonacoEditorValue(element: HTMLElement, value: string): Promise<void> {
+    if (trySetMonacoModelValue(element, value)) {
+      return;
+    }
     element.focus();
     await this.clearMonacoEditor(element);
     this.setNativeTextareaValue(element, value);


### PR DESCRIPTION
## What

Fixes formfill steps that target the Monaco query editor not taking effect on the **live tab when driven from the two-tab controller** (they worked fine in the in-sidebar path). Discovered on the `prometheus-advanced-queries` guide, whose query steps are `formfill` into `textarea.inputarea`.

Stacked on top of the two-tab controller stack (#1133).

## Root cause

`FormFillHandler.setMonacoEditorValue` wrote to Monaco by setting the **hidden textarea's native `.value`** and dispatching synthetic `input`/`keydown` events, relying on Monaco to mirror the textarea into its model. That mirroring only happens while the editor's tab is **focused/foreground**. When the guide is driven from the popped-out controller window, the live Grafana tab is **backgrounded**, so Monaco ignores the synthetic input and the query never lands — even though the executor runs the formfill end-to-end (element resolves, Monaco is detected, clear+set run).

Confirmed by tracing the live-tab path: `dispatching step-command (formfill) → runAction → formfill handleDoMode { isMonacoEditor: true, shouldClear: true }` all fire, but the editor stays empty. Plain `element.click()` actions (button/highlight) aren't foreground-sensitive, which is why those worked.

## Fix

Write through the **Monaco model API** instead of the hidden textarea — `editor.setValue()` / `model.setValue()` go straight to the editor model and are foreground-independent. New `trySetMonacoModelValue(element, value)` in `code-block-handler.ts` (where `window.monaco` access already lives — same pattern as the existing `clearAndInsertCode`); `setMonacoEditorValue` calls it first and **falls back to the existing synthetic-textarea path** when the Monaco API or a matching model isn't found.

Behavior-equivalent for the in-tab path: `setMonacoEditorValue` already did a full clear-then-set, and `setValue()` is likewise a full replace — so this is strictly more robust, not a semantic change.

## Tests

New `code-block-handler.test.ts` covers `trySetMonacoModelValue`: API-unavailable → false, no `[data-uri]` editor → false, matching editor → `setValue` + `focus`, and the `getModels()` fallback. `form-fill-handler.test.ts` and the interactive-step suite stay green (jsdom has no `window.monaco`, so they exercise the synthetic fallback unchanged). `npm run test:ci`, typecheck, eslint, prettier, and `npm run build` all pass.

## Out of scope

The `prometheus-advanced-queries` guide is poorly authored (bare top-level steps; should use sections) — a separate guide-quality PR will address that. This PR is the engine fix that makes its formfill steps work under the controller regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
