### PR TITLE
feat(telemetry): enrich Faro with identity, session attributes, and funnel instrumentation

### DIFF
--- a/src/components/App/ContextPanel.tsx
+++ b/src/components/App/ContextPanel.tsx
@@ -4,6 +4,7 @@ import { CombinedLearningJourneyPanel } from 'components/docs-panel/docs-panel';
 import { getConfigWithDefaults } from '../../constants';
 import { PathfinderFeatureProvider } from '../OpenFeatureProvider';
 import { panelModeManager, type PanelMode } from '../../global-state/panel-mode';
+import { PANEL_MODE_CHANGE_EVENT } from '../../lib/event-names';
 
 export default function MemoizedContextPanel() {
   const pluginContext = usePluginContext();
@@ -14,9 +15,9 @@ export default function MemoizedContextPanel() {
     const handleModeChange = (e: CustomEvent<{ mode: PanelMode }>) => {
       setMode(e.detail.mode);
     };
-    document.addEventListener('pathfinder-panel-mode-change', handleModeChange as EventListener);
+    document.addEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
     return () => {
-      document.removeEventListener('pathfinder-panel-mode-change', handleModeChange as EventListener);
+      document.removeEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
     };
   }, []);
 

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -15,6 +15,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import type { ViewMode } from './types';
 import { testIds } from '../../constants/testIds';
 import { panelModeManager, type PanelMode } from '../../global-state/panel-mode';
+import { PANEL_MODE_CHANGE_EVENT } from '../../lib/event-names';
 
 export interface BlockEditorHeaderProps {
   /** Guide title to display */
@@ -286,9 +287,9 @@ export function BlockEditorHeader({
     const handleModeChange = (e: CustomEvent<{ mode: PanelMode }>) => {
       setPanelMode(e.detail.mode);
     };
-    document.addEventListener('pathfinder-panel-mode-change', handleModeChange as EventListener);
+    document.addEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
     return () => {
-      document.removeEventListener('pathfinder-panel-mode-change', handleModeChange as EventListener);
+      document.removeEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
     };
   }, []);
 

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -18,6 +18,7 @@ import { useContextPanel, Recommendation } from '../../context-engine';
 import type { ResolvedNavLink } from '../../types/context.types';
 import { reportAppInteraction, UserInteraction, getContentTypeForAnalytics } from '../../lib/analytics';
 import { logger } from '../../lib/logging';
+import { RECOMMENDATIONS_READY_EVENT } from '../../lib/event-names';
 import { getConfigWithDefaults, PLUGIN_BASE_URL } from '../../constants';
 import { isDevModeEnabled } from '../../utils/dev-mode';
 import { testIds } from '../../constants/testIds';
@@ -1118,6 +1119,14 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
   const recommendationsScrollReady =
     !contextData.isLoading && !isLoadingRecommendations && hasFetchedRecommendations && hasLoadedCustomGuides;
   const scrollContainerRef = useRecommendationsScrollPosition(recommendationsScrollReady);
+
+  // Signals docs-panel's panel_lcp_ms measurement that the recommendations
+  // list (this renderer's content) is actually showing, not just mounted.
+  useEffect(() => {
+    if (hasFetchedRecommendations) {
+      document.dispatchEvent(new CustomEvent(RECOMMENDATIONS_READY_EVENT));
+    }
+  }, [hasFetchedRecommendations]);
 
   return (
     <div className={styles.container} data-testid={testIds.contextPanel.container}>

--- a/src/components/docs-panel/docs-panel.panel-mode.test.tsx
+++ b/src/components/docs-panel/docs-panel.panel-mode.test.tsx
@@ -26,6 +26,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { PANEL_MODE_CHANGE_EVENT } from '../../lib/event-names';
 
 const PANEL_ROOT = path.join(__dirname);
 
@@ -36,8 +37,8 @@ const PANEL_ROOT = path.join(__dirname);
 const TRACKED_FILES = ['docs-panel.tsx', 'hooks/usePanelMode.ts'];
 
 const REQUIRED_REFERENCES = {
-  listenerRegistration: "addEventListener('pathfinder-panel-mode-change'",
-  listenerCleanup: "removeEventListener('pathfinder-panel-mode-change'",
+  listenerRegistration: 'addEventListener(PANEL_MODE_CHANGE_EVENT',
+  listenerCleanup: 'removeEventListener(PANEL_MODE_CHANGE_EVENT',
   // The setter name is React-state implementation detail, but the symbol is
   // stable enough to act as a "we propagate the event into React state" pin.
   stateUpdate: 'setPanelMode(',
@@ -56,6 +57,10 @@ function loadTrackedSources(): Array<{ file: string; src: string | null }> {
 }
 
 describe('Phase 0 tripwire: pathfinder-panel-mode-change CustomEvent contract', () => {
+  it('the shared event-name constant stays pinned to the external contract value', () => {
+    expect(PANEL_MODE_CHANGE_EVENT).toBe('pathfinder-panel-mode-change');
+  });
+
   it('listener registration exists in exactly one tracked file', () => {
     const matches = loadTrackedSources().filter(
       ({ src }) => src && src.includes(REQUIRED_REFERENCES.listenerRegistration)

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -31,6 +31,8 @@ import { isDevModeEnabled } from '../../utils/dev-mode';
 
 import { reportAppInteraction, UserInteraction, getContentTypeForAnalytics } from '../../lib/analytics';
 import { logger } from '../../lib/logging';
+import { pushFaroMeasurement, withFaroUserAction } from '../../lib/faro';
+import { RECOMMENDATIONS_READY_EVENT } from '../../lib/event-names';
 import { tabStorage, useUserStorage } from '../../lib/user-storage';
 import { useGuideProgressState, useAutoLaunchTutorial, type AutoLaunchTutorialDetail } from '../../hooks';
 import {
@@ -375,13 +377,24 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     url: string,
     options?: { skipReadyToBegin?: boolean; packageInfo?: PackageOpenInfo }
   ): Promise<void> {
-    const tab = this.state.tabs.find((t) => t.id === tabId);
-    const needsDocsLoader = options?.packageInfo != null || (tab ? shouldUseDocsLoader(tab) : false);
-    if (needsDocsLoader) {
-      await this.loadDocsTabContent(tabId, url, options?.skipReadyToBegin, options?.packageInfo);
-      return;
-    }
-    await this.loadTabContent(tabId, url);
+    // Real start/end timestamps (unlike the pushFaroUserAction mirror, which
+    // stamps and ends in the same tick) — this is the funnel action the
+    // Frontend Observability Actions tab's avg/P95 duration should reflect.
+    await withFaroUserAction(
+      'pathfinder_guide_open',
+      { content_url: url },
+      async () => {
+        const tab = this.state.tabs.find((t) => t.id === tabId);
+        const needsDocsLoader = options?.packageInfo != null || (tab ? shouldUseDocsLoader(tab) : false);
+        if (needsDocsLoader) {
+          await this.loadDocsTabContent(tabId, url, options?.skipReadyToBegin, options?.packageInfo);
+          return;
+        }
+        await this.loadTabContent(tabId, url);
+      },
+      undefined,
+      { critical: true }
+    );
   }
 
   private async loadTabContent(tabId: string, url: string) {
@@ -930,6 +943,33 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   // STABILITY: Memoize activeTab.content to prevent ContentRenderer from remounting
   // when other tab properties change (isLoading, error, etc.)
   const stableContent = React.useMemo(() => activeTab?.content, [activeTab?.content]);
+
+  // Panel-scoped analog of LCP: time from this component's first render to
+  // the first tab (or the recommendations list) actually showing content.
+  // Deliberately not Faro's page-level Web Vitals — those would measure
+  // Grafana core's render, not Pathfinder's. Fires once per panel mount.
+  const panelMountTimeRef = useRef<number | undefined>(undefined);
+  const panelLcpRecordedRef = useRef(false);
+  const [recommendationsReady, setRecommendationsReady] = React.useState(false);
+  React.useEffect(() => {
+    const onReady = () => setRecommendationsReady(true);
+    document.addEventListener(RECOMMENDATIONS_READY_EVENT, onReady);
+    return () => document.removeEventListener(RECOMMENDATIONS_READY_EVENT, onReady);
+  }, []);
+  React.useEffect(() => {
+    panelMountTimeRef.current ??= performance.now();
+    if (panelLcpRecordedRef.current) {
+      return;
+    }
+    if (stableContent || (isRecommendationsTab && recommendationsReady)) {
+      panelLcpRecordedRef.current = true;
+      pushFaroMeasurement(
+        'pathfinder_panel',
+        { panel_lcp_ms: performance.now() - panelMountTimeRef.current },
+        { surface: panelMode }
+      );
+    }
+  }, [stableContent, isRecommendationsTab, recommendationsReady, panelMode]);
 
   // STABILITY: Memoize the AlignmentPendingContext value keyed on the two
   // underlying primitives so consumers (`useStepChecker` in every interactive

--- a/src/components/docs-panel/hooks/useGlobalActiveTabExposure.test.ts
+++ b/src/components/docs-panel/hooks/useGlobalActiveTabExposure.test.ts
@@ -1,12 +1,14 @@
 import { renderHook } from '@testing-library/react';
 import { useGlobalActiveTabExposure } from './useGlobalActiveTabExposure';
-import { setFaroView } from '../../../lib/faro';
+import { setFaroView, setFaroViewName } from '../../../lib/faro';
 
 jest.mock('../../../lib/faro', () => ({
   setFaroView: jest.fn(),
+  setFaroViewName: jest.fn(),
 }));
 
 const mockSetFaroView = setFaroView as jest.Mock;
+const mockSetFaroViewName = setFaroViewName as jest.Mock;
 
 describe('useGlobalActiveTabExposure', () => {
   beforeEach(() => {
@@ -64,6 +66,19 @@ describe('useGlobalActiveTabExposure', () => {
       })
     );
     expect(mockSetFaroView).toHaveBeenCalledWith('https://example.com/cur');
+    expect(mockSetFaroViewName).not.toHaveBeenCalled();
+  });
+
+  it('sets the view to "recommendations" when there is no URL to derive one from', () => {
+    renderHook(() =>
+      useGlobalActiveTabExposure({
+        activeTabId: undefined,
+        activeTabCurrentUrl: undefined,
+        activeTabBaseUrl: undefined,
+      })
+    );
+    expect(mockSetFaroViewName).toHaveBeenCalledWith('recommendations');
+    expect(mockSetFaroView).not.toHaveBeenCalled();
   });
 
   it('updates globals when props change across re-renders', () => {

--- a/src/components/docs-panel/hooks/useGlobalActiveTabExposure.ts
+++ b/src/components/docs-panel/hooks/useGlobalActiveTabExposure.ts
@@ -18,7 +18,7 @@
  * in unusual host environments (e.g. some sandboxed Grafana embeds).
  */
 import * as React from 'react';
-import { setFaroView } from '../../../lib/faro';
+import { setFaroView, setFaroViewName } from '../../../lib/faro';
 
 export interface UseGlobalActiveTabExposureParams {
   activeTabId: string | undefined;
@@ -38,6 +38,13 @@ export function useGlobalActiveTabExposure({
     } catch {
       // no-op
     }
-    setFaroView(activeTabCurrentUrl || activeTabBaseUrl || '');
+    const url = activeTabCurrentUrl || activeTabBaseUrl || '';
+    if (url) {
+      setFaroView(url);
+    } else {
+      // No URL to derive a view from — cold start or the recommendations
+      // tab (which has no `content.url`). Previously left the view stale.
+      setFaroViewName('recommendations');
+    }
   }, [activeTabId, activeTabCurrentUrl, activeTabBaseUrl]);
 }

--- a/src/components/docs-panel/hooks/usePanelMode.ts
+++ b/src/components/docs-panel/hooks/usePanelMode.ts
@@ -19,6 +19,7 @@
  */
 import * as React from 'react';
 import { PLUGIN_BASE_URL, ROUTES } from '../../../constants';
+import { PANEL_MODE_CHANGE_EVENT } from '../../../lib/event-names';
 import { panelModeManager, type PanelMode } from '../../../global-state/panel-mode';
 
 export interface UsePanelModeResult {
@@ -33,9 +34,9 @@ export function usePanelMode(): UsePanelModeResult {
     const handleModeChange = (e: CustomEvent<{ mode: PanelMode }>) => {
       setPanelMode(e.detail.mode);
     };
-    document.addEventListener('pathfinder-panel-mode-change', handleModeChange as EventListener);
+    document.addEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
     return () => {
-      document.removeEventListener('pathfinder-panel-mode-change', handleModeChange as EventListener);
+      document.removeEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
     };
   }, []);
 

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -11,6 +11,7 @@ import { panelModeManager, type PanelMode } from '../../global-state/panel-mode'
 import { sidebarState } from '../../global-state/sidebar';
 import { getConfigWithDefaults, PLUGIN_BASE_URL, ROUTES } from '../../constants';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import { PANEL_MODE_CHANGE_EVENT } from '../../lib/event-names';
 import { buildFullScreenRouteUrl } from '../../utils/pathfinder-search-params';
 import { FloatingPanel } from './FloatingPanel';
 import { FloatingPanelContent } from './FloatingPanelContent';
@@ -42,9 +43,9 @@ export function FloatingPanelManager() {
       setMode(e.detail.mode);
     };
 
-    document.addEventListener('pathfinder-panel-mode-change', handleModeChange as EventListener);
+    document.addEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
     return () => {
-      document.removeEventListener('pathfinder-panel-mode-change', handleModeChange as EventListener);
+      document.removeEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
     };
   }, []);
 

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -1046,7 +1046,8 @@ export function InteractiveSection({
           });
         }
       },
-      USER_ACTION_TIMEOUT_LONG_MS
+      USER_ACTION_TIMEOUT_LONG_MS,
+      { critical: true }
     );
   }, [
     disabled,

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../requirements-manager';
 import { reportAppInteraction, UserInteraction, buildInteractiveStepProperties } from '../../lib/analytics';
 import { logger } from '../../lib/logging';
+import { pushFaroMeasurement } from '../../lib/faro';
 import type { InteractiveStepProps } from '../../types/component-props.types';
 import {
   type DetectedActionEvent,
@@ -825,6 +826,8 @@ export const InteractiveStep = forwardRef<
       }
 
       setIsDoRunning(true);
+      const stepExecStart = performance.now();
+      let stepOutcome: 'ok' | 'error' = 'error';
       try {
         // Use lazy scroll wrapper to ensure element is found before executing
         const result = await executeWithLazyScroll(
@@ -837,6 +840,7 @@ export const InteractiveStep = forwardRef<
           targetAction
         );
 
+        stepOutcome = result.success ? 'ok' : 'error';
         if (!result.success) {
           // Lazy scroll failed to find element
           setLazyScrollError(result.error || 'Element not found');
@@ -845,6 +849,11 @@ export const InteractiveStep = forwardRef<
         logger.error('Interactive do action failed', { error });
         setLazyScrollError(error instanceof Error ? error.message : 'Action failed');
       } finally {
+        pushFaroMeasurement(
+          'pathfinder_step',
+          { step_exec_ms: performance.now() - stepExecStart },
+          { target_action: targetAction, outcome: stepOutcome }
+        );
         setIsDoRunning(false);
       }
     }, [

--- a/src/context-engine/context-v1-recommend.test.ts
+++ b/src/context-engine/context-v1-recommend.test.ts
@@ -72,15 +72,11 @@ jest.mock('../lib/hash.util', () => ({
 }));
 
 const mockPushFaroMeasurement = jest.fn();
+const mockPushFaroEvent = jest.fn();
 jest.mock('../lib/faro', () => ({
   ...jest.requireActual('../lib/faro'),
   pushFaroMeasurement: (...args: unknown[]) => mockPushFaroMeasurement(...args),
-}));
-
-const mockReportAppInteraction = jest.fn();
-jest.mock('../lib/analytics', () => ({
-  ...jest.requireActual('../lib/analytics'),
-  reportAppInteraction: (...args: unknown[]) => mockReportAppInteraction(...args),
+  pushFaroEvent: (...args: unknown[]) => mockPushFaroEvent(...args),
 }));
 
 jest.mock('../docs-retrieval', () => ({
@@ -592,7 +588,7 @@ describe('V1 error handling and edge cases', () => {
       { recommender_ms: expect.any(Number) },
       { outcome: 'other' }
     );
-    expect(mockReportAppInteraction).toHaveBeenCalledWith('recommender_fallback', {
+    expect(mockPushFaroEvent).toHaveBeenCalledWith('recommender_fallback', {
       fallback_tier: 'bundled+static',
       error_type: 'other',
     });
@@ -662,7 +658,7 @@ describe('V1 error handling and edge cases', () => {
       { recommender_ms: expect.any(Number) },
       { outcome: 'unavailable' }
     );
-    expect(mockReportAppInteraction).toHaveBeenCalledWith('recommender_fallback', {
+    expect(mockPushFaroEvent).toHaveBeenCalledWith('recommender_fallback', {
       fallback_tier: 'bundled+static',
       error_type: 'unavailable',
     });
@@ -681,7 +677,7 @@ describe('V1 error handling and edge cases', () => {
       { recommender_ms: expect.any(Number) },
       { outcome: 'ok' }
     );
-    expect(mockReportAppInteraction).not.toHaveBeenCalledWith('recommender_fallback', expect.anything());
+    expect(mockPushFaroEvent).not.toHaveBeenCalledWith('recommender_fallback', expect.anything());
   });
 });
 

--- a/src/context-engine/context-v1-recommend.test.ts
+++ b/src/context-engine/context-v1-recommend.test.ts
@@ -71,6 +71,18 @@ jest.mock('../lib/hash.util', () => ({
   }),
 }));
 
+const mockPushFaroMeasurement = jest.fn();
+jest.mock('../lib/faro', () => ({
+  ...jest.requireActual('../lib/faro'),
+  pushFaroMeasurement: (...args: unknown[]) => mockPushFaroMeasurement(...args),
+}));
+
+const mockReportAppInteraction = jest.fn();
+jest.mock('../lib/analytics', () => ({
+  ...jest.requireActual('../lib/analytics'),
+  reportAppInteraction: (...args: unknown[]) => mockReportAppInteraction(...args),
+}));
+
 jest.mock('../docs-retrieval', () => ({
   fetchContent: jest.fn().mockResolvedValue({
     content: { metadata: { learningJourney: { milestones: [], summary: '' } } },
@@ -575,6 +587,15 @@ describe('V1 error handling and edge cases', () => {
 
     expect(result.recommendations).toBeDefined();
     expect(result.errorType).toBe('other');
+    expect(mockPushFaroMeasurement).toHaveBeenCalledWith(
+      'pathfinder_recommender',
+      { recommender_ms: expect.any(Number) },
+      { outcome: 'other' }
+    );
+    expect(mockReportAppInteraction).toHaveBeenCalledWith('recommender_fallback', {
+      fallback_tier: 'bundled+static',
+      error_type: 'other',
+    });
   });
 
   it('should fall back gracefully when v1 returns HTTP 403', async () => {
@@ -636,6 +657,31 @@ describe('V1 error handling and edge cases', () => {
 
     expect(result.recommendations).toBeDefined();
     expect(result.errorType).toBe('unavailable');
+    expect(mockPushFaroMeasurement).toHaveBeenCalledWith(
+      'pathfinder_recommender',
+      { recommender_ms: expect.any(Number) },
+      { outcome: 'unavailable' }
+    );
+    expect(mockReportAppInteraction).toHaveBeenCalledWith('recommender_fallback', {
+      fallback_tier: 'bundled+static',
+      error_type: 'unavailable',
+    });
+  });
+
+  it('pushes an ok-outcome measurement (no fallback event) on a successful recommend call', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(makeV1Response()),
+    });
+
+    await ContextService.fetchRecommendations(makeContextData(), PLUGIN_CONFIG);
+
+    expect(mockPushFaroMeasurement).toHaveBeenCalledWith(
+      'pathfinder_recommender',
+      { recommender_ms: expect.any(Number) },
+      { outcome: 'ok' }
+    );
+    expect(mockReportAppInteraction).not.toHaveBeenCalledWith('recommender_fallback', expect.anything());
   });
 });
 

--- a/src/context-engine/context.service.ts
+++ b/src/context-engine/context.service.ts
@@ -25,6 +25,8 @@ import { interactiveCompletionStorage } from '../lib/user-storage';
 import { hashUserData } from '../lib/hash.util';
 import { logger } from '../lib/logging';
 import { withTimeout } from '../lib/async-utils';
+import { pushFaroMeasurement } from '../lib/faro';
+import { reportAppInteraction, UserInteraction } from '../lib/analytics';
 import { isDevModeEnabledGlobal } from '../utils/dev-mode';
 import { sanitizeTextForDisplay, parseUrlSafely, sanitizeForLogging } from '../security';
 import {
@@ -198,7 +200,11 @@ export class ContextService {
       // Always try external recommendations when T&C are enabled, regardless of previous errors
       return this.getExternalRecommendations(contextData, pluginConfig, bundledRecommendations);
     } catch (error) {
-      logger.exception(error, { source: 'fetchRecommendations' });
+      logger.exception(error, {
+        source: 'fetchRecommendations',
+        platform: this.getCurrentPlatform(),
+        timeout_ms: DEFAULT_RECOMMENDER_TIMEOUT,
+      });
       const bundledRecommendations = await this.getBundledInteractiveRecommendations(contextData, pluginConfig);
       const fallbackResult = await this.getFallbackRecommendations(contextData, bundledRecommendations);
       return {
@@ -284,17 +290,15 @@ export class ContextService {
     errorType: 'unavailable' | 'rate-limit' | 'other' | null;
     usingFallbackRecommendations: boolean;
   }> {
+    const recommenderStart = performance.now();
+    const fail = (errorType: 'unavailable' | 'rate-limit' | 'other', errorMessage: string) =>
+      this.handleRecommenderError(errorType, errorMessage, contextData, bundledRecommendations, recommenderStart);
     try {
       const configWithDefaults = getConfigWithDefaults(pluginConfig);
 
       // SECURITY: Validate recommender service URL before making request
       if (!this.validateRecommenderUrl(configWithDefaults.recommenderServiceUrl)) {
-        return this.handleRecommenderError(
-          'other',
-          'Recommender service URL failed security validation',
-          contextData,
-          bundledRecommendations
-        );
+        return fail('other', 'Recommender service URL failed security validation');
       }
 
       const isCloud = config.bootData.settings.buildInfo.versionString.startsWith('Grafana Cloud');
@@ -362,33 +366,27 @@ export class ContextService {
         if (!response.ok) {
           // Handle specific HTTP error codes
           if (response.status === 404) {
-            return this.handleRecommenderError(
-              'unavailable',
-              'Recommender service not found',
-              contextData,
-              bundledRecommendations
-            );
+            return fail('unavailable', 'Recommender service not found');
           }
 
           if (response.status === 429) {
-            return this.handleRecommenderError(
-              'rate-limit',
-              'Recommender service is under strain',
-              contextData,
-              bundledRecommendations
-            );
+            return fail('rate-limit', 'Recommender service is under strain');
           }
 
           // Handle other HTTP errors
-          return this.handleRecommenderError(
-            'other',
-            `HTTP error! status: ${response.status}`,
-            contextData,
-            bundledRecommendations
-          );
+          return fail('other', `HTTP error! status: ${response.status}`);
         }
 
         const data: V1RecommenderResponse = await response.json();
+        // Measured here, not at the successful return below — the
+        // processing between them (processLearningJourneys) does its own
+        // content fetches, which would make ok durations incomparable with
+        // the error outcomes recorded in handleRecommenderError.
+        pushFaroMeasurement(
+          'pathfinder_recommender',
+          { recommender_ms: performance.now() - recommenderStart },
+          { outcome: 'ok' }
+        );
 
         const mappedExternalRecommendations = (data.recommendations ?? []).map((rec) =>
           this.sanitizeV1Recommendation(rec)
@@ -442,12 +440,7 @@ export class ContextService {
 
         // Handle AbortError (timeout)
         if (fetchError instanceof Error && fetchError.name === 'AbortError') {
-          return this.handleRecommenderError(
-            'unavailable',
-            'Recommender service timeout',
-            contextData,
-            bundledRecommendations
-          );
+          return fail('unavailable', 'Recommender service timeout');
         }
 
         // Handle network errors (CORS, network failures, etc.)
@@ -459,21 +452,15 @@ export class ContextService {
           errorMessage.includes('NetworkError') ||
           errorMessage.includes('Failed to fetch')
         ) {
-          return this.handleRecommenderError(
-            'unavailable',
-            'Recommender service unavailable',
-            contextData,
-            bundledRecommendations
-          );
+          return fail('unavailable', 'Recommender service unavailable');
         }
 
         // Handle other errors
-        return this.handleRecommenderError('other', errorMessage, contextData, bundledRecommendations);
+        return fail('other', errorMessage);
       }
     } catch (error) {
       // Handle outer errors (hashing, payload construction, etc.)
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      return this.handleRecommenderError('other', errorMessage, contextData, bundledRecommendations);
+      return fail('other', error instanceof Error ? error.message : 'Unknown error');
     }
   }
 
@@ -484,7 +471,8 @@ export class ContextService {
     errorType: 'unavailable' | 'rate-limit' | 'other',
     errorMessage: string,
     contextData: ContextData,
-    bundledRecommendations: Recommendation[]
+    bundledRecommendations: Recommendation[],
+    startTime: number
   ): Promise<{
     recommendations: Recommendation[];
     featuredRecommendations: Recommendation[];
@@ -498,6 +486,19 @@ export class ContextService {
       timestamp: Date.now(),
       message: errorMessage,
     };
+
+    pushFaroMeasurement(
+      'pathfinder_recommender',
+      { recommender_ms: performance.now() - startTime },
+      { outcome: errorType }
+    );
+    // Fallback here always merges bundled + static-link recommendations
+    // (getFallbackRecommendations); there is no separate online-packages
+    // tier to distinguish once the external recommender has failed.
+    reportAppInteraction(UserInteraction.RecommenderFallback, {
+      fallback_tier: 'bundled+static',
+      error_type: errorType,
+    });
 
     // Get fallback recommendations
     const fallbackResult = await this.getFallbackRecommendations(contextData, bundledRecommendations);

--- a/src/context-engine/context.service.ts
+++ b/src/context-engine/context.service.ts
@@ -25,8 +25,7 @@ import { interactiveCompletionStorage } from '../lib/user-storage';
 import { hashUserData } from '../lib/hash.util';
 import { logger } from '../lib/logging';
 import { withTimeout } from '../lib/async-utils';
-import { pushFaroMeasurement } from '../lib/faro';
-import { reportAppInteraction, UserInteraction } from '../lib/analytics';
+import { pushFaroEvent, pushFaroMeasurement } from '../lib/faro';
 import { isDevModeEnabledGlobal } from '../utils/dev-mode';
 import { sanitizeTextForDisplay, parseUrlSafely, sanitizeForLogging } from '../security';
 import {
@@ -495,7 +494,7 @@ export class ContextService {
     // Fallback here always merges bundled + static-link recommendations
     // (getFallbackRecommendations); there is no separate online-packages
     // tier to distinguish once the external recommender has failed.
-    reportAppInteraction(UserInteraction.RecommenderFallback, {
+    pushFaroEvent('recommender_fallback', {
       fallback_tier: 'bundled+static',
       error_type: errorType,
     });

--- a/src/docs-retrieval/content-fetcher.test.ts
+++ b/src/docs-retrieval/content-fetcher.test.ts
@@ -4,15 +4,11 @@
 import { fetchContent, simpleMarkdownToHtml } from './content-fetcher';
 
 const mockPushFaroMeasurement = jest.fn();
+const mockPushFaroEvent = jest.fn();
 jest.mock('../lib/faro', () => ({
   ...jest.requireActual('../lib/faro'),
   pushFaroMeasurement: (...args: unknown[]) => mockPushFaroMeasurement(...args),
-}));
-
-const mockReportAppInteraction = jest.fn();
-jest.mock('../lib/analytics', () => ({
-  ...jest.requireActual('../lib/analytics'),
-  reportAppInteraction: (...args: unknown[]) => mockReportAppInteraction(...args),
+  pushFaroEvent: (...args: unknown[]) => mockPushFaroEvent(...args),
 }));
 
 // Mock AbortSignal.timeout for Node environments that don't support it
@@ -82,7 +78,7 @@ describe('content.json → unstyled.html ladder', () => {
     expect(htmlIdx).toBeGreaterThanOrEqual(0);
     expect(jsonIdx).toBeLessThan(htmlIdx);
 
-    expect(mockReportAppInteraction).toHaveBeenCalledWith('content_fetch_fallback', {
+    expect(mockPushFaroEvent).toHaveBeenCalledWith('content_fetch_fallback', {
       content_url: journeyUrl,
       tier_used: 'unstyled-html',
       error_type: 'content-json-unavailable',
@@ -105,7 +101,7 @@ describe('content.json → unstyled.html ladder', () => {
 
     expect(result.content?.isNativeJson).toBe(true);
     expect(order).not.toContain('unstyled.html');
-    expect(mockReportAppInteraction).not.toHaveBeenCalledWith('content_fetch_fallback', expect.anything());
+    expect(mockPushFaroEvent).not.toHaveBeenCalledWith('content_fetch_fallback', expect.anything());
     expect(mockPushFaroMeasurement).toHaveBeenCalledWith(
       'pathfinder_content_fetch',
       { content_fetch_ms: expect.any(Number) },

--- a/src/docs-retrieval/content-fetcher.test.ts
+++ b/src/docs-retrieval/content-fetcher.test.ts
@@ -3,6 +3,18 @@
  */
 import { fetchContent, simpleMarkdownToHtml } from './content-fetcher';
 
+const mockPushFaroMeasurement = jest.fn();
+jest.mock('../lib/faro', () => ({
+  ...jest.requireActual('../lib/faro'),
+  pushFaroMeasurement: (...args: unknown[]) => mockPushFaroMeasurement(...args),
+}));
+
+const mockReportAppInteraction = jest.fn();
+jest.mock('../lib/analytics', () => ({
+  ...jest.requireActual('../lib/analytics'),
+  reportAppInteraction: (...args: unknown[]) => mockReportAppInteraction(...args),
+}));
+
 // Mock AbortSignal.timeout for Node environments that don't support it
 if (!AbortSignal.timeout) {
   (AbortSignal as any).timeout = jest.fn((ms: number) => {
@@ -18,6 +30,7 @@ if (!AbortSignal.timeout) {
 // behavior-preserving. Replaces the prior `expect(true).toBe(true)` doc-tests.
 describe('content.json → unstyled.html ladder', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     global.fetch = jest.fn();
   });
 
@@ -68,6 +81,17 @@ describe('content.json → unstyled.html ladder', () => {
     expect(jsonIdx).toBeGreaterThanOrEqual(0);
     expect(htmlIdx).toBeGreaterThanOrEqual(0);
     expect(jsonIdx).toBeLessThan(htmlIdx);
+
+    expect(mockReportAppInteraction).toHaveBeenCalledWith('content_fetch_fallback', {
+      content_url: journeyUrl,
+      tier_used: 'unstyled-html',
+      error_type: 'content-json-unavailable',
+    });
+    expect(mockPushFaroMeasurement).toHaveBeenCalledWith(
+      'pathfinder_content_fetch',
+      { content_fetch_ms: expect.any(Number) },
+      { tier: 'unstyled-html', outcome: 'ok', content_url: journeyUrl }
+    );
   });
 
   it('uses content.json directly and never fetches unstyled.html when it returns a valid guide', async () => {
@@ -81,6 +105,12 @@ describe('content.json → unstyled.html ladder', () => {
 
     expect(result.content?.isNativeJson).toBe(true);
     expect(order).not.toContain('unstyled.html');
+    expect(mockReportAppInteraction).not.toHaveBeenCalledWith('content_fetch_fallback', expect.anything());
+    expect(mockPushFaroMeasurement).toHaveBeenCalledWith(
+      'pathfinder_content_fetch',
+      { content_fetch_ms: expect.any(Number) },
+      { tier: 'content-json', outcome: 'ok', content_url: journeyUrl }
+    );
   });
 
   it('falls through to unstyled.html when content.json returns the null signal', async () => {

--- a/src/docs-retrieval/content-fetcher.ts
+++ b/src/docs-retrieval/content-fetcher.ts
@@ -14,6 +14,10 @@ import { fetchBundledInteractive } from './content-fetcher/bundled';
 import { fetchBackendInteractive } from './content-fetcher/backend-guide';
 import { enforceHttps, fetchRawHtml, generateUserFriendlyError } from './content-fetcher/fetch-raw';
 import { logger } from '../lib/logging';
+import { pushFaroMeasurement } from '../lib/faro';
+import { reportAppInteraction, UserInteraction } from '../lib/analytics';
+
+type ContentFetchTier = 'bundled' | 'backend-guide' | 'content-json' | 'unstyled-html' | 'other';
 
 // Re-exported to keep the barrel surface stable: `injectJourneyExtrasIntoJsonGuide`
 // is consumed by `components/docs-panel`, and `simpleMarkdownToHtml` by the
@@ -55,6 +59,15 @@ function wrapContentAsJsonGuide(content: string, url: string, title: string): st
  * Determines content type and fetches accordingly
  */
 export async function fetchContent(url: string, options: ContentFetchOptions = {}): Promise<ContentFetchResult> {
+  const fetchStart = performance.now();
+  let tier: ContentFetchTier = 'other';
+  const recordFetch = (outcome: 'ok' | 'error') =>
+    pushFaroMeasurement(
+      'pathfinder_content_fetch',
+      { content_fetch_ms: performance.now() - fetchStart },
+      { tier, outcome, content_url: url }
+    );
+
   try {
     // Validate URL
     if (!url || typeof url !== 'string' || url.trim() === '') {
@@ -64,11 +77,17 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
 
     // Handle bundled interactive content
     if (url.startsWith('bundled:')) {
-      return await fetchBundledInteractive(url);
+      tier = 'bundled';
+      const result = await fetchBundledInteractive(url);
+      recordFetch(result.error ? 'error' : 'ok');
+      return result;
     }
     // Handle custom guides stored in backend CRDs
     if (url.startsWith('backend-guide:')) {
-      return await fetchBackendInteractive(url);
+      tier = 'backend-guide';
+      const result = await fetchBackendInteractive(url);
+      recordFetch(result.error ? 'error' : 'ok');
+      return result;
     }
 
     // SECURITY: Validate URL is from a trusted source before fetching
@@ -106,11 +125,14 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
     // Determine content type based on URL patterns
     const contentType = determineContentType(url);
 
-    // Fetch raw HTML with structured error handling
+    // fetchRawHtml resolves the content.json ↔ unstyled.html ladder
+    // internally (tryGrafanaDocsContentLadder) — the tier isn't knowable
+    // from the requested URL alone, only from its result.
     const fetchResult = await fetchRawHtml(cleanUrl, options);
     if (!fetchResult.html) {
       // Generate user-friendly error message based on error type
       const userFriendlyError = generateUserFriendlyError(fetchResult.error, cleanUrl);
+      recordFetch('error');
       return {
         content: null,
         error: userFriendlyError,
@@ -124,6 +146,18 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
 
     // Determine if this is native JSON content (content.json) that doesn't need wrapping
     const isNativeJson = fetchResult.isNativeJson || false;
+    tier = isNativeJson ? 'content-json' : 'unstyled-html';
+
+    // Learning-journey URLs always try content.json first (see
+    // tryGrafanaDocsContentLadder in fetch-raw.ts) — landing on the HTML
+    // tier for one of them means that ladder fell back.
+    if (contentType === 'learning-journey' && tier === 'unstyled-html') {
+      reportAppInteraction(UserInteraction.ContentFetchFallback, {
+        content_url: url,
+        tier_used: 'unstyled-html',
+        error_type: 'content-json-unavailable',
+      });
+    }
 
     const metadata = await extractMetadata(fetchResult.html, finalUrl, contentType, isNativeJson);
 
@@ -138,10 +172,17 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
         // Check if the server returned null as a signal to fetch unstyled.html
         // JSON.parse("null") returns the JavaScript value null
         if (parsed === null) {
+          tier = 'unstyled-html';
+          reportAppInteraction(UserInteraction.ContentFetchFallback, {
+            content_url: url,
+            tier_used: 'unstyled-html',
+            error_type: 'content-json-null',
+          });
           const htmlUrl = finalUrl.replace('/content.json', '/unstyled.html');
           const htmlFetchResult = await fetchRawHtml(htmlUrl, options);
 
           if (!htmlFetchResult.html) {
+            recordFetch('error');
             return {
               content: null,
               error: 'Content not available. The server returned null and no HTML fallback exists.',
@@ -173,6 +214,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
             isNativeJson: false,
           };
 
+          recordFetch('ok');
           return { content: rawContent };
         }
 
@@ -181,6 +223,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
         if (!validationResult.isValid) {
           // Use the first error message for the main error
           const errorMessage = validationResult.errors[0]?.message || 'Schema validation failed';
+          recordFetch('error');
           return {
             content: null,
             error: `Invalid guide: ${errorMessage}`,
@@ -190,7 +233,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
         jsonContent = fetchResult.html; // Valid JSON guide
       } catch {
         // Invalid JSON - treat as HTML and wrap
-        logger.warn('Failed to parse native JSON, treating as HTML');
+        logger.warn('Failed to parse native JSON, treating as HTML', { content_url: url, tier });
         jsonContent = wrapContentAsJsonGuide(fetchResult.html, finalUrl, metadata.title);
       }
     } else {
@@ -219,9 +262,11 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
       isNativeJson,
     };
 
+    recordFetch('ok');
     return { content: rawContent };
   } catch (error) {
     logger.error(`Failed to fetch content from ${url}`, { error });
+    recordFetch('error');
     return {
       content: null,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/src/docs-retrieval/content-fetcher.ts
+++ b/src/docs-retrieval/content-fetcher.ts
@@ -14,8 +14,7 @@ import { fetchBundledInteractive } from './content-fetcher/bundled';
 import { fetchBackendInteractive } from './content-fetcher/backend-guide';
 import { enforceHttps, fetchRawHtml, generateUserFriendlyError } from './content-fetcher/fetch-raw';
 import { logger } from '../lib/logging';
-import { pushFaroMeasurement } from '../lib/faro';
-import { reportAppInteraction, UserInteraction } from '../lib/analytics';
+import { pushFaroEvent, pushFaroMeasurement } from '../lib/faro';
 
 type ContentFetchTier = 'bundled' | 'backend-guide' | 'content-json' | 'unstyled-html' | 'other';
 
@@ -152,7 +151,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
     // tryGrafanaDocsContentLadder in fetch-raw.ts) — landing on the HTML
     // tier for one of them means that ladder fell back.
     if (contentType === 'learning-journey' && tier === 'unstyled-html') {
-      reportAppInteraction(UserInteraction.ContentFetchFallback, {
+      pushFaroEvent('content_fetch_fallback', {
         content_url: url,
         tier_used: 'unstyled-html',
         error_type: 'content-json-unavailable',
@@ -173,7 +172,7 @@ export async function fetchContent(url: string, options: ContentFetchOptions = {
         // JSON.parse("null") returns the JavaScript value null
         if (parsed === null) {
           tier = 'unstyled-html';
-          reportAppInteraction(UserInteraction.ContentFetchFallback, {
+          pushFaroEvent('content_fetch_fallback', {
             content_url: url,
             tier_used: 'unstyled-html',
             error_type: 'content-json-null',

--- a/src/docs-retrieval/content-fetcher/fetch-raw.ts
+++ b/src/docs-retrieval/content-fetcher/fetch-raw.ts
@@ -393,7 +393,7 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
         errorType,
         statusCode: response.status,
       };
-      logger.warn(`Failed to fetch from ${url}: ${lastError.message}`);
+      logger.warn(`Failed to fetch from ${url}: ${lastError.message}`, { content_url: url, error_type: errorType });
     }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -408,11 +408,15 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
       message: errorMessage,
       errorType: isTimeout ? 'timeout' : isNetwork ? 'network' : 'other',
     };
-    logger.warn(`Failed to fetch from ${url}`, { error });
+    logger.warn(`Failed to fetch from ${url}`, { error, content_url: url });
   }
 
   if (lastError) {
-    logger.error(`Failed to fetch content from ${url}`, { lastErrorMessage: lastError.message });
+    logger.error(`Failed to fetch content from ${url}`, {
+      lastErrorMessage: lastError.message,
+      content_url: url,
+      error_type: lastError.errorType,
+    });
   }
 
   return { html: null, error: lastError };

--- a/src/global-state/panel-mode.ts
+++ b/src/global-state/panel-mode.ts
@@ -1,5 +1,6 @@
 import { getAppEvents } from '@grafana/runtime';
 import { StorageKeys } from '../lib/storage-keys';
+import { PANEL_MODE_CHANGE_EVENT } from '../lib/event-names';
 import { type FloatingPanelGeometry, getDefaultFloatingPanelGeometry } from '../constants/floating-panel';
 import type { PackageOpenInfo } from '../types/content-panel.types';
 
@@ -82,7 +83,7 @@ class PanelModeManager {
     }
 
     document.dispatchEvent(
-      new CustomEvent('pathfinder-panel-mode-change', {
+      new CustomEvent(PANEL_MODE_CHANGE_EVENT, {
         detail: { mode, previous },
       })
     );

--- a/src/interactive-engine/action-handlers/guided-handler.test.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.test.ts
@@ -156,7 +156,8 @@ describe('GuidedHandler', () => {
         'pathfinder_guided_step',
         { target_action: 'highlight', ref_target: refTarget, step_index: 0, total_steps: 1 },
         expect.any(Function),
-        10_005
+        10_005,
+        { critical: true }
       );
 
       consoleErrorSpy.mockRestore();

--- a/src/interactive-engine/action-handlers/guided-handler.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.ts
@@ -96,7 +96,8 @@ export class GuidedHandler {
       },
       () => this.runGuidedStep(action, stepIndex, totalSteps, timeout),
       // Internal waits are bounded by `timeout`; the margin only catches a hung step.
-      timeout + 10_000
+      timeout + 10_000,
+      { critical: true }
     );
   }
 
@@ -392,7 +393,12 @@ export class GuidedHandler {
         }
 
         if (remaining <= 0) {
-          logger.error(`Element not found after ${attemptCount} attempts (${elapsed}ms): ${selector}`);
+          logger.error(`Element not found after ${attemptCount} attempts (${elapsed}ms): ${selector}`, {
+            selector,
+            action_type: actionType,
+            attempt_count: attemptCount,
+            elapsed_ms: elapsed,
+          });
           throw error;
         }
         // Wait before retrying, but don't exceed timeout

--- a/src/interactive-engine/interactive-state-manager.test.ts
+++ b/src/interactive-engine/interactive-state-manager.test.ts
@@ -49,6 +49,34 @@ describe('InteractiveStateManager', () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith('context: error message', { data });
   });
 
+  it('reports a real Error via logError with target_action/ref_target/element_id context (Faro exception, not just a log)', () => {
+    const boom = new Error('click failed');
+    manager.logError('ButtonHandler', boom, { ...data, id: 'save-btn' });
+    expect(consoleErrorSpy).toHaveBeenCalledWith('ButtonHandler: click failed', boom, {
+      source: 'ButtonHandler',
+      target_action: 'button',
+      ref_target: 'selector',
+      element_id: 'save-btn',
+    });
+  });
+
+  it('falls back to an empty element_id when the failing element has none', () => {
+    const boom = new Error('click failed');
+    manager.logError('ButtonHandler', boom, data);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'ButtonHandler: click failed',
+      boom,
+      expect.objectContaining({ element_id: '' })
+    );
+  });
+
+  it('reports the same Error instance only once, even across handler + caller reporting', () => {
+    const boom = new Error('click failed');
+    manager.logError('ButtonHandler', boom, data);
+    manager.logError('executeInteractiveAction', boom, data);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('should call setState and throw on handleError with shouldThrow', () => {
     const setStateSpy = jest.spyOn(manager, 'setState');
     expect(() => manager.handleError('err', 'ctx', data, true)).toThrow('err');

--- a/src/interactive-engine/interactive-state-manager.ts
+++ b/src/interactive-engine/interactive-state-manager.ts
@@ -5,6 +5,11 @@ import GlobalInteractionBlocker from './global-interaction-blocker';
 
 export type InteractiveState = 'idle' | 'running' | 'completed' | 'error';
 
+// Handlers report with shouldThrow=true and callers catch and report again
+// (e.g. PopoutHandler → executeInteractiveAction), so the same Error can
+// reach logError twice; report it to Faro only once.
+const reportedErrors = new WeakSet<Error>();
+
 export interface StateManagerOptions {
   enableLogging?: boolean;
   enableEvents?: boolean;
@@ -55,6 +60,24 @@ export class InteractiveStateManager {
     }
 
     const errorMessage = typeof error === 'string' ? error : error.message;
+
+    // A real Error is a failure while driving Grafana core's DOM — its stack
+    // has no plugin frame, so it must be reported as an explicit Faro
+    // exception (logger.error's Error branch) or it's invisible to Faro.
+    if (error instanceof Error) {
+      if (reportedErrors.has(error)) {
+        return;
+      }
+      reportedErrors.add(error);
+      logger.error(`${context}: ${errorMessage}`, error, {
+        source: context,
+        target_action: data.targetAction ?? '',
+        ref_target: data.refTarget ?? '',
+        element_id: data.id ?? '',
+      });
+      return;
+    }
+
     logger.error(`${context}: ${errorMessage}`, { data });
   }
 

--- a/src/interactive-engine/interactive.hook.test.ts
+++ b/src/interactive-engine/interactive.hook.test.ts
@@ -264,7 +264,8 @@ describe('useInteractiveElements', () => {
         'pathfinder_step_show',
         { target_action: 'highlight', ref_target: '#target' },
         expect.any(Function),
-        undefined
+        undefined,
+        { critical: false }
       );
     });
 
@@ -279,7 +280,8 @@ describe('useInteractiveElements', () => {
         'pathfinder_step_do',
         { target_action: 'button', ref_target: 'Save' },
         expect.any(Function),
-        undefined
+        undefined,
+        { critical: true }
       );
     });
   });

--- a/src/interactive-engine/interactive.hook.ts
+++ b/src/interactive-engine/interactive.hook.ts
@@ -180,7 +180,10 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
           } else if (data.targetAction === 'popout') {
             await interactivePopout(data, click);
           }
-        }
+        },
+        undefined,
+        // "Do it" is the funnel action; "Show me" is just a preview.
+        { critical: click }
       );
     },
     [
@@ -463,7 +466,8 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
             stateManager.handleError(error as Error, 'executeInteractiveAction', elementData, true);
           }
         },
-        targetAction === 'sequence' ? USER_ACTION_TIMEOUT_LONG_MS : undefined
+        targetAction === 'sequence' ? USER_ACTION_TIMEOUT_LONG_MS : undefined,
+        { critical: !isShowMode }
       );
     },
     [

--- a/src/interactive-engine/sequence-manager.test.ts
+++ b/src/interactive-engine/sequence-manager.test.ts
@@ -3,6 +3,18 @@ import { InteractiveStateManager } from './interactive-state-manager';
 import { InteractiveElementData } from '../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 
+const mockPushFaroMeasurement = jest.fn();
+jest.mock('../lib/faro', () => ({
+  ...jest.requireActual('../lib/faro'),
+  pushFaroMeasurement: (...args: unknown[]) => mockPushFaroMeasurement(...args),
+}));
+
+const mockReportAppInteraction = jest.fn();
+jest.mock('../lib/analytics', () => ({
+  ...jest.requireActual('../lib/analytics'),
+  reportAppInteraction: (...args: unknown[]) => mockReportAppInteraction(...args),
+}));
+
 // Mock dependencies
 const mockStateManager = {
   logError: jest.fn(),
@@ -134,6 +146,24 @@ describe('SequenceManager', () => {
 
       expect(mockCheckRequirementsFromData).toHaveBeenCalledTimes(INTERACTIVE_CONFIG.maxRetries);
       expect(mockDispatchInteractiveAction).not.toHaveBeenCalled();
+      expect(mockPushFaroMeasurement).toHaveBeenCalledWith(
+        'pathfinder_requirements',
+        { retry_count: INTERACTIVE_CONFIG.maxRetries },
+        { requirement: 'test-requirements' }
+      );
+      expect(mockReportAppInteraction).toHaveBeenCalledWith('requirements_exhausted', {
+        requirement: 'test-requirements',
+        retry_count: INTERACTIVE_CONFIG.maxRetries,
+      });
+    });
+
+    it('does not report exhaustion when a step eventually succeeds', async () => {
+      mockCheckRequirementsFromData.mockResolvedValueOnce({ pass: false }).mockResolvedValueOnce({ pass: true });
+
+      await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
+
+      expect(mockPushFaroMeasurement).not.toHaveBeenCalled();
+      expect(mockReportAppInteraction).not.toHaveBeenCalled();
     });
 
     it('should handle errors gracefully', async () => {
@@ -231,6 +261,15 @@ describe('SequenceManager', () => {
 
       expect(mockCheckRequirementsFromData).toHaveBeenCalledTimes(INTERACTIVE_CONFIG.maxRetries);
       expect(mockDispatchInteractiveAction).not.toHaveBeenCalled();
+      expect(mockPushFaroMeasurement).toHaveBeenCalledWith(
+        'pathfinder_requirements',
+        { retry_count: INTERACTIVE_CONFIG.maxRetries },
+        { requirement: 'test-requirements' }
+      );
+      expect(mockReportAppInteraction).toHaveBeenCalledWith('requirements_exhausted', {
+        requirement: 'test-requirements',
+        retry_count: INTERACTIVE_CONFIG.maxRetries,
+      });
     });
 
     it('should handle errors gracefully', async () => {

--- a/src/interactive-engine/sequence-manager.test.ts
+++ b/src/interactive-engine/sequence-manager.test.ts
@@ -4,15 +4,11 @@ import { InteractiveElementData } from '../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 
 const mockPushFaroMeasurement = jest.fn();
+const mockPushFaroEvent = jest.fn();
 jest.mock('../lib/faro', () => ({
   ...jest.requireActual('../lib/faro'),
   pushFaroMeasurement: (...args: unknown[]) => mockPushFaroMeasurement(...args),
-}));
-
-const mockReportAppInteraction = jest.fn();
-jest.mock('../lib/analytics', () => ({
-  ...jest.requireActual('../lib/analytics'),
-  reportAppInteraction: (...args: unknown[]) => mockReportAppInteraction(...args),
+  pushFaroEvent: (...args: unknown[]) => mockPushFaroEvent(...args),
 }));
 
 // Mock dependencies
@@ -151,7 +147,7 @@ describe('SequenceManager', () => {
         { retry_count: INTERACTIVE_CONFIG.maxRetries },
         { requirement: 'test-requirements' }
       );
-      expect(mockReportAppInteraction).toHaveBeenCalledWith('requirements_exhausted', {
+      expect(mockPushFaroEvent).toHaveBeenCalledWith('requirements_exhausted', {
         requirement: 'test-requirements',
         retry_count: INTERACTIVE_CONFIG.maxRetries,
       });
@@ -163,7 +159,7 @@ describe('SequenceManager', () => {
       await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
 
       expect(mockPushFaroMeasurement).not.toHaveBeenCalled();
-      expect(mockReportAppInteraction).not.toHaveBeenCalled();
+      expect(mockPushFaroEvent).not.toHaveBeenCalled();
     });
 
     it('should handle errors gracefully', async () => {
@@ -266,7 +262,7 @@ describe('SequenceManager', () => {
         { retry_count: INTERACTIVE_CONFIG.maxRetries },
         { requirement: 'test-requirements' }
       );
-      expect(mockReportAppInteraction).toHaveBeenCalledWith('requirements_exhausted', {
+      expect(mockPushFaroEvent).toHaveBeenCalledWith('requirements_exhausted', {
         requirement: 'test-requirements',
         retry_count: INTERACTIVE_CONFIG.maxRetries,
       });

--- a/src/interactive-engine/sequence-manager.ts
+++ b/src/interactive-engine/sequence-manager.ts
@@ -2,6 +2,10 @@ import { InteractiveElementData } from '../types/interactive.types';
 import { InteractiveStateManager } from './interactive-state-manager';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import { logger } from '../lib/logging';
+import { pushFaroMeasurement } from '../lib/faro';
+import { reportAppInteraction, UserInteraction } from '../lib/analytics';
+
+const MAX_REQUIREMENT_CONTEXT_LENGTH = 200;
 
 /**
  * Result of a retry operation
@@ -66,6 +70,12 @@ export class SequenceManager {
     logger.warn(
       `${context.stepName} ${context.stepIndex + 1} failed after ${this.MAX_RETRIES} retries, stopping sequence`
     );
+    const requirement = (context.data.requirements ?? '').slice(0, MAX_REQUIREMENT_CONTEXT_LENGTH);
+    pushFaroMeasurement('pathfinder_requirements', { retry_count: this.MAX_RETRIES }, { requirement });
+    reportAppInteraction(UserInteraction.RequirementsExhausted, {
+      requirement,
+      retry_count: this.MAX_RETRIES,
+    });
     return 'failed';
   }
 

--- a/src/interactive-engine/sequence-manager.ts
+++ b/src/interactive-engine/sequence-manager.ts
@@ -2,8 +2,7 @@ import { InteractiveElementData } from '../types/interactive.types';
 import { InteractiveStateManager } from './interactive-state-manager';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import { logger } from '../lib/logging';
-import { pushFaroMeasurement } from '../lib/faro';
-import { reportAppInteraction, UserInteraction } from '../lib/analytics';
+import { pushFaroEvent, pushFaroMeasurement } from '../lib/faro';
 
 const MAX_REQUIREMENT_CONTEXT_LENGTH = 200;
 
@@ -72,7 +71,7 @@ export class SequenceManager {
     );
     const requirement = (context.data.requirements ?? '').slice(0, MAX_REQUIREMENT_CONTEXT_LENGTH);
     pushFaroMeasurement('pathfinder_requirements', { retry_count: this.MAX_RETRIES }, { requirement });
-    reportAppInteraction(UserInteraction.RequirementsExhausted, {
+    pushFaroEvent('requirements_exhausted', {
       requirement,
       retry_count: this.MAX_RETRIES,
     });

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -171,6 +171,21 @@ describe('reportAppInteraction experiment enrichment', () => {
     expect(props).not.toHaveProperty('variant');
   });
 
+  it('strips experiments from the Faro mirror but keeps it in the RudderStack payload', () => {
+    bindExperimentsProvider(() => [
+      { flag: HIGHLIGHTED, variant: 'treatment', pages: [], guideId: 'g', docType: 'learning-journey' },
+    ]);
+
+    reportAppInteraction(UserInteraction.SummaryClick, {});
+
+    const reportedProps = mockReportInteraction.mock.calls[0][1];
+    const mirroredProps = mockPushFaroUserAction.mock.calls[0][1];
+    expect(reportedProps).toHaveProperty('experiments');
+    expect(mirroredProps).not.toHaveProperty('experiments');
+    // Everything else still mirrors, including the small `variant` rollup.
+    expect(mirroredProps.variant).toBe(reportedProps.variant);
+  });
+
   it('does not enrich FeatureFlagEvaluated events (recursion guard)', () => {
     bindExperimentsProvider(() => [{ flag: HIGHLIGHTED, variant: 'treatment', pages: [], guideId: 'g' }]);
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -108,11 +108,6 @@ export enum UserInteraction {
   AiFixAccepted = 'ai_fix_accepted',
   AiFixApplied = 'ai_fix_applied',
   AiFixFailed = 'ai_fix_failed',
-
-  // Funnel degradation — silent failures worth alerting on
-  RecommenderFallback = 'recommender_fallback',
-  ContentFetchFallback = 'content_fetch_fallback',
-  RequirementsExhausted = 'requirements_exhausted',
 }
 
 // ============================================================================

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -108,6 +108,11 @@ export enum UserInteraction {
   AiFixAccepted = 'ai_fix_accepted',
   AiFixApplied = 'ai_fix_applied',
   AiFixFailed = 'ai_fix_failed',
+
+  // Funnel degradation — silent failures worth alerting on
+  RecommenderFallback = 'recommender_fallback',
+  ContentFetchFallback = 'content_fetch_fallback',
+  RequirementsExhausted = 'requirements_exhausted',
 }
 
 // ============================================================================
@@ -211,7 +216,12 @@ export function reportAppInteraction(
       // each other. The finally keeps the mirror alive when reportInteraction
       // itself throws — a lost RudderStack event is exactly the divergence the
       // mirror exists to surface. pushFaroUserAction never throws.
-      pushFaroUserAction(interactionName, { ...enrichedProperties });
+      // `experiments` is dropped here — it's carried once as a session
+      // attribute (setFaroSessionAttributes after initFaro in module.tsx)
+      // instead of repeated on every mirrored action; RudderStack keeps it.
+      const faroProperties = { ...enrichedProperties };
+      delete faroProperties.experiments;
+      pushFaroUserAction(interactionName, faroProperties);
     }
   } catch (error) {
     logger.warn('Analytics reporting failed', { error });

--- a/src/lib/event-names.ts
+++ b/src/lib/event-names.ts
@@ -6,6 +6,14 @@ export const StorageEvents = {
 
 export type StorageEventName = (typeof StorageEvents)[keyof typeof StorageEvents];
 
+// Dispatched by global-state/panel-mode's panelModeManager.setMode with
+// detail { mode, previous }; consumed by every Pathfinder surface.
+export const PANEL_MODE_CHANGE_EVENT = 'pathfinder-panel-mode-change';
+
+// Dispatched by ContextPanelRenderer when the recommendations list has
+// finished loading; consumed by docs-panel's panel_lcp_ms measurement.
+export const RECOMMENDATIONS_READY_EVENT = 'pathfinder-recommendations-ready';
+
 export const FloatingPanelEvents = {
   Dodge: 'pathfinder-floating-dodge',
   Compact: 'pathfinder-floating-compact',

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -430,14 +430,14 @@ describe('initFaro', () => {
     expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
   });
 
-  it("stamps meta.user with the recommender's hashed identity, never raw PII", async () => {
+  it("stamps meta.user with the recommender's hashed identity (email hash as id), never raw PII", async () => {
     const faro = freshFaro();
     await faro.initFaro();
     await flushMicrotasks();
     expect(mockHashUserData).toHaveBeenCalledWith('abc', 'x@y.z');
     expect(mockSetUser).toHaveBeenCalledWith({
-      id: 'hashed-abc',
-      attributes: { email_hash: 'hashed-x@y.z', org_role: 'Admin' },
+      id: 'hashed-x@y.z',
+      attributes: { user_id_hash: 'hashed-abc', org_role: 'Admin' },
     });
   });
 
@@ -460,7 +460,7 @@ describe('initFaro', () => {
     expect(mockSetUser).not.toHaveBeenCalled();
   });
 
-  it('includes edition and language in the initial session attributes', async () => {
+  it('includes edition, language, and the instance hostname in the initial session attributes', async () => {
     mockedConfig.bootData!.user.language = 'fr-FR';
     mockedConfig.buildInfo.edition = 'Enterprise';
     const faro = freshFaro();
@@ -469,7 +469,12 @@ describe('initFaro', () => {
       sessionTracking: { session: { attributes: Record<string, string> } };
     };
     expect(calledWith.sessionTracking.session.attributes).toEqual(
-      expect.objectContaining({ grafana_version: '13.1.0', edition: 'Enterprise', language: 'fr-FR' })
+      expect.objectContaining({
+        grafana_version: '13.1.0',
+        edition: 'Enterprise',
+        language: 'fr-FR',
+        instance: window.location.hostname,
+      })
     );
   });
 

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -24,7 +24,17 @@ const mockStartUserAction = jest.fn(() => ({
 }));
 const mockGetActiveUserAction = jest.fn((): unknown => undefined);
 const mockSetView = jest.fn();
+const mockSetUser = jest.fn();
 const mockPause = jest.fn();
+let mockSessionMeta: { id: string; attributes?: Record<string, string> } | undefined = {
+  id: 'session-1',
+  attributes: {},
+};
+const mockGetSession = jest.fn(() => mockSessionMeta);
+const mockSetSession = jest.fn((session?: { id?: string; attributes?: Record<string, string> }) => {
+  mockSessionMeta = session as typeof mockSessionMeta;
+});
+const mockPushMeasurement = jest.fn();
 const mockFaroInstance = {
   api: {
     pushError: mockPushError,
@@ -33,6 +43,10 @@ const mockFaroInstance = {
     startUserAction: mockStartUserAction,
     getActiveUserAction: mockGetActiveUserAction,
     setView: mockSetView,
+    setUser: mockSetUser,
+    getSession: mockGetSession,
+    setSession: mockSetSession,
+    pushMeasurement: mockPushMeasurement,
   },
   pause: mockPause,
 };
@@ -42,6 +56,7 @@ interface CapturedFaroConfig {
   sessionTracking: { samplingRate?: number; persistent: boolean };
   instrumentations: Array<{ constructor: { name: string } }>;
   beforeSend: (item: TransportItem<APIEvent>) => TransportItem<APIEvent> | null;
+  ignoreUrls?: Array<string | RegExp>;
 }
 
 const mockInitializeFaro = jest.fn((_cfg: CapturedFaroConfig) => mockFaroInstance);
@@ -54,18 +69,41 @@ jest.mock('@grafana/faro-web-sdk', () => ({
   PerformanceInstrumentation: class PerformanceInstrumentation {},
 }));
 
+const mockHashUserData = jest.fn(async (userId: string, email: string) => ({
+  hashedUserId: `hashed-${userId}`,
+  hashedEmail: `hashed-${email}`,
+}));
+
+jest.mock('./hash.util', () => ({ hashUserData: (...args: [string, string]) => mockHashUserData(...args) }));
+
 // A stable object reference, not a fresh literal per require: `freshFaro()`
 // resets the module registry (so `./faro`'s internal init/instance state
 // starts clean), and re-requiring this mock must keep resolving to the same
 // `config` object so mutations made between tests are still visible.
+interface MockedBootDataUser {
+  email: string;
+  orgRole: string;
+  analytics: { identifier: string };
+  language?: string;
+}
+
 const mockedConfig = {
-  buildInfo: { env: 'production', version: '13.1.0' },
-  bootData: { settings: { buildInfo: { versionString: 'Grafana Cloud' } } } as
-    { settings: { buildInfo: { versionString: string } } } | undefined,
+  buildInfo: { env: 'production', version: '13.1.0', edition: undefined as string | undefined },
+  bootData: {
+    settings: { buildInfo: { versionString: 'Grafana Cloud' } },
+    user: { email: 'x@y.z', orgRole: 'Admin', analytics: { identifier: 'abc' } } as MockedBootDataUser,
+  } as { settings: { buildInfo: { versionString: string } }; user: MockedBootDataUser } | undefined,
   analytics: { enabled: true } as { enabled: boolean } | undefined,
 };
 
 jest.mock('@grafana/runtime', () => ({ config: mockedConfig }));
+
+// stampFaroUser() is fire-and-forget inside initFaro() — flush the
+// microtask queue so its `await hashUserData(...)` resolves before assertions.
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 // Loaded via `require`, not a static ES `import`: ES imports are evaluated
 // before any of this file's own top-level statements, which would trigger
@@ -76,6 +114,7 @@ const {
   isGrafanaCloud,
   filterPathfinderTelemetry,
   stringifyAttributes,
+  buildResourceIgnorePattern,
 }: typeof import('./faro') = require('./faro');
 
 function freshFaro(): typeof import('./faro') {
@@ -87,9 +126,13 @@ beforeEach(() => {
   jest.clearAllMocks();
   localStorage.clear();
   sessionStorage.clear();
-  mockedConfig.buildInfo = { env: 'production', version: '13.1.0' };
-  mockedConfig.bootData = { settings: { buildInfo: { versionString: 'Grafana Cloud' } } };
+  mockedConfig.buildInfo = { env: 'production', version: '13.1.0', edition: undefined };
+  mockedConfig.bootData = {
+    settings: { buildInfo: { versionString: 'Grafana Cloud' } },
+    user: { email: 'x@y.z', orgRole: 'Admin', analytics: { identifier: 'abc' } },
+  };
   mockedConfig.analytics = { enabled: true };
+  mockSessionMeta = { id: 'session-1', attributes: {} };
 });
 
 describe('getEnvironment', () => {
@@ -285,6 +328,23 @@ describe('filterPathfinderTelemetry', () => {
   });
 });
 
+describe('buildResourceIgnorePattern', () => {
+  const pattern = buildResourceIgnorePattern(
+    new Set(['grafana.com', 'recommender.grafana.com', 'interactive-learning.grafana.net'])
+  );
+
+  it('does not match (allows) tracked hostnames', () => {
+    expect(pattern.test('https://grafana.com/docs/x')).toBe(false);
+    expect(pattern.test('https://recommender.grafana.com/api/v1/recommend')).toBe(false);
+    expect(pattern.test('https://interactive-learning.grafana.net/x')).toBe(false);
+  });
+
+  it('matches (ignores) untracked hostnames — Grafana core and third parties', () => {
+    expect(pattern.test('https://foo.grafana.net/api/dashboards/uid/abc')).toBe(true);
+    expect(pattern.test('https://cdn.jsdelivr.net/x')).toBe(true);
+  });
+});
+
 describe('initFaro', () => {
   it('does not initialize when the instance is not Grafana Cloud', async () => {
     mockedConfig.bootData!.settings.buildInfo.versionString = 'Grafana Enterprise';
@@ -314,6 +374,14 @@ describe('initFaro', () => {
     expect(calledWith.app.name).toBe('grafana-pathfinder-app');
     expect(calledWith.app.version).toBe('9.9.9-test');
     expect(calledWith.app.version).not.toBe('%VERSION%');
+  });
+
+  it('sets a non-empty ignoreUrls so core resource noise is dropped before a payload is built', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    const calledWith = mockInitializeFaro.mock.calls[0]![0];
+    expect(calledWith.ignoreUrls).toBeDefined();
+    expect(calledWith.ignoreUrls!.length).toBeGreaterThan(0);
   });
 
   it('includes PerformanceInstrumentation (filtered down in beforeSend, not excluded outright)', async () => {
@@ -360,6 +428,81 @@ describe('initFaro', () => {
     await faro.initFaro();
     await faro.initFaro();
     expect(mockInitializeFaro).toHaveBeenCalledTimes(1);
+  });
+
+  it("stamps meta.user with the recommender's hashed identity, never raw PII", async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    await flushMicrotasks();
+    expect(mockHashUserData).toHaveBeenCalledWith('abc', 'x@y.z');
+    expect(mockSetUser).toHaveBeenCalledWith({
+      id: 'hashed-abc',
+      attributes: { email_hash: 'hashed-x@y.z', org_role: 'Admin' },
+    });
+  });
+
+  it('uses the OSS identity placeholders (not the recommender hash) outside Grafana Cloud', async () => {
+    mockedConfig.bootData!.settings.buildInfo.versionString = 'Grafana Enterprise';
+    localStorage.setItem('pathfinder.faro.local', 'true');
+    mockedConfig.buildInfo.env = 'development';
+    const faro = freshFaro();
+    await faro.initFaro();
+    await flushMicrotasks();
+    expect(mockHashUserData).toHaveBeenCalledWith('oss-user', 'oss-user@example.com');
+  });
+
+  it('does not stamp a user when init is skipped (outside Grafana Cloud)', async () => {
+    mockedConfig.bootData!.settings.buildInfo.versionString = 'Grafana Enterprise';
+    const faro = freshFaro();
+    await faro.initFaro();
+    await flushMicrotasks();
+    expect(mockHashUserData).not.toHaveBeenCalled();
+    expect(mockSetUser).not.toHaveBeenCalled();
+  });
+
+  it('includes edition and language in the initial session attributes', async () => {
+    mockedConfig.bootData!.user.language = 'fr-FR';
+    mockedConfig.buildInfo.edition = 'Enterprise';
+    const faro = freshFaro();
+    await faro.initFaro();
+    const calledWith = mockInitializeFaro.mock.calls[0]![0] as unknown as {
+      sessionTracking: { session: { attributes: Record<string, string> } };
+    };
+    expect(calledWith.sessionTracking.session.attributes).toEqual(
+      expect.objectContaining({ grafana_version: '13.1.0', edition: 'Enterprise', language: 'fr-FR' })
+    );
+  });
+
+  it('stamps the current surface onto the session on init', async () => {
+    localStorage.setItem('grafana-pathfinder-app-panel-mode', 'floating');
+    const faro = freshFaro();
+    await faro.initFaro();
+    expect(mockSetSession).toHaveBeenCalledWith(
+      expect.objectContaining({ attributes: expect.objectContaining({ surface: 'floating' }) })
+    );
+  });
+
+  it('re-stamps the surface when a pathfinder-panel-mode-change event fires', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    localStorage.setItem('grafana-pathfinder-app-panel-mode', 'fullscreen');
+    document.dispatchEvent(new CustomEvent('pathfinder-panel-mode-change', { detail: { mode: 'fullscreen' } }));
+
+    // toHaveBeenLastCalledWith (not a call-count assertion): this module's own
+    // listener is registered last among any accumulated from other tests in
+    // this file, so it fires last on dispatch — its args are what matters.
+    expect(mockSetSession).toHaveBeenLastCalledWith(
+      expect.objectContaining({ attributes: expect.objectContaining({ surface: 'fullscreen' }) })
+    );
+  });
+
+  it('swallows errors from the hashing/setUser pipeline', async () => {
+    mockHashUserData.mockRejectedValueOnce(new Error('crypto unavailable'));
+    const faro = freshFaro();
+    await expect(faro.initFaro()).resolves.not.toThrow();
+    await flushMicrotasks();
+    expect(mockSetUser).not.toHaveBeenCalled();
   });
 });
 
@@ -423,6 +566,46 @@ describe('pushFaroLog', () => {
       throw new Error('transport down');
     });
     expect(() => faro.pushFaroLog('error', 'boom')).not.toThrow();
+  });
+});
+
+describe('pushFaroMeasurement', () => {
+  it('no-ops before initialization without throwing', () => {
+    const faro = freshFaro();
+    expect(() => faro.pushFaroMeasurement('pathfinder_panel', { panel_lcp_ms: 120 })).not.toThrow();
+    expect(mockPushMeasurement).not.toHaveBeenCalled();
+  });
+
+  it('forwards type/values/context once initialized', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.pushFaroMeasurement('pathfinder_recommender', { recommender_ms: 250 }, { outcome: 'ok' });
+    expect(mockPushMeasurement).toHaveBeenCalledWith(
+      { type: 'pathfinder_recommender', values: { recommender_ms: 250 } },
+      { context: { outcome: 'ok' } }
+    );
+  });
+
+  it('omits the options object entirely when no context is passed', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.pushFaroMeasurement('pathfinder_panel', { panel_lcp_ms: 120 });
+    expect(mockPushMeasurement).toHaveBeenCalledWith(
+      { type: 'pathfinder_panel', values: { panel_lcp_ms: 120 } },
+      undefined
+    );
+  });
+
+  it('swallows errors thrown by the underlying Faro API', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockPushMeasurement.mockImplementationOnce(() => {
+      throw new Error('transport down');
+    });
+    expect(() => faro.pushFaroMeasurement('pathfinder_panel', { panel_lcp_ms: 120 })).not.toThrow();
   });
 });
 
@@ -572,10 +755,26 @@ describe('withFaroUserAction', () => {
 
     const result = await faro.withFaroUserAction('pathfinder_step_do', { step: 2 }, async () => 'done');
     expect(result).toBe('done');
-    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_step_do', { step: '2' });
+    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_step_do', { step: '2' }, undefined);
     const action = mockStartUserAction.mock.results[0]!.value;
     expect(action.attributes).toEqual({ outcome: 'ok' });
     expect(mockActionEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes importance: critical when options.critical is set', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    await faro.withFaroUserAction('pathfinder_guide_open', {}, async () => 'done', undefined, { critical: true });
+    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_guide_open', {}, { importance: 'critical' });
+  });
+
+  it('omits the options object entirely when not marked critical', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    await faro.withFaroUserAction('pathfinder_step_do', {}, async () => 'done', undefined, { critical: false });
+    expect(mockStartUserAction).toHaveBeenCalledWith('pathfinder_step_do', {}, undefined);
   });
 
   it('stamps outcome error and rethrows the same error instance on rejection', async () => {
@@ -707,6 +906,37 @@ describe('setFaroUserActionAttributes', () => {
   it('no-ops without an active action or before initialization', () => {
     const faro = freshFaro();
     expect(() => faro.setFaroUserActionAttributes({ a: 1 })).not.toThrow();
+  });
+});
+
+describe('setFaroSessionAttributes', () => {
+  it('merges onto existing session attributes and preserves the session id', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    mockSetSession.mockClear();
+    mockSessionMeta = { id: 'session-1', attributes: { grafana_version: '13.1.0' } };
+
+    faro.setFaroSessionAttributes({ experiments: '[{"flag":"x"}]' });
+
+    expect(mockSetSession).toHaveBeenCalledWith({
+      id: 'session-1',
+      attributes: { grafana_version: '13.1.0', experiments: '[{"flag":"x"}]' },
+    });
+  });
+
+  it('no-ops before initialization without throwing', () => {
+    const faro = freshFaro();
+    expect(() => faro.setFaroSessionAttributes({ surface: 'floating' })).not.toThrow();
+    expect(mockSetSession).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors thrown by the underlying Faro API', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    mockGetSession.mockImplementationOnce(() => {
+      throw new Error('transport down');
+    });
+    expect(() => faro.setFaroSessionAttributes({ surface: 'floating' })).not.toThrow();
   });
 });
 
@@ -855,5 +1085,39 @@ describe('setFaroView', () => {
       throw new Error('transport down');
     });
     expect(() => faro.setFaroView('https://grafana.com/docs/')).not.toThrow();
+  });
+});
+
+describe('setFaroViewName', () => {
+  it('no-ops before initialization without throwing', () => {
+    const faro = freshFaro();
+    expect(() => faro.setFaroViewName('recommendations')).not.toThrow();
+    expect(mockSetView).not.toHaveBeenCalled();
+  });
+
+  it('sets the view to the literal name once initialized', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.setFaroViewName('recommendations');
+    expect(mockSetView).toHaveBeenCalledWith({ name: 'recommendations' });
+  });
+
+  it('ignores an empty name, keeping the previous view', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.setFaroViewName('');
+    expect(mockSetView).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors thrown by the underlying Faro API', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockSetView.mockImplementationOnce(() => {
+      throw new Error('transport down');
+    });
+    expect(() => faro.setFaroViewName('recommendations')).not.toThrow();
   });
 });

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -569,6 +569,37 @@ describe('pushFaroLog', () => {
   });
 });
 
+describe('pushFaroEvent', () => {
+  it('no-ops before initialization without throwing', () => {
+    const faro = freshFaro();
+    expect(() => faro.pushFaroEvent('recommender_fallback', { error_type: 'timeout' })).not.toThrow();
+    expect(mockPushEvent).not.toHaveBeenCalled();
+  });
+
+  it('forwards name and stringified attributes with skipDedupe once initialized', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.pushFaroEvent('requirements_exhausted', { requirement: 'has-role:admin', retry_count: 3 });
+    expect(mockPushEvent).toHaveBeenCalledWith(
+      'requirements_exhausted',
+      { requirement: 'has-role:admin', retry_count: '3' },
+      undefined,
+      { skipDedupe: true }
+    );
+  });
+
+  it('swallows errors thrown by the underlying Faro API', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    mockPushEvent.mockImplementationOnce(() => {
+      throw new Error('transport down');
+    });
+    expect(() => faro.pushFaroEvent('recommender_fallback')).not.toThrow();
+  });
+});
+
 describe('pushFaroMeasurement', () => {
   it('no-ops before initialization without throwing', () => {
     const faro = freshFaro();

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -17,7 +17,9 @@ import {
   ALLOWED_RECOMMENDER_DOMAINS,
 } from '../constants';
 import { StorageKeys } from './storage-keys';
+import { PANEL_MODE_CHANGE_EVENT } from './event-names';
 import { isExtensionSidebarOwnedByPathfinder } from './storage/extension-sidebar';
+import { hashUserData } from './hash.util';
 
 const COLLECTOR_URL = 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/d6ec87b657b65de6e363de05623d9c57';
 const APP_NAME = packageJson.name;
@@ -111,6 +113,18 @@ const TRACKED_RESOURCE_HOSTNAMES = new Set([
 const SHARED_HOSTNAME = 'grafana.com';
 const SHARED_HOSTNAME_PATH_PREFIXES = ['/docs', '/tutorials'];
 
+// Belt-and-braces with isTrackedResourceUrl/filterPathfinderTelemetry below:
+// this one runs *inside* PerformanceInstrumentation's PerformanceObserver
+// (via Faro's `ignoreUrls` config), before a resource-timing payload is even
+// built, so the ~99% of entries that are Grafana core's own requests never
+// get constructed at all. It's hostname-only (no path awareness), so the
+// `/docs`|`/tutorials` restriction on shared grafana.com still has to live in
+// the beforeSend filter below.
+export function buildResourceIgnorePattern(hostnames: ReadonlySet<string>): RegExp {
+  const escaped = [...hostnames].map((hostname) => hostname.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  return new RegExp(`^(?!https?://(${escaped.join('|')})/)`);
+}
+
 function isTrackedResourceUrl(resourceUrl: string | undefined): boolean {
   if (typeof resourceUrl !== 'string') {
     return false;
@@ -160,23 +174,36 @@ export function filterPathfinderTelemetry(item: TransportItem<APIEvent>): Transp
 }
 
 const SIDEBAR_COMPONENT_TITLE = 'Interactive learning';
-const OVERLAY_ROOT_IDS = ['pathfinder-controller-root', 'pathfinder-kiosk-root'];
+const KIOSK_ROOT_ID = 'pathfinder-kiosk-root';
+const CONTROLLER_ROOT_ID = 'pathfinder-controller-root';
+
+type PathfinderSurface = 'sidebar' | 'floating' | 'fullscreen' | 'kiosk' | 'controller' | 'closed';
 
 // Mode literals mirror PanelMode in global-state/panel-mode — importing
 // panelModeManager here would cycle via global-state → analytics → faro.
-function isPathfinderOpen(): boolean {
+function readPathfinderSurface(): PathfinderSurface {
   try {
     const mode = localStorage.getItem(StorageKeys.PANEL_MODE);
     if (mode === 'floating' || mode === 'fullscreen') {
-      return true;
+      return mode;
     }
   } catch {
     // localStorage unavailable — fall through to the DOM checks.
   }
   if (isExtensionSidebarOwnedByPathfinder(pluginJson.id, SIDEBAR_COMPONENT_TITLE)) {
-    return true;
+    return 'sidebar';
   }
-  return OVERLAY_ROOT_IDS.some((id) => document.getElementById(id) !== null);
+  if (document.getElementById(KIOSK_ROOT_ID) !== null) {
+    return 'kiosk';
+  }
+  if (document.getElementById(CONTROLLER_ROOT_ID) !== null) {
+    return 'controller';
+  }
+  return 'closed';
+}
+
+function isPathfinderOpen(): boolean {
+  return readPathfinderSurface() !== 'closed';
 }
 
 // Latched for the rest of the page load: the sidebar-close mirror fires
@@ -240,6 +267,7 @@ export async function initFaro(): Promise<void> {
     // without this, initializing here would clobber the global object Grafana
     // core attaches its own Faro instance to.
     isolate: true,
+    ignoreUrls: [buildResourceIgnorePattern(TRACKED_RESOURCE_HOSTNAMES)],
     app: {
       name: APP_NAME,
       version: APP_VERSION,
@@ -266,11 +294,37 @@ export async function initFaro(): Promise<void> {
       session: {
         attributes: {
           grafana_version: config.buildInfo.version,
+          edition: config.buildInfo.edition ?? '',
+          language: config.bootData?.user?.language ?? '',
         },
       },
     },
     beforeSend: (item) => (passesActivityGate(item) ? filterPathfinderTelemetry(item) : null),
   });
+
+  void stampFaroUser();
+
+  const stampSurface = () => setFaroSessionAttributes({ surface: readPathfinderSurface() });
+  document.addEventListener(PANEL_MODE_CHANGE_EVENT, stampSurface);
+  stampSurface();
+}
+
+// Reuses the same hashes as the recommender's context payload
+// (context.service.ts) so Faro sessions are joinable with recommender data
+// without introducing a second identity scheme or any raw PII.
+async function stampFaroUser(): Promise<void> {
+  try {
+    const isCloud = isGrafanaCloud();
+    const userId = isCloud ? config.bootData.user.analytics.identifier || 'unknown' : 'oss-user';
+    const userEmail = isCloud ? config.bootData.user.email || 'unknown@example.com' : 'oss-user@example.com';
+    const { hashedUserId, hashedEmail } = await hashUserData(userId, userEmail);
+    faroInstance?.api.setUser({
+      id: hashedUserId,
+      attributes: { email_hash: hashedEmail, org_role: config.bootData.user.orgRole || 'Viewer' },
+    });
+  } catch {
+    // Telemetry must never break the app it's observing.
+  }
 }
 
 export function pushFaroError(error: Error, context?: Record<string, string>): void {
@@ -303,6 +357,22 @@ export function stringifyAttributes(attributes: Record<string, unknown>): Record
     result[key] = stringified.slice(0, MAX_ATTRIBUTE_LENGTH);
   }
   return result;
+}
+
+// Merges onto the existing session attributes rather than replacing them —
+// setSession() itself replaces the whole meta, so the current session
+// (including its id) must be read back first or the SDK would rotate it.
+export function setFaroSessionAttributes(attributes: Record<string, unknown>): void {
+  guardTelemetry(() => {
+    if (!faroInstance) {
+      return;
+    }
+    const session = faroInstance.api.getSession();
+    faroInstance.api.setSession({
+      ...session,
+      attributes: { ...session?.attributes, ...stringifyAttributes(attributes) },
+    });
+  });
 }
 
 let userActionSeq = 0;
@@ -346,17 +416,27 @@ type StampableUserAction = UserActionInternalInterface & { attributes?: Record<s
 // re-entry from the Cancelled state, so calling it again after the safety
 // timeout already ended the action would emit a duplicate faro.user.action
 // event; `settled` is the idempotency guard for both.
+export interface WithFaroUserActionOptions {
+  // `@grafana/faro-web-sdk` only re-exports UserActionImportance as a type,
+  // not a value, so the literal is passed straight through to startUserAction.
+  critical?: boolean;
+}
+
 export async function withFaroUserAction<T>(
   name: string,
   attributes: Record<string, unknown>,
   work: () => Promise<T> | T,
-  timeoutMs = USER_ACTION_TIMEOUT_MS
+  timeoutMs = USER_ACTION_TIMEOUT_MS,
+  options?: WithFaroUserActionOptions
 ): Promise<T> {
   let action: StampableUserAction | undefined;
   guardTelemetry(() => {
     if (faroInstance && faroInstance.api.getActiveUserAction() === undefined) {
-      action = faroInstance.api.startUserAction(name, stringifyAttributes(attributes)) as
-        StampableUserAction | undefined;
+      action = faroInstance.api.startUserAction(
+        name,
+        stringifyAttributes(attributes),
+        options?.critical ? { importance: 'critical' } : undefined
+      ) as StampableUserAction | undefined;
     }
   });
   if (!action) {
@@ -398,6 +478,20 @@ export function setFaroUserActionAttributes(attributes: Record<string, unknown>)
   });
 }
 
+// Namespaced type + analogy-legible value names (e.g. `panel_lcp_ms`), never
+// Faro's default web-vitals names (`lcp`/`cls`/`inp`/...) — those are scored
+// against Google's Core Web Vitals thresholds in the Frontend Observability
+// UI, which don't fit panel-scoped measurements and would be misleading.
+export function pushFaroMeasurement(
+  type: string,
+  values: Record<string, number>,
+  context?: Record<string, string>
+): void {
+  guardTelemetry(() => {
+    faroInstance?.api.pushMeasurement({ type, values }, context ? { context } : undefined);
+  });
+}
+
 export function setFaroView(url: string): void {
   guardTelemetry(() => {
     if (!url || !faroInstance) {
@@ -405,6 +499,17 @@ export function setFaroView(url: string): void {
     }
     const { hostname, pathname } = new URL(url, window.location.origin);
     faroInstance.api.setView({ name: `${hostname}${pathname}` });
+  });
+}
+
+// For surfaces with no URL to derive a view name from (e.g. the
+// recommendations tab) — setFaroView's hostname+pathname derivation doesn't
+// apply there, so the view would otherwise stay unset/stale until a doc opens.
+export function setFaroViewName(name: string): void {
+  guardTelemetry(() => {
+    if (name && faroInstance) {
+      faroInstance.api.setView({ name });
+    }
   });
 }
 

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -296,6 +296,10 @@ export async function initFaro(): Promise<void> {
           grafana_version: config.buildInfo.version,
           edition: config.buildInfo.edition ?? '',
           language: config.bootData?.user?.language ?? '',
+          // Stack hostname (slug.grafana.net on Cloud) so sessions are
+          // attributable to an instance; the recommender payload sends the
+          // same hostname unhashed as `source`.
+          instance: window.location.hostname,
         },
       },
     },
@@ -311,7 +315,9 @@ export async function initFaro(): Promise<void> {
 
 // Reuses the same hashes as the recommender's context payload
 // (context.service.ts) so Faro sessions are joinable with recommender data
-// without introducing a second identity scheme or any raw PII.
+// without introducing a second identity scheme or any raw PII. The hashed
+// email is the primary id (joins on the recommender's user_email); the
+// hashed analytics identifier rides along for the user_id join.
 async function stampFaroUser(): Promise<void> {
   try {
     const isCloud = isGrafanaCloud();
@@ -319,8 +325,8 @@ async function stampFaroUser(): Promise<void> {
     const userEmail = isCloud ? config.bootData.user.email || 'unknown@example.com' : 'oss-user@example.com';
     const { hashedUserId, hashedEmail } = await hashUserData(userId, userEmail);
     faroInstance?.api.setUser({
-      id: hashedUserId,
-      attributes: { email_hash: hashedEmail, org_role: config.bootData.user.orgRole || 'Viewer' },
+      id: hashedEmail,
+      attributes: { user_id_hash: hashedUserId, org_role: config.bootData.user.orgRole || 'Viewer' },
     });
   } catch {
     // Telemetry must never break the app it's observing.

--- a/src/lib/faro.ts
+++ b/src/lib/faro.ts
@@ -478,6 +478,18 @@ export function setFaroUserActionAttributes(attributes: Record<string, unknown>)
   });
 }
 
+// For operational signals (funnel degradations, silent fallbacks) that
+// belong in Faro for alerting but are not product analytics — unlike
+// reportAppInteraction, nothing here reaches RudderStack. skipDedupe keeps
+// repeated identical failures countable.
+export function pushFaroEvent(name: string, attributes?: Record<string, unknown>): void {
+  guardTelemetry(() => {
+    faroInstance?.api.pushEvent(name, attributes ? stringifyAttributes(attributes) : undefined, undefined, {
+      skipDedupe: true,
+    });
+  });
+}
+
 // Namespaced type + analogy-legible value names (e.g. `panel_lcp_ms`), never
 // Faro's default web-vitals names (`lcp`/`cls`/`inp`/...) — those are scored
 // against Google's Core Web Vitals thresholds in the Frontend Observability

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -6,6 +6,7 @@ import { logger } from './lib/logging';
 import { initPluginTranslations } from '@grafana/i18n';
 import pluginJson from './plugin.json';
 import { getConfigWithDefaults, DocsPluginConfig } from './constants';
+import { PANEL_MODE_CHANGE_EVENT } from './lib/event-names';
 import { linkInterceptionState } from './global-state/link-interception';
 import { sidebarState } from 'global-state/sidebar';
 import { panelModeManager } from './global-state/panel-mode';
@@ -60,8 +61,19 @@ const hostname = window.location.hostname;
 // is open in one of its surfaces.
 try {
   if (getFeatureFlagValue('pathfinder.frontend-telemetry', true)) {
-    const { initFaro } = await import('./lib/faro');
-    initFaro().catch((e) => logger.exception(e, { source: 'Faro init' }));
+    const { initFaro, setFaroSessionAttributes } = await import('./lib/faro');
+    initFaro()
+      .then(async () => {
+        // Stamped once per session instead of repeated on every mirrored
+        // Faro user action (see the `experiments` strip in
+        // analytics.ts reportAppInteraction).
+        const { getActiveExperiments } = await import('./utils/openfeature');
+        const activeExperiments = getActiveExperiments();
+        if (activeExperiments.length > 0) {
+          setFaroSessionAttributes({ experiments: JSON.stringify(activeExperiments) });
+        }
+      })
+      .catch((e) => logger.exception(e, { source: 'Faro init' }));
   }
 } catch (e) {
   logger.exception(e, { source: 'Faro init' });
@@ -265,7 +277,7 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
       mountFloatingPanel();
     }
 
-    document.addEventListener('pathfinder-panel-mode-change', ((e: CustomEvent<{ mode: string }>) => {
+    document.addEventListener(PANEL_MODE_CHANGE_EVENT, ((e: CustomEvent<{ mode: string }>) => {
       if (e.detail.mode === 'floating') {
         mountFloatingPanel();
       }


### PR DESCRIPTION
## Summary

Enriches Pathfinder's Faro telemetry so Frontend Observability data becomes joinable, filterable, and alertable. None of the existing isolation mechanisms (activity gate, attribution filter, `guardTelemetry`) are weakened.

- **Identity**: `setUser` with the same SHA-256 hashes the recommender payload uses (`hashUserData`) — the email hash is `meta.user.id` (primary join key), with the hashed analytics identifier as a `user_id_hash` attribute. Sessions also carry an `instance` attribute (stack hostname) so they are attributable to a Grafana instance. No raw PII.
- **Session attributes**: `surface` (sidebar/floating/fullscreen/kiosk/controller), `edition`, `language`, and `experiments` are stamped once per session via a new merge-style `setFaroSessionAttributes`, instead of repeating the ~300-char experiments JSON on every mirrored user action.
- **Resource noise**: an inverted-allowlist `ignoreUrls` regex drops Grafana core's resource-timing entries inside the `PerformanceObserver`, before payloads are built (~6,000 discarded payloads per session previously). The `beforeSend` path filter stays as the belt-and-braces layer.
- **Funnel measurements** (`pushMeasurement`): recommender latency (measured at the response, so ok/error durations are comparable), content-fetch ladder tiers, step execution, requirements-retry exhaustion, and panel time-to-content (gated on the recommendations list actually rendering via a `pathfinder-recommendations-ready` event, not just the tab being active).
- **Funnel failure events**: `recommender_fallback`, `content_fetch_fallback`, `requirements_exhausted` — pushed as plain Faro events (new `pushFaroEvent`) for alerting only; they do not reach RudderStack, since they are operational signals rather than product analytics.
- **Real durations**: guide-open, section-run, and "do it" flows wrapped in `withFaroUserAction` with `importance: critical`, so the Actions tab's avg/P95 stop reading ~0ms.
- **Explicit error capture**: interactive handlers failing against Grafana core's DOM (no plugin stack frame, previously invisible) now report Faro exceptions with step/action context, deduped per Error instance so handler+caller double-reporting counts once.
- **Cold-start view fix**: `setFaroViewName('recommendations')` when the active tab has no URL.
- **Ride-along cleanups**: `pathfinder-panel-mode-change` hoisted to a shared constant in `lib/event-names.ts` (was a raw literal in 8 files), `isPathfinderOpen` collapsed onto the new `readPathfinderSurface`, and structured context added to funnel-path `logger.warn/error` calls.

## What to look at

- `src/lib/faro.ts` — the new API surface (`setFaroSessionAttributes`, `pushFaroMeasurement`, `setFaroViewName`, `buildResourceIgnorePattern`, critical-importance option) and the user/surface stamping in `initFaro`.
- `src/components/docs-panel/docs-panel.tsx` + `context-panel.tsx` — the `panel_lcp_ms` ready-event handshake.
- `src/interactive-engine/interactive-state-manager.ts` — the `WeakSet` exception dedupe.

## How to verify

- `npm run test:ci` — 333 suites / 5,248 tests green (includes ~40 new tests across faro, analytics, state-manager, sequence-manager, content-fetcher, recommender, and view-exposure suites).
- `npm run lint` + typecheck — clean (pre-existing warnings only).
- Manual (optional, Grafana Cloud dev): set `localStorage['pathfinder.faro.local']='true'`, open Pathfinder, confirm collector POSTs carry `meta.user.id` (64-char hex), session attributes with `surface`, and no `faro.performance.resource` items for core hosts.

## Breaking changes

None. Existing `pathfinder_*` event names are unchanged (RudderStack parity preserved); `experiments` still reaches RudderStack in full and is only stripped from the Faro mirror.

