### PR TITLE
fix(test): eliminate race condition in cross-tab reconnect acceptance test

### DIFF
--- a/src/integrations/cross-tab/cross-tab-protocol.acceptance.test.tsx
+++ b/src/integrations/cross-tab/cross-tab-protocol.acceptance.test.tsx
@@ -739,10 +739,18 @@ describe('cross-tab pairing protocol acceptance', () => {
 
     it('keeps verifying signed commands after a re-pair (accepted session persists)', async () => {
       const harness = await pairOverBus();
+      const before = harness.live.postedPayloads.filter((p) => p.kind === 'pairing-accept').length;
+
       await act(async () => {
         await setPendingChallenge(harness.acceptedChallenge);
         await Promise.resolve();
       });
+
+      // Ensure the reconnect HMAC chain has settled before the step-command ECDSA chain
+      // starts; concurrent crypto work saturates the UV thread pool under CI load.
+      await waitFor(() =>
+        expect(harness.live.postedPayloads.filter((p) => p.kind === 'pairing-accept').length).toBeGreaterThan(before)
+      );
 
       act(() => {
         harness.channel.post({


### PR DESCRIPTION
## Summary

- The `keeps verifying signed commands after a re-pair` test in `cross-tab-protocol.acceptance.test.tsx` was flaky under CI load (run [#28903118447](https://github.com/grafana/grafana-pathfinder-app/actions/runs/28903118447/job/85744268501), cleared on re-run)
- Root cause: the test fired the step-command ECDSA signing chain while the reconnect HMAC chain (`createPairingAcceptForSession`) was still in flight — both competed for Node.js's UV thread pool (4 default slots shared across 4 parallel Jest workers), pushing total latency past `waitFor`'s 1000ms timeout
- Fix: wait for the re-emitted `pairing-accept` (confirming the HMAC chain drained) before posting the step-command — mirrors the pattern the first reconnect test already uses

## Test plan

- [x] All 35 tests in `cross-tab-protocol.acceptance.test.tsx` pass locally
- [x] The previously flaky test now has deterministic sequencing (HMAC settles before ECDSA starts)
- [x] No production code changed — test-only fix

Generated with [Claude Code](https://claude.com/claude-code)