### PR TITLE
feat(faro): re-enable Faro frontend telemetry (errors, sessions, logs, user actions, sourcemaps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,13 +212,9 @@ jobs:
 
       # main-only: a PR build's sourcemaps would tie a real user-facing stack
       # trace to code that may never merge, or may differ from what does.
-      # TEMPORARY (revert before merge): also allow this one branch, to test
-      # the upload end-to-end pre-merge. bundleId is randomly generated per
-      # build (not derived from git ref/version), so a test upload here can't
-      # collide with or misattribute a real release's sourcemaps.
       - name: Get Faro sourcemap secrets from Vault
         id: faro-secrets
-        if: github.event_name == 'push' || github.head_ref == 'faro/sourcemap-upload'
+        if: github.event_name == 'push'
         uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
         with:
           repo_secrets: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      id-token: write
     outputs:
       plugin-id: ${{ steps.metadata.outputs.plugin-id }}
       plugin-version: ${{ steps.metadata.outputs.plugin-version }}
@@ -210,31 +209,18 @@ jobs:
       - if: steps.node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      # main-only: a PR build's sourcemaps would tie a real user-facing stack
-      # trace to code that may never merge, or may differ from what does.
-      # continue-on-error: a Vault lookup failure (e.g. a renamed field) must
-      # degrade to "sourcemap upload skipped", never fail the whole build —
-      # the outcome-guard below already treats a non-success outcome as "no
-      # secrets" and leaves the plugin inert.
-      - name: Get Faro sourcemap secrets from Vault
-        id: faro-secrets
-        if: github.event_name == 'push'
-        continue-on-error: true
-        uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
-        with:
-          repo_secrets: |
-            FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:FARO_SOURCEMAP_API_KEY
-            FARO_SOURCEMAP_ENDPOINT=faro-connection:endpoint
-            FARO_SOURCEMAP_APP_ID=faro-connection:appId
-            FARO_SOURCEMAP_STACK_ID=faro-connection:stackId
-
+      # No sourcemap upload here: this job's build artifact is archived for
+      # CI inspection only (5-day retention) and never deployed anywhere —
+      # publish.yml's CD path does its own independent build for real
+      # deploys. Uploading sourcemaps for a bundle no browser will ever load
+      # would just accumulate orphaned artifacts in Frontend Observability
+      # for zero benefit. See webpack.config.ts for the upload itself, which
+      # activates only when all four FARO_SOURCEMAP_* env vars are present —
+      # currently blocked upstream (grafana/plugin-ci-workflows' cd.yml
+      # fetches frontend-secrets from Vault but never wires them into its
+      # own build step's env).
       - name: Build frontend
         run: npm run build
-        env:
-          FARO_SOURCEMAP_API_KEY: ${{ steps.faro-secrets.outcome == 'success' && fromJSON(steps.faro-secrets.outputs.secrets).FARO_SOURCEMAP_API_KEY || '' }}
-          FARO_SOURCEMAP_ENDPOINT: ${{ steps.faro-secrets.outcome == 'success' && fromJSON(steps.faro-secrets.outputs.secrets).FARO_SOURCEMAP_ENDPOINT || '' }}
-          FARO_SOURCEMAP_APP_ID: ${{ steps.faro-secrets.outcome == 'success' && fromJSON(steps.faro-secrets.outputs.secrets).FARO_SOURCEMAP_APP_ID || '' }}
-          FARO_SOURCEMAP_STACK_ID: ${{ steps.faro-secrets.outcome == 'success' && fromJSON(steps.faro-secrets.outputs.secrets).FARO_SOURCEMAP_STACK_ID || '' }}
 
       # --- Backend steps (conditional) ---
       - name: Check for backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
       # secrets" and leaves the plugin inert.
       - name: Get Faro sourcemap secrets from Vault
         id: faro-secrets
-        if: github.event_name == 'push' || github.head_ref == 'faro/sourcemap-upload'
+        if: github.event_name == 'push'
         continue-on-error: true
         uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,16 +209,6 @@ jobs:
       - if: steps.node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      # No sourcemap upload here: this job's build artifact is archived for
-      # CI inspection only (5-day retention) and never deployed anywhere —
-      # publish.yml's CD path does its own independent build for real
-      # deploys. Uploading sourcemaps for a bundle no browser will ever load
-      # would just accumulate orphaned artifacts in Frontend Observability
-      # for zero benefit. See webpack.config.ts for the upload itself, which
-      # activates only when all four FARO_SOURCEMAP_* env vars are present —
-      # currently blocked upstream (grafana/plugin-ci-workflows' cd.yml
-      # fetches frontend-secrets from Vault but never wires them into its
-      # own build step's env).
       - name: Build frontend
         run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,13 +212,18 @@ jobs:
 
       # main-only: a PR build's sourcemaps would tie a real user-facing stack
       # trace to code that may never merge, or may differ from what does.
+      # continue-on-error: a Vault lookup failure (e.g. a renamed field) must
+      # degrade to "sourcemap upload skipped", never fail the whole build —
+      # the outcome-guard below already treats a non-success outcome as "no
+      # secrets" and leaves the plugin inert.
       - name: Get Faro sourcemap secrets from Vault
         id: faro-secrets
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.head_ref == 'faro/sourcemap-upload'
+        continue-on-error: true
         uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
         with:
           repo_secrets: |
-            FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:value
+            FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:FARO_SOURCEMAP_API_KEY
             FARO_SOURCEMAP_ENDPOINT=faro-connection:endpoint
             FARO_SOURCEMAP_APP_ID=faro-connection:appId
             FARO_SOURCEMAP_STACK_ID=faro-connection:stackId

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,9 @@ jobs:
       has-backend: ${{ steps.check-for-backend.outputs.has-backend }}
     env:
       GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+      # main-only: a PR build's sourcemaps would tie a real user-facing stack
+      # trace to code that may never merge, or may differ from what does.
+      FARO_SOURCEMAP_API_KEY: ${{ github.event_name == 'push' && secrets.FARO_SOURCEMAP_API_KEY || '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,9 +212,13 @@ jobs:
 
       # main-only: a PR build's sourcemaps would tie a real user-facing stack
       # trace to code that may never merge, or may differ from what does.
+      # TEMPORARY (revert before merge): also allow this one branch, to test
+      # the upload end-to-end pre-merge. bundleId is randomly generated per
+      # build (not derived from git ref/version), so a test upload here can't
+      # collide with or misattribute a real release's sourcemaps.
       - name: Get Faro sourcemap secrets from Vault
         id: faro-secrets
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.head_ref == 'faro/sourcemap-upload'
         uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
         with:
           repo_secrets: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,15 +187,13 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      id-token: write
     outputs:
       plugin-id: ${{ steps.metadata.outputs.plugin-id }}
       plugin-version: ${{ steps.metadata.outputs.plugin-version }}
       has-backend: ${{ steps.check-for-backend.outputs.has-backend }}
     env:
       GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
-      # main-only: a PR build's sourcemaps would tie a real user-facing stack
-      # trace to code that may never merge, or may differ from what does.
-      FARO_SOURCEMAP_API_KEY: ${{ github.event_name == 'push' && secrets.FARO_SOURCEMAP_API_KEY || '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -212,8 +210,26 @@ jobs:
       - if: steps.node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
+      # main-only: a PR build's sourcemaps would tie a real user-facing stack
+      # trace to code that may never merge, or may differ from what does.
+      - name: Get Faro sourcemap secrets from Vault
+        id: faro-secrets
+        if: github.event_name == 'push'
+        uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
+        with:
+          repo_secrets: |
+            FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:value
+            FARO_SOURCEMAP_ENDPOINT=faro-connection:endpoint
+            FARO_SOURCEMAP_APP_ID=faro-connection:appId
+            FARO_SOURCEMAP_STACK_ID=faro-connection:stackId
+
       - name: Build frontend
         run: npm run build
+        env:
+          FARO_SOURCEMAP_API_KEY: ${{ steps.faro-secrets.outcome == 'success' && fromJSON(steps.faro-secrets.outputs.secrets).FARO_SOURCEMAP_API_KEY || '' }}
+          FARO_SOURCEMAP_ENDPOINT: ${{ steps.faro-secrets.outcome == 'success' && fromJSON(steps.faro-secrets.outputs.secrets).FARO_SOURCEMAP_ENDPOINT || '' }}
+          FARO_SOURCEMAP_APP_ID: ${{ steps.faro-secrets.outcome == 'success' && fromJSON(steps.faro-secrets.outputs.secrets).FARO_SOURCEMAP_APP_ID || '' }}
+          FARO_SOURCEMAP_STACK_ID: ${{ steps.faro-secrets.outcome == 'success' && fromJSON(steps.faro-secrets.outputs.secrets).FARO_SOURCEMAP_STACK_ID || '' }}
 
       # --- Backend steps (conditional) ---
       - name: Check for backend

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,8 +53,13 @@ jobs:
       # main only: publishing an arbitrary branch to dev/ops for testing must
       # never upload sourcemaps under the real release's version — that would
       # tie a production stack trace to code that isn't what's actually live.
-      # Vault path: ci/data/repo/grafana/grafana-pathfinder-app/FARO_SOURCEMAP_API_KEY
-      frontend-secrets: ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:value' || '' }}
+      # Vault paths: ci/data/repo/grafana/grafana-pathfinder-app/FARO_SOURCEMAP_API_KEY
+      #              ci/data/repo/grafana/grafana-pathfinder-app/faro-connection (endpoint/appId/stackId fields)
+      frontend-secrets: |
+        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:value' || '' }}
+        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_ENDPOINT=faro-connection:endpoint' || '' }}
+        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_APP_ID=faro-connection:appId' || '' }}
+        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_STACK_ID=faro-connection:stackId' || '' }}
 
       # TODO: add here any other CI custom inputs you may need:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
       # Vault paths: ci/data/repo/grafana/grafana-pathfinder-app/FARO_SOURCEMAP_API_KEY
       #              ci/data/repo/grafana/grafana-pathfinder-app/faro-connection (endpoint/appId/stackId fields)
       frontend-secrets: |
-        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:value' || '' }}
+        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:FARO_SOURCEMAP_API_KEY' || '' }}
         ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_ENDPOINT=faro-connection:endpoint' || '' }}
         ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_APP_ID=faro-connection:appId' || '' }}
         ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_STACK_ID=faro-connection:stackId' || '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,16 +50,5 @@ jobs:
       # temp disable while https://github.com/grafana/plugin-actions/pull/118 is being fixed
       run-playwright: false
 
-      # main only: publishing an arbitrary branch to dev/ops for testing must
-      # never upload sourcemaps under the real release's version — that would
-      # tie a production stack trace to code that isn't what's actually live.
-      # Vault paths: ci/data/repo/grafana/grafana-pathfinder-app/FARO_SOURCEMAP_API_KEY
-      #              ci/data/repo/grafana/grafana-pathfinder-app/faro-connection (endpoint/appId/stackId fields)
-      frontend-secrets: |
-        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:FARO_SOURCEMAP_API_KEY' || '' }}
-        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_ENDPOINT=faro-connection:endpoint' || '' }}
-        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_APP_ID=faro-connection:appId' || '' }}
-        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_STACK_ID=faro-connection:stackId' || '' }}
-
       # TODO: add here any other CI custom inputs you may need:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,13 +53,16 @@ jobs:
       # main only: publishing an arbitrary branch to dev/ops for testing must
       # never upload sourcemaps under the real release's version — that would
       # tie a production stack trace to code that isn't what's actually live.
+      # TEMPORARY (revert before merge): also allow this one branch, to test
+      # whether the reusable cd.yml workflow actually exposes fetched Vault
+      # secrets to the build step's env (a suspected upstream gap).
       # Vault paths: ci/data/repo/grafana/grafana-pathfinder-app/FARO_SOURCEMAP_API_KEY
       #              ci/data/repo/grafana/grafana-pathfinder-app/faro-connection (endpoint/appId/stackId fields)
       frontend-secrets: |
-        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:FARO_SOURCEMAP_API_KEY' || '' }}
-        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_ENDPOINT=faro-connection:endpoint' || '' }}
-        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_APP_ID=faro-connection:appId' || '' }}
-        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_STACK_ID=faro-connection:stackId' || '' }}
+        ${{ (github.event.inputs.branch == 'main' || github.event.inputs.branch == 'faro/sourcemap-upload') && 'FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:FARO_SOURCEMAP_API_KEY' || '' }}
+        ${{ (github.event.inputs.branch == 'main' || github.event.inputs.branch == 'faro/sourcemap-upload') && 'FARO_SOURCEMAP_ENDPOINT=faro-connection:endpoint' || '' }}
+        ${{ (github.event.inputs.branch == 'main' || github.event.inputs.branch == 'faro/sourcemap-upload') && 'FARO_SOURCEMAP_APP_ID=faro-connection:appId' || '' }}
+        ${{ (github.event.inputs.branch == 'main' || github.event.inputs.branch == 'faro/sourcemap-upload') && 'FARO_SOURCEMAP_STACK_ID=faro-connection:stackId' || '' }}
 
       # TODO: add here any other CI custom inputs you may need:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,5 +50,11 @@ jobs:
       # temp disable while https://github.com/grafana/plugin-actions/pull/118 is being fixed
       run-playwright: false
 
+      # main only: publishing an arbitrary branch to dev/ops for testing must
+      # never upload sourcemaps under the real release's version — that would
+      # tie a production stack trace to code that isn't what's actually live.
+      # Vault path: ci/data/repo/grafana/grafana-pathfinder-app/FARO_SOURCEMAP_API_KEY
+      frontend-secrets: ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:value' || '' }}
+
       # TODO: add here any other CI custom inputs you may need:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,16 +53,13 @@ jobs:
       # main only: publishing an arbitrary branch to dev/ops for testing must
       # never upload sourcemaps under the real release's version — that would
       # tie a production stack trace to code that isn't what's actually live.
-      # TEMPORARY (revert before merge): also allow this one branch, to test
-      # whether the reusable cd.yml workflow actually exposes fetched Vault
-      # secrets to the build step's env (a suspected upstream gap).
       # Vault paths: ci/data/repo/grafana/grafana-pathfinder-app/FARO_SOURCEMAP_API_KEY
       #              ci/data/repo/grafana/grafana-pathfinder-app/faro-connection (endpoint/appId/stackId fields)
       frontend-secrets: |
-        ${{ (github.event.inputs.branch == 'main' || github.event.inputs.branch == 'faro/sourcemap-upload') && 'FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:FARO_SOURCEMAP_API_KEY' || '' }}
-        ${{ (github.event.inputs.branch == 'main' || github.event.inputs.branch == 'faro/sourcemap-upload') && 'FARO_SOURCEMAP_ENDPOINT=faro-connection:endpoint' || '' }}
-        ${{ (github.event.inputs.branch == 'main' || github.event.inputs.branch == 'faro/sourcemap-upload') && 'FARO_SOURCEMAP_APP_ID=faro-connection:appId' || '' }}
-        ${{ (github.event.inputs.branch == 'main' || github.event.inputs.branch == 'faro/sourcemap-upload') && 'FARO_SOURCEMAP_STACK_ID=faro-connection:stackId' || '' }}
+        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_API_KEY=FARO_SOURCEMAP_API_KEY:FARO_SOURCEMAP_API_KEY' || '' }}
+        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_ENDPOINT=faro-connection:endpoint' || '' }}
+        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_APP_ID=faro-connection:appId' || '' }}
+        ${{ github.event.inputs.branch == 'main' && 'FARO_SOURCEMAP_STACK_ID=faro-connection:stackId' || '' }}
 
       # TODO: add here any other CI custom inputs you may need:
       #   https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#customizing-the-workflows-with-inputs

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ Admins can configure Interactive learning from the plugin's configuration page i
 - **Auto-completion detection** – (Experimental) Enable automatic step completion when users perform actions themselves (without clicking "Do it" buttons)
 - **Timing settings** – Configure timeouts for requirement checks and guided steps to optimize the guide experience
 
+### Frontend telemetry
+
+Interactive learning sends frontend telemetry (errors and session data, via [Grafana Faro](https://grafana.com/oss/faro/)) to help us detect and fix bugs in the plugin. This telemetry:
+
+- Is only sent from Grafana Cloud instances – OSS and self-hosted instances never send it
+- Respects the instance-level analytics/reporting setting – disabling analytics reporting for your Grafana instance also disables this telemetry
+- Contains no user-identifying data (no user id, email, or IP)
+- Can be disabled fleet-wide independently of the plugin itself, without a release, if needed
+
 ## Creating interactive guides
 
 Editors and admins can author custom interactive guides in two ways:

--- a/README.md
+++ b/README.md
@@ -66,15 +66,6 @@ Admins can configure Interactive learning from the plugin's configuration page i
 - **Auto-completion detection** – (Experimental) Enable automatic step completion when users perform actions themselves (without clicking "Do it" buttons)
 - **Timing settings** – Configure timeouts for requirement checks and guided steps to optimize the guide experience
 
-### Frontend telemetry
-
-Interactive learning sends frontend telemetry (errors and session data, via [Grafana Faro](https://grafana.com/oss/faro/)) to help us detect and fix bugs in the plugin. This telemetry:
-
-- Is only sent from Grafana Cloud instances – OSS and self-hosted instances never send it
-- Respects the instance-level analytics/reporting setting – disabling analytics reporting for your Grafana instance also disables this telemetry
-- Contains no user-identifying data (no user id, email, or IP)
-- Can be disabled fleet-wide independently of the plugin itself, without a release, if needed
-
 ## Creating interactive guides
 
 Editors and admins can author custom interactive guides in two ways:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -116,6 +116,17 @@ export default defineConfig([
   },
   ...baseConfig,
 
+  // console.warn/error must go through the Faro-backed logger (src/lib/logging.ts)
+  // so warnings and errors reach frontend observability. console.log/info/debug
+  // stay local-only by design. The CLI is a Node tool where console IS the output.
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['**/*.test.*', '**/*.spec.*', 'src/cli/**', 'src/test-utils/**', 'src/lib/logging.ts'],
+    rules: {
+      'no-console': ['error', { allow: ['log', 'info', 'debug'] }],
+    },
+  },
+
   // Phase 6: Security and architecture lint rules (Epic #603)
   // Mechanically enforce security patterns (F1, F5) and architecture patterns.
   // Test files are excluded — they legitimately use innerHTML for DOM setup/teardown.

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,6 +1,15 @@
 // Jest setup provided by Grafana scaffolding
 import './.config/jest-setup';
 
+// Prism (pulled in transitively via @grafana/ui) auto-highlights the whole
+// document on a rAF after load; in jsdom that sweep races tests that mock
+// document.querySelectorAll. Manual mode disables only the automatic sweep —
+// explicit Prism.highlightElement calls still work. Guarded because some
+// suites opt into `@jest-environment node`.
+if (typeof window !== 'undefined') {
+  window.Prism = { manual: true };
+}
+
 // Polyfill crypto.subtle for jsdom — used by session-crypto tests
 import { webcrypto } from 'crypto';
 if (!globalThis.crypto.subtle) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@emotion/css": "^11.13.5",
         "@grafana/assistant": "^0.1.25",
         "@grafana/data": "13.1.0",
-        "@grafana/faro-react": "^2.8.2",
+        "@grafana/faro-web-sdk": "^2.8.2",
         "@grafana/faro-web-tracing": "^2.8.2",
         "@grafana/i18n": "13.1.0",
         "@grafana/runtime": "13.1.0",
@@ -127,7 +127,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -176,7 +176,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
       "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -186,7 +186,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -217,14 +217,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -250,7 +250,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
@@ -267,7 +267,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -299,7 +299,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
@@ -345,7 +345,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -355,7 +355,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
       "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
@@ -1713,7 +1713,6 @@
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1723,7 +1722,6 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
       "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
@@ -1738,7 +1736,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1749,7 +1746,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1762,7 +1758,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.17.0"
@@ -1775,7 +1770,6 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -1788,7 +1782,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
       "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -1812,7 +1805,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1823,7 +1815,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -1833,7 +1824,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1856,7 +1846,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1869,7 +1858,6 @@
       "version": "9.39.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
       "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1882,7 +1870,6 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1892,7 +1879,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.17.0",
@@ -2143,34 +2129,6 @@
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/otlp-transformer": "^0.219.0"
-      }
-    },
-    "node_modules/@grafana/faro-react": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-react/-/faro-react-2.8.2.tgz",
-      "integrity": "sha512-Cd32yIDTIR+kqAZkP8m4Vpz84+/D77ODMyR9Ame7psCg89NwoA30m+C7lPWzkGdFpKJdX47Sd3JGzii+cVoXwQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grafana/faro-web-sdk": "^2.8.2",
-        "@grafana/faro-web-tracing": "^2.8.2",
-        "hoist-non-react-statics": "^3.3.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-router": "^7.12.0 || ^8.0.0",
-        "react-router-dom": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-router": {
-          "optional": true
-        },
-        "react-router-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/@grafana/faro-web-sdk": {
@@ -2716,7 +2674,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -2726,7 +2683,6 @@
       "version": "0.16.7",
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
@@ -2740,7 +2696,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -2754,7 +2709,6 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -7016,7 +6970,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -7156,7 +7109,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
@@ -7245,7 +7197,6 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -8851,7 +8802,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -8865,7 +8815,6 @@
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -8891,7 +8840,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -8930,7 +8878,6 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -9113,7 +9060,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/array-includes": {
@@ -9452,7 +9398,7 @@
       "version": "2.10.42",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
       "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -9514,7 +9460,6 @@
       "version": "1.20.5",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
       "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -9539,7 +9484,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -9549,7 +9493,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -9559,7 +9502,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -9580,7 +9522,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -9593,14 +9534,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/body-parser/node_modules/raw-body": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
       "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -9616,7 +9555,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -9740,7 +9678,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9894,7 +9832,7 @@
       "version": "1.0.30001769",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
       "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9915,7 +9853,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -10350,14 +10287,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -10400,7 +10335,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
@@ -10833,7 +10767,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -10923,7 +10856,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -11128,7 +11060,7 @@
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -11494,7 +11426,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11555,7 +11487,6 @@
       "version": "9.39.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
@@ -11809,7 +11740,6 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -11862,7 +11792,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11873,7 +11802,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -11883,7 +11811,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -11896,7 +11823,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -11928,7 +11854,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -11941,7 +11866,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -11963,7 +11887,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -11973,7 +11896,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -12088,7 +12010,6 @@
       "version": "4.22.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -12153,7 +12074,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -12163,14 +12083,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -12233,14 +12151,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-shallow-equal": {
@@ -12330,7 +12246,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -12367,7 +12282,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -12386,7 +12300,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -12396,7 +12309,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/find-root": {
@@ -12409,7 +12321,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -12436,7 +12347,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -12450,7 +12360,6 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/for-each": {
@@ -12633,7 +12542,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12807,7 +12715,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -13005,7 +12913,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -13077,7 +12984,6 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13156,7 +13062,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13420,7 +13325,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -13830,7 +13734,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -16576,7 +16479,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -16589,7 +16491,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
@@ -16602,14 +16503,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -16657,7 +16557,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -16703,7 +16602,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -16902,7 +16800,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -16931,7 +16828,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-update": {
@@ -17071,7 +16967,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -17198,7 +17094,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -17242,7 +17137,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -17268,7 +17162,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -17297,7 +17190,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -17310,7 +17202,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -17320,7 +17211,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -17615,14 +17505,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -17711,7 +17599,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -17941,7 +17829,6 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -17983,7 +17870,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -17999,7 +17885,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -18697,7 +18582,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -19037,7 +18921,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -20366,7 +20249,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -20634,7 +20516,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
       "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -20659,7 +20540,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -20669,14 +20549,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/send/node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -20696,7 +20574,6 @@
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
       "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
@@ -21323,7 +21200,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -21661,7 +21537,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21703,7 +21578,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -22362,7 +22236,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -22398,7 +22271,6 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -22503,7 +22375,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -22663,7 +22534,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -22700,7 +22571,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -22740,7 +22610,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -23433,7 +23302,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23651,7 +23519,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -23735,7 +23603,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@grafana/assistant": "^0.1.25",
         "@grafana/data": "13.1.0",
         "@grafana/faro-web-sdk": "^2.8.2",
-        "@grafana/faro-web-tracing": "^2.8.2",
         "@grafana/i18n": "13.1.0",
         "@grafana/runtime": "13.1.0",
         "@grafana/scenes": "^8.0.0",
@@ -2140,25 +2139,6 @@
         "@grafana/faro-core": "^2.8.2",
         "ua-parser-js": "1.0.41",
         "web-vitals": "^5.1.0"
-      }
-    },
-    "node_modules/@grafana/faro-web-tracing": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-web-tracing/-/faro-web-tracing-2.8.2.tgz",
-      "integrity": "sha512-3MTOVHaW138Te2k1RTlM8a0WngYHwAJoSMX2EcZNn9elq1/5eNADN+75k89jYcCtcdiQAIq/hmT2WfRtUTD+kQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grafana/faro-web-sdk": "^2.8.2",
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
-        "@opentelemetry/instrumentation": "^0.219.0",
-        "@opentelemetry/instrumentation-fetch": "^0.219.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.219.0",
-        "@opentelemetry/otlp-transformer": "^0.219.0",
-        "@opentelemetry/resources": "^2.0.0",
-        "@opentelemetry/sdk-trace-web": "^2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.32.0"
       }
     },
     "node_modules/@grafana/faro-webpack-plugin": {
@@ -4601,126 +4581,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.219.0.tgz",
-      "integrity": "sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.219.0",
-        "@opentelemetry/otlp-transformer": "0.219.0",
-        "@opentelemetry/resources": "2.8.0",
-        "@opentelemetry/sdk-trace-base": "2.8.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.219.0.tgz",
-      "integrity": "sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.219.0",
-        "import-in-the-middle": "^3.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-fetch": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.219.0.tgz",
-      "integrity": "sha512-nhjrhJ/tlE+1I1950dJkcl0xCGf7IrZGwWHS0X5J4gZtqP4YD+qp/gVfXkzZZBjFDx+39IaDQLS296E+Pcw5Tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/instrumentation": "0.219.0",
-        "@opentelemetry/sdk-trace-web": "2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-fetch/node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.8.0.tgz",
-      "integrity": "sha512-P3ZM8BGJ5mwjtyfAxRyxsCyWHvaj+xahdhLoS3YiPsEyTHcWTVzx2691C8SrGkpvro3tNFCsWuNNrvM+spKODg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/sdk-trace-base": "2.8.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.219.0.tgz",
-      "integrity": "sha512-R1qn0xVh4OPFta1A2hMgYiOpxUWdZlYuol4ZqQLYonklgo+gQTCtQyAVco/5FqM34h2mYd6KRQfo3kjiQdUe4A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/instrumentation": "0.219.0",
-        "@opentelemetry/sdk-trace-web": "2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-xml-http-request/node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.8.0.tgz",
-      "integrity": "sha512-P3ZM8BGJ5mwjtyfAxRyxsCyWHvaj+xahdhLoS3YiPsEyTHcWTVzx2691C8SrGkpvro3tNFCsWuNNrvM+spKODg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/sdk-trace-base": "2.8.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
-      "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/otlp-transformer": "0.219.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/otlp-transformer": {
       "version": "0.219.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
@@ -4791,23 +4651,6 @@
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
-      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
@@ -4816,72 +4659,6 @@
       "dependencies": {
         "@opentelemetry/core": "2.8.0",
         "@opentelemetry/resources": "2.8.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.9.0.tgz",
-      "integrity": "sha512-LS4XlzOK3e6YYdt84m15AmRR04121rKipmifi4XFZToH1h75f7F2bzHLbB1NMgIEYJ0jSKYm4VsK5mws/5kfTQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/sdk-trace-base": "2.9.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/resources": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
-      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
-      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.9.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-trace": "2.9.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
-      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.9.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -9975,6 +9752,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/classnames": {
@@ -11319,6 +11097,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
       "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -13673,20 +13452,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-in-the-middle": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.0.tgz",
-      "integrity": "sha512-v4+k+PLt4z6g2ydEcXhfinTJxfgKJDWOW0v0GZNA5n2qToHFObpH4nGLhJdwnXnX4T14oREx/M62dS9GkpmSbQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "cjs-module-lexer": "^2.2.0",
-        "es-module-lexer": "^2.2.0",
-        "module-details-from-path": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/import-local": {
@@ -17401,12 +17166,6 @@
         "node": ">0.9"
       }
     },
-    "node_modules/module-details-from-path": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-      "license": "MIT"
-    },
     "node_modules/moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -19902,19 +19661,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-in-the-middle": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
-      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/require-main-filename": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@emotion/css": "^11.13.5",
     "@grafana/assistant": "^0.1.25",
     "@grafana/data": "13.1.0",
-    "@grafana/faro-react": "^2.8.2",
+    "@grafana/faro-web-sdk": "^2.8.2",
     "@grafana/faro-web-tracing": "^2.8.2",
     "@grafana/i18n": "13.1.0",
     "@grafana/runtime": "13.1.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "@grafana/assistant": "^0.1.25",
     "@grafana/data": "13.1.0",
     "@grafana/faro-web-sdk": "^2.8.2",
-    "@grafana/faro-web-tracing": "^2.8.2",
     "@grafana/i18n": "13.1.0",
     "@grafana/runtime": "13.1.0",
     "@grafana/scenes": "^8.0.0",

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -36,6 +36,7 @@ class PluginErrorBoundary extends Component<{ children: ReactNode }, ErrorBounda
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // eslint-disable-next-line no-console -- local debug output; pushFaroError below already reports to Faro
     console.error('Pathfinder plugin error:', error, errorInfo);
     this.setState({ errorInfo });
 

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,6 +1,4 @@
 import { AppRootProps, GrafanaTheme2 } from '@grafana/data';
-// TODO: Re-enable Faro once collector CORS is configured correctly
-// import { faro } from '@grafana/faro-react';
 import React, { useMemo, useEffect, Component, ReactNode } from 'react';
 import { SceneApp } from '@grafana/scenes';
 import { Button, useStyles2 } from '@grafana/ui';
@@ -13,6 +11,7 @@ import { PluginPropsContext } from '../../utils/utils.plugin';
 import { getConfigWithDefaults } from '../../constants';
 import { onPluginStart } from '../../context-engine';
 import { PathfinderFeatureProvider } from '../OpenFeatureProvider';
+import { pauseFaroBeforeReload, pushFaroError } from '../../lib/faro';
 
 /**
  * Error Boundary to catch render errors in the plugin tree (R6)
@@ -40,18 +39,10 @@ class PluginErrorBoundary extends Component<{ children: ReactNode }, ErrorBounda
     console.error('Pathfinder plugin error:', error, errorInfo);
     this.setState({ errorInfo });
 
-    // TODO: Re-enable Faro once collector CORS is configured correctly
-    // Report error to Faro if available
-    // try {
-    //   faro.api?.pushError(error, {
-    //     context: {
-    //       componentStack: errorInfo.componentStack ?? 'unknown',
-    //       source: 'PluginErrorBoundary',
-    //     },
-    //   });
-    // } catch {
-    //   // Faro may not be initialized, ignore silently
-    // }
+    pushFaroError(error, {
+      componentStack: errorInfo.componentStack ?? 'unknown',
+      source: 'PluginErrorBoundary',
+    });
   }
 
   handleReset = () => {
@@ -84,7 +75,14 @@ function ErrorFallback({ error, onReset }: { error: Error | null; onReset: () =>
           <Button variant="primary" onClick={onReset} data-testid={testIds.app.errorTryAgain}>
             Try Again
           </Button>
-          <Button variant="secondary" onClick={() => window.location.reload()} data-testid={testIds.app.errorRefresh}>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              pauseFaroBeforeReload();
+              window.location.reload();
+            }}
+            data-testid={testIds.app.errorRefresh}
+          >
             Refresh Page
           </Button>
         </div>

--- a/src/components/AppConfig/ConfigurationForm.tsx
+++ b/src/components/AppConfig/ConfigurationForm.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../constants';
 import { updatePluginSettings } from '../../utils/utils.plugin';
 import { isDevModeEnabled, toggleDevMode } from '../../utils/dev-mode';
+import { logger } from '../../lib/logging';
 import { config, getBackendSrv } from '@grafana/runtime';
 
 type JsonData = DocsPluginConfig;
@@ -134,7 +135,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
         window.location.reload();
       }, 500);
     } catch (error) {
-      console.error('Failed to toggle dev mode:', error);
+      logger.error('Failed to toggle dev mode', { error });
 
       // Show user-friendly error message
       const errorMessage =
@@ -164,7 +165,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
         window.location.reload();
       }, 500);
     } catch (error) {
-      console.error('Failed to toggle assistant dev mode:', error);
+      logger.error('Failed to toggle assistant dev mode', { error });
 
       const errorMessage =
         error instanceof Error ? error.message : 'Failed to toggle assistant dev mode. You may need admin permissions.';
@@ -275,7 +276,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
           window.location.reload();
         }, 500);
       } catch (error) {
-        console.error('Failed to register with Coda:', error);
+        logger.error('Failed to register with Coda', { error });
         const errorMessage =
           error instanceof Error ? error.message : 'Failed to register with Coda. Please check your enrollment key.';
         setRegistrationError(errorMessage);
@@ -392,11 +393,11 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
         try {
           window.location.reload();
         } catch (e) {
-          console.error('Failed to reload page after saving configuration', e);
+          logger.error('Failed to reload page after saving configuration', { error: e });
         }
       }, 100);
     } catch (error) {
-      console.error('Error saving configuration:', error);
+      logger.error('Error saving configuration', { error });
       const errorMessage = error instanceof Error ? error.message : 'Failed to save configuration. Please try again.';
       if (state.enableCodaTerminal && state.codaEnrollmentKey && !codaRegistered) {
         setRegistrationError(errorMessage);

--- a/src/components/AppConfig/InteractiveFeatures.tsx
+++ b/src/components/AppConfig/InteractiveFeatures.tsx
@@ -16,6 +16,7 @@ import {
   getConfigWithDefaults,
 } from '../../constants';
 import { updatePluginSettings } from '../../utils/utils.plugin';
+import { logger } from '../../lib/logging';
 
 type JsonData = DocsPluginConfig;
 
@@ -158,13 +159,13 @@ const InteractiveFeatures = ({ plugin }: InteractiveFeaturesProps) => {
         try {
           window.location.reload();
         } catch (e) {
-          console.error('Failed to reload page after saving settings', e);
+          logger.error('Failed to reload page after saving settings', { error: e });
         }
       }, 100);
 
       setIsSaving(false);
     } catch (error) {
-      console.error('Error saving Interactive Features:', error);
+      logger.error('Error saving Interactive Features', { error });
       setIsSaving(false);
       throw error;
     }

--- a/src/components/AppConfig/TermsAndConditions.tsx
+++ b/src/components/AppConfig/TermsAndConditions.tsx
@@ -7,6 +7,7 @@ import { DocsPluginConfig, TERMS_VERSION, getConfigWithDefaults } from '../../co
 import { TERMS_AND_CONDITIONS_CONTENT } from './terms-content';
 import { updatePluginSettings } from '../../utils/utils.plugin';
 import { sanitizeDocumentationHTML } from '../../security/html-sanitizer';
+import { logger } from '../../lib/logging';
 
 type JsonData = DocsPluginConfig & {
   isDocsPasswordSet?: boolean;
@@ -56,14 +57,14 @@ const TermsAndConditions = ({ plugin }: TermsAndConditionsProps) => {
         try {
           window.location.reload();
         } catch (e) {
-          console.error('Failed to reload page after saving settings', e);
+          logger.error('Failed to reload page after saving settings', { error: e });
         }
       }, 100);
 
       // Reset saving state - let Grafana's plugin context system handle the refresh
       setIsSaving(false);
     } catch (error) {
-      console.error('Error saving Terms and Conditions:', error);
+      logger.error('Error saving Terms and Conditions', { error });
       setIsSaving(false);
       // Re-throw to let user know something went wrong
       throw error;

--- a/src/components/ControlGroupDocPopup.tsx
+++ b/src/components/ControlGroupDocPopup.tsx
@@ -11,6 +11,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import grotDiscouragedSvg from '../img/Grot-Emotions-Discouraged.svg';
 import { reportAppInteraction, UserInteraction } from '../lib/analytics';
+import { logger } from '../lib/logging';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   content: css({
@@ -87,6 +88,6 @@ export async function showControlGroupDocPopup(source = 'url_param'): Promise<vo
       source,
     });
   } catch (err) {
-    console.error('[Pathfinder] Failed to load control group popup:', err);
+    logger.error('[Pathfinder] Failed to load control group popup', { error: err });
   }
 }

--- a/src/components/LiveSession/AttendeeJoin.tsx
+++ b/src/components/LiveSession/AttendeeJoin.tsx
@@ -12,6 +12,7 @@ import { parseJoinCode, parseSessionFromUrl, useSession } from '../../integratio
 import { FOLLOW_MODE_ENABLED } from '../../integrations/workshop/flags';
 import type { SessionOffer, AttendeeMode } from '../../types/collaboration.types';
 import { testIds } from '../../constants/testIds';
+import { logger } from '../../lib/logging';
 
 /**
  * Get user-friendly error guidance based on error type
@@ -224,7 +225,7 @@ export function AttendeeJoin({ isOpen, onClose, onJoined }: AttendeeJoinProps) {
       onJoined();
       onClose();
     } catch (err) {
-      console.error('[AttendeeJoin] Failed to join session:', err);
+      logger.error('[AttendeeJoin] Failed to join session', { error: err });
       setError(err); // Store the actual error for better guidance
       setIsJoining(false);
     }

--- a/src/components/LiveSession/PresenterControls.tsx
+++ b/src/components/LiveSession/PresenterControls.tsx
@@ -12,6 +12,7 @@ import { useSession } from '../../integrations/workshop';
 import { ConnectionIndicator } from './ConnectionIndicator';
 import type { SessionConfig, AttendeeInfo } from '../../types/collaboration.types';
 import { testIds } from '../../constants/testIds';
+import { logger } from '../../lib/logging';
 
 /**
  * Props for PresenterControls
@@ -60,7 +61,7 @@ export function PresenterControls({ tutorialUrl }: PresenterControlsProps) {
       await createSession(config);
       console.log('[PresenterControls] Session created successfully');
     } catch (err) {
-      console.error('[PresenterControls] Failed to create session:', err);
+      logger.error('[PresenterControls] Failed to create session', { error: err });
       setError('Failed to create session. Please try again.');
     } finally {
       setIsCreating(false);
@@ -76,7 +77,7 @@ export function PresenterControls({ tutorialUrl }: PresenterControlsProps) {
       setCopied(type);
       setTimeout(() => setCopied(null), 2000);
     } catch (error) {
-      console.error('[PresenterControls] Failed to copy:', error);
+      logger.error('[PresenterControls] Failed to copy', { error });
     }
   };
 

--- a/src/components/PrTester/PrTester.tsx
+++ b/src/components/PrTester/PrTester.tsx
@@ -22,6 +22,7 @@ import type { ManifestJson } from '../../types/package.types';
 import type { PackageOpenInfo } from '../../types/content-panel.types';
 import { testIds } from '../../constants/testIds';
 import { StorageKeys } from '../../lib/storage-keys';
+import { logger } from '../../lib/logging';
 
 const PR_URL_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_URL;
 const SELECTED_FILE_STORAGE_KEY = StorageKeys.DEVTOOLS_PR_TESTER_SELECTED_FILE;
@@ -293,7 +294,7 @@ export function PrTester({ onOpenDocsPage }: PrTesterProps) {
         // this block must still flip us out of the loading state or path mode
         // is stranded on "Loading…" with no recovery.
         if (!cancelled && !controller.signal.aborted) {
-          console.error('[PrTester] PR metadata preload failed', error);
+          logger.error('[PrTester] PR metadata preload failed', { error });
           setAllManifests(new Map());
           setPrContentById(new Map());
         }

--- a/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
+++ b/src/components/SelectorDebugPanel/SelectorDebugPanel.tsx
@@ -5,6 +5,7 @@ import { UrlTester } from 'components/UrlTester';
 import { PrTester } from 'components/PrTester';
 import type { PackageOpenInfo } from 'types/content-panel.types';
 import { StorageKeys } from 'lib/storage-keys';
+import { logger } from 'lib/logging';
 import { usePersistedBoolean } from '../../hooks';
 
 export interface SelectorDebugPanelProps {
@@ -45,7 +46,7 @@ export function SelectorDebugPanel({ onOpenDocsPage, onOpenLearningJourney }: Se
 
       window.location.reload();
     } catch (error) {
-      console.error('Failed to disable dev mode:', error);
+      logger.error('Failed to disable dev mode', { error });
 
       // Show user-friendly error message
       const errorMessage = error instanceof Error ? error.message : 'Failed to disable dev mode. Please try again.';

--- a/src/components/block-editor/BlockEditor.tsx
+++ b/src/components/block-editor/BlockEditor.tsx
@@ -40,6 +40,7 @@ import { HealthStatusBar } from './HealthStatusBar';
 import { ConfirmModal } from './NotificationModals';
 import { BACKEND_TRACKING_STORAGE_KEY, DEFAULT_GUIDE_METADATA } from './constants';
 import { testIds } from '../../constants/testIds';
+import { logger } from '../../lib/logging';
 import {
   assignNestedInstanceId,
   findSectionNestedBlockByInstanceId,
@@ -852,7 +853,7 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
           currentGuideBackendStatus
         );
       } catch (error) {
-        console.error('[BlockEditor] Failed to save guide:', error);
+        logger.error('[BlockEditor] Failed to save guide', { error });
         notify('error', 'Save failed', error instanceof Error ? error.message : 'Unknown error');
       }
     },
@@ -885,7 +886,7 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
       setLastPublishedJson(JSON.stringify(editor.getGuide()));
       notify('success', 'Guide unpublished.');
     } catch (error) {
-      console.error('[BlockEditor] Failed to unpublish guide:', error);
+      logger.error('[BlockEditor] Failed to unpublish guide', { error });
       notify('error', 'Unpublish failed', error instanceof Error ? error.message : 'Unknown error');
     }
   }, [backendGuides, currentGuideResourceName, currentGuideMetadata, editor]);

--- a/src/components/block-editor/ElementPicker.tsx
+++ b/src/components/block-editor/ElementPicker.tsx
@@ -12,6 +12,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import { generateSelectorFromEvent, generateFullDomPath } from '../../utils/devtools';
 import { DomPathTooltip } from '../DomPathTooltip';
+import { logger } from '../../lib/logging';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   overlay: css({
@@ -165,14 +166,14 @@ export function ElementPicker({ onSelect, onCancel }: ElementPickerProps) {
       const target = getElementUnderCursor(clientX, clientY);
 
       if (!target) {
-        console.warn('[ElementPicker] No element found under cursor');
+        logger.warn('[ElementPicker] No element found under cursor');
         return;
       }
 
       const result = generateSelectorFromEvent(target, event);
 
       if (result.warnings.length > 0) {
-        console.warn('[ElementPicker] Selector warnings:', result.warnings);
+        logger.warn('[ElementPicker] Selector warnings', { warnings: result.warnings });
       }
 
       onSelect(result.selector);

--- a/src/components/block-editor/hooks/useBackendGuides.ts
+++ b/src/components/block-editor/hooks/useBackendGuides.ts
@@ -8,6 +8,7 @@ import { lastValueFrom } from 'rxjs';
 import type { JsonGuide } from '../types';
 import { fetchBackendGuides } from '../../../utils/fetchBackendGuides';
 import { stripAuthorNotes } from '../utils/block-export';
+import { logger } from '../../../lib/logging';
 
 interface BackendGuide {
   metadata: {
@@ -78,7 +79,7 @@ export function useBackendGuides(): UseBackendGuidesReturn {
       }
       return fetchedGuides;
     } catch (err) {
-      console.error('[useBackendGuides] Failed to fetch guides:', err);
+      logger.error('[useBackendGuides] Failed to fetch guides', { error: err });
       if (isMountedRef.current) {
         setError(err instanceof Error ? err.message : 'Failed to fetch guides');
       }
@@ -309,7 +310,7 @@ export function useBackendGuides(): UseBackendGuidesReturn {
         // Refresh the list after deleting
         await refreshGuides();
       } catch (err) {
-        console.error('[useBackendGuides] Failed to delete guide:', err);
+        logger.error('[useBackendGuides] Failed to delete guide', { error: err });
         throw err;
       }
     },

--- a/src/components/block-editor/hooks/useBlockConversionHandlers.ts
+++ b/src/components/block-editor/hooks/useBlockConversionHandlers.ts
@@ -16,6 +16,7 @@ import type { JsonInteractiveBlock, JsonMultistepBlock, JsonGuidedBlock } from '
 import { convertBlockType } from '../utils/block-conversion';
 import { stepGuidedToMultistep, stepMultistepToGuided } from '../utils/stepFieldMapping';
 import type { NestedBlockEditingState, ConditionalBranchEditingState } from './useBlockFormState';
+import { logger } from '../../../lib/logging';
 
 /**
  * Minimal interface for editor functionality needed by this hook.
@@ -207,7 +208,7 @@ export function useBlockConversionHandlers(
     (newType: BlockType) => {
       const sourceBlock = editingConditionalBranchBlock?.block ?? editingNestedBlock?.block ?? editingBlock?.block;
       if (!sourceBlock) {
-        console.warn('handleSwitchBlockType called with no active block');
+        logger.warn('handleSwitchBlockType called with no active block');
         return;
       }
 
@@ -243,7 +244,7 @@ export function useBlockConversionHandlers(
         // Update block type - triggers form remount via key prop change
         setEditingBlockType(newType);
       } catch (error) {
-        console.error('Failed to convert block type:', error);
+        logger.error('Failed to convert block type', { error });
         getAppEvents().publish({
           type: 'alert-error',
           payload: ['Conversion failed', 'Could not convert to the selected block type.'],

--- a/src/components/block-editor/hooks/useBlockPersistence.test.ts
+++ b/src/components/block-editor/hooks/useBlockPersistence.test.ts
@@ -183,7 +183,7 @@ describe('useBlockPersistence — load() / clear() / hasSavedGuide / getLastSave
     const loaded = result.current.load();
 
     expect(loaded?.title).toBe('legacy');
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('version mismatch'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('version mismatch'), '');
     warnSpy.mockRestore();
   });
 

--- a/src/components/block-editor/hooks/useBlockPersistence.ts
+++ b/src/components/block-editor/hooks/useBlockPersistence.ts
@@ -7,6 +7,7 @@
 import { useEffect, useCallback, useRef } from 'react';
 import { BLOCK_EDITOR_STORAGE_KEY } from '../constants';
 import type { JsonGuide } from '../types';
+import { logger } from '../../../lib/logging';
 
 /**
  * Debounce delay for auto-save (ms)
@@ -91,7 +92,7 @@ export function useBlockPersistence({
       // Notify that save was successful
       onSave?.();
     } catch (e) {
-      console.error('Failed to save guide to localStorage:', e);
+      logger.error('Failed to save guide to localStorage', { error: e });
     }
   }, [guide, blockIds, storageKey, onSave]);
 
@@ -107,12 +108,12 @@ export function useBlockPersistence({
 
       // Version check for future migrations
       if (parsed.version !== STORAGE_VERSION) {
-        console.warn('Stored guide version mismatch, may need migration');
+        logger.warn('Stored guide version mismatch, may need migration');
       }
 
       return parsed.guide;
     } catch (e) {
-      console.error('Failed to load guide from localStorage:', e);
+      logger.error('Failed to load guide from localStorage', { error: e });
       return null;
     }
   }, [storageKey]);
@@ -123,7 +124,7 @@ export function useBlockPersistence({
       localStorage.removeItem(storageKey);
       lastGuideRef.current = '';
     } catch (e) {
-      console.error('Failed to clear guide from localStorage:', e);
+      logger.error('Failed to clear guide from localStorage', { error: e });
     }
   }, [storageKey]);
 
@@ -195,7 +196,7 @@ export function useBlockPersistence({
           onLoad(parsed.guide, parsed.blockIds);
         }
       } catch (e) {
-        console.error('Failed to load guide from localStorage:', e);
+        logger.error('Failed to load guide from localStorage', { error: e });
       }
     }
     // Only run on mount

--- a/src/components/block-editor/hooks/useGuidePreviewProgress.ts
+++ b/src/components/block-editor/hooks/useGuidePreviewProgress.ts
@@ -4,6 +4,7 @@ import { StorageEvents } from '../../../lib/event-names';
 import { evictContentCache } from '../../../global-state/completion-store';
 import { getContentKey } from '../../../global-state/content-key';
 import { subscribeProgressEvent } from '../../../global-state/progress-events';
+import { logger } from '../../../lib/logging';
 
 export interface GuidePreviewProgress {
   hasProgress: boolean;
@@ -83,7 +84,7 @@ export function useGuidePreviewProgress(progressKey: string): GuidePreviewProgre
         })
       );
     } catch (error) {
-      console.error('[useGuidePreviewProgress] Failed to reset progress:', error);
+      logger.error('[useGuidePreviewProgress] Failed to reset progress', { error });
     }
   }, [progressKey]);
 

--- a/src/components/block-editor/hooks/useRecordingPersistence.ts
+++ b/src/components/block-editor/hooks/useRecordingPersistence.ts
@@ -8,6 +8,7 @@
 import { useEffect, useCallback, useRef } from 'react';
 import { RECORDING_STATE_STORAGE_KEY } from '../constants';
 import type { RecordedStep } from '../../../utils/devtools/tutorial-exporter';
+import { logger } from '../../../lib/logging';
 
 /**
  * State that needs to be persisted for recording mode
@@ -91,7 +92,7 @@ export function useRecordingPersistence({
       };
       localStorage.setItem(RECORDING_STATE_STORAGE_KEY, JSON.stringify(state));
     } catch (e) {
-      console.error('Failed to save recording state to localStorage:', e);
+      logger.error('Failed to save recording state to localStorage', { error: e });
     }
   }, [isRecording, recordingIntoSection, recordingIntoConditionalBranch, recordingStartUrl, recordedSteps]);
 
@@ -104,7 +105,7 @@ export function useRecordingPersistence({
       }
       return JSON.parse(stored) as PersistedRecordingState;
     } catch (e) {
-      console.error('Failed to load recording state from localStorage:', e);
+      logger.error('Failed to load recording state from localStorage', { error: e });
       return null;
     }
   }, []);
@@ -114,7 +115,7 @@ export function useRecordingPersistence({
     try {
       localStorage.removeItem(RECORDING_STATE_STORAGE_KEY);
     } catch (e) {
-      console.error('Failed to clear recording state from localStorage:', e);
+      logger.error('Failed to clear recording state from localStorage', { error: e });
     }
   }, []);
 

--- a/src/components/block-editor/utils/block-conversion.ts
+++ b/src/components/block-editor/utils/block-conversion.ts
@@ -11,6 +11,7 @@
 import { JsonBlockSchema, KNOWN_FIELDS } from '../../../types/json-guide.schema';
 import type { BlockType } from '../types';
 import type { JsonBlock } from '../../../types/json-guide.types';
+import { logger } from '../../../lib/logging';
 
 // ============ Configuration Maps ============
 
@@ -222,7 +223,7 @@ export function convertBlockType(source: JsonBlock, targetType: BlockType): Json
   // 5. Validate against schema
   const result = JsonBlockSchema.safeParse(converted);
   if (!result.success) {
-    console.error('Block conversion produced invalid block:', result.error);
+    logger.error('Block conversion produced invalid block', { error: result.error });
     throw new Error(`Conversion to ${targetType} failed validation: ${result.error.message}`);
   }
 

--- a/src/components/block-editor/utils/block-export.ts
+++ b/src/components/block-editor/utils/block-export.ts
@@ -6,6 +6,7 @@
 
 import type { JsonBlock, JsonGuide, JsonStep } from '../types';
 import { validateGuide as validateGuideCanonical, validateGuideFromString, toLegacyResult } from '../../../validation';
+import { logger } from '../../../lib/logging';
 
 /**
  * Recursively remove editor-only `authorNote` fields from every block in
@@ -128,10 +129,7 @@ export function formatGuideJson(guide: JsonGuide): string {
 export function parseGuideJson(json: string): JsonGuide | null {
   const result = validateGuideFromString(json, { skipUnknownFieldCheck: true });
   if (!result.isValid || !result.guide) {
-    console.error(
-      'Invalid guide JSON:',
-      result.errors.map((e) => e.message)
-    );
+    logger.error('Invalid guide JSON', { errors: result.errors.map((e) => e.message) });
     return null;
   }
   return result.guide;

--- a/src/components/block-editor/utils/github-pr.ts
+++ b/src/components/block-editor/utils/github-pr.ts
@@ -7,6 +7,7 @@
 
 import type { JsonGuide } from '../types';
 import { validateGuide, formatFileSize } from './block-export';
+import { logger } from '../../../lib/logging';
 
 /**
  * GitHub repository configuration
@@ -98,7 +99,7 @@ async function copyToClipboard(json: string): Promise<boolean> {
     await navigator.clipboard.writeText(json);
     return true;
   } catch (e) {
-    console.warn('Clipboard copy failed:', e);
+    logger.warn('Clipboard copy failed', { error: e });
     return false;
   }
 }

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -4,6 +4,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { TabsBar, Tab, TabContent, Badge, Tooltip, LoadingPlaceholder } from '@grafana/ui';
 
 import { RawContent, ContentParseResult } from '../../types/content.types';
+import { logger } from '../../lib/logging';
 import {
   parseHTMLToComponents,
   ParsedElement,
@@ -87,10 +88,10 @@ function scrollToFragment(fragment: string, container: HTMLElement): void {
         targetElement!.classList.remove('fragment-highlight');
       }, 3000);
     } else {
-      console.warn(`Fragment element not found: #${fragment}`);
+      logger.warn(`Fragment element not found: #${fragment}`);
     }
   } catch (error) {
-    console.warn(`Error scrolling to fragment #${fragment}:`, error);
+    logger.warn(`Error scrolling to fragment #${fragment}`, { error });
   }
 }
 
@@ -679,7 +680,7 @@ function ContentProcessor({ html, contentType, baseUrl, onReady, responses }: Co
 
   // Single decision point: either we have valid React components or we display errors
   if (!parseResult.isValid) {
-    console.error('Content parsing failed:', parseResult.errors);
+    logger.error('Content parsing failed', { errors: parseResult.errors });
     return (
       <div ref={ref}>
         <ContentParsingError
@@ -698,7 +699,7 @@ function ContentProcessor({ html, contentType, baseUrl, onReady, responses }: Co
   const { data: parsedContent } = parseResult;
 
   if (!parsedContent) {
-    console.error('[DocsPlugin] Parsing succeeded but no data returned');
+    logger.error('[DocsPlugin] Parsing succeeded but no data returned');
     return (
       <div ref={ref}>
         <ContentParsingError
@@ -826,7 +827,7 @@ function TabsWrapper({ element }: { element: ParsedElement }) {
   const activeTab = selectedTab || tabsData[0]?.key || '';
 
   if (!tabsBarElement || !tabContentElement) {
-    console.warn('Missing required tabs elements');
+    logger.warn('Missing required tabs elements');
     return null;
   }
 
@@ -875,7 +876,7 @@ function TabContentRenderer({ html }: { html: string }) {
 
   if (!parseResult.isValid || !parseResult.data) {
     // SECURITY: No dangerouslySetInnerHTML fallback - return null on parse failure
-    console.error('TabContentRenderer: Failed to parse content.');
+    logger.error('TabContentRenderer: Failed to parse content.');
     return null;
   }
 
@@ -1343,7 +1344,7 @@ function renderParsedElement(
       );
     case 'raw-html':
       // SECURITY: raw-html type is removed - all HTML must go through the parser
-      console.error('raw-html element type encountered - this should have been caught during parsing');
+      logger.error('raw-html element type encountered - this should have been caught during parsing');
       return null;
     default:
       // Handle tabs root
@@ -1400,7 +1401,7 @@ function renderParsedElement(
 
       // Standard HTML elements - strict validation
       if (!element.type || (typeof element.type !== 'string' && typeof element.type !== 'function')) {
-        console.error('Invalid element type for parsed element:', element);
+        logger.error('Invalid element type for parsed element', { element });
         throw new Error(`Invalid element type: ${element.type}. This should have been caught during parsing.`);
       }
 

--- a/src/components/docs-panel/components/MyLearningErrorBoundary.tsx
+++ b/src/components/docs-panel/components/MyLearningErrorBoundary.tsx
@@ -5,6 +5,7 @@
 
 import React, { Component, ReactNode } from 'react';
 import { Icon, Button } from '@grafana/ui';
+import { pushFaroError } from '../../../lib/faro';
 
 interface MyLearningErrorBoundaryState {
   hasError: boolean;
@@ -29,6 +30,7 @@ export class MyLearningErrorBoundary extends Component<MyLearningErrorBoundaryPr
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('MyLearningTab error:', error, errorInfo);
+    pushFaroError(error, { componentStack: errorInfo.componentStack ?? 'unknown', source: 'MyLearningErrorBoundary' });
   }
 
   render() {

--- a/src/components/docs-panel/components/MyLearningErrorBoundary.tsx
+++ b/src/components/docs-panel/components/MyLearningErrorBoundary.tsx
@@ -29,6 +29,7 @@ export class MyLearningErrorBoundary extends Component<MyLearningErrorBoundaryPr
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    // eslint-disable-next-line no-console -- local debug output; pushFaroError below already reports to Faro
     console.error('MyLearningTab error:', error, errorInfo);
     pushFaroError(error, { componentStack: errorInfo.componentStack ?? 'unknown', source: 'MyLearningErrorBoundary' });
   }

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -17,6 +17,7 @@ import { getSkeletonStyles } from '../../styles/skeleton.styles';
 import { useContextPanel, Recommendation } from '../../context-engine';
 import type { ResolvedNavLink } from '../../types/context.types';
 import { reportAppInteraction, UserInteraction, getContentTypeForAnalytics } from '../../lib/analytics';
+import { logger } from '../../lib/logging';
 import { getConfigWithDefaults, PLUGIN_BASE_URL } from '../../constants';
 import { isDevModeEnabled } from '../../utils/dev-mode';
 import { testIds } from '../../constants/testIds';
@@ -110,7 +111,7 @@ const getRecommendationContentUrl = (recommendation: Recommendation): string => 
   if (recommendation.type === 'package') {
     const url = recommendation.contentUrl ?? '';
     if (!url && process.env.NODE_ENV !== 'production') {
-      console.warn('[context-panel] Package recommendation missing contentUrl:', recommendation.title);
+      logger.warn('[context-panel] Package recommendation missing contentUrl', { title: recommendation.title });
     }
     return url;
   }
@@ -200,7 +201,7 @@ export class ContextPanel extends SceneObjectBase<ContextPanelState> {
     if (this.state.onOpenDocsPage) {
       this.state.onOpenDocsPage(url, title, packageInfo);
     } else {
-      console.warn('No onOpenDocsPage callback available');
+      logger.warn('No onOpenDocsPage callback available');
     }
   }
 

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -30,6 +30,7 @@ import { useLinkClickHandler } from './link-handler.hook';
 import { isDevModeEnabled } from '../../utils/dev-mode';
 
 import { reportAppInteraction, UserInteraction, getContentTypeForAnalytics } from '../../lib/analytics';
+import { logger } from '../../lib/logging';
 import { tabStorage, useUserStorage } from '../../lib/user-storage';
 import { useGuideProgressState, useAutoLaunchTutorial, type AutoLaunchTutorialDetail } from '../../hooks';
 import {
@@ -266,7 +267,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       // Save both tabs and active tab
       await Promise.all([tabStorage.setTabs(tabsToSave), tabStorage.setActiveTab(this.state.activeTabId)]);
     } catch (error) {
-      console.error('Failed to save tabs to storage:', error);
+      logger.error('Failed to save tabs to storage', { error });
     }
   }
 
@@ -274,7 +275,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     try {
       await tabStorage.clear();
     } catch (error) {
-      console.error('Failed to clear persisted tabs:', error);
+      logger.error('Failed to clear persisted tabs', { error });
     }
   }
 
@@ -440,7 +441,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
         this.failTab(tabId, result.error || 'Failed to load content');
       }
     } catch (error) {
-      console.error(`Failed to load journey content for tab ${tabId}:`, error);
+      logger.error(`Failed to load journey content for tab ${tabId}`, { error });
       this.failTab(tabId, error instanceof Error ? error.message : 'Failed to load content');
     }
   }
@@ -781,7 +782,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
         this.failTab(tabId, result.error || 'Failed to load documentation');
       }
     } catch (error) {
-      console.error(`Failed to load docs content for tab ${tabId}:`, error);
+      logger.error(`Failed to load docs content for tab ${tabId}`, { error });
       this.failTab(tabId, error instanceof Error ? error.message : 'Failed to load documentation');
     }
   }

--- a/src/components/docs-panel/hooks/useContentReset.ts
+++ b/src/components/docs-panel/hooks/useContentReset.ts
@@ -16,6 +16,7 @@ import {
   getContentTypeForAnalytics,
   enrichWithStepContext,
 } from '../../../lib/analytics';
+import { logger } from '../../../lib/logging';
 import { interactiveStepStorage, interactiveCompletionStorage } from '../../../lib/user-storage';
 import { StorageEvents } from '../../../lib/event-names';
 import { evictContentCache } from '../../../global-state/completion-store';
@@ -83,7 +84,7 @@ export function useContentReset({ model }: UseContentResetOptions) {
         model._recordAutoLaunchSource('internal_reload');
         await model.loadTab(activeTab.id, activeTab.currentUrl || activeTab.baseUrl);
       } catch (error) {
-        console.error('[DocsPanel] Failed to reset guide progress:', error);
+        logger.error('[DocsPanel] Failed to reset guide progress', { error });
         getAppEvents().publish({
           type: 'alert-error',
           payload: [

--- a/src/components/docs-panel/hooks/useGlobalActiveTabExposure.test.ts
+++ b/src/components/docs-panel/hooks/useGlobalActiveTabExposure.test.ts
@@ -1,8 +1,16 @@
 import { renderHook } from '@testing-library/react';
 import { useGlobalActiveTabExposure } from './useGlobalActiveTabExposure';
+import { setFaroView } from '../../../lib/faro';
+
+jest.mock('../../../lib/faro', () => ({
+  setFaroView: jest.fn(),
+}));
+
+const mockSetFaroView = setFaroView as jest.Mock;
 
 describe('useGlobalActiveTabExposure', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     delete (window as any).__DocsPluginActiveTabId;
     delete (window as any).__DocsPluginActiveTabUrl;
   });
@@ -45,6 +53,17 @@ describe('useGlobalActiveTabExposure', () => {
     );
     expect((window as any).__DocsPluginActiveTabId).toBe('');
     expect((window as any).__DocsPluginActiveTabUrl).toBe('');
+  });
+
+  it('mirrors the active URL (with baseUrl fallback) into the Faro view meta', () => {
+    renderHook(() =>
+      useGlobalActiveTabExposure({
+        activeTabId: 'tab-7',
+        activeTabCurrentUrl: 'https://example.com/cur',
+        activeTabBaseUrl: 'https://example.com/base',
+      })
+    );
+    expect(mockSetFaroView).toHaveBeenCalledWith('https://example.com/cur');
   });
 
   it('updates globals when props change across re-renders', () => {

--- a/src/components/docs-panel/hooks/useGlobalActiveTabExposure.ts
+++ b/src/components/docs-panel/hooks/useGlobalActiveTabExposure.ts
@@ -1,6 +1,7 @@
 /**
  * Exposes the active tab's id and URL on `window` for interactive persistence
- * keys (read by `InteractiveSection` during progress restoration).
+ * keys (read by `InteractiveSection` during progress restoration), and mirrors
+ * the active URL into Faro's view meta.
  *
  * MUST use `useLayoutEffect` (not `useEffect`) so the globals are set
  * synchronously before any child's passive `useEffect` runs. `useEffect`
@@ -17,6 +18,7 @@
  * in unusual host environments (e.g. some sandboxed Grafana embeds).
  */
 import * as React from 'react';
+import { setFaroView } from '../../../lib/faro';
 
 export interface UseGlobalActiveTabExposureParams {
   activeTabId: string | undefined;
@@ -36,5 +38,6 @@ export function useGlobalActiveTabExposure({
     } catch {
       // no-op
     }
+    setFaroView(activeTabCurrentUrl || activeTabBaseUrl || '');
   }, [activeTabId, activeTabCurrentUrl, activeTabBaseUrl]);
 }

--- a/src/components/docs-panel/link-handler.hook.ts
+++ b/src/components/docs-panel/link-handler.hook.ts
@@ -8,6 +8,7 @@ import {
   enrichWithStepContext,
   getContentTypeForAnalytics,
 } from '../../lib/analytics';
+import { logger } from '../../lib/logging';
 import { getJourneyProgress, getMilestoneSlug, markMilestoneDone } from '../../docs-retrieval';
 import {
   parseUrlSafely,
@@ -100,7 +101,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
             model.loadTab(activeTab.id, firstMilestone.url);
           }
         } else {
-          console.warn('No milestone URL found to navigate to');
+          logger.warn('No milestone URL found to navigate to');
         }
       }
 
@@ -158,7 +159,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
                 const baseUrl = new URL(currentPageUrl);
                 resolvedUrl = new URL(href, baseUrl).href;
               } catch (error) {
-                console.warn('Failed to resolve relative URL:', href, 'against base:', currentPageUrl, error);
+                logger.warn('Failed to resolve relative URL', { href, base: currentPageUrl, error });
                 // Fallback: assume it's relative to Grafana docs root
                 resolvedUrl = `https://grafana.com/docs/${href}`;
               }
@@ -180,7 +181,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
             try {
               fullUrl = new URL(resolvedUrl, baseUrl).href;
             } catch (error) {
-              console.warn('Failed to resolve URL against base:', resolvedUrl, baseUrl, error);
+              logger.warn('Failed to resolve URL against base', { url: resolvedUrl, base: baseUrl, error });
               // Fallback to grafana.com only if resolution fails
               fullUrl = `https://grafana.com${resolvedUrl}`;
             }
@@ -337,7 +338,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
             try {
               fullUrl = new URL(linkUrl, baseUrl).href;
             } catch (error) {
-              console.warn('Failed to resolve side journey URL:', linkUrl, error);
+              logger.warn('Failed to resolve side journey URL', { url: linkUrl, error });
               // Fallback to grafana.com only if resolution fails
               fullUrl = linkUrl.startsWith('/')
                 ? `https://grafana.com${linkUrl}`
@@ -425,7 +426,7 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
             try {
               fullUrl = new URL(linkUrl, baseUrl).href;
             } catch (error) {
-              console.warn('Failed to resolve related journey URL:', linkUrl, error);
+              logger.warn('Failed to resolve related journey URL', { url: linkUrl, error });
               // Fallback to grafana.com only if resolution fails
               fullUrl = linkUrl.startsWith('/')
                 ? `https://grafana.com${linkUrl}`

--- a/src/components/docs-panel/utils/tab-storage-restore.ts
+++ b/src/components/docs-panel/utils/tab-storage-restore.ts
@@ -10,6 +10,7 @@
 
 import { LearningJourneyTab, PersistedTabData } from '../../../types/content-panel.types';
 import { isAllowedContentUrl, isLocalhostUrl, isGitHubRawUrl } from '../../../security';
+import { logger } from '../../../lib/logging';
 
 /**
  * Tab storage interface for dependency injection
@@ -131,7 +132,7 @@ export async function restoreTabsFromStorage(
       const isValidCurrent = !data.currentUrl || validateUrl(data.currentUrl);
 
       if (!isValidBase || !isValidCurrent) {
-        console.warn('Rejected potentially unsafe URL from storage:', {
+        logger.warn('Rejected potentially unsafe URL from storage', {
           baseUrl: data.baseUrl,
           currentUrl: data.currentUrl,
           isValidBase,
@@ -155,7 +156,7 @@ export async function restoreTabsFromStorage(
 
     return tabs;
   } catch (error) {
-    console.error('Failed to restore tabs from storage:', error);
+    logger.error('Failed to restore tabs from storage', { error });
     return [
       {
         id: 'recommendations',
@@ -190,7 +191,7 @@ export async function restoreActiveTabFromStorage(tabStorage: TabStorage, tabs: 
       return tabExists ? activeTabId : 'recommendations';
     }
   } catch (error) {
-    console.error('Failed to restore active tab from storage:', error);
+    logger.error('Failed to restore active tab from storage', { error });
   }
 
   return 'recommendations';

--- a/src/components/interactive-tutorial/code-block-step.tsx
+++ b/src/components/interactive-tutorial/code-block-step.tsx
@@ -17,6 +17,7 @@ import { STEP_STATES, type StepStateValue } from './step-states';
 import { markStepCompleted, useStepCompletion } from '../../global-state/completion-store';
 import { CodeBlock } from '../../docs-retrieval';
 import { testIds } from '../../constants/testIds';
+import { logger } from '../../lib/logging';
 
 export interface CodeBlockStepProps {
   code: string;
@@ -183,7 +184,7 @@ export const CodeBlockStep = forwardRef<
         // Highlight the target Monaco editor using the interactive engine
         await executeInteractiveAction('highlight', refTarget, undefined, 'show');
       } catch (err) {
-        console.error('[CodeBlockStep] Show me failed:', err);
+        logger.error('[CodeBlockStep] Show me failed', { error: err });
       } finally {
         setIsShowRunning(false);
       }
@@ -200,7 +201,7 @@ export const CodeBlockStep = forwardRef<
           setInsertError(result.error || 'Failed to insert code');
         }
       } catch (err) {
-        console.error('[CodeBlockStep] Insert failed:', err);
+        logger.error('[CodeBlockStep] Insert failed', { error: err });
         setInsertError(err instanceof Error ? err.message : 'Insert failed');
       } finally {
         setIsInsertRunning(false);

--- a/src/components/interactive-tutorial/hooks/use-section-requirements.ts
+++ b/src/components/interactive-tutorial/hooks/use-section-requirements.ts
@@ -27,6 +27,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getRequirementExplanation, dispatchFix } from '../../../requirements-manager';
 import { subscribeProgressEvent } from '../../../global-state/progress-events';
+import { logger } from '../../../lib/logging';
 import { DEFAULT_INTERACTIVE_SECTION_TITLE } from '../interactive-section';
 
 interface SectionRequirementsResult {
@@ -138,7 +139,7 @@ export function useSectionRequirements({
         });
       }
     } catch (error) {
-      console.warn('Section requirements check failed:', error);
+      logger.warn('Section requirements check failed', { error });
       if (sectionMountedRef.current) {
         // On error, allow section to proceed (fail open for better UX).
         setStatus({ checking: false, passed: true });
@@ -171,11 +172,11 @@ export function useSectionRequirements({
         fixNavigationRequirements: () => navigationManager.fixNavigationRequirements(),
       });
       if (!result.ok) {
-        console.warn('useSectionRequirements: fix failed:', result.error);
+        logger.warn('useSectionRequirements: fix failed', { error: result.error });
       }
       await recheck();
     } catch (fixError) {
-      console.warn('Failed to fix section requirements:', fixError);
+      logger.warn('Failed to fix section requirements', { error: fixError });
     }
   }, [requirements, sectionId, recheck]);
 

--- a/src/components/interactive-tutorial/input-block.tsx
+++ b/src/components/interactive-tutorial/input-block.tsx
@@ -13,6 +13,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { useGuideResponsesOptional } from '../../docs-retrieval';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
 import { StorageEvents } from '../../lib/event-names';
+import { logger } from '../../lib/logging';
 import { testIds } from '../../constants/testIds';
 
 /** Props for the InputBlock component */
@@ -116,7 +117,7 @@ function getDatasourceOptions(filter?: string): Array<ComboboxOption<string>> {
       description: ds.type,
     }));
   } catch (error) {
-    console.warn('[InputBlock] Failed to get datasources:', error);
+    logger.warn('[InputBlock] Failed to get datasources', { error });
     return [];
   }
 }
@@ -192,7 +193,7 @@ export function InputBlock({
     try {
       return new RegExp(pattern);
     } catch {
-      console.warn(`[InputBlock] Invalid pattern regex: ${pattern}`);
+      logger.warn(`[InputBlock] Invalid pattern regex: ${pattern}`);
       return null;
     }
   }, [pattern]);

--- a/src/components/interactive-tutorial/interactive-conditional.tsx
+++ b/src/components/interactive-tutorial/interactive-conditional.tsx
@@ -15,6 +15,7 @@ import { testIds } from '../../constants/testIds';
 import type { ConditionalDisplayMode, ConditionalSectionConfig } from '../../types/json-guide.types';
 import { InteractiveSection } from './interactive-section';
 import { subscribeProgressEvent } from '../../global-state/progress-events';
+import { logger } from '../../lib/logging';
 
 export interface InteractiveConditionalProps {
   /** Conditions to evaluate (uses same syntax as requirements) */
@@ -143,7 +144,7 @@ export function InteractiveConditional({
         setConditionsPassed(result.pass);
         setIsChecking(false);
       } catch (error) {
-        console.warn('Failed to evaluate conditional conditions:', error);
+        logger.warn('Failed to evaluate conditional conditions', { error });
         if (!isMountedRef.current || myRunId !== runIdRef.current) {
           return;
         }

--- a/src/components/interactive-tutorial/interactive-guided.test.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.test.tsx
@@ -51,6 +51,10 @@ jest.mock('../../lib/analytics', () => ({
   buildInteractiveStepProperties: jest.fn(() => ({})),
 }));
 
+jest.mock('../../lib/logging', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
+}));
+
 // ─── Mock constants ──────────────────────────────────────────────────────────
 jest.mock('../../constants', () => ({
   getConfigWithDefaults: jest.fn(() => ({})),

--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -12,6 +12,7 @@ import {
   type DetectedActionEvent,
 } from '../../interactive-engine';
 import { waitForReactUpdates } from '../../lib/async-utils';
+import { logger } from '../../lib/logging';
 import { useStepChecker, validateInteractiveRequirements } from '../../requirements-manager';
 import { getInteractiveConfig } from '../../constants/interactive-config';
 import { getConfigWithDefaults } from '../../constants';
@@ -368,7 +369,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
 
         return true;
       } catch (error) {
-        console.error(`Guided execution failed: ${stepId}`, error);
+        logger.error(`Guided execution failed: ${stepId}`, { error });
         const errorMessage = error instanceof Error ? error.message : 'Guided execution failed';
         setExecutionError(errorMessage);
         return false;
@@ -476,7 +477,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
           }
         } catch (error) {
           // Element resolution failed, fall back to selector-based matching
-          console.warn('Failed to resolve target element for coordinate matching:', error);
+          logger.warn('Failed to resolve target element for coordinate matching', { error });
         }
 
         // Check if action matches (with coordinate support)

--- a/src/components/interactive-tutorial/interactive-multi-step.tsx
+++ b/src/components/interactive-tutorial/interactive-multi-step.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../interactive-engine';
 import { useStepChecker, validateInteractiveRequirements } from '../../requirements-manager';
 import { reportAppInteraction, UserInteraction, buildInteractiveStepProperties } from '../../lib/analytics';
+import { logger } from '../../lib/logging';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
 import { InternalAction } from '../../types/interactive-actions.types';
 import type { InteractiveElementData } from '../../types/interactive.types';
@@ -111,7 +112,7 @@ async function checkActionRequirements(
       };
     }
   } catch (error) {
-    console.error(`Requirements check failed for action ${actionIndex + 1}:`, error);
+    logger.error(`Requirements check failed for action ${actionIndex + 1}`, { error });
     return {
       pass: false,
       explanation: `Step ${actionIndex + 1} requirements check failed: ${
@@ -362,10 +363,9 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
           if (action.requirements) {
             const requirementsResult = await checkActionRequirements(action, i, checkRequirementsFromData);
             if (!requirementsResult.pass) {
-              console.error(
-                `Multi-step ${stepId}: Internal action ${i + 1} requirements failed`,
-                requirementsResult.explanation
-              );
+              logger.error(`Multi-step ${stepId}: Internal action ${i + 1} requirements failed`, {
+                explanation: requirementsResult.explanation,
+              });
               setFailedStepIndex(i);
               setExecutionError(requirementsResult.explanation || 'Action requirements not met');
               return false;
@@ -418,7 +418,7 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
               }
             }
           } catch (actionError) {
-            console.error(`Multi-step ${stepId}: Internal action ${i + 1} execution failed`, actionError);
+            logger.error(`Multi-step ${stepId}: Internal action ${i + 1} execution failed`, { error: actionError });
             const errorMessage = actionError instanceof Error ? actionError.message : 'Action execution failed';
             setFailedStepIndex(i);
             setExecutionError(`Step ${i + 1} failed: ${errorMessage}`);
@@ -449,7 +449,7 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
 
         return true;
       } catch (error) {
-        console.error(`Multi-step execution failed: ${stepId}`, error);
+        logger.error(`Multi-step execution failed: ${stepId}`, { error });
         const errorMessage = error instanceof Error ? error.message : 'Multi-step execution failed';
         setExecutionError(errorMessage);
         return false;

--- a/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
@@ -42,6 +42,9 @@ jest.mock('../../constants', () => {
 jest.mock('../../constants/interactive-config', () => {
   return require('../../test-utils/interactive-section-harness').createInteractiveConfigMock();
 });
+jest.mock('../../lib/logging', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
+}));
 jest.mock('../../lib/user-storage', () => {
   return require('../../test-utils/interactive-section-harness').createUserStorageMock();
 });

--- a/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.contracts.tripwire.test.tsx
@@ -45,6 +45,11 @@ jest.mock('../../constants/interactive-config', () => {
 jest.mock('../../lib/logging', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
 }));
+jest.mock('../../lib/faro', () => ({
+  withFaroUserAction: jest.fn((_name: string, _attributes: unknown, work: () => unknown) => work()),
+  setFaroUserActionAttributes: jest.fn(),
+  USER_ACTION_TIMEOUT_LONG_MS: 600000,
+}));
 jest.mock('../../lib/user-storage', () => {
   return require('../../test-utils/interactive-section-harness').createUserStorageMock();
 });

--- a/src/components/interactive-tutorial/interactive-section.display-title.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.display-title.test.tsx
@@ -25,6 +25,10 @@ jest.mock('../../constants', () => {
   return require('../../test-utils/interactive-section-harness').createConstantsMock();
 });
 
+jest.mock('../../lib/logging', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
+}));
+
 jest.mock('../../constants/interactive-config', () => {
   return require('../../test-utils/interactive-section-harness').createInteractiveConfigMock();
 });

--- a/src/components/interactive-tutorial/interactive-section.display-title.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.display-title.test.tsx
@@ -28,6 +28,11 @@ jest.mock('../../constants', () => {
 jest.mock('../../lib/logging', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
 }));
+jest.mock('../../lib/faro', () => ({
+  withFaroUserAction: jest.fn((_name: string, _attributes: unknown, work: () => unknown) => work()),
+  setFaroUserActionAttributes: jest.fn(),
+  USER_ACTION_TIMEOUT_LONG_MS: 600000,
+}));
 
 jest.mock('../../constants/interactive-config', () => {
   return require('../../test-utils/interactive-section-harness').createInteractiveConfigMock();

--- a/src/components/interactive-tutorial/interactive-section.runner.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.runner.tripwire.test.tsx
@@ -53,6 +53,11 @@ jest.mock('../../constants/interactive-config', () => {
 jest.mock('../../lib/logging', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
 }));
+jest.mock('../../lib/faro', () => ({
+  withFaroUserAction: jest.fn((_name: string, _attributes: unknown, work: () => unknown) => work()),
+  setFaroUserActionAttributes: jest.fn(),
+  USER_ACTION_TIMEOUT_LONG_MS: 600000,
+}));
 jest.mock('../../lib/user-storage', () => {
   return require('../../test-utils/interactive-section-harness').createUserStorageMock();
 });

--- a/src/components/interactive-tutorial/interactive-section.runner.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.runner.tripwire.test.tsx
@@ -50,6 +50,9 @@ jest.mock('../../constants', () => {
 jest.mock('../../constants/interactive-config', () => {
   return require('../../test-utils/interactive-section-harness').createInteractiveConfigMock();
 });
+jest.mock('../../lib/logging', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
+}));
 jest.mock('../../lib/user-storage', () => {
   return require('../../test-utils/interactive-section-harness').createUserStorageMock();
 });

--- a/src/components/interactive-tutorial/interactive-section.state-machine.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.state-machine.test.tsx
@@ -43,6 +43,10 @@ jest.mock('../../constants/interactive-config', () => {
   return require('../../test-utils/interactive-section-harness').createInteractiveConfigMock();
 });
 
+jest.mock('../../lib/logging', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
+}));
+
 jest.mock('../../lib/user-storage', () => {
   return require('../../test-utils/interactive-section-harness').createUserStorageMock();
 });

--- a/src/components/interactive-tutorial/interactive-section.state-machine.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.state-machine.test.tsx
@@ -46,6 +46,11 @@ jest.mock('../../constants/interactive-config', () => {
 jest.mock('../../lib/logging', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
 }));
+jest.mock('../../lib/faro', () => ({
+  withFaroUserAction: jest.fn((_name: string, _attributes: unknown, work: () => unknown) => work()),
+  setFaroUserActionAttributes: jest.fn(),
+  USER_ACTION_TIMEOUT_LONG_MS: 600000,
+}));
 
 jest.mock('../../lib/user-storage', () => {
   return require('../../test-utils/interactive-section-harness').createUserStorageMock();

--- a/src/components/interactive-tutorial/interactive-section.symmetry.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.symmetry.tripwire.test.tsx
@@ -68,6 +68,9 @@ jest.mock('../../constants', () => {
 jest.mock('../../constants/interactive-config', () => {
   return require('../../test-utils/interactive-section-harness').createInteractiveConfigMock();
 });
+jest.mock('../../lib/logging', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
+}));
 jest.mock('../../lib/user-storage', () => {
   return require('../../test-utils/interactive-section-harness').createUserStorageMock();
 });

--- a/src/components/interactive-tutorial/interactive-section.symmetry.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.symmetry.tripwire.test.tsx
@@ -71,6 +71,11 @@ jest.mock('../../constants/interactive-config', () => {
 jest.mock('../../lib/logging', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
 }));
+jest.mock('../../lib/faro', () => ({
+  withFaroUserAction: jest.fn((_name: string, _attributes: unknown, work: () => unknown) => work()),
+  setFaroUserActionAttributes: jest.fn(),
+  USER_ACTION_TIMEOUT_LONG_MS: 600000,
+}));
 jest.mock('../../lib/user-storage', () => {
   return require('../../test-utils/interactive-section-harness').createUserStorageMock();
 });

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -6,6 +6,7 @@ import { useInteractiveElements, ActionMonitor } from '../../interactive-engine'
 import { useStepChecker, stripTabLocalRequirements } from '../../requirements-manager';
 import { useIsAlignmentPaused, useAlignmentStartingLocation } from '../../global-state/alignment-pending-context';
 import { useInteractiveMode } from '../../global-state/interactive-mode-context';
+import { logger } from '../../lib/logging';
 import { InteractiveStep, resetStepCounter } from './interactive-step';
 import { InteractiveMultiStep, resetMultiStepCounter } from './interactive-multi-step';
 import { InteractiveGuided, resetGuidedCounter } from './interactive-guided';
@@ -605,11 +606,11 @@ export function InteractiveSection({
           try {
             return await multiStepRef.executeStep();
           } catch (error) {
-            console.error(`Multi-step execution failed: ${stepInfo.stepId}`, error);
+            logger.error(`Multi-step execution failed: ${stepInfo.stepId}`, { error });
             return false;
           }
         } else {
-          console.error(`Multi-step ref not found for: ${stepInfo.stepId}`);
+          logger.error(`Multi-step ref not found for: ${stepInfo.stepId}`);
           return false;
         }
       }
@@ -636,14 +637,14 @@ export function InteractiveSection({
             stepInfo.stepId
           );
           if (!result.pass) {
-            console.warn(`Post-verify failed for ${stepInfo.stepId}:`, result.error);
+            logger.warn(`Post-verify failed for ${stepInfo.stepId}`, { error: result.error });
             return false;
           }
         }
 
         return true;
       } catch (error) {
-        console.error(`Step execution failed: ${stepInfo.stepId}`, error);
+        logger.error(`Step execution failed: ${stepInfo.stepId}`, { error });
         return false;
       }
     },
@@ -661,7 +662,7 @@ export function InteractiveSection({
     // Reset user scroll tracking + set isProgrammaticScroll=true for
     // the entire section run. The hook keeps both flags consistent.
     beginProgrammaticScroll();
-    console.warn(
+    logger.warn(
       '[Section] Starting section run, reset userScrolled=false, isProgrammatic=TRUE (will stay true during execution)'
     );
 
@@ -725,27 +726,27 @@ export function InteractiveSection({
 
               if (!sectionRecheckResult.pass) {
                 // Section requirements still not met after fix attempt
-                console.warn('Section requirements could not be fixed, stopping execution');
+                logger.warn('Section requirements could not be fixed, stopping execution');
                 ActionMonitor.getInstance().forceEnable(); // Re-enable monitor
                 setIsRunning(false);
                 return;
               }
             } catch (fixError) {
-              console.warn('Failed to fix section requirements:', fixError);
+              logger.warn('Failed to fix section requirements', { error: fixError });
               ActionMonitor.getInstance().forceEnable(); // Re-enable monitor
               setIsRunning(false);
               return;
             }
           } else {
             // No fix available for section requirements
-            console.warn('Section requirements not met and no fix available, stopping execution');
+            logger.warn('Section requirements not met and no fix available, stopping execution');
             ActionMonitor.getInstance().forceEnable(); // Re-enable monitor
             setIsRunning(false);
             return;
           }
         }
       } catch (error) {
-        console.warn('Section requirements check failed:', error);
+        logger.warn('Section requirements check failed', { error });
         ActionMonitor.getInstance().forceEnable(); // Re-enable monitor
         setIsRunning(false);
         return;
@@ -863,7 +864,7 @@ export function InteractiveSection({
                   }
                   // If recheck passed, continue with normal execution below
                 } catch (fixError) {
-                  console.warn(`Failed to fix requirements for step ${i + 1}:`, fixError);
+                  logger.warn(`Failed to fix requirements for step ${i + 1}`, { error: fixError });
 
                   // Fix failed - check if step is skippable
                   if (stepInfo.skippable) {
@@ -900,7 +901,7 @@ export function InteractiveSection({
               }
             }
           } catch (error) {
-            console.warn(`Step ${i + 1} requirements check failed, stopping section execution:`, error);
+            logger.warn(`Step ${i + 1} requirements check failed, stopping section execution`, { error });
             stoppedDueToRequirements = true;
             break;
           }
@@ -984,7 +985,7 @@ export function InteractiveSection({
         markStepsCompleted(allStepIds, sectionId, 'manual');
       }
     } catch (error) {
-      console.error('Error running section sequence:', error);
+      logger.error('Error running section sequence', { error });
     } finally {
       // Re-enable action monitor after section execution completes
       ActionMonitor.getInstance().forceEnable();

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -7,6 +7,7 @@ import { useStepChecker, stripTabLocalRequirements } from '../../requirements-ma
 import { useIsAlignmentPaused, useAlignmentStartingLocation } from '../../global-state/alignment-pending-context';
 import { useInteractiveMode } from '../../global-state/interactive-mode-context';
 import { logger } from '../../lib/logging';
+import { setFaroUserActionAttributes, USER_ACTION_TIMEOUT_LONG_MS, withFaroUserAction } from '../../lib/faro';
 import { InteractiveStep, resetStepCounter } from './interactive-step';
 import { InteractiveMultiStep, resetMultiStepCounter } from './interactive-multi-step';
 import { InteractiveGuided, resetGuidedCounter } from './interactive-guided';
@@ -776,74 +777,123 @@ export function InteractiveSection({
     // wrapped in a functional setState updater, which React skipped on
     // unmount and silently lost the per-step writes.
 
-    try {
-      for (let i = startIndex; i < stepComponents.length; i++) {
-        // Check for cancellation before each step
-        if (isCancelledRef.current) {
-          break;
-        }
+    await withFaroUserAction(
+      'pathfinder_section_run',
+      {
+        section_id: sectionId,
+        section_title: title || DEFAULT_INTERACTIVE_SECTION_TITLE,
+        total_steps: stepComponents.length,
+        start_index: startIndex,
+        resumed: startIndex > 0,
+      },
+      async () => {
+        try {
+          for (let i = startIndex; i < stepComponents.length; i++) {
+            // Check for cancellation before each step
+            if (isCancelledRef.current) {
+              break;
+            }
 
-        const stepInfo = stepComponents[i]!;
+            const stepInfo = stepComponents[i]!;
 
-        // PAUSE: If this is a guided step, stop automated execution
-        // User must manually click the guided step's "Do it" button
-        // Once complete, they can click "Resume" to continue
-        if (stepInfo.isGuided) {
-          ActionMonitor.getInstance().forceEnable(); // Re-enable monitor for guided mode
-          // (cursor is already at `i` via the prior COMPLETE_STEP dispatches)
-          setIsRunning(false); // Stop the automated loop
-          stopSectionBlocking(sectionId); // Remove blocking overlay
+            // PAUSE: If this is a guided step, stop automated execution
+            // User must manually click the guided step's "Do it" button
+            // Once complete, they can click "Resume" to continue
+            if (stepInfo.isGuided) {
+              ActionMonitor.getInstance().forceEnable(); // Re-enable monitor for guided mode
+              // (cursor is already at `i` via the prior COMPLETE_STEP dispatches)
+              setIsRunning(false); // Stop the automated loop
+              stopSectionBlocking(sectionId); // Remove blocking overlay
 
-          // Don't set currentlyExecutingStep - let the guided step handle its own execution
-          return; // Exit the section execution loop
-        }
+              // Don't set currentlyExecutingStep - let the guided step handle its own execution
+              return; // Exit the section execution loop
+            }
 
-        setCurrentlyExecutingStep(stepInfo.stepId);
-        setExecutingStepNumber(i + 1); // 1-indexed for display
-        scrollToStep(stepInfo.stepId); // Auto-scroll to the step
+            setCurrentlyExecutingStep(stepInfo.stepId);
+            setExecutingStepNumber(i + 1); // 1-indexed for display
+            scrollToStep(stepInfo.stepId); // Auto-scroll to the step
 
-        // Check step requirements before attempting execution
-        if (stepInfo.requirements) {
-          const stepRequirementsData = {
-            requirements: stepInfo.requirements,
-            targetAction: stepInfo.targetAction || 'button',
-            refTarget: stepInfo.refTarget || '',
-            targetValue: stepInfo.targetValue,
-            textContent: stepInfo.stepId,
-            tagName: 'div',
-          };
+            // Check step requirements before attempting execution
+            if (stepInfo.requirements) {
+              const stepRequirementsData = {
+                requirements: stepInfo.requirements,
+                targetAction: stepInfo.targetAction || 'button',
+                refTarget: stepInfo.refTarget || '',
+                targetValue: stepInfo.targetValue,
+                textContent: stepInfo.stepId,
+                tagName: 'div',
+              };
 
-          try {
-            const requirementsResult = await checkRequirementsFromData(stepRequirementsData);
-            if (!requirementsResult.pass) {
-              // Requirements not met - apply priority logic
+              try {
+                const requirementsResult = await checkRequirementsFromData(stepRequirementsData);
+                if (!requirementsResult.pass) {
+                  // Requirements not met - apply priority logic
 
-              // Priority 2: Try to fix the requirement if possible
-              if (requirementsResult.error?.some((e: any) => e.canFix)) {
-                const fixableError = requirementsResult.error.find((e: any) => e.canFix);
+                  // Priority 2: Try to fix the requirement if possible
+                  if (requirementsResult.error?.some((e: any) => e.canFix)) {
+                    const fixableError = requirementsResult.error.find((e: any) => e.canFix);
 
-                try {
-                  // Try to fix the requirement automatically
-                  const { NavigationManager } = await import('../../interactive-engine');
-                  const navigationManager = new NavigationManager();
+                    try {
+                      // Try to fix the requirement automatically
+                      const { NavigationManager } = await import('../../interactive-engine');
+                      const navigationManager = new NavigationManager();
 
-                  if (fixableError?.fixType === 'expand-parent-navigation' && fixableError.targetHref) {
-                    await navigationManager.expandParentNavigationSection(fixableError.targetHref);
-                  } else if (fixableError?.fixType === 'location' && fixableError.targetHref) {
-                    await navigationManager.fixLocationRequirement(fixableError.targetHref);
-                  } else if (fixableError?.fixType === 'navigation') {
-                    await navigationManager.fixNavigationRequirements();
-                  } else if (stepInfo.requirements?.includes('navmenu-open')) {
-                    // Only fix navigation requirements if no other specific fix type is available
-                    await navigationManager.fixNavigationRequirements();
-                  }
+                      if (fixableError?.fixType === 'expand-parent-navigation' && fixableError.targetHref) {
+                        await navigationManager.expandParentNavigationSection(fixableError.targetHref);
+                      } else if (fixableError?.fixType === 'location' && fixableError.targetHref) {
+                        await navigationManager.fixLocationRequirement(fixableError.targetHref);
+                      } else if (fixableError?.fixType === 'navigation') {
+                        await navigationManager.fixNavigationRequirements();
+                      } else if (stepInfo.requirements?.includes('navmenu-open')) {
+                        // Only fix navigation requirements if no other specific fix type is available
+                        await navigationManager.fixNavigationRequirements();
+                      }
 
-                  // Recheck requirements after fix attempt
-                  await new Promise((resolve) => setTimeout(resolve, 200)); // Wait for UI to settle
-                  const recheckResult = await checkRequirementsFromData(stepRequirementsData);
+                      // Recheck requirements after fix attempt
+                      await new Promise((resolve) => setTimeout(resolve, 200)); // Wait for UI to settle
+                      const recheckResult = await checkRequirementsFromData(stepRequirementsData);
 
-                  if (!recheckResult.pass) {
-                    // Fix didn't work - check if step is skippable
+                      if (!recheckResult.pass) {
+                        // Fix didn't work - check if step is skippable
+                        // Priority 3: Skip if possible
+                        if (stepInfo.skippable) {
+                          // Skip this step properly using the step's own markSkipped function
+                          const stepRef = stepRefs.current.get(stepInfo.stepId);
+                          if (stepRef?.markSkipped) {
+                            stepRef.markSkipped(); // This handles the blue state properly
+                            handleStepComplete(stepInfo.stepId, true); // This handles the flow continuation
+                          }
+                          continue; // Continue to next step
+                        } else {
+                          // Priority 4: Stop execution if not skippable.
+                          // (cursor is already at `i` via the prior
+                          // COMPLETE_STEP dispatches — no explicit setter
+                          // needed.)
+                          stoppedDueToRequirements = true;
+                          break;
+                        }
+                      }
+                      // If recheck passed, continue with normal execution below
+                    } catch (fixError) {
+                      logger.warn(`Failed to fix requirements for step ${i + 1}`, { error: fixError });
+
+                      // Fix failed - check if step is skippable
+                      if (stepInfo.skippable) {
+                        // Skip this step properly using the step's own markSkipped function
+                        const stepRef = stepRefs.current.get(stepInfo.stepId);
+                        if (stepRef?.markSkipped) {
+                          stepRef.markSkipped(); // This handles the blue state properly
+                          handleStepComplete(stepInfo.stepId, true); // This handles the flow continuation
+                        }
+                        continue;
+                      } else {
+                        // Stop execution (cursor already at `i`)
+                        stoppedDueToRequirements = true;
+                        break;
+                      }
+                    }
+                  } else {
+                    // No fix available - check if step is skippable
                     // Priority 3: Skip if possible
                     if (stepInfo.skippable) {
                       // Skip this step properly using the step's own markSkipped function
@@ -854,186 +904,151 @@ export function InteractiveSection({
                       }
                       continue; // Continue to next step
                     } else {
-                      // Priority 4: Stop execution if not skippable.
-                      // (cursor is already at `i` via the prior
-                      // COMPLETE_STEP dispatches — no explicit setter
-                      // needed.)
+                      // Priority 4: Stop execution if not skippable and no fix available
+                      // (cursor already at `i`)
                       stoppedDueToRequirements = true;
                       break;
                     }
                   }
-                  // If recheck passed, continue with normal execution below
-                } catch (fixError) {
-                  logger.warn(`Failed to fix requirements for step ${i + 1}`, { error: fixError });
-
-                  // Fix failed - check if step is skippable
-                  if (stepInfo.skippable) {
-                    // Skip this step properly using the step's own markSkipped function
-                    const stepRef = stepRefs.current.get(stepInfo.stepId);
-                    if (stepRef?.markSkipped) {
-                      stepRef.markSkipped(); // This handles the blue state properly
-                      handleStepComplete(stepInfo.stepId, true); // This handles the flow continuation
-                    }
-                    continue;
-                  } else {
-                    // Stop execution (cursor already at `i`)
-                    stoppedDueToRequirements = true;
-                    break;
-                  }
                 }
-              } else {
-                // No fix available - check if step is skippable
-                // Priority 3: Skip if possible
-                if (stepInfo.skippable) {
-                  // Skip this step properly using the step's own markSkipped function
-                  const stepRef = stepRefs.current.get(stepInfo.stepId);
-                  if (stepRef?.markSkipped) {
-                    stepRef.markSkipped(); // This handles the blue state properly
-                    handleStepComplete(stepInfo.stepId, true); // This handles the flow continuation
-                  }
-                  continue; // Continue to next step
-                } else {
-                  // Priority 4: Stop execution if not skippable and no fix available
-                  // (cursor already at `i`)
-                  stoppedDueToRequirements = true;
-                  break;
-                }
-              }
-            }
-          } catch (error) {
-            logger.warn(`Step ${i + 1} requirements check failed, stopping section execution`, { error });
-            stoppedDueToRequirements = true;
-            break;
-          }
-        }
-
-        // First, show the step (highlight it) - skip for multi-step components OR if showMe is false
-        if (!stepInfo.isMultiStep && stepInfo.showMe !== false) {
-          await executeInteractiveAction(
-            stepInfo.targetAction!,
-            stepInfo.refTarget!,
-            stepInfo.targetValue,
-            'show',
-            stepInfo.targetComment
-          );
-
-          // Wait for highlight to be visible and animation to complete
-          // Check cancellation during wait
-          for (let j = 0; j < INTERACTIVE_CONFIG.delays.section.showPhaseIterations; j++) {
-            if (isCancelledRef.current) {
-              break;
-            }
-            await new Promise((resolve) => setTimeout(resolve, INTERACTIVE_CONFIG.delays.section.baseInterval));
-          }
-          if (isCancelledRef.current) {
-            continue;
-          } // Skip to cancellation check at loop start
-        }
-
-        // Then, execute the step (verifyStepResult already has retry logic)
-        const success = await executeStep(stepInfo);
-
-        if (success) {
-          completedStepsCount = i + 1;
-
-          // Single synchronous write to the store; survives a mid-section
-          // unmount because the store is module-scope and storage writes
-          // are fire-and-forget.
-          markStepCompleted(stepInfo.stepId, sectionId, 'manual');
-
-          // Also call the standard completion handler for other side effects (skip state update to avoid double-setting)
-          handleStepComplete(stepInfo.stepId, true);
-
-          // Wait between steps for both visual feedback AND DOM settling
-          // This ensures the next step's requirements are ready before checking
-          if (i < stepComponents.length - 1) {
-            // First: Wait for React updates to propagate
-            await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
-
-            // Then: Wait for visual feedback with cancellation checks
-            for (let j = 0; j < INTERACTIVE_CONFIG.delays.section.betweenStepsIterations; j++) {
-              if (isCancelledRef.current) {
+              } catch (error) {
+                logger.warn(`Step ${i + 1} requirements check failed, stopping section execution`, { error });
+                stoppedDueToRequirements = true;
                 break;
               }
-              await new Promise((resolve) => setTimeout(resolve, INTERACTIVE_CONFIG.delays.section.baseInterval));
+            }
+
+            // First, show the step (highlight it) - skip for multi-step components OR if showMe is false
+            if (!stepInfo.isMultiStep && stepInfo.showMe !== false) {
+              await executeInteractiveAction(
+                stepInfo.targetAction!,
+                stepInfo.refTarget!,
+                stepInfo.targetValue,
+                'show',
+                stepInfo.targetComment
+              );
+
+              // Wait for highlight to be visible and animation to complete
+              // Check cancellation during wait
+              for (let j = 0; j < INTERACTIVE_CONFIG.delays.section.showPhaseIterations; j++) {
+                if (isCancelledRef.current) {
+                  break;
+                }
+                await new Promise((resolve) => setTimeout(resolve, INTERACTIVE_CONFIG.delays.section.baseInterval));
+              }
+              if (isCancelledRef.current) {
+                continue;
+              } // Skip to cancellation check at loop start
+            }
+
+            // Then, execute the step (verifyStepResult already has retry logic)
+            const success = await executeStep(stepInfo);
+
+            if (success) {
+              completedStepsCount = i + 1;
+
+              // Single synchronous write to the store; survives a mid-section
+              // unmount because the store is module-scope and storage writes
+              // are fire-and-forget.
+              markStepCompleted(stepInfo.stepId, sectionId, 'manual');
+
+              // Also call the standard completion handler for other side effects (skip state update to avoid double-setting)
+              handleStepComplete(stepInfo.stepId, true);
+
+              // Wait between steps for both visual feedback AND DOM settling
+              // This ensures the next step's requirements are ready before checking
+              if (i < stepComponents.length - 1) {
+                // First: Wait for React updates to propagate
+                await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+                // Then: Wait for visual feedback with cancellation checks
+                for (let j = 0; j < INTERACTIVE_CONFIG.delays.section.betweenStepsIterations; j++) {
+                  if (isCancelledRef.current) {
+                    break;
+                  }
+                  await new Promise((resolve) => setTimeout(resolve, INTERACTIVE_CONFIG.delays.section.baseInterval));
+                }
+              }
+            } else {
+              // Step execution failed after retries - stop and don't auto-complete remaining steps
+              // (cursor already at `i` via the prior COMPLETE_STEP dispatches)
+              stoppedDueToRequirements = true;
+
+              // Wait for state to settle, then trigger reactive check
+              // This ensures remaining steps update their eligibility based on completed steps
+              setTimeout(() => {
+                import('../../requirements-manager').then(({ SequentialRequirementsManager }) => {
+                  const manager = SequentialRequirementsManager.getInstance();
+                  manager.triggerReactiveCheck();
+                });
+              }, 200);
+
+              break;
             }
           }
-        } else {
-          // Step execution failed after retries - stop and don't auto-complete remaining steps
-          // (cursor already at `i` via the prior COMPLETE_STEP dispatches)
-          stoppedDueToRequirements = true;
 
-          // Wait for state to settle, then trigger reactive check
-          // This ensures remaining steps update their eligibility based on completed steps
-          setTimeout(() => {
-            import('../../requirements-manager').then(({ SequentialRequirementsManager }) => {
-              const manager = SequentialRequirementsManager.getInstance();
-              manager.triggerReactiveCheck();
-            });
-          }, 200);
+          // Section sequence completed or cancelled
+          if (!isCancelledRef.current && !stoppedDueToRequirements) {
+            // Belt-and-braces bulk write so any steps that didn't go through the
+            // per-step path (e.g. skipped via fix → `markSkipped` → `handleStepComplete`)
+            // also end up in the store. `markStepsCompleted` is idempotent.
+            const allStepIds = stepComponents.map((step) => step.stepId);
+            markStepsCompleted(allStepIds, sectionId, 'manual');
+          }
+        } catch (error) {
+          logger.error('Error running section sequence', { error });
+        } finally {
+          // Re-enable action monitor after section execution completes
+          ActionMonitor.getInstance().forceEnable();
 
-          break;
+          // Stop section-level blocking
+          stopSectionBlocking(sectionId);
+          setIsRunning(false);
+          setCurrentlyExecutingStep(null);
+          setExecutingStepNumber(0);
+          // Reset programmatic scroll flag now that section is done.
+          endProgrammaticScroll();
+          // Keep isCancelled state for UI feedback, will be reset on next run
+
+          // Track "Do Section" analytics after completion (success or cancel)
+          const wasCanceled = isCancelledRef.current || stoppedDueToRequirements;
+          setFaroUserActionAttributes({ steps_completed: completedStepsCount, canceled: wasCanceled });
+          const docInfo = getSourceDocument(sectionId);
+
+          // Section-scoped metrics (completedStepsCount is the count of steps completed in this section)
+          const currentSectionStep = completedStepsCount;
+          const currentSectionPercentage = Math.round((completedStepsCount / stepComponents.length) * 100);
+
+          // Document-scoped metrics (use last completed step's index for position)
+          // If no steps completed, use 0 as the index; otherwise use completedStepsCount - 1
+          const lastCompletedStepIndex = completedStepsCount > 0 ? completedStepsCount - 1 : 0;
+          const { stepIndex: documentStepIndex, totalSteps: documentTotalSteps } = getDocumentStepPosition(
+            sectionId,
+            lastCompletedStepIndex
+          );
+          const documentCompletionPercentage = calculateStepCompletion(documentStepIndex, documentTotalSteps);
+
+          reportAppInteraction(UserInteraction.DoSectionButtonClick, {
+            ...docInfo,
+            content_type: 'interactive_guide',
+            section_title: title,
+            // Section-scoped
+            total_steps: stepComponents.length,
+            current_section_step: currentSectionStep,
+            current_section_percentage: currentSectionPercentage,
+            // Document-scoped
+            total_document_steps: documentTotalSteps,
+            current_step: documentStepIndex + 1, // 1-indexed for analytics
+            ...(documentCompletionPercentage !== undefined && { completion_percentage: documentCompletionPercentage }),
+            // Completion status
+            canceled: wasCanceled,
+            resumed: startIndex > 0, // true if user resumed from a previous position
+            interaction_location: 'interactive_section',
+          });
         }
-      }
-
-      // Section sequence completed or cancelled
-      if (!isCancelledRef.current && !stoppedDueToRequirements) {
-        // Belt-and-braces bulk write so any steps that didn't go through the
-        // per-step path (e.g. skipped via fix → `markSkipped` → `handleStepComplete`)
-        // also end up in the store. `markStepsCompleted` is idempotent.
-        const allStepIds = stepComponents.map((step) => step.stepId);
-        markStepsCompleted(allStepIds, sectionId, 'manual');
-      }
-    } catch (error) {
-      logger.error('Error running section sequence', { error });
-    } finally {
-      // Re-enable action monitor after section execution completes
-      ActionMonitor.getInstance().forceEnable();
-
-      // Stop section-level blocking
-      stopSectionBlocking(sectionId);
-      setIsRunning(false);
-      setCurrentlyExecutingStep(null);
-      setExecutingStepNumber(0);
-      // Reset programmatic scroll flag now that section is done.
-      endProgrammaticScroll();
-      // Keep isCancelled state for UI feedback, will be reset on next run
-
-      // Track "Do Section" analytics after completion (success or cancel)
-      const wasCanceled = isCancelledRef.current || stoppedDueToRequirements;
-      const docInfo = getSourceDocument(sectionId);
-
-      // Section-scoped metrics (completedStepsCount is the count of steps completed in this section)
-      const currentSectionStep = completedStepsCount;
-      const currentSectionPercentage = Math.round((completedStepsCount / stepComponents.length) * 100);
-
-      // Document-scoped metrics (use last completed step's index for position)
-      // If no steps completed, use 0 as the index; otherwise use completedStepsCount - 1
-      const lastCompletedStepIndex = completedStepsCount > 0 ? completedStepsCount - 1 : 0;
-      const { stepIndex: documentStepIndex, totalSteps: documentTotalSteps } = getDocumentStepPosition(
-        sectionId,
-        lastCompletedStepIndex
-      );
-      const documentCompletionPercentage = calculateStepCompletion(documentStepIndex, documentTotalSteps);
-
-      reportAppInteraction(UserInteraction.DoSectionButtonClick, {
-        ...docInfo,
-        content_type: 'interactive_guide',
-        section_title: title,
-        // Section-scoped
-        total_steps: stepComponents.length,
-        current_section_step: currentSectionStep,
-        current_section_percentage: currentSectionPercentage,
-        // Document-scoped
-        total_document_steps: documentTotalSteps,
-        current_step: documentStepIndex + 1, // 1-indexed for analytics
-        ...(documentCompletionPercentage !== undefined && { completion_percentage: documentCompletionPercentage }),
-        // Completion status
-        canceled: wasCanceled,
-        resumed: startIndex > 0, // true if user resumed from a previous position
-        interaction_location: 'interactive_section',
-      });
-    }
+      },
+      USER_ACTION_TIMEOUT_LONG_MS
+    );
   }, [
     disabled,
     isRunning,

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -9,6 +9,7 @@ import {
   validateInteractiveRequirements,
 } from '../../requirements-manager';
 import { reportAppInteraction, UserInteraction, buildInteractiveStepProperties } from '../../lib/analytics';
+import { logger } from '../../lib/logging';
 import type { InteractiveStepProps } from '../../types/component-props.types';
 import {
   type DetectedActionEvent,
@@ -508,7 +509,7 @@ export const InteractiveStep = forwardRef<
 
         return true;
       } catch (error) {
-        console.error(`Step execution failed: ${stepId}`, error);
+        logger.error(`Step execution failed: ${stepId}`, { error });
         setPostVerifyError(error instanceof Error ? error.message : 'Execution failed');
         return false;
       }
@@ -674,7 +675,7 @@ export const InteractiveStep = forwardRef<
           // F-1063-3: a controller-mode step must carry an author/parser-assigned
           // stepId. The anonymous fallback is mount-instance-derived and would
           // mis-address the live tab, so fail loud rather than dispatch a guess.
-          console.warn('[Pathfinder] controller "show" skipped: step has no stepId');
+          logger.warn('[Pathfinder] controller "show" skipped: step has no stepId');
           return;
         }
         // Cross-tab state can be stale; re-verify against the live tab and gate.
@@ -739,7 +740,7 @@ export const InteractiveStep = forwardRef<
           }
         }
       } catch (error) {
-        console.error('Interactive show action failed:', error);
+        logger.error('Interactive show action failed', { error });
         setLazyScrollError(error instanceof Error ? error.message : 'Action failed');
       } finally {
         setIsShowRunning(false);
@@ -796,7 +797,7 @@ export const InteractiveStep = forwardRef<
           // F-1063-3: a controller-mode step must carry an author/parser-assigned
           // stepId. The anonymous fallback is mount-instance-derived and would
           // mis-address the live tab, so fail loud rather than dispatch a guess.
-          console.warn('[Pathfinder] controller "do" skipped: step has no stepId');
+          logger.warn('[Pathfinder] controller "do" skipped: step has no stepId');
           return;
         }
         // Cross-tab state can be stale; re-verify against the live tab and gate.
@@ -843,7 +844,7 @@ export const InteractiveStep = forwardRef<
           setLazyScrollError(result.error || 'Element not found');
         }
       } catch (error) {
-        console.error('Interactive do action failed:', error);
+        logger.error('Interactive do action failed', { error });
         setLazyScrollError(error instanceof Error ? error.message : 'Action failed');
       } finally {
         setIsDoRunning(false);

--- a/src/components/interactive-tutorial/section-registry.tripwire.test.ts
+++ b/src/components/interactive-tutorial/section-registry.tripwire.test.ts
@@ -42,6 +42,11 @@ jest.mock('../../constants/interactive-config', () => createInteractiveConfigMoc
 jest.mock('../../lib/logging', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
 }));
+jest.mock('../../lib/faro', () => ({
+  withFaroUserAction: jest.fn((_name: string, _attributes: unknown, work: () => unknown) => work()),
+  setFaroUserActionAttributes: jest.fn(),
+  USER_ACTION_TIMEOUT_LONG_MS: 600000,
+}));
 jest.mock('../../lib/user-storage', () => {
   return require('../../test-utils/interactive-section-harness').createUserStorageMock();
 });

--- a/src/components/interactive-tutorial/section-registry.tripwire.test.ts
+++ b/src/components/interactive-tutorial/section-registry.tripwire.test.ts
@@ -39,6 +39,9 @@ jest.mock('../../lib/analytics', () => {
 });
 jest.mock('../../constants', () => createConstantsMock());
 jest.mock('../../constants/interactive-config', () => createInteractiveConfigMock());
+jest.mock('../../lib/logging', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
+}));
 jest.mock('../../lib/user-storage', () => {
   return require('../../test-utils/interactive-section-harness').createUserStorageMock();
 });

--- a/src/components/interactive-tutorial/terminal-step.test.tsx
+++ b/src/components/interactive-tutorial/terminal-step.test.tsx
@@ -25,6 +25,10 @@ jest.mock('@grafana/ui', () => ({
   }),
 }));
 
+jest.mock('../../lib/logging', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
+}));
+
 // Mock useStepChecker
 jest.mock('../../requirements-manager', () => ({
   useStepChecker: () => ({

--- a/src/components/interactive-tutorial/terminal-step.tsx
+++ b/src/components/interactive-tutorial/terminal-step.tsx
@@ -16,6 +16,7 @@ import { useStepChecker, validateInteractiveRequirements } from '../../requireme
 import { useTerminalContext } from '../../integrations/coda/TerminalContext';
 import { STEP_STATES, type StepStateValue } from './step-states';
 import { markStepCompleted, useStepCompletion } from '../../global-state/completion-store';
+import { logger } from '../../lib/logging';
 
 export interface TerminalStepProps {
   command: string;
@@ -181,7 +182,7 @@ export const TerminalStep = forwardRef<
         markComplete();
         setTimeout(() => setCopyFeedback(false), 2000);
       } catch (err) {
-        console.error('[TerminalStep] Copy failed:', err);
+        logger.error('[TerminalStep] Copy failed', { error: err });
       }
     }, [command, markComplete]);
 
@@ -195,7 +196,7 @@ export const TerminalStep = forwardRef<
         await terminalCtx.sendCommand(command);
         markComplete();
       } catch (err) {
-        console.error('[TerminalStep] Exec failed:', err);
+        logger.error('[TerminalStep] Exec failed', { error: err });
       } finally {
         setIsExecRunning(false);
       }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -207,6 +207,7 @@ const getPlatformSpecificDefault = (): boolean => {
     const isCloud = config.bootData.settings.buildInfo.versionString.startsWith('Grafana Cloud');
     return isCloud; // Cloud = true (enabled), OSS = false (disabled)
   } catch (error) {
+    // eslint-disable-next-line no-console -- tier 0 cannot import lib/logging (it's in the logger's own import chain)
     console.warn('Failed to detect platform, defaulting to disabled:', error);
     return false; // Conservative default
   }

--- a/src/context-engine/context-event-bus.test.ts
+++ b/src/context-engine/context-event-bus.test.ts
@@ -76,7 +76,7 @@ describe('initializeEchoLogging', () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(() => initializeEchoLogging()).not.toThrow();
-    expect(consoleSpy).toHaveBeenCalledWith('Failed to initialize EchoSrv logging', { error: expect.any(Error) });
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to initialize EchoSrv logging', expect.any(Error), '');
 
     consoleSpy.mockRestore();
   });
@@ -195,7 +195,7 @@ describe('listeners', () => {
 
     expect(bad).toHaveBeenCalled();
     expect(good).toHaveBeenCalled();
-    expect(consoleSpy).toHaveBeenCalledWith('Error in context change listener', { error: expect.any(Error) });
+    expect(consoleSpy).toHaveBeenCalledWith('Error in context change listener', expect.any(Error), '');
     consoleSpy.mockRestore();
   });
 });

--- a/src/context-engine/context-event-bus.test.ts
+++ b/src/context-engine/context-event-bus.test.ts
@@ -76,7 +76,7 @@ describe('initializeEchoLogging', () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(() => initializeEchoLogging()).not.toThrow();
-    expect(consoleSpy).toHaveBeenCalledWith('Failed to initialize EchoSrv logging:', expect.any(Error));
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to initialize EchoSrv logging', { error: expect.any(Error) });
 
     consoleSpy.mockRestore();
   });
@@ -195,7 +195,7 @@ describe('listeners', () => {
 
     expect(bad).toHaveBeenCalled();
     expect(good).toHaveBeenCalled();
-    expect(consoleSpy).toHaveBeenCalledWith('Error in context change listener:', expect.any(Error));
+    expect(consoleSpy).toHaveBeenCalledWith('Error in context change listener', { error: expect.any(Error) });
     consoleSpy.mockRestore();
   });
 });

--- a/src/context-engine/context-event-bus.ts
+++ b/src/context-engine/context-event-bus.ts
@@ -1,4 +1,5 @@
 import { getEchoSrv, EchoEventType } from '@grafana/runtime';
+import { logger } from '../lib/logging';
 
 /**
  * Context event bus.
@@ -74,7 +75,7 @@ function notifyContextChange(): void {
     try {
       listener();
     } catch (error) {
-      console.error('Error in context change listener:', error);
+      logger.error('Error in context change listener', { error });
     }
   });
 }
@@ -185,7 +186,7 @@ export function initializeEchoLogging(): void {
 
     echoLoggingInitialized = true;
   } catch (error) {
-    console.error('Failed to initialize EchoSrv logging:', error);
+    logger.error('Failed to initialize EchoSrv logging', { error });
   }
 }
 

--- a/src/context-engine/context.hook.ts
+++ b/src/context-engine/context.hook.ts
@@ -7,6 +7,7 @@ import { ContextData, Recommendation, UseContextPanelOptions, UseContextPanelRet
 import type { PackageOpenInfo } from '../types/content-panel.types';
 import { useTimeoutManager } from '../utils/timeout-manager';
 import { StorageEvents } from '../lib/event-names';
+import { logger } from '../lib/logging';
 import { suggestionState, SUGGESTIONS_UPDATED_EVENT } from '../global-state/suggestion';
 
 export function useContextPanel(options: UseContextPanelOptions = {}): UseContextPanelReturn {
@@ -68,7 +69,7 @@ export function useContextPanel(options: UseContextPanelOptions = {}): UseContex
       const newContextData = await ContextService.getContextData();
       setContextData(newContextData);
     } catch (error) {
-      console.error('Failed to fetch context data:', error);
+      logger.error('Failed to fetch context data', { error });
       setContextData((prev) => ({ ...prev, isLoading: false }));
     }
   }, []); // Empty dependency array - setContextData is stable
@@ -111,7 +112,7 @@ export function useContextPanel(options: UseContextPanelOptions = {}): UseContex
           usingFallbackRecommendations,
         }));
       } catch (error) {
-        console.error('Failed to fetch recommendations:', error);
+        logger.error('Failed to fetch recommendations', { error });
         setContextData((prev) => ({
           ...prev,
           recommendationsError: 'Failed to fetch recommendations',

--- a/src/context-engine/context.init.ts
+++ b/src/context-engine/context.init.ts
@@ -1,6 +1,7 @@
 import { getBackendSrv, config } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
 import { initializeEchoLogging, initializeFromRecentEvents } from './context-event-bus';
+import { logger } from '../lib/logging';
 
 /**
  * Fetch interactive guides from Pathfinder backend
@@ -33,7 +34,7 @@ export async function fetchInteractiveGuidesFromBackend(): Promise<void> {
       return;
     }
 
-    console.error('[Pathfinder] Failed to fetch interactive guides:', error);
+    logger.error('[Pathfinder] Failed to fetch interactive guides', { error });
   }
 }
 
@@ -49,7 +50,7 @@ export function initializeContextServices(): void {
     // Initialize from any recent events that might have been cached
     initializeFromRecentEvents();
   } catch (error) {
-    console.error('Failed to initialize context services:', error);
+    logger.error('Failed to initialize context services', { error });
   }
 }
 

--- a/src/context-engine/context.service.ts
+++ b/src/context-engine/context.service.ts
@@ -232,7 +232,7 @@ export class ContextService {
     const parsedUrl = parseUrlSafely(url);
 
     if (!parsedUrl) {
-      console.error('Invalid recommender service URL');
+      logger.error('Invalid recommender service URL');
       return false;
     }
 
@@ -244,7 +244,7 @@ export class ContextService {
 
     // Production: Require HTTPS
     if (parsedUrl.protocol !== 'https:') {
-      console.error('Recommender service URL must use HTTPS (dev mode disabled)');
+      logger.error('Recommender service URL must use HTTPS (dev mode disabled)');
       return false;
     }
 
@@ -254,7 +254,7 @@ export class ContextService {
     });
 
     if (!isAllowedDomain) {
-      console.error('Recommender service domain not in allowlist');
+      logger.error('Recommender service domain not in allowlist');
       return false;
     }
 
@@ -308,7 +308,7 @@ export class ContextService {
 
           return hostname;
         } catch (error) {
-          console.warn('Failed to extract/hash source:', error);
+          logger.warn('Failed to extract/hash source', { error });
           return undefined;
         }
       };
@@ -864,7 +864,7 @@ export class ContextService {
               completionPercentage,
             };
           } catch (error) {
-            console.warn(`Failed to fetch journey data for ${sanitizeForLogging(rec.title)}:`, error);
+            logger.warn(`Failed to fetch journey data for ${sanitizeForLogging(rec.title)}`, { error });
             return {
               ...rec,
               totalSteps: 0,
@@ -1011,7 +1011,7 @@ export class ContextService {
       const language = config.bootData.user.language;
       return language;
     } catch (error) {
-      console.warn('Failed to get current language:', error);
+      logger.warn('Failed to get current language', { error });
       return 'en-US';
     }
   }
@@ -1024,7 +1024,7 @@ export class ContextService {
       const dataSources = await getBackendSrv().get('/api/datasources');
       return dataSources || [];
     } catch (error) {
-      console.warn('Failed to fetch data sources:', error);
+      logger.warn('Failed to fetch data sources', { error });
       return [];
     }
   }
@@ -1037,7 +1037,7 @@ export class ContextService {
       const plugins = await getBackendSrv().get('/api/plugins');
       return plugins || [];
     } catch (error) {
-      console.warn('Failed to fetch plugins:', error);
+      logger.warn('Failed to fetch plugins', { error });
       return [];
     }
   }
@@ -1055,7 +1055,7 @@ export class ContextService {
       });
       return dashboards || [];
     } catch (error) {
-      console.warn('Failed to fetch dashboards:', error);
+      logger.warn('Failed to fetch dashboards', { error });
       return [];
     }
   }
@@ -1080,7 +1080,7 @@ export class ContextService {
       }
       return null;
     } catch (error) {
-      console.warn('Failed to fetch dashboard info:', error);
+      logger.warn('Failed to fetch dashboard info', { error });
       return null;
     }
   }
@@ -1394,11 +1394,11 @@ export class ContextService {
             });
           }
         } catch (error) {
-          console.warn(`Failed to load static links file ${filename}:`, error);
+          logger.warn(`Failed to load static links file ${filename}`, { error });
         }
       }
     } catch (error) {
-      console.warn('Failed to load static link recommendations:', error);
+      logger.warn('Failed to load static link recommendations', { error });
     }
 
     return staticRecommendations;
@@ -1688,7 +1688,7 @@ export class ContextService {
     } catch (error) {
       // The client itself never throws, but guard against future regressions
       // — a failure here must not break the bundled flow.
-      console.warn('Failed to load online package recommendations:', error);
+      logger.warn('Failed to load online package recommendations', { error });
       return [];
     }
   }
@@ -1751,7 +1751,7 @@ export class ContextService {
         bundledRecommendations.push(...recommendations);
       }
     } catch (error) {
-      console.warn('Failed to load bundled interactives index.json:', error);
+      logger.warn('Failed to load bundled interactives index.json', { error });
       // Fallback to empty array - no bundled interactives will be shown
     }
 

--- a/src/context-engine/context.service.ts
+++ b/src/context-engine/context.service.ts
@@ -22,6 +22,7 @@ import {
 } from '../docs-retrieval';
 import { interactiveCompletionStorage } from '../lib/user-storage';
 import { hashUserData } from '../lib/hash.util';
+import { logger } from '../lib/logging';
 import { isDevModeEnabledGlobal } from '../utils/dev-mode';
 import { sanitizeTextForDisplay, parseUrlSafely, sanitizeForLogging } from '../security';
 import {
@@ -188,7 +189,7 @@ export class ContextService {
       // Always try external recommendations when T&C are enabled, regardless of previous errors
       return this.getExternalRecommendations(contextData, pluginConfig, bundledRecommendations);
     } catch (error) {
-      console.warn('Failed to fetch recommendations:', error);
+      logger.exception(error, { source: 'fetchRecommendations' });
       const bundledRecommendations = await this.getBundledInteractiveRecommendations(contextData, pluginConfig);
       const fallbackResult = await this.getFallbackRecommendations(contextData, bundledRecommendations);
       return {

--- a/src/docs-retrieval/components/docs/code-block.tsx
+++ b/src/docs-retrieval/components/docs/code-block.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { IconButton } from '@grafana/ui';
 import Prism from 'prismjs';
+import { logger } from '../../../lib/logging';
 
 // Import Prism CSS theme
 import 'prismjs/themes/prism.css';
@@ -34,7 +35,7 @@ export function CodeBlock({ code, language, showCopy = true, inline = false, cla
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (error) {
-      console.warn('Failed to copy code:', error);
+      logger.warn('Failed to copy code', { error });
     }
   }, [code]);
 
@@ -44,7 +45,7 @@ export function CodeBlock({ code, language, showCopy = true, inline = false, cla
       try {
         Prism.highlightElement(codeRef.current);
       } catch (error) {
-        console.warn('Failed to highlight code with Prism:', error);
+        logger.warn('Failed to highlight code with Prism', { error });
       }
     }
   }, [code, language]);

--- a/src/docs-retrieval/components/docs/image-renderer.tsx
+++ b/src/docs-retrieval/components/docs/image-renderer.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { logger } from '../../../lib/logging';
 
 export interface ImageRendererProps {
   src?: string;
@@ -29,7 +30,7 @@ export function ImageRenderer({
     // Handle both camelCase dataSrc and kebab-case data-src
     const imgSrc = src || dataSrc || (props as any)['data-src'];
     if (!imgSrc) {
-      console.error('ImageRenderer: No image source found', {
+      logger.error('ImageRenderer: No image source found', {
         src,
         dataSrc,
         'data-src': (props as any)['data-src'],

--- a/src/docs-retrieval/components/docs/video-renderer.tsx
+++ b/src/docs-retrieval/components/docs/video-renderer.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useEffect, useRef } from 'react';
+import { logger } from '../../../lib/logging';
 
 export interface VideoRendererProps {
   src?: string;
@@ -50,11 +51,11 @@ export function VideoRenderer({ src, type, baseUrl, onClick, start, end, ...prop
   const resolvedSrc = useMemo(() => {
     const videoSrc = src;
     if (!videoSrc) {
-      console.error('VideoRenderer: No video source found', { src });
+      logger.error('VideoRenderer: No video source found', { src });
       return undefined;
     }
     if (!baseUrl) {
-      console.warn('VideoRenderer: No baseUrl provided, using relative URL', {
+      logger.warn('VideoRenderer: No baseUrl provided, using relative URL', {
         videoSrc,
       });
       return videoSrc;

--- a/src/docs-retrieval/components/docs/youtube-video-renderer.tsx
+++ b/src/docs-retrieval/components/docs/youtube-video-renderer.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useCallback } from 'react';
 import { reportAppInteraction, UserInteraction } from '../../../lib/analytics';
 import { getActiveTabUrl, getContentKeyOverride } from '../../../global-state/content-key';
 import { parseUrlSafely } from '../../../security/url-validator';
+import { logger } from '../../../lib/logging';
 
 export interface YouTubeVideoRendererProps {
   src: string;
@@ -100,7 +101,7 @@ export function YouTubeVideoRenderer({
           videoPosition = Math.round(playerRef.current.getCurrentTime());
         }
       } catch (error) {
-        console.warn('Could not get video duration/position:', error);
+        logger.warn('Could not get video duration/position', { error });
       }
 
       reportAppInteraction(UserInteraction.VideoViewLength, {
@@ -157,7 +158,7 @@ export function YouTubeVideoRenderer({
                 actualVideoTitleRef.current = videoData.title;
               }
             } catch (error) {
-              console.warn('Could not get video title from YouTube API:', error);
+              logger.warn('Could not get video title from YouTube API', { error });
             }
           },
           onStateChange: (event: any) => {
@@ -184,7 +185,7 @@ export function YouTubeVideoRenderer({
                   lastPositionRef.current = playerRef.current.getCurrentTime();
                 }
               } catch (error) {
-                console.warn('Could not get current video position:', error);
+                logger.warn('Could not get current video position', { error });
               }
             } else if (event.data === window.YT.PlayerState.PAUSED || event.data === window.YT.PlayerState.ENDED) {
               // Calculate and accumulate viewing time
@@ -204,7 +205,7 @@ export function YouTubeVideoRenderer({
         },
       });
     } catch (error) {
-      console.warn('Failed to initialize YouTube player for analytics:', error);
+      logger.warn('Failed to initialize YouTube player for analytics', { error });
     }
   }, [src, getVideoId, getDocumentInfo, trackViewLength]);
 
@@ -219,7 +220,7 @@ export function YouTubeVideoRenderer({
           initializePlayer();
         }, 100);
       } catch (error) {
-        console.warn('Failed to setup YouTube analytics tracking:', error);
+        logger.warn('Failed to setup YouTube analytics tracking', { error });
       }
     };
 
@@ -242,7 +243,7 @@ export function YouTubeVideoRenderer({
         try {
           playerRef.current.destroy();
         } catch (error) {
-          console.warn('Error destroying YouTube player:', error);
+          logger.warn('Error destroying YouTube player', { error });
         }
       }
     };
@@ -250,7 +251,7 @@ export function YouTubeVideoRenderer({
 
   const videoId = getVideoId(src);
   if (!videoId) {
-    console.warn('Invalid YouTube URL provided to YouTubeVideoRenderer:', src);
+    logger.warn('Invalid YouTube URL provided to YouTubeVideoRenderer', { src });
     // Fallback to regular iframe
     return (
       <iframe
@@ -271,7 +272,7 @@ export function YouTubeVideoRenderer({
   const embedUrl = (() => {
     const url = parseUrlSafely(src);
     if (!url) {
-      console.error('YouTubeVideoRenderer: Invalid URL provided, cannot safely construct embed URL', { src });
+      logger.error('YouTubeVideoRenderer: Invalid URL provided, cannot safely construct embed URL', { src });
       return null;
     }
 

--- a/src/docs-retrieval/content-fetcher.ts
+++ b/src/docs-retrieval/content-fetcher.ts
@@ -13,6 +13,7 @@ import { simpleMarkdownToHtml, injectJourneyExtrasIntoJsonGuide } from './conten
 import { fetchBundledInteractive } from './content-fetcher/bundled';
 import { fetchBackendInteractive } from './content-fetcher/backend-guide';
 import { enforceHttps, fetchRawHtml, generateUserFriendlyError } from './content-fetcher/fetch-raw';
+import { logger } from '../lib/logging';
 
 // Re-exported to keep the barrel surface stable: `injectJourneyExtrasIntoJsonGuide`
 // is consumed by `components/docs-panel`, and `simpleMarkdownToHtml` by the
@@ -57,7 +58,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
   try {
     // Validate URL
     if (!url || typeof url !== 'string' || url.trim() === '') {
-      console.error('fetchContent called with invalid URL:', url);
+      logger.error('fetchContent called with invalid URL', { url });
       return { content: null, error: 'Invalid URL provided', errorType: 'other' };
     }
 
@@ -189,7 +190,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
         jsonContent = fetchResult.html; // Valid JSON guide
       } catch {
         // Invalid JSON - treat as HTML and wrap
-        console.warn('Failed to parse native JSON, treating as HTML');
+        logger.warn('Failed to parse native JSON, treating as HTML');
         jsonContent = wrapContentAsJsonGuide(fetchResult.html, finalUrl, metadata.title);
       }
     } else {
@@ -220,7 +221,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
 
     return { content: rawContent };
   } catch (error) {
-    console.error(`Failed to fetch content from ${url}:`, error);
+    logger.error(`Failed to fetch content from ${url}`, { error });
     return {
       content: null,
       error: error instanceof Error ? error.message : 'Unknown error',
@@ -236,7 +237,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
 function determineContentType(url: string): ContentType {
   // Handle undefined or empty URL
   if (!url || typeof url !== 'string') {
-    console.warn('determineContentType called with invalid URL:', url);
+    logger.warn('determineContentType called with invalid URL', { url });
     return 'single-doc';
   }
 

--- a/src/docs-retrieval/content-fetcher/bundled.ts
+++ b/src/docs-retrieval/content-fetcher/bundled.ts
@@ -4,6 +4,7 @@
 // (WYSIWYG preview + E2E test guides).
 import { RawContent, ContentFetchResult } from '../../types/content.types';
 import { StorageKeys } from '../../lib/user-storage';
+import { logger } from '../../lib/logging';
 
 /**
  * Discriminated representation of a `bundled:` URL. Adding a new
@@ -68,7 +69,7 @@ function readBundledLocalStorageGuide(
     };
     return { content: rawContent };
   } catch (error) {
-    console.error(`${errorPrefix}:`, error);
+    logger.error(errorPrefix, { error });
     return {
       content: null,
       error: `${errorPrefix}: ${error instanceof Error ? error.message : 'Unknown error'}`,
@@ -122,7 +123,7 @@ function loadBundledPackage(url: string, relativePath: string): ContentFetchResu
     };
     return { content: rawContent };
   } catch (err) {
-    console.warn(`[docs-retrieval] Failed to load bundled package file: ${relativePath}`, err);
+    logger.warn(`[docs-retrieval] Failed to load bundled package file: ${relativePath}`, { error: err });
     return {
       content: null,
       error: `Bundled package file not found: ${relativePath}`,
@@ -153,7 +154,7 @@ function loadBundledIndexed(url: string, id: string): ContentFetchResult {
     };
     return { content: rawContent };
   } catch (error) {
-    console.error(`Failed to load bundled interactive ${id}:`, error);
+    logger.error(`Failed to load bundled interactive ${id}`, { error });
     return {
       content: null,
       error: `Failed to load bundled interactive: ${id}. Error: ${

--- a/src/docs-retrieval/content-fetcher/fetch-raw.ts
+++ b/src/docs-retrieval/content-fetcher/fetch-raw.ts
@@ -13,6 +13,7 @@ import {
   isTrustedFinalUrl,
 } from '../../security';
 import { isDevModeEnabledGlobal } from '../../utils/dev-mode';
+import { logger } from '../../lib/logging';
 import { isJsonContentUrl, generateInteractiveLearningVariations, getContentUrls } from './url-utils';
 
 // Internal error structure for detailed error handling
@@ -148,7 +149,7 @@ async function tryUrlVariations(urls: string[], options: ContentFetchOptions): P
 
   // All variations failed
   if (lastError) {
-    console.error(`Failed to fetch from any URL variation. Last error: ${lastError.message}`);
+    logger.error('Failed to fetch from any URL variation', { lastErrorMessage: lastError.message });
   }
   return { html: null, error: lastError || { message: 'No content found', errorType: 'not-found' } };
 }
@@ -411,7 +412,7 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
   }
 
   if (lastError) {
-    console.error(`Failed to fetch content from ${url}. Last error: ${lastError.message}`);
+    logger.error(`Failed to fetch content from ${url}`, { lastErrorMessage: lastError.message });
   }
 
   return { html: null, error: lastError };

--- a/src/docs-retrieval/content-fetcher/fetch-raw.ts
+++ b/src/docs-retrieval/content-fetcher/fetch-raw.ts
@@ -42,7 +42,7 @@ export function enforceHttps(url: string): boolean {
   // Parse URL safely
   const parsedUrl = parseUrlSafely(url);
   if (!parsedUrl) {
-    console.error('Invalid URL format:');
+    logger.error('Invalid URL format:');
     return false;
   }
 
@@ -53,7 +53,7 @@ export function enforceHttps(url: string): boolean {
 
   // Require HTTPS for all other URLs
   if (parsedUrl.protocol !== 'https:') {
-    console.error('Only HTTPS URLs are allowed');
+    logger.error('Only HTTPS URLs are allowed');
     return false;
   }
 
@@ -110,7 +110,7 @@ async function tryUrlVariations(urls: string[], options: ContentFetchOptions): P
           const isFinalUrlTrusted = isTrustedFinalUrl(finalUrl);
 
           if (!isFinalUrlTrusted) {
-            console.warn(`URL variation ${urlVariation} redirected to untrusted URL: ${finalUrl}`);
+            logger.warn(`URL variation ${urlVariation} redirected to untrusted URL: ${finalUrl}`);
             continue; // Try next variation
           }
 
@@ -284,7 +284,7 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
         const isFinalUrlTrusted = isTrustedFinalUrl(finalUrl);
 
         if (!isFinalUrlTrusted) {
-          console.warn(
+          logger.warn(
             `Redirect target not in trusted domain list.\n` +
               `Original URL: ${url}\n` +
               `Final URL: ${finalUrl}\n` +
@@ -335,7 +335,7 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
           errorType: 'other',
           statusCode: response.status,
         };
-        console.warn(`Manual redirect detected from ${url}:`, lastError.message);
+        logger.warn(`Manual redirect detected from ${url}`, { lastErrorMessage: lastError.message });
 
         if (location.startsWith('/')) {
           try {
@@ -343,7 +343,7 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
             const redirectUrl = new URL(location, originalUrl.origin);
 
             if (redirectUrl.origin !== originalUrl.origin) {
-              console.warn(`Blocked redirect to different origin: ${redirectUrl.origin}`);
+              logger.warn(`Blocked redirect to different origin: ${redirectUrl.origin}`);
               lastError = {
                 message: `Cross-origin redirect blocked for security: ${redirectUrl.origin}`,
                 errorType: 'other',
@@ -352,7 +352,7 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
               const isRedirectTrusted = isTrustedFinalUrl(redirectUrl.href);
 
               if (!isRedirectTrusted) {
-                console.warn(`Redirect target not in trusted domain list: ${redirectUrl.href}`);
+                logger.warn(`Redirect target not in trusted domain list: ${redirectUrl.href}`);
                 lastError = {
                   message: 'Redirect target is not in trusted domain list',
                   errorType: 'other',
@@ -372,7 +372,7 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
               }
             }
           } catch (redirectError) {
-            console.warn(`Failed to fetch redirect target:`, redirectError);
+            logger.warn('Failed to fetch redirect target', { redirectError });
             lastError = {
               message: redirectError instanceof Error ? redirectError.message : 'Redirect failed',
               errorType: 'other',
@@ -393,7 +393,7 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
         errorType,
         statusCode: response.status,
       };
-      console.warn(`Failed to fetch from ${url}: ${lastError.message}`);
+      logger.warn(`Failed to fetch from ${url}: ${lastError.message}`);
     }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -408,7 +408,7 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
       message: errorMessage,
       errorType: isTimeout ? 'timeout' : isNetwork ? 'network' : 'other',
     };
-    console.warn(`Failed to fetch from ${url}:`, error);
+    logger.warn(`Failed to fetch from ${url}`, { error });
   }
 
   if (lastError) {

--- a/src/docs-retrieval/content-fetcher/metadata-extract.ts
+++ b/src/docs-retrieval/content-fetcher/metadata-extract.ts
@@ -9,6 +9,7 @@ import {
   Milestone,
 } from '../../types/content.types';
 import { getLearningJourneyBaseUrl, urlsMatch } from './url-utils';
+import { logger } from '../../lib/logging';
 
 /**
  * Extract metadata from HTML without DOM processing
@@ -185,10 +186,10 @@ export async function fetchLearningJourneyMetadataFromJson(baseUrl: string): Pro
         return milestones; // Already in sequential order, no need to sort
       }
     } else {
-      console.warn(`Failed to fetch metadata (${response.status}): ${indexJsonUrl}`);
+      logger.warn(`Failed to fetch metadata (${response.status}): ${indexJsonUrl}`);
     }
   } catch (error) {
-    console.warn(`Failed to fetch learning journey metadata from ${baseUrl}/index.json:`, error);
+    logger.warn(`Failed to fetch learning journey metadata from ${baseUrl}/index.json`, { error });
   }
 
   return [];

--- a/src/docs-retrieval/content-fetcher/package-content.ts
+++ b/src/docs-retrieval/content-fetcher/package-content.ts
@@ -11,6 +11,7 @@ import type { ResolvedNavLink } from '../../types/context.types';
 import { getPackageRenderType } from '../../types/package.types';
 import { fetchContent } from '../content-fetcher';
 import { injectJourneyExtrasIntoJsonGuide } from './cover-page';
+import { logger } from '../../lib/logging';
 
 /**
  * Module-level PackageResolver injected at Tier 3+ (docs-panel wires the
@@ -81,13 +82,13 @@ export async function resolvePackageMilestones(milestoneIds: string[], pathSlug?
     const id = milestoneIds[i]!;
 
     if (result.status === 'rejected') {
-      console.warn(`[resolvePackageMilestones] Error resolving milestone ${id}:`, result.reason);
+      logger.warn(`[resolvePackageMilestones] Error resolving milestone ${id}`, { reason: result.reason });
       continue;
     }
 
     const resolution = result.value;
     if (!resolution.ok) {
-      console.warn(`[resolvePackageMilestones] Skipping unresolvable milestone: ${id}`);
+      logger.warn(`[resolvePackageMilestones] Skipping unresolvable milestone: ${id}`);
       continue;
     }
 
@@ -129,13 +130,13 @@ export async function resolvePackageNavLinks(packageIds: string[]): Promise<Reso
     const id = packageIds[i]!;
 
     if (result.status === 'rejected') {
-      console.warn(`[resolvePackageNavLinks] Error resolving package ${id}:`, result.reason);
+      logger.warn(`[resolvePackageNavLinks] Error resolving package ${id}`, { reason: result.reason });
       continue;
     }
 
     const resolution = result.value;
     if (!resolution.ok) {
-      console.warn(`[resolvePackageNavLinks] Skipping unresolvable package: ${id}`);
+      logger.warn(`[resolvePackageNavLinks] Skipping unresolvable package: ${id}`);
       continue;
     }
 

--- a/src/docs-retrieval/resolve-relative-urls.ts
+++ b/src/docs-retrieval/resolve-relative-urls.ts
@@ -1,3 +1,5 @@
+import { logger } from '../lib/logging';
+
 export function resolveRelativeUrls(html: string, baseUrl: string): string {
   try {
     if (!baseUrl) {
@@ -30,7 +32,7 @@ export function resolveRelativeUrls(html: string, baseUrl: string): string {
             const resolvedUrl = new URL(attrValue, baseUrlObj).href;
             element.setAttribute(attr, resolvedUrl);
           } catch (urlError) {
-            console.warn(`Failed to resolve URL: ${attrValue}`, urlError);
+            logger.warn(`Failed to resolve URL: ${attrValue}`, { urlError });
           }
         }
       });
@@ -41,7 +43,7 @@ export function resolveRelativeUrls(html: string, baseUrl: string): string {
     }
     return doc.documentElement.outerHTML;
   } catch (error) {
-    console.warn('Failed to resolve relative URLs in content:', error);
+    logger.warn('Failed to resolve relative URLs in content', { error });
     return html;
   }
 }

--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -35,6 +35,7 @@ import {
 } from '../lib/user-storage';
 import { StorageEvents } from '../lib/event-names';
 import { StorageKeys } from '../lib/storage-keys';
+import { logger } from '../lib/logging';
 
 import { getContentKey } from './content-key';
 import { getRegisteredSectionCount, getTotalDocumentSteps } from './section-registry';
@@ -229,7 +230,7 @@ function ensureHydrated(contentKey: string, sectionId: string): void {
     })
     .catch((error) => {
       hydrationClears.delete(key);
-      console.warn('[completion-store] hydration failed', { contentKey, sectionId, error });
+      logger.warn('[completion-store] hydration failed', { contentKey, sectionId, error });
     });
 }
 

--- a/src/global-state/suggestion.ts
+++ b/src/global-state/suggestion.ts
@@ -7,6 +7,7 @@
  */
 
 import { StorageKeys } from '../lib/storage-keys';
+import { logger } from '../lib/logging';
 import type { Recommendation } from '../types/context.types';
 
 export const SUGGESTIONS_UPDATED_EVENT = 'pathfinder-suggestions-updated';
@@ -16,7 +17,7 @@ class GlobalSuggestionState {
     try {
       sessionStorage.setItem(StorageKeys.SUGGESTIONS, JSON.stringify(suggestions));
     } catch {
-      console.warn('[Pathfinder] Failed to persist suggestions to sessionStorage');
+      logger.warn('[Pathfinder] Failed to persist suggestions to sessionStorage');
     }
 
     document.dispatchEvent(new CustomEvent(SUGGESTIONS_UPDATED_EVENT));

--- a/src/integrations/assistant-integration/AssistantBlockWrapper.tsx
+++ b/src/integrations/assistant-integration/AssistantBlockWrapper.tsx
@@ -23,6 +23,7 @@ import {
   buildQuerySystemPrompt,
   buildContentSystemPrompt,
 } from './useAssistantGeneration.hook';
+import { logger } from '../../lib/logging';
 
 export interface AssistantBlockWrapperProps {
   /** Unique ID for this assistant element */
@@ -207,7 +208,7 @@ export function AssistantBlockWrapper({
             )
           );
         } catch (error) {
-          console.warn('[AssistantBlockWrapper] Failed to save to localStorage:', error);
+          logger.warn('[AssistantBlockWrapper] Failed to save to localStorage', { error });
         }
       }
 
@@ -238,7 +239,7 @@ export function AssistantBlockWrapper({
     const dsContext = await getDatasourceContext();
 
     if (!dsContext.currentDatasource) {
-      console.error('[AssistantBlockWrapper] No datasource available');
+      logger.error('[AssistantBlockWrapper] No datasource available');
       setGenerationError('No datasource available. Please select a datasource first.');
       return;
     }
@@ -370,12 +371,12 @@ Return only the customized content text.`;
               })
             );
           } catch (error) {
-            console.warn('[AssistantBlockWrapper] Failed to save to localStorage:', error);
+            logger.warn('[AssistantBlockWrapper] Failed to save to localStorage', { error });
           }
         }
       },
       onError: (err) => {
-        console.error('[AssistantBlockWrapper] Generation failed:', err);
+        logger.error('[AssistantBlockWrapper] Generation failed', { error: err });
 
         // Set error state for UI feedback
         const errorMessage = err instanceof Error ? err.message : 'Generation failed. Please try again.';
@@ -423,7 +424,7 @@ Return only the customized content text.`;
         })
       );
     } catch (error) {
-      console.warn('[AssistantBlockWrapper] Failed to revert:', error);
+      logger.warn('[AssistantBlockWrapper] Failed to revert', { error });
     }
   }, [getStorageKey, reset, getAnalyticsContext, blockType]);
 

--- a/src/integrations/assistant-integration/AssistantCustomizable.tsx
+++ b/src/integrations/assistant-integration/AssistantCustomizable.tsx
@@ -15,6 +15,7 @@ import { useAssistantCustomizableContext } from './AssistantCustomizableContext'
 import { reportAppInteraction, UserInteraction, buildAssistantCustomizableProperties } from '../../lib/analytics';
 import { buildAssistantStorageKey } from '../../lib/storage-keys';
 import { createDatasourceMetadataTool, type DatasourceMetadataArtifact, isSupportedDatasourceType } from './tools';
+import { logger } from '../../lib/logging';
 
 export interface AssistantCustomizableProps {
   /** Default value from the HTML */
@@ -157,7 +158,7 @@ export function AssistantCustomizable({
       const storedValue = localStorage.getItem(storageKey);
       return storedValue || defaultValue;
     } catch (error) {
-      console.warn('[AssistantCustomizable] Failed to load from localStorage:', error);
+      logger.warn('[AssistantCustomizable] Failed to load from localStorage', { error });
       return defaultValue;
     }
   }, [contentKey, assistantId, defaultValue]);
@@ -256,7 +257,7 @@ export function AssistantCustomizable({
             )
           );
         } catch (error) {
-          console.warn('[AssistantCustomizable] Failed to save (workaround):', error);
+          logger.warn('[AssistantCustomizable] Failed to save (workaround)', { error });
         }
       }
 
@@ -302,7 +303,7 @@ export function AssistantCustomizable({
           customizableContext.updateTargetValue(value);
         }
       } catch (error) {
-        console.warn('[AssistantCustomizable] Failed to save to localStorage:', error);
+        logger.warn('[AssistantCustomizable] Failed to save to localStorage', { error });
       }
     },
     [getStorageKey, customizableContext]
@@ -352,7 +353,7 @@ export function AssistantCustomizable({
           : null,
       };
     } catch (error) {
-      console.warn('[AssistantCustomizable] Failed to fetch datasources:', error);
+      logger.warn('[AssistantCustomizable] Failed to fetch datasources', { error });
       return { dataSources: [], currentDatasource: null };
     }
   }, [setPageContext]);
@@ -377,7 +378,7 @@ export function AssistantCustomizable({
     const dsContext = await getDatasourceContext();
 
     if (!dsContext.currentDatasource) {
-      console.error('[AssistantCustomizable] No datasource available');
+      logger.error('[AssistantCustomizable] No datasource available');
       return;
     }
 
@@ -472,7 +473,7 @@ Output only the content - no markdown, no explanation.`;
         }
       },
       onError: (err) => {
-        console.error('[AssistantCustomizable] Generation failed:', err);
+        logger.error('[AssistantCustomizable] Generation failed', { error: err });
 
         // Track customization error
         reportAppInteraction(
@@ -520,7 +521,7 @@ Output only the content - no markdown, no explanation.`;
         })
       );
     } catch (error) {
-      console.warn('[AssistantCustomizable] Failed to revert:', error);
+      logger.warn('[AssistantCustomizable] Failed to revert', { error });
     }
   }, [getStorageKey, defaultValue, reset, customizableContext, currentValue, getAnalyticsContext]);
 

--- a/src/integrations/assistant-integration/assistant-context.utils.ts
+++ b/src/integrations/assistant-integration/assistant-context.utils.ts
@@ -1,5 +1,6 @@
 import { createAssistantContextItem, type ChatContextItem } from '@grafana/assistant';
 import { RawContent } from '../../types/content.types';
+import { logger } from '../../lib/logging';
 
 /**
  * Build the prompt for the assistant based on highlighted text
@@ -66,7 +67,7 @@ export const buildDocumentContext = (content: RawContent): ChatContextItem[] => 
 
     contexts.push(structuredContext);
   } catch (error) {
-    console.warn('[AssistantIntegration] Failed to build document context:', error);
+    logger.warn('[AssistantIntegration] Failed to build document context', { error });
   }
 
   return contexts;

--- a/src/integrations/assistant-integration/assistant-dev-mode.test.ts
+++ b/src/integrations/assistant-integration/assistant-dev-mode.test.ts
@@ -1,0 +1,41 @@
+import { renderHook, act } from '@testing-library/react';
+
+jest.mock('../../lib/logging', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../utils/dev-mode', () => ({ isAssistantDevModeEnabledGlobal: jest.fn(() => true) }));
+jest.mock('@grafana/assistant', () => ({
+  isAssistantAvailable: jest.fn(),
+  openAssistant: jest.fn(),
+}));
+
+import { logger } from '../../lib/logging';
+import { getOpenAssistant, useMockInlineAssistant } from './assistant-dev-mode';
+
+const faroBackedLevels = () => [logger.info, logger.warn, logger.error] as jest.Mock[];
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('assistant dev mode dumps stay local-only', () => {
+  it('openAssistant dump uses logger.debug, never a Faro-backed level', () => {
+    getOpenAssistant({ origin: 'test/origin', prompt: 'sensitive prompt', context: [], autoSend: false });
+
+    expect(logger.debug).toHaveBeenCalledWith('Prompt', { prompt: 'sensitive prompt' });
+    faroBackedLevels().forEach((level) => expect(level).not.toHaveBeenCalled());
+  });
+
+  it('inline assistant dump uses logger.debug, never a Faro-backed level', async () => {
+    const { result } = renderHook(() => useMockInlineAssistant());
+
+    await act(async () => {
+      await result.current.generate({
+        origin: 'test/origin',
+        prompt: 'sensitive prompt',
+        systemPrompt: 'sensitive system prompt',
+      });
+    });
+
+    expect(logger.debug).toHaveBeenCalledWith('System Prompt', { systemPrompt: 'sensitive system prompt' });
+    faroBackedLevels().forEach((level) => expect(level).not.toHaveBeenCalled());
+  });
+});

--- a/src/integrations/assistant-integration/assistant-dev-mode.ts
+++ b/src/integrations/assistant-integration/assistant-dev-mode.ts
@@ -22,6 +22,7 @@ import {
   type InlineAssistantResult,
 } from '@grafana/assistant';
 import { isAssistantDevModeEnabledGlobal } from '../../utils/dev-mode';
+import { logger } from '../../lib/logging';
 
 // Create a persistent BehaviorSubject for mock availability
 // This ensures the mock stays active and doesn't get overridden
@@ -44,12 +45,12 @@ const getMockOpenAssistant = (props: {
   context?: ChatContextItem[];
   autoSend?: boolean;
 }): void => {
-  console.warn('=== Assistant Dev Mode ===');
-  console.warn('Origin:', props.origin);
-  console.warn('Prompt:', props.prompt || '(no prompt)');
-  console.warn('AutoSend:', props.autoSend ?? true);
-  console.warn('Context:', props.context);
-  console.warn('=========================');
+  logger.warn('=== Assistant Dev Mode ===');
+  logger.warn('Origin', { origin: props.origin });
+  logger.warn('Prompt', { prompt: props.prompt || '(no prompt)' });
+  logger.warn('AutoSend', { autoSend: props.autoSend ?? true });
+  logger.warn('Context', { context: props.context });
+  logger.warn('=========================');
 };
 
 /**
@@ -105,11 +106,11 @@ export const useMockInlineAssistant = (): InlineAssistantResult => {
   const [error, setError] = useState<Error | null>(null);
 
   const generate = useCallback(async (options: InlineAssistantOptions) => {
-    console.warn('=== Inline Assistant Dev Mode ===');
-    console.warn('Origin:', options.origin);
-    console.warn('Prompt:', options.prompt);
-    console.warn('System Prompt:', options.systemPrompt || '(none)');
-    console.warn('=====================================');
+    logger.warn('=== Inline Assistant Dev Mode ===');
+    logger.warn('Origin', { origin: options.origin });
+    logger.warn('Prompt', { prompt: options.prompt });
+    logger.warn('System Prompt', { systemPrompt: options.systemPrompt || '(none)' });
+    logger.warn('=====================================');
 
     // Set isGenerating to true at the start
     setIsGenerating(true);
@@ -143,12 +144,12 @@ export const useMockInlineAssistant = (): InlineAssistantResult => {
   }, []);
 
   const cancel = useCallback(() => {
-    console.warn('[Dev Mode] Cancel called');
+    logger.warn('[Dev Mode] Cancel called');
     setIsGenerating(false);
   }, []);
 
   const reset = useCallback(() => {
-    console.warn('[Dev Mode] Reset called');
+    logger.warn('[Dev Mode] Reset called');
     setIsGenerating(false);
     setContent('');
     setError(null);

--- a/src/integrations/assistant-integration/assistant-dev-mode.ts
+++ b/src/integrations/assistant-integration/assistant-dev-mode.ts
@@ -10,6 +10,9 @@
  * - useInlineAssistant() returns a mock that logs instead of generating
  *
  * This allows developers to test the text selection and popover UI locally.
+ *
+ * Dumps go through logger.debug (console-only): prompt/context/systemPrompt
+ * must never reach Faro-backed log levels, which ship to remote telemetry.
  */
 
 import { useState, useEffect, useCallback } from 'react';
@@ -45,12 +48,12 @@ const getMockOpenAssistant = (props: {
   context?: ChatContextItem[];
   autoSend?: boolean;
 }): void => {
-  logger.warn('=== Assistant Dev Mode ===');
-  logger.warn('Origin', { origin: props.origin });
-  logger.warn('Prompt', { prompt: props.prompt || '(no prompt)' });
-  logger.warn('AutoSend', { autoSend: props.autoSend ?? true });
-  logger.warn('Context', { context: props.context });
-  logger.warn('=========================');
+  logger.debug('=== Assistant Dev Mode ===');
+  logger.debug('Origin', { origin: props.origin });
+  logger.debug('Prompt', { prompt: props.prompt || '(no prompt)' });
+  logger.debug('AutoSend', { autoSend: props.autoSend ?? true });
+  logger.debug('Context', { context: props.context });
+  logger.debug('=========================');
 };
 
 /**
@@ -106,11 +109,11 @@ export const useMockInlineAssistant = (): InlineAssistantResult => {
   const [error, setError] = useState<Error | null>(null);
 
   const generate = useCallback(async (options: InlineAssistantOptions) => {
-    logger.warn('=== Inline Assistant Dev Mode ===');
-    logger.warn('Origin', { origin: options.origin });
-    logger.warn('Prompt', { prompt: options.prompt });
-    logger.warn('System Prompt', { systemPrompt: options.systemPrompt || '(none)' });
-    logger.warn('=====================================');
+    logger.debug('=== Inline Assistant Dev Mode ===');
+    logger.debug('Origin', { origin: options.origin });
+    logger.debug('Prompt', { prompt: options.prompt });
+    logger.debug('System Prompt', { systemPrompt: options.systemPrompt || '(none)' });
+    logger.debug('=====================================');
 
     // Set isGenerating to true at the start
     setIsGenerating(true);
@@ -144,12 +147,12 @@ export const useMockInlineAssistant = (): InlineAssistantResult => {
   }, []);
 
   const cancel = useCallback(() => {
-    logger.warn('[Dev Mode] Cancel called');
+    logger.debug('[Dev Mode] Cancel called');
     setIsGenerating(false);
   }, []);
 
   const reset = useCallback(() => {
-    logger.warn('[Dev Mode] Reset called');
+    logger.debug('[Dev Mode] Reset called');
     setIsGenerating(false);
     setContent('');
     setError(null);

--- a/src/integrations/assistant-integration/tools/grafana-context.tool.ts
+++ b/src/integrations/assistant-integration/tools/grafana-context.tool.ts
@@ -10,6 +10,7 @@ import { config, locationService, getBackendSrv, getDataSourceSrv } from '@grafa
 
 import type { GrafanaContextArtifact, DatasourceInfo } from './types';
 import { getDetectedDatasourceType, getDetectedVisualizationType } from '../../../context-engine';
+import { logger } from '../../../lib/logging';
 
 /**
  * Tool input schema - no input required
@@ -101,7 +102,7 @@ const fetchDashboardInfo = async (
     }
     return undefined;
   } catch (error) {
-    console.warn('[GrafanaContextTool] Failed to fetch dashboard info:', error);
+    logger.warn('[GrafanaContextTool] Failed to fetch dashboard info', { error });
     return undefined;
   }
 };
@@ -118,7 +119,7 @@ const getDatasourcesInfo = (): DatasourceInfo[] => {
       type: ds.type,
     }));
   } catch (error) {
-    console.warn('[GrafanaContextTool] Failed to get datasources:', error);
+    logger.warn('[GrafanaContextTool] Failed to get datasources', { error });
     return [];
   }
 };

--- a/src/integrations/assistant-integration/tools/utils/loki.utils.ts
+++ b/src/integrations/assistant-integration/tools/utils/loki.utils.ts
@@ -7,6 +7,7 @@
 
 import type { DataSourceApi } from '@grafana/data';
 import type { MetricsMetadata } from '../types';
+import { logger } from '../../../../lib/logging';
 
 /**
  * Loki datasource with language provider
@@ -56,10 +57,10 @@ const fetchLabelNames = async (ds: LokiDatasource): Promise<string[]> => {
       return await lp.fetchLabels();
     }
 
-    console.warn('[LokiUtils] No suitable method found to fetch label names');
+    logger.warn('[LokiUtils] No suitable method found to fetch label names');
     return [];
   } catch (error) {
-    console.warn('[LokiUtils] Failed to fetch label names:', error);
+    logger.warn('[LokiUtils] Failed to fetch label names', { error });
     return [];
   }
 };
@@ -82,10 +83,10 @@ const fetchLabelValues = async (ds: LokiDatasource, labelName: string, limit = M
       return Array.isArray(values) ? values.slice(0, limit) : [];
     }
 
-    console.warn('[LokiUtils] No suitable method found to fetch label values');
+    logger.warn('[LokiUtils] No suitable method found to fetch label values');
     return [];
   } catch (error) {
-    console.warn(`[LokiUtils] Failed to fetch values for label ${labelName}:`, error);
+    logger.warn(`[LokiUtils] Failed to fetch values for label ${labelName}`, { error });
     return [];
   }
 };

--- a/src/integrations/assistant-integration/tools/utils/prometheus.utils.ts
+++ b/src/integrations/assistant-integration/tools/utils/prometheus.utils.ts
@@ -7,6 +7,7 @@
 
 import { getDefaultTimeRange, type DataSourceApi, type TimeRange } from '@grafana/data';
 import type { MetricsMetadata } from '../types';
+import { logger } from '../../../../lib/logging';
 
 /**
  * Prometheus datasource with language provider
@@ -124,7 +125,7 @@ const fetchLabelNames = async (ds: PrometheusDatasource, timeRange: TimeRange): 
     // Filter out internal labels (starting with __)
     return labels.filter((label) => !label.startsWith('__'));
   } catch (error) {
-    console.warn('[PrometheusUtils] Failed to fetch label names:', error);
+    logger.warn('[PrometheusUtils] Failed to fetch label names', { error });
     return [];
   }
 };
@@ -142,7 +143,7 @@ const fetchLabelValues = async (
     const values = await ds.languageProvider.queryLabelValues(timeRange, labelName);
     return Array.isArray(values) ? values.slice(0, limit) : [];
   } catch (error) {
-    console.warn(`[PrometheusUtils] Failed to fetch values for label ${labelName}:`, error);
+    logger.warn(`[PrometheusUtils] Failed to fetch values for label ${labelName}`, { error });
     return [];
   }
 };

--- a/src/integrations/assistant-integration/tools/utils/pyroscope.utils.ts
+++ b/src/integrations/assistant-integration/tools/utils/pyroscope.utils.ts
@@ -7,6 +7,7 @@
 import { getBackendSrv } from '@grafana/runtime';
 import type { DataSourceApi } from '@grafana/data';
 import type { ProfilingMetadata } from '../types';
+import { logger } from '../../../../lib/logging';
 
 /**
  * Pyroscope datasource interface
@@ -49,7 +50,7 @@ const fetchProfileTypes = async (ds: PyroscopeDatasource): Promise<string[]> => 
 
     return [];
   } catch (error) {
-    console.warn('[PyroscopeUtils] Failed to fetch profile types:', error);
+    logger.warn('[PyroscopeUtils] Failed to fetch profile types', { error });
     return [];
   }
 };
@@ -68,7 +69,7 @@ const fetchLabels = async (ds: PyroscopeDatasource): Promise<string[]> => {
 
     return [];
   } catch (error) {
-    console.warn('[PyroscopeUtils] Failed to fetch labels:', error);
+    logger.warn('[PyroscopeUtils] Failed to fetch labels', { error });
     return [];
   }
 };
@@ -88,7 +89,7 @@ const fetchLabelValues = async (ds: PyroscopeDatasource, labelName: string): Pro
 
     return [];
   } catch (error) {
-    console.warn(`[PyroscopeUtils] Failed to fetch values for label ${labelName}:`, error);
+    logger.warn(`[PyroscopeUtils] Failed to fetch values for label ${labelName}`, { error });
     return [];
   }
 };

--- a/src/integrations/assistant-integration/tools/utils/tempo.utils.ts
+++ b/src/integrations/assistant-integration/tools/utils/tempo.utils.ts
@@ -7,6 +7,7 @@
 import { getBackendSrv } from '@grafana/runtime';
 import type { DataSourceApi } from '@grafana/data';
 import type { TracingMetadata } from '../types';
+import { logger } from '../../../../lib/logging';
 
 /**
  * Tempo datasource interface
@@ -57,7 +58,7 @@ const fetchTags = async (ds: TempoDatasource): Promise<string[]> => {
 
     return [];
   } catch (error) {
-    console.warn('[TempoUtils] Failed to fetch tags:', error);
+    logger.warn('[TempoUtils] Failed to fetch tags', { error });
     return [];
   }
 };
@@ -77,7 +78,7 @@ const fetchTagValues = async (ds: TempoDatasource, tagName: string): Promise<str
 
     return [];
   } catch (error) {
-    console.warn(`[TempoUtils] Failed to fetch values for tag ${tagName}:`, error);
+    logger.warn(`[TempoUtils] Failed to fetch values for tag ${tagName}`, { error });
     return [];
   }
 };

--- a/src/integrations/assistant-integration/useAssistantGeneration.hook.ts
+++ b/src/integrations/assistant-integration/useAssistantGeneration.hook.ts
@@ -22,6 +22,7 @@ import { getIsAssistantAvailable, useMockInlineAssistant } from './assistant-dev
 import { isAssistantDevModeEnabledGlobal } from '../../utils/dev-mode';
 import { buildAssistantStorageKey } from '../../lib/storage-keys';
 import { createDatasourceMetadataTool, type DatasourceMetadataArtifact, isSupportedDatasourceType } from './tools';
+import { logger } from '../../lib/logging';
 
 // REACT: Stable array reference to prevent context thrashing (R3)
 const EMPTY_CONTEXT_DEPS: ChatContextItem[] = [];
@@ -156,7 +157,7 @@ export function useAssistantGeneration(options: UseAssistantGenerationOptions): 
           : null,
       };
     } catch (error) {
-      console.warn('[useAssistantGeneration] Failed to fetch datasources:', error);
+      logger.warn('[useAssistantGeneration] Failed to fetch datasources', { error });
       return { dataSources: [], currentDatasource: null };
     }
   }, [setPageContext]);

--- a/src/integrations/assistant-integration/useTextSelection.hook.ts
+++ b/src/integrations/assistant-integration/useTextSelection.hook.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, RefObject } from 'react';
 import { isValidSelection } from './assistant-context.utils';
 import type { TextSelectionState } from '../../types/hooks.types';
+import { logger } from '../../lib/logging';
 
 /** Delay (ms) after user stops selecting before showing the popover */
 const SELECTION_DEBOUNCE_MS = 400;
@@ -102,7 +103,7 @@ export const useTextSelection = (containerRef: RefObject<HTMLElement>): TextSele
         debounceRef.current = null;
       }, SELECTION_DEBOUNCE_MS);
     } catch (error) {
-      console.warn('[useTextSelection] Error handling selection change:', error);
+      logger.warn('[useTextSelection] Error handling selection change', { error });
       clearSelectionState();
     }
   }, [containerRef, clearDebounceTimer, clearSelectionState]);

--- a/src/integrations/coda/TerminalContext.tsx
+++ b/src/integrations/coda/TerminalContext.tsx
@@ -12,6 +12,7 @@
 import React, { createContext, useContext, useCallback, useRef, useState, useEffect } from 'react';
 import type { ConnectionStatus, TerminalVMOptions } from './useTerminalLive.hook';
 import { setLastVmOpts } from './terminal-storage';
+import { logger } from '../../lib/logging';
 
 export type { TerminalVMOptions };
 
@@ -128,7 +129,7 @@ export function TerminalProvider({ children }: TerminalProviderProps) {
 
   const sendCommand = useCallback(async (command: string) => {
     if (!registeredSendCommandRef.current) {
-      console.warn('[TerminalContext] Cannot send command: terminal not registered');
+      logger.warn('[TerminalContext] Cannot send command: terminal not registered');
       return;
     }
     await registeredSendCommandRef.current(command);

--- a/src/integrations/coda/TerminalPanel.tsx
+++ b/src/integrations/coda/TerminalPanel.tsx
@@ -35,6 +35,7 @@ import {
   clearScrollback,
   getLastVmOpts,
 } from './terminal-storage';
+import { logger } from '../../lib/logging';
 
 interface TerminalPanelProps {
   /** Callback when panel is closed via X button */
@@ -309,7 +310,7 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
   // Routes through the context so activeVmOptsRef and storage stay in sync.
   const handleConnect = useCallback(() => {
     if (!terminalInstanceRef.current) {
-      console.warn('[CodaTerminal] Terminal not initialized yet');
+      logger.warn('[CodaTerminal] Terminal not initialized yet');
       return;
     }
     const savedOpts = getLastVmOpts();

--- a/src/integrations/coda/useTerminalLive.hook.ts
+++ b/src/integrations/coda/useTerminalLive.hook.ts
@@ -18,6 +18,7 @@ import {
 } from '@grafana/data';
 import { Subscription } from 'rxjs';
 import type { Terminal } from '@xterm/xterm';
+import { logger } from '../../lib/logging';
 
 interface ConnectionLog {
   error: (message: string, error?: unknown, data?: Record<string, unknown>) => void;
@@ -31,10 +32,10 @@ function createConnectionLog(): ConnectionLog {
         error instanceof Error
           ? { errorName: error.name, errorMessage: error.message, errorStack: error.stack }
           : { rawError: error };
-      console.error(`[Terminal] ${message}`, { ...errorDetails, ...data });
+      logger.error(`[Terminal] ${message}`, { ...errorDetails, ...data });
     },
     warn: (message: string, data?: Record<string, unknown>) => {
-      console.warn(`[Terminal] ${message}`, data);
+      logger.warn(`[Terminal] ${message}`, data);
     },
   };
 }

--- a/src/integrations/cross-tab/live-tab-executor.test.ts
+++ b/src/integrations/cross-tab/live-tab-executor.test.ts
@@ -7,11 +7,17 @@ import { sidebarState } from '../../global-state/sidebar';
 import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
 import { FakeCrossTabTransport } from '../../test-utils/fake-cross-tab-transport';
 import type { CrossTabMessage } from '../../types/cross-tab.types';
+import { withFaroUserAction } from '../../lib/faro';
 
 jest.mock('../../requirements-manager', () => {
   const actual = jest.requireActual('../../requirements-manager');
   return { ...actual, checkRequirements: jest.fn(), dispatchFix: jest.fn() };
 });
+jest.mock('../../lib/faro', () => ({
+  withFaroUserAction: jest.fn((_name: string, _attributes: unknown, work: () => unknown) => work()),
+  setFaroUserActionAttributes: jest.fn(),
+  USER_ACTION_TIMEOUT_LONG_MS: 600000,
+}));
 
 jest.mock('../../interactive-engine/action-handlers', () => {
   const makeHandler = () => ({ execute: jest.fn().mockResolvedValue(undefined) });
@@ -130,6 +136,12 @@ describe('installLiveTabExecutor', () => {
     expect(executeOf(FocusHandler)).toHaveBeenCalledWith(
       expect.objectContaining({ refTarget: '#target', targetAction: 'highlight' }),
       true
+    );
+    expect(withFaroUserAction).toHaveBeenCalledWith(
+      'pathfinder_remote_step',
+      expect.objectContaining({ target_action: 'highlight', ref_target: '#target', phase: 'do' }),
+      expect.any(Function),
+      600000
     );
     uninstall();
   });

--- a/src/integrations/cross-tab/live-tab-executor.ts
+++ b/src/integrations/cross-tab/live-tab-executor.ts
@@ -32,6 +32,7 @@ import { sidebarState } from '../../global-state/sidebar';
 import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
 import pluginJson from '../../plugin.json';
 import { logger } from '../../lib/logging';
+import { setFaroUserActionAttributes, USER_ACTION_TIMEOUT_LONG_MS, withFaroUserAction } from '../../lib/faro';
 
 // The verbs the guided handler can actually drive — narrower than the receive
 // gate's KNOWN_TARGET_ACTIONS, so runGuided checks against this before casting.
@@ -262,29 +263,44 @@ export function installLiveTabExecutor(
     const internalActions = command.action.internalActions;
     const postProgress = (index: number) =>
       transport.post({ kind: 'step-progress', stepId, runId, index, total: internalActions?.length ?? 0 });
-    let ok = false;
-    try {
-      if (internalActions?.length) {
-        if (command.action.targetAction === 'guided') {
-          ok = await runGuided(internalActions, postProgress);
-        } else {
-          await runComposite(internalActions, postProgress);
-          ok = true;
+    await withFaroUserAction(
+      'pathfinder_remote_step',
+      {
+        target_action: command.action.targetAction,
+        ref_target: command.action.refTarget ?? '',
+        phase: command.phase,
+        step_id: stepId,
+        run_id: runId,
+        internal_action_count: internalActions?.length ?? 0,
+      },
+      async () => {
+        let ok = false;
+        try {
+          if (internalActions?.length) {
+            if (command.action.targetAction === 'guided') {
+              ok = await runGuided(internalActions, postProgress);
+            } else {
+              await runComposite(internalActions, postProgress);
+              ok = true;
+            }
+          } else {
+            await runAction(command.action, command.phase === 'show');
+            ok = true;
+          }
+        } catch (error) {
+          logger.error('[Pathfinder] cross-tab executor: failed to run remote step', { error });
+          ok = false;
         }
-      } else {
-        await runAction(command.action, command.phase === 'show');
-        ok = true;
-      }
-    } catch (error) {
-      logger.error('[Pathfinder] cross-tab executor: failed to run remote step', { error });
-      ok = false;
-    }
-    // Tell the controller whether a composite actually finished, so it surfaces
-    // failure instead of completing early. Simple steps stay optimistic by design
-    // and report nothing back.
-    if (internalActions?.length) {
-      transport.post({ kind: 'step-complete', stepId, runId, ok });
-    }
+        setFaroUserActionAttributes({ step_ok: ok });
+        // Tell the controller whether a composite actually finished, so it surfaces
+        // failure instead of completing early. Simple steps stay optimistic by design
+        // and report nothing back.
+        if (internalActions?.length) {
+          transport.post({ kind: 'step-complete', stepId, runId, ok });
+        }
+      },
+      USER_ACTION_TIMEOUT_LONG_MS
+    );
   };
 
   // Evaluate the controller's tab-local requirements against this tab's DOM.

--- a/src/integrations/cross-tab/live-tab-executor.ts
+++ b/src/integrations/cross-tab/live-tab-executor.ts
@@ -31,6 +31,7 @@ import * as pairingManager from '../../lib/pairing-manager';
 import { sidebarState } from '../../global-state/sidebar';
 import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
 import pluginJson from '../../plugin.json';
+import { logger } from '../../lib/logging';
 
 // The verbs the guided handler can actually drive — narrower than the receive
 // gate's KNOWN_TARGET_ACTIONS, so runGuided checks against this before casting.
@@ -106,7 +107,7 @@ export function installLiveTabExecutor(
     addGlobalInteractiveStyles();
     updateInteractiveThemeColors(config.theme2);
   } catch (error) {
-    console.warn('[Pathfinder] cross-tab executor: style init failed', error);
+    logger.warn('[Pathfinder] cross-tab executor: style init failed', { error });
   }
 
   const stateManager = new InteractiveStateManager();
@@ -185,12 +186,12 @@ export function installLiveTabExecutor(
         // A composite verb reaching runAction means its internalActions were
         // empty/absent — runStepCommand expands them before dispatch, so this
         // is a malformed command, not a directly-executable action.
-        console.warn(
+        logger.warn(
           `[Pathfinder] cross-tab executor: composite action "${action.targetAction}" carried no internalActions to replay`
         );
         break;
       default:
-        console.warn(`[Pathfinder] cross-tab executor: unsupported action "${action.targetAction}"`);
+        logger.warn(`[Pathfinder] cross-tab executor: unsupported action "${action.targetAction}"`);
     }
   };
 
@@ -233,7 +234,7 @@ export function installLiveTabExecutor(
       // the guided verb set — guard the cast so a non-guided verb (e.g. navigate)
       // fails loud instead of being mistyped into the guided handler (F-1073-nit-cast).
       if (!GUIDED_VERBS.has(action.targetAction as GuidedAction['targetAction'])) {
-        console.warn(`[Pathfinder] cross-tab executor: guided step has non-guided verb "${action.targetAction}"`);
+        logger.warn(`[Pathfinder] cross-tab executor: guided step has non-guided verb "${action.targetAction}"`);
         return false;
       }
       const result = await guidedHandler.executeGuidedStep(
@@ -275,7 +276,7 @@ export function installLiveTabExecutor(
         ok = true;
       }
     } catch (error) {
-      console.error('[Pathfinder] cross-tab executor: failed to run remote step', error);
+      logger.error('[Pathfinder] cross-tab executor: failed to run remote step', { error });
       ok = false;
     }
     // Tell the controller whether a composite actually finished, so it surfaces

--- a/src/integrations/workshop/action-capture.ts
+++ b/src/integrations/workshop/action-capture.ts
@@ -7,6 +7,7 @@
 
 import type { SessionManager } from './session-manager';
 import type { InteractiveStepEvent, InteractiveAction } from '../../types/collaboration.types';
+import { logger } from '../../lib/logging';
 
 /**
  * Action capture system that intercepts and broadcasts presenter actions
@@ -30,7 +31,7 @@ export class ActionCaptureSystem {
    */
   startCapture(): void {
     if (this.isCapturing) {
-      console.warn('[ActionCapture] Already capturing');
+      logger.warn('[ActionCapture] Already capturing');
       return;
     }
 
@@ -86,14 +87,14 @@ export class ActionCaptureSystem {
     // Get the interactive step element
     const stepElement = this.findInteractiveStepElement(button);
     if (!stepElement) {
-      console.warn('[ActionCapture] Could not find interactive step element');
+      logger.warn('[ActionCapture] Could not find interactive step element');
       return;
     }
 
     // Extract action details
     const action = this.extractActionFromElement(stepElement);
     if (!action) {
-      console.warn('[ActionCapture] Could not extract action details');
+      logger.warn('[ActionCapture] Could not extract action details');
       return;
     }
 
@@ -258,7 +259,7 @@ export class ActionCaptureSystem {
         try {
           action.internalActions = JSON.parse(internalActionsStr);
         } catch (err) {
-          console.error('[ActionCapture] Failed to parse internal actions:', err);
+          logger.error('[ActionCapture] Failed to parse internal actions', { error: err });
         }
       }
     }

--- a/src/integrations/workshop/action-replay.ts
+++ b/src/integrations/workshop/action-replay.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../types/collaboration.types';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 import { querySelectorAllEnhanced } from '../../lib/dom/enhanced-selector';
+import { logger } from '../../lib/logging';
 
 /**
  * Action replay system for attendees
@@ -94,7 +95,7 @@ export class ActionReplaySystem {
           console.log(`[ActionReplay] Unhandled event type: ${event.type}`);
       }
     } catch (error) {
-      console.error(`[ActionReplay] Error handling ${event.type}:`, error);
+      logger.error(`[ActionReplay] Error handling ${event.type}`, { error });
       // Don't throw - gracefully handle errors
     }
   }
@@ -149,7 +150,7 @@ export class ActionReplaySystem {
       console.log('[ActionReplay] Follow mode: Executing action');
       await this.executeAction(event);
     } else {
-      console.warn(`[ActionReplay] Unknown mode: ${this.mode}`);
+      logger.warn(`[ActionReplay] Unknown mode: ${this.mode}`);
     }
 
     // Update last event
@@ -184,7 +185,7 @@ export class ActionReplaySystem {
       const elements = this.findElements(action.refTarget, action.targetAction);
 
       if (elements.length === 0) {
-        console.warn(`[ActionReplay] Element not found: ${action.refTarget}`);
+        logger.warn(`[ActionReplay] Element not found: ${action.refTarget}`);
         this.showNotification(`Element not found: ${action.refTarget}`, 'warning');
         return;
       }
@@ -202,7 +203,7 @@ export class ActionReplaySystem {
 
       console.log(`[ActionReplay] Highlighted element: ${action.refTarget}`);
     } catch (error) {
-      console.error('[ActionReplay] Error showing highlight:', error);
+      logger.error('[ActionReplay] Error showing highlight', { error });
       this.showNotification('Failed to show highlight', 'error');
     }
   }
@@ -225,12 +226,12 @@ export class ActionReplaySystem {
       const stepElement = this.findStepElement(event.stepId, action);
 
       if (!stepElement) {
-        console.error('[ActionReplay] ❌ Step element not found:', {
+        logger.error('[ActionReplay] ❌ Step element not found', {
           stepId: event.stepId,
           actionType: action.targetAction,
           refTarget: action.refTarget,
         });
-        console.warn('[ActionReplay] Attendee may be on different page');
+        logger.warn('[ActionReplay] Attendee may be on different page');
         this.showNotification(
           'Unable to execute action - please ensure you are on the same page as presenter',
           'warning'
@@ -255,10 +256,10 @@ export class ActionReplaySystem {
         console.log('[ActionReplay] ✅ Do It button clicked');
       } else {
         // Fallback: should rarely happen
-        console.warn('[ActionReplay] ❌ Do It button not found');
+        logger.warn('[ActionReplay] ❌ Do It button not found');
       }
     } catch (error) {
-      console.error('[ActionReplay] Error executing action:', error);
+      logger.error('[ActionReplay] Error executing action', { error });
       this.showNotification('Failed to execute action', 'error');
     }
   }
@@ -321,7 +322,7 @@ export class ActionReplaySystem {
         return Array.from(elements);
       }
     } catch (error) {
-      console.error(`[ActionReplay] Error finding elements:`, error);
+      logger.error(`[ActionReplay] Error finding elements`, { error });
       return [];
     }
   }

--- a/src/integrations/workshop/join-code-utils.ts
+++ b/src/integrations/workshop/join-code-utils.ts
@@ -6,6 +6,7 @@
 
 import QRCode from 'qrcode';
 import type { SessionOffer, SessionAnswer, SessionError } from '../../types/collaboration.types';
+import { logger } from '../../lib/logging';
 
 /**
  * Generate a base64-encoded join code from a session offer
@@ -25,7 +26,7 @@ export function generateJoinCode(offer: SessionOffer): string {
     }
     return btoa(JSON.stringify(compact));
   } catch (error) {
-    console.error('Failed to generate join code:', error);
+    logger.error('Failed to generate join code', { error });
     throw error;
   }
 }
@@ -80,7 +81,7 @@ export function parseJoinCode(code: string): SessionOffer {
 
     throw new Error('Invalid join code format');
   } catch (error) {
-    console.error('Failed to parse join code:', error);
+    logger.error('Failed to parse join code', { error });
     const sessionError: SessionError = {
       code: 'INVALID_CODE',
       message: 'Invalid join code. Please check and try again.',
@@ -131,7 +132,7 @@ export function parseSessionFromUrl(): SessionOffer | null {
       tutorialUrl: tutorialUrl || baseSession.tutorialUrl,
     };
   } catch (error) {
-    console.error('Failed to parse session from URL:', error);
+    logger.error('Failed to parse session from URL', { error });
     return null;
   }
 }
@@ -158,7 +159,7 @@ export async function generateQRCode(offer: SessionOffer, baseUrl?: string): Pro
     });
     return qrCode;
   } catch (error) {
-    console.error('Failed to generate QR code:', error);
+    logger.error('Failed to generate QR code', { error });
     throw error;
   }
 }
@@ -174,7 +175,7 @@ export function generateAnswerCode(answer: SessionAnswer): string {
     const json = JSON.stringify(answer);
     return btoa(json);
   } catch (error) {
-    console.error('Failed to generate answer code:', error);
+    logger.error('Failed to generate answer code', { error });
     throw error;
   }
 }
@@ -198,7 +199,7 @@ export function parseAnswerCode(code: string): SessionAnswer {
 
     return answer;
   } catch (error) {
-    console.error('Failed to parse answer code:', error);
+    logger.error('Failed to parse answer code', { error });
     const sessionError: SessionError = {
       code: 'INVALID_CODE',
       message: 'Invalid or malformed answer code',

--- a/src/integrations/workshop/reconnection-manager.ts
+++ b/src/integrations/workshop/reconnection-manager.ts
@@ -5,6 +5,8 @@
  * to avoid overwhelming the server during connection issues.
  */
 
+import { logger } from '../../lib/logging';
+
 export interface ReconnectionConfig {
   /** Maximum number of reconnection attempts */
   maxAttempts?: number;
@@ -84,7 +86,7 @@ export class ReconnectionManager {
     onAttempt?: (attempt: number, maxAttempts: number, delay: number) => void
   ): Promise<boolean> {
     if (this.reconnecting) {
-      console.warn('[ReconnectionManager] Reconnection already in progress');
+      logger.warn('[ReconnectionManager] Reconnection already in progress');
       return false;
     }
 
@@ -117,14 +119,13 @@ export class ReconnectionManager {
         return true;
       } catch (err) {
         this.attempts++;
-        console.warn(
-          `[ReconnectionManager] Attempt ${this.attempts}/${this.maxAttempts} failed:`,
-          err instanceof Error ? err.message : err
-        );
+        logger.warn(`[ReconnectionManager] Attempt ${this.attempts}/${this.maxAttempts} failed`, {
+          error: err instanceof Error ? err.message : err,
+        });
 
         // If we've exhausted all attempts, give up
         if (this.attempts >= this.maxAttempts) {
-          console.error('[ReconnectionManager] All reconnection attempts exhausted');
+          logger.error('[ReconnectionManager] All reconnection attempts exhausted');
           this.reconnecting = false;
           return false;
         }

--- a/src/integrations/workshop/session-manager.ts
+++ b/src/integrations/workshop/session-manager.ts
@@ -20,6 +20,7 @@ import type {
   HandRaiseInfo,
   SessionOffer,
 } from '../../types/collaboration.types';
+import { logger } from '../../lib/logging';
 
 export interface PeerJSConfig {
   host: string;
@@ -139,7 +140,7 @@ export class SessionManager {
         });
 
         this.peer.on('error', (err) => {
-          console.error('[SessionManager] Peer error:', err);
+          logger.error('[SessionManager] Peer error', { error: err });
           reject(err);
         });
 
@@ -183,7 +184,7 @@ export class SessionManager {
           errorCorrectionLevel: 'M',
         });
       } catch (error) {
-        console.error('[SessionManager] Failed to generate QR code:', error);
+        logger.error('[SessionManager] Failed to generate QR code', { error });
         // Non-fatal - continue without QR code
       }
 
@@ -197,7 +198,7 @@ export class SessionManager {
         config,
       };
     } catch (error) {
-      console.error('[SessionManager] Failed to create session:', error);
+      logger.error('[SessionManager] Failed to create session', { error });
       this.handleError({
         code: 'CONNECTION_FAILED',
         message: 'Failed to create session',
@@ -227,7 +228,7 @@ export class SessionManager {
         // Enforce a 30-second handshake timeout (C1)
         const handshakeTimeout = setTimeout(() => {
           if (this.pendingConnections.has(conn.peer)) {
-            console.warn(`[SessionManager] Handshake timeout for ${conn.peer} — closing`);
+            logger.warn(`[SessionManager] Handshake timeout for ${conn.peer} — closing`);
             this.pendingConnections.delete(conn.peer);
             this.challengedConnections.delete(conn.peer);
             conn.close();
@@ -309,7 +310,7 @@ export class SessionManager {
               this.attendees.set(conn.peer, updatedAttendee);
               this.notifyAttendeeListUpdate();
             } else {
-              console.warn(`[SessionManager] Received mode_change for unknown attendee: ${conn.peer}`);
+              logger.warn(`[SessionManager] Received mode_change for unknown attendee: ${conn.peer}`);
             }
             this.eventHandlers.forEach((handler) => handler(data));
           } else if (data.type === 'hand_raise') {
@@ -415,7 +416,7 @@ export class SessionManager {
         });
 
         conn.on('error', (err) => {
-          console.error(`[SessionManager] Connection error with ${conn.peer}:`, err);
+          logger.error(`[SessionManager] Connection error with ${conn.peer}`, { error: err });
 
           // Clean up pending state (C1)
           if (this.pendingConnections.has(conn.peer)) {
@@ -496,7 +497,7 @@ export class SessionManager {
         });
 
         this.peer.on('error', (err) => {
-          console.error('[SessionManager] Peer error:', err);
+          logger.error('[SessionManager] Peer error', { error: err });
           reject(err);
         });
 
@@ -512,7 +513,7 @@ export class SessionManager {
       await new Promise<void>((resolve, reject) => {
         conn.on('open', resolve);
         conn.on('error', (err) => {
-          console.error('[SessionManager] Failed to connect:', err);
+          logger.error('[SessionManager] Failed to connect', { error: err });
           reject(err);
         });
         setTimeout(() => reject(new Error('Connection timeout')), 10000);
@@ -604,7 +605,7 @@ export class SessionManager {
         });
 
         conn.on('error', (err) => {
-          console.error('[SessionManager] Connection error:', err);
+          logger.error('[SessionManager] Connection error', { error: err });
           this.handleError({
             code: 'CONNECTION_FAILED',
             message: 'Connection error',
@@ -618,7 +619,7 @@ export class SessionManager {
 
       console.log(`[SessionManager] Successfully joined session`);
     } catch (error) {
-      console.error('[SessionManager] Failed to join session:', error);
+      logger.error('[SessionManager] Failed to join session', { error });
       this.handleError({
         code: 'CONNECTION_FAILED',
         message: 'Failed to join session',
@@ -639,7 +640,7 @@ export class SessionManager {
    */
   broadcastToAttendees(event: AnySessionEvent): void {
     if (this.role !== 'presenter') {
-      console.warn('[SessionManager] Only presenter can broadcast to attendees');
+      logger.warn('[SessionManager] Only presenter can broadcast to attendees');
       return;
     }
 
@@ -650,10 +651,10 @@ export class SessionManager {
         if (conn.open) {
           conn.send(event);
         } else {
-          console.warn(`[SessionManager] Connection to ${peerId} is not open`);
+          logger.warn(`[SessionManager] Connection to ${peerId} is not open`);
         }
       } catch (error) {
-        console.error(`[SessionManager] Failed to send to ${peerId}:`, error);
+        logger.error(`[SessionManager] Failed to send to ${peerId}`, { error });
       }
     });
   }
@@ -665,7 +666,7 @@ export class SessionManager {
    */
   sendToPresenter(event: AnySessionEvent): void {
     if (this.role !== 'attendee' || !this.sessionId) {
-      console.warn('[SessionManager] Can only send to presenter as attendee');
+      logger.warn('[SessionManager] Can only send to presenter as attendee');
       return;
     }
 
@@ -673,7 +674,7 @@ export class SessionManager {
     if (conn && conn.open) {
       conn.send(event);
     } else {
-      console.error('[SessionManager] No connection to presenter');
+      logger.error('[SessionManager] No connection to presenter');
     }
   }
 
@@ -730,7 +731,7 @@ export class SessionManager {
       try {
         handler(attendeeList);
       } catch (error) {
-        console.error('[SessionManager] Error in attendee update handler:', error);
+        logger.error('[SessionManager] Error in attendee update handler', { error });
       }
     });
   }
@@ -771,7 +772,7 @@ export class SessionManager {
       try {
         handler(handRaiseList);
       } catch (error) {
-        console.error('[SessionManager] Error in hand raise update handler:', error);
+        logger.error('[SessionManager] Error in hand raise update handler', { error });
       }
     });
   }
@@ -803,7 +804,7 @@ export class SessionManager {
             presenterConn.close();
           }, 100);
         } catch (error) {
-          console.error('[SessionManager] Error sending leave event:', error);
+          logger.error('[SessionManager] Error sending leave event', { error });
           presenterConn.close();
         }
       }
@@ -822,7 +823,7 @@ export class SessionManager {
           }
           conn.close();
         } catch (error) {
-          console.error(`[SessionManager] Error closing connection to ${peerId}:`, error);
+          logger.error(`[SessionManager] Error closing connection to ${peerId}`, { error });
         }
       });
     }
@@ -896,7 +897,7 @@ export class SessionManager {
             const timeSinceLastHeartbeat = now - lastHeartbeat;
 
             if (timeSinceLastHeartbeat > 15000) {
-              console.warn(`[SessionManager] No heartbeat from ${peerId} for ${timeSinceLastHeartbeat}ms`);
+              logger.warn(`[SessionManager] No heartbeat from ${peerId} for ${timeSinceLastHeartbeat}ms`);
 
               // Update connection state to disconnected if no response
               const currentState = this.connectionStates.get(peerId);
@@ -915,7 +916,7 @@ export class SessionManager {
               }
             }
           } catch (error) {
-            console.error(`[SessionManager] Failed to send heartbeat to ${peerId}:`, error);
+            logger.error(`[SessionManager] Failed to send heartbeat to ${peerId}`, { error });
           }
         }
       });
@@ -979,7 +980,7 @@ export class SessionManager {
    * Handle errors
    */
   private handleError(error: SessionError): void {
-    console.error('[SessionManager] Error:', error);
+    logger.error('[SessionManager] Error', { error });
     this.errorHandlers.forEach((handler) => handler(error));
   }
 }

--- a/src/integrations/workshop/session-state.tsx
+++ b/src/integrations/workshop/session-state.tsx
@@ -17,6 +17,7 @@ import type {
   SessionStartEvent,
   HandRaiseInfo,
 } from '../../types/collaboration.types';
+import { logger } from '../../lib/logging';
 
 /**
  * Session context value
@@ -153,7 +154,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
         try {
           callback(event);
         } catch (error) {
-          console.error('[SessionState] Error in event callback:', error);
+          logger.error('[SessionState] Error in event callback', { error });
         }
       });
     });
@@ -187,7 +188,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
         setSessionRole('presenter');
         return info;
       } catch (error) {
-        console.error('[SessionState] Failed to create session:', error);
+        logger.error('[SessionState] Failed to create session', { error });
         throw error;
       }
     },
@@ -257,7 +258,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
 
         console.log('[SessionState] Successfully joined session:', info);
       } catch (error) {
-        console.error('[SessionState] Failed to join session:', error);
+        logger.error('[SessionState] Failed to join session', { error });
         throw error;
       }
     },

--- a/src/interactive-engine/action-handlers/button-handler.test.ts
+++ b/src/interactive-engine/action-handlers/button-handler.test.ts
@@ -42,6 +42,10 @@ const mockIsElementVisible = elementValidator.isElementVisible as jest.MockedFun
   typeof elementValidator.isElementVisible
 >;
 
+const mockDescribeElement = elementValidator.describeElement as jest.MockedFunction<
+  typeof elementValidator.describeElement
+>;
+
 const mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
 describe('ButtonHandler', () => {
@@ -51,6 +55,7 @@ describe('ButtonHandler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsElementVisible.mockReturnValue(true);
+    mockDescribeElement.mockReturnValue('button');
 
     mockButtons = [
       { click: jest.fn() } as unknown as HTMLButtonElement,
@@ -110,7 +115,7 @@ describe('ButtonHandler', () => {
 
       await buttonHandler.execute(mockData, false);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible', { button: mockButtons[0]! });
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible', { button: 'button' });
       expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalled();
       expect(mockNavigationManager.highlightWithComment).toHaveBeenCalled();
     });
@@ -120,7 +125,7 @@ describe('ButtonHandler', () => {
 
       await buttonHandler.execute(mockData, true);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible', { button: mockButtons[0]! });
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible', { button: 'button' });
       expect(mockButtons[0]!.click).toHaveBeenCalled();
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'completed');
     });

--- a/src/interactive-engine/action-handlers/button-handler.test.ts
+++ b/src/interactive-engine/action-handlers/button-handler.test.ts
@@ -110,7 +110,7 @@ describe('ButtonHandler', () => {
 
       await buttonHandler.execute(mockData, false);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible:', mockButtons[0]!);
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible', { button: mockButtons[0]! });
       expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalled();
       expect(mockNavigationManager.highlightWithComment).toHaveBeenCalled();
     });
@@ -120,7 +120,7 @@ describe('ButtonHandler', () => {
 
       await buttonHandler.execute(mockData, true);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible:', mockButtons[0]!);
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target button is not visible', { button: mockButtons[0]! });
       expect(mockButtons[0]!.click).toHaveBeenCalled();
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'completed');
     });

--- a/src/interactive-engine/action-handlers/button-handler.ts
+++ b/src/interactive-engine/action-handlers/button-handler.ts
@@ -3,6 +3,7 @@ import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
 import { isElementVisible } from '../../lib/dom';
+import { logger } from '../../lib/logging';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 import { resolveWithRetry } from '../../lib/dom/selector-retry';
 
@@ -63,7 +64,7 @@ export class ButtonHandler {
     for (const button of buttons) {
       // Validate visibility before interaction
       if (!isElementVisible(button)) {
-        console.warn('Target button is not visible:', button);
+        logger.warn('Target button is not visible', { button });
         // Continue anyway (non-breaking)
       }
 
@@ -81,7 +82,7 @@ export class ButtonHandler {
     for (const button of buttons) {
       // Validate visibility before interaction
       if (!isElementVisible(button)) {
-        console.warn('Target button is not visible:', button);
+        logger.warn('Target button is not visible', { button });
         // Continue anyway (non-breaking)
       }
 

--- a/src/interactive-engine/action-handlers/button-handler.ts
+++ b/src/interactive-engine/action-handlers/button-handler.ts
@@ -2,7 +2,7 @@ import { InteractiveStateManager } from '../interactive-state-manager';
 import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
-import { isElementVisible } from '../../lib/dom';
+import { describeElement, isElementVisible } from '../../lib/dom';
 import { logger } from '../../lib/logging';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 import { resolveWithRetry } from '../../lib/dom/selector-retry';
@@ -64,7 +64,7 @@ export class ButtonHandler {
     for (const button of buttons) {
       // Validate visibility before interaction
       if (!isElementVisible(button)) {
-        logger.warn('Target button is not visible', { button });
+        logger.warn('Target button is not visible', { button: describeElement(button) });
         // Continue anyway (non-breaking)
       }
 
@@ -82,7 +82,7 @@ export class ButtonHandler {
     for (const button of buttons) {
       // Validate visibility before interaction
       if (!isElementVisible(button)) {
-        logger.warn('Target button is not visible', { button });
+        logger.warn('Target button is not visible', { button: describeElement(button) });
         // Continue anyway (non-breaking)
       }
 

--- a/src/interactive-engine/action-handlers/focus-handler.test.ts
+++ b/src/interactive-engine/action-handlers/focus-handler.test.ts
@@ -46,6 +46,7 @@ jest.mock('../../lib/dom', () => ({
     originalSelector: selector,
   })),
   isElementVisible: jest.fn(),
+  describeElement: jest.fn(() => 'element'),
   resolveSelector: jest.fn((selector: string) => selector), // Pass through selector as-is for tests
 }));
 
@@ -150,7 +151,7 @@ describe('FocusHandler', () => {
 
       await focusHandler.execute(mockData, false);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible', { element: mockElements[0]! });
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible', { element: 'element' });
       expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalled();
       expect(mockNavigationManager.highlightWithComment).toHaveBeenCalled();
     });
@@ -160,7 +161,7 @@ describe('FocusHandler', () => {
 
       await focusHandler.execute(mockData, true);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible', { element: mockElements[0]! });
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible', { element: 'element' });
       expect(mockElements[0]!.click).toHaveBeenCalled();
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'completed');
     });

--- a/src/interactive-engine/action-handlers/focus-handler.test.ts
+++ b/src/interactive-engine/action-handlers/focus-handler.test.ts
@@ -150,7 +150,7 @@ describe('FocusHandler', () => {
 
       await focusHandler.execute(mockData, false);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible:', mockElements[0]!);
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible', { element: mockElements[0]! });
       expect(mockNavigationManager.ensureNavigationOpen).toHaveBeenCalled();
       expect(mockNavigationManager.highlightWithComment).toHaveBeenCalled();
     });
@@ -160,7 +160,7 @@ describe('FocusHandler', () => {
 
       await focusHandler.execute(mockData, true);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible:', mockElements[0]!);
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Target element is not visible', { element: mockElements[0]! });
       expect(mockElements[0]!.click).toHaveBeenCalled();
       expect(mockStateManager.setState).toHaveBeenCalledWith(mockData, 'completed');
     });

--- a/src/interactive-engine/action-handlers/focus-handler.ts
+++ b/src/interactive-engine/action-handlers/focus-handler.ts
@@ -3,6 +3,7 @@ import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
 import { isElementVisible } from '../../lib/dom';
+import { logger } from '../../lib/logging';
 import { resolveWithRetry } from '../../lib/dom/selector-retry';
 
 export class FocusHandler {
@@ -44,7 +45,7 @@ export class FocusHandler {
     for (const element of targetElements) {
       // Validate visibility before interaction
       if (!isElementVisible(element)) {
-        console.warn('Target element is not visible:', element);
+        logger.warn('Target element is not visible', { element });
         // Continue anyway (non-breaking)
       }
 
@@ -62,7 +63,7 @@ export class FocusHandler {
     for (const element of targetElements) {
       // Validate visibility before interaction
       if (!isElementVisible(element)) {
-        console.warn('Target element is not visible:', element);
+        logger.warn('Target element is not visible', { element });
         // Continue anyway (non-breaking)
       }
 

--- a/src/interactive-engine/action-handlers/focus-handler.ts
+++ b/src/interactive-engine/action-handlers/focus-handler.ts
@@ -2,7 +2,7 @@ import { InteractiveStateManager } from '../interactive-state-manager';
 import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
-import { isElementVisible } from '../../lib/dom';
+import { describeElement, isElementVisible } from '../../lib/dom';
 import { logger } from '../../lib/logging';
 import { resolveWithRetry } from '../../lib/dom/selector-retry';
 
@@ -45,7 +45,7 @@ export class FocusHandler {
     for (const element of targetElements) {
       // Validate visibility before interaction
       if (!isElementVisible(element)) {
-        logger.warn('Target element is not visible', { element });
+        logger.warn('Target element is not visible', { element: describeElement(element) });
         // Continue anyway (non-breaking)
       }
 
@@ -63,7 +63,7 @@ export class FocusHandler {
     for (const element of targetElements) {
       // Validate visibility before interaction
       if (!isElementVisible(element)) {
-        logger.warn('Target element is not visible', { element });
+        logger.warn('Target element is not visible', { element: describeElement(element) });
         // Continue anyway (non-breaking)
       }
 

--- a/src/interactive-engine/action-handlers/form-fill-handler.test.ts
+++ b/src/interactive-engine/action-handlers/form-fill-handler.test.ts
@@ -287,7 +287,8 @@ describe('FormFillHandler', () => {
       await formFillHandler.execute(mockData, true);
 
       expect(mockConsoleWarn).toHaveBeenCalledWith(
-        expect.stringContaining('Multiple elements found matching selector')
+        expect.stringContaining('Multiple elements found matching selector'),
+        ''
       );
     });
 

--- a/src/interactive-engine/action-handlers/form-fill-handler.ts
+++ b/src/interactive-engine/action-handlers/form-fill-handler.ts
@@ -3,6 +3,7 @@ import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG, CLEAR_COMMAND } from '../../constants/interactive-config';
 import { resetValueTracker, isElementVisible } from '../../lib/dom';
+import { logger } from '../../lib/logging';
 import { resolveWithRetry } from '../../lib/dom/selector-retry';
 import { trySetMonacoModelValue } from './code-block-handler';
 
@@ -41,7 +42,7 @@ export class FormFillHandler {
     }
 
     if (resolved.elements.length > 1) {
-      console.warn(`Multiple elements found matching selector: ${selector}`);
+      logger.warn(`Multiple elements found matching selector: ${selector}`);
     }
 
     return resolved.element;
@@ -50,7 +51,7 @@ export class FormFillHandler {
   private async prepareElement(targetElement: HTMLElement): Promise<void> {
     // Validate visibility before interaction
     if (!isElementVisible(targetElement)) {
-      console.warn('Target element is not visible:', targetElement);
+      logger.warn('Target element is not visible', { targetElement });
       // Continue anyway (non-breaking)
     }
 
@@ -288,7 +289,7 @@ export class FormFillHandler {
 
     // SECURITY: Prevent ReDoS attacks with length limit
     if (fullValue.length > 1000) {
-      console.warn('Input too long for combobox, truncating to 1000 chars');
+      logger.warn('Input too long for combobox, truncating to 1000 chars');
       fullValue = fullValue.substring(0, 1000);
     }
 

--- a/src/interactive-engine/action-handlers/form-fill-handler.ts
+++ b/src/interactive-engine/action-handlers/form-fill-handler.ts
@@ -2,7 +2,7 @@ import { InteractiveStateManager } from '../interactive-state-manager';
 import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG, CLEAR_COMMAND } from '../../constants/interactive-config';
-import { resetValueTracker, isElementVisible } from '../../lib/dom';
+import { describeElement, resetValueTracker, isElementVisible } from '../../lib/dom';
 import { logger } from '../../lib/logging';
 import { resolveWithRetry } from '../../lib/dom/selector-retry';
 import { trySetMonacoModelValue } from './code-block-handler';
@@ -51,7 +51,7 @@ export class FormFillHandler {
   private async prepareElement(targetElement: HTMLElement): Promise<void> {
     // Validate visibility before interaction
     if (!isElementVisible(targetElement)) {
-      logger.warn('Target element is not visible', { targetElement });
+      logger.warn('Target element is not visible', { targetElement: describeElement(targetElement) });
       // Continue anyway (non-breaking)
     }
 

--- a/src/interactive-engine/action-handlers/guided-handler.test.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.test.ts
@@ -2,10 +2,14 @@ import { GuidedHandler } from './guided-handler';
 import { InteractiveStateManager } from '../interactive-state-manager';
 import { NavigationManager } from '../navigation-manager';
 import { querySelectorAllEnhanced } from '../../lib/dom';
+import { withFaroUserAction } from '../../lib/faro';
 
 // Mock dependencies
 jest.mock('../interactive-state-manager');
 jest.mock('../navigation-manager');
+jest.mock('../../lib/faro', () => ({
+  withFaroUserAction: jest.fn((_name: string, _attributes: unknown, work: () => unknown) => work()),
+}));
 jest.mock('../../lib/dom', () => ({
   querySelectorAllEnhanced: jest.fn().mockReturnValue({ elements: [], usedFallback: false }),
   findButtonByText: jest.fn().mockReturnValue([]),
@@ -146,6 +150,13 @@ describe('GuidedHandler', () => {
         undefined,
         undefined,
         expect.objectContaining({ actionType: 'highlight', refTarget: refTarget })
+      );
+
+      expect(withFaroUserAction).toHaveBeenCalledWith(
+        'pathfinder_guided_step',
+        { target_action: 'highlight', ref_target: refTarget, step_index: 0, total_steps: 1 },
+        expect.any(Function),
+        10_005
       );
 
       consoleErrorSpy.mockRestore();

--- a/src/interactive-engine/action-handlers/guided-handler.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.ts
@@ -1,7 +1,13 @@
 import { InteractiveStateManager } from '../interactive-state-manager';
 import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
-import { querySelectorAllEnhanced, findButtonByText, isElementVisible, resolveSelector } from '../../lib/dom';
+import {
+  describeElement,
+  querySelectorAllEnhanced,
+  findButtonByText,
+  isElementVisible,
+  resolveSelector,
+} from '../../lib/dom';
 import { logger } from '../../lib/logging';
 import { withFaroUserAction } from '../../lib/faro';
 import { isCssSelector } from '../../lib/dom/selector-detector';
@@ -511,7 +517,7 @@ export class GuidedHandler {
   private async prepareElement(targetElement: HTMLElement): Promise<void> {
     // Validate visibility before interaction
     if (!isElementVisible(targetElement)) {
-      logger.warn('Target element is not visible', { targetElement });
+      logger.warn('Target element is not visible', { targetElement: describeElement(targetElement) });
       // Continue anyway (non-breaking)
     }
 

--- a/src/interactive-engine/action-handlers/guided-handler.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.ts
@@ -3,6 +3,7 @@ import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
 import { querySelectorAllEnhanced, findButtonByText, isElementVisible, resolveSelector } from '../../lib/dom';
 import { logger } from '../../lib/logging';
+import { withFaroUserAction } from '../../lib/faro';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 import { GuidedAction } from '../../types/interactive-actions.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
@@ -78,6 +79,26 @@ export class GuidedHandler {
     stepIndex: number,
     totalSteps: number,
     timeout: number = INTERACTIVE_CONFIG.guided.stepTimeout
+  ): Promise<CompletionResult> {
+    return withFaroUserAction(
+      'pathfinder_guided_step',
+      {
+        target_action: action.targetAction,
+        ref_target: action.refTarget ?? '',
+        step_index: stepIndex,
+        total_steps: totalSteps,
+      },
+      () => this.runGuidedStep(action, stepIndex, totalSteps, timeout),
+      // Internal waits are bounded by `timeout`; the margin only catches a hung step.
+      timeout + 10_000
+    );
+  }
+
+  private async runGuidedStep(
+    action: GuidedAction,
+    stepIndex: number,
+    totalSteps: number,
+    timeout: number
   ): Promise<CompletionResult> {
     // Clean up any stale listeners from previous cancelled sessions
     // This prevents interference when user cancels mid-session and restarts

--- a/src/interactive-engine/action-handlers/guided-handler.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.ts
@@ -2,6 +2,7 @@ import { InteractiveStateManager } from '../interactive-state-manager';
 import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
 import { querySelectorAllEnhanced, findButtonByText, isElementVisible, resolveSelector } from '../../lib/dom';
+import { logger } from '../../lib/logging';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 import { GuidedAction } from '../../types/interactive-actions.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
@@ -167,7 +168,7 @@ export class GuidedHandler {
 
       return result;
     } catch (error) {
-      console.error(`Guided step ${stepIndex + 1} failed:`, error);
+      logger.error(`Guided step ${stepIndex + 1} failed`, { error });
       // Clean up abort controller and listeners on error to prevent resource leaks
       this.cancel();
       return 'cancelled';
@@ -364,7 +365,7 @@ export class GuidedHandler {
         }
 
         if (remaining <= 0) {
-          console.error(`Element not found after ${attemptCount} attempts (${elapsed}ms): ${selector}`);
+          logger.error(`Element not found after ${attemptCount} attempts (${elapsed}ms): ${selector}`);
           throw error;
         }
         // Wait before retrying, but don't exceed timeout
@@ -419,12 +420,12 @@ export class GuidedHandler {
 
           if (targetElements.length > 0) {
             if (targetElements.length > 1) {
-              console.warn(`Multiple buttons found matching selector: ${resolvedSelector}, using first button`);
+              logger.warn(`Multiple buttons found matching selector: ${resolvedSelector}, using first button`);
             }
             return targetElements[0]!;
           }
         } catch (error) {
-          console.warn(`Button selector matching failed for "${resolvedSelector}", trying text match:`, error);
+          logger.warn(`Button selector matching failed for "${resolvedSelector}", trying text match`, { error });
         }
       }
 
@@ -433,13 +434,13 @@ export class GuidedHandler {
         targetElements = findButtonByText(resolvedSelector);
         if (targetElements.length > 0) {
           if (targetElements.length > 1) {
-            console.warn(`Multiple buttons found matching text: ${resolvedSelector}, using first button`);
+            logger.warn(`Multiple buttons found matching text: ${resolvedSelector}, using first button`);
           }
           return targetElements[0]!;
         }
       } catch (error) {
         // Fall through to enhanced selector as last resort
-        console.warn(`findButtonByText failed for "${resolvedSelector}", trying enhanced selector:`, error);
+        logger.warn(`findButtonByText failed for "${resolvedSelector}", trying enhanced selector`, { error });
       }
     }
 
@@ -453,7 +454,7 @@ export class GuidedHandler {
 
       if (formElements.length > 0) {
         if (formElements.length > 1) {
-          console.warn(`Multiple form elements found matching selector: ${resolvedSelector}, using first element`);
+          logger.warn(`Multiple form elements found matching selector: ${resolvedSelector}, using first element`);
         }
         return formElements[0]!;
       }
@@ -477,7 +478,7 @@ export class GuidedHandler {
     }
 
     if (targetElements.length > 1) {
-      console.warn(`Multiple elements found matching selector: ${resolvedSelector}, using first element`);
+      logger.warn(`Multiple elements found matching selector: ${resolvedSelector}, using first element`);
     }
 
     return targetElements[0]!;
@@ -489,7 +490,7 @@ export class GuidedHandler {
   private async prepareElement(targetElement: HTMLElement): Promise<void> {
     // Validate visibility before interaction
     if (!isElementVisible(targetElement)) {
-      console.warn('Target element is not visible:', targetElement);
+      logger.warn('Target element is not visible', { targetElement });
       // Continue anyway (non-breaking)
     }
 

--- a/src/interactive-engine/action-handlers/hover-handler.test.ts
+++ b/src/interactive-engine/action-handlers/hover-handler.test.ts
@@ -8,6 +8,7 @@ jest.mock('../interactive-state-manager');
 jest.mock('../navigation-manager');
 jest.mock('../../lib/dom', () => ({
   isElementVisible: jest.fn().mockReturnValue(true),
+  describeElement: jest.fn(() => 'div'),
 }));
 jest.mock('../../lib/dom/selector-retry', () => ({
   resolveWithRetry: jest.fn().mockResolvedValue(null),
@@ -233,7 +234,7 @@ describe('HoverHandler', () => {
 
       await hoverHandler.execute(data, true);
 
-      expect(consoleSpy).toHaveBeenCalledWith('Target element is not visible', { targetElement: mockElement });
+      expect(consoleSpy).toHaveBeenCalledWith('Target element is not visible', { targetElement: 'div' });
       expect(mockStateManager.setState).toHaveBeenCalledWith(data, 'completed');
 
       consoleSpy.mockRestore();

--- a/src/interactive-engine/action-handlers/hover-handler.test.ts
+++ b/src/interactive-engine/action-handlers/hover-handler.test.ts
@@ -233,7 +233,7 @@ describe('HoverHandler', () => {
 
       await hoverHandler.execute(data, true);
 
-      expect(consoleSpy).toHaveBeenCalledWith('Target element is not visible:', mockElement);
+      expect(consoleSpy).toHaveBeenCalledWith('Target element is not visible', { targetElement: mockElement });
       expect(mockStateManager.setState).toHaveBeenCalledWith(data, 'completed');
 
       consoleSpy.mockRestore();
@@ -333,7 +333,7 @@ describe('HoverHandler', () => {
 
       await hoverHandler.execute(data, true);
 
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Multiple elements found'));
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Multiple elements found'), '');
       // Should use first element - verify by checking data attribute was set
       expect(mockElement1.getAttribute('data-interactive-hover')).toBe('true');
 

--- a/src/interactive-engine/action-handlers/hover-handler.ts
+++ b/src/interactive-engine/action-handlers/hover-handler.ts
@@ -3,6 +3,7 @@ import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
 import { isElementVisible } from '../../lib/dom';
+import { logger } from '../../lib/logging';
 import { resolveWithRetry } from '../../lib/dom/selector-retry';
 
 /**
@@ -44,7 +45,7 @@ export class HoverHandler {
     }
 
     if (resolved.elements.length > 1) {
-      console.warn(`Multiple elements found matching selector: ${selector}, using first element`);
+      logger.warn(`Multiple elements found matching selector: ${selector}, using first element`);
     }
 
     return resolved.element;
@@ -53,7 +54,7 @@ export class HoverHandler {
   private async prepareElement(targetElement: HTMLElement): Promise<void> {
     // Validate visibility before interaction
     if (!isElementVisible(targetElement)) {
-      console.warn('Target element is not visible:', targetElement);
+      logger.warn('Target element is not visible', { targetElement });
       // Continue anyway (non-breaking)
     }
 

--- a/src/interactive-engine/action-handlers/hover-handler.ts
+++ b/src/interactive-engine/action-handlers/hover-handler.ts
@@ -2,7 +2,7 @@ import { InteractiveStateManager } from '../interactive-state-manager';
 import { NavigationManager } from '../navigation-manager';
 import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
-import { isElementVisible } from '../../lib/dom';
+import { describeElement, isElementVisible } from '../../lib/dom';
 import { logger } from '../../lib/logging';
 import { resolveWithRetry } from '../../lib/dom/selector-retry';
 
@@ -54,7 +54,7 @@ export class HoverHandler {
   private async prepareElement(targetElement: HTMLElement): Promise<void> {
     // Validate visibility before interaction
     if (!isElementVisible(targetElement)) {
-      logger.warn('Target element is not visible', { targetElement });
+      logger.warn('Target element is not visible', { targetElement: describeElement(targetElement) });
       // Continue anyway (non-breaking)
     }
 

--- a/src/interactive-engine/action-handlers/navigate-handler.ts
+++ b/src/interactive-engine/action-handlers/navigate-handler.ts
@@ -3,6 +3,7 @@ import { InteractiveElementData } from '../../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
 import { config, locationService } from '@grafana/runtime';
 import { parseUrlSafely, validateRedirectPath } from '../../security/url-validator';
+import { logger } from '../../lib/logging';
 import { autoLaunchChannel } from '../../global-state/auto-launch';
 
 export class NavigateHandler {
@@ -48,7 +49,7 @@ export class NavigateHandler {
       // SECURITY: Validate external URL scheme to prevent javascript:/data: injection
       const parsed = parseUrlSafely(data.refTarget);
       if (!parsed || !['http:', 'https:'].includes(parsed.protocol)) {
-        console.warn(`[NavigateHandler] Blocked navigation to invalid URL: ${data.refTarget.slice(0, 100)}`);
+        logger.warn(`[NavigateHandler] Blocked navigation to invalid URL: ${data.refTarget.slice(0, 100)}`);
         return;
       }
       // External URL - open in new tab to preserve current Grafana session
@@ -58,7 +59,7 @@ export class NavigateHandler {
       // '//evil.com' parses via new URL() as cross-origin with pathname '/', which
       // collides with validateRedirectPath's rejection sentinel and bypasses the check.
       if (!data.refTarget.startsWith('/') || data.refTarget.startsWith('//')) {
-        console.warn(`[NavigateHandler] Blocked navigation to invalid path: ${data.refTarget.slice(0, 100)}`);
+        logger.warn(`[NavigateHandler] Blocked navigation to invalid path: ${data.refTarget.slice(0, 100)}`);
         return;
       }
 
@@ -71,12 +72,12 @@ export class NavigateHandler {
       try {
         parsed = new URL(data.refTarget, window.location.origin);
       } catch {
-        console.warn(`[NavigateHandler] Blocked navigation to unparseable path: ${data.refTarget.slice(0, 100)}`);
+        logger.warn(`[NavigateHandler] Blocked navigation to unparseable path: ${data.refTarget.slice(0, 100)}`);
         return;
       }
 
       if (safePath !== parsed.pathname) {
-        console.warn(`[NavigateHandler] Blocked navigation to restricted path: ${data.refTarget.slice(0, 100)}`);
+        logger.warn(`[NavigateHandler] Blocked navigation to restricted path: ${data.refTarget.slice(0, 100)}`);
         return;
       }
 
@@ -127,7 +128,7 @@ export class NavigateHandler {
     const docPage = findDocPage(guideParam);
 
     if (!docPage) {
-      console.warn(`[NavigateHandler] Could not resolve guide param: ${guideParam}`);
+      logger.warn(`[NavigateHandler] Could not resolve guide param: ${guideParam}`);
       return;
     }
 

--- a/src/interactive-engine/auto-completion/action-matcher.ts
+++ b/src/interactive-engine/auto-completion/action-matcher.ts
@@ -9,6 +9,7 @@
 
 import type { DetectedAction } from '../../lib/dom/action-detector';
 import { findButtonByText } from '../../lib/dom';
+import { logger } from '../../lib/logging';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 
 // ============ REGEX PATTERN MATCHING ============
@@ -95,7 +96,7 @@ export function parseRegexPattern(pattern: string): RegExp | null {
     // Bare anchor pattern: treat entire string as regex
     return new RegExp(pattern);
   } catch (error) {
-    console.warn('Invalid regex pattern:', pattern, error);
+    logger.warn('Invalid regex pattern', { pattern, error });
     return null;
   }
 }
@@ -636,7 +637,7 @@ export class ActionMatcher {
           targetElement = elementResolver();
         } catch (error) {
           // Element resolution failed, fall back to selector-based matching
-          console.warn(`Element resolver failed for step ${stepId}:`, error);
+          logger.warn(`Element resolver failed for step ${stepId}`, { error });
         }
       }
 

--- a/src/interactive-engine/auto-completion/useAutoDetection.ts
+++ b/src/interactive-engine/auto-completion/useAutoDetection.ts
@@ -13,6 +13,7 @@ import { matchesStepAction, type DetectedActionEvent, type StepActionConfig } fr
 import { getInteractiveConfig } from '../../constants/interactive-config';
 import { getConfigWithDefaults } from '../../constants';
 import { findButtonByText, querySelectorAllEnhanced } from '../../lib/dom';
+import { logger } from '../../lib/logging';
 import { resolveSelector } from '../../lib/dom/selector-resolver';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 
@@ -108,7 +109,7 @@ export function resolveTargetElement(action: ActionToDetect): HTMLElement | null
     }
     // Note: navigate doesn't use coordinate matching
   } catch (error) {
-    console.warn('Failed to resolve target element for coordinate matching:', error);
+    logger.warn('Failed to resolve target element for coordinate matching', { error });
   }
 
   return null;

--- a/src/interactive-engine/global-interaction-blocker.ts
+++ b/src/interactive-engine/global-interaction-blocker.ts
@@ -2,6 +2,7 @@ import { InteractiveElementData } from '../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import { INTERACTIVE_Z_INDEX } from '../constants/interactive-z-index';
 import { TimeoutManager } from '../utils/timeout-manager';
+import { logger } from '../lib/logging';
 
 /**
  * Global interaction blocking state (singleton pattern)
@@ -95,7 +96,7 @@ class GlobalInteractionBlocker {
     const header = document.querySelector('header') as HTMLElement;
 
     if (!header) {
-      console.warn('No header element found for overlay creation');
+      logger.warn('No header element found for overlay creation');
       return;
     }
 

--- a/src/interactive-engine/interactive-state-manager.test.ts
+++ b/src/interactive-engine/interactive-state-manager.test.ts
@@ -46,7 +46,7 @@ describe('InteractiveStateManager', () => {
 
   it('should log error with logError', () => {
     manager.logError('context', 'error message', data);
-    expect(consoleErrorSpy).toHaveBeenCalledWith('context: error message', data);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('context: error message', { data });
   });
 
   it('should call setState and throw on handleError with shouldThrow', () => {

--- a/src/interactive-engine/interactive-state-manager.ts
+++ b/src/interactive-engine/interactive-state-manager.ts
@@ -1,4 +1,5 @@
 import { waitForReactUpdates } from '../lib/async-utils';
+import { logger } from '../lib/logging';
 import { InteractiveElementData } from '../types/interactive.types';
 import GlobalInteractionBlocker from './global-interaction-blocker';
 
@@ -54,7 +55,7 @@ export class InteractiveStateManager {
     }
 
     const errorMessage = typeof error === 'string' ? error : error.message;
-    console.error(`${context}: ${errorMessage}`, data);
+    logger.error(`${context}: ${errorMessage}`, { data });
   }
 
   /**

--- a/src/interactive-engine/interactive.hook.test.ts
+++ b/src/interactive-engine/interactive.hook.test.ts
@@ -1,5 +1,11 @@
 import { renderHook, act } from '@testing-library/react';
 import { useInteractiveElements } from './interactive.hook';
+import { withFaroUserAction } from '../lib/faro';
+
+jest.mock('../lib/faro', () => ({
+  withFaroUserAction: jest.fn((_name: string, _attributes: unknown, work: () => unknown) => work()),
+  USER_ACTION_TIMEOUT_LONG_MS: 600000,
+}));
 
 // Mock Grafana's location service
 jest.mock('@grafana/runtime', () => ({
@@ -243,6 +249,38 @@ describe('useInteractiveElements', () => {
 
       // Since we're using mocked handlers, we just verify the function was called
       expect(result.current.interactiveFocus).toBeDefined();
+    });
+  });
+
+  describe('Faro user action wiring', () => {
+    it('wraps show-mode execution in a pathfinder_step_show action', async () => {
+      const { result } = renderHook(() => useInteractiveElements({ containerRef }));
+
+      await act(async () => {
+        await result.current.executeInteractiveAction('highlight', '#target', undefined, 'show');
+      });
+
+      expect(withFaroUserAction).toHaveBeenCalledWith(
+        'pathfinder_step_show',
+        { target_action: 'highlight', ref_target: '#target' },
+        expect.any(Function),
+        undefined
+      );
+    });
+
+    it('wraps do-mode execution in a pathfinder_step_do action', async () => {
+      const { result } = renderHook(() => useInteractiveElements({ containerRef }));
+
+      await act(async () => {
+        await result.current.executeInteractiveAction('button', 'Save', undefined, 'do');
+      });
+
+      expect(withFaroUserAction).toHaveBeenCalledWith(
+        'pathfinder_step_do',
+        { target_action: 'button', ref_target: 'Save' },
+        expect.any(Function),
+        undefined
+      );
     });
   });
 

--- a/src/interactive-engine/interactive.hook.test.ts
+++ b/src/interactive-engine/interactive.hook.test.ts
@@ -649,7 +649,7 @@ describe('useInteractiveElements', () => {
         await result.current.executeInteractiveAction('unknown', 'test-target', undefined, 'do');
       });
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith('Unknown interactive action: unknown');
+      expect(consoleWarnSpy).toHaveBeenCalledWith('Unknown interactive action: unknown', '');
     });
 
     it('should handle errors in executeInteractiveAction', async () => {

--- a/src/interactive-engine/interactive.hook.ts
+++ b/src/interactive-engine/interactive.hook.ts
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useCallback, useRef, useMemo } from 'react'
 import { useTheme2 } from '@grafana/ui';
 import { addGlobalInteractiveStyles, updateInteractiveThemeColors } from '../styles/interactive.styles';
 import { waitForReactUpdates } from '../lib/async-utils';
+import { logger } from '../lib/logging';
 // eslint-disable-next-line no-restricted-imports -- [ratchet] ALLOWED_LATERAL_VIOLATIONS: interactive-engine -> requirements-manager
 import { checkRequirements, checkPostconditions, RequirementsCheckOptions } from '../requirements-manager';
 import { extractInteractiveDataFromElement } from '../lib/dom';
@@ -445,7 +446,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
             break;
 
           default:
-            console.warn(`Unknown interactive action: ${targetAction}`);
+            logger.warn(`Unknown interactive action: ${targetAction}`);
         }
       } catch (error) {
         stateManager.handleError(error as Error, 'executeInteractiveAction', elementData, true);

--- a/src/interactive-engine/interactive.hook.ts
+++ b/src/interactive-engine/interactive.hook.ts
@@ -3,6 +3,7 @@ import { useTheme2 } from '@grafana/ui';
 import { addGlobalInteractiveStyles, updateInteractiveThemeColors } from '../styles/interactive.styles';
 import { waitForReactUpdates } from '../lib/async-utils';
 import { logger } from '../lib/logging';
+import { USER_ACTION_TIMEOUT_LONG_MS, withFaroUserAction } from '../lib/faro';
 // eslint-disable-next-line no-restricted-imports -- [ratchet] ALLOWED_LATERAL_VIOLATIONS: interactive-engine -> requirements-manager
 import { checkRequirements, checkPostconditions, RequirementsCheckOptions } from '../requirements-manager';
 import { extractInteractiveDataFromElement } from '../lib/dom';
@@ -160,21 +161,27 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
   // Define helper functions using refs to avoid circular dependencies
   const dispatchInteractiveAction = useCallback(
     async (data: InteractiveElementData, click: boolean) => {
-      if (data.targetAction === 'highlight') {
-        await interactiveFocus(data, click);
-      } else if (data.targetAction === 'button') {
-        await interactiveButton(data, click);
-      } else if (data.targetAction === 'formfill') {
-        await interactiveFormFill(data, click);
-      } else if (data.targetAction === 'navigate') {
-        interactiveNavigate(data, click);
-      } else if (data.targetAction === 'hover') {
-        await interactiveHover(data, click);
-      } else if (data.targetAction === 'guided') {
-        await interactiveGuided(data, click);
-      } else if (data.targetAction === 'popout') {
-        await interactivePopout(data, click);
-      }
+      await withFaroUserAction(
+        click ? 'pathfinder_step_do' : 'pathfinder_step_show',
+        { target_action: data.targetAction, ref_target: data.refTarget },
+        async () => {
+          if (data.targetAction === 'highlight') {
+            await interactiveFocus(data, click);
+          } else if (data.targetAction === 'button') {
+            await interactiveButton(data, click);
+          } else if (data.targetAction === 'formfill') {
+            await interactiveFormFill(data, click);
+          } else if (data.targetAction === 'navigate') {
+            interactiveNavigate(data, click);
+          } else if (data.targetAction === 'hover') {
+            await interactiveHover(data, click);
+          } else if (data.targetAction === 'guided') {
+            await interactiveGuided(data, click);
+          } else if (data.targetAction === 'popout') {
+            await interactivePopout(data, click);
+          }
+        }
+      );
     },
     [
       interactiveFocus,
@@ -396,61 +403,68 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
       // No DOM element needed - React components manage their own state
       const isShowMode = buttonType === 'show';
 
-      try {
-        switch (targetAction) {
-          case 'highlight':
-            await interactiveFocus(elementData, !isShowMode);
-            break;
+      await withFaroUserAction(
+        isShowMode ? 'pathfinder_step_show' : 'pathfinder_step_do',
+        { target_action: targetAction, ref_target: refTarget },
+        async () => {
+          try {
+            switch (targetAction) {
+              case 'highlight':
+                await interactiveFocus(elementData, !isShowMode);
+                break;
 
-          case 'button':
-            await interactiveButton(elementData, !isShowMode);
-            break;
+              case 'button':
+                await interactiveButton(elementData, !isShowMode);
+                break;
 
-          case 'formfill':
-            await interactiveFormFill(elementData, !isShowMode);
-            break;
+              case 'formfill':
+                await interactiveFormFill(elementData, !isShowMode);
+                break;
 
-          case 'navigate':
-            interactiveNavigate(elementData, !isShowMode);
-            break;
+              case 'navigate':
+                interactiveNavigate(elementData, !isShowMode);
+                break;
 
-          case 'hover':
-            await interactiveHover(elementData, !isShowMode);
-            break;
+              case 'hover':
+                await interactiveHover(elementData, !isShowMode);
+                break;
 
-          case 'guided':
-            await interactiveGuided(elementData, !isShowMode);
-            break;
+              case 'guided':
+                await interactiveGuided(elementData, !isShowMode);
+                break;
 
-          case 'popout':
-            await interactivePopout(elementData, !isShowMode);
-            break;
+              case 'popout':
+                await interactivePopout(elementData, !isShowMode);
+                break;
 
-          case 'sequence':
-            await interactiveSequence(elementData, isShowMode);
-            break;
+              case 'sequence':
+                await interactiveSequence(elementData, isShowMode);
+                break;
 
-          case 'noop':
-            // Noop actions are informational - no element interaction needed
-            // In show mode, briefly display the comment if provided
-            // In do mode, just mark as completed (nothing to execute)
-            if (isShowMode && targetComment) {
-              // Show a brief notification with the comment
-              // Use navigationManager to show a floating comment briefly
-              navigationManager.showNoopComment(targetComment);
-              // Auto-dismiss after a delay
-              await new Promise((resolve) => setTimeout(resolve, 2000));
-              navigationManager.clearAllHighlights();
+              case 'noop':
+                // Noop actions are informational - no element interaction needed
+                // In show mode, briefly display the comment if provided
+                // In do mode, just mark as completed (nothing to execute)
+                if (isShowMode && targetComment) {
+                  // Show a brief notification with the comment
+                  // Use navigationManager to show a floating comment briefly
+                  navigationManager.showNoopComment(targetComment);
+                  // Auto-dismiss after a delay
+                  await new Promise((resolve) => setTimeout(resolve, 2000));
+                  navigationManager.clearAllHighlights();
+                }
+                // Do mode: nothing to do - noop steps complete immediately
+                break;
+
+              default:
+                logger.warn(`Unknown interactive action: ${targetAction}`);
             }
-            // Do mode: nothing to do - noop steps complete immediately
-            break;
-
-          default:
-            logger.warn(`Unknown interactive action: ${targetAction}`);
-        }
-      } catch (error) {
-        stateManager.handleError(error as Error, 'executeInteractiveAction', elementData, true);
-      }
+          } catch (error) {
+            stateManager.handleError(error as Error, 'executeInteractiveAction', elementData, true);
+          }
+        },
+        targetAction === 'sequence' ? USER_ACTION_TIMEOUT_LONG_MS : undefined
+      );
     },
     [
       interactiveFocus,

--- a/src/interactive-engine/navigation-manager.test.ts
+++ b/src/interactive-engine/navigation-manager.test.ts
@@ -15,6 +15,10 @@ global.ResizeObserver = MockResizeObserver as any;
 const mockIsElementVisible = elementValidator.isElementVisible as jest.MockedFunction<
   typeof elementValidator.isElementVisible
 >;
+
+const mockDescribeElement = elementValidator.describeElement as jest.MockedFunction<
+  typeof elementValidator.describeElement
+>;
 const mockHasFixedPosition = elementValidator.hasFixedPosition as jest.MockedFunction<
   typeof elementValidator.hasFixedPosition
 >;
@@ -38,6 +42,7 @@ describe('NavigationManager', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDescribeElement.mockReturnValue('div');
     navigationManager = new NavigationManager();
 
     // Create mock element
@@ -93,7 +98,7 @@ describe('NavigationManager', () => {
 
       await navigationManager.ensureElementVisible(mockElement);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Element is hidden or not visible', { element: mockElement });
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Element is hidden or not visible', { element: 'div' });
     });
 
     it('should scroll element into view when not in viewport', async () => {

--- a/src/interactive-engine/navigation-manager.test.ts
+++ b/src/interactive-engine/navigation-manager.test.ts
@@ -93,7 +93,7 @@ describe('NavigationManager', () => {
 
       await navigationManager.ensureElementVisible(mockElement);
 
-      expect(mockConsoleWarn).toHaveBeenCalledWith('Element is hidden or not visible:', mockElement);
+      expect(mockConsoleWarn).toHaveBeenCalledWith('Element is hidden or not visible', { element: mockElement });
     });
 
     it('should scroll element into view when not in viewport', async () => {

--- a/src/interactive-engine/navigation-manager.ts
+++ b/src/interactive-engine/navigation-manager.ts
@@ -1,7 +1,13 @@
 import { waitForReactUpdates } from '../lib/async-utils';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import logoSvg from '../img/logo.svg';
-import { isElementVisible, getScrollParent, getStickyHeaderOffset, getVisibleHighlightTarget } from '../lib/dom';
+import {
+  describeElement,
+  isElementVisible,
+  getScrollParent,
+  getStickyHeaderOffset,
+  getVisibleHighlightTarget,
+} from '../lib/dom';
 import { logger } from '../lib/logging';
 import { sanitizeDocumentationHTML } from '../security';
 import { applyE2ECommentBoxAttributes } from './e2e-attributes';
@@ -498,7 +504,7 @@ export class NavigationManager {
   async ensureElementVisible(element: HTMLElement): Promise<void> {
     // 1. Check if element is visible in DOM (not hidden by CSS)
     if (!isElementVisible(element)) {
-      logger.warn('Element is hidden or not visible', { element });
+      logger.warn('Element is hidden or not visible', { element: describeElement(element) });
       // Continue anyway - element might become visible during interaction
     }
 

--- a/src/interactive-engine/navigation-manager.ts
+++ b/src/interactive-engine/navigation-manager.ts
@@ -2,6 +2,7 @@ import { waitForReactUpdates } from '../lib/async-utils';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import logoSvg from '../img/logo.svg';
 import { isElementVisible, getScrollParent, getStickyHeaderOffset, getVisibleHighlightTarget } from '../lib/dom';
+import { logger } from '../lib/logging';
 import { sanitizeDocumentationHTML } from '../security';
 import { applyE2ECommentBoxAttributes } from './e2e-attributes';
 
@@ -497,7 +498,7 @@ export class NavigationManager {
   async ensureElementVisible(element: HTMLElement): Promise<void> {
     // 1. Check if element is visible in DOM (not hidden by CSS)
     if (!isElementVisible(element)) {
-      console.warn('Element is hidden or not visible:', element);
+      logger.warn('Element is hidden or not visible', { element });
       // Continue anyway - element might become visible during interaction
     }
 
@@ -656,7 +657,7 @@ export class NavigationManager {
     // Check if element has no valid position at all (truly invalid)
     const hasNoPosition = rect.top === 0 && rect.left === 0 && rect.width === 0 && rect.height === 0;
     if (hasNoPosition) {
-      console.warn('Cannot highlight element: invalid position or dimensions', {
+      logger.warn('Cannot highlight element: invalid position or dimensions', {
         rect,
       });
       return element;
@@ -1326,7 +1327,7 @@ export class NavigationManager {
 
       return true;
     } catch (error) {
-      console.error('Failed to expand parent navigation section:', error);
+      logger.error('Failed to expand parent navigation section', { error });
       return false;
     }
   }
@@ -1481,7 +1482,7 @@ export class NavigationManager {
 
       return true;
     } catch (error) {
-      console.error('Failed to expand all navigation sections:', error);
+      logger.error('Failed to expand all navigation sections', { error });
       return false;
     }
   }
@@ -1509,7 +1510,7 @@ export class NavigationManager {
     const megaMenuToggle = document.querySelector('#mega-menu-toggle') as HTMLButtonElement;
     if (!megaMenuToggle) {
       if (logWarnings) {
-        console.warn('Mega menu toggle button not found - navigation may already be open or use different structure');
+        logger.warn('Mega menu toggle button not found - navigation may already be open or use different structure');
       }
       return;
     }
@@ -1545,7 +1546,7 @@ export class NavigationManager {
         await waitForReactUpdates();
         await this.pollForNavItems();
       } else if (logWarnings) {
-        console.warn('Dock menu button not found after polling, navigation will remain in modal mode');
+        logger.warn('Dock menu button not found after polling, navigation will remain in modal mode');
       }
     }
   }

--- a/src/interactive-engine/sequence-manager.ts
+++ b/src/interactive-engine/sequence-manager.ts
@@ -1,6 +1,7 @@
 import { InteractiveElementData } from '../types/interactive.types';
 import { InteractiveStateManager } from './interactive-state-manager';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
+import { logger } from '../lib/logging';
 
 /**
  * Result of a retry operation
@@ -62,7 +63,7 @@ export class SequenceManager {
       }
     }
 
-    console.warn(
+    logger.warn(
       `${context.stepName} ${context.stepIndex + 1} failed after ${this.MAX_RETRIES} retries, stopping sequence`
     );
     return 'failed';

--- a/src/learning-paths/badge-coordinator.ts
+++ b/src/learning-paths/badge-coordinator.ts
@@ -23,6 +23,7 @@
 import { reportAppInteraction, UserInteraction } from '../lib/analytics';
 import { StorageEvents } from '../lib/event-names';
 import { learningProgressStorage } from '../lib/user-storage';
+import { logger } from '../lib/logging';
 
 import { getBadgeById, getBadgesToAward } from './badges';
 import { getPathsData } from './paths-data';
@@ -92,7 +93,7 @@ export async function markGuideCompleted(guideId: string): Promise<void> {
       );
     }
   } catch (error) {
-    console.error('Failed to mark guide as completed:', error);
+    logger.error('Failed to mark guide as completed', { error });
     // Still dispatch the event so UI components that wait on completion
     // are not left hanging.
     window.dispatchEvent(

--- a/src/learning-paths/fetch-path-guides.ts
+++ b/src/learning-paths/fetch-path-guides.ts
@@ -8,6 +8,7 @@
  */
 
 import type { GuideMetadataEntry } from '../types/learning-paths.types';
+import { logger } from '../lib/logging';
 
 // ============================================================================
 // TYPES
@@ -56,14 +57,14 @@ export async function fetchPathGuides(pathUrl: string, signal?: AbortSignal): Pr
     const response = await fetch(indexJsonUrl.toString(), { signal });
 
     if (!response.ok) {
-      console.warn(`[fetchPathGuides] Failed to fetch (${response.status}): ${indexJsonUrl.toString()}`);
+      logger.warn(`[fetchPathGuides] Failed to fetch (${response.status}): ${indexJsonUrl.toString()}`);
       return null;
     }
 
     const data = await response.json();
 
     if (!Array.isArray(data)) {
-      console.warn(`[fetchPathGuides] Unexpected response shape from ${indexJsonUrl.toString()}`);
+      logger.warn(`[fetchPathGuides] Unexpected response shape from ${indexJsonUrl.toString()}`);
       return null;
     }
 
@@ -98,7 +99,7 @@ export async function fetchPathGuides(pathUrl: string, signal?: AbortSignal): Pr
     if (error instanceof DOMException && error.name === 'AbortError') {
       return null;
     }
-    console.warn(`[fetchPathGuides] Failed to fetch guides from ${indexJsonUrl.toString()}:`, error);
+    logger.warn(`[fetchPathGuides] Failed to fetch guides from ${indexJsonUrl.toString()}`, { error });
     return null;
   }
 }

--- a/src/learning-paths/learning-paths.hook.ts
+++ b/src/learning-paths/learning-paths.hook.ts
@@ -18,6 +18,7 @@ import type {
 } from '../types/learning-paths.types';
 
 import { StorageEvents } from '../lib/event-names';
+import { logger } from '../lib/logging';
 import {
   learningProgressStorage,
   interactiveStepStorage,
@@ -179,7 +180,7 @@ export function useLearningPaths(): UseLearningPathsReturn {
         setIsLoading(false);
       }
     } catch (error) {
-      console.warn('Failed to load learning progress:', error);
+      logger.warn('Failed to load learning progress', { error });
       if (mounted.current) {
         setIsLoading(false);
       }

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,6 +1,6 @@
 import { reportAppInteraction, UserInteraction, bindExperimentsProvider } from './analytics';
 import { reportInteraction } from '@grafana/runtime';
-import { pushFaroEvent } from './faro';
+import { pushFaroUserAction } from './faro';
 
 jest.mock('@grafana/runtime', () => ({
   reportInteraction: jest.fn(),
@@ -15,11 +15,11 @@ jest.mock('../security/url-validator', () => ({
 }));
 
 jest.mock('./faro', () => ({
-  pushFaroEvent: jest.fn(),
+  pushFaroUserAction: jest.fn(),
 }));
 
 const mockReportInteraction = reportInteraction as jest.Mock;
-const mockPushFaroEvent = pushFaroEvent as jest.Mock;
+const mockPushFaroUserAction = pushFaroUserAction as jest.Mock;
 
 describe('reportAppInteraction', () => {
   beforeEach(() => {
@@ -84,16 +84,16 @@ describe('reportAppInteraction Faro mirroring', () => {
     reportAppInteraction(UserInteraction.ShowMeButtonClick, { step_id: 'step-1' });
 
     expect(mockReportInteraction).toHaveBeenCalledTimes(1);
-    expect(mockPushFaroEvent).toHaveBeenCalledTimes(1);
+    expect(mockPushFaroUserAction).toHaveBeenCalledTimes(1);
 
     const [reportedName, reportedProperties] = mockReportInteraction.mock.calls[0];
-    const [mirroredName, mirroredProperties] = mockPushFaroEvent.mock.calls[0];
+    const [mirroredName, mirroredProperties] = mockPushFaroUserAction.mock.calls[0];
     expect(mirroredName).toBe(reportedName);
     expect(mirroredProperties).toBe(reportedProperties);
   });
 
   it('still reports to Rudderstack even if the Faro mirror throws', () => {
-    mockPushFaroEvent.mockImplementationOnce(() => {
+    mockPushFaroUserAction.mockImplementationOnce(() => {
       throw new Error('faro is down');
     });
 

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -93,7 +93,10 @@ describe('reportAppInteraction Faro mirroring', () => {
     const [reportedName, reportedProperties] = mockReportInteraction.mock.calls[0];
     const [mirroredName, mirroredProperties] = mockPushFaroUserAction.mock.calls[0];
     expect(mirroredName).toBe(reportedName);
-    expect(mirroredProperties).toBe(reportedProperties);
+    expect(mirroredProperties).toEqual(reportedProperties);
+    // A defensive copy, not the shared reference — neither pipeline can
+    // mutate the other's payload.
+    expect(mirroredProperties).not.toBe(reportedProperties);
   });
 
   it('still reports to Rudderstack even if the Faro mirror throws', () => {
@@ -105,6 +108,18 @@ describe('reportAppInteraction Faro mirroring', () => {
     // means a later mirror failure can't unwind or suppress that earlier call.
     expect(() => reportAppInteraction(UserInteraction.ShowMeButtonClick, {})).not.toThrow();
     expect(mockReportInteraction).toHaveBeenCalledTimes(1);
+  });
+
+  it('still mirrors to Faro when reportInteraction itself throws', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    mockReportInteraction.mockImplementationOnce(() => {
+      throw new Error('rudderstack down');
+    });
+
+    expect(() => reportAppInteraction(UserInteraction.ShowMeButtonClick, { step_id: 'step-1' })).not.toThrow();
+    expect(mockPushFaroUserAction).toHaveBeenCalledTimes(1);
+    expect(mockNotifyFaroEngagement).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
   });
 });
 

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,6 +1,6 @@
 import { reportAppInteraction, UserInteraction, bindExperimentsProvider } from './analytics';
 import { reportInteraction } from '@grafana/runtime';
-import { notifyFaroEngagement, pushFaroUserAction } from './faro';
+import { pushFaroUserAction } from './faro';
 
 jest.mock('@grafana/runtime', () => ({
   reportInteraction: jest.fn(),
@@ -18,12 +18,10 @@ jest.mock('./faro', () => ({
   pushFaroUserAction: jest.fn(),
   pushFaroLog: jest.fn(),
   pushFaroError: jest.fn(),
-  notifyFaroEngagement: jest.fn(() => Promise.resolve()),
 }));
 
 const mockReportInteraction = reportInteraction as jest.Mock;
 const mockPushFaroUserAction = pushFaroUserAction as jest.Mock;
-const mockNotifyFaroEngagement = notifyFaroEngagement as jest.Mock;
 
 describe('reportAppInteraction', () => {
   beforeEach(() => {
@@ -118,7 +116,6 @@ describe('reportAppInteraction Faro mirroring', () => {
 
     expect(() => reportAppInteraction(UserInteraction.ShowMeButtonClick, { step_id: 'step-1' })).not.toThrow();
     expect(mockPushFaroUserAction).toHaveBeenCalledTimes(1);
-    expect(mockNotifyFaroEngagement).toHaveBeenCalledTimes(1);
     warnSpy.mockRestore();
   });
 });
@@ -185,15 +182,8 @@ describe('reportAppInteraction experiment enrichment', () => {
     expect(props.flag_key).toBe(HIGHLIGHTED);
   });
 
-  it('signals Faro engagement for regular interactions', () => {
-    reportAppInteraction(UserInteraction.DocsPanelInteraction, { action: 'open' });
-    expect(mockNotifyFaroEngagement).toHaveBeenCalledTimes(1);
-    expect(mockPushFaroUserAction).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not signal Faro engagement for flag exposures, but still mirrors them', () => {
+  it('still mirrors flag exposures to Faro (beforeSend gates delivery, not the mirror)', () => {
     reportAppInteraction(UserInteraction.FeatureFlagEvaluated, { flag_key: HIGHLIGHTED });
-    expect(mockNotifyFaroEngagement).not.toHaveBeenCalled();
     expect(mockPushFaroUserAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -16,6 +16,8 @@ jest.mock('../security/url-validator', () => ({
 
 jest.mock('./faro', () => ({
   pushFaroUserAction: jest.fn(),
+  pushFaroLog: jest.fn(),
+  pushFaroError: jest.fn(),
 }));
 
 const mockReportInteraction = reportInteraction as jest.Mock;

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,6 +1,6 @@
 import { reportAppInteraction, UserInteraction, bindExperimentsProvider } from './analytics';
 import { reportInteraction } from '@grafana/runtime';
-import { pushFaroUserAction } from './faro';
+import { notifyFaroEngagement, pushFaroUserAction } from './faro';
 
 jest.mock('@grafana/runtime', () => ({
   reportInteraction: jest.fn(),
@@ -18,10 +18,12 @@ jest.mock('./faro', () => ({
   pushFaroUserAction: jest.fn(),
   pushFaroLog: jest.fn(),
   pushFaroError: jest.fn(),
+  notifyFaroEngagement: jest.fn(() => Promise.resolve()),
 }));
 
 const mockReportInteraction = reportInteraction as jest.Mock;
 const mockPushFaroUserAction = pushFaroUserAction as jest.Mock;
+const mockNotifyFaroEngagement = notifyFaroEngagement as jest.Mock;
 
 describe('reportAppInteraction', () => {
   beforeEach(() => {
@@ -166,5 +168,17 @@ describe('reportAppInteraction experiment enrichment', () => {
     expect(props).not.toHaveProperty('experiments');
     expect(props).not.toHaveProperty('variant');
     expect(props.flag_key).toBe(HIGHLIGHTED);
+  });
+
+  it('signals Faro engagement for regular interactions', () => {
+    reportAppInteraction(UserInteraction.DocsPanelInteraction, { action: 'open' });
+    expect(mockNotifyFaroEngagement).toHaveBeenCalledTimes(1);
+    expect(mockPushFaroUserAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not signal Faro engagement for flag exposures, but still mirrors them', () => {
+    reportAppInteraction(UserInteraction.FeatureFlagEvaluated, { flag_key: HIGHLIGHTED });
+    expect(mockNotifyFaroEngagement).not.toHaveBeenCalled();
+    expect(mockPushFaroUserAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,5 +1,6 @@
 import { reportAppInteraction, UserInteraction, bindExperimentsProvider } from './analytics';
 import { reportInteraction } from '@grafana/runtime';
+import { pushFaroEvent } from './faro';
 
 jest.mock('@grafana/runtime', () => ({
   reportInteraction: jest.fn(),
@@ -13,7 +14,12 @@ jest.mock('../security/url-validator', () => ({
   isInteractiveLearningUrl: jest.fn(() => false),
 }));
 
+jest.mock('./faro', () => ({
+  pushFaroEvent: jest.fn(),
+}));
+
 const mockReportInteraction = reportInteraction as jest.Mock;
+const mockPushFaroEvent = pushFaroEvent as jest.Mock;
 
 describe('reportAppInteraction', () => {
   beforeEach(() => {
@@ -66,6 +72,35 @@ describe('reportAppInteraction', () => {
     expect(properties.step_id).toBe('step-1');
     expect(properties.content_type).toBe('interactive_guide');
     expect(properties.plugin_version).toBe('1.0.0-test');
+  });
+});
+
+describe('reportAppInteraction Faro mirroring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('mirrors the same interaction name and enriched properties to Faro', () => {
+    reportAppInteraction(UserInteraction.ShowMeButtonClick, { step_id: 'step-1' });
+
+    expect(mockReportInteraction).toHaveBeenCalledTimes(1);
+    expect(mockPushFaroEvent).toHaveBeenCalledTimes(1);
+
+    const [reportedName, reportedProperties] = mockReportInteraction.mock.calls[0];
+    const [mirroredName, mirroredProperties] = mockPushFaroEvent.mock.calls[0];
+    expect(mirroredName).toBe(reportedName);
+    expect(mirroredProperties).toBe(reportedProperties);
+  });
+
+  it('still reports to Rudderstack even if the Faro mirror throws', () => {
+    mockPushFaroEvent.mockImplementationOnce(() => {
+      throw new Error('faro is down');
+    });
+
+    // reportInteraction is called before the mirror, and the outer try/catch
+    // means a later mirror failure can't unwind or suppress that earlier call.
+    expect(() => reportAppInteraction(UserInteraction.ShowMeButtonClick, {})).not.toThrow();
+    expect(mockReportInteraction).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -8,7 +8,7 @@
 import { reportInteraction } from '@grafana/runtime';
 import packageJson from '../../package.json';
 import { isInteractiveLearningUrl } from '../security/url-validator';
-import { pushFaroEvent } from './faro';
+import { pushFaroUserAction } from './faro';
 import type { ExperimentConfig, ExperimentAnalyticsEntry } from '../utils/openfeature';
 
 type GetActiveExperimentsFn = () => ExperimentAnalyticsEntry[];
@@ -203,10 +203,11 @@ export function reportAppInteraction(
     };
 
     reportInteraction(interactionName, enrichedProperties);
-    // Mirrors every analytics event into Faro (same name, same properties) so the
-    // two pipelines can be cross-checked against each other. pushFaroEvent never
-    // throws, so a mirror failure can't affect the reportInteraction call above.
-    pushFaroEvent(interactionName, enrichedProperties);
+    // Mirrors every analytics event into Faro as a User Action (same name, same
+    // properties) so the two pipelines can be cross-checked against each other.
+    // pushFaroUserAction never throws, so a mirror failure can't affect the
+    // reportInteraction call above.
+    pushFaroUserAction(interactionName, enrichedProperties);
   } catch (error) {
     console.warn('Analytics reporting failed:', error);
   }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -9,6 +9,7 @@ import { reportInteraction } from '@grafana/runtime';
 import packageJson from '../../package.json';
 import { isInteractiveLearningUrl } from '../security/url-validator';
 import { pushFaroUserAction } from './faro';
+import { logger } from './logging';
 import type { ExperimentConfig, ExperimentAnalyticsEntry } from '../utils/openfeature';
 
 type GetActiveExperimentsFn = () => ExperimentAnalyticsEntry[];
@@ -209,7 +210,7 @@ export function reportAppInteraction(
     // reportInteraction call above.
     pushFaroUserAction(interactionName, enrichedProperties);
   } catch (error) {
-    console.warn('Analytics reporting failed:', error);
+    logger.warn('Analytics reporting failed', { error });
   }
 }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -8,6 +8,7 @@
 import { reportInteraction } from '@grafana/runtime';
 import packageJson from '../../package.json';
 import { isInteractiveLearningUrl } from '../security/url-validator';
+import { pushFaroEvent } from './faro';
 import type { ExperimentConfig, ExperimentAnalyticsEntry } from '../utils/openfeature';
 
 type GetActiveExperimentsFn = () => ExperimentAnalyticsEntry[];
@@ -202,6 +203,10 @@ export function reportAppInteraction(
     };
 
     reportInteraction(interactionName, enrichedProperties);
+    // Mirrors every analytics event into Faro (same name, same properties) so the
+    // two pipelines can be cross-checked against each other. pushFaroEvent never
+    // throws, so a mirror failure can't affect the reportInteraction call above.
+    pushFaroEvent(interactionName, enrichedProperties);
   } catch (error) {
     console.warn('Analytics reporting failed:', error);
   }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -8,7 +8,7 @@
 import { reportInteraction } from '@grafana/runtime';
 import packageJson from '../../package.json';
 import { isInteractiveLearningUrl } from '../security/url-validator';
-import { pushFaroUserAction } from './faro';
+import { notifyFaroEngagement, pushFaroUserAction } from './faro';
 import { logger } from './logging';
 import type { ExperimentConfig, ExperimentAnalyticsEntry } from '../utils/openfeature';
 
@@ -204,6 +204,12 @@ export function reportAppInteraction(
     };
 
     reportInteraction(interactionName, enrichedProperties);
+    // Flag exposures fire for the whole experiment population on page load —
+    // they must not summon Faro (a session would then exist for every user).
+    // They ride the pre-init buffer until real engagement instead.
+    if (type !== UserInteraction.FeatureFlagEvaluated) {
+      void notifyFaroEngagement();
+    }
     // Mirrors every analytics event into Faro as a User Action (same name, same
     // properties) so the two pipelines can be cross-checked against each other.
     // pushFaroUserAction never throws, so a mirror failure can't affect the

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -203,18 +203,22 @@ export function reportAppInteraction(
       ...(kioskSessionId && { kiosk_session_id: kioskSessionId }),
     };
 
-    reportInteraction(interactionName, enrichedProperties);
-    // Flag exposures fire for the whole experiment population on page load —
-    // they must not summon Faro (a session would then exist for every user).
-    // They ride the pre-init buffer until real engagement instead.
-    if (type !== UserInteraction.FeatureFlagEvaluated) {
-      void notifyFaroEngagement();
+    try {
+      reportInteraction(interactionName, enrichedProperties);
+    } finally {
+      // Flag exposures fire for the whole experiment population on page load —
+      // they must not summon Faro (a session would then exist for every user).
+      // They ride the pre-init buffer until real engagement instead.
+      if (type !== UserInteraction.FeatureFlagEvaluated) {
+        void notifyFaroEngagement();
+      }
+      // Mirrors every analytics event into Faro as a User Action (same name,
+      // copied properties) so the two pipelines can be cross-checked against
+      // each other. The finally keeps the mirror alive when reportInteraction
+      // itself throws — a lost RudderStack event is exactly the divergence the
+      // mirror exists to surface. pushFaroUserAction never throws.
+      pushFaroUserAction(interactionName, { ...enrichedProperties });
     }
-    // Mirrors every analytics event into Faro as a User Action (same name, same
-    // properties) so the two pipelines can be cross-checked against each other.
-    // pushFaroUserAction never throws, so a mirror failure can't affect the
-    // reportInteraction call above.
-    pushFaroUserAction(interactionName, enrichedProperties);
   } catch (error) {
     logger.warn('Analytics reporting failed', { error });
   }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -8,7 +8,7 @@
 import { reportInteraction } from '@grafana/runtime';
 import packageJson from '../../package.json';
 import { isInteractiveLearningUrl } from '../security/url-validator';
-import { notifyFaroEngagement, pushFaroUserAction } from './faro';
+import { pushFaroUserAction } from './faro';
 import { logger } from './logging';
 import type { ExperimentConfig, ExperimentAnalyticsEntry } from '../utils/openfeature';
 
@@ -206,12 +206,6 @@ export function reportAppInteraction(
     try {
       reportInteraction(interactionName, enrichedProperties);
     } finally {
-      // Flag exposures fire for the whole experiment population on page load —
-      // they must not summon Faro (a session would then exist for every user).
-      // They ride the pre-init buffer until real engagement instead.
-      if (type !== UserInteraction.FeatureFlagEvaluated) {
-        void notifyFaroEngagement();
-      }
       // Mirrors every analytics event into Faro as a User Action (same name,
       // copied properties) so the two pipelines can be cross-checked against
       // each other. The finally keeps the mirror alive when reportInteraction

--- a/src/lib/cross-tab-transport.ts
+++ b/src/lib/cross-tab-transport.ts
@@ -4,6 +4,7 @@ import {
   type CrossTabPayload,
   validateCrossTabMessage,
 } from '../types/cross-tab.types';
+import { logger } from './logging';
 
 export interface BroadcastChannelLike {
   postMessage(message: unknown): void;
@@ -93,7 +94,7 @@ export class CrossTabTransport {
         listener(message);
       } catch (err) {
         // One throwing listener must not starve the rest (F-1056-5).
-        console.error('cross-tab listener threw', err);
+        logger.error('cross-tab listener threw', { error: err });
       }
     });
   };

--- a/src/lib/dom/dom-utils.test.ts
+++ b/src/lib/dom/dom-utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  describeElement,
   getAllTextContent,
   extractInteractiveDataFromElement,
   findButtonByText,
@@ -756,5 +757,32 @@ describe('getVisibleHighlightTarget', () => {
 
     // Should not find wrapper (beyond maxDepth=5), return original
     expect(result).toBe(input);
+  });
+});
+
+describe('describeElement', () => {
+  it('renders tag, id, classes, and data-testid as a compact selector-like string', () => {
+    const el = document.createElement('button');
+    el.id = 'save';
+    el.className = 'btn primary';
+    el.setAttribute('data-testid', 'save-button');
+    expect(describeElement(el)).toBe('button#save.btn.primary[data-testid="save-button"]');
+  });
+
+  it('caps the class list at three entries', () => {
+    const el = document.createElement('div');
+    el.className = 'a b c d e';
+    expect(describeElement(el)).toBe('div.a.b.c');
+  });
+
+  it('handles a bare element and nullish input', () => {
+    expect(describeElement(document.createElement('span'))).toBe('span');
+    expect(describeElement(null)).toBe('null');
+    expect(describeElement(undefined)).toBe('undefined');
+  });
+
+  it('tolerates SVG elements, whose className is not a string', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    expect(describeElement(svg)).toBe('svg');
   });
 });

--- a/src/lib/dom/dom-utils.test.ts
+++ b/src/lib/dom/dom-utils.test.ts
@@ -161,7 +161,8 @@ describe('extractInteractiveDataFromElement', () => {
     extractInteractiveDataFromElement(element);
 
     expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('refTarget "This is a very long suspicious value" matches element text')
+      expect.stringContaining('refTarget "This is a very long suspicious value" matches element text'),
+      ''
     );
   });
 

--- a/src/lib/dom/dom-utils.ts
+++ b/src/lib/dom/dom-utils.ts
@@ -1,4 +1,5 @@
 import { InteractiveElementData } from '../../types/interactive.types';
+import { logger } from '../logging';
 import { querySelectorAllEnhanced } from './enhanced-selector';
 import { resolveSelector } from './selector-resolver';
 import { isCssSelector } from './selector-detector';
@@ -66,7 +67,7 @@ export function extractInteractiveDataFromElement(element: HTMLElement): Interac
   const textContent = element.textContent?.trim() || undefined;
 
   if (refTarget && textContent && refTarget === textContent && refTarget.length > 5) {
-    console.warn(`refTarget "${refTarget}" matches element text — check data-reftarget attribute`);
+    logger.warn(`refTarget "${refTarget}" matches element text — check data-reftarget attribute`);
   }
 
   return {
@@ -327,7 +328,7 @@ export async function scrollUntilElementFound(
   // Find the scroll container
   const scrollContainer = document.querySelector(scrollContainerSelector);
   if (!scrollContainer || !(scrollContainer instanceof HTMLElement)) {
-    console.warn(`[LazyScroll] Scroll container not found: ${scrollContainerSelector}`);
+    logger.warn(`[LazyScroll] Scroll container not found: ${scrollContainerSelector}`);
     return null;
   }
 

--- a/src/lib/dom/dom-utils.ts
+++ b/src/lib/dom/dom-utils.ts
@@ -577,3 +577,14 @@ export async function formValidCheck(check: string): Promise<{
     };
   }
 }
+
+export function describeElement(element: Element | null | undefined): string {
+  if (!element) {
+    return String(element);
+  }
+  const id = element.id ? `#${element.id}` : '';
+  const className = typeof element.className === 'string' ? element.className.trim() : '';
+  const classes = className ? `.${className.split(/\s+/).slice(0, 3).join('.')}` : '';
+  const testId = element.getAttribute('data-testid');
+  return `${element.tagName.toLowerCase()}${id}${classes}${testId ? `[data-testid="${testId}"]` : ''}`;
+}

--- a/src/lib/dom/enhanced-selector.ts
+++ b/src/lib/dom/enhanced-selector.ts
@@ -4,6 +4,8 @@
  * that aren't universally supported in browsers
  */
 
+import { logger } from '../logging';
+
 export interface SelectorResult {
   elements: HTMLElement[];
   usedFallback: boolean;
@@ -49,7 +51,7 @@ export function querySelectorAllEnhanced(selector: string): SelectorResult {
     // If native selector failed (threw error), check if it's just a simple selector with no elements
     // Don't treat standard CSS selectors as "complex" just because they failed
     if (nativeResult === null && !isComplexSelector(selector)) {
-      console.warn(`Native selector failed for standard CSS selector: "${selector}"`);
+      logger.warn(`Native selector failed for standard CSS selector: "${selector}"`);
       return {
         elements: [],
         usedFallback: false,
@@ -61,7 +63,7 @@ export function querySelectorAllEnhanced(selector: string): SelectorResult {
     // parse and handle complex selectors
     return handleComplexSelector(selector);
   } catch (error) {
-    console.warn(`Enhanced selector failed for "${selector}":`, error);
+    logger.warn(`Enhanced selector failed for "${selector}"`, { error });
     return {
       elements: [],
       usedFallback: true,
@@ -132,9 +134,9 @@ function handleComplexSelector(selector: string): SelectorResult {
   // If no special handling needed but we got here, the native selector must have failed
   // This could be an invalid selector or just a selector with no matches
   // Log more details to help debug
-  console.warn(`Unsupported complex selector (no :contains, :has, :text, or :nth-match found): "${selector}"`);
-  console.warn('This selector was flagged as complex but has no recognized pseudo-selectors');
-  console.warn('It may be corrupted or invalid. Original length:', selector.length);
+  logger.warn(`Unsupported complex selector (no :contains, :has, :text, or :nth-match found): "${selector}"`);
+  logger.warn('This selector was flagged as complex but has no recognized pseudo-selectors');
+  logger.warn('It may be corrupted or invalid. Original length', { selectorLength: selector.length });
 
   return {
     elements: [],
@@ -180,7 +182,7 @@ function handleContainsSelector(selector: string): SelectorResult {
   const containsMatch = selector.match(/^(.+?):contains\((['"]?)(.*?)\2\)(.*)$/);
 
   if (!containsMatch) {
-    console.warn(`Invalid :contains() syntax: ${selector}`);
+    logger.warn(`Invalid :contains() syntax: ${selector}`);
     return {
       elements: [],
       usedFallback: true,
@@ -218,7 +220,7 @@ function handleContainsSelector(selector: string): SelectorResult {
       effectiveSelector: `${baseSelector} (text contains "${searchText}")${afterContains ? ` then ${afterContains}` : ''}`,
     };
   } catch (error) {
-    console.warn(`Error processing :contains() selector "${selector}":`, error);
+    logger.warn(`Error processing :contains() selector "${selector}"`, { error });
     return {
       elements: [],
       usedFallback: true,
@@ -294,7 +296,7 @@ function handleHasSelector(selector: string): SelectorResult {
   const hasMatch = parseHasSelector(selector);
 
   if (!hasMatch) {
-    console.warn(`Invalid :has() syntax: ${selector}`);
+    logger.warn(`Invalid :has() syntax: ${selector}`);
     return {
       elements: [],
       usedFallback: true,
@@ -338,7 +340,7 @@ function handleHasSelector(selector: string): SelectorResult {
               (desc.textContent || '').toLowerCase().includes(innerSearchText.toLowerCase())
             );
           } catch (error) {
-            console.warn(`Error checking inner :contains() selector "${hasSelector}":`, error);
+            logger.warn(`Error checking inner :contains() selector "${hasSelector}"`, { error });
             continue;
           }
         } else {
@@ -354,7 +356,7 @@ function handleHasSelector(selector: string): SelectorResult {
           const descendants = element.querySelectorAll(hasSelector);
           hasDescendant = descendants.length > 0;
         } catch (error) {
-          console.warn(`Error checking descendant selector "${hasSelector}":`, error);
+          logger.warn(`Error checking descendant selector "${hasSelector}"`, { error });
           continue;
         }
       }
@@ -391,7 +393,7 @@ function handleHasSelector(selector: string): SelectorResult {
                 const descendants = element.querySelectorAll(nextHasSelector);
                 alsoHasDescendant = descendants.length > 0;
               } catch (error) {
-                console.warn(`Error checking descendant selector "${nextHasSelector}":`, error);
+                logger.warn(`Error checking descendant selector "${nextHasSelector}"`, { error });
               }
             }
 
@@ -438,7 +440,7 @@ function handleHasSelector(selector: string): SelectorResult {
           );
           nestedElements.push(...nestedInContainer);
         } catch (nestedError) {
-          console.warn(`Error applying nested selector "${afterHas}":`, nestedError);
+          logger.warn(`Error applying nested selector "${afterHas}"`, { nestedError });
         }
       }
       return {
@@ -456,7 +458,7 @@ function handleHasSelector(selector: string): SelectorResult {
       effectiveSelector: `${baseSelector} (has descendant: ${hasSelector})`,
     };
   } catch (error) {
-    console.warn(`Error processing :has() selector "${selector}":`, error);
+    logger.warn(`Error processing :has() selector "${selector}"`, { error });
     return {
       elements: [],
       usedFallback: true,
@@ -513,7 +515,7 @@ function handleTextSelector(selector: string): SelectorResult {
       effectiveSelector: `${textBaseSelector} (text equals "${textSearchText}")${textAfter ? ` then ${textAfter}` : ''}`,
     };
   } catch (error) {
-    console.warn(`Error processing :text() selector "${selector}":`, error);
+    logger.warn(`Error processing :text() selector "${selector}"`, { error });
     return {
       elements: [],
       usedFallback: true,
@@ -619,7 +621,7 @@ function handleTestIdSelector(selector: string): SelectorResult {
       };
     }
   } catch (error) {
-    console.warn(`Native selector failed for testid selector: "${selector}"`, error);
+    logger.warn(`Native selector failed for testid selector: "${selector}"`, { error });
   }
 
   // 2. Fallback: If selector uses strict child combinator (>), try relaxing to descendant (space)
@@ -749,7 +751,7 @@ function handleNthMatchSelector(selector: string): SelectorResult {
   const match = selector.match(nthMatchPattern);
 
   if (!match) {
-    console.warn(`Invalid :nth-match() syntax: ${selector}`);
+    logger.warn(`Invalid :nth-match() syntax: ${selector}`);
     return {
       elements: [],
       usedFallback: true,
@@ -764,7 +766,7 @@ function handleNthMatchSelector(selector: string): SelectorResult {
   const index = parseInt(indexStr, 10);
 
   if (isNaN(index) || index < 1) {
-    console.warn(`Invalid :nth-match() index: ${indexStr}. Must be a positive integer.`);
+    logger.warn(`Invalid :nth-match() index: ${indexStr}. Must be a positive integer.`);
     return {
       elements: [],
       usedFallback: true,
@@ -803,7 +805,7 @@ function handleNthMatchSelector(selector: string): SelectorResult {
           effectiveSelector: `${nthBaseSelector} (${index}th match) ${afterMatch}`,
         };
       } catch (nestedError) {
-        console.warn(`Error applying nested selector "${afterMatch}":`, nestedError);
+        logger.warn(`Error applying nested selector "${afterMatch}"`, { nestedError });
         return {
           elements: [targetElement],
           usedFallback: true,
@@ -820,7 +822,7 @@ function handleNthMatchSelector(selector: string): SelectorResult {
       effectiveSelector: `${nthBaseSelector} (${index}th match)`,
     };
   } catch (error) {
-    console.warn(`Error processing :nth-match() selector "${selector}":`, error);
+    logger.warn(`Error processing :nth-match() selector "${selector}"`, { error });
     return {
       elements: [],
       usedFallback: true,

--- a/src/lib/dom/selector-resolver.ts
+++ b/src/lib/dom/selector-resolver.ts
@@ -3,6 +3,7 @@
  * Central resolver for handling different selector formats including Grafana e2e selectors
  */
 
+import { logger } from '../logging';
 import { toGrafanaSelector } from './grafana-selector';
 
 /**
@@ -57,7 +58,7 @@ export function resolveSelector(reftarget: string): string {
     try {
       return toGrafanaSelector(selectorPath, selectorId);
     } catch (error) {
-      console.error(`Failed to resolve Grafana selector: ${reftarget}`, error);
+      logger.error(`Failed to resolve Grafana selector: ${reftarget}`, { error });
       // Return original selector as fallback
       return reftarget;
     }

--- a/src/lib/faro-sdk-contract.test.ts
+++ b/src/lib/faro-sdk-contract.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Contract tests against the *installed* @grafana/faro-web-sdk (not a mock).
+ *
+ * pushFaroUserAction() casts startUserAction()'s result to
+ * UserActionInternalInterface to call end() — an internal API with no public
+ * equivalent. A type-level rename fails the build, but a runtime-semantics
+ * change (end() no longer emitting the faro.user.action event) would compile
+ * and silently kill the analytics mirror. These tests fail loudly on an SDK
+ * bump instead.
+ */
+import {
+  BaseTransport,
+  initializeFaro,
+  type TransportItem,
+  type UserActionInternalInterface,
+} from '@grafana/faro-web-sdk';
+
+class CaptureTransport extends BaseTransport {
+  readonly name = '@pathfinder/capture-transport';
+  readonly version = '0.0.0';
+  items: TransportItem[] = [];
+
+  send(items: TransportItem | TransportItem[]): void {
+    this.items.push(...(Array.isArray(items) ? items : [items]));
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe('faro-web-sdk user action contract', () => {
+  const transport = new CaptureTransport();
+  const faro = initializeFaro({
+    app: { name: 'pathfinder-sdk-contract-test', version: '0.0.0' },
+    transports: [transport],
+    instrumentations: [],
+    isolate: true,
+    globalObjectKey: 'pathfinderSdkContractTest',
+    batching: { enabled: false },
+    dedupe: false,
+  });
+
+  it('startUserAction returns an action exposing the internal end()', () => {
+    const action = faro.api.startUserAction('pathfinder_contract_check', { seq: '0' });
+    expect(action).toBeDefined();
+    expect(typeof (action as UserActionInternalInterface).end).toBe('function');
+    (action as UserActionInternalInterface).end();
+  });
+
+  it('ending the action emits a faro.user.action event that reaches the transport', async () => {
+    transport.items = [];
+    const action = faro.api.startUserAction('pathfinder_contract_emit', { seq: '1' });
+    (action as UserActionInternalInterface | undefined)?.end();
+
+    await waitFor(() =>
+      transport.items.some(
+        (item) => item.type === 'event' && (item.payload as { name?: string }).name === 'faro.user.action'
+      )
+    );
+
+    const userActionEvent = transport.items.find(
+      (item) => item.type === 'event' && (item.payload as { name?: string }).name === 'faro.user.action'
+    );
+    expect(userActionEvent).toBeDefined();
+    expect(JSON.stringify(userActionEvent!.payload)).toContain('pathfinder_contract_emit');
+  });
+});

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -12,8 +12,9 @@ import type { TransportItem, APIEvent } from '@grafana/faro-web-sdk';
 jest.mock('../../package.json', () => ({ name: 'grafana-pathfinder-app', version: '9.9.9-test' }));
 
 const mockPushError = jest.fn();
+const mockPushLog = jest.fn();
 const mockPause = jest.fn();
-const mockFaroInstance = { api: { pushError: mockPushError }, pause: mockPause };
+const mockFaroInstance = { api: { pushError: mockPushError, pushLog: mockPushLog }, pause: mockPause };
 interface CapturedFaroConfig {
   isolate: boolean;
   app: { name: string; version: string; environment: string };
@@ -260,5 +261,34 @@ describe('pushFaroError / pauseFaroBeforeReload', () => {
       throw new Error('transport down');
     });
     expect(() => faro.pushFaroError(new Error('boom'))).not.toThrow();
+  });
+});
+
+describe('pushFaroLog', () => {
+  it('no-ops before initialization without throwing', () => {
+    const faro = freshFaro();
+    expect(() => faro.pushFaroLog('info', 'hello')).not.toThrow();
+    expect(mockPushLog).not.toHaveBeenCalled();
+  });
+
+  it('prefixes the message with [pathfinder] and forwards level/context once initialized', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.pushFaroLog('warn', 'something happened', { step: 'one' });
+    expect(mockPushLog).toHaveBeenCalledWith(['[pathfinder] something happened'], {
+      level: 'warn',
+      context: { step: 'one' },
+    });
+  });
+
+  it('swallows errors thrown by the underlying Faro API', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockPushLog.mockImplementationOnce(() => {
+      throw new Error('transport down');
+    });
+    expect(() => faro.pushFaroLog('error', 'boom')).not.toThrow();
   });
 });

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -24,6 +24,7 @@ interface CapturedFaroConfig {
   isolate: boolean;
   app: { name: string; version: string; environment: string };
   sessionTracking: { samplingRate: number };
+  instrumentations: Array<{ constructor: { name: string } }>;
 }
 
 const mockInitializeFaro = jest.fn((_cfg: CapturedFaroConfig) => mockFaroInstance);
@@ -33,6 +34,7 @@ jest.mock('@grafana/faro-web-sdk', () => ({
   ErrorsInstrumentation: class ErrorsInstrumentation {},
   SessionInstrumentation: class SessionInstrumentation {},
   ViewInstrumentation: class ViewInstrumentation {},
+  PerformanceInstrumentation: class PerformanceInstrumentation {},
 }));
 
 // A stable object reference, not a fresh literal per require: `freshFaro()`
@@ -157,6 +159,26 @@ function eventItem(): TransportItem<APIEvent> {
   } as unknown as TransportItem<APIEvent>;
 }
 
+function performanceResourceItem(resourceUrl: string): TransportItem<APIEvent> {
+  return {
+    type: 'event',
+    payload: {
+      name: 'faro.performance.resource',
+      timestamp: new Date().toISOString(),
+      attributes: { name: resourceUrl },
+    },
+    meta: {},
+  } as unknown as TransportItem<APIEvent>;
+}
+
+function performanceNavigationItem(): TransportItem<APIEvent> {
+  return {
+    type: 'event',
+    payload: { name: 'faro.performance.navigation', timestamp: new Date().toISOString(), attributes: {} },
+    meta: {},
+  } as unknown as TransportItem<APIEvent>;
+}
+
 describe('filterPathfinderTelemetry', () => {
   it('keeps an exception with a pathfinder stack frame', () => {
     const item = exceptionItem(['webpack://grafana-pathfinder-app/./src/lib/faro.ts']);
@@ -189,6 +211,35 @@ describe('filterPathfinderTelemetry', () => {
   it('passes through other item types unfiltered', () => {
     const item = eventItem();
     expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+
+  it('always drops page-wide navigation timing', () => {
+    expect(filterPathfinderTelemetry(performanceNavigationItem())).toBeNull();
+  });
+
+  it('keeps a resource-timing entry for the docs domain', () => {
+    const item = performanceResourceItem('https://grafana.com/docs/some-page/content.json');
+    expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+
+  it('keeps a resource-timing entry for the recommender domain', () => {
+    const item = performanceResourceItem('https://recommender.grafana.com/api/v1/recommend');
+    expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+
+  it('keeps a resource-timing entry for the interactive-learning domain', () => {
+    const item = performanceResourceItem('https://interactive-learning.grafana.net/guide/content.json');
+    expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+
+  it('drops a resource-timing entry for an untracked (e.g. Grafana core) domain', () => {
+    const item = performanceResourceItem('https://foo.grafana.net/api/dashboards/uid/abc');
+    expect(filterPathfinderTelemetry(item)).toBeNull();
+  });
+
+  it('drops a resource-timing entry with a malformed URL', () => {
+    const item = performanceResourceItem('not-a-valid-url');
+    expect(filterPathfinderTelemetry(item)).toBeNull();
   });
 });
 
@@ -223,6 +274,21 @@ describe('initFaro', () => {
     expect(calledWith.app.name).toBe('grafana-pathfinder-app');
     expect(calledWith.app.version).toBe('9.9.9-test');
     expect(calledWith.app.version).not.toBe('%VERSION%');
+  });
+
+  it('includes PerformanceInstrumentation (filtered down in beforeSend, not excluded outright)', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    const calledWith = mockInitializeFaro.mock.calls[0]![0];
+    const instrumentationNames = calledWith.instrumentations.map((i) => i.constructor.name);
+    expect(instrumentationNames).toEqual(
+      expect.arrayContaining([
+        'ErrorsInstrumentation',
+        'SessionInstrumentation',
+        'ViewInstrumentation',
+        'PerformanceInstrumentation',
+      ])
+    );
   });
 
   it('skips the cloud/analytics checks under the dev-build local override', async () => {

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -1,0 +1,264 @@
+/**
+ * jsdom's `window.location` (and its individual accessor properties) are
+ * non-configurable, so tests fix the origin here instead of mocking hostname
+ * per test. Only the `initFaro` gating tests below depend on this value —
+ * `getEnvironment` takes hostname as an explicit argument and is tested
+ * independently of the ambient location.
+ *
+ * @jest-environment-options {"url": "https://foo.grafana.net"}
+ */
+import type { TransportItem, APIEvent } from '@grafana/faro-web-sdk';
+
+jest.mock('../../package.json', () => ({ name: 'grafana-pathfinder-app', version: '9.9.9-test' }));
+
+const mockPushError = jest.fn();
+const mockPause = jest.fn();
+const mockFaroInstance = { api: { pushError: mockPushError }, pause: mockPause };
+interface CapturedFaroConfig {
+  isolate: boolean;
+  app: { name: string; version: string; environment: string };
+}
+
+const mockInitializeFaro = jest.fn((_cfg: CapturedFaroConfig) => mockFaroInstance);
+
+jest.mock('@grafana/faro-web-sdk', () => ({
+  initializeFaro: (cfg: CapturedFaroConfig) => mockInitializeFaro(cfg),
+  ErrorsInstrumentation: class ErrorsInstrumentation {},
+  SessionInstrumentation: class SessionInstrumentation {},
+  ViewInstrumentation: class ViewInstrumentation {},
+}));
+
+// A stable object reference, not a fresh literal per require: `freshFaro()`
+// resets the module registry (so `./faro`'s internal init/instance state
+// starts clean), and re-requiring this mock must keep resolving to the same
+// `config` object so mutations made between tests are still visible.
+const mockedConfig = {
+  buildInfo: { env: 'production', version: '13.1.0' },
+  bootData: { settings: { buildInfo: { versionString: 'Grafana Cloud' } } } as
+    { settings: { buildInfo: { versionString: string } } } | undefined,
+  analytics: { enabled: true } as { enabled: boolean } | undefined,
+};
+
+jest.mock('@grafana/runtime', () => ({ config: mockedConfig }));
+
+// Loaded via `require`, not a static ES `import`: ES imports are evaluated
+// before any of this file's own top-level statements, which would trigger
+// the `@grafana/runtime` mock factory above before `mockedConfig` is
+// assigned. Requiring here, after the assignment, avoids that ordering trap.
+const { getEnvironment, isGrafanaCloud, filterPathfinderTelemetry }: typeof import('./faro') = require('./faro');
+
+function freshFaro(): typeof import('./faro') {
+  jest.resetModules();
+  return require('./faro');
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  mockedConfig.buildInfo = { env: 'production', version: '13.1.0' };
+  mockedConfig.bootData = { settings: { buildInfo: { versionString: 'Grafana Cloud' } } };
+  mockedConfig.analytics = { enabled: true };
+});
+
+describe('getEnvironment', () => {
+  it('returns null for an unrecognized hostname in production', () => {
+    expect(getEnvironment('my-oss-instance.example.com')).toBeNull();
+  });
+
+  it.each([
+    ['foo.grafana-dev.net', 'dev'],
+    ['foo.grafana-ops.net', 'ops'],
+    ['foo.grafana.net', 'prod'],
+    ['foo.grafana.com', 'prod'],
+  ])('maps %s to %s', (hostname, expected) => {
+    expect(getEnvironment(hostname)).toBe(expected);
+  });
+
+  it('returns null in a development build without the local override', () => {
+    mockedConfig.buildInfo.env = 'development';
+    expect(getEnvironment('foo.grafana.net')).toBeNull();
+  });
+
+  it('returns "local" in a development build with the override flag set', () => {
+    mockedConfig.buildInfo.env = 'development';
+    localStorage.setItem('pathfinder.faro.local', 'true');
+    expect(getEnvironment('localhost')).toBe('local');
+  });
+
+  it('ignores the override flag outside a development build', () => {
+    localStorage.setItem('pathfinder.faro.local', 'true');
+    expect(getEnvironment('foo.grafana.net')).toBe('prod');
+    expect(getEnvironment('localhost')).toBeNull();
+  });
+});
+
+describe('isGrafanaCloud', () => {
+  it('returns true when versionString starts with "Grafana Cloud"', () => {
+    expect(isGrafanaCloud()).toBe(true);
+  });
+
+  it('returns false for a non-cloud versionString', () => {
+    mockedConfig.bootData!.settings.buildInfo.versionString = 'Grafana Enterprise';
+    expect(isGrafanaCloud()).toBe(false);
+  });
+
+  it('returns false when bootData is missing entirely', () => {
+    mockedConfig.bootData = undefined;
+    expect(isGrafanaCloud()).toBe(false);
+  });
+});
+
+function exceptionItem(filenames: Array<string | undefined>): TransportItem<APIEvent> {
+  return {
+    type: 'exception',
+    payload: {
+      type: 'Error',
+      value: 'boom',
+      timestamp: new Date().toISOString(),
+      stacktrace: { frames: filenames.map((filename) => ({ filename, function: 'fn' })) },
+    },
+    meta: {},
+  } as unknown as TransportItem<APIEvent>;
+}
+
+function exceptionItemWithoutStacktrace(): TransportItem<APIEvent> {
+  return {
+    type: 'exception',
+    payload: { type: 'Error', value: 'boom', timestamp: new Date().toISOString() },
+    meta: {},
+  } as unknown as TransportItem<APIEvent>;
+}
+
+function logItem(message: string): TransportItem<APIEvent> {
+  return {
+    type: 'log',
+    payload: { message, level: 'error', timestamp: new Date().toISOString(), context: undefined },
+    meta: {},
+  } as unknown as TransportItem<APIEvent>;
+}
+
+function eventItem(): TransportItem<APIEvent> {
+  return {
+    type: 'event',
+    payload: { name: 'custom_event', timestamp: new Date().toISOString(), attributes: {} },
+    meta: {},
+  } as unknown as TransportItem<APIEvent>;
+}
+
+describe('filterPathfinderTelemetry', () => {
+  it('keeps an exception with a pathfinder stack frame', () => {
+    const item = exceptionItem(['webpack://grafana-pathfinder-app/./src/lib/faro.ts']);
+    expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+
+  it('keeps an exception matching the /pathfinder/ path fallback', () => {
+    const item = exceptionItem(['/public/plugins/pathfinder/module.js']);
+    expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+
+  it('drops an exception with only foreign stack frames', () => {
+    const item = exceptionItem(['webpack://grafana-core/./src/app.ts', undefined]);
+    expect(filterPathfinderTelemetry(item)).toBeNull();
+  });
+
+  it('drops an exception with no stacktrace at all', () => {
+    expect(filterPathfinderTelemetry(exceptionItemWithoutStacktrace())).toBeNull();
+  });
+
+  it('keeps a log message prefixed with [pathfinder]', () => {
+    const item = logItem('[pathfinder] something happened');
+    expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+
+  it('drops a log message without the prefix', () => {
+    expect(filterPathfinderTelemetry(logItem('something happened'))).toBeNull();
+  });
+
+  it('passes through other item types unfiltered', () => {
+    const item = eventItem();
+    expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+});
+
+describe('initFaro', () => {
+  it('does not initialize when the instance is not Grafana Cloud', async () => {
+    mockedConfig.bootData!.settings.buildInfo.versionString = 'Grafana Enterprise';
+    const faro = freshFaro();
+    await faro.initFaro();
+    expect(mockInitializeFaro).not.toHaveBeenCalled();
+    expect(faro.isFaroEnabled()).toBe(false);
+  });
+
+  it('does not initialize when analytics reporting is disabled', async () => {
+    mockedConfig.analytics = { enabled: false };
+    const faro = freshFaro();
+    await faro.initFaro();
+    expect(mockInitializeFaro).not.toHaveBeenCalled();
+  });
+
+  it('initializes on a recognized Grafana Cloud hostname', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+    expect(faro.isFaroEnabled()).toBe(true);
+  });
+
+  it('initializes with isolate: true and the real package version, not the %VERSION% placeholder', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    const calledWith = mockInitializeFaro.mock.calls[0]![0];
+    expect(calledWith.isolate).toBe(true);
+    expect(calledWith.app.name).toBe('grafana-pathfinder-app');
+    expect(calledWith.app.version).toBe('9.9.9-test');
+    expect(calledWith.app.version).not.toBe('%VERSION%');
+  });
+
+  it('skips the cloud/analytics checks under the dev-build local override', async () => {
+    mockedConfig.buildInfo.env = 'development';
+    localStorage.setItem('pathfinder.faro.local', 'true');
+    mockedConfig.bootData!.settings.buildInfo.versionString = 'Grafana Enterprise';
+    mockedConfig.analytics = { enabled: false };
+    const faro = freshFaro();
+    await faro.initFaro();
+    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-initialize on a second call (idempotent)', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    await faro.initFaro();
+    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('pushFaroError / pauseFaroBeforeReload', () => {
+  it('no-op before initialization without throwing', () => {
+    const faro = freshFaro();
+    expect(() => faro.pushFaroError(new Error('boom'))).not.toThrow();
+    expect(() => faro.pauseFaroBeforeReload()).not.toThrow();
+    expect(mockPushError).not.toHaveBeenCalled();
+    expect(mockPause).not.toHaveBeenCalled();
+  });
+
+  it('forwards to the Faro instance once initialized', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    const error = new Error('boom');
+    faro.pushFaroError(error, { source: 'test' });
+    expect(mockPushError).toHaveBeenCalledWith(error, { context: { source: 'test' } });
+
+    faro.pauseFaroBeforeReload();
+    expect(mockPause).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows errors thrown by the underlying Faro API', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockPushError.mockImplementationOnce(() => {
+      throw new Error('transport down');
+    });
+    expect(() => faro.pushFaroError(new Error('boom'))).not.toThrow();
+  });
+});

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -617,6 +617,37 @@ describe('withFaroUserAction', () => {
     expect(mockActionEnd).not.toHaveBeenCalled();
   });
 
+  it('captures the first pathfinder_section_run in a fresh armed tab (init completes first)', async () => {
+    const faro = freshFaro();
+    faro.armFaro();
+    expect(mockInitializeFaro).not.toHaveBeenCalled();
+
+    const result = await faro.withFaroUserAction('pathfinder_section_run', { section_id: 's1' }, () => 'ran');
+    expect(result).toBe('ran');
+    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_section_run', { section_id: 's1' });
+    expect(mockActionEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures the first pathfinder_remote_step in a fresh armed tab', async () => {
+    const faro = freshFaro();
+    faro.armFaro();
+
+    await faro.withFaroUserAction('pathfinder_remote_step', {}, async () => 'ok');
+    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_remote_step', {});
+    expect(mockActionEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays a passthrough when Faro never armed (outside Grafana Cloud)', async () => {
+    mockedConfig.bootData!.settings.buildInfo.versionString = 'Grafana Enterprise';
+    const faro = freshFaro();
+    faro.armFaro();
+
+    await expect(faro.withFaroUserAction('pathfinder_section_run', {}, () => 'ok')).resolves.toBe('ok');
+    expect(mockInitializeFaro).not.toHaveBeenCalled();
+    expect(mockStartUserAction).not.toHaveBeenCalled();
+  });
+
   it('force-ends a hung action after the safety timeout with outcome timeout', async () => {
     const faro = freshFaro();
     await faro.initFaro();

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -41,6 +41,7 @@ interface CapturedFaroConfig {
   app: { name: string; version: string; environment: string };
   sessionTracking: { samplingRate?: number; persistent: boolean };
   instrumentations: Array<{ constructor: { name: string } }>;
+  beforeSend: (item: TransportItem<APIEvent>) => TransportItem<APIEvent> | null;
 }
 
 const mockInitializeFaro = jest.fn((_cfg: CapturedFaroConfig) => mockFaroInstance);
@@ -164,10 +165,10 @@ function exceptionItemWithoutStacktrace(context?: Record<string, string>): Trans
   } as unknown as TransportItem<APIEvent>;
 }
 
-function logItem(message: string): TransportItem<APIEvent> {
+function logItem(message: string, level = 'error'): TransportItem<APIEvent> {
   return {
     type: 'log',
-    payload: { message, level: 'error', timestamp: new Date().toISOString(), context: undefined },
+    payload: { message, level, timestamp: new Date().toISOString(), context: undefined },
     meta: {},
   } as unknown as TransportItem<APIEvent>;
 }
@@ -290,7 +291,6 @@ describe('initFaro', () => {
     const faro = freshFaro();
     await faro.initFaro();
     expect(mockInitializeFaro).not.toHaveBeenCalled();
-    expect(faro.isFaroEnabled()).toBe(false);
   });
 
   it('does not initialize when analytics reporting is disabled', async () => {
@@ -304,7 +304,6 @@ describe('initFaro', () => {
     const faro = freshFaro();
     await faro.initFaro();
     expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
-    expect(faro.isFaroEnabled()).toBe(true);
   });
 
   it('initializes with isolate: true and the real package version, not the %VERSION% placeholder', async () => {
@@ -617,31 +616,10 @@ describe('withFaroUserAction', () => {
     expect(mockActionEnd).not.toHaveBeenCalled();
   });
 
-  it('captures the first pathfinder_section_run in a fresh armed tab (init completes first)', async () => {
-    const faro = freshFaro();
-    faro.armFaro();
-    expect(mockInitializeFaro).not.toHaveBeenCalled();
-
-    const result = await faro.withFaroUserAction('pathfinder_section_run', { section_id: 's1' }, () => 'ran');
-    expect(result).toBe('ran');
-    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
-    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_section_run', { section_id: 's1' });
-    expect(mockActionEnd).toHaveBeenCalledTimes(1);
-  });
-
-  it('captures the first pathfinder_remote_step in a fresh armed tab', async () => {
-    const faro = freshFaro();
-    faro.armFaro();
-
-    await faro.withFaroUserAction('pathfinder_remote_step', {}, async () => 'ok');
-    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_remote_step', {});
-    expect(mockActionEnd).toHaveBeenCalledTimes(1);
-  });
-
-  it('stays a passthrough when Faro never armed (outside Grafana Cloud)', async () => {
+  it('stays a passthrough when init was skipped (outside Grafana Cloud)', async () => {
     mockedConfig.bootData!.settings.buildInfo.versionString = 'Grafana Enterprise';
     const faro = freshFaro();
-    faro.armFaro();
+    await faro.initFaro();
 
     await expect(faro.withFaroUserAction('pathfinder_section_run', {}, () => 'ok')).resolves.toBe('ok');
     expect(mockInitializeFaro).not.toHaveBeenCalled();
@@ -732,89 +710,117 @@ describe('setFaroUserActionAttributes', () => {
   });
 });
 
-describe('armFaro / engagement gating', () => {
-  it('does not initialize until an engagement trigger fires', () => {
+describe('passesActivityGate', () => {
+  const DOCKED_KEY = 'grafana.navigation.extensionSidebarDocked';
+  const PANEL_MODE_KEY = 'grafana-pathfinder-app-panel-mode';
+
+  it('drops events while no Pathfinder surface is open', () => {
     const faro = freshFaro();
-    faro.armFaro();
-    expect(mockInitializeFaro).not.toHaveBeenCalled();
+    expect(faro.passesActivityGate(eventItem())).toBe(false);
   });
 
-  it('notifyFaroEngagement initializes and flushes buffered calls in order', async () => {
+  it('passes events when the panel mode is floating', () => {
+    localStorage.setItem(PANEL_MODE_KEY, 'floating');
     const faro = freshFaro();
-    faro.armFaro();
-    faro.pushFaroLog('warn', 'early warning');
-    faro.pushFaroUserAction('pathfinder_feature_flag_evaluated', { flag_key: 'x' });
-    expect(mockInitializeFaro).not.toHaveBeenCalled();
-    expect(mockPushLog).not.toHaveBeenCalled();
-
-    await faro.notifyFaroEngagement();
-    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
-    expect(mockPushLog).toHaveBeenCalledWith(['[pathfinder] early warning'], { level: 'warn', context: undefined });
-    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_feature_flag_evaluated', {
-      flag_key: 'x',
-      seq: '0',
-    });
+    expect(faro.passesActivityGate(eventItem())).toBe(true);
   });
 
-  it('a buffered error triggers initialization by itself', async () => {
+  it('passes events when the panel mode is fullscreen', () => {
+    localStorage.setItem(PANEL_MODE_KEY, 'fullscreen');
     const faro = freshFaro();
-    faro.armFaro();
-    const boom = new Error('boom');
-    faro.pushFaroError(boom);
-    await faro.notifyFaroEngagement();
-    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
-    expect(mockPushError).toHaveBeenCalledWith(boom, { context: { pathfinder_reported: 'true' } });
+    expect(faro.passesActivityGate(eventItem())).toBe(true);
   });
 
-  it('an error-level log triggers initialization; warn does not', async () => {
+  it('stays closed for the default sidebar mode with nothing docked', () => {
+    localStorage.setItem(PANEL_MODE_KEY, 'sidebar');
     const faro = freshFaro();
-    faro.armFaro();
-    faro.pushFaroLog('warn', 'just a warning');
-    await Promise.resolve();
-    expect(mockInitializeFaro).not.toHaveBeenCalled();
-
-    faro.pushFaroLog('error', 'broken');
-    await faro.notifyFaroEngagement();
-    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
-    expect(mockPushLog).toHaveBeenCalledTimes(2);
+    expect(faro.passesActivityGate(eventItem())).toBe(false);
   });
 
-  it('initializes immediately when a live Faro session already exists in this tab', async () => {
-    sessionStorage.setItem('com.grafana.faro.session', '{}');
+  it('passes events when the extension sidebar is docked by Pathfinder', () => {
+    localStorage.setItem(DOCKED_KEY, JSON.stringify({ pluginId: pluginJson.id }));
     const faro = freshFaro();
-    faro.armFaro();
-    await faro.notifyFaroEngagement();
-    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+    expect(faro.passesActivityGate(eventItem())).toBe(true);
   });
 
-  it('initializes immediately under the dev-build local override', async () => {
-    mockedConfig.buildInfo.env = 'development';
-    localStorage.setItem('pathfinder.faro.local', 'true');
+  it('recognizes the legacy plain-string docked format', () => {
+    localStorage.setItem(DOCKED_KEY, pluginJson.id);
     const faro = freshFaro();
-    faro.armFaro();
-    await faro.notifyFaroEngagement();
-    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+    expect(faro.passesActivityGate(eventItem())).toBe(true);
   });
 
-  it('never arms outside Grafana Cloud — pushes stay no-ops and no init happens', async () => {
-    mockedConfig.bootData!.settings.buildInfo.versionString = 'Grafana Enterprise';
+  it('recognizes a componentTitle match from older Grafana versions', () => {
+    localStorage.setItem(DOCKED_KEY, JSON.stringify({ componentTitle: 'Interactive learning' }));
     const faro = freshFaro();
-    faro.armFaro();
-    faro.pushFaroLog('error', 'broken');
-    await faro.notifyFaroEngagement();
-    expect(mockInitializeFaro).not.toHaveBeenCalled();
-    expect(mockPushLog).not.toHaveBeenCalled();
+    expect(faro.passesActivityGate(eventItem())).toBe(true);
   });
 
-  it('caps the pre-init buffer at 30, dropping the oldest entries', async () => {
+  it('stays closed when another plugin owns the docked sidebar', () => {
+    localStorage.setItem(DOCKED_KEY, JSON.stringify({ pluginId: 'some-other-app' }));
     const faro = freshFaro();
-    faro.armFaro();
-    for (let i = 0; i < 35; i++) {
-      faro.pushFaroLog('warn', `message ${i}`);
+    expect(faro.passesActivityGate(eventItem())).toBe(false);
+  });
+
+  it.each(['pathfinder-controller-root', 'pathfinder-kiosk-root'])(
+    'passes events when the %s overlay is mounted in this tab',
+    (id) => {
+      const el = document.createElement('div');
+      el.id = id;
+      document.body.appendChild(el);
+      try {
+        const faro = freshFaro();
+        expect(faro.passesActivityGate(eventItem())).toBe(true);
+      } finally {
+        el.remove();
+      }
     }
-    await faro.notifyFaroEngagement();
-    expect(mockPushLog).toHaveBeenCalledTimes(30);
-    expect(mockPushLog).toHaveBeenNthCalledWith(1, ['[pathfinder] message 5'], { level: 'warn', context: undefined });
+  );
+
+  it('latches open for the rest of the page load once Pathfinder was open', () => {
+    localStorage.setItem(PANEL_MODE_KEY, 'floating');
+    const faro = freshFaro();
+    expect(faro.passesActivityGate(eventItem())).toBe(true);
+    localStorage.removeItem(PANEL_MODE_KEY);
+    expect(faro.passesActivityGate(eventItem())).toBe(true);
+  });
+
+  it('opens on a later check after starting closed — closed does not latch', () => {
+    const faro = freshFaro();
+    expect(faro.passesActivityGate(eventItem())).toBe(false);
+    localStorage.setItem(PANEL_MODE_KEY, 'floating');
+    expect(faro.passesActivityGate(eventItem())).toBe(true);
+  });
+
+  it('lets exceptions through while closed', () => {
+    const faro = freshFaro();
+    expect(faro.passesActivityGate(exceptionItem(['webpack://grafana-core/x.ts']))).toBe(true);
+  });
+
+  it('lets error-level logs through while closed, but not warn-level ones', () => {
+    const faro = freshFaro();
+    expect(faro.passesActivityGate(logItem('[pathfinder] broke'))).toBe(true);
+    expect(faro.passesActivityGate(logItem('[pathfinder] hmm', 'warn'))).toBe(false);
+  });
+
+  it('an exception while closed does not latch the gate open', () => {
+    const faro = freshFaro();
+    faro.passesActivityGate(exceptionItem(['webpack://grafana-core/x.ts']));
+    expect(faro.passesActivityGate(eventItem())).toBe(false);
+  });
+});
+
+describe('beforeSend wiring', () => {
+  it('composes the activity gate with attribution filtering', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    const { beforeSend } = mockInitializeFaro.mock.calls[0]![0];
+
+    expect(beforeSend(eventItem())).toBeNull();
+    expect(beforeSend(exceptionItem(['webpack://grafana-pathfinder-app/./src/lib/faro.ts']))).not.toBeNull();
+    expect(beforeSend(exceptionItem(['webpack://grafana-core/./src/app.ts']))).toBeNull();
+
+    localStorage.setItem('grafana-pathfinder-app-panel-mode', 'floating');
+    expect(beforeSend(eventItem())).not.toBeNull();
   });
 });
 

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -22,6 +22,7 @@ const mockFaroInstance = {
 interface CapturedFaroConfig {
   isolate: boolean;
   app: { name: string; version: string; environment: string };
+  sessionTracking: { samplingRate: number };
 }
 
 const mockInitializeFaro = jest.fn((_cfg: CapturedFaroConfig) => mockFaroInstance);
@@ -231,6 +232,29 @@ describe('initFaro', () => {
     const faro = freshFaro();
     await faro.initFaro();
     expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults sessionTracking.samplingRate to 1 when no rate is passed', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    const calledWith = mockInitializeFaro.mock.calls[0]![0];
+    expect(calledWith.sessionTracking.samplingRate).toBe(1);
+  });
+
+  it('forwards a custom sample rate into sessionTracking.samplingRate', async () => {
+    const faro = freshFaro();
+    await faro.initFaro(0.25);
+    const calledWith = mockInitializeFaro.mock.calls[0]![0];
+    expect(calledWith.sessionTracking.samplingRate).toBe(0.25);
+  });
+
+  it('ignores the passed sample rate under the local override — always samples at 1', async () => {
+    mockedConfig.buildInfo.env = 'development';
+    localStorage.setItem('pathfinder.faro.local', 'true');
+    const faro = freshFaro();
+    await faro.initFaro(0);
+    const calledWith = mockInitializeFaro.mock.calls[0]![0];
+    expect(calledWith.sessionTracking.samplingRate).toBe(1);
   });
 
   it('does not re-initialize on a second call (idempotent)', async () => {

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -13,8 +13,12 @@ jest.mock('../../package.json', () => ({ name: 'grafana-pathfinder-app', version
 
 const mockPushError = jest.fn();
 const mockPushLog = jest.fn();
+const mockPushEvent = jest.fn();
 const mockPause = jest.fn();
-const mockFaroInstance = { api: { pushError: mockPushError, pushLog: mockPushLog }, pause: mockPause };
+const mockFaroInstance = {
+  api: { pushError: mockPushError, pushLog: mockPushLog, pushEvent: mockPushEvent },
+  pause: mockPause,
+};
 interface CapturedFaroConfig {
   isolate: boolean;
   app: { name: string; version: string; environment: string };
@@ -46,7 +50,12 @@ jest.mock('@grafana/runtime', () => ({ config: mockedConfig }));
 // before any of this file's own top-level statements, which would trigger
 // the `@grafana/runtime` mock factory above before `mockedConfig` is
 // assigned. Requiring here, after the assignment, avoids that ordering trap.
-const { getEnvironment, isGrafanaCloud, filterPathfinderTelemetry }: typeof import('./faro') = require('./faro');
+const {
+  getEnvironment,
+  isGrafanaCloud,
+  filterPathfinderTelemetry,
+  stringifyAttributes,
+}: typeof import('./faro') = require('./faro');
 
 function freshFaro(): typeof import('./faro') {
   jest.resetModules();
@@ -290,5 +299,60 @@ describe('pushFaroLog', () => {
       throw new Error('transport down');
     });
     expect(() => faro.pushFaroLog('error', 'boom')).not.toThrow();
+  });
+});
+
+describe('stringifyAttributes', () => {
+  it('passes strings through, truncated to 500 characters', () => {
+    expect(stringifyAttributes({ foo: 'bar' })).toEqual({ foo: 'bar' });
+    expect(stringifyAttributes({ long: 'a'.repeat(600) }).long).toHaveLength(500);
+  });
+
+  it('coerces numbers and booleans with String()', () => {
+    expect(stringifyAttributes({ count: 3, ok: false })).toEqual({ count: '3', ok: 'false' });
+  });
+
+  it('JSON.stringifies objects and arrays', () => {
+    expect(stringifyAttributes({ experiments: [{ flag: 'x', variant: 'treatment' }] })).toEqual({
+      experiments: '[{"flag":"x","variant":"treatment"}]',
+    });
+  });
+
+  it('drops null and undefined attributes entirely', () => {
+    expect(stringifyAttributes({ a: null, b: undefined, c: 'kept' })).toEqual({ c: 'kept' });
+  });
+});
+
+describe('pushFaroEvent', () => {
+  it('no-ops before initialization without throwing', () => {
+    const faro = freshFaro();
+    expect(() => faro.pushFaroEvent('pathfinder_docs_panel_interaction', { action: 'open' })).not.toThrow();
+    expect(mockPushEvent).not.toHaveBeenCalled();
+  });
+
+  it('forwards the same event name with stringified attributes once initialized', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.pushFaroEvent('pathfinder_docs_panel_interaction', { action: 'open', step: 2 });
+    expect(mockPushEvent).toHaveBeenCalledWith('pathfinder_docs_panel_interaction', { action: 'open', step: '2' });
+  });
+
+  it('forwards undefined attributes as undefined, not an empty object', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.pushFaroEvent('pathfinder_docs_panel_interaction');
+    expect(mockPushEvent).toHaveBeenCalledWith('pathfinder_docs_panel_interaction', undefined);
+  });
+
+  it('swallows errors thrown by the underlying Faro API', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockPushEvent.mockImplementationOnce(() => {
+      throw new Error('transport down');
+    });
+    expect(() => faro.pushFaroEvent('pathfinder_docs_panel_interaction', {})).not.toThrow();
   });
 });

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -8,6 +8,7 @@
  * @jest-environment-options {"url": "https://foo.grafana.net"}
  */
 import type { TransportItem, APIEvent } from '@grafana/faro-web-sdk';
+import pluginJson from '../plugin.json';
 
 jest.mock('../../package.json', () => ({ name: 'grafana-pathfinder-app', version: '9.9.9-test' }));
 
@@ -38,7 +39,7 @@ const mockFaroInstance = {
 interface CapturedFaroConfig {
   isolate: boolean;
   app: { name: string; version: string; environment: string };
-  sessionTracking: { samplingRate: number; persistent: boolean };
+  sessionTracking: { samplingRate?: number; persistent: boolean };
   instrumentations: Array<{ constructor: { name: string } }>;
 }
 
@@ -138,7 +139,10 @@ describe('isGrafanaCloud', () => {
   });
 });
 
-function exceptionItem(filenames: Array<string | undefined>): TransportItem<APIEvent> {
+function exceptionItem(
+  filenames: Array<string | undefined>,
+  context?: Record<string, string>
+): TransportItem<APIEvent> {
   return {
     type: 'exception',
     payload: {
@@ -146,15 +150,16 @@ function exceptionItem(filenames: Array<string | undefined>): TransportItem<APIE
       value: 'boom',
       timestamp: new Date().toISOString(),
       stacktrace: { frames: filenames.map((filename) => ({ filename, function: 'fn' })) },
+      ...(context && { context }),
     },
     meta: {},
   } as unknown as TransportItem<APIEvent>;
 }
 
-function exceptionItemWithoutStacktrace(): TransportItem<APIEvent> {
+function exceptionItemWithoutStacktrace(context?: Record<string, string>): TransportItem<APIEvent> {
   return {
     type: 'exception',
-    payload: { type: 'Error', value: 'boom', timestamp: new Date().toISOString() },
+    payload: { type: 'Error', value: 'boom', timestamp: new Date().toISOString(), ...(context && { context }) },
     meta: {},
   } as unknown as TransportItem<APIEvent>;
 }
@@ -201,8 +206,8 @@ describe('filterPathfinderTelemetry', () => {
     expect(filterPathfinderTelemetry(item)).toBe(item);
   });
 
-  it('keeps an exception matching the /pathfinder/ path fallback', () => {
-    const item = exceptionItem(['/public/plugins/pathfinder/module.js']);
+  it('keeps an exception served from the real plugin asset path, derived from plugin.json', () => {
+    const item = exceptionItem([`https://foo.grafana.net/public/plugins/${pluginJson.id}/613.js`]);
     expect(filterPathfinderTelemetry(item)).toBe(item);
   });
 
@@ -213,6 +218,16 @@ describe('filterPathfinderTelemetry', () => {
 
   it('drops an exception with no stacktrace at all', () => {
     expect(filterPathfinderTelemetry(exceptionItemWithoutStacktrace())).toBeNull();
+  });
+
+  it('keeps a stackless exception carrying the explicit-report marker', () => {
+    const item = exceptionItemWithoutStacktrace({ pathfinder_reported: 'true' });
+    expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+
+  it('keeps an explicitly-reported exception even when every frame is foreign (e.g. a shared chunk)', () => {
+    const item = exceptionItem(['webpack://grafana-core/./src/app.ts'], { pathfinder_reported: 'true' });
+    expect(filterPathfinderTelemetry(item)).toBe(item);
   });
 
   it('keeps a log message prefixed with [pathfinder]', () => {
@@ -236,6 +251,16 @@ describe('filterPathfinderTelemetry', () => {
   it('keeps a resource-timing entry for the docs domain', () => {
     const item = performanceResourceItem('https://grafana.com/docs/some-page/content.json');
     expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+
+  it('keeps a resource-timing entry for a tutorials path on the shared hostname', () => {
+    const item = performanceResourceItem('https://grafana.com/tutorials/some-tutorial/');
+    expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+
+  it('drops Grafana core traffic to the shared grafana.com hostname (non-docs paths)', () => {
+    expect(filterPathfinderTelemetry(performanceResourceItem('https://grafana.com/api/plugins/foo'))).toBeNull();
+    expect(filterPathfinderTelemetry(performanceResourceItem('https://grafana.com/docs-lookalike/x'))).toBeNull();
   });
 
   it('keeps a resource-timing entry for the recommender domain', () => {
@@ -324,27 +349,11 @@ describe('initFaro', () => {
     expect(calledWith.sessionTracking.persistent).toBe(false);
   });
 
-  it('defaults sessionTracking.samplingRate to 1 when no rate is passed', async () => {
+  it('sets no samplingRate — every engaged session sends (the SDK default of 1 applies)', async () => {
     const faro = freshFaro();
     await faro.initFaro();
     const calledWith = mockInitializeFaro.mock.calls[0]![0];
-    expect(calledWith.sessionTracking.samplingRate).toBe(1);
-  });
-
-  it('forwards a custom sample rate into sessionTracking.samplingRate', async () => {
-    const faro = freshFaro();
-    await faro.initFaro(0.25);
-    const calledWith = mockInitializeFaro.mock.calls[0]![0];
-    expect(calledWith.sessionTracking.samplingRate).toBe(0.25);
-  });
-
-  it('ignores the passed sample rate under the local override — always samples at 1', async () => {
-    mockedConfig.buildInfo.env = 'development';
-    localStorage.setItem('pathfinder.faro.local', 'true');
-    const faro = freshFaro();
-    await faro.initFaro(0);
-    const calledWith = mockInitializeFaro.mock.calls[0]![0];
-    expect(calledWith.sessionTracking.samplingRate).toBe(1);
+    expect(calledWith.sessionTracking.samplingRate).toBeUndefined();
   });
 
   it('does not re-initialize on a second call (idempotent)', async () => {
@@ -370,7 +379,9 @@ describe('pushFaroError / pauseFaroBeforeReload', () => {
 
     const error = new Error('boom');
     faro.pushFaroError(error, { source: 'test' });
-    expect(mockPushError).toHaveBeenCalledWith(error, { context: { source: 'test' } });
+    expect(mockPushError).toHaveBeenCalledWith(error, {
+      context: { source: 'test', pathfinder_reported: 'true' },
+    });
 
     faro.pauseFaroBeforeReload();
     expect(mockPause).toHaveBeenCalledTimes(1);
@@ -693,7 +704,7 @@ describe('setFaroUserActionAttributes', () => {
 describe('armFaro / engagement gating', () => {
   it('does not initialize until an engagement trigger fires', () => {
     const faro = freshFaro();
-    faro.armFaro(0.5);
+    faro.armFaro();
     expect(mockInitializeFaro).not.toHaveBeenCalled();
   });
 
@@ -721,7 +732,7 @@ describe('armFaro / engagement gating', () => {
     faro.pushFaroError(boom);
     await faro.notifyFaroEngagement();
     expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
-    expect(mockPushError).toHaveBeenCalledWith(boom, undefined);
+    expect(mockPushError).toHaveBeenCalledWith(boom, { context: { pathfinder_reported: 'true' } });
   });
 
   it('an error-level log triggers initialization; warn does not', async () => {

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -13,10 +13,11 @@ jest.mock('../../package.json', () => ({ name: 'grafana-pathfinder-app', version
 
 const mockPushError = jest.fn();
 const mockPushLog = jest.fn();
-const mockPushEvent = jest.fn();
+const mockActionEnd = jest.fn();
+const mockStartUserAction = jest.fn(() => ({ name: 'x', parentId: 'x', end: mockActionEnd }));
 const mockPause = jest.fn();
 const mockFaroInstance = {
-  api: { pushError: mockPushError, pushLog: mockPushLog, pushEvent: mockPushEvent },
+  api: { pushError: mockPushError, pushLog: mockPushLog, startUserAction: mockStartUserAction },
   pause: mockPause,
 };
 interface CapturedFaroConfig {
@@ -347,56 +348,59 @@ describe('stringifyAttributes', () => {
   });
 });
 
-describe('pushFaroEvent', () => {
+describe('pushFaroUserAction', () => {
   it('no-ops before initialization without throwing', () => {
     const faro = freshFaro();
-    expect(() => faro.pushFaroEvent('pathfinder_docs_panel_interaction', { action: 'open' })).not.toThrow();
-    expect(mockPushEvent).not.toHaveBeenCalled();
+    expect(() => faro.pushFaroUserAction('pathfinder_docs_panel_interaction', { action: 'open' })).not.toThrow();
+    expect(mockStartUserAction).not.toHaveBeenCalled();
   });
 
-  it('forwards the same event name with stringified attributes once initialized', async () => {
+  it('starts a user action with the same name and stringified attributes, and ends it immediately', async () => {
     const faro = freshFaro();
     await faro.initFaro();
 
-    faro.pushFaroEvent('pathfinder_docs_panel_interaction', { action: 'open', step: 2 });
-    expect(mockPushEvent).toHaveBeenCalledWith(
-      'pathfinder_docs_panel_interaction',
-      { action: 'open', step: '2' },
-      undefined,
-      { skipDedupe: true }
-    );
+    faro.pushFaroUserAction('pathfinder_docs_panel_interaction', { action: 'open', step: 2 });
+    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_docs_panel_interaction', {
+      action: 'open',
+      step: '2',
+    });
+    expect(mockActionEnd).toHaveBeenCalledTimes(1);
   });
 
   it('forwards undefined attributes as undefined, not an empty object', async () => {
     const faro = freshFaro();
     await faro.initFaro();
 
-    faro.pushFaroEvent('pathfinder_docs_panel_interaction');
-    expect(mockPushEvent).toHaveBeenCalledWith('pathfinder_docs_panel_interaction', undefined, undefined, {
-      skipDedupe: true,
-    });
+    faro.pushFaroUserAction('pathfinder_docs_panel_interaction');
+    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_docs_panel_interaction', undefined);
   });
 
-  it('always skips Faro’s built-in dedupe, since a repeated identical interaction is legitimate and Rudderstack (the pipeline being cross-checked) does not dedupe', async () => {
+  it('does not throw if startUserAction returns undefined (e.g. Faro declines to start one)', async () => {
     const faro = freshFaro();
     await faro.initFaro();
 
-    faro.pushFaroEvent('pathfinder_do_it_button_click', { step_id: 'step-1' });
-    faro.pushFaroEvent('pathfinder_do_it_button_click', { step_id: 'step-1' });
-
-    expect(mockPushEvent).toHaveBeenCalledTimes(2);
-    for (const call of mockPushEvent.mock.calls) {
-      expect(call[3]).toEqual({ skipDedupe: true });
-    }
+    mockStartUserAction.mockReturnValueOnce(undefined as unknown as ReturnType<typeof mockStartUserAction>);
+    expect(() => faro.pushFaroUserAction('pathfinder_docs_panel_interaction', {})).not.toThrow();
+    expect(mockActionEnd).not.toHaveBeenCalled();
   });
 
-  it('swallows errors thrown by the underlying Faro API', async () => {
+  it('swallows errors thrown by startUserAction', async () => {
     const faro = freshFaro();
     await faro.initFaro();
 
-    mockPushEvent.mockImplementationOnce(() => {
+    mockStartUserAction.mockImplementationOnce(() => {
       throw new Error('transport down');
     });
-    expect(() => faro.pushFaroEvent('pathfinder_docs_panel_interaction', {})).not.toThrow();
+    expect(() => faro.pushFaroUserAction('pathfinder_docs_panel_interaction', {})).not.toThrow();
+  });
+
+  it('swallows errors thrown by the action’s end()', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockActionEnd.mockImplementationOnce(() => {
+      throw new Error('transport down');
+    });
+    expect(() => faro.pushFaroUserAction('pathfinder_docs_panel_interaction', {})).not.toThrow();
   });
 });

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -13,12 +13,26 @@ jest.mock('../../package.json', () => ({ name: 'grafana-pathfinder-app', version
 
 const mockPushError = jest.fn();
 const mockPushLog = jest.fn();
+const mockPushEvent = jest.fn();
 const mockActionEnd = jest.fn();
-const mockStartUserAction = jest.fn(() => ({ name: 'x', parentId: 'x', end: mockActionEnd }));
+const mockStartUserAction = jest.fn(() => ({
+  name: 'x',
+  parentId: 'x',
+  attributes: undefined as Record<string, string> | undefined,
+  end: mockActionEnd,
+}));
+const mockGetActiveUserAction = jest.fn((): unknown => undefined);
 const mockSetView = jest.fn();
 const mockPause = jest.fn();
 const mockFaroInstance = {
-  api: { pushError: mockPushError, pushLog: mockPushLog, startUserAction: mockStartUserAction, setView: mockSetView },
+  api: {
+    pushError: mockPushError,
+    pushLog: mockPushLog,
+    pushEvent: mockPushEvent,
+    startUserAction: mockStartUserAction,
+    getActiveUserAction: mockGetActiveUserAction,
+    setView: mockSetView,
+  },
   pause: mockPause,
 };
 interface CapturedFaroConfig {
@@ -70,6 +84,7 @@ function freshFaro(): typeof import('./faro') {
 beforeEach(() => {
   jest.clearAllMocks();
   localStorage.clear();
+  sessionStorage.clear();
   mockedConfig.buildInfo = { env: 'production', version: '13.1.0' };
   mockedConfig.bootData = { settings: { buildInfo: { versionString: 'Grafana Cloud' } } };
   mockedConfig.analytics = { enabled: true };
@@ -493,6 +508,271 @@ describe('pushFaroUserAction', () => {
       throw new Error('transport down');
     });
     expect(() => faro.pushFaroUserAction('pathfinder_docs_panel_interaction', {})).not.toThrow();
+  });
+});
+
+describe('pushFaroUserAction fallback while a real action is active', () => {
+  it('pushes a plain skip-dedupe event instead of starting a second action', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockGetActiveUserAction.mockReturnValueOnce({ name: 'outer' });
+    faro.pushFaroUserAction('pathfinder_docs_panel_interaction', { action: 'open' });
+    expect(mockPushEvent).toHaveBeenCalledWith(
+      'pathfinder_docs_panel_interaction',
+      { action: 'open', seq: '0' },
+      undefined,
+      { skipDedupe: true }
+    );
+    expect(mockStartUserAction).not.toHaveBeenCalled();
+  });
+
+  it('keeps one monotonic seq counter across both mirror shapes', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.pushFaroUserAction('pathfinder_a');
+    mockGetActiveUserAction.mockReturnValueOnce({ name: 'outer' });
+    faro.pushFaroUserAction('pathfinder_b');
+    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_a', { seq: '0' });
+    expect(mockPushEvent).toHaveBeenCalledWith('pathfinder_b', { seq: '1' }, undefined, { skipDedupe: true });
+  });
+});
+
+describe('withFaroUserAction', () => {
+  it('runs the work directly before initialization and never starts an action', async () => {
+    const faro = freshFaro();
+    await expect(faro.withFaroUserAction('pathfinder_step_do', {}, () => 42)).resolves.toBe(42);
+    expect(mockStartUserAction).not.toHaveBeenCalled();
+  });
+
+  it('propagates a rejection with the same error instance when uninitialized', async () => {
+    const faro = freshFaro();
+    const boom = new Error('boom');
+    await expect(
+      faro.withFaroUserAction('pathfinder_step_do', {}, () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+  });
+
+  it('starts an action with stringified attributes, stamps outcome ok, and ends it once', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    const result = await faro.withFaroUserAction('pathfinder_step_do', { step: 2 }, async () => 'done');
+    expect(result).toBe('done');
+    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_step_do', { step: '2' });
+    const action = mockStartUserAction.mock.results[0]!.value;
+    expect(action.attributes).toEqual({ outcome: 'ok' });
+    expect(mockActionEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('stamps outcome error and rethrows the same error instance on rejection', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    const boom = new Error('boom');
+    await expect(
+      faro.withFaroUserAction('pathfinder_step_do', {}, async () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+    const action = mockStartUserAction.mock.results[0]!.value;
+    expect(action.attributes).toEqual({ outcome: 'error' });
+    expect(mockActionEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a synchronous throw from work like a rejection', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    const boom = new Error('sync boom');
+    await expect(
+      faro.withFaroUserAction('pathfinder_step_do', {}, () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+    expect(mockActionEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a passthrough while another action is active — no start, no end', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockGetActiveUserAction.mockReturnValueOnce({ name: 'outer' });
+    await expect(faro.withFaroUserAction('pathfinder_step_do', {}, () => 'inner')).resolves.toBe('inner');
+    expect(mockStartUserAction).not.toHaveBeenCalled();
+    expect(mockActionEnd).not.toHaveBeenCalled();
+  });
+
+  it('force-ends a hung action after the safety timeout with outcome timeout', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    jest.useFakeTimers();
+    try {
+      void faro.withFaroUserAction('pathfinder_step_do', {}, () => new Promise<never>(() => {}));
+      jest.advanceTimersByTime(30_000);
+      const action = mockStartUserAction.mock.results[0]!.value;
+      expect(action.attributes).toEqual({ outcome: 'timeout' });
+      expect(mockActionEnd).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('never double-ends: work settles first, then the timer fires', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    jest.useFakeTimers();
+    try {
+      await faro.withFaroUserAction('pathfinder_step_do', {}, async () => 'v');
+      jest.advanceTimersByTime(60_000);
+      const action = mockStartUserAction.mock.results[0]!.value;
+      expect(action.attributes).toEqual({ outcome: 'ok' });
+      expect(mockActionEnd).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('honors a custom timeout', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    jest.useFakeTimers();
+    try {
+      void faro.withFaroUserAction('pathfinder_step_do', {}, () => new Promise<never>(() => {}), 5_000);
+      jest.advanceTimersByTime(5_000);
+      expect(mockActionEnd).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('still runs the work when startUserAction throws', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockStartUserAction.mockImplementationOnce(() => {
+      throw new Error('transport down');
+    });
+    await expect(faro.withFaroUserAction('pathfinder_step_do', {}, () => 'ok')).resolves.toBe('ok');
+  });
+
+  it('swallows errors thrown by end() and still returns the value', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockActionEnd.mockImplementationOnce(() => {
+      throw new Error('transport down');
+    });
+    await expect(faro.withFaroUserAction('pathfinder_step_do', {}, () => 'ok')).resolves.toBe('ok');
+  });
+});
+
+describe('setFaroUserActionAttributes', () => {
+  it('merges stringified attributes onto the active action', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    const active = { name: 'outer', attributes: { a: '1' } };
+    mockGetActiveUserAction.mockReturnValueOnce(active);
+    faro.setFaroUserActionAttributes({ b: 2 });
+    expect(active.attributes).toEqual({ a: '1', b: '2' });
+  });
+
+  it('no-ops without an active action or before initialization', () => {
+    const faro = freshFaro();
+    expect(() => faro.setFaroUserActionAttributes({ a: 1 })).not.toThrow();
+  });
+});
+
+describe('armFaro / engagement gating', () => {
+  it('does not initialize until an engagement trigger fires', () => {
+    const faro = freshFaro();
+    faro.armFaro(0.5);
+    expect(mockInitializeFaro).not.toHaveBeenCalled();
+  });
+
+  it('notifyFaroEngagement initializes and flushes buffered calls in order', async () => {
+    const faro = freshFaro();
+    faro.armFaro();
+    faro.pushFaroLog('warn', 'early warning');
+    faro.pushFaroUserAction('pathfinder_feature_flag_evaluated', { flag_key: 'x' });
+    expect(mockInitializeFaro).not.toHaveBeenCalled();
+    expect(mockPushLog).not.toHaveBeenCalled();
+
+    await faro.notifyFaroEngagement();
+    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+    expect(mockPushLog).toHaveBeenCalledWith(['[pathfinder] early warning'], { level: 'warn', context: undefined });
+    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_feature_flag_evaluated', {
+      flag_key: 'x',
+      seq: '0',
+    });
+  });
+
+  it('a buffered error triggers initialization by itself', async () => {
+    const faro = freshFaro();
+    faro.armFaro();
+    const boom = new Error('boom');
+    faro.pushFaroError(boom);
+    await faro.notifyFaroEngagement();
+    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+    expect(mockPushError).toHaveBeenCalledWith(boom, undefined);
+  });
+
+  it('an error-level log triggers initialization; warn does not', async () => {
+    const faro = freshFaro();
+    faro.armFaro();
+    faro.pushFaroLog('warn', 'just a warning');
+    await Promise.resolve();
+    expect(mockInitializeFaro).not.toHaveBeenCalled();
+
+    faro.pushFaroLog('error', 'broken');
+    await faro.notifyFaroEngagement();
+    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+    expect(mockPushLog).toHaveBeenCalledTimes(2);
+  });
+
+  it('initializes immediately when a live Faro session already exists in this tab', async () => {
+    sessionStorage.setItem('com.grafana.faro.session', '{}');
+    const faro = freshFaro();
+    faro.armFaro();
+    await faro.notifyFaroEngagement();
+    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+  });
+
+  it('initializes immediately under the dev-build local override', async () => {
+    mockedConfig.buildInfo.env = 'development';
+    localStorage.setItem('pathfinder.faro.local', 'true');
+    const faro = freshFaro();
+    faro.armFaro();
+    await faro.notifyFaroEngagement();
+    expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+  });
+
+  it('never arms outside Grafana Cloud — pushes stay no-ops and no init happens', async () => {
+    mockedConfig.bootData!.settings.buildInfo.versionString = 'Grafana Enterprise';
+    const faro = freshFaro();
+    faro.armFaro();
+    faro.pushFaroLog('error', 'broken');
+    await faro.notifyFaroEngagement();
+    expect(mockInitializeFaro).not.toHaveBeenCalled();
+    expect(mockPushLog).not.toHaveBeenCalled();
+  });
+
+  it('caps the pre-init buffer at 30, dropping the oldest entries', async () => {
+    const faro = freshFaro();
+    faro.armFaro();
+    for (let i = 0; i < 35; i++) {
+      faro.pushFaroLog('warn', `message ${i}`);
+    }
+    await faro.notifyFaroEngagement();
+    expect(mockPushLog).toHaveBeenCalledTimes(30);
+    expect(mockPushLog).toHaveBeenNthCalledWith(1, ['[pathfinder] message 5'], { level: 'warn', context: undefined });
   });
 });
 

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -335,7 +335,12 @@ describe('pushFaroEvent', () => {
     await faro.initFaro();
 
     faro.pushFaroEvent('pathfinder_docs_panel_interaction', { action: 'open', step: 2 });
-    expect(mockPushEvent).toHaveBeenCalledWith('pathfinder_docs_panel_interaction', { action: 'open', step: '2' });
+    expect(mockPushEvent).toHaveBeenCalledWith(
+      'pathfinder_docs_panel_interaction',
+      { action: 'open', step: '2' },
+      undefined,
+      { skipDedupe: true }
+    );
   });
 
   it('forwards undefined attributes as undefined, not an empty object', async () => {
@@ -343,7 +348,22 @@ describe('pushFaroEvent', () => {
     await faro.initFaro();
 
     faro.pushFaroEvent('pathfinder_docs_panel_interaction');
-    expect(mockPushEvent).toHaveBeenCalledWith('pathfinder_docs_panel_interaction', undefined);
+    expect(mockPushEvent).toHaveBeenCalledWith('pathfinder_docs_panel_interaction', undefined, undefined, {
+      skipDedupe: true,
+    });
+  });
+
+  it('always skips Faro’s built-in dedupe, since a repeated identical interaction is legitimate and Rudderstack (the pipeline being cross-checked) does not dedupe', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.pushFaroEvent('pathfinder_do_it_button_click', { step_id: 'step-1' });
+    faro.pushFaroEvent('pathfinder_do_it_button_click', { step_id: 'step-1' });
+
+    expect(mockPushEvent).toHaveBeenCalledTimes(2);
+    for (const call of mockPushEvent.mock.calls) {
+      expect(call[3]).toEqual({ skipDedupe: true });
+    }
   });
 
   it('swallows errors thrown by the underlying Faro API', async () => {

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -15,15 +15,16 @@ const mockPushError = jest.fn();
 const mockPushLog = jest.fn();
 const mockActionEnd = jest.fn();
 const mockStartUserAction = jest.fn(() => ({ name: 'x', parentId: 'x', end: mockActionEnd }));
+const mockSetView = jest.fn();
 const mockPause = jest.fn();
 const mockFaroInstance = {
-  api: { pushError: mockPushError, pushLog: mockPushLog, startUserAction: mockStartUserAction },
+  api: { pushError: mockPushError, pushLog: mockPushLog, startUserAction: mockStartUserAction, setView: mockSetView },
   pause: mockPause,
 };
 interface CapturedFaroConfig {
   isolate: boolean;
   app: { name: string; version: string; environment: string };
-  sessionTracking: { samplingRate: number };
+  sessionTracking: { samplingRate: number; persistent: boolean };
   instrumentations: Array<{ constructor: { name: string } }>;
 }
 
@@ -301,6 +302,13 @@ describe('initFaro', () => {
     expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
   });
 
+  it('uses volatile (sessionStorage) sessions — persistent sessions would share localStorage with Grafana core', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    const calledWith = mockInitializeFaro.mock.calls[0]![0];
+    expect(calledWith.sessionTracking.persistent).toBe(false);
+  });
+
   it('defaults sessionTracking.samplingRate to 1 when no rate is passed', async () => {
     const faro = freshFaro();
     await faro.initFaro();
@@ -429,16 +437,33 @@ describe('pushFaroUserAction', () => {
     expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_docs_panel_interaction', {
       action: 'open',
       step: '2',
+      seq: '0',
     });
     expect(mockActionEnd).toHaveBeenCalledTimes(1);
   });
 
-  it('forwards undefined attributes as undefined, not an empty object', async () => {
+  it('adds an incrementing seq attribute so identical rapid-fire mirrors survive Faro dedupe', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.pushFaroUserAction('pathfinder_docs_panel_interaction', { action: 'open' });
+    faro.pushFaroUserAction('pathfinder_docs_panel_interaction', { action: 'open' });
+    expect(mockStartUserAction).toHaveBeenNthCalledWith(1, 'pathfinder_docs_panel_interaction', {
+      action: 'open',
+      seq: '0',
+    });
+    expect(mockStartUserAction).toHaveBeenNthCalledWith(2, 'pathfinder_docs_panel_interaction', {
+      action: 'open',
+      seq: '1',
+    });
+  });
+
+  it('sends only the seq attribute when no attributes are passed', async () => {
     const faro = freshFaro();
     await faro.initFaro();
 
     faro.pushFaroUserAction('pathfinder_docs_panel_interaction');
-    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_docs_panel_interaction', undefined);
+    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_docs_panel_interaction', { seq: '0' });
   });
 
   it('does not throw if startUserAction returns undefined (e.g. Faro declines to start one)', async () => {
@@ -468,5 +493,39 @@ describe('pushFaroUserAction', () => {
       throw new Error('transport down');
     });
     expect(() => faro.pushFaroUserAction('pathfinder_docs_panel_interaction', {})).not.toThrow();
+  });
+});
+
+describe('setFaroView', () => {
+  it('no-ops before initialization without throwing', () => {
+    const faro = freshFaro();
+    expect(() => faro.setFaroView('https://grafana.com/docs/grafana/latest/')).not.toThrow();
+    expect(mockSetView).not.toHaveBeenCalled();
+  });
+
+  it('sets the view to hostname + pathname, dropping query and fragment', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.setFaroView('https://grafana.com/docs/grafana/latest/alerting/?pg=docs#section-2');
+    expect(mockSetView).toHaveBeenCalledWith({ name: 'grafana.com/docs/grafana/latest/alerting/' });
+  });
+
+  it('no-ops on an empty URL, keeping the previous view', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.setFaroView('');
+    expect(mockSetView).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors thrown by the underlying Faro API', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockSetView.mockImplementationOnce(() => {
+      throw new Error('transport down');
+    });
+    expect(() => faro.setFaroView('https://grafana.com/docs/')).not.toThrow();
   });
 });

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -1,4 +1,12 @@
-import type { ExceptionEvent, Faro, LogEvent, LogLevel, TransportItem, APIEvent } from '@grafana/faro-web-sdk';
+import type {
+  ExceptionEvent,
+  Faro,
+  LogEvent,
+  LogLevel,
+  TransportItem,
+  APIEvent,
+  UserActionInternalInterface,
+} from '@grafana/faro-web-sdk';
 import { config } from '@grafana/runtime';
 import packageJson from '../../package.json';
 
@@ -164,16 +172,14 @@ export function stringifyAttributes(attributes: Record<string, unknown>): Record
   return result;
 }
 
-export function pushFaroEvent(name: string, attributes?: Record<string, unknown>): void {
+// Faro's public startUserAction() return type only exposes `name`/`parentId` —
+// ending it requires the internal interface. This isn't a hack: Faro's own
+// built-in click instrumentation (UserActionController) does the exact same
+// cast internally, since UserActionsAPI has no top-level `endUserAction()`.
+export function pushFaroUserAction(name: string, attributes?: Record<string, unknown>): void {
   try {
-    // Faro's pushEvent dedupes consecutive identical (name + attributes)
-    // pushes by default. That's wrong for an analytics mirror meant for
-    // exact cross-checking against Rudderstack, which doesn't dedupe — a
-    // legitimate repeated interaction (e.g. retrying the same button) would
-    // otherwise silently vanish from Faro's side only.
-    faroInstance?.api.pushEvent(name, attributes ? stringifyAttributes(attributes) : undefined, undefined, {
-      skipDedupe: true,
-    });
+    const action = faroInstance?.api.startUserAction(name, attributes ? stringifyAttributes(attributes) : undefined);
+    (action as UserActionInternalInterface | undefined)?.end();
   } catch {
     // Telemetry must never break the app it's observing.
   }

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -142,6 +142,32 @@ export function pushFaroLog(level: FaroLogLevel, message: string, context?: Reco
   }
 }
 
+const MAX_ATTRIBUTE_LENGTH = 500;
+
+// Faro event attributes are string-only; analytics properties are not
+// (numbers, booleans, the experiments array). Stringify here so every
+// caller of pushFaroEvent gets the same coercion.
+export function stringifyAttributes(attributes: Record<string, unknown>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    const stringified =
+      typeof value === 'string' ? value : typeof value === 'object' ? JSON.stringify(value) : String(value);
+    result[key] = stringified.slice(0, MAX_ATTRIBUTE_LENGTH);
+  }
+  return result;
+}
+
+export function pushFaroEvent(name: string, attributes?: Record<string, unknown>): void {
+  try {
+    faroInstance?.api.pushEvent(name, attributes ? stringifyAttributes(attributes) : undefined);
+  } catch {
+    // Telemetry must never break the app it's observing.
+  }
+}
+
 export function pauseFaroBeforeReload(): void {
   try {
     faroInstance?.pause();

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -1,4 +1,5 @@
 import type {
+  EventEvent,
   ExceptionEvent,
   Faro,
   LogEvent,
@@ -9,6 +10,11 @@ import type {
 } from '@grafana/faro-web-sdk';
 import { config } from '@grafana/runtime';
 import packageJson from '../../package.json';
+import {
+  ALLOWED_GRAFANA_DOCS_HOSTNAMES,
+  ALLOWED_INTERACTIVE_LEARNING_HOSTNAMES,
+  ALLOWED_RECOMMENDER_DOMAINS,
+} from '../constants';
 
 const COLLECTOR_URL = 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/d6ec87b657b65de6e363de05623d9c57';
 const APP_NAME = packageJson.name;
@@ -68,10 +74,39 @@ function isLogItem(item: TransportItem<APIEvent>): item is TransportItem<LogEven
   return item.type === 'log';
 }
 
+function isEventItem(item: TransportItem<APIEvent>): item is TransportItem<EventEvent> {
+  return item.type === 'event';
+}
+
+// PerformanceInstrumentation reports every fetch/xhr resource load on the
+// page (Grafana core's own requests included) — these two are the only
+// domains this plugin itself ever fetches from, so anything else is core's
+// traffic, not ours.
+const TRACKED_RESOURCE_HOSTNAMES = new Set([
+  ...ALLOWED_GRAFANA_DOCS_HOSTNAMES,
+  ...ALLOWED_RECOMMENDER_DOMAINS,
+  ...ALLOWED_INTERACTIVE_LEARNING_HOSTNAMES,
+]);
+
+function isTrackedResourceUrl(resourceUrl: string | undefined): boolean {
+  if (typeof resourceUrl !== 'string') {
+    return false;
+  }
+  try {
+    return TRACKED_RESOURCE_HOSTNAMES.has(new URL(resourceUrl).hostname);
+  } catch {
+    return false;
+  }
+}
+
 // Whitelist, not blocklist: Grafana core and other app plugins run their own
 // Faro instances on the same page, so exceptions/logs must be attributable to
-// Pathfinder. Other item types (events, measurements) only ever originate
-// from this isolated instance's own API, so they pass through unfiltered.
+// Pathfinder, and PerformanceInstrumentation's resource entries must be
+// attributable to a domain we actually fetch from. Page-wide navigation
+// timing (the whole page's load, not a specific resource) is always dropped.
+// Everything else — our own pushed events/user-actions/measurements — only
+// ever originates from this isolated instance's own API, so it passes
+// through unfiltered.
 export function filterPathfinderTelemetry(item: TransportItem<APIEvent>): TransportItem<APIEvent> | null {
   if (isExceptionItem(item)) {
     const frames = item.payload.stacktrace?.frames ?? [];
@@ -79,6 +114,14 @@ export function filterPathfinderTelemetry(item: TransportItem<APIEvent>): Transp
   }
   if (isLogItem(item)) {
     return item.payload.message.startsWith(LOG_PREFIX) ? item : null;
+  }
+  if (isEventItem(item)) {
+    if (item.payload.name === 'faro.performance.navigation') {
+      return null;
+    }
+    if (item.payload.name === 'faro.performance.resource') {
+      return isTrackedResourceUrl(item.payload.attributes?.['name']) ? item : null;
+    }
   }
   return item;
 }
@@ -103,8 +146,13 @@ export async function initFaro(sampleRate = 1): Promise<void> {
     return;
   }
 
-  const { initializeFaro, ErrorsInstrumentation, SessionInstrumentation, ViewInstrumentation } =
-    await import('@grafana/faro-web-sdk');
+  const {
+    initializeFaro,
+    ErrorsInstrumentation,
+    SessionInstrumentation,
+    ViewInstrumentation,
+    PerformanceInstrumentation,
+  } = await import('@grafana/faro-web-sdk');
 
   faroInstance = initializeFaro({
     url: COLLECTOR_URL,
@@ -118,7 +166,15 @@ export async function initFaro(sampleRate = 1): Promise<void> {
       version: APP_VERSION,
       environment,
     },
-    instrumentations: [new ErrorsInstrumentation(), new SessionInstrumentation(), new ViewInstrumentation()],
+    instrumentations: [
+      new ErrorsInstrumentation(),
+      new SessionInstrumentation(),
+      new ViewInstrumentation(),
+      // Only fetch/xhr resources are tracked by default (config.trackResources
+      // is left unset) — not every image/script/CSS on the page. Filtered
+      // further in beforeSend down to docs/recommender hosts specifically.
+      new PerformanceInstrumentation(),
+    ],
     sessionTracking: {
       enabled: true,
       persistent: true,

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -407,6 +407,13 @@ export async function withFaroUserAction<T>(
   work: () => Promise<T> | T,
   timeoutMs = USER_ACTION_TIMEOUT_MS
 ): Promise<T> {
+  // Reaching an interactive funnel is engagement by definition: complete an
+  // armed init before deciding to pass through, so the first action in a
+  // fresh tab is captured rather than run outside an action envelope. Only
+  // awaited pre-init — once initialized the action must start synchronously.
+  if (!faroInstance) {
+    await notifyFaroEngagement().catch(() => undefined);
+  }
   let action: StampableUserAction | undefined;
   guardTelemetry(() => {
     if (faroInstance && faroInstance.api.getActiveUserAction() === undefined) {

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -10,6 +10,7 @@ import type {
 } from '@grafana/faro-web-sdk';
 import { config } from '@grafana/runtime';
 import packageJson from '../../package.json';
+import pluginJson from '../plugin.json';
 import {
   ALLOWED_GRAFANA_DOCS_HOSTNAMES,
   ALLOWED_INTERACTIVE_LEARNING_HOSTNAMES,
@@ -39,8 +40,15 @@ type BufferedFaroCall =
 
 const PRE_INIT_BUFFER_CAP = 30;
 let preInitBuffer: BufferedFaroCall[] | null = null;
-let armedSampleRate = 1;
 let pendingInit: Promise<void> | null = null;
+
+function guardTelemetry(fn: () => void): void {
+  try {
+    fn();
+  } catch {
+    // Telemetry must never break the app it's observing.
+  }
+}
 
 // The SDK's fixed volatile-session sessionStorage key. Hardcoded because
 // importing the constant would pull @grafana/faro-web-sdk into the entry
@@ -82,14 +90,14 @@ function flushPreInitBuffer(): void {
 
 function triggerFaroInit(): Promise<void> {
   if (!pendingInit) {
-    pendingInit = initFaro(armedSampleRate)
+    pendingInit = initFaro()
       .catch(() => undefined)
       .then(() => flushPreInitBuffer());
   }
   return pendingInit;
 }
 
-export function armFaro(sampleRate = 1): void {
+export function armFaro(): void {
   if (initStarted || preInitBuffer) {
     return;
   }
@@ -97,7 +105,6 @@ export function armFaro(sampleRate = 1): void {
   if (!resolved) {
     return;
   }
-  armedSampleRate = sampleRate;
   if (resolved.isLocalOverride || hasLiveFaroSession()) {
     void triggerFaroInit();
     return;
@@ -144,11 +151,19 @@ export function isGrafanaCloud(): boolean {
   }
 }
 
+// Both derived from their source of truth (Grafana serves plugin assets from
+// /public/plugins/<id>/; sourcemapped frames use webpack://<package name>/),
+// so a plugin rename can't silently break the whitelist.
+const PLUGIN_ASSET_PATH = `/public/plugins/${pluginJson.id}/`;
+
 function isPathfinderStackFrame(filename: string | undefined): boolean {
-  return (
-    typeof filename === 'string' && (filename.includes('grafana-pathfinder-app') || filename.includes('/pathfinder/'))
-  );
+  return typeof filename === 'string' && (filename.includes(PLUGIN_ASSET_PATH) || filename.includes(APP_NAME));
 }
+
+// Exceptions we report explicitly (error boundaries, logger) must survive the
+// beforeSend frame filter even when the stack is missing or lives entirely in
+// a shared chunk; ambient window errors still need a Pathfinder frame.
+const EXPLICIT_REPORT_MARKER = 'pathfinder_reported';
 
 function isExceptionItem(item: TransportItem<APIEvent>): item is TransportItem<ExceptionEvent> {
   return item.type === 'exception';
@@ -163,21 +178,32 @@ function isEventItem(item: TransportItem<APIEvent>): item is TransportItem<Event
 }
 
 // PerformanceInstrumentation reports every fetch/xhr resource load on the
-// page (Grafana core's own requests included) — these two are the only
-// domains this plugin itself ever fetches from, so anything else is core's
-// traffic, not ours.
+// page (Grafana core's own requests included); only hosts this plugin itself
+// fetches from are kept.
 const TRACKED_RESOURCE_HOSTNAMES = new Set([
   ...ALLOWED_GRAFANA_DOCS_HOSTNAMES,
   ...ALLOWED_RECOMMENDER_DOMAINS,
   ...ALLOWED_INTERACTIVE_LEARNING_HOSTNAMES,
 ]);
 
+// Bare grafana.com is shared with Grafana core (plugin catalog, news feed);
+// only the docs/tutorials paths url-validator lets this plugin fetch count.
+const SHARED_HOSTNAME = 'grafana.com';
+const SHARED_HOSTNAME_PATH_PREFIXES = ['/docs', '/tutorials'];
+
 function isTrackedResourceUrl(resourceUrl: string | undefined): boolean {
   if (typeof resourceUrl !== 'string') {
     return false;
   }
   try {
-    return TRACKED_RESOURCE_HOSTNAMES.has(new URL(resourceUrl).hostname);
+    const { hostname, pathname } = new URL(resourceUrl);
+    if (!TRACKED_RESOURCE_HOSTNAMES.has(hostname)) {
+      return false;
+    }
+    return (
+      hostname !== SHARED_HOSTNAME ||
+      SHARED_HOSTNAME_PATH_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`))
+    );
   } catch {
     return false;
   }
@@ -193,6 +219,9 @@ function isTrackedResourceUrl(resourceUrl: string | undefined): boolean {
 // through unfiltered.
 export function filterPathfinderTelemetry(item: TransportItem<APIEvent>): TransportItem<APIEvent> | null {
   if (isExceptionItem(item)) {
+    if (item.payload.context?.[EXPLICIT_REPORT_MARKER] === 'true') {
+      return item;
+    }
     const frames = item.payload.stacktrace?.frames ?? [];
     return frames.some((frame) => isPathfinderStackFrame(frame.filename)) ? item : null;
   }
@@ -226,7 +255,7 @@ function resolveFaroEnvironment(): { environment: FaroEnvironment; isLocalOverri
   return { environment, isLocalOverride };
 }
 
-export async function initFaro(sampleRate = 1): Promise<void> {
+export async function initFaro(): Promise<void> {
   if (initStarted) {
     return;
   }
@@ -236,7 +265,7 @@ export async function initFaro(sampleRate = 1): Promise<void> {
   if (!resolved) {
     return;
   }
-  const { environment, isLocalOverride } = resolved;
+  const { environment } = resolved;
 
   const {
     initializeFaro,
@@ -272,14 +301,10 @@ export async function initFaro(sampleRate = 1): Promise<void> {
       // Faro's persistent-session localStorage key is a fixed SDK constant
       // (`com.grafana.faro.session`) that `isolate` does not namespace, and
       // Grafana core's Faro uses it too — persistent:true would resume core's
-      // session, inherit its sampling decision (making samplingRate below a
-      // no-op), and could contaminate core's RUM sampling in return. Volatile
-      // sessions live in sessionStorage, which core doesn't touch.
+      // session, inherit its sampling decision, and could contaminate core's
+      // RUM sampling in return. Volatile sessions live in sessionStorage,
+      // which core doesn't touch.
       persistent: false,
-      // A session not selected by the sample sends nothing for its entire
-      // lifetime. The local QA override always gets the real rate (1), not
-      // whatever the remote production-volume control happens to be set to.
-      samplingRate: isLocalOverride ? 1 : sampleRate,
       session: {
         attributes: {
           grafana_version: config.buildInfo.version,
@@ -291,21 +316,19 @@ export async function initFaro(sampleRate = 1): Promise<void> {
 }
 
 export function pushFaroError(error: Error, context?: Record<string, string>): void {
-  try {
+  guardTelemetry(() => {
     if (bufferPreInitCall({ kind: 'error', error, context })) {
       void triggerFaroInit();
       return;
     }
-    faroInstance?.api.pushError(error, context ? { context } : undefined);
-  } catch {
-    // Telemetry must never break the app it's observing.
-  }
+    faroInstance?.api.pushError(error, { context: { ...context, [EXPLICIT_REPORT_MARKER]: 'true' } });
+  });
 }
 
 export type FaroLogLevel = 'info' | 'warn' | 'error';
 
 export function pushFaroLog(level: FaroLogLevel, message: string, context?: Record<string, string>): void {
-  try {
+  guardTelemetry(() => {
     if (bufferPreInitCall({ kind: 'log', level, message, context })) {
       if (level === 'error') {
         void triggerFaroInit();
@@ -313,16 +336,14 @@ export function pushFaroLog(level: FaroLogLevel, message: string, context?: Reco
       return;
     }
     faroInstance?.api.pushLog([`${LOG_PREFIX} ${message}`], { level: level as LogLevel, context });
-  } catch {
-    // Telemetry must never break the app it's observing.
-  }
+  });
 }
 
 const MAX_ATTRIBUTE_LENGTH = 500;
 
 // Faro event attributes are string-only; analytics properties are not
 // (numbers, booleans, the experiments array). Stringify here so every
-// caller of pushFaroEvent gets the same coercion.
+// user-action producer gets the same coercion.
 export function stringifyAttributes(attributes: Record<string, unknown>): Record<string, string> {
   const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(attributes)) {
@@ -343,7 +364,7 @@ let userActionSeq = 0;
 // built-in click instrumentation (UserActionController) does the exact same
 // cast internally, since UserActionsAPI has no top-level `endUserAction()`.
 export function pushFaroUserAction(name: string, attributes?: Record<string, unknown>): void {
-  try {
+  guardTelemetry(() => {
     if (bufferPreInitCall({ kind: 'userAction', name, attributes })) {
       return;
     }
@@ -366,9 +387,7 @@ export function pushFaroUserAction(name: string, attributes?: Record<string, unk
     }
     const action = faroInstance.api.startUserAction(name, attrs);
     (action as UserActionInternalInterface | undefined)?.end();
-  } catch {
-    // Telemetry must never break the app it's observing.
-  }
+  });
 }
 
 const USER_ACTION_TIMEOUT_MS = 30_000;
@@ -389,14 +408,12 @@ export async function withFaroUserAction<T>(
   timeoutMs = USER_ACTION_TIMEOUT_MS
 ): Promise<T> {
   let action: StampableUserAction | undefined;
-  try {
+  guardTelemetry(() => {
     if (faroInstance && faroInstance.api.getActiveUserAction() === undefined) {
       action = faroInstance.api.startUserAction(name, stringifyAttributes(attributes)) as
         StampableUserAction | undefined;
     }
-  } catch {
-    // Telemetry must never break the app it's observing.
-  }
+  });
   if (!action) {
     return work();
   }
@@ -411,12 +428,10 @@ export async function withFaroUserAction<T>(
     if (timer !== undefined) {
       clearTimeout(timer);
     }
-    try {
+    guardTelemetry(() => {
       started.attributes = { ...started.attributes, outcome };
       started.end();
-    } catch {
-      // Telemetry must never break the app it's observing.
-    }
+    });
   };
   timer = setTimeout(() => finish('timeout'), timeoutMs);
   try {
@@ -430,32 +445,26 @@ export async function withFaroUserAction<T>(
 }
 
 export function setFaroUserActionAttributes(attributes: Record<string, unknown>): void {
-  try {
+  guardTelemetry(() => {
     const action = faroInstance?.api.getActiveUserAction() as StampableUserAction | undefined;
     if (action) {
       action.attributes = { ...action.attributes, ...stringifyAttributes(attributes) };
     }
-  } catch {
-    // Telemetry must never break the app it's observing.
-  }
+  });
 }
 
 export function setFaroView(url: string): void {
-  try {
+  guardTelemetry(() => {
     if (!url || !faroInstance) {
       return;
     }
     const { hostname, pathname } = new URL(url, window.location.origin);
     faroInstance.api.setView({ name: `${hostname}${pathname}` });
-  } catch {
-    // Telemetry must never break the app it's observing.
-  }
+  });
 }
 
 export function pauseFaroBeforeReload(): void {
-  try {
+  guardTelemetry(() => {
     faroInstance?.pause();
-  } catch {
-    // best-effort only
-  }
+  });
 }

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -162,7 +162,14 @@ export function stringifyAttributes(attributes: Record<string, unknown>): Record
 
 export function pushFaroEvent(name: string, attributes?: Record<string, unknown>): void {
   try {
-    faroInstance?.api.pushEvent(name, attributes ? stringifyAttributes(attributes) : undefined);
+    // Faro's pushEvent dedupes consecutive identical (name + attributes)
+    // pushes by default. That's wrong for an analytics mirror meant for
+    // exact cross-checking against Rudderstack, which doesn't dedupe — a
+    // legitimate repeated interaction (e.g. retrying the same button) would
+    // otherwise silently vanish from Faro's side only.
+    faroInstance?.api.pushEvent(name, attributes ? stringifyAttributes(attributes) : undefined, undefined, {
+      skipDedupe: true,
+    });
   } catch {
     // Telemetry must never break the app it's observing.
   }

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -28,6 +28,90 @@ type FaroEnvironment = 'dev' | 'ops' | 'prod' | 'local';
 let faroInstance: Faro | null = null;
 let initStarted = false;
 
+// Faro init is engagement-gated: sessions must mean "used Pathfinder or
+// Pathfinder errored", not "loaded a Grafana page". While armed, facade calls
+// queue here and flush after the first trigger (any analytics event except
+// flag exposures, or an error) completes the real init.
+type BufferedFaroCall =
+  | { kind: 'error'; error: Error; context?: Record<string, string> }
+  | { kind: 'log'; level: FaroLogLevel; message: string; context?: Record<string, string> }
+  | { kind: 'userAction'; name: string; attributes?: Record<string, unknown> };
+
+const PRE_INIT_BUFFER_CAP = 30;
+let preInitBuffer: BufferedFaroCall[] | null = null;
+let armedSampleRate = 1;
+let pendingInit: Promise<void> | null = null;
+
+// The SDK's fixed volatile-session sessionStorage key. Hardcoded because
+// importing the constant would pull @grafana/faro-web-sdk into the entry
+// bundle — the SDK must stay behind the dynamic import in initFaro.
+const FARO_SESSION_STORAGE_KEY = 'com.grafana.faro.session';
+
+function hasLiveFaroSession(): boolean {
+  try {
+    return sessionStorage.getItem(FARO_SESSION_STORAGE_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+function bufferPreInitCall(call: BufferedFaroCall): boolean {
+  if (!preInitBuffer) {
+    return false;
+  }
+  if (preInitBuffer.length >= PRE_INIT_BUFFER_CAP) {
+    preInitBuffer.shift();
+  }
+  preInitBuffer.push(call);
+  return true;
+}
+
+function flushPreInitBuffer(): void {
+  const buffered = preInitBuffer ?? [];
+  preInitBuffer = null;
+  for (const call of buffered) {
+    if (call.kind === 'error') {
+      pushFaroError(call.error, call.context);
+    } else if (call.kind === 'log') {
+      pushFaroLog(call.level, call.message, call.context);
+    } else {
+      pushFaroUserAction(call.name, call.attributes);
+    }
+  }
+}
+
+function triggerFaroInit(): Promise<void> {
+  if (!pendingInit) {
+    pendingInit = initFaro(armedSampleRate)
+      .catch(() => undefined)
+      .then(() => flushPreInitBuffer());
+  }
+  return pendingInit;
+}
+
+export function armFaro(sampleRate = 1): void {
+  if (initStarted || preInitBuffer) {
+    return;
+  }
+  const resolved = resolveFaroEnvironment();
+  if (!resolved) {
+    return;
+  }
+  armedSampleRate = sampleRate;
+  if (resolved.isLocalOverride || hasLiveFaroSession()) {
+    void triggerFaroInit();
+    return;
+  }
+  preInitBuffer = [];
+}
+
+export function notifyFaroEngagement(): Promise<void> {
+  if (!preInitBuffer && !pendingInit) {
+    return Promise.resolve();
+  }
+  return triggerFaroInit();
+}
+
 // Pathfinder is a micro-frontend inside Grafana; multiple Faro instances can
 // share the page. `local` only activates via an explicit localStorage flag in
 // a dev build, so a real production bundle can never take this path.
@@ -130,21 +214,29 @@ export function isFaroEnabled(): boolean {
   return faroInstance !== null;
 }
 
+function resolveFaroEnvironment(): { environment: FaroEnvironment; isLocalOverride: boolean } | null {
+  const environment = getEnvironment(window.location.hostname);
+  if (!environment) {
+    return null;
+  }
+  const isLocalOverride = environment === 'local';
+  if (!isLocalOverride && (!isGrafanaCloud() || config.analytics?.enabled === false)) {
+    return null;
+  }
+  return { environment, isLocalOverride };
+}
+
 export async function initFaro(sampleRate = 1): Promise<void> {
   if (initStarted) {
     return;
   }
   initStarted = true;
 
-  const environment = getEnvironment(window.location.hostname);
-  if (!environment) {
+  const resolved = resolveFaroEnvironment();
+  if (!resolved) {
     return;
   }
-
-  const isLocalOverride = environment === 'local';
-  if (!isLocalOverride && (!isGrafanaCloud() || config.analytics?.enabled === false)) {
-    return;
-  }
+  const { environment, isLocalOverride } = resolved;
 
   const {
     initializeFaro,
@@ -200,6 +292,10 @@ export async function initFaro(sampleRate = 1): Promise<void> {
 
 export function pushFaroError(error: Error, context?: Record<string, string>): void {
   try {
+    if (bufferPreInitCall({ kind: 'error', error, context })) {
+      void triggerFaroInit();
+      return;
+    }
     faroInstance?.api.pushError(error, context ? { context } : undefined);
   } catch {
     // Telemetry must never break the app it's observing.
@@ -210,6 +306,12 @@ export type FaroLogLevel = 'info' | 'warn' | 'error';
 
 export function pushFaroLog(level: FaroLogLevel, message: string, context?: Record<string, string>): void {
   try {
+    if (bufferPreInitCall({ kind: 'log', level, message, context })) {
+      if (level === 'error') {
+        void triggerFaroInit();
+      }
+      return;
+    }
     faroInstance?.api.pushLog([`${LOG_PREFIX} ${message}`], { level: level as LogLevel, context });
   } catch {
     // Telemetry must never break the app it's observing.
@@ -242,14 +344,97 @@ let userActionSeq = 0;
 // cast internally, since UserActionsAPI has no top-level `endUserAction()`.
 export function pushFaroUserAction(name: string, attributes?: Record<string, unknown>): void {
   try {
-    const action = faroInstance?.api.startUserAction(name, {
+    if (bufferPreInitCall({ kind: 'userAction', name, attributes })) {
+      return;
+    }
+    if (!faroInstance) {
+      return;
+    }
+    const attrs = {
       ...(attributes ? stringifyAttributes(attributes) : {}),
       // Faro's dedupe compares name+attributes but not timestamps, so two
       // identical mirrors in the same millisecond would collapse into one
       // event; `seq` keeps the count in parity with RudderStack.
       seq: String(userActionSeq++),
-    });
+    };
+    // A real action is in flight: starting another would return undefined and
+    // silently drop this mirror. Push it as a plain event instead — the SDK
+    // buffers it into the open action and stamps action.parentId/name on end.
+    if (faroInstance.api.getActiveUserAction() !== undefined) {
+      faroInstance.api.pushEvent(name, attrs, undefined, { skipDedupe: true });
+      return;
+    }
+    const action = faroInstance.api.startUserAction(name, attrs);
     (action as UserActionInternalInterface | undefined)?.end();
+  } catch {
+    // Telemetry must never break the app it's observing.
+  }
+}
+
+const USER_ACTION_TIMEOUT_MS = 30_000;
+export const USER_ACTION_TIMEOUT_LONG_MS = 600_000;
+
+type StampableUserAction = UserActionInternalInterface & { attributes?: Record<string, string> };
+
+// UserActionInternalInterface.end() declares an attributes parameter, but the
+// 2.8.2 implementation ignores it — outcome must be stamped by mutating the
+// action's public `attributes` field before end(). end() also only guards
+// re-entry from the Cancelled state, so calling it again after the safety
+// timeout already ended the action would emit a duplicate faro.user.action
+// event; `settled` is the idempotency guard for both.
+export async function withFaroUserAction<T>(
+  name: string,
+  attributes: Record<string, unknown>,
+  work: () => Promise<T> | T,
+  timeoutMs = USER_ACTION_TIMEOUT_MS
+): Promise<T> {
+  let action: StampableUserAction | undefined;
+  try {
+    if (faroInstance && faroInstance.api.getActiveUserAction() === undefined) {
+      action = faroInstance.api.startUserAction(name, stringifyAttributes(attributes)) as
+        StampableUserAction | undefined;
+    }
+  } catch {
+    // Telemetry must never break the app it's observing.
+  }
+  if (!action) {
+    return work();
+  }
+  const started = action;
+  let settled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const finish = (outcome: 'ok' | 'error' | 'timeout') => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+    try {
+      started.attributes = { ...started.attributes, outcome };
+      started.end();
+    } catch {
+      // Telemetry must never break the app it's observing.
+    }
+  };
+  timer = setTimeout(() => finish('timeout'), timeoutMs);
+  try {
+    const result = await work();
+    finish('ok');
+    return result;
+  } catch (error) {
+    finish('error');
+    throw error;
+  }
+}
+
+export function setFaroUserActionAttributes(attributes: Record<string, unknown>): void {
+  try {
+    const action = faroInstance?.api.getActiveUserAction() as StampableUserAction | undefined;
+    if (action) {
+      action.attributes = { ...action.attributes, ...stringifyAttributes(attributes) };
+    }
   } catch {
     // Telemetry must never break the app it's observing.
   }

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -177,7 +177,13 @@ export async function initFaro(sampleRate = 1): Promise<void> {
     ],
     sessionTracking: {
       enabled: true,
-      persistent: true,
+      // Faro's persistent-session localStorage key is a fixed SDK constant
+      // (`com.grafana.faro.session`) that `isolate` does not namespace, and
+      // Grafana core's Faro uses it too — persistent:true would resume core's
+      // session, inherit its sampling decision (making samplingRate below a
+      // no-op), and could contaminate core's RUM sampling in return. Volatile
+      // sessions live in sessionStorage, which core doesn't touch.
+      persistent: false,
       // A session not selected by the sample sends nothing for its entire
       // lifetime. The local QA override always gets the real rate (1), not
       // whatever the remote production-volume control happens to be set to.
@@ -228,14 +234,34 @@ export function stringifyAttributes(attributes: Record<string, unknown>): Record
   return result;
 }
 
+let userActionSeq = 0;
+
 // Faro's public startUserAction() return type only exposes `name`/`parentId` —
 // ending it requires the internal interface. This isn't a hack: Faro's own
 // built-in click instrumentation (UserActionController) does the exact same
 // cast internally, since UserActionsAPI has no top-level `endUserAction()`.
 export function pushFaroUserAction(name: string, attributes?: Record<string, unknown>): void {
   try {
-    const action = faroInstance?.api.startUserAction(name, attributes ? stringifyAttributes(attributes) : undefined);
+    const action = faroInstance?.api.startUserAction(name, {
+      ...(attributes ? stringifyAttributes(attributes) : {}),
+      // Faro's dedupe compares name+attributes but not timestamps, so two
+      // identical mirrors in the same millisecond would collapse into one
+      // event; `seq` keeps the count in parity with RudderStack.
+      seq: String(userActionSeq++),
+    });
     (action as UserActionInternalInterface | undefined)?.end();
+  } catch {
+    // Telemetry must never break the app it's observing.
+  }
+}
+
+export function setFaroView(url: string): void {
+  try {
+    if (!url || !faroInstance) {
+      return;
+    }
+    const { hostname, pathname } = new URL(url, window.location.origin);
+    faroInstance.api.setView({ name: `${hostname}${pathname}` });
   } catch {
     // Telemetry must never break the app it's observing.
   }

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -1,152 +1,141 @@
-/**
- * Grafana Faro v2 Frontend Observability
- *
- * This module initializes Faro for capturing errors, performance metrics,
- * traces, and console logs from the pathfinder plugin.
- *
- * Faro telemetry is ONLY enabled for Grafana Cloud users. OSS/self-hosted
- * users do not send any telemetry data to Grafana.
- *
- * In development mode or OSS environments, a minimal Faro instance is created
- * that doesn't send any events but prevents crashes in error boundaries.
- *
- * In Grafana Cloud production, full instrumentation is enabled with error
- * filtering to only capture events originating from this plugin.
- */
-
-import type { APIEvent, ExceptionEvent, TransportItem } from '@grafana/faro-react';
+import type { ExceptionEvent, Faro, LogEvent, TransportItem, APIEvent } from '@grafana/faro-web-sdk';
 import { config } from '@grafana/runtime';
-import pluginJson from '../plugin.json';
+import packageJson from '../../package.json';
 
-const COLLECTOR_URL = 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/a81c4a455fd66a459225762586e121f2';
-const VERSION = pluginJson.info.version ?? '0.0.0';
-const FARO_GLOBAL_OBJECT_KEY = 'grafanaPathfinderApp';
+const COLLECTOR_URL = 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/d6ec87b657b65de6e363de05623d9c57';
+const APP_NAME = packageJson.name;
+const APP_VERSION = packageJson.version;
+const GLOBAL_OBJECT_KEY = 'grafanaPathfinderApp';
+const LOG_PREFIX = '[pathfinder]';
+const LOCAL_OVERRIDE_KEY = 'pathfinder.faro.local';
 
-/**
- * Check if running in Grafana Cloud
- * Uses the same detection pattern as the rest of the codebase
- */
-const isGrafanaCloud = (): boolean => {
+type FaroEnvironment = 'dev' | 'ops' | 'prod' | 'local';
+
+let faroInstance: Faro | null = null;
+let initStarted = false;
+
+// Pathfinder is a micro-frontend inside Grafana; multiple Faro instances can
+// share the page. `local` only activates via an explicit localStorage flag in
+// a dev build, so a real production bundle can never take this path.
+export function getEnvironment(hostname: string): FaroEnvironment | null {
+  if (config.buildInfo.env === 'development') {
+    try {
+      return localStorage.getItem(LOCAL_OVERRIDE_KEY) === 'true' ? 'local' : null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (hostname.endsWith('.grafana-dev.net')) {
+    return 'dev';
+  }
+  if (hostname.endsWith('.grafana-ops.net')) {
+    return 'ops';
+  }
+  if (hostname.endsWith('.grafana.net') || hostname.endsWith('.grafana.com')) {
+    return 'prod';
+  }
+  return null;
+}
+
+export function isGrafanaCloud(): boolean {
   try {
     return config.bootData?.settings?.buildInfo?.versionString?.startsWith('Grafana Cloud') ?? false;
   } catch {
     return false;
   }
-};
+}
 
-/**
- * Initialize Faro metrics collection
- *
- * Uses dynamic imports to keep the main bundle small and allows
- * conditional loading of tracing instrumentation only in production.
- *
- * Telemetry is only sent for Grafana Cloud users - OSS users get a
- * minimal no-op instance to prevent error boundary crashes.
- */
-export const initializeFaroMetrics = async (): Promise<void> => {
-  const isDevelopment = config.buildInfo.env === 'development';
-  const isCloud = isGrafanaCloud();
+function isPathfinderStackFrame(filename: string | undefined): boolean {
+  return (
+    typeof filename === 'string' && (filename.includes('grafana-pathfinder-app') || filename.includes('/pathfinder/'))
+  );
+}
 
-  // Skip sending events in development mode or OSS environments
-  if (isDevelopment || !isCloud) {
-    const reason = isDevelopment ? 'local development' : 'OSS environment';
-    console.log(`[Faro] skipping frontend metrics initialization (${reason})`);
+function isExceptionItem(item: TransportItem<APIEvent>): item is TransportItem<ExceptionEvent> {
+  return item.type === 'exception';
+}
 
-    // Dynamically import Faro modules
-    const { initializeFaro, ReactIntegration } = await import('@grafana/faro-react');
+function isLogItem(item: TransportItem<APIEvent>): item is TransportItem<LogEvent> {
+  return item.type === 'log';
+}
 
-    // Initialize minimal Faro to prevent crashes in error boundaries
-    initializeFaro({
-      url: 'http://localhost:12345', // dummy URL that won't be used
-      globalObjectKey: FARO_GLOBAL_OBJECT_KEY,
-      app: {
-        name: 'grafana-pathfinder-dev',
-        version: VERSION,
-        environment: isDevelopment ? 'development' : 'oss',
-      },
-      isolate: true,
-      instrumentations: [
-        // Minimal setup - just React integration for error boundary compatibility
-        new ReactIntegration(),
-      ],
-      beforeSend: () => null, // Don't send any events
-    });
+// Whitelist, not blocklist: Grafana core and other app plugins run their own
+// Faro instances on the same page, so exceptions/logs must be attributable to
+// Pathfinder. Other item types (events, measurements) only ever originate
+// from this isolated instance's own API, so they pass through unfiltered.
+export function filterPathfinderTelemetry(item: TransportItem<APIEvent>): TransportItem<APIEvent> | null {
+  if (isExceptionItem(item)) {
+    const frames = item.payload.stacktrace?.frames ?? [];
+    return frames.some((frame) => isPathfinderStackFrame(frame.filename)) ? item : null;
+  }
+  if (isLogItem(item)) {
+    return item.payload.message.startsWith(LOG_PREFIX) ? item : null;
+  }
+  return item;
+}
+
+export function isFaroEnabled(): boolean {
+  return faroInstance !== null;
+}
+
+export async function initFaro(): Promise<void> {
+  if (initStarted) {
+    return;
+  }
+  initStarted = true;
+
+  const environment = getEnvironment(window.location.hostname);
+  if (!environment) {
     return;
   }
 
-  // Grafana Cloud Production: Full Faro initialization with v2 features
-  const { initializeFaro, getWebInstrumentations, ReactIntegration } = await import('@grafana/faro-react');
-  const { TracingInstrumentation } = await import('@grafana/faro-web-tracing');
+  const isLocalOverride = environment === 'local';
+  if (!isLocalOverride && (!isGrafanaCloud() || config.analytics?.enabled === false)) {
+    return;
+  }
 
-  initializeFaro({
+  const { initializeFaro, ErrorsInstrumentation, SessionInstrumentation, ViewInstrumentation } =
+    await import('@grafana/faro-web-sdk');
+
+  faroInstance = initializeFaro({
     url: COLLECTOR_URL,
-    globalObjectKey: FARO_GLOBAL_OBJECT_KEY,
-    app: {
-      name: 'grafana-pathfinder',
-      version: VERSION,
-      environment: config.buildInfo.env,
-    },
-    // Isolate from Grafana's own telemetry
+    globalObjectKey: GLOBAL_OBJECT_KEY,
+    // Isolate from Grafana core's own Faro instance and other app plugins' —
+    // without this, initializing here would clobber the global object Grafana
+    // core attaches its own Faro instance to.
     isolate: true,
-    instrumentations: [
-      ...getWebInstrumentations({
-        captureConsole: true,
-        enablePerformanceInstrumentation: true,
-      }),
-      // Tracing for HTTP request visibility
-      new TracingInstrumentation(),
-      // React integration for component-level insights
-      new ReactIntegration(),
-    ],
-    // v2: Web Vitals attribution is now always collected (no config needed)
-    // v2: Uses session.id automatically (no migration needed for default setup)
-    beforeSend: (event: TransportItem<APIEvent>) => {
-      return filterPathfinderErrors(event);
+    app: {
+      name: APP_NAME,
+      version: APP_VERSION,
+      environment,
     },
+    instrumentations: [new ErrorsInstrumentation(), new SessionInstrumentation(), new ViewInstrumentation()],
+    sessionTracking: {
+      enabled: true,
+      persistent: true,
+      session: {
+        attributes: {
+          grafana_version: config.buildInfo.version,
+        },
+      },
+    },
+    beforeSend: filterPathfinderTelemetry,
   });
-
-  console.log(`[Faro] successfully initialized frontend metrics (v2)`);
-};
-
-/**
- * Typeguard to check if an event is an exception event
- */
-function isExceptionEvent(event: TransportItem<APIEvent>): event is TransportItem<ExceptionEvent> {
-  return event.type === 'exception';
 }
 
-/**
- * Filter errors to only include those originating from the pathfinder plugin
- *
- * This prevents noise from other Grafana errors appearing in our Faro dashboard.
- * The filter checks if the error stack trace includes the plugin's file paths.
- *
- * @param event - The Faro transport item to evaluate
- * @returns The event if it's from pathfinder, null otherwise
- */
-export function filterPathfinderErrors(event: TransportItem<APIEvent>): TransportItem<APIEvent> | null {
-  // In development we want to see all errors (if faro is enabled)
-  if (config.buildInfo.env === 'development') {
-    return event;
+export function pushFaroError(error: Error, context?: Record<string, string>): void {
+  try {
+    faroInstance?.api.pushError(error, context ? { context } : undefined);
+  } catch {
+    // Telemetry must never break the app it's observing.
   }
+}
 
-  /**
-   * Filter out errors not from the pathfinder plugin.
-   * Check if the error stack trace contains the plugin's file paths.
-   */
-  if (isExceptionEvent(event) && event.payload.type === 'Error') {
-    const trace = event.payload.stacktrace;
-    if (trace) {
-      const isPathfinderError = trace.frames.some(
-        (frame) => typeof frame.filename === 'string' && frame.filename.includes('/grafana-pathfinder-app/./')
-      );
-
-      // Discard anything not from the pathfinder plugin
-      if (!isPathfinderError) {
-        return null;
-      }
-    }
+export function pauseFaroBeforeReload(): void {
+  try {
+    faroInstance?.pause();
+  } catch {
+    // best-effort only
   }
-
-  return event;
 }

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -16,6 +16,8 @@ import {
   ALLOWED_INTERACTIVE_LEARNING_HOSTNAMES,
   ALLOWED_RECOMMENDER_DOMAINS,
 } from '../constants';
+import { StorageKeys } from './storage-keys';
+import { isExtensionSidebarOwnedByPathfinder } from './storage/extension-sidebar';
 
 const COLLECTOR_URL = 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/d6ec87b657b65de6e363de05623d9c57';
 const APP_NAME = packageJson.name;
@@ -29,94 +31,12 @@ type FaroEnvironment = 'dev' | 'ops' | 'prod' | 'local';
 let faroInstance: Faro | null = null;
 let initStarted = false;
 
-// Faro init is engagement-gated: sessions must mean "used Pathfinder or
-// Pathfinder errored", not "loaded a Grafana page". While armed, facade calls
-// queue here and flush after the first trigger (any analytics event except
-// flag exposures, or an error) completes the real init.
-type BufferedFaroCall =
-  | { kind: 'error'; error: Error; context?: Record<string, string> }
-  | { kind: 'log'; level: FaroLogLevel; message: string; context?: Record<string, string> }
-  | { kind: 'userAction'; name: string; attributes?: Record<string, unknown> };
-
-const PRE_INIT_BUFFER_CAP = 30;
-let preInitBuffer: BufferedFaroCall[] | null = null;
-let pendingInit: Promise<void> | null = null;
-
 function guardTelemetry(fn: () => void): void {
   try {
     fn();
   } catch {
     // Telemetry must never break the app it's observing.
   }
-}
-
-// The SDK's fixed volatile-session sessionStorage key. Hardcoded because
-// importing the constant would pull @grafana/faro-web-sdk into the entry
-// bundle — the SDK must stay behind the dynamic import in initFaro.
-const FARO_SESSION_STORAGE_KEY = 'com.grafana.faro.session';
-
-function hasLiveFaroSession(): boolean {
-  try {
-    return sessionStorage.getItem(FARO_SESSION_STORAGE_KEY) !== null;
-  } catch {
-    return false;
-  }
-}
-
-function bufferPreInitCall(call: BufferedFaroCall): boolean {
-  if (!preInitBuffer) {
-    return false;
-  }
-  if (preInitBuffer.length >= PRE_INIT_BUFFER_CAP) {
-    preInitBuffer.shift();
-  }
-  preInitBuffer.push(call);
-  return true;
-}
-
-function flushPreInitBuffer(): void {
-  const buffered = preInitBuffer ?? [];
-  preInitBuffer = null;
-  for (const call of buffered) {
-    if (call.kind === 'error') {
-      pushFaroError(call.error, call.context);
-    } else if (call.kind === 'log') {
-      pushFaroLog(call.level, call.message, call.context);
-    } else {
-      pushFaroUserAction(call.name, call.attributes);
-    }
-  }
-}
-
-function triggerFaroInit(): Promise<void> {
-  if (!pendingInit) {
-    pendingInit = initFaro()
-      .catch(() => undefined)
-      .then(() => flushPreInitBuffer());
-  }
-  return pendingInit;
-}
-
-export function armFaro(): void {
-  if (initStarted || preInitBuffer) {
-    return;
-  }
-  const resolved = resolveFaroEnvironment();
-  if (!resolved) {
-    return;
-  }
-  if (resolved.isLocalOverride || hasLiveFaroSession()) {
-    void triggerFaroInit();
-    return;
-  }
-  preInitBuffer = [];
-}
-
-export function notifyFaroEngagement(): Promise<void> {
-  if (!preInitBuffer && !pendingInit) {
-    return Promise.resolve();
-  }
-  return triggerFaroInit();
 }
 
 // Pathfinder is a micro-frontend inside Grafana; multiple Faro instances can
@@ -239,8 +159,46 @@ export function filterPathfinderTelemetry(item: TransportItem<APIEvent>): Transp
   return item;
 }
 
-export function isFaroEnabled(): boolean {
-  return faroInstance !== null;
+const SIDEBAR_COMPONENT_TITLE = 'Interactive learning';
+const OVERLAY_ROOT_IDS = ['pathfinder-controller-root', 'pathfinder-kiosk-root'];
+
+// Mode literals mirror PanelMode in global-state/panel-mode — importing
+// panelModeManager here would cycle via global-state → analytics → faro.
+function isPathfinderOpen(): boolean {
+  try {
+    const mode = localStorage.getItem(StorageKeys.PANEL_MODE);
+    if (mode === 'floating' || mode === 'fullscreen') {
+      return true;
+    }
+  } catch {
+    // localStorage unavailable — fall through to the DOM checks.
+  }
+  if (isExtensionSidebarOwnedByPathfinder(pluginJson.id, SIDEBAR_COMPONENT_TITLE)) {
+    return true;
+  }
+  return OVERLAY_ROOT_IDS.some((id) => document.getElementById(id) !== null);
+}
+
+// Latched for the rest of the page load: the sidebar-close mirror fires
+// after unmount, when the docked key is already gone.
+let pathfinderWasOpen = false;
+
+// Attribution (filterPathfinderTelemetry) asks "is this ours?"; this gate
+// asks "is Pathfinder actually in use?". Everything except exceptions and
+// error-level logs is dropped until Pathfinder is open in one of its
+// surfaces, so collector sessions mean "used Pathfinder or Pathfinder
+// errored", not "loaded a Grafana page".
+export function passesActivityGate(item: TransportItem<APIEvent>): boolean {
+  if (isExceptionItem(item)) {
+    return true;
+  }
+  if (isLogItem(item) && String(item.payload.level) === 'error') {
+    return true;
+  }
+  if (!pathfinderWasOpen && isPathfinderOpen()) {
+    pathfinderWasOpen = true;
+  }
+  return pathfinderWasOpen;
 }
 
 function resolveFaroEnvironment(): { environment: FaroEnvironment; isLocalOverride: boolean } | null {
@@ -311,16 +269,12 @@ export async function initFaro(): Promise<void> {
         },
       },
     },
-    beforeSend: filterPathfinderTelemetry,
+    beforeSend: (item) => (passesActivityGate(item) ? filterPathfinderTelemetry(item) : null),
   });
 }
 
 export function pushFaroError(error: Error, context?: Record<string, string>): void {
   guardTelemetry(() => {
-    if (bufferPreInitCall({ kind: 'error', error, context })) {
-      void triggerFaroInit();
-      return;
-    }
     faroInstance?.api.pushError(error, { context: { ...context, [EXPLICIT_REPORT_MARKER]: 'true' } });
   });
 }
@@ -329,12 +283,6 @@ export type FaroLogLevel = 'info' | 'warn' | 'error';
 
 export function pushFaroLog(level: FaroLogLevel, message: string, context?: Record<string, string>): void {
   guardTelemetry(() => {
-    if (bufferPreInitCall({ kind: 'log', level, message, context })) {
-      if (level === 'error') {
-        void triggerFaroInit();
-      }
-      return;
-    }
     faroInstance?.api.pushLog([`${LOG_PREFIX} ${message}`], { level: level as LogLevel, context });
   });
 }
@@ -365,9 +313,6 @@ let userActionSeq = 0;
 // cast internally, since UserActionsAPI has no top-level `endUserAction()`.
 export function pushFaroUserAction(name: string, attributes?: Record<string, unknown>): void {
   guardTelemetry(() => {
-    if (bufferPreInitCall({ kind: 'userAction', name, attributes })) {
-      return;
-    }
     if (!faroInstance) {
       return;
     }
@@ -407,13 +352,6 @@ export async function withFaroUserAction<T>(
   work: () => Promise<T> | T,
   timeoutMs = USER_ACTION_TIMEOUT_MS
 ): Promise<T> {
-  // Reaching an interactive funnel is engagement by definition: complete an
-  // armed init before deciding to pass through, so the first action in a
-  // fresh tab is captured rather than run outside an action envelope. Only
-  // awaited pre-init — once initialized the action must start synchronously.
-  if (!faroInstance) {
-    await notifyFaroEngagement().catch(() => undefined);
-  }
   let action: StampableUserAction | undefined;
   guardTelemetry(() => {
     if (faroInstance && faroInstance.api.getActiveUserAction() === undefined) {

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -79,7 +79,7 @@ export function isFaroEnabled(): boolean {
   return faroInstance !== null;
 }
 
-export async function initFaro(): Promise<void> {
+export async function initFaro(sampleRate = 1): Promise<void> {
   if (initStarted) {
     return;
   }
@@ -114,6 +114,10 @@ export async function initFaro(): Promise<void> {
     sessionTracking: {
       enabled: true,
       persistent: true,
+      // A session not selected by the sample sends nothing for its entire
+      // lifetime. The local QA override always gets the real rate (1), not
+      // whatever the remote production-volume control happens to be set to.
+      samplingRate: isLocalOverride ? 1 : sampleRate,
       session: {
         attributes: {
           grafana_version: config.buildInfo.version,

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -1,4 +1,4 @@
-import type { ExceptionEvent, Faro, LogEvent, TransportItem, APIEvent } from '@grafana/faro-web-sdk';
+import type { ExceptionEvent, Faro, LogEvent, LogLevel, TransportItem, APIEvent } from '@grafana/faro-web-sdk';
 import { config } from '@grafana/runtime';
 import packageJson from '../../package.json';
 
@@ -127,6 +127,16 @@ export async function initFaro(): Promise<void> {
 export function pushFaroError(error: Error, context?: Record<string, string>): void {
   try {
     faroInstance?.api.pushError(error, context ? { context } : undefined);
+  } catch {
+    // Telemetry must never break the app it's observing.
+  }
+}
+
+export type FaroLogLevel = 'info' | 'warn' | 'error';
+
+export function pushFaroLog(level: FaroLogLevel, message: string, context?: Record<string, string>): void {
+  try {
+    faroInstance?.api.pushLog([`${LOG_PREFIX} ${message}`], { level: level as LogLevel, context });
   } catch {
     // Telemetry must never break the app it's observing.
   }

--- a/src/lib/logging.test.ts
+++ b/src/lib/logging.test.ts
@@ -1,0 +1,101 @@
+import { logger } from './logging';
+import { pushFaroError, pushFaroLog } from './faro';
+
+jest.mock('./faro', () => ({
+  pushFaroLog: jest.fn(),
+  pushFaroError: jest.fn(),
+}));
+
+const mockPushFaroLog = pushFaroLog as jest.Mock;
+const mockPushFaroError = pushFaroError as jest.Mock;
+
+describe('logger', () => {
+  let debugSpy: jest.SpyInstance;
+  let infoSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    debugSpy = jest.spyOn(console, 'log').mockImplementation();
+    infoSpy = jest.spyOn(console, 'info').mockImplementation();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  describe('debug', () => {
+    it('logs to console but never reaches Faro', () => {
+      logger.debug('debugging', { step: 'one' });
+      expect(debugSpy).toHaveBeenCalledWith('debugging', { step: 'one' });
+      expect(mockPushFaroLog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('info / warn / error', () => {
+    it('routes info to console.info and pushFaroLog with level "info"', () => {
+      logger.info('something happened', { step: 'one' });
+      expect(infoSpy).toHaveBeenCalledWith('something happened', { step: 'one' });
+      expect(mockPushFaroLog).toHaveBeenCalledWith('info', 'something happened', { step: 'one' });
+    });
+
+    it('routes warn to console.warn and pushFaroLog with level "warn"', () => {
+      logger.warn('careful', { step: 'two' });
+      expect(warnSpy).toHaveBeenCalledWith('careful', { step: 'two' });
+      expect(mockPushFaroLog).toHaveBeenCalledWith('warn', 'careful', { step: 'two' });
+    });
+
+    it('routes error to console.error and pushFaroLog with level "error"', () => {
+      logger.error('broken', { step: 'three' });
+      expect(errorSpy).toHaveBeenCalledWith('broken', { step: 'three' });
+      expect(mockPushFaroLog).toHaveBeenCalledWith('error', 'broken', { step: 'three' });
+    });
+
+    it('omits context entirely when none is passed', () => {
+      logger.warn('no context here');
+      expect(warnSpy).toHaveBeenCalledWith('no context here', '');
+      expect(mockPushFaroLog).toHaveBeenCalledWith('warn', 'no context here', undefined);
+    });
+
+    it('sanitizes the message before logging (newline injection)', () => {
+      logger.warn('line one\nFAKE ENTRY: line two');
+      expect(warnSpy).toHaveBeenCalledWith('line one\\nFAKE ENTRY: line two', '');
+      expect(mockPushFaroLog).toHaveBeenCalledWith('warn', 'line one\\nFAKE ENTRY: line two', undefined);
+    });
+
+    it('coerces non-string context values to sanitized strings', () => {
+      logger.error('failed', { count: 3, ok: false });
+      expect(mockPushFaroLog).toHaveBeenCalledWith('error', 'failed', { count: '3', ok: 'false' });
+    });
+
+    it('does not add its own try/catch around pushFaroLog, which already guarantees no-throw', () => {
+      mockPushFaroLog.mockImplementationOnce(() => {
+        throw new Error('transport down');
+      });
+      expect(() => logger.error('boom')).toThrow('transport down');
+    });
+  });
+
+  describe('exception', () => {
+    it('logs a real Error unchanged and forwards it to pushFaroError', () => {
+      const error = new Error('kaboom');
+      logger.exception(error, { source: 'test' });
+      expect(errorSpy).toHaveBeenCalledWith(error, { source: 'test' });
+      expect(mockPushFaroError).toHaveBeenCalledWith(error, { source: 'test' });
+    });
+
+    it('normalizes a non-Error throwable into an Error before forwarding', () => {
+      logger.exception('a raw string throw');
+      expect(mockPushFaroError).toHaveBeenCalledTimes(1);
+      const [normalized] = mockPushFaroError.mock.calls[0];
+      expect(normalized).toBeInstanceOf(Error);
+      expect(normalized.message).toBe('a raw string throw');
+    });
+  });
+});

--- a/src/lib/logging.test.ts
+++ b/src/lib/logging.test.ts
@@ -82,6 +82,43 @@ describe('logger', () => {
     });
   });
 
+  describe('error with a throwable — routes to pushFaroError, not pushFaroLog', () => {
+    it('accepts an Error as the second argument', () => {
+      const boom = new Error('boom');
+      logger.error('operation failed', boom);
+      expect(errorSpy).toHaveBeenCalledWith('operation failed', boom, '');
+      expect(mockPushFaroError).toHaveBeenCalledWith(boom, { message: 'operation failed' });
+      expect(mockPushFaroLog).not.toHaveBeenCalled();
+    });
+
+    it('accepts an Error second argument with a separate context object', () => {
+      const boom = new Error('boom');
+      logger.error('operation failed', boom, { step: 'two' });
+      expect(mockPushFaroError).toHaveBeenCalledWith(boom, { step: 'two', message: 'operation failed' });
+    });
+
+    it('extracts an Error from the legacy { error } context shape, keeping the other keys', () => {
+      const boom = new Error('boom');
+      logger.error('operation failed', { error: boom, step: 'two' });
+      expect(errorSpy).toHaveBeenCalledWith('operation failed', boom, { step: 'two' });
+      expect(mockPushFaroError).toHaveBeenCalledWith(boom, { step: 'two', message: 'operation failed' });
+      expect(mockPushFaroLog).not.toHaveBeenCalled();
+    });
+
+    it('stays a plain error log when the error context key is not an Error instance', () => {
+      logger.error('operation failed', { error: 'not found' });
+      expect(mockPushFaroError).not.toHaveBeenCalled();
+      expect(mockPushFaroLog).toHaveBeenCalledWith('error', 'operation failed', { error: 'not found' });
+    });
+
+    it('serializes an Error left in a warn context instead of collapsing it to "{}"', () => {
+      logger.warn('careful', { error: new Error('boom') });
+      const [, , context] = mockPushFaroLog.mock.calls[0];
+      expect(context.error).toContain('Error: boom');
+      expect(context.error).not.toBe('{}');
+    });
+  });
+
   describe('exception', () => {
     it('logs a real Error unchanged and forwards it to pushFaroError', () => {
       const error = new Error('kaboom');

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -1,0 +1,39 @@
+import { sanitizeForLogging } from '../security/log-sanitizer';
+import { pushFaroError, pushFaroLog } from './faro';
+
+function sanitizeContext(context?: Record<string, unknown>): Record<string, string> | undefined {
+  if (!context) {
+    return undefined;
+  }
+  return Object.fromEntries(Object.entries(context).map(([key, value]) => [key, sanitizeForLogging(value)]));
+}
+
+export const logger = {
+  debug(message: string, context?: Record<string, unknown>): void {
+    console.log(message, context ?? '');
+  },
+
+  info(message: string, context?: Record<string, unknown>): void {
+    const sanitized = sanitizeForLogging(message);
+    console.info(sanitized, context ?? '');
+    pushFaroLog('info', sanitized, sanitizeContext(context));
+  },
+
+  warn(message: string, context?: Record<string, unknown>): void {
+    const sanitized = sanitizeForLogging(message);
+    console.warn(sanitized, context ?? '');
+    pushFaroLog('warn', sanitized, sanitizeContext(context));
+  },
+
+  error(message: string, context?: Record<string, unknown>): void {
+    const sanitized = sanitizeForLogging(message);
+    console.error(sanitized, context ?? '');
+    pushFaroLog('error', sanitized, sanitizeContext(context));
+  },
+
+  exception(error: unknown, context?: Record<string, unknown>): void {
+    const normalizedError = error instanceof Error ? error : new Error(sanitizeForLogging(error));
+    console.error(normalizedError, context ?? '');
+    pushFaroError(normalizedError, sanitizeContext(context));
+  },
+};

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -8,6 +8,20 @@ function sanitizeContext(context?: Record<string, unknown>): Record<string, stri
   return Object.fromEntries(Object.entries(context).map(([key, value]) => [key, sanitizeForLogging(value)]));
 }
 
+function splitThrowable(
+  errorOrContext?: Error | Record<string, unknown>,
+  context?: Record<string, unknown>
+): { error?: Error; context?: Record<string, unknown> } {
+  if (errorOrContext instanceof Error) {
+    return { error: errorOrContext, context };
+  }
+  if (errorOrContext && errorOrContext.error instanceof Error) {
+    const { error, ...rest } = errorOrContext;
+    return { error, context: Object.keys(rest).length > 0 ? rest : undefined };
+  }
+  return { context: errorOrContext };
+}
+
 export const logger = {
   debug(message: string, context?: Record<string, unknown>): void {
     console.log(message, context ?? '');
@@ -25,10 +39,18 @@ export const logger = {
     pushFaroLog('warn', sanitized, sanitizeContext(context));
   },
 
-  error(message: string, context?: Record<string, unknown>): void {
+  // A throwable (second arg, or an `error` context key) becomes a Faro
+  // *exception* signal — error-level logs never reach Error Tracking.
+  error(message: string, errorOrContext?: Error | Record<string, unknown>, context?: Record<string, unknown>): void {
     const sanitized = sanitizeForLogging(message);
-    console.error(sanitized, context ?? '');
-    pushFaroLog('error', sanitized, sanitizeContext(context));
+    const split = splitThrowable(errorOrContext, context);
+    if (split.error) {
+      console.error(sanitized, split.error, split.context ?? '');
+      pushFaroError(split.error, sanitizeContext({ ...split.context, message: sanitized }));
+      return;
+    }
+    console.error(sanitized, split.context ?? '');
+    pushFaroLog('error', sanitized, sanitizeContext(split.context));
   },
 
   exception(error: unknown, context?: Record<string, unknown>): void {

--- a/src/lib/storage/bounded-record-storage.ts
+++ b/src/lib/storage/bounded-record-storage.ts
@@ -1,3 +1,4 @@
+import { logger } from '../logging';
 import { createUserStorage, warnQuotaExceededOnce } from '../user-storage';
 
 export interface BoundedRecordStorage {
@@ -39,15 +40,15 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
         if (hasRetried) {
           // Quota still exceeded after cleanup — likely consumed by other keys.
           // Stop here rather than recursing forever.
-          console.warn(`Failed to save ${label} percentage after cleanup retry:`, error);
+          logger.warn(`Failed to save ${label} percentage after cleanup retry`, { error });
           return;
         }
-        console.warn(`Storage quota exceeded, clearing old ${label} data`);
+        logger.warn(`Storage quota exceeded, clearing old ${label} data`);
         warnQuotaExceededOnce();
         await api.cleanup();
         await setInternal(key, percentage, true);
       } else {
-        console.warn(`Failed to save ${label} percentage:`, error);
+        logger.warn(`Failed to save ${label} percentage`, { error });
       }
     }
   };
@@ -74,7 +75,7 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
         delete data[key];
         await storage.setItem(storageKey, data);
       } catch (error) {
-        console.warn(`Failed to clear ${label}:`, error);
+        logger.warn(`Failed to clear ${label}`, { error });
       }
     },
 
@@ -95,7 +96,7 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
           await writeWithCap(data);
         }
       } catch (error) {
-        console.warn(`Failed to cleanup ${label} entries:`, error);
+        logger.warn(`Failed to cleanup ${label} entries`, { error });
       }
     },
 
@@ -104,7 +105,7 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
         const storage = createUserStorage();
         await storage.removeItem(storageKey);
       } catch (error) {
-        console.warn(`Failed to clear all ${label} entries:`, error);
+        logger.warn(`Failed to clear all ${label} entries`, { error });
       }
     },
   };

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -42,6 +42,7 @@ import { z } from 'zod';
 
 import type { LearningProgress, EarnedBadgeRecord } from '../types/learning-paths.types';
 import { StorageEvents } from './event-names';
+import { logger } from './logging';
 import { createBoundedRecordStorage } from './storage/bounded-record-storage';
 import { StorageKeys } from './storage-keys';
 
@@ -280,7 +281,7 @@ export function createLocalStorage(): UserStorage {
           return value as unknown as T;
         }
       } catch (error) {
-        console.warn(`Failed to get item from localStorage: ${key}`, error);
+        logger.warn(`Failed to get item from localStorage: ${key}`, { error });
         return null;
       }
     },
@@ -292,11 +293,11 @@ export function createLocalStorage(): UserStorage {
       } catch (error) {
         // SECURITY: Handle QuotaExceededError
         if (error instanceof Error && error.name === 'QuotaExceededError') {
-          console.warn('localStorage quota exceeded', error);
+          logger.warn('localStorage quota exceeded', { error });
           warnQuotaExceededOnce();
           throw error;
         }
-        console.error(`Failed to set item in localStorage: ${key}`, error);
+        logger.error(`Failed to set item in localStorage: ${key}`, { error });
         throw error;
       }
     },
@@ -305,7 +306,7 @@ export function createLocalStorage(): UserStorage {
       try {
         localStorage.removeItem(key);
       } catch (error) {
-        console.warn(`Failed to remove item from localStorage: ${key}`, error);
+        logger.warn(`Failed to remove item from localStorage: ${key}`, { error });
       }
     },
 
@@ -321,7 +322,7 @@ export function createLocalStorage(): UserStorage {
         }
         keys.forEach((key) => localStorage.removeItem(key));
       } catch (error) {
-        console.warn('Failed to clear localStorage', error);
+        logger.warn('Failed to clear localStorage', { error });
       }
     },
   };
@@ -374,7 +375,7 @@ export function createHybridStorage(grafanaStorage: GrafanaUserStorage): UserSto
       try {
         await grafanaStorage.setItem(key, value);
       } catch (error) {
-        console.warn(`Failed to sync to Grafana storage: ${key}`, error);
+        logger.warn(`Failed to sync to Grafana storage: ${key}`, { error });
         // Don't retry - localStorage is the immediate source of truth
       }
     }
@@ -387,7 +388,7 @@ export function createHybridStorage(grafanaStorage: GrafanaUserStorage): UserSto
     // Process them now.
     if (writeQueue.length > 0) {
       processQueue().catch((error) => {
-        console.warn('Error processing Grafana storage queue:', error);
+        logger.warn('Error processing Grafana storage queue', { error });
       });
     }
   };
@@ -401,7 +402,7 @@ export function createHybridStorage(grafanaStorage: GrafanaUserStorage): UserSto
     debounceTimer = setTimeout(() => {
       debounceTimer = null;
       processQueue().catch((error) => {
-        console.warn('Error processing Grafana storage queue:', error);
+        logger.warn('Error processing Grafana storage queue', { error });
       });
     }, 500);
   };
@@ -429,13 +430,13 @@ export function createHybridStorage(grafanaStorage: GrafanaUserStorage): UserSto
         scheduleQueueProcessing();
       } catch (error) {
         // If localStorage fails, at least try Grafana storage
-        console.warn(`Failed to write to localStorage: ${key}, trying Grafana storage`, error);
+        logger.warn(`Failed to write to localStorage: ${key}, trying Grafana storage`, { error });
         try {
           const serialized = JSON.stringify(value);
           const timestamp = Date.now();
           await grafanaStorage.setItem(key, wrapEnvelope(serialized, timestamp));
         } catch (grafanaError) {
-          console.error(`Failed to write to both storages: ${key}`, grafanaError);
+          logger.error(`Failed to write to both storages: ${key}`, { grafanaError });
           throw grafanaError;
         }
       }
@@ -459,7 +460,7 @@ export function createHybridStorage(grafanaStorage: GrafanaUserStorage): UserSto
       await localStorage.clear();
 
       // Note: Grafana storage doesn't support bulk clear
-      console.warn('Clear operation not fully supported for Grafana user storage');
+      logger.warn('Clear operation not fully supported for Grafana user storage');
     },
   };
 }
@@ -519,7 +520,7 @@ async function readGrafanaKeyWithMigration(
       // Clear orphaned __timestamp key from Grafana storage (API has no removeItem, so set to empty)
       await grafanaStorage.setItem(getTimestampKey(key), '');
     } catch (error) {
-      console.warn(`Failed to migrate key to envelope format: ${key}`, error);
+      logger.warn(`Failed to migrate key to envelope format: ${key}`, { error });
     }
 
     // NOTE: Do NOT clean up localStorage __timestamp key here.
@@ -623,7 +624,7 @@ export async function syncFromGrafanaStorage(grafanaStorage: GrafanaUserStorage)
         }
         // If neither has data, nothing to sync
       } catch (error) {
-        console.warn(`Failed to sync key from Grafana storage: ${key}`, error);
+        logger.warn(`Failed to sync key from Grafana storage: ${key}`, { error });
       }
     }
 
@@ -632,7 +633,7 @@ export async function syncFromGrafanaStorage(grafanaStorage: GrafanaUserStorage)
     // The Grafana storage side has been migrated to envelope format, but localStorage
     // continues using the separate timestamp key pattern.
   } catch (error) {
-    console.warn('Failed to sync from Grafana storage:', error);
+    logger.warn('Failed to sync from Grafana storage', { error });
   }
 }
 
@@ -690,7 +691,7 @@ export function useUserStorage(): UserStorage {
         // Sync from Grafana storage to localStorage on init
         // Grafana storage is the source of truth across devices/sessions
         syncFromGrafanaStorage(grafanaStorage).catch((error) => {
-          console.warn('Failed initial sync from Grafana storage:', error);
+          logger.warn('Failed initial sync from Grafana storage', { error });
         });
       } else {
         // Fall back to localStorage only
@@ -781,7 +782,7 @@ export const milestoneCompletionStorage = {
       data[journeyBaseUrl] = Array.from(existing);
       await storage.setItem(StorageKeys.MILESTONE_COMPLETION, data);
     } catch (error) {
-      console.warn('Failed to save milestone completion:', error);
+      logger.warn('Failed to save milestone completion', { error });
     }
   },
 
@@ -797,7 +798,7 @@ export const milestoneCompletionStorage = {
       delete data[journeyBaseUrl];
       await storage.setItem(StorageKeys.MILESTONE_COMPLETION, data);
     } catch (error) {
-      console.warn('Failed to clear milestone completion:', error);
+      logger.warn('Failed to clear milestone completion', { error });
     }
   },
 };
@@ -846,14 +847,14 @@ export const tabStorage = {
     } catch (error) {
       // SECURITY: Handle QuotaExceededError
       if (error instanceof Error && error.name === 'QuotaExceededError') {
-        console.warn('Storage quota exceeded, reducing number of tabs');
+        logger.warn('Storage quota exceeded, reducing number of tabs');
         warnQuotaExceededOnce();
         // Save only the most recent 25 tabs
         const reducedTabs = tabs.slice(-25);
         const storage = createUserStorage();
         await storage.setItem(StorageKeys.TABS, reducedTabs);
       } else {
-        console.warn('Failed to save tabs:', error);
+        logger.warn('Failed to save tabs', { error });
       }
     }
   },
@@ -878,7 +879,7 @@ export const tabStorage = {
       const storage = createUserStorage();
       await storage.setItem(StorageKeys.ACTIVE_TAB, tabId);
     } catch (error) {
-      console.warn('Failed to save active tab:', error);
+      logger.warn('Failed to save active tab', { error });
     }
   },
 
@@ -891,7 +892,7 @@ export const tabStorage = {
       await storage.removeItem(StorageKeys.TABS);
       await storage.removeItem(StorageKeys.ACTIVE_TAB);
     } catch (error) {
-      console.warn('Failed to clear tab data:', error);
+      logger.warn('Failed to clear tab data', { error });
     }
   },
 };
@@ -944,7 +945,7 @@ export const interactiveStepStorage = {
       const key = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${contentKey}-${sectionId}`;
       await storage.setItem(key, Array.from(completedIds));
     } catch (error) {
-      console.warn('Failed to save completed steps:', error);
+      logger.warn('Failed to save completed steps', { error });
     }
   },
 
@@ -958,7 +959,7 @@ export const interactiveStepStorage = {
       const key = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${contentKey}-${sectionId}`;
       await storage.removeItem(key);
     } catch (error) {
-      console.warn('Failed to clear completed steps:', error);
+      logger.warn('Failed to clear completed steps', { error });
     }
   },
 
@@ -1021,7 +1022,7 @@ export const interactiveStepStorage = {
       // Remove all matching keys
       keysToRemove.forEach((key) => localStorage.removeItem(key));
     } catch (error) {
-      console.warn('Failed to clear all progress for content:', error);
+      logger.warn('Failed to clear all progress for content', { error });
     }
   },
 
@@ -1062,7 +1063,7 @@ export const interactiveStepStorage = {
       }
       keysToRemove.forEach((key) => localStorage.removeItem(key));
     } catch (error) {
-      console.warn('Failed to clear all interactive step data:', error);
+      logger.warn('Failed to clear all interactive step data', { error });
     }
   },
 
@@ -1130,7 +1131,7 @@ export const sectionCollapseStorage = {
       const key = `${StorageKeys.SECTION_COLLAPSE_PREFIX}${contentKey}-${sectionId}`;
       await storage.setItem(key, isCollapsed);
     } catch (error) {
-      console.warn('Failed to save section collapse state:', error);
+      logger.warn('Failed to save section collapse state', { error });
     }
   },
 
@@ -1143,7 +1144,7 @@ export const sectionCollapseStorage = {
       const key = `${StorageKeys.SECTION_COLLAPSE_PREFIX}${contentKey}-${sectionId}`;
       await storage.removeItem(key);
     } catch (error) {
-      console.warn('Failed to clear section collapse state:', error);
+      logger.warn('Failed to clear section collapse state', { error });
     }
   },
 };
@@ -1196,7 +1197,7 @@ export const sectionAcknowledgementStorage = {
       const key = `${StorageKeys.SECTION_ACKNOWLEDGED_PREFIX}${contentKey}-${sectionId}`;
       await storage.setItem(key, isAcknowledged);
     } catch (error) {
-      console.warn('Failed to save section acknowledgement state:', error);
+      logger.warn('Failed to save section acknowledgement state', { error });
     }
   },
 
@@ -1212,7 +1213,7 @@ export const sectionAcknowledgementStorage = {
       const key = `${StorageKeys.SECTION_ACKNOWLEDGED_PREFIX}${contentKey}-${sectionId}`;
       await storage.removeItem(key);
     } catch (error) {
-      console.warn('Failed to clear section acknowledgement state:', error);
+      logger.warn('Failed to clear section acknowledgement state', { error });
     }
   },
 
@@ -1277,7 +1278,7 @@ export const sectionDoneStorage = {
       const key = `${StorageKeys.SECTION_DONE_PREFIX}${contentKey}-${sectionId}`;
       await storage.setItem(key, isDone);
     } catch (error) {
-      console.warn('Failed to save section done state:', error);
+      logger.warn('Failed to save section done state', { error });
     }
   },
 
@@ -1287,7 +1288,7 @@ export const sectionDoneStorage = {
       const key = `${StorageKeys.SECTION_DONE_PREFIX}${contentKey}-${sectionId}`;
       await storage.removeItem(key);
     } catch (error) {
-      console.warn('Failed to clear section done state:', error);
+      logger.warn('Failed to clear section done state', { error });
     }
   },
 };
@@ -1344,7 +1345,7 @@ export const fullScreenModeStorage = {
       const storage = createUserStorage();
       await storage.setItem(StorageKeys.FULLSCREEN_MODE_STATE, state);
     } catch (error) {
-      console.warn('Failed to save full screen mode state:', error);
+      logger.warn('Failed to save full screen mode state', { error });
     }
   },
 
@@ -1368,7 +1369,7 @@ export const fullScreenModeStorage = {
       const storage = createUserStorage();
       await storage.setItem(StorageKeys.FULLSCREEN_BUNDLED_STEPS, steps);
     } catch (error) {
-      console.warn('Failed to save bundled steps:', error);
+      logger.warn('Failed to save bundled steps', { error });
     }
   },
 
@@ -1396,7 +1397,7 @@ export const fullScreenModeStorage = {
         await storage.setItem(StorageKeys.FULLSCREEN_BUNDLING_ACTION, action);
       }
     } catch (error) {
-      console.warn('Failed to save bundling action:', error);
+      logger.warn('Failed to save bundling action', { error });
     }
   },
 
@@ -1424,7 +1425,7 @@ export const fullScreenModeStorage = {
         await storage.setItem(StorageKeys.FULLSCREEN_SECTION_INFO, info);
       }
     } catch (error) {
-      console.warn('Failed to save section info:', error);
+      logger.warn('Failed to save section info', { error });
     }
   },
 
@@ -1441,7 +1442,7 @@ export const fullScreenModeStorage = {
         storage.removeItem(StorageKeys.FULLSCREEN_SECTION_INFO),
       ]);
     } catch (error) {
-      console.warn('Failed to clear full screen mode state:', error);
+      logger.warn('Failed to clear full screen mode state', { error });
     }
   },
 };
@@ -1477,7 +1478,7 @@ export const learningProgressStorage = {
       }
 
       // Log validation failure for debugging but return defaults gracefully
-      console.warn('Learning progress validation failed, using defaults:', parsed.error.issues);
+      logger.warn('Learning progress validation failed, using defaults', { issues: parsed.error.issues });
       return DEFAULT_PROGRESS;
     } catch {
       return DEFAULT_PROGRESS;
@@ -1494,7 +1495,7 @@ export const learningProgressStorage = {
       const updated = { ...current, ...updates };
       await storage.setItem(StorageKeys.LEARNING_PROGRESS, updated);
     } catch (error) {
-      console.warn('Failed to update learning progress:', error);
+      logger.warn('Failed to update learning progress', { error });
     }
   },
 
@@ -1519,7 +1520,7 @@ export const learningProgressStorage = {
       }
       return false; // Badge already earned
     } catch (error) {
-      console.warn('Failed to award badge:', error);
+      logger.warn('Failed to award badge', { error });
       return false;
     }
   },
@@ -1533,7 +1534,7 @@ export const learningProgressStorage = {
       progress.pendingCelebrations = progress.pendingCelebrations.filter((id) => id !== badgeId);
       await learningProgressStorage.update(progress);
     } catch (error) {
-      console.warn('Failed to dismiss celebration:', error);
+      logger.warn('Failed to dismiss celebration', { error });
     }
   },
 
@@ -1544,7 +1545,7 @@ export const learningProgressStorage = {
     try {
       await learningProgressStorage.update({ streakDays, lastActivityDate });
     } catch (error) {
-      console.warn('Failed to update streak:', error);
+      logger.warn('Failed to update streak', { error });
     }
   },
 
@@ -1589,7 +1590,7 @@ export const learningProgressStorage = {
         })
       );
     } catch (error) {
-      console.warn('Failed to remove completed guides:', error);
+      logger.warn('Failed to remove completed guides', { error });
     }
   },
 
@@ -1608,7 +1609,7 @@ export const learningProgressStorage = {
         })
       );
     } catch (error) {
-      console.warn('Failed to clear learning progress:', error);
+      logger.warn('Failed to clear learning progress', { error });
     }
   },
 };
@@ -1648,10 +1649,10 @@ export const guideResponseStorage = {
         return parsed.data;
       }
 
-      console.warn('Guide responses validation failed, using defaults:', parsed.error);
+      logger.warn('Guide responses validation failed, using defaults', { error: parsed.error });
       return DEFAULT_GUIDE_RESPONSES;
     } catch (error) {
-      console.warn('Failed to get guide responses:', error);
+      logger.warn('Failed to get guide responses', { error });
       return DEFAULT_GUIDE_RESPONSES;
     }
   },
@@ -1703,7 +1704,7 @@ export const guideResponseStorage = {
         })
       );
     } catch (error) {
-      console.warn('Failed to set guide response:', error);
+      logger.warn('Failed to set guide response', { error });
     }
   },
 
@@ -1733,7 +1734,7 @@ export const guideResponseStorage = {
         })
       );
     } catch (error) {
-      console.warn('Failed to delete guide response:', error);
+      logger.warn('Failed to delete guide response', { error });
     }
   },
 
@@ -1755,7 +1756,7 @@ export const guideResponseStorage = {
         })
       );
     } catch (error) {
-      console.warn('Failed to clear guide responses:', error);
+      logger.warn('Failed to clear guide responses', { error });
     }
   },
 
@@ -1773,7 +1774,7 @@ export const guideResponseStorage = {
         })
       );
     } catch (error) {
-      console.warn('Failed to clear all guide responses:', error);
+      logger.warn('Failed to clear all guide responses', { error });
     }
   },
 };

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -54,12 +54,14 @@ const pathfinderEnabled = getFeatureFlagValue('pathfinder.enabled', true);
 const hostname = window.location.hostname;
 
 // Faro frontend telemetry: Grafana Cloud only, behind its own remote kill-switch.
-// Import stays dynamic so the SDK never downloads when the flag is off.
+// Arming is engagement-gated — the SDK downloads and a session starts only on
+// the first real interaction or Pathfinder error, so sessions mean "used
+// Pathfinder", not "loaded a Grafana page".
 try {
   if (getFeatureFlagValue('pathfinder.frontend-telemetry', true)) {
     const sampleRate = getNumberFlagValue('pathfinder.frontend-telemetry-sample-rate', 1);
-    const { initFaro } = await import('./lib/faro');
-    await initFaro(sampleRate);
+    const { armFaro } = await import('./lib/faro');
+    armFaro(sampleRate);
   }
 } catch (e) {
   logger.exception(e, { source: 'Faro init' });

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -47,21 +47,21 @@ const { createExperimentDebugger, initializeHighlightedGuideExperiment, setupHig
   await import('./utils/experiments');
 const { attemptAutoOpen, getAutoOpenFeatureFlag, getCurrentPath, setupConfigAutoOpen } =
   await import('./utils/sidebar-auto-open');
-const { getFeatureFlagValue, getNumberFlagValue } = await import('./utils/openfeature');
+const { getFeatureFlagValue } = await import('./utils/openfeature');
 
 // The pathfinder.enabled kill-switch is the only gate on whether Pathfinder mounts.
 const pathfinderEnabled = getFeatureFlagValue('pathfinder.enabled', true);
 const hostname = window.location.hostname;
 
-// Faro frontend telemetry: Grafana Cloud only, behind its own remote kill-switch.
-// Arming is engagement-gated — the SDK downloads and a session starts only on
-// the first real interaction or Pathfinder error, so sessions mean "used
-// Pathfinder", not "loaded a Grafana page".
+// Faro frontend telemetry, behind its own remote kill-switch — default-on, so
+// a missing flag means enabled; armFaro itself enforces the Grafana Cloud-only
+// gate. Arming is engagement-gated — the SDK downloads and a session starts
+// only on the first real interaction or Pathfinder error, so sessions mean
+// "used Pathfinder", not "loaded a Grafana page".
 try {
   if (getFeatureFlagValue('pathfinder.frontend-telemetry', true)) {
-    const sampleRate = getNumberFlagValue('pathfinder.frontend-telemetry-sample-rate', 1);
     const { armFaro } = await import('./lib/faro');
-    armFaro(sampleRate);
+    armFaro();
   }
 } catch (e) {
   logger.exception(e, { source: 'Faro init' });

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -54,14 +54,14 @@ const pathfinderEnabled = getFeatureFlagValue('pathfinder.enabled', true);
 const hostname = window.location.hostname;
 
 // Faro frontend telemetry, behind its own remote kill-switch — default-on, so
-// a missing flag means enabled; armFaro itself enforces the Grafana Cloud-only
-// gate. Arming is engagement-gated — the SDK downloads and a session starts
-// only on the first real interaction or Pathfinder error, so sessions mean
-// "used Pathfinder", not "loaded a Grafana page".
+// a missing flag means enabled; initFaro itself enforces the Grafana Cloud-only
+// gate. Init is eager (not awaited — the SDK chunk must not block boot); the
+// beforeSend activity gate in lib/faro drops all telemetry until Pathfinder
+// is open in one of its surfaces.
 try {
   if (getFeatureFlagValue('pathfinder.frontend-telemetry', true)) {
-    const { armFaro } = await import('./lib/faro');
-    armFaro();
+    const { initFaro } = await import('./lib/faro');
+    initFaro().catch((e) => logger.exception(e, { source: 'Faro init' }));
   }
 } catch (e) {
   logger.exception(e, { source: 'Faro init' });

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -47,7 +47,7 @@ const { createExperimentDebugger, initializeHighlightedGuideExperiment, setupHig
   await import('./utils/experiments');
 const { attemptAutoOpen, getAutoOpenFeatureFlag, getCurrentPath, setupConfigAutoOpen } =
   await import('./utils/sidebar-auto-open');
-const { getFeatureFlagValue } = await import('./utils/openfeature');
+const { getFeatureFlagValue, getNumberFlagValue } = await import('./utils/openfeature');
 
 // The pathfinder.enabled kill-switch is the only gate on whether Pathfinder mounts.
 const pathfinderEnabled = getFeatureFlagValue('pathfinder.enabled', true);
@@ -57,8 +57,9 @@ const hostname = window.location.hostname;
 // Import stays dynamic so the SDK never downloads when the flag is off.
 try {
   if (getFeatureFlagValue('pathfinder.frontend-telemetry', true)) {
+    const sampleRate = getNumberFlagValue('pathfinder.frontend-telemetry-sample-rate', 1);
     const { initFaro } = await import('./lib/faro');
-    await initFaro();
+    await initFaro(sampleRate);
   }
 } catch (e) {
   logger.exception(e, { source: 'Faro init' });

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -2,6 +2,7 @@ import { AppPlugin, AppPluginMeta, type AppRootProps, PluginExtensionPoints, use
 import React, { lazy, Suspense, useEffect, useMemo } from 'react';
 import { LoadingPlaceholder } from '@grafana/ui';
 import { reportAppInteraction, UserInteraction } from './lib/analytics';
+import { logger } from './lib/logging';
 import { initPluginTranslations } from '@grafana/i18n';
 import pluginJson from './plugin.json';
 import { getConfigWithDefaults, DocsPluginConfig } from './constants';
@@ -37,7 +38,7 @@ try {
   const { bindExperimentsProvider } = await import('./lib/analytics');
   bindExperimentsProvider(getActiveExperiments);
 } catch (e) {
-  console.error('[OpenFeature] Error initializing feature flags:', e);
+  logger.exception(e, { source: 'OpenFeature init' });
 }
 
 // Highlighted-guide experiment + config-driven auto-open (dynamic imports keep
@@ -60,7 +61,7 @@ try {
     await initFaro();
   }
 } catch (e) {
-  console.error('[Faro] Error initializing frontend telemetry:', e);
+  logger.exception(e, { source: 'Faro init' });
 }
 
 // Initialize highlighted-guide experiment (reads flag, processes resetCache).

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -2,9 +2,6 @@ import { AppPlugin, AppPluginMeta, type AppRootProps, PluginExtensionPoints, use
 import React, { lazy, Suspense, useEffect, useMemo } from 'react';
 import { LoadingPlaceholder } from '@grafana/ui';
 import { reportAppInteraction, UserInteraction } from './lib/analytics';
-
-// TODO: Re-enable Faro once collector CORS is configured correctly
-// import { initializeFaroMetrics } from './lib/faro';
 import { initPluginTranslations } from '@grafana/i18n';
 import pluginJson from './plugin.json';
 import { getConfigWithDefaults, DocsPluginConfig } from './constants';
@@ -28,15 +25,6 @@ const earlySuggestListener = ((event: CustomEvent) => {
   pendingSuggestEvents.push(event);
 }) as EventListener;
 document.addEventListener('pathfinder-suggest', earlySuggestListener);
-
-// TODO: Re-enable Faro once collector CORS is configured correctly
-// Initialize Faro metrics (before translations to capture early errors)
-// Wrapped in try-catch to prevent plugin load failure if Faro has issues
-// try {
-//   await initializeFaroMetrics();
-// } catch (e) {
-//   console.error('[Faro] Error initializing frontend metrics:', e);
-// }
 
 // Initialize OpenFeature provider for dynamic feature flag evaluation
 // This connects to the Multi-Tenant Feature Flag Service (MTFF) in Grafana Cloud
@@ -63,6 +51,17 @@ const { getFeatureFlagValue } = await import('./utils/openfeature');
 // The pathfinder.enabled kill-switch is the only gate on whether Pathfinder mounts.
 const pathfinderEnabled = getFeatureFlagValue('pathfinder.enabled', true);
 const hostname = window.location.hostname;
+
+// Faro frontend telemetry: Grafana Cloud only, behind its own remote kill-switch.
+// Import stays dynamic so the SDK never downloads when the flag is off.
+try {
+  if (getFeatureFlagValue('pathfinder.frontend-telemetry', true)) {
+    const { initFaro } = await import('./lib/faro');
+    await initFaro();
+  }
+} catch (e) {
+  console.error('[Faro] Error initializing frontend telemetry:', e);
+}
 
 // Initialize highlighted-guide experiment (reads flag, processes resetCache).
 // The popout half is set up later, after the sidebar-mount decision, so it

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -157,7 +157,7 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
           );
         })
         .catch((err) => {
-          console.error('[Pathfinder] Failed to load interactive controller:', err);
+          logger.error('[Pathfinder] Failed to load interactive controller', { error: err });
           container.remove();
         });
     }
@@ -178,13 +178,13 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
           root.render(React.createElement(PairingRequestBanner));
         })
         .catch((err) => {
-          console.error('[Pathfinder] Failed to load pairing banner:', err);
+          logger.error('[Pathfinder] Failed to load pairing banner', { error: err });
           bannerContainer.remove();
         });
     }
     import('./integrations/cross-tab/live-tab-executor')
       .then(({ installLiveTabExecutor }) => installLiveTabExecutor())
-      .catch((err) => console.error('[Pathfinder] Failed to load cross-tab executor:', err));
+      .catch((err) => logger.error('[Pathfinder] Failed to load cross-tab executor', { error: err }));
   }
 
   const sidebarMountable = pathfinderEnabled;
@@ -228,7 +228,7 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
           );
         })
         .catch((err) => {
-          console.error('[Pathfinder] Failed to load kiosk mode:', err);
+          logger.error('[Pathfinder] Failed to load kiosk mode', { error: err });
         });
     }
   }
@@ -255,7 +255,7 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
           root.render(React.createElement(FloatingPanelManager));
         })
         .catch((err) => {
-          console.error('[Pathfinder] Failed to load floating panel:', err);
+          logger.error('[Pathfinder] Failed to load floating panel', { error: err });
         });
     };
 
@@ -436,11 +436,11 @@ if (pathfinderEnabled) {
 function handlePathfinderSuggest(event: CustomEvent): void {
   const detail = event.detail;
   if (!detail) {
-    console.warn('[Pathfinder] pathfinder-suggest event missing detail');
+    logger.warn('[Pathfinder] pathfinder-suggest event missing detail');
     return;
   }
   if (!Array.isArray(detail.suggestions)) {
-    console.warn('[Pathfinder] pathfinder-suggest event missing suggestions array');
+    logger.warn('[Pathfinder] pathfinder-suggest event missing suggestions array');
     detail.status = 'rejected';
     detail.reason = 'invalid_payload';
     return;
@@ -455,7 +455,7 @@ function handlePathfinderSuggest(event: CustomEvent): void {
   );
 
   if (valid.length === 0) {
-    console.warn('[Pathfinder] pathfinder-suggest event had no valid suggestions (need title + url)');
+    logger.warn('[Pathfinder] pathfinder-suggest event had no valid suggestions (need title + url)');
     detail.status = 'rejected';
     detail.reason = 'no_valid_suggestions';
     return;
@@ -464,7 +464,7 @@ function handlePathfinderSuggest(event: CustomEvent): void {
   // Check if another plugin is occupying the sidebar
   const docked = parseExtensionSidebarDocked();
   if (docked?.pluginId && docked.pluginId !== pluginJson.id) {
-    console.warn('[Pathfinder] pathfinder-suggest rejected: sidebar occupied by', docked.pluginId);
+    logger.warn('[Pathfinder] pathfinder-suggest rejected: sidebar occupied by', { pluginId: docked.pluginId });
     detail.status = 'rejected';
     detail.reason = 'sidebar_in_use';
     return;

--- a/src/requirements-manager/checks/section-completed-check.ts
+++ b/src/requirements-manager/checks/section-completed-check.ts
@@ -25,6 +25,7 @@
 
 import { getContentKey } from '../../global-state/content-key';
 import { sectionDoneStorage } from '../../lib/user-storage';
+import { logger } from '../../lib/logging';
 
 export async function sectionCompletedCheck(check: string): Promise<{
   requirement: string;
@@ -61,7 +62,7 @@ export async function sectionCompletedCheck(check: string): Promise<{
       },
     };
   } catch (error) {
-    console.error('Section completion check error:', error);
+    logger.error('Section completion check error', { error });
     return {
       requirement: check,
       pass: false,

--- a/src/requirements-manager/requirements-checker.hook.ts
+++ b/src/requirements-manager/requirements-checker.hook.ts
@@ -1,4 +1,5 @@
 import { StorageEvents } from '../lib/event-names';
+import { logger } from '../lib/logging';
 import { TimeoutManager } from '../utils/timeout-manager';
 
 /**
@@ -215,7 +216,7 @@ export class SequentialRequirementsManager {
             try {
               checker();
             } catch (error) {
-              console.error(`Error in selective step checker for ${stepId}:`, error);
+              logger.error(`Error in selective step checker for ${stepId}`, { error });
             }
           }, 300); // Wait for DOM to settle after state changes
         }
@@ -237,7 +238,7 @@ export class SequentialRequirementsManager {
           try {
             checker();
           } catch (error) {
-            console.error(`Error in eligibility-triggered check for ${stepId}:`, error);
+            logger.error(`Error in eligibility-triggered check for ${stepId}`, { error });
           }
         });
       }
@@ -318,7 +319,7 @@ export class SequentialRequirementsManager {
             try {
               checker();
             } catch (error) {
-              console.error(`Error in context-triggered check for ${stepId}:`, error);
+              logger.error(`Error in context-triggered check for ${stepId}`, { error });
             }
           }
         });
@@ -355,7 +356,7 @@ export class SequentialRequirementsManager {
       .catch((error) => {
         // Only log if not cancelled
         if (!this.contextMonitoringCancelled) {
-          console.error('Failed to start context monitoring:', error);
+          logger.error('Failed to start context monitoring', { error });
         }
       });
   }

--- a/src/requirements-manager/requirements-checker.utils.test.ts
+++ b/src/requirements-manager/requirements-checker.utils.test.ts
@@ -802,7 +802,8 @@ describe('requirements-checker.utils', () => {
       expect(result.error[0]!.error).toContain('Warning: Unknown requirement type');
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Unknown requirement type: 'unknown-requirement-type'")
+        expect.stringContaining("Unknown requirement type: 'unknown-requirement-type'"),
+        ''
       );
 
       consoleSpy.mockRestore();
@@ -837,7 +838,8 @@ describe('requirements-checker.utils', () => {
       expect(unknownResult?.error).toContain('Warning: Unknown requirement type');
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Unknown requirement type: 'unknown-requirement'")
+        expect.stringContaining("Unknown requirement type: 'unknown-requirement'"),
+        ''
       );
 
       consoleSpy.mockRestore();
@@ -1021,7 +1023,7 @@ describe('requirements-checker.utils', () => {
         'InteractiveMultiStep'
       );
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('[InteractiveMultiStep]'));
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('[InteractiveMultiStep]'), '');
     });
   });
 });

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -19,6 +19,7 @@ import { reftargetExistsCheck, navmenuOpenCheck, formValidCheck } from '../lib/d
 import { sectionCompletedCheck } from './checks/section-completed-check';
 import { isValidRequirement } from '../types/requirements.types';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
+import { logger } from '../lib/logging';
 import { TimeoutManager } from '../utils/timeout-manager';
 
 import {
@@ -143,7 +144,7 @@ export { CHECK_HANDLERS };
 async function routeUnifiedCheck(check: string, ctx: CheckContext): Promise<CheckResultError> {
   // Type-safe validation with helpful developer feedback
   if (!isValidRequirement(check)) {
-    console.warn(
+    logger.warn(
       `Unknown requirement type: '${check}'. Check the requirement syntax and ensure it's supported. Allowing step to proceed.`
     );
 
@@ -161,7 +162,7 @@ async function routeUnifiedCheck(check: string, ctx: CheckContext): Promise<Chec
   }
 
   // Should never be reached due to the validation above, but keep as a fallback.
-  console.error(
+  logger.error(
     `Unexpected requirement type reached end of router: '${check}'. This indicates a bug in the type validation.`
   );
 
@@ -347,7 +348,7 @@ export function validateInteractiveRequirements(
       );
     }
 
-    console.error(errorMessage.join('\n'));
+    logger.error(errorMessage.join('\n'));
 
     return false;
   }

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -32,6 +32,7 @@ import { stepReducer, createInitialState, toLegacyState, type StepAction } from 
 // eslint-disable-next-line no-restricted-imports -- [ratchet] ALLOWED_LATERAL_VIOLATIONS: requirements-manager -> interactive-engine
 import { useInteractiveElements, useSequentialStepState } from '../interactive-engine';
 import { INTERACTIVE_CONFIG, isFirstStep } from '../constants/interactive-config';
+import { logger } from '../lib/logging';
 import { useTimeoutManager } from '../utils/timeout-manager';
 import { useIsAlignmentPaused } from '../global-state/alignment-pending-context';
 import { checkRequirements, type RequirementsCheckResult } from './requirements-checker.utils';
@@ -495,7 +496,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
           // Timeout or unexpected error: log and fall through. The outer `catch`
           // is reserved for failures in Phase 2/3, where erroring is the correct
           // user-facing outcome.
-          console.warn('Objectives check failed; falling through to requirements:', objectivesError);
+          logger.warn('Objectives check failed; falling through to requirements', { error: objectivesError });
         }
 
         if (objectivesPassed) {
@@ -689,7 +690,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
             });
 
       if (!result.ok) {
-        console.warn('Fix failed:', result.error);
+        logger.warn('Fix failed', { error: result.error });
         if (isMountedRef.current) {
           // Preserve the existing fix metadata so the user can retry.
           // The reducer's `SET_ERROR` defaults `canFix` to `false` and clears
@@ -724,7 +725,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       );
       await checkStep();
     } catch (error) {
-      console.error('Failed to fix requirements:', error);
+      logger.error('Failed to fix requirements', { error });
       // Same preservation rationale as the `!result.ok` branch above.
       safeDispatch({
         type: 'SET_ERROR',

--- a/src/security/log-sanitizer.test.ts
+++ b/src/security/log-sanitizer.test.ts
@@ -92,6 +92,38 @@ describe('sanitizeForLogging', () => {
     });
   });
 
+  describe('Crash-proof serialization', () => {
+    it('serializes an Error with its name, message, and stack — not "{}"', () => {
+      const sanitized = sanitizeForLogging(new Error('boom'));
+      expect(sanitized).toContain('Error: boom');
+      expect(sanitized).toContain('log-sanitizer.test');
+      expect(sanitized).not.toBe('{}');
+    });
+
+    it('serializes an Error subclass with its own name', () => {
+      expect(sanitizeForLogging(new TypeError('bad type'))).toContain('TypeError: bad type');
+    });
+
+    it('does not throw on a circular object (e.g. a React-managed DOM node)', () => {
+      const circular: Record<string, unknown> = { tag: 'button' };
+      circular.self = circular;
+      expect(() => sanitizeForLogging(circular)).not.toThrow();
+      expect(sanitizeForLogging(circular)).toBe('[object Object]');
+    });
+
+    it('falls back to String() for values JSON.stringify cannot represent', () => {
+      expect(sanitizeForLogging(() => 42)).toContain('42');
+      expect(sanitizeForLogging(Symbol('s'))).toBe('Symbol(s)');
+    });
+
+    it('never throws even when String() also fails', () => {
+      const hostile = Object.create(null);
+      hostile.self = hostile;
+      expect(() => sanitizeForLogging(hostile)).not.toThrow();
+      expect(sanitizeForLogging(hostile)).toBe('[unserializable]');
+    });
+  });
+
   describe('Real-world attack scenarios', () => {
     it('should prevent multi-line fake admin message', () => {
       const attack = 'user@evil.com\n[ADMIN] Password reset: newpass123\n[INFO]';

--- a/src/security/log-sanitizer.ts
+++ b/src/security/log-sanitizer.ts
@@ -24,12 +24,29 @@
  * // Logs: URL: https://evil.com\nFAKE LOG ENTRY (newline is escaped)
  * ```
  */
+function stringifyValue(value: unknown): string {
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}${value.stack ? `\n${value.stack}` : ''}`;
+  }
+  try {
+    // JSON.stringify returns undefined for functions/symbols and throws on
+    // circular values (e.g. React-managed DOM nodes via __reactFiber$).
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return '[unserializable]';
+    }
+  }
+}
+
 export function sanitizeForLogging(value: unknown): string {
   if (value === null || value === undefined) {
     return String(value);
   }
 
-  const str = typeof value === 'string' ? value : JSON.stringify(value);
+  const str = typeof value === 'string' ? value : stringifyValue(value);
 
   // IMPORTANT: Escape newlines/tabs/cr FIRST, then remove other control chars
   // Otherwise they get removed before we can escape them

--- a/src/utils/dev-mode.ts
+++ b/src/utils/dev-mode.ts
@@ -26,6 +26,7 @@
 import { config, getBackendSrv } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
 import { DocsPluginConfig } from '../constants';
+import { logger } from '../lib/logging';
 import { updatePluginSettings } from './utils.plugin';
 import pluginJson from '../plugin.json';
 
@@ -92,7 +93,7 @@ export const enableDevMode = async (currentUserId: number, currentUserIds: numbe
       },
     });
   } catch (e: any) {
-    console.error('Failed to enable dev mode:', e);
+    logger.error('Failed to enable dev mode', { error: e });
     throw new Error('Failed to enable dev mode. You may need admin permissions to modify plugin settings.');
   }
 };
@@ -124,7 +125,7 @@ export const disableDevModeForUser = async (userId: number, currentUserIds: numb
       },
     });
   } catch (e: any) {
-    console.error('Failed to disable dev mode for user:', e);
+    logger.error('Failed to disable dev mode for user', { error: e });
     throw new Error('Failed to disable dev mode. You may need admin permissions to modify plugin settings.');
   }
 };
@@ -148,7 +149,7 @@ export const disableDevMode = async (): Promise<void> => {
       },
     });
   } catch (e: any) {
-    console.error('Failed to disable dev mode:', e);
+    logger.error('Failed to disable dev mode', { error: e });
     throw new Error('Failed to disable dev mode. You may need admin permissions to modify plugin settings.');
   }
 };

--- a/src/utils/devtools/action-recorder.hook.ts
+++ b/src/utils/devtools/action-recorder.hook.ts
@@ -4,6 +4,7 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { shouldCaptureElement, getActionDescription } from '../../lib/dom/action-detector';
+import { logger } from '../../lib/logging';
 import { generateSelectorFromEvent } from './selector-generator.util';
 import { exportStepsToHTML, type RecordedStep, type ExportOptions } from './tutorial-exporter';
 import { formatStepsToString } from './step-parser.util';
@@ -566,7 +567,7 @@ export function useActionRecorder(options: UseActionRecorderOptions = {}): UseAc
 
       // Log validation warnings for debugging
       if (result.warnings.length > 0) {
-        console.warn('Selector validation warnings:', result.warnings);
+        logger.warn('Selector validation warnings', { warnings: result.warnings });
       }
 
       const description = getActionDescription(action, target);
@@ -599,7 +600,7 @@ export function useActionRecorder(options: UseActionRecorderOptions = {}): UseAc
           // Check for duplicate in pending group
           const lastPendingStep = pendingGroupSteps.length > 0 ? pendingGroupSteps[pendingGroupSteps.length - 1] : null;
           if (lastPendingStep && lastPendingStep.selector === selector && lastPendingStep.action === action) {
-            console.warn('Skipping duplicate selector in modal:', selector);
+            logger.warn('Skipping duplicate selector in modal', { selector });
             return;
           }
           setPendingGroupSteps((prev) => [...prev, newStep]);
@@ -660,7 +661,7 @@ export function useActionRecorder(options: UseActionRecorderOptions = {}): UseAc
       setRecordedSteps((prev) => {
         const lastStep = prev.length > 0 ? prev[prev.length - 1] : null;
         if (lastStep && lastStep.selector === selector && lastStep.action === action) {
-          console.warn('Skipping duplicate selector:', selector);
+          logger.warn('Skipping duplicate selector', { selector });
           return prev;
         }
 
@@ -741,7 +742,7 @@ export function useActionRecorder(options: UseActionRecorderOptions = {}): UseAc
 
         // Log validation warnings for debugging
         if (result.warnings.length > 0) {
-          console.warn('Selector validation warnings:', result.warnings);
+          logger.warn('Selector validation warnings', { warnings: result.warnings });
         }
 
         const description = getActionDescription(action, target);
@@ -767,7 +768,7 @@ export function useActionRecorder(options: UseActionRecorderOptions = {}): UseAc
             lastPendingStep.action === action &&
             lastPendingStep.value === tracked.value
           ) {
-            console.warn('Skipping duplicate formfill in modal:', selector);
+            logger.warn('Skipping duplicate formfill in modal', { selector });
             return;
           }
           setPendingGroupSteps((prev) => [...prev, newStep]);
@@ -783,7 +784,7 @@ export function useActionRecorder(options: UseActionRecorderOptions = {}): UseAc
             lastStep.action === action &&
             lastStep.value === tracked.value
           ) {
-            console.warn('Skipping duplicate formfill:', selector);
+            logger.warn('Skipping duplicate formfill', { selector });
             return prev; // Skip duplicate
           }
 

--- a/src/utils/experiments/experiment-debug.ts
+++ b/src/utils/experiments/experiment-debug.ts
@@ -8,6 +8,7 @@
 
 import { collectKeysByPrefix } from '../../lib/storage/key-utils';
 import { StorageKeys } from '../../lib/storage-keys';
+import { logger } from '../../lib/logging';
 import {
   setFlagOverride,
   removeFlagOverride,
@@ -54,7 +55,9 @@ export function createExperimentDebugger(config: HighlightedGuideConfig): void {
 
     setOverride: (flagName: string, value: unknown) => {
       if (!(flagName in pathfinderFeatureFlags)) {
-        console.warn(`[Pathfinder] Unknown flag '${flagName}'. Known flags:`, Object.keys(pathfinderFeatureFlags));
+        logger.warn(`[Pathfinder] Unknown flag '${flagName}'. Known flags`, {
+          knownFlags: Object.keys(pathfinderFeatureFlags),
+        });
       }
       setFlagOverride(flagName, value);
       console.log(`[Pathfinder] Override set for '${flagName}':`, value);

--- a/src/utils/experiments/highlighted-guide-orchestrator.ts
+++ b/src/utils/experiments/highlighted-guide-orchestrator.ts
@@ -24,6 +24,7 @@ import { locationService } from '@grafana/runtime';
 
 import pluginJson from '../../plugin.json';
 import { StorageKeys } from '../../lib/storage-keys';
+import { logger } from '../../lib/logging';
 import { sidebarState } from '../../global-state/sidebar';
 import { autoLaunchChannel } from '../../global-state/auto-launch';
 import { findDocPage } from '../find-doc-page';
@@ -152,7 +153,7 @@ export function setupHighlightedGuideAutoOpen(
     // fallback path for misconfigured flags).
     const docsPage = findDocPage(config.guideId);
     if (!docsPage) {
-      console.warn(
+      logger.warn(
         `[Pathfinder] Highlighted-guide auto-open: findDocPage returned null for guideId="${config.guideId}". Opening sidebar without auto-launch; Featured-slot injection remains as fallback.`
       );
       attemptAutoOpen();

--- a/src/utils/find-doc-page.ts
+++ b/src/utils/find-doc-page.ts
@@ -1,4 +1,5 @@
 import { isGrafanaDocsUrl, isInteractiveLearningUrl } from '../security';
+import { logger } from '../lib/logging';
 
 export interface DocPage {
   type: 'docs-page' | 'learning-journey' | 'interactive';
@@ -61,7 +62,7 @@ export function findDocPage(param: string): DocPage | null {
         };
       }
     } catch (e) {
-      console.warn('Failed to load bundled interactives index', e);
+      logger.warn('Failed to load bundled interactives index', { error: e });
     }
   }
 
@@ -74,7 +75,7 @@ export function findDocPage(param: string): DocPage | null {
 
     // SECURITY: Use validated interactive learning URL check
     if (!isInteractiveLearningUrl(url)) {
-      console.warn('Security: Rejected non-interactive-learning URL:', url);
+      logger.warn('Security: Rejected non-interactive-learning URL', { url });
       return null;
     }
 
@@ -111,7 +112,7 @@ export function findDocPage(param: string): DocPage | null {
       }
     }
   } catch (error) {
-    console.error('Failed to load static links:', error);
+    logger.error('Failed to load static links', { error });
   }
 
   // Case 4: Any Grafana docs URL (fallback for non-curated content)
@@ -130,7 +131,7 @@ export function findDocPage(param: string): DocPage | null {
     // 2. Protocol is https (prevents protocol injection)
     // 3. Path contains valid docs paths (prevents arbitrary URL injection)
     if (!isGrafanaDocsUrl(fullUrl)) {
-      console.warn('Security: Rejected non-Grafana docs URL:', fullUrl);
+      logger.warn('Security: Rejected non-Grafana docs URL', { url: fullUrl });
       return null;
     }
 

--- a/src/utils/openfeature.test.ts
+++ b/src/utils/openfeature.test.ts
@@ -126,6 +126,9 @@ describe('openfeature', () => {
           'highlighted_guide_experiment'
         );
         expect(pathfinderFeatureFlags['pathfinder.frontend-telemetry'].trackingKey).toBe('frontend_telemetry');
+        expect(pathfinderFeatureFlags['pathfinder.frontend-telemetry-sample-rate'].trackingKey).toBe(
+          'frontend_telemetry_sample_rate'
+        );
       });
     });
 
@@ -138,6 +141,18 @@ describe('openfeature', () => {
 
         const { pathfinderFeatureFlags } = require('./openfeature');
         expect(pathfinderFeatureFlags['pathfinder.frontend-telemetry'].defaultValue).toBe(true);
+      });
+    });
+
+    it('pathfinder.frontend-telemetry-sample-rate should default to 1 (every session)', () => {
+      jest.isolateModules(() => {
+        const mockOF = createMockOpenFeature();
+        const mockReact = createMockReactSdk();
+        jest.doMock('@openfeature/web-sdk', () => mockOF);
+        jest.doMock('@openfeature/react-sdk', () => mockReact);
+
+        const { pathfinderFeatureFlags } = require('./openfeature');
+        expect(pathfinderFeatureFlags['pathfinder.frontend-telemetry-sample-rate'].defaultValue).toBe(1);
       });
     });
   });
@@ -325,6 +340,49 @@ describe('openfeature', () => {
         expect(result).toBe('default-variant');
         expect(consoleSpy).toHaveBeenCalledWith(
           expect.stringContaining("[OpenFeature] Error evaluating flag 'experiment-flag'"),
+          expect.any(Error)
+        );
+
+        consoleSpy.mockRestore();
+      });
+    });
+  });
+
+  describe('getNumberFlagValue', () => {
+    it('should return number flag value from client', () => {
+      jest.isolateModules(() => {
+        const mockOF = createMockOpenFeature();
+        const mockReact = createMockReactSdk();
+        mockOF.mockClient.getNumberValue.mockReturnValue(0.25);
+        jest.doMock('@openfeature/web-sdk', () => mockOF);
+        jest.doMock('@openfeature/react-sdk', () => mockReact);
+
+        const { getNumberFlagValue } = require('./openfeature');
+        const result = getNumberFlagValue('pathfinder.frontend-telemetry-sample-rate', 1);
+
+        expect(mockOF.mockClient.getNumberValue).toHaveBeenCalledWith('pathfinder.frontend-telemetry-sample-rate', 1);
+        expect(result).toBe(0.25);
+      });
+    });
+
+    it('should return default value on error', () => {
+      jest.isolateModules(() => {
+        const mockOF = createMockOpenFeature();
+        const mockReact = createMockReactSdk();
+        mockOF.mockClient.getNumberValue.mockImplementation(() => {
+          throw new Error('Provider not ready');
+        });
+        jest.doMock('@openfeature/web-sdk', () => mockOF);
+        jest.doMock('@openfeature/react-sdk', () => mockReact);
+
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+        const { getNumberFlagValue } = require('./openfeature');
+        const result = getNumberFlagValue('pathfinder.frontend-telemetry-sample-rate', 1);
+
+        expect(result).toBe(1);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining("[OpenFeature] Error evaluating flag 'pathfinder.frontend-telemetry-sample-rate'"),
           expect.any(Error)
         );
 

--- a/src/utils/openfeature.test.ts
+++ b/src/utils/openfeature.test.ts
@@ -126,9 +126,6 @@ describe('openfeature', () => {
           'highlighted_guide_experiment'
         );
         expect(pathfinderFeatureFlags['pathfinder.frontend-telemetry'].trackingKey).toBe('frontend_telemetry');
-        expect(pathfinderFeatureFlags['pathfinder.frontend-telemetry-sample-rate'].trackingKey).toBe(
-          'frontend_telemetry_sample_rate'
-        );
       });
     });
 
@@ -141,18 +138,6 @@ describe('openfeature', () => {
 
         const { pathfinderFeatureFlags } = require('./openfeature');
         expect(pathfinderFeatureFlags['pathfinder.frontend-telemetry'].defaultValue).toBe(true);
-      });
-    });
-
-    it('pathfinder.frontend-telemetry-sample-rate should default to 1 (every session)', () => {
-      jest.isolateModules(() => {
-        const mockOF = createMockOpenFeature();
-        const mockReact = createMockReactSdk();
-        jest.doMock('@openfeature/web-sdk', () => mockOF);
-        jest.doMock('@openfeature/react-sdk', () => mockReact);
-
-        const { pathfinderFeatureFlags } = require('./openfeature');
-        expect(pathfinderFeatureFlags['pathfinder.frontend-telemetry-sample-rate'].defaultValue).toBe(1);
       });
     });
   });
@@ -283,7 +268,8 @@ describe('openfeature', () => {
         expect(result).toBe(true);
         expect(consoleSpy).toHaveBeenCalledWith(
           expect.stringContaining("[OpenFeature] Error evaluating flag 'some-flag'"),
-          { error: expect.any(Error) }
+          expect.any(Error),
+          ''
         );
 
         consoleSpy.mockRestore();
@@ -341,50 +327,8 @@ describe('openfeature', () => {
         expect(result).toBe('default-variant');
         expect(consoleSpy).toHaveBeenCalledWith(
           expect.stringContaining("[OpenFeature] Error evaluating flag 'experiment-flag'"),
-          { error: expect.any(Error) }
-        );
-
-        consoleSpy.mockRestore();
-      });
-    });
-  });
-
-  describe('getNumberFlagValue', () => {
-    it('should return number flag value from client', () => {
-      jest.isolateModules(() => {
-        const mockOF = createMockOpenFeature();
-        const mockReact = createMockReactSdk();
-        mockOF.mockClient.getNumberValue.mockReturnValue(0.25);
-        jest.doMock('@openfeature/web-sdk', () => mockOF);
-        jest.doMock('@openfeature/react-sdk', () => mockReact);
-
-        const { getNumberFlagValue } = require('./openfeature');
-        const result = getNumberFlagValue('pathfinder.frontend-telemetry-sample-rate', 1);
-
-        expect(mockOF.mockClient.getNumberValue).toHaveBeenCalledWith('pathfinder.frontend-telemetry-sample-rate', 1);
-        expect(result).toBe(0.25);
-      });
-    });
-
-    it('should return default value on error', () => {
-      jest.isolateModules(() => {
-        const mockOF = createMockOpenFeature();
-        const mockReact = createMockReactSdk();
-        mockOF.mockClient.getNumberValue.mockImplementation(() => {
-          throw new Error('Provider not ready');
-        });
-        jest.doMock('@openfeature/web-sdk', () => mockOF);
-        jest.doMock('@openfeature/react-sdk', () => mockReact);
-
-        const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-
-        const { getNumberFlagValue } = require('./openfeature');
-        const result = getNumberFlagValue('pathfinder.frontend-telemetry-sample-rate', 1);
-
-        expect(result).toBe(1);
-        expect(consoleSpy).toHaveBeenCalledWith(
-          expect.stringContaining("[OpenFeature] Error evaluating flag 'pathfinder.frontend-telemetry-sample-rate'"),
-          { error: expect.any(Error) }
+          expect.any(Error),
+          ''
         );
 
         consoleSpy.mockRestore();

--- a/src/utils/openfeature.test.ts
+++ b/src/utils/openfeature.test.ts
@@ -222,7 +222,8 @@ describe('openfeature', () => {
         await initializeOpenFeature();
 
         expect(consoleSpy).toHaveBeenCalledWith(
-          '[OpenFeature] config.namespace not available, skipping initialization'
+          '[OpenFeature] config.namespace not available, skipping initialization',
+          ''
         );
         expect(mockOF.OpenFeature.setProviderAndWait).not.toHaveBeenCalled();
 
@@ -282,7 +283,7 @@ describe('openfeature', () => {
         expect(result).toBe(true);
         expect(consoleSpy).toHaveBeenCalledWith(
           expect.stringContaining("[OpenFeature] Error evaluating flag 'some-flag'"),
-          expect.any(Error)
+          { error: expect.any(Error) }
         );
 
         consoleSpy.mockRestore();
@@ -340,7 +341,7 @@ describe('openfeature', () => {
         expect(result).toBe('default-variant');
         expect(consoleSpy).toHaveBeenCalledWith(
           expect.stringContaining("[OpenFeature] Error evaluating flag 'experiment-flag'"),
-          expect.any(Error)
+          { error: expect.any(Error) }
         );
 
         consoleSpy.mockRestore();
@@ -383,7 +384,7 @@ describe('openfeature', () => {
         expect(result).toBe(1);
         expect(consoleSpy).toHaveBeenCalledWith(
           expect.stringContaining("[OpenFeature] Error evaluating flag 'pathfinder.frontend-telemetry-sample-rate'"),
-          expect.any(Error)
+          { error: expect.any(Error) }
         );
 
         consoleSpy.mockRestore();

--- a/src/utils/openfeature.test.ts
+++ b/src/utils/openfeature.test.ts
@@ -125,6 +125,19 @@ describe('openfeature', () => {
         expect(pathfinderFeatureFlags['pathfinder.highlighted-guide-experiment'].trackingKey).toBe(
           'highlighted_guide_experiment'
         );
+        expect(pathfinderFeatureFlags['pathfinder.frontend-telemetry'].trackingKey).toBe('frontend_telemetry');
+      });
+    });
+
+    it('pathfinder.frontend-telemetry should default to true', () => {
+      jest.isolateModules(() => {
+        const mockOF = createMockOpenFeature();
+        const mockReact = createMockReactSdk();
+        jest.doMock('@openfeature/web-sdk', () => mockOF);
+        jest.doMock('@openfeature/react-sdk', () => mockReact);
+
+        const { pathfinderFeatureFlags } = require('./openfeature');
+        expect(pathfinderFeatureFlags['pathfinder.frontend-telemetry'].defaultValue).toBe(true);
       });
     });
   });

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -119,19 +119,6 @@ const pathfinderFeatureFlags = {
     trackingKey: 'frontend_telemetry',
   },
   /**
-   * Fraction of sessions Faro actually sends telemetry for (Faro's own
-   * `sessionTracking.samplingRate`), remotely tunable without a release.
-   * A session not selected by the sample sends nothing — errors, events,
-   * logs — for its entire lifetime, not just a fraction of its signals.
-   * 1 = every session (default, current behavior unchanged); 0 = none.
-   */
-  'pathfinder.frontend-telemetry-sample-rate': {
-    valueType: 'number',
-    values: [1],
-    defaultValue: 1,
-    trackingKey: 'frontend_telemetry_sample_rate',
-  },
-  /**
    * Controls whether the sidebar automatically opens on first Grafana load per session
    * When true: sidebar opens automatically on first page load
    * When false: sidebar only opens when user explicitly requests it
@@ -450,28 +437,6 @@ export const getStringFlagValue = (flagName: string, defaultValue: string): stri
   try {
     const client = getFeatureFlagClient();
     return client.getStringValue(flagName, defaultValue);
-  } catch (error) {
-    logger.error(`[OpenFeature] Error evaluating flag '${flagName}'`, { error });
-    return defaultValue;
-  }
-};
-
-/**
- * Synchronously get a number feature flag value (for non-React code)
- *
- * Use this for flags with a numeric value, e.g. a sample rate.
- *
- * @param flagName - The feature flag name
- * @param defaultValue - Default value if flag evaluation fails
- * @returns The evaluated flag value or default
- *
- * @example
- * const sampleRate = getNumberFlagValue('pathfinder.frontend-telemetry-sample-rate', 1);
- */
-export const getNumberFlagValue = (flagName: string, defaultValue: number): number => {
-  try {
-    const client = getFeatureFlagClient();
-    return client.getNumberValue(flagName, defaultValue);
   } catch (error) {
     logger.error(`[OpenFeature] Error evaluating flag '${flagName}'`, { error });
     return defaultValue;

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -118,6 +118,19 @@ const pathfinderFeatureFlags = {
     trackingKey: 'frontend_telemetry',
   },
   /**
+   * Fraction of sessions Faro actually sends telemetry for (Faro's own
+   * `sessionTracking.samplingRate`), remotely tunable without a release.
+   * A session not selected by the sample sends nothing — errors, events,
+   * logs — for its entire lifetime, not just a fraction of its signals.
+   * 1 = every session (default, current behavior unchanged); 0 = none.
+   */
+  'pathfinder.frontend-telemetry-sample-rate': {
+    valueType: 'number',
+    values: [1],
+    defaultValue: 1,
+    trackingKey: 'frontend_telemetry_sample_rate',
+  },
+  /**
    * Controls whether the sidebar automatically opens on first Grafana load per session
    * When true: sidebar opens automatically on first page load
    * When false: sidebar only opens when user explicitly requests it
@@ -436,6 +449,28 @@ export const getStringFlagValue = (flagName: string, defaultValue: string): stri
   try {
     const client = getFeatureFlagClient();
     return client.getStringValue(flagName, defaultValue);
+  } catch (error) {
+    console.error(`[OpenFeature] Error evaluating flag '${flagName}':`, error);
+    return defaultValue;
+  }
+};
+
+/**
+ * Synchronously get a number feature flag value (for non-React code)
+ *
+ * Use this for flags with a numeric value, e.g. a sample rate.
+ *
+ * @param flagName - The feature flag name
+ * @param defaultValue - Default value if flag evaluation fails
+ * @returns The evaluated flag value or default
+ *
+ * @example
+ * const sampleRate = getNumberFlagValue('pathfinder.frontend-telemetry-sample-rate', 1);
+ */
+export const getNumberFlagValue = (flagName: string, defaultValue: number): number => {
+  try {
+    const client = getFeatureFlagClient();
+    return client.getNumberValue(flagName, defaultValue);
   } catch (error) {
     console.error(`[OpenFeature] Error evaluating flag '${flagName}':`, error);
     return defaultValue;

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -5,6 +5,7 @@ import { config } from '@grafana/runtime';
 
 import { TrackingHook, reportFeatureFlagExposure } from './openfeature-tracking';
 import { StorageKeys } from '../lib/storage-keys';
+import { logger } from '../lib/logging';
 
 // ============================================================================
 // TYPES
@@ -236,7 +237,7 @@ export async function initializeOpenFeature(): Promise<void> {
   const namespace = config.namespace;
 
   if (!namespace) {
-    console.warn('[OpenFeature] config.namespace not available, skipping initialization');
+    logger.warn('[OpenFeature] config.namespace not available, skipping initialization');
     return;
   }
 
@@ -339,7 +340,7 @@ export async function evaluateFeatureFlag<T extends FeatureFlagName>(flagName: T
         throw new Error(`Invalid flag value type for flag ${flagName}`);
     }
   } catch (error) {
-    console.error(`[OpenFeature] Error evaluating flag '${flagName}':`, error);
+    logger.error(`[OpenFeature] Error evaluating flag '${flagName}'`, { error });
     return pathfinderFeatureFlags[flagName].defaultValue as FlagValue<T>;
   }
 }
@@ -421,14 +422,14 @@ export const getFeatureFlagValue = (flagName: string, defaultValue: boolean): bo
   try {
     const overrides = getFlagOverrides();
     if (flagName in overrides && typeof overrides[flagName] === 'boolean') {
-      console.warn(`[OpenFeature] Using local override for '${flagName}':`, overrides[flagName]);
+      logger.warn(`[OpenFeature] Using local override for '${flagName}'`, { override: overrides[flagName] });
       return overrides[flagName] as boolean;
     }
 
     const client = getFeatureFlagClient();
     return client.getBooleanValue(flagName, defaultValue);
   } catch (error) {
-    console.error(`[OpenFeature] Error evaluating flag '${flagName}':`, error);
+    logger.error(`[OpenFeature] Error evaluating flag '${flagName}'`, { error });
     return defaultValue;
   }
 };
@@ -450,7 +451,7 @@ export const getStringFlagValue = (flagName: string, defaultValue: string): stri
     const client = getFeatureFlagClient();
     return client.getStringValue(flagName, defaultValue);
   } catch (error) {
-    console.error(`[OpenFeature] Error evaluating flag '${flagName}':`, error);
+    logger.error(`[OpenFeature] Error evaluating flag '${flagName}'`, { error });
     return defaultValue;
   }
 };
@@ -472,7 +473,7 @@ export const getNumberFlagValue = (flagName: string, defaultValue: number): numb
     const client = getFeatureFlagClient();
     return client.getNumberValue(flagName, defaultValue);
   } catch (error) {
-    console.error(`[OpenFeature] Error evaluating flag '${flagName}':`, error);
+    logger.error(`[OpenFeature] Error evaluating flag '${flagName}'`, { error });
     return defaultValue;
   }
 };
@@ -503,7 +504,7 @@ export const getHighlightedGuideConfig = (): HighlightedGuideConfig => {
       const override = overrides[flagName];
       const validated = validateHighlightedGuideValue(override);
       if (validated) {
-        console.warn(`[OpenFeature] Using local override for '${flagName}':`, validated);
+        logger.warn(`[OpenFeature] Using local override for '${flagName}'`, { override: validated });
         // Fire the exposure event so override-driven QA / demo runs produce
         // the same analytics as a real MTFF assignment. The dedup state is
         // shared with the OpenFeature hook path — see openfeature-tracking.ts.
@@ -516,7 +517,7 @@ export const getHighlightedGuideConfig = (): HighlightedGuideConfig => {
     const value = client.getObjectValue(flagName, DEFAULT_HIGHLIGHTED_GUIDE_CONFIG as unknown as JsonValue);
     return validateHighlightedGuideValue(value) ?? DEFAULT_HIGHLIGHTED_GUIDE_CONFIG;
   } catch (error) {
-    console.error(`[OpenFeature] Error evaluating flag '${flagName}':`, error);
+    logger.error(`[OpenFeature] Error evaluating flag '${flagName}'`, { error });
     return DEFAULT_HIGHLIGHTED_GUIDE_CONFIG;
   }
 };

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -105,6 +105,19 @@ const pathfinderFeatureFlags = {
     trackingKey: 'pathfinder_enabled',
   },
   /**
+   * Remote kill-switch for Faro frontend telemetry (errors, sessions, and — in
+   * later phases — logs and analytics-event mirroring). Independent of
+   * `pathfinder.enabled`: this only stops the telemetry stream, not the plugin.
+   * Telemetry is already gated to Grafana Cloud; this flag exists to disable
+   * it fleet-wide without a release if the collector or filtering misbehaves.
+   */
+  'pathfinder.frontend-telemetry': {
+    valueType: 'boolean',
+    values: [true, false],
+    defaultValue: true,
+    trackingKey: 'frontend_telemetry',
+  },
+  /**
    * Controls whether the sidebar automatically opens on first Grafana load per session
    * When true: sidebar opens automatically on first page load
    * When false: sidebar only opens when user explicitly requests it

--- a/src/utils/pathfinder-deep-link-handler.ts
+++ b/src/utils/pathfinder-deep-link-handler.ts
@@ -12,6 +12,7 @@
 import { locationService } from '@grafana/runtime';
 
 import pluginJson from '../plugin.json';
+import { logger } from '../lib/logging';
 import { panelModeManager } from '../global-state/panel-mode';
 import { sidebarState } from '../global-state/sidebar';
 import { autoLaunchChannel } from '../global-state/auto-launch';
@@ -99,7 +100,7 @@ export function handlePathfinderDeepLink(deps: DeepLinkHandlerDeps): boolean {
     deps
       .loadControlGroupDocPopup()
       .then(({ showControlGroupDocPopup }) => showControlGroupDocPopup(docOpenSource))
-      .catch((err) => console.error('[Pathfinder] Failed to load control group popup:', err));
+      .catch((err) => logger.error('[Pathfinder] Failed to load control group popup', { error: err }));
     return true;
   }
 
@@ -120,11 +121,11 @@ export function handlePathfinderDeepLink(deps: DeepLinkHandlerDeps): boolean {
       const redirectTarget = rawRedirectTarget ? validateRedirectPath(rawRedirectTarget) : null;
 
       if (!docsPage) {
-        console.warn(
-          'Could not parse doc param:',
-          ctx.docsParam,
-          '- Supported formats: api:<resourceName>, bundled:<id>, interactive-learning.grafana.net/..., /docs/..., https://grafana.com/docs/...'
-        );
+        logger.warn('Could not parse doc param', {
+          docsParam: ctx.docsParam,
+          supportedFormats:
+            '- Supported formats: api:<resourceName>, bundled:<id>, interactive-learning.grafana.net/..., /docs/..., https://grafana.com/docs/...',
+        });
         rewriteCurrentUrl(stripPathfinderParams);
         sidebarState.setPendingOpenSource(ctx.docOpenSource, 'auto-open');
         deps.attemptAutoOpen(200);
@@ -159,7 +160,7 @@ export function handlePathfinderDeepLink(deps: DeepLinkHandlerDeps): boolean {
       });
     })
     .catch((err) => {
-      console.error('[Pathfinder] Failed to load find-doc-page chunk:', err);
+      logger.error('[Pathfinder] Failed to load find-doc-page chunk', { error: err });
       sidebarState.setPendingOpenSource(ctx.docOpenSource, 'auto-open');
       deps.attemptAutoOpen(200);
       setTimeout(() => {

--- a/src/utils/sidebar-auto-open.ts
+++ b/src/utils/sidebar-auto-open.ts
@@ -8,6 +8,7 @@ import { getAppEvents, locationService } from '@grafana/runtime';
 import pluginJson from '../plugin.json';
 import { sidebarState } from '../global-state/sidebar';
 import { isExtensionSidebarInUse } from '../lib/storage/extension-sidebar';
+import { logger } from '../lib/logging';
 import { getFeatureFlagValue } from './openfeature';
 
 export interface ConfigAutoOpenContext {
@@ -27,7 +28,7 @@ export function attemptAutoOpen(delay = 200): void {
         },
       });
     } catch (error) {
-      console.error('Failed to auto-open Interactive learning panel:', error);
+      logger.error('Failed to auto-open Interactive learning panel', { error });
     }
   }, delay);
 }

--- a/src/utils/timeout-manager.ts
+++ b/src/utils/timeout-manager.ts
@@ -7,6 +7,7 @@
  */
 
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
+import { logger } from '../lib/logging';
 
 export class TimeoutManager {
   private static instance: TimeoutManager;
@@ -50,7 +51,7 @@ export class TimeoutManager {
       try {
         await callback();
       } catch (error) {
-        console.error(`Timeout callback error for key '${key}':`, error);
+        logger.error(`Timeout callback error for key '${key}'`, { error });
       } finally {
         // Clean up after execution
         this.timeouts.delete(key);
@@ -77,7 +78,7 @@ export class TimeoutManager {
       try {
         await callback();
       } catch (error) {
-        console.error(`Timeout callback error for key '${key}':`, error);
+        logger.error(`Timeout callback error for key '${key}'`, { error });
       } finally {
         this.timeouts.delete(key);
       }
@@ -126,7 +127,7 @@ export class TimeoutManager {
       try {
         await callback();
       } catch (error) {
-        console.error(`Interval callback error for key '${key}':`, error);
+        logger.error(`Interval callback error for key '${key}'`, { error });
       }
     }, delay);
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -6,7 +6,23 @@ import grafanaConfig, { type Env } from './.config/webpack/webpack.config';
 
 const config = async (env: Env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
-  const faroSourceMapApiKey = process.env.FARO_SOURCEMAP_API_KEY;
+
+  // Sourced from Vault (repo/grafana/grafana-pathfinder-app/faro-connection +
+  // .../FARO_SOURCEMAP_API_KEY) via CI, never hardcoded. appName is the one
+  // exception — it's not connection-specific, just this plugin's identity.
+  const faroSourceMap =
+    env.production &&
+    process.env.FARO_SOURCEMAP_API_KEY &&
+    process.env.FARO_SOURCEMAP_ENDPOINT &&
+    process.env.FARO_SOURCEMAP_APP_ID &&
+    process.env.FARO_SOURCEMAP_STACK_ID
+      ? {
+          apiKey: process.env.FARO_SOURCEMAP_API_KEY,
+          endpoint: process.env.FARO_SOURCEMAP_ENDPOINT,
+          appId: process.env.FARO_SOURCEMAP_APP_ID,
+          stackId: process.env.FARO_SOURCEMAP_STACK_ID,
+        }
+      : null;
 
   return merge(baseConfig, {
     externals: ['react/jsx-runtime', 'react/jsx-dev-runtime'],
@@ -20,22 +36,18 @@ const config = async (env: Env): Promise<Configuration> => {
         '@grafana/i18n': path.resolve(__dirname, 'node_modules/@grafana/i18n/dist/cjs/index.cjs'),
       },
     },
-    // Absent outside of CI runs that supply the API key, so local and PR builds
-    // never attempt an upload.
-    plugins:
-      env.production && faroSourceMapApiKey
-        ? [
-            new FaroSourceMapUploaderPlugin({
-              appName: 'grafana-pathfinder-app',
-              endpoint: 'https://faro-api-ops-eu-south-0.grafana-ops.net/faro/api/v1',
-              appId: '77',
-              stackId: '27821',
-              apiKey: faroSourceMapApiKey,
-              gzipContents: true,
-              verbose: true,
-            }),
-          ]
-        : [],
+    // Absent outside of CI runs that supply the full connection config, so
+    // local and PR builds never attempt an upload.
+    plugins: faroSourceMap
+      ? [
+          new FaroSourceMapUploaderPlugin({
+            appName: 'grafana-pathfinder-app',
+            ...faroSourceMap,
+            gzipContents: true,
+            verbose: true,
+          }),
+        ]
+      : [],
   });
 };
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,10 +1,12 @@
 import path from 'path';
 import type { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
+import FaroSourceMapUploaderPlugin from '@grafana/faro-webpack-plugin';
 import grafanaConfig, { type Env } from './.config/webpack/webpack.config';
 
 const config = async (env: Env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
+  const faroSourceMapApiKey = process.env.FARO_SOURCEMAP_API_KEY;
 
   return merge(baseConfig, {
     externals: ['react/jsx-runtime', 'react/jsx-dev-runtime'],
@@ -18,6 +20,22 @@ const config = async (env: Env): Promise<Configuration> => {
         '@grafana/i18n': path.resolve(__dirname, 'node_modules/@grafana/i18n/dist/cjs/index.cjs'),
       },
     },
+    // Absent outside of CI runs that supply the API key, so local and PR builds
+    // never attempt an upload.
+    plugins:
+      env.production && faroSourceMapApiKey
+        ? [
+            new FaroSourceMapUploaderPlugin({
+              appName: 'grafana-pathfinder-app',
+              endpoint: 'https://faro-api-ops-eu-south-0.grafana-ops.net/faro/api/v1',
+              appId: '77',
+              stackId: '27821',
+              apiKey: faroSourceMapApiKey,
+              gzipContents: true,
+              verbose: true,
+            }),
+          ]
+        : [],
   });
 };
 


### PR DESCRIPTION
## Summary

Re-enables Grafana Faro frontend telemetry for Pathfinder in Grafana Cloud — disabled since #389 pending a collector CORS fix — and builds out the full pipeline: errors, sessions, logs, analytics mirroring, resource timing, and view tracking. Everything is Cloud-only, sits behind a remote kill-switch (`pathfinder.frontend-telemetry`), and is filtered so only telemetry attributable to Pathfinder leaves the page. Faro initializes at plugin start (the pattern the Faro team recommends), but a `beforeSend` activity gate drops every item until Pathfinder is open in one of its surfaces — docked sidebar, floating panel, fullscreen, controller tab, or kiosk — read from localStorage and per-tab DOM roots, so sessions at the collector mean "used Pathfinder", not "loaded a Grafana page". Exceptions and error-level logs bypass the gate, so a session can also mean "Pathfinder broke". Real interactive work (steps, sections, guided steps, remote steps) runs inside real-duration user actions, so logs/errors/mirrored events emitted during a run are stamped with the action's `parentId`/`name` — causal correlation without tracing. The other historical blocker — OTel's fetch instrumentation dropping `response.url`, which the docs fetcher needs — is fixed upstream (otel-js #6343, in Faro ≥ 2.7.1).

Originally landed as a 5-PR stack (#1271–#1274 superseded this one); consolidated into a single PR per request.

## What to look at

- **Faro core** ([`src/lib/faro.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/d58f39e6ccb840e29825eccd3ecee5f81666b91e/src/lib/faro.ts)) — an isolated instance (`isolate: true`, own collector, own global object key) with a whitelist `beforeSend`: exceptions must carry a Pathfinder stack frame, logs must carry the `[pathfinder]` prefix, resource-timing entries must hit the docs/recommender/interactive-learning hosts, and page-wide navigation timing is always dropped. Sessions are **volatile (sessionStorage), not persistent** — this looks conservative but is load-bearing: Faro's persistent-session localStorage key is a fixed SDK constant that `isolate` does not namespace, and Grafana core's Faro writes the same key. Persistent sessions would resume core's session and inherit core's sampling decision, and could contaminate core's RUM sampling in return.
- **Activity-gated delivery** (`passesActivityGate` in `src/lib/faro.ts`) — init is eager per Faro team review (the previous engagement-gated init and its pre-init buffer are gone); send/drop is decided per transport item instead. Everything is dropped until Pathfinder is open in one of its surfaces. Open-state comes from localStorage — the panel-mode key (floating/fullscreen; closing the floating panel resets it to sidebar) and Grafana's `extensionSidebarDocked` key — plus per-tab DOM roots for the controller and kiosk overlays, which have no storage footprint. The gate latches for the rest of the page load once open, so the sidebar-close mirror (which fires after unmount, when the docked key is already gone) and teardown errors still send. Exceptions and error-level logs bypass the gate entirely — Pathfinder code runs with every panel closed (module init, link interception, cross-tab executor), and a session that exists only because Pathfinder broke is exactly what error telemetry is for.
- **Analytics mirroring** (`src/lib/analytics.ts` → `pushFaroUserAction`) — every `reportAppInteraction` event is mirrored into Faro as a User Action under the identical `pathfinder_*` name, so the RudderStack and Faro pipelines can be cross-checked. Mirrors carry an incrementing `seq` attribute because Faro's dedupe compares name + attributes but not timestamps; without it, identical rapid-fire events collapse and the counts drift.
- **Logging** ([`src/lib/logging.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/d58f39e6ccb840e29825eccd3ecee5f81666b91e/src/lib/logging.ts) + ~110 call-site files) — all ~420 `console.warn`/`console.error` call sites now route through the `logger` facade: console output is preserved (sanitized message + raw context object, so DevTools fidelity is intact) and a sanitized copy goes to Faro when it is active. A new `no-console` ESLint rule (log/info/debug still allowed) makes the migration provably complete and blocks regressions; exemptions are tests, `src/cli` (a Node CLI where console is the output), the facade itself, and three justified inline disables (tier-0 `constants.ts` sits inside the logger's own import chain; the two error boundaries already report via `pushFaroError`).
- **Real-duration user actions** (`withFaroUserAction` in `src/lib/faro.ts`, applied at five execution funnels: the interactive hook's two dispatchers, `handleDoSection`, `GuidedHandler.executeGuidedStep`, and the cross-tab `runStepCommand`) — opens a real action around actual work with an `outcome` attribute (ok/error/timeout) and a safety timeout. Two SDK gotchas are load-bearing here: `end(attributes)` is ignored by the 2.8.2 implementation (outcome is stamped by mutating the action's `attributes` field) and `end()` is not idempotent (a `settled` guard prevents duplicate action events). The mirror falls back to a plain skip-dedupe event while an action is open — previously those mirrors were silently dropped; now they parent into the action. Dashboards counting mirrors must union both shapes (`faro.user.action` events + plain events by name).
- **Views and resource timing** — the active docs tab sets Faro's view meta to the doc's hostname + pathname (via `useGlobalActiveTabExposure`), and PerformanceInstrumentation entries are kept only for the three domains the plugin actually fetches from, giving load metrics for docs/CDN/recommender requests.
- **Source maps** (`webpack.config.ts`) — `FaroSourceMapUploaderPlugin` is wired in but dormant: it only activates when all four `FARO_SOURCEMAP_*` env vars are present, and nothing in CI/CD sets them in this PR. The CI/CD wiring to actually drive it is deferred to a follow-up — see Known open items for why.
- **Test infrastructure** (`jest-setup.js`) — Prism is forced into manual mode: importing the logger pulls `@grafana/runtime` → `@grafana/ui` → `prismjs` into test module graphs, and Prism's document-wide auto-highlight rAF raced tests that mock `document.querySelectorAll`.

## Why

Pathfinder had no frontend observability: errors, guide failures, and docs-fetch problems in Cloud were invisible unless a user reported them. RudderStack measures product usage but cannot answer "is the plugin healthy", and there was no way to cross-check the analytics pipeline itself. This PR provides error/session/log/User-Action telemetry with per-signal attribution on a page shared with other Faro instances, remote controls to disable without shipping a release, and de-minified production stack traces.

Tracing was evaluated and deliberately excluded: a plugin's `TracingInstrumentation` collides with Grafana core's through OTel's page-global API — "attempted duplicate registration of API: trace" — which `isolate: true` cannot prevent (faro-web-sdk #1818, still open upstream). Our interesting fetches are cross-origin, so spans would not connect server-side anyway; client-only spans would largely duplicate the resource-timing events already collected here.

## How to verify

1. Dev-build QA: run `npm run dev`, set `localStorage['pathfinder.faro.local'] = 'true'`, reload, and open Pathfinder. The Network tab shows batched POSTs to the `faro-collector-ops-eu-south-0` collector; clicking around Pathfinder emits `faro.user.action` events named `pathfinder_*`, each with a `seq` attribute.
2. On a Cloud dev stack, confirm in Frontend Observability that exceptions carry Pathfinder stack frames only, logs are `[pathfinder]`-prefixed, and resource entries appear only for grafana.com / recommender / interactive-learning hosts.
3. Open two different docs tabs and switch between them — view-changed events fire and subsequent telemetry carries the doc's hostname + path as its view.
4. Flip `pathfinder.frontend-telemetry` to false in MTFF — no collector requests on next load.
5. Trigger a guide warning (e.g. run a step against a missing element) and confirm the DevTools console still shows the warning with an expandable context object.
6. ~~After the next main release, open a production error in Frontend Observability and confirm the stack trace is de-minified~~ — not yet possible; sourcemap upload has no CI/CD wiring in this PR (see Known open items).
7. Activity gating: on a dev stack, browse Grafana without touching Pathfinder — no collector traffic; dock the sidebar (or pop out the floating panel, or enter fullscreen) — telemetry begins, and it keeps flowing for the rest of the page load even after the panel closes.
8. Run "Do section" in a guide — one `pathfinder_section_run` user action with realistic duration, an `outcome` attribute, and the `DoSectionButtonClick` mirror parented inside it; individual "Do it" clicks appear as `pathfinder_step_do` actions.

## Breaking changes

None user-facing. Console output shape changes slightly at migrated call sites: `console.error('msg:', err)` becomes message + context object (`'msg', { error: err }`), with objects still expandable in DevTools.

## Reversibility

The telemetry stream can be stopped fleet-wide without a release via the kill-switch flag. Event and attribute names (`pathfinder_*` User Actions, the `[pathfinder]` log prefix, `seq`) become downstream query contracts once dashboards are built on them — rename with care. Data already collected persists in the ops stack.

## Known open items

- Collector CORS status (the original #389 blocker) needs reconfirming on a live Cloud stack before merge.
- **Sourcemap CI/CD wiring is deferred to a follow-up PR, blocked on an upstream fix.** `publish.yml`'s `cd:` job (the only build whose output is actually deployed) is a call into `grafana/plugin-ci-workflows`'s reusable `cd.yml` workflow — we don't own any steps inside that job, only its `frontend-secrets` input. Live-tested via a scoped CD dispatch: Vault successfully fetched all four `FARO_SOURCEMAP_*` secrets, but the actual `npm run build` step's env had none of them. Root cause, confirmed by reading `actions/internal/plugins/frontend/action.yml` at `ci-cd-workflows/v10.1.0` (the latest tag): its "Build" step has no `env:` block wiring the fetched secrets in at all — a plain oversight in their action, not intentional, and not something we can fix from this repo. Also confirmed separately: the Vault field for `FARO_SOURCEMAP_API_KEY` is named `FARO_SOURCEMAP_API_KEY`, not `value` (whoever revisits this will need that fix too). Wiring it into `ci.yml`'s push-to-main build instead was considered and rejected: that job's build artifact is archived for CI inspection only and never deployed, so even a working upload there would tag a bundle no real browser ever loads — just orphaned sourcemap sets for no benefit. A tag-based `release.yml` alternative was also rejected: its build runs inside a third-party composite action, so getting secrets into it would require exporting them via `$GITHUB_ENV`, visible to every later step in that job including any nested action in that chain.

## Out of scope

- Sourcemap CI/CD wiring — blocked upstream (see Known open items); `webpack.config.ts`'s `FaroSourceMapUploaderPlugin` is in place and dormant, ready for a follow-up PR once `grafana/plugin-ci-workflows` exposes fetched secrets to its build step's env.
- Developer docs — a telemetry pipeline doc plus `pathfinder.frontend-telemetry` entries in `FEATURE_FLAGS.md` follow in a separate PR.
- Tracing — blocked upstream (faro-web-sdk #1818); revisit when it lands, at which point stock `TracingInstrumentation` suffices (the `response.url` fix removes any need for a custom provider).
- `console.log`/`info`/`debug` call sites — intentionally local-only; only warn/error carry observability value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



