### PR TITLE
feat(e2e): add cloud guide side-effect routing

### DIFF
--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -49,6 +49,7 @@ import type { ManifestJson, RepositoryEntry, RepositoryJson } from '../../types/
 import { randomUUID } from 'crypto';
 import { createCloudAuthPolicy, type CloudAuthPolicy } from '../e2e/cloud-auth';
 import { cloudTargetsInChain, provisionCloudTargetsForChain, sweepCloudTargets } from '../e2e/cloud-provisioning';
+import { unsafeCloudGuidesInChain, unsafeSharedStackMessage, unsafeSharedStackSkipResults } from '../e2e/cloud-routing';
 
 /**
  * CLI options for the e2e command
@@ -393,18 +394,33 @@ async function maybeCleanStart(cleanEnv: CleanEnvironment, options: E2ECommandOp
   }
 }
 
+function idsSkippedForUnsafeSharedStack(plan: ExecutionPlan, packageMetaById: Map<string, PackageMeta>): Set<string> {
+  const ids = new Set<string>();
+  for (const chain of plan.chains) {
+    if (unsafeCloudGuidesInChain(chain, packageMetaById).length > 0) {
+      for (const planned of chain) {
+        ids.add(planned.id);
+      }
+    }
+  }
+  return ids;
+}
+
 /**
  * Distinct target URLs that will actually be exercised this run. Remote guides
  * carry their own resolved `targetUrl` (cloud guides differ per instance);
  * local runs fall back to the global Grafana URL. Used so reachability checks
  * hit the real targets instead of always probing the global URL.
  */
-function targetUrlsToCheck(inputs: RunInputs, globalUrl: string): string[] {
+function targetUrlsToCheck(inputs: RunInputs, globalUrl: string, idsToSkip: Set<string>): string[] {
   const urls = new Set<string>();
-  for (const meta of inputs.packageMetaById.values()) {
+  for (const [id, meta] of inputs.packageMetaById) {
+    if (idsToSkip.has(id)) {
+      continue;
+    }
     urls.add(meta.targetUrl ?? globalUrl);
   }
-  if (urls.size === 0) {
+  if (inputs.packageMetaById.size === 0) {
     urls.add(globalUrl);
   }
   return [...urls];
@@ -470,7 +486,11 @@ async function runPreflightChecks(
     }
   }
 
-  console.log(`   ✓ Grafana is reachable (${targetUrls.length} target(s))`);
+  if (targetUrls.length > 0) {
+    console.log(`   ✓ Grafana is reachable (${targetUrls.length} target(s))`);
+  } else if (options.verbose) {
+    console.log('   ⊘ No runnable targets require Grafana reachability checks');
+  }
 
   // 2. Manifest pre-flight — version and plugin checks (local package dir only).
   //    A local package dir is always a single local target (options.grafanaUrl).
@@ -533,7 +553,6 @@ async function runChains(
   let allPassed = true;
   let hasAuthExpiry = false;
   const results: GuideRunResult[] = [];
-
   for (const [chainIndex, chain] of plan.chains.entries()) {
     if (options.clean && chainIndex > 0) {
       console.log(`\n🧹 Resetting docker compose between chains...`);
@@ -548,6 +567,13 @@ async function runChains(
       }
     }
 
+    const unsafeCloudGuides = unsafeCloudGuidesInChain(chain, packageMetaById);
+    if (unsafeCloudGuides.length > 0) {
+      const message = unsafeSharedStackMessage(unsafeCloudGuides.map((planned) => planned.id));
+      console.log(`\n⊘ Skipping cloud chain: ${message}`);
+      results.push(...unsafeSharedStackSkipResults(chain, packageMetaById, message));
+      continue;
+    }
     const provisionedTargets = await provisionCloudTargetsForChain({
       targetUrls: cloudTargetsInChain(chain, packageMetaById, cloudAuth),
       cloudAuth,
@@ -835,8 +861,12 @@ export const e2eCommand = new Command('e2e')
         cloudAuth: inputs.cloudAuth,
         verbose: options.verbose,
       });
-
-      await runPreflightChecks(options, targetUrlsToCheck(inputs, options.grafanaUrl), inputs.localPackageDir);
+      const idsToSkip = idsSkippedForUnsafeSharedStack(plan, inputs.packageMetaById);
+      await runPreflightChecks(
+        options,
+        targetUrlsToCheck(inputs, options.grafanaUrl, idsToSkip),
+        inputs.localPackageDir
+      );
 
       const outcome = await runChains(plan, options, cleanEnv, inputs.packageMetaById, inputs.cloudAuth);
 

--- a/src/cli/e2e/cloud-routing.test.ts
+++ b/src/cli/e2e/cloud-routing.test.ts
@@ -1,0 +1,82 @@
+import { unsafeCloudGuidesInChain, unsafeSharedStackMessage, unsafeSharedStackSkipResults } from './cloud-routing';
+import { ExitCode } from './exit-codes';
+import type { PackageMeta } from './e2e-results';
+
+describe('unsafeCloudGuidesInChain', () => {
+  it('returns cloud guides with unsafe or missing side-effect classifications', () => {
+    const packageMetaById = new Map<string, PackageMeta>([
+      [
+        'readonly-cloud',
+        { packageId: 'readonly-cloud', tier: 'cloud', sideEffects: { level: 'readonly', reasons: [] } },
+      ],
+      [
+        'mutating-cloud',
+        {
+          packageId: 'mutating-cloud',
+          tier: 'cloud',
+          sideEffects: {
+            level: 'mutating',
+            reasons: [{ level: 'mutating', path: 'blocks[0]', message: 'Button target looks state-changing: Save' }],
+          },
+        },
+      ],
+      ['unknown-cloud', { packageId: 'unknown-cloud', tier: 'cloud' }],
+      [
+        'local-mutating',
+        { packageId: 'local-mutating', tier: 'local', sideEffects: { level: 'mutating', reasons: [] } },
+      ],
+    ]);
+
+    expect(
+      unsafeCloudGuidesInChain(
+        [{ id: 'readonly-cloud' }, { id: 'mutating-cloud' }, { id: 'unknown-cloud' }, { id: 'local-mutating' }],
+        packageMetaById
+      ).map((guide) => guide.id)
+    ).toEqual(['mutating-cloud', 'unknown-cloud']);
+  });
+
+  it('formats the shared-stack skip message', () => {
+    expect(unsafeSharedStackMessage(['mutating-cloud', 'unknown-cloud'])).toBe(
+      'Cloud chain contains unsafe guide(s) mutating-cloud, unknown-cloud and requires an isolated stack path'
+    );
+  });
+
+  it('builds the skip result contract used by unsafe shared-stack routing', () => {
+    const sideEffects = {
+      level: 'mutating' as const,
+      reasons: [{ level: 'mutating' as const, path: 'blocks[0]', message: 'Button target looks state-changing: Save' }],
+    };
+    const packageMetaById = new Map<string, PackageMeta>([
+      [
+        'mutating-cloud',
+        { packageId: 'mutating-cloud', tier: 'cloud', targetUrl: 'https://learn.grafana.net/', sideEffects },
+      ],
+    ]);
+    const message = unsafeSharedStackMessage(['mutating-cloud']);
+
+    expect(
+      unsafeSharedStackSkipResults(
+        [
+          {
+            id: 'mutating-cloud',
+            guide: { path: 'https://cdn.test/mutating-cloud/content.json' },
+            autoIncluded: true,
+          },
+        ],
+        packageMetaById,
+        message
+      )
+    ).toEqual([
+      {
+        guide: 'https://cdn.test/mutating-cloud/content.json',
+        id: 'mutating-cloud',
+        status: 'skipped_unsafe_shared_stack',
+        exitCode: ExitCode.SUCCESS,
+        autoIncluded: true,
+        abortMessage: message,
+        tier: 'cloud',
+        sideEffects,
+      },
+    ]);
+  });
+});

--- a/src/cli/e2e/cloud-routing.ts
+++ b/src/cli/e2e/cloud-routing.ts
@@ -1,0 +1,48 @@
+import { ExitCode } from './exit-codes';
+import type { GuideRunResult, PackageMeta } from './e2e-results';
+import { isUnsafeSideEffectLevel } from './side-effects';
+
+interface PlannedGuideRef {
+  id: string;
+}
+
+interface PlannedGuideForSkip extends PlannedGuideRef {
+  guide: {
+    path: string;
+  };
+  autoIncluded: boolean;
+}
+
+export function unsafeCloudGuidesInChain(
+  chain: PlannedGuideRef[],
+  packageMetaById: Map<string, PackageMeta>
+): PlannedGuideRef[] {
+  return chain.filter((planned) => {
+    const meta = packageMetaById.get(planned.id);
+    return meta?.tier === 'cloud' && (!meta.sideEffects || isUnsafeSideEffectLevel(meta.sideEffects.level));
+  });
+}
+
+export function unsafeSharedStackMessage(unsafeIds: string[]): string {
+  return `Cloud chain contains unsafe guide(s) ${unsafeIds.join(', ')} and requires an isolated stack path`;
+}
+
+export function unsafeSharedStackSkipResults(
+  chain: PlannedGuideForSkip[],
+  packageMetaById: Map<string, PackageMeta>,
+  message: string
+): GuideRunResult[] {
+  return chain.map((planned) => {
+    const meta = packageMetaById.get(planned.id);
+    return {
+      guide: planned.guide.path,
+      id: planned.id,
+      status: 'skipped_unsafe_shared_stack',
+      exitCode: ExitCode.SUCCESS,
+      autoIncluded: planned.autoIncluded,
+      abortMessage: message,
+      tier: meta?.tier,
+      sideEffects: meta?.sideEffects,
+    };
+  });
+}

--- a/src/cli/e2e/e2e-console-reporter.ts
+++ b/src/cli/e2e/e2e-console-reporter.ts
@@ -31,6 +31,7 @@ import {
 import type { RemoteResolution } from './e2e-package';
 import type { LoadedGuide } from '../utils/file-loader';
 import type { PreflightOutcome } from './manifest-preflight';
+import type { SideEffectClassification } from './side-effects';
 
 function skipOnlyReport(preRunSkipped: MultiGuideReport['preRunSkipped']): MultiGuideReport {
   return {
@@ -57,6 +58,16 @@ function skipOnlyReport(preRunSkipped: MultiGuideReport['preRunSkipped']): Multi
     reports: [],
     preRunSkipped,
   };
+}
+
+function formatSideEffects(sideEffects: SideEffectClassification | undefined): string {
+  if (!sideEffects) {
+    return 'side effects unknown';
+  }
+  if (sideEffects.reasons.length === 0) {
+    return sideEffects.level;
+  }
+  return `${sideEffects.level}: ${sideEffects.reasons.map((r) => `${r.path} ${r.message}`).join('; ')}`;
 }
 
 /** The resolved run settings rendered by printRunConfiguration. */
@@ -243,10 +254,11 @@ export function printRemoteResolution(
   console.log(`\n📦 Resolved ${source}: ${resolution.runnable.length} runnable, ${resolution.skipped.length} skipped`);
   if (verbose) {
     for (const g of resolution.runnable) {
-      console.log(`   ✓ ${g.id} (${g.tier}) → ${g.sourceUrl}`);
+      console.log(`   ✓ ${g.id} (${g.tier}, ${formatSideEffects(g.sideEffects)}) → ${g.sourceUrl}`);
     }
     for (const s of resolution.skipped) {
-      console.log(`   ⊘ ${s.id}: ${s.reason} — ${s.message}`);
+      const sideEffects = s.sideEffects ? ` (${formatSideEffects(s.sideEffects)})` : '';
+      console.log(`   ⊘ ${s.id}: ${s.reason}${sideEffects} — ${s.message}`);
     }
   }
 }

--- a/src/cli/e2e/e2e-package.test.ts
+++ b/src/cli/e2e/e2e-package.test.ts
@@ -79,7 +79,10 @@ describe('resolveRemotePackage (single, recommender)', () => {
       manifest: { id: 'alerting-101', type: 'guide', testEnvironment: { tier: 'local' } },
     });
     mockIndex([{ id: 'alerting-101', path: 'alerting-101/', type: 'guide', testEnvironment: { tier: 'local' } }]);
-    mockFetch({ ok: true, text: '{"id":"alerting-101"}' });
+    mockFetch({
+      ok: true,
+      text: '{"id":"alerting-101","title":"Alerting","blocks":[{"type":"markdown","content":"Read this"}]}',
+    });
 
     const result = await resolveRemotePackage('alerting-101', OPTIONS);
 
@@ -90,8 +93,11 @@ describe('resolveRemotePackage (single, recommender)', () => {
       tier: 'local',
       targetUrl: 'http://localhost:3000',
       sourceUrl: 'https://cdn.test/alerting-101/content.json',
+      sideEffects: { level: 'readonly', reasons: [] },
     });
-    expect(result.runnable[0]!.guide.content).toBe('{"id":"alerting-101"}');
+    expect(result.runnable[0]!.guide.content).toBe(
+      '{"id":"alerting-101","title":"Alerting","blocks":[{"type":"markdown","content":"Read this"}]}'
+    );
   });
 
   it('maps a recommender failure to resolution_failed', async () => {

--- a/src/cli/e2e/e2e-package.ts
+++ b/src/cli/e2e/e2e-package.ts
@@ -21,6 +21,7 @@ import { planGuideExecution } from './guide-chains';
 import type { LoadedGuide } from '../utils/file-loader';
 import { resolveTarget, type CloudAuthTargets } from './e2e-targets';
 import type { CurrentTier } from './manifest-preflight';
+import { classifyGuideSideEffectsFromString, type SideEffectClassification } from './side-effects';
 
 const FETCH_TIMEOUT_MS = 15_000;
 
@@ -38,6 +39,7 @@ export const REMOTE_SKIP_REASONS = [
   'validation_failed',
   'unsupported_type',
   'prerequisite_failed',
+  'skipped_unsafe_shared_stack',
 ] as const;
 
 /** Why a remote package was skipped instead of run. */
@@ -54,6 +56,8 @@ export interface ResolvedRemoteGuide {
   targetUrl: string;
   /** The content.json URL the guide was fetched from. */
   sourceUrl: string;
+  /** Conservative side-effect classification for the fetched content. */
+  sideEffects: SideEffectClassification;
 }
 
 /** A remote package that will not be run, with a structured reason. */
@@ -63,6 +67,7 @@ export interface SkippedPackage {
   message: string;
   sourceUrl?: string;
   tier?: string;
+  sideEffects?: SideEffectClassification;
 }
 
 /** Result of resolving one or more remote packages. */
@@ -179,6 +184,7 @@ async function buildGuideOrSkip(
       },
     };
   }
+  const sideEffects = classifyGuideSideEffectsFromString(fetched.text);
 
   return {
     runnable: {
@@ -188,6 +194,7 @@ async function buildGuideOrSkip(
       instance: target.instance,
       targetUrl: target.targetUrl!,
       sourceUrl: contentUrl,
+      sideEffects,
     },
   };
 }
@@ -246,6 +253,7 @@ function prerequisiteFailedSkip(target: ResolvedRemoteGuide, detail: string): Sk
     message: `Prerequisite(s) did not resolve: ${detail}`,
     sourceUrl: target.sourceUrl,
     tier: target.tier,
+    sideEffects: target.sideEffects,
   };
 }
 
@@ -256,6 +264,7 @@ function resolutionFailedSkip(target: ResolvedRemoteGuide, message: string): Ski
     message,
     sourceUrl: target.sourceUrl,
     tier: target.tier,
+    sideEffects: target.sideEffects,
   };
 }
 

--- a/src/cli/e2e/e2e-reporter.ts
+++ b/src/cli/e2e/e2e-reporter.ts
@@ -9,6 +9,7 @@
 
 import { writeFileSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
+import type { SideEffectClassification } from './side-effects';
 
 // ============================================
 // Types - JSON Report Structure
@@ -34,6 +35,7 @@ export interface GuideMetadata {
   targetUrl?: string;
   /** Source content.json URL for remotely-resolved guides. */
   sourceUrl?: string;
+  sideEffects?: SideEffectClassification;
 }
 
 /**
@@ -154,6 +156,7 @@ export interface PreRunSkip {
   tier?: string;
   /** Source content.json URL, when known. */
   sourceUrl?: string;
+  sideEffects?: SideEffectClassification;
 }
 
 /**
@@ -461,6 +464,7 @@ export interface GuideResult {
   summary: ReportSummary;
   /** Duration in milliseconds */
   duration: number;
+  sideEffects?: SideEffectClassification;
 }
 
 /**
@@ -549,6 +553,7 @@ export function toGuideResult(report: E2ETestReport): GuideResult {
     success: isReportSuccess(report) && report.abortReason !== 'SKIPPED_PREREQ',
     summary: report.summary,
     duration: report.summary.duration,
+    sideEffects: report.guide.sideEffects,
   };
 
   if (report.abortReason) {

--- a/src/cli/e2e/e2e-results.test.ts
+++ b/src/cli/e2e/e2e-results.test.ts
@@ -34,6 +34,8 @@ import type { ResolvedRemoteGuide, SkippedPackage } from './e2e-package';
 import type { TestResultsData } from './e2e-reporter';
 import { ExitCode } from './exit-codes';
 
+const READONLY_SIDE_EFFECTS = { level: 'readonly' as const, reasons: [] };
+
 describe('resolveRunMode', () => {
   beforeEach(() => {
     (existsSync as jest.Mock).mockReset();
@@ -118,6 +120,7 @@ describe('buildPackageMetaMap', () => {
         instance: 'play.grafana.org',
         targetUrl: 'http://localhost:3000',
         sourceUrl: 'https://cdn.test/a/content.json',
+        sideEffects: READONLY_SIDE_EFFECTS,
       },
     ];
 
@@ -127,6 +130,7 @@ describe('buildPackageMetaMap', () => {
       instance: 'play.grafana.org',
       targetUrl: 'http://localhost:3000',
       sourceUrl: 'https://cdn.test/a/content.json',
+      sideEffects: READONLY_SIDE_EFFECTS,
     });
   });
 });
@@ -151,6 +155,7 @@ describe('applyPackageMeta', () => {
       // targetUrl is intentionally NOT propagated; the runner already set it.
       targetUrl: 'http://should-not-overwrite:3000',
       sourceUrl: 'https://cdn.test/a/content.json',
+      sideEffects: READONLY_SIDE_EFFECTS,
     });
 
     expect(data.guide).toMatchObject({
@@ -161,6 +166,7 @@ describe('applyPackageMeta', () => {
       tier: 'local',
       instance: 'play.grafana.org',
       sourceUrl: 'https://cdn.test/a/content.json',
+      sideEffects: READONLY_SIDE_EFFECTS,
     });
   });
 
@@ -187,6 +193,7 @@ describe('preRunSkipsFromResults', () => {
         autoIncluded: false,
         abortMessage: 'requires cloud',
         tier: 'cloud',
+        sideEffects: READONLY_SIDE_EFFECTS,
       },
       {
         guide: 'https://cdn.test/c/content.json',
@@ -220,6 +227,7 @@ describe('preRunSkipsFromResults', () => {
       failed: false,
       tier: 'cloud',
       sourceUrl: 'https://cdn.test/b/content.json',
+      sideEffects: READONLY_SIDE_EFFECTS,
     });
 
     // validation_failed is the one pre-run skip that counts as a failure, and an
@@ -267,6 +275,13 @@ describe('status label / icon tables', () => {
 
     expect(label).toBe('❌ Validation failed');
     expect(GUIDE_STATUS_ICONS.validation_failed).toBe('❌');
+  });
+
+  it('defines the unsafe shared-stack skip status', () => {
+    const label = GUIDE_STATUS_LABELS.find(([status]) => status === 'skipped_unsafe_shared_stack')?.[1];
+
+    expect(label).toBe('⊘ Skipped (unsafe shared stack)');
+    expect(GUIDE_STATUS_ICONS.skipped_unsafe_shared_stack).toBe('⊘');
   });
 });
 

--- a/src/cli/e2e/e2e-results.ts
+++ b/src/cli/e2e/e2e-results.ts
@@ -20,6 +20,7 @@ import {
 import type { PreRunSkip, TestResultsData } from './e2e-reporter';
 import { ExitCode } from './exit-codes';
 import type { AbortReason } from './playwright-runner';
+import type { SideEffectClassification } from './side-effects';
 
 /** How guide inputs are resolved for a run. */
 export type RunMode = 'local' | 'remote-package' | 'remote-repository';
@@ -31,6 +32,7 @@ export interface PackageMeta {
   instance?: string;
   targetUrl?: string;
   sourceUrl?: string;
+  sideEffects?: SideEffectClassification;
 }
 
 /**
@@ -54,6 +56,7 @@ export interface GuideRunResult {
   failedPrerequisite?: string;
   /** Declared tier for pre-run skips (for reporting). */
   tier?: string;
+  sideEffects?: SideEffectClassification;
 }
 
 /** Statuses that count as a test failure (non-zero exit). */
@@ -73,6 +76,7 @@ export const GUIDE_STATUS_LABELS: ReadonlyArray<readonly [GuideStatus, string]> 
   ['skipped_tier_mismatch', '⊘ Skipped (tier mismatch)'],
   ['skipped_no_auth', '⊘ Skipped (no cloud auth)'],
   ['skipped_invalid_instance', '⊘ Skipped (invalid instance)'],
+  ['skipped_unsafe_shared_stack', '⊘ Skipped (unsafe shared stack)'],
   ['unsupported_type', '⊘ Skipped (unsupported type)'],
   ['fetch_failed', '⊘ Skipped (fetch failed)'],
   ['resolution_failed', '⊘ Skipped (resolution failed)'],
@@ -89,6 +93,7 @@ export const GUIDE_STATUS_ICONS: Record<GuideStatus, string> = {
   skipped_tier_mismatch: '⊘',
   skipped_no_auth: '⊘',
   skipped_invalid_instance: '⊘',
+  skipped_unsafe_shared_stack: '⊘',
   unsupported_type: '⊘',
   fetch_failed: '⊘',
   resolution_failed: '⊘',
@@ -132,6 +137,7 @@ export function skipToResult(skip: SkippedPackage): GuideRunResult {
     autoIncluded: false,
     abortMessage: skip.message,
     tier: skip.tier,
+    sideEffects: skip.sideEffects,
   };
 }
 
@@ -140,7 +146,14 @@ export function buildPackageMetaMap(runnable: ResolvedRemoteGuide[]): Map<string
   return new Map(
     runnable.map((g) => [
       g.id,
-      { packageId: g.id, tier: g.tier, instance: g.instance, targetUrl: g.targetUrl, sourceUrl: g.sourceUrl },
+      {
+        packageId: g.id,
+        tier: g.tier,
+        instance: g.instance,
+        targetUrl: g.targetUrl,
+        sourceUrl: g.sourceUrl,
+        sideEffects: g.sideEffects,
+      },
     ])
   );
 }
@@ -159,6 +172,7 @@ export function applyPackageMeta(data: TestResultsData | undefined, meta: Packag
     tier: meta.tier,
     instance: meta.instance,
     sourceUrl: meta.sourceUrl,
+    sideEffects: meta.sideEffects,
   };
 }
 
@@ -175,6 +189,7 @@ export function preRunSkipsFromResults(results: GuideRunResult[]): PreRunSkip[] 
       failed: FAILURE_STATUSES.has(r.status),
       tier: r.tier,
       sourceUrl: r.guide,
+      sideEffects: r.sideEffects,
     }));
 }
 

--- a/src/cli/e2e/side-effects.test.ts
+++ b/src/cli/e2e/side-effects.test.ts
@@ -1,0 +1,151 @@
+import { classifyGuideSideEffects, classifyGuideSideEffectsFromString } from './side-effects';
+import type { JsonGuide } from '../../types/json-guide.types';
+
+function guide(blocks: JsonGuide['blocks']): JsonGuide {
+  return { id: 'g', title: 'Guide', blocks };
+}
+
+describe('classifyGuideSideEffects', () => {
+  it('classifies instructional and observational guides as readonly', () => {
+    const result = classifyGuideSideEffects(
+      guide([
+        { type: 'markdown', content: 'Read this' },
+        { type: 'quiz', question: 'Pick one', choices: [{ id: 'a', text: 'A', correct: true }] },
+        { type: 'interactive', action: 'highlight', reftarget: '[data-testid="panel"]', content: 'Look here' },
+        { type: 'interactive', action: 'navigate', reftarget: '/explore', content: 'Open Explore' },
+      ])
+    );
+
+    expect(result).toEqual({ level: 'readonly', reasons: [] });
+  });
+
+  it('classifies destructive and save-like buttons as mutating', () => {
+    const result = classifyGuideSideEffects(
+      guide([{ type: 'interactive', action: 'button', reftarget: 'Save dashboard', content: 'Save your work' }])
+    );
+
+    expect(result.level).toBe('mutating');
+    expect(result.reasons[0]).toMatchObject({ level: 'mutating', path: 'blocks[0]' });
+    expect(result.reasons[0]!.message).toContain('Save dashboard');
+  });
+
+  it('classifies generic button and formfill actions as possible mutations', () => {
+    const result = classifyGuideSideEffects(
+      guide([
+        { type: 'interactive', action: 'button', reftarget: '[data-testid="refresh"]', content: 'Click refresh' },
+        { type: 'interactive', action: 'formfill', reftarget: 'textarea[data-testid="query"]', content: 'Enter query' },
+      ])
+    );
+
+    expect(result.level).toBe('possibly_mutating');
+    expect(result.reasons).toHaveLength(2);
+  });
+
+  it('uses target values as classifier evidence', () => {
+    const result = classifyGuideSideEffects(
+      guide([
+        {
+          type: 'interactive',
+          action: 'formfill',
+          reftarget: 'input[name="name"]',
+          targetvalue: 'new dashboard',
+          content: 'Name the dashboard',
+        },
+      ])
+    );
+
+    expect(result.level).toBe('possibly_mutating');
+    expect(result.reasons[0]!.message).toContain('new dashboard');
+  });
+
+  it('classifies creation and admin routes as possible mutations', () => {
+    const result = classifyGuideSideEffects(
+      guide([
+        { type: 'interactive', action: 'navigate', reftarget: '/connections/datasources/new', content: 'Add one' },
+      ])
+    );
+
+    expect(result.level).toBe('possibly_mutating');
+    expect(result.reasons[0]!.message).toContain('/connections/datasources/new');
+  });
+
+  it('lets explicit read-only routes override broader mutating route families', () => {
+    const result = classifyGuideSideEffects(
+      guide([{ type: 'interactive', action: 'navigate', reftarget: '/alerting/list', content: 'View alert rules' }])
+    );
+
+    expect(result).toEqual({ level: 'readonly', reasons: [] });
+  });
+
+  it('does not let read-only list routes cover creation subroutes', () => {
+    const list = classifyGuideSideEffects(
+      guide([
+        {
+          type: 'interactive',
+          action: 'navigate',
+          reftarget: '/connections/datasources',
+          content: 'View data sources',
+        },
+      ])
+    );
+    const create = classifyGuideSideEffects(
+      guide([
+        {
+          type: 'interactive',
+          action: 'navigate',
+          reftarget: '/connections/datasources/new',
+          content: 'Create data source',
+        },
+      ])
+    );
+
+    expect(list).toEqual({ level: 'readonly', reasons: [] });
+    expect(create.level).toBe('possibly_mutating');
+  });
+
+  it('walks nested sections, conditionals, assistants, guided, and multistep blocks', () => {
+    const result = classifyGuideSideEffects(
+      guide([
+        {
+          type: 'section',
+          blocks: [
+            {
+              type: 'conditional',
+              conditions: ['has-datasource:prometheus'],
+              whenTrue: [{ type: 'assistant', blocks: [{ type: 'markdown', content: 'No-op' }] }],
+              whenFalse: [
+                {
+                  type: 'guided',
+                  content: 'Create a data source',
+                  steps: [{ action: 'button', reftarget: 'Create data source' }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'multistep',
+          content: 'Read-only tour',
+          steps: [{ action: 'highlight', reftarget: '[data-testid="x"]' }],
+        },
+      ])
+    );
+
+    expect(result.level).toBe('mutating');
+    expect(result.reasons[0]).toMatchObject({ path: 'blocks[0].blocks[0].whenFalse[0].steps[0]' });
+  });
+
+  it('keeps unknown blocks distinct from possible mutations', () => {
+    const result = classifyGuideSideEffects(guide([{ type: 'snippet-ref', snippetId: 'shared-setup' }]));
+
+    expect(result.level).toBe('unknown');
+    expect(result.reasons[0]!.message).toMatch(/Snippet content/);
+  });
+
+  it('classifies invalid JSON as unknown', () => {
+    const result = classifyGuideSideEffectsFromString('{not json');
+
+    expect(result.level).toBe('unknown');
+    expect(result.reasons[0]).toMatchObject({ path: '$' });
+  });
+});

--- a/src/cli/e2e/side-effects.ts
+++ b/src/cli/e2e/side-effects.ts
@@ -1,0 +1,224 @@
+import {
+  isAssistantBlock,
+  isChallengeBlock,
+  isCodeBlockBlock,
+  isConditionalBlock,
+  isGrotGuideBlock,
+  isGuidedBlock,
+  isHtmlBlock,
+  isImageBlock,
+  isInputBlock,
+  isInteractiveBlock,
+  isMarkdownBlock,
+  isMultistepBlock,
+  isQuizBlock,
+  isSectionBlock,
+  isSnippetRefBlock,
+  isTerminalBlock,
+  isTerminalConnectBlock,
+  isVideoBlock,
+  type JsonBlock,
+  type JsonGuide,
+  type JsonInteractiveAction,
+  type JsonStep,
+} from '../../types/json-guide.types';
+
+export type SideEffectLevel = 'readonly' | 'possibly_mutating' | 'mutating' | 'unknown';
+
+export interface SideEffectReason {
+  level: Exclude<SideEffectLevel, 'readonly'>;
+  path: string;
+  message: string;
+}
+
+export interface SideEffectClassification {
+  level: SideEffectLevel;
+  reasons: SideEffectReason[];
+}
+
+const LEVEL_SCORE: Record<SideEffectLevel, number> = {
+  readonly: 0,
+  possibly_mutating: 1,
+  unknown: 2,
+  mutating: 3,
+};
+
+const MUTATING_TEXT_PATTERN =
+  /\b(save|create|delete|destroy|remove|update|submit|apply|import|provision|install|enable|disable|add)\b/i;
+const POSSIBLY_MUTATING_TEXT_PATTERN = /\b(new|edit|configure|config|settings|admin|manage)\b/i;
+const MUTATING_ROUTE_PATTERN =
+  /\/(dashboard\/new|dashboards\/new|connections\/datasources\/new|datasources\/new|alerting|admin|plugins|org|users|teams|serviceaccounts|api-keys)(?:\/|$|[?#])/i;
+const READONLY_ROUTE_PATTERN =
+  /\/(explore|drilldown)(?:\/|$|[?#])|\/dashboards(?:$|[?#])|\/d\/[^/?#]+(?:\/|$|[?#])|\/alerting\/list(?:\/|$|[?#])|\/connections\/datasources(?:$|[?#])/i;
+
+function mergeClassifications(classifications: SideEffectClassification[]): SideEffectClassification {
+  const reasons = classifications.flatMap((classification) => classification.reasons);
+  const level = classifications.reduce<SideEffectLevel>(
+    (highest, classification) =>
+      LEVEL_SCORE[classification.level] > LEVEL_SCORE[highest] ? classification.level : highest,
+    'readonly'
+  );
+  return { level, reasons };
+}
+
+function reason(level: Exclude<SideEffectLevel, 'readonly'>, path: string, message: string): SideEffectClassification {
+  return { level, reasons: [{ level, path, message }] };
+}
+
+function readonly(): SideEffectClassification {
+  return { level: 'readonly', reasons: [] };
+}
+
+function textEvidence(action: string, value: string | undefined, path: string): SideEffectClassification | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (MUTATING_TEXT_PATTERN.test(value)) {
+    return reason('mutating', path, `${action} target looks state-changing: ${value}`);
+  }
+  if (POSSIBLY_MUTATING_TEXT_PATTERN.test(value)) {
+    return reason('possibly_mutating', path, `${action} target may lead to state changes: ${value}`);
+  }
+  return undefined;
+}
+
+function routeEvidence(path: string, route: string | undefined): SideEffectClassification | undefined {
+  if (!route) {
+    return undefined;
+  }
+  if (READONLY_ROUTE_PATTERN.test(route)) {
+    return readonly();
+  }
+  if (MUTATING_ROUTE_PATTERN.test(route)) {
+    return reason('possibly_mutating', path, `Navigation target is a configuration or creation route: ${route}`);
+  }
+  return undefined;
+}
+
+function classifyAction(
+  action: JsonInteractiveAction | undefined,
+  target: string | undefined,
+  targetValue: string | undefined,
+  path: string
+): SideEffectClassification {
+  if (!action) {
+    return reason('unknown', path, 'Interactive action is missing');
+  }
+
+  if (action === 'noop' || action === 'highlight' || action === 'hover' || action === 'popout') {
+    return readonly();
+  }
+
+  if (action === 'navigate') {
+    return routeEvidence(path, target) ?? readonly();
+  }
+
+  if (action === 'button') {
+    return (
+      textEvidence('Button', target, path) ??
+      textEvidence('Button value', targetValue, path) ??
+      reason('possibly_mutating', path, 'Button click may mutate Grafana state')
+    );
+  }
+
+  if (action === 'formfill') {
+    return (
+      textEvidence('Form fill', target, path) ??
+      textEvidence('Form fill value', targetValue, path) ??
+      reason('possibly_mutating', path, 'Form fill may be submitted later')
+    );
+  }
+
+  return reason('unknown', path, `Unrecognized action: ${action}`);
+}
+
+function classifyStep(step: JsonStep, path: string): SideEffectClassification {
+  return classifyAction(
+    step.action ?? step.targetAction,
+    step.reftarget ?? step.refTarget,
+    step.targetvalue ?? step.targetValue,
+    path
+  );
+}
+
+function classifySteps(steps: JsonStep[] | undefined, path: string): SideEffectClassification {
+  if (!Array.isArray(steps)) {
+    return reason('unknown', path, 'Step list is missing or invalid');
+  }
+  return mergeClassifications(steps.map((step, index) => classifyStep(step, `${path}.steps[${index}]`)));
+}
+
+function classifyBlocks(blocks: JsonBlock[] | undefined, path: string): SideEffectClassification {
+  if (!Array.isArray(blocks)) {
+    return reason('unknown', path, 'Block list is missing or invalid');
+  }
+  return mergeClassifications(blocks.map((block, index) => classifyBlock(block, `${path}[${index}]`)));
+}
+
+function classifyBlock(block: JsonBlock, path: string): SideEffectClassification {
+  if (
+    isMarkdownBlock(block) ||
+    isHtmlBlock(block) ||
+    isImageBlock(block) ||
+    isVideoBlock(block) ||
+    isQuizBlock(block) ||
+    isInputBlock(block) ||
+    isGrotGuideBlock(block)
+  ) {
+    return readonly();
+  }
+  if (isInteractiveBlock(block)) {
+    return classifyAction(
+      block.action ?? block.targetAction,
+      block.reftarget ?? block.refTarget,
+      block.targetvalue ?? block.targetValue,
+      path
+    );
+  }
+  if (isMultistepBlock(block) || isGuidedBlock(block)) {
+    return classifySteps(block.steps, path);
+  }
+  if (isSectionBlock(block)) {
+    return classifyBlocks(block.blocks, `${path}.blocks`);
+  }
+  if (isConditionalBlock(block)) {
+    return mergeClassifications([
+      classifyBlocks(block.whenTrue, `${path}.whenTrue`),
+      classifyBlocks(block.whenFalse, `${path}.whenFalse`),
+    ]);
+  }
+  if (isAssistantBlock(block)) {
+    return classifyBlocks(block.blocks, `${path}.blocks`);
+  }
+  if (isCodeBlockBlock(block)) {
+    return reason('possibly_mutating', path, 'Code insertion may be saved or executed later');
+  }
+  if (isTerminalBlock(block) || isTerminalConnectBlock(block) || isChallengeBlock(block)) {
+    return reason('unknown', path, `${block.type} block can have side effects outside static guide analysis`);
+  }
+  if (isSnippetRefBlock(block)) {
+    return reason('unknown', path, 'Snippet content is resolved at parse time and must be classified after expansion');
+  }
+  return reason('unknown', path, 'Unknown block type');
+}
+
+export function classifyGuideSideEffects(guide: JsonGuide): SideEffectClassification {
+  return classifyBlocks(guide.blocks, 'blocks');
+}
+
+export function classifyGuideSideEffectsFromString(content: string): SideEffectClassification {
+  try {
+    const guide = JSON.parse(content) as JsonGuide;
+    return classifyGuideSideEffects(guide);
+  } catch (err) {
+    return reason(
+      'unknown',
+      '$',
+      `Guide JSON could not be parsed: ${err instanceof Error ? err.message : 'Unknown error'}`
+    );
+  }
+}
+
+export function isUnsafeSideEffectLevel(level: SideEffectLevel): boolean {
+  return level !== 'readonly';
+}


### PR DESCRIPTION
> [!NOTE]
> For broader context, see the **E2E Cloud isolation epic**: https://github.com/grafana/grafana-pathfinder-app/issues/1184

## Summary

Adds a static side-effect classifier and routing layer to the Cloud E2E runner. Remote guide chains are now classified as `readonly`, `possibly_mutating`, `mutating`, or `unknown` during package resolution; unsafe chains are routed away from the shared Grafana Cloud stack and skipped with a clear status when no isolated stack path is available. Classification metadata surfaces in both console and JSON reports so skipped chains explain their routing decision.

Closes issues #1185 (classify remote guide side effects) and #1186 (route Cloud E2E chains between shared and isolated stacks). Builds on the approach prototyped in [spike PR #1183](https://github.com/grafana/grafana-pathfinder-app/pull/1183).

## What to look at

- **`src/cli/e2e/` — classifier ([`side-effects.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8b1c9d617de4e02d7928a3456054ab8b8925c627/src/cli/e2e/side-effects.ts))**: walks all nested block types (conditionals, guided blocks, multisteps, assistant blocks, terminal/interactive actions) and assigns a side-effect level by combining text and route pattern matching with a max-score merge. The classifier is deliberately conservative — false positives route to the skipped path; false negatives would silently pollute shared stack state. Note that chains with no `sideEffects` metadata are treated as unsafe by the router, not readonly.
- **`src/cli/e2e/` — router ([`cloud-routing.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8b1c9d617de4e02d7928a3456054ab8b8925c627/src/cli/e2e/cloud-routing.ts))**: given a chain's resolved package metadata, identifies cloud-tier guides whose classification is unsafe and produces the `skipped_unsafe_shared_stack` skip message. The skip is surfaced via `unsafeSharedStackMessage` so the reason travels with the result.
- **`src/cli/e2e/` — package resolution ([`e2e-package.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8b1c9d617de4e02d7928a3456054ab8b8925c627/src/cli/e2e/e2e-package.ts))**: attaches the `SideEffectClassification` to each resolved cloud guide's `PackageMeta`, threading it forward into results and reports.
- **`src/cli/e2e/` — results and reporting ([`e2e-results.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8b1c9d617de4e02d7928a3456054ab8b8925c627/src/cli/e2e/e2e-results.ts), [`e2e-reporter.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8b1c9d617de4e02d7928a3456054ab8b8925c627/src/cli/e2e/e2e-reporter.ts), [`e2e-console-reporter.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/8b1c9d617de4e02d7928a3456054ab8b8925c627/src/cli/e2e/e2e-console-reporter.ts))**: result types gain `sideEffects` and routing-decision fields; both JSON output and console output render the new `skipped_unsafe_shared_stack` outcome with its classification reasons.
- **`src/cli/commands/e2e.ts`**: wires the classifier and router into the remote cloud resolution path.

## Why

Cloud E2E runs share a single Grafana Cloud test stack. Guides that create dashboards, data sources, folders, alerting rules, or other org-global resources can corrupt that shared state, causing later guide tests to fail for reasons unrelated to the guide under test. Epic #1184 ("Isolate Grafana Cloud E2E guide runs from shared stack state") defines the three-piece solution; spike PR #1183 validated the classifier-driven approach. This PR delivers the first two pieces — classification (#1185) and routing (#1186) — without yet wiring in ephemeral stack provisioning or hot-pool leasing.

## How to verify

1. Run a remote E2E package containing a read-only cloud guide (no dashboard/datasource creation steps). Confirm it continues to run on the shared-stack path and the JSON report shows `sideEffects.level: "readonly"` with no routing-skip reason.

```
pathfinder-cli e2e \
  --tier cloud \
  --package drilldown-metrics-open-metrics-explore \
  --cloud-url "https://${CLOUD_STACK_HOST}/" \
  --cloud-instance-admin-token "${CLOUD_STACK_HOST}=GRAFANA_CLOUD_ADMIN_TOKEN" \
  --verbose
```

2. Run a remote E2E package containing a guide with a mutation step (e.g., a step that navigates to `/connections/datasources/new` or uses a button labelled "Save"). Confirm the chain classification is `mutating` or `possibly_mutating` and the result shows `skipped_unsafe_shared_stack` with a `reasons` list in both console and JSON output.

```
pathfinder-cli e2e \
  --tier cloud \
  --package iis-web-server-install-dashboards \
  --cloud-url "https://${CLOUD_STACK_HOST}/" \
  --cloud-instance-admin-token "${CLOUD_STACK_HOST}=GRAFANA_CLOUD_ADMIN_TOKEN" \
  --verbose
```

## Breaking changes

None. This change is additive and fully reversible. The new `skipped_unsafe_shared_stack` outcome type is returned only for unsafe cloud chains; all existing local, bundled, and shared-stack-safe cloud E2E flows are unaffected.

## Out of scope

- **Ephemeral stack provisioning** (cold-provision a disposable Grafana Cloud stack for unsafe chains) — remaining piece of epic #1184.
- **Hot-pool leasing** (lease and retire a pre-provisioned pool stack) — remaining piece of epic #1184.
- **`testEnvironment` manifest field changes** — deferred until runner behavior is proven in production CI, per the key design decision in #1184.

Closes #1185
Closes #1186
Refs #1184
Refs #1183