### PR TITLE
fix(quality): move step-type-registry import above its first use

### DIFF
--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -16,6 +16,18 @@ import { TerminalStep, resetTerminalStepCounter } from './terminal-step';
 import { TerminalConnectStep, resetTerminalConnectStepCounter } from './terminal-connect-step';
 import { CodeBlockStep, resetCodeBlockStepCounter } from './code-block-step';
 import { ChallengeBlock, resetChallengeCounter } from './challenge-block';
+import {
+  CHALLENGE_BLOCK_SCHEMA,
+  CODE_BLOCK_STEP_SCHEMA,
+  type EnhanceContext,
+  INTERACTIVE_GUIDED_SCHEMA,
+  INTERACTIVE_MULTISTEP_SCHEMA,
+  INTERACTIVE_QUIZ_SCHEMA,
+  INTERACTIVE_STEP_SCHEMA,
+  type StepTypeSchema,
+  TERMINAL_CONNECT_STEP_SCHEMA,
+  TERMINAL_STEP_SCHEMA,
+} from './step-type-registry';
 import { wrapSectionChildrenForNumbering } from './section-numbering';
 // Re-exports preserved for back-compat with `section-numbering.test.tsx`,
 // which imports both helpers from this module. New code should import
@@ -87,19 +99,6 @@ import {
   registerSectionSteps,
   resetRegistry,
 } from '../../global-state/section-registry';
-import {
-  CHALLENGE_BLOCK_SCHEMA,
-  CODE_BLOCK_STEP_SCHEMA,
-  type EnhanceContext,
-  INTERACTIVE_GUIDED_SCHEMA,
-  INTERACTIVE_MULTISTEP_SCHEMA,
-  INTERACTIVE_QUIZ_SCHEMA,
-  INTERACTIVE_STEP_SCHEMA,
-  type StepTypeSchema,
-  TERMINAL_CONNECT_STEP_SCHEMA,
-  TERMINAL_STEP_SCHEMA,
-} from './step-type-registry';
-
 // Re-exports preserved for back-compat with `content-renderer.tsx`. New code
 // should import directly from `./section-registry`.
 export {


### PR DESCRIPTION
## Summary

Resolves 8 open CodeQL "Variable not declared before use" findings on `src/components/interactive-tutorial/interactive-section.tsx`.

`STEP_TYPE_LOOKUP` (lines 30-42 on `main`) builds a `Map` pairing each step component with its schema constant (`INTERACTIVE_STEP_SCHEMA`, `INTERACTIVE_MULTISTEP_SCHEMA`, `INTERACTIVE_GUIDED_SCHEMA`, `INTERACTIVE_QUIZ_SCHEMA`, `TERMINAL_STEP_SCHEMA`, `TERMINAL_CONNECT_STEP_SCHEMA`, `CODE_BLOCK_STEP_SCHEMA`, `CHALLENGE_BLOCK_SCHEMA`) — all 8 imported from `./step-type-registry`. That import was textually placed at lines 90-101, after the `Map` literal that uses every one of them, apparently pulled down there by an unrelated mid-file refactor that scattered several import statements between chunks of code.

ES module imports are hoisted, so this was never a runtime bug — the bindings exist before any top-level code executes — but it's exactly the "can't tell where this came from" pattern the CodeQL query targets, and it reads badly (the constants look like they materialize from nowhere).

Fix: move the `step-type-registry` import up to sit with its sibling step-component imports (right after `challenge-block`, since `STEP_TYPE_LOOKUP` pairs the same 8 components with these same 8 schemas). Pure relocation, zero behavior change — nothing else in the file touched.

## Test plan

- [x] `npm run typecheck` — clean
- [x] All 5 `interactive-section*.test.tsx` suites — 43 passing, no regressions
- [x] `npm run check` — 331/331 suites, 5194 tests passing
- [x] `npm run build` — production bundle builds clean