### PR TITLE
fix(quality): remove dead error-boundary state properties

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -20,7 +20,6 @@ import { pauseFaroBeforeReload, pushFaroError } from '../../lib/faro';
 interface ErrorBoundaryState {
   hasError: boolean;
   error: Error | null;
-  errorInfo: React.ErrorInfo | null;
 }
 
 // eslint-disable-next-line no-restricted-syntax -- Error boundaries require componentDidCatch (no hook equivalent)
@@ -28,7 +27,6 @@ class PluginErrorBoundary extends Component<{ children: ReactNode }, ErrorBounda
   state: ErrorBoundaryState = {
     hasError: false,
     error: null,
-    errorInfo: null,
   };
 
   static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
@@ -38,7 +36,6 @@ class PluginErrorBoundary extends Component<{ children: ReactNode }, ErrorBounda
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     // eslint-disable-next-line no-console -- local debug output; pushFaroError below already reports to Faro
     console.error('Pathfinder plugin error:', error, errorInfo);
-    this.setState({ errorInfo });
 
     pushFaroError(error, {
       componentStack: errorInfo.componentStack ?? 'unknown',
@@ -47,7 +44,7 @@ class PluginErrorBoundary extends Component<{ children: ReactNode }, ErrorBounda
   }
 
   handleReset = () => {
-    this.setState({ hasError: false, error: null, errorInfo: null });
+    this.setState({ hasError: false, error: null });
   };
 
   render() {

--- a/src/components/docs-panel/components/MyLearningErrorBoundary.tsx
+++ b/src/components/docs-panel/components/MyLearningErrorBoundary.tsx
@@ -9,7 +9,6 @@ import { pushFaroError } from '../../../lib/faro';
 
 interface MyLearningErrorBoundaryState {
   hasError: boolean;
-  error: Error | null;
 }
 
 interface MyLearningErrorBoundaryProps {
@@ -22,10 +21,10 @@ interface MyLearningErrorBoundaryProps {
  */
 // eslint-disable-next-line no-restricted-syntax -- Error boundaries require componentDidCatch (no hook equivalent)
 export class MyLearningErrorBoundary extends Component<MyLearningErrorBoundaryProps, MyLearningErrorBoundaryState> {
-  state: MyLearningErrorBoundaryState = { hasError: false, error: null };
+  state: MyLearningErrorBoundaryState = { hasError: false };
 
-  static getDerivedStateFromError(error: Error): MyLearningErrorBoundaryState {
-    return { hasError: true, error };
+  static getDerivedStateFromError(): MyLearningErrorBoundaryState {
+    return { hasError: true };
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
@@ -40,7 +39,7 @@ export class MyLearningErrorBoundary extends Component<MyLearningErrorBoundaryPr
         <div style={{ padding: 16, textAlign: 'center' }}>
           <Icon name="exclamation-triangle" size="xl" />
           <p style={{ marginTop: 8 }}>Unable to load learning progress</p>
-          <Button size="sm" variant="secondary" onClick={() => this.setState({ hasError: false, error: null })}>
+          <Button size="sm" variant="secondary" onClick={() => this.setState({ hasError: false })}>
             Try again
           </Button>
         </div>


### PR DESCRIPTION
## Summary

Resolves both open CodeQL "Unused or undefined state property" findings.

In both error boundaries, `componentDidCatch(error, errorInfo)` already receives everything it needs as function parameters and uses those directly for `console.error` + `pushFaroError` — error reporting to Faro/console is completely independent of anything stored in `this.state`. Neither flagged field was ever read back:

- **`MyLearningErrorBoundary.tsx`**: `error` was written in `getDerivedStateFromError` and cleared on retry, but the fallback UI only ever branches on `hasError` — it shows a generic "Unable to load learning progress" message with no error detail, so `this.state.error` had no reader anywhere.
- **`App.tsx`'s `PluginErrorBoundary`**: `errorInfo` was written in `componentDidCatch` (`this.setState({ errorInfo })`) but never read — `componentStack` for the Faro report is already pulled from the local `errorInfo` parameter, not from state. (`error` stays untouched — `ErrorFallback` does render `this.state.error.message`, so that field is correctly in use.)

Removed both dead fields from their state interfaces, initializers, and every write site. No behavior change: error logging/Faro reporting is untouched (still driven by the `componentDidCatch` parameters), and neither fallback UI's rendered output changes.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `MyLearningErrorBoundary.test.tsx` — 5/5 passing
- [x] `npm run check` — 331/331 suites, 5194 tests passing
- [x] `npm run build` — production bundle builds clean