### PR TITLE
Guide: changes to support bundled guides

### DIFF
--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-create-ping-check/content.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-create-ping-check/content.json
@@ -1,0 +1,80 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "detect-outages-synthetic-monitoring-create-ping-check",
+  "title": "Create a ping check",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "A ping check is the simplest type of synthetic check. It tests whether an endpoint is reachable by sending ICMP packets to a target host and measuring the response time. Ping checks verify basic network connectivity and availability without testing application-level functionality.\n\nPing checks are ideal for monitoring infrastructure components, verifying that servers are online, and establishing baseline network latency measurements. They run quickly and use minimal resources, making them suitable for frequent monitoring intervals."
+    },
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/GAzh8nHj2w8",
+      "provider": "youtube"
+    },
+    {
+      "type": "markdown",
+      "content": "To create a ping check, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='action create check']",
+          "content": "On the Synthetic Monitoring home page, click **Create new check**."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href='/a/grafana-synthetic-monitoring-app/checks/new/api-endpoint']",
+          "content": "Click **API endpoint**."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[data-testid='checkEditor form job']",
+          "targetvalue": "grafana-ping-check",
+          "content": "In the **Job name** field, enter a descriptive name for your check.",
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "label[for^='option-ping-radiogroup-']",
+          "content": "Under **Request type**, click **Ping**."
+        },
+        {
+          "type": "interactive",
+          "action": "formfill",
+          "reftarget": "input[name='target'][placeholder='grafana.com']",
+          "targetvalue": "grafana.com",
+          "content": "In the **Request target** field, enter the hostname or IP address to ping. You can use `grafana.com` for testing.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "image",
+      "src": "https://grafana.com/media/docs/learning-journey/detect-outages-synthetic-monitoring/grafana-cloud-synthetic-monitoring-create-ping-check-2.png",
+      "alt": "Synthetic Monitoring application in Grafana Cloud, showing the API Endpoint check creation page with Ping selected as the request type"
+    },
+    {
+      "type": "markdown",
+      "content": "The check configuration form displays your **Job name** and **Target**. To finish setting up your check, you must now configure where and how often it runs."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll navigate to the execution step to select your probe locations."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Ping check reference](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/checks/ping/)"
+    }
+  ]
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-create-ping-check/manifest.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-create-ping-check/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "detect-outages-synthetic-monitoring-create-ping-check",
+  "type": "guide",
+  "description": "Learn how to create your first ping check to test endpoint reachability and measure response latency.",
+  "category": "data-availability",
+  "author": {
+    "name": "heitortsergent",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["detect-outages-synthetic-monitoring-initialize-plugin"],
+  "recommends": ["detect-outages-synthetic-monitoring-select-probe-locations"],
+  "suggests": []
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-end-journey/content.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-end-journey/content.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "detect-outages-synthetic-monitoring-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!\n\nWe hope you've enjoyed traveling with us as you:\n\n- Learned about the value of Synthetic Monitoring for proactive blackbox monitoring\n- Navigated to Synthetic Monitoring in Grafana Cloud\n- Initialized the Synthetic Monitoring plugin for your account\n- Created your first ping check to test endpoint reachability\n- Selected global probe locations to monitor from multiple regions\n- Explored the check dashboard with uptime, latency, and reachability metrics\n- Explored the time point explorer to analyze individual check executions"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nThe world is your oyster! Read more about how you can:\n\n- [Create HTTP checks](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/checks/http/)\n- [Create k6 scripted checks](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/checks/k6/)\n- [Configure Synthetic Monitoring alerts](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/configure-alerts/)\n- [Set up private probes](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/)"
+    }
+  ]
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-end-journey/manifest.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-end-journey/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "detect-outages-synthetic-monitoring-end-journey",
+  "type": "guide",
+  "description": "Congratulations on completing the Synthetic Monitoring get started learning path! Explore next steps for expanding your monitoring capabilities.",
+  "category": "data-availability",
+  "author": {
+    "name": "heitortsergent",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["detect-outages-synthetic-monitoring-view-check-dashboard"],
+  "recommends": [],
+  "suggests": []
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-initialize-plugin/content.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-initialize-plugin/content.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "detect-outages-synthetic-monitoring-initialize-plugin",
+  "title": "Initialize the Synthetic Monitoring plugin",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Before you can create checks, you need to initialize the Synthetic Monitoring plugin. This one-time setup process configures the connection between the plugin and your Grafana Cloud account, automatically creating the required Prometheus and Loki data sources for storing metrics and logs from your checks.\n\nThe initialization process ensures that all check results are stored in your Grafana Cloud stack, where you can query them using familiar tools like Explore and build custom dashboards and alerts.\n\nTo initialize the Synthetic Monitoring plugin, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='app-init init-button']",
+          "content": "On the Synthetic Monitoring home page, click **Initialize the plugin**. If you can see a **Create new check** button, the plugin has already been initialized and you can proceed to the next milestone.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "skippable": true
+        },
+        {
+          "type": "markdown",
+          "content": "Wait for the initialization process to complete. This typically takes a few seconds."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "After initialization completes, the Synthetic Monitoring home page refreshes and displays options to create your first check. You’re now ready to start monitoring your endpoints."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll learn how to create your first ping check."
+    }
+  ]
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-initialize-plugin/manifest.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-initialize-plugin/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "detect-outages-synthetic-monitoring-initialize-plugin",
+  "type": "guide",
+  "description": "Learn how to initialize the Synthetic Monitoring plugin to set up the required data sources for your checks.",
+  "category": "data-availability",
+  "author": {
+    "name": "heitortsergent",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["detect-outages-synthetic-monitoring-navigate-to-synthetic-monitoring"],
+  "recommends": ["detect-outages-synthetic-monitoring-create-ping-check"],
+  "suggests": []
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-lj/content.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-lj/content.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "detect-outages-synthetic-monitoring-lj",
+  "title": "Detect customer-visible outages using Synthetic Monitoring",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Synthetic Monitoring is a blackbox monitoring solution that lets you test your applications and services from an external perspective. Unlike traditional monitoring that observes systems from within, Synthetic Monitoring emulates user behavior from probe locations around the world, giving you insight into how your services appear to actual users."
+    },
+    {
+      "type": "markdown",
+      "content": "When you complete this journey, you'll be able to:\n\n- Understand the value of Synthetic Monitoring for proactive blackbox monitoring\n- Navigate to Synthetic Monitoring in Grafana Cloud\n- Initialize the Synthetic Monitoring plugin for your account\n- Create a ping check to test endpoint reachability\n- Select global probe locations to monitor from multiple regions\n- View the check dashboard with uptime, latency, and reachability metrics\n- Explore the time point explorer to analyze individual check executions"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nBefore you get started with Synthetic Monitoring, ensure that you have:\n\n- Access to your Grafana Cloud instance with permissions to install plugins.\n- A target endpoint to monitor (you can use `grafana.com` for testing purposes)."
+    }
+  ]
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-lj/manifest.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-lj/manifest.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "detect-outages-synthetic-monitoring-lj",
+  "type": "path",
+  "description": "Step-by-step guide: Detect customer-visible outages using Synthetic Monitoring.",
+  "category": "data-availability",
+  "author": {
+    "name": "heitortsergent",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/grafana-synthetic-monitoring-app/home",
+  "targeting": {
+    "match": {
+      "and": [
+        {
+          "urlPrefix": "/a/grafana-synthetic-monitoring-app/home"
+        },
+        {
+          "targetPlatform": "cloud"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "detect-outages-synthetic-monitoring-navigate-to-synthetic-monitoring",
+    "detect-outages-synthetic-monitoring-initialize-plugin",
+    "detect-outages-synthetic-monitoring-create-ping-check",
+    "detect-outages-synthetic-monitoring-select-probe-locations",
+    "detect-outages-synthetic-monitoring-view-check-dashboard",
+    "detect-outages-synthetic-monitoring-end-journey"
+  ],
+  "recommends": [],
+  "suggests": []
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-navigate-to-synthetic-monitoring/content.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-navigate-to-synthetic-monitoring/content.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "detect-outages-synthetic-monitoring-navigate-to-synthetic-monitoring",
+  "title": "Navigate to Synthetic Monitoring",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Synthetic Monitoring is available as an app within Grafana Cloud. The home page provides an overview of all your checks, their current status, and key performance metrics. rom this central location, you can create new checks, view dashboards, and access detailed check results.\n\nWhen you first access Synthetic Monitoring, you’ll see a summary of your checks’ health, including uptime percentages, latency measurements, and error rates across all probe locations. This overview helps you quickly identify any services that need attention.\n\nTo navigate to Synthetic Monitoring in Grafana Cloud, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "objectives": [
+        "on-page:/a/grafana-synthetic-monitoring-app/home"
+      ],
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/testing-and-synthetics']",
+          "content": "In the main menu, navigate to **Testing & synthetics**.",
+          "requirements": [
+            "navmenu-open"
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[id='pageContent'] a[href='/a/grafana-synthetic-monitoring-app/home']",
+          "content": "Next, click **Synthetics**.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "objectives": [
+            "on-page:/a/grafana-synthetic-monitoring-app/home"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The Synthetic Monitoring home page displays. If this is your first time accessing Synthetic Monitoring, you'll see an option to initialize the plugin and get started with creating checks."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll learn how to initialize the Synthetic Monitoring plugin."
+    }
+  ]
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-navigate-to-synthetic-monitoring/manifest.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-navigate-to-synthetic-monitoring/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "detect-outages-synthetic-monitoring-navigate-to-synthetic-monitoring",
+  "type": "guide",
+  "description": "Learn how to access the Synthetic Monitoring app within Grafana Cloud to view and manage your checks.",
+  "category": "data-availability",
+  "author": {
+    "name": "heitortsergent",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["detect-outages-synthetic-monitoring-initialize-plugin"],
+  "suggests": []
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-select-probe-locations/content.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-select-probe-locations/content.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "detect-outages-synthetic-monitoring-select-probe-locations",
+  "title": "Select probe locations",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Probe locations are the global locations from which Synthetic Monitoring runs your checks. Grafana Labs operates public probes in data centers around the world, enabling you to test your services from multiple geographic regions simultaneously."
+    },
+    {
+      "type": "markdown",
+      "content": "Selecting multiple probe locations helps you understand availability and performance from where your users are located. If your service is accessible from some locations but not others, using multiple probes helps you identify region-specific issues such as DNS problems, network routing failures, or CDN misconfigurations.\n\nTo select probe locations and create your check, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='checkEditor navigation execution']",
+          "content": "In the check creation stepper, click **Execution**."
+        },
+        {
+          "type": "markdown",
+          "content": "In the **Probe locations** section, select the locations from which to run your check. For example, select **North California**, **Singapore**, and **Frankfurt** to test from three continents."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "label:contains('1m')",
+          "content": "Leave the **Frequency** parameter with its default value, or adjust based on your monitoring needs. The default frequency runs checks every minute.",
+          "skippable": true,
+          "hint": "The default frequency is suitable for most checks.",
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='checkEditor form submit']",
+          "content": "Click **Save** to create your check."
+        }
+      ]
+    },
+    {
+      "type": "image",
+      "src": "https://grafana.com/media/docs/learning-journey/detect-outages-synthetic-monitoring/grafana-cloud-synthetic-monitoring-create-ping-check-probes.png",
+      "alt": "Synthetic Monitoring application in Grafana Cloud, showing the API Endpoint check creation page in the Execution step, with North California, Singapore, and Frankfurt selected"
+    },
+    {
+      "type": "markdown",
+      "content": "After you click **Save**, the check is created, and the check dashboard page is displayed. Synthetic Monitoring starts executing your check at the configured frequency. After a few executions, the Uptime, Reachability, and Latency columns populate with data."
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll explore the check dashboard data."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Public probes reference](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/public-probes/)\n- [Private probes reference](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/)"
+    }
+  ]
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-select-probe-locations/manifest.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-select-probe-locations/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "detect-outages-synthetic-monitoring-select-probe-locations",
+  "type": "guide",
+  "description": "Learn how to select global probe locations and create your check to start monitoring your services.",
+  "category": "data-availability",
+  "author": {
+    "name": "heitortsergent",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["detect-outages-synthetic-monitoring-create-ping-check"],
+  "recommends": ["detect-outages-synthetic-monitoring-view-check-dashboard"],
+  "suggests": []
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-view-check-dashboard/content.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-view-check-dashboard/content.json
@@ -1,0 +1,111 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "detect-outages-synthetic-monitoring-view-check-dashboard",
+  "title": "View the check dashboard",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Each check in Synthetic Monitoring has a dedicated dashboard that displays key performance metrics over time. The dashboard provides a comprehensive view of your check's health, including uptime percentage, reachability from each probe location, average latency, and error rates."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "hover",
+          "reftarget": "section[data-testid='data-testid Panel header Uptime']",
+          "content": "Review the **Uptime** panel to see the percentage of successful checks over the selected time range. Refresh the page after a few minutes to allow data to populate if you don't see any results.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "hover",
+          "reftarget": "section[data-testid='data-testid Panel header Reachability']",
+          "content": "Review the **Reachability** panel to see how often the target responds from each probe location.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "hover",
+          "reftarget": "section[data-testid='data-testid Panel header Average latency']",
+          "content": "Review the **Average latency** panel to see response times from each probe location.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "hover",
+          "reftarget": "[data-testid='data-testid template variable']",
+          "content": "Use the **probe** filter at the top of the dashboard to focus on specific locations.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "hover",
+          "reftarget": "button[data-testid='data-testid TimePicker Open Button']",
+          "content": "Use the time picker to adjust the time range for the displayed data.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "### Explore the time point explorer\n\nThe check dashboard includes a time point explorer, a specialized visualization that combines logs and metrics to provide a detailed view of individual check executions."
+    },
+    {
+      "type": "markdown",
+      "content": "To investigate a specific execution:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "id": "guide-section-99978",
+      "title": "View check execution",
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "div[data-testid='timepoint-list']",
+          "content": "Locate the Time point graph, and click on a specific data point in the graph.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "[data-testid='timepoint-viewer']",
+          "content": "Review the Time point viewer at the bottom to see the logs, response headers, and execution details for that specific moment.",
+          "requirements": [
+            "exists-reftarget"
+          ],
+          "doIt": false
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you'll review what you've accomplished in this journey."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nAt this point in your journey, you can explore the following paths:\n\n- [Analyze results with Synthetic Monitoring](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/analyze-results/)\n- [Visualize check execution with the time point explorer](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/analyze-results/visualize-check-execution/)"
+    }
+  ]
+}

--- a/src/bundled-interactives/detect-outages-synthetic-monitoring-view-check-dashboard/manifest.json
+++ b/src/bundled-interactives/detect-outages-synthetic-monitoring-view-check-dashboard/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "detect-outages-synthetic-monitoring-view-check-dashboard",
+  "type": "guide",
+  "description": "Learn how to view and interpret the check dashboard with uptime, latency, and reachability metrics.",
+  "category": "data-availability",
+  "author": {
+    "name": "heitortsergent",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["detect-outages-synthetic-monitoring-select-probe-locations"],
+  "recommends": ["detect-outages-synthetic-monitoring-end-journey"],
+  "suggests": []
+}

--- a/src/bundled-interactives/get-started-connect-data/content.json
+++ b/src/bundled-interactives/get-started-connect-data/content.json
@@ -1,0 +1,83 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-connect-data",
+  "title": "Query data where it lives",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana Cloud queries your data where it already lives, so you don't have to move it. In this guide you'll connect an existing data source and confirm you can query it."
+    },
+    {
+      "type": "markdown",
+      "content": "You need a Grafana Cloud user with the **Admin** role and a reachable data source. Don't have one yet? You can use the built-in **TestData** data source to generate sample time series and still complete this guide."
+    },
+    {
+      "type": "markdown",
+      "content": "You start on the **Add data source** page, which lists data source types. Pick one and configure it."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Filter by name or type, then click your data source type to open its configuration page. If you don't have one, choose **TestData** to generate sample time series."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Enter the connection details for your data source, such as a fully qualified host name or URL. Grafana Cloud connects over the public network, so use a public address, not localhost or a private IP."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "If your data source requires credentials, enter them now. Use an account with least-privilege, read-only access.",
+          "skippable": true
+        },
+        {
+          "type": "interactive",
+          "action": "button",
+          "reftarget": "Save & test",
+          "content": "Click **Save & test** to confirm Grafana Cloud can reach your data source.",
+          "requirements": ["exists-reftarget"]
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You've connected and tested a data source. Grafana Cloud can now query it in place."
+    },
+    {
+      "type": "markdown",
+      "content": "Now confirm you can query your data."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/explore",
+          "content": "Go to **Explore**, select your new data source, and run a query."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You've queried your own data in Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "As you connect more data, keep an eye on cost. Usage scales with the data you query and store. Refer to [Cost management and billing](/docs/grafana-cloud/cost-management-and-billing/)."
+    },
+    {
+      "type": "interactive",
+      "action": "navigate",
+      "reftarget": "/a/cloud-home-app",
+      "openGuide": "bundled:get-started-hub",
+      "content": "**Return to Get started with Grafana Cloud** to pick another path, such as **Monitor a host or service**."
+    }
+  ]
+}

--- a/src/bundled-interactives/get-started-explore/content.json
+++ b/src/bundled-interactives/get-started-explore/content.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-explore",
+  "title": "See Grafana Cloud in action with demo data",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "See Grafana Cloud in action in a few minutes. You'll install a set of ready-made demo dashboards and read your first one, with no data setup or instrumentation required. You're not billed for this demo data."
+    },
+    {
+      "type": "markdown",
+      "content": "You'll install demo data sources and dashboards for a sample scenario. Installing requires a role that can create data sources and dashboards, such as **Administrator**. No admin access? Use the Grafana Play option below instead."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/a/grafana-demodashboards-app",
+          "content": "Open the **Demo Data Dashboards** app, found under **More apps** in the main menu."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "button[data-testid='install-quickpizza']",
+          "content": "On the **QuickPizza SRE Demo** card, click **Install Dashboards** to add its dashboards and data sources, including metrics, logs, and traces.",
+          "requirements": ["exists-reftarget", "is-admin"],
+          "skippable": true
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "A dashboard folder named after the demo now appears in your dashboards."
+    },
+    {
+      "type": "markdown",
+      "content": "### No admin access?\n\nIf you can't install demo data, explore a live Grafana instance instead. Open [play.grafana.org](https://play.grafana.org) to browse dashboards and try queries across metrics, logs, and traces without any setup."
+    },
+    {
+      "type": "markdown",
+      "content": "Now open one of the dashboards you just installed and get oriented."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "navigate",
+          "reftarget": "/dashboards",
+          "content": "Go to **Dashboards** and open the demo folder you just installed."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Open a dashboard, then notice the time range picker, the panels, and any dashboard variables near the top. These are the controls you'll use to explore any dashboard."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You've read your first Grafana Cloud dashboard and know where the core controls live."
+    },
+    {
+      "type": "interactive",
+      "action": "navigate",
+      "reftarget": "/a/cloud-home-app",
+      "openGuide": "bundled:get-started-hub",
+      "content": "**Return to Get started with Grafana Cloud** to pick another path, such as **Query data where it lives** or **Monitor a host or service**."
+    }
+  ]
+}

--- a/src/bundled-interactives/get-started-hub/content.json
+++ b/src/bundled-interactives/get-started-hub/content.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-hub",
+  "title": "Get started with Grafana Cloud",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Grafana Cloud can do a lot, and there's no single right place to begin. Pick the path that matches what you want to do first. You can come back and choose another anytime.\n\n**Not sure where to start?** Choose **See Grafana Cloud in action** for a quick win with demo data. No setup or instrumentation required, and you're not billed for it."
+    },
+    {
+      "type": "interactive",
+      "action": "navigate",
+      "reftarget": "/dashboards",
+      "openGuide": "bundled:get-started-explore",
+      "content": "**See Grafana Cloud in action**\n\nInstall ready-made demo dashboards and read your first one. The fastest way to see value with no data setup."
+    },
+    {
+      "type": "interactive",
+      "action": "navigate",
+      "reftarget": "/connections/datasources/new",
+      "openGuide": "bundled:get-started-connect-data",
+      "content": "**Query data where it lives**\n\nConnect a data source and query it in place, with no moving or duplicating your data."
+    },
+    {
+      "type": "interactive",
+      "action": "navigate",
+      "reftarget": "/connections/add-new-connection?cat=integration",
+      "openGuide": "bundled:get-started-monitor-host",
+      "content": "**Monitor a host or service**\n\nInstall an integration that sets up data collection and a prebuilt dashboard for a host, database, or web server."
+    },
+    {
+      "type": "interactive",
+      "action": "navigate",
+      "reftarget": "/connections/add-new-connection/hmInstancePromId",
+      "openGuide": "bundled:prom-remote-write-lj",
+      "content": "**Send metrics from an existing collector**\n\nAlready running Prometheus? Push its metrics to Grafana Cloud with remote write."
+    },
+    {
+      "type": "interactive",
+      "action": "navigate",
+      "reftarget": "/a/k6-app",
+      "openGuide": "bundled:run-first-k6-test-lj",
+      "content": "**Run a load test with k6**\n\nCreate and run your first performance test against a target."
+    },
+    {
+      "type": "interactive",
+      "action": "navigate",
+      "reftarget": "/a/grafana-synthetic-monitoring-app/home",
+      "openGuide": "bundled:detect-outages-synthetic-monitoring-lj",
+      "content": "**Monitor uptime with Synthetic Monitoring**\n\nCreate your first check to track availability and latency."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Moving from another tool?\n\nComing from Datadog, Elastic, New Relic, or Splunk? Refer to [Migrate to Grafana Cloud](/docs/grafana-cloud/) for the migration path."
+    }
+  ]
+}

--- a/src/bundled-interactives/get-started-monitor-host/content.json
+++ b/src/bundled-interactives/get-started-monitor-host/content.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": "1.1.0",
+  "id": "get-started-monitor-host",
+  "title": "Monitor a host or service",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Start monitoring a host or service by installing an integration. An integration sets up the Grafana Alloy collector and prebuilt dashboards for a host, database, or web server, so you can see data in minutes."
+    },
+    {
+      "type": "markdown",
+      "content": "You'll need a host or service to monitor, terminal and admin access to it, and outbound HTTPS on port 443 to `*.grafana.net` allowed."
+    },
+    {
+      "type": "markdown",
+      "content": "You start on the **Add new connection** page, filtered to integrations. Choose the one that matches your host or service, then run its install command."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Search for the integration that matches what you want to monitor, for example a Linux, macOS, or Windows host, a database, or a web server, then click its tile."
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "On the **Configuration details** tab, copy the install command and run it in your terminal. The command includes a token, so treat it like a secret and don't share it."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "Optionally set a **Hostname value** to label this host. Use the **Advanced integration** toggle to send only the metrics the integration needs, which helps control cost."
+    },
+    {
+      "type": "markdown",
+      "content": "You've installed an integration. Alloy is now collecting metrics and sending them to Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "See your metrics on the dashboard the integration installed."
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
+          "content": "Open the main menu and click **Dashboards**.",
+          "requirements": ["exists-reftarget", "navmenu-open"]
+        },
+        {
+          "type": "interactive",
+          "action": "noop",
+          "content": "Open the folder the integration created, then open one of its prebuilt dashboards."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "The dashboard stays empty until the first scrape, then data appears. You can adjust the scrape interval later to balance detail and cost."
+    },
+    {
+      "type": "markdown",
+      "content": "You're viewing your first metrics in Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "Metrics usage scales with what you send. The **Advanced integration** option and the scrape interval are your main cost levers. Refer to [Manage metrics costs](/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/)."
+    },
+    {
+      "type": "interactive",
+      "action": "navigate",
+      "reftarget": "/a/cloud-home-app",
+      "openGuide": "bundled:get-started-hub",
+      "content": "**Return to Get started with Grafana Cloud** to pick another path."
+    }
+  ]
+}

--- a/src/bundled-interactives/index.json
+++ b/src/bundled-interactives/index.json
@@ -54,6 +54,62 @@
       "filename": "first-dashboard-cloud/content.json",
       "url": ["/"],
       "targetPlatform": "cloud"
+    },
+    {
+      "id": "get-started-hub",
+      "title": "Get started with Grafana Cloud",
+      "summary": "Choose how to get started with Grafana Cloud and reach a first success fast: explore demo data, query data where it lives, monitor a host or service, send metrics from a collector, load test with k6, or monitor uptime.",
+      "filename": "get-started-hub/content.json",
+      "url": ["/a/cloud-home-app", "/a/grafana-setupguide-app/getting-started"],
+      "targetPlatform": "cloud"
+    },
+    {
+      "id": "get-started-explore",
+      "title": "See Grafana Cloud in action with demo data",
+      "summary": "Install ready-made demo dashboards and read your first one. The fastest way to see value with no data setup.",
+      "filename": "get-started-explore/content.json",
+      "url": ["/dashboards"],
+      "targetPlatform": "cloud"
+    },
+    {
+      "id": "get-started-connect-data",
+      "title": "Query data where it lives",
+      "summary": "Connect a data source and query it in place, with no moving or duplicating your data.",
+      "filename": "get-started-connect-data/content.json",
+      "url": ["/connections/add-new-connection"],
+      "targetPlatform": "cloud"
+    },
+    {
+      "id": "get-started-monitor-host",
+      "title": "Monitor a host or service",
+      "summary": "Install an integration that sets up data collection and a prebuilt dashboard for a host, database, or web server.",
+      "filename": "get-started-monitor-host/content.json",
+      "url": ["/connections/add-new-connection"],
+      "targetPlatform": "cloud"
+    },
+    {
+      "id": "run-first-k6-test-lj",
+      "title": "Run your first k6 performance test",
+      "summary": "Create and run your first performance test against a target.",
+      "filename": "run-first-k6-test-lj/content.json",
+      "url": ["/a/k6-app"],
+      "targetPlatform": "cloud"
+    },
+    {
+      "id": "detect-outages-synthetic-monitoring-lj",
+      "title": "Detect customer-visible outages using Synthetic Monitoring",
+      "summary": "Create your first check to track availability and latency.",
+      "filename": "detect-outages-synthetic-monitoring-lj/content.json",
+      "url": ["/a/grafana-synthetic-monitoring-app/home"],
+      "targetPlatform": "cloud"
+    },
+    {
+      "id": "prom-remote-write-lj",
+      "title": "Send metrics to Grafana Cloud using Prometheus remote write",
+      "summary": "Already running Prometheus? Push its metrics to Grafana Cloud with remote write.",
+      "filename": "prom-remote-write-lj/content.json",
+      "url": ["/connections/add-new-connection/hmInstancePromId"],
+      "targetPlatform": "cloud"
     }
   ]
 }

--- a/src/bundled-interactives/prom-remote-write-configure/content.json
+++ b/src/bundled-interactives/prom-remote-write-configure/content.json
@@ -1,0 +1,115 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "prom-remote-write-configure",
+  "title": "Configure Prometheus remote write to send metrics to Grafana Cloud",
+  "blocks": [
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/BDJO-vC-gEw",
+      "provider": "youtube",
+      "title": "Configure Prometheus remote write",
+      "start": 194,
+      "end": 349
+    },
+    {
+      "type": "markdown",
+      "content": "In this step of the journey you'll update a YAML file in your Prometheus installation with a snippet of code taken from your Grafana Cloud Portal account. The snippet of code provides Prometheus with the URL of the Grafana Cloud metrics instance and credentials for sending metrics."
+    },
+    {
+      "type": "markdown",
+      "content": "To configure Prometheus to remote write to Grafana Cloud, complete the following steps:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Log into your Cloud Portal and select your stack."
+        },
+        {
+          "type": "image",
+          "src": "https://grafana.com/media/docs/learning-journey/remote-write/select-stack.png",
+          "alt": "Image of stack selected in the Grafana Cloud Portal"
+        },
+        {
+          "type": "markdown",
+          "content": "Click the name of your stack under **Grafana Cloud** located on the left navigation panel."
+        },
+        {
+          "type": "markdown",
+          "content": "On the **Prometheus** tile, click **Send Metrics**."
+        },
+        {
+          "type": "markdown",
+          "content": "Scroll down the page until you locate the **Sending metrics with Prometheus** section.\n\nThis section contains a snippet of code that you'll add to your Prometheus deployment."
+        },
+        {
+          "type": "markdown",
+          "content": "Just below the code sample, click **Generate now** to generate an API token.\n\nThe API token ensures a secure connection to Grafana Cloud."
+        },
+        {
+          "type": "image",
+          "src": "https://grafana.com/media/docs/learning-journey/remote-write/api-token.png",
+          "alt": "Picture of Generate now link to create API token"
+        },
+        {
+          "type": "markdown",
+          "content": "On the **Create an API token** screen, enter a name for the token and click **Create token**.\n\nThe code snippet populates with the token you just created."
+        },
+        {
+          "type": "markdown",
+          "content": "On the **Create an API token** screen, click **Close**."
+        },
+        {
+          "type": "markdown",
+          "content": "Just below the code snippet, click **Copy to clipboard**.\n\nIn the following steps, you'll add the code snippet to the `prometheus.yml` file."
+        },
+        {
+          "type": "markdown",
+          "content": "Log into the machine on which Prometheus is installed."
+        },
+        {
+          "type": "markdown",
+          "content": "Open a terminal and if required, switch to a user with write privileges.\n\nFor example:\n\n```\nsudo su -\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Open the `prometheus.yml` file located under `/etc/prometheus`.\n\nFor example, if you are using Vim, run:\n\n```\nvim /etc/prometheus/prometheus.yml\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Edit the YAML file.\n\nWhen using Vi or Vim as the text editor, press `i` to edit the YAML file.\n\nThe button you use to the edit the YAML file depends on the text editor you are using."
+        },
+        {
+          "type": "markdown",
+          "content": "Scroll to the end of the file and paste the snippet of code you copied from the Grafana Cloud Portal."
+        },
+        {
+          "type": "markdown",
+          "content": "Exit edit mode and save your changes.\n\nFor example, when using Vi or Vim, press the `Esc` key to exit insert mode type `:wq` to save your changes and exit."
+        },
+        {
+          "type": "markdown",
+          "content": "Restart the Prometheus service to apply the changes.\n\nFor example: run the command\n\n```\nsystemctl restart prometheus.yml\n```\n\nAfter restarting the Prometheus service, metrics should be forwarded to Grafana Cloud."
+        },
+        {
+          "type": "markdown",
+          "content": "To check the Prometheus service status, run the following command:\n\n```\nsystemctl status prometheus.service\n```\n\nIf there are errors, refer to the relevant logs in `/var/log/syslog` or `journalctl`."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next stop in your journey, you'll verify that Prometheus is sending metrics to Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topics if you need help:\n\n- [/etc/prometheus/prometheus.yml is read-only](https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-prometheus/#troubleshooting)\n- [/etc/prometheus/prometheus.yml Can't open file for writing](https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-prometheus/#troubleshooting)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\n- [Send data from multiple Prometheus instances](https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-prometheus/#send-data-from-multiple-prometheus-instances)\n- [Send data from multiple high-availability Prometheus instances](https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-prometheus/#send-data-from-multiple-high-availability-prometheus-instances)"
+    }
+  ]
+}

--- a/src/bundled-interactives/prom-remote-write-configure/manifest.json
+++ b/src/bundled-interactives/prom-remote-write-configure/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "prom-remote-write-configure",
+  "type": "guide",
+  "description": "How to configure Prometheus to send metrics to Grafana Cloud.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "prom-remote-write-verify-prom-data"
+  ],
+  "recommends": [
+    "prom-remote-write-verify-metrics"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/src/bundled-interactives/prom-remote-write-end/content.json
+++ b/src/bundled-interactives/prom-remote-write-end/content.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "prom-remote-write-end",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! Job well done!"
+    },
+    {
+      "type": "markdown",
+      "content": "We hope you've enjoyed traveling with us as you:\n\n- Learned about the value of observability and the advantages of Prometheus remote write\n- Verified that your Prometheus server is capturing metrics\n- Configure Prometheus to send metrics to Grafana Cloud\n- Verified that metrics appear in Grafana Cloud"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Related paths\n\nConsider taking the following paths after you complete this journey:\n\n- [Explore data using Metrics Drilldown](https://grafana.com/docs/learning-paths/drilldown-metrics/)"
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### More to explore (optional)\n\nThe world is your oyster! Read more about how you can:\n\n- [Monitor alerts](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/monitor-status)\n- [Get started with incident response](https://grafana.com/docs/grafana-cloud/alerting-and-irm/irm/incident/get-started)\n- [Set up Slack to manage incidents](https://grafana.com/docs/grafana-cloud/alerting-and-irm/irm/irm-slack)\n- [Set up a Service Level Objective](https://grafana.com/docs/grafana-cloud/alerting-and-irm/slo/set-up)"
+    }
+  ]
+}

--- a/src/bundled-interactives/prom-remote-write-end/manifest.json
+++ b/src/bundled-interactives/prom-remote-write-end/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "prom-remote-write-end",
+  "type": "guide",
+  "description": "Your journey concludes and it's time to learn about related paths you can take.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "prom-remote-write-verify-metrics"
+  ],
+  "recommends": [],
+  "suggests": [
+    "drilldown-metrics-lj"
+  ],
+  "provides": []
+}

--- a/src/bundled-interactives/prom-remote-write-lj/content.json
+++ b/src/bundled-interactives/prom-remote-write-lj/content.json
@@ -1,0 +1,18 @@
+{
+  "id": "prom-remote-write-lj",
+  "title": "Send metrics to Grafana Cloud using Prometheus remote write",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Welcome to the Grafana learning path that provides best practices for sending Prometheus data to Grafana Cloud.\n\nPrometheus is an open source systems monitoring and alerting toolkit that captures metrics as time series data and optional key-value pairs called labels. Prometheus scrapes metrics from instrumented jobs, either directly or by way of an intermediary push gateway for short-lived jobs. It stores all scraped samples locally and runs rules over this data to either aggregate and record new time series from existing data, or generate alerts.\n\nThis journey teaches you how to configure your Prometheus server to send metrics so that you can query, drill down, and visualize them in Grafana Cloud."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this journey, you'll be able to:\n\n1. Verify that your self-managed Prometheus server is capturing metrics\n1. Configure Prometheus to send metrics to Grafana Cloud\n1. Verify that metrics appear in Grafana Metrics Drilldown"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nBefore you send Prometheus metrics to Grafana Cloud, ensure that you have:\n\n- Experience working with Prometheus and understand its basic set up and operation.\n- Downloaded, installed, and configured Prometheus to collect metrics.\n- Access to the machine on which Prometheus is installed and that your user has root privileges."
+    }
+  ]
+}

--- a/src/bundled-interactives/prom-remote-write-lj/manifest.json
+++ b/src/bundled-interactives/prom-remote-write-lj/manifest.json
@@ -1,0 +1,38 @@
+{
+  "id": "prom-remote-write-lj",
+  "type": "path",
+  "description": "A learning path that shows you how to send metrics to Grafana Cloud using Prometheus remote write.",
+  "category": "data-availability",
+  "author": {
+    "name": "knylander-grafana",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/connections/add-new-connection/hmInstancePromId",
+  "targeting": {
+    "match": {
+      "and": [
+        {
+          "urlPrefix": "/connections/add-new-connection/hmInstancePromId"
+        },
+        {
+          "targetPlatform": "cloud"
+        }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "prom-remote-write-verify-prom-data",
+    "prom-remote-write-configure",
+    "prom-remote-write-verify-metrics",
+    "prom-remote-write-end"
+  ],
+  "depends": [],
+  "recommends": [
+    "drilldown-metrics-lj"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/src/bundled-interactives/prom-remote-write-verify-metrics/content.json
+++ b/src/bundled-interactives/prom-remote-write-verify-metrics/content.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "prom-remote-write-verify-metrics",
+  "title": "Verify metrics query successful",
+  "blocks": [
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/BDJO-vC-gEw",
+      "provider": "youtube",
+      "title": "Verify metrics query successful",
+      "start": 349
+    },
+    {
+      "type": "markdown",
+      "content": "As the final step in your journey, complete the following steps to confirm that you've successfully sent Prometheus metrics to Grafana Cloud:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[href=\"/a/grafana-metricsdrilldown-app/drilldown\"]",
+          "requirements": ["navmenu-open", "exists-reftarget"],
+          "content": "In the Grafana side menu, click **Drilldown > Metrics**."
+        },
+        {
+          "type": "markdown",
+          "content": "If you see a **Let's start!** button, click it."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You should see Prometheus metrics displayed in the Grafana Drilldown Metrics app."
+    },
+    {
+      "type": "markdown",
+      "content": "**Congratulations!** You've successfully connected to your Prometheus data source."
+    },
+    {
+      "type": "markdown",
+      "content": "---\n\n### Troubleshooting\n\nExplore the following troubleshooting topic if you need help:\n\n- [Data doesn't appear in Explore metrics](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/prometheus/configure-prometheus-data-source/#troubleshooting)"
+    }
+  ]
+}

--- a/src/bundled-interactives/prom-remote-write-verify-metrics/manifest.json
+++ b/src/bundled-interactives/prom-remote-write-verify-metrics/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "prom-remote-write-verify-metrics",
+  "type": "guide",
+  "description": "How to verify that a Prometheus data source query works.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [
+    "prom-remote-write-configure"
+  ],
+  "recommends": [
+    "prom-remote-write-end"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/src/bundled-interactives/prom-remote-write-verify-prom-data/content.json
+++ b/src/bundled-interactives/prom-remote-write-verify-prom-data/content.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "prom-remote-write-verify-prom-data",
+  "title": "Verify Prometheus metrics are written to an endpoint",
+  "blocks": [
+    {
+      "type": "video",
+      "src": "https://www.youtube.com/embed/BDJO-vC-gEw",
+      "provider": "youtube",
+      "title": "Verify Prometheus metrics are written to an endpoint",
+      "start": 127,
+      "end": 193
+    },
+    {
+      "type": "markdown",
+      "content": "While installing and configuring Prometheus in your local environment is out of scope for this journey, a good first step in this journey is to verify that your system is writing metrics to the Prometheus endpoint."
+    },
+    {
+      "type": "markdown",
+      "content": "To verify Prometheus metrics are written to an endpoint:"
+    },
+    {
+      "type": "section",
+      "autoCollapse": false,
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Log into the machine on which Prometheus is installed."
+        },
+        {
+          "type": "markdown",
+          "content": "If required, switch to a user that has administrative privileges."
+        },
+        {
+          "type": "markdown",
+          "content": "To check the Prometheus service status, run one of the following commands:\n\nFor Linux:\n\n```\nsystemctl status prometheus.service\n```\n\nFor Windows:\n\n```\nsc query prometheus\n```\n\nYou should see something similar to the following:"
+        },
+        {
+          "type": "image",
+          "src": "https://grafana.com/media/docs/learning-journey/prom-data-source/verify-prom-data-1.png",
+          "alt": "Picture that shows the Prometheus service up and running"
+        },
+        {
+          "type": "markdown",
+          "content": "To ensure that Prometheus is capturing the metrics, open a browser tab and navigate to the metrics endpoint URL.\n\nFor example, navigate to `http://localhost:9090/metrics`\n\nYou should see something similar to the following:"
+        },
+        {
+          "type": "image",
+          "src": "https://grafana.com/media/docs/learning-journey/prom-data-source/verify-prom-data-2.png",
+          "alt": "Picture that shows metrics in a browser tab"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "**Tip:** Consult the Prometheus documentation if you are unable to run the Prometheus service or can't verify that Prometheus is capturing metrics."
+    }
+  ]
+}

--- a/src/bundled-interactives/prom-remote-write-verify-prom-data/manifest.json
+++ b/src/bundled-interactives/prom-remote-write-verify-prom-data/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "prom-remote-write-verify-prom-data",
+  "type": "guide",
+  "description": "How to verify that metrics are being written to an endpoint.",
+  "category": "data-availability",
+  "author": {
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": [
+    "prom-remote-write-configure"
+  ],
+  "suggests": [],
+  "provides": []
+}

--- a/src/bundled-interactives/repository.json
+++ b/src/bundled-interactives/repository.json
@@ -42,8 +42,13 @@
       "team": "Grafana Developer Advocacy"
     },
     "startingLocation": "/",
-    "recommends": ["welcome-to-grafana", "prometheus-grafana-101"],
-    "provides": ["first-dashboard-created"],
+    "recommends": [
+      "welcome-to-grafana",
+      "prometheus-grafana-101"
+    ],
+    "provides": [
+      "first-dashboard-created"
+    ],
     "targeting": {
       "match": {
         "and": [
@@ -72,8 +77,12 @@
       "team": "Grafana Developer Advocacy"
     },
     "startingLocation": "/",
-    "recommends": ["welcome-to-grafana-cloud"],
-    "provides": ["first-dashboard-created-cloud"],
+    "recommends": [
+      "welcome-to-grafana-cloud"
+    ],
+    "provides": [
+      "first-dashboard-created-cloud"
+    ],
     "targeting": {
       "match": {
         "and": [
@@ -118,8 +127,12 @@
       "team": "Grafana Developer Advocacy"
     },
     "startingLocation": "/connections",
-    "depends": ["prometheus-grafana-101"],
-    "provides": ["loki-configured"],
+    "depends": [
+      "prometheus-grafana-101"
+    ],
+    "provides": [
+      "loki-configured"
+    ],
     "targeting": {
       "match": {
         "and": [
@@ -148,7 +161,10 @@
       "team": "Grafana Developer Advocacy"
     },
     "startingLocation": "/explore",
-    "recommends": ["prometheus-grafana-101", "loki-grafana-101"],
+    "recommends": [
+      "prometheus-grafana-101",
+      "loki-grafana-101"
+    ],
     "targeting": {
       "match": {
         "urlPrefix": "/explore"
@@ -170,8 +186,12 @@
       "team": "Grafana Developer Advocacy"
     },
     "startingLocation": "/connections",
-    "recommends": ["welcome-to-grafana"],
-    "provides": ["prometheus-configured"],
+    "recommends": [
+      "welcome-to-grafana"
+    ],
+    "provides": [
+      "prometheus-configured"
+    ],
     "targeting": {
       "match": {
         "and": [
@@ -200,7 +220,9 @@
       "team": "Grafana Developer Advocacy"
     },
     "startingLocation": "/",
-    "provides": ["grafana-tour-oss"],
+    "provides": [
+      "grafana-tour-oss"
+    ],
     "targeting": {
       "match": {
         "and": [
@@ -229,7 +251,9 @@
       "team": "Grafana Developer Advocacy"
     },
     "startingLocation": "/",
-    "provides": ["grafana-tour-cloud"],
+    "provides": [
+      "grafana-tour-cloud"
+    ],
     "targeting": {
       "match": {
         "and": [
@@ -246,5 +270,257 @@
       "tier": "cloud",
       "minVersion": "12.2.0"
     }
+  },
+  "get-started-hub": {
+    "path": "get-started-hub/",
+    "title": "Get started with Grafana Cloud",
+    "type": "guide",
+    "description": "Choose how to get started with Grafana Cloud and reach a first success fast: explore demo data, connect existing data, send metrics, load test with k6, or monitor uptime.",
+    "category": "getting-started",
+    "author": {
+      "name": "Chris Moyer",
+      "team": "Interactive Learning"
+    },
+    "startingLocation": "/a/cloud-home-app",
+    "suggests": [
+      "get-started-explore",
+      "get-started-connect-data",
+      "get-started-monitor-host",
+      "prom-remote-write-lj",
+      "run-first-k6-test-lj",
+      "detect-outages-synthetic-monitoring-lj"
+    ],
+    "targeting": {
+      "match": {
+        "and": [
+          {
+            "urlPrefixIn": [
+              "/a/cloud-home-app",
+              "/a/grafana-setupguide-app/getting-started"
+            ]
+          },
+          {
+            "targetPlatform": "cloud"
+          }
+        ]
+      }
+    },
+    "testEnvironment": {
+      "tier": "cloud",
+      "minVersion": "12.2.0"
+    }
+  },
+  "get-started-explore": {
+    "path": "get-started-explore/",
+    "title": "See Grafana Cloud in action with demo data",
+    "type": "guide",
+    "description": "Install ready-made demo dashboards and read your first one. The fastest way to see value with no data setup.",
+    "category": "getting-started",
+    "author": {
+      "name": "Chris Moyer",
+      "team": "Interactive Learning"
+    },
+    "startingLocation": "/dashboards",
+    "testEnvironment": {
+      "tier": "cloud",
+      "minVersion": "12.2.0"
+    }
+  },
+  "get-started-connect-data": {
+    "path": "get-started-connect-data/",
+    "title": "Query data where it lives",
+    "type": "guide",
+    "description": "Connect a data source and query it in place, with no moving or duplicating your data.",
+    "category": "getting-started",
+    "author": {
+      "name": "Chris Moyer",
+      "team": "Interactive Learning"
+    },
+    "startingLocation": "/connections/datasources/new",
+    "testEnvironment": {
+      "tier": "cloud",
+      "minVersion": "12.2.0"
+    }
+  },
+  "get-started-monitor-host": {
+    "path": "get-started-monitor-host/",
+    "title": "Monitor a host or service",
+    "type": "guide",
+    "description": "Install an integration that sets up data collection and a prebuilt dashboard for a host, database, or web server.",
+    "category": "getting-started",
+    "author": {
+      "name": "Chris Moyer",
+      "team": "Interactive Learning"
+    },
+    "startingLocation": "/connections/add-new-connection?cat=integration",
+    "testEnvironment": {
+      "tier": "cloud",
+      "minVersion": "12.2.0"
+    }
+  },
+  "run-first-k6-test-lj": {
+    "path": "run-first-k6-test-lj/",
+    "title": "Run your first k6 performance test",
+    "type": "path",
+    "description": "Create and run your first performance test against a target.",
+    "category": "testing",
+    "author": {
+      "name": "Chris Moyer",
+      "team": "Interactive Learning"
+    },
+    "startingLocation": "/a/k6-app",
+    "testEnvironment": {
+      "tier": "cloud",
+      "minVersion": "12.2.0"
+    },
+    "milestones": [
+      "run-first-k6-test-install-k6",
+      "run-first-k6-test-write-test-script",
+      "run-first-k6-test-run-locally",
+      "run-first-k6-test-send-to-grafana-cloud",
+      "run-first-k6-test-analyze-results",
+      "run-first-k6-test-end-journey"
+    ]
+  },
+  "detect-outages-synthetic-monitoring-lj": {
+    "path": "detect-outages-synthetic-monitoring-lj/",
+    "title": "Detect customer-visible outages using Synthetic Monitoring",
+    "type": "path",
+    "description": "Create your first check to track availability and latency.",
+    "category": "testing",
+    "author": {
+      "name": "Chris Moyer",
+      "team": "Interactive Learning"
+    },
+    "startingLocation": "/a/grafana-synthetic-monitoring-app/home",
+    "testEnvironment": {
+      "tier": "cloud",
+      "minVersion": "12.2.0"
+    },
+    "milestones": [
+      "detect-outages-synthetic-monitoring-navigate-to-synthetic-monitoring",
+      "detect-outages-synthetic-monitoring-initialize-plugin",
+      "detect-outages-synthetic-monitoring-create-ping-check",
+      "detect-outages-synthetic-monitoring-select-probe-locations",
+      "detect-outages-synthetic-monitoring-view-check-dashboard",
+      "detect-outages-synthetic-monitoring-end-journey"
+    ]
+  },
+  "prom-remote-write-lj": {
+    "path": "prom-remote-write-lj/",
+    "title": "Send metrics to Grafana Cloud using Prometheus remote write",
+    "type": "path",
+    "description": "Already running Prometheus? Push its metrics to Grafana Cloud with remote write.",
+    "category": "getting-started",
+    "author": {
+      "name": "knylander-grafana",
+      "team": "Grafana Documentation"
+    },
+    "startingLocation": "/connections/add-new-connection/hmInstancePromId",
+    "testEnvironment": {
+      "tier": "cloud"
+    },
+    "milestones": [
+      "prom-remote-write-verify-prom-data",
+      "prom-remote-write-configure",
+      "prom-remote-write-verify-metrics",
+      "prom-remote-write-end"
+    ]
+  },
+  "run-first-k6-test-install-k6": {
+    "path": "run-first-k6-test-install-k6/",
+    "title": "Install k6",
+    "type": "guide",
+    "description": "Hands-on guide: Install k6 on your machine and verify the installation."
+  },
+  "run-first-k6-test-write-test-script": {
+    "path": "run-first-k6-test-write-test-script/",
+    "title": "Write your first k6 test script",
+    "type": "guide",
+    "description": "Hands-on guide: Create a k6 test script with HTTP requests and checks."
+  },
+  "run-first-k6-test-run-locally": {
+    "path": "run-first-k6-test-run-locally/",
+    "title": "Run your k6 test locally",
+    "type": "guide",
+    "description": "Hands-on guide: Execute your k6 test and review results in your terminal."
+  },
+  "run-first-k6-test-send-to-grafana-cloud": {
+    "path": "run-first-k6-test-send-to-grafana-cloud/",
+    "title": "Send test results to Grafana Cloud",
+    "type": "guide",
+    "description": "Hands-on guide: Find your API token and stream k6 test results to Grafana Cloud."
+  },
+  "run-first-k6-test-analyze-results": {
+    "path": "run-first-k6-test-analyze-results/",
+    "title": "Analyze test results in Grafana Cloud",
+    "type": "guide",
+    "description": "Hands-on guide: Navigate test results and explore Performance Overview, Cloud Insights, HTTP, and Thresholds tabs."
+  },
+  "run-first-k6-test-end-journey": {
+    "path": "run-first-k6-test-end-journey/",
+    "title": "Destination reached!",
+    "type": "guide",
+    "description": "Congratulations on completing your first k6 performance test journey."
+  },
+  "detect-outages-synthetic-monitoring-navigate-to-synthetic-monitoring": {
+    "path": "detect-outages-synthetic-monitoring-navigate-to-synthetic-monitoring/",
+    "title": "Navigate to Synthetic Monitoring",
+    "type": "guide",
+    "description": "Learn how to access the Synthetic Monitoring app within Grafana Cloud to view and manage your checks."
+  },
+  "detect-outages-synthetic-monitoring-initialize-plugin": {
+    "path": "detect-outages-synthetic-monitoring-initialize-plugin/",
+    "title": "Initialize the Synthetic Monitoring plugin",
+    "type": "guide",
+    "description": "Learn how to initialize the Synthetic Monitoring plugin to set up the required data sources for your checks."
+  },
+  "detect-outages-synthetic-monitoring-create-ping-check": {
+    "path": "detect-outages-synthetic-monitoring-create-ping-check/",
+    "title": "Create a ping check",
+    "type": "guide",
+    "description": "Learn how to create your first ping check to test endpoint reachability and measure response latency."
+  },
+  "detect-outages-synthetic-monitoring-select-probe-locations": {
+    "path": "detect-outages-synthetic-monitoring-select-probe-locations/",
+    "title": "Select probe locations",
+    "type": "guide",
+    "description": "Learn how to select global probe locations and create your check to start monitoring your services."
+  },
+  "detect-outages-synthetic-monitoring-view-check-dashboard": {
+    "path": "detect-outages-synthetic-monitoring-view-check-dashboard/",
+    "title": "View the check dashboard",
+    "type": "guide",
+    "description": "Learn how to view and interpret the check dashboard with uptime, latency, and reachability metrics."
+  },
+  "detect-outages-synthetic-monitoring-end-journey": {
+    "path": "detect-outages-synthetic-monitoring-end-journey/",
+    "title": "Destination reached!",
+    "type": "guide",
+    "description": "Congratulations on completing the Synthetic Monitoring get started learning path! Explore next steps for expanding your monitoring capabilities."
+  },
+  "prom-remote-write-verify-prom-data": {
+    "path": "prom-remote-write-verify-prom-data/",
+    "title": "Verify Prometheus metrics are written to an endpoint",
+    "type": "guide",
+    "description": "How to verify that metrics are being written to an endpoint."
+  },
+  "prom-remote-write-configure": {
+    "path": "prom-remote-write-configure/",
+    "title": "Configure Prometheus remote write to send metrics to Grafana Cloud",
+    "type": "guide",
+    "description": "How to configure Prometheus to send metrics to Grafana Cloud."
+  },
+  "prom-remote-write-verify-metrics": {
+    "path": "prom-remote-write-verify-metrics/",
+    "title": "Verify metrics query successful",
+    "type": "guide",
+    "description": "How to verify that a Prometheus data source query works."
+  },
+  "prom-remote-write-end": {
+    "path": "prom-remote-write-end/",
+    "title": "Destination reached!",
+    "type": "guide",
+    "description": "Your journey concludes and it's time to learn about related paths you can take."
   }
 }

--- a/src/bundled-interactives/run-first-k6-test-analyze-results/content.json
+++ b/src/bundled-interactives/run-first-k6-test-analyze-results/content.json
@@ -1,0 +1,59 @@
+{
+  "id": "run-first-k6-test-analyze-results",
+  "title": "Analyze test results in Grafana Cloud",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you analyze your k6 test results in Grafana Cloud dashboards to understand performance metrics and identify potential issues."
+    },
+    {
+      "type": "section",
+      "id": "explore-results",
+      "title": "Explore test results",
+      "blocks": [
+        {
+          "type": "multistep",
+          "content": "In the main menu, navigate to **Testing & synthetics > Performance**.",
+          "requirements": ["navmenu-open"],
+          "skippable": true,
+          "steps": [
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/testing-and-synthetics']" },
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/k6-app']" }
+          ]
+        },
+        {
+          "type": "markdown",
+          "content": "On the Performance page, select the project that contains your test."
+        },
+        {
+          "type": "markdown",
+          "content": "Select your test, then choose the most recent test run from the list to open the **Performance Overview** dashboard."
+        },
+        {
+          "type": "markdown",
+          "content": "Review the **Performance Overview** dashboard, which displays test summary information (duration, virtual users, iterations), HTTP request statistics (total requests, success rate, error rate), response time metrics (average, median, p95), and throughput metrics (requests per second, data transfer rates)."
+        },
+        {
+          "type": "markdown",
+          "content": "Scroll down to the **Cloud Insights** section.\n\nCloud Insights analyzes your test script and results, then generates scores and recommendations across categories such as best practice, reliability, and system performance."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Tab HTTP']",
+          "content": "Select the **HTTP** tab to explore detailed request metrics for each endpoint, including count, response times (min, average, p95, p99, max), and status codes."
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Tab THRESHOLDS']",
+          "content": "Select the **Thresholds** tab to review the default and custom thresholds for your test.\n\nGrafana Cloud k6 automatically applies thresholds like `http_req_failed` and `http_req_duration`."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "You now know how to find your test results in Grafana Cloud and read the performance overview, Cloud Insights, HTTP details, and thresholds for your test."
+    }
+  ]
+}

--- a/src/bundled-interactives/run-first-k6-test-analyze-results/manifest.json
+++ b/src/bundled-interactives/run-first-k6-test-analyze-results/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "run-first-k6-test-analyze-results",
+  "type": "guide",
+  "description": "Hands-on guide: Navigate test results and explore Performance Overview, Cloud Insights, HTTP, and Thresholds tabs.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/k6-app/runs",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/a/k6-app/runs" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["run-first-k6-test-send-to-grafana-cloud"],
+  "recommends": ["run-first-k6-test-end-journey"],
+  "suggests": [],
+  "provides": []
+}

--- a/src/bundled-interactives/run-first-k6-test-end-journey/content.json
+++ b/src/bundled-interactives/run-first-k6-test-end-journey/content.json
@@ -1,0 +1,22 @@
+{
+  "id": "run-first-k6-test-end-journey",
+  "title": "Destination reached!",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Congratulations on completing this journey! You now have the foundational knowledge to create and run k6 performance tests."
+    },
+    {
+      "type": "markdown",
+      "content": "**What you achieved**\n\nThroughout this journey you:\n\n- Learned the value of performance testing with k6\n- Installed k6 on your machine\n- Wrote your first test script with HTTP requests and checks\n- Ran a test locally and reviewed results in your terminal\n- Sent test results to Grafana Cloud\n- Analyzed results in Grafana Cloud dashboards"
+    },
+    {
+      "type": "markdown",
+      "content": "**What's next**\n\nContinue your k6 learning by exploring:\n\n- **Advanced test scripting**: Multiple requests, data parameterization, and custom logic\n- **Thresholds and checks**: Automatic pass/fail criteria for test results\n- **Browser testing**: Test web applications with real browser automation using k6 browser\n- **CI/CD integration**: Add k6 tests to your continuous integration pipeline"
+    },
+    {
+      "type": "markdown",
+      "content": "In Grafana Cloud, go to **Testing & synthetics > Performance** to explore the interactive onboarding: try k6 Studio, OpenAPI to k6, and running tests from the UI."
+    }
+  ]
+}

--- a/src/bundled-interactives/run-first-k6-test-end-journey/manifest.json
+++ b/src/bundled-interactives/run-first-k6-test-end-journey/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "run-first-k6-test-end-journey",
+  "type": "guide",
+  "description": "Congratulations on completing your first k6 performance test journey.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["run-first-k6-test-analyze-results"],
+  "recommends": [],
+  "suggests": ["detect-outages-synthetic-monitoring-lj", "create-availability-slo-lj"],
+  "provides": []
+}

--- a/src/bundled-interactives/run-first-k6-test-install-k6/content.json
+++ b/src/bundled-interactives/run-first-k6-test-install-k6/content.json
@@ -1,0 +1,37 @@
+{
+  "id": "run-first-k6-test-install-k6",
+  "title": "Install k6",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you install k6 on your machine using your preferred package manager and verify that it is working as expected."
+    },
+    {
+      "type": "section",
+      "id": "install",
+      "title": "Install k6",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "Choose the installation method for your operating system:\n\n| OS | Method |\n|---|---|\n| **macOS** | Homebrew |\n| **Linux (Debian/Ubuntu)** | APT |\n| **Linux (Fedora/CentOS)** | DNF/YUM |\n| **Windows** | Chocolatey or Winget |\n| **Any platform** | Docker or standalone binary |"
+        },
+        {
+          "type": "markdown",
+          "content": "**In your terminal**, install k6 using your chosen method.\n\nFor macOS:\n```bash\nbrew install k6\n```\n\nFor Linux (Debian/Ubuntu):\n```bash\nsudo gpg -k\nsudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69\necho \"deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main\" | sudo tee /etc/apt/sources.list.d/k6.list\nsudo apt-get update\nsudo apt-get install k6\n```\n\nFor Docker:\n```bash\ndocker pull grafana/k6\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Verify the installation by checking the k6 version:\n\n```bash\nk6 version\n```\n\nYou should see version information displayed in your terminal."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "**Troubleshooting**\n\nExplore the following troubleshooting topic if you need help:\n\n- [k6 installation troubleshooting guide](/docs/k6/latest/set-up/install-k6/troubleshooting/)"
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you write your first k6 test script with HTTP requests and checks."
+    }
+  ]
+}

--- a/src/bundled-interactives/run-first-k6-test-install-k6/manifest.json
+++ b/src/bundled-interactives/run-first-k6-test-install-k6/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "run-first-k6-test-install-k6",
+  "type": "guide",
+  "description": "Hands-on guide: Install k6 on your machine and verify the installation.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/testing-and-synthetics",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/testing-and-synthetics" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": [],
+  "recommends": ["run-first-k6-test-write-test-script"],
+  "suggests": [],
+  "provides": []
+}

--- a/src/bundled-interactives/run-first-k6-test-lj/content.json
+++ b/src/bundled-interactives/run-first-k6-test-lj/content.json
@@ -1,0 +1,22 @@
+{
+  "id": "run-first-k6-test-lj",
+  "title": "Run your first k6 performance test",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "k6 is a modern performance testing tool that helps developers simulate realistic user behavior and test how their systems behave under load. By writing k6 test scripts, you can identify potential issues such as slow response times or system failures before they occur in production.\n\nThis journey guides you through the complete process of creating and running a k6 performance test, from understanding the value of performance testing to analyzing results in Grafana Cloud. You'll learn how to write test scripts, run them locally, send results to Grafana Cloud, and visualize metrics in dashboards.\n\n_Grafana Cloud users:_ you can also try the interactive onboarding in the k6 app. Go to **Testing & synthetics** > **Performance** to:\n\n- Explore test authoring tools (k6 Studio, OpenAPI to k6)\n- Run tests from the UI or CLI\n- Understand results\n\nThis guide complements the in-product onboarding with step-by-step instructions you can follow at your own pace."
+    },
+    {
+      "type": "markdown",
+      "content": "## Here's what to expect\n\nWhen you complete this journey, you'll be able to:\n\n- Understand the value of performance testing with k6\n- Install k6 on your machine\n- Write your first k6 test script\n- Run a test locally and view results\n- Send test results to Grafana Cloud\n- Analyze test results in Grafana Cloud dashboards"
+    },
+    {
+      "type": "markdown",
+      "content": "## Before you begin\n\nBefore you run your first k6 performance test, ensure that you have:\n\n- Basic knowledge of JavaScript or TypeScript (k6 scripts are written in JavaScript/TypeScript).\n- A code editor to write your scripts, such as [Visual Studio Code](https://code.visualstudio.com/) or [Cursor editors](https://www.cursor.com/).\n- Access to a terminal or command line interface.\n- A basic understanding of HTTP requests and web applications."
+    },
+    {
+      "type": "markdown",
+      "content": "## Troubleshooting\n\nIf you get stuck, we've got your back! Where appropriate, troubleshooting information is just a click away.\n\n## More to explore\n\nWe understand you might want to explore other capabilities not strictly on this path. We'll provide you opportunities where it makes sense."
+    }
+  ]
+}

--- a/src/bundled-interactives/run-first-k6-test-lj/manifest.json
+++ b/src/bundled-interactives/run-first-k6-test-lj/manifest.json
@@ -1,0 +1,34 @@
+{
+  "id": "run-first-k6-test-lj",
+  "type": "path",
+  "description": "Step-by-step guide: Install k6, write a test script, run it locally, and stream results to Grafana Cloud.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/k6-app",
+  "targeting": {
+    "match": {
+      "and": [
+        { "urlPrefix": "/a/k6-app" },
+        { "targetPlatform": "cloud" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "milestones": [
+    "run-first-k6-test-install-k6",
+    "run-first-k6-test-write-test-script",
+    "run-first-k6-test-run-locally",
+    "run-first-k6-test-send-to-grafana-cloud",
+    "run-first-k6-test-analyze-results",
+    "run-first-k6-test-end-journey"
+  ],
+  "depends": [],
+  "recommends": [],
+  "suggests": ["detect-outages-synthetic-monitoring-lj", "create-availability-slo-lj"],
+  "provides": []
+}

--- a/src/bundled-interactives/run-first-k6-test-run-locally/content.json
+++ b/src/bundled-interactives/run-first-k6-test-run-locally/content.json
@@ -1,0 +1,37 @@
+{
+  "id": "run-first-k6-test-run-locally",
+  "title": "Run your k6 test locally",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you run your k6 test script locally and review the results in your terminal."
+    },
+    {
+      "type": "section",
+      "id": "run-test",
+      "title": "Run the test",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "**In your terminal**, navigate to the directory containing your `script.js` file and run the test:\n\n```bash\nk6 run script.js\n```\n\nIf you're using Docker:\n```bash\ndocker run --rm -i grafana/k6 run - < script.js\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "Observe the test execution in your terminal. k6 displays real-time progress including iteration count, HTTP request statistics, and response time metrics."
+        },
+        {
+          "type": "markdown",
+          "content": "When the test completes, review the summary. Look for:\n\n- **checks_succeeded**: Should be 100% if all requests returned status 200\n- **http_req_duration**: Average, median, and p95 response times\n- **http_req_failed**: Should be 0% for a healthy endpoint\n- **iterations**: Should show 10 completed iterations"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "**Troubleshooting**\n\nIf the test fails to run, check that your script syntax is correct and that you have network connectivity to `https://quickpizza.grafana.com`.\n\n- [Running k6 tests](/docs/k6/latest/get-started/running-k6/)"
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you send your test results to Grafana Cloud for visualization and analysis."
+    }
+  ]
+}

--- a/src/bundled-interactives/run-first-k6-test-run-locally/manifest.json
+++ b/src/bundled-interactives/run-first-k6-test-run-locally/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "run-first-k6-test-run-locally",
+  "type": "guide",
+  "description": "Hands-on guide: Execute your k6 test and review results in your terminal.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/testing-and-synthetics",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/testing-and-synthetics" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["run-first-k6-test-write-test-script"],
+  "recommends": ["run-first-k6-test-send-to-grafana-cloud"],
+  "suggests": [],
+  "provides": []
+}

--- a/src/bundled-interactives/run-first-k6-test-send-to-grafana-cloud/content.json
+++ b/src/bundled-interactives/run-first-k6-test-send-to-grafana-cloud/content.json
@@ -1,0 +1,58 @@
+{
+  "id": "run-first-k6-test-send-to-grafana-cloud",
+  "title": "Send test results to Grafana Cloud",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you send your k6 test results to Grafana Cloud for real-time visualization and analysis."
+    },
+    {
+      "type": "section",
+      "id": "send-results",
+      "title": "Send results to Grafana Cloud",
+      "blocks": [
+        {
+          "type": "multistep",
+          "content": "In the main menu, navigate to **Testing & synthetics > Performance**.",
+          "requirements": ["navmenu-open"],
+          "skippable": true,
+          "steps": [
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/testing-and-synthetics']" },
+            { "action": "highlight", "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/k6-app']" }
+          ]
+        },
+        {
+          "type": "interactive",
+          "action": "highlight",
+          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/a/k6-app/settings']",
+          "requirements": ["navmenu-open"],
+          "content": "In the left navigation under **Performance**, select **Settings** to find your API token."
+        },
+        {
+          "type": "markdown",
+          "content": "Copy your API token from the Settings page. You'll use it in the next step to authenticate k6."
+        },
+        {
+          "type": "markdown",
+          "content": "**In your terminal**, navigate to the directory where you saved your `script.js` file, then log in to Grafana Cloud k6:\n\n```bash\nk6 cloud login --token YOUR_API_TOKEN\n```\n\nReplace `YOUR_API_TOKEN` with the token you just copied."
+        },
+        {
+          "type": "markdown",
+          "content": "Run your test with the `--local-execution` flag to stream results to Grafana Cloud:\n\n```bash\nk6 cloud run --local-execution script.js\n```"
+        },
+        {
+          "type": "markdown",
+          "content": "After the test completes, scroll up in your terminal output and find the `output:` line. It contains a URL like:\n\n`output: cloud (https://your-stack.grafana.net/a/k6-app/runs/...)`"
+        },
+        {
+          "type": "markdown",
+          "content": "Copy this URL — it links to your test results in Grafana Cloud. You'll use it in the next milestone to view your results."
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you analyze your test results in Grafana Cloud dashboards."
+    }
+  ]
+}

--- a/src/bundled-interactives/run-first-k6-test-send-to-grafana-cloud/manifest.json
+++ b/src/bundled-interactives/run-first-k6-test-send-to-grafana-cloud/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "run-first-k6-test-send-to-grafana-cloud",
+  "type": "guide",
+  "description": "Hands-on guide: Find your API token and stream k6 test results to Grafana Cloud.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/a/k6-app/settings",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/a/k6-app/settings" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["run-first-k6-test-run-locally"],
+  "recommends": ["run-first-k6-test-analyze-results"],
+  "suggests": [],
+  "provides": []
+}

--- a/src/bundled-interactives/run-first-k6-test-write-test-script/content.json
+++ b/src/bundled-interactives/run-first-k6-test-write-test-script/content.json
@@ -1,0 +1,41 @@
+{
+  "id": "run-first-k6-test-write-test-script",
+  "title": "Write your first k6 test script",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "In this milestone, you create your first k6 test script. k6 tests are written in JavaScript, making them accessible and easy to integrate into existing projects."
+    },
+    {
+      "type": "section",
+      "id": "write-script",
+      "title": "Write the test script",
+      "blocks": [
+        {
+          "type": "markdown",
+          "content": "**In your terminal**, create a new test file:\n\n```bash\ntouch script.js\n```\n\nYou can name the file anything you like, but it should have a `.js` or `.ts` extension."
+        },
+        {
+          "type": "markdown",
+          "content": "Open the file in your code editor and import the k6 modules:\n\n```javascript\nimport http from 'k6/http';\nimport { check, sleep } from 'k6';\n```\n\nThe `http` module makes HTTP requests, and `sleep` simulates real-world delays between requests."
+        },
+        {
+          "type": "markdown",
+          "content": "Define the test options to configure execution:\n\n```javascript\nexport const options = {\n  iterations: 10,\n};\n```\n\nThis tells k6 to execute the default function 10 times."
+        },
+        {
+          "type": "markdown",
+          "content": "Define the default function with your test logic:\n\n```javascript\nexport default function () {\n  const res = http.get('https://quickpizza.grafana.com');\n  check(res, { 'status was 200': (r) => r.status === 200 });\n  sleep(1);\n}\n```\n\nThis makes a GET request, verifies a 200 status, and waits 1 second between iterations."
+        },
+        {
+          "type": "markdown",
+          "content": "Save the complete script. Your `script.js` file should contain:\n\n```javascript\nimport http from 'k6/http';\nimport { check, sleep } from 'k6';\n\nexport const options = {\n  iterations: 10,\n};\n\nexport default function () {\n  const res = http.get('https://quickpizza.grafana.com');\n  check(res, { 'status was 200': (r) => r.status === 200 });\n  sleep(1);\n}\n```"
+        }
+      ]
+    },
+    {
+      "type": "markdown",
+      "content": "In the next milestone, you run this test locally and review the results in your terminal."
+    }
+  ]
+}

--- a/src/bundled-interactives/run-first-k6-test-write-test-script/manifest.json
+++ b/src/bundled-interactives/run-first-k6-test-write-test-script/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "run-first-k6-test-write-test-script",
+  "type": "guide",
+  "description": "Hands-on guide: Create a k6 test script with HTTP requests and checks.",
+  "category": "take-action",
+  "author": {
+    "name": "bonnywelsford-source",
+    "team": "Grafana Documentation"
+  },
+  "startingLocation": "/testing-and-synthetics",
+  "targeting": {
+    "match": {
+      "and": [
+        { "targetPlatform": "cloud" },
+        { "urlPrefix": "/testing-and-synthetics" }
+      ]
+    }
+  },
+  "testEnvironment": {
+    "tier": "cloud"
+  },
+  "depends": ["run-first-k6-test-install-k6"],
+  "recommends": ["run-first-k6-test-run-locally"],
+  "suggests": [],
+  "provides": []
+}

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -1091,6 +1091,7 @@ function renderParsedElement(
           title={sub(element.props.title)}
           lazyRender={element.props.lazyRender}
           scrollContainer={element.props.scrollContainer}
+          openGuide={element.props.openGuide}
           // Standalone step position (for guides without sections)
           stepIndex={standaloneStepPosition?.stepIndex}
           totalSteps={standaloneStepPosition?.totalSteps}

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -43,6 +43,8 @@ import {
   injectJourneyExtrasIntoJsonGuide,
   fetchPackageInfoFromUrl,
   isPackageContentUrl,
+  fetchBundledPackageInfo,
+  isBundledPackageUrl,
 } from '../../docs-retrieval';
 import { createCompositeResolver } from '../../package-engine';
 
@@ -723,6 +725,13 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       // appears. See package-info-from-url.ts for the URL pattern.
       if (!packageInfo && isPackageContentUrl(url)) {
         packageInfo = await fetchPackageInfoFromUrl(url);
+      }
+      // Same rationale for bundled path/journey packages opened via
+      // `openGuide: "bundled:<id>"` (hub → spoke). The auto-launch event
+      // carries no manifest, so resolve it from the bundled repository here
+      // to restore the milestone toolbar.
+      if (!packageInfo && isBundledPackageUrl(url)) {
+        packageInfo = await fetchBundledPackageInfo(url);
       }
       const result = await loadDocsTabContentResult(url, { skipReadyToBegin, packageInfo });
 

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -458,7 +458,7 @@ export const InteractiveStep = forwardRef<
         }
 
         // Execute the action using existing interactive logic
-        await executeInteractiveAction(targetAction, refTarget, currentTargetValue, 'do', targetComment);
+        await executeInteractiveAction(targetAction, refTarget, currentTargetValue, 'do', targetComment, openGuide);
 
         // Wait for DOM to settle after action (especially important for navigation, form fills, etc.)
         await waitForReactUpdates();
@@ -523,6 +523,7 @@ export const InteractiveStep = forwardRef<
       refTarget,
       currentTargetValue,
       targetComment,
+      openGuide,
       postVerify,
       verifyStepResult,
       executeInteractiveAction,

--- a/src/docs-retrieval/content-fetcher/package-content.ts
+++ b/src/docs-retrieval/content-fetcher/package-content.ts
@@ -7,6 +7,7 @@
 // here (one-directional — the orchestrator never imports back).
 import { ContentFetchResult, LearningJourneyMetadata, Milestone } from '../../types/content.types';
 import type { PackageResolver } from '../../types';
+import type { PackageOpenInfo } from '../../types/content-panel.types';
 import type { ResolvedNavLink } from '../../types/context.types';
 import { getPackageRenderType } from '../../types/package.types';
 import { fetchContent } from '../content-fetcher';
@@ -154,6 +155,51 @@ export async function resolvePackageNavLinks(packageIds: string[]): Promise<Reso
   }
 
   return links;
+}
+
+/**
+ * True if the URL is a bundled package ID reference (e.g.
+ * "bundled:run-first-k6-test-lj") rather than a bundled package file path
+ * ("bundled:foo/content.json"), the wysiwyg preview, or the e2e-test guide.
+ */
+export function isBundledPackageUrl(url: string): boolean {
+  if (!url.startsWith('bundled:')) {
+    return false;
+  }
+  const id = url.slice('bundled:'.length);
+  if (id === 'wysiwyg-preview' || id === 'e2e-test' || id.includes('/')) {
+    return false;
+  }
+  return id.length > 0;
+}
+
+/**
+ * Derive {@link PackageOpenInfo} for a bundled package ID by resolving its
+ * manifest through the injected PackageResolver (bundled tier resolves first).
+ *
+ * Only path/journey packages return info: their milestone toolbar depends on
+ * `packageInfo` being threaded through `openDocsPage`. When a `path` package is
+ * launched via `openGuide: "bundled:<id>"` (auto-launch emits only url/title),
+ * no recommender-provided manifest is available, so without this the model
+ * falls through to plain `fetchContent` and the milestone arrows never appear —
+ * the same gap `fetchPackageInfoFromUrl` closes for remote `/packages/` URLs.
+ *
+ * Single guides return `undefined` so they keep the plain-fetch render path.
+ */
+export async function fetchBundledPackageInfo(url: string): Promise<PackageOpenInfo | undefined> {
+  if (!_packageResolver || !isBundledPackageUrl(url)) {
+    return undefined;
+  }
+  const packageId = url.slice('bundled:'.length);
+  const resolution = await _packageResolver.resolve(packageId, { loadContent: 'metadata-only' });
+  if (!resolution.ok || !resolution.manifest) {
+    return undefined;
+  }
+  const manifest = resolution.manifest as unknown as Record<string, unknown>;
+  if (!isPathManifest(manifest)) {
+    return undefined;
+  }
+  return { packageId, packageManifest: manifest };
 }
 
 function isPathManifest(manifest?: Record<string, unknown>): boolean {

--- a/src/docs-retrieval/index.ts
+++ b/src/docs-retrieval/index.ts
@@ -29,6 +29,8 @@ export { fetchContent as fetchUnifiedContent } from './content-fetcher';
 export {
   fetchPackageContent,
   fetchPackageById,
+  fetchBundledPackageInfo,
+  isBundledPackageUrl,
   setPackageResolver,
   resolvePackageMilestones,
   resolvePackageNavLinks,

--- a/src/interactive-engine/interactive.hook.ts
+++ b/src/interactive-engine/interactive.hook.ts
@@ -386,7 +386,8 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
       refTarget: string,
       targetValue?: string,
       buttonType: 'show' | 'do' = 'do',
-      targetComment?: string
+      targetComment?: string,
+      openGuide?: string
     ): Promise<void> => {
       // Create InteractiveElementData directly from parameters
       const elementData: InteractiveElementData = {
@@ -394,6 +395,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
         targetAction: targetAction,
         targetValue: targetValue,
         targetComment: targetComment,
+        openGuide: openGuide,
         requirements: undefined,
         tagName: 'button', // Simulated for React components
         textContent: `${buttonType === 'show' ? 'Show me' : 'Do'}: ${refTarget}`,


### PR DESCRIPTION
This PR bundles the new "Get started" hub-and-spoke guides (and the k6, Synthetic Monitoring, and Prometheus remote write journeys they route to) into the plugin and fixes two gaps that prevented a guide launched from another guide from working end-to-end.

Related PR: https://github.com/grafana/interactive-tutorials/pull/429