### PR TITLE
fix(quality): remove duplicate apostrophe in EXPECT_HEADING_RE

### DIFF
--- a/src/docs-retrieval/content-fetcher/cover-page.ts
+++ b/src/docs-retrieval/content-fetcher/cover-page.ts
@@ -100,7 +100,7 @@ function wrapInOrangeOutlineList(heading: string, bodyMarkdown: string): string 
   ].join('\n');
 }
 
-const EXPECT_HEADING_RE = /^#{1,3}\s+(?:here[''\u2019]s\s+)?what\s+to\s+expect/im;
+const EXPECT_HEADING_RE = /^#{1,3}\s+(?:here['\u2019]s\s+)?what\s+to\s+expect/im;
 const NEXT_HEADING_RE = /^#{1,3}\s+/m;
 
 /**


### PR DESCRIPTION
## Summary

Resolves the one open CodeQL "Duplicate character in character class" finding.

`EXPECT_HEADING_RE` matches headings like "Here's what to expect", tolerating either a straight (`'`) or curly (`'`/`’`) apostrophe. The character class was `['’]` — spelled with the straight apostrophe written twice plus the curly-quote escape, instead of one of each. Pure accidental duplication: the set of matched characters is identical before and after (`'` or `'`), so this is a zero-behavior-change fix, not a bug — this isn't the `[a|b|c]`-vs-`(a|b|c)` mistake the query usually catches, just a literal typo'd duplicate.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `cover-page.test.ts` — 11/11 passing (covers both apostrophe variants)
- [x] `npm run check` — 331/331 suites, 5194 tests passing
- [x] `npm run build` — production bundle builds clean