### PR TITLE
fix(e2e): avoid loading Faro in Node logger imports

### DIFF
--- a/src/lib/logging.node.test.ts
+++ b/src/lib/logging.node.test.ts
@@ -1,0 +1,20 @@
+/**
+ * @jest-environment node
+ */
+
+describe('logger in Node', () => {
+  it('does not load Faro when imported or used without a browser window', () => {
+    jest.isolateModules(() => {
+      jest.doMock('./faro', () => {
+        throw new Error('Faro should not load in Node logging');
+      });
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const { logger } = require('./logging') as typeof import('./logging');
+
+      expect(() => logger.warn('node-side warning')).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith('node-side warning', '');
+
+      warnSpy.mockRestore();
+    });
+  });
+});

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -1,5 +1,17 @@
 import { sanitizeForLogging } from '../security/log-sanitizer';
-import { pushFaroError, pushFaroLog } from './faro';
+
+type FaroTelemetry = Pick<typeof import('./faro'), 'pushFaroError' | 'pushFaroLog'>;
+
+function getFaroTelemetry(): FaroTelemetry | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return require('./faro') as FaroTelemetry;
+  } catch {
+    return null;
+  }
+}
 
 function sanitizeContext(context?: Record<string, unknown>): Record<string, string> | undefined {
   if (!context) {
@@ -30,13 +42,13 @@ export const logger = {
   info(message: string, context?: Record<string, unknown>): void {
     const sanitized = sanitizeForLogging(message);
     console.info(sanitized, context ?? '');
-    pushFaroLog('info', sanitized, sanitizeContext(context));
+    getFaroTelemetry()?.pushFaroLog('info', sanitized, sanitizeContext(context));
   },
 
   warn(message: string, context?: Record<string, unknown>): void {
     const sanitized = sanitizeForLogging(message);
     console.warn(sanitized, context ?? '');
-    pushFaroLog('warn', sanitized, sanitizeContext(context));
+    getFaroTelemetry()?.pushFaroLog('warn', sanitized, sanitizeContext(context));
   },
 
   // A throwable (second arg, or an `error` context key) becomes a Faro
@@ -46,16 +58,16 @@ export const logger = {
     const split = splitThrowable(errorOrContext, context);
     if (split.error) {
       console.error(sanitized, split.error, split.context ?? '');
-      pushFaroError(split.error, sanitizeContext({ ...split.context, message: sanitized }));
+      getFaroTelemetry()?.pushFaroError(split.error, sanitizeContext({ ...split.context, message: sanitized }));
       return;
     }
     console.error(sanitized, split.context ?? '');
-    pushFaroLog('error', sanitized, sanitizeContext(split.context));
+    getFaroTelemetry()?.pushFaroLog('error', sanitized, sanitizeContext(split.context));
   },
 
   exception(error: unknown, context?: Record<string, unknown>): void {
     const normalizedError = error instanceof Error ? error : new Error(sanitizeForLogging(error));
     console.error(normalizedError, context ?? '');
-    pushFaroError(normalizedError, sanitizeContext(context));
+    getFaroTelemetry()?.pushFaroError(normalizedError, sanitizeContext(context));
   },
 };


### PR DESCRIPTION
## Summary

The shared logger no longer imports Faro at module load time, which prevents Node-side e2e runner imports from evaluating Grafana runtime modules that expect browser globals. Browser logging still forwards warnings, errors, and exceptions to Faro once a `window` exists, while Node logging remains console-only.

## What to look at

- Logger telemetry loading: [`src/lib/logging.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/a6d3e85487100c2bd82740328a826de3b6b9ac93/src/lib/logging.ts) now lazy-loads the Faro bridge behind a browser-global guard instead of statically importing it.
- Regression coverage: [`src/lib/logging.node.test.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/a6d3e85487100c2bd82740328a826de3b6b9ac93/src/lib/logging.node.test.ts) proves the logger can be imported and used in a Node test environment without loading the Faro module.

## Why

The e2e CLI runs Playwright orchestration from Node, but some shared guide-runner utilities import the shared logger. A recent Faro change made that logger import `src/lib/faro.ts` eagerly, which pulled in `@grafana/runtime` and crashed during test discovery with `ReferenceError: window is not defined`. The rejected alternative was mocking browser globals for the runner; keeping the shared logger Node-safe is narrower and preserves the runtime boundary instead.

## How to verify

1. Reproduce the original path by running the e2e CLI against a cloud guide package; confirm Playwright reaches test execution instead of failing during import with `ReferenceError: window is not defined`.
2. Run the targeted logger regression test:
   `npm test -- --runTestsByPath src/lib/logging.test.ts src/lib/logging.node.test.ts --runInBand`
3. In a browser-backed plugin session, trigger a warning or error path that uses the shared logger and confirm normal console logging still occurs while Faro remains available for telemetry.

## Breaking changes

None. This change preserves the logger API and only changes when the Faro telemetry bridge is loaded.

## Reversibility

This is reversible by restoring the static Faro import, but doing so would also restore the Node import crash for e2e runner code paths that import the shared logger. No persisted state, public API shape, storage format, or telemetry payload schema is changed.
