### PR TITLE
fix(quality): capture IntersectionObserver options in the test mock

### DIFF
--- a/src/hooks/useActiveOutlineItem.test.ts
+++ b/src/hooks/useActiveOutlineItem.test.ts
@@ -6,7 +6,10 @@ class MockIntersectionObserver {
   static instances: MockIntersectionObserver[] = [];
   observe = jest.fn();
   disconnect = jest.fn();
-  constructor(public callback: IntersectionObserverCallback) {
+  constructor(
+    public callback: IntersectionObserverCallback,
+    public options?: IntersectionObserverInit
+  ) {
     MockIntersectionObserver.instances.push(this);
   }
   trigger() {


### PR DESCRIPTION
## Summary

Goes through the 6 open CodeQL "Superfluous trailing arguments" findings. 1 is a real (test-only) fidelity gap, fixed here. The other 5 are a CodeQL false positive on a native DOM API — explained below, not touched.

### Fixed

- **`useActiveOutlineItem.test.ts`**: `MockIntersectionObserver`'s constructor only declared `callback`, so the `{ root, rootMargin }` options object that `useActiveOutlineItem.ts` actually passes (`new IntersectionObserver(recompute, { root, rootMargin })`) was silently dropped on the floor. Not a production bug — the real browser `IntersectionObserver` receives and respects those options fine — but it meant this test file had no way to ever verify the `rootMargin` computation (`` `0% 0% -${(1 - TOP_BAND_FRACTION) * 100}% 0%` ``) is correct, since the mock never captured it. Now stores it as a public field so a future test can assert on it.

### Investigated, not changed — false positive

- **`completion-store.test.tsx`** (5 findings, all `new StorageEvent('storage', { key, newValue, oldValue })`): CodeQL says these trailing arguments are superfluous, but `key`/`newValue`/`oldValue` are exactly the fields `completion-store.ts`'s real `storage` event listener reads (`event.key`, checked against `StorageKeys.INTERACTIVE_STEPS_PREFIX`, etc.) — see `src/global-state/completion-store.ts` around the `if (event.key === null)` / `event.key.startsWith(...)` checks. `new StorageEvent(type, eventInitDict)` is the exact standard 2-argument DOM constructor per spec (and what every browser and jsdom actually implement). CodeQL's built-in extern model for this less-common Web API just doesn't model the second parameter — there's nothing to fix in the source; "fixing" it by removing those fields would break the tests for real.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `useActiveOutlineItem.test.ts` — 6/6 passing
- [x] `npm run check` — 331/331 suites, 5194 tests passing
- [x] `npm run build` — production bundle builds clean