### PR TITLE
feat(guide-reader): add document outline extraction hook

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,3 +6,4 @@ export {
 } from './useAutoLaunchTutorial';
 export { useStepProgressFromEvents } from './useStepProgressFromEvents';
 export { usePersistedBoolean, usePersistedLocalState, usePersistedString } from './usePersistedLocalState';
+export { useDocumentOutline, type OutlineItem } from './useDocumentOutline';

--- a/src/hooks/useDocumentOutline.test.ts
+++ b/src/hooks/useDocumentOutline.test.ts
@@ -1,0 +1,125 @@
+import { renderHook } from '@testing-library/react';
+import { useDocumentOutline } from './useDocumentOutline';
+
+function containerWith(html: string): React.RefObject<HTMLDivElement> {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return { current: div };
+}
+
+describe('useDocumentOutline', () => {
+  it('returns [] when the container has fewer than 2 headings', () => {
+    const containerRef = containerWith('<h2>Only one</h2>');
+    const { result } = renderHook(() => useDocumentOutline(containerRef, 'doc-1', true));
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns [] when not ready', () => {
+    const containerRef = containerWith('<h2>One</h2><h2>Two</h2>');
+    const { result } = renderHook(() => useDocumentOutline(containerRef, 'doc-1', false));
+    expect(result.current).toEqual([]);
+  });
+
+  it('extracts HTML-doc headings in order, preserving existing ids and generating missing ones', () => {
+    const containerRef = containerWith(`
+      <h2 id="already-set">Introduction</h2>
+      <p>Some text</p>
+      <h3>Getting started</h3>
+      <h2>Advanced usage</h2>
+    `);
+    const { result } = renderHook(() => useDocumentOutline(containerRef, 'doc-1', true));
+
+    expect(result.current).toEqual([
+      { id: 'already-set', text: 'Introduction', level: 2, kind: 'heading' },
+      { id: 'getting-started', text: 'Getting started', level: 3, kind: 'heading' },
+      { id: 'advanced-usage', text: 'Advanced usage', level: 2, kind: 'heading' },
+    ]);
+
+    // ids are written onto the actual DOM elements, not just returned
+    expect(containerRef.current!.querySelector('h3')!.id).toBe('getting-started');
+  });
+
+  it('extracts interactive-guide sections using their existing id and title text', () => {
+    const containerRef = containerWith(`
+      <div data-interactive-section="true" id="section-1">
+        <span class="interactive-section-title">Explore your data</span>
+      </div>
+      <div data-interactive-section="true" id="section-2">
+        <span class="interactive-section-title">Create a dashboard</span>
+      </div>
+    `);
+    const { result } = renderHook(() => useDocumentOutline(containerRef, 'doc-1', true));
+
+    expect(result.current).toEqual([
+      { id: 'section-1', text: 'Explore your data', level: 2, kind: 'section' },
+      { id: 'section-2', text: 'Create a dashboard', level: 2, kind: 'section' },
+    ]);
+  });
+
+  it('collapses a lead-in heading into the section that repeats its title', () => {
+    // Mirrors bundled-interactives/first-dashboard: a markdown heading immediately
+    // followed by an interactive section sharing the same title text.
+    const containerRef = containerWith(`
+      <h2>Explore your data</h2>
+      <p>Before building a dashboard, explore your data.</p>
+      <div data-interactive-section="true" id="section-explore-tutorial">
+        <span class="interactive-section-title">Explore your data</span>
+      </div>
+      <h2>Create a dashboard</h2>
+      <div data-interactive-section="true" id="section-dashboard">
+        <span class="interactive-section-title">Create a dashboard</span>
+      </div>
+    `);
+    const { result } = renderHook(() => useDocumentOutline(containerRef, 'doc-1', true));
+
+    expect(result.current).toEqual([
+      { id: 'section-explore-tutorial', text: 'Explore your data', level: 2, kind: 'section' },
+      { id: 'section-dashboard', text: 'Create a dashboard', level: 2, kind: 'section' },
+    ]);
+  });
+
+  it('does not collapse a heading into an unrelated following section', () => {
+    const containerRef = containerWith(`
+      <h2>Overview</h2>
+      <div data-interactive-section="true" id="section-1">
+        <span class="interactive-section-title">Step one</span>
+      </div>
+    `);
+    const { result } = renderHook(() => useDocumentOutline(containerRef, 'doc-1', true));
+
+    expect(result.current).toEqual([
+      { id: 'overview', text: 'Overview', level: 2, kind: 'heading' },
+      { id: 'section-1', text: 'Step one', level: 2, kind: 'section' },
+    ]);
+  });
+
+  it('keeps ids stable across re-runs with the same content key', () => {
+    const containerRef = containerWith('<h2>First</h2><h2>Second</h2>');
+    const { result, rerender } = renderHook(({ key }) => useDocumentOutline(containerRef, key, true), {
+      initialProps: { key: 'doc-1' },
+    });
+
+    const firstRun = result.current;
+    rerender({ key: 'doc-1-again' });
+
+    expect(result.current).toEqual(firstRun);
+  });
+
+  it('re-extracts when the content key changes after the DOM is swapped', () => {
+    const containerRef = containerWith('<h2>First</h2><h2>Second</h2>');
+    const { result, rerender } = renderHook(({ key }) => useDocumentOutline(containerRef, key, true), {
+      initialProps: { key: 'doc-1' },
+    });
+
+    expect(result.current).toHaveLength(2);
+
+    containerRef.current!.innerHTML = '<h2>New heading</h2><h2>Another new heading</h2><h2>Third</h2>';
+    rerender({ key: 'doc-2' });
+
+    expect(result.current).toEqual([
+      { id: 'new-heading', text: 'New heading', level: 2, kind: 'heading' },
+      { id: 'another-new-heading', text: 'Another new heading', level: 2, kind: 'heading' },
+      { id: 'third', text: 'Third', level: 2, kind: 'heading' },
+    ]);
+  });
+});

--- a/src/hooks/useDocumentOutline.ts
+++ b/src/hooks/useDocumentOutline.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { slugify, uniqueSlug } from '../utils/slug';
+
+export interface OutlineItem {
+  id: string;
+  text: string;
+  level: number;
+  kind: 'heading' | 'section';
+}
+
+const OUTLINE_SELECTOR = 'h2, h3, h4, [data-interactive-section="true"]';
+const SECTION_TITLE_SELECTOR = '.interactive-section-title';
+
+function normalizeText(text: string): string {
+  return text.trim().toLowerCase();
+}
+
+function extractOutline(container: HTMLElement): OutlineItem[] {
+  const taken = new Set<string>();
+  container.querySelectorAll('[id]').forEach((el) => {
+    if (el.id) {
+      taken.add(el.id);
+    }
+  });
+
+  const elements = Array.from(container.querySelectorAll<HTMLElement>(OUTLINE_SELECTOR));
+  const items: OutlineItem[] = [];
+
+  for (const el of elements) {
+    const isSection = el.getAttribute('data-interactive-section') === 'true';
+    const text = (isSection ? el.querySelector(SECTION_TITLE_SELECTOR)?.textContent : el.textContent)?.trim() ?? '';
+    if (!text) {
+      continue;
+    }
+
+    let id = el.id;
+    if (!id) {
+      id = uniqueSlug(slugify(text), taken);
+      el.id = id;
+      taken.add(id);
+    }
+
+    const kind: OutlineItem['kind'] = isSection ? 'section' : 'heading';
+    const level = isSection ? 2 : Number(el.tagName.charAt(1));
+
+    // A section's title is often preceded by an identical markdown heading acting as
+    // its lead-in (see e.g. bundled-interactives/first-dashboard) — collapse that pair
+    // into a single entry rather than showing the same title twice in a row.
+    const previous = items[items.length - 1];
+    if (previous?.kind === 'heading' && kind === 'section' && normalizeText(previous.text) === normalizeText(text)) {
+      items.pop();
+    }
+
+    items.push({ id, text, level, kind });
+  }
+
+  return items.length >= 2 ? items : [];
+}
+
+export function useDocumentOutline(
+  containerRef: React.RefObject<HTMLDivElement>,
+  contentKey: string | null,
+  ready: boolean
+): OutlineItem[] {
+  const [outline, setOutline] = useState<OutlineItem[]>([]);
+
+  useEffect(() => {
+    if (!ready || !containerRef.current) {
+      setOutline([]);
+      return;
+    }
+    setOutline(extractOutline(containerRef.current));
+  }, [containerRef, contentKey, ready]);
+
+  return outline;
+}

--- a/src/utils/slug.test.ts
+++ b/src/utils/slug.test.ts
@@ -1,0 +1,52 @@
+import { slugify, uniqueSlug } from './slug';
+
+describe('slugify', () => {
+  it('lowercases and hyphenates basic text', () => {
+    expect(slugify('Explore your data')).toBe('explore-your-data');
+  });
+
+  it('strips diacritics', () => {
+    expect(slugify('Café Résumé')).toBe('cafe-resume');
+  });
+
+  it('strips punctuation', () => {
+    expect(slugify('Hello, World! (Really?)')).toBe('hello-world-really');
+  });
+
+  it('preserves leading digits', () => {
+    expect(slugify('123 Start with digits')).toBe('123-start-with-digits');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(slugify('')).toBe('');
+  });
+
+  it('returns an empty string for input with no alphanumerics', () => {
+    expect(slugify('!!!')).toBe('');
+  });
+
+  it('trims and collapses repeated separators', () => {
+    expect(slugify('  Multiple---dashes___here  ')).toBe('multiple-dashes-here');
+  });
+});
+
+describe('uniqueSlug', () => {
+  it('returns the base slug when it is not taken', () => {
+    expect(uniqueSlug('overview', new Set())).toBe('overview');
+  });
+
+  it('appends -1 on a single collision', () => {
+    expect(uniqueSlug('overview', new Set(['overview']))).toBe('overview-1');
+  });
+
+  it('increments through multiple collisions', () => {
+    const taken = new Set(['overview', 'overview-1', 'overview-2']);
+    expect(uniqueSlug('overview', taken)).toBe('overview-3');
+  });
+
+  it('respects a pre-seeded taken set', () => {
+    const taken = new Set(['overview', 'overview-1']);
+    expect(uniqueSlug('overview', taken)).toBe('overview-2');
+    expect(uniqueSlug('summary', taken)).toBe('summary');
+  });
+});

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,0 +1,24 @@
+const COMBINING_MARKS = /\p{M}/gu;
+
+export function slugify(text: string): string {
+  return text
+    .normalize('NFKD')
+    .replace(COMBINING_MARKS, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function uniqueSlug(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) {
+    return base;
+  }
+  let suffix = 1;
+  let candidate = `${base}-${suffix}`;
+  while (taken.has(candidate)) {
+    suffix += 1;
+    candidate = `${base}-${suffix}`;
+  }
+  return candidate;
+}


### PR DESCRIPTION
## Summary

Adds a pure extraction layer for a future GitHub-style document outline in the two-tab guide reader: a slugify/uniqueSlug util for generating stable heading ids, and a `useDocumentOutline` hook that scans a rendered guide's DOM for headings and interactive-guide sections. No UI changes yet — this lands the logic the outline rail PR builds on.

## What to look at

- `src/hooks/useDocumentOutline.ts` — queries `h2, h3, h4, [data-interactive-section="true"]` in document order, assigns generated ids onto heading elements that don't already have one, and reads existing ids/section titles as-is.
- The dedup rule in the same file: when a plain heading is immediately followed by an interactive section sharing the same title text (the common `## Explore your data` + `<InteractiveSection title="Explore your data">` authoring pattern — see `src/bundled-interactives/first-dashboard/content.json`), the heading entry collapses into the section entry so the outline doesn't show the same title twice in a row.
- `src/utils/slug.ts` — GitHub-style slugify (diacritics stripped via a `\p{M}` Unicode property match, non-alphanumerics collapsed to hyphens) plus a `-1`/`-2` collision suffixer seeded from ids already present in the container.

## Why

The two-tab reader's planned outline navigation needs id generation before any rail UI can jump to headings, since most guide headings ship without DOM ids (`renderMarkdown()` doesn't generate them for JSON-guide markdown, and only some fetched HTML docs have author-provided ids). Splitting extraction into its own PR keeps the rail UI PR (next in this stack) reviewable as pure layout/interaction work.

## How to verify

No manual verification surface in this PR — it adds a hook and a util with unit test coverage (`slug.test.ts`, `useDocumentOutline.test.ts`) but isn't wired into any rendered component yet.

## Breaking changes

None.

## Out of scope

The outline rail UI, scroll-spy, and keyboard nav land in the next two PRs in this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
