### PR TITLE
fix(requirements): call the real datasource health endpoint

### DIFF
--- a/src/requirements-manager/checks/grafana-api.ts
+++ b/src/requirements-manager/checks/grafana-api.ts
@@ -399,7 +399,7 @@ export async function dashboardExistsCheck(check: string): Promise<CheckResultEr
 
 /**
  * Data source connection test. Stronger than `hasDataSourceCheck` — verifies
- * the data source's `/test` endpoint returns success, not just that it's listed.
+ * the data source's health endpoint reports OK, not just that it's listed.
  */
 export async function datasourceConfiguredCheck(check: string): Promise<CheckResultError> {
   try {
@@ -452,17 +452,18 @@ export async function datasourceConfiguredCheck(check: string): Promise<CheckRes
     }
 
     try {
-      // Use the data source test API
-      const testResult = await getBackendSrv().post(`/api/datasources/uid/${targetDataSource.uid}/test`);
+      // Grafana returns 400 (which throws) when the health check fails, so the
+      // non-OK branch below only covers unexpected 200-with-error payloads.
+      const healthResult = await getBackendSrv().get(`/api/datasources/uid/${targetDataSource.uid}/health`);
 
-      const isConfigured = testResult && testResult.status === 'success';
+      const isConfigured = healthResult?.status === 'OK';
 
       return {
         requirement: check,
         pass: isConfigured,
         error: isConfigured
           ? undefined
-          : `Data source '${targetDataSource.name}' test failed: ${testResult?.message || 'Unknown error'}`,
+          : `Data source '${targetDataSource.name}' health check failed: ${healthResult?.message || 'Unknown error'}`,
         context: {
           searched: dsRequirement,
           testedDataSource: {
@@ -470,7 +471,7 @@ export async function datasourceConfiguredCheck(check: string): Promise<CheckRes
             name: targetDataSource.name,
             type: targetDataSource.type,
           },
-          testResult: testResult?.status || 'unknown',
+          testResult: healthResult?.status || 'unknown',
           suggestion: isConfigured
             ? undefined
             : `Data source '${targetDataSource.name}' exists but configuration test failed. Check connection settings.`,

--- a/src/requirements-manager/requirements-checker.utils.test.ts
+++ b/src/requirements-manager/requirements-checker.utils.test.ts
@@ -211,9 +211,8 @@ describe('requirements-checker.utils', () => {
 
   describe('datasourceConfiguredCHECK', () => {
     beforeEach(() => {
-      // Mock getBackendSrv
       (getBackendSrv as jest.Mock).mockReturnValue({
-        post: jest.fn(),
+        get: jest.fn(),
       });
     });
 
@@ -224,7 +223,7 @@ describe('requirements-checker.utils', () => {
       ]);
 
       const mockBackend = getBackendSrv();
-      (mockBackend.post as jest.Mock).mockResolvedValue({ status: 'success' });
+      (mockBackend.get as jest.Mock).mockResolvedValue({ status: 'OK', message: 'Data source is working' });
 
       const options: RequirementsCheckOptions = {
         requirements: 'datasource-configured:prometheus',
@@ -233,16 +232,16 @@ describe('requirements-checker.utils', () => {
       const result = await checkRequirements(options);
       expect(result.pass).toBe(true);
       expect(result.error[0]!.pass).toBe(true);
-      expect(mockBackend.post).toHaveBeenCalledWith('/api/datasources/uid/prom-uid/test');
+      expect(mockBackend.get).toHaveBeenCalledWith('/api/datasources/uid/prom-uid/health');
     });
 
-    it('should fail when data source test fails', async () => {
+    it('should fail when the health check reports a non-OK status', async () => {
       (ContextService.fetchDataSources as jest.Mock).mockResolvedValue([
         { id: 1, name: 'Prometheus', type: 'prometheus', uid: 'prom-uid' },
       ]);
 
       const mockBackend = getBackendSrv();
-      (mockBackend.post as jest.Mock).mockResolvedValue({ status: 'error', message: 'Connection failed' });
+      (mockBackend.get as jest.Mock).mockResolvedValue({ status: 'ERROR', message: 'Connection failed' });
 
       const options: RequirementsCheckOptions = {
         requirements: 'datasource-configured:prometheus',
@@ -251,7 +250,25 @@ describe('requirements-checker.utils', () => {
       const result = await checkRequirements(options);
       expect(result.pass).toBe(false);
       expect(result.error[0]!.pass).toBe(false);
-      expect(result.error[0]!.error).toContain('test failed');
+      expect(result.error[0]!.error).toContain('health check failed');
+    });
+
+    it('should fail when the health endpoint rejects (Grafana returns 400 on failed checks)', async () => {
+      (ContextService.fetchDataSources as jest.Mock).mockResolvedValue([
+        { id: 1, name: 'Prometheus', type: 'prometheus', uid: 'prom-uid' },
+      ]);
+
+      const mockBackend = getBackendSrv();
+      (mockBackend.get as jest.Mock).mockRejectedValue(new Error('Bad request'));
+
+      const options: RequirementsCheckOptions = {
+        requirements: 'datasource-configured:prometheus',
+      };
+
+      const result = await checkRequirements(options);
+      expect(result.pass).toBe(false);
+      expect(result.error[0]!.pass).toBe(false);
+      expect(result.error[0]!.error).toContain('configuration test failed');
     });
 
     it('should fail when data source not found', async () => {


### PR DESCRIPTION
## What

`datasource-configured:` requirement checks POSTed to `/api/datasources/uid/{uid}/test` — an endpoint that has **never existed** in Grafana's route table. Every check 404ed into the catch branch, so the requirement always failed ("configuration test failed") even for perfectly healthy data sources.

This switches the check to `GET /api/datasources/uid/{uid}/health`, verified against Grafana's route registrations on both `main` and `v12.3.0` (our `grafanaDependency` floor). The success predicate now matches the real response shape (`{status: "OK", message}`); a failed health check returns HTTP 400, which throws into the existing catch branch.

## Why now

Found during an audit of the plugin's Grafana API usage for out-of-date/deprecated surfaces. This was the one call that is actually broken today (the rest of our HTTP surface is current).

Related follow-up (not in this PR): migrating off the deprecated `getDataSourceSrv()` is blocked until `grafanaDependency >= 13.1.0` — its replacements (`getDataSourceInstance` / `getDataSourceInstanceSettings` in `@grafana/runtime/unstable`) only exist in the host runtime from Grafana 13.1.0, so migrating now would break 12.3–13.0 instances.

## Testing

- Updated the unit tests to mock `GET .../health` with the real response shape, plus a new case for the thrown-400 failure path.
- `test:ci` on the suite, `eslint`, and `tsc --noEmit` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)