### PR TITLE
fix(docs-panel): move overflow-tab chevron to the right and flip it when open

### DIFF
--- a/src/components/docs-panel/components/DocsPanelTabBar.test.tsx
+++ b/src/components/docs-panel/components/DocsPanelTabBar.test.tsx
@@ -88,4 +88,21 @@ describe('DocsPanelTabBar', () => {
     expect(props.onSetActiveTab).toHaveBeenCalledWith('recommendations');
     expect(mockPush).not.toHaveBeenCalled();
   });
+
+  describe('overflow chevron', () => {
+    const overflowTab: any = { id: 'overflow-1', title: 'overflow-1', baseUrl: '', currentUrl: '' };
+
+    it('renders the count before the chevron and points it down when the dropdown is closed', () => {
+      render(<DocsPanelTabBar {...makeProps({ overflowGuideTabs: [overflowTab], isDropdownOpen: false })} />);
+      const button = screen.getByTestId(testIds.docsPanel.tabOverflowButton);
+      expect(button.firstElementChild?.textContent).toBe('+1');
+      expect(screen.getByTestId('angle-down')).toBeInTheDocument();
+    });
+
+    it('points the chevron up when the dropdown is open', () => {
+      render(<DocsPanelTabBar {...makeProps({ overflowGuideTabs: [overflowTab], isDropdownOpen: true })} />);
+      expect(screen.getByTestId('angle-up')).toBeInTheDocument();
+      expect(screen.queryByTestId('angle-down')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/docs-panel/components/DocsPanelTabBar.tsx
+++ b/src/components/docs-panel/components/DocsPanelTabBar.tsx
@@ -179,8 +179,8 @@ export function DocsPanelTabBar({
             aria-haspopup="true"
             data-testid={testIds.docsPanel.tabOverflowButton}
           >
-            <Icon name="angle-down" size="sm" />
             <span>+{overflowGuideTabs.length}</span>
+            <Icon name={isDropdownOpen ? 'angle-up' : 'angle-down'} size="sm" />
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary

The "Show N more tabs" overflow control in the docs panel tab bar rendered the chevron to the left of the count, and the chevron stayed `angle-down` even while the dropdown was open. This puts the count first so the chevron sits on the right, and flips it to `angle-up` while the dropdown is open so it reflects the open/closed state.

## What to look at

- `DocsPanelTabBar` overflow button: the `<span>+N</span>` and `<Icon>` are swapped so the chevron trails the count, and the icon name is now `isDropdownOpen ? 'angle-up' : 'angle-down'`.

## How to verify

1. Open enough guide tabs to trigger the overflow control: the "+N" count appears with the chevron on its right, pointing down.
2. Click the control to open the dropdown: the chevron flips to point up. Close it: it points down again.

## Breaking changes

None.

Fixes #1252

🤖 Generated with [Claude Code](https://claude.com/claude-code)