### PR TITLE
fix(block-editor): reject invalid regex patterns in InputBlockForm

### DIFF
--- a/src/components/block-editor/forms/InputBlockForm.test.tsx
+++ b/src/components/block-editor/forms/InputBlockForm.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { InputBlockForm } from './InputBlockForm';
+import type { JsonBlock } from '../types';
+
+function renderForm(onSubmit: (block: JsonBlock) => void = jest.fn()) {
+  render(<InputBlockForm onSubmit={onSubmit} onCancel={jest.fn()} />);
+  return {
+    promptInput: screen.getByPlaceholderText('e.g., What is the name of your Prometheus data source?'),
+    variableNameInput: screen.getByPlaceholderText('e.g., prometheusDataSource'),
+    submitButton: screen.getByRole('button', { name: 'Add block' }),
+  };
+}
+
+describe('InputBlockForm', () => {
+  it('keeps submit disabled until required fields are filled', () => {
+    const { promptInput, variableNameInput, submitButton } = renderForm();
+
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.change(promptInput, { target: { value: 'Enter a name' } });
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.change(variableNameInput, { target: { value: 'datasourceName' } });
+    expect(submitButton).toBeEnabled();
+  });
+
+  it('rejects invalid variable names before submit', () => {
+    const onSubmit = jest.fn();
+    const { promptInput, variableNameInput, submitButton } = renderForm(onSubmit);
+
+    fireEvent.change(promptInput, { target: { value: 'Enter a name' } });
+    fireEvent.change(variableNameInput, { target: { value: '123bad' } });
+
+    expect(
+      screen.getByText('Must start with letter/underscore, contain only letters, numbers, underscores')
+    ).toBeInTheDocument();
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.click(submitButton);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid regex pattern before submit', () => {
+    const onSubmit = jest.fn();
+    const { promptInput, variableNameInput, submitButton } = renderForm(onSubmit);
+    const patternInput = screen.getByPlaceholderText('e.g., ^[a-z][a-z0-9-]*$');
+
+    fireEvent.change(promptInput, { target: { value: 'Enter a name' } });
+    fireEvent.change(variableNameInput, { target: { value: 'datasourceName' } });
+    fireEvent.change(patternInput, { target: { value: '[unclosed' } });
+    fireEvent.blur(patternInput);
+
+    expect(screen.getByText('Invalid regex pattern')).toBeInTheDocument();
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.click(submitButton);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not block submit when switching away from text with an invalid pattern', () => {
+    const onSubmit = jest.fn();
+    const { promptInput, variableNameInput, submitButton } = renderForm(onSubmit);
+    const patternInput = screen.getByPlaceholderText('e.g., ^[a-z][a-z0-9-]*$');
+
+    fireEvent.change(promptInput, { target: { value: 'Enter a name' } });
+    fireEvent.change(variableNameInput, { target: { value: 'datasourceName' } });
+    fireEvent.change(patternInput, { target: { value: '[unclosed' } });
+    fireEvent.click(screen.getByRole('radio', { name: 'Checkbox' }));
+
+    expect(submitButton).toBeEnabled();
+    fireEvent.click(submitButton);
+    expect(onSubmit).toHaveBeenCalledWith({
+      type: 'input',
+      prompt: 'Enter a name',
+      inputType: 'boolean',
+      variableName: 'datasourceName',
+    });
+  });
+
+  it('surfaces an inline error for an initially invalid pattern', () => {
+    const onSubmit = jest.fn();
+    render(
+      <InputBlockForm
+        initialData={{
+          type: 'input',
+          prompt: 'Enter a name',
+          inputType: 'text',
+          variableName: 'datasourceName',
+          pattern: '[unclosed',
+        }}
+        onSubmit={onSubmit}
+        onCancel={jest.fn()}
+        isEditing
+      />
+    );
+
+    expect(screen.getByText('Invalid regex pattern')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Update block' })).toBeDisabled();
+  });
+
+  it('submits trimmed required fields', () => {
+    const onSubmit = jest.fn();
+    const { promptInput, variableNameInput, submitButton } = renderForm(onSubmit);
+
+    fireEvent.change(promptInput, { target: { value: '  Enter a name  ' } });
+    fireEvent.change(variableNameInput, { target: { value: '  datasourceName  ' } });
+    fireEvent.click(submitButton);
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      type: 'input',
+      prompt: 'Enter a name',
+      inputType: 'text',
+      variableName: 'datasourceName',
+    });
+  });
+});

--- a/src/components/block-editor/forms/InputBlockForm.tsx
+++ b/src/components/block-editor/forms/InputBlockForm.tsx
@@ -36,6 +36,18 @@ function isValidVariableName(name: string): boolean {
 }
 
 /**
+ * Validate regex pattern
+ */
+function isValidRegexPattern(pattern: string): boolean {
+  try {
+    new RegExp(pattern);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Input block form component
  */
 export function InputBlockForm({
@@ -49,6 +61,12 @@ export function InputBlockForm({
 
   // Initialize from existing data or defaults
   const initial = initialData && isInputBlock(initialData) ? initialData : null;
+
+  // Blur-gate inline errors (regex is often temporarily invalid while typing); seed when editing bad data.
+  const [patternBlurred, setPatternBlurred] = useState(() => {
+    const initialPattern = initial?.pattern?.trim() ?? '';
+    return initialPattern.length > 0 && !isValidRegexPattern(initialPattern);
+  });
 
   const [prompt, setPrompt] = useState(initial?.prompt ?? '');
   const [inputType, setInputType] = useState<'text' | 'boolean' | 'datasource'>(initial?.inputType ?? 'text');
@@ -77,6 +95,11 @@ export function InputBlockForm({
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
+
+      if (inputType === 'text' && pattern.trim().length > 0 && !isValidRegexPattern(pattern.trim())) {
+        setPatternBlurred(true);
+        return;
+      }
 
       // Parse requirements
       const reqArray = requirements
@@ -126,7 +149,9 @@ export function InputBlockForm({
   // Validation
   const hasPrompt = prompt.trim().length > 0;
   const hasValidVariableName = variableName.trim().length > 0 && isValidVariableName(variableName.trim());
-  const isValid = hasPrompt && hasValidVariableName;
+  const hasValidRegexPattern =
+    inputType !== 'text' || pattern.trim().length === 0 || isValidRegexPattern(pattern.trim());
+  const isValid = hasPrompt && hasValidVariableName && hasValidRegexPattern;
 
   return (
     <form onSubmit={handleSubmit} className={styles.form}>
@@ -195,10 +220,16 @@ export function InputBlockForm({
             />
           </Field>
 
-          <Field label="Validation pattern" description="Regex pattern for validating input (optional)">
+          <Field
+            label="Validation pattern"
+            description="Regex pattern for validating input (optional)"
+            invalid={patternBlurred && !hasValidRegexPattern}
+            error={patternBlurred && !hasValidRegexPattern ? 'Invalid regex pattern' : undefined}
+          >
             <Input
               value={pattern}
               onChange={(e) => setPattern(e.currentTarget.value)}
+              onBlur={() => setPatternBlurred(true)}
               placeholder="e.g., ^[a-z][a-z0-9-]*$"
             />
           </Field>


### PR DESCRIPTION
## Summary

The input block authoring form allowed saving an optional Validation pattern that was not a valid JavaScript regex, which made it easy for guide authors to persist mistakes that only show up later. This change compiles the pattern with `new RegExp` before submit, disables save when it fails for text inputs, and shows an inline error after blur (or immediately when editing a block that already has a bad pattern).

## What to look at

- [InputBlockForm](https://github.com/grafana/grafana-pathfinder-app/blob/602237560667cf61f5affc09c2e7eed8b55e6bbf/src/components/block-editor/forms/InputBlockForm.tsx) — submit/`isValid` gate vs blur-gated error display: invalid patterns block save immediately, but the inline error waits for blur so mid-typing noise is avoided. Validation applies only when `inputType === 'text'` so leftover pattern state does not brick Checkbox/Datasource after a type switch. New unit coverage lives alongside the form; keep or trim if the team prefers thinner form tests.

## Why

Authors could previously submit a broken pattern from the form builder and only discover the problem downstream. A keystroke-level error (matching other fields more closely) was considered, but blur-gated messaging was chosen for this field because regex is often temporarily invalid while typing.

## How to verify

1. Open the block editor, add an Input block, leave type as Text, fill Prompt and Variable name.
2. Enter an invalid pattern such as `[unclosed`, blur the field — confirm "Invalid regex pattern" appears and Add block stays disabled.
3. Switch Input type to Checkbox with that invalid pattern still in state — confirm Add block enables and saving produces a boolean input without a `pattern` field.
4. Edit an existing text input whose stored `pattern` is already invalid — confirm the error shows on open and Update block is disabled until the pattern is fixed or cleared.

## Breaking changes

None. This change is additive and fully reversible.

Fixes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)
