### PR TITLE
fix(guides): repair broken selectors in cloud welcome/first-dashboard guides

### DIFF
--- a/src/bundled-interactives/first-dashboard-cloud/content.json
+++ b/src/bundled-interactives/first-dashboard-cloud/content.json
@@ -84,8 +84,8 @@
             {
               "action": "highlight",
               "reftarget": "grafana:components.DataSourcePicker.inputV2",
-              "tooltip": "Lets select the TestData data source to work with sample data.",
-              "requirements": ["exists-reftarget"]
+              "requirements": ["exists-reftarget"],
+              "tooltip": "Lets select the TestData data source to work with sample data."
             },
             {
               "action": "highlight",
@@ -219,11 +219,11 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "input[id=\"barchart-unit\"]",
-          "targetvalue": "ALT",
+          "reftarget": "div[data-testid='input-wrapper'] #unit",
           "content": "We can give our walking data meaning by setting a unit.",
           "tooltip": "Units give meaning to numbers. Is that value 42 seconds, bytes, requests, or meters? Without units, numbers are just numbers. Grafana can automatically format values based on their units - bytes become KB/MB/GB, seconds become ms/s/m, and so on. This polish makes your dashboards professional and removes ambiguity.",
-          "requirements": ["exists-reftarget"]
+          "requirements": ["exists-reftarget"],
+          "doIt": false
         },
         {
           "type": "multistep",

--- a/src/bundled-interactives/welcome-to-grafana-cloud/content.json
+++ b/src/bundled-interactives/welcome-to-grafana-cloud/content.json
@@ -19,10 +19,10 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/']",
-          "requirements": ["navmenu-open"],
+          "reftarget": "div[data-testid='data-testid navigation mega-menu'] a[data-testid='data-testid Home breadcrumb']",
           "content": "First, let's visit the **Home** page - your starting point in Grafana.",
-          "tooltip": "The **Home** page in Grafana Cloud is your central hub. It shows your cloud instance overview, recent activity, and quick access to getting started guides. Perfect *starting point* for your observability journey!"
+          "tooltip": "The **Home** page in Grafana Cloud is your central hub. It shows your cloud instance overview, recent activity, and quick access to getting started guides. Perfect *starting point* for your observability journey!",
+          "requirements": ["navmenu-open", "exists-reftarget"]
         },
         {
           "type": "interactive",
@@ -35,9 +35,9 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/explore']",
-          "skippable": true,
           "content": "Then **Explore** - perfect for ad-hoc queries and data exploration.",
-          "tooltip": "**Explore** is your data playground! Query logs with `LogQL`, run `PromQL` queries against metrics, and investigate traces with `TraceQL`. Perfect for troubleshooting and *data discovery*."
+          "tooltip": "**Explore** is your data playground! Query logs with `LogQL`, run `PromQL` queries against metrics, and investigate traces with `TraceQL`. Perfect for troubleshooting and *data discovery*.",
+          "skippable": true
         },
         {
           "type": "interactive",
@@ -50,11 +50,11 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
+          "content": "You need the Admin role to connect data sources. You can skip this step if you don't have permissions.",
+          "tooltip": "Grafana Cloud comes with **pre-configured data sources**! Your `Prometheus`, `Loki`, and `Tempo` instances are already connected. You can also add external sources like `AWS`, `GCP`, or your own infrastructure.",
           "requirements": ["is-admin"],
           "skippable": true,
-          "hint": "Connections requires admin permissions to access",
-          "content": "You need the Admin role to connect data sources. You can skip this step if you don't have permissions.",
-          "tooltip": "Grafana Cloud comes with **pre-configured data sources**! Your `Prometheus`, `Loki`, and `Tempo` instances are already connected. You can also add external sources like `AWS`, `GCP`, or your own infrastructure."
+          "hint": "Connections requires admin permissions to access"
         },
         {
           "type": "interactive",
@@ -67,10 +67,10 @@
           "type": "interactive",
           "action": "highlight",
           "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/plugins']",
-          "requirements": ["exists-reftarget"],
-          "skippable": true,
           "content": "Plugins extend Grafana by adding capabilities that are not available by default. For example, you can install plugins that add the ability to import data from diverse sources, that bundle data sources and panels, or that provide new visualization types for use in dashboards.",
-          "tooltip": "Plugins and data allows you to extend Grafana's functionality. You can install custom plugins from here."
+          "tooltip": "Plugins and data allows you to extend Grafana's functionality. You can install custom plugins from here.",
+          "requirements": ["exists-reftarget"],
+          "skippable": true
         }
       ]
     },


### PR DESCRIPTION
## Summary
- `welcome-to-grafana-cloud`: the first step highlighted the Home nav menu link via a selector that no longer matches in Grafana Cloud. Repointed it at the Home breadcrumb inside the mega-menu, and added an `exists-reftarget` guard so the step degrades gracefully if the selector ever drifts again.
- `first-dashboard-cloud`: the "set a unit" step's selector (`input#barchart-unit`) no longer matched the unit input's current id. Repointed it at the unit input inside its wrapper, and disabled the "Do it" button since setting the unit needs manual interaction with the dropdown.

## Test plan
- [x] `npx jest src/validation/bundled-guides.test.ts src/validation/bundled-repository.test.ts src/validation/build-repository.test.ts` — all pass
- [x] `npx prettier --check` on both changed files
- [ ] Manually run both guides in a local Grafana Cloud-like instance to confirm the updated selectors highlight correctly