### PR TITLE
fix(recommendations): bound the online package index fetch so OSS boot isn't blocked

### DIFF
--- a/pkg/plugin/package_recommendations.go
+++ b/pkg/plugin/package_recommendations.go
@@ -30,10 +30,10 @@ const (
 	packageRepositoryPartialCacheTTL = 15 * time.Minute
 
 	// Per-manifest fetch limits — keep manifests small and the fan-out bounded
-	// so a slow CDN can't stall the whole response or run us out of memory.
-	packageManifestFetchTimeout = 5 * time.Second
-	packageManifestMaxBytes     = 256 * 1024
-	packageManifestConcurrency  = 16
+	// so the enrichment can't run us out of memory. Latency is bounded by
+	// packageManifestEnrichTotalBudget, not per fetch.
+	packageManifestMaxBytes    = 256 * 1024
+	packageManifestConcurrency = 16
 )
 
 // packageManifestEnrichTotalBudget caps the whole manifest fan-out so the
@@ -229,9 +229,9 @@ func (a *App) getCachedPackageRecommendations(ctx context.Context) (*PackageReco
 
 	// Detach the upstream fetch from the request's cancellation: a canceled
 	// request (browser closed, panel collapsed mid-flight) must not poison
-	// the 6-hour cache with a "context canceled" error. The per-fetch
-	// timeouts inside fetchAndParsePackageRepository / enrichPackagesWithManifests
-	// still apply because they're added with their own context.WithTimeout.
+	// the 6-hour cache with a "context canceled" error. The index fetch
+	// timeout and the enrichment budget still apply because they're added
+	// with their own context.WithTimeout.
 	resp, partial, err := fetchAndParsePackageRepository(context.WithoutCancel(ctx), packageRepositoryURL)
 
 	packageCacheMu.Lock()
@@ -356,14 +356,11 @@ func enrichPackagesWithManifests(
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			fetchCtx, cancel := context.WithTimeout(budgetCtx, packageManifestFetchTimeout)
-			defer cancel()
-
 			// Pass the manifest cap directly so the body is bounded at read
 			// time. Without this, a misconfigured 4 MB manifest would be
 			// fully buffered before the post-read check rejected it,
 			// transiently allocating ~64 MB across 16 in-flight goroutines.
-			body, err := fetch(fetchCtx, url, packageManifestMaxBytes)
+			body, err := fetch(budgetCtx, url, packageManifestMaxBytes)
 			if err != nil {
 				return
 			}

--- a/pkg/plugin/package_recommendations.go
+++ b/pkg/plugin/package_recommendations.go
@@ -25,12 +25,23 @@ const (
 	packageRepositoryMaxBytes     = 5 * 1024 * 1024
 	packageRepositoryCacheTTL     = 6 * time.Hour
 
+	// Budget-expired (partially enriched) results are still served, but cached
+	// briefly so degraded responses self-heal instead of persisting for 6 h.
+	packageRepositoryPartialCacheTTL = 15 * time.Minute
+
 	// Per-manifest fetch limits — keep manifests small and the fan-out bounded
 	// so a slow CDN can't stall the whole response or run us out of memory.
 	packageManifestFetchTimeout = 5 * time.Second
 	packageManifestMaxBytes     = 256 * 1024
-	packageManifestConcurrency  = 8
+	packageManifestConcurrency  = 16
 )
+
+// packageManifestEnrichTotalBudget caps the whole manifest fan-out so the
+// first (cold-cache) request can never stall the recommendations UI behind
+// hundreds of sequential CDN round-trips. Entries that miss the budget ship
+// without a manifest — the frontend renders a stub and OnlineCdnPackageResolver
+// lazily fetches manifest.json on demand. var so tests can shrink it.
+var packageManifestEnrichTotalBudget = 3 * time.Second
 
 // allowedPackageRepositoryHosts mirrors the frontend
 // ALLOWED_INTERACTIVE_LEARNING_HOSTNAMES allowlist (exact match).
@@ -93,7 +104,7 @@ type rawRepositoryEntry struct {
 // `maxBytes` lets the caller bound the in-memory buffer per request — the
 // repository index gets 5 MB while individual manifests get 256 KB. Without
 // this, a manifest fetch would inherit the larger repository cap and could
-// transiently allocate up to (concurrency × repo cap) — ~40 MB at 8-way
+// transiently allocate up to (concurrency × repo cap) — ~80 MB at 16-way
 // parallelism — before the post-read cap rejected the body.
 type packageRepositoryFetcher func(ctx context.Context, rawURL string, maxBytes int64) ([]byte, error)
 
@@ -101,6 +112,9 @@ type packageCacheEntry struct {
 	resp      *PackageRecommendationsResponse
 	err       error
 	fetchedAt time.Time
+	// partial marks a response whose manifest enrichment hit the total budget;
+	// it expires on the short TTL so the degraded tail gets refetched soon.
+	partial bool
 }
 
 // packageRefreshFlight is a single-flight handle for an active refresh.
@@ -174,19 +188,26 @@ func (a *App) handlePackageRecommendations(w http.ResponseWriter, r *http.Reques
 }
 
 // getCachedPackageRecommendations returns the cached index, refreshing it at
-// most once per packageRepositoryCacheTTL window. Both successful and failed
-// fetches are cached; a sticky failure prevents repeat upstream hits.
+// most once per packageRepositoryCacheTTL window (packageRepositoryPartialCacheTTL
+// for budget-expired partial results). Both successful and failed fetches are
+// cached; a sticky failure prevents repeat upstream hits.
 //
 // The mutex is held only for cache lookup and inflight-slot management — the
 // upstream fetch runs unlocked. Concurrent callers that arrive during a
 // refresh wait on the inflight channel instead of serializing on the mutex
-// (which would block them for the full ~50 s manifest fan-out window).
+// (which would block them for the index fetch plus the enrichment budget).
 func (a *App) getCachedPackageRecommendations(ctx context.Context) (*PackageRecommendationsResponse, error) {
 	packageCacheMu.Lock()
-	if packageCache != nil && timeNow().Sub(packageCache.fetchedAt) < packageRepositoryCacheTTL {
-		resp, err := packageCache.resp, packageCache.err
-		packageCacheMu.Unlock()
-		return resp, err
+	if packageCache != nil {
+		ttl := packageRepositoryCacheTTL
+		if packageCache.partial {
+			ttl = packageRepositoryPartialCacheTTL
+		}
+		if timeNow().Sub(packageCache.fetchedAt) < ttl {
+			resp, err := packageCache.resp, packageCache.err
+			packageCacheMu.Unlock()
+			return resp, err
+		}
 	}
 
 	if existing := packageActiveFlight; existing != nil {
@@ -211,13 +232,14 @@ func (a *App) getCachedPackageRecommendations(ctx context.Context) (*PackageReco
 	// the 6-hour cache with a "context canceled" error. The per-fetch
 	// timeouts inside fetchAndParsePackageRepository / enrichPackagesWithManifests
 	// still apply because they're added with their own context.WithTimeout.
-	resp, err := fetchAndParsePackageRepository(context.WithoutCancel(ctx), packageRepositoryURL)
+	resp, partial, err := fetchAndParsePackageRepository(context.WithoutCancel(ctx), packageRepositoryURL)
 
 	packageCacheMu.Lock()
 	packageCache = &packageCacheEntry{
 		resp:      resp,
 		err:       err,
 		fetchedAt: timeNow(),
+		partial:   partial,
 	}
 	flight.resp = resp
 	flight.err = err
@@ -229,10 +251,11 @@ func (a *App) getCachedPackageRecommendations(ctx context.Context) (*PackageReco
 }
 
 // fetchAndParsePackageRepository performs the network fetch and trims the
-// response to the slim shape the frontend consumes.
-func fetchAndParsePackageRepository(ctx context.Context, rawURL string) (*PackageRecommendationsResponse, error) {
+// response to the slim shape the frontend consumes. The bool reports whether
+// manifest enrichment was cut short by its total budget (partial result).
+func fetchAndParsePackageRepository(ctx context.Context, rawURL string) (*PackageRecommendationsResponse, bool, error) {
 	if !isAllowedInteractiveLearningHost(rawURL) {
-		return nil, fmt.Errorf("package repository host not allowed")
+		return nil, false, fmt.Errorf("package repository host not allowed")
 	}
 
 	fetch := packageRepositoryFetcherOverride
@@ -242,12 +265,12 @@ func fetchAndParsePackageRepository(ctx context.Context, rawURL string) (*Packag
 
 	body, err := fetch(ctx, rawURL, packageRepositoryMaxBytes)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var index map[string]rawRepositoryEntry
 	if err := json.Unmarshal(body, &index); err != nil {
-		return nil, fmt.Errorf("parse repository.json: %w", err)
+		return nil, false, fmt.Errorf("parse repository.json: %w", err)
 	}
 
 	baseURL := baseURLFromRepositoryURL(rawURL)
@@ -272,34 +295,43 @@ func fetchAndParsePackageRepository(ctx context.Context, rawURL string) (*Packag
 		})
 	}
 
-	enrichPackagesWithManifests(ctx, baseURL, packages, fetch)
+	partial := enrichPackagesWithManifests(ctx, baseURL, packages, fetch)
 
 	return &PackageRecommendationsResponse{
 		BaseURL:  baseURL,
 		Packages: packages,
-	}, nil
+	}, partial, nil
 }
 
-// enrichPackagesWithManifests fetches every package's manifest.json in parallel
-// (bounded concurrency) and inlines it into each PackageEntry. Per-package
-// failures are silently skipped — the entry stays in the response without a
-// manifest, so the frontend still gets discovery + a working "Start" button
-// even when one package's manifest is unavailable.
+// enrichPackagesWithManifests fetches targeted packages' manifest.json in
+// parallel (bounded concurrency, bounded total time) and inlines it into each
+// PackageEntry. Untargeted entries are skipped: they can only surface through
+// by-ID resolution, and OnlineCdnPackageResolver.loadFromCdn fetches
+// manifest.json itself when none is inlined. Per-package failures and
+// budget misses are silently skipped — the entry stays in the response
+// without a manifest, so the frontend still gets discovery + a working
+// "Start" button. Returns true when the total budget expired (partial result).
 func enrichPackagesWithManifests(
 	ctx context.Context,
 	baseURL string,
 	packages []PackageEntry,
 	fetch packageRepositoryFetcher,
-) {
+) bool {
 	if baseURL == "" || len(packages) == 0 {
-		return
+		return false
 	}
+
+	budgetCtx, cancel := context.WithTimeout(ctx, packageManifestEnrichTotalBudget)
+	defer cancel()
 
 	sem := make(chan struct{}, packageManifestConcurrency)
 	var wg sync.WaitGroup
 
 	for i := range packages {
 		entry := &packages[i]
+		if entry.Targeting == nil {
+			continue
+		}
 		manifestURL := buildPackageFileURL(baseURL, entry.Path, "manifest.json")
 		if manifestURL == "" {
 			continue
@@ -309,19 +341,28 @@ func enrichPackagesWithManifests(
 			continue
 		}
 
+		// Acquire a slot or give up when the budget expires — blocking on the
+		// semaphore alone would keep queueing fetches past the deadline.
+		select {
+		case sem <- struct{}{}:
+		case <-budgetCtx.Done():
+		}
+		if budgetCtx.Err() != nil {
+			break
+		}
+
 		wg.Add(1)
-		sem <- struct{}{}
 		go func(target *PackageEntry, url string) {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			fetchCtx, cancel := context.WithTimeout(ctx, packageManifestFetchTimeout)
+			fetchCtx, cancel := context.WithTimeout(budgetCtx, packageManifestFetchTimeout)
 			defer cancel()
 
 			// Pass the manifest cap directly so the body is bounded at read
 			// time. Without this, a misconfigured 4 MB manifest would be
 			// fully buffered before the post-read check rejected it,
-			// transiently allocating ~32 MB across 8 in-flight goroutines.
+			// transiently allocating ~64 MB across 16 in-flight goroutines.
 			body, err := fetch(fetchCtx, url, packageManifestMaxBytes)
 			if err != nil {
 				return
@@ -334,6 +375,8 @@ func enrichPackagesWithManifests(
 		}(entry, manifestURL)
 	}
 	wg.Wait()
+
+	return budgetCtx.Err() != nil
 }
 
 // buildPackageFileURL joins the CDN base, the entry path, and a file name

--- a/pkg/plugin/package_recommendations_test.go
+++ b/pkg/plugin/package_recommendations_test.go
@@ -64,7 +64,8 @@ func validPayload(t *testing.T) []byte {
 		},
 		"untargeted": {
 			"path": "untargeted/v1.0.0",
-			// no targeting -> must be dropped
+			// no targeting -> kept in the response (for by-ID resolution) but
+			// skipped by manifest enrichment
 		},
 		"no-path": {
 			"targeting": map[string]any{
@@ -131,9 +132,10 @@ func TestHandlePackageRecommendations_Success(t *testing.T) {
 	if promMatch["urlPrefix"] != "/connections" {
 		t.Errorf("urlPrefix not preserved on prom-101: %+v", promMatch)
 	}
-	// 1 repo fetch + 2 manifest fetches (one per kept entry).
-	if got := atomic.LoadInt32(calls); got != 3 {
-		t.Errorf("calls = %d, want 3 (repo + 2 manifests)", got)
+	// 1 repo fetch + 1 manifest fetch (targeted entry only; untargeted
+	// entries resolve their manifests lazily on the frontend).
+	if got := atomic.LoadInt32(calls); got != 2 {
+		t.Errorf("calls = %d, want 2 (repo + 1 manifest)", got)
 	}
 }
 
@@ -191,10 +193,10 @@ func TestHandlePackageRecommendations_DetachesFetchFromRequestCancellation(t *te
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
 	}
-	// 1 repo + 2 manifest fetches (one per kept entry in validPayload), all
+	// 1 repo + 1 manifest fetch (targeted entry in validPayload), all
 	// succeeding because the fetcher's ctx.Err() check passes.
-	if got := atomic.LoadInt32(calls); got != 3 {
-		t.Errorf("upstream calls = %d, want 3", got)
+	if got := atomic.LoadInt32(calls); got != 2 {
+		t.Errorf("upstream calls = %d, want 2", got)
 	}
 }
 
@@ -289,7 +291,7 @@ func TestIsAllowedInteractiveLearningHost(t *testing.T) {
 }
 
 func TestFetchAndParsePackageRepository_RejectsDisallowedHost(t *testing.T) {
-	_, err := fetchAndParsePackageRepository(context.Background(), "https://evil.example.com/repository.json")
+	_, _, err := fetchAndParsePackageRepository(context.Background(), "https://evil.example.com/repository.json")
 	if err == nil || !strings.Contains(err.Error(), "host not allowed") {
 		t.Fatalf("expected host-not-allowed error, got %v", err)
 	}
@@ -303,7 +305,8 @@ func TestEnrichPackagesWithManifests_InlinesParsedJSON(t *testing.T) {
 		"prom-101": {"path": "prom-101/v1", "type": "guide", "title": "Prom",
 			"targeting": {"match": {"urlPrefix": "/connections"}}},
 		"prom-lj": {"path": "prom-lj/v1", "type": "path", "title": "Prom journey",
-			"targeting": {"match": {"urlPrefix": "/connections"}}}
+			"targeting": {"match": {"urlPrefix": "/connections"}}},
+		"milestone-only": {"path": "milestone-only/v1", "type": "guide"}
 	}`)
 	manifestBody := []byte(`{
 		"id": "prom-lj",
@@ -357,18 +360,21 @@ func TestEnrichPackagesWithManifests_InlinesParsedJSON(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 
-	if len(resp.Packages) != 2 {
-		t.Fatalf("expected 2 packages, got %d", len(resp.Packages))
+	if len(resp.Packages) != 3 {
+		t.Fatalf("expected 3 packages, got %d", len(resp.Packages))
 	}
 
 	var promLJ *PackageEntry
 	var prom101 *PackageEntry
+	var milestoneOnly *PackageEntry
 	for i := range resp.Packages {
 		switch resp.Packages[i].ID {
 		case "prom-lj":
 			promLJ = &resp.Packages[i]
 		case "prom-101":
 			prom101 = &resp.Packages[i]
+		case "milestone-only":
+			milestoneOnly = &resp.Packages[i]
 		}
 	}
 
@@ -390,6 +396,22 @@ func TestEnrichPackagesWithManifests_InlinesParsedJSON(t *testing.T) {
 		t.Errorf("prom-101 manifest should be nil after fetch failure, got %+v", prom101.Manifest)
 	}
 
+	// Untargeted entries survive in the response but are never enriched —
+	// their manifests resolve lazily via OnlineCdnPackageResolver.
+	if milestoneOnly == nil {
+		t.Fatal("milestone-only missing from response")
+	}
+	if milestoneOnly.Manifest != nil {
+		t.Errorf("milestone-only manifest should be nil (untargeted, not enriched), got %+v", milestoneOnly.Manifest)
+	}
+	mu.Lock()
+	for url := range calls {
+		if strings.Contains(url, "milestone-only") {
+			t.Errorf("untargeted entry's manifest was fetched: %s", url)
+		}
+	}
+	mu.Unlock()
+
 	// Bug 3 regression: every manifest fetch must request the tighter
 	// 256 KB cap, not the 5 MB repository cap.
 	mu.Lock()
@@ -402,6 +424,132 @@ func TestEnrichPackagesWithManifests_InlinesParsedJSON(t *testing.T) {
 			t.Errorf("manifest fetch %q maxBytes = %d, want %d (manifest cap, not repo cap)",
 				url, got, packageManifestMaxBytes)
 		}
+	}
+}
+
+func withEnrichBudgetOverride(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := packageManifestEnrichTotalBudget
+	packageManifestEnrichTotalBudget = d
+	t.Cleanup(func() { packageManifestEnrichTotalBudget = prev })
+}
+
+// slowManifestRepo builds a repo index with n targeted entries and a fetcher
+// whose manifest branch blocks until its context expires — simulating a CDN
+// slow enough to trip the total enrichment budget.
+func slowManifestRepo(t *testing.T, n int) packageRepositoryFetcher {
+	t.Helper()
+	raw := map[string]map[string]any{}
+	for i := 0; i < n; i++ {
+		raw[fmt.Sprintf("pkg-%d", i)] = map[string]any{
+			"path":      fmt.Sprintf("pkg-%d/v1", i),
+			"type":      "guide",
+			"targeting": map[string]any{"match": map[string]any{"urlPrefix": "/connections"}},
+		}
+	}
+	repoBody, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return func(ctx context.Context, rawURL string, maxBytes int64) ([]byte, error) {
+		if strings.HasSuffix(rawURL, "repository.json") {
+			return repoBody, nil
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+}
+
+func TestEnrichPackagesWithManifests_RespectsTotalBudget(t *testing.T) {
+	resetPackageRecommendationsCache()
+	withFrozenTime(t, time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC))
+	withEnrichBudgetOverride(t, 100*time.Millisecond)
+	withFetcherOverride(t, slowManifestRepo(t, 64))
+
+	app := newTestApp(t)
+	start := time.Now()
+	rr := httptest.NewRecorder()
+	app.handlePackageRecommendations(rr, httptest.NewRequest(http.MethodGet, "/package-recommendations", nil))
+	elapsed := time.Since(start)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	// Generous ceiling: the response must arrive in ~budget time, not
+	// batches × per-fetch-timeout.
+	if elapsed > 2*time.Second {
+		t.Errorf("handler took %v; budget should bound it near 100ms", elapsed)
+	}
+
+	var resp PackageRecommendationsResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Packages) != 64 {
+		t.Fatalf("expected all 64 packages in response, got %d", len(resp.Packages))
+	}
+	for _, p := range resp.Packages {
+		if p.Manifest != nil {
+			t.Errorf("package %s has a manifest despite budget expiry", p.ID)
+		}
+	}
+
+	packageCacheMu.Lock()
+	partial := packageCache != nil && packageCache.partial
+	packageCacheMu.Unlock()
+	if !partial {
+		t.Error("budget-expired response was not cached as partial")
+	}
+}
+
+func TestHandlePackageRecommendations_PartialResultUsesShortTTL(t *testing.T) {
+	resetPackageRecommendationsCache()
+	advance := withFrozenTime(t, time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC))
+	withEnrichBudgetOverride(t, 50*time.Millisecond)
+
+	var repoFetches int32
+	slow := slowManifestRepo(t, 4)
+	withFetcherOverride(t, func(ctx context.Context, rawURL string, maxBytes int64) ([]byte, error) {
+		if strings.HasSuffix(rawURL, "repository.json") {
+			atomic.AddInt32(&repoFetches, 1)
+		}
+		return slow(ctx, rawURL, maxBytes)
+	})
+
+	app := newTestApp(t)
+	app.handlePackageRecommendations(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/package-recommendations", nil))
+	if got := atomic.LoadInt32(&repoFetches); got != 1 {
+		t.Fatalf("repo fetches = %d, want 1", got)
+	}
+
+	// Within the short TTL the partial result is served from cache.
+	advance(packageRepositoryPartialCacheTTL - time.Minute)
+	app.handlePackageRecommendations(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/package-recommendations", nil))
+	if got := atomic.LoadInt32(&repoFetches); got != 1 {
+		t.Errorf("repo fetches = %d before partial TTL expiry, want 1", got)
+	}
+
+	// Past the short TTL the partial result is refetched — this time let the
+	// manifests succeed instantly so the refresh completes within budget.
+	withFetcherOverride(t, func(ctx context.Context, rawURL string, maxBytes int64) ([]byte, error) {
+		if strings.HasSuffix(rawURL, "repository.json") {
+			atomic.AddInt32(&repoFetches, 1)
+			return slow(ctx, rawURL, maxBytes)
+		}
+		return []byte(`{"id": "x", "type": "guide"}`), nil
+	})
+	advance(2 * time.Minute)
+	app.handlePackageRecommendations(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/package-recommendations", nil))
+	if got := atomic.LoadInt32(&repoFetches); got != 2 {
+		t.Errorf("repo fetches = %d after partial TTL expiry, want 2", got)
+	}
+
+	// The refreshed result enriched fully, so it's complete and now honours
+	// the long TTL: another short-TTL-sized advance must NOT refetch.
+	advance(packageRepositoryPartialCacheTTL + time.Minute)
+	app.handlePackageRecommendations(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/package-recommendations", nil))
+	if got := atomic.LoadInt32(&repoFetches); got != 2 {
+		t.Errorf("repo fetches = %d; complete result must use the 6h TTL, want 2", got)
 	}
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,6 +83,7 @@ export const DEFAULT_PEERJS_SECURE = false;
 // Network timeout defaults
 export const DEFAULT_CONTENT_FETCH_TIMEOUT = 10000; // 10 seconds for document retrieval
 export const DEFAULT_RECOMMENDER_TIMEOUT = 5000; // 5 seconds for recommender API
+export const ONLINE_PACKAGES_BOOT_BUDGET_MS = 3000; // max wait before rendering recommendations without the online package index
 
 // Security: Allowed interactive learning hostnames (exact match only, no wildcards)
 // These are the only hostnames permitted for fetching interactive guides

--- a/src/context-engine/context.service.online-packages.test.ts
+++ b/src/context-engine/context.service.online-packages.test.ts
@@ -57,6 +57,7 @@ jest.mock('../lib/package-recommendations-client', () => {
 
 import { ContextService } from './context.service';
 import { fetchOnlinePackageRecommendations } from '../lib/package-recommendations-client';
+import { ONLINE_PACKAGES_BOOT_BUDGET_MS } from '../constants';
 
 const baseContext = {
   currentPath: '/connections',
@@ -382,5 +383,61 @@ describe('ContextService: online package recommendations (recommender-disabled b
 
     expect(fetchOnlinePackageRecommendations).toHaveBeenCalledTimes(1);
     expect(Array.isArray(result.recommendations)).toBe(true);
+  });
+});
+
+describe('ContextService: online package boot budget', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns bundled/static recommendations without error when the online fetch exceeds the boot budget', async () => {
+    (fetchOnlinePackageRecommendations as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+    const pending = ContextService.fetchRecommendations(baseContext, {
+      acceptedTermsAndConditions: false,
+    });
+    await jest.advanceTimersByTimeAsync(ONLINE_PACKAGES_BOOT_BUDGET_MS + 1);
+    const result = await pending;
+
+    expect(result.error).toBeNull();
+    expect(result.errorType).toBeNull();
+    expect(Array.isArray(result.recommendations)).toBe(true);
+    // The race abandons the await; it must not retry or cancel the request.
+    expect(fetchOnlinePackageRecommendations).toHaveBeenCalledTimes(1);
+  });
+
+  it('picks up late-arriving online packages on the next fetchRecommendations cycle', async () => {
+    const online = {
+      baseUrl: 'https://interactive-learning.grafana.net/packages/',
+      packages: [
+        {
+          id: 'prom-101',
+          path: 'prom-101/v1.0.0',
+          title: 'Prometheus 101',
+          targeting: { match: { urlPrefix: '/connections' } },
+        },
+      ],
+    };
+    (fetchOnlinePackageRecommendations as jest.Mock)
+      .mockReturnValueOnce(new Promise(() => {}))
+      // Second cycle: the client serves its now-populated module cache.
+      .mockResolvedValueOnce(online);
+
+    const first = ContextService.fetchRecommendations(baseContext, {
+      acceptedTermsAndConditions: false,
+    });
+    await jest.advanceTimersByTimeAsync(ONLINE_PACKAGES_BOOT_BUDGET_MS + 1);
+    const firstResult = await first;
+    expect(firstResult.recommendations.map((r) => r.title)).not.toContain('Prometheus 101');
+
+    const second = await ContextService.fetchRecommendations(baseContext, {
+      acceptedTermsAndConditions: false,
+    });
+    expect(second.recommendations.map((r) => r.title)).toContain('Prometheus 101');
   });
 });

--- a/src/context-engine/context.service.ts
+++ b/src/context-engine/context.service.ts
@@ -10,6 +10,7 @@ import {
   isRecommenderEnabled,
   DocsPluginConfig,
   DEFAULT_RECOMMENDER_TIMEOUT,
+  ONLINE_PACKAGES_BOOT_BUDGET_MS,
   ALLOWED_RECOMMENDER_DOMAINS,
 } from '../constants';
 // eslint-disable-next-line no-restricted-imports -- [ratchet] ALLOWED_LATERAL_VIOLATIONS: context-engine -> docs-retrieval
@@ -22,6 +23,7 @@ import {
 } from '../docs-retrieval';
 import { interactiveCompletionStorage } from '../lib/user-storage';
 import { hashUserData } from '../lib/hash.util';
+import { withTimeout } from '../lib/async-utils';
 import { isDevModeEnabledGlobal } from '../utils/dev-mode';
 import { sanitizeTextForDisplay, parseUrlSafely, sanitizeForLogging } from '../security';
 import {
@@ -54,6 +56,10 @@ const SUPPORTED_MATCH_PREDICATE_KEYS: ReadonlySet<string> = new Set([
   'and',
   'or',
 ]);
+
+// Sentinel used to tell an expected boot-budget timeout apart from real
+// failures in getOnlinePackageRecommendations' catch.
+export const ONLINE_PACKAGES_TIMEOUT_MESSAGE = 'Online package recommendations timed out; continuing without them';
 
 export class ContextService {
   // Error handling state
@@ -168,8 +174,11 @@ export class ContextService {
       if (!isRecommenderEnabled(pluginConfig)) {
         // When the recommender is disabled, OSS users with internet access can
         // still see guides authored on the public CDN. The fetch is gated on
-        // navigator.onLine and goes sticky-disabled on the first failure, so
-        // air-gapped installs make at most one attempt per session.
+        // navigator.onLine, goes sticky-disabled on the first failure (so
+        // air-gapped installs make at most one attempt per session), and the
+        // wait is capped so a cold backend cache never holds bundled
+        // recommendations hostage — a timed-out fetch keeps running and the
+        // next recommendations cycle picks its result up from the cache.
         const onlinePackageRecommendations = await this.getOnlinePackageRecommendations(contextData);
         const merged = [...bundledRecommendations, ...onlinePackageRecommendations];
         const fallbackResult = await this.getFallbackRecommendations(contextData, merged);
@@ -1648,7 +1657,15 @@ export class ContextService {
    */
   private static async getOnlinePackageRecommendations(contextData: ContextData): Promise<Recommendation[]> {
     try {
-      const { baseUrl, packages } = await fetchOnlinePackageRecommendations();
+      // The race abandons the await, not the request: the client's shared
+      // in-flight promise keeps running and populates its module cache, and
+      // its sticky `unavailable` flag is untouched by a timeout — so the next
+      // recommendations cycle returns the packages instantly.
+      const { baseUrl, packages } = await withTimeout(
+        fetchOnlinePackageRecommendations(),
+        ONLINE_PACKAGES_BOOT_BUDGET_MS,
+        ONLINE_PACKAGES_TIMEOUT_MESSAGE
+      );
       if (!packages.length) {
         return [];
       }
@@ -1685,6 +1702,11 @@ export class ContextService {
         };
       });
     } catch (error) {
+      if (error instanceof Error && error.message === ONLINE_PACKAGES_TIMEOUT_MESSAGE) {
+        // Expected on a cold backend cache or slow CDN — not a failure.
+        console.info(ONLINE_PACKAGES_TIMEOUT_MESSAGE);
+        return [];
+      }
       // The client itself never throws, but guard against future regressions
       // — a failure here must not break the bundled flow.
       console.warn('Failed to load online package recommendations:', error);

--- a/src/lib/package-recommendations-client.test.ts
+++ b/src/lib/package-recommendations-client.test.ts
@@ -148,6 +148,29 @@ describe('fetchOnlinePackageRecommendations', () => {
     expect(result.packages[0]?.id).toBe('prom-101');
   });
 
+  it('populates the cache when the caller stops awaiting a slow response', async () => {
+    let resolveFetch!: (value: typeof samplePayload) => void;
+    mockGet.mockImplementation(
+      () =>
+        new Promise<typeof samplePayload>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    // Caller abandons the await (boot-budget timeout race in ContextService).
+    void fetchOnlinePackageRecommendations();
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    resolveFetch(samplePayload);
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Next call is served from the module cache — no new backend hit and no
+    // sticky-unavailable misfire from the abandoned await.
+    const result = await fetchOnlinePackageRecommendations();
+    expect(result.packages[0]?.id).toBe('prom-101');
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
   it('does not flip unavailable when offline (recovery is still possible)', async () => {
     setOnline(false);
     await fetchOnlinePackageRecommendations();

--- a/src/lib/package-recommendations-client.ts
+++ b/src/lib/package-recommendations-client.ts
@@ -125,7 +125,9 @@ async function performFetch(): Promise<PackageRecommendationsResponse | null> {
  *  - the backend returned a malformed response
  *
  * Never throws. Concurrent callers share a single in-flight promise so the
- * backend is hit at most once per cache window.
+ * backend is hit at most once per cache window. Callers may stop awaiting
+ * (e.g. a boot-budget timeout race); the in-flight fetch keeps running and
+ * still populates the cache for later calls.
  */
 export async function fetchOnlinePackageRecommendations(): Promise<{
   baseUrl: string;

--- a/src/package-engine/online-cdn-resolver.test.ts
+++ b/src/package-engine/online-cdn-resolver.test.ts
@@ -76,4 +76,35 @@ describe('OnlineCdnPackageResolver', () => {
       expect(result.contentUrl).not.toContain('//content.json');
     }
   });
+
+  it('fetches manifest.json from the CDN on metadata-only resolve when no manifest is inlined', async () => {
+    // The backend only inlines manifests for targeted entries; untargeted
+    // (milestone/recommends-only) entries rely on this lazy fallback.
+    (fetchOnlinePackageRecommendations as jest.Mock).mockResolvedValue({
+      baseUrl,
+      packages: [{ id: 'milestone-only', path: 'milestone-only/', title: 'Milestone only', type: 'guide' }],
+    });
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 'milestone-only', type: 'guide', description: 'Lazy manifest' }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const resolver = new OnlineCdnPackageResolver();
+      const result = await resolver.resolve('milestone-only', { loadContent: 'metadata-only' });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.manifest).toBeDefined();
+        expect((result.manifest as unknown as Record<string, unknown>).id).toBe('milestone-only');
+      }
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://interactive-learning.grafana.net/packages/milestone-only/manifest.json'
+      );
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

OSS users who haven't accepted T&C (recommender disabled — the OSS default) stared at the recommendations skeleton for 12–15s on first panel open (minutes on slow networks). The disabled branch of `ContextService.fetchRecommendations` awaits the backend `/package-recommendations` resource, which on a cold cache (every plugin restart) fetched `repository.json` and then synchronously downloaded **all 389** packages' `manifest.json` (8-way, 5s timeout each) before responding — the code's own comment admitted a "~50s manifest fan-out window". Meanwhile even locally-bundled recommendations were held back, and the frontend had no timeout on the call.

Three layered bounds fix it:

1. **Backend — enrich only targeted entries** (389 → 89 manifest fetches). The 300 untargeted entries exist solely for lazy by-ID resolution, and `OnlineCdnPackageResolver.loadFromCdn` already falls back to fetching `manifest.json` itself when none is inlined (now pinned by a test).
2. **Backend — 3s total enrichment budget.** Entries that miss the deadline ship manifest-less (the frontend already renders a stub); budget-expired responses are cached for 15min instead of 6h so the degraded tail self-heals. Durable against CDN growth and slow RTT.
3. **Frontend — 3s boot budget** racing `fetchOnlinePackageRecommendations()`. On timeout, bundled/static recommendations render immediately; the race abandons the await, not the request — the client's shared in-flight promise keeps populating its module cache and the sticky `unavailable` flag is untouched, so the next recommendations cycle (any navigation) picks the packages up instantly.

Also bumps manifest fan-out concurrency 8 → 16 (a one-constant change, independently revertable).

**Measured against the live CDN: cold-cache fetch 12–15s → 1.35s**, all 89 targeted entries fully enriched within budget (`partial=false`).

## What to look at

- `pkg/plugin/package_recommendations.go` — the budget context threading in `enrichPackagesWithManifests` (per-fetch contexts now derive from `budgetCtx`; the select stops queueing on expiry) and the `partial` flag → short-TTL path in `getCachedPackageRecommendations`.
- `src/context-engine/context.service.ts` — `getOnlinePackageRecommendations` timeout race semantics; the sentinel message distinguishes expected timeouts (info) from real failures (warn).
- The enrichment budget still derives from the `context.WithoutCancel` context, so a cancelled request can't shrink the budget for single-flight waiters.

## Why

Air-gapped installs improve too: a TCP-level hang now costs ≤3s of skeleton instead of the full backend timeout chain, and the one-attempt-per-session contract is unchanged.

## How to verify

1. Build backend + `npm run server`, leave T&C unaccepted, restart the Grafana container (clears the in-process cache), open the panel → recommendations paint in ~1.5–2s with CDN cards and milestone counts intact (previously ~12–15s of skeleton).
2. Slow-CDN sim (delay is backend-side, browser throttling won't work): `docker compose exec -u root grafana sh -c "apk add iproute2 && tc qdisc add dev eth0 root netem delay 1000ms"` → bundled/static recommendations paint at ≤ ~3s; navigate to another page → CDN cards appear (progressive pickup). Clean up with `tc qdisc del dev eth0 root netem`.
3. Lazy fallback: expand a path-type CDN guide card → milestones resolve via per-ID `manifest.json` fetches in the Network tab.
4. `go test ./pkg/plugin/...` and `npm run check` both pass (new tests: total-budget bound, partial short-TTL, untargeted-never-enriched, frontend timeout race, cache population after abandoned await, resolver manifest fallback).

## Breaking changes

None. Response shape is unchanged; untargeted entries simply arrive without inlined manifests, which the existing stub/fallback paths already handle.

## Reversibility

Fully reversible. Each bound is independent: the concurrency bump is one constant, the frontend budget is one `withTimeout` wrapper, and the backend budget/targeted-only enrichment are contained in `enrichPackagesWithManifests` + the `partial` cache flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)