### PR TITLE
fix(interactive): let secondary step buttons hug their content

### DIFF
--- a/src/styles/interactive.styles.ts
+++ b/src/styles/interactive.styles.ts
@@ -612,12 +612,10 @@ const getInteractiveComponentStyles = (theme: GrafanaTheme2) => ({
   },
 
   '.interactive-step-show-btn': {
-    minWidth: '80px',
     fontSize: theme.typography.bodySmall.fontSize,
   },
 
   '.interactive-step-do-btn': {
-    minWidth: '80px',
     fontSize: theme.typography.bodySmall.fontSize,
   },
 


### PR DESCRIPTION
## Summary

The "Show me" and "Do it" buttons on interactive guide steps had a hardcoded `minWidth: '80px'`, so short labels rendered inside an oversized, fixed-width button instead of sizing to their text. Removes the `minWidth` constraint from `.interactive-step-show-btn` and `.interactive-step-do-btn` in [`src/styles/interactive.styles.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/6155e844e4b58168f784546312089965c98cefa1/src/styles/interactive.styles.ts#L614-L622) so both buttons hug their content.

## How to verify

1. Open a guide with an interactive step that shows "Show me" and "Do it" buttons.
2. Confirm each button now sizes to its label instead of a fixed 80px minimum — including longer label states like "Executing..." and "Go there", which should still render without truncation or overflow.

## Breaking changes

None. This change is additive and fully reversible.

Fixes #1259

🤖 Generated with [Claude Code](https://claude.com/claude-code)
