### PR TITLE
Release: 2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.13.1
+
+### Added
+
+- **PR tester assembles full learning paths from the CDN catalog**: Learning-path mode now overlays a PR onto the published CDN catalog instead of requiring every milestone's `content.json` and `manifest.json` to be present in the diff, so a PR that edits only a subset of a path's milestones can still be tested end to end. (#1214)
+
+### Fixed
+
+- **Sidebar no longer re-opens on unrelated page navigation**: An explicit close now clears the persisted docked-sidebar state, so Grafana's `browser_restore` stops re-opening the Pathfinder panel on later page loads (`/alerting`, `/dashboards`, `/explore`, and others). (#1217)
+- **Auto-launched guides always render**: Guide delivery now flows through a reusable latched broadcast channel, closing a race where the one-shot auto-launch event could fire before the lazy-loaded panel's listener attached — leaving the experiment open recorded but the guide never shown. Covers both the highlighted-guide experiment and the `?doc=` deep-link path. (#1218)
+- **No spurious guide opens after the sidebar unmounts**: Delayed auto-launch emits are now guarded on the sidebar being mounted at fire time, so a latched post-unmount emit can no longer replay on a later manual open (which also raised a spurious `auto_launch_tutorial` analytics event). Follow-up to #1218. (#1219)
+
+### Chore
+
+- **Retired unused A/B experiments**: Removed dormant A/B experiment scaffolding, keeping the active highlighted-guide experiment. (#1215)
+- **Shared cloud-stack E2E targeting clarified**: Renamed the shared cloud-stack environment module and tightened how E2E runs target it. (#1211)
+- **Docs**: Trimmed and centralized per-session agent context. (#1216)
+
 ## 2.13.0
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-pathfinder-app",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-pathfinder-app",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-pathfinder-app",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "bin": {
     "pathfinder-cli": "./dist/cli/cli/index.js"
   },


### PR DESCRIPTION
## Release 2.13.1

Patch release. Bumps `package.json` / `package-lock.json` to `2.13.1` and drafts the CHANGELOG entry for the 7 PRs merged since `v2.13.0`.

### Added

- **PR tester assembles full learning paths from the CDN catalog** — overlays a PR onto the published CDN catalog so a PR editing only a subset of a path's milestones can still be tested end to end. (#1214)

### Fixed

- **Sidebar no longer re-opens on unrelated page navigation** — explicit close now clears the persisted docked-sidebar state. (#1217)
- **Auto-launched guides always render** — delivery flows through a reusable latched broadcast channel, closing the listener-attach race. (#1218)
- **No spurious guide opens after the sidebar unmounts** — delayed auto-launch emits are guarded on the sidebar being mounted at fire time. (#1219)

### Chore

- **Retired unused A/B experiments**, keeping the active highlighted-guide experiment. (#1215)
- **Shared cloud-stack E2E targeting clarified.** (#1211)
- **Docs**: trimmed and centralized per-session agent context. (#1216)

---

After merge, cut the release by tagging on `main`:

```
git checkout main && git pull
git tag -a v2.13.1 -m "Release v2.13.1"
git push origin v2.13.1
```

The `release.yml` workflow fires on the `v*` tag push and creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
