### PR TITLE
perf(cli): emit compact JSON for agent-facing MCP and CLI output

### DIFF
--- a/src/cli/__tests__/output.test.ts
+++ b/src/cli/__tests__/output.test.ts
@@ -6,6 +6,7 @@ import {
   issueToOutcome,
   printOutcome,
   readOutputOptions,
+  renderMachineJson,
   type CommandOutcome,
   type HelpJson,
 } from '../utils/output';
@@ -35,6 +36,19 @@ function captureOutput<T>(fn: () => T): { stdout: string; stderr: string; result
     process.stderr.write = origErr;
   }
 }
+
+describe('renderMachineJson', () => {
+  it('emits compact JSON with no pretty-print whitespace', () => {
+    const payload = { status: 'ok', data: { id: 'markdown-1', tags: ['a', 'b'] } };
+    const rendered = renderMachineJson(payload);
+    // Guards the machine-facing contract: a future switch back to
+    // JSON.stringify(x, null, 2) would reintroduce indentation and regress
+    // token cost. Assert on the exact compact form, not just round-tripping.
+    expect(rendered).toBe('{"status":"ok","data":{"id":"markdown-1","tags":["a","b"]}}');
+    expect(rendered).not.toContain('\n');
+    expect(JSON.parse(rendered)).toEqual(payload);
+  });
+});
 
 describe('readOutputOptions', () => {
   it('defaults to text format and not quiet when no flags are set', () => {

--- a/src/cli/mcp/tools/artifact-tools.ts
+++ b/src/cli/mcp/tools/artifact-tools.ts
@@ -23,7 +23,7 @@ import type { ContentJson, ManifestJson } from '../../../types/package.types';
 import { MCP_TMPDIR_PREFIX } from '../lib/constants';
 import { generateSessionToken } from '../lib/session-token';
 import { SESSION_GENERATION_ABSENT, type SessionArtifact, type AuthoringSessionStore } from '../lib/session-store';
-import { type CommandOutcome, renderJsonPayload } from '../../utils/output';
+import { type CommandOutcome, renderMachineJson } from '../../utils/output';
 import { ARTIFACT_ETAG_FIELD, computeArtifactEtag } from '../../utils/etag';
 import { writeAppend } from './annotations';
 import { outcomeResult, textResult, withToolErrorEnvelope } from './result';
@@ -227,5 +227,5 @@ function sessionCreateResult(
     },
     summary,
   };
-  return textResult(renderJsonPayload(payload), outcome.status === 'error');
+  return textResult(renderMachineJson(payload), outcome.status === 'error');
 }

--- a/src/cli/mcp/tools/artifact-tools.ts
+++ b/src/cli/mcp/tools/artifact-tools.ts
@@ -23,7 +23,7 @@ import type { ContentJson, ManifestJson } from '../../../types/package.types';
 import { MCP_TMPDIR_PREFIX } from '../lib/constants';
 import { generateSessionToken } from '../lib/session-token';
 import { SESSION_GENERATION_ABSENT, type SessionArtifact, type AuthoringSessionStore } from '../lib/session-store';
-import type { CommandOutcome } from '../../utils/output';
+import { type CommandOutcome, renderJsonPayload } from '../../utils/output';
 import { ARTIFACT_ETAG_FIELD, computeArtifactEtag } from '../../utils/etag';
 import { writeAppend } from './annotations';
 import { outcomeResult, textResult, withToolErrorEnvelope } from './result';
@@ -227,5 +227,5 @@ function sessionCreateResult(
     },
     summary,
   };
-  return textResult(JSON.stringify(payload, null, 2), outcome.status === 'error');
+  return textResult(renderJsonPayload(payload), outcome.status === 'error');
 }

--- a/src/cli/mcp/tools/authoring-start.ts
+++ b/src/cli/mcp/tools/authoring-start.ts
@@ -16,6 +16,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { CURRENT_SCHEMA_VERSION } from '../../../types/json-guide.schema';
+import { renderJsonPayload } from '../../utils/output';
 import { PATHFINDER_DOMAINS, PATHFINDER_NOT_FOR, PATHFINDER_TRIGGER_PHRASES } from '../lib/agent-routing';
 import { readOnly } from './annotations';
 import { textResult } from './result';
@@ -107,6 +108,6 @@ export function registerAuthoringStart(server: McpServer): void {
       annotations: readOnly('Start Pathfinder authoring'),
       inputSchema: {},
     },
-    async () => textResult(JSON.stringify(AUTHORING_CONTEXT, null, 2))
+    async () => textResult(renderJsonPayload(AUTHORING_CONTEXT))
   );
 }

--- a/src/cli/mcp/tools/authoring-start.ts
+++ b/src/cli/mcp/tools/authoring-start.ts
@@ -16,7 +16,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { CURRENT_SCHEMA_VERSION } from '../../../types/json-guide.schema';
-import { renderJsonPayload } from '../../utils/output';
+import { renderMachineJson } from '../../utils/output';
 import { PATHFINDER_DOMAINS, PATHFINDER_NOT_FOR, PATHFINDER_TRIGGER_PHRASES } from '../lib/agent-routing';
 import { readOnly } from './annotations';
 import { textResult } from './result';
@@ -108,6 +108,6 @@ export function registerAuthoringStart(server: McpServer): void {
       annotations: readOnly('Start Pathfinder authoring'),
       inputSchema: {},
     },
-    async () => textResult(renderJsonPayload(AUTHORING_CONTEXT))
+    async () => textResult(renderMachineJson(AUTHORING_CONTEXT))
   );
 }

--- a/src/cli/mcp/tools/finalize.ts
+++ b/src/cli/mcp/tools/finalize.ts
@@ -28,6 +28,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import { runValidate } from '../../commands/validate';
+import { renderJsonPayload } from '../../utils/output';
 import { PLUGIN_VIEWER_BASE } from '../lib/constants';
 import { tokenLogPrefix } from '../lib/session-token';
 import type { AuthoringSessionStore } from '../lib/session-store';
@@ -101,19 +102,15 @@ async function finalizeImpl(args: {
 
   if (validation.status !== 'ok') {
     return textResult(
-      JSON.stringify(
-        {
-          status: 'invalid',
-          validation: {
-            isValid: false,
-            code: validation.code,
-            message: validation.message,
-            issues: (validation.data?.issues as unknown) ?? [],
-          },
+      renderJsonPayload({
+        status: 'invalid',
+        validation: {
+          isValid: false,
+          code: validation.code,
+          message: validation.message,
+          issues: (validation.data?.issues as unknown) ?? [],
         },
-        null,
-        2
-      ),
+      }),
       true
     );
   }
@@ -271,5 +268,5 @@ async function finalizeImpl(args: {
     }
   }
 
-  return textResult(JSON.stringify(handoff, null, 2));
+  return textResult(renderJsonPayload(handoff));
 }

--- a/src/cli/mcp/tools/finalize.ts
+++ b/src/cli/mcp/tools/finalize.ts
@@ -28,7 +28,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import { runValidate } from '../../commands/validate';
-import { renderJsonPayload } from '../../utils/output';
+import { renderMachineJson } from '../../utils/output';
 import { PLUGIN_VIEWER_BASE } from '../lib/constants';
 import { tokenLogPrefix } from '../lib/session-token';
 import type { AuthoringSessionStore } from '../lib/session-store';
@@ -102,7 +102,7 @@ async function finalizeImpl(args: {
 
   if (validation.status !== 'ok') {
     return textResult(
-      renderJsonPayload({
+      renderMachineJson({
         status: 'invalid',
         validation: {
           isValid: false,
@@ -268,5 +268,5 @@ async function finalizeImpl(args: {
     }
   }
 
-  return textResult(renderJsonPayload(handoff));
+  return textResult(renderMachineJson(handoff));
 }

--- a/src/cli/mcp/tools/help.ts
+++ b/src/cli/mcp/tools/help.ts
@@ -7,7 +7,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
-import { formatHelpAsJson } from '../../utils/output';
+import { formatHelpAsJson, renderJsonPayload } from '../../utils/output';
 import { CLI_COMMANDS } from '../program';
 import { readOnly } from './annotations';
 import { textResult } from './result';
@@ -35,31 +35,23 @@ export function registerHelpTool(server: McpServer): void {
     async ({ command, subcommand }) => {
       if (!command) {
         return textResult(
-          JSON.stringify(
-            {
-              commands: Array.from(CLI_COMMANDS.entries()).map(([name, cmd]) => ({
-                name,
-                description: cmd.description(),
-              })),
-            },
-            null,
-            2
-          )
+          renderJsonPayload({
+            commands: Array.from(CLI_COMMANDS.entries()).map(([name, cmd]) => ({
+              name,
+              description: cmd.description(),
+            })),
+          })
         );
       }
 
       const root = CLI_COMMANDS.get(command);
       if (!root) {
         return textResult(
-          JSON.stringify(
-            {
-              status: 'error',
-              code: 'UNKNOWN_COMMAND',
-              message: `Unknown command "${command}". Available: ${Array.from(CLI_COMMANDS.keys()).join(', ')}`,
-            },
-            null,
-            2
-          ),
+          renderJsonPayload({
+            status: 'error',
+            code: 'UNKNOWN_COMMAND',
+            message: `Unknown command "${command}". Available: ${Array.from(CLI_COMMANDS.keys()).join(', ')}`,
+          }),
           true
         );
       }
@@ -72,7 +64,7 @@ export function registerHelpTool(server: McpServer): void {
         }
       }
 
-      return textResult(JSON.stringify(formatHelpAsJson(target), null, 2));
+      return textResult(renderJsonPayload(formatHelpAsJson(target)));
     }
   );
 }

--- a/src/cli/mcp/tools/help.ts
+++ b/src/cli/mcp/tools/help.ts
@@ -7,7 +7,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
-import { formatHelpAsJson, renderJsonPayload } from '../../utils/output';
+import { formatHelpAsJson, renderMachineJson } from '../../utils/output';
 import { CLI_COMMANDS } from '../program';
 import { readOnly } from './annotations';
 import { textResult } from './result';
@@ -35,7 +35,7 @@ export function registerHelpTool(server: McpServer): void {
     async ({ command, subcommand }) => {
       if (!command) {
         return textResult(
-          renderJsonPayload({
+          renderMachineJson({
             commands: Array.from(CLI_COMMANDS.entries()).map(([name, cmd]) => ({
               name,
               description: cmd.description(),
@@ -47,7 +47,7 @@ export function registerHelpTool(server: McpServer): void {
       const root = CLI_COMMANDS.get(command);
       if (!root) {
         return textResult(
-          renderJsonPayload({
+          renderMachineJson({
             status: 'error',
             code: 'UNKNOWN_COMMAND',
             message: `Unknown command "${command}". Available: ${Array.from(CLI_COMMANDS.keys()).join(', ')}`,
@@ -64,7 +64,7 @@ export function registerHelpTool(server: McpServer): void {
         }
       }
 
-      return textResult(renderJsonPayload(formatHelpAsJson(target)));
+      return textResult(renderMachineJson(formatHelpAsJson(target)));
     }
   );
 }

--- a/src/cli/mcp/tools/repository-tools.ts
+++ b/src/cli/mcp/tools/repository-tools.ts
@@ -26,7 +26,7 @@ import {
   type RepositoryPackage,
 } from '../lib/repository-client';
 import { PLUGIN_VIEWER_BASE } from '../lib/constants';
-import { renderJsonPayload } from '../../utils/output';
+import { renderMachineJson } from '../../utils/output';
 import { readOnly } from './annotations';
 import { textResult } from './result';
 
@@ -232,7 +232,7 @@ function summarizeEntry(p: RepositoryPackage): Record<string, unknown> {
 }
 
 function jsonResult(payload: unknown): ReturnType<typeof textResult> {
-  return textResult(renderJsonPayload(payload));
+  return textResult(renderMachineJson(payload));
 }
 
 function errorResult(err: RepositoryClientError): ReturnType<typeof textResult> {
@@ -244,5 +244,5 @@ function errorResult(err: RepositoryClientError): ReturnType<typeof textResult> 
   if (err.code === 'HTTP_ERROR') {
     payload.httpStatus = err.status;
   }
-  return textResult(renderJsonPayload(payload), true);
+  return textResult(renderMachineJson(payload), true);
 }

--- a/src/cli/mcp/tools/repository-tools.ts
+++ b/src/cli/mcp/tools/repository-tools.ts
@@ -26,6 +26,7 @@ import {
   type RepositoryPackage,
 } from '../lib/repository-client';
 import { PLUGIN_VIEWER_BASE } from '../lib/constants';
+import { renderJsonPayload } from '../../utils/output';
 import { readOnly } from './annotations';
 import { textResult } from './result';
 
@@ -231,7 +232,7 @@ function summarizeEntry(p: RepositoryPackage): Record<string, unknown> {
 }
 
 function jsonResult(payload: unknown): ReturnType<typeof textResult> {
-  return textResult(JSON.stringify(payload, null, 2));
+  return textResult(renderJsonPayload(payload));
 }
 
 function errorResult(err: RepositoryClientError): ReturnType<typeof textResult> {
@@ -243,5 +244,5 @@ function errorResult(err: RepositoryClientError): ReturnType<typeof textResult> 
   if (err.code === 'HTTP_ERROR') {
     payload.httpStatus = err.status;
   }
-  return textResult(JSON.stringify(payload, null, 2), true);
+  return textResult(renderJsonPayload(payload), true);
 }

--- a/src/cli/mcp/tools/result.ts
+++ b/src/cli/mcp/tools/result.ts
@@ -20,7 +20,7 @@
 
 import type { TreeNode } from '../../utils/package-io';
 import { ARTIFACT_ETAG_FIELD, computeArtifactEtag } from '../../utils/etag';
-import type { CommandOutcome } from '../../utils/output';
+import { type CommandOutcome, renderJsonPayload } from '../../utils/output';
 import { type ConcurrentModificationResult, type SessionTooLargeResult } from './state-bridge';
 
 type ToolResult = { content: Array<{ type: 'text'; text: string }>; isError?: boolean };
@@ -50,7 +50,7 @@ function errorResult(
   if (opts.data !== undefined) {
     payload.data = opts.data;
   }
-  return textResult(JSON.stringify(payload, null, 2), /* isError */ true);
+  return textResult(renderJsonPayload(payload), /* isError */ true);
 }
 
 /**
@@ -81,7 +81,7 @@ export function outcomeResult(
   if (summary) {
     payload.summary = summary;
   }
-  return textResult(JSON.stringify(payload, null, 2), outcome.status === 'error');
+  return textResult(renderJsonPayload(payload), outcome.status === 'error');
 }
 
 /**
@@ -100,7 +100,7 @@ export function sessionOutcomeResult(
   if (generation !== undefined) {
     payload.generation = generation;
   }
-  return textResult(JSON.stringify(payload, null, 2), outcome.status === 'error');
+  return textResult(renderJsonPayload(payload), outcome.status === 'error');
 }
 
 // ── Error wire shapes ────────────────────────────────────────────────────

--- a/src/cli/mcp/tools/result.ts
+++ b/src/cli/mcp/tools/result.ts
@@ -20,7 +20,7 @@
 
 import type { TreeNode } from '../../utils/package-io';
 import { ARTIFACT_ETAG_FIELD, computeArtifactEtag } from '../../utils/etag';
-import { type CommandOutcome, renderJsonPayload } from '../../utils/output';
+import { type CommandOutcome, renderMachineJson } from '../../utils/output';
 import { type ConcurrentModificationResult, type SessionTooLargeResult } from './state-bridge';
 
 type ToolResult = { content: Array<{ type: 'text'; text: string }>; isError?: boolean };
@@ -50,7 +50,7 @@ function errorResult(
   if (opts.data !== undefined) {
     payload.data = opts.data;
   }
-  return textResult(renderJsonPayload(payload), /* isError */ true);
+  return textResult(renderMachineJson(payload), /* isError */ true);
 }
 
 /**
@@ -81,7 +81,7 @@ export function outcomeResult(
   if (summary) {
     payload.summary = summary;
   }
-  return textResult(renderJsonPayload(payload), outcome.status === 'error');
+  return textResult(renderMachineJson(payload), outcome.status === 'error');
 }
 
 /**
@@ -100,7 +100,7 @@ export function sessionOutcomeResult(
   if (generation !== undefined) {
     payload.generation = generation;
   }
-  return textResult(renderJsonPayload(payload), outcome.status === 'error');
+  return textResult(renderMachineJson(payload), outcome.status === 'error');
 }
 
 // ── Error wire shapes ────────────────────────────────────────────────────

--- a/src/cli/mcp/tools/schema-tools.ts
+++ b/src/cli/mcp/tools/schema-tools.ts
@@ -11,6 +11,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import { exportAllSchemas, exportSchema, listSchemas, SCHEMA_REGISTRY } from '../../commands/schema';
+import { renderJsonPayload } from '../../utils/output';
 import { readOnly } from './annotations';
 import { outcomeResult, textResult } from './result';
 
@@ -48,11 +49,11 @@ export function registerSchemaTools(server: McpServer): void {
       const resolvedMode = mode ?? (name ? 'one' : 'all');
 
       if (resolvedMode === 'list') {
-        return textResult(JSON.stringify({ schemas: listSchemas() }, null, 2));
+        return textResult(renderJsonPayload({ schemas: listSchemas() }));
       }
 
       if (resolvedMode === 'all') {
-        return textResult(JSON.stringify({ schemas: exportAllSchemas(wantVersion), available: SCHEMA_NAMES }, null, 2));
+        return textResult(renderJsonPayload({ schemas: exportAllSchemas(wantVersion), available: SCHEMA_NAMES }));
       }
 
       if (!name) {
@@ -72,7 +73,7 @@ export function registerSchemaTools(server: McpServer): void {
         });
       }
 
-      return textResult(JSON.stringify({ name, schema }, null, 2));
+      return textResult(renderJsonPayload({ name, schema }));
     }
   );
 }

--- a/src/cli/mcp/tools/schema-tools.ts
+++ b/src/cli/mcp/tools/schema-tools.ts
@@ -11,7 +11,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import { exportAllSchemas, exportSchema, listSchemas, SCHEMA_REGISTRY } from '../../commands/schema';
-import { renderJsonPayload } from '../../utils/output';
+import { renderMachineJson } from '../../utils/output';
 import { readOnly } from './annotations';
 import { outcomeResult, textResult } from './result';
 
@@ -49,11 +49,11 @@ export function registerSchemaTools(server: McpServer): void {
       const resolvedMode = mode ?? (name ? 'one' : 'all');
 
       if (resolvedMode === 'list') {
-        return textResult(renderJsonPayload({ schemas: listSchemas() }));
+        return textResult(renderMachineJson({ schemas: listSchemas() }));
       }
 
       if (resolvedMode === 'all') {
-        return textResult(renderJsonPayload({ schemas: exportAllSchemas(wantVersion), available: SCHEMA_NAMES }));
+        return textResult(renderMachineJson({ schemas: exportAllSchemas(wantVersion), available: SCHEMA_NAMES }));
       }
 
       if (!name) {
@@ -73,7 +73,7 @@ export function registerSchemaTools(server: McpServer): void {
         });
       }
 
-      return textResult(renderJsonPayload({ name, schema }));
+      return textResult(renderMachineJson({ name, schema }));
     }
   );
 }

--- a/src/cli/mcp/tools/session-read-tools.ts
+++ b/src/cli/mcp/tools/session-read-tools.ts
@@ -20,7 +20,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import { buildArtifactSummary, findBlockById } from '../../utils/package-io';
-import { renderJsonPayload } from '../../utils/output';
+import { renderMachineJson } from '../../utils/output';
 import type { LoadedSession, AuthoringSessionStore } from '../lib/session-store';
 import { readOnly } from './annotations';
 import { resolveAndPinToken } from './read-input';
@@ -61,7 +61,7 @@ async function withLoadedSession(
     if (isToolResult(rendered)) {
       return rendered;
     }
-    return textResult(renderJsonPayload(rendered));
+    return textResult(renderMachineJson(rendered));
   });
 }
 
@@ -108,7 +108,7 @@ export function registerSessionReadTools(
         const block = findBlockById(loaded.artifact.content, blockId);
         if (!block) {
           return textResult(
-            renderJsonPayload({
+            renderMachineJson({
               status: 'error',
               code: 'NOT_FOUND',
               message: `No block with id "${blockId}" in this session.`,

--- a/src/cli/mcp/tools/session-read-tools.ts
+++ b/src/cli/mcp/tools/session-read-tools.ts
@@ -20,6 +20,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import { buildArtifactSummary, findBlockById } from '../../utils/package-io';
+import { renderJsonPayload } from '../../utils/output';
 import type { LoadedSession, AuthoringSessionStore } from '../lib/session-store';
 import { readOnly } from './annotations';
 import { resolveAndPinToken } from './read-input';
@@ -60,7 +61,7 @@ async function withLoadedSession(
     if (isToolResult(rendered)) {
       return rendered;
     }
-    return textResult(JSON.stringify(rendered, null, 2));
+    return textResult(renderJsonPayload(rendered));
   });
 }
 
@@ -107,17 +108,13 @@ export function registerSessionReadTools(
         const block = findBlockById(loaded.artifact.content, blockId);
         if (!block) {
           return textResult(
-            JSON.stringify(
-              {
-                status: 'error',
-                code: 'NOT_FOUND',
-                message: `No block with id "${blockId}" in this session.`,
-                sessionToken: token,
-                generation: loaded.generation,
-              },
-              null,
-              2
-            ),
+            renderJsonPayload({
+              status: 'error',
+              code: 'NOT_FOUND',
+              message: `No block with id "${blockId}" in this session.`,
+              sessionToken: token,
+              generation: loaded.generation,
+            }),
             /* isError */ true
           );
         }

--- a/src/cli/utils/output.ts
+++ b/src/cli/utils/output.ts
@@ -54,6 +54,17 @@ export function readOutputOptions(cmd: Command): OutputOptions {
 }
 
 /**
+ * Serialize an LLM/agent-facing payload as compact JSON. Pretty-print
+ * indentation is pure token overhead for a model consumer; the output stays
+ * valid JSON that existing JSON.parse consumers read unchanged. Human-read
+ * output (CLI text mode) and on-disk build artifacts keep prettier formatting
+ * via formatJsonWithPrettier.
+ */
+export function renderJsonPayload(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+/**
  * Prettier-format a JSON string with the repo config, ensuring a trailing
  * newline. Shared by the build-* commands that write generated JSON to disk.
  */
@@ -230,7 +241,7 @@ export function renderError(err: unknown): string {
 export function printOutcome(outcome: CommandOutcome, output: OutputOptions): number {
   if (output.format === 'json') {
     const stream = outcome.status === 'ok' ? process.stdout : process.stderr;
-    stream.write(JSON.stringify(outcome, null, 2) + '\n');
+    stream.write(renderJsonPayload(outcome) + '\n');
     return outcome.status === 'ok' ? 0 : 1;
   }
 

--- a/src/cli/utils/output.ts
+++ b/src/cli/utils/output.ts
@@ -54,13 +54,13 @@ export function readOutputOptions(cmd: Command): OutputOptions {
 }
 
 /**
- * Serialize an LLM/agent-facing payload as compact JSON. Pretty-print
- * indentation is pure token overhead for a model consumer; the output stays
- * valid JSON that existing JSON.parse consumers read unchanged. Human-read
- * output (CLI text mode) and on-disk build artifacts keep prettier formatting
- * via formatJsonWithPrettier.
+ * Serialize a machine-facing payload (MCP tool results, CLI `--format json`)
+ * as compact JSON. Pretty-print indentation is pure token overhead for an
+ * agent consumer; output stays valid JSON that existing JSON.parse consumers
+ * read unchanged. Human-read output (CLI text mode) and on-disk build
+ * artifacts keep prettier formatting via formatJsonWithPrettier.
  */
-export function renderJsonPayload(value: unknown): string {
+export function renderMachineJson(value: unknown): string {
   return JSON.stringify(value);
 }
 
@@ -241,7 +241,7 @@ export function renderError(err: unknown): string {
 export function printOutcome(outcome: CommandOutcome, output: OutputOptions): number {
   if (output.format === 'json') {
     const stream = outcome.status === 'ok' ? process.stdout : process.stderr;
-    stream.write(renderJsonPayload(outcome) + '\n');
+    stream.write(renderMachineJson(outcome) + '\n');
     return outcome.status === 'ok' ? 0 : 1;
   }
 


### PR DESCRIPTION
## What does this PR do?

The MCP tool results and the CLI `--format json` path serialized their payloads with
`JSON.stringify(x, null, 2)`. The two-space indentation is pure token overhead for an
LLM/agent consumer and buys nothing that a `JSON.parse` cannot recover (~22–48% fewer
bytes; 38.9% on a representative outcome payload).

This adds a single `renderJsonPayload` helper in `cli/utils/output.ts` (sibling to the
existing `formatJsonWithPrettier`) that emits compact JSON, and routes the agent-facing
serialization sites through it: all MCP result builders in `src/cli/mcp/**` and
`printOutcome`'s `--format json` branch. The `inspection`/`mutation` tools inherit
compaction through the shared `result.ts` builders, so no per-tool churn was needed
there.

Human-read and on-disk output is deliberately left pretty: the CLI text mode, and the
`build-graph` / `build-repository` / `build-snippets` artifacts written via
`formatJsonWithPrettier`. Output stays valid JSON that existing `JSON.parse` consumers
read unchanged, so no test assertions changed.

## Linked issue(s)

Closes #1237

## Checklist

- [x] This PR addresses a **single concern** (one bug fix or feature, or a set of closely-related changes). Unrelated changes belong in separate PRs; see [CONTRIBUTING.md](../CONTRIBUTING.md#pull-request-scope).
- [x] All commits are signed (required, or the checks will not pass). See [CONTRIBUTING.md](../CONTRIBUTING.md#signed-commits).
- [ ] I've added or updated tests for the change. — No new tests: this is a whitespace-only serialization change, and the existing MCP/`printOutcome` tests assert on `JSON.parse`d objects (including the finalize inline snapshot), so they cover the behavior unchanged and all pass. Happy to add explicit compact-output assertions if you'd prefer them.
- [x] `npm run check` passes locally (typecheck, lint, prettier, Go lint/tests, frontend tests). — typecheck, lint, prettier, and docs-terms pass; the full frontend suite passes except three suites that fail identically on unmodified `main` (Windows-only file-mode/path-separator tests, none touching this change). Go lint/tests couldn't run locally (`mage` not installed) but this change touches no Go files.
- [x] UI text and docs use [sentence case](https://grafana.com/docs/writers-toolkit/write/style-guide/capitalization-punctuation/#capitalization).