### PR TITLE
[SPIKE] feat(e2e): add cloud stack isolation for guide tests

### DIFF
--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -56,6 +56,11 @@ npx pathfinder-cli e2e [options] [files...]
 | `--resolver-url <url>`                    | Recommender base URL for `--package <id>` resolution                                                                                                     | `https://recommender.grafana.com` |
 | `--cloud-instance-admin-token <host=env>` | Admin service-account token env var for a cloud target. Repeat for multiple cloud instances.                                                             | None                              |
 | `--cloud-url <url>`                       | Default Grafana Cloud instance URL for cloud-tier guides without a manifest `instance`.                                                                  | `https://learn.grafana.net/`      |
+| `--cloud-stack-access-policy-token <env>` | Cloud Access Policy token env var for provisioning ephemeral Grafana Cloud stacks for state-mutating cloud guide chains.                                 | None                              |
+| `--cloud-stack-region <region>`           | Grafana Cloud region for ephemeral stacks. Required when stack provisioning is enabled.                                                                  | None                              |
+| `--cloud-stack-slug-prefix <prefix>`      | Alphanumeric prefix for generated ephemeral stack slugs. Hyphens are stripped because Cloud stack slugs must be alphanumeric.                            | `pfe2e`                           |
+| `--cloud-stack-plugin-version <version>`  | Pathfinder plugin version to install on ephemeral stacks.                                                                                                | `latest`                          |
+| `--cloud-stack-pool-id <id>`              | Optional pool namespace. When omitted, any stack labeled `pathfinder-e2e-pool=true` is eligible.                                                         | None                              |
 
 ### Input formats
 
@@ -382,6 +387,10 @@ These variables are consumed by the CLI or passed to the spawned Playwright proc
 
 For cloud targets, pass `--cloud-instance-admin-token host=ENV_VAR_NAME`; the named env var contains an admin service-account token for that exact host. The env var name is user-defined, for example `GRAFANA_PLAY_ADMIN_TOKEN`.
 
+For ephemeral Cloud stacks, pass `--cloud-stack-access-policy-token ENV_VAR_NAME` and `--cloud-stack-region <region>`. The named env var contains a Grafana Cloud Access Policy token with stack lifecycle and plugin-install permissions. The CLI passes this token to Terraform through `TF_VAR_cloud_access_policy_token`; it is not written into generated Terraform configuration.
+
+For a manual hot pool, pass `--cloud-stack-access-policy-token ENV_VAR_NAME`. The CLI discovers stacks labeled `pathfinder-e2e-pool=true`, leases one, and mints a short-lived service-account token for the runner. Add `--cloud-stack-pool-id <id>` to restrict leasing to stacks whose `pathfinder-e2e-pool-id` label matches that value. Pool leases are tried before cold stack provisioning.
+
 ## Error classification
 
 When a step fails, the runner assigns an error classification to help with triage:
@@ -414,8 +423,57 @@ Guides are routed by their manifest's `testEnvironment.tier`:
 Cloud auth:
 
 - **Admin token per cloud target.** Pass `--cloud-instance-admin-token learn.grafana.net=GRAFANA_LEARN_ADMIN_TOKEN` to associate an admin service-account token env var with a cloud target. The CLI uses that admin token only to mint a fresh service account and short-lived token for each dependency chain; the browser runner receives only the minted token. Repeat the flag for each supported instance.
+- **Ephemeral stack provisioning for unsafe chains.** When `--cloud-stack-access-policy-token` and `--cloud-stack-region` are provided, the CLI can create a fresh Grafana Cloud stack for cloud guide chains that are unsafe to run on a shared stack. The generated stack creates a short-lived Admin service-account token for the runner, probes whether `grafana-pathfinder-app` is already installed, installs it only when missing, and is destroyed after the chain.
+- **Manual hot-pool leasing.** When a Cloud Access Policy token is provided, unsafe cloud chains can lease a pre-provisioned stack labeled `pathfinder-e2e-pool=true` before cold provisioning a new stack. `--cloud-stack-pool-id` narrows the eligible stacks by `pathfinder-e2e-pool-id`. A pool stack is used at most once and is destroyed after use; a future replenisher is expected to create replacements.
 
-Per-chain isolation mirrors how `--clean` resets the local docker stack per chain. Minted tokens carry a TTL, and accounts orphaned by crashed runs are swept on the next run. This isolates per-identity state (preferences, stars, sessions) between chains; it does **not** reset org data such as dashboards or data sources created by guides (that needs ephemeral stacks, a future phase).
+Per-chain isolation mirrors how `--clean` resets the local docker stack per chain. The shared-stack service-account flow isolates per-identity state (preferences, stars, sessions), while ephemeral stacks isolate the whole Grafana Cloud stack for chains that may mutate org-global resources such as dashboards, folders, data sources, or alert rules.
+
+### Cloud side-effect classification
+
+Before running a remote cloud guide, the CLI classifies the fetched `content.json` as:
+
+- `readonly`: instructional content and observational actions such as markdown, quiz, highlight, hover, noop, popout, and ordinary navigation.
+- `possibly_mutating`: actions that may lead to persisted changes, such as generic button clicks, form fills, code insertion, or navigation to creation/configuration routes.
+- `mutating`: strong static evidence of a persisted change, such as selectors or button text containing save, create, delete, remove, update, import, install, or similar state-changing verbs.
+- `unknown`: content that cannot be statically classified, such as unresolved snippet references, terminal blocks, challenges, or invalid guide JSON.
+
+Routing behavior:
+
+- `readonly` cloud chains use the existing shared-stack service-account flow when a matching `--cloud-instance-admin-token` is available.
+- `possibly_mutating`, `mutating`, and `unknown` cloud chains use an isolated stack when stack provisioning or pool flags are present. Pool stacks are tried before cold stack provisioning.
+- If a cloud chain is unsafe and no ephemeral stack config is present, the chain is skipped as `skipped_unsafe_shared_stack` instead of mutating the shared target.
+- If fixed-stack auth is absent but stack provisioning is configured, cloud guides can run on an ephemeral stack even when they are `readonly`.
+
+This classifier is conservative and explainable, not a manifest contract. The external `testEnvironment` schema is unchanged; manifest-level `stateIsolation` or `sideEffects` fields are deferred until the stack path has production signal.
+
+Ephemeral stack prerequisites:
+
+- Terraform must be available on `PATH`.
+- The Cloud Access Policy token needs at least `stacks:read`, `stacks:write`, `stacks:delete`, `stack-service-accounts:write`, `stack-plugins:read`, `stack-plugins:write`, and `stack-plugins:delete`.
+- If Pathfinder is not already pre-provisioned on the stack, the requested Pathfinder plugin version must be published and installable in Grafana Cloud. This path does not test an unpublished local plugin build.
+- Follow-up: install plugins declared by a guide's `testEnvironment.plugins` on ephemeral stacks. Today those plugins are checked by preflight/requirements, but they are not installed automatically.
+- Stack creation consumes hosted-instance quota and is slower than minting a service account on an existing stack.
+
+The CLI tags generated stacks with Pathfinder E2E labels and best-effort sweeps stale labeled stacks matching the configured slug prefix on later runs.
+
+### Manual hot-pool workflow
+
+To avoid waiting for a new stack during every run, prepare one or more Grafana Cloud stacks ahead of time and label them as pool members. Each stack must have Pathfinder installed or pre-provisioned. The CLI discovers pool stacks through the Cloud Access Policy token and mints a short-lived service-account token for the runner.
+
+Required labels:
+
+- `pathfinder-e2e-pool=true`
+- optional `pathfinder-e2e-pool-id=<pool id>`
+- optional `pathfinder-e2e-state=available`
+
+```bash
+export GRAFANA_CLOUD_E2E_TOKEN=glc_xxx
+
+npx pathfinder-cli e2e --remote --tier cloud \
+  --cloud-stack-access-policy-token GRAFANA_CLOUD_E2E_TOKEN
+```
+
+Leased pool stacks are always destroyed after use. This manual pool is process-local. It avoids reusing a stack within one CLI invocation, but it does not coordinate leases across multiple concurrent CLI invocations. A future replenisher service or scheduled job should own durable lease state and automatic replacement.
 
 Interactive SSO/Okta login (driving the identity provider's login UI) is not supported. Path/journey (`milestones`) expansion is also not yet implemented; `path` and `journey` packages are skipped as an unsupported type. See the [Package-Aware Testing](../design/e2e-test-runner-design.md#package-aware-testing) design for the full picture.
 
@@ -423,18 +481,19 @@ Interactive SSO/Okta login (driving the identity provider's login UI) is not sup
 
 In remote modes a package can end in one of these states. Only `validation_failed` counts as a test failure; the rest are logged and the batch continues:
 
-| Outcome                    | Meaning                                                    | Test failure? |
-| -------------------------- | ---------------------------------------------------------- | ------------- |
-| `passed` / `failed`        | The guide ran (see step results)                           | `failed` only |
-| `skipped_tier_mismatch`    | `cloud` guide on a `local` environment                     | No            |
-| `skipped_no_auth`          | `cloud` guide with no matching cloud auth                  | No            |
-| `skipped_invalid_instance` | manifest `instance` is not a bare hostname                 | No            |
-| `resolution_failed`        | Recommender returned 404 or a network error                | No            |
-| `fetch_failed`             | Could not fetch `content.json` from the CDN                | No            |
-| `unsupported_type`         | Package is a `path` / `journey` (milestone expansion TODO) | No            |
-| `validation_failed`        | Fetched `content.json` failed guide schema validation      | **Yes**       |
+| Outcome                       | Meaning                                                                                             | Test failure? |
+| ----------------------------- | --------------------------------------------------------------------------------------------------- | ------------- |
+| `passed` / `failed`           | The guide ran (see step results)                                                                    | `failed` only |
+| `skipped_tier_mismatch`       | `cloud` guide on a `local` environment                                                              | No            |
+| `skipped_no_auth`             | `cloud` guide with no matching cloud auth                                                           | No            |
+| `skipped_invalid_instance`    | manifest `instance` is not a bare hostname                                                          | No            |
+| `skipped_unsafe_shared_stack` | Cloud chain was classified as unsafe for a shared stack and no ephemeral stack config was available | No            |
+| `resolution_failed`           | Recommender returned 404 or a network error                                                         | No            |
+| `fetch_failed`                | Could not fetch `content.json` from the CDN                                                         | No            |
+| `unsupported_type`            | Package is a `path` / `journey` (milestone expansion TODO)                                          | No            |
+| `validation_failed`           | Fetched `content.json` failed guide schema validation                                               | **Yes**       |
 
-With `--output`, pre-run skips are recorded under a `preRunSkipped` array, and each tested guide's report carries package metadata (`packageId`, `tier`, `instance`, `targetUrl`, `sourceUrl`).
+With `--output`, pre-run skips are recorded under a `preRunSkipped` array, and each tested guide's report carries package metadata (`packageId`, `tier`, `instance`, `targetUrl`, `sourceUrl`, `sideEffects`).
 
 ```bash
 # Resolve and test a single published guide against local Grafana
@@ -458,6 +517,19 @@ npx pathfinder-cli e2e --remote --tier cloud \
 export GRAFANA_PLAY_ADMIN_TOKEN=glsa_play_admin_xxx
 npx pathfinder-cli e2e --tier cloud --package play-guide \
   --cloud-instance-admin-token play.grafana.org=GRAFANA_PLAY_ADMIN_TOKEN
+
+# Run unsafe cloud guide chains on ephemeral Grafana Cloud stacks
+export GRAFANA_CLOUD_E2E_TOKEN=glc_xxx
+npx pathfinder-cli e2e --remote --tier cloud \
+  --cloud-stack-access-policy-token GRAFANA_CLOUD_E2E_TOKEN \
+  --cloud-stack-region prod-us-east-0 \
+  --cloud-stack-plugin-version latest
+
+# Run unsafe cloud guide chains on a manual hot pool before cold-provision fallback
+npx pathfinder-cli e2e --remote --tier cloud \
+  --cloud-stack-pool-id pathfinder-e2e-prod-us-east-3 \
+  --cloud-stack-access-policy-token GRAFANA_CLOUD_E2E_TOKEN \
+  --cloud-stack-region prod-us-east-0
 ```
 
 ## Related documentation

--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -48,7 +48,19 @@ import type { ManifestJson, RepositoryEntry, RepositoryJson } from '../../types/
 
 import { randomUUID } from 'crypto';
 import { createCloudAuthPolicy, type CloudAuthPolicy } from '../e2e/cloud-auth';
-import { cloudTargetsInChain, provisionCloudTargetsForChain, sweepCloudTargets } from '../e2e/cloud-provisioning';
+import {
+  cloudTargetsInChain,
+  provisionCloudTargetsForChain,
+  sweepCloudTargets,
+  unsafeCloudGuidesWithoutStack,
+} from '../e2e/cloud-provisioning';
+import {
+  createCloudStackProvisioningConfig,
+  DEFAULT_CLOUD_STACK_SLUG_PREFIX,
+  sweepCloudStacks,
+  type CloudStackProvisioningConfig,
+} from '../e2e/cloud-stack-environment';
+import { CloudStackPool, createCloudStackPoolConfig } from '../e2e/cloud-stack-pool';
 
 /**
  * CLI options for the e2e command
@@ -77,6 +89,16 @@ interface E2ECommandOptions {
   cloudInstanceAdminToken: string[];
   /** Default cloud instance URL for cloud-tier guides without an `instance`. */
   cloudUrl: string;
+  /** Env var containing a Grafana Cloud Access Policy token for ephemeral stack provisioning. */
+  cloudStackAccessPolicyToken?: string;
+  /** Grafana Cloud region used when provisioning ephemeral stacks. */
+  cloudStackRegion?: string;
+  /** Prefix for generated ephemeral stack slugs. */
+  cloudStackSlugPrefix: string;
+  /** Pathfinder plugin version to install on ephemeral stacks. Defaults to latest. */
+  cloudStackPluginVersion?: string;
+  /** Pool id used to discover labeled pre-provisioned Cloud stacks. */
+  cloudStackPoolId?: string;
 }
 
 function collectOption(value: string, previous: string[]): string[] {
@@ -111,6 +133,10 @@ interface RunInputs {
   packageMetaById: Map<string, PackageMeta>;
   /** Cloud credential policy for target resolution and runner auth (remote modes). */
   cloudAuth?: CloudAuthPolicy;
+  /** Optional ephemeral Cloud stack provisioning config for unsafe cloud chains. */
+  cloudStack?: CloudStackProvisioningConfig;
+  /** Optional hot pool of pre-provisioned Cloud stacks. */
+  cloudStackPool?: CloudStackPool;
   /** Local package directory for manifest pre-flight, when applicable. */
   localPackageDir?: string;
 }
@@ -399,12 +425,27 @@ async function maybeCleanStart(cleanEnv: CleanEnvironment, options: E2ECommandOp
  * local runs fall back to the global Grafana URL. Used so reachability checks
  * hit the real targets instead of always probing the global URL.
  */
+function shouldUseEphemeralStackForMeta(
+  meta: PackageMeta,
+  cloudAuth: CloudAuthPolicy | undefined,
+  cloudStack: CloudStackProvisioningConfig | undefined,
+  cloudStackPool: CloudStackPool | undefined
+): boolean {
+  if ((!cloudStack && !cloudStackPool) || meta.tier !== 'cloud') {
+    return false;
+  }
+  return meta.sideEffects?.level !== 'readonly' || !cloudAuth?.needsProvisioningFor(meta.targetUrl);
+}
+
 function targetUrlsToCheck(inputs: RunInputs, globalUrl: string): string[] {
   const urls = new Set<string>();
   for (const meta of inputs.packageMetaById.values()) {
+    if (shouldUseEphemeralStackForMeta(meta, inputs.cloudAuth, inputs.cloudStack, inputs.cloudStackPool)) {
+      continue;
+    }
     urls.add(meta.targetUrl ?? globalUrl);
   }
-  if (urls.size === 0) {
+  if (urls.size === 0 && inputs.packageMetaById.size === 0) {
     urls.add(globalUrl);
   }
   return [...urls];
@@ -526,7 +567,9 @@ async function runChains(
   options: E2ECommandOptions,
   cleanEnv: CleanEnvironment,
   packageMetaById: Map<string, PackageMeta> = new Map(),
-  cloudAuth?: CloudAuthPolicy
+  cloudAuth?: CloudAuthPolicy,
+  cloudStack?: CloudStackProvisioningConfig,
+  cloudStackPool?: CloudStackPool
 ): Promise<ChainRunOutcome> {
   console.log('\n🎭 Running Playwright tests...\n');
 
@@ -547,10 +590,41 @@ async function runChains(
         break;
       }
     }
+    const unsafeSharedStackGuides = unsafeCloudGuidesWithoutStack(chain, packageMetaById, cloudStack, cloudStackPool);
+    if (unsafeSharedStackGuides.length > 0) {
+      const unsafeIds = new Set(unsafeSharedStackGuides.map((guide) => guide.id));
+      const classified = unsafeSharedStackGuides.map((guide) => {
+        const meta = packageMetaById.get(guide.id);
+        return `${guide.id} (${meta?.sideEffects?.level ?? 'unknown'})`;
+      });
+      for (const planned of chain) {
+        const meta = packageMetaById.get(planned.id);
+        results.push({
+          guide: planned.guide.path,
+          id: planned.id,
+          status: 'skipped_unsafe_shared_stack',
+          exitCode: ExitCode.SUCCESS,
+          autoIncluded: planned.autoIncluded,
+          abortMessage: unsafeIds.has(planned.id)
+            ? `Cloud guide classified as ${meta?.sideEffects?.level ?? 'unknown'}; provide --cloud-stack-access-policy-token and --cloud-stack-region to run it in an ephemeral stack.`
+            : `Skipped because this dependency chain contains cloud guide(s) unsafe for a shared stack: ${classified.join(', ')}.`,
+          tier: meta?.tier,
+          sideEffects: meta?.sideEffects,
+        });
+      }
+      console.log(
+        `\n⊘ Skipped chain: cloud guide(s) unsafe for a shared stack (${classified.join(', ')}). Provide --cloud-stack-access-policy-token and --cloud-stack-region to run them in an ephemeral stack.`
+      );
+      continue;
+    }
 
     const provisionedTargets = await provisionCloudTargetsForChain({
       targetUrls: cloudTargetsInChain(chain, packageMetaById, cloudAuth),
       cloudAuth,
+      chain,
+      packageMetaById,
+      cloudStack,
+      cloudStackPool,
       verbose: options.verbose,
     });
     try {
@@ -600,17 +674,22 @@ async function runChains(
         // to the global Grafana URL. Cloud auth policy owns credential selection.
         const meta = packageMetaById.get(planned.id);
         const isCloudTarget = meta?.tier === 'cloud';
-        const runnerAuth = isCloudTarget
-          ? cloudAuth?.runnerAuthFor(meta?.targetUrl, provisionedTargets.tokenFor(meta?.targetUrl))
+        const baseTargetUrl = meta?.targetUrl ?? options.grafanaUrl;
+        const targetUrl = isCloudTarget
+          ? provisionedTargets.targetUrlForGuide(planned.id, baseTargetUrl)
+          : baseTargetUrl;
+        const provisionedToken = isCloudTarget
+          ? provisionedTargets.tokenForGuide(planned.id, baseTargetUrl)
           : undefined;
+        const runnerAuth = isCloudTarget ? (cloudAuth?.runnerAuthFor(targetUrl, provisionedToken) ?? {}) : undefined;
         const runGuideOptions: RunGuideOptions = {
-          targetUrl: meta?.targetUrl ?? options.grafanaUrl,
+          targetUrl,
           verbose: options.verbose,
           trace: options.trace,
           headed: options.headed,
           artifacts: options.artifacts,
           alwaysScreenshot: options.alwaysScreenshot,
-          token: runnerAuth?.token,
+          token: runnerAuth?.token ?? provisionedToken,
         };
 
         const result = await runPlaywrightTests(planned.guide, runGuideOptions);
@@ -701,6 +780,21 @@ function remoteLoadGuideById(
  */
 async function resolveRunInputs(files: string[], options: E2ECommandOptions): Promise<RunInputs> {
   const mode = resolveRunMode(options);
+  const coldStackConfigRequested = Boolean(options.cloudStackRegion || options.cloudStackPluginVersion);
+  const cloudStack = createCloudStackProvisioningConfig({
+    accessPolicyTokenEnvVar: coldStackConfigRequested ? options.cloudStackAccessPolicyToken : undefined,
+    region: options.cloudStackRegion,
+    slugPrefix: options.cloudStackAccessPolicyToken ? options.cloudStackSlugPrefix : undefined,
+    pluginVersion: options.cloudStackPluginVersion,
+  });
+  const cloudStackPoolConfig = createCloudStackPoolConfig({
+    poolId: options.cloudStackPoolId,
+    accessPolicyTokenEnvVar: options.cloudStackAccessPolicyToken,
+    region: options.cloudStackRegion,
+    slugPrefix: options.cloudStackSlugPrefix,
+    verbose: options.verbose,
+  });
+  const cloudStackPool = cloudStackPoolConfig ? new CloudStackPool(cloudStackPoolConfig) : undefined;
 
   if (mode === 'local') {
     return {
@@ -709,6 +803,8 @@ async function resolveRunInputs(files: string[], options: E2ECommandOptions): Pr
       preRunSkipped: [],
       packageMetaById: new Map(),
       localPackageDir: options.package,
+      cloudStack,
+      cloudStackPool,
     };
   }
 
@@ -722,6 +818,7 @@ async function resolveRunInputs(files: string[], options: E2ECommandOptions): Pr
     repoUrl: options.repoUrl,
     cloudUrl: options.cloudUrl,
     cloudAuthTargets: cloudAuth.targets,
+    cloudStackProvisioningAvailable: Boolean(cloudStack || cloudStackPool),
   };
   const resolution =
     mode === 'remote-package'
@@ -749,6 +846,8 @@ async function resolveRunInputs(files: string[], options: E2ECommandOptions): Pr
     preRunSkipped: resolution.skipped.map(skipToResult),
     packageMetaById: buildPackageMetaMap(loadable),
     cloudAuth,
+    cloudStack,
+    cloudStackPool,
   };
 }
 
@@ -804,6 +903,18 @@ export const e2eCommand = new Command('e2e')
     `Default cloud instance URL for cloud-tier guides without an instance (default ${DEFAULT_CLOUD_URL})`,
     DEFAULT_CLOUD_URL
   )
+  .option(
+    '--cloud-stack-access-policy-token <envVar>',
+    'Grafana Cloud Access Policy token env var for provisioning ephemeral Cloud stacks'
+  )
+  .option('--cloud-stack-region <region>', 'Grafana Cloud region for ephemeral Cloud stacks')
+  .option(
+    '--cloud-stack-slug-prefix <prefix>',
+    'Alphanumeric prefix for generated ephemeral Cloud stack slugs',
+    DEFAULT_CLOUD_STACK_SLUG_PREFIX
+  )
+  .option('--cloud-stack-plugin-version <version>', 'Pathfinder plugin version to install on ephemeral Cloud stacks')
+  .option('--cloud-stack-pool-id <id>', 'Pool id used to discover labeled pre-provisioned Cloud stacks')
   .action(async (files: string[], options: E2ECommandOptions) => {
     const cleanEnv = new CleanEnvironment(options.verbose);
 
@@ -835,10 +946,21 @@ export const e2eCommand = new Command('e2e')
         cloudAuth: inputs.cloudAuth,
         verbose: options.verbose,
       });
+      if (inputs.cloudStack) {
+        await sweepCloudStacks({ config: inputs.cloudStack, verbose: options.verbose });
+      }
 
       await runPreflightChecks(options, targetUrlsToCheck(inputs, options.grafanaUrl), inputs.localPackageDir);
 
-      const outcome = await runChains(plan, options, cleanEnv, inputs.packageMetaById, inputs.cloudAuth);
+      const outcome = await runChains(
+        plan,
+        options,
+        cleanEnv,
+        inputs.packageMetaById,
+        inputs.cloudAuth,
+        inputs.cloudStack,
+        inputs.cloudStackPool
+      );
 
       reportResults([...inputs.preRunSkipped, ...outcome.results], options);
     } catch (error) {

--- a/src/cli/e2e/cloud-provisioning.test.ts
+++ b/src/cli/e2e/cloud-provisioning.test.ts
@@ -7,13 +7,27 @@ jest.mock('./cloud-environment', () => ({
     sweepOrphans: jest.fn(async () => undefined),
   })),
 }));
+jest.mock('./cloud-stack-environment', () => ({
+  CloudStackEnvironment: jest.fn().mockImplementation(() => ({
+    provisionChain: jest.fn(async () => ({
+      targetUrl: 'https://ephemeral.grafana.net/',
+      token: 'ephemeral-token',
+      stackSlug: 'pfe2eabc',
+    })),
+    teardownChain: jest.fn(async () => undefined),
+  })),
+}));
 
 import { CloudEnvironment } from './cloud-environment';
+import { CloudStackEnvironment, type CloudStackProvisioningConfig } from './cloud-stack-environment';
+import type { CloudStackPool } from './cloud-stack-pool';
 import {
+  chainNeedsCloudStack,
   cloudTargetsInChain,
   provisionCloudTargetsForChain,
   ProvisionedCloudTargets,
   sweepCloudTargets,
+  unsafeCloudGuidesWithoutStack,
 } from './cloud-provisioning';
 import type { CloudAuthPolicy } from './cloud-auth';
 import type { PackageMeta } from './e2e-results';
@@ -32,6 +46,12 @@ const cloudAuth: CloudAuthPolicy = {
   needsProvisioningFor: (targetUrl) => Boolean(targetUrl?.includes('grafana.')),
   runnerAuthFor: () => ({}),
 };
+const cloudStack: CloudStackProvisioningConfig = {
+  accessPolicyTokenEnvVar: 'GRAFANA_TOKEN',
+  accessPolicyToken: 'token',
+  region: 'us',
+  slugPrefix: 'pfe2e',
+};
 
 describe('cloudTargetsInChain', () => {
   it('deduplicates provisionable targets by URL', () => {
@@ -46,6 +66,42 @@ describe('cloudTargetsInChain', () => {
       'https://play.grafana.org/',
     ]);
   });
+
+  it('leases a hot-pool stack before falling back to cold provisioning', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    const packageMetaById = new Map<string, PackageMeta>([
+      [
+        'mutating',
+        {
+          packageId: 'mutating',
+          tier: 'cloud',
+          targetUrl: 'https://learn.grafana.net/',
+          sideEffects: { level: 'mutating', reasons: [{ level: 'mutating', path: 'blocks[0]', message: 'save' }] },
+        },
+      ],
+    ]);
+    const lease = {
+      provisionChain: () => ({ targetUrl: 'https://pool-a.grafana.net/', token: 'pool-token', stackSlug: 'pool-a' }),
+      teardownChain: jest.fn(async () => undefined),
+    };
+    const pool = { lease: jest.fn(async () => lease) } as unknown as CloudStackPool;
+
+    const provisioned = await provisionCloudTargetsForChain({
+      targetUrls: ['https://learn.grafana.net/'],
+      cloudAuth,
+      chain: [{ id: 'mutating' }],
+      packageMetaById,
+      cloudStack,
+      cloudStackPool: pool,
+      verbose: false,
+    });
+    expect(pool.lease).toHaveBeenCalledWith('https://learn.grafana.net/');
+
+    expect(CloudStackEnvironment).not.toHaveBeenCalled();
+    expect(provisioned.targetUrlForGuide('mutating', 'https://learn.grafana.net/')).toBe('https://pool-a.grafana.net/');
+    expect(provisioned.tokenForGuide('mutating', 'https://learn.grafana.net/')).toBe('pool-token');
+    logSpy.mockRestore();
+  });
 });
 
 describe('ProvisionedCloudTargets', () => {
@@ -56,22 +112,93 @@ describe('ProvisionedCloudTargets', () => {
     const playEnv = { teardownChain: jest.fn(async () => undefined) } as unknown as InstanceType<
       typeof CloudEnvironment
     >;
+    const stackEnv = { teardownChain: jest.fn(async () => undefined) };
     const provisioned = new ProvisionedCloudTargets();
 
     provisioned.add('https://learn.grafana.net/', { env: learnEnv, token: 'learn-token' });
     provisioned.add('https://play.grafana.org/', { env: playEnv, token: 'play-token' });
+    provisioned.addForGuides(['cloud-guide'], {
+      env: stackEnv,
+      token: 'stack-token',
+      targetUrl: 'https://ephemeral.grafana.net/',
+    });
 
     expect(provisioned.tokenFor('https://learn.grafana.net/dashboards')).toBe('learn-token');
     expect(provisioned.tokenFor('https://play.grafana.org/a')).toBe('play-token');
     expect(provisioned.tokenFor('https://other.grafana.net/')).toBeUndefined();
+    expect(provisioned.targetUrlForGuide('cloud-guide', 'https://learn.grafana.net/')).toBe(
+      'https://ephemeral.grafana.net/'
+    );
+    expect(provisioned.tokenForGuide('cloud-guide', 'https://learn.grafana.net/')).toBe('stack-token');
+    expect(provisioned.tokenForGuide('other-guide', 'https://learn.grafana.net/')).toBe('learn-token');
 
     await provisioned.teardownAll();
-
+    expect(stackEnv.teardownChain).toHaveBeenCalledTimes(1);
     expect(learnEnv.teardownChain).toHaveBeenCalledTimes(1);
     expect(playEnv.teardownChain).toHaveBeenCalledTimes(1);
   });
 });
 
+describe('cloud stack routing helpers', () => {
+  const unsafeMeta = new Map<string, PackageMeta>([
+    [
+      'mutating',
+      {
+        packageId: 'mutating',
+        tier: 'cloud',
+        targetUrl: 'https://learn.grafana.net/',
+        sideEffects: { level: 'mutating', reasons: [{ level: 'mutating', path: 'blocks[0]', message: 'save' }] },
+      },
+    ],
+  ]);
+  const readonlyMeta = new Map<string, PackageMeta>([
+    [
+      'readonly',
+      {
+        packageId: 'readonly',
+        tier: 'cloud',
+        targetUrl: 'https://learn.grafana.net/',
+        sideEffects: { level: 'readonly', reasons: [] },
+      },
+    ],
+  ]);
+
+  it('requires a stack for unsafe cloud guides when stack config is present', () => {
+    expect(
+      chainNeedsCloudStack({ chain: [{ id: 'mutating' }], packageMetaById: unsafeMeta, cloudAuth, cloudStack })
+    ).toBe(true);
+  });
+
+  it('requires a stack for readonly cloud guides that lack shared auth', () => {
+    expect(
+      chainNeedsCloudStack({
+        chain: [{ id: 'readonly' }],
+        packageMetaById: readonlyMeta,
+        cloudAuth: undefined,
+        cloudStack,
+      })
+    ).toBe(true);
+  });
+
+  it('does not require a stack for readonly guides with shared auth', () => {
+    expect(
+      chainNeedsCloudStack({ chain: [{ id: 'readonly' }], packageMetaById: readonlyMeta, cloudAuth, cloudStack })
+    ).toBe(false);
+  });
+
+  it('identifies unsafe cloud guides that would pollute a shared stack', () => {
+    expect(unsafeCloudGuidesWithoutStack([{ id: 'mutating' }], unsafeMeta, undefined)).toEqual([{ id: 'mutating' }]);
+    expect(unsafeCloudGuidesWithoutStack([{ id: 'mutating' }], unsafeMeta, cloudStack)).toEqual([]);
+  });
+
+  it('treats missing side-effect metadata on cloud guides as unsafe', () => {
+    const missingMeta = new Map<string, PackageMeta>([
+      ['missing', { packageId: 'missing', tier: 'cloud', targetUrl: 'https://learn.grafana.net/' }],
+    ]);
+
+    expect(unsafeCloudGuidesWithoutStack([{ id: 'missing' }], missingMeta, undefined)).toEqual([{ id: 'missing' }]);
+  });
+});
 describe('provisionCloudTargetsForChain', () => {
   let logSpy: jest.SpyInstance;
   beforeEach(() => {
@@ -94,6 +221,36 @@ describe('provisionCloudTargetsForChain', () => {
     expect(CloudEnvironment).toHaveBeenCalledWith('play-admin', 'https://play.grafana.org/', false);
     expect(provisioned.tokenFor('https://learn.grafana.net/')).toBe('minted:https://learn.grafana.net/');
     expect(provisioned.tokenFor('https://play.grafana.org/')).toBe('minted:https://play.grafana.org/');
+  });
+
+  it('provisions one ephemeral stack for a cloud chain that needs stack isolation', async () => {
+    const packageMetaById = new Map<string, PackageMeta>([
+      [
+        'mutating',
+        {
+          packageId: 'mutating',
+          tier: 'cloud',
+          targetUrl: 'https://learn.grafana.net/',
+          sideEffects: { level: 'mutating', reasons: [{ level: 'mutating', path: 'blocks[0]', message: 'save' }] },
+        },
+      ],
+    ]);
+
+    const provisioned = await provisionCloudTargetsForChain({
+      targetUrls: ['https://learn.grafana.net/'],
+      cloudAuth,
+      chain: [{ id: 'mutating' }],
+      packageMetaById,
+      cloudStack,
+      verbose: false,
+    });
+
+    expect(CloudStackEnvironment).toHaveBeenCalledWith(cloudStack, false);
+    expect(CloudEnvironment).not.toHaveBeenCalled();
+    expect(provisioned.targetUrlForGuide('mutating', 'https://learn.grafana.net/')).toBe(
+      'https://ephemeral.grafana.net/'
+    );
+    expect(provisioned.tokenForGuide('mutating', 'https://learn.grafana.net/')).toBe('ephemeral-token');
   });
 
   it('tears down already-provisioned targets when a later target fails', async () => {

--- a/src/cli/e2e/cloud-provisioning.ts
+++ b/src/cli/e2e/cloud-provisioning.ts
@@ -2,21 +2,42 @@ import { sameOrigin } from './e2e-targets';
 import { CloudEnvironment } from './cloud-environment';
 import type { CloudAuthPolicy } from './cloud-auth';
 import type { PackageMeta } from './e2e-results';
+import { CloudStackEnvironment, type CloudStackProvisioningConfig } from './cloud-stack-environment';
+import type { CloudStackPool } from './cloud-stack-pool';
 
 interface PlannedGuideRef {
   id: string;
 }
 
 interface ProvisionedCloudTarget {
-  env: CloudEnvironment;
+  env: { teardownChain(): Promise<void> };
   token: string;
+  targetUrl?: string;
 }
 
 export class ProvisionedCloudTargets {
   private readonly targets = new Map<string, ProvisionedCloudTarget>();
+  private readonly guideTargets = new Map<string, ProvisionedCloudTarget>();
 
   add(targetUrl: string, provisioned: ProvisionedCloudTarget): void {
     this.targets.set(new URL(targetUrl).origin, provisioned);
+  }
+  addForGuides(guideIds: string[], provisioned: ProvisionedCloudTarget & { targetUrl: string }): void {
+    for (const guideId of guideIds) {
+      this.guideTargets.set(guideId, provisioned);
+    }
+  }
+
+  targetUrlForGuide(guideId: string, fallbackTargetUrl: string): string {
+    return this.guideTargets.get(guideId)?.targetUrl ?? fallbackTargetUrl;
+  }
+
+  tokenForGuide(guideId: string, fallbackTargetUrl: string | undefined): string | undefined {
+    const guideTarget = this.guideTargets.get(guideId);
+    if (guideTarget) {
+      return guideTarget.token;
+    }
+    return this.tokenFor(fallbackTargetUrl);
   }
 
   tokenFor(targetUrl: string | undefined): string | undefined {
@@ -32,10 +53,62 @@ export class ProvisionedCloudTargets {
   }
 
   async teardownAll(): Promise<void> {
+    const tornDown = new Set<ProvisionedCloudTarget>();
+    for (const provisioned of this.guideTargets.values()) {
+      if (!tornDown.has(provisioned)) {
+        tornDown.add(provisioned);
+        await provisioned.env.teardownChain();
+      }
+    }
     for (const { env } of this.targets.values()) {
       await env.teardownChain();
     }
   }
+}
+
+function isCloudGuide(meta: PackageMeta | undefined): boolean {
+  return meta?.tier === 'cloud';
+}
+
+function hasUnsafeSideEffects(meta: PackageMeta | undefined): boolean {
+  const level = meta?.sideEffects?.level;
+  return isCloudGuide(meta) && level !== 'readonly';
+}
+
+function lacksSharedAuth(meta: PackageMeta | undefined, cloudAuth: CloudAuthPolicy | undefined): boolean {
+  return isCloudGuide(meta) && !cloudAuth?.needsProvisioningFor(meta?.targetUrl);
+}
+
+function cloudGuideIds(chain: PlannedGuideRef[], packageMetaById: Map<string, PackageMeta>): string[] {
+  return chain.filter((planned) => isCloudGuide(packageMetaById.get(planned.id))).map((planned) => planned.id);
+}
+
+export function chainNeedsCloudStack(options: {
+  chain: PlannedGuideRef[];
+  packageMetaById: Map<string, PackageMeta>;
+  cloudAuth: CloudAuthPolicy | undefined;
+  cloudStack: CloudStackProvisioningConfig | undefined;
+  cloudStackPool?: CloudStackPool | undefined;
+}): boolean {
+  if (!options.cloudStack && !options.cloudStackPool) {
+    return false;
+  }
+  return options.chain.some((planned) => {
+    const meta = options.packageMetaById.get(planned.id);
+    return hasUnsafeSideEffects(meta) || lacksSharedAuth(meta, options.cloudAuth);
+  });
+}
+
+export function unsafeCloudGuidesWithoutStack(
+  chain: PlannedGuideRef[],
+  packageMetaById: Map<string, PackageMeta>,
+  cloudStack: CloudStackProvisioningConfig | undefined,
+  cloudStackPool?: CloudStackPool | undefined
+): PlannedGuideRef[] {
+  if (cloudStack || cloudStackPool) {
+    return [];
+  }
+  return chain.filter((planned) => hasUnsafeSideEffects(packageMetaById.get(planned.id)));
 }
 
 export function cloudTargetsInChain(
@@ -56,10 +129,50 @@ export function cloudTargetsInChain(
 export async function provisionCloudTargetsForChain(options: {
   targetUrls: string[];
   cloudAuth: CloudAuthPolicy | undefined;
+  chain?: PlannedGuideRef[];
+  packageMetaById?: Map<string, PackageMeta>;
+  cloudStack?: CloudStackProvisioningConfig;
+  cloudStackPool?: CloudStackPool;
   verbose: boolean;
 }): Promise<ProvisionedCloudTargets> {
   const provisionedTargets = new ProvisionedCloudTargets();
   try {
+    if (
+      options.chain &&
+      options.packageMetaById &&
+      chainNeedsCloudStack({
+        chain: options.chain,
+        packageMetaById: options.packageMetaById,
+        cloudAuth: options.cloudAuth,
+        cloudStack: options.cloudStack,
+        cloudStackPool: options.cloudStackPool,
+      })
+    ) {
+      const ids = cloudGuideIds(options.chain, options.packageMetaById);
+      const firstTargetUrl = ids.map((id) => options.packageMetaById?.get(id)?.targetUrl).find(Boolean);
+      const lease = options.cloudStackPool ? await options.cloudStackPool.lease(firstTargetUrl) : undefined;
+      if (lease) {
+        const stack = lease.provisionChain();
+        console.log(`\n☁️  Leased hot-pool Grafana Cloud stack ${stack.stackSlug} for ${ids.length} guide(s)...`);
+        provisionedTargets.addForGuides(ids, {
+          env: { teardownChain: () => lease.teardownChain() },
+          token: stack.token,
+          targetUrl: stack.targetUrl,
+        });
+        return provisionedTargets;
+      }
+      if (!options.cloudStack) {
+        const diagnostics = options.cloudStackPool?.diagnostics();
+        throw new Error(
+          `Cloud stack pool is exhausted and no --cloud-stack-region cold-provision fallback is configured.${diagnostics ? ` ${diagnostics}` : ''}`
+        );
+      }
+      console.log(`\n☁️  Provisioning an ephemeral Grafana Cloud stack for ${ids.length} guide(s)...`);
+      const env = new CloudStackEnvironment(options.cloudStack!, options.verbose);
+      const stack = await env.provisionChain();
+      provisionedTargets.addForGuides(ids, { env, token: stack.token, targetUrl: stack.targetUrl });
+      return provisionedTargets;
+    }
     for (const targetUrl of options.targetUrls) {
       const adminToken = options.cloudAuth?.adminTokenFor(targetUrl);
       if (!adminToken) {

--- a/src/cli/e2e/cloud-stack-environment.test.ts
+++ b/src/cli/e2e/cloud-stack-environment.test.ts
@@ -1,0 +1,263 @@
+import { existsSync, readFileSync } from 'fs';
+
+import {
+  CloudStackEnvironment,
+  createCloudStackProvisioningConfig,
+  sweepCloudStacks,
+  type CommandRunner,
+} from './cloud-stack-environment';
+
+const CONFIG = {
+  accessPolicyTokenEnvVar: 'GRAFANA_CLOUD_ACCESS_POLICY_TOKEN',
+  accessPolicyToken: 'secret-token',
+  region: 'prod-us-east-0',
+  slugPrefix: 'pfe2e',
+  pluginVersion: '1.2.3',
+};
+
+function pluginProbe(status = 200): typeof fetch {
+  return jest.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 404 ? 'Not Found' : 'OK',
+  })) as unknown as typeof fetch;
+}
+
+describe('createCloudStackProvisioningConfig', () => {
+  it('returns undefined when no stack options are present', () => {
+    expect(createCloudStackProvisioningConfig({ env: {} })).toBeUndefined();
+  });
+
+  it('loads the Cloud Access Policy token from an env var without changing manifest schema', () => {
+    expect(
+      createCloudStackProvisioningConfig({
+        accessPolicyTokenEnvVar: 'TOKEN_ENV',
+        region: 'us',
+        slugPrefix: 'pathfinder-e2e',
+        env: { TOKEN_ENV: 'token' },
+      })
+    ).toEqual({
+      accessPolicyTokenEnvVar: 'TOKEN_ENV',
+      accessPolicyToken: 'token',
+      region: 'us',
+      slugPrefix: 'pathfindere2',
+      pluginVersion: undefined,
+    });
+  });
+
+  it('rejects partial or invalid stack config', () => {
+    expect(() => createCloudStackProvisioningConfig({ region: 'us', env: {} })).toThrow(
+      /cloud-stack-access-policy-token/
+    );
+    expect(() =>
+      createCloudStackProvisioningConfig({ accessPolicyTokenEnvVar: 'TOKEN_ENV', region: 'us', env: {} })
+    ).toThrow(/TOKEN_ENV/);
+    expect(() =>
+      createCloudStackProvisioningConfig({ accessPolicyTokenEnvVar: '1_BAD', region: 'us', env: { '1_BAD': 'x' } })
+    ).toThrow(/Invalid/);
+  });
+});
+
+describe('CloudStackEnvironment', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(2_000_000_000_000);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('skips the Terraform plugin resource when Pathfinder is already installed', async () => {
+    const calls: Array<{ args: string[]; cwd: string; token?: string }> = [];
+    let generatedHcl = '';
+    let moduleDir = '';
+    const runner: CommandRunner = async (_command, args, options) => {
+      calls.push({ args, cwd: options.cwd, token: options.env.TF_VAR_cloud_access_policy_token });
+      moduleDir = options.cwd;
+      if (args[0] === 'output') {
+        generatedHcl = readFileSync(`${options.cwd}/main.tf`, 'utf-8');
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            stack_url: { value: 'https://pfe2eabc.grafana.net/' },
+            stack_slug: { value: 'pfe2eabc' },
+            service_account_token: { value: 'glsa_stack' },
+          }),
+          stderr: '',
+        };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const fetchImpl = pluginProbe(200);
+    const env = new CloudStackEnvironment(CONFIG, false, runner, fetchImpl);
+    const provisioned = await env.provisionChain();
+
+    expect(provisioned).toEqual({
+      targetUrl: 'https://pfe2eabc.grafana.net/',
+      stackSlug: 'pfe2eabc',
+      token: 'glsa_stack',
+    });
+    expect(calls.map((call) => call.args[0])).toEqual(['init', 'apply', 'output']);
+    expect(calls.every((call) => call.token === 'secret-token')).toBe(true);
+    expect(generatedHcl).toContain('resource "grafana_cloud_stack" "e2e"');
+    expect(generatedHcl).not.toContain('resource "grafana_cloud_plugin_installation" "pathfinder"');
+    expect(generatedHcl).not.toContain('secret-token');
+    expect(fetchImpl).toHaveBeenCalledWith('https://pfe2eabc.grafana.net/api/plugins/grafana-pathfinder-app/settings', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer glsa_stack',
+        Accept: 'application/json',
+      },
+      signal: expect.any(AbortSignal),
+    });
+
+    await env.teardownChain();
+
+    expect(calls.map((call) => call.args[0])).toEqual(['init', 'apply', 'output', 'destroy']);
+    expect(existsSync(moduleDir)).toBe(false);
+  });
+
+  it('adds the Terraform plugin resource when Pathfinder is missing', async () => {
+    const calls: string[] = [];
+    const generatedHclByOutput: string[] = [];
+    const runner: CommandRunner = async (_command, args, options) => {
+      calls.push(args[0]!);
+      if (args[0] === 'output') {
+        generatedHclByOutput.push(readFileSync(`${options.cwd}/main.tf`, 'utf-8'));
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            stack_url: { value: 'https://pfe2eabc.grafana.net/' },
+            stack_slug: { value: 'pfe2eabc' },
+            service_account_token: { value: 'glsa_stack' },
+          }),
+          stderr: '',
+        };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const env = new CloudStackEnvironment(CONFIG, false, runner, pluginProbe(404));
+    await env.provisionChain();
+
+    expect(calls).toEqual(['init', 'apply', 'output', 'apply', 'output']);
+    expect(generatedHclByOutput[0]).not.toContain('grafana_cloud_plugin_installation');
+    expect(generatedHclByOutput[1]).toContain('resource "grafana_cloud_plugin_installation" "pathfinder"');
+    expect(generatedHclByOutput[1]).toContain('version    = "1.2.3"');
+  });
+
+  it('destroys any partially-created stack when Terraform output parsing fails', async () => {
+    const calls: string[] = [];
+    const runner: CommandRunner = async (_command, args) => {
+      calls.push(args[0]!);
+      if (args[0] === 'output') {
+        return { exitCode: 0, stdout: JSON.stringify({}), stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const env = new CloudStackEnvironment(CONFIG, false, runner, pluginProbe(200));
+
+    await expect(env.provisionChain()).rejects.toThrow(/terraform output/);
+    expect(calls).toEqual(['init', 'apply', 'output', 'destroy']);
+  });
+
+  it('redacts the access token in Terraform errors', async () => {
+    const runner: CommandRunner = async (_command, args) => {
+      if (args[0] === 'apply') {
+        return { exitCode: 1, stdout: '', stderr: 'bad secret-token' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const env = new CloudStackEnvironment(CONFIG, false, runner, pluginProbe(200));
+
+    await expect(env.provisionChain()).rejects.toThrow('bad [redacted]');
+  });
+
+  it('logs and cleans local state when destroy fails', async () => {
+    let moduleDir = '';
+    const runner: CommandRunner = async (_command, args, options) => {
+      moduleDir = options.cwd;
+      if (args[0] === 'destroy') {
+        return { exitCode: 1, stdout: '', stderr: 'nope' };
+      }
+      if (args[0] === 'output') {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            stack_url: { value: 'https://pfe2eabc.grafana.net/' },
+            stack_slug: { value: 'pfe2eabc' },
+            service_account_token: { value: 'glsa_stack' },
+          }),
+          stderr: '',
+        };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const env = new CloudStackEnvironment(CONFIG, false, runner, pluginProbe(200));
+    await env.provisionChain();
+    await env.teardownChain();
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to destroy Cloud stack'));
+    expect(existsSync(moduleDir)).toBe(false);
+  });
+});
+
+describe('sweepCloudStacks', () => {
+  it('deletes only stale Pathfinder stacks matching the configured prefix', async () => {
+    const calls: Array<{ url: string; method: string }> = [];
+    const fetchImpl = jest.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method ?? 'GET' });
+      if ((init?.method ?? 'GET') === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                id: 1,
+                slug: 'pfe2eold',
+                labels: { 'pathfinder-e2e': 'true', 'pathfinder-e2e-created-at': '1000' },
+              },
+              {
+                id: 2,
+                slug: 'pfe2efresh',
+                labels: { 'pathfinder-e2e': 'true', 'pathfinder-e2e-created-at': '1900' },
+              },
+              {
+                id: 3,
+                slug: 'otherold',
+                labels: { 'pathfinder-e2e': 'true', 'pathfinder-e2e-created-at': '1000' },
+              },
+            ],
+          }),
+        } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    }) as unknown as typeof fetch;
+
+    await sweepCloudStacks({ config: CONFIG, verbose: false, nowSeconds: 5_000, fetchImpl });
+
+    expect(calls).toEqual([
+      { url: 'https://grafana.com/api/instances', method: 'GET' },
+      { url: 'https://grafana.com/api/instances/1', method: 'DELETE' },
+    ]);
+  });
+
+  it('does not throw when sweeping fails', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fetchImpl = jest.fn(async () => ({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+    })) as unknown as typeof fetch;
+
+    await expect(sweepCloudStacks({ config: CONFIG, verbose: false, fetchImpl })).resolves.toBeUndefined();
+    warnSpy.mockRestore();
+  });
+});

--- a/src/cli/e2e/cloud-stack-environment.ts
+++ b/src/cli/e2e/cloud-stack-environment.ts
@@ -1,0 +1,394 @@
+import { spawn } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+
+const TERRAFORM_PROVIDER_VERSION = '>= 4.5.3';
+const PLUGIN_ID = 'grafana-pathfinder-app';
+const TOKEN_TTL_SECONDS = 3600;
+const SWEEP_GRACE_SECONDS = 300;
+export const DEFAULT_CLOUD_STACK_SLUG_PREFIX = 'pfe2e';
+
+export interface CloudStackConfigInput {
+  accessPolicyTokenEnvVar?: string;
+  region?: string;
+  slugPrefix?: string;
+  pluginVersion?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface CloudStackProvisioningConfig {
+  accessPolicyTokenEnvVar: string;
+  accessPolicyToken: string;
+  region: string;
+  slugPrefix: string;
+  pluginVersion?: string;
+}
+
+export interface ProvisionedCloudStack {
+  targetUrl: string;
+  token: string;
+  stackSlug: string;
+}
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv }
+) => Promise<CommandResult>;
+
+interface TerraformOutput {
+  stack_url?: { value?: unknown };
+  stack_slug?: { value?: unknown };
+  service_account_token?: { value?: unknown };
+}
+
+interface CloudStackListResponse {
+  items?: Array<{ id?: string | number; slug?: string; labels?: Record<string, string> }>;
+}
+
+export function createCloudStackProvisioningConfig(
+  input: CloudStackConfigInput
+): CloudStackProvisioningConfig | undefined {
+  if (!input.accessPolicyTokenEnvVar && !input.region && !input.pluginVersion) {
+    return undefined;
+  }
+  const env = input.env ?? process.env;
+  const envVar = input.accessPolicyTokenEnvVar;
+  if (!envVar) {
+    throw new Error('--cloud-stack-access-policy-token is required when Cloud stack provisioning options are set.');
+  }
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(envVar)) {
+    throw new Error(`Invalid --cloud-stack-access-policy-token env var "${envVar}".`);
+  }
+  const accessPolicyToken = env[envVar];
+  if (!accessPolicyToken) {
+    throw new Error(`--cloud-stack-access-policy-token references unset or empty environment variable ${envVar}.`);
+  }
+  if (!input.region) {
+    throw new Error('--cloud-stack-region is required when Cloud stack provisioning is enabled.');
+  }
+  const slugPrefix = normalizeSlugPrefix(input.slugPrefix ?? DEFAULT_CLOUD_STACK_SLUG_PREFIX);
+  return {
+    accessPolicyTokenEnvVar: envVar,
+    accessPolicyToken,
+    region: input.region,
+    slugPrefix,
+    pluginVersion: input.pluginVersion,
+  };
+}
+
+function normalizeSlugPrefix(value: string): string {
+  const normalized = value.toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (!/^[a-z][a-z0-9]*$/.test(normalized)) {
+    throw new Error(
+      '--cloud-stack-slug-prefix must contain at least one letter and only alphanumeric characters after normalization.'
+    );
+  }
+  return normalized.slice(0, 12);
+}
+
+function stackSlug(prefix: string): string {
+  const suffix = `${Date.now().toString(36)}${randomUUID().replace(/-/g, '').slice(0, 6)}`;
+  return `${prefix}${suffix}`.slice(0, 29);
+}
+
+function pathfinderPluginResource(config: CloudStackProvisioningConfig): string {
+  const pluginVersion = config.pluginVersion ?? '';
+  return `
+resource "grafana_cloud_plugin_installation" "pathfinder" {
+  provider   = grafana.cloud
+  stack_slug = grafana_cloud_stack.e2e.slug
+  slug       = "${PLUGIN_ID}"
+  version    = "${pluginVersion || 'latest'}"
+}
+`;
+}
+
+function terraformModule(
+  config: CloudStackProvisioningConfig,
+  slug: string,
+  createdAtSeconds: number,
+  installPathfinderPlugin: boolean
+): string {
+  return `terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "${TERRAFORM_PROVIDER_VERSION}"
+    }
+  }
+}
+
+variable "cloud_access_policy_token" {
+  type      = string
+  sensitive = true
+}
+
+provider "grafana" {
+  alias                     = "cloud"
+  cloud_access_policy_token = var.cloud_access_policy_token
+}
+
+resource "grafana_cloud_stack" "e2e" {
+  provider          = grafana.cloud
+  name              = "${slug}"
+  slug              = "${slug}"
+  region_slug       = "${config.region}"
+  delete_protection = false
+  labels = {
+    "pathfinder-e2e"            = "true"
+    "pathfinder-e2e-created-at" = "${createdAtSeconds}"
+    "pathfinder-e2e-run-id"     = "${randomUUID()}"
+  }
+}
+${installPathfinderPlugin ? pathfinderPluginResource(config) : ''}
+
+resource "grafana_cloud_stack_service_account" "e2e" {
+  provider   = grafana.cloud
+  stack_slug = grafana_cloud_stack.e2e.slug
+  name       = "pathfinder-e2e"
+  role       = "Admin"
+}
+
+resource "grafana_cloud_stack_service_account_token" "e2e" {
+  provider           = grafana.cloud
+  stack_slug         = grafana_cloud_stack.e2e.slug
+  name               = "pathfinder-e2e"
+  service_account_id = grafana_cloud_stack_service_account.e2e.id
+  seconds_to_live    = ${TOKEN_TTL_SECONDS}
+}
+
+output "stack_url" {
+  value = grafana_cloud_stack.e2e.url
+}
+
+output "stack_slug" {
+  value = grafana_cloud_stack.e2e.slug
+}
+
+output "service_account_token" {
+  value     = grafana_cloud_stack_service_account_token.e2e.key
+  sensitive = true
+}
+`;
+}
+
+async function defaultCommandRunner(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv }
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd: options.cwd, env: options.env, shell: false });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+function redact(text: string, secrets: string[]): string {
+  return secrets.reduce((current, secret) => (secret ? current.split(secret).join('[redacted]') : current), text);
+}
+
+function assertTerraformSuccess(result: CommandResult, action: string, secrets: string[]): void {
+  if (result.exitCode === 0) {
+    return;
+  }
+  const detail = redact(result.stderr || result.stdout || `exit ${result.exitCode}`, secrets);
+  throw new Error(`terraform ${action} failed: ${detail}`);
+}
+
+function terraformEnv(config: CloudStackProvisioningConfig): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    TF_IN_AUTOMATION: '1',
+    TF_VAR_cloud_access_policy_token: config.accessPolicyToken,
+  };
+}
+
+function parseTerraformOutput(text: string): ProvisionedCloudStack {
+  const parsed = JSON.parse(text) as TerraformOutput;
+  const targetUrl = parsed.stack_url?.value;
+  const token = parsed.service_account_token?.value;
+  const stackSlugValue = parsed.stack_slug?.value;
+  if (typeof targetUrl !== 'string' || typeof token !== 'string' || typeof stackSlugValue !== 'string') {
+    throw new Error('terraform output did not include stack_url, stack_slug, and service_account_token string values.');
+  }
+  return { targetUrl, token, stackSlug: stackSlugValue };
+}
+
+export class CloudStackEnvironment {
+  private moduleDir: string | null = null;
+  private currentStackSlug: string | null = null;
+
+  constructor(
+    private readonly config: CloudStackProvisioningConfig,
+    private readonly verbose: boolean,
+    private readonly runner: CommandRunner = defaultCommandRunner,
+    private readonly fetchImpl: typeof fetch = fetch
+  ) {}
+
+  async provisionChain(): Promise<ProvisionedCloudStack> {
+    const slug = stackSlug(this.config.slugPrefix);
+    const moduleDir = mkdtempSync(join(tmpdir(), 'pathfinder-e2e-stack-'));
+    this.moduleDir = moduleDir;
+    this.currentStackSlug = slug;
+    const createdAtSeconds = Math.floor(Date.now() / 1000);
+    const modulePath = join(moduleDir, 'main.tf');
+    writeFileSync(modulePath, terraformModule(this.config, slug, createdAtSeconds, false));
+
+    try {
+      await this.runTerraform(['init', '-input=false', '-no-color'], 'init');
+      await this.runTerraform(['apply', '-input=false', '-auto-approve', '-no-color'], 'apply');
+      const output = await this.runTerraform(['output', '-json', '-no-color'], 'output');
+      let provisioned = parseTerraformOutput(output.stdout);
+      const pathfinderAlreadyInstalled = await this.isPathfinderPluginInstalled(provisioned);
+      if (!pathfinderAlreadyInstalled) {
+        writeFileSync(modulePath, terraformModule(this.config, slug, createdAtSeconds, true));
+        await this.runTerraform(['apply', '-input=false', '-auto-approve', '-no-color'], 'apply');
+        const updatedOutput = await this.runTerraform(['output', '-json', '-no-color'], 'output');
+        provisioned = parseTerraformOutput(updatedOutput.stdout);
+      } else if (this.verbose) {
+        console.log(`   ☁️  Pathfinder plugin already installed on ${provisioned.stackSlug}; skipping plugin install`);
+      }
+      if (this.verbose) {
+        console.log(`   ☁️  Provisioned Cloud stack ${provisioned.stackSlug} (${provisioned.targetUrl})`);
+      }
+      return provisioned;
+    } catch (err) {
+      await this.teardownChain();
+      throw err;
+    }
+  }
+
+  async teardownChain(): Promise<void> {
+    const moduleDir = this.moduleDir;
+    if (!moduleDir) {
+      return;
+    }
+    try {
+      await this.runTerraform(['destroy', '-input=false', '-auto-approve', '-no-color'], 'destroy');
+      if (this.verbose && this.currentStackSlug) {
+        console.log(`   🧹 Destroyed Cloud stack ${this.currentStackSlug}`);
+      }
+    } catch (err) {
+      const slug = this.currentStackSlug ?? 'unknown';
+      console.warn(
+        `   ⚠ Failed to destroy Cloud stack ${slug}: ${err instanceof Error ? err.message : 'Unknown error'}`
+      );
+    } finally {
+      rmSync(moduleDir, { recursive: true, force: true });
+      this.moduleDir = null;
+      this.currentStackSlug = null;
+    }
+  }
+
+  async teardownAll(): Promise<void> {
+    await this.teardownChain();
+  }
+
+  private async runTerraform(args: string[], action: string): Promise<CommandResult> {
+    if (!this.moduleDir) {
+      throw new Error('Terraform module directory has not been initialized.');
+    }
+    const result = await this.runner('terraform', args, {
+      cwd: this.moduleDir,
+      env: terraformEnv(this.config),
+    });
+    assertTerraformSuccess(result, action, [this.config.accessPolicyToken]);
+    return result;
+  }
+
+  private async isPathfinderPluginInstalled(stack: ProvisionedCloudStack): Promise<boolean> {
+    const url = new URL(`/api/plugins/${PLUGIN_ID}/settings`, stack.targetUrl).toString();
+    const response = await this.fetchImpl(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${stack.token}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (response.ok) {
+      return true;
+    }
+    if (response.status === 404) {
+      return false;
+    }
+    throw new Error(`Pathfinder plugin probe failed: HTTP ${response.status} ${response.statusText}`);
+  }
+}
+
+export async function sweepCloudStacks(options: {
+  config: CloudStackProvisioningConfig;
+  verbose: boolean;
+  nowSeconds?: number;
+  fetchImpl?: typeof fetch;
+}): Promise<void> {
+  const now = options.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  try {
+    const response = await fetchImpl('https://grafana.com/api/instances', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${options.config.accessPolicyToken}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+    const data = (await response.json()) as CloudStackListResponse;
+    const stale = (data.items ?? []).filter((item) => {
+      const createdAt = Number(item.labels?.['pathfinder-e2e-created-at']);
+      return (
+        item.labels?.['pathfinder-e2e'] === 'true' &&
+        typeof item.slug === 'string' &&
+        item.slug.startsWith(options.config.slugPrefix) &&
+        Number.isFinite(createdAt) &&
+        now - createdAt > TOKEN_TTL_SECONDS + SWEEP_GRACE_SECONDS
+      );
+    });
+    for (const stack of stale) {
+      const id = stack.id ?? stack.slug;
+      if (id === undefined) {
+        continue;
+      }
+      try {
+        await fetchImpl(`https://grafana.com/api/instances/${encodeURIComponent(String(id))}`, {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${options.config.accessPolicyToken}`,
+            Accept: 'application/json',
+          },
+          signal: AbortSignal.timeout(15_000),
+        });
+      } catch {
+        // Best effort.
+      }
+    }
+    if (options.verbose && stale.length > 0) {
+      console.log(`   🧹 Swept ${stale.length} stale Cloud stack(s)`);
+    }
+  } catch (err) {
+    console.warn(`   ⚠ Could not sweep stale Cloud stacks: ${err instanceof Error ? err.message : 'Unknown error'}`);
+  }
+}

--- a/src/cli/e2e/cloud-stack-pool-create.ts
+++ b/src/cli/e2e/cloud-stack-pool-create.ts
@@ -1,0 +1,145 @@
+import { spawn } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+
+import type { CommandResult, CommandRunner } from './cloud-stack-environment';
+
+const TERRAFORM_PROVIDER_VERSION = '>= 4.5.3';
+const DEFAULT_SLUG_PREFIX = 'pfe2epool';
+
+export interface CreateCloudStackPoolStackOptions {
+  accessPolicyToken: string;
+  region: string;
+  poolId?: string;
+  slugPrefix?: string;
+  verbose?: boolean;
+  runner?: CommandRunner;
+}
+
+async function defaultCommandRunner(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv }
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd: options.cwd, env: options.env, shell: false });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+function terraformEnv(accessPolicyToken: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    TF_IN_AUTOMATION: '1',
+    TF_VAR_cloud_access_policy_token: accessPolicyToken,
+  };
+}
+
+function redact(text: string, secret: string): string {
+  return secret ? text.split(secret).join('[redacted]') : text;
+}
+
+function assertCommandSuccess(result: CommandResult, action: string, accessPolicyToken: string): void {
+  if (result.exitCode === 0) {
+    return;
+  }
+  const detail = redact(result.stderr || result.stdout || `exit ${result.exitCode}`, accessPolicyToken);
+  throw new Error(`terraform ${action} failed: ${detail}`);
+}
+
+function normalizeSlugPrefix(value: string): string {
+  const normalized = value.toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (!/^[a-z][a-z0-9]*$/.test(normalized)) {
+    throw new Error(
+      '--slug-prefix must contain at least one letter and only alphanumeric characters after normalization.'
+    );
+  }
+  return normalized.slice(0, 12);
+}
+
+function generatedSlug(prefix: string): string {
+  const suffix = `${Date.now().toString(36)}${randomUUID().replace(/-/g, '').slice(0, 6)}`;
+  return `${prefix}${suffix}`.slice(0, 29);
+}
+
+function poolStackLabels(poolId: string | undefined, createdAtSeconds: number): Record<string, string> {
+  return {
+    'pathfinder-e2e-pool': 'true',
+    ...(poolId ? { 'pathfinder-e2e-pool-id': poolId } : {}),
+    'pathfinder-e2e-state': 'available',
+    'pathfinder-e2e-created-at': String(createdAtSeconds),
+  };
+}
+
+function hclStringMap(value: Record<string, string>): string {
+  return Object.entries(value)
+    .map(([key, mapValue]) => `    "${key}" = "${mapValue}"`)
+    .join('\n');
+}
+
+function poolStackModule(options: CreateCloudStackPoolStackOptions, slug: string): string {
+  const labels = poolStackLabels(options.poolId, Math.floor(Date.now() / 1000));
+  return `terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "${TERRAFORM_PROVIDER_VERSION}"
+    }
+  }
+}
+
+variable "cloud_access_policy_token" {
+  type      = string
+  sensitive = true
+}
+
+provider "grafana" {
+  alias                     = "cloud"
+  cloud_access_policy_token = var.cloud_access_policy_token
+}
+
+resource "grafana_cloud_stack" "pool" {
+  provider          = grafana.cloud
+  name              = "${slug}"
+  slug              = "${slug}"
+  region_slug       = "${options.region}"
+  delete_protection = false
+  labels = {
+${hclStringMap(labels)}
+  }
+}
+`;
+}
+
+export async function createCloudStackPoolStack(options: CreateCloudStackPoolStackOptions): Promise<string> {
+  const runner = options.runner ?? defaultCommandRunner;
+  const slug = generatedSlug(normalizeSlugPrefix(options.slugPrefix ?? DEFAULT_SLUG_PREFIX));
+  const moduleDir = mkdtempSync(join(tmpdir(), 'pathfinder-e2e-pool-maintain-'));
+  try {
+    writeFileSync(join(moduleDir, 'main.tf'), poolStackModule(options, slug));
+    const env = terraformEnv(options.accessPolicyToken);
+    for (const args of [
+      ['init', '-input=false', '-no-color'],
+      ['apply', '-input=false', '-auto-approve', '-no-color'],
+    ]) {
+      const result = await runner('terraform', args, { cwd: moduleDir, env });
+      assertCommandSuccess(result, args[0]!, options.accessPolicyToken);
+    }
+    return slug;
+  } finally {
+    rmSync(moduleDir, { recursive: true, force: true });
+  }
+}

--- a/src/cli/e2e/cloud-stack-pool.test.ts
+++ b/src/cli/e2e/cloud-stack-pool.test.ts
@@ -1,0 +1,216 @@
+import { existsSync, readFileSync } from 'fs';
+
+import { CloudStackPool, CloudStackPoolLease, createCloudStackPoolConfig } from './cloud-stack-pool';
+import type { CommandRunner } from './cloud-stack-environment';
+
+const CONFIG = {
+  poolId: 'pool-1',
+  accessPolicyToken: 'cloud-access-policy',
+  region: 'prod-us-east-3',
+};
+
+function stackListFetch(items: unknown[]): typeof fetch {
+  return jest.fn(async () => ({ ok: true, json: async () => ({ items }) })) as unknown as typeof fetch;
+}
+
+describe('createCloudStackPoolConfig', () => {
+  it('returns undefined when no pool token is configured', () => {
+    expect(createCloudStackPoolConfig({ env: {} })).toBeUndefined();
+  });
+
+  it('loads a default pool config from only a Cloud Access Policy token env var', () => {
+    expect(
+      createCloudStackPoolConfig({
+        accessPolicyTokenEnvVar: 'CLOUD_TOKEN',
+        env: { CLOUD_TOKEN: 'token' },
+      })
+    ).toEqual({ accessPolicyToken: 'token', verbose: undefined });
+  });
+
+  it('loads pool config from a Cloud Access Policy token env var', () => {
+    expect(
+      createCloudStackPoolConfig({
+        poolId: 'pool-1',
+        accessPolicyTokenEnvVar: 'CLOUD_TOKEN',
+        env: { CLOUD_TOKEN: 'token' },
+      })
+    ).toEqual({ poolId: 'pool-1', accessPolicyToken: 'token', verbose: undefined });
+  });
+
+  it('requires a valid Cloud Access Policy token env var when pool id is set', () => {
+    expect(() => createCloudStackPoolConfig({ poolId: 'pool-1', env: {} })).toThrow(/Cloud stack pool/);
+    expect(() =>
+      createCloudStackPoolConfig({ poolId: 'pool-1', accessPolicyTokenEnvVar: 'TOKEN_ENV', env: {} })
+    ).toThrow(/TOKEN_ENV/);
+  });
+});
+
+describe('CloudStackPool', () => {
+  it('leases any pool stack when no pool id is configured', async () => {
+    const runner: CommandRunner = async (_command, args) =>
+      args[0] === 'output'
+        ? { exitCode: 0, stdout: JSON.stringify({ service_account_token: { value: 'runner-token' } }), stderr: '' }
+        : { exitCode: 0, stdout: '', stderr: '' };
+    const fetchImpl = stackListFetch([
+      { slug: 'pool-a', labels: { 'pathfinder-e2e-pool': 'true', 'pathfinder-e2e-pool-id': 'other' } },
+    ]);
+    const pool = new CloudStackPool({ accessPolicyToken: 'cloud-access-policy' }, runner, fetchImpl);
+
+    const lease = await pool.lease(undefined);
+
+    expect(lease?.provisionChain().stackSlug).toBe('pool-a');
+  });
+
+  it('hydrates missing labels from stack detail responses before filtering', async () => {
+    const runner: CommandRunner = async (_command, args) =>
+      args[0] === 'output'
+        ? { exitCode: 0, stdout: JSON.stringify({ service_account_token: { value: 'runner-token' } }), stderr: '' }
+        : { exitCode: 0, stdout: '', stderr: '' };
+    const fetchImpl = jest.fn(async (url: string) => {
+      if (url === 'https://grafana.com/api/instances') {
+        return { ok: true, json: async () => ({ items: [{ slug: 'pool-a' }] }) } as Response;
+      }
+      if (url === 'https://grafana.com/api/instances/pool-a') {
+        return {
+          ok: true,
+          json: async () => ({
+            slug: 'pool-a',
+            labels: { 'pathfinder-e2e-pool': 'true' },
+          }),
+        } as Response;
+      }
+      return { ok: false } as Response;
+    }) as unknown as typeof fetch;
+    const pool = new CloudStackPool({ accessPolicyToken: 'cloud-access-policy' }, runner, fetchImpl);
+
+    const lease = await pool.lease(undefined);
+
+    expect(lease?.provisionChain().stackSlug).toBe('pool-a');
+    expect(pool.diagnostics()).toContain('1 had pathfinder-e2e-pool=true');
+  });
+
+  it('records diagnostics when no pool stack can be leased', async () => {
+    const fetchImpl = stackListFetch([
+      { slug: 'not-pool', labels: {} },
+      { slug: 'leased', labels: { 'pathfinder-e2e-pool': 'true', 'pathfinder-e2e-state': 'leased' } },
+    ]);
+    const pool = new CloudStackPool({ accessPolicyToken: 'cloud-access-policy' }, jest.fn(), fetchImpl);
+
+    expect(await pool.lease(undefined)).toBeUndefined();
+    expect(pool.diagnostics()).toBe(
+      'listed 2 stack(s); 1 had pathfinder-e2e-pool=true; 1 matched pool id any; 0 were available.'
+    );
+  });
+  it('discovers labeled available stacks, mints a runner token, and leases once', async () => {
+    const calls: Array<{ args: string[]; cwd: string; token?: string }> = [];
+    let generatedHcl = '';
+    const runner: CommandRunner = async (_command, args, options) => {
+      calls.push({ args, cwd: options.cwd, token: options.env.TF_VAR_cloud_access_policy_token });
+      if (args[0] === 'output') {
+        generatedHcl = readFileSync(`${options.cwd}/main.tf`, 'utf-8');
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ service_account_token: { value: 'runner-token' } }),
+          stderr: '',
+        };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+    const fetchImpl = stackListFetch([
+      {
+        slug: 'pool-a',
+        labels: {
+          'pathfinder-e2e-pool': 'true',
+          'pathfinder-e2e-pool-id': 'pool-1',
+          'pathfinder-e2e-state': 'available',
+        },
+      },
+      {
+        slug: 'other',
+        labels: { 'pathfinder-e2e-pool': 'true', 'pathfinder-e2e-pool-id': 'other' },
+      },
+    ]);
+    const pool = new CloudStackPool(CONFIG, runner, fetchImpl);
+
+    const lease = await pool.lease(undefined);
+
+    expect(lease?.provisionChain()).toEqual({
+      targetUrl: 'https://pool-a.grafana.net/',
+      token: 'runner-token',
+      stackSlug: 'pool-a',
+    });
+    expect(calls.map((call) => call.args[0])).toEqual(['init', 'apply', 'output']);
+    expect(calls.every((call) => call.token === 'cloud-access-policy')).toBe(true);
+    expect(generatedHcl).toContain('stack_slug = "pool-a"');
+
+    await lease?.teardownChain();
+
+    expect(calls.map((call) => call.args[0])).toEqual(['init', 'apply', 'output', 'destroy', 'init', 'apply']);
+    expect(existsSync(calls[0]!.cwd)).toBe(false);
+    expect(await pool.lease(undefined)).toBeUndefined();
+  });
+
+  it('prefers a pool stack matching the requested origin', async () => {
+    const runner: CommandRunner = async (_command, args) =>
+      args[0] === 'output'
+        ? { exitCode: 0, stdout: JSON.stringify({ service_account_token: { value: 'runner-token' } }), stderr: '' }
+        : { exitCode: 0, stdout: '', stderr: '' };
+    const fetchImpl = stackListFetch([
+      { slug: 'pool-a', labels: { 'pathfinder-e2e-pool': 'true', 'pathfinder-e2e-pool-id': 'pool-1' } },
+      { slug: 'pool-b', labels: { 'pathfinder-e2e-pool': 'true', 'pathfinder-e2e-pool-id': 'pool-1' } },
+    ]);
+    const pool = new CloudStackPool(CONFIG, runner, fetchImpl);
+
+    const lease = await pool.lease('https://pool-b.grafana.net/');
+
+    expect(lease?.provisionChain().stackSlug).toBe('pool-b');
+  });
+
+  it('returns undefined when no matching available stacks exist', async () => {
+    const fetchImpl = stackListFetch([
+      {
+        slug: 'leased',
+        labels: {
+          'pathfinder-e2e-pool': 'true',
+          'pathfinder-e2e-pool-id': 'pool-1',
+          'pathfinder-e2e-state': 'leased',
+        },
+      },
+      { slug: 'other', labels: { 'pathfinder-e2e-pool': 'true', 'pathfinder-e2e-pool-id': 'other' } },
+    ]);
+    const pool = new CloudStackPool(CONFIG, jest.fn(), fetchImpl);
+
+    expect(await pool.lease(undefined)).toBeUndefined();
+  });
+});
+
+describe('CloudStackPoolLease', () => {
+  it('deletes the leased stack by default', async () => {
+    const calls: Array<{ url: string; method: string; auth: string | undefined }> = [];
+    const runner: CommandRunner = jest.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' }));
+    const fetchImpl = jest.fn(async (url: string, init?: RequestInit) => {
+      const headers = init?.headers as Record<string, string> | undefined;
+      calls.push({ url, method: init?.method ?? 'GET', auth: headers?.Authorization });
+      return { ok: true } as Response;
+    }) as unknown as typeof fetch;
+    const lease = new CloudStackPoolLease(
+      { targetUrl: 'https://pool-a.grafana.net/', token: 'runner-token', stackSlug: 'pool-a' },
+      '/tmp/not-used',
+      'cloud-access-policy',
+      { region: 'prod-us-east-3' },
+      runner,
+      fetchImpl
+    );
+
+    await lease.teardownChain();
+
+    expect(calls).toEqual([
+      {
+        url: 'https://grafana.com/api/instances/pool-a',
+        method: 'DELETE',
+        auth: 'Bearer cloud-access-policy',
+      },
+    ]);
+    expect((runner as jest.Mock).mock.calls.map((call) => call[1][0])).toEqual(['destroy', 'init', 'apply']);
+  });
+});

--- a/src/cli/e2e/cloud-stack-pool.ts
+++ b/src/cli/e2e/cloud-stack-pool.ts
@@ -1,0 +1,407 @@
+import { spawn } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+
+import { sameOrigin } from './e2e-targets';
+import type { CommandResult, CommandRunner, ProvisionedCloudStack } from './cloud-stack-environment';
+import { createCloudStackPoolStack } from './cloud-stack-pool-create';
+
+const TOKEN_TTL_SECONDS = 3600;
+const TERRAFORM_PROVIDER_VERSION = '>= 4.5.3';
+
+export interface CloudStackPoolConfigInput {
+  poolId?: string;
+  accessPolicyTokenEnvVar?: string;
+  region?: string;
+  slugPrefix?: string;
+  verbose?: boolean;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface CloudStackPoolConfig {
+  poolId?: string;
+  accessPolicyToken: string;
+  region?: string;
+  slugPrefix?: string;
+  verbose?: boolean;
+}
+
+interface CloudStackListResponse {
+  items?: CloudStackListItem[];
+}
+
+interface CloudStackListItem {
+  id?: string | number;
+  slug?: string;
+  url?: string;
+  region?: string;
+  regionSlug?: string;
+  labels?: Record<string, string>;
+}
+
+interface TerraformOutput {
+  service_account_token?: { value?: unknown };
+}
+
+export function createCloudStackPoolConfig(input: CloudStackPoolConfigInput): CloudStackPoolConfig | undefined {
+  if (!input.poolId && !input.accessPolicyTokenEnvVar) {
+    return undefined;
+  }
+  const accessPolicyToken = parseAccessPolicyToken(input.accessPolicyTokenEnvVar, input.env ?? process.env);
+  return {
+    poolId: input.poolId,
+    accessPolicyToken,
+    region: input.region,
+    slugPrefix: input.slugPrefix,
+    verbose: input.verbose,
+  };
+}
+
+function parseAccessPolicyToken(envVar: string | undefined, env: NodeJS.ProcessEnv): string {
+  if (!envVar) {
+    throw new Error('--cloud-stack-access-policy-token is required to use a Cloud stack pool.');
+  }
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(envVar)) {
+    throw new Error(`Invalid --cloud-stack-access-policy-token env var "${envVar}".`);
+  }
+  const token = env[envVar];
+  if (!token) {
+    throw new Error(`--cloud-stack-access-policy-token references unset or empty environment variable ${envVar}.`);
+  }
+  return token;
+}
+
+async function defaultCommandRunner(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv }
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd: options.cwd, env: options.env, shell: false });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+function runnerEnv(accessPolicyToken: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    TF_IN_AUTOMATION: '1',
+    TF_VAR_cloud_access_policy_token: accessPolicyToken,
+  };
+}
+
+function tokenModule(stackSlug: string): string {
+  const name = `pathfinder-e2e-${randomUUID().slice(0, 8)}`;
+  return `terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "${TERRAFORM_PROVIDER_VERSION}"
+    }
+  }
+}
+
+variable "cloud_access_policy_token" {
+  type      = string
+  sensitive = true
+}
+
+provider "grafana" {
+  alias                     = "cloud"
+  cloud_access_policy_token = var.cloud_access_policy_token
+}
+
+resource "grafana_cloud_stack_service_account" "runner" {
+  provider   = grafana.cloud
+  stack_slug = "${stackSlug}"
+  name       = "${name}"
+  role       = "Admin"
+}
+
+resource "grafana_cloud_stack_service_account_token" "runner" {
+  provider           = grafana.cloud
+  stack_slug         = "${stackSlug}"
+  name               = "${name}"
+  service_account_id = grafana_cloud_stack_service_account.runner.id
+  seconds_to_live    = ${TOKEN_TTL_SECONDS}
+}
+
+output "service_account_token" {
+  value     = grafana_cloud_stack_service_account_token.runner.key
+  sensitive = true
+}
+`;
+}
+
+function stackUrl(stack: CloudStackListItem): string | undefined {
+  if (stack.url) {
+    return new URL('/', stack.url).toString();
+  }
+  if (stack.slug) {
+    return `https://${stack.slug}.grafana.net/`;
+  }
+  return undefined;
+}
+
+function isAvailablePoolStack(stack: CloudStackListItem, poolId: string | undefined): boolean {
+  const labels = stack.labels ?? {};
+  const state = labels['pathfinder-e2e-state'];
+  return (
+    labels['pathfinder-e2e-pool'] === 'true' &&
+    (poolId === undefined || labels['pathfinder-e2e-pool-id'] === poolId) &&
+    (!state || state === 'available') &&
+    typeof stack.slug === 'string'
+  );
+}
+
+function redact(text: string, secret: string): string {
+  return secret ? text.split(secret).join('[redacted]') : text;
+}
+
+function assertCommandSuccess(result: CommandResult, action: string, accessPolicyToken: string): void {
+  if (result.exitCode === 0) {
+    return;
+  }
+  const detail = redact(result.stderr || result.stdout || `exit ${result.exitCode}`, accessPolicyToken);
+  throw new Error(`terraform ${action} failed: ${detail}`);
+}
+
+function parseTokenOutput(text: string): string {
+  const parsed = JSON.parse(text) as TerraformOutput;
+  const token = parsed.service_account_token?.value;
+  if (typeof token !== 'string') {
+    throw new Error('terraform output did not include service_account_token string value.');
+  }
+  return token;
+}
+
+interface LeasablePoolStack {
+  targetUrl: string;
+  stackSlug: string;
+  region?: string;
+}
+
+export class CloudStackPool {
+  private readonly leasedSlugs = new Set<string>();
+  private lastDiagnostics: string | undefined;
+
+  constructor(
+    private readonly config: CloudStackPoolConfig,
+    private readonly runner: CommandRunner = defaultCommandRunner,
+    private readonly fetchImpl?: typeof fetch
+  ) {}
+
+  async lease(targetUrl: string | undefined): Promise<CloudStackPoolLease | undefined> {
+    const candidates = await this.availableStacks();
+    const matchingIndex = targetUrl
+      ? candidates.findIndex((candidate) => sameOrigin(candidate.targetUrl, targetUrl))
+      : -1;
+    const target = candidates[matchingIndex >= 0 ? matchingIndex : 0];
+    if (!target) {
+      return undefined;
+    }
+    this.leasedSlugs.add(target.stackSlug);
+    const moduleDir = mkdtempSync(join(tmpdir(), 'pathfinder-e2e-pool-'));
+    writeFileSync(join(moduleDir, 'main.tf'), tokenModule(target.stackSlug));
+    const env = runnerEnv(this.config.accessPolicyToken);
+
+    try {
+      await this.runTerraform(moduleDir, ['init', '-input=false', '-no-color'], 'init', env);
+      await this.runTerraform(moduleDir, ['apply', '-input=false', '-auto-approve', '-no-color'], 'apply', env);
+      const output = await this.runTerraform(moduleDir, ['output', '-json', '-no-color'], 'output', env);
+      const token = parseTokenOutput(output.stdout);
+      return new CloudStackPoolLease(
+        { ...target, token },
+        moduleDir,
+        this.config.accessPolicyToken,
+        {
+          region: target.region ?? this.config.region,
+          poolId: this.config.poolId,
+          slugPrefix: this.config.slugPrefix,
+          verbose: this.config.verbose,
+        },
+        this.runner,
+        this.fetchImpl
+      );
+    } catch (err) {
+      rmSync(moduleDir, { recursive: true, force: true });
+      this.leasedSlugs.delete(target.stackSlug);
+      throw err;
+    }
+  }
+
+  diagnostics(): string | undefined {
+    return this.lastDiagnostics;
+  }
+
+  private async availableStacks(): Promise<LeasablePoolStack[]> {
+    const fetchImpl = this.fetchImpl ?? fetch;
+    const headers = {
+      Authorization: `Bearer ${this.config.accessPolicyToken}`,
+      Accept: 'application/json',
+    };
+    const response = await fetchImpl('https://grafana.com/api/instances', {
+      method: 'GET',
+      headers,
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) {
+      const poolLabel = this.config.poolId ?? 'default';
+      throw new Error(`Could not list Cloud stack pool "${poolLabel}": HTTP ${response.status} ${response.statusText}`);
+    }
+    const data = (await response.json()) as CloudStackListResponse;
+    const items = await hydrateStackDetails(data.items ?? [], headers, fetchImpl);
+    const poolStacks = items.filter((stack) => stack.labels?.['pathfinder-e2e-pool'] === 'true');
+    const poolLabel = this.config.poolId ?? 'any';
+    const matchingPoolId = poolStacks.filter((stack) =>
+      this.config.poolId === undefined ? true : stack.labels?.['pathfinder-e2e-pool-id'] === this.config.poolId
+    );
+    const available = matchingPoolId.filter((stack) => {
+      const state = stack.labels?.['pathfinder-e2e-state'];
+      return !state || state === 'available';
+    });
+    this.lastDiagnostics = `listed ${items.length} stack(s); ${poolStacks.length} had pathfinder-e2e-pool=true; ${matchingPoolId.length} matched pool id ${poolLabel}; ${available.length} were available.`;
+    if (this.config.verbose) {
+      console.log(`   ☁️  Cloud stack pool: ${this.lastDiagnostics}`);
+    }
+    return items
+      .filter((stack) => isAvailablePoolStack(stack, this.config.poolId))
+      .filter((stack) => !this.leasedSlugs.has(stack.slug!))
+      .flatMap((stack) => {
+        const targetUrl = stackUrl(stack);
+        const region = stack.regionSlug ?? stack.region;
+        return targetUrl && stack.slug ? [{ targetUrl, stackSlug: stack.slug, region }] : [];
+      });
+  }
+
+  private async runTerraform(
+    cwd: string,
+    args: string[],
+    action: string,
+    env: NodeJS.ProcessEnv
+  ): Promise<CommandResult> {
+    const result = await this.runner('terraform', args, { cwd, env });
+    assertCommandSuccess(result, action, this.config.accessPolicyToken);
+    return result;
+  }
+}
+
+async function hydrateStackDetails(
+  stacks: CloudStackListItem[],
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch
+): Promise<CloudStackListItem[]> {
+  return Promise.all(
+    stacks.map(async (stack) => {
+      if (stack.labels !== undefined || !stack.slug) {
+        return stack;
+      }
+      try {
+        const response = await fetchImpl(`https://grafana.com/api/instances/${encodeURIComponent(stack.slug)}`, {
+          method: 'GET',
+          headers,
+          signal: AbortSignal.timeout(15_000),
+        });
+        if (!response.ok) {
+          return stack;
+        }
+        const detail = (await response.json()) as CloudStackListItem;
+        return { ...stack, ...detail };
+      } catch {
+        return stack;
+      }
+    })
+  );
+}
+
+export class CloudStackPoolLease {
+  constructor(
+    private readonly stack: ProvisionedCloudStack,
+    private readonly moduleDir: string,
+    private readonly accessPolicyToken: string,
+    private readonly replacement: {
+      region?: string;
+      poolId?: string;
+      slugPrefix?: string;
+      verbose?: boolean;
+    },
+    private readonly runner: CommandRunner = defaultCommandRunner,
+    private readonly fetchImpl?: typeof fetch
+  ) {}
+
+  provisionChain(): ProvisionedCloudStack {
+    return this.stack;
+  }
+
+  async teardownChain(): Promise<void> {
+    try {
+      const result = await this.runner('terraform', ['destroy', '-input=false', '-auto-approve', '-no-color'], {
+        cwd: this.moduleDir,
+        env: runnerEnv(this.accessPolicyToken),
+      });
+      assertCommandSuccess(result, 'destroy', this.accessPolicyToken);
+    } catch (err) {
+      console.warn(
+        `   ⚠ Failed to remove runner token for Cloud stack pool lease ${this.stack.stackSlug}: ${
+          err instanceof Error ? err.message : 'Unknown error'
+        }`
+      );
+    } finally {
+      rmSync(this.moduleDir, { recursive: true, force: true });
+    }
+
+    try {
+      const fetchImpl = this.fetchImpl ?? fetch;
+      const response = await fetchImpl(
+        `https://grafana.com/api/instances/${encodeURIComponent(this.stack.stackSlug)}`,
+        {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${this.accessPolicyToken}`,
+            Accept: 'application/json',
+          },
+          signal: AbortSignal.timeout(15_000),
+        }
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+      if (!this.replacement.region) {
+        console.warn(
+          `   ⚠ Cloud stack pool lease ${this.stack.stackSlug} was retired, but no region was available to create a replacement. Pass --cloud-stack-region to replenish immediately.`
+        );
+        return;
+      }
+      const replacementSlug = await createCloudStackPoolStack({
+        accessPolicyToken: this.accessPolicyToken,
+        region: this.replacement.region,
+        poolId: this.replacement.poolId,
+        slugPrefix: this.replacement.slugPrefix,
+        verbose: this.replacement.verbose,
+        runner: this.runner,
+      });
+      if (this.replacement.verbose) {
+        console.log(`   ☁️  Replaced retired pool stack ${this.stack.stackSlug} with ${replacementSlug}`);
+      }
+    } catch (err) {
+      console.warn(
+        `   ⚠ Failed to retire Cloud stack pool lease ${this.stack.stackSlug}: ${
+          err instanceof Error ? err.message : 'Unknown error'
+        }`
+      );
+    }
+  }
+}

--- a/src/cli/e2e/e2e-console-reporter.ts
+++ b/src/cli/e2e/e2e-console-reporter.ts
@@ -31,6 +31,17 @@ import {
 import type { RemoteResolution } from './e2e-package';
 import type { LoadedGuide } from '../utils/file-loader';
 import type { PreflightOutcome } from './manifest-preflight';
+import type { SideEffectClassification } from './side-effects';
+
+function formatSideEffects(sideEffects: SideEffectClassification | undefined): string {
+  if (!sideEffects) {
+    return '';
+  }
+  if (sideEffects.reasons.length === 0) {
+    return sideEffects.level;
+  }
+  return `${sideEffects.level}: ${sideEffects.reasons.map((reason) => reason.message).join('; ')}`;
+}
 
 function skipOnlyReport(preRunSkipped: MultiGuideReport['preRunSkipped']): MultiGuideReport {
   return {
@@ -243,10 +254,12 @@ export function printRemoteResolution(
   console.log(`\n📦 Resolved ${source}: ${resolution.runnable.length} runnable, ${resolution.skipped.length} skipped`);
   if (verbose) {
     for (const g of resolution.runnable) {
-      console.log(`   ✓ ${g.id} (${g.tier}) → ${g.sourceUrl}`);
+      console.log(`   ✓ ${g.id} (${g.tier}, side effects: ${formatSideEffects(g.sideEffects)}) → ${g.sourceUrl}`);
     }
     for (const s of resolution.skipped) {
-      console.log(`   ⊘ ${s.id}: ${s.reason} — ${s.message}`);
+      const sideEffects = formatSideEffects(s.sideEffects);
+      const suffix = sideEffects ? ` (side effects: ${sideEffects})` : '';
+      console.log(`   ⊘ ${s.id}: ${s.reason} — ${s.message}${suffix}`);
     }
   }
 }

--- a/src/cli/e2e/e2e-package.test.ts
+++ b/src/cli/e2e/e2e-package.test.ts
@@ -209,6 +209,36 @@ describe('resolveRemotePackage (single, recommender)', () => {
     expect(result.skipped[0]).toMatchObject({ id: 'cloud-guide', reason: 'skipped_no_auth' });
   });
 
+  it('resolves a cloud guide without fixed credentials when stack provisioning is available', async () => {
+    mockResolve({
+      ok: true,
+      id: 'cloud-guide',
+      contentUrl: 'https://cdn.test/cloud-guide/content.json',
+      manifestUrl: 'https://cdn.test/cloud-guide/manifest.json',
+      repository: 'r',
+      manifest: { id: 'cloud-guide', type: 'guide', testEnvironment: { tier: 'cloud' } },
+    });
+    mockIndex([{ id: 'cloud-guide', path: 'cloud-guide/', type: 'guide', testEnvironment: { tier: 'cloud' } }]);
+    mockFetch({
+      ok: true,
+      text: '{"id":"cloud-guide","title":"Cloud guide","blocks":[{"type":"markdown","content":"Read"}]}',
+    });
+
+    const result = await resolveRemotePackage('cloud-guide', {
+      ...CLOUD_OPTIONS,
+      cloudAuthTargets: { provisionable: [] },
+      cloudStackProvisioningAvailable: true,
+    });
+
+    expect(result.skipped).toHaveLength(0);
+    expect(result.runnable[0]).toMatchObject({
+      id: 'cloud-guide',
+      tier: 'cloud',
+      targetUrl: 'https://learn.grafana.net/',
+      sideEffects: { level: 'readonly', reasons: [] },
+    });
+  });
+
   it('resolves an instance-targeted cloud guide with credentials for that instance', async () => {
     mockResolve({
       ok: true,

--- a/src/cli/e2e/e2e-package.ts
+++ b/src/cli/e2e/e2e-package.ts
@@ -21,6 +21,7 @@ import { planGuideExecution } from './guide-chains';
 import type { LoadedGuide } from '../utils/file-loader';
 import { resolveTarget, type CloudAuthTargets } from './e2e-targets';
 import type { CurrentTier } from './manifest-preflight';
+import { classifyGuideSideEffectsFromString, type SideEffectClassification } from './side-effects';
 
 const FETCH_TIMEOUT_MS = 15_000;
 
@@ -38,6 +39,7 @@ export const REMOTE_SKIP_REASONS = [
   'validation_failed',
   'unsupported_type',
   'prerequisite_failed',
+  'skipped_unsafe_shared_stack',
 ] as const;
 
 /** Why a remote package was skipped instead of run. */
@@ -54,6 +56,8 @@ export interface ResolvedRemoteGuide {
   targetUrl: string;
   /** The content.json URL the guide was fetched from. */
   sourceUrl: string;
+  /** Static side-effect classification derived from the fetched guide content. */
+  sideEffects: SideEffectClassification;
 }
 
 /** A remote package that will not be run, with a structured reason. */
@@ -63,6 +67,7 @@ export interface SkippedPackage {
   message: string;
   sourceUrl?: string;
   tier?: string;
+  sideEffects?: SideEffectClassification;
 }
 
 /** Result of resolving one or more remote packages. */
@@ -93,6 +98,8 @@ export interface RemoteResolveOptions {
   cloudUrl?: string;
   /** Cloud target URLs that can be authenticated without exposing credential values to resolution. */
   cloudAuthTargets?: CloudAuthTargets;
+  /** Whether an ephemeral Cloud stack can be provisioned later for cloud-tier guides. */
+  cloudStackProvisioningAvailable?: boolean;
 }
 
 /** Fetch a URL as raw text with a timeout. Never throws. */
@@ -141,6 +148,7 @@ async function buildGuideOrSkip(
     currentTier: options.currentTier,
     cloudUrl: options.cloudUrl,
     cloudAuthTargets: options.cloudAuthTargets,
+    cloudStackProvisioningAvailable: options.cloudStackProvisioningAvailable,
   });
   if (!target.runnable) {
     return {
@@ -180,6 +188,8 @@ async function buildGuideOrSkip(
     };
   }
 
+  const sideEffects = classifyGuideSideEffectsFromString(fetched.text);
+
   return {
     runnable: {
       id,
@@ -188,6 +198,7 @@ async function buildGuideOrSkip(
       instance: target.instance,
       targetUrl: target.targetUrl!,
       sourceUrl: contentUrl,
+      sideEffects,
     },
   };
 }

--- a/src/cli/e2e/e2e-reporter.ts
+++ b/src/cli/e2e/e2e-reporter.ts
@@ -9,6 +9,7 @@
 
 import { writeFileSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
+import type { SideEffectClassification } from './side-effects';
 
 // ============================================
 // Types - JSON Report Structure
@@ -34,6 +35,8 @@ export interface GuideMetadata {
   targetUrl?: string;
   /** Source content.json URL for remotely-resolved guides. */
   sourceUrl?: string;
+  /** Static side-effect classification for remote guide safety routing. */
+  sideEffects?: SideEffectClassification;
 }
 
 /**
@@ -154,6 +157,8 @@ export interface PreRunSkip {
   tier?: string;
   /** Source content.json URL, when known. */
   sourceUrl?: string;
+  /** Static side-effect classification, when guide content was fetched. */
+  sideEffects?: SideEffectClassification;
 }
 
 /**

--- a/src/cli/e2e/e2e-results.test.ts
+++ b/src/cli/e2e/e2e-results.test.ts
@@ -118,6 +118,7 @@ describe('buildPackageMetaMap', () => {
         instance: 'play.grafana.org',
         targetUrl: 'http://localhost:3000',
         sourceUrl: 'https://cdn.test/a/content.json',
+        sideEffects: { level: 'readonly', reasons: [] },
       },
     ];
 
@@ -127,6 +128,7 @@ describe('buildPackageMetaMap', () => {
       instance: 'play.grafana.org',
       targetUrl: 'http://localhost:3000',
       sourceUrl: 'https://cdn.test/a/content.json',
+      sideEffects: { level: 'readonly', reasons: [] },
     });
   });
 });

--- a/src/cli/e2e/e2e-results.ts
+++ b/src/cli/e2e/e2e-results.ts
@@ -20,6 +20,7 @@ import {
 import type { PreRunSkip, TestResultsData } from './e2e-reporter';
 import { ExitCode } from './exit-codes';
 import type { AbortReason } from './playwright-runner';
+import type { SideEffectClassification } from './side-effects';
 
 /** How guide inputs are resolved for a run. */
 export type RunMode = 'local' | 'remote-package' | 'remote-repository';
@@ -31,6 +32,7 @@ export interface PackageMeta {
   instance?: string;
   targetUrl?: string;
   sourceUrl?: string;
+  sideEffects?: SideEffectClassification;
 }
 
 /**
@@ -54,6 +56,7 @@ export interface GuideRunResult {
   failedPrerequisite?: string;
   /** Declared tier for pre-run skips (for reporting). */
   tier?: string;
+  sideEffects?: SideEffectClassification;
 }
 
 /** Statuses that count as a test failure (non-zero exit). */
@@ -73,6 +76,7 @@ export const GUIDE_STATUS_LABELS: ReadonlyArray<readonly [GuideStatus, string]> 
   ['skipped_tier_mismatch', '⊘ Skipped (tier mismatch)'],
   ['skipped_no_auth', '⊘ Skipped (no cloud auth)'],
   ['skipped_invalid_instance', '⊘ Skipped (invalid instance)'],
+  ['skipped_unsafe_shared_stack', '⊘ Skipped (unsafe shared stack)'],
   ['unsupported_type', '⊘ Skipped (unsupported type)'],
   ['fetch_failed', '⊘ Skipped (fetch failed)'],
   ['resolution_failed', '⊘ Skipped (resolution failed)'],
@@ -89,6 +93,7 @@ export const GUIDE_STATUS_ICONS: Record<GuideStatus, string> = {
   skipped_tier_mismatch: '⊘',
   skipped_no_auth: '⊘',
   skipped_invalid_instance: '⊘',
+  skipped_unsafe_shared_stack: '⊘',
   unsupported_type: '⊘',
   fetch_failed: '⊘',
   resolution_failed: '⊘',
@@ -132,6 +137,7 @@ export function skipToResult(skip: SkippedPackage): GuideRunResult {
     autoIncluded: false,
     abortMessage: skip.message,
     tier: skip.tier,
+    sideEffects: skip.sideEffects,
   };
 }
 
@@ -140,7 +146,14 @@ export function buildPackageMetaMap(runnable: ResolvedRemoteGuide[]): Map<string
   return new Map(
     runnable.map((g) => [
       g.id,
-      { packageId: g.id, tier: g.tier, instance: g.instance, targetUrl: g.targetUrl, sourceUrl: g.sourceUrl },
+      {
+        packageId: g.id,
+        tier: g.tier,
+        instance: g.instance,
+        targetUrl: g.targetUrl,
+        sourceUrl: g.sourceUrl,
+        sideEffects: g.sideEffects,
+      },
     ])
   );
 }
@@ -159,6 +172,7 @@ export function applyPackageMeta(data: TestResultsData | undefined, meta: Packag
     tier: meta.tier,
     instance: meta.instance,
     sourceUrl: meta.sourceUrl,
+    sideEffects: meta.sideEffects,
   };
 }
 
@@ -175,6 +189,7 @@ export function preRunSkipsFromResults(results: GuideRunResult[]): PreRunSkip[] 
       failed: FAILURE_STATUSES.has(r.status),
       tier: r.tier,
       sourceUrl: r.guide,
+      ...(r.sideEffects ? { sideEffects: r.sideEffects } : {}),
     }));
 }
 

--- a/src/cli/e2e/e2e-targets.test.ts
+++ b/src/cli/e2e/e2e-targets.test.ts
@@ -50,6 +50,21 @@ describe('resolveTarget', () => {
     expect(target.skipReason).toBe('skipped_no_auth');
   });
 
+  it('runs a cloud guide without fixed credentials when stack provisioning is available', () => {
+    const target = resolveTarget(
+      { tier: 'cloud' },
+      {
+        grafanaUrl: LOCAL_URL,
+        currentTier: 'cloud',
+        cloudUrl: CLOUD_URL,
+        cloudStackProvisioningAvailable: true,
+      }
+    );
+
+    expect(target.runnable).toBe(true);
+    expect(target.targetUrl).toBe(CLOUD_URL);
+  });
+
   it('runs a cloud guide with credentials against the default cloud URL when no instance is declared', () => {
     const target = resolveTarget(
       { tier: 'cloud' },
@@ -127,6 +142,21 @@ describe('resolveTarget', () => {
     expect(target.runnable).toBe(false);
     expect(target.skipReason).toBe('skipped_no_auth');
     expect(target.message).toContain('--cloud-instance-admin-token for https://play.grafana.org/');
+  });
+
+  it('allows an instance-targeted cloud guide when only stack provisioning is available', () => {
+    const target = resolveTarget(
+      { tier: 'cloud', instance: 'play.grafana.org' },
+      {
+        grafanaUrl: LOCAL_URL,
+        currentTier: 'cloud',
+        cloudUrl: CLOUD_URL,
+        cloudStackProvisioningAvailable: true,
+      }
+    );
+
+    expect(target.runnable).toBe(true);
+    expect(target.targetUrl).toBe('https://play.grafana.org/');
   });
 
   it('skips a cloud guide whose instance is not a bare hostname with invalid-instance', () => {

--- a/src/cli/e2e/e2e-targets.ts
+++ b/src/cli/e2e/e2e-targets.ts
@@ -47,6 +47,8 @@ export interface ResolveTargetOptions {
   cloudUrl?: string;
   /** Cloud target URLs that can be authenticated without exposing credential values to resolution. */
   cloudAuthTargets?: CloudAuthTargets;
+  /** Whether the runner can provision an ephemeral Cloud stack for this guide later. */
+  cloudStackProvisioningAvailable?: boolean;
 }
 
 /**
@@ -105,7 +107,7 @@ export function resolveTarget(testEnvironment: TestEnvironment, options: Resolve
   if (tier === 'cloud') {
     const authTargets = options.cloudAuthTargets ?? { provisionable: [] };
     const defaultTargetUrl = options.cloudUrl;
-    if (authTargets.provisionable.length === 0) {
+    if (authTargets.provisionable.length === 0 && !options.cloudStackProvisioningAvailable) {
       return {
         runnable: false,
         tier,
@@ -127,6 +129,9 @@ export function resolveTarget(testEnvironment: TestEnvironment, options: Resolve
         };
       }
       if (!canProvisionFor(instanceUrl, options)) {
+        if (options.cloudStackProvisioningAvailable) {
+          return { runnable: true, tier, instance, targetUrl: instanceUrl };
+        }
         return {
           runnable: false,
           tier,
@@ -147,6 +152,9 @@ export function resolveTarget(testEnvironment: TestEnvironment, options: Resolve
       };
     }
     if (!canProvisionFor(defaultTargetUrl, options)) {
+      if (options.cloudStackProvisioningAvailable) {
+        return { runnable: true, tier, instance, targetUrl: defaultTargetUrl };
+      }
       return {
         runnable: false,
         tier,

--- a/src/cli/e2e/side-effects.test.ts
+++ b/src/cli/e2e/side-effects.test.ts
@@ -1,0 +1,105 @@
+import { classifyGuideSideEffects, classifyGuideSideEffectsFromString } from './side-effects';
+import type { JsonGuide } from '../../types/json-guide.types';
+
+function guide(blocks: JsonGuide['blocks']): JsonGuide {
+  return { id: 'g', title: 'Guide', blocks };
+}
+
+describe('classifyGuideSideEffects', () => {
+  it('classifies purely instructional and observational guides as readonly', () => {
+    const result = classifyGuideSideEffects(
+      guide([
+        { type: 'markdown', content: 'Read this' },
+        { type: 'quiz', question: 'Pick one', choices: [{ id: 'a', text: 'A', correct: true }] },
+        { type: 'interactive', action: 'highlight', reftarget: '[data-testid="panel"]', content: 'Look here' },
+        { type: 'interactive', action: 'navigate', reftarget: '/explore', content: 'Open Explore' },
+      ])
+    );
+
+    expect(result).toEqual({ level: 'readonly', reasons: [] });
+  });
+
+  it('classifies destructive and save-like buttons as mutating', () => {
+    const result = classifyGuideSideEffects(
+      guide([{ type: 'interactive', action: 'button', reftarget: 'Save dashboard', content: 'Save your work' }])
+    );
+
+    expect(result.level).toBe('mutating');
+    expect(result.reasons[0]).toMatchObject({
+      level: 'mutating',
+      path: 'blocks[0]',
+    });
+    expect(result.reasons[0]!.message).toContain('Save dashboard');
+  });
+
+  it('classifies generic button and formfill actions as possible mutations', () => {
+    const result = classifyGuideSideEffects(
+      guide([
+        { type: 'interactive', action: 'button', reftarget: '[data-testid="refresh"]', content: 'Click refresh' },
+        { type: 'interactive', action: 'formfill', reftarget: 'textarea[data-testid="query"]', content: 'Enter query' },
+      ])
+    );
+
+    expect(result.level).toBe('possibly_mutating');
+    expect(result.reasons).toHaveLength(2);
+  });
+
+  it('classifies creation and admin routes as possible mutations', () => {
+    const result = classifyGuideSideEffects(
+      guide([
+        { type: 'interactive', action: 'navigate', reftarget: '/connections/datasources/new', content: 'Add one' },
+      ])
+    );
+
+    expect(result.level).toBe('possibly_mutating');
+    expect(result.reasons[0]!.message).toContain('/connections/datasources/new');
+  });
+
+  it('walks nested sections, conditionals, assistants, guided, and multistep blocks', () => {
+    const result = classifyGuideSideEffects(
+      guide([
+        {
+          type: 'section',
+          blocks: [
+            {
+              type: 'conditional',
+              conditions: ['has-datasource:prometheus'],
+              whenTrue: [{ type: 'assistant', blocks: [{ type: 'markdown', content: 'No-op' }] }],
+              whenFalse: [
+                {
+                  type: 'guided',
+                  content: 'Create a data source',
+                  steps: [{ action: 'button', reftarget: 'Create data source' }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'multistep',
+          content: 'Read-only tour',
+          steps: [{ action: 'highlight', reftarget: '[data-testid="x"]' }],
+        },
+      ])
+    );
+
+    expect(result.level).toBe('mutating');
+    expect(result.reasons[0]).toMatchObject({
+      path: 'blocks[0].blocks[0].whenFalse[0].steps[0]',
+    });
+  });
+
+  it('keeps unknown blocks distinct from possible mutations', () => {
+    const result = classifyGuideSideEffects(guide([{ type: 'snippet-ref', snippetId: 'shared-setup' }]));
+
+    expect(result.level).toBe('unknown');
+    expect(result.reasons[0]!.message).toMatch(/Snippet content/);
+  });
+
+  it('classifies invalid JSON as unknown', () => {
+    const result = classifyGuideSideEffectsFromString('{not json');
+
+    expect(result.level).toBe('unknown');
+    expect(result.reasons[0]).toMatchObject({ path: '$' });
+  });
+});

--- a/src/cli/e2e/side-effects.ts
+++ b/src/cli/e2e/side-effects.ts
@@ -1,0 +1,203 @@
+import {
+  isAssistantBlock,
+  isChallengeBlock,
+  isCodeBlockBlock,
+  isConditionalBlock,
+  isGuidedBlock,
+  isInputBlock,
+  isInteractiveBlock,
+  isMarkdownBlock,
+  isMultistepBlock,
+  isSectionBlock,
+  isSnippetRefBlock,
+  isTerminalBlock,
+  isTerminalConnectBlock,
+  isHtmlBlock,
+  isImageBlock,
+  isQuizBlock,
+  isVideoBlock,
+  type JsonBlock,
+  type JsonGuide,
+  type JsonInteractiveAction,
+  type JsonStep,
+} from '../../types/json-guide.types';
+
+export type SideEffectLevel = 'readonly' | 'possibly_mutating' | 'mutating' | 'unknown';
+
+export interface SideEffectReason {
+  level: Exclude<SideEffectLevel, 'readonly'>;
+  path: string;
+  message: string;
+}
+
+export interface SideEffectClassification {
+  level: SideEffectLevel;
+  reasons: SideEffectReason[];
+}
+
+const LEVEL_SCORE: Record<SideEffectLevel, number> = {
+  readonly: 0,
+  possibly_mutating: 1,
+  unknown: 2,
+  mutating: 3,
+};
+
+const MUTATING_TEXT_PATTERN =
+  /\b(save|create|delete|destroy|remove|update|submit|apply|import|provision|install|enable|disable|add)\b/i;
+const POSSIBLY_MUTATING_TEXT_PATTERN = /\b(new|edit|configure|config|settings|admin|manage)\b/i;
+const MUTATING_ROUTE_PATTERN =
+  /\/(dashboard\/new|dashboards\/new|connections\/datasources\/new|datasources\/new|alerting|admin|plugins|org|users|teams|serviceaccounts|api-keys)(?:\/|$|[?#])/i;
+const READONLY_ROUTE_PATTERN =
+  /\/(explore|dashboards|d\/|drilldown|alerting\/list|connections\/datasources)(?:\/|$|[?#])/i;
+
+function mergeClassifications(classifications: SideEffectClassification[]): SideEffectClassification {
+  const reasons = classifications.flatMap((classification) => classification.reasons);
+  const level = classifications.reduce<SideEffectLevel>(
+    (highest, classification) =>
+      LEVEL_SCORE[classification.level] > LEVEL_SCORE[highest] ? classification.level : highest,
+    'readonly'
+  );
+  return { level, reasons };
+}
+
+function reason(level: Exclude<SideEffectLevel, 'readonly'>, path: string, message: string): SideEffectClassification {
+  return { level, reasons: [{ level, path, message }] };
+}
+
+function readonly(): SideEffectClassification {
+  return { level: 'readonly', reasons: [] };
+}
+
+function textEvidence(action: string, value: string | undefined, path: string): SideEffectClassification | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (MUTATING_TEXT_PATTERN.test(value)) {
+    return reason('mutating', path, `${action} target looks state-changing: ${value}`);
+  }
+  if (POSSIBLY_MUTATING_TEXT_PATTERN.test(value)) {
+    return reason('possibly_mutating', path, `${action} target may lead to state changes: ${value}`);
+  }
+  return undefined;
+}
+
+function routeEvidence(path: string, route: string | undefined): SideEffectClassification | undefined {
+  if (!route) {
+    return undefined;
+  }
+  if (MUTATING_ROUTE_PATTERN.test(route)) {
+    return reason('possibly_mutating', path, `Navigation target is a configuration or creation route: ${route}`);
+  }
+  if (READONLY_ROUTE_PATTERN.test(route)) {
+    return undefined;
+  }
+  return undefined;
+}
+
+function classifyAction(
+  action: JsonInteractiveAction | undefined,
+  target: string | undefined,
+  path: string
+): SideEffectClassification {
+  if (!action) {
+    return reason('unknown', path, 'Interactive action is missing');
+  }
+
+  if (action === 'noop' || action === 'highlight' || action === 'hover' || action === 'popout') {
+    return readonly();
+  }
+
+  if (action === 'navigate') {
+    return routeEvidence(path, target) ?? readonly();
+  }
+
+  if (action === 'button') {
+    return (
+      textEvidence('Button', target, path) ?? reason('possibly_mutating', path, 'Button click may mutate Grafana state')
+    );
+  }
+
+  if (action === 'formfill') {
+    return (
+      textEvidence('Form fill', target, path) ?? reason('possibly_mutating', path, 'Form fill may be submitted later')
+    );
+  }
+
+  return reason('unknown', path, `Unrecognized action: ${action}`);
+}
+
+function classifyStep(step: JsonStep, path: string): SideEffectClassification {
+  return classifyAction(step.action ?? step.targetAction, step.reftarget ?? step.refTarget, path);
+}
+
+function classifySteps(steps: JsonStep[] | undefined, path: string): SideEffectClassification {
+  if (!Array.isArray(steps)) {
+    return reason('unknown', path, 'Step list is missing or invalid');
+  }
+  return mergeClassifications(steps.map((step, index) => classifyStep(step, `${path}.steps[${index}]`)));
+}
+
+function classifyBlocks(blocks: JsonBlock[] | undefined, path: string): SideEffectClassification {
+  if (!Array.isArray(blocks)) {
+    return reason('unknown', path, 'Block list is missing or invalid');
+  }
+  return mergeClassifications(blocks.map((block, index) => classifyBlock(block, `${path}[${index}]`)));
+}
+
+function classifyBlock(block: JsonBlock, path: string): SideEffectClassification {
+  if (
+    isMarkdownBlock(block) ||
+    isHtmlBlock(block) ||
+    isImageBlock(block) ||
+    isVideoBlock(block) ||
+    isQuizBlock(block) ||
+    isInputBlock(block)
+  ) {
+    return readonly();
+  }
+  if (isInteractiveBlock(block)) {
+    return classifyAction(block.action ?? block.targetAction, block.reftarget ?? block.refTarget, path);
+  }
+  if (isMultistepBlock(block) || isGuidedBlock(block)) {
+    return classifySteps(block.steps, path);
+  }
+  if (isSectionBlock(block)) {
+    return classifyBlocks(block.blocks, `${path}.blocks`);
+  }
+  if (isConditionalBlock(block)) {
+    return mergeClassifications([
+      classifyBlocks(block.whenTrue, `${path}.whenTrue`),
+      classifyBlocks(block.whenFalse, `${path}.whenFalse`),
+    ]);
+  }
+  if (isAssistantBlock(block)) {
+    return classifyBlocks(block.blocks, `${path}.blocks`);
+  }
+  if (isCodeBlockBlock(block)) {
+    return reason('possibly_mutating', path, 'Code insertion may be saved or executed later');
+  }
+  if (isTerminalBlock(block) || isTerminalConnectBlock(block) || isChallengeBlock(block)) {
+    return reason('unknown', path, `${block.type} block can have side effects outside static guide analysis`);
+  }
+  if (isSnippetRefBlock(block)) {
+    return reason('unknown', path, 'Snippet content is resolved at parse time and must be classified after expansion');
+  }
+  return reason('unknown', path, 'Unknown block type');
+}
+
+export function classifyGuideSideEffects(guide: JsonGuide): SideEffectClassification {
+  return classifyBlocks(guide.blocks, 'blocks');
+}
+
+export function classifyGuideSideEffectsFromString(content: string): SideEffectClassification {
+  try {
+    const guide = JSON.parse(content) as JsonGuide;
+    return classifyGuideSideEffects(guide);
+  } catch (err) {
+    return reason(
+      'unknown',
+      '$',
+      `Guide JSON could not be parsed: ${err instanceof Error ? err.message : 'Unknown error'}`
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds classifier-driven isolation for cloud-tier E2E guide tests so guides that may mutate Grafana Cloud state can run against disposable stacks instead of polluting a shared target. The runner can now cold-provision ephemeral stacks, lease pre-provisioned hot-pool stacks, mint short-lived runner tokens, retire leased stacks after use, and immediately create replacements for the pool.

## What to look at

- E2E cloud routing and side-effect detection: [`side-effects.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/6ea1044fe293f0d9b1ea5f430e6ff37dee553096/src/cli/e2e/side-effects.ts), [`e2e-package.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/6ea1044fe293f0d9b1ea5f430e6ff37dee553096/src/cli/e2e/e2e-package.ts), and [`e2e-results.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/6ea1044fe293f0d9b1ea5f430e6ff37dee553096/src/cli/e2e/e2e-results.ts) classify remote guide content, propagate the classification into reports, and add the `skipped_unsafe_shared_stack` outcome for unsafe chains that cannot get an isolated stack.
- Stack provisioning and leasing: [`cloud-stack-environment.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/6ea1044fe293f0d9b1ea5f430e6ff37dee553096/src/cli/e2e/cloud-stack-environment.ts), [`cloud-stack-pool.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/6ea1044fe293f0d9b1ea5f430e6ff37dee553096/src/cli/e2e/cloud-stack-pool.ts), and [`cloud-provisioning.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/6ea1044fe293f0d9b1ea5f430e6ff37dee553096/src/cli/e2e/cloud-provisioning.ts) contain the Terraform-backed cold stack path, pool discovery, per-chain target/token selection, teardown, and immediate replacement behavior.
- CLI integration: [`e2e.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/6ea1044fe293f0d9b1ea5f430e6ff37dee553096/src/cli/commands/e2e.ts) wires the new Cloud stack flags into remote resolution, skips shared-stack preflight for isolated chains, and routes Playwright to the leased/provisioned stack.
- Operator documentation: [`E2E_TESTING.md`](https://github.com/grafana/grafana-pathfinder-app/blob/6ea1044fe293f0d9b1ea5f430e6ff37dee553096/docs/developer/E2E_TESTING.md) documents required Cloud Access Policy scopes, pool labels, Terraform dependency, side-effect classifications, and follow-up gaps such as manifest-declared plugin installation.

## Why

Cloud auth on the current branch isolates users and sessions per dependency chain, but it does not isolate org-global Grafana Cloud state such as dashboards, folders, data sources, and alerting resources. We considered relying only on service-account isolation plus cleanup, but that would be incomplete for guides that mutate existing or product-specific state; this spike instead gives unsafe cloud chains a disposable stack while preserving the faster shared-stack path for read-only guides.

## How to verify

1. Label one or more pre-created Grafana Cloud stacks with `pathfinder-e2e-pool=true`, then run a mutating cloud package with `--cloud-stack-access-policy-token <env var>` and confirm the runner leases one of those stacks, executes the guide, retires the leased stack, and creates a replacement.
2. Run the same package with no pool stack available but with `--cloud-stack-region <region>` and confirm the runner falls back to cold Terraform stack provisioning.
3. Run a cloud package that the classifier marks read-only with a matching `--cloud-instance-admin-token host=env` and confirm it keeps using the shared-stack service-account path.
4. Run an unsafe cloud package without pool labels or `--cloud-stack-region` and confirm it exits with `skipped_unsafe_shared_stack` instead of running against the shared stack.
5. Inspect a JSON report from a remote package run and confirm package metadata includes the side-effect classification used for routing.

## Breaking changes

None. This change is additive and keeps existing local, bundled, remote, and shared-stack cloud E2E flows available.

## Reversibility

Reverting this PR removes the new isolated-stack routing and returns cloud package E2E runs to the previous service-account-only behavior. Any Grafana Cloud stacks created or destroyed while using the new flags are external side effects and cannot be restored by a git revert; failed teardown leaves labeled stacks discoverable for manual cleanup.

## Out of scope

- Installing plugins declared by `testEnvironment.plugins` on ephemeral stacks is deferred. Today those plugin requirements are still checked by preflight and requirements logic, but they are not automatically installed.
- Durable cross-process lease coordination for hot pools is deferred. The current pool lease tracking is process-local, so concurrent CLI invocations still require external coordination.
- Manifest schema changes such as `stateIsolation` or `sideEffects` are deferred because `testEnvironment` is an external manifest contract.
