### PR TITLE
fix(auto-launch): buffer delivery via reusable latched channel so the guide always renders

### DIFF
--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -31,7 +31,7 @@ import { isDevModeEnabled } from '../../utils/dev-mode';
 
 import { reportAppInteraction, UserInteraction, getContentTypeForAnalytics } from '../../lib/analytics';
 import { tabStorage, useUserStorage } from '../../lib/user-storage';
-import { useGuideProgressState, useAutoLaunchTutorial } from '../../hooks';
+import { useGuideProgressState, useAutoLaunchTutorial, type AutoLaunchTutorialDetail } from '../../hooks';
 import {
   fetchContent,
   getNextMilestoneUrlFromContent,
@@ -1157,32 +1157,23 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   // No need for automatic saving here as it's done when tabs are created/modified
   // Note: Click-outside and dropdown positioning now handled by useTabOverflow hook
 
-  // Auto-launch tutorial detection.
-  //
-  // The hook owns the routing (typed source coercion + the
-  // `learning-journey || learning-hub` rule) so all surfaces agree on what
-  // an `auto-launch-tutorial` event means. The sidebar additionally fires
-  // `OpenResourceClick` analytics and a follow-up `auto-launch-complete`
-  // window event — both fire unconditionally, mirroring the legacy
-  // behavior, so callers downstream can wait for completion regardless of
-  // whether url/title were present.
-  useAutoLaunchTutorial(model, {
-    onIncoming: (detail) => {
-      const { url, title, type, source } = detail;
-      const openAsLearningJourney = shouldOpenAsLearningJourney(type, source);
-      reportAppInteraction(UserInteraction.OpenResourceClick, {
-        content_title: title,
-        content_url: url,
-        content_type: getContentTypeForAnalytics(url, openAsLearningJourney ? 'learning-journey' : 'docs'),
-        trigger_source: 'auto_launch_tutorial',
-        interaction_location: 'docs_panel',
-        ...(openAsLearningJourney && {
-          completion_percentage: 0, // Auto-launch is always starting fresh
-        }),
-      });
-      window.dispatchEvent(new CustomEvent('auto-launch-complete', { detail }));
-    },
-  });
+  const handleAutoLaunchIncoming = useCallback((detail: AutoLaunchTutorialDetail) => {
+    const { url, title, type, source } = detail;
+    const openAsLearningJourney = shouldOpenAsLearningJourney(type, source);
+    reportAppInteraction(UserInteraction.OpenResourceClick, {
+      content_title: title,
+      content_url: url,
+      content_type: getContentTypeForAnalytics(url, openAsLearningJourney ? 'learning-journey' : 'docs'),
+      trigger_source: 'auto_launch_tutorial',
+      interaction_location: 'docs_panel',
+      ...(openAsLearningJourney && {
+        completion_percentage: 0, // Auto-launch is always starting fresh
+      }),
+    });
+    window.dispatchEvent(new CustomEvent('auto-launch-complete', { detail }));
+  }, []);
+
+  useAutoLaunchTutorial(model, { onIncoming: handleAutoLaunchIncoming });
 
   // Pop-out to floating panel: hand off the active guide before switching modes
   usePopOutHandoff(model);

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -104,10 +104,9 @@ function FloatingPanelInner() {
 
   // Fire panel-mounted event so auto-launch and MCP flows work
   useEffect(() => {
-    // Catch the synchronous signal from module.tsx's dispatchAutoLaunch —
-    // this fires within the same microtask as pathfinder-panel-mounted,
-    // preventing the fallback-to-sidebar effect from racing the 500ms
-    // delayed auto-launch-tutorial event.
+    // Catch the synchronous `pathfinder-auto-launch-pending` signal — it fires
+    // within the same microtask as pathfinder-panel-mounted, preventing the
+    // fallback-to-sidebar effect from racing the 500ms delayed auto-launch emit.
     const handlePending = () => {
       guideOpenInFlightRef.current = true;
     };
@@ -144,14 +143,12 @@ function FloatingPanelInner() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run once on mount
 
-  // Listen for auto-launch-tutorial events (shared across all panel surfaces).
-  // The hook owns the routing; we just flip the in-flight flag synchronously
-  // so the empty-state fallback doesn't fire on top of an incoming guide.
-  useAutoLaunchTutorial(panel, {
-    onIncoming: () => {
-      guideOpenInFlightRef.current = true;
-    },
-  });
+  // Flip the in-flight flag synchronously so the empty-state fallback doesn't
+  // fire on top of an incoming guide.
+  const markGuideOpenInFlight = useCallback(() => {
+    guideOpenInFlightRef.current = true;
+  }, []);
+  useAutoLaunchTutorial(panel, { onIncoming: markGuideOpenInFlight });
 
   // Get active tab content
   const activeTab = tabs.find((t) => t.id === activeTabId);

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -164,20 +164,21 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     }
   }, [restorationDone, panel]);
 
-  // Listen for auto-launch-tutorial events (shared across all panel surfaces).
-  // The hook owns the routing; we just flip the in-flight flag synchronously
-  // so the empty-state fallback doesn't fire on top of an incoming guide.
+  // Flip the in-flight flag synchronously so the empty-state fallback doesn't
+  // fire on top of an incoming guide.
+  const markGuideOpenInFlight = useCallback(() => {
+    guideOpenInFlightRef.current = true;
+  }, []);
+  // The floating→fullscreen handoff pushes a `?doc=` URL, which makes
+  // `handlePathfinderDeepLink` schedule a delayed auto-launch ~500ms later.
+  // By then the pending-guide mount effect has already opened the guide
+  // (with packageInfo). Without this skip, the duplicate open goes through
+  // `openLearningJourney` without packageInfo and replaces the journey
+  // content with a flat single-doc — the milestone arrows disappear.
+  const skipLaunchWhenGuideInFlight = useCallback(() => guideOpenInFlightRef.current, []);
   useAutoLaunchTutorial(panel, {
-    onIncoming: () => {
-      guideOpenInFlightRef.current = true;
-    },
-    // The floating→fullscreen handoff pushes a `?doc=` URL, which makes
-    // `handlePathfinderDeepLink` schedule a delayed auto-launch ~500ms later.
-    // By then the pending-guide mount effect has already opened the guide
-    // (with packageInfo). Without this skip, the duplicate open goes through
-    // `openLearningJourney` without packageInfo and replaces the journey
-    // content with a flat single-doc — the milestone arrows disappear.
-    skipLaunch: () => guideOpenInFlightRef.current,
+    onIncoming: markGuideOpenInFlight,
+    skipLaunch: skipLaunchWhenGuideInFlight,
   });
 
   // Active tab projection.

--- a/src/global-state/auto-launch.ts
+++ b/src/global-state/auto-launch.ts
@@ -1,0 +1,18 @@
+import { createLatchedBroadcast } from '../lib/latched-broadcast';
+
+// Detail payload of an auto-launch-tutorial request, consumed by the panel
+// surfaces via `useAutoLaunchTutorial`. `type` and `source` are untyped here —
+// they arrive from producers and are narrowed inside the hook.
+export interface AutoLaunchTutorialDetail {
+  url: string;
+  title: string;
+  type?: string;
+  source?: string;
+}
+
+// Shared channel carrying auto-launch-tutorial requests from producers (the
+// highlighted-guide orchestrator, the ?doc= deep-link handler, navigate
+// actions) to whichever panel surface is active. It latches so a request
+// emitted before the lazy-loaded panel has attached its listener is still
+// delivered once the listener mounts.
+export const autoLaunchChannel = createLatchedBroadcast<AutoLaunchTutorialDetail>({ ttlMs: 30_000 });

--- a/src/global-state/sidebar.ts
+++ b/src/global-state/sidebar.ts
@@ -3,6 +3,7 @@ import { BusEventWithPayload } from '@grafana/data';
 import { reportAppInteraction, UserInteraction } from '../lib/analytics';
 import pluginJson from '../plugin.json';
 import { panelModeManager } from './panel-mode';
+import { autoLaunchChannel } from './auto-launch';
 
 interface OpenExtensionSidebarPayload {
   pluginId: string;
@@ -111,16 +112,12 @@ class GlobalSidebarState {
       document.removeEventListener('pathfinder-panel-mounted', dispatch);
       // Small delay so docs-panel's useEffect listener is registered after mount
       setTimeout(() => {
-        document.dispatchEvent(
-          new CustomEvent('auto-launch-tutorial', {
-            detail: {
-              url: `bundled:${guideId}`,
-              title: guideId,
-              type: 'docs-page',
-              source: 'mcp_launch',
-            },
-          })
-        );
+        autoLaunchChannel.emit({
+          url: `bundled:${guideId}`,
+          title: guideId,
+          type: 'docs-page',
+          source: 'mcp_launch',
+        });
       }, 300);
     };
 

--- a/src/global-state/sidebar.ts
+++ b/src/global-state/sidebar.ts
@@ -69,7 +69,7 @@ class GlobalSidebarState {
   public openSidebar(componentTitle: string, props?: Record<string, unknown>): void {
     const mode = panelModeManager.getMode();
     // In floating mode, the panel is already mounted and listening for
-    // auto-launch-tutorial events. No sidebar open needed.
+    // auto-launch requests. No sidebar open needed.
     // In full-screen mode, the dedicated full-screen page owns the active
     // session; opening the sidebar would mount a *second*
     // CombinedLearningJourneyPanel that races on tabStorage. The user can

--- a/src/hooks/useAutoLaunchTutorial.test.ts
+++ b/src/hooks/useAutoLaunchTutorial.test.ts
@@ -10,6 +10,7 @@
 
 import { renderHook } from '@testing-library/react';
 import { useAutoLaunchTutorial, type AutoLaunchPanel } from './useAutoLaunchTutorial';
+import { autoLaunchChannel, type AutoLaunchTutorialDetail } from '../global-state/auto-launch';
 
 function makePanel() {
   return {
@@ -22,11 +23,32 @@ function asPanel(panel: ReturnType<typeof makePanel>): AutoLaunchPanel {
   return panel as unknown as AutoLaunchPanel;
 }
 
-function dispatchAutoLaunch(detail?: { url?: string; title?: string; type?: string; source?: string }) {
-  document.dispatchEvent(new CustomEvent('auto-launch-tutorial', { detail }));
+function dispatchAutoLaunch(detail: Partial<AutoLaunchTutorialDetail> = {}) {
+  autoLaunchChannel.emit(detail as AutoLaunchTutorialDetail);
 }
 
 describe('useAutoLaunchTutorial', () => {
+  afterEach(() => {
+    // Drain any value latched by a test that emitted while unsubscribed so it
+    // cannot leak into the next test's mount.
+    autoLaunchChannel.subscribe(() => {})();
+  });
+
+  it('delivers a launch emitted before the hook mounts (latched replay, race fix)', () => {
+    // Producers can emit before the lazy panel's listener attaches; the latch
+    // must replay the request to the hook when it subscribes on mount.
+    autoLaunchChannel.emit({ url: 'bundled:late', title: 'Late', type: 'docs', source: 'url_param' });
+
+    const panel = makePanel();
+    renderHook(() => useAutoLaunchTutorial(asPanel(panel)));
+
+    expect(panel.openDocsPage).toHaveBeenCalledWith(
+      'bundled:late',
+      'Late',
+      expect.objectContaining({ source: 'url_param' })
+    );
+  });
+
   it('routes type=learning-journey through openLearningJourney', () => {
     const panel = makePanel();
     renderHook(() => useAutoLaunchTutorial(asPanel(panel)));

--- a/src/hooks/useAutoLaunchTutorial.ts
+++ b/src/hooks/useAutoLaunchTutorial.ts
@@ -1,20 +1,6 @@
-/**
- * Subscribe a panel model to the `auto-launch-tutorial` event.
- *
- * Why this exists: the same listener was duplicated across the three
- * surfaces that consume `auto-launch-tutorial` — the sidebar, the floating
- * panel manager, and the fullscreen panel. All three call
- * `coerceLaunchSource` and apply the same "open as learning journey" rule
- * (`type === 'learning-journey' || source === 'learning-hub'`). Drift
- * between those copies has produced real bugs and the routing decision
- * is exactly the kind of cross-surface contract that should live in one
- * place.
- *
- * The sidebar variant additionally fires `OpenResourceClick` analytics and
- * a `auto-launch-complete` window event — the consumer wires those in via
- * the optional `onLaunched` callback so the hook stays minimal for the
- * floating / fullscreen consumers that don't need them.
- */
+// Shared auto-launch routing: the panel surfaces (sidebar, floating, fullscreen)
+// subscribe to `autoLaunchChannel` through this hook so source coercion and the
+// learning-journey rule live in one place instead of drifting across copies.
 
 import { useEffect } from 'react';
 
@@ -36,7 +22,7 @@ export interface AutoLaunchPanel {
 
 export interface UseAutoLaunchTutorialOptions {
   /**
-   * Called synchronously when the event arrives, BEFORE the panel is
+   * Called synchronously when an auto-launch arrives, BEFORE the panel is
    * mutated. Used by floating / fullscreen surfaces to flip their
    * `guideOpenInFlightRef` so the empty-state fallback doesn't fire on top
    * of an incoming guide.
@@ -50,9 +36,9 @@ export interface UseAutoLaunchTutorialOptions {
    */
   onLaunched?: (detail: AutoLaunchTutorialDetail, openedAsLearningJourney: boolean) => void;
   /**
-   * When true, the auto-launch event is ignored. Fullscreen uses this to
-   * skip the deep-link handler's delayed `auto-launch-tutorial` dispatch
-   * when a pending-guide handoff already opened the guide on mount.
+   * When true, the incoming auto-launch is skipped. Fullscreen uses this to
+   * skip the deep-link handler's delayed auto-launch emit when a pending-guide
+   * handoff already opened the guide on mount.
    */
   skipLaunch?: () => boolean;
 }

--- a/src/hooks/useAutoLaunchTutorial.ts
+++ b/src/hooks/useAutoLaunchTutorial.ts
@@ -20,21 +20,9 @@ import { useEffect } from 'react';
 
 import { coerceLaunchSource, type LaunchSource } from '../recovery';
 import { shouldOpenAsLearningJourney } from '../utils/pathfinder-search-params';
+import { autoLaunchChannel, type AutoLaunchTutorialDetail } from '../global-state/auto-launch';
 
-/**
- * Detail payload of the `auto-launch-tutorial` CustomEvent.
- *
- * `type` and `source` are intentionally untyped strings here — they arrive
- * from external consumers (`module.tsx`, the link interceptor) and are
- * narrowed inside the hook via `coerceLaunchSource` and the shared
- * `shouldOpenAsLearningJourney` rule.
- */
-export interface AutoLaunchTutorialDetail {
-  url: string;
-  title: string;
-  type?: string;
-  source?: string;
-}
+export type { AutoLaunchTutorialDetail };
 
 /**
  * Minimal panel shape the hook depends on. Inlined here (rather than
@@ -75,11 +63,7 @@ export function useAutoLaunchTutorial(panel: AutoLaunchPanel, options?: UseAutoL
   const skipLaunch = options?.skipLaunch;
 
   useEffect(() => {
-    const handleAutoLaunch = (event: Event) => {
-      const detail = (event as CustomEvent<AutoLaunchTutorialDetail>).detail;
-      if (!detail) {
-        return;
-      }
+    const handleAutoLaunch = (detail: AutoLaunchTutorialDetail) => {
       onIncoming?.(detail);
 
       if (skipLaunch?.()) {
@@ -105,9 +89,6 @@ export function useAutoLaunchTutorial(panel: AutoLaunchPanel, options?: UseAutoL
       onLaunched?.(detail, openedAsLearningJourney);
     };
 
-    document.addEventListener('auto-launch-tutorial', handleAutoLaunch);
-    return () => {
-      document.removeEventListener('auto-launch-tutorial', handleAutoLaunch);
-    };
+    return autoLaunchChannel.subscribe(handleAutoLaunch);
   }, [panel, onIncoming, onLaunched, skipLaunch]);
 }

--- a/src/interactive-engine/action-handlers/navigate-handler.ts
+++ b/src/interactive-engine/action-handlers/navigate-handler.ts
@@ -118,8 +118,8 @@ export class NavigateHandler {
   }
 
   /**
-   * Open a guide in the sidebar after SPA navigation completes.
-   * Uses the same auto-launch-tutorial event pattern as module.tsx.
+   * Open a guide in the sidebar after SPA navigation completes, by emitting
+   * onto `autoLaunchChannel` once navigation settles.
    */
   private async openGuideAfterNavigation(guideParam: string): Promise<void> {
     // Dynamic import to keep find-doc-page in a lazy chunk
@@ -131,7 +131,7 @@ export class NavigateHandler {
       return;
     }
 
-    // Wait for navigation to settle before dispatching
+    // Wait for navigation to settle before emitting
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     autoLaunchChannel.emit({

--- a/src/interactive-engine/action-handlers/navigate-handler.ts
+++ b/src/interactive-engine/action-handlers/navigate-handler.ts
@@ -3,6 +3,7 @@ import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
 import { config, locationService } from '@grafana/runtime';
 import { parseUrlSafely, validateRedirectPath } from '../../security/url-validator';
+import { autoLaunchChannel } from '../../global-state/auto-launch';
 
 export class NavigateHandler {
   constructor(
@@ -133,15 +134,12 @@ export class NavigateHandler {
     // Wait for navigation to settle before dispatching
     await new Promise((resolve) => setTimeout(resolve, 500));
 
-    const autoLaunchEvent = new CustomEvent('auto-launch-tutorial', {
-      detail: {
-        url: docPage.url,
-        title: docPage.title,
-        type: docPage.type,
-        source: 'navigate-action',
-      },
+    autoLaunchChannel.emit({
+      url: docPage.url,
+      title: docPage.title,
+      type: docPage.type,
+      source: 'navigate-action',
     });
-    document.dispatchEvent(autoLaunchEvent);
   }
 
   private async markAsCompleted(data: InteractiveElementData): Promise<void> {

--- a/src/lib/latched-broadcast.test.ts
+++ b/src/lib/latched-broadcast.test.ts
@@ -1,0 +1,97 @@
+import { createLatchedBroadcast } from './latched-broadcast';
+
+describe('createLatchedBroadcast', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('delivers live to a subscriber present when emit is called', () => {
+    const channel = createLatchedBroadcast<string>();
+    const handler = jest.fn();
+
+    channel.subscribe(handler);
+    channel.emit('a');
+
+    expect(handler).toHaveBeenCalledWith('a');
+  });
+
+  it('latches for a subscriber that attaches after emit, within ttl', () => {
+    const channel = createLatchedBroadcast<string>({ ttlMs: 1000 });
+    channel.emit('a');
+
+    jest.setSystemTime(500);
+    const handler = jest.fn();
+    channel.subscribe(handler);
+
+    expect(handler).toHaveBeenCalledWith('a');
+  });
+
+  it('does not deliver a latched value to a subscriber that attaches after ttl', () => {
+    const channel = createLatchedBroadcast<string>({ ttlMs: 1000 });
+    channel.emit('a');
+
+    jest.setSystemTime(1500);
+    const handler = jest.fn();
+    channel.subscribe(handler);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('broadcasts a live emit to all current subscribers and does not latch for later ones', () => {
+    const channel = createLatchedBroadcast<string>();
+    const first = jest.fn();
+    const second = jest.fn();
+    channel.subscribe(first);
+    channel.subscribe(second);
+
+    channel.emit('x');
+
+    expect(first).toHaveBeenCalledWith('x');
+    expect(second).toHaveBeenCalledWith('x');
+
+    const late = jest.fn();
+    channel.subscribe(late);
+    expect(late).not.toHaveBeenCalled();
+  });
+
+  it('delivers a latched value to only the first late subscriber', () => {
+    const channel = createLatchedBroadcast<string>();
+    channel.emit('once');
+
+    const first = jest.fn();
+    const second = jest.fn();
+    channel.subscribe(first);
+    channel.subscribe(second);
+
+    expect(first).toHaveBeenCalledWith('once');
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it('stops delivering after unsubscribe', () => {
+    const channel = createLatchedBroadcast<string>();
+    const handler = jest.fn();
+    const unsubscribe = channel.subscribe(handler);
+
+    unsubscribe();
+    channel.emit('a');
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('keeps only the last value when multiple emits happen with no subscribers', () => {
+    const channel = createLatchedBroadcast<string>();
+    channel.emit('first');
+    channel.emit('second');
+
+    const handler = jest.fn();
+    channel.subscribe(handler);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith('second');
+  });
+});

--- a/src/lib/latched-broadcast.test.ts
+++ b/src/lib/latched-broadcast.test.ts
@@ -72,6 +72,22 @@ describe('createLatchedBroadcast', () => {
     expect(second).not.toHaveBeenCalled();
   });
 
+  it('clears the latch on the first drain even when that subscriber then unsubscribes', () => {
+    const channel = createLatchedBroadcast<string>({ ttlMs: 1000 });
+    channel.emit('once');
+
+    const first = jest.fn();
+    const unsubscribe = channel.subscribe(first);
+    expect(first).toHaveBeenCalledWith('once');
+    unsubscribe();
+
+    jest.setSystemTime(500);
+    const second = jest.fn();
+    channel.subscribe(second);
+
+    expect(second).not.toHaveBeenCalled();
+  });
+
   it('stops delivering after unsubscribe', () => {
     const channel = createLatchedBroadcast<string>();
     const handler = jest.fn();

--- a/src/lib/latched-broadcast.ts
+++ b/src/lib/latched-broadcast.ts
@@ -1,0 +1,43 @@
+// A tiny pub/sub channel that latches the last value when nobody is subscribed,
+// so a consumer that attaches shortly after an emit still receives it once.
+// Decouples producers from late-mounting (e.g. lazy-loaded) consumers without
+// losing the event. A TTL bounds the latch so a stale value can't be delivered
+// to a subscriber that attaches much later.
+
+export interface LatchedBroadcast<T> {
+  emit(detail: T): void;
+  subscribe(handler: (detail: T) => void): () => void;
+}
+
+const DEFAULT_TTL_MS = 30_000;
+
+export function createLatchedBroadcast<T>(opts: { ttlMs?: number } = {}): LatchedBroadcast<T> {
+  const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+  const subscribers = new Set<(detail: T) => void>();
+  let latched: { detail: T; at: number } | null = null;
+
+  return {
+    emit(detail: T): void {
+      if (subscribers.size > 0) {
+        latched = null;
+        for (const handler of [...subscribers]) {
+          handler(detail);
+        }
+        return;
+      }
+      latched = { detail, at: Date.now() };
+    },
+
+    subscribe(handler: (detail: T) => void): () => void {
+      subscribers.add(handler);
+      if (latched && Date.now() - latched.at <= ttlMs) {
+        const { detail } = latched;
+        latched = null;
+        handler(detail);
+      }
+      return () => {
+        subscribers.delete(handler);
+      };
+    },
+  };
+}

--- a/src/utils/experiments/highlighted-guide-orchestrator.test.ts
+++ b/src/utils/experiments/highlighted-guide-orchestrator.test.ts
@@ -76,6 +76,7 @@ jest.mock('../../lib/storage/extension-sidebar', () => ({
 }));
 
 import { initializeHighlightedGuideExperiment, setupHighlightedGuideAutoOpen } from './highlighted-guide-orchestrator';
+import { autoLaunchChannel } from '../../global-state/auto-launch';
 
 const HOSTNAME = 'stack-a.grafana.net';
 
@@ -227,6 +228,8 @@ describe('setupHighlightedGuideAutoOpen', () => {
 // that payload to `openDocsPage` / `openLearningJourney` without navigating
 // the user away from their current page.
 describe('setupHighlightedGuideAutoOpen → auto-launch-tutorial dispatch', () => {
+  const channelUnsubscribers: Array<() => void> = [];
+
   beforeEach(() => {
     localStorage.clear();
     jest.useFakeTimers();
@@ -247,15 +250,20 @@ describe('setupHighlightedGuideAutoOpen → auto-launch-tutorial dispatch', () =
       title: 'Onboarding',
       type: 'docs-page',
     });
+    // Clear any auto-launch value latched by the mount-listener flush above so
+    // it can't leak into this test's channel subscriber.
+    autoLaunchChannel.subscribe(() => {})();
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    channelUnsubscribers.forEach((unsubscribe) => unsubscribe());
+    channelUnsubscribers.length = 0;
   });
 
   function captureAutoLaunch(): jest.Mock {
     const handler = jest.fn();
-    document.addEventListener('auto-launch-tutorial', handler);
+    channelUnsubscribers.push(autoLaunchChannel.subscribe(handler));
     return handler;
   }
 
@@ -268,8 +276,7 @@ describe('setupHighlightedGuideAutoOpen → auto-launch-tutorial dispatch', () =
     jest.advanceTimersByTime(500);
 
     expect(handler).toHaveBeenCalledTimes(1);
-    const event = handler.mock.calls[0][0] as CustomEvent;
-    expect(event.detail).toEqual({
+    expect(handler.mock.calls[0][0]).toEqual({
       url: 'https://grafana.com/docs/onboarding',
       title: 'Onboarding',
       type: 'docs-page',
@@ -311,8 +318,7 @@ describe('setupHighlightedGuideAutoOpen → auto-launch-tutorial dispatch', () =
     window.dispatchEvent(new Event('pathfinder-sidebar-mounted'));
     jest.advanceTimersByTime(500);
 
-    const event = handler.mock.calls[0][0] as CustomEvent;
-    expect(event.detail).toEqual(
+    expect(handler.mock.calls[0][0]).toEqual(
       expect.objectContaining({
         type: 'learning-journey',
         source: 'highlighted_guide_experiment',

--- a/src/utils/experiments/highlighted-guide-orchestrator.ts
+++ b/src/utils/experiments/highlighted-guide-orchestrator.ts
@@ -25,6 +25,7 @@ import { locationService } from '@grafana/runtime';
 import pluginJson from '../../plugin.json';
 import { StorageKeys } from '../../lib/storage-keys';
 import { sidebarState } from '../../global-state/sidebar';
+import { autoLaunchChannel } from '../../global-state/auto-launch';
 import { findDocPage } from '../find-doc-page';
 import { getHighlightedGuideConfig, type HighlightedGuideConfig } from '../openfeature';
 import { attemptAutoOpen } from '../sidebar-auto-open';
@@ -208,16 +209,12 @@ function installAutoLaunchOnMount(detail: { url: string; title: string; type: st
     document.dispatchEvent(new CustomEvent('pathfinder-auto-launch-pending'));
 
     setTimeout(() => {
-      document.dispatchEvent(
-        new CustomEvent('auto-launch-tutorial', {
-          detail: {
-            url: detail.url,
-            title: detail.title,
-            type: detail.type,
-            source: 'highlighted_guide_experiment',
-          },
-        })
-      );
+      autoLaunchChannel.emit({
+        url: detail.url,
+        title: detail.title,
+        type: detail.type,
+        source: 'highlighted_guide_experiment',
+      });
     }, 500);
   };
 

--- a/src/utils/experiments/highlighted-guide-orchestrator.ts
+++ b/src/utils/experiments/highlighted-guide-orchestrator.ts
@@ -7,8 +7,8 @@
  *     key so a true→false→true sequence re-arms.
  *   - On a matched page, auto-opens the Pathfinder extension sidebar once per
  *     (hostname, guideId) — persisted in localStorage, NOT sessionStorage —
- *     and dispatches `auto-launch-tutorial` so the configured guide opens as
- *     a sidebar tab on mount (the same seam used by the `?doc=` deep link).
+ *     and emits an auto-launch request via `autoLaunchChannel` so the configured
+ *     guide opens as a sidebar tab on mount (the same seam used by `?doc=`).
  *     Crucially, no `locationService.replace` is called — the user stays on
  *     the page they were on. The Featured-slot injection remains as a
  *     re-entry point if the user later closes the auto-opened tab.
@@ -95,9 +95,9 @@ function handleHighlightedGuideResetCache(hostname: string, config: HighlightedG
  *   3. Page does NOT match — install a nav listener and return.
  *   4. Already auto-opened for this `guideId` — done.
  *   5. Extension sidebar owned by another plugin (e.g. Assistant) — don't steal.
- *   6. Auto-open: write marker, publish `open-extension-sidebar`, then dispatch
- *      `auto-launch-tutorial` on sidebar/panel mount so the configured guide
- *      opens as a tab without navigating the user away from their current page.
+ *   6. Auto-open: write marker, publish `open-extension-sidebar`, then emit an
+ *      auto-launch request on sidebar/panel mount so the configured guide opens
+ *      as a tab without navigating the user away from their current page.
  *
  * The nav listener uses the same logic, so a user navigating into a matched
  * page later in the same SPA navigation will trigger auto-open on first
@@ -146,10 +146,10 @@ export function setupHighlightedGuideAutoOpen(
     markHighlightedGuideAutoOpened(hostname, config.guideId);
     sidebarState.setPendingOpenSource('highlighted_guide_experiment', 'auto-open');
 
-    // Resolve the guide so we can dispatch `auto-launch-tutorial` on mount —
-    // same seam used by `?doc=` in `module.tsx`. If the guideId can't be
-    // resolved we still open the sidebar (Featured-slot injection in
-    // `context.service.ts` is the fallback path for misconfigured flags).
+    // Resolve the guide so we can emit the auto-launch on mount — same seam
+    // used by the `?doc=` deep link. If the guideId can't be resolved we still
+    // open the sidebar (Featured-slot injection in `context.service.ts` is the
+    // fallback path for misconfigured flags).
     const docsPage = findDocPage(config.guideId);
     if (!docsPage) {
       console.warn(
@@ -182,16 +182,15 @@ export function setupHighlightedGuideAutoOpen(
 }
 
 /**
- * Wire the `auto-launch-tutorial` dispatch to whichever panel surface mounts
- * first. Mirrors the `dispatchAutoLaunch` pattern in `module.tsx` so the
- * highlighted-guide experiment and `?doc=` deep links share the same
- * mount-then-dispatch contract.
+ * Emit the auto-launch onto `autoLaunchChannel` once whichever panel surface
+ * mounts first, so the highlighted-guide experiment and `?doc=` deep links
+ * share the same mount-then-emit contract.
  *
- * The dispatch fires exactly once even when both `pathfinder-sidebar-mounted`
- * and `pathfinder-panel-mounted` arrive (the floating panel can race the
- * sidebar). If the sidebar is already mounted (SPA navigation case — the user
- * already had the sidebar open from a prior page), we dispatch synchronously
- * so the listener isn't left dangling waiting for a mount that already fired.
+ * Fires exactly once even when both `pathfinder-sidebar-mounted` and
+ * `pathfinder-panel-mounted` arrive (the floating panel can race the sidebar).
+ * If the sidebar is already mounted (SPA navigation case — the user already had
+ * the sidebar open from a prior page), we invoke it synchronously so the listener
+ * isn't left dangling waiting for a mount that already fired.
  */
 function installAutoLaunchOnMount(detail: { url: string; title: string; type: string }): void {
   let autoLaunched = false;

--- a/src/utils/pathfinder-deep-link-handler.test.ts
+++ b/src/utils/pathfinder-deep-link-handler.test.ts
@@ -60,6 +60,7 @@ import {
   handlePathfinderDeepLink,
   installDeepLinkNavListener,
 } from './pathfinder-deep-link-handler';
+import { autoLaunchChannel, type AutoLaunchTutorialDetail } from '../global-state/auto-launch';
 
 type Deps = Parameters<typeof handlePathfinderDeepLink>[0];
 
@@ -180,9 +181,10 @@ describe('handlePathfinderDeepLink', () => {
       mockGetIsSidebarMounted.mockReturnValue(true);
 
       const deps = mkDeps();
-      const events: CustomEvent[] = [];
-      const captureAutoLaunch = (e: Event) => events.push(e as CustomEvent);
-      document.addEventListener('auto-launch-tutorial', captureAutoLaunch);
+      const events: AutoLaunchTutorialDetail[] = [];
+      const unsubscribe = autoLaunchChannel.subscribe((detail) => events.push(detail));
+      // Discard any value a prior test latched and delivered on subscribe.
+      events.length = 0;
 
       expect(handlePathfinderDeepLink(deps)).toBe(true);
 
@@ -190,12 +192,12 @@ describe('handlePathfinderDeepLink', () => {
       // before we advance fake timers for the auto-launch delay.
       await flushPromises();
 
-      // The mount-then-dispatch waits 500ms before dispatching.
+      // The mount-then-dispatch waits 500ms before emitting.
       jest.advanceTimersByTime(500);
-      document.removeEventListener('auto-launch-tutorial', captureAutoLaunch);
+      unsubscribe();
 
       expect(events).toHaveLength(1);
-      expect(events[0]?.detail).toMatchObject({
+      expect(events[0]).toMatchObject({
         url: 'https://grafana.com/docs/foo',
         title: 'Foo',
         type: 'docs-page',
@@ -220,16 +222,16 @@ describe('handlePathfinderDeepLink', () => {
         type: 'interactive',
       });
 
-      const events: CustomEvent[] = [];
-      const captureAutoLaunch = (e: Event) => events.push(e as CustomEvent);
-      document.addEventListener('auto-launch-tutorial', captureAutoLaunch);
+      const events: AutoLaunchTutorialDetail[] = [];
+      const unsubscribe = autoLaunchChannel.subscribe((detail) => events.push(detail));
+      events.length = 0;
 
       handlePathfinderDeepLink(mkDeps());
       await flushPromises();
       jest.advanceTimersByTime(500);
-      document.removeEventListener('auto-launch-tutorial', captureAutoLaunch);
+      unsubscribe();
 
-      expect(events[0]?.detail?.type).toBe('learning-journey');
+      expect(events[0]?.type).toBe('learning-journey');
     } finally {
       jest.useRealTimers();
     }

--- a/src/utils/pathfinder-deep-link-handler.ts
+++ b/src/utils/pathfinder-deep-link-handler.ts
@@ -199,7 +199,7 @@ function hasAnyPathfinderParam(search: string): boolean {
   return PATHFINDER_ACTIVATION_PARAMS.some((p) => params.has(p));
 }
 
-/** Dispatch `auto-launch-tutorial` once whichever panel surface mounts first. */
+/** Emit the auto-launch onto `autoLaunchChannel` once whichever panel surface mounts first. */
 function installAutoLaunchOnMount(detail: { url: string; title: string; type: string; source: string }): void {
   let autoLaunched = false;
   const dispatch = () => {

--- a/src/utils/pathfinder-deep-link-handler.ts
+++ b/src/utils/pathfinder-deep-link-handler.ts
@@ -14,6 +14,7 @@ import { locationService } from '@grafana/runtime';
 import pluginJson from '../plugin.json';
 import { panelModeManager } from '../global-state/panel-mode';
 import { sidebarState } from '../global-state/sidebar';
+import { autoLaunchChannel } from '../global-state/auto-launch';
 import { validateRedirectPath } from '../security/url-validator';
 import {
   parsePathfinderDeepLink,
@@ -212,11 +213,7 @@ function installAutoLaunchOnMount(detail: { url: string; title: string; type: st
     document.dispatchEvent(new CustomEvent('pathfinder-auto-launch-pending'));
 
     setTimeout(() => {
-      document.dispatchEvent(
-        new CustomEvent('auto-launch-tutorial', {
-          detail,
-        })
-      );
+      autoLaunchChannel.emit(detail);
     }, 500);
   };
 


### PR DESCRIPTION
## Problem

Some sessions record the experiment open (`source: highlighted_guide_experiment`) but the guide never renders. It's a race in the auto-launch handshake:

1. The experiment fires → the sidebar **shell** mounts, records analytics, fires `pathfinder-sidebar-mounted`.
2. The orchestrator dispatches the one-shot `auto-launch-tutorial` DOM event **500 ms later**.
3. The listener (`useAutoLaunchTutorial`) lives in the **lazy-loaded** panel and only attaches after its chunk loads.

On slow chunk loads the listener isn't attached within 500 ms, so the one-shot event fires into the void — open recorded, guide never rendered. The `?doc=` deep-link path has the same race.

## Fix — one reusable latched channel (no copy-paste)

`src/lib/latched-broadcast.ts` — `createLatchedBroadcast<T>({ ttlMs })`:
- `emit` broadcasts to current subscribers; if none are subscribed, it **latches** the value.
- `subscribe` drains a fresh latched value once on attach, then receives future emits.
- A **TTL** (30 s) bounds the latch so a stale value can't re-open a guide on a much-later manual open (the "opens for no reason" class we've been fixing).

The `auto-launch-tutorial` mechanic now flows through a shared `autoLaunchChannel` (`src/global-state/auto-launch.ts`) instead of a one-shot DOM event: producers `emit`, `useAutoLaunchTutorial` subscribes. Delivery is **order-independent** — whether the listener attaches before or after the emit, the guide opens exactly once. The `?doc=` deep-link and navigate-action paths get the same reliability for free.

Only the final delivery was swapped — the surrounding coordination (`pathfinder-sidebar-mounted` / `-panel-mounted` / `pathfinder-auto-launch-pending`, empty-state suppression, analytics, the mount/timer logic) is unchanged.

## Why not route it through `pathfinder-suggest`?

`pathfinder-suggest` only populates the Featured/recommendations zone with clickable cards; the experiment needs the guide **rendered directly** as a tab. So instead of reusing that event, this extracts its *buffering* behavior into a reusable primitive and applies it to the direct-open path.

## Tests
- `latched-broadcast.test.ts` — live delivery, latch-within-TTL, dropped-after-TTL, broadcast-to-all, single late-subscriber drain, unsubscribe, last-write-wins.
- Migrated the 3 auto-launch tests to the channel, including a **race-fix test**: emit *before* the hook mounts → the guide still opens on subscribe.

`npm run check` green: typecheck, lint (0 errors), prettier, tests (311 suites / 4872), coverage thresholds met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
