### PR TITLE
fix(docs-panel): keep "my learning" navigation in the sidebar panel

### DIFF
--- a/src/components/docs-panel/components/DocsPanelContentArea.test.tsx
+++ b/src/components/docs-panel/components/DocsPanelContentArea.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tests for DocsPanelContentArea.
+ *
+ * Focused on the "Return to my learning" footer button, which must switch the
+ * panel back to the recommendations tab in place (issue #1051) rather than
+ * navigating away from the Grafana UI.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DocsPanelContentArea, type DocsPanelContentAreaProps } from './DocsPanelContentArea';
+
+jest.mock('@grafana/i18n', () => ({
+  t: (_key: string, fallback: string) => fallback,
+}));
+
+jest.mock('@grafana/data', () => ({
+  ...jest.requireActual('@grafana/data'),
+  usePluginContext: () => ({ meta: { jsonData: {} } }),
+}));
+
+jest.mock('../../../lib/analytics', () => ({
+  reportAppInteraction: jest.fn(),
+  getContentTypeForAnalytics: jest.fn(() => 'docs'),
+  UserInteraction: {
+    DocsPanelInteraction: 'docs_panel_interaction',
+    OpenExtraResource: 'open_extra_resource',
+  },
+}));
+
+jest.mock('../../../docs-retrieval', () => ({
+  getMilestoneSlug: jest.fn(),
+  markMilestoneDone: jest.fn(),
+  setJourneyCompletionPercentage: jest.fn(),
+}));
+
+// Heavy leaf children are irrelevant to the footer button — stub them out so
+// the branch renders without their dependency trees.
+jest.mock('../../content-renderer/content-renderer', () => ({ ContentRenderer: () => null }));
+jest.mock('./LearningJourneyMilestoneToolbar', () => ({ LearningJourneyMilestoneToolbar: () => null }));
+jest.mock('./PanelModeActionButtons', () => ({ PanelModeActionButtons: () => null }));
+
+const { reportAppInteraction } = jest.requireMock('../../../lib/analytics');
+
+function makeProps(overrides: Partial<DocsPanelContentAreaProps> = {}): DocsPanelContentAreaProps {
+  const activeTab: any = {
+    id: 'tab-1',
+    title: 'My guide',
+    type: 'learning-journey',
+    baseUrl: 'https://example.com/guide',
+    currentUrl: 'https://example.com/guide',
+    content: { url: 'https://example.com/guide', type: 'docs', metadata: {}, content: '' },
+    isLoading: false,
+    error: null,
+  };
+
+  // Proxy returns each requested style key as its own class name — every
+  // `styles.foo` access yields a truthy string without hand-maintaining a map.
+  const styles = new Proxy({}, { get: (_target, prop) => String(prop) }) as any;
+
+  return {
+    styles,
+    journeyStyles: 'journeyStyles',
+    docsStyles: 'docsStyles',
+    interactiveStyles: 'interactiveStyles',
+    prismStyles: 'prismStyles',
+    model: {
+      setActiveTab: jest.fn(),
+      openEditorTab: jest.fn(),
+      confirmAlignment: jest.fn(),
+      dismissAlignment: jest.fn(),
+    } as any,
+    contextPanel: { Component: () => null } as any,
+    isFullScreenActive: false,
+    isRecommendationsTab: false,
+    isEditorUser: false,
+    isWysiwygPreview: false,
+    activeTabId: 'tab-1',
+    activeTab,
+    stableContent: activeTab.content,
+    hasInteractiveProgress: false,
+    progressKey: null,
+    alignmentPendingValue: { isPending: false, startingLocation: null },
+    contentRef: React.createRef<HTMLDivElement>(),
+    handleResetGuide: jest.fn(),
+    reloadActiveTab: jest.fn(),
+    restoreScrollPosition: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('DocsPanelContentArea', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Return to my learning footer button', () => {
+    it('switches to the recommendations tab in place instead of navigating away', () => {
+      const props = makeProps();
+      render(<DocsPanelContentArea {...props} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Return to my learning' }));
+
+      expect(props.model.setActiveTab).toHaveBeenCalledWith('recommendations');
+    });
+
+    it('reports the return-to-recommendations interaction', () => {
+      render(<DocsPanelContentArea {...makeProps()} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Return to my learning' }));
+
+      expect(reportAppInteraction).toHaveBeenCalledWith('docs_panel_interaction', {
+        action: 'navigate_to_recommendations',
+        source: 'content_footer',
+      });
+    });
+  });
+});

--- a/src/components/docs-panel/components/DocsPanelContentArea.tsx
+++ b/src/components/docs-panel/components/DocsPanelContentArea.tsx
@@ -25,7 +25,7 @@ import React, { Suspense, lazy } from 'react';
 import { Button, Icon, IconButton } from '@grafana/ui';
 import { t } from '@grafana/i18n';
 import { usePluginContext } from '@grafana/data';
-import { PLUGIN_BASE_URL, getConfigWithDefaults } from '../../../constants';
+import { getConfigWithDefaults } from '../../../constants';
 import { testIds } from '../../../constants/testIds';
 import type { LearningJourneyTab, PackageOpenInfo, ContextPanelState } from '../../../types/content-panel.types';
 import type { getStyles as getDocsPanelStyles } from '../../../styles/docs-panel.styles';
@@ -437,7 +437,11 @@ export function DocsPanelContentArea(props: DocsPanelContentAreaProps): React.Re
                     icon="book-open"
                     size="md"
                     onClick={() => {
-                      window.location.assign(PLUGIN_BASE_URL);
+                      reportAppInteraction(UserInteraction.DocsPanelInteraction, {
+                        action: 'navigate_to_recommendations',
+                        source: 'content_footer',
+                      });
+                      model.setActiveTab('recommendations');
                     }}
                   >
                     {t('docsPanel.returnToMyLearning', 'Return to my learning')}

--- a/src/components/docs-panel/components/DocsPanelTabBar.test.tsx
+++ b/src/components/docs-panel/components/DocsPanelTabBar.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tests for DocsPanelTabBar.
+ *
+ * Focused on the "My learning" wiring seam: the tab bar must pass an in-panel
+ * handler to TabBarActions so the button switches to the recommendations tab
+ * (issue #1051) rather than navigating away. If this wiring is dropped, the
+ * header button silently reverts to a full-page navigation.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DocsPanelTabBar, type DocsPanelTabBarProps } from './DocsPanelTabBar';
+import { testIds } from '../../../constants/testIds';
+
+jest.mock('@grafana/i18n', () => ({
+  t: (_key: string, fallback: string) => fallback,
+}));
+
+jest.mock('@grafana/runtime', () => {
+  const mockPush = jest.fn();
+  return {
+    config: { bootData: { user: { orgRole: 'Admin', isGrafanaAdmin: false } } },
+    getAppEvents: jest.fn(() => ({ publish: jest.fn() })),
+    locationService: { push: mockPush },
+    __mockPush: mockPush,
+  };
+});
+
+jest.mock('../../../lib/analytics', () => ({
+  reportAppInteraction: jest.fn(),
+  getContentTypeForAnalytics: jest.fn(() => 'docs'),
+  UserInteraction: {
+    DocsPanelInteraction: 'docs_panel_interaction',
+    GeneralPluginFeedbackButton: 'general_plugin_feedback_button',
+    CloseTabClick: 'close_tab_click',
+  },
+}));
+
+jest.mock('../../../lib/storage/extension-sidebar', () => ({
+  clearExtensionSidebarDocked: jest.fn(),
+}));
+
+jest.mock('../../../docs-retrieval', () => ({
+  getJourneyProgress: jest.fn(() => 0),
+}));
+
+const { __mockPush: mockPush } = jest.requireMock('@grafana/runtime');
+
+function makeProps(overrides: Partial<DocsPanelTabBarProps> = {}): DocsPanelTabBarProps {
+  const recommendationsTab: any = { id: 'recommendations', title: 'Recommendations', baseUrl: '', currentUrl: '' };
+  const styles = new Proxy({}, { get: (_target, prop) => String(prop) }) as any;
+  const ref = { current: null } as any;
+
+  return {
+    styles,
+    tabs: [recommendationsTab],
+    activeTabId: 'recommendations',
+    activeTab: recommendationsTab,
+    visibleTabs: [recommendationsTab],
+    overflowGuideTabs: [],
+    isEditorUser: false,
+    isDevMode: false,
+    isDropdownOpen: false,
+    setIsDropdownOpen: jest.fn(),
+    tabBarRef: ref,
+    tabListRef: ref,
+    dropdownRef: ref,
+    chevronButtonRef: ref,
+    dropdownOpenTimeRef: { current: 0 },
+    onSetActiveTab: jest.fn(),
+    onCloseTab: jest.fn(),
+    reloadActiveTab: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('DocsPanelTabBar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('wires the "My learning" button to switch to the recommendations tab in place', () => {
+    const props = makeProps();
+    render(<DocsPanelTabBar {...props} />);
+
+    fireEvent.click(screen.getByTestId(testIds.docsPanel.myLearningTab));
+
+    expect(props.onSetActiveTab).toHaveBeenCalledWith('recommendations');
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/docs-panel/components/DocsPanelTabBar.tsx
+++ b/src/components/docs-panel/components/DocsPanelTabBar.tsx
@@ -260,6 +260,7 @@ export function DocsPanelTabBar({
         activeTab={activeTab}
         isDevMode={isDevMode}
         onReloadActiveTab={reloadActiveTab}
+        onNavigateToRecommendations={() => onSetActiveTab('recommendations')}
       />
     </div>
   );

--- a/src/components/docs-panel/components/TabBarActions.test.tsx
+++ b/src/components/docs-panel/components/TabBarActions.test.tsx
@@ -146,11 +146,20 @@ describe('TabBarActions', () => {
   });
 
   describe('My learning button', () => {
-    it('navigates to my learning home page when clicked', () => {
+    it('switches to the recommendations tab in place when an in-panel handler is provided', () => {
+      const onNavigateToRecommendations = jest.fn();
+      render(<TabBarActions onNavigateToRecommendations={onNavigateToRecommendations} />);
+
+      fireEvent.click(screen.getByTestId(testIds.docsPanel.myLearningTab));
+
+      expect(onNavigateToRecommendations).toHaveBeenCalledTimes(1);
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('falls back to full-page navigation when no in-panel handler is provided', () => {
       render(<TabBarActions />);
 
-      const myLearningButton = screen.getByTestId(testIds.docsPanel.myLearningTab);
-      fireEvent.click(myLearningButton);
+      fireEvent.click(screen.getByTestId(testIds.docsPanel.myLearningTab));
 
       expect(mockPush).toHaveBeenCalledWith(PLUGIN_BASE_URL);
     });

--- a/src/components/docs-panel/components/TabBarActions.tsx
+++ b/src/components/docs-panel/components/TabBarActions.tsx
@@ -24,6 +24,13 @@ export interface TabBarActionsProps {
   isDevMode?: boolean;
   /** Reload handler for the `Refresh (dev)` item. */
   onReloadActiveTab?: (tab: LearningJourneyTab) => void;
+  /**
+   * Switch the panel back to the recommendations tab in place. When supplied,
+   * the "My learning" button keeps the user in the sidebar instead of a
+   * full-page navigation to the plugin home. Falls back to navigation when
+   * absent (e.g. the component rendered outside the panel).
+   */
+  onNavigateToRecommendations?: () => void;
 }
 
 /**
@@ -35,6 +42,7 @@ export const TabBarActions: React.FC<TabBarActionsProps> = ({
   activeTab,
   isDevMode = false,
   onReloadActiveTab,
+  onNavigateToRecommendations,
 }) => {
   const user = config.bootData?.user;
   const canAccessPluginSettings = user?.isGrafanaAdmin === true || user?.orgRole === 'Admin';
@@ -86,6 +94,14 @@ export const TabBarActions: React.FC<TabBarActionsProps> = ({
   };
 
   const handleMyLearningClick = () => {
+    reportAppInteraction(UserInteraction.DocsPanelInteraction, {
+      action: 'navigate_to_recommendations',
+      source: 'header_my_learning',
+    });
+    if (onNavigateToRecommendations) {
+      onNavigateToRecommendations();
+      return;
+    }
     locationService.push(PLUGIN_BASE_URL);
   };
 

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -303,13 +303,15 @@ export const RecommendationsSection = memo(function RecommendationsSection({
             icon="book-open"
             variant="secondary"
             onClick={() => {
-              // Close the extension sidebar
+              // Empty list: unlike the header/footer "my learning" buttons (which
+              // switch to the in-panel recommendations tab), there is nothing to
+              // return to in-panel here, so close the sidebar and open the full
+              // My Learning page instead.
               const appEvents = getAppEvents();
               appEvents.publish({
                 type: 'close-extension-sidebar',
                 payload: {},
               });
-              // Navigate to the home page
               locationService.push(PLUGIN_BASE_URL);
             }}
           >


### PR DESCRIPTION
## Summary

"Return to my learning" (the guide footer button) and the "My learning" tab-bar icon did a full-page navigation to the plugin home page, dropping users out of the Grafana page they were on and tearing down the sidebar. Multiple field-event attendees reported this context loss while working through guides alongside the Grafana UI. Both controls now switch to the in-panel recommendations tab instead, so users stay in the sidebar next to whatever they were doing.

## What to look at

- **[`DocsPanelContentArea.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/f333c8790af1317466fbab10ab0586b276f18359/src/components/docs-panel/components/DocsPanelContentArea.tsx)** — the footer button changed from `window.location.assign(PLUGIN_BASE_URL)` (a hard reload) to `model.setActiveTab('recommendations')`. `recommendations` is a permanent tab, so the switch is a pure `activeTabId` state change with no content fetch.
- **[`TabBarActions.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/f333c8790af1317466fbab10ab0586b276f18359/src/components/docs-panel/components/TabBarActions.tsx)** + **[`DocsPanelTabBar.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/f333c8790af1317466fbab10ab0586b276f18359/src/components/docs-panel/components/DocsPanelTabBar.tsx)** — new optional `onNavigateToRecommendations` prop, wired from the tab bar's existing `onSetActiveTab`. The old `locationService.push` is kept only as a fallback for when `TabBarActions` renders without the handler.
- **[`context-panel.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/f333c8790af1317466fbab10ab0586b276f18359/src/components/docs-panel/context-panel.tsx)** — the recommendations empty-state "My learning" button is deliberately left as a full-page navigation (now with a comment explaining why): it only renders when there are no recommendations to return to in-panel, so opening the full My Learning page is the correct escape hatch. It also closes the sidebar, which the two fixed buttons do not.
- **Scope confinement** — these components render only in the sidebar surface. The floating panel and the fullscreen page use `FloatingPanelContent`/`FullScreenLayout`, so no cross-mode behavior changes. The one shared case (the sidebar showing the fullscreen-mode notice) intentionally keeps the tab bar interactive, and switching to recommendations there is consistent with that notice's documented "queue the next active tab" behavior.

## How to verify

1. In the Pathfinder sidebar, open a guide while on a dashboard (or Explore) page. Scroll to the bottom of the guide and click **Return to my learning** — the sidebar should switch to the recommendations list, and the underlying Grafana page should **not** reload or navigate away.
2. With a guide tab open, click the **My learning** (book) icon in the tab bar — same in-panel switch, no navigation away.
3. Confirm the guide tab stays open and you can switch back to it from the tab bar.

## Breaking changes

None. Fully reversible — no storage, schema, telemetry, or URL contract changes.

## Out of scope

- **Scroll-position preservation in the guide list** — the second ask in #1051. The existing scroll machinery (`#inner-docs-content`) only wraps guide content, not the recommendations list, so preserving list scroll is a separate change tracked in #1232.

Addresses #1051. Refs #1232, #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
