### PR TITLE
chore(renovate): reduce PR noise with stability filter and rebase tuning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,9 +54,15 @@
         "!/^@types/jest/",
         "!/^@types/testing-library/"
       ]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
     }
   ],
   "prConcurrentLimit": 10,
   "minimumReleaseAge": "14 days",
-  "rebaseWhen": "behind-base-branch"
+  "internalChecksFilter": "strict",
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
## Intent

Reduce noisy Renovate pull requests in the grafana-pathfinder-app repository by making exactly three targeted changes to renovate.json.

1. add internalChecksFilter set to "strict" at the top level so that PRs are not created until the configured 14-day minimumReleaseAge stability period has passed. 
2. change rebaseWhen from "behind-base-branch" to "conflicted" to stop Renovate from rebasing all open PRs on every commit to main, matching the setting used by grafana/grafana. 
4. new packageRule added to disable indirect Go module updates via the gomod manager, since Go handles these automatically through go mod tidy. The developer explicitly required no other changes to the file, no reformatting or reordering, and that the resulting JSON remain valid.

## What Changed

- Added `internalChecksFilter: "strict"` so Renovate waits for the 14-day `minimumReleaseAge` stability window before opening a PR, preventing premature dependency bumps
- Changed `rebaseWhen` from `"behind-base-branch"` to `"conflicted"` so Renovate only rebases PRs that have actual merge conflicts, not on every push to main
- Added a package rule to disable indirect Go module updates via the `gomod` manager, since Go handles these automatically through `go mod tidy`

## Risk Assessment

✅ Low: Three targeted Renovate config changes — stability filter, rebase policy, and disabling indirect Go updates — each correct and isolated, with no interaction risks or unintended side effects.

## Testing

All three required renovate.json changes are present and correct — `internalChecksFilter: "strict"`, `rebaseWhen: "conflicted"`, and the gomod indirect-dep disable rule — with no other modifications to the file and valid JSON throughout.

<details>
<summary>Evidence: Validation evidence</summary>

<code>PASS internalChecksFilter=strict&#10;PASS rebaseWhen=conflicted&#10;PASS gomod_indirect_disabled&#10;&#10;Files changed: renovate.json only. JSON: VALID.</code>

```text
renovate.json validation — fm/renovate-cfg-q7
==============================================

Files changed: renovate.json (only)
JSON validity: VALID

Required changes verified:
  PASS  internalChecksFilter = "strict"  (top-level, ensures minimumReleaseAge=14d is honoured before PR creation)
  PASS  rebaseWhen = "conflicted"        (was "behind-base-branch"; stops Renovate rebasing all open PRs on every main commit)
  PASS  gomod indirect rule disabled     (matchManagers:["gomod"], matchDepTypes:["indirect"], enabled:false)

Diff summary:
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": false
+    }
   "prConcurrentLimit": 10,
   "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict",
-  "rebaseWhen": "behind-base-branch"
+  "rebaseWhen": "conflicted"

No other fields added, removed, or reordered.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 92f68b7..a754c68 -- renovate.json` — reviewed the full diff to confirm scope and content</code>
- <code>`python3 -m json.tool` — validated JSON syntax of both base and target files</code>
- `Python assertion script — verified all three required fields/rules are present with correct values in the target commit`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
