### PR TITLE
fix(interactive): fix pluralization and sizing on the resume/do section button

### DIFF
--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -1453,9 +1453,13 @@ export function InteractiveSection({
                 return 'Reset section and clear all step completion to allow manual re-interaction';
               }
               if (resumeInfo.isResume) {
-                return `Resume from step ${resumeInfo.nextStepIndex + 1}, ${resumeInfo.remainingSteps} steps remaining`;
+                const stepWord = resumeInfo.remainingSteps === 1 ? 'step' : 'steps';
+                return `Resume from step ${resumeInfo.nextStepIndex + 1}, ${resumeInfo.remainingSteps} ${stepWord} remaining`;
               }
-              return hints || `Run through all ${nonNoopSteps.length} steps in sequence`;
+              return (
+                hints ||
+                `Run through all ${nonNoopSteps.length} ${nonNoopSteps.length === 1 ? 'step' : 'steps'} in sequence`
+              );
             })()}
           >
             {(() => {
@@ -1466,9 +1470,9 @@ export function InteractiveSection({
                 return 'Reset section';
               }
               if (resumeInfo.isResume) {
-                return `▶ Resume (${resumeInfo.remainingSteps} steps)`;
+                return `▶ Resume (${resumeInfo.remainingSteps} ${resumeInfo.remainingSteps === 1 ? 'step' : 'steps'})`;
               }
-              return `▶ Do Section (${nonNoopSteps.length} steps)`;
+              return `▶ Do Section (${nonNoopSteps.length} ${nonNoopSteps.length === 1 ? 'step' : 'steps'})`;
             })()}
           </Button>
         )}

--- a/src/styles/interactive.styles.ts
+++ b/src/styles/interactive.styles.ts
@@ -545,7 +545,6 @@ const getInteractiveComponentStyles = (theme: GrafanaTheme2) => ({
   },
 
   '.interactive-section-do-button': {
-    minWidth: '200px',
     fontWeight: theme.typography.fontWeightMedium,
 
     '&:disabled': {


### PR DESCRIPTION
## Summary

The interactive section's catch-all action button hardcoded "steps" regardless of count, producing grammatically wrong labels like "▶ Resume (1 steps)" (and the matching tooltip text). The button also had a hardcoded `minWidth: 200px`, making it wider than its label needed. This fixes the pluralization at all four affected template literals in [`interactive-section.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/e5a34222212e9b6dc04b703e79e1b6d65c569161/src/components/interactive-tutorial/interactive-section.tsx) (resume label, resume tooltip, do-section label, do-section tooltip) and removes the fixed width in [`interactive.styles.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/e5a34222212e9b6dc04b703e79e1b6d65c569161/src/styles/interactive.styles.ts) so the button hugs its content. The button stays centered via the existing `justifyContent: center` on its parent `.interactive-section-actions` flex container.

## How to verify

1. Open a guide with a section that has exactly one remaining interactive step, collapse and reopen it (or otherwise trigger the resume state) and confirm the button reads "▶ Resume (1 step)" and its tooltip reads "...1 step remaining" (singular, no trailing "s").
2. Open a section with a single step that hasn't started yet and confirm the "▶ Do Section (1 step)" label and its "Run through all 1 step in sequence" tooltip are also singular.
3. Confirm sections with 2+ steps still read "steps" (plural) in both the label and tooltip.
4. Visually confirm the button now hugs its label width instead of a fixed 200px, and remains centered in the section footer.

## Breaking changes

None. This change is additive and fully reversible.

Fixes #1261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
