### PR TITLE
fix(ci): post PR comments via workflow_run so fork PRs stay green

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -24,4 +24,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # The bundle-size action builds, compares against main, and comments in a single
+      # composite step. On PRs from forks the GITHUB_TOKEN is read-only, so the comment step
+      # fails with "Resource not accessible by integration". This is informational reporting,
+      # not a gate, so we let it fail without reddening the build. The action cannot be split
+      # into a workflow_run flow (like ci.yml's comment) without reimplementing its diff logic.
       - uses: grafana/plugin-actions/bundle-size@4698961fa64137fcac207108397ebe8a738a33d1
+        continue-on-error: true

--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -1,0 +1,98 @@
+name: CI comment
+
+# Posts the aggregated Playwright e2e results table as a PR comment.
+#
+# WHY THIS IS A SEPARATE WORKFLOW (and why it is safe):
+# The CI workflow runs on `pull_request`. For PRs opened from forks, GitHub forcibly
+# downgrades that workflow's GITHUB_TOKEN to read-only regardless of any `permissions:`
+# block, so it cannot comment on the PR. This is GitHub's defense against "pwn requests"
+# (untrusted fork code running with a write-capable token).
+#
+# This workflow runs on `workflow_run`, which executes in the context of the BASE repo's
+# default branch, so its token is write-capable even for fork PRs. That is only safe
+# because of two invariants that MUST be preserved:
+#   1. It runs ONLY trusted code from the default branch. The checkout below takes the
+#      default ref - it never checks out `github.event.workflow_run.head_sha`, so fork
+#      source code is never placed on disk or executed here.
+#   2. Everything crossing the trust boundary from the fork-triggered run arrives as inert
+#      DATA (downloaded artifacts), never as code. Artifact contents are treated as
+#      untrusted: the PR number is validated as a bare integer before use, and the results
+#      table is rendered by our own trusted script.
+# Do NOT add a checkout of the PR head ref or execute any downloaded/fork-provided code in
+# this workflow - that would reintroduce the pwn-request vulnerability this design avoids.
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
+
+permissions: {} # Granted per job
+
+jobs:
+  playwright-comment:
+    name: Comment PR with e2e results
+    # Only for PR-triggered CI runs; skip pushes to main.
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read # Checkout the trusted comment-generation script from the default branch
+      pull-requests: write # Comment on PRs - honored here even for fork PRs (see file header)
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Download PR number
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: pr-number
+          path: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download report summaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: all-reports
+          pattern: gf-playwright-report-*
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read and validate PR number
+        id: pr
+        run: |
+          num="$(cat pr-number/pr-number.txt)"
+          # Artifact contents come from the fork-triggered run and are untrusted. Only accept
+          # a bare integer so it cannot inject into the comment step's expressions.
+          if [[ "$num" =~ ^[0-9]+$ ]]; then
+            echo "number=$num" >> "$GITHUB_OUTPUT"
+          else
+            echo "Refusing to use non-numeric PR number: '$num'"
+          fi
+
+      - name: Generate results table
+        id: results
+        run: |
+          if [ ! -d all-reports ]; then
+            echo "No report artifacts found; skipping summary."
+            exit 0
+          fi
+          table=$(node .github/scripts/build-playwright-comment.js)
+          {
+            echo "table<<EOF"
+            echo "$table"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "$table" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment PR with results
+        if: ${{ steps.pr.outputs.number != '' && steps.results.outputs.table != '' }}
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          pr-number: ${{ steps.pr.outputs.number }}
+          comment-tag: gf-playwright-test-results
+          create-if-not-exists: true
+          message: ${{ steps.results.outputs.table }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,49 +414,33 @@ jobs:
       #     path: grafana-server.log
       #     retention-days: 5
 
-  # Aggregates the per-version e2e summaries and posts them as a single PR comment.
+  # The per-version e2e summaries are uploaded as `gf-playwright-report-*` artifacts by
+  # the matrix job above. They are aggregated into a single PR comment by the separate
+  # "CI comment" workflow (.github/workflows/ci-comment.yml), which runs on `workflow_run`
+  # so it holds a write-capable token even for PRs from forks. This `pull_request` workflow
+  # runs with a read-only token on fork PRs and therefore cannot comment itself.
+  #
+  # `workflow_run` does not reliably know the PR number for fork PRs, so we persist it here
+  # as an artifact for the comment workflow to read back.
+  #
   # We deliberately do NOT deploy to the gh-pages branch: the org-wide "Signed Commits"
   # ruleset (required_signatures on ~ALL branches) rejects the unsigned commit that the
   # shared deploy-report-pages action pushes, which reddens every PR. The hosted report
   # carried no content anyway because upload-report is false in the matrix job above.
-  publish-report:
-    if: ${{ always() && !cancelled() }}
-    needs: [playwright-tests]
+  save-pr-number:
+    name: Save PR number for comment workflow
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read # Checkout to access the comment-generation script
-      pull-requests: write # Comment on PRs with the e2e results table
+    timeout-minutes: 2
+    permissions: {} # No token access needed - only writes a static artifact
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          persist-credentials: false
+      - name: Write PR number to file
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: echo "$PR_NUMBER" > pr-number.txt
 
-      - name: Download report summaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - name: Upload PR number
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          path: all-reports
-          pattern: gf-playwright-report-*
-          merge-multiple: true
-
-      - name: Generate results table
-        id: results
-        run: |
-          if [ ! -d all-reports ]; then
-            echo "No report artifacts found; skipping summary."
-            exit 0
-          fi
-          table=$(node .github/scripts/build-playwright-comment.js)
-          {
-            echo "table<<EOF"
-            echo "$table"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-          echo "$table" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Comment PR with results
-        if: ${{ github.event.number != null && steps.results.outputs.table != '' }}
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-        with:
-          comment-tag: gf-playwright-test-results
-          create-if-not-exists: true
-          message: ${{ steps.results.outputs.table }}
+          name: pr-number
+          path: pr-number.txt


### PR DESCRIPTION
## Problem

CI comments on PRs in two places — the `publish-report` job (Playwright e2e results table) and the `bundle-size` step (bundle-size diff). Both run on the `pull_request` trigger.

For PRs opened from **forks**, GitHub forcibly downgrades the workflow's `GITHUB_TOKEN` to **read-only**, regardless of any `permissions:` block. The comment steps then fail with:

```
Resource not accessible by integration
```

So CI goes red on every PR from an external collaborator, even though nothing is actually broken. (Example: [run 28970282474](https://github.com/grafana/grafana-pathfinder-app/actions/runs/28970282474/job/85967229765?pr=1279).) Same-repo PRs are unaffected because they get a full write token.

The read-only-token restriction is deliberate on GitHub's side: it's the defense against **"pwn requests"** — untrusted fork code running in a job that also holds a write-capable token. The `permissions:` block is a *ceiling*, not a *grant*, and GitHub applies a lower ceiling to forks.

## What changed

### `ci.yml` — Playwright results comment → `workflow_run` split
- Removed the `publish-report` job.
- Added a tiny `save-pr-number` job that persists `github.event.number` as an artifact (the `workflow_run` event doesn't reliably know the PR number for fork PRs).
- The matrix job continues to upload the per-version `gf-playwright-report-*` summary artifacts unchanged.

### New `ci-comment.yml` — the write-back, triggered by `workflow_run`
Runs when **CI** completes, downloads the report + PR-number artifacts from the triggering run, aggregates the table with our existing `build-playwright-comment.js`, and posts the comment.

### `bundle-stats.yml` — `continue-on-error` on the bundle-size step
The `grafana/plugin-actions/bundle-size` action couples build → compare-against-main → comment in a single third-party composite step, gated only on `pull_request`. It can't be split into a `workflow_run` flow without reimplementing its diff logic, and its comment code expects a `pull_request` context. So instead of splitting it, the step is marked `continue-on-error: true`: on fork PRs its comment failure no longer reds the build. Structure is otherwise unchanged; on same-repo PRs it still comments as before.

## Why the `workflow_run` model is safe (and avoids pwn attacks)

A pwn request requires **both** in one job: (1) execution of attacker-controlled fork input as *code*, and (2) a privileged context (write token / secrets). This design keeps those two apart:

1. **It runs only trusted code from the default branch.** A `workflow_run` workflow is defined by the version of `ci-comment.yml` on the base repo's default branch — a fork's edits to it are ignored. The `checkout` takes the **default ref**; it never checks out `github.event.workflow_run.head_sha`, so fork source is never placed on disk or executed.
2. **Everything crossing the trust boundary is inert data, never code.** The only things flowing from the fork-triggered run are downloaded artifacts (a results table + a PR number). They are consumed by *our* trusted script and rendered into a comment — never executed.
3. **Untrusted input is validated.** Artifact contents are treated as tainted: the PR number is accepted only if it matches `^[0-9]+$` before being used in any later step, so it can't inject into an expression.

Because the write-capable token in `ci-comment.yml` only ever touches trusted code + inert data, the fork author gains no execution and therefore can't abuse the token. The one rule that keeps this safe — **never check out the PR head ref or execute downloaded/fork-provided content in this workflow** — is documented in a header comment in `ci-comment.yml` to prevent future regressions.

`workflow_run` is preferred over `pull_request_target` here: both yield a write token on fork PRs, but `pull_request_target`'s natural shape tempts you to check out and build the PR (untrusted code + write token = the exact vulnerability), whereas `workflow_run`'s natural shape is "download results, act on them" — data-in, no code execution.

## Notes / trade-offs
- `workflow_run` workflows do **not** appear as PR status checks — they run in the Actions tab against the default branch. So even if commenting fails, it can never red or block a PR.
- **This workflow only takes effect once merged to the default branch** (that's how `workflow_run` resolves its definition), so it can't be fully exercised from this PR itself.
- Audited the change with `zizmor` — `ci-comment.yml` is clean; no new findings introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
