### PR TITLE
feat(pr-tester): assemble learning paths from CDN catalog + PR overlay

### DIFF
--- a/docs/developer/components/PrTester/README.md
+++ b/docs/developer/components/PrTester/README.md
@@ -50,11 +50,10 @@ PR Tester exists to:
 
 **Learning Path Mode**
 
-- Create ordered sequence of guides
-- Drag-and-drop reordering
-- Test guides in logical sequence
-- Opens as connected learning path
-- Ideal for multi-guide PRs
+- Detects `path`/`journey` manifests and opens them as a real package (cover + milestone toolbar + Alt+arrow navigation)
+- Milestones the PR changes are served from the PR; unchanged milestones are resolved from the published CDN catalog (post-merge state)
+- Auto-discovers the parent path from the catalog even when the path's own manifest isn't in the PR
+- Ideal for multi-guide PRs and PRs that touch only a subset of a path's milestones
 
 ### Content File Detection
 
@@ -144,22 +143,26 @@ All state persists to localStorage:
 
 ### Learning Path Mode
 
-**Use Case**: Sequential testing, related guides
+**Use Case**: Testing a `path`/`journey` package end-to-end, including PRs that change only some of its milestones
 
 **Flow:**
 
 1. Paste PR URL
 2. Click "Fetch PR"
-3. Select "Learning Path" mode
-4. Drag files to reorder
-5. Click "Create Learning Path"
-6. Opens as connected journey with navigation
+3. Select "Learning path" mode
+4. Pick a path package (PR manifests plus any published path the PR's changed guides belong to)
+5. Click "Test as learning path"
+6. Opens as a real package: changed milestones from the PR, unchanged milestones from the published catalog
+
+**Notes:**
+
+- The milestone list labels each milestone `from PR` or `from published`. A note flags when unchanged milestones load from the published version, so the test reflects the post-merge state.
+- Resolution leans on the published package catalog (`fetchOnlinePackageRecommendations`). If the catalog is unavailable, path mode degrades to PR-only (milestones not in the PR are reported missing).
 
 **Best For:**
 
-- Multi-guide PRs
-- Sequential content
-- Path-based content
+- Multi-guide PRs and path-based content
+- PRs that edit a subset of an existing path's milestones
 - Testing navigation flow
 
 ## Data Collected

--- a/src/components/PrTester/PrTester.tsx
+++ b/src/components/PrTester/PrTester.tsx
@@ -2,14 +2,22 @@ import React, { useCallback, useEffect, useState, useMemo, useRef } from 'react'
 import { Box, Button, Icon, Input, Combobox, useStyles2, RadioButtonGroup, type ComboboxOption } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { getPrTesterStyles } from './pr-tester.styles';
-import { fetchPrContentFilesFromUrl, fetchPrManifest, isValidPrUrl, type PrJsonFile } from './github-api';
+import {
+  fetchPrContentFilesFromUrl,
+  fetchPrContentMeta,
+  fetchPrManifest,
+  isValidPrUrl,
+  type PrJsonFile,
+} from './github-api';
 import {
   buildPathPackageInfo,
-  indexContentByPackageId,
-  indexPrFiles,
+  discoverCatalogPaths,
+  getCatalogMilestoneIds,
   type PathPackageBuildResult,
+  type PrContentEntry,
 } from './pr-path-package';
 import { resolveEffectiveTestMode, type TestMode } from './pr-tester-mode';
+import { fetchOnlinePackageRecommendations, type OnlinePackageEntry } from '../../lib/package-recommendations-client';
 import type { ManifestJson } from '../../types/package.types';
 import type { PackageOpenInfo } from '../../types/content-panel.types';
 import { testIds } from '../../constants/testIds';
@@ -21,6 +29,28 @@ const SELECTED_PATH_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_SELECTED_PATH;
 const TEST_MODE_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_MODE;
 const FETCHED_FILES_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_FETCHED_FILES;
 const FETCHED_URL_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_FETCHED_URL;
+
+const EMPTY_CATALOG_BY_ID: ReadonlyMap<string, OnlinePackageEntry> = new Map();
+
+/** The published catalog, indexed for reverse lookup + URL building. */
+interface CatalogState {
+  baseUrl: string;
+  entries: OnlinePackageEntry[];
+  byId: Map<string, OnlinePackageEntry>;
+}
+
+/** A path/journey testable in path mode — either from the PR or auto-discovered from the catalog. */
+interface PathCandidate {
+  /** Selector value: PR directory name, or `cdn:<id>` for a catalog-discovered path. */
+  key: string;
+  id: string;
+  origin: 'pr' | 'cdn';
+  label: string;
+  type: string;
+  milestoneIds: string[];
+  description?: string;
+  manifest?: Record<string, unknown>;
+}
 
 export interface PrTesterProps {
   /**
@@ -40,9 +70,9 @@ type FetchState = 'idle' | 'fetching' | 'fetched' | 'error';
  * Modes:
  * 1. Single — open one content.json
  * 2. Open all — open every content.json in separate tabs
- * 3. Learning path — detect a `path`/`journey` manifest in the PR and open
- *    it as a real package (cover page + milestone toolbar + Alt+arrow nav)
- *    using the same pipeline the recommender uses for production paths.
+ * 3. Learning path — open a `path`/`journey` as a real package. Milestones the
+ *    PR changes are served from the PR; unchanged milestones (and paths whose
+ *    manifest isn't in the PR) are resolved from the published CDN catalog.
  */
 export function PrTester({ onOpenDocsPage }: PrTesterProps) {
   const styles = useStyles2(getPrTesterStyles);
@@ -101,28 +131,32 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
     }
   });
 
-  /**
-   * All parsed manifests in the PR, indexed by directoryName.
-   *
-   * We keep every manifest (not just path/journey) because child packages of
-   * a path use their *own* `manifest.id` as the canonical key. Without those
-   * we can't translate `manifest.milestones` (package IDs) into raw URLs in
-   * the PR — directory names are storage, package IDs are identity.
-   */
+  /** All parsed manifests in the PR, indexed by directoryName — used to detect path/journey packages. */
   const [allManifests, setAllManifests] = useState<Map<string, ManifestJson>>(new Map());
-  const [manifestsLoading, setManifestsLoading] = useState(false);
+
+  /**
+   * PR content.json files keyed by their own package `id`. The content's `id`
+   * is the canonical milestone ID, so this maps a changed milestone to a path's
+   * `manifest.milestones[]` even when its sibling manifest.json isn't in the diff.
+   */
+  const [prContentById, setPrContentById] = useState<Map<string, PrContentEntry>>(new Map());
+  const [metaLoading, setMetaLoading] = useState(false);
+
+  /** Published package catalog, used to discover paths and resolve unchanged milestones. */
+  const [catalog, setCatalog] = useState<CatalogState | null>(null);
+  const [catalogLoading, setCatalogLoading] = useState(false);
 
   const [testSuccess, setTestSuccess] = useState(false);
 
   // REACT: refs for cleanup on unmount (R1, R4)
   const abortControllerRef = useRef<AbortController>();
-  const manifestAbortRef = useRef<AbortController>();
+  const metaAbortRef = useRef<AbortController>();
   const successTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
     return () => {
       abortControllerRef.current?.abort();
-      manifestAbortRef.current?.abort();
+      metaAbortRef.current?.abort();
       if (successTimeoutRef.current) {
         clearTimeout(successTimeoutRef.current);
       }
@@ -178,87 +212,94 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
 
   // Content-only subset for single/all modes
   const contentFiles = useMemo(() => files.filter((f) => f.kind === 'content'), [files]);
-  const manifestFiles = useMemo(() => files.filter((f) => f.kind === 'manifest'), [files]);
 
   /**
-   * Stable signature for the manifest set. The preload effect below depends
-   * on this string instead of the `manifestFiles` array reference so we don't
-   * abort + restart in-flight fetches every time `files` changes — even when
-   * the manifest subset is identical (e.g. a content-only update). The rawUrl
-   * encodes both the file path AND the head SHA, so a force-push or directory
-   * rename produces a different fingerprint and correctly triggers a refetch.
+   * Stable signature for the file set. The preload effects below depend on this
+   * string instead of the `files` array reference so we don't abort + restart
+   * in-flight fetches on every render. Each rawUrl encodes both the file path
+   * AND the head SHA, so a force-push or rename produces a different fingerprint
+   * and correctly triggers a refetch.
    */
-  const manifestFingerprint = useMemo(
+  const filesFingerprint = useMemo(
     () =>
-      manifestFiles
+      files
         .map((f) => f.rawUrl)
         .sort()
         .join('|'),
-    [manifestFiles]
+    [files]
   );
 
-  /**
-   * Latest manifestFiles, read inside the preload effect via ref so the
-   * effect can depend on the stable fingerprint while still using the
-   * up-to-date file list when it does run.
-   */
-  const manifestFilesRef = useRef(manifestFiles);
-  // eslint-disable-next-line react-hooks/refs -- intentional latest-value ref read inside the preload effect (see comment above)
-  manifestFilesRef.current = manifestFiles;
+  const filesRef = useRef(files);
+  // eslint-disable-next-line react-hooks/refs -- intentional latest-value ref read inside the preload effects (see fingerprint comment above)
+  filesRef.current = files;
 
   /**
-   * Load every manifest.json in the PR in parallel.
-   *
-   * We keep them all (not just path/journey) so we can resolve milestone
-   * package IDs to raw URLs via each child manifest's `id` field, even when
-   * the directory name and the canonical package ID disagree.
+   * Preload every manifest.json (to detect path/journey packages) and every
+   * content.json's metadata (to map changed milestones by their package id).
    */
   useEffect(() => {
-    const currentManifestFiles = manifestFilesRef.current;
-    if (currentManifestFiles.length === 0) {
+    const currentFiles = filesRef.current;
+    if (currentFiles.length === 0) {
       setAllManifests(new Map());
-      setManifestsLoading(false);
+      setPrContentById(new Map());
+      setMetaLoading(false);
       return;
     }
 
-    manifestAbortRef.current?.abort();
+    metaAbortRef.current?.abort();
     const controller = new AbortController();
-    manifestAbortRef.current = controller;
+    metaAbortRef.current = controller;
 
-    setManifestsLoading(true);
+    setMetaLoading(true);
     let cancelled = false;
 
     (async () => {
       try {
-        const results = await Promise.all(
-          currentManifestFiles.map(async (file) => {
-            const manifest = await fetchPrManifest(file.rawUrl, controller.signal);
-            return { file, manifest };
-          })
-        );
+        const manifestFiles = currentFiles.filter((f) => f.kind === 'manifest');
+        const contentFilesNow = currentFiles.filter((f) => f.kind === 'content');
+        const [manifestResults, contentResults] = await Promise.all([
+          Promise.all(
+            manifestFiles.map(async (file) => ({
+              file,
+              manifest: await fetchPrManifest(file.rawUrl, controller.signal),
+            }))
+          ),
+          Promise.all(
+            contentFilesNow.map(async (file) => ({
+              file,
+              meta: await fetchPrContentMeta(file.rawUrl, controller.signal),
+            }))
+          ),
+        ]);
         if (cancelled || controller.signal.aborted) {
           return;
         }
-        const next = new Map<string, ManifestJson>();
-        for (const { file, manifest } of results) {
+        const nextManifests = new Map<string, ManifestJson>();
+        for (const { file, manifest } of manifestResults) {
           if (manifest) {
-            next.set(file.directoryName, manifest);
+            nextManifests.set(file.directoryName, manifest);
           }
         }
-        setAllManifests(next);
+        const nextContent = new Map<string, PrContentEntry>();
+        for (const { file, meta } of contentResults) {
+          if (meta) {
+            nextContent.set(meta.id, { file, title: meta.title });
+          }
+        }
+        setAllManifests(nextManifests);
+        setPrContentById(nextContent);
       } catch (error) {
-        // `fetchPrManifest` already swallows its own errors, but anything
-        // else inside this block (Promise.all rejection from an unexpected
-        // throw, a post-unmount setState, etc.) must still flip us out of
-        // the loading state. Without this `finally`, the path-mode UI
-        // would be stuck on "Loading manifests..." with no recovery path.
+        // The fetch helpers swallow their own errors, but anything else inside
+        // this block must still flip us out of the loading state or path mode
+        // is stranded on "Loading…" with no recovery.
         if (!cancelled && !controller.signal.aborted) {
-          console.error('[PrTester] manifest preload failed', error);
+          console.error('[PrTester] PR metadata preload failed', error);
           setAllManifests(new Map());
+          setPrContentById(new Map());
         }
       } finally {
         if (!cancelled && !controller.signal.aborted) {
-          setManifestsLoading(false);
+          setMetaLoading(false);
         }
       }
     })();
@@ -267,9 +308,60 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
       cancelled = true;
       controller.abort();
     };
-  }, [manifestFingerprint]);
+  }, [filesFingerprint]);
 
-  /** Subset that drives the path-mode UI: only path/journey manifests. */
+  /**
+   * Load the published package catalog once a PR is fetched. The client is
+   * session-cached and never throws; an empty result degrades path mode to
+   * diff-only (no auto-discovery, no CDN fallback for unchanged milestones).
+   */
+  useEffect(() => {
+    if (filesRef.current.length === 0) {
+      setCatalog(null);
+      setCatalogLoading(false);
+      return;
+    }
+
+    setCatalogLoading(true);
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const response = await fetchOnlinePackageRecommendations();
+        if (cancelled) {
+          return;
+        }
+        if (!response.baseUrl || response.packages.length === 0) {
+          setCatalog(null);
+          return;
+        }
+        const byId = new Map<string, OnlinePackageEntry>();
+        for (const entry of response.packages) {
+          byId.set(entry.id, entry);
+        }
+        setCatalog({ baseUrl: response.baseUrl, entries: response.packages, byId });
+      } catch {
+        if (!cancelled) {
+          setCatalog(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setCatalogLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filesFingerprint]);
+
+  const pathDiscoveryLoading = metaLoading || catalogLoading;
+
+  /** IDs of the content.json files changed in this PR. */
+  const changedIds = useMemo(() => new Set(prContentById.keys()), [prContentById]);
+
+  /** Path/journey manifests found directly in the PR diff. */
   const pathManifests = useMemo(() => {
     const next = new Map<string, ManifestJson>();
     for (const [dir, manifest] of allManifests) {
@@ -281,23 +373,50 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
   }, [allManifests]);
 
   /**
-   * Index PR files by directory once and share the result with everything
-   * downstream (`indexContentByPackageId` for milestone resolution and
-   * `buildPathPackageInfo` for the cover-page lookup). Without this each
-   * call site would re-iterate `files`, doubling work on every render that
-   * touches the PR.
+   * Paths testable in path mode: those whose manifest is in the PR, plus
+   * published paths that contain a changed milestone (auto-discovery). PR
+   * manifests win when both describe the same path id.
    */
-  const contentByDir = useMemo(() => indexPrFiles(files).contentByDir, [files]);
+  const pathCandidates = useMemo<PathCandidate[]>(() => {
+    const prCandidates: PathCandidate[] = [];
+    for (const [dir, manifest] of pathManifests) {
+      prCandidates.push({
+        key: dir,
+        id: manifest.id,
+        origin: 'pr',
+        label: manifest.id,
+        type: manifest.type,
+        milestoneIds: Array.isArray(manifest.milestones) ? manifest.milestones : [],
+        description: typeof manifest.description === 'string' ? manifest.description : undefined,
+        manifest: manifest as unknown as Record<string, unknown>,
+      });
+    }
 
-  /**
-   * `manifest.milestones[]` lists package IDs, not directory names.
-   * Build the ID→file index by reading each child's manifest.id so the path
-   * tester resolves milestones the same way the production resolver does.
-   */
-  const contentByPackageId = useMemo(
-    () => indexContentByPackageId(contentByDir, allManifests),
-    [contentByDir, allManifests]
-  );
+    const prIds = new Set(prCandidates.map((c) => c.id));
+    const cdnCandidates: PathCandidate[] = [];
+    if (catalog) {
+      for (const entry of discoverCatalogPaths(catalog.entries, changedIds)) {
+        if (prIds.has(entry.id)) {
+          continue;
+        }
+        const manifestType = typeof entry.manifest?.type === 'string' ? (entry.manifest.type as string) : undefined;
+        const manifestDescription =
+          typeof entry.manifest?.description === 'string' ? (entry.manifest.description as string) : undefined;
+        cdnCandidates.push({
+          key: `cdn:${entry.id}`,
+          id: entry.id,
+          origin: 'cdn',
+          label: entry.id,
+          type: entry.type ?? manifestType ?? 'path',
+          milestoneIds: getCatalogMilestoneIds(entry),
+          description: entry.description ?? manifestDescription,
+          manifest: entry.manifest,
+        });
+      }
+    }
+
+    return [...prCandidates, ...cdnCandidates];
+  }, [pathManifests, catalog, changedIds]);
 
   // Effective selected single-mode file
   const selectedFile = useMemo(() => {
@@ -325,50 +444,54 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
     [contentFiles, selectedFile]
   );
 
-  const pathManifestEntries = useMemo(() => Array.from(pathManifests.entries()), [pathManifests]);
-
-  // Effective selected path manifest
+  // Effective selected path candidate
   const selectedPath = useMemo(() => {
-    if (pathManifestEntries.length === 0) {
+    if (pathCandidates.length === 0) {
       return null;
     }
-    if (userSelectedPath && pathManifests.has(userSelectedPath)) {
+    if (userSelectedPath && pathCandidates.some((c) => c.key === userSelectedPath)) {
       return userSelectedPath;
     }
-    return pathManifestEntries[0]![0];
-  }, [pathManifestEntries, pathManifests, userSelectedPath]);
+    return pathCandidates[0]!.key;
+  }, [pathCandidates, userSelectedPath]);
+
+  const selectedCandidate = useMemo(
+    () => pathCandidates.find((c) => c.key === selectedPath) ?? null,
+    [pathCandidates, selectedPath]
+  );
 
   const pathOptions: Array<ComboboxOption<string>> = useMemo(
     () =>
-      pathManifestEntries.map(([dir, manifest]) => ({
-        value: dir,
-        label: manifest.id,
-        description: manifest.type,
+      pathCandidates.map((c) => ({
+        value: c.key,
+        label: c.label,
+        description: c.origin === 'pr' ? c.type : `${c.type} · from published catalog`,
       })),
-    [pathManifestEntries]
+    [pathCandidates]
   );
 
   /**
-   * Build the path package preview for the currently selected manifest. Pure
-   * derivation from the shared `contentByDir` index + `pathManifests` — no
-   * side effects, so we memo it and use the same value for both the preview
-   * list and the action.
+   * Build the path package preview for the selected candidate by overlaying the
+   * PR's changed content on the published catalog. Pure derivation from fetched
+   * state, so we memo it and reuse the same value for preview + action.
    */
   const pathBuild: PathPackageBuildResult | null = useMemo(() => {
-    if (!selectedPath) {
-      return null;
-    }
-    const manifest = pathManifests.get(selectedPath);
-    if (!manifest) {
+    if (!selectedCandidate) {
       return null;
     }
     return buildPathPackageInfo({
-      contentByDir,
-      manifest,
-      manifestDirectory: selectedPath,
-      contentByPackageId,
+      pathId: selectedCandidate.id,
+      description: selectedCandidate.description,
+      milestoneIds: selectedCandidate.milestoneIds,
+      coverFromPr: prContentById.get(selectedCandidate.id)?.file,
+      packageManifest: selectedCandidate.manifest,
+      prContentById,
+      catalogById: catalog?.byId ?? EMPTY_CATALOG_BY_ID,
+      catalogBaseUrl: catalog?.baseUrl ?? '',
     });
-  }, [contentByDir, pathManifests, selectedPath, contentByPackageId]);
+  }, [selectedCandidate, prContentById, catalog]);
+
+  const hasAnyPathPackage = pathCandidates.length > 0;
 
   // testMode is restored from localStorage and can outlive the PR it was
   // chosen for. A single-guide PR hides the mode selector, so a stale 'path'
@@ -376,10 +499,10 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
   const effectiveTestMode: TestMode = useMemo(
     () =>
       resolveEffectiveTestMode(testMode, {
-        manifestsLoading,
-        hasAnyPathPackage: pathManifestEntries.length > 0,
+        manifestsLoading: pathDiscoveryLoading,
+        hasAnyPathPackage,
       }),
-    [manifestsLoading, testMode, pathManifestEntries.length]
+    [pathDiscoveryLoading, testMode, hasAnyPathPackage]
   );
 
   const handleFetchPr = useCallback(async () => {
@@ -399,6 +522,8 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
     setWarning(null);
     setFiles([]);
     setAllManifests(new Map());
+    setPrContentById(new Map());
+    setCatalog(null);
 
     const result = await fetchPrContentFilesFromUrl(cleanedUrl, abortControllerRef.current.signal);
 
@@ -451,6 +576,8 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
         setError(null);
         setFiles([]);
         setAllManifests(new Map());
+        setPrContentById(new Map());
+        setCatalog(null);
         localStorage.removeItem(FETCHED_FILES_STORAGE_KEY);
         localStorage.removeItem(FETCHED_URL_STORAGE_KEY);
       }
@@ -459,6 +586,8 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
       setError(null);
       setFiles([]);
       setAllManifests(new Map());
+      setPrContentById(new Map());
+      setCatalog(null);
     }
   }, []);
 
@@ -489,9 +618,8 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
   const hasFetched = fetchState === 'fetched';
   const hasMultipleContentFiles = contentFiles.length > 1;
   const hasSingleContentFile = contentFiles.length === 1;
-  const hasAnyPathPackage = pathManifestEntries.length > 0;
 
-  // Path mode is only meaningful when at least one path/journey manifest is in the PR.
+  // Path mode is only meaningful when at least one path/journey is testable.
   const modeOptions: Array<SelectableValue<TestMode>> = [
     { label: 'Single', value: 'single' as TestMode, description: 'Test one guide at a time' },
     { label: 'Open all', value: 'all' as TestMode, description: 'Open all guides in tabs' },
@@ -500,7 +628,7 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
       value: 'path' as TestMode,
       description: hasAnyPathPackage
         ? 'Test a path/journey package as a real journey'
-        : 'No path/journey manifest found in this PR',
+        : 'No path/journey found for this PR',
     },
   ];
 
@@ -524,37 +652,35 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
     return !pathBuild || !pathBuild.ok;
   })();
 
+  /** True when the assembled path pulls any milestone from the published catalog. */
+  const usesPublishedContent = pathBuild?.ok ? pathBuild.preview.some((m) => m.source === 'cdn') : false;
+
   /**
    * Human-readable explanation when the path build is not OK. Surfaces in a
    * warning box so the author knows why "Test as learning path" is disabled.
    */
   const pathErrorMessage = useMemo(() => {
-    if (!hasFetched || effectiveTestMode !== 'path') {
-      return null;
-    }
-    if (manifestsLoading) {
+    if (!hasFetched || effectiveTestMode !== 'path' || pathDiscoveryLoading) {
       return null;
     }
     if (!hasAnyPathPackage) {
-      return 'No path or journey manifest found in this PR. Add a manifest.json with type "path" or "journey" to test as a learning path.';
+      return 'No path or journey manifest is in this PR, and no published path contains the changed guides. Add a path/journey manifest.json, or check that the path is published.';
     }
-    if (!pathBuild) {
-      return null;
-    }
-    if (pathBuild.ok) {
+    if (!pathBuild || pathBuild.ok) {
       return null;
     }
     if (pathBuild.reason === 'no_milestones') {
       return 'The selected manifest has no milestones to chain together.';
     }
     if (pathBuild.reason === 'missing_cover') {
-      return 'The selected manifest has no sibling content.json in the PR. Add the cover page to test it as a learning path.';
+      return 'The selected path has no cover content.json in the PR and none published yet.';
     }
     if (pathBuild.reason === 'missing_milestones' && pathBuild.missingMilestones?.length) {
-      return `Missing milestone content in this PR: ${pathBuild.missingMilestones.join(', ')}. Include each milestone's content.json in the PR.`;
+      const catalogNote = catalog ? '' : ' (Could not load the published catalog.)';
+      return `These milestones aren't in the PR and aren't published yet: ${pathBuild.missingMilestones.join(', ')}.${catalogNote}`;
     }
     return null;
-  }, [hasFetched, effectiveTestMode, manifestsLoading, hasAnyPathPackage, pathBuild]);
+  }, [hasFetched, effectiveTestMode, pathDiscoveryLoading, hasAnyPathPackage, pathBuild, catalog]);
 
   return (
     <div className={styles.formGroup} data-testid={testIds.prTester.form}>
@@ -606,52 +732,58 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
         </div>
       )}
 
-      {/* Path mode: pick a manifest + show its milestones in manifest order */}
+      {/* Path mode: pick a path + show its milestones in manifest order */}
       {hasFetched && effectiveTestMode === 'path' && (
         <div className={styles.pathOrderContainer}>
-          {manifestsLoading && (
+          {pathDiscoveryLoading && (
             <p className={styles.helpText}>
-              <Icon name="fa fa-spinner" /> Loading manifests...
+              <Icon name="fa fa-spinner" /> Resolving paths…
             </p>
           )}
-          {!manifestsLoading && hasAnyPathPackage && pathManifestEntries.length > 1 && (
+          {!pathDiscoveryLoading && hasAnyPathPackage && pathCandidates.length > 1 && (
             <div className={styles.selectContainer}>
               <label className={styles.label}>Path package to test</label>
-              <Combobox options={pathOptions} value={selectedPath} onChange={handlePathSelect} />
+              <Combobox
+                options={pathOptions}
+                value={selectedPath}
+                onChange={handlePathSelect}
+                data-testid={testIds.prTester.pathSelect}
+              />
             </div>
           )}
-          {/* Only render the milestones list when we actually have items to
-              show: a successful build, OR a `missing_milestones` failure
-              where each manifest milestone ID is rendered with its missing
-              badge. The other failure reasons (`no_milestones`,
-              `missing_cover`, `not_path_package`) are surfaced via
-              `pathErrorMessage` below — without this gate they leave the
-              "Milestones (from manifest)" label hovering above an empty
-              <ol>. */}
-          {!manifestsLoading && pathBuild?.ok && (
+          {!pathDiscoveryLoading && pathBuild?.ok && (
             <>
-              <label className={styles.label}>Milestones (from manifest)</label>
+              <label className={styles.label}>Milestones</label>
               <ol className={styles.guidesList}>
-                {pathBuild.packageInfo.resolvedMilestones?.map((milestone) => (
-                  <li key={milestone.title} className={styles.guidesListItem}>
+                {pathBuild.preview.map((milestone) => (
+                  <li key={milestone.id} className={styles.guidesListItem}>
                     <Icon name="document-info" />
                     <span>{milestone.title}</span>
+                    <span className={milestone.source === 'pr' ? getStatusClass('modified') : styles.statusBadge}>
+                      {milestone.source === 'pr' ? 'from PR' : 'from published'}
+                    </span>
                   </li>
                 ))}
               </ol>
+              {usesPublishedContent && (
+                <p className={styles.helpText}>
+                  <Icon name="info-circle" /> Unchanged milestones load from the published version, so this reflects the
+                  post-merge state.
+                </p>
+              )}
             </>
           )}
-          {!manifestsLoading && pathBuild && !pathBuild.ok && pathBuild.reason === 'missing_milestones' && (
+          {!pathDiscoveryLoading && pathBuild && !pathBuild.ok && pathBuild.reason === 'missing_milestones' && (
             <>
-              <label className={styles.label}>Milestones (from manifest)</label>
+              <label className={styles.label}>Milestones</label>
               <ol className={styles.guidesList}>
-                {pathManifests.get(selectedPath ?? '')?.milestones?.map((id) => {
+                {selectedCandidate?.milestoneIds.map((id) => {
                   const isMissing = pathBuild.missingMilestones?.includes(id);
                   return (
                     <li key={id} className={styles.guidesListItem}>
                       <Icon name={isMissing ? 'exclamation-triangle' : 'document-info'} />
                       <span>{id}</span>
-                      {isMissing && <span className={getStatusClass('removed')}>not in PR</span>}
+                      {isMissing && <span className={getStatusClass('removed')}>not available</span>}
                     </li>
                   );
                 })}

--- a/src/components/PrTester/github-api.test.ts
+++ b/src/components/PrTester/github-api.test.ts
@@ -6,6 +6,7 @@ import {
   isValidPrUrl,
   fetchPrContentFiles,
   fetchPrContentFilesFromUrl,
+  fetchPrContentMeta,
   fetchPrManifest,
 } from './github-api';
 
@@ -1076,5 +1077,69 @@ describe('fetchPrManifest', () => {
     expect(added.length).toBe(1);
     expect(removed.length).toBe(1);
     expect(removed[0]![1]).toBe(added[0]![1]);
+  });
+});
+
+describe('fetchPrContentMeta', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('reads the id and title from a valid content.json', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: 'my-guide', title: 'My guide', blocks: [] }),
+    });
+
+    const result = await fetchPrContentMeta('https://raw.githubusercontent.com/org/repo/abc/my-guide/content.json');
+
+    expect(result).toEqual({ id: 'my-guide', title: 'My guide' });
+  });
+
+  it('yields the id even when title is absent (in-progress content)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id: 'my-guide' }),
+    });
+
+    const result = await fetchPrContentMeta('https://raw.githubusercontent.com/org/repo/abc/my-guide/content.json');
+
+    expect(result).toEqual({ id: 'my-guide' });
+  });
+
+  it('returns undefined for non-OK responses', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const result = await fetchPrContentMeta('https://raw.githubusercontent.com/org/repo/abc/missing/content.json');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when the JSON has no valid package id', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ title: 'no id here' }),
+    });
+
+    const result = await fetchPrContentMeta('https://raw.githubusercontent.com/org/repo/abc/bad/content.json');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined on fetch errors (no throw)', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network failure'));
+
+    const result = await fetchPrContentMeta('https://raw.githubusercontent.com/org/repo/abc/x/content.json');
+
+    expect(result).toBeUndefined();
   });
 });

--- a/src/components/PrTester/github-api.ts
+++ b/src/components/PrTester/github-api.ts
@@ -10,9 +10,23 @@
  * single mega-guide.
  */
 
-import { ManifestJsonObjectSchema } from '../../types/package.schema';
+import { z } from 'zod';
+
+import { ContentJsonSchema, ManifestJsonObjectSchema } from '../../types/package.schema';
 import type { ManifestJson } from '../../types/package.types';
 import { DEFAULT_CONTENT_FETCH_TIMEOUT } from '../../constants';
+
+/**
+ * The package `id` (and optional `title`) read from a content.json. `title` is
+ * optional so an in-progress content.json without one still yields its id.
+ */
+const ContentMetaSchema = ContentJsonSchema.pick({ id: true }).extend({ title: z.string().optional() });
+
+/** Minimal content.json metadata the PR tester reads to map a file to its package ID. */
+export interface PrContentMeta {
+  id: string;
+  title?: string;
+}
 
 /** Parsed GitHub PR URL components */
 export interface ParsedPrUrl {
@@ -497,6 +511,39 @@ export async function fetchPrManifest(rawUrl: string, signal?: AbortSignal): Pro
       return undefined;
     }
     return parsed.data as unknown as ManifestJson;
+  } catch {
+    return undefined;
+  } finally {
+    composed.dispose();
+  }
+}
+
+/**
+ * Fetch a content.json from a PR raw URL and read its own package `id` (+ title).
+ *
+ * The content's `id` is the canonical package ID — so a milestone whose
+ * content.json is in the PR can be matched to a path's `manifest.milestones[]`
+ * even when its sibling manifest.json isn't in the diff. Mirrors
+ * {@link fetchPrManifest}'s timeout + signal composition and error swallowing.
+ */
+export async function fetchPrContentMeta(rawUrl: string, signal?: AbortSignal): Promise<PrContentMeta | undefined> {
+  const timeoutSignal = AbortSignal.timeout(DEFAULT_CONTENT_FETCH_TIMEOUT);
+  const composed = signal ? composeAbortSignals(signal, timeoutSignal) : { signal: timeoutSignal, dispose: () => {} };
+  try {
+    const response = await fetch(rawUrl, {
+      method: 'GET',
+      signal: composed.signal,
+      redirect: 'follow',
+    });
+    if (!response.ok) {
+      return undefined;
+    }
+    const json: unknown = await response.json();
+    const parsed = ContentMetaSchema.safeParse(json);
+    if (!parsed.success) {
+      return undefined;
+    }
+    return parsed.data;
   } catch {
     return undefined;
   } finally {

--- a/src/components/PrTester/pr-path-package.test.ts
+++ b/src/components/PrTester/pr-path-package.test.ts
@@ -1,133 +1,125 @@
-import { buildPathPackageInfo, indexContentByPackageId, indexPrFiles } from './pr-path-package';
+import {
+  buildPathPackageInfo,
+  discoverCatalogPaths,
+  getCatalogMilestoneIds,
+  isCatalogPathEntry,
+  type PrContentEntry,
+} from './pr-path-package';
 import type { PrJsonFile } from './github-api';
-import type { ManifestJson } from '../../types/package.types';
+import type { OnlinePackageEntry } from '../../lib/package-recommendations-client';
 
 const SHA = '0123456789abcdef0123456789abcdef01234567';
 const RAW_BASE = `https://raw.githubusercontent.com/org/repo/${SHA}`;
+const CDN_BASE = 'https://interactive-learning.grafana.net/packages';
 
-function content(directoryName: string): PrJsonFile {
+function prFile(directoryName: string, kind: 'content' | 'manifest' = 'content'): PrJsonFile {
   return {
     directoryName,
-    rawUrl: `${RAW_BASE}/${directoryName}/content.json`,
-    status: 'added',
-    kind: 'content',
+    rawUrl: `${RAW_BASE}/${directoryName}/${kind}.json`,
+    status: 'modified',
+    kind,
   };
 }
 
-function manifestFile(directoryName: string): PrJsonFile {
-  return {
-    directoryName,
-    rawUrl: `${RAW_BASE}/${directoryName}/manifest.json`,
-    status: 'added',
-    kind: 'manifest',
-  };
+function prContentEntry(directoryName: string, title?: string): PrContentEntry {
+  return { file: prFile(directoryName, 'content'), title };
 }
 
-function pathManifest(overrides: Partial<ManifestJson> = {}): ManifestJson {
+function catalogPath(id: string, milestones: string[], extra: Partial<OnlinePackageEntry> = {}): OnlinePackageEntry {
   return {
-    id: 'my-path',
+    id,
+    path: `${id}/v1.0.0`,
     type: 'path',
-    milestones: ['guide-one', 'guide-two'],
-    ...overrides,
+    manifest: { id, type: 'path', milestones },
+    ...extra,
   };
 }
 
-function guideManifest(id: string): ManifestJson {
-  return { id, type: 'guide' };
+function catalogGuide(id: string, extra: Partial<OnlinePackageEntry> = {}): OnlinePackageEntry {
+  return {
+    id,
+    path: `${id}/v1.0.0`,
+    type: 'guide',
+    manifest: { id, type: 'guide' },
+    ...extra,
+  };
 }
 
-/**
- * Helper that builds the package-id index assuming `manifest.id` matches
- * `directoryName`. Tests for the prefix-mismatch scenario (where directory
- * and id differ) construct the index manually.
- */
-function idIndexMatchingDir(files: readonly PrJsonFile[]): Map<string, PrJsonFile> {
-  const manifests = new Map<string, ManifestJson>();
-  for (const file of files) {
-    if (file.kind === 'manifest') {
-      manifests.set(file.directoryName, guideManifest(file.directoryName));
-    }
-  }
-  return indexContentByPackageId(indexPrFiles(files).contentByDir, manifests);
+function byId(entries: OnlinePackageEntry[]): Map<string, OnlinePackageEntry> {
+  return new Map(entries.map((e) => [e.id, e]));
 }
 
-describe('indexPrFiles', () => {
-  it('separates content and manifest files by directory', () => {
-    const files: PrJsonFile[] = [content('a'), manifestFile('a'), content('b'), manifestFile('c')];
+describe('getCatalogMilestoneIds', () => {
+  it('reads milestone IDs from the inlined manifest', () => {
+    expect(getCatalogMilestoneIds(catalogPath('p', ['a', 'b']))).toEqual(['a', 'b']);
+  });
 
-    const { contentByDir, manifestByDir } = indexPrFiles(files);
+  it('returns [] when there is no manifest or milestones array', () => {
+    expect(getCatalogMilestoneIds({ id: 'p', path: 'p/' })).toEqual([]);
+    expect(getCatalogMilestoneIds({ id: 'p', path: 'p/', manifest: { id: 'p' } })).toEqual([]);
+  });
 
-    expect(contentByDir.size).toBe(2);
-    expect(contentByDir.get('a')?.kind).toBe('content');
-    expect(contentByDir.get('b')?.kind).toBe('content');
-    expect(manifestByDir.size).toBe(2);
-    expect(manifestByDir.get('a')?.kind).toBe('manifest');
-    expect(manifestByDir.get('c')?.kind).toBe('manifest');
+  it('filters out non-string milestone entries', () => {
+    const entry: OnlinePackageEntry = { id: 'p', path: 'p/', manifest: { milestones: ['a', 5, null, 'b'] } };
+    expect(getCatalogMilestoneIds(entry)).toEqual(['a', 'b']);
   });
 });
 
-describe('indexContentByPackageId', () => {
-  it('keys content files by the sibling manifest.id, not the directory name', () => {
-    const files: PrJsonFile[] = [
-      content('01-where-we-are'),
-      manifestFile('01-where-we-are'),
-      content('02-event-demo-suite'),
-      manifestFile('02-event-demo-suite'),
-    ];
-    const manifests = new Map<string, ManifestJson>([
-      ['01-where-we-are', guideManifest('pathfinder-roadmap-where-we-are')],
-      ['02-event-demo-suite', guideManifest('pathfinder-roadmap-event-demo-suite')],
-    ]);
-
-    const index = indexContentByPackageId(indexPrFiles(files).contentByDir, manifests);
-
-    expect(index.size).toBe(2);
-    expect(index.get('pathfinder-roadmap-where-we-are')?.rawUrl).toBe(`${RAW_BASE}/01-where-we-are/content.json`);
-    expect(index.get('pathfinder-roadmap-event-demo-suite')?.rawUrl).toBe(
-      `${RAW_BASE}/02-event-demo-suite/content.json`
-    );
-    // Directory names are NOT exposed as keys
-    expect(index.has('01-where-we-are')).toBe(false);
+describe('isCatalogPathEntry', () => {
+  it('recognizes path/journey via the top-level type', () => {
+    expect(isCatalogPathEntry({ id: 'p', path: 'p/', type: 'path' })).toBe(true);
+    expect(isCatalogPathEntry({ id: 'p', path: 'p/', type: 'journey' })).toBe(true);
+    expect(isCatalogPathEntry({ id: 'g', path: 'g/', type: 'guide' })).toBe(false);
   });
 
-  it('skips manifests whose sibling content.json is not in the PR', () => {
-    const files: PrJsonFile[] = [manifestFile('orphan-manifest')];
-    const manifests = new Map<string, ManifestJson>([['orphan-manifest', guideManifest('orphan')]]);
+  it('falls back to the manifest type when the top-level type is absent', () => {
+    expect(isCatalogPathEntry({ id: 'p', path: 'p/', manifest: { type: 'path' } })).toBe(true);
+    expect(isCatalogPathEntry({ id: 'g', path: 'g/', manifest: { type: 'guide' } })).toBe(false);
+  });
+});
 
-    const index = indexContentByPackageId(indexPrFiles(files).contentByDir, manifests);
+describe('discoverCatalogPaths', () => {
+  const catalog = [
+    catalogPath('alpha-lj', ['a1', 'a2', 'shared']),
+    catalogPath('beta-lj', ['b1', 'shared']),
+    catalogGuide('shared'),
+    catalogGuide('a1'),
+  ];
 
-    expect(index.size).toBe(0);
+  it('finds paths whose milestones intersect the changed IDs', () => {
+    const found = discoverCatalogPaths(catalog, new Set(['a2']));
+    expect(found.map((e) => e.id)).toEqual(['alpha-lj']);
   });
 
-  it('skips orphan content.json files (no sibling manifest)', () => {
-    // Without a sibling manifest we cannot recover the canonical package ID,
-    // so the file is unreachable for milestone resolution.
-    const files: PrJsonFile[] = [content('orphan-content')];
-    const manifests = new Map<string, ManifestJson>();
+  it('returns every path that contains a shared changed milestone', () => {
+    const found = discoverCatalogPaths(catalog, new Set(['shared']));
+    expect(found.map((e) => e.id).sort()).toEqual(['alpha-lj', 'beta-lj']);
+  });
 
-    const index = indexContentByPackageId(indexPrFiles(files).contentByDir, manifests);
+  it('ignores guide-type entries even if their id matches', () => {
+    const found = discoverCatalogPaths(catalog, new Set(['a1']));
+    // a1 is a milestone of alpha-lj AND a guide entry; only the path is returned.
+    expect(found.map((e) => e.id)).toEqual(['alpha-lj']);
+  });
 
-    expect(index.size).toBe(0);
+  it('returns [] when nothing intersects or the changed set is empty', () => {
+    expect(discoverCatalogPaths(catalog, new Set(['nope']))).toEqual([]);
+    expect(discoverCatalogPaths(catalog, new Set())).toEqual([]);
   });
 });
 
 describe('buildPathPackageInfo', () => {
-  it('builds a packageInfo with milestones in manifest order, mapped to PR raw URLs', () => {
-    const manifest = pathManifest();
-    const files: PrJsonFile[] = [
-      manifestFile('my-path'),
-      content('my-path'),
-      manifestFile('guide-two'),
-      content('guide-two'), // intentionally out of order vs. manifest
-      manifestFile('guide-one'),
-      content('guide-one'),
-    ];
-
+  it('builds milestones in manifest order from PR raw URLs when all are in the PR', () => {
     const result = buildPathPackageInfo({
-      contentByDir: indexPrFiles(files).contentByDir,
-      manifest,
-      manifestDirectory: 'my-path',
-      contentByPackageId: idIndexMatchingDir(files),
+      pathId: 'my-path',
+      milestoneIds: ['guide-one', 'guide-two'],
+      coverFromPr: prFile('my-path', 'content'),
+      prContentById: new Map<string, PrContentEntry>([
+        ['guide-one', prContentEntry('guide-one', 'Guide One')],
+        ['guide-two', prContentEntry('guide-two')],
+      ]),
+      catalogById: new Map(),
+      catalogBaseUrl: '',
     });
 
     expect(result.ok).toBe(true);
@@ -135,197 +127,83 @@ describe('buildPathPackageInfo', () => {
       return;
     }
     expect(result.coverUrl).toBe(`${RAW_BASE}/my-path/content.json`);
-    // Slug-formatted fallback when the manifest has no `description`. Mirrors
-    // the `formatSlug` convention used by `find-doc-page.ts` for `?doc=` deep
-    // links so PR-tester tabs and deep-link tabs read the same.
     expect(result.title).toBe('My Path');
-    expect(result.packageInfo.packageId).toBe('my-path');
-    expect(result.packageInfo.packageManifest).toBe(manifest as unknown as Record<string, unknown>);
-
     const milestones = result.packageInfo.resolvedMilestones ?? [];
-    expect(milestones).toHaveLength(2);
-    // Order must follow manifest.milestones, not file order
-    expect(milestones.map((m) => m.title)).toEqual(['guide-one', 'guide-two']);
-    expect(milestones[0]?.number).toBe(1);
-    expect(milestones[0]?.url).toBe(`${RAW_BASE}/guide-one/content.json`);
-    expect(milestones[1]?.number).toBe(2);
-    expect(milestones[1]?.url).toBe(`${RAW_BASE}/guide-two/content.json`);
-  });
-
-  describe('title resolution', () => {
-    function buildWithManifest(manifest: ManifestJson) {
-      const files: PrJsonFile[] = [manifestFile('my-path'), content('my-path')];
-      // Self-reference so the cover resolves; we only care about `result.title`.
-      return buildPathPackageInfo({
-        contentByDir: indexPrFiles(files).contentByDir,
-        manifest,
-        manifestDirectory: 'my-path',
-        contentByPackageId: new Map([['stub', content('my-path')]]),
-      });
-    }
-
-    it('prefers `manifest.description` over the slug-formatted id', () => {
-      const result = buildWithManifest({
-        id: 'pathfinder-roadmap-2026-lj',
-        type: 'path',
-        milestones: ['stub'],
-        description: 'Pathfinder roadmap 2026',
-      });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.title).toBe('Pathfinder roadmap 2026');
-      }
-    });
-
-    it('falls back to slug-formatted id when description is missing', () => {
-      const result = buildWithManifest({
-        id: 'pathfinder-roadmap-2026',
-        type: 'path',
-        milestones: ['stub'],
-      });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.title).toBe('Pathfinder Roadmap 2026');
-      }
-    });
-
-    it('falls back to slug-formatted id when description is whitespace-only', () => {
-      const result = buildWithManifest({
-        id: 'my-cool-path',
-        type: 'path',
-        milestones: ['stub'],
-        description: '   ',
-      });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.title).toBe('My Cool Path');
-      }
-    });
-
-    it('keeps the raw id as the package identity even when title comes from description', () => {
-      const result = buildWithManifest({
-        id: 'pathfinder-roadmap-2026-lj',
-        type: 'path',
-        milestones: ['stub'],
-        description: 'Pathfinder roadmap 2026',
-      });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        // Identity must remain the slug so milestone progress + storage keys
-        // match production lookups.
-        expect(result.packageInfo.packageId).toBe('pathfinder-roadmap-2026-lj');
-      }
-    });
-  });
-
-  it('resolves milestones via package id even when the directory name differs (the real-world prefix case)', () => {
-    const manifest: ManifestJson = {
-      id: 'pathfinder-roadmap-2026-lj',
-      type: 'path',
-      milestones: ['pathfinder-roadmap-where-we-are', 'pathfinder-roadmap-event-demo-suite'],
-    };
-    const files: PrJsonFile[] = [
-      content('pathfinder-roadmap-2026-lj'),
-      manifestFile('pathfinder-roadmap-2026-lj'),
-      content('pathfinder-roadmap-2026-lj/01-where-we-are'),
-      manifestFile('pathfinder-roadmap-2026-lj/01-where-we-are'),
-      content('pathfinder-roadmap-2026-lj/02-event-demo-suite'),
-      manifestFile('pathfinder-roadmap-2026-lj/02-event-demo-suite'),
-    ];
-    // The path manifest's own id matches its directory name, but the children
-    // declare ids without the numeric prefix.
-    const manifests = new Map<string, ManifestJson>([
-      ['pathfinder-roadmap-2026-lj', manifest],
-      ['pathfinder-roadmap-2026-lj/01-where-we-are', guideManifest('pathfinder-roadmap-where-we-are')],
-      ['pathfinder-roadmap-2026-lj/02-event-demo-suite', guideManifest('pathfinder-roadmap-event-demo-suite')],
+    expect(milestones.map((m) => m.url)).toEqual([
+      `${RAW_BASE}/guide-one/content.json`,
+      `${RAW_BASE}/guide-two/content.json`,
     ]);
+    expect(milestones[0]?.title).toBe('Guide One');
+    expect(result.preview.map((p) => p.source)).toEqual(['pr', 'pr']);
+  });
 
-    const { contentByDir } = indexPrFiles(files);
+  it('overlays the PR onto the catalog: changed milestones win, unchanged come from the CDN', () => {
     const result = buildPathPackageInfo({
-      contentByDir,
-      manifest,
-      manifestDirectory: 'pathfinder-roadmap-2026-lj',
-      contentByPackageId: indexContentByPackageId(contentByDir, manifests),
+      pathId: 'my-path',
+      milestoneIds: ['guide-one', 'guide-two'],
+      coverFromPr: undefined,
+      prContentById: new Map<string, PrContentEntry>([['guide-one', prContentEntry('guide-one', 'PR One')]]),
+      catalogById: byId([
+        catalogPath('my-path', ['guide-one', 'guide-two']),
+        catalogGuide('guide-one', { title: 'Published One' }),
+        catalogGuide('guide-two', { title: 'Published Two' }),
+      ]),
+      catalogBaseUrl: CDN_BASE,
     });
 
     expect(result.ok).toBe(true);
     if (!result.ok) {
       return;
     }
+    // Cover falls back to the published path package.
+    expect(result.coverUrl).toBe(`${CDN_BASE}/my-path/v1.0.0/content.json`);
     const milestones = result.packageInfo.resolvedMilestones ?? [];
-    expect(milestones.map((m) => m.url)).toEqual([
-      `${RAW_BASE}/pathfinder-roadmap-2026-lj/01-where-we-are/content.json`,
-      `${RAW_BASE}/pathfinder-roadmap-2026-lj/02-event-demo-suite/content.json`,
-    ]);
+    // guide-one: PR wins. guide-two: from the catalog.
+    expect(milestones[0]?.url).toBe(`${RAW_BASE}/guide-one/content.json`);
+    expect(milestones[0]?.title).toBe('PR One');
+    expect(milestones[1]?.url).toBe(`${CDN_BASE}/guide-two/v1.0.0/content.json`);
+    expect(milestones[1]?.title).toBe('Published Two');
+    expect(result.preview.map((p) => p.source)).toEqual(['pr', 'cdn']);
   });
 
-  it('also accepts journey-type manifests', () => {
-    const manifest = pathManifest({ type: 'journey' });
-    const files: PrJsonFile[] = [
-      content('my-path'),
-      content('guide-one'),
-      manifestFile('guide-one'),
-      content('guide-two'),
-      manifestFile('guide-two'),
-    ];
-
+  it('prefers the PR cover when the path content.json is in the diff', () => {
     const result = buildPathPackageInfo({
-      contentByDir: indexPrFiles(files).contentByDir,
-      manifest,
-      manifestDirectory: 'my-path',
-      contentByPackageId: idIndexMatchingDir(files),
+      pathId: 'my-path',
+      milestoneIds: ['guide-one'],
+      coverFromPr: prFile('my-path', 'content'),
+      prContentById: new Map<string, PrContentEntry>([['guide-one', prContentEntry('guide-one')]]),
+      catalogById: byId([catalogPath('my-path', ['guide-one'])]),
+      catalogBaseUrl: CDN_BASE,
     });
 
-    expect(result.ok).toBe(true);
+    expect(result.ok && result.coverUrl).toBe(`${RAW_BASE}/my-path/content.json`);
   });
 
-  it('rejects guide-type manifests as not a path package', () => {
-    const manifest: ManifestJson = { id: 'g', type: 'guide' };
+  it('reports missing_milestones for IDs in neither the PR nor the catalog', () => {
     const result = buildPathPackageInfo({
-      contentByDir: indexPrFiles([content('g')]).contentByDir,
-      manifest,
-      manifestDirectory: 'g',
-      contentByPackageId: new Map(),
+      pathId: 'my-path',
+      milestoneIds: ['guide-one', 'guide-missing'],
+      coverFromPr: prFile('my-path', 'content'),
+      prContentById: new Map<string, PrContentEntry>([['guide-one', prContentEntry('guide-one')]]),
+      catalogById: byId([catalogGuide('guide-one')]),
+      catalogBaseUrl: CDN_BASE,
     });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.reason).toBe('not_path_package');
+      expect(result.reason).toBe('missing_milestones');
+      expect(result.missingMilestones).toEqual(['guide-missing']);
     }
   });
 
-  it('reports no_milestones when the manifest has an empty milestones array', () => {
-    const manifest = pathManifest({ milestones: [] });
+  it('reports missing_cover when there is no PR cover and the path is not published', () => {
     const result = buildPathPackageInfo({
-      contentByDir: indexPrFiles([content('my-path')]).contentByDir,
-      manifest,
-      manifestDirectory: 'my-path',
-      contentByPackageId: new Map(),
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toBe('no_milestones');
-    }
-  });
-
-  it('reports missing_cover when the path package itself has no content.json in the PR', () => {
-    const manifest = pathManifest();
-    const files: PrJsonFile[] = [
-      content('guide-one'),
-      manifestFile('guide-one'),
-      content('guide-two'),
-      manifestFile('guide-two'),
-    ];
-    const result = buildPathPackageInfo({
-      contentByDir: indexPrFiles(files).contentByDir,
-      manifest,
-      manifestDirectory: 'my-path',
-      contentByPackageId: idIndexMatchingDir(files),
+      pathId: 'my-path',
+      milestoneIds: ['guide-one'],
+      coverFromPr: undefined,
+      prContentById: new Map<string, PrContentEntry>([['guide-one', prContentEntry('guide-one')]]),
+      catalogById: byId([catalogGuide('guide-one')]), // no 'my-path' entry
+      catalogBaseUrl: CDN_BASE,
     });
 
     expect(result.ok).toBe(false);
@@ -334,26 +212,50 @@ describe('buildPathPackageInfo', () => {
     }
   });
 
-  it('reports missing_milestones with the list of unresolved IDs', () => {
-    const manifest = pathManifest({ milestones: ['guide-one', 'guide-missing', 'guide-two'] });
-    const files: PrJsonFile[] = [
-      content('my-path'),
-      content('guide-one'),
-      manifestFile('guide-one'),
-      content('guide-two'),
-      manifestFile('guide-two'),
-    ];
+  it('reports no_milestones for an empty milestone list', () => {
     const result = buildPathPackageInfo({
-      contentByDir: indexPrFiles(files).contentByDir,
-      manifest,
-      manifestDirectory: 'my-path',
-      contentByPackageId: idIndexMatchingDir(files),
+      pathId: 'my-path',
+      milestoneIds: [],
+      coverFromPr: prFile('my-path', 'content'),
+      prContentById: new Map(),
+      catalogById: new Map(),
+      catalogBaseUrl: '',
     });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.reason).toBe('missing_milestones');
-      expect(result.missingMilestones).toEqual(['guide-missing']);
+      expect(result.reason).toBe('no_milestones');
     }
+  });
+
+  describe('title resolution', () => {
+    function buildWithDescription(pathId: string, description?: string) {
+      return buildPathPackageInfo({
+        pathId,
+        description,
+        milestoneIds: ['guide-one'],
+        coverFromPr: prFile(pathId, 'content'),
+        prContentById: new Map<string, PrContentEntry>([['guide-one', prContentEntry('guide-one')]]),
+        catalogById: new Map(),
+        catalogBaseUrl: '',
+      });
+    }
+
+    it('prefers the description over the slug-formatted id', () => {
+      const result = buildWithDescription('pathfinder-roadmap-2026-lj', 'Pathfinder roadmap 2026');
+      expect(result.ok && result.title).toBe('Pathfinder roadmap 2026');
+    });
+
+    it('falls back to the slug-formatted id when description is missing or whitespace', () => {
+      expect((buildWithDescription('pathfinder-roadmap-2026') as { title: string }).title).toBe(
+        'Pathfinder Roadmap 2026'
+      );
+      expect((buildWithDescription('my-cool-path', '   ') as { title: string }).title).toBe('My Cool Path');
+    });
+
+    it('keeps the raw id as the package identity even when the title comes from description', () => {
+      const result = buildWithDescription('pathfinder-roadmap-2026-lj', 'Pathfinder roadmap 2026');
+      expect(result.ok && result.packageInfo.packageId).toBe('pathfinder-roadmap-2026-lj');
+    });
   });
 });

--- a/src/components/PrTester/pr-path-package.ts
+++ b/src/components/PrTester/pr-path-package.ts
@@ -1,200 +1,184 @@
 /**
- * Build a `PackageOpenInfo` for a path/journey package found in a PR.
+ * Assemble a `PackageOpenInfo` for a path/journey package by overlaying the
+ * PR's changed files on top of the published CDN catalog.
  *
- * Mirrors the recommender's `getRecommendationPackageInfo` shape so the PR
- * tester can hand the docs panel a manifest plus pre-resolved milestones, and
- * the existing `fetchPackageContent` pipeline takes care of the cover page,
- * milestone toolbar, and Alt+arrow navigation. No synthetic mega-guide, no
- * sessionStorage round-trips.
+ * Changed milestones (content.json in the diff) win; unchanged milestones are
+ * served from the CDN. The result mirrors the recommender's package shape so
+ * the existing `fetchPackageContent` pipeline renders the cover page, milestone
+ * toolbar, and Alt+arrow navigation unchanged.
  */
 
 import type { Milestone } from '../../types/content.types';
 import type { PackageOpenInfo } from '../../types/content-panel.types';
-import type { ManifestJson } from '../../types/package.types';
+import { buildPackageFileUrl, type OnlinePackageEntry } from '../../lib/package-recommendations-client';
 import type { PrJsonFile } from './github-api';
 
+/** Where a single milestone's content comes from. */
+export type MilestoneSource = 'pr' | 'cdn';
+
+/** A content.json found in the PR, paired with its parsed metadata. */
+export interface PrContentEntry {
+  file: PrJsonFile;
+  title?: string;
+}
+
 export interface PathPackageBuildInputs {
-  /**
-   * Content files indexed by directory name — used to locate the path
-   * package's own `content.json` (the cover page).
-   *
-   * The caller computes this once via {@link indexPrFiles} and shares it
-   * with {@link indexContentByPackageId}, avoiding a second iteration over
-   * the full `files` array per build.
-   */
-  contentByDir: ReadonlyMap<string, PrJsonFile>;
-  /** A loaded path/journey manifest (one entry from the PR). */
-  manifest: ManifestJson;
-  /** Directory name of the package the manifest belongs to. */
-  manifestDirectory: string;
-  /**
-   * Resolves a milestone package ID (from `manifest.milestones[]`) to its
-   * `content.json` file in the PR.
-   *
-   * Built by the caller from sibling `manifest.json` files: each child
-   * package's `manifest.id` is the canonical key, *not* its directory name.
-   * Production behaves the same way — directory layout is storage, package ID
-   * is identity (see `package.schema.ts` `PACKAGE_ID_REGEX` notes).
-   */
-  contentByPackageId: ReadonlyMap<string, PrJsonFile>;
+  /** Canonical package ID of the path/journey. */
+  pathId: string;
+  /** Author-provided description, used as the tab title when present. */
+  description?: string;
+  /** Ordered milestone package IDs (from the PR manifest, else the catalog). */
+  milestoneIds: string[];
+  /** The path's own content.json when it is in the diff (the cover page). */
+  coverFromPr?: PrJsonFile;
+  /** Manifest to hand the docs panel (PR manifest or the catalog entry's). */
+  packageManifest?: Record<string, unknown>;
+  /** PR content.json files keyed by their own package ID. */
+  prContentById: ReadonlyMap<string, PrContentEntry>;
+  /** Published catalog entries keyed by package ID. */
+  catalogById: ReadonlyMap<string, OnlinePackageEntry>;
+  /** Catalog `baseUrl` for building CDN file URLs. */
+  catalogBaseUrl: string;
+}
+
+/** A milestone row for the path-mode preview, annotated with its source. */
+export interface PathMilestonePreview {
+  id: string;
+  title: string;
+  source: MilestoneSource;
 }
 
 export type PathPackageBuildResult =
   | {
       ok: true;
-      /** URL of the path package's own content.json — opens as the cover page. */
       coverUrl: string;
-      /** Title to display on the tab. */
       title: string;
-      /** Manifest + pre-resolved milestones to feed straight into openDocsPage. */
       packageInfo: PackageOpenInfo;
-      /** Manifest milestone IDs that have no matching content.json in the PR. */
-      missingMilestones: string[];
+      preview: PathMilestonePreview[];
     }
   | {
       ok: false;
-      reason: 'not_path_package' | 'no_milestones' | 'missing_cover' | 'missing_milestones';
+      reason: 'no_milestones' | 'missing_cover' | 'missing_milestones';
+      /** IDs present in neither the PR nor the CDN catalog. */
       missingMilestones?: string[];
     };
 
 /**
  * Format a package ID slug like `pathfinder-roadmap-2026` into a tab-friendly
- * title `Pathfinder Roadmap 2026`. Mirrors the `formatSlug` helper in
- * `src/utils/find-doc-page.ts` so deep-link tabs and PR-tester tabs use the
- * same convention. Used as a fallback when a path manifest has no
- * `description` to display.
+ * title `Pathfinder Roadmap 2026`. Mirrors `formatSlug` in
+ * `src/utils/find-doc-page.ts` so PR-tester tabs and deep-link tabs read alike.
  */
 function formatPackageIdAsTitle(id: string): string {
   return id.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-/**
- * Index PR JSON files by `(directoryName, kind)` for O(1) lookup during
- * milestone resolution.
- */
-export function indexPrFiles(files: readonly PrJsonFile[]): {
-  contentByDir: Map<string, PrJsonFile>;
-  manifestByDir: Map<string, PrJsonFile>;
-} {
-  const contentByDir = new Map<string, PrJsonFile>();
-  const manifestByDir = new Map<string, PrJsonFile>();
-  for (const file of files) {
-    if (file.kind === 'content') {
-      contentByDir.set(file.directoryName, file);
-    } else {
-      manifestByDir.set(file.directoryName, file);
-    }
-  }
-  return { contentByDir, manifestByDir };
+/** Read the milestone package IDs from a catalog entry's inlined manifest. */
+export function getCatalogMilestoneIds(entry: OnlinePackageEntry): string[] {
+  const milestones = entry.manifest?.milestones;
+  return Array.isArray(milestones) ? milestones.filter((id): id is string => typeof id === 'string') : [];
+}
+
+/** Whether a catalog entry is a path or journey (top-level type, else manifest type). */
+export function isCatalogPathEntry(entry: OnlinePackageEntry): boolean {
+  const manifestType = typeof entry.manifest?.type === 'string' ? (entry.manifest.type as string) : undefined;
+  const type = entry.type ?? manifestType;
+  return type === 'path' || type === 'journey';
 }
 
 /**
- * Build a `(packageId -> contentFile)` index by joining sibling
- * `manifest.json` and `content.json` files in the PR.
- *
- * Critical: `manifest.milestones` lists **package IDs**, not directory names.
- * In production the resolver maps IDs to paths via `repository.json`; for
- * the PR tester we read each child package's own manifest to recover that
- * mapping locally. (Without this we'd silently fail when authors organise
- * packages under numbered/prefixed directories like `01-where-we-are/`
- * while the manifest declares `id: "pathfinder-roadmap-where-we-are"`.)
- *
- * Manifests without a sibling `content.json` are skipped (no file to index);
- * orphan content files (no sibling manifest) are also skipped because their
- * canonical package ID is unknown.
- *
- * Takes a pre-computed `contentByDir` map so the caller can share one
- * {@link indexPrFiles} iteration across this function and
- * {@link buildPathPackageInfo}.
+ * Find published path/journey entries whose milestones include any of the IDs
+ * changed in the PR — so a path is testable even when its own manifest.json
+ * isn't in the diff.
  */
-export function indexContentByPackageId(
-  contentByDir: ReadonlyMap<string, PrJsonFile>,
-  manifestsByDirectory: ReadonlyMap<string, ManifestJson>
-): Map<string, PrJsonFile> {
-  const result = new Map<string, PrJsonFile>();
-  for (const [directory, manifest] of manifestsByDirectory) {
-    const contentFile = contentByDir.get(directory);
-    if (!contentFile) {
-      continue;
-    }
-    if (typeof manifest.id === 'string' && manifest.id.length > 0) {
-      result.set(manifest.id, contentFile);
-    }
+export function discoverCatalogPaths(
+  catalog: readonly OnlinePackageEntry[],
+  changedIds: ReadonlySet<string>
+): OnlinePackageEntry[] {
+  if (changedIds.size === 0) {
+    return [];
   }
-  return result;
+  return catalog.filter(
+    (entry) => isCatalogPathEntry(entry) && getCatalogMilestoneIds(entry).some((id) => changedIds.has(id))
+  );
 }
 
 /**
- * Build milestones + packageInfo for a single path/journey manifest in the PR.
- *
- * Each milestone ID in `manifest.milestones` is resolved through
- * `contentByPackageId` (built by {@link indexContentByPackageId} from sibling
- * manifests). Missing milestones are reported but do not silently fail —
- * callers decide how to surface them.
+ * Resolve a single milestone to a URL + title, preferring the PR's changed
+ * content over the published catalog. Returns `undefined` when the ID is in
+ * neither source.
+ */
+function resolveMilestone(
+  id: string,
+  inputs: Pick<PathPackageBuildInputs, 'prContentById' | 'catalogById' | 'catalogBaseUrl'>
+): { url: string; title: string; source: MilestoneSource } | undefined {
+  const pr = inputs.prContentById.get(id);
+  const catalogEntry = inputs.catalogById.get(id);
+  if (pr) {
+    return { url: pr.file.rawUrl, title: pr.title ?? catalogEntry?.title ?? id, source: 'pr' };
+  }
+  if (catalogEntry) {
+    const url = buildPackageFileUrl(inputs.catalogBaseUrl, catalogEntry.path, 'content.json');
+    if (url) {
+      return { url, title: catalogEntry.title ?? id, source: 'cdn' };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build milestones + packageInfo for a path/journey, overlaying PR-changed
+ * content on the published catalog. Fails only when a milestone (or the cover)
+ * is resolvable from neither source.
  */
 export function buildPathPackageInfo(inputs: PathPackageBuildInputs): PathPackageBuildResult {
-  const { contentByDir, manifest, manifestDirectory, contentByPackageId } = inputs;
+  const { pathId, description, milestoneIds, coverFromPr, packageManifest, catalogById, catalogBaseUrl } = inputs;
 
-  if (manifest.type !== 'path' && manifest.type !== 'journey') {
-    return { ok: false, reason: 'not_path_package' };
-  }
-
-  const milestoneIds = Array.isArray(manifest.milestones) ? manifest.milestones : [];
   if (milestoneIds.length === 0) {
     return { ok: false, reason: 'no_milestones' };
   }
 
-  const cover = contentByDir.get(manifestDirectory);
-  if (!cover) {
-    // The path package's own content.json is the cover page; without it
-    // fetchPackageContent has nothing to render at currentMilestone === 0.
+  const catalogCover = catalogById.get(pathId);
+  const coverUrl = coverFromPr
+    ? coverFromPr.rawUrl
+    : catalogCover
+      ? buildPackageFileUrl(catalogBaseUrl, catalogCover.path, 'content.json')
+      : '';
+  if (!coverUrl) {
     return { ok: false, reason: 'missing_cover' };
   }
 
   const missingMilestones: string[] = [];
-  const milestones: Milestone[] = milestoneIds.map((id, index) => {
-    const file = contentByPackageId.get(id);
-    if (!file) {
+  const milestones: Milestone[] = [];
+  const preview: PathMilestonePreview[] = [];
+
+  milestoneIds.forEach((id, index) => {
+    const resolved = resolveMilestone(id, inputs);
+    if (!resolved) {
       missingMilestones.push(id);
+      return;
     }
-    return {
+    milestones.push({
       number: index + 1,
-      title: id,
+      title: resolved.title,
       duration: '',
-      // Empty URL signals "unresolved" to the milestone navigator; the caller
-      // gates the open action when missingMilestones is non-empty so this
-      // never reaches the runtime in practice.
-      url: file ? file.rawUrl : '',
+      url: resolved.url,
       isActive: false,
-    };
+    });
+    preview.push({ id, title: resolved.title, source: resolved.source });
   });
 
   if (missingMilestones.length > 0) {
     return { ok: false, reason: 'missing_milestones', missingMilestones };
   }
 
-  // Tab title preference order:
-  //   1. `manifest.description` — author-provided human-readable label.
-  //   2. Slug-formatted `manifest.id` — same dash-to-space + capitalize
-  //      convention `find-doc-page.ts` uses for `?doc=` deep links, so the
-  //      PR tester produces the same "Looks like a tab title" output for
-  //      paths whose authors haven't filled in a description yet.
-  // The raw slug `manifest.id` is preserved as the package identity inside
-  // `packageInfo` so milestone progress and storage keys stay correct.
-  const description = typeof manifest.description === 'string' ? manifest.description.trim() : '';
-  const title = description || formatPackageIdAsTitle(manifest.id);
+  const trimmedDescription = typeof description === 'string' ? description.trim() : '';
+  const title = trimmedDescription || formatPackageIdAsTitle(pathId);
 
   const packageInfo: PackageOpenInfo = {
-    packageId: manifest.id,
-    packageManifest: manifest as unknown as Record<string, unknown>,
+    packageId: pathId,
+    packageManifest,
     resolvedMilestones: milestones,
   };
 
-  return {
-    ok: true,
-    coverUrl: cover.rawUrl,
-    title,
-    packageInfo,
-    missingMilestones,
-  };
+  return { ok: true, coverUrl, title, packageInfo, preview };
 }

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -316,6 +316,7 @@ export const testIds = {
     form: 'pr-tester-form',
     prNumberInput: 'pr-tester-pr-number',
     fileSelect: 'pr-tester-file-select',
+    pathSelect: 'pr-tester-path-select',
     loadButton: 'pr-tester-load',
   },
 


### PR DESCRIPTION
## What & why

Closes #1151.

PR Tester's **learning path** mode was diff-only: every milestone in a path's `manifest.milestones[]` needed **both** its `content.json` and `manifest.json` present in the PR. A PR that edits only a subset of a path's milestones (e.g. `grafana/interactive-tutorials#402`, which touches only milestone `content.json` files) failed with *"Missing milestone content in this PR"* — the full journey couldn't be tested without artificially touching unchanged files.

This makes path mode assemble the **full path by overlaying the PR on the published CDN catalog** (the post-merge state a reviewer actually wants to test).

## How

- **Read the changed content's own `id`** (`fetchPrContentMeta` in `github-api.ts`) — a `content.json` carries the canonical package id, so a changed milestone resolves even when its sibling `manifest.json` isn't in the diff.
- **Overlay assembly** (`buildPathPackageInfo` in `pr-path-package.ts`): per milestone, **PR wins → else CDN catalog → else missing**. Cover from the PR, else the catalog. Fails only when a milestone (or cover) is in neither source.
- **Auto-discover the parent path** (`discoverCatalogPaths`): reverse lookup over the published catalog (`fetchOnlinePackageRecommendations`) for path/journey entries whose `milestones[]` include a changed id — so a path is testable even when its own manifest isn't in the PR.
- Mixed PR-raw + CDN milestone URLs render unchanged because `fetchPackageContent` uses pre-resolved milestone URLs as-is.

Removed the now-obsolete `indexContentByPackageId` / `indexPrFiles`.

## UX

- Path selector lists PR manifests **plus** auto-discovered published paths (labeled by origin).
- Milestone preview labels each row `from PR` / `from published`, with a note that unchanged milestones reflect the **post-merge** state.
- Catalog unavailable → path mode degrades to PR-only (milestones not in the PR reported missing).

## Scope decisions
- **Auto-discovery** of the path from the CDN (not just when the manifest is in the diff).
- **CDN-only** for unchanged milestones (no extra GitHub API calls); a milestone in neither the PR nor the catalog is a hard error.

## Testing
- `typecheck`, `eslint`, `prettier`, architecture/tier governance: ✅
- 120 unit tests pass, incl. new coverage for `discoverCatalogPaths`, the overlay (PR-wins / CDN-fallback / cover-from-CDN / missing / titles), and `fetchPrContentMeta`.
- **Manual (pending):** open `interactive-tutorials#402` in path mode → changed milestones `from PR`, unchanged `from published`, Alt+→ walks the full journey.

## Docs
Updated `docs/developer/components/PrTester/README.md` path-mode sections to match (also corrected pre-existing drift in that section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)