### PR TITLE
feat(e2e): wire cold cloud stack routing

### DIFF
--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -56,6 +56,10 @@ npx pathfinder-cli e2e [options] [files...]
 | `--resolver-url <url>`                    | Recommender base URL for `--package <id>` resolution                                                                                                     | `https://recommender.grafana.com` |
 | `--cloud-instance-admin-token <host=env>` | Admin service-account token env var for a cloud target. Repeat for multiple cloud instances.                                                             | None                              |
 | `--cloud-url <url>`                       | Default Grafana Cloud instance URL for cloud-tier guides without a manifest `instance`.                                                                  | `https://learn.grafana.net/`      |
+| `--cloud-stack-access-policy-token <env>` | Cloud Access Policy token env var for cold isolated Grafana Cloud stack provisioning.                                                                    | None                              |
+| `--cloud-stack-region <region>`           | Grafana Cloud region slug for cold isolated stack provisioning. Required with `--cloud-stack-access-policy-token`.                                       | None                              |
+| `--cloud-stack-slug-prefix <prefix>`      | Slug prefix for cold-provisioned Grafana Cloud stacks.                                                                                                   | `pfe2e`                           |
+| `--cloud-stack-plugin-version <version>`  | Pathfinder plugin version to install when the cold-provisioned stack does not already include the plugin.                                                | `latest`                          |
 
 ### Input formats
 
@@ -409,13 +413,18 @@ The CLI can resolve published guides instead of reading local files, then test t
 Guides are routed by their manifest's `testEnvironment.tier`:
 
 - `local` (or no tier) guides run against `--grafana-url`.
-- `cloud` guides run against `--cloud-url` (default `https://learn.grafana.net/`), or against `https://{instance}/` when the manifest declares a host-only `testEnvironment.instance`. Every resolved cloud target requires an admin token explicitly associated with that host via `--cloud-instance-admin-token host=ENV_VAR_NAME`.
+- `cloud` guides run against `--cloud-url` (default `https://learn.grafana.net/`), or against `https://{instance}/` when the manifest declares a host-only `testEnvironment.instance`. Shared-stack runs require an admin token explicitly associated with that host via `--cloud-instance-admin-token host=ENV_VAR_NAME`; cold isolated-stack runs require Cloud stack provisioning config instead.
 
 Cloud auth:
 
 - **Admin token per cloud target.** Pass `--cloud-instance-admin-token learn.grafana.net=GRAFANA_LEARN_ADMIN_TOKEN` to associate an admin service-account token env var with a cloud target. The CLI uses that admin token only to mint a fresh service account and short-lived token for each dependency chain; the browser runner receives only the minted token. Repeat the flag for each supported instance.
+- **Cold isolated stack provisioning.** Pass `--cloud-stack-access-policy-token GRAFANA_CLOUD_ACCESS_POLICY_TOKEN --cloud-stack-region <region>` to let unsafe cloud dependency chains run against a fresh Grafana Cloud stack instead of the shared target. The token value must live in the named environment variable; the CLI passes it to Terraform as `TF_VAR_cloud_access_policy_token` and passes region/plugin version through Terraform variables rather than generated HCL. The local `terraform` CLI must be installed.
 
-Per-chain isolation mirrors how `--clean` resets the local docker stack per chain. Minted tokens carry a TTL, and accounts orphaned by crashed runs are swept on the next run. This isolates per-identity state (preferences, stars, sessions) between chains; it does **not** reset org data such as dashboards or data sources created by guides (that needs ephemeral stacks, a future phase).
+Per-chain service-account isolation mirrors how `--clean` resets the local docker stack per chain. Minted tokens carry a TTL, and accounts orphaned by crashed runs are swept on the next run. This isolates per-identity state (preferences, stars, sessions) between chains; it does **not** reset org data such as dashboards or data sources created by guides.
+
+Cold isolated stack routing is used for cloud dependency chains classified as `possibly_mutating`, `mutating`, or `unknown` when cold-stack config is present. The CLI creates a Grafana Cloud stack with `delete_protection=false`, mints a short-lived Admin runner token, probes for `grafana-pathfinder-app`, installs the plugin only when missing, runs the chain against the fresh stack URL, and then attempts `terraform destroy`. Teardown is best-effort: cleanup failures are reported as warnings without replacing the primary guide result. Ctrl-C and SIGTERM also attempt to destroy any active cold-provisioned stack before exiting. If the process is killed before signal handling or Terraform teardown runs, a labeled cold stack may require manual cleanup; future hot-pool/reconciler work will add durable recovery. If cold-stack config is absent, unsafe cloud chains remain `skipped_unsafe_shared_stack`.
+
+Read-only cloud chains with matching `--cloud-instance-admin-token` keep using the faster shared-stack service-account path. If a cloud chain lacks shared-stack auth but cold-stack config is present, the runner can use a cold isolated stack for that chain.
 
 Interactive SSO/Okta login (driving the identity provider's login UI) is not supported. Path/journey (`milestones`) expansion is also not yet implemented; `path` and `journey` packages are skipped as an unsupported type. See the [Package-Aware Testing](../design/e2e-test-runner-design.md#package-aware-testing) design for the full picture.
 

--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -35,6 +35,7 @@ import {
   applyPackageMeta,
   buildPackageMetaMap,
   exitCodeFromResults,
+  provisioningFailureResults,
   resolveRunMode,
   skipToResult,
   type GuideRunResult,
@@ -249,22 +250,45 @@ interface ChainRunOutcome {
   cleanupWarnings: string[];
 }
 
+const REPEATED_SIGNAL_FORCE_EXIT_GRACE_MS = 30_000;
+
 /**
  * Install exit/signal handlers that tear down owned isolated environments.
  * On SIGINT/SIGTERM, re-raise with the conventional 128+signal code.
  */
 function installTeardownHandlers(cleanEnv: CleanEnvironment, cloudStackCleanup: ColdCloudStackCleanupRegistry): void {
-  let exiting = false;
+  let cleanupStartedAtMs: number | undefined;
   const exitHandler = () => cleanEnv.teardownIfOwned();
+  const exitCodeForSignal = (signal: NodeJS.Signals) => (signal === 'SIGINT' ? 130 : signal === 'SIGTERM' ? 143 : 1);
   const signalHandler = async (signal: NodeJS.Signals) => {
-    if (exiting) {
+    const code = exitCodeForSignal(signal);
+    if (cleanupStartedAtMs !== undefined) {
+      const elapsedMs = Date.now() - cleanupStartedAtMs;
+      if (elapsedMs >= REPEATED_SIGNAL_FORCE_EXIT_GRACE_MS) {
+        console.warn('\n⚠ Force exiting before cleanup completed; Cloud stacks may require manual teardown.');
+        process.exit(code);
+        return;
+      }
+      const remainingSeconds = Math.ceil((REPEATED_SIGNAL_FORCE_EXIT_GRACE_MS - elapsedMs) / 1000);
+      console.warn(
+        `\n⚠ Cleanup is still running; ignoring repeated ${signal}. Press again in ${remainingSeconds}s to force exit, which may leave Cloud stacks running.`
+      );
       return;
     }
-    exiting = true;
-    await cloudStackCleanup.teardownAll();
-    cleanEnv.teardownIfOwned();
-    const code = signal === 'SIGINT' ? 130 : signal === 'SIGTERM' ? 143 : 1;
-    process.exit(code);
+    cleanupStartedAtMs = Date.now();
+    try {
+      const warnings = await cloudStackCleanup.teardownAll();
+      for (const warning of warnings) {
+        console.warn(`   ⚠ ${warning}`);
+      }
+    } catch (err) {
+      console.warn(
+        `   ⚠ Failed to tear down active Cloud stacks: ${err instanceof Error ? err.message : 'Unknown error'}`
+      );
+    } finally {
+      cleanEnv.teardownIfOwned();
+      process.exit(code);
+    }
   };
   process.on('exit', exitHandler);
   process.on('SIGINT', signalHandler);
@@ -569,15 +593,24 @@ async function runChains(
       results.push(...unsafeSharedStackSkipResults(chain, packageMetaById, message));
       continue;
     }
-    const provisionedTargets = await provisionCloudTargetsForChain({
-      targetUrls: cloudTargetsInChain(chain, packageMetaById, cloudAuth),
-      cloudAuth,
-      chain,
-      packageMetaById,
-      cloudStack,
-      cloudStackCleanup,
-      verbose: options.verbose,
-    });
+    let provisionedTargets: Awaited<ReturnType<typeof provisionCloudTargetsForChain>>;
+    try {
+      provisionedTargets = await provisionCloudTargetsForChain({
+        targetUrls: cloudTargetsInChain(chain, packageMetaById, cloudAuth),
+        cloudAuth,
+        chain,
+        packageMetaById,
+        cloudStack,
+        cloudStackCleanup,
+        verbose: options.verbose,
+      });
+    } catch (err) {
+      const message = `Cloud target provisioning failed: ${err instanceof Error ? err.message : 'Unknown error'}`;
+      console.error(`\n❌ ${message}`);
+      results.push(...provisioningFailureResults(chain, packageMetaById, options.grafanaUrl, message));
+      allPassed = false;
+      continue;
+    }
     try {
       // IDs in this chain that failed or were skipped; their dependents skip.
       const blocked = new Set<string>();

--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -18,7 +18,7 @@ import {
   bundledRepositoryPath,
   type LoadedGuide,
 } from '../utils/file-loader';
-import { planGuideExecution } from '../e2e/guide-chains';
+import { planGuideExecution, type ExecutionPlan } from '../e2e/guide-chains';
 import type { TestResultsData } from '../e2e/e2e-reporter';
 import { checkTier, loadManifestFromDir, runManifestPreflight, type CurrentTier } from '../e2e/manifest-preflight';
 import {
@@ -55,6 +55,12 @@ import { randomUUID } from 'crypto';
 import { createCloudAuthPolicy, type CloudAuthPolicy } from '../e2e/cloud-auth';
 import { cloudTargetsInChain, provisionCloudTargetsForChain, sweepCloudTargets } from '../e2e/cloud-provisioning';
 import { unsafeCloudGuidesInChain, unsafeSharedStackMessage, unsafeSharedStackSkipResults } from '../e2e/cloud-routing';
+import {
+  ColdCloudStackCleanupRegistry,
+  createColdCloudStackProvisioningConfig,
+  type ColdCloudStackProvisioningConfig,
+} from '../e2e/cold-cloud-stack-environment';
+import { preflightTargetUrlsForPlan } from '../e2e/preflight-targets';
 
 /**
  * CLI options for the e2e command
@@ -83,6 +89,14 @@ interface E2ECommandOptions {
   cloudInstanceAdminToken: string[];
   /** Default cloud instance URL for cloud-tier guides without an `instance`. */
   cloudUrl: string;
+  /** Env var containing a Grafana Cloud Access Policy token for cold stack provisioning. */
+  cloudStackAccessPolicyToken?: string;
+  /** Grafana Cloud region slug for cold stack provisioning. */
+  cloudStackRegion?: string;
+  /** Slug prefix for cold-provisioned Grafana Cloud stacks. */
+  cloudStackSlugPrefix?: string;
+  /** Pathfinder plugin version to install on cold-provisioned stacks. */
+  cloudStackPluginVersion?: string;
 }
 
 function collectOption(value: string, previous: string[]): string[] {
@@ -117,6 +131,8 @@ interface RunInputs {
   packageMetaById: Map<string, PackageMeta>;
   /** Cloud credential policy for target resolution and runner auth (remote modes). */
   cloudAuth?: CloudAuthPolicy;
+  /** Cold isolated-stack provisioning config for unsafe cloud chains. */
+  cloudStack?: ColdCloudStackProvisioningConfig;
   /** Local package directory for manifest pre-flight, when applicable. */
   localPackageDir?: string;
 }
@@ -225,25 +241,28 @@ function resolveGuides(files: string[], options: E2ECommandOptions): LoadedGuide
   return guides;
 }
 
-/** The dependency-aware execution plan produced by planGuideExecution. */
-type ExecutionPlan = ReturnType<typeof planGuideExecution>;
-
 /** Outcome of running every planned chain: per-guide results plus exit signals. */
 interface ChainRunOutcome {
   results: GuideRunResult[];
   allPassed: boolean;
   hasAuthExpiry: boolean;
+  cleanupWarnings: string[];
 }
 
 /**
- * Install exit/signal handlers that tear down the isolated --clean docker stack.
+ * Install exit/signal handlers that tear down owned isolated environments.
  * On SIGINT/SIGTERM, re-raise with the conventional 128+signal code.
  */
-function installTeardownHandlers(cleanEnv: CleanEnvironment): void {
+function installTeardownHandlers(cleanEnv: CleanEnvironment, cloudStackCleanup: ColdCloudStackCleanupRegistry): void {
+  let exiting = false;
   const exitHandler = () => cleanEnv.teardownIfOwned();
   const signalHandler = async (signal: NodeJS.Signals) => {
+    if (exiting) {
+      return;
+    }
+    exiting = true;
+    await cloudStackCleanup.teardownAll();
     cleanEnv.teardownIfOwned();
-    // Re-raise the signal with the conventional 128 + signal-number exit code
     const code = signal === 'SIGINT' ? 130 : signal === 'SIGTERM' ? 143 : 1;
     process.exit(code);
   };
@@ -399,38 +418,6 @@ async function maybeCleanStart(cleanEnv: CleanEnvironment, options: E2ECommandOp
   }
 }
 
-function idsSkippedForUnsafeSharedStack(plan: ExecutionPlan, packageMetaById: Map<string, PackageMeta>): Set<string> {
-  const ids = new Set<string>();
-  for (const chain of plan.chains) {
-    if (unsafeCloudGuidesInChain(chain, packageMetaById).length > 0) {
-      for (const planned of chain) {
-        ids.add(planned.id);
-      }
-    }
-  }
-  return ids;
-}
-
-/**
- * Distinct target URLs that will actually be exercised this run. Remote guides
- * carry their own resolved `targetUrl` (cloud guides differ per instance);
- * local runs fall back to the global Grafana URL. Used so reachability checks
- * hit the real targets instead of always probing the global URL.
- */
-function targetUrlsToCheck(inputs: RunInputs, globalUrl: string, idsToSkip: Set<string>): string[] {
-  const urls = new Set<string>();
-  for (const [id, meta] of inputs.packageMetaById) {
-    if (idsToSkip.has(id)) {
-      continue;
-    }
-    urls.add(meta.targetUrl ?? globalUrl);
-  }
-  if (inputs.packageMetaById.size === 0) {
-    urls.add(globalUrl);
-  }
-  return [...urls];
-}
-
 /**
  * Run CLI-level pre-flight checks: load the package manifest (when --package),
  * apply the tier check, verify each target's Grafana health, then run manifest
@@ -551,12 +538,15 @@ async function runChains(
   options: E2ECommandOptions,
   cleanEnv: CleanEnvironment,
   packageMetaById: Map<string, PackageMeta> = new Map(),
-  cloudAuth?: CloudAuthPolicy
+  cloudAuth?: CloudAuthPolicy,
+  cloudStack?: ColdCloudStackProvisioningConfig,
+  cloudStackCleanup?: ColdCloudStackCleanupRegistry
 ): Promise<ChainRunOutcome> {
   console.log('\n🎭 Running Playwright tests...\n');
 
   let allPassed = true;
   let hasAuthExpiry = false;
+  const cleanupWarnings: string[] = [];
   const results: GuideRunResult[] = [];
   for (const [chainIndex, chain] of plan.chains.entries()) {
     if (options.clean && chainIndex > 0) {
@@ -573,7 +563,7 @@ async function runChains(
     }
 
     const unsafeCloudGuides = unsafeCloudGuidesInChain(chain, packageMetaById);
-    if (unsafeCloudGuides.length > 0) {
+    if (unsafeCloudGuides.length > 0 && !cloudStack) {
       const message = unsafeSharedStackMessage(unsafeCloudGuides.map((planned) => planned.id));
       console.log(`\n⊘ Skipping cloud chain: ${message}`);
       results.push(...unsafeSharedStackSkipResults(chain, packageMetaById, message));
@@ -582,6 +572,10 @@ async function runChains(
     const provisionedTargets = await provisionCloudTargetsForChain({
       targetUrls: cloudTargetsInChain(chain, packageMetaById, cloudAuth),
       cloudAuth,
+      chain,
+      packageMetaById,
+      cloudStack,
+      cloudStackCleanup,
       verbose: options.verbose,
     });
     try {
@@ -596,12 +590,16 @@ async function runChains(
 📚 ${planned.guide.path}`);
           console.log(`   ⊘ Skipped: prerequisite "${blockingDep}" did not pass`);
           const skippedMeta = packageMetaById.get(planned.id);
+          const skippedTargetUrl = provisionedTargets.targetUrlForGuide(
+            planned.id,
+            skippedMeta?.targetUrl ?? options.grafanaUrl
+          );
           const prereqResultsData: TestResultsData = {
             guide: {
               id: planned.id,
               title: planned.id,
               path: planned.guide.path,
-              targetUrl: skippedMeta?.targetUrl ?? options.grafanaUrl,
+              targetUrl: skippedTargetUrl,
             },
             timestamp: new Date().toISOString(),
             results: [],
@@ -627,21 +625,17 @@ async function runChains(
         console.log(`
 📚 Testing: ${planned.guide.path}${suffix}`);
 
-        // Remote guides carry their own resolved targetUrl; local guides fall back
-        // to the global Grafana URL. Cloud auth policy owns credential selection.
         const meta = packageMetaById.get(planned.id);
         const isCloudTarget = meta?.tier === 'cloud';
-        const runnerAuth = isCloudTarget
-          ? cloudAuth?.runnerAuthFor(meta?.targetUrl, provisionedTargets.tokenFor(meta?.targetUrl))
-          : undefined;
+        const targetUrl = provisionedTargets.targetUrlForGuide(planned.id, meta?.targetUrl ?? options.grafanaUrl);
         const runGuideOptions: RunGuideOptions = {
-          targetUrl: meta?.targetUrl ?? options.grafanaUrl,
+          targetUrl,
           verbose: options.verbose,
           trace: options.trace,
           headed: options.headed,
           artifacts: options.artifacts,
           alwaysScreenshot: options.alwaysScreenshot,
-          token: runnerAuth?.token,
+          token: isCloudTarget ? provisionedTargets.tokenForGuide(planned.id, meta?.targetUrl) : undefined,
         };
 
         const result = await runPlaywrightTests(planned.guide, runGuideOptions);
@@ -683,11 +677,11 @@ async function runChains(
         }
       }
     } finally {
-      await provisionedTargets.teardownAll();
+      cleanupWarnings.push(...(await provisionedTargets.teardownAll()));
     }
   }
 
-  return { results, allPassed, hasAuthExpiry };
+  return { results, allPassed, hasAuthExpiry, cleanupWarnings };
 }
 
 /**
@@ -706,9 +700,9 @@ function exitFromResults(results: GuideRunResult[]): void {
  * exit per the results' statuses. Shared by the normal path and the
  * nothing-to-run path so both report identically.
  */
-function reportResults(results: GuideRunResult[], options: E2ECommandOptions): void {
-  printSummary(results);
-  writeJsonReport(results, options.output);
+function reportResults(results: GuideRunResult[], options: E2ECommandOptions, cleanupWarnings: string[] = []): void {
+  printSummary(results, cleanupWarnings);
+  writeJsonReport(results, options.output, cleanupWarnings);
   exitFromResults(results);
 }
 
@@ -746,13 +740,19 @@ async function resolveRunInputs(files: string[], options: E2ECommandOptions): Pr
   const cloudAuth = createCloudAuthPolicy({
     cloudInstanceAdminTokenSpecs: options.cloudInstanceAdminToken,
   });
+  const cloudStack = createColdCloudStackProvisioningConfig({
+    accessPolicyTokenEnvVar: options.cloudStackAccessPolicyToken,
+    region: options.cloudStackRegion,
+    slugPrefix: options.cloudStackSlugPrefix,
+    pluginVersion: options.cloudStackPluginVersion,
+  });
   const remoteOptions: RemoteResolveOptions = {
     grafanaUrl: options.grafanaUrl,
     currentTier: options.tier,
     resolverUrl: options.resolverUrl,
     repoUrl: options.repoUrl,
     cloudUrl: options.cloudUrl,
-    cloudTargetCapabilities: cloudAuth.targets,
+    cloudTargetCapabilities: { ...cloudAuth.targets, isolatedStack: Boolean(cloudStack) },
   };
   const resolution =
     mode === 'remote-package'
@@ -780,6 +780,7 @@ async function resolveRunInputs(files: string[], options: E2ECommandOptions): Pr
     preRunSkipped: resolution.skipped.map(skipToResult),
     packageMetaById: buildPackageMetaMap(loadable),
     cloudAuth,
+    cloudStack,
   };
 }
 
@@ -835,12 +836,18 @@ export const e2eCommand = new Command('e2e')
     `Default cloud instance URL for cloud-tier guides without an instance (default ${DEFAULT_CLOUD_URL})`,
     DEFAULT_CLOUD_URL
   )
+  .option(
+    '--cloud-stack-access-policy-token <envVar>',
+    'Cloud Access Policy token env var for cold isolated Grafana Cloud stack provisioning'
+  )
+  .option('--cloud-stack-region <region>', 'Grafana Cloud region slug for cold isolated stack provisioning')
+  .option('--cloud-stack-slug-prefix <prefix>', 'Slug prefix for cold-provisioned Grafana Cloud stacks')
+  .option('--cloud-stack-plugin-version <version>', 'Pathfinder plugin version to install on cold-provisioned stacks')
   .action(async (files: string[], options: E2ECommandOptions) => {
     const cleanEnv = new CleanEnvironment(options.verbose);
+    const cloudStackCleanup = new ColdCloudStackCleanupRegistry();
 
-    if (options.clean) {
-      installTeardownHandlers(cleanEnv);
-    }
+    installTeardownHandlers(cleanEnv, cloudStackCleanup);
     if (options.clean && options.grafanaUrl === DEFAULT_GRAFANA_URL) {
       options.grafanaUrl = CLEAN_GRAFANA_URL;
     }
@@ -866,16 +873,29 @@ export const e2eCommand = new Command('e2e')
         cloudAuth: inputs.cloudAuth,
         verbose: options.verbose,
       });
-      const idsToSkip = idsSkippedForUnsafeSharedStack(plan, inputs.packageMetaById);
       await runPreflightChecks(
         options,
-        targetUrlsToCheck(inputs, options.grafanaUrl, idsToSkip),
+        preflightTargetUrlsForPlan({
+          plan,
+          packageMetaById: inputs.packageMetaById,
+          cloudAuth: inputs.cloudAuth,
+          cloudStack: inputs.cloudStack,
+          globalUrl: options.grafanaUrl,
+        }),
         inputs.localPackageDir
       );
 
-      const outcome = await runChains(plan, options, cleanEnv, inputs.packageMetaById, inputs.cloudAuth);
+      const outcome = await runChains(
+        plan,
+        options,
+        cleanEnv,
+        inputs.packageMetaById,
+        inputs.cloudAuth,
+        inputs.cloudStack,
+        cloudStackCleanup
+      );
 
-      reportResults([...inputs.preRunSkipped, ...outcome.results], options);
+      reportResults([...inputs.preRunSkipped, ...outcome.results], options, outcome.cleanupWarnings);
     } catch (error) {
       console.error('❌ Error:', error instanceof Error ? error.message : 'Unknown error');
       process.exit(ExitCode.CONFIGURATION_ERROR);

--- a/src/cli/e2e/cloud-auth.test.ts
+++ b/src/cli/e2e/cloud-auth.test.ts
@@ -14,7 +14,6 @@ describe('createCloudAuthPolicy', () => {
     });
     expect(auth.adminTokenFor(CLOUD_URL)).toBe('glsa_admin');
     expect(auth.needsProvisioningFor(CLOUD_URL)).toBe(true);
-    expect(auth.runnerAuthFor(CLOUD_URL)).toEqual({});
   });
 
   it('resolves instance admin tokens from env vars and scopes them to their hosts', () => {
@@ -28,16 +27,6 @@ describe('createCloudAuthPolicy', () => {
     });
     expect(auth.adminTokenFor('https://play.grafana.org/')).toBe('glsa_play_admin');
     expect(auth.adminTokenFor(CLOUD_URL)).toBeUndefined();
-  });
-
-  it('returns the provisioned token as runner auth for that target', () => {
-    const auth = createCloudAuthPolicy({
-      cloudInstanceAdminTokenSpecs: ['learn.grafana.net=GRAFANA_LEARN_ADMIN_TOKEN'],
-      env: { GRAFANA_LEARN_ADMIN_TOKEN: 'glsa_admin' },
-    });
-
-    expect(auth.runnerAuthFor(CLOUD_URL, 'glsa_provisioned')).toEqual({ token: 'glsa_provisioned' });
-    expect(auth.runnerAuthFor('https://play.grafana.org/', 'glsa_provisioned')).toEqual({});
   });
 
   it('throws when an admin token mapping references an unset env var', () => {

--- a/src/cli/e2e/cloud-auth.ts
+++ b/src/cli/e2e/cloud-auth.ts
@@ -5,15 +5,10 @@ export interface CloudAuthConfigInput {
   env?: NodeJS.ProcessEnv;
 }
 
-export interface RunnerAuth {
-  token?: string;
-}
-
 export interface CloudAuthPolicy {
   targets: CloudTargetCapabilities;
   adminTokenFor(targetUrl: string | undefined): string | undefined;
   needsProvisioningFor(targetUrl: string | undefined): boolean;
-  runnerAuthFor(targetUrl: string | undefined, provisionedToken?: string): RunnerAuth;
 }
 
 interface CloudInstanceAdminTokenConfig {
@@ -87,12 +82,6 @@ export function createCloudAuthPolicy(input: CloudAuthConfigInput): CloudAuthPol
     },
     needsProvisioningFor(targetUrl) {
       return Boolean(this.adminTokenFor(targetUrl));
-    },
-    runnerAuthFor(targetUrl, provisionedToken) {
-      if (provisionedToken && this.needsProvisioningFor(targetUrl)) {
-        return { token: provisionedToken };
-      }
-      return {};
     },
   };
 }

--- a/src/cli/e2e/cloud-provisioning.test.ts
+++ b/src/cli/e2e/cloud-provisioning.test.ts
@@ -44,7 +44,6 @@ const cloudAuth: CloudAuthPolicy = {
   needsProvisioningFor(targetUrl) {
     return Boolean(this.adminTokenFor(targetUrl));
   },
-  runnerAuthFor: () => ({}),
 };
 
 const cloudStack: ColdCloudStackProvisioningConfig = {
@@ -188,6 +187,8 @@ describe('provisionCloudTargetsForChain', () => {
     const provisioned = await provisionCloudTargetsForChain({
       targetUrls: ['https://learn.grafana.net/', 'https://play.grafana.org/'],
       cloudAuth,
+      chain: [],
+      packageMetaById: new Map(),
       verbose: false,
     });
 
@@ -223,6 +224,8 @@ describe('provisionCloudTargetsForChain', () => {
       provisionCloudTargetsForChain({
         targetUrls: ['https://learn.grafana.net/', 'https://play.grafana.org/'],
         cloudAuth,
+        chain: [],
+        packageMetaById: new Map(),
         verbose: false,
       })
     ).rejects.toThrow('boom');

--- a/src/cli/e2e/cloud-provisioning.test.ts
+++ b/src/cli/e2e/cloud-provisioning.test.ts
@@ -7,9 +7,21 @@ jest.mock('./shared-cloud-stack-environment', () => ({
     sweepOrphans: jest.fn(async () => undefined),
   })),
 }));
+jest.mock('./cold-cloud-stack-environment', () => ({
+  ColdCloudStackEnvironment: jest.fn().mockImplementation(() => ({
+    provisionChain: jest.fn(async () => ({
+      targetUrl: 'https://isolated.grafana.net/',
+      token: 'isolated-token',
+      stackSlug: 'isolated',
+    })),
+    teardownChain: jest.fn(async () => ['cleanup warning']),
+  })),
+}));
 
 import { SharedCloudStackEnvironment } from './shared-cloud-stack-environment';
+import { ColdCloudStackEnvironment, type ColdCloudStackProvisioningConfig } from './cold-cloud-stack-environment';
 import {
+  chainNeedsCloudStack,
   cloudTargetsInChain,
   provisionCloudTargetsForChain,
   ProvisionedCloudTargets,
@@ -29,8 +41,17 @@ const cloudAuth: CloudAuthPolicy = {
     }
     return undefined;
   },
-  needsProvisioningFor: (targetUrl) => Boolean(targetUrl?.includes('grafana.')),
+  needsProvisioningFor(targetUrl) {
+    return Boolean(this.adminTokenFor(targetUrl));
+  },
   runnerAuthFor: () => ({}),
+};
+
+const cloudStack: ColdCloudStackProvisioningConfig = {
+  accessPolicyTokenEnvVar: 'GRAFANA_CLOUD_ACCESS_POLICY_TOKEN',
+  accessPolicyToken: 'cloud-access-token',
+  region: 'prod-us-east-0',
+  slugPrefix: 'pfe2e',
 };
 
 describe('cloudTargetsInChain', () => {
@@ -65,15 +86,95 @@ describe('ProvisionedCloudTargets', () => {
     expect(provisioned.tokenFor('https://play.grafana.org/a')).toBe('play-token');
     expect(provisioned.tokenFor('https://other.grafana.net/')).toBeUndefined();
 
-    await provisioned.teardownAll();
-
+    await expect(provisioned.teardownAll()).resolves.toEqual([]);
     expect(learnEnv.teardownChain).toHaveBeenCalledTimes(1);
     expect(playEnv.teardownChain).toHaveBeenCalledTimes(1);
+  });
+
+  it('looks up isolated target URLs and tokens by guide id', async () => {
+    const env = { teardownChain: jest.fn(async () => ['warning']) };
+    const provisioned = new ProvisionedCloudTargets();
+
+    provisioned.addForGuides(['a', 'b'], {
+      env,
+      token: 'isolated-token',
+      targetUrl: 'https://isolated.grafana.net/',
+    });
+
+    expect(provisioned.targetUrlForGuide('a', 'https://learn.grafana.net/')).toBe('https://isolated.grafana.net/');
+    expect(provisioned.tokenForGuide('b', 'https://learn.grafana.net/')).toBe('isolated-token');
+    expect(provisioned.targetUrlForGuide('c', 'https://learn.grafana.net/')).toBe('https://learn.grafana.net/');
+
+    await expect(provisioned.teardownAll()).resolves.toEqual(['warning']);
+    expect(env.teardownChain).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('chainNeedsCloudStack', () => {
+  it('requires a cold stack for unsafe cloud guides when stack config is available', () => {
+    const packageMetaById = new Map<string, PackageMeta>([
+      [
+        'readonly',
+        {
+          packageId: 'readonly',
+          tier: 'cloud',
+          targetUrl: 'https://learn.grafana.net/',
+          sideEffects: { level: 'readonly', reasons: [] },
+        },
+      ],
+      [
+        'mutating',
+        {
+          packageId: 'mutating',
+          tier: 'cloud',
+          targetUrl: 'https://learn.grafana.net/',
+          sideEffects: { level: 'mutating', reasons: [] },
+        },
+      ],
+    ]);
+
+    expect(chainNeedsCloudStack({ chain: [{ id: 'readonly' }], packageMetaById, cloudAuth, cloudStack })).toBe(false);
+    expect(chainNeedsCloudStack({ chain: [{ id: 'mutating' }], packageMetaById, cloudAuth, cloudStack })).toBe(true);
+  });
+
+  it('uses a cold stack for cloud guides that lack shared-stack auth', () => {
+    const packageMetaById = new Map<string, PackageMeta>([
+      [
+        'readonly',
+        {
+          packageId: 'readonly',
+          tier: 'cloud',
+          targetUrl: 'https://other.grafana.net/',
+          sideEffects: { level: 'readonly', reasons: [] },
+        },
+      ],
+    ]);
+
+    expect(chainNeedsCloudStack({ chain: [{ id: 'readonly' }], packageMetaById, cloudAuth, cloudStack })).toBe(true);
+  });
+
+  it('does not require a cold stack when no stack config exists', () => {
+    const packageMetaById = new Map<string, PackageMeta>([
+      [
+        'mutating',
+        {
+          packageId: 'mutating',
+          tier: 'cloud',
+          targetUrl: 'https://learn.grafana.net/',
+          sideEffects: { level: 'mutating', reasons: [] },
+        },
+      ],
+    ]);
+
+    expect(
+      chainNeedsCloudStack({ chain: [{ id: 'mutating' }], packageMetaById, cloudAuth, cloudStack: undefined })
+    ).toBe(false);
   });
 });
 
 describe('provisionCloudTargetsForChain', () => {
   let logSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -133,6 +234,49 @@ describe('provisionCloudTargetsForChain', () => {
     expect(second).toBeDefined();
     expect(first!.teardownChain).toHaveBeenCalledTimes(1);
     expect(second!.teardownChain).not.toHaveBeenCalled();
+  });
+
+  it('provisions one isolated stack for an unsafe cloud chain', async () => {
+    const packageMetaById = new Map<string, PackageMeta>([
+      [
+        'mutating',
+        {
+          packageId: 'mutating',
+          tier: 'cloud',
+          targetUrl: 'https://learn.grafana.net/',
+          sideEffects: { level: 'mutating', reasons: [] },
+        },
+      ],
+      [
+        'dependent',
+        {
+          packageId: 'dependent',
+          tier: 'cloud',
+          targetUrl: 'https://learn.grafana.net/',
+          sideEffects: { level: 'readonly', reasons: [] },
+        },
+      ],
+    ]);
+
+    const provisioned = await provisionCloudTargetsForChain({
+      targetUrls: ['https://learn.grafana.net/'],
+      cloudAuth,
+      chain: [{ id: 'mutating' }, { id: 'dependent' }],
+      packageMetaById,
+      cloudStack,
+      verbose: false,
+    });
+
+    expect(ColdCloudStackEnvironment).toHaveBeenCalledWith(cloudStack, false);
+    expect(SharedCloudStackEnvironment).not.toHaveBeenCalled();
+    expect(provisioned.targetUrlForGuide('mutating', 'https://learn.grafana.net/')).toBe(
+      'https://isolated.grafana.net/'
+    );
+    expect(provisioned.targetUrlForGuide('dependent', 'https://learn.grafana.net/')).toBe(
+      'https://isolated.grafana.net/'
+    );
+    expect(provisioned.tokenForGuide('mutating', 'https://learn.grafana.net/')).toBe('isolated-token');
+    await expect(provisioned.teardownAll()).resolves.toEqual(['cleanup warning']);
   });
 });
 

--- a/src/cli/e2e/cloud-provisioning.ts
+++ b/src/cli/e2e/cloud-provisioning.ts
@@ -11,15 +11,16 @@ import {
 interface PlannedGuideRef {
   id: string;
 }
+interface CloudTargetEnvironment {
+  teardownChain(): Promise<void | string[]>;
+}
 
 interface ProvisionedCloudTarget {
-  env: { teardownChain(): Promise<void | string[]> };
+  env: CloudTargetEnvironment;
   token: string;
   targetUrl?: string;
   cleanupRegistry?: ColdCloudStackCleanupRegistry;
-  cleanupTarget?: ColdCloudStackEnvironment;
 }
-
 export class ProvisionedCloudTargets {
   private readonly targets = new Map<string, ProvisionedCloudTarget>();
   private readonly guideTargets = new Map<string, ProvisionedCloudTarget>();
@@ -64,8 +65,8 @@ export class ProvisionedCloudTargets {
       if (!tornDown.has(provisioned)) {
         tornDown.add(provisioned);
         warnings.push(...((await provisioned.env.teardownChain()) ?? []));
-        if (provisioned.cleanupTarget) {
-          provisioned.cleanupRegistry?.untrack(provisioned.cleanupTarget);
+        if (provisioned.cleanupRegistry) {
+          provisioned.cleanupRegistry.untrack(provisioned.env as ColdCloudStackEnvironment);
         }
       }
     }
@@ -126,27 +127,27 @@ export function cloudTargetsInChain(
 export async function provisionCloudTargetsForChain(options: {
   targetUrls: string[];
   cloudAuth: CloudAuthPolicy | undefined;
-  chain?: PlannedGuideRef[];
-  packageMetaById?: Map<string, PackageMeta>;
+  chain: PlannedGuideRef[];
+  packageMetaById: Map<string, PackageMeta>;
   cloudStack?: ColdCloudStackProvisioningConfig;
   cloudStackCleanup?: ColdCloudStackCleanupRegistry;
   verbose: boolean;
 }): Promise<ProvisionedCloudTargets> {
   const provisionedTargets = new ProvisionedCloudTargets();
   try {
+    const cloudStack = options.cloudStack;
     if (
-      options.chain &&
-      options.packageMetaById &&
+      cloudStack &&
       chainNeedsCloudStack({
         chain: options.chain,
         packageMetaById: options.packageMetaById,
         cloudAuth: options.cloudAuth,
-        cloudStack: options.cloudStack,
+        cloudStack,
       })
     ) {
       const ids = cloudGuideIds(options.chain, options.packageMetaById);
       console.log(`\n☁️ Provisioning an ephemeral Grafana Cloud stack for ${ids.length} guide(s)...`);
-      const env = new ColdCloudStackEnvironment(options.cloudStack!, options.verbose);
+      const env = new ColdCloudStackEnvironment(cloudStack, options.verbose);
       options.cloudStackCleanup?.track(env);
       try {
         const stack = await env.provisionChain();
@@ -155,7 +156,6 @@ export async function provisionCloudTargetsForChain(options: {
           token: stack.token,
           targetUrl: stack.targetUrl,
           cleanupRegistry: options.cloudStackCleanup,
-          cleanupTarget: env,
         });
       } catch (err) {
         options.cloudStackCleanup?.untrack(env);

--- a/src/cli/e2e/cloud-provisioning.ts
+++ b/src/cli/e2e/cloud-provisioning.ts
@@ -2,21 +2,47 @@ import { sameOrigin } from './e2e-targets';
 import { SharedCloudStackEnvironment } from './shared-cloud-stack-environment';
 import type { CloudAuthPolicy } from './cloud-auth';
 import type { PackageMeta } from './e2e-results';
+import {
+  ColdCloudStackEnvironment,
+  type ColdCloudStackCleanupRegistry,
+  type ColdCloudStackProvisioningConfig,
+} from './cold-cloud-stack-environment';
 
 interface PlannedGuideRef {
   id: string;
 }
 
 interface ProvisionedCloudTarget {
-  env: SharedCloudStackEnvironment;
+  env: { teardownChain(): Promise<void | string[]> };
   token: string;
+  targetUrl?: string;
+  cleanupRegistry?: ColdCloudStackCleanupRegistry;
+  cleanupTarget?: ColdCloudStackEnvironment;
 }
 
 export class ProvisionedCloudTargets {
   private readonly targets = new Map<string, ProvisionedCloudTarget>();
+  private readonly guideTargets = new Map<string, ProvisionedCloudTarget>();
 
   add(targetUrl: string, provisioned: ProvisionedCloudTarget): void {
     this.targets.set(new URL(targetUrl).origin, provisioned);
+  }
+  addForGuides(guideIds: string[], provisioned: ProvisionedCloudTarget & { targetUrl: string }): void {
+    for (const guideId of guideIds) {
+      this.guideTargets.set(guideId, provisioned);
+    }
+  }
+
+  targetUrlForGuide(guideId: string, fallbackTargetUrl: string): string {
+    return this.guideTargets.get(guideId)?.targetUrl ?? fallbackTargetUrl;
+  }
+
+  tokenForGuide(guideId: string, fallbackTargetUrl: string | undefined): string | undefined {
+    const guideTarget = this.guideTargets.get(guideId);
+    if (guideTarget) {
+      return guideTarget.token;
+    }
+    return this.tokenFor(fallbackTargetUrl);
   }
 
   tokenFor(targetUrl: string | undefined): string | undefined {
@@ -31,11 +57,55 @@ export class ProvisionedCloudTargets {
     return undefined;
   }
 
-  async teardownAll(): Promise<void> {
-    for (const { env } of this.targets.values()) {
-      await env.teardownChain();
+  async teardownAll(): Promise<string[]> {
+    const warnings: string[] = [];
+    const tornDown = new Set<ProvisionedCloudTarget>();
+    for (const provisioned of this.guideTargets.values()) {
+      if (!tornDown.has(provisioned)) {
+        tornDown.add(provisioned);
+        warnings.push(...((await provisioned.env.teardownChain()) ?? []));
+        if (provisioned.cleanupTarget) {
+          provisioned.cleanupRegistry?.untrack(provisioned.cleanupTarget);
+        }
+      }
     }
+    for (const { env } of this.targets.values()) {
+      warnings.push(...((await env.teardownChain()) ?? []));
+    }
+    return warnings;
   }
+}
+
+function isCloudGuide(meta: PackageMeta | undefined): boolean {
+  return meta?.tier === 'cloud';
+}
+
+function hasUnsafeSideEffects(meta: PackageMeta | undefined): boolean {
+  const level = meta?.sideEffects?.level;
+  return isCloudGuide(meta) && level !== 'readonly';
+}
+
+function lacksSharedAuth(meta: PackageMeta | undefined, cloudAuth: CloudAuthPolicy | undefined): boolean {
+  return isCloudGuide(meta) && !cloudAuth?.needsProvisioningFor(meta?.targetUrl);
+}
+
+function cloudGuideIds(chain: PlannedGuideRef[], packageMetaById: Map<string, PackageMeta>): string[] {
+  return chain.filter((planned) => isCloudGuide(packageMetaById.get(planned.id))).map((planned) => planned.id);
+}
+
+export function chainNeedsCloudStack(options: {
+  chain: PlannedGuideRef[];
+  packageMetaById: Map<string, PackageMeta>;
+  cloudAuth: CloudAuthPolicy | undefined;
+  cloudStack: ColdCloudStackProvisioningConfig | undefined;
+}): boolean {
+  if (!options.cloudStack) {
+    return false;
+  }
+  return options.chain.some((planned) => {
+    const meta = options.packageMetaById.get(planned.id);
+    return hasUnsafeSideEffects(meta) || lacksSharedAuth(meta, options.cloudAuth);
+  });
 }
 
 export function cloudTargetsInChain(
@@ -56,10 +126,43 @@ export function cloudTargetsInChain(
 export async function provisionCloudTargetsForChain(options: {
   targetUrls: string[];
   cloudAuth: CloudAuthPolicy | undefined;
+  chain?: PlannedGuideRef[];
+  packageMetaById?: Map<string, PackageMeta>;
+  cloudStack?: ColdCloudStackProvisioningConfig;
+  cloudStackCleanup?: ColdCloudStackCleanupRegistry;
   verbose: boolean;
 }): Promise<ProvisionedCloudTargets> {
   const provisionedTargets = new ProvisionedCloudTargets();
   try {
+    if (
+      options.chain &&
+      options.packageMetaById &&
+      chainNeedsCloudStack({
+        chain: options.chain,
+        packageMetaById: options.packageMetaById,
+        cloudAuth: options.cloudAuth,
+        cloudStack: options.cloudStack,
+      })
+    ) {
+      const ids = cloudGuideIds(options.chain, options.packageMetaById);
+      console.log(`\n☁️ Provisioning an ephemeral Grafana Cloud stack for ${ids.length} guide(s)...`);
+      const env = new ColdCloudStackEnvironment(options.cloudStack!, options.verbose);
+      options.cloudStackCleanup?.track(env);
+      try {
+        const stack = await env.provisionChain();
+        provisionedTargets.addForGuides(ids, {
+          env,
+          token: stack.token,
+          targetUrl: stack.targetUrl,
+          cleanupRegistry: options.cloudStackCleanup,
+          cleanupTarget: env,
+        });
+      } catch (err) {
+        options.cloudStackCleanup?.untrack(env);
+        throw err;
+      }
+      return provisionedTargets;
+    }
     for (const targetUrl of options.targetUrls) {
       const adminToken = options.cloudAuth?.adminTokenFor(targetUrl);
       if (!adminToken) {

--- a/src/cli/e2e/cold-cloud-stack-environment.test.ts
+++ b/src/cli/e2e/cold-cloud-stack-environment.test.ts
@@ -170,6 +170,13 @@ describe('ColdCloudStackEnvironment', () => {
     await env.teardownChain();
 
     expect(calls.map((call) => call.args[0])).toEqual(['init', 'apply', 'output', 'destroy']);
+    expect(calls.find((call) => call.args[0] === 'destroy')?.args).toEqual([
+      'destroy',
+      '-input=false',
+      '-auto-approve',
+      '-lock-timeout=60s',
+      '-no-color',
+    ]);
     expect(existsSync(moduleDir)).toBe(false);
   });
 

--- a/src/cli/e2e/cold-cloud-stack-environment.ts
+++ b/src/cli/e2e/cold-cloud-stack-environment.ts
@@ -363,7 +363,10 @@ export class ColdCloudStackEnvironment {
 
     const warnings: string[] = [];
     try {
-      await this.runTerraform(['destroy', '-input=false', '-auto-approve', '-no-color'], 'destroy');
+      await this.runTerraform(
+        ['destroy', '-input=false', '-auto-approve', '-lock-timeout=60s', '-no-color'],
+        'destroy'
+      );
       if (this.verbose && this.currentStackSlug) {
         console.log(`   🧹 Destroyed Cloud stack ${this.currentStackSlug}`);
       }

--- a/src/cli/e2e/e2e-console-reporter.ts
+++ b/src/cli/e2e/e2e-console-reporter.ts
@@ -33,7 +33,10 @@ import type { LoadedGuide } from '../utils/file-loader';
 import type { PreflightOutcome } from './manifest-preflight';
 import type { SideEffectClassification } from './side-effects';
 
-function skipOnlyReport(preRunSkipped: MultiGuideReport['preRunSkipped']): MultiGuideReport {
+function skipOnlyReport(
+  preRunSkipped: MultiGuideReport['preRunSkipped'],
+  cleanupWarnings: string[] = []
+): MultiGuideReport {
   return {
     type: 'multi-guide',
     config: { timestamp: new Date().toISOString() },
@@ -57,6 +60,7 @@ function skipOnlyReport(preRunSkipped: MultiGuideReport['preRunSkipped']): Multi
     guides: [],
     reports: [],
     preRunSkipped,
+    cleanupWarnings: cleanupWarnings.length > 0 ? cleanupWarnings : undefined,
   };
 }
 
@@ -139,7 +143,7 @@ export function printRunConfiguration(valid: LoadedGuide[], config: RunConfigura
  * Print the run summary: aggregate guide/step counts for multi-guide runs, or a
  * compact pass/fail breakdown for a single guide.
  */
-export function printSummary(results: GuideRunResult[]): void {
+export function printSummary(results: GuideRunResult[], cleanupWarnings: string[] = []): void {
   const resultsWithData = results.filter((r) => r.resultsData).map((r) => r.resultsData!);
   const isMultiGuide = results.length > 1;
   const counts = countGuideStatuses(results);
@@ -189,6 +193,12 @@ export function printSummary(results: GuideRunResult[]): void {
     }
   }
 
+  if (cleanupWarnings.length > 0) {
+    console.log(`\n   Cleanup warnings: ${cleanupWarnings.length}`);
+    for (const warning of cleanupWarnings) {
+      console.log(`   ⚠ ${warning}`);
+    }
+  }
   console.log('\n' + '─'.repeat(68));
 }
 
@@ -197,7 +207,11 @@ export function printSummary(results: GuideRunResult[]): void {
  * report or a single detailed report. A failure to write is a warning, not an
  * error.
  */
-export function writeJsonReport(results: GuideRunResult[], outputPath: string | undefined): void {
+export function writeJsonReport(
+  results: GuideRunResult[],
+  outputPath: string | undefined,
+  cleanupWarnings: string[] = []
+): void {
   if (!outputPath) {
     return;
   }
@@ -208,7 +222,7 @@ export function writeJsonReport(results: GuideRunResult[], outputPath: string | 
 
   if (resultsWithData.length === 0 && preRunSkipped.length > 0) {
     try {
-      const report = skipOnlyReport(preRunSkipped);
+      const report = skipOnlyReport(preRunSkipped, cleanupWarnings);
       writeMultiGuideReport(report, outputPath);
       console.log(`\n📄 Multi-guide JSON report written to: ${outputPath}`);
       console.log(`   ${formatMultiGuideSummary(report)}`);
@@ -223,6 +237,9 @@ export function writeJsonReport(results: GuideRunResult[], outputPath: string | 
       if (preRunSkipped.length > 0) {
         report.preRunSkipped = preRunSkipped;
       }
+      if (cleanupWarnings.length > 0) {
+        report.cleanupWarnings = cleanupWarnings;
+      }
       writeMultiGuideReport(report, outputPath);
       console.log(`\n📄 Multi-guide JSON report written to: ${outputPath}`);
       console.log(`   ${formatMultiGuideSummary(report)}`);
@@ -234,6 +251,9 @@ export function writeJsonReport(results: GuideRunResult[], outputPath: string | 
       const report = generateReport(resultsWithData[0]!);
       if (preRunSkipped.length > 0) {
         report.preRunSkipped = preRunSkipped;
+      }
+      if (cleanupWarnings.length > 0) {
+        report.cleanupWarnings = cleanupWarnings;
       }
       writeReport(report, outputPath);
       console.log(`\n📄 JSON report written to: ${outputPath}`);

--- a/src/cli/e2e/e2e-reporter.test.ts
+++ b/src/cli/e2e/e2e-reporter.test.ts
@@ -38,6 +38,17 @@ function skippedGuide(id: string, failedPrerequisite: string): TestResultsData {
   };
 }
 
+function provisioningFailedGuide(id: string): TestResultsData {
+  return {
+    guide: { id, title: id, path: `${id}/content.json`, targetUrl: 'https://learn.grafana.net/' },
+    timestamp: '2026-01-01T00:00:00.000Z',
+    results: [],
+    aborted: true,
+    abortReason: 'PROVISIONING_FAILED',
+    abortMessage: 'Cloud target provisioning failed: terraform apply failed',
+  };
+}
+
 describe('generateMultiGuideReport — dependency-skipped guides', () => {
   it('counts a skipped dependent without treating it as passed', () => {
     const report = generateMultiGuideReport([
@@ -60,5 +71,16 @@ describe('generateMultiGuideReport — dependency-skipped guides', () => {
     expect(report.summary.totalGuides).toBe(2);
     expect(report.summary.skippedGuides).toBe(0);
     expect(report.guides.every((g) => g.abortReason === undefined)).toBe(true);
+  });
+
+  it('counts provisioning failures as failed guides', () => {
+    const report = generateMultiGuideReport([ranGuide('a'), provisioningFailedGuide('cloud-guide')]);
+
+    expect(report.summary.totalGuides).toBe(2);
+    expect(report.summary.passedGuides).toBe(1);
+    expect(report.summary.failedGuides).toBe(1);
+
+    const failedResult = report.guides.find((g) => g.id === 'cloud-guide');
+    expect(failedResult).toMatchObject({ abortReason: 'PROVISIONING_FAILED', success: false });
   });
 });

--- a/src/cli/e2e/e2e-reporter.ts
+++ b/src/cli/e2e/e2e-reporter.ts
@@ -181,6 +181,8 @@ export interface E2ETestReport {
   abortMessage?: string;
   /** Packages skipped before execution (remote modes). */
   preRunSkipped?: PreRunSkip[];
+  /** Best-effort cleanup failures that did not replace the primary guide outcome. */
+  cleanupWarnings?: string[];
 }
 
 // ============================================
@@ -486,6 +488,8 @@ export interface MultiGuideReport {
   reports: E2ETestReport[];
   /** Packages skipped before execution (remote modes). */
   preRunSkipped?: PreRunSkip[];
+  /** Best-effort cleanup failures that did not replace the primary guide outcome. */
+  cleanupWarnings?: string[];
 }
 
 // ============================================

--- a/src/cli/e2e/e2e-reporter.ts
+++ b/src/cli/e2e/e2e-reporter.ts
@@ -176,7 +176,7 @@ export interface E2ETestReport {
   /** Whether test was aborted (L3-3D) */
   aborted?: boolean;
   /** Reason for abort if aborted is true */
-  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE' | 'SKIPPED_PREREQ';
+  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE' | 'SKIPPED_PREREQ' | 'PROVISIONING_FAILED';
   /** Human-readable abort message */
   abortMessage?: string;
   /** Packages skipped before execution (remote modes). */
@@ -222,7 +222,7 @@ export interface TestResultsData {
   /** Whether execution was aborted */
   aborted: boolean;
   /** Reason for abort if aborted */
-  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE' | 'SKIPPED_PREREQ';
+  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE' | 'SKIPPED_PREREQ' | 'PROVISIONING_FAILED';
   /** Abort message */
   abortMessage?: string;
 }
@@ -381,14 +381,14 @@ export function generateAndWriteReport(
 /**
  * Check if a report indicates overall success.
  *
- * Per L3-4C design doc: only mandatory failures count against success.
+ * Report-level failures without step data also count against success.
  * Skippable step failures do NOT fail the overall test.
  *
  * @param report - The test report
- * @returns true if the test passed (no mandatory failures)
+ * @returns true if the test passed without mandatory or provisioning failures
  */
 export function isReportSuccess(report: E2ETestReport): boolean {
-  return report.summary.mandatoryFailed === 0;
+  return report.summary.mandatoryFailed === 0 && report.abortReason !== 'PROVISIONING_FAILED';
 }
 
 /**
@@ -461,7 +461,7 @@ export interface GuideResult {
   /** Whether this guide passed (no mandatory failures) */
   success: boolean;
   /** Reason for failure/abort if any */
-  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE' | 'SKIPPED_PREREQ';
+  abortReason?: 'AUTH_EXPIRED' | 'MANDATORY_FAILURE' | 'SKIPPED_PREREQ' | 'PROVISIONING_FAILED';
   /** Summary statistics for this guide */
   summary: ReportSummary;
   /** Duration in milliseconds */
@@ -621,13 +621,13 @@ export function writeMultiGuideReport(report: MultiGuideReport, outputPath: stri
 /**
  * Check if a multi-guide report indicates overall success (L3-7B).
  *
- * Per L3-4C design doc: only mandatory failures count against success.
+ * Uses the aggregated guide outcomes so setup failures without step data count.
  *
  * @param report - The multi-guide report
- * @returns true if all guides passed (no mandatory failures in any guide)
+ * @returns true if all guides passed without auth or provisioning failures
  */
 export function isMultiGuideReportSuccess(report: MultiGuideReport): boolean {
-  return report.summary.steps.mandatoryFailed === 0;
+  return report.summary.failedGuides === 0 && report.summary.authExpiredGuides === 0;
 }
 
 /**

--- a/src/cli/e2e/e2e-results.test.ts
+++ b/src/cli/e2e/e2e-results.test.ts
@@ -23,6 +23,7 @@ import {
   exitCodeFromResults,
   guideResultReason,
   preRunSkipsFromResults,
+  provisioningFailureResults,
   resolveRunMode,
   skipToResult,
   summarizeSteps,
@@ -152,7 +153,6 @@ describe('applyPackageMeta', () => {
       packageId: 'a',
       tier: 'local',
       instance: 'play.grafana.org',
-      // targetUrl is intentionally NOT propagated; the runner already set it.
       targetUrl: 'http://should-not-overwrite:3000',
       sourceUrl: 'https://cdn.test/a/content.json',
       sideEffects: READONLY_SIDE_EFFECTS,
@@ -178,6 +178,59 @@ describe('applyPackageMeta', () => {
     expect(data.guide).toEqual(before);
 
     expect(() => applyPackageMeta(undefined, { packageId: 'a' })).not.toThrow();
+  });
+});
+
+describe('provisioningFailureResults', () => {
+  it('builds failed aborted guide results with package metadata', () => {
+    const results = provisioningFailureResults(
+      [{ id: 'cloud-guide', guide: { path: 'https://cdn.test/cloud-guide/content.json' }, autoIncluded: true }],
+      new Map([
+        [
+          'cloud-guide',
+          {
+            packageId: 'cloud-guide',
+            tier: 'cloud',
+            instance: 'learn.grafana.net',
+            targetUrl: 'https://learn.grafana.net/',
+            sourceUrl: 'https://cdn.test/cloud-guide/content.json',
+            sideEffects: READONLY_SIDE_EFFECTS,
+          },
+        ],
+      ]),
+      'http://localhost:3000',
+      'Cloud target provisioning failed: terraform apply failed'
+    );
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        guide: 'https://cdn.test/cloud-guide/content.json',
+        id: 'cloud-guide',
+        status: 'provisioning_failed',
+        exitCode: ExitCode.TEST_FAILURE,
+        autoIncluded: true,
+        abortMessage: 'Cloud target provisioning failed: terraform apply failed',
+        tier: 'cloud',
+        sideEffects: READONLY_SIDE_EFFECTS,
+      }),
+    ]);
+    expect(results[0]!.resultsData).toMatchObject({
+      guide: {
+        id: 'cloud-guide',
+        title: 'cloud-guide',
+        path: 'https://cdn.test/cloud-guide/content.json',
+        targetUrl: 'https://learn.grafana.net/',
+        packageId: 'cloud-guide',
+        tier: 'cloud',
+        instance: 'learn.grafana.net',
+        sourceUrl: 'https://cdn.test/cloud-guide/content.json',
+        sideEffects: READONLY_SIDE_EFFECTS,
+      },
+      results: [],
+      aborted: true,
+      abortReason: 'PROVISIONING_FAILED',
+      abortMessage: 'Cloud target provisioning failed: terraform apply failed',
+    });
   });
 });
 
@@ -211,6 +264,14 @@ describe('preRunSkipsFromResults', () => {
         exitCode: 0,
         autoIncluded: false,
         failedPrerequisite: 'x',
+      },
+      {
+        guide: 'f/content.json',
+        id: 'f',
+        status: 'provisioning_failed',
+        exitCode: 1,
+        autoIncluded: false,
+        abortMessage: 'terraform failed',
       },
     ];
 
@@ -253,9 +314,10 @@ describe('exitCodeFromResults', () => {
     expect(exitCodeFromResults([])).toBe(ExitCode.SUCCESS);
   });
 
-  it('returns TEST_FAILURE when a guide failed or failed validation', () => {
+  it('returns TEST_FAILURE when a guide failed, failed validation, or provisioning failed', () => {
     expect(exitCodeFromResults([result('passed'), result('failed')])).toBe(ExitCode.TEST_FAILURE);
     expect(exitCodeFromResults([result('validation_failed')])).toBe(ExitCode.TEST_FAILURE);
+    expect(exitCodeFromResults([result('provisioning_failed')])).toBe(ExitCode.TEST_FAILURE);
   });
 
   it('prioritizes AUTH_FAILURE over a generic test failure', () => {
@@ -275,6 +337,13 @@ describe('status label / icon tables', () => {
 
     expect(label).toBe('❌ Validation failed');
     expect(GUIDE_STATUS_ICONS.validation_failed).toBe('❌');
+  });
+
+  it('classifies provisioning_failed with a failure label and icon', () => {
+    const label = GUIDE_STATUS_LABELS.find(([status]) => status === 'provisioning_failed')?.[1];
+
+    expect(label).toBe('❌ Provisioning failed');
+    expect(GUIDE_STATUS_ICONS.provisioning_failed).toBe('❌');
   });
 
   it('defines the unsafe shared-stack skip status', () => {
@@ -328,6 +397,12 @@ describe('guideResultReason', () => {
 
   it('surfaces an abortMessage for a skip status', () => {
     expect(guideResultReason({ ...base, status: 'fetch_failed', abortMessage: 'HTTP 503' })).toBe(' (HTTP 503)');
+  });
+
+  it('surfaces an abortMessage for provisioning failures', () => {
+    expect(guideResultReason({ ...base, status: 'provisioning_failed', abortMessage: 'terraform failed' })).toBe(
+      ' (terraform failed)'
+    );
   });
 
   it('suppresses the abortMessage for passed and failed statuses', () => {

--- a/src/cli/e2e/e2e-results.ts
+++ b/src/cli/e2e/e2e-results.ts
@@ -41,7 +41,13 @@ export interface PackageMeta {
  * skip half is derived from the resolver's `RemoteSkipReason` so the two
  * vocabularies cannot drift.
  */
-export type GuideStatus = 'passed' | 'failed' | 'auth_expired' | 'skipped_prereq' | RemoteSkipReason;
+export type GuideStatus =
+  | 'passed'
+  | 'failed'
+  | 'provisioning_failed'
+  | 'auth_expired'
+  | 'skipped_prereq'
+  | RemoteSkipReason;
 
 export interface GuideRunResult {
   guide: string;
@@ -60,7 +66,11 @@ export interface GuideRunResult {
 }
 
 /** Statuses that count as a test failure (non-zero exit). */
-export const FAILURE_STATUSES: ReadonlySet<GuideStatus> = new Set<GuideStatus>(['failed', 'validation_failed']);
+export const FAILURE_STATUSES: ReadonlySet<GuideStatus> = new Set<GuideStatus>([
+  'failed',
+  'provisioning_failed',
+  'validation_failed',
+]);
 
 /** Pre-run skips (the resolver's skip reasons) recorded in the JSON report; excludes skipped_prereq, which carries step data. */
 export const PRE_RUN_SKIP_STATUSES: ReadonlySet<GuideStatus> = new Set<GuideStatus>(REMOTE_SKIP_REASONS);
@@ -69,6 +79,7 @@ export const PRE_RUN_SKIP_STATUSES: ReadonlySet<GuideStatus> = new Set<GuideStat
 export const GUIDE_STATUS_LABELS: ReadonlyArray<readonly [GuideStatus, string]> = [
   ['passed', '✅ Passed'],
   ['failed', '❌ Failed'],
+  ['provisioning_failed', '❌ Provisioning failed'],
   ['validation_failed', '❌ Validation failed'],
   ['auth_expired', '🔐 Auth expired'],
   ['skipped_prereq', '⊘ Skipped (prerequisite failed)'],
@@ -86,6 +97,7 @@ export const GUIDE_STATUS_LABELS: ReadonlyArray<readonly [GuideStatus, string]> 
 export const GUIDE_STATUS_ICONS: Record<GuideStatus, string> = {
   passed: '✅',
   failed: '❌',
+  provisioning_failed: '❌',
   validation_failed: '❌',
   auth_expired: '🔐',
   skipped_prereq: '⊘',
@@ -174,6 +186,48 @@ export function applyPackageMeta(data: TestResultsData | undefined, meta: Packag
     sourceUrl: meta.sourceUrl,
     sideEffects: meta.sideEffects,
   };
+}
+
+interface PlannedGuideForResult {
+  id: string;
+  guide: { path: string };
+  autoIncluded: boolean;
+}
+
+export function provisioningFailureResults(
+  chain: PlannedGuideForResult[],
+  packageMetaById: Map<string, PackageMeta>,
+  fallbackTargetUrl: string,
+  message: string
+): GuideRunResult[] {
+  return chain.map((planned) => {
+    const meta = packageMetaById.get(planned.id);
+    const resultsData: TestResultsData = {
+      guide: {
+        id: planned.id,
+        title: planned.id,
+        path: planned.guide.path,
+        targetUrl: meta?.targetUrl ?? fallbackTargetUrl,
+      },
+      timestamp: new Date().toISOString(),
+      results: [],
+      aborted: true,
+      abortReason: 'PROVISIONING_FAILED',
+      abortMessage: message,
+    };
+    applyPackageMeta(resultsData, meta);
+    return {
+      guide: planned.guide.path,
+      id: planned.id,
+      status: 'provisioning_failed',
+      exitCode: ExitCode.TEST_FAILURE,
+      autoIncluded: planned.autoIncluded,
+      abortMessage: message,
+      tier: meta?.tier,
+      sideEffects: meta?.sideEffects,
+      resultsData,
+    };
+  });
 }
 
 /**

--- a/src/cli/e2e/preflight-targets.test.ts
+++ b/src/cli/e2e/preflight-targets.test.ts
@@ -1,0 +1,145 @@
+import type { CloudAuthPolicy } from './cloud-auth';
+import type { ColdCloudStackProvisioningConfig } from './cold-cloud-stack-environment';
+import type { PackageMeta } from './e2e-results';
+import type { ExecutionPlan, PlannedGuide } from './guide-chains';
+import { preflightTargetUrlsForPlan } from './preflight-targets';
+
+const GLOBAL_URL = 'http://localhost:3000';
+const READONLY_SHARED_URL = 'https://learn.grafana.net/';
+const MUTATING_SHARED_URL = 'https://mutating.grafana.net/';
+const DEPENDENT_SHARED_URL = 'https://dependent.grafana.net/';
+const NO_AUTH_SHARED_URL = 'https://no-auth.grafana.net/';
+
+const cloudAuth: CloudAuthPolicy = {
+  targets: { sharedStackUrls: [READONLY_SHARED_URL, MUTATING_SHARED_URL, DEPENDENT_SHARED_URL] },
+  adminTokenFor: (targetUrl) => {
+    if (targetUrl === READONLY_SHARED_URL || targetUrl === MUTATING_SHARED_URL || targetUrl === DEPENDENT_SHARED_URL) {
+      return 'admin-token';
+    }
+    return undefined;
+  },
+  needsProvisioningFor(targetUrl) {
+    return Boolean(this.adminTokenFor(targetUrl));
+  },
+  runnerAuthFor: () => ({}),
+};
+
+const cloudStack: ColdCloudStackProvisioningConfig = {
+  accessPolicyTokenEnvVar: 'GRAFANA_CLOUD_ACCESS_POLICY_TOKEN',
+  accessPolicyToken: 'cloud-access-token',
+  region: 'prod-us-east-0',
+  slugPrefix: 'pfe2e',
+};
+
+function plannedGuide(id: string, dependencies: string[] = []): PlannedGuide {
+  return {
+    id,
+    guide: {
+      path: `${id}/content.json`,
+      content: JSON.stringify({ id, title: id, schemaVersion: '1.1.0', type: 'guide', blocks: [] }),
+    },
+    dependencies,
+    autoIncluded: false,
+  };
+}
+
+function planWithMutatingCloudChain(): ExecutionPlan {
+  return {
+    chains: [
+      [plannedGuide('local')],
+      [plannedGuide('readonly-cloud')],
+      [plannedGuide('mutating-cloud'), plannedGuide('dependent-cloud', ['mutating-cloud'])],
+    ],
+    autoIncludedIds: [],
+    errors: [],
+  };
+}
+
+function packageMetaWithMutatingCloudChain(): Map<string, PackageMeta> {
+  return new Map<string, PackageMeta>([
+    ['local', { packageId: 'local', tier: 'local' }],
+    [
+      'readonly-cloud',
+      {
+        packageId: 'readonly-cloud',
+        tier: 'cloud',
+        targetUrl: READONLY_SHARED_URL,
+        sideEffects: { level: 'readonly', reasons: [] },
+      },
+    ],
+    [
+      'mutating-cloud',
+      {
+        packageId: 'mutating-cloud',
+        tier: 'cloud',
+        targetUrl: MUTATING_SHARED_URL,
+        sideEffects: { level: 'mutating', reasons: [] },
+      },
+    ],
+    [
+      'dependent-cloud',
+      {
+        packageId: 'dependent-cloud',
+        tier: 'cloud',
+        targetUrl: DEPENDENT_SHARED_URL,
+        sideEffects: { level: 'readonly', reasons: [] },
+      },
+    ],
+  ]);
+}
+
+describe('e2e preflight targets', () => {
+  it('excludes guides routed through cold cloud stacks from original target preflight checks', () => {
+    const targets = preflightTargetUrlsForPlan({
+      plan: planWithMutatingCloudChain(),
+      packageMetaById: packageMetaWithMutatingCloudChain(),
+      cloudAuth,
+      cloudStack,
+      globalUrl: GLOBAL_URL,
+    });
+
+    expect(targets).toEqual([GLOBAL_URL, READONLY_SHARED_URL]);
+  });
+
+  it('excludes unsafe cloud chains when no cold cloud stack is configured', () => {
+    const targets = preflightTargetUrlsForPlan({
+      plan: planWithMutatingCloudChain(),
+      packageMetaById: packageMetaWithMutatingCloudChain(),
+      cloudAuth,
+      cloudStack: undefined,
+      globalUrl: GLOBAL_URL,
+    });
+
+    expect(targets).toEqual([GLOBAL_URL, READONLY_SHARED_URL]);
+  });
+
+  it('excludes readonly cloud guides that lack shared stack auth when cold stacks are available', () => {
+    const plan: ExecutionPlan = {
+      chains: [[plannedGuide('local')], [plannedGuide('readonly-no-auth-cloud')]],
+      autoIncludedIds: [],
+      errors: [],
+    };
+    const packageMetaById = new Map<string, PackageMeta>([
+      ['local', { packageId: 'local', tier: 'local' }],
+      [
+        'readonly-no-auth-cloud',
+        {
+          packageId: 'readonly-no-auth-cloud',
+          tier: 'cloud',
+          targetUrl: NO_AUTH_SHARED_URL,
+          sideEffects: { level: 'readonly', reasons: [] },
+        },
+      ],
+    ]);
+
+    const targets = preflightTargetUrlsForPlan({
+      plan,
+      packageMetaById,
+      cloudAuth,
+      cloudStack,
+      globalUrl: GLOBAL_URL,
+    });
+
+    expect(targets).toEqual([GLOBAL_URL]);
+  });
+});

--- a/src/cli/e2e/preflight-targets.test.ts
+++ b/src/cli/e2e/preflight-targets.test.ts
@@ -21,7 +21,6 @@ const cloudAuth: CloudAuthPolicy = {
   needsProvisioningFor(targetUrl) {
     return Boolean(this.adminTokenFor(targetUrl));
   },
-  runnerAuthFor: () => ({}),
 };
 
 const cloudStack: ColdCloudStackProvisioningConfig = {

--- a/src/cli/e2e/preflight-targets.ts
+++ b/src/cli/e2e/preflight-targets.ts
@@ -1,0 +1,79 @@
+import { chainNeedsCloudStack } from './cloud-provisioning';
+import { unsafeCloudGuidesInChain } from './cloud-routing';
+import type { CloudAuthPolicy } from './cloud-auth';
+import type { ColdCloudStackProvisioningConfig } from './cold-cloud-stack-environment';
+import type { PackageMeta } from './e2e-results';
+import type { ExecutionPlan } from './guide-chains';
+interface PreflightTargetUrlsForPlanOptions {
+  plan: ExecutionPlan;
+  packageMetaById: Map<string, PackageMeta>;
+  cloudAuth: CloudAuthPolicy | undefined;
+  cloudStack: ColdCloudStackProvisioningConfig | undefined;
+  globalUrl: string;
+}
+
+/** Preflight runs before cold-stack provisioning, so exclude guides that will run
+ * against isolated stacks or be skipped for unsafe shared-stack access
+ */
+export function preflightTargetUrlsForPlan(options: PreflightTargetUrlsForPlanOptions): string[] {
+  const idsToSkip = new Set([
+    ...idsSkippedForUnsafeSharedStack(options.plan, options.packageMetaById, options.cloudStack),
+    ...idsUsingColdCloudStack(options.plan, options.packageMetaById, options.cloudAuth, options.cloudStack),
+  ]);
+
+  return targetUrlsToCheck(options.packageMetaById, options.globalUrl, idsToSkip);
+}
+
+function idsSkippedForUnsafeSharedStack(
+  plan: ExecutionPlan,
+  packageMetaById: Map<string, PackageMeta>,
+  cloudStack: ColdCloudStackProvisioningConfig | undefined
+): Set<string> {
+  const ids = new Set<string>();
+  if (cloudStack) {
+    return ids;
+  }
+  for (const chain of plan.chains) {
+    if (unsafeCloudGuidesInChain(chain, packageMetaById).length > 0) {
+      for (const planned of chain) {
+        ids.add(planned.id);
+      }
+    }
+  }
+  return ids;
+}
+
+function idsUsingColdCloudStack(
+  plan: ExecutionPlan,
+  packageMetaById: Map<string, PackageMeta>,
+  cloudAuth: CloudAuthPolicy | undefined,
+  cloudStack: ColdCloudStackProvisioningConfig | undefined
+): Set<string> {
+  const ids = new Set<string>();
+  for (const chain of plan.chains) {
+    if (chainNeedsCloudStack({ chain, packageMetaById, cloudAuth, cloudStack })) {
+      for (const planned of chain) {
+        ids.add(planned.id);
+      }
+    }
+  }
+  return ids;
+}
+
+function targetUrlsToCheck(
+  packageMetaById: Map<string, PackageMeta>,
+  globalUrl: string,
+  idsToSkip: Set<string>
+): string[] {
+  const urls = new Set<string>();
+  for (const [id, meta] of packageMetaById) {
+    if (idsToSkip.has(id)) {
+      continue;
+    }
+    urls.add(meta.targetUrl ?? globalUrl);
+  }
+  if (packageMetaById.size === 0) {
+    urls.add(globalUrl);
+  }
+  return [...urls];
+}


### PR DESCRIPTION
> [!NOTE]
> For broader context, see the **E2E Cloud isolation epic**: https://github.com/grafana/grafana-pathfinder-app/issues/1184. 
>
> This change completes the cold isolated stack lifecycle work in https://github.com/grafana/grafana-pathfinder-app/issues/1187 **(Part 3 of 3)**.

## Summary

Routes unsafe or unauthenticated non-instance Cloud E2E guide chains through cold-provisioned Grafana Cloud stacks when cold-stack config is available. Read-only shared-stack runs remain on the existing service-account path, while unsafe chains without isolated-stack config still skip with `skipped_unsafe_shared_stack`.

## What to look at

- **E2E command orchestration**: [`e2e.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/d89d544cb534b7c43a9f768bca86af9b527f707a/src/cli/commands/e2e.ts) adds the cold-stack CLI flags, exposes isolated-stack capability during remote resolution, skips preflight against the original Cloud URL for chains that will be cold-provisioned, and registers active cold-stack cleanup for signals.
- **Cloud target provisioning**: [`cloud-provisioning.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/d89d544cb534b7c43a9f768bca86af9b527f707a/src/cli/e2e/cloud-provisioning.ts) decides whether a chain needs a cold stack, maps all Cloud guides in that chain to the provisioned target URL/token, and preserves the shared-stack service-account path for read-only/shared-auth runs.
- **Result reporting and docs**: [`e2e-console-reporter.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/d89d544cb534b7c43a9f768bca86af9b527f707a/src/cli/e2e/e2e-console-reporter.ts) and [`E2E_TESTING.md`](https://github.com/grafana/grafana-pathfinder-app/blob/d89d544cb534b7c43a9f768bca86af9b527f707a/docs/developer/E2E_TESTING.md) surface best-effort cleanup warnings and document the cold-stack operator flags and cleanup limits.

## Why

Phase 1 made unsafe Cloud guide chains skip rather than pollute shared stacks. This change wires the cold-stack lifecycle into the runner so those chains can execute against disposable Grafana Cloud stacks while preserving the fast shared-stack path for read-only or instance-specific guides.

## How to verify

1. Run an unsafe Cloud package with `--tier cloud`, `--cloud-stack-access-policy-token <envVar>`, and `--cloud-stack-region <region>`; confirm the runner provisions an ephemeral Cloud stack, runs Playwright against the generated stack URL, and attempts teardown after the chain.
2. Run the same unsafe Cloud package without cold-stack config; confirm it reports `skipped_unsafe_shared_stack` instead of running against the shared target.
3. Run a read-only Cloud package with matching `--cloud-instance-admin-token host=ENV_VAR_NAME`; confirm it continues to use the shared-stack service-account path.
4. Start a cold-stack run and interrupt it with Ctrl-C; confirm the CLI attempts best-effort teardown for any active cold-provisioned stack before exiting.

## Breaking changes

None. This change is additive and fully reversible.

## Reversibility

Reverting this change disables cold-stack routing and returns unsafe Cloud chains to the existing skip behavior. Cloud stacks created while using the new flags are external side effects; normal completion, setup failure, guide failure, Ctrl-C, and SIGTERM attempt cleanup, but a process killed before signal handling or Terraform teardown may leave a labeled stack that requires manual cleanup.

## Out of scope

- Hot-pool discovery, leasing, and replacement.
- Durable stale-stack reconciliation after crashes.
- Installing manifest-declared plugins beyond `grafana-pathfinder-app`.

Refs #1184
Refs #1187

Closes #1187