### PR TITLE
fix(quality): resolve CodeQL useless-conditional findings

### DIFF
--- a/src/components/docs-panel/components/DocsPanelContentArea.tsx
+++ b/src/components/docs-panel/components/DocsPanelContentArea.tsx
@@ -161,7 +161,7 @@ export function DocsPanelContentArea(props: DocsPanelContentAreaProps): React.Re
           );
         }
 
-        if (!isRecommendationsTab && activeTab?.isLoading) {
+        if (activeTab?.isLoading) {
           const ljMeta = activeTab.content?.metadata?.learningJourney;
           const showBarWhileLoading =
             ljMeta &&
@@ -221,7 +221,7 @@ export function DocsPanelContentArea(props: DocsPanelContentAreaProps): React.Re
           );
         }
 
-        if (!isRecommendationsTab && activeTab?.error && !activeTab.isLoading) {
+        if (activeTab?.error && !activeTab.isLoading) {
           return (
             <ErrorDisplay
               className={isDocsLikeTab(activeTab.type) ? styles.docsContent : styles.journeyContent}
@@ -232,7 +232,7 @@ export function DocsPanelContentArea(props: DocsPanelContentAreaProps): React.Re
           );
         }
 
-        if (!isRecommendationsTab && activeTab?.content && !activeTab.isLoading) {
+        if (activeTab?.content && !activeTab.isLoading) {
           const isLearningJourneyTab = activeTab.type === 'learning-journey' || !isDocsLikeTab(activeTab.type);
           const showMilestoneProgress =
             isLearningJourneyTab &&

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -353,9 +353,7 @@ export const InteractiveStep = forwardRef<
     // via the onObjectivesComplete callback passed above.
 
     const shouldShowExplanation = isPartOfSection
-      ? !isNoopAction &&
-        (!isEligibleForChecking ||
-          (isEligibleForChecking && requirements && !checker.isEnabled && !lazyScrollAvailable))
+      ? !isNoopAction && (!isEligibleForChecking || (requirements && !checker.isEnabled && !lazyScrollAvailable))
       : !checker.isEnabled && !lazyScrollAvailable;
 
     // Choose appropriate explanation text based on step state

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -213,7 +213,7 @@ async function executeChecksWithRetry(
 
   if (!requirements) {
     return {
-      requirements: requirements || '',
+      requirements,
       pass: true,
       error: [],
     };
@@ -276,11 +276,11 @@ async function executeChecksWithRetry(
     // If we've exhausted retries, return error result
     const checkTypeName = checkType.charAt(0).toUpperCase() + checkType.slice(1);
     return {
-      requirements: requirements || '',
+      requirements,
       pass: false,
       error: [
         {
-          requirement: requirements || 'unknown',
+          requirement: requirements,
           pass: false,
           error: `${checkTypeName} check failed after ${maxRetries + 1} attempts: ${error}`,
           context: { error: String(error), retryCount, maxRetries },

--- a/src/utils/devtools/action-recorder.hook.ts
+++ b/src/utils/devtools/action-recorder.hook.ts
@@ -81,16 +81,11 @@ function findModalInNodes(nodes: NodeList): Element | null {
  * Scan the entire DOM for any visible modal elements
  * Used as a backup when MutationObserver might have missed the modal
  */
-function findAnyVisibleModal(excludeElement?: Element | null): Element | null {
+function findAnyVisibleModal(): Element | null {
   const selector = MODAL_SELECTORS.join(',');
   const modals = document.querySelectorAll(selector);
 
   for (const modal of modals) {
-    // Skip the element we're already tracking
-    if (excludeElement && (modal === excludeElement || modal.contains(excludeElement))) {
-      continue;
-    }
-
     // Check if it's visible (has dimensions and is not hidden)
     const rect = modal.getBoundingClientRect();
     const style = window.getComputedStyle(modal);


### PR DESCRIPTION
## Summary

Goes through the 10 open findings on the repo's code-quality scan ("Useless conditional", CodeQL) and fixes the 8 that are genuinely dead/redundant code, with the root cause investigated for each rather than a blind code-quality pass. The remaining 2 are a deliberate feature gate, left untouched — explained below.

### Fixed (dead/redundant conditions, zero behavior change)

- **`requirements-checker.utils.ts`** (3 findings, lines 216/279/283): `requirements` is typed as a required `string` (never `undefined`). `executeChecksWithRetry` early-returns at line 214 if it's falsy (empty string) — so every later use in the function is provably non-empty, and every earlier use is provably empty. The `|| ''` / `|| 'unknown'` fallbacks never fire either way. Removed them.
- **`DocsPanelContentArea.tsx`** (3 findings, lines 164/224/235): `isRecommendationsTab` is already handled by an early return two branches above (`if (isRecommendationsTab) return <contextPanel.Component ... />`). By the time control reaches these three branches, it's provably `false`, so the `!isRecommendationsTab &&` re-checks are dead. Removed them.
- **`action-recorder.hook.ts:90`**: `findAnyVisibleModal`'s `excludeElement` parameter has never been passed by its only caller, going back to the commit that introduced both the function and the caller (#406, 2025-12-05). That call site is structurally gated behind `!activeModal`, so there's never an already-tracked modal to exclude from this path. Not a regression — it was unreachable from day one. Removed the parameter and its dead check.
- **`interactive-step.tsx:358`**: classic `!X || (X && Y)` redundancy — once the left side of the `||` is false, `X` is already guaranteed true, so the explicit `isEligibleForChecking &&` inside adds nothing. Simplified to `!X || Y`.

### Investigated, not changed — intentional

- **`FOLLOW_MODE_ENABLED`** (`LiveSessionTopBar.tsx:116`, `AttendeeJoin.tsx:322`): this constant is hardcoded `false` in `src/integrations/workshop/flags.ts`, introduced in #680 ("disable follow mode + ECDSA presenter authentication") specifically to gate a live-session feature behind a pending security review — there's an inline `TODO(GrafanaCon)` comment saying as much. It's not incomplete/broken code; #680's own test plan explicitly verifies "follow mode UI is hidden for attendees" as the *intended* current behavior. No tracking issue exists for the follow-up security review beyond that TODO comment, worth a maintainer's attention separately, but flipping or deleting this isn't something I should do unprompted.

## Test plan

- [x] `npm run typecheck` — clean
- [x] Targeted tests for all touched files (`requirements-checker.utils.test.ts`, `interactive-step.test.tsx`, `DocsPanelContentArea.test.tsx`) — 112 passing, no regressions
- [x] `npm run check` — 331/331 suites, 5194 tests passing
- [x] `npm run build` — production bundle builds clean