### PR TITLE
fix(sidebar): clear docked state on explicit close so it doesn't reopen

### DIFF
--- a/src/components/docs-panel/components/TabBarActions.test.tsx
+++ b/src/components/docs-panel/components/TabBarActions.test.tsx
@@ -45,6 +45,11 @@ jest.mock('../../../lib/analytics', () => ({
   },
 }));
 
+// Mock extension-sidebar docked-state storage
+jest.mock('../../../lib/storage/extension-sidebar', () => ({
+  clearExtensionSidebarDocked: jest.fn(),
+}));
+
 // Get mock reference after imports
 const {
   __mockPublish: mockPublish,
@@ -112,6 +117,16 @@ describe('TabBarActions', () => {
         action: 'close_sidebar',
         source: 'header_close_button',
       });
+    });
+
+    it('clears the persisted docked state so the panel is not restored on the next load', () => {
+      const { clearExtensionSidebarDocked } = jest.requireMock('../../../lib/storage/extension-sidebar');
+
+      render(<TabBarActions />);
+
+      fireEvent.click(screen.getByTestId(testIds.docsPanel.closeButton));
+
+      expect(clearExtensionSidebarDocked).toHaveBeenCalled();
     });
   });
 

--- a/src/components/docs-panel/components/TabBarActions.tsx
+++ b/src/components/docs-panel/components/TabBarActions.tsx
@@ -11,6 +11,7 @@ import { config, getAppEvents, locationService } from '@grafana/runtime';
 import { reportAppInteraction, UserInteraction } from '../../../lib/analytics';
 import { PLUGIN_BASE_URL } from '../../../constants';
 import { testIds } from '../../../constants/testIds';
+import { clearExtensionSidebarDocked } from '../../../lib/storage/extension-sidebar';
 
 export interface TabBarActionsProps {
   /** CSS class name for the container */
@@ -58,6 +59,9 @@ export const TabBarActions: React.FC<TabBarActionsProps> = ({ className }) => {
       type: 'close-extension-sidebar',
       payload: {},
     });
+    // Clear the persisted docked state too, so an explicit close isn't undone by
+    // Grafana restoring the panel (browser_restore) on the next page load.
+    clearExtensionSidebarDocked();
   };
 
   const handleMyLearningClick = () => {


### PR DESCRIPTION
## Problem

Users report the Pathfinder sidebar re-opening on page navigation across unrelated pages (`/alerting/*`, `/dashboards`, `/explore`, `/profile`, …). RudderStack shows these opens are overwhelmingly `source: browser_restore` — Grafana restoring the **docked** extension sidebar on each page load from `localStorage['grafana.navigation.extensionSidebarDocked']`.

Once the panel is opened/docked once (e.g. by the highlighted-guide experiment on an IRM page), that docked state is global and follows the user everywhere. Closing the panel via the in-panel close button (`header_close_button` → `close-extension-sidebar`) did **not** clear the persisted docked key, so `browser_restore` re-opened it on the next load — the close never "stuck."

## Fix

`handleCloseSidebar` now also calls `clearExtensionSidebarDocked()` after publishing `close-extension-sidebar`, so an explicit close clears Grafana's persisted docked key and the panel is not restored on the next page load.

Scope is deliberately narrow:
- Only the **explicit** close path clears the key. The normal navigation-unmount is untouched, so a genuinely-docked panel still persists across navigation as intended.
- **No new localStorage key** — this only clears the existing Grafana-owned key.

## Test

Added a `TabBarActions` test asserting the close button clears the docked state. Typecheck, lint, prettier, and tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
