### PR TITLE
fix(auto-launch): skip stale channel emits after surface unmount

### DIFF
--- a/src/global-state/sidebar.ts
+++ b/src/global-state/sidebar.ts
@@ -112,6 +112,11 @@ class GlobalSidebarState {
       document.removeEventListener('pathfinder-panel-mounted', dispatch);
       // Small delay so docs-panel's useEffect listener is registered after mount
       setTimeout(() => {
+        // If the surface unmounted during the delay, skip the emit — the channel
+        // latches, so a stale value would replay on a later manual open.
+        if (!this.getIsSidebarMounted()) {
+          return;
+        }
         autoLaunchChannel.emit({
           url: `bundled:${guideId}`,
           title: guideId,

--- a/src/utils/experiments/highlighted-guide-orchestrator.test.ts
+++ b/src/utils/experiments/highlighted-guide-orchestrator.test.ts
@@ -244,7 +244,8 @@ describe('setupHighlightedGuideAutoOpen → auto-launch-tutorial dispatch', () =
     jest.runAllTimers();
     jest.clearAllMocks();
     mockIsExtensionSidebarOwnedByOther.mockReturnValue(false);
-    mockGetIsSidebarMounted.mockReturnValue(false);
+    // A surface is mounted when the delayed emit fires; the emit is now guarded on it.
+    mockGetIsSidebarMounted.mockReturnValue(true);
     mockFindDocPage.mockReturnValue({
       url: 'https://grafana.com/docs/onboarding',
       title: 'Onboarding',
@@ -357,6 +358,19 @@ describe('setupHighlightedGuideAutoOpen → auto-launch-tutorial dispatch', () =
     expect(localStorage.getItem(`grafana-pathfinder-highlighted-guide-auto-open-${HOSTNAME}:bundled:onboarding`)).toBe(
       'true'
     );
+  });
+
+  it('skips the auto-launch emit when the surface unmounts before the 500ms timer fires', () => {
+    mockGetIsSidebarMounted.mockReturnValue(true);
+    const handler = captureAutoLaunch();
+    setupHighlightedGuideAutoOpen(baseConfig, '/connections/datasources/new', HOSTNAME);
+
+    // Surface unmounts during the delay: the queued emit must not fire, or a
+    // stale value latches and replays on a later manual open.
+    mockGetIsSidebarMounted.mockReturnValue(false);
+    jest.advanceTimersByTime(500);
+
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it('fires the pathfinder-auto-launch-pending coordination event synchronously on mount', () => {

--- a/src/utils/experiments/highlighted-guide-orchestrator.ts
+++ b/src/utils/experiments/highlighted-guide-orchestrator.ts
@@ -208,6 +208,11 @@ function installAutoLaunchOnMount(detail: { url: string; title: string; type: st
     document.dispatchEvent(new CustomEvent('pathfinder-auto-launch-pending'));
 
     setTimeout(() => {
+      // If the surface unmounted during the delay, skip the emit — the channel
+      // latches, so a stale value would replay on a later manual open.
+      if (!sidebarState.getIsSidebarMounted()) {
+        return;
+      }
       autoLaunchChannel.emit({
         url: detail.url,
         title: detail.title,

--- a/src/utils/pathfinder-deep-link-handler.test.ts
+++ b/src/utils/pathfinder-deep-link-handler.test.ts
@@ -209,6 +209,31 @@ describe('handlePathfinderDeepLink', () => {
     }
   });
 
+  it('skips the auto-launch emit when the surface unmounts before the 500ms timer fires', async () => {
+    jest.useFakeTimers();
+    try {
+      setSearch('?doc=bundled%3Afoo&source=url_param');
+      mockGetIsSidebarMounted.mockReturnValue(true);
+
+      const events: AutoLaunchTutorialDetail[] = [];
+      const unsubscribe = autoLaunchChannel.subscribe((detail) => events.push(detail));
+      events.length = 0;
+
+      handlePathfinderDeepLink(mkDeps());
+      await flushPromises();
+
+      // Surface unmounts during the 500ms delay: the queued emit must not fire,
+      // or a stale value latches and replays on a later manual open.
+      mockGetIsSidebarMounted.mockReturnValue(false);
+      jest.advanceTimersByTime(500);
+      unsubscribe();
+
+      expect(events).toHaveLength(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('honors explicit ?type=learning-journey over findDocPage classification', async () => {
     jest.useFakeTimers();
     try {

--- a/src/utils/pathfinder-deep-link-handler.ts
+++ b/src/utils/pathfinder-deep-link-handler.ts
@@ -213,6 +213,11 @@ function installAutoLaunchOnMount(detail: { url: string; title: string; type: st
     document.dispatchEvent(new CustomEvent('pathfinder-auto-launch-pending'));
 
     setTimeout(() => {
+      // If the surface unmounted during the delay, skip the emit — the channel
+      // latches, so a stale value would replay on a later manual open.
+      if (!sidebarState.getIsSidebarMounted()) {
+        return;
+      }
       autoLaunchChannel.emit(detail);
     }, 500);
   };


### PR DESCRIPTION
## Problem

Follow-up to #1218. In review, @leslie-heinzen [flagged](https://github.com/grafana/grafana-pathfinder-app/pull/1218#discussion_r3507682078) that the auto-launch emits are scheduled inside 300–500 ms `setTimeout`s:

```
component mounts → setTimeout schedules → component unmounts → the event is emitted after the timeout elapses
```

Because `autoLaunchChannel` **latches** when no subscriber is present, a stale post-unmount emit isn't a harmless no-op — it lingers for up to the 30 s TTL and can **replay on a later manual open**, causing a guide to open unprompted plus a spurious `auto_launch_tutorial` analytics event.

(This is specific to the new latched channel — the old one-shot DOM event just fired into the void after unmount, which is why it only surfaces now.)

## Fix

Guard each delayed emit on `getIsSidebarMounted()` at **fire time** — the symmetric completion of the `getIsSidebarMounted()` check these sites already do at dispatch-*setup* time:

- `sidebar.ts` `openWithGuide` (`mcp_launch`, 300 ms)
- `highlighted-guide-orchestrator.ts` (`highlighted_guide_experiment`, 500 ms)
- `pathfinder-deep-link-handler.ts` (`?doc=`, 500 ms)

This does **not** defeat the latch's purpose: in the normal flow the sidebar/panel **shell** keeps the flag `true` while the lazy panel's subscriber is still loading, so the emit still latches and drains correctly. The guard only suppresses the emit when *no* surface is mounted at all.

`navigate-handler.ts` is intentionally left alone — there the emit is the user's explicit navigate-and-open intent, not a mount-driven auto-launch.

## Tests

- New regression tests in `highlighted-guide-orchestrator.test.ts` and `pathfinder-deep-link-handler.test.ts` for the mount → unmount → timer-fires → **no emit** path.
- Corrected the orchestrator emit-dispatch block's `getIsSidebarMounted` default from `false` to `true`, since those tests simulate a mounted surface (which sets the flag `true` in production, via `openSidebar`/mount effects).
- `openWithGuide` has no pre-existing test harness, so its (identical) guard isn't covered by a new test here.

Verified locally: typecheck, lint (0 errors), prettier, and the full frontend suite (**311 suites / 4890 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
