### PR TITLE
fix(ui): pluralize step count and let section button hug content

### DIFF
--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -1438,9 +1438,14 @@ export function InteractiveSection({
                 return 'Reset section and clear all step completion to allow manual re-interaction';
               }
               if (resumeInfo.isResume) {
-                return `Resume from step ${resumeInfo.nextStepIndex + 1}, ${resumeInfo.remainingSteps} steps remaining`;
+                return `Resume from step ${resumeInfo.nextStepIndex + 1}, ${resumeInfo.remainingSteps} ${
+                  resumeInfo.remainingSteps === 1 ? 'step' : 'steps'
+                } remaining`;
               }
-              return hints || `Run through all ${nonNoopSteps.length} steps in sequence`;
+              return (
+                hints ||
+                `Run through all ${nonNoopSteps.length} ${nonNoopSteps.length === 1 ? 'step' : 'steps'} in sequence`
+              );
             })()}
           >
             {(() => {
@@ -1451,9 +1456,9 @@ export function InteractiveSection({
                 return 'Reset section';
               }
               if (resumeInfo.isResume) {
-                return `▶ Resume (${resumeInfo.remainingSteps} steps)`;
+                return `▶ Resume (${resumeInfo.remainingSteps} ${resumeInfo.remainingSteps === 1 ? 'step' : 'steps'})`;
               }
-              return `▶ Do Section (${nonNoopSteps.length} steps)`;
+              return `▶ Do Section (${nonNoopSteps.length} ${nonNoopSteps.length === 1 ? 'step' : 'steps'})`;
             })()}
           </Button>
         )}

--- a/src/styles/interactive.styles.ts
+++ b/src/styles/interactive.styles.ts
@@ -545,7 +545,6 @@ const getInteractiveComponentStyles = (theme: GrafanaTheme2) => ({
   },
 
   '.interactive-section-do-button': {
-    minWidth: '200px',
     fontWeight: theme.typography.fontWeightMedium,
 
     '&:disabled': {


### PR DESCRIPTION
## Summary

Fixes #1261.

Two small fixes on the section action button, as prescribed in the issue:

1. **Pluralization** — "▶ Resume (1 steps)" now reads "▶ Resume (1 step)". The same singular/plural check is applied to the "▶ Do Section" label and both tooltip strings in `src/components/interactive-tutorial/interactive-section.tsx`.
2. **Button sizing** — removed the hardcoded `minWidth: '200px'` from `.interactive-section-do-button` in `src/styles/interactive.styles.ts` so the button hugs its content.

## Verification

- `npx tsc --noEmit` — passes
- `npx eslint` on both changed files — passes
- `npx prettier --check` on both changed files — passes
- `npx jest src/components/interactive-tutorial` — 22 suites, 330 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
