### PR TITLE
fix(floating-panel): use columns icon for the dock-to-sidebar action

### DIFF
--- a/src/components/floating-panel/FloatingPanel.tsx
+++ b/src/components/floating-panel/FloatingPanel.tsx
@@ -257,7 +257,7 @@ export function FloatingPanel({
               />
             )}
             <IconButton
-              name="angle-double-right"
+              name="columns"
               size="sm"
               tooltip="Dock to sidebar"
               onClick={handleSwitchToSidebar}


### PR DESCRIPTION
Fixes #1301

One-line swap in `src/components/floating-panel/FloatingPanel.tsx`: the popout header's dock-to-sidebar `IconButton` used `angle-double-right` (reads as navigate-forward); it now uses `columns` as the issue suggests, which matches the sidebar layout the action produces. Verified `columns` is in `@grafana/data`'s `availableIconsIndex`; tooltip and aria-label are unchanged.

Verification: `npm run typecheck`, `eslint` on the file, and the 20 floating-panel jest tests all pass.