### PR TITLE
feat(e2e): add cold cloud stack lifecycle

### DIFF
--- a/src/cli/e2e/cold-cloud-stack-environment.test.ts
+++ b/src/cli/e2e/cold-cloud-stack-environment.test.ts
@@ -1,0 +1,323 @@
+import { existsSync, readFileSync, statSync } from 'fs';
+
+import {
+  ColdCloudStackCleanupRegistry,
+  ColdCloudStackEnvironment,
+  createColdCloudStackProvisioningConfig,
+  type ColdCloudStackProvisioningConfig,
+  type CommandRunner,
+} from './cold-cloud-stack-environment';
+
+const CONFIG: ColdCloudStackProvisioningConfig = {
+  accessPolicyTokenEnvVar: 'GRAFANA_CLOUD_ACCESS_POLICY_TOKEN',
+  accessPolicyToken: 'secret-token',
+  region: 'prod-us-east-0',
+  slugPrefix: 'pfe2e',
+  pluginVersion: '1.2.3',
+};
+
+function terraformOutput(token = 'glsa_stack'): string {
+  return JSON.stringify({
+    stack_url: { value: 'https://pfe2eabc.grafana.net/' },
+    stack_slug: { value: 'pfe2eabc' },
+    service_account_token: { value: token },
+  });
+}
+
+function pluginProbe(status = 200): typeof fetch {
+  return jest.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 404 ? 'Not Found' : 'Error',
+  })) as unknown as typeof fetch;
+}
+
+describe('createColdCloudStackProvisioningConfig', () => {
+  it('returns undefined when no stack options are present', () => {
+    expect(createColdCloudStackProvisioningConfig({ env: {} })).toBeUndefined();
+  });
+
+  it('loads the Cloud Access Policy token from an env var and normalizes the slug prefix', () => {
+    expect(
+      createColdCloudStackProvisioningConfig({
+        accessPolicyTokenEnvVar: 'TOKEN_ENV',
+        region: 'prod-us-east-0',
+        slugPrefix: 'Pathfinder E2E!',
+        env: { TOKEN_ENV: 'token' },
+      })
+    ).toEqual({
+      accessPolicyTokenEnvVar: 'TOKEN_ENV',
+      accessPolicyToken: 'token',
+      region: 'prod-us-east-0',
+      slugPrefix: 'pathfindere2',
+      pluginVersion: undefined,
+    });
+  });
+
+  it('rejects partial or invalid stack config', () => {
+    expect(() => createColdCloudStackProvisioningConfig({ region: 'prod-us-east-0', env: {} })).toThrow(
+      /cloud-stack-access-policy-token/
+    );
+    expect(() =>
+      createColdCloudStackProvisioningConfig({
+        accessPolicyTokenEnvVar: 'TOKEN_ENV',
+        region: 'prod-us-east-0',
+        env: {},
+      })
+    ).toThrow(/TOKEN_ENV/);
+    expect(() =>
+      createColdCloudStackProvisioningConfig({
+        accessPolicyTokenEnvVar: '1_BAD',
+        region: 'prod-us-east-0',
+        env: { '1_BAD': 'x' },
+      })
+    ).toThrow(/Invalid/);
+    expect(() =>
+      createColdCloudStackProvisioningConfig({
+        accessPolicyTokenEnvVar: 'TOKEN_ENV',
+        region: 'prod-us-east-0',
+        slugPrefix: '123',
+        env: { TOKEN_ENV: 'x' },
+      })
+    ).toThrow(/slug-prefix/);
+  });
+});
+
+describe('ColdCloudStackCleanupRegistry', () => {
+  it('tears down tracked stacks once and untracks them', async () => {
+    const registry = new ColdCloudStackCleanupRegistry();
+    const first = { teardownChain: jest.fn(async () => ['first warning']) };
+    const second = { teardownChain: jest.fn(async () => []) };
+
+    registry.track(first);
+    registry.track(second);
+
+    await expect(registry.teardownAll()).resolves.toEqual(['first warning']);
+    await expect(registry.teardownAll()).resolves.toEqual([]);
+    expect(first.teardownChain).toHaveBeenCalledTimes(1);
+    expect(second.teardownChain).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a warning when a tracked stack teardown throws', async () => {
+    const registry = new ColdCloudStackCleanupRegistry();
+    const target = {
+      teardownChain: jest.fn(async () => {
+        throw new Error('destroy failed');
+      }),
+    };
+
+    registry.track(target);
+
+    await expect(registry.teardownAll()).resolves.toEqual(['Failed to tear down active Cloud stack: destroy failed']);
+    await expect(registry.teardownAll()).resolves.toEqual([]);
+  });
+});
+
+describe('ColdCloudStackEnvironment', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(2_000_000_000_000);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('skips the Terraform plugin resource when Pathfinder is already installed', async () => {
+    const calls: Array<{ args: string[]; cwd: string; env: NodeJS.ProcessEnv }> = [];
+    let generatedHcl = '';
+    let moduleDir = '';
+    const runner: CommandRunner = async (_command, args, options) => {
+      calls.push({ args, cwd: options.cwd, env: options.env });
+      moduleDir = options.cwd;
+      if (args[0] === 'output') {
+        generatedHcl = readFileSync(`${options.cwd}/main.tf`, 'utf-8');
+        return { exitCode: 0, stdout: terraformOutput(), stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const fetchImpl = pluginProbe(200);
+    const env = new ColdCloudStackEnvironment(CONFIG, false, runner, fetchImpl);
+    const provisioned = await env.provisionChain();
+
+    expect(provisioned).toEqual({
+      targetUrl: 'https://pfe2eabc.grafana.net/',
+      stackSlug: 'pfe2eabc',
+      token: 'glsa_stack',
+    });
+    expect(calls.map((call) => call.args[0])).toEqual(['init', 'apply', 'output']);
+    expect(calls.every((call) => call.env.TF_VAR_cloud_access_policy_token === 'secret-token')).toBe(true);
+    expect(calls.every((call) => call.env.TF_VAR_cloud_stack_region === 'prod-us-east-0')).toBe(true);
+    expect(calls.every((call) => call.env.TF_VAR_pathfinder_plugin_version === '1.2.3')).toBe(true);
+    expect(generatedHcl).toContain('resource "grafana_cloud_stack" "e2e"');
+    expect(generatedHcl).toContain('version = "~> 4.5"');
+    expect(generatedHcl).toContain('"pathfinder-e2e-kind" = "cold-run"');
+    expect(generatedHcl).not.toContain('resource "grafana_cloud_plugin_installation" "pathfinder"');
+    expect(generatedHcl).not.toContain('secret-token');
+    expect(statSync(moduleDir).mode & 0o777).toBe(0o700);
+    expect(fetchImpl).toHaveBeenCalledWith('https://pfe2eabc.grafana.net/api/plugins/grafana-pathfinder-app/settings', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer glsa_stack',
+        Accept: 'application/json',
+      },
+      signal: expect.any(AbortSignal),
+    });
+
+    await env.teardownChain();
+
+    expect(calls.map((call) => call.args[0])).toEqual(['init', 'apply', 'output', 'destroy']);
+    expect(existsSync(moduleDir)).toBe(false);
+  });
+
+  it('adds the Terraform plugin resource when Pathfinder is missing', async () => {
+    const calls: string[] = [];
+    const generatedHclByOutput: string[] = [];
+    const runner: CommandRunner = async (_command, args, options) => {
+      calls.push(args[0]!);
+      if (args[0] === 'output') {
+        generatedHclByOutput.push(readFileSync(`${options.cwd}/main.tf`, 'utf-8'));
+        return { exitCode: 0, stdout: terraformOutput(), stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const env = new ColdCloudStackEnvironment(CONFIG, false, runner, pluginProbe(404));
+    await env.provisionChain();
+
+    expect(calls).toEqual(['init', 'apply', 'output', 'apply', 'output']);
+    expect(generatedHclByOutput[0]).not.toContain('grafana_cloud_plugin_installation');
+    expect(generatedHclByOutput[1]).toContain('resource "grafana_cloud_plugin_installation" "pathfinder"');
+    expect(generatedHclByOutput[1]).toContain('version = var.pathfinder_plugin_version');
+  });
+
+  it('passes operator-provided strings through Terraform variables instead of generated HCL', async () => {
+    const unsafeConfig = {
+      ...CONFIG,
+      region: 'prod-us-east-0${bad}',
+      pluginVersion: '1.2.3${bad}',
+    };
+    let generatedHcl = '';
+    const envByCall: NodeJS.ProcessEnv[] = [];
+    const runner: CommandRunner = async (_command, args, options) => {
+      envByCall.push(options.env);
+      if (args[0] === 'output') {
+        generatedHcl = readFileSync(`${options.cwd}/main.tf`, 'utf-8');
+        return { exitCode: 0, stdout: terraformOutput(), stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const env = new ColdCloudStackEnvironment(unsafeConfig, false, runner, pluginProbe(404));
+    await env.provisionChain();
+    expect(generatedHcl).toContain('region_slug = var.cloud_stack_region');
+    expect(generatedHcl).toContain('version = var.pathfinder_plugin_version');
+    expect(generatedHcl).not.toContain('${bad}');
+    expect(envByCall.every((env) => env.TF_VAR_cloud_stack_region === 'prod-us-east-0${bad}')).toBe(true);
+    expect(envByCall.every((env) => env.TF_VAR_pathfinder_plugin_version === '1.2.3${bad}')).toBe(true);
+  });
+
+  it('destroys any partially-created stack when Terraform output parsing fails', async () => {
+    const calls: string[] = [];
+    const runner: CommandRunner = async (_command, args) => {
+      calls.push(args[0]!);
+      if (args[0] === 'output') {
+        return { exitCode: 0, stdout: JSON.stringify({}), stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const env = new ColdCloudStackEnvironment(CONFIG, false, runner, pluginProbe(200));
+
+    await expect(env.provisionChain()).rejects.toThrow(/terraform output/);
+    expect(calls).toEqual(['init', 'apply', 'output', 'destroy']);
+  });
+
+  it('destroys a partially-created stack when plugin probing fails', async () => {
+    const calls: string[] = [];
+    const runner: CommandRunner = async (_command, args) => {
+      calls.push(args[0]!);
+      if (args[0] === 'output') {
+        return { exitCode: 0, stdout: terraformOutput(), stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const env = new ColdCloudStackEnvironment(CONFIG, false, runner, pluginProbe(500));
+
+    await expect(env.provisionChain()).rejects.toThrow(/Pathfinder plugin probe failed/);
+    expect(calls).toEqual(['init', 'apply', 'output', 'destroy']);
+  });
+
+  it('redacts the access token and minted token in Terraform errors', async () => {
+    const runner: CommandRunner = async (_command, args) => {
+      if (args[0] === 'output') {
+        return { exitCode: 0, stdout: terraformOutput('glsa_minted'), stderr: '' };
+      }
+      if (args[0] === 'apply') {
+        if (args.includes('-auto-approve')) {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+    const failingRunner: CommandRunner = async (command, args, options) => {
+      if (
+        args[0] === 'apply' &&
+        options.cwd &&
+        readFileSync(`${options.cwd}/main.tf`, 'utf-8').includes('grafana_cloud_plugin_installation')
+      ) {
+        return { exitCode: 1, stdout: '', stderr: 'bad secret-token glsa_minted' };
+      }
+      return runner(command, args, options);
+    };
+
+    const env = new ColdCloudStackEnvironment(CONFIG, false, failingRunner, pluginProbe(404));
+
+    await expect(env.provisionChain()).rejects.toThrow('bad [redacted] [redacted]');
+  });
+
+  it('returns warnings and cleans local state when destroy fails', async () => {
+    let moduleDir = '';
+    const runner: CommandRunner = async (_command, args, options) => {
+      moduleDir = options.cwd;
+      if (args[0] === 'destroy') {
+        return { exitCode: 1, stdout: '', stderr: 'nope secret-token' };
+      }
+      if (args[0] === 'output') {
+        return { exitCode: 0, stdout: terraformOutput(), stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const env = new ColdCloudStackEnvironment(CONFIG, false, runner, pluginProbe(200));
+    await env.provisionChain();
+    const warnings = await env.teardownChain();
+
+    expect(warnings).toEqual([expect.stringContaining('Failed to destroy Cloud stack')]);
+    expect(warnings[0]).toContain('[redacted]');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to destroy Cloud stack'));
+    expect(existsSync(moduleDir)).toBe(false);
+  });
+
+  it('runs a single destroy when teardown is invoked concurrently', async () => {
+    const calls: string[] = [];
+    const runner: CommandRunner = async (_command, args) => {
+      calls.push(args[0]!);
+      if (args[0] === 'output') {
+        return { exitCode: 0, stdout: terraformOutput(), stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const env = new ColdCloudStackEnvironment(CONFIG, false, runner, pluginProbe(200));
+    await env.provisionChain();
+
+    await Promise.all([env.teardownChain(), env.teardownChain()]);
+
+    expect(calls.filter((arg) => arg === 'destroy')).toHaveLength(1);
+  });
+});

--- a/src/cli/e2e/cold-cloud-stack-environment.ts
+++ b/src/cli/e2e/cold-cloud-stack-environment.ts
@@ -1,0 +1,417 @@
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { CLOUD_STACK_FETCH_TIMEOUT_MS } from './shared-cloud-stack-environment';
+
+const TERRAFORM_PROVIDER_VERSION = '~> 4.5';
+const PLUGIN_ID = 'grafana-pathfinder-app';
+const TOKEN_TTL_SECONDS = 3600;
+export const DEFAULT_CLOUD_STACK_SLUG_PREFIX = 'pfe2e';
+
+export interface ColdCloudStackConfigInput {
+  accessPolicyTokenEnvVar?: string;
+  region?: string;
+  slugPrefix?: string;
+  pluginVersion?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface ColdCloudStackProvisioningConfig {
+  accessPolicyTokenEnvVar: string;
+  accessPolicyToken: string;
+  region: string;
+  slugPrefix: string;
+  pluginVersion?: string;
+}
+
+export interface ProvisionedCloudStack {
+  targetUrl: string;
+  token: string;
+  stackSlug: string;
+}
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv }
+) => Promise<CommandResult>;
+
+interface TerraformOutput {
+  stack_url?: { value?: unknown };
+  stack_slug?: { value?: unknown };
+  service_account_token?: { value?: unknown };
+}
+
+interface CloudStackTeardownTarget {
+  teardownChain(): Promise<string[]>;
+}
+
+export class ColdCloudStackCleanupRegistry {
+  private readonly targets = new Set<CloudStackTeardownTarget>();
+
+  track(target: CloudStackTeardownTarget): void {
+    this.targets.add(target);
+  }
+
+  untrack(target: CloudStackTeardownTarget): void {
+    this.targets.delete(target);
+  }
+
+  async teardownAll(): Promise<string[]> {
+    const warnings: string[] = [];
+    const targets = [...this.targets];
+    for (const target of targets) {
+      try {
+        warnings.push(...(await target.teardownChain()));
+      } catch (err) {
+        warnings.push(`Failed to tear down active Cloud stack: ${errorMessage(err)}`);
+      } finally {
+        this.untrack(target);
+      }
+    }
+    return warnings;
+  }
+}
+
+function hasAnyStackConfig(input: ColdCloudStackConfigInput): boolean {
+  return Boolean(input.accessPolicyTokenEnvVar || input.region || input.slugPrefix || input.pluginVersion);
+}
+
+function normalizeSlugPrefix(value: string): string {
+  const normalized = value.toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (!/^[a-z][a-z0-9]*$/.test(normalized)) {
+    throw new Error(
+      '--cloud-stack-slug-prefix must contain at least one letter and only alphanumeric characters after normalization.'
+    );
+  }
+  return normalized.slice(0, 12);
+}
+
+function requireNonEmptyOption(value: string | undefined, missingMessage: string): string {
+  if (value === undefined) {
+    throw new Error(missingMessage);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${missingMessage} The provided value must not be empty.`);
+  }
+  return trimmed;
+}
+
+export function createColdCloudStackProvisioningConfig(
+  input: ColdCloudStackConfigInput
+): ColdCloudStackProvisioningConfig | undefined {
+  if (!hasAnyStackConfig(input)) {
+    return undefined;
+  }
+
+  const env = input.env ?? process.env;
+  const envVar = requireNonEmptyOption(
+    input.accessPolicyTokenEnvVar,
+    '--cloud-stack-access-policy-token is required when Cloud stack provisioning options are set'
+  );
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(envVar)) {
+    throw new Error(`Invalid --cloud-stack-access-policy-token env var "${envVar}".`);
+  }
+  const accessPolicyToken = env[envVar];
+  if (!accessPolicyToken) {
+    throw new Error(`--cloud-stack-access-policy-token references unset or empty environment variable ${envVar}.`);
+  }
+
+  return {
+    accessPolicyTokenEnvVar: envVar,
+    accessPolicyToken,
+    region: requireNonEmptyOption(
+      input.region,
+      '--cloud-stack-region is required when Cloud stack provisioning is enabled'
+    ),
+    slugPrefix: normalizeSlugPrefix(input.slugPrefix ?? DEFAULT_CLOUD_STACK_SLUG_PREFIX),
+    pluginVersion: input.pluginVersion?.trim() || undefined,
+  };
+}
+
+function generatedStackSlug(prefix: string): string {
+  const suffix = `${Date.now().toString(36)}${randomUUID().replace(/-/g, '').slice(0, 6)}`;
+  return `${prefix}${suffix}`.slice(0, 29);
+}
+
+function hclString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function hclStringMap(value: Record<string, string>): string {
+  return Object.entries(value)
+    .map(([key, mapValue]) => `    ${hclString(key)} = ${hclString(mapValue)}`)
+    .join('\n');
+}
+
+function pathfinderPluginResource(): string {
+  return `
+resource "grafana_cloud_plugin_installation" "pathfinder" {
+  provider = grafana.cloud
+  stack_slug = grafana_cloud_stack.e2e.slug
+  slug = ${hclString(PLUGIN_ID)}
+  version = var.pathfinder_plugin_version
+}
+`;
+}
+
+function terraformModule(options: {
+  slug: string;
+  createdAtSeconds: number;
+  runId: string;
+  installPathfinderPlugin: boolean;
+}): string {
+  const labels = {
+    'pathfinder-e2e': 'true',
+    'pathfinder-e2e-kind': 'cold-run',
+    'pathfinder-e2e-created-at': String(options.createdAtSeconds),
+    'pathfinder-e2e-run-id': options.runId,
+  };
+
+  return `terraform {
+  required_providers {
+    grafana = {
+      source = "grafana/grafana"
+      version = ${hclString(TERRAFORM_PROVIDER_VERSION)}
+    }
+  }
+}
+
+variable "cloud_access_policy_token" {
+  type = string
+  sensitive = true
+}
+
+variable "cloud_stack_region" {
+  type = string
+}
+
+variable "pathfinder_plugin_version" {
+  type = string
+}
+
+provider "grafana" {
+  alias = "cloud"
+  cloud_access_policy_token = var.cloud_access_policy_token
+}
+
+resource "grafana_cloud_stack" "e2e" {
+  provider = grafana.cloud
+  name = ${hclString(options.slug)}
+  slug = ${hclString(options.slug)}
+  region_slug = var.cloud_stack_region
+  delete_protection = false
+  labels = {
+${hclStringMap(labels)}
+  }
+}
+${options.installPathfinderPlugin ? pathfinderPluginResource() : ''}
+
+resource "grafana_cloud_stack_service_account" "e2e" {
+  provider = grafana.cloud
+  stack_slug = grafana_cloud_stack.e2e.slug
+  name = "pathfinder-e2e"
+  role = "Admin"
+}
+
+resource "grafana_cloud_stack_service_account_token" "e2e" {
+  provider = grafana.cloud
+  stack_slug = grafana_cloud_stack.e2e.slug
+  name = "pathfinder-e2e"
+  service_account_id = grafana_cloud_stack_service_account.e2e.id
+  seconds_to_live = ${TOKEN_TTL_SECONDS}
+}
+
+output "stack_url" {
+  value = grafana_cloud_stack.e2e.url
+}
+
+output "stack_slug" {
+  value = grafana_cloud_stack.e2e.slug
+}
+
+output "service_account_token" {
+  value = grafana_cloud_stack_service_account_token.e2e.key
+  sensitive = true
+}
+`;
+}
+
+async function defaultCommandRunner(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv }
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd: options.cwd, env: options.env, shell: false });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+function redact(text: string, secrets: string[]): string {
+  return secrets.reduce((current, secret) => (secret ? current.split(secret).join('[redacted]') : current), text);
+}
+
+function terraformEnv(config: ColdCloudStackProvisioningConfig): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    TF_IN_AUTOMATION: '1',
+    TF_VAR_cloud_access_policy_token: config.accessPolicyToken,
+    TF_VAR_cloud_stack_region: config.region,
+    TF_VAR_pathfinder_plugin_version: config.pluginVersion ?? 'latest',
+  };
+}
+
+function parseTerraformOutput(text: string): ProvisionedCloudStack {
+  const parsed = JSON.parse(text) as TerraformOutput;
+  const targetUrl = parsed.stack_url?.value;
+  const token = parsed.service_account_token?.value;
+  const stackSlug = parsed.stack_slug?.value;
+  if (typeof targetUrl !== 'string' || typeof token !== 'string' || typeof stackSlug !== 'string') {
+    throw new Error('terraform output did not include stack_url, stack_slug, and service_account_token string values.');
+  }
+  return { targetUrl, token, stackSlug };
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : 'Unknown error';
+}
+
+export class ColdCloudStackEnvironment {
+  private moduleDir: string | null = null;
+  private currentStackSlug: string | null = null;
+  private teardownPromise: Promise<string[]> | null = null;
+  private readonly secrets: string[];
+
+  constructor(
+    private readonly config: ColdCloudStackProvisioningConfig,
+    private readonly verbose: boolean,
+    private readonly runner: CommandRunner = defaultCommandRunner,
+    private readonly fetchImpl: typeof fetch = fetch
+  ) {
+    this.secrets = [config.accessPolicyToken];
+  }
+
+  async provisionChain(): Promise<ProvisionedCloudStack> {
+    const slug = generatedStackSlug(this.config.slugPrefix);
+    const moduleDir = mkdtempSync(join(tmpdir(), 'pathfinder-e2e-stack-'));
+    chmodSync(moduleDir, 0o700);
+    const createdAtSeconds = Math.floor(Date.now() / 1000);
+    const runId = randomUUID();
+    const modulePath = join(moduleDir, 'main.tf');
+
+    this.moduleDir = moduleDir;
+    this.currentStackSlug = slug;
+    writeFileSync(modulePath, terraformModule({ slug, createdAtSeconds, runId, installPathfinderPlugin: false }));
+
+    try {
+      await this.runTerraform(['init', '-input=false', '-no-color'], 'init');
+      await this.runTerraform(['apply', '-input=false', '-auto-approve', '-no-color'], 'apply');
+      const output = await this.runTerraform(['output', '-json', '-no-color'], 'output');
+      let provisioned = parseTerraformOutput(output.stdout);
+      this.secrets.push(provisioned.token);
+
+      if (!(await this.isPathfinderPluginInstalled(provisioned))) {
+        writeFileSync(modulePath, terraformModule({ slug, createdAtSeconds, runId, installPathfinderPlugin: true }));
+        await this.runTerraform(['apply', '-input=false', '-auto-approve', '-no-color'], 'apply');
+        const updatedOutput = await this.runTerraform(['output', '-json', '-no-color'], 'output');
+        provisioned = parseTerraformOutput(updatedOutput.stdout);
+        this.secrets.push(provisioned.token);
+      } else if (this.verbose) {
+        console.log(`   ☁️ Pathfinder plugin already installed on ${provisioned.stackSlug}; skipping plugin install`);
+      }
+
+      if (this.verbose) {
+        console.log(`   ☁️ Provisioned Cloud stack ${provisioned.stackSlug} (${provisioned.targetUrl})`);
+      }
+      return provisioned;
+    } catch (err) {
+      await this.teardownChain();
+      throw new Error(redact(errorMessage(err), this.secrets));
+    }
+  }
+
+  teardownChain(): Promise<string[]> {
+    return (this.teardownPromise ??= this.runTeardown());
+  }
+
+  private async runTeardown(): Promise<string[]> {
+    const moduleDir = this.moduleDir;
+    if (!moduleDir) {
+      return [];
+    }
+
+    const warnings: string[] = [];
+    try {
+      await this.runTerraform(['destroy', '-input=false', '-auto-approve', '-no-color'], 'destroy');
+      if (this.verbose && this.currentStackSlug) {
+        console.log(`   🧹 Destroyed Cloud stack ${this.currentStackSlug}`);
+      }
+    } catch (err) {
+      const slug = this.currentStackSlug ?? 'unknown';
+      const warning = `Failed to destroy Cloud stack ${slug}: ${redact(errorMessage(err), this.secrets)}`;
+      warnings.push(warning);
+      console.warn(`   ⚠ ${warning}`);
+    } finally {
+      rmSync(moduleDir, { recursive: true, force: true });
+      this.moduleDir = null;
+      this.currentStackSlug = null;
+    }
+    return warnings;
+  }
+
+  async teardownAll(): Promise<string[]> {
+    return this.teardownChain();
+  }
+
+  private async runTerraform(args: string[], action: string): Promise<CommandResult> {
+    if (!this.moduleDir) {
+      throw new Error('Terraform module directory has not been initialized.');
+    }
+    const result = await this.runner('terraform', args, { cwd: this.moduleDir, env: terraformEnv(this.config) });
+    if (result.exitCode !== 0) {
+      const detail = redact(result.stderr || result.stdout || `exit ${result.exitCode}`, this.secrets);
+      throw new Error(`terraform ${action} failed: ${detail}`);
+    }
+    return result;
+  }
+
+  private async isPathfinderPluginInstalled(stack: ProvisionedCloudStack): Promise<boolean> {
+    const url = new URL(`/api/plugins/${PLUGIN_ID}/settings`, stack.targetUrl).toString();
+    const response = await this.fetchImpl(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${stack.token}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(CLOUD_STACK_FETCH_TIMEOUT_MS),
+    });
+    if (response.ok) {
+      return true;
+    }
+    if (response.status === 404) {
+      return false;
+    }
+    throw new Error(`Pathfinder plugin probe failed: HTTP ${response.status} ${response.statusText}`);
+  }
+}

--- a/src/cli/e2e/shared-cloud-stack-environment.ts
+++ b/src/cli/e2e/shared-cloud-stack-environment.ts
@@ -26,7 +26,7 @@ const SWEEP_GRACE_SECONDS = 300;
  * This is a requirement for guides that require the Admin role to succeed.
  */
 const SA_ROLE = 'Admin';
-const FETCH_TIMEOUT_MS = 15_000;
+export const CLOUD_STACK_FETCH_TIMEOUT_MS = 15_000;
 
 interface CreatedServiceAccount {
   id: number;
@@ -165,7 +165,7 @@ export class SharedCloudStackEnvironment {
         Accept: 'application/json',
       },
       body: body === undefined ? undefined : JSON.stringify(body),
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      signal: AbortSignal.timeout(CLOUD_STACK_FETCH_TIMEOUT_MS),
     });
     if (!response.ok) {
       throw new Error(`${method} ${path} failed: HTTP ${response.status} ${response.statusText}`);


### PR DESCRIPTION
> [!NOTE]
> For broader context, see the **E2E Cloud isolation epic**: https://github.com/grafana/grafana-pathfinder-app/issues/1184. 
>
> This change is part of the cold isolated stack lifecycle work in https://github.com/grafana/grafana-pathfinder-app/issues/1187 **(Part 2 of 3)**.

## Summary

Adds the standalone `ColdCloudStackEnvironment` lifecycle for creating disposable Grafana Cloud stacks, minting short-lived runner tokens, probing/installing Pathfinder, and best-effort destroying the stack after use. This PR only introduces the cold-stack implementation and tests; it does not yet route E2E guide chains through it.

## What to look at

- **Cold Cloud stack lifecycle**: [`cold-cloud-stack-environment.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/3bd098ab8995d5fa5df78f74b808efa629e7eee7/src/cli/e2e/cold-cloud-stack-environment.ts) owns the Terraform module generation, env-var based Cloud Access Policy token handling, plugin probe/install pass, teardown memoization, and cleanup registry used for signal-triggered teardown.

## Why

Unsafe Cloud guide chains need a disposable stack path before the runner can stop skipping them. Keeping the cold-stack lifecycle isolated in its own module makes the Terraform, token-redaction, plugin-install, and teardown behavior reviewable before CLI routing is added.

## How to verify

No manual runtime verification is expected for this PR because the module is not wired into the E2E command yet. Review the unit coverage for config parsing, generated Terraform safety, plugin probe/install behavior, partial setup teardown, token redaction, and concurrent teardown.

## Breaking changes

None. This change is additive and fully reversible.

## Out of scope

- Routing unsafe Cloud guide chains to this lifecycle is handled separately.
- Hot-pool leasing and durable pool coordination are not included here.
- Installing manifest-declared plugins beyond `grafana-pathfinder-app` remains future work.

Refs #1184
Refs #1187
