### PR TITLE
fix(interactive): use the shared secondary Button for the Redo control

### DIFF
--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -1021,15 +1021,16 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
               </span>
               <span className="interactive-guided-completed-text">Completed</span>
             </div>
-            <button
-              className="interactive-guided-redo-btn"
+            <Button
+              size="sm"
+              variant="secondary"
               onClick={handleStepRedo}
               disabled={disabled || isAnyActionRunning}
               data-testid={testIds.interactive.redoButton(renderedStepId)}
               title="Redo this guided tour"
             >
               ↻ Redo
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/src/components/interactive-tutorial/interactive-multi-step.tsx
+++ b/src/components/interactive-tutorial/interactive-multi-step.tsx
@@ -882,15 +882,16 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
               </span>
               <span className="interactive-guided-completed-text">Completed</span>
             </div>
-            <button
-              className="interactive-guided-redo-btn"
+            <Button
+              size="sm"
+              variant="secondary"
               onClick={handleStepRedo}
               disabled={disabled || isAnyActionRunning}
               data-testid={testIds.interactive.redoButton(renderedStepId)}
               title="Redo this multi-step"
             >
               ↻ Redo
-            </button>
+            </Button>
           </div>
         )}
 

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -1115,8 +1115,9 @@ export const InteractiveStep = forwardRef<
                   {checker.completionReason === 'skipped' ? 'Skipped' : 'Completed'}
                 </span>
               </div>
-              <button
-                className="interactive-guided-redo-btn"
+              <Button
+                size="sm"
+                variant="secondary"
                 onClick={handleStepRedo}
                 disabled={disabled || isAnyActionRunning}
                 data-testid={testIds.interactive.redoButton(renderedStepId)}
@@ -1127,7 +1128,7 @@ export const InteractiveStep = forwardRef<
                 }
               >
                 ↻ Redo
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/src/styles/interactive.styles.ts
+++ b/src/styles/interactive.styles.ts
@@ -1156,22 +1156,6 @@ const getInteractiveComponentStyles = (theme: GrafanaTheme2) => ({
     color: theme.colors.text.secondary,
   },
 
-  '.interactive-guided-redo-btn': {
-    padding: '4px 10px',
-    fontSize: '0.8rem',
-    border: `1px solid ${theme.colors.border.weak}`,
-    background: 'transparent',
-    color: theme.colors.text.secondary,
-    borderRadius: '4px',
-    cursor: 'pointer',
-    transition: 'all 0.15s ease',
-    '&:hover': {
-      borderColor: theme.colors.border.medium,
-      color: theme.colors.text.primary,
-      background: theme.colors.action.hover,
-    },
-  },
-
   // ─── SKIP BUTTON (shared) ─────────────────────────────────────────────────
   '.interactive-guided-skip-btn': {
     opacity: 0.8,


### PR DESCRIPTION
## Summary

The Redo control shown on completed interactive steps was a raw `<button>` with its own `.interactive-guided-redo-btn` styling, so it looked different from the shared secondary Buttons (Show me / Skip) next to it. This replaces it with the standard `<Button variant="secondary" size="sm">` in all three call sites and removes the now-unused style block.

## What to look at

- `interactive-step.tsx`, `interactive-guided.tsx`, `interactive-multi-step.tsx`: the raw Redo `<button>` is now `<Button variant="secondary" size="sm">`. `onClick`, `disabled`, `data-testid`, and `title` are carried over unchanged.
- `interactive.styles.ts`: the dead `.interactive-guided-redo-btn` block is removed.

## Why

The Redo button is the odd one out in the completed-step footer. Reusing the shared Button component gives it the same padding, border, and typography as the other secondary actions, and drops ~15 lines of bespoke CSS.

## How to verify

1. Complete an interactive step, a guided tour, and a multi-step: the Redo button now matches the secondary Show me / Skip buttons.
2. Click Redo: it still restarts the step (behaviour is unchanged; existing tests that drive the Redo `data-testid` still pass).

## Breaking changes

None.

Fixes #1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)