### PR TITLE
Fix cloud home guide recommendations after landing page moved to /

### DIFF
--- a/src/bundled-interactives/first-dashboard-cloud/manifest.json
+++ b/src/bundled-interactives/first-dashboard-cloud/manifest.json
@@ -8,12 +8,12 @@
     "name": "Interactive Learning",
     "team": "Grafana Developer Advocacy"
   },
-  "startingLocation": "/a/grafana-setupguide-app/home",
+  "startingLocation": "/",
   "recommends": ["welcome-to-grafana-cloud"],
   "provides": ["first-dashboard-created-cloud"],
   "targeting": {
     "match": {
-      "and": [{ "urlPrefix": "/a/grafana-setupguide-app/home" }, { "targetPlatform": "cloud" }]
+      "and": [{ "urlPrefix": "/" }, { "targetPlatform": "cloud" }]
     }
   },
   "testEnvironment": {

--- a/src/bundled-interactives/first-dashboard/manifest.json
+++ b/src/bundled-interactives/first-dashboard/manifest.json
@@ -13,7 +13,7 @@
   "provides": ["first-dashboard-created"],
   "targeting": {
     "match": {
-      "urlPrefix": "/"
+      "and": [{ "urlPrefix": "/" }, { "targetPlatform": "oss" }]
     }
   },
   "testEnvironment": {

--- a/src/bundled-interactives/index.json
+++ b/src/bundled-interactives/index.json
@@ -13,7 +13,7 @@
       "title": "Welcome to Grafana Cloud",
       "summary": "Take a guided tour of Grafana Cloud's key areas. Perfect for getting started and understanding where everything is located.",
       "filename": "welcome-to-grafana-cloud/content.json",
-      "url": ["/a/grafana-setupguide-app/home"],
+      "url": ["/"],
       "targetPlatform": "cloud"
     },
     {
@@ -44,14 +44,16 @@
       "title": "Create your first dashboard",
       "summary": "Learn to create a dashboard in Grafana. Covering features such as Explore, dashboard creation, visualizations and more",
       "filename": "first-dashboard/content.json",
-      "url": ["/"]
+      "url": ["/"],
+      "targetPlatform": "oss"
     },
     {
       "id": "first-dashboard-cloud",
       "title": "Create your first dashboard in Grafana Cloud",
       "summary": "Learn to create a dashboard in Grafana Cloud. Covering features such as Explore, dashboard creation, visualizations and more",
       "filename": "first-dashboard-cloud/content.json",
-      "url": ["/a/grafana-setupguide-app/home"]
+      "url": ["/"],
+      "targetPlatform": "cloud"
     }
   ]
 }

--- a/src/bundled-interactives/repository.json
+++ b/src/bundled-interactives/repository.json
@@ -46,7 +46,14 @@
     "provides": ["first-dashboard-created"],
     "targeting": {
       "match": {
-        "urlPrefix": "/"
+        "and": [
+          {
+            "urlPrefix": "/"
+          },
+          {
+            "targetPlatform": "oss"
+          }
+        ]
       }
     },
     "testEnvironment": {
@@ -64,14 +71,14 @@
       "name": "Interactive Learning",
       "team": "Grafana Developer Advocacy"
     },
-    "startingLocation": "/a/grafana-setupguide-app/home",
+    "startingLocation": "/",
     "recommends": ["welcome-to-grafana-cloud"],
     "provides": ["first-dashboard-created-cloud"],
     "targeting": {
       "match": {
         "and": [
           {
-            "urlPrefix": "/a/grafana-setupguide-app/home"
+            "urlPrefix": "/"
           },
           {
             "targetPlatform": "cloud"
@@ -221,13 +228,13 @@
       "name": "Interactive Learning",
       "team": "Grafana Developer Advocacy"
     },
-    "startingLocation": "/a/grafana-setupguide-app/home",
+    "startingLocation": "/",
     "provides": ["grafana-tour-cloud"],
     "targeting": {
       "match": {
         "and": [
           {
-            "urlPrefix": "/a/grafana-setupguide-app/home"
+            "urlPrefix": "/"
           },
           {
             "targetPlatform": "cloud"

--- a/src/bundled-interactives/welcome-to-grafana-cloud/content.json
+++ b/src/bundled-interactives/welcome-to-grafana-cloud/content.json
@@ -19,7 +19,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/grafana-setupguide-app/home']",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/']",
           "requirements": ["navmenu-open"],
           "content": "First, let's visit the **Home** page - your starting point in Grafana.",
           "tooltip": "The **Home** page in Grafana Cloud is your central hub. It shows your cloud instance overview, recent activity, and quick access to getting started guides. Perfect *starting point* for your observability journey!"

--- a/src/bundled-interactives/welcome-to-grafana-cloud/manifest.json
+++ b/src/bundled-interactives/welcome-to-grafana-cloud/manifest.json
@@ -8,11 +8,11 @@
     "name": "Interactive Learning",
     "team": "Grafana Developer Advocacy"
   },
-  "startingLocation": "/a/grafana-setupguide-app/home",
+  "startingLocation": "/",
   "provides": ["grafana-tour-cloud"],
   "targeting": {
     "match": {
-      "and": [{ "urlPrefix": "/a/grafana-setupguide-app/home" }, { "targetPlatform": "cloud" }]
+      "and": [{ "urlPrefix": "/" }, { "targetPlatform": "cloud" }]
     }
   },
   "testEnvironment": {


### PR DESCRIPTION
## Summary
- Grafana Cloud's main screen is now `/` (e.g. https://pathfinder.grafana-dev.net/) — the setupguide app home is no longer the landing page. Cloud users were recommended the OSS **Create your first dashboard** guide (it matched `/` with no platform gate), while the cloud variants (keyed to `/a/grafana-setupguide-app/home`) never surfaced.
- Distinguishes the variants by platform type instead of the retired setupguide path:
  - `first-dashboard`: gated to `targetPlatform: oss` (index.json + manifest targeting)
  - `first-dashboard-cloud` and `welcome-to-grafana-cloud`: retargeted to `/` with a `targetPlatform: cloud` gate; `startingLocation` moved to `/` so the alignment prompt no longer sends users to the setupguide app
- Regenerated `repository.json` from the manifests (`npm run repository:build`).
- Updated the cloud tour's first step to highlight the Home nav item at `href='/'` (mirrors the OSS guide) instead of the setupguide nav entry.

Left untouched, flagged for follow-up:
- `static-links/navigation-cloud.json` still keys two cloud links to `/a/cloud-home-app` / setupguide getting-started. Retargeting them to `/` would surface them on every cloud page (static-link matching is prefix-based), so that needs a UX decision.
- `sidebar-auto-open.ts` still watches `/a/grafana-setupguide-app/onboarding-flow` — separate surface from the home page.

## Test plan
- [x] `npm run test:ci -- bundled-repository package-engine` — 106 tests pass (includes repository.json freshness check against manifests)
- [x] `npm run test:ci -- validation-integration context-v1-recommend package-content content-fetcher/bundled` — 91 tests pass
- [x] CLI `validate` — all 10 bundled packages valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)