### PR TITLE
refactor(e2e): clarify shared cloud stack targeting

### DIFF
--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -21,7 +21,12 @@ import {
 import { planGuideExecution } from '../e2e/guide-chains';
 import type { TestResultsData } from '../e2e/e2e-reporter';
 import { checkTier, loadManifestFromDir, runManifestPreflight, type CurrentTier } from '../e2e/manifest-preflight';
-import { resolveRemotePackage, resolveRemoteRepository, type ResolvedRemoteGuide } from '../e2e/e2e-package';
+import {
+  resolveRemotePackage,
+  resolveRemoteRepository,
+  type RemoteResolveOptions,
+  type ResolvedRemoteGuide,
+} from '../e2e/e2e-package';
 import { checkGrafanaHealth } from '../e2e/grafana-health';
 import { CleanEnvironment, CLEAN_COMPOSE_PROJECT, CLEAN_GRAFANA_URL } from '../e2e/clean-environment';
 import { ExitCode } from '../e2e/exit-codes';
@@ -741,13 +746,13 @@ async function resolveRunInputs(files: string[], options: E2ECommandOptions): Pr
   const cloudAuth = createCloudAuthPolicy({
     cloudInstanceAdminTokenSpecs: options.cloudInstanceAdminToken,
   });
-  const remoteOptions = {
+  const remoteOptions: RemoteResolveOptions = {
     grafanaUrl: options.grafanaUrl,
     currentTier: options.tier,
     resolverUrl: options.resolverUrl,
     repoUrl: options.repoUrl,
     cloudUrl: options.cloudUrl,
-    cloudAuthTargets: cloudAuth.targets,
+    cloudTargetCapabilities: cloudAuth.targets,
   };
   const resolution =
     mode === 'remote-package'
@@ -857,7 +862,7 @@ export const e2eCommand = new Command('e2e')
       await maybeCleanStart(cleanEnv, options);
 
       await sweepCloudTargets({
-        targetUrls: inputs.cloudAuth?.targets.provisionable ?? [],
+        targetUrls: inputs.cloudAuth?.targets.sharedStackUrls ?? [],
         cloudAuth: inputs.cloudAuth,
         verbose: options.verbose,
       });

--- a/src/cli/e2e/cloud-auth.test.ts
+++ b/src/cli/e2e/cloud-auth.test.ts
@@ -3,14 +3,14 @@ import { createCloudAuthPolicy } from './cloud-auth';
 const CLOUD_URL = 'https://learn.grafana.net/';
 
 describe('createCloudAuthPolicy', () => {
-  it('declares a cloud URL provisionable when an admin token mapping exists', () => {
+  it('declares shared-stack URLs when an admin token mapping exists', () => {
     const auth = createCloudAuthPolicy({
       cloudInstanceAdminTokenSpecs: ['learn.grafana.net=GRAFANA_LEARN_ADMIN_TOKEN'],
       env: { GRAFANA_LEARN_ADMIN_TOKEN: 'glsa_admin' },
     });
 
     expect(auth.targets).toEqual({
-      provisionable: [CLOUD_URL],
+      sharedStackUrls: [CLOUD_URL],
     });
     expect(auth.adminTokenFor(CLOUD_URL)).toBe('glsa_admin');
     expect(auth.needsProvisioningFor(CLOUD_URL)).toBe(true);
@@ -24,7 +24,7 @@ describe('createCloudAuthPolicy', () => {
     });
 
     expect(auth.targets).toEqual({
-      provisionable: ['https://play.grafana.org/'],
+      sharedStackUrls: ['https://play.grafana.org/'],
     });
     expect(auth.adminTokenFor('https://play.grafana.org/')).toBe('glsa_play_admin');
     expect(auth.adminTokenFor(CLOUD_URL)).toBeUndefined();

--- a/src/cli/e2e/cloud-auth.ts
+++ b/src/cli/e2e/cloud-auth.ts
@@ -1,4 +1,4 @@
-import { cloudInstanceUrl, sameOrigin, type CloudAuthTargets } from './e2e-targets';
+import { cloudInstanceUrl, sameOrigin, type CloudTargetCapabilities } from './e2e-targets';
 
 export interface CloudAuthConfigInput {
   cloudInstanceAdminTokenSpecs?: string[];
@@ -10,7 +10,7 @@ export interface RunnerAuth {
 }
 
 export interface CloudAuthPolicy {
-  targets: CloudAuthTargets;
+  targets: CloudTargetCapabilities;
   adminTokenFor(targetUrl: string | undefined): string | undefined;
   needsProvisioningFor(targetUrl: string | undefined): boolean;
   runnerAuthFor(targetUrl: string | undefined, provisionedToken?: string): RunnerAuth;
@@ -80,7 +80,7 @@ export function createCloudAuthPolicy(input: CloudAuthConfigInput): CloudAuthPol
 
   return {
     targets: {
-      provisionable: adminTokenConfig.targetUrls,
+      sharedStackUrls: adminTokenConfig.targetUrls,
     },
     adminTokenFor(targetUrl) {
       return tokenForTarget(adminTokenConfig.adminTokensByOrigin, targetUrl);

--- a/src/cli/e2e/cloud-provisioning.test.ts
+++ b/src/cli/e2e/cloud-provisioning.test.ts
@@ -1,5 +1,5 @@
-jest.mock('./cloud-environment', () => ({
-  CloudEnvironment: jest.fn().mockImplementation((adminToken: string, cloudUrl: string) => ({
+jest.mock('./shared-cloud-stack-environment', () => ({
+  SharedCloudStackEnvironment: jest.fn().mockImplementation((adminToken: string, cloudUrl: string) => ({
     adminToken,
     cloudUrl,
     provisionChain: jest.fn(async () => `minted:${cloudUrl}`),
@@ -8,7 +8,7 @@ jest.mock('./cloud-environment', () => ({
   })),
 }));
 
-import { CloudEnvironment } from './cloud-environment';
+import { SharedCloudStackEnvironment } from './shared-cloud-stack-environment';
 import {
   cloudTargetsInChain,
   provisionCloudTargetsForChain,
@@ -19,7 +19,7 @@ import type { CloudAuthPolicy } from './cloud-auth';
 import type { PackageMeta } from './e2e-results';
 
 const cloudAuth: CloudAuthPolicy = {
-  targets: { provisionable: ['https://learn.grafana.net/', 'https://play.grafana.org/'] },
+  targets: { sharedStackUrls: ['https://learn.grafana.net/', 'https://play.grafana.org/'] },
   adminTokenFor: (targetUrl) => {
     if (targetUrl?.startsWith('https://learn.grafana.net')) {
       return 'learn-admin';
@@ -34,7 +34,7 @@ const cloudAuth: CloudAuthPolicy = {
 };
 
 describe('cloudTargetsInChain', () => {
-  it('deduplicates provisionable targets by URL', () => {
+  it('deduplicates shared-stack target URLs', () => {
     const packageMetaById = new Map<string, PackageMeta>([
       ['a', { packageId: 'a', tier: 'cloud', targetUrl: 'https://learn.grafana.net/' }],
       ['b', { packageId: 'b', tier: 'cloud', targetUrl: 'https://learn.grafana.net/' }],
@@ -51,10 +51,10 @@ describe('cloudTargetsInChain', () => {
 describe('ProvisionedCloudTargets', () => {
   it('looks up minted tokens by origin and tears down all targets', async () => {
     const learnEnv = { teardownChain: jest.fn(async () => undefined) } as unknown as InstanceType<
-      typeof CloudEnvironment
+      typeof SharedCloudStackEnvironment
     >;
     const playEnv = { teardownChain: jest.fn(async () => undefined) } as unknown as InstanceType<
-      typeof CloudEnvironment
+      typeof SharedCloudStackEnvironment
     >;
     const provisioned = new ProvisionedCloudTargets();
 
@@ -90,29 +90,33 @@ describe('provisionCloudTargetsForChain', () => {
       verbose: false,
     });
 
-    expect(CloudEnvironment).toHaveBeenCalledWith('learn-admin', 'https://learn.grafana.net/', false);
-    expect(CloudEnvironment).toHaveBeenCalledWith('play-admin', 'https://play.grafana.org/', false);
+    expect(SharedCloudStackEnvironment).toHaveBeenCalledWith('learn-admin', 'https://learn.grafana.net/', false);
+    expect(SharedCloudStackEnvironment).toHaveBeenCalledWith('play-admin', 'https://play.grafana.org/', false);
     expect(provisioned.tokenFor('https://learn.grafana.net/')).toBe('minted:https://learn.grafana.net/');
     expect(provisioned.tokenFor('https://play.grafana.org/')).toBe('minted:https://play.grafana.org/');
   });
 
   it('tears down already-provisioned targets when a later target fails', async () => {
-    (CloudEnvironment as unknown as jest.Mock).mockImplementationOnce((adminToken: string, cloudUrl: string) => ({
-      adminToken,
-      cloudUrl,
-      provisionChain: jest.fn(async () => `minted:${cloudUrl}`),
-      teardownChain: jest.fn(async () => undefined),
-      sweepOrphans: jest.fn(async () => undefined),
-    }));
-    (CloudEnvironment as unknown as jest.Mock).mockImplementationOnce((adminToken: string, cloudUrl: string) => ({
-      adminToken,
-      cloudUrl,
-      provisionChain: jest.fn(async () => {
-        throw new Error('boom');
-      }),
-      teardownChain: jest.fn(async () => undefined),
-      sweepOrphans: jest.fn(async () => undefined),
-    }));
+    (SharedCloudStackEnvironment as unknown as jest.Mock).mockImplementationOnce(
+      (adminToken: string, cloudUrl: string) => ({
+        adminToken,
+        cloudUrl,
+        provisionChain: jest.fn(async () => `minted:${cloudUrl}`),
+        teardownChain: jest.fn(async () => undefined),
+        sweepOrphans: jest.fn(async () => undefined),
+      })
+    );
+    (SharedCloudStackEnvironment as unknown as jest.Mock).mockImplementationOnce(
+      (adminToken: string, cloudUrl: string) => ({
+        adminToken,
+        cloudUrl,
+        provisionChain: jest.fn(async () => {
+          throw new Error('boom');
+        }),
+        teardownChain: jest.fn(async () => undefined),
+        sweepOrphans: jest.fn(async () => undefined),
+      })
+    );
 
     await expect(
       provisionCloudTargetsForChain({
@@ -122,8 +126,8 @@ describe('provisionCloudTargetsForChain', () => {
       })
     ).rejects.toThrow('boom');
 
-    const first = (CloudEnvironment as unknown as jest.Mock).mock.results[0]?.value;
-    const second = (CloudEnvironment as unknown as jest.Mock).mock.results[1]?.value;
+    const first = (SharedCloudStackEnvironment as unknown as jest.Mock).mock.results[0]?.value;
+    const second = (SharedCloudStackEnvironment as unknown as jest.Mock).mock.results[1]?.value;
 
     expect(first).toBeDefined();
     expect(second).toBeDefined();
@@ -144,11 +148,11 @@ describe('sweepCloudTargets', () => {
       verbose: true,
     });
 
-    const first = (CloudEnvironment as unknown as jest.Mock).mock.results[0]?.value;
-    const second = (CloudEnvironment as unknown as jest.Mock).mock.results[1]?.value;
+    const first = (SharedCloudStackEnvironment as unknown as jest.Mock).mock.results[0]?.value;
+    const second = (SharedCloudStackEnvironment as unknown as jest.Mock).mock.results[1]?.value;
 
-    expect(CloudEnvironment).toHaveBeenCalledWith('learn-admin', 'https://learn.grafana.net/', true);
-    expect(CloudEnvironment).toHaveBeenCalledWith('play-admin', 'https://play.grafana.org/', true);
+    expect(SharedCloudStackEnvironment).toHaveBeenCalledWith('learn-admin', 'https://learn.grafana.net/', true);
+    expect(SharedCloudStackEnvironment).toHaveBeenCalledWith('play-admin', 'https://play.grafana.org/', true);
     expect(first).toBeDefined();
     expect(second).toBeDefined();
     expect(first!.sweepOrphans).toHaveBeenCalledTimes(1);

--- a/src/cli/e2e/cloud-provisioning.ts
+++ b/src/cli/e2e/cloud-provisioning.ts
@@ -1,5 +1,5 @@
 import { sameOrigin } from './e2e-targets';
-import { CloudEnvironment } from './cloud-environment';
+import { SharedCloudStackEnvironment } from './shared-cloud-stack-environment';
 import type { CloudAuthPolicy } from './cloud-auth';
 import type { PackageMeta } from './e2e-results';
 
@@ -8,7 +8,7 @@ interface PlannedGuideRef {
 }
 
 interface ProvisionedCloudTarget {
-  env: CloudEnvironment;
+  env: SharedCloudStackEnvironment;
   token: string;
 }
 
@@ -66,7 +66,7 @@ export async function provisionCloudTargetsForChain(options: {
         continue;
       }
       console.log(`\n🔑 Provisioning a service account for ${new URL(targetUrl).origin}...`);
-      const env = new CloudEnvironment(adminToken, targetUrl, options.verbose);
+      const env = new SharedCloudStackEnvironment(adminToken, targetUrl, options.verbose);
       provisionedTargets.add(targetUrl, { env, token: await env.provisionChain() });
     }
     return provisionedTargets;
@@ -84,7 +84,7 @@ export async function sweepCloudTargets(options: {
   for (const targetUrl of options.targetUrls) {
     const adminToken = options.cloudAuth?.adminTokenFor(targetUrl);
     if (adminToken) {
-      await new CloudEnvironment(adminToken, targetUrl, options.verbose).sweepOrphans();
+      await new SharedCloudStackEnvironment(adminToken, targetUrl, options.verbose).sweepOrphans();
     }
   }
 }

--- a/src/cli/e2e/e2e-package.test.ts
+++ b/src/cli/e2e/e2e-package.test.ts
@@ -32,7 +32,7 @@ const CLOUD_OPTIONS = {
   currentTier: 'cloud' as const,
   resolverUrl: 'https://recommender.test',
   cloudUrl: 'https://learn.grafana.net/',
-  cloudAuthTargets: { provisionable: ['https://learn.grafana.net/'] },
+  cloudTargetCapabilities: { sharedStackUrls: ['https://learn.grafana.net/'] },
 };
 
 /** Configure the recommender resolver mock to return a fixed resolution. */
@@ -208,7 +208,7 @@ describe('resolveRemotePackage (single, recommender)', () => {
 
     const result = await resolveRemotePackage('cloud-guide', {
       ...CLOUD_OPTIONS,
-      cloudAuthTargets: { provisionable: [] },
+      cloudTargetCapabilities: { sharedStackUrls: [] },
     });
 
     expect(result.runnable).toHaveLength(0);
@@ -236,7 +236,7 @@ describe('resolveRemotePackage (single, recommender)', () => {
 
     const result = await resolveRemotePackage('play-guide', {
       ...CLOUD_OPTIONS,
-      cloudAuthTargets: { provisionable: ['https://play.grafana.org/'] },
+      cloudTargetCapabilities: { sharedStackUrls: ['https://play.grafana.org/'] },
     });
 
     expect(result.skipped).toHaveLength(0);
@@ -260,7 +260,31 @@ describe('resolveRemotePackage (single, recommender)', () => {
 
     const result = await resolveRemotePackage('play-guide', {
       ...CLOUD_OPTIONS,
-      cloudAuthTargets: { provisionable: [CLOUD_OPTIONS.cloudUrl] },
+      cloudTargetCapabilities: { sharedStackUrls: [CLOUD_OPTIONS.cloudUrl] },
+    });
+
+    expect(result.runnable).toHaveLength(0);
+    expect(result.skipped[0]).toMatchObject({
+      id: 'play-guide',
+      reason: 'skipped_no_auth',
+      tier: 'cloud',
+    });
+    expect(result.skipped[0]!.message).toContain('--cloud-instance-admin-token for https://play.grafana.org/');
+  });
+
+  it('skips an instance-targeted cloud guide when only isolated stack capability is available', async () => {
+    mockResolve({
+      ok: true,
+      id: 'play-guide',
+      contentUrl: 'https://cdn.test/play-guide/content.json',
+      manifestUrl: 'https://cdn.test/play-guide/manifest.json',
+      repository: 'r',
+      manifest: { id: 'play-guide', type: 'guide', testEnvironment: { tier: 'cloud', instance: 'play.grafana.org' } },
+    });
+
+    const result = await resolveRemotePackage('play-guide', {
+      ...CLOUD_OPTIONS,
+      cloudTargetCapabilities: { sharedStackUrls: [], isolatedStack: true },
     });
 
     expect(result.runnable).toHaveLength(0);

--- a/src/cli/e2e/e2e-package.ts
+++ b/src/cli/e2e/e2e-package.ts
@@ -19,7 +19,7 @@ import { resolvePackageById } from './recommender-resolver';
 import { fetchRepositoryIndex, buildPackageFileUrl, type RepositoryPackage } from '../mcp/lib/repository-client';
 import { planGuideExecution } from './guide-chains';
 import type { LoadedGuide } from '../utils/file-loader';
-import { resolveTarget, type CloudAuthTargets } from './e2e-targets';
+import { resolveTarget, type CloudTargetCapabilities } from './e2e-targets';
 import type { CurrentTier } from './manifest-preflight';
 import { classifyGuideSideEffectsFromString, type SideEffectClassification } from './side-effects';
 
@@ -96,8 +96,8 @@ export interface RemoteResolveOptions {
   repoUrl?: string;
   /** Default cloud instance URL for `cloud`-tier guides without an `instance`. */
   cloudUrl?: string;
-  /** Cloud target URLs that can be authenticated without exposing credential values to resolution. */
-  cloudAuthTargets?: CloudAuthTargets;
+  /** Cloud execution capabilities without exposing credential values to resolution. */
+  cloudTargetCapabilities?: CloudTargetCapabilities;
 }
 
 /** Fetch a URL as raw text with a timeout. Never throws. */
@@ -145,7 +145,7 @@ async function buildGuideOrSkip(
     grafanaUrl: options.grafanaUrl,
     currentTier: options.currentTier,
     cloudUrl: options.cloudUrl,
-    cloudAuthTargets: options.cloudAuthTargets,
+    cloudTargetCapabilities: options.cloudTargetCapabilities,
   });
   if (!target.runnable) {
     return {

--- a/src/cli/e2e/e2e-targets.test.ts
+++ b/src/cli/e2e/e2e-targets.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests for the e2e target resolver. Covers tier → target mapping, the skip
- * reasons, and cloud credential/instance resolution.
+ * Tests for the e2e target resolver. Covers tier → target mapping, skip
+ * reasons, and cloud execution capabilities.
  */
 
 import { resolveTarget } from './e2e-targets';
@@ -43,21 +43,54 @@ describe('resolveTarget', () => {
     expect(target.message).toBeDefined();
   });
 
-  it('skips a cloud guide on a cloud environment when credentials are absent', () => {
-    const target = resolveTarget({ tier: 'cloud' }, { grafanaUrl: LOCAL_URL, currentTier: 'cloud' });
+  it('skips a cloud guide on a cloud environment when no cloud execution capability is available', () => {
+    const target = resolveTarget(
+      { tier: 'cloud' },
+      { grafanaUrl: LOCAL_URL, currentTier: 'cloud', cloudUrl: CLOUD_URL }
+    );
 
     expect(target.runnable).toBe(false);
     expect(target.skipReason).toBe('skipped_no_auth');
   });
 
-  it('runs a cloud guide with credentials against the default cloud URL when no instance is declared', () => {
+  it('runs a cloud guide when isolated stack provisioning is available without shared-stack auth', () => {
     const target = resolveTarget(
       { tier: 'cloud' },
       {
         grafanaUrl: LOCAL_URL,
         currentTier: 'cloud',
         cloudUrl: CLOUD_URL,
-        cloudAuthTargets: { provisionable: [CLOUD_URL] },
+        cloudTargetCapabilities: { sharedStackUrls: [], isolatedStack: true },
+      }
+    );
+
+    expect(target.runnable).toBe(true);
+    expect(target.targetUrl).toBe(CLOUD_URL);
+  });
+
+  it('does not use isolated stack provisioning for a declared cloud instance', () => {
+    const target = resolveTarget(
+      { tier: 'cloud', instance: 'play.grafana.org' },
+      {
+        grafanaUrl: LOCAL_URL,
+        currentTier: 'cloud',
+        cloudUrl: CLOUD_URL,
+        cloudTargetCapabilities: { sharedStackUrls: [CLOUD_URL], isolatedStack: true },
+      }
+    );
+    expect(target.runnable).toBe(false);
+    expect(target.skipReason).toBe('skipped_no_auth');
+    expect(target.message).toContain('--cloud-instance-admin-token for https://play.grafana.org/');
+  });
+
+  it('runs a cloud guide with shared-stack auth against the default cloud URL when no instance is declared', () => {
+    const target = resolveTarget(
+      { tier: 'cloud' },
+      {
+        grafanaUrl: LOCAL_URL,
+        currentTier: 'cloud',
+        cloudUrl: CLOUD_URL,
+        cloudTargetCapabilities: { sharedStackUrls: [CLOUD_URL] },
       }
     );
 
@@ -74,7 +107,7 @@ describe('resolveTarget', () => {
         grafanaUrl: LOCAL_URL,
         currentTier: 'cloud',
         cloudUrl: CLOUD_URL,
-        cloudAuthTargets: { provisionable: ['https://play.grafana.org/'] },
+        cloudTargetCapabilities: { sharedStackUrls: ['https://play.grafana.org/'] },
       }
     );
 
@@ -83,14 +116,14 @@ describe('resolveTarget', () => {
     expect(target.instance).toBe('play.grafana.org');
   });
 
-  it('does not use default cloud credentials for a different declared instance', () => {
+  it('does not use default shared-stack auth for a different declared instance', () => {
     const target = resolveTarget(
       { tier: 'cloud', instance: 'play.grafana.org' },
       {
         grafanaUrl: LOCAL_URL,
         currentTier: 'cloud',
         cloudUrl: CLOUD_URL,
-        cloudAuthTargets: { provisionable: [CLOUD_URL] },
+        cloudTargetCapabilities: { sharedStackUrls: [CLOUD_URL] },
       }
     );
 
@@ -105,7 +138,7 @@ describe('resolveTarget', () => {
         grafanaUrl: LOCAL_URL,
         currentTier: 'cloud',
         cloudUrl: CLOUD_URL,
-        cloudAuthTargets: { provisionable: [CLOUD_URL] },
+        cloudTargetCapabilities: { sharedStackUrls: [CLOUD_URL] },
       }
     );
 
@@ -120,7 +153,7 @@ describe('resolveTarget', () => {
         grafanaUrl: LOCAL_URL,
         currentTier: 'cloud',
         cloudUrl: CLOUD_URL,
-        cloudAuthTargets: { provisionable: [CLOUD_URL] },
+        cloudTargetCapabilities: { sharedStackUrls: [CLOUD_URL] },
       }
     );
 
@@ -136,7 +169,7 @@ describe('resolveTarget', () => {
         grafanaUrl: LOCAL_URL,
         currentTier: 'cloud',
         cloudUrl: CLOUD_URL,
-        cloudAuthTargets: { provisionable: [CLOUD_URL] },
+        cloudTargetCapabilities: { sharedStackUrls: [CLOUD_URL] },
       }
     );
 
@@ -152,7 +185,7 @@ describe('resolveTarget', () => {
         grafanaUrl: LOCAL_URL,
         currentTier: 'cloud',
         cloudUrl: CLOUD_URL,
-        cloudAuthTargets: { provisionable: [CLOUD_URL] },
+        cloudTargetCapabilities: { sharedStackUrls: [CLOUD_URL] },
       }
     );
 
@@ -160,10 +193,10 @@ describe('resolveTarget', () => {
     expect(target.skipReason).toBe('skipped_invalid_instance');
   });
 
-  it('skips a cloud guide with credentials but no resolvable cloud URL', () => {
+  it('skips a cloud guide with target capabilities but no resolvable cloud URL', () => {
     const target = resolveTarget(
       { tier: 'cloud' },
-      { grafanaUrl: LOCAL_URL, currentTier: 'cloud', cloudAuthTargets: { provisionable: [CLOUD_URL] } }
+      { grafanaUrl: LOCAL_URL, currentTier: 'cloud', cloudTargetCapabilities: { sharedStackUrls: [CLOUD_URL] } }
     );
 
     expect(target.runnable).toBe(false);

--- a/src/cli/e2e/e2e-targets.ts
+++ b/src/cli/e2e/e2e-targets.ts
@@ -18,8 +18,9 @@ import { checkTier, type CurrentTier } from './manifest-preflight';
  * for (a legitimate routing decision). Collapsing them would hide a typo.
  */
 export type TargetSkipReason = 'skipped_no_auth' | 'skipped_tier_mismatch' | 'skipped_invalid_instance';
-export interface CloudAuthTargets {
-  provisionable: string[];
+export interface CloudTargetCapabilities {
+  sharedStackUrls: string[];
+  isolatedStack?: boolean;
 }
 
 /** Resolution of a guide's `testEnvironment` to a concrete test target. */
@@ -45,8 +46,8 @@ export interface ResolveTargetOptions {
   currentTier: CurrentTier;
   /** Default cloud instance URL for `cloud`-tier guides without an `instance`. */
   cloudUrl?: string;
-  /** Cloud target URLs that can be authenticated without exposing credential values to resolution. */
-  cloudAuthTargets?: CloudAuthTargets;
+  /** Cloud execution capabilities without exposing credential values to resolution. */
+  cloudTargetCapabilities?: CloudTargetCapabilities;
 }
 
 /**
@@ -67,9 +68,9 @@ export function cloudInstanceUrl(instance: string): string | undefined {
   }
 }
 
-function canProvisionFor(targetUrl: string, options: ResolveTargetOptions): boolean {
-  return (options.cloudAuthTargets?.provisionable ?? []).some((provisionableTargetUrl) =>
-    sameOrigin(targetUrl, provisionableTargetUrl)
+function hasSharedStackAuthFor(targetUrl: string, options: ResolveTargetOptions): boolean {
+  return (options.cloudTargetCapabilities?.sharedStackUrls ?? []).some((sharedStackUrl) =>
+    sameOrigin(targetUrl, sharedStackUrl)
   );
 }
 
@@ -89,9 +90,10 @@ export function sameOrigin(left: string | undefined, right: string | undefined):
  *
  * - `local` / absent / unknown tier → runnable against `options.grafanaUrl`
  * - `cloud` tier on a `local` environment → `skipped_tier_mismatch`
- * - `cloud` tier without credentials → `skipped_no_auth`
+ * - `cloud` tier without shared-stack auth or isolated-stack support → `skipped_no_auth`
  * - `cloud` tier with a malformed `instance` → `skipped_invalid_instance`
- * - `cloud` tier with credentials → runnable against the resolved cloud URL
+ * - `cloud` tier with `instance` → runnable only with shared-stack auth for that exact instance
+ * - `cloud` tier without `instance` → runnable with shared-stack auth or isolated-stack support
  */
 export function resolveTarget(testEnvironment: TestEnvironment, options: ResolveTargetOptions): ResolvedTarget {
   const tier = testEnvironment.tier ?? 'local';
@@ -103,17 +105,8 @@ export function resolveTarget(testEnvironment: TestEnvironment, options: Resolve
   }
 
   if (tier === 'cloud') {
-    const authTargets = options.cloudAuthTargets ?? { provisionable: [] };
+    const targetCapabilities = options.cloudTargetCapabilities ?? { sharedStackUrls: [] };
     const defaultTargetUrl = options.cloudUrl;
-    if (authTargets.provisionable.length === 0) {
-      return {
-        runnable: false,
-        tier,
-        instance,
-        skipReason: 'skipped_no_auth',
-        message: 'Cloud-tier guide requires --cloud-instance-admin-token for its target',
-      };
-    }
 
     if (instance !== undefined) {
       const instanceUrl = cloudInstanceUrl(instance);
@@ -126,7 +119,7 @@ export function resolveTarget(testEnvironment: TestEnvironment, options: Resolve
           message: `Cloud instance "${instance}" is not a bare hostname (no protocol, port, or path allowed)`,
         };
       }
-      if (!canProvisionFor(instanceUrl, options)) {
+      if (!hasSharedStackAuthFor(instanceUrl, options)) {
         return {
           runnable: false,
           tier,
@@ -146,7 +139,19 @@ export function resolveTarget(testEnvironment: TestEnvironment, options: Resolve
         message: 'No cloud URL configured for this guide (set --cloud-url)',
       };
     }
-    if (!canProvisionFor(defaultTargetUrl, options)) {
+    if (targetCapabilities.sharedStackUrls.length === 0 && !targetCapabilities.isolatedStack) {
+      return {
+        runnable: false,
+        tier,
+        instance,
+        skipReason: 'skipped_no_auth',
+        message: 'Cloud-tier guide requires --cloud-instance-admin-token for its target',
+      };
+    }
+    if (!hasSharedStackAuthFor(defaultTargetUrl, options)) {
+      if (targetCapabilities.isolatedStack) {
+        return { runnable: true, tier, instance, targetUrl: defaultTargetUrl };
+      }
       return {
         runnable: false,
         tier,

--- a/src/cli/e2e/shared-cloud-stack-environment.test.ts
+++ b/src/cli/e2e/shared-cloud-stack-environment.test.ts
@@ -4,7 +4,7 @@
  * handling without real network or a Grafana stack.
  */
 
-import { CloudEnvironment } from './cloud-environment';
+import { SharedCloudStackEnvironment } from './shared-cloud-stack-environment';
 
 const ADMIN_TOKEN = 'glsa_admin';
 const CLOUD_URL = 'https://stack.grafana.net/';
@@ -46,7 +46,7 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-describe('CloudEnvironment.provisionChain', () => {
+describe('SharedCloudStackEnvironment.provisionChain', () => {
   it('creates a service account then a token and returns the key', async () => {
     const calls = mockFetch((call) => {
       if (call.method === 'POST' && call.url.endsWith('/api/serviceaccounts')) {
@@ -58,7 +58,7 @@ describe('CloudEnvironment.provisionChain', () => {
       return { ok: false, status: 404 };
     });
 
-    const env = new CloudEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
+    const env = new SharedCloudStackEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
     const token = await env.provisionChain();
 
     expect(token).toBe('glsa_minted');
@@ -76,13 +76,13 @@ describe('CloudEnvironment.provisionChain', () => {
 
   it('throws when service-account creation fails', async () => {
     mockFetch(() => ({ ok: false, status: 401 }));
-    const env = new CloudEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
+    const env = new SharedCloudStackEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
 
     await expect(env.provisionChain()).rejects.toThrow(/HTTP 401/);
   });
 });
 
-describe('CloudEnvironment.teardownChain', () => {
+describe('SharedCloudStackEnvironment.teardownChain', () => {
   it('deletes the provisioned service account by id', async () => {
     const calls = mockFetch((call) => {
       if (call.url.endsWith('/api/serviceaccounts')) {
@@ -94,7 +94,7 @@ describe('CloudEnvironment.teardownChain', () => {
       return { ok: true };
     });
 
-    const env = new CloudEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
+    const env = new SharedCloudStackEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
     await env.provisionChain();
     await env.teardownChain();
 
@@ -104,7 +104,7 @@ describe('CloudEnvironment.teardownChain', () => {
 
   it('is a no-op when nothing was provisioned', async () => {
     const calls = mockFetch(() => ({ ok: true }));
-    const env = new CloudEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
+    const env = new SharedCloudStackEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
 
     await env.teardownChain();
 
@@ -122,14 +122,14 @@ describe('CloudEnvironment.teardownChain', () => {
       return { ok: true, json: { id: 9, name: 'pathfinder-e2e-y' } };
     });
 
-    const env = new CloudEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
+    const env = new SharedCloudStackEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
     await env.provisionChain();
 
     await expect(env.teardownChain()).resolves.toBeUndefined();
   });
 });
 
-describe('CloudEnvironment.sweepOrphans', () => {
+describe('SharedCloudStackEnvironment.sweepOrphans', () => {
   it('deletes only stale provisioned service accounts', async () => {
     const staleTimestamp = NOW_SECONDS - 3901;
     const freshTimestamp = NOW_SECONDS - 60;
@@ -150,7 +150,7 @@ describe('CloudEnvironment.sweepOrphans', () => {
       return { ok: true };
     });
 
-    const env = new CloudEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
+    const env = new SharedCloudStackEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
     await env.sweepOrphans();
 
     const deletedIds = calls.filter((c) => c.method === 'DELETE').map((c) => c.url);
@@ -159,7 +159,7 @@ describe('CloudEnvironment.sweepOrphans', () => {
 
   it('does not throw when the search request fails', async () => {
     mockFetch(() => ({ ok: false, status: 403 }));
-    const env = new CloudEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
+    const env = new SharedCloudStackEnvironment(ADMIN_TOKEN, CLOUD_URL, false);
 
     await expect(env.sweepOrphans()).resolves.toBeUndefined();
   });

--- a/src/cli/e2e/shared-cloud-stack-environment.ts
+++ b/src/cli/e2e/shared-cloud-stack-environment.ts
@@ -8,10 +8,11 @@
  *
  * Scope: this isolates per-identity state (preferences, stars, sessions)
  * between chains. It does NOT reset org-global data (dashboards, data sources,
- * folders) created by guides — that requires ephemeral stacks, a future phase.
+ * folders) created by guides — unsafe guides require isolated stack execution.
  *
- * One CloudEnvironment owns one cloud stack. Multi-instance runs create one
- * CloudEnvironment per target origin that has a configured admin token.
+ * One SharedCloudStackEnvironment owns service-account lifecycle for one existing
+ * cloud stack. Multi-instance runs create one per target origin with configured
+ * shared-stack admin auth.
  */
 
 import { randomUUID } from 'crypto';
@@ -65,7 +66,7 @@ function isStaleOrphan(name: string): boolean {
  * one SA is live at a time (chains run sequentially), tracked in `currentSaId`
  * so teardown — including from signal handlers — can always find it.
  */
-export class CloudEnvironment {
+export class SharedCloudStackEnvironment {
   private currentSaId: number | null = null;
   private readonly runId = randomUUID().slice(0, 8);
 


### PR DESCRIPTION
> [!NOTE]
> For broader context, see the **E2E Cloud isolation epic**: https://github.com/grafana/grafana-pathfinder-app/issues/1184
>
> This is the first setup PR for #1187 **(Part 1 of 3)**

## Summary

Renames the existing cloud E2E service-account lifecycle to `SharedCloudStackEnvironment` and clarifies target resolution around shared stack auth; it also keeps instance-declared guides pinned to their declared shared stack instead of allowing them to fall back to future isolated-stack execution.

## What to look at

- **CLI E2E target resolution**: [`e2e-targets.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/794f4af0309c63fd736b40622fc006e2af1294f0/src/cli/e2e/e2e-targets.ts) now models cloud execution as target capabilities (`sharedStackUrls`, future `isolatedStack`) and requires matching shared-stack auth for manifest-declared `instance` guides.
- **Shared stack lifecycle naming**: [`shared-cloud-stack-environment.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/794f4af0309c63fd736b40622fc006e2af1294f0/src/cli/e2e/shared-cloud-stack-environment.ts) is the old per-chain service-account lifecycle under a more precise name.
- **Remote package resolution**: [`e2e-package.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/794f4af0309c63fd736b40622fc006e2af1294f0/src/cli/e2e/e2e-package.ts) threads the renamed target capabilities into package resolution so later cold-stack routing can build on the same contract.

## Why

Some Cloud guides must be tested against a specific shared stack, such as manifests that declare `play.grafana.org`. This PR makes that invariant explicit before adding cold isolated stack execution: an instance-declared guide needs matching shared-stack auth, while non-instance cloud guides can later be routed to an isolated stack when appropriate.

## Out of scope

- Cold isolated stack provisioning is handled in the next PR.
- CLI routing from unsafe cloud chains to cold stacks is handled after the cold-stack lifecycle module lands.

## How to verify

No manual runtime verification is needed for this rename-focused PR. Review the target-resolution tests for the key behavior: instance-declared cloud guides skip without matching shared-stack auth, while non-instance cloud target resolution remains available for later isolated-stack routing.

## Breaking changes

None. This change is additive and fully reversible.

Refs #1184
Refs #1187