### PR TITLE
Remove @grafana/docs-tooling from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grafana/docs-tooling @Jayclifford345 @tomglenn @leslie-heinzen
+* @Jayclifford345 @tomglenn @leslie-heinzen


### PR DESCRIPTION
We're not true maintainers. We'd want our contributions reviewed by the true maintainers listed here.
