### PR TITLE
skill:maintain-docs refresh custom guide and selector docs

### DIFF
--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -6,12 +6,14 @@ Persistent tracker for the maintain-docs skill's persistent state across runs.
 
 <!-- Structural issues requiring dedicated effort. Format: date, description, rationale. Remove when resolved. -->
 
-- 2026-05-21: No CONCERNS.md concern covers `src/snippet-engine/`. Consider adding one or extending `package-engine` / `docs-retrieval-and-rendering` to include the new tier-1 engine. Rationale: prevent-doc-drift cannot edit `docs/design/CONCERNS.md`; surfacing here for a human review pass.
+- 2026-05-21: No CONCERNS.md concern covers `src/snippet-engine/`. Consider adding one or extending `package-engine` / `docs-retrieval-and-rendering` to include the new tier-1 engine. Rationale: prevent-doc-drift cannot edit `docs/design/CONCERNS.md`; surfacing here for a human review pass. Blocked: the maintain-docs hard constraint also excludes `docs/design/`, so this requires a human design review.
 
 ## Validated docs
 
 <!-- Docs checked against source and found accurate. Format: date, doc path. Update date on re-validation. -->
 
+- **2026-07-15**: `docs/developer/interactive-examples/selectors-reference.md` — Added version-aware `grafana:` selector guidance, stable ancestor and descendant-anchored `:has()` generation, Pathfinder-owned content exclusion, and corrected the runtime resilience pipeline stages. Validated against `grafana-selector.ts`, `selector-generator.ts`, `pathfinder-content.ts`, `action-detector.ts`, and related tests. Supersedes the 2026-04-27 entry.
+- **2026-07-15**: `docs/developer/CUSTOM_GUIDES.md` — Corrected Library access and ID-lock timing; documented JSON draft/remount recovery, session-only undo/redo, preview progress reset, collision handling, and backend-status derivation. Validated against the current block editor persistence, JSON mode, guide history, preview progress, header, library, and backend save flows. Supersedes the 2026-04-27 entry.
 - **2026-06-16**: `docs/developer/CLI_TOOLS.md` — Added a `build-snippets` command section and updated the intro command list/coverage line. Validated against `src/cli/commands/build-snippets.ts` and the `snippets:build` npm script. Supersedes the 2026-03-20 entry.
 - **2026-06-16**: `docs/developer/CODA.md` — Added a Command execution section documenting `POST /coda/exec` (raw/gated modes, active-session auth, 5s default / 120s max timeout, 32 KB output cap, per-user token-bucket rate limit, error statuses). Validated against `pkg/plugin/coda_exec.go`, `coda_exec_ratelimit.go`, and `resources.go`. Supersedes the 2026-03-20 entry.
 - **2026-06-16**: `docs/developer/MCP_SERVER.md` — Confirmed current: no structural changes in `src/cli/mcp/` since the doc's last commit (2026-05-19); already documents the Go MCP retirement (MH5).
@@ -27,9 +29,7 @@ Persistent tracker for the maintain-docs skill's persistent state across runs.
 - **2026-04-27**: `docs/developer/GETTING_STARTED.md` — NEW onboarding entrypoint: 5-min quickstart, 15-min full setup, IDE setup, first-week reading list, troubleshooting.
 - **2026-04-27**: `docs/developer/LOCAL_DEV.md` — Added prerequisites table, `npm run check` documentation, IDE setup, mage installation, troubleshooting section, container port table.
 - **2026-04-27**: `docs/developer/DEV_MODE.md` — Added admonition noting block editor and kiosk mode no longer require dev mode.
-- **2026-04-27**: `docs/developer/CUSTOM_GUIDES.md` — Cross-link to user-facing block editor doc; removed dev-mode caveat from creation flow; added floating panel + popout step section.
 - **2026-04-27**: `docs/developer/interactive-examples/json-guide-format.md` — Added popout action; added schema sections for code-block, terminal, terminal-connect, grot-guide block types; updated block summary table.
-- **2026-04-27**: `docs/developer/interactive-examples/selectors-reference.md` — Added selector resilience pipeline section (retry/backoff, `:text()` exact match, `data-testid` prefix matching, `panel:` domain prefix, confidence scoring, Selector Health badge).
 - **2026-04-27**: `docs/developer/LIVE_SESSIONS.md` — Added ECDSA P-256 presenter authentication section; noted legacy unauthenticated path removed.
 - **2026-04-27**: `README.md` — Updated authoring section to point to block editor user guide; added For developers pointer to `GETTING_STARTED.md`; refreshed action type list to include `popout`.
 - **2026-03-20**: `.cursor/rules/systemPatterns.mdc` — Updated Utils description (removed stale keyboard-shortcuts/link-handling refs), added Package Engine subsystem, updated Learning Paths Critical Path for `paths-cloud.json` and `paths-data.ts`.
@@ -79,5 +79,6 @@ Persistent tracker for the maintain-docs skill's persistent state across runs.
 - `.cursor/skills/plugin-bundle-size/SKILL.md` — Discovered automatically by IDE via `.cursor/skills/` glob pattern. No AGENTS.md entry needed.
 - `.cursor/skills/bugfix/SKILL.md` — Workflow skill invoked via `/bugfix`; auto-discovered by the IDE via the `.cursor/skills/` glob. Consistent with the other workflow-skill exclusions; no AGENTS.md entry needed. (Its companion reference `docs/developer/bugfix-patterns.md` is already indexed.)
 - `.cursor/skills/refactor/SKILL.md` — Workflow skill invoked via `/refactor-investigate` / `/refactor-plan` / `/refactor-execute`; auto-discovered by the IDE. No AGENTS.md entry needed.
+- `.cursor/skills/maintain-docs/intent.md` — Design rationale linked directly from `.cursor/skills/maintain-docs/SKILL.md`; it supplements that workflow rather than defining a separate task domain.
 - `docs/sources/block-editor/_index.md` — End-user documentation published to Grafana.com. Not agent-relevant for implementation tasks.
 - `docs/sources/terms-and-conditions/_index.md` — End-user data-usage notice published to Grafana.com; auto-generated from `src/components/AppConfig/terms-content.ts` via `npm run docs:sync-terms` (do not hand-edit). Not agent-relevant for implementation tasks.

--- a/docs/developer/CUSTOM_GUIDES.md
+++ b/docs/developer/CUSTOM_GUIDES.md
@@ -27,9 +27,19 @@ A custom guide moves through three states:
 1. Open the Pathfinder sidebar and click the **Editor** tab in the tab bar (visible to users with editor or admin role; **no dev mode required**).
 2. Click the title field at the top and type a name for your guide. Press **Enter** or click away to confirm.
 3. On first commit the editor auto-generates a unique ID from the title (e.g. `my-guide-a3f9`). This ID is used as the backend resource name and does not change if you rename the guide later.
-4. Add blocks using the **+** button at the bottom of the editor. Available block types include markdown, interactive steps (with the new `popout` action), sections, conditionals, quizzes, terminals, code blocks, grot guides, and more — see [json-guide-format.md](interactive-examples/json-guide-format.md) for the full list.
+4. Add blocks using the **+** button at the bottom of the editor. Available block types include markdown, interactive steps (including the `popout` action), sections, conditionals, quizzes, terminals, code blocks, grot guides, and more — see [json-guide-format.md](interactive-examples/json-guide-format.md) for the full list.
 
-> **Tip:** Content is auto-saved to localStorage as you work, so a browser refresh won't lose your progress. This local save is separate from the backend — the status badge in the header reflects both.
+> **Tip:** Guide content, block identities, and the current **Edit**, **Preview**, or **JSON** view are auto-saved to localStorage as you work, so a panel remount or browser refresh won't lose your progress. Unapplied JSON text is also preserved while you remain in JSON view. This local save is separate from the backend — the status badge in the header reflects both.
+
+### JSON editing and recovery
+
+The **JSON** view edits the complete guide document. Invalid JSON or an invalid guide cannot be applied, and the editor remains in JSON view with inline validation errors. A valid change is applied when you switch to **Edit** or **Preview**; leaving JSON view clears the saved JSON draft. Loading, importing, or starting another guide also replaces the current local draft.
+
+### Undo, preview, and progress
+
+- **Undo** and **Redo** are available in Edit view for changes made during the current editor session. History is not persisted across a browser refresh and is cleared when a guide is loaded or reset.
+- **Preview** renders the full guide through the same content renderer used by the docs panel. Interactive completion is tracked against the preview guide ID. After progress is recorded, **Reset guide** appears in the header and clears the preview's interactive progress.
+- Supported blocks also have an eye button for pinned inline previews while editing. Multiple block previews can remain open at the same time.
 
 ---
 
@@ -52,13 +62,13 @@ The **•••** menu provides the alternative action:
 
 ### Collision detection
 
-When saving a new guide for the first time, if a guide with the same resource name already exists in the library, you are prompted to confirm an overwrite. To save as a separate guide instead, cancel and change the guide's title before saving.
+When saving a new guide for the first time, if a guide with the same resource name already exists in the library, you are prompted to confirm an overwrite. The editor avoids known library names when it generates an ID, but a collision can still occur if the library changed after it was loaded. To keep both guides, cancel, start a new guide, and commit a distinct title so the editor generates a new ID before saving.
 
 ---
 
 ## Editing a published guide
 
-1. Open the library (**Library** button in the header) and click **Load** next to the guide.
+1. Open **•••** → **Library** and click **Load** next to the guide.
 2. Make your changes in the editor.
 3. The status badge changes to **Published (modified)** to indicate the live version is out of date.
 4. Click **Update** to push changes to the live guide.
@@ -83,7 +93,7 @@ Draft guides are not shown in the docs panel. They can only be accessed through 
 
 ## The guide library
 
-The library (**Library** button) lists all guides stored in the Pathfinder backend — both drafts and published. From here you can:
+The library (**•••** → **Library**) lists all guides stored in the Pathfinder backend — both drafts and published. The menu item stays available while the guide list loads or if a refresh fails, and is hidden only after a successful fetch confirms there are no saved guides. From here you can:
 
 - **Load** a guide into the editor for editing.
 - **Delete** a guide permanently (requires confirmation).
@@ -112,12 +122,13 @@ See [`EXTERNAL_API.md`](EXTERNAL_API.md) for the full reference, including the K
 
 The badge in the top-right of the header reflects the backend sync state:
 
-| Badge                             | Meaning                                         |
-| --------------------------------- | ----------------------------------------------- |
-| **Draft** (purple)                | Saved to backend, in sync, not published.       |
-| **Draft (modified)** (orange)     | Local changes not yet saved to the draft.       |
-| **Published** (blue)              | Live and in sync with the backend.              |
-| **Published (modified)** (orange) | Local changes not yet pushed to the live guide. |
+| Badge                             | Meaning                                                                      |
+| --------------------------------- | ---------------------------------------------------------------------------- |
+| **Draft** (purple, not yet saved) | Exists only in localStorage. Use **Save as draft** to add it to the library. |
+| **Draft** (purple)                | Saved to backend, in sync, not published.                                    |
+| **Draft (modified)** (orange)     | Local changes not yet saved to the draft.                                    |
+| **Published** (blue)              | Live and in sync with the backend.                                           |
+| **Published (modified)** (orange) | Local changes not yet pushed to the live guide.                              |
 
 When the backend is unavailable the badge area instead shows a **Saved** / **Saving…** indicator reflecting the localStorage auto-save state.
 
@@ -125,10 +136,10 @@ When the backend is unavailable the badge area instead shows a **Saved** / **Sav
 
 ## Technical notes
 
-- Guide IDs are auto-generated as `<title-slug>-<4-char-random>` and locked after first save. Renaming a guide does not change its ID or resource name.
+- Guide IDs are auto-generated as `<title-slug>-<4-char-random>` when a new title is first committed. Later title edits do not change the ID or backend resource name.
 - The backend stores guides as `InteractiveGuide` custom resources in the `pathfinderbackend.ext.grafana.com/v1alpha1` API group.
 - `resourceVersion` is used for optimistic concurrency control — the editor always fetches the latest version after a save before allowing a subsequent write.
-- Backend tracking state (`resourceName`, `backendStatus`, `lastPublishedJson`) is persisted to localStorage so the correct button state survives a page refresh.
+- Backend tracking state (`resourceName` and the last backend-synced guide JSON) is persisted to localStorage. Draft or published status is derived from the refreshed backend guide list, so the correct button state survives a page refresh.
 
 ## Floating panel and popout step
 

--- a/docs/developer/interactive-examples/selectors-reference.md
+++ b/docs/developer/interactive-examples/selectors-reference.md
@@ -6,13 +6,37 @@ How to target DOM elements in interactive guides using the enhanced selector eng
 
 Follow this priority order when choosing selectors:
 
-1. **`data-testid` attributes** -- most stable, maintained by Grafana core
-2. **Semantic attributes** -- `href`, `aria-*`, `id`, `role`
-3. **`:contains()` text matching** -- reliable for buttons and labels
-4. **`:has()` structural matching** -- when you need to match by descendants
-5. **CSS class selectors** -- least stable; avoid auto-generated class names
+1. **`grafana:` selector paths** -- version-aware references to selectors maintained by Grafana core
+2. **`data-testid` attributes** -- stable when no known Grafana selector path exists
+3. **Semantic attributes** -- `href`, `aria-*`, `id`, `role`
+4. **`:contains()` text matching** -- reliable for buttons and labels
+5. **`:has()` structural matching** -- when you need to match by descendants
+6. **CSS class selectors** -- least stable; avoid auto-generated class names
 
 > Avoid selecting by auto-generated class names or deep DOM nesting. Use attributes (`data-testid`, `href`, `aria-*`, `id`) instead.
+
+### Version-aware `grafana:` selectors
+
+When the element picker recognizes a `data-testid` or `aria-label` from Grafana's E2E selector catalog, it emits a `grafana:` path instead of copying the rendered attribute value:
+
+```text
+grafana:components.RefreshPicker.runButton
+grafana:pages.Login.username
+grafana:components.Breadcrumbs.breadcrumb:Home
+```
+
+The final segment after the last colon is the argument for a parameterized selector. At runtime, Pathfinder resolves the path against the running Grafana version and queries both the resolved `data-testid` and `aria-label` forms. Reverse lookup covers both `components.*` and `pages.*`; if an attribute value maps ambiguously to multiple paths, the picker skips `grafana:` and uses its CSS strategies instead. The raw test ID remains available as an alternative selector.
+
+### Generated structural fallbacks
+
+The element picker only uses positional selectors as a last resort:
+
+- A candidate that is not unique is scoped to the nearest stable ancestor with a test ID, a non-generated ID, or a stable `data-*` attribute.
+- A bare tag such as `button` is accepted only when a stable ancestor makes the scoped form unique.
+- An identity-less wrapper can borrow a stable descendant's identity with `:has()`. The generator prefers unique interactive descendants and tightens the selector with a parent-child relationship or stable ancestor scope until it identifies only the clicked wrapper.
+- Primary and alternative selectors pass the same uniqueness and scoping checks. If no stable option exists, the picker can emit a positional fallback that Selector Health marks as structural.
+
+The recorder ignores clicks inside `[data-pathfinder-content="true"]`, which marks Pathfinder's sidebar, floating panel, and full-screen surfaces. Record against the target Grafana UI, not controls inside Pathfinder itself.
 
 ## Pseudo-selectors
 
@@ -244,17 +268,15 @@ The default hover duration is 2000 ms, configured in `INTERACTIVE_CONFIG.delays.
 
 ## Selector resilience pipeline
 
-Single-pass selector resolution is fragile against lazy-loaded UI and minor markup churn. The interactive engine ships with a resilience pipeline (`resolveSelectorPipeline`) that escalates strategies until it finds a unique match, returning a confidence score for each result.
+Single-pass selector resolution is fragile against lazy-loaded UI and minor markup churn. The interactive engine ships with a resilience pipeline (`resolveSelectorPipeline`) that retries while lazy-loaded UI mounts and reports whether the match was exact or retried.
 
-The pipeline runs through these strategies in order:
+The pipeline runs through these stages:
 
-1. **Native CSS** — `document.querySelectorAll(selector)` against the user-provided selector. Fastest path; used unchanged when the user-supplied selector is clean.
-2. **Enhanced selectors** — JavaScript fallbacks for `:contains()`, `:has()` (on older browsers), `:nth-match()`, and the `panel:` domain prefix.
-3. **`:text()` exact match** — for short button labels (under 20 characters), eliminating false positives that substring matches would produce. Prefer `:text("Save")` over `:contains("Save")` when the label is short.
-4. **`data-testid` prefix matching** — when the exact ID isn't found but a unique prefix exists, the engine matches the prefix (uniqueness-guarded — never returns multiple elements).
-5. **Retry with backoff** — `resolveWithRetry()` waits 200 ms, 600 ms, then 1.8 s between attempts to give lazy-loaded UI time to mount.
+1. **Resolve prefixes** — `grafana:` paths resolve against the running Grafana version; `panel:` paths resolve to a panel container by title.
+2. **Exact attempt** — the enhanced query engine evaluates native CSS and the `:contains()`, `:has()`, `:text()`, and `:nth-match()` extensions. Plain-text `button` actions use button-text lookup. `data-testid` prefix matching is handled inside this query step and only succeeds for a unique prefix match.
+3. **Retry with backoff** — the pipeline waits 200 ms, 600 ms, then 1.8 s between attempts. From the second retry onward, it can relax child combinators (`>`) to descendant combinators when the original selector still has no match.
 
-Each successful resolution returns a **confidence score** that the block editor surfaces as a Selector Health badge:
+Exact pipeline matches report confidence `1.0`; retried matches report `0.95`. Separately, the block editor derives the Selector Health badge from the selector's stability signals:
 
 | Badge     | Confidence | Meaning                                                                    |
 | --------- | ---------- | -------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-07-15.

### Changes made

- Updated the selector authoring reference for version-aware `grafana:` paths, stable ancestor and descendant-anchored `:has()` generation, Pathfinder-owned content exclusion, and the actual retry/confidence pipeline.
- Updated the custom-guide lifecycle for current Library access, ID locking and collision handling, JSON draft recovery, undo/redo, preview progress reset, status badges, and backend state derivation.
- Recorded both validations and classified the maintain-docs intent companion as intentionally excluded from the AGENTS.md index.
- Marked the long-running snippet-engine review-routing backlog item as blocked on a human design review because this skill excludes `docs/design/`.

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| HIGH | Selector reference drifted from current `grafana:` resolution, picker generation, and runtime retry behavior | Fixed in this PR |
| HIGH | Custom-guide lifecycle drifted from current block-editor persistence, Library, preview, and backend flows | Fixed in this PR |
| HIGH | Snippet-engine has no dedicated `CONCERNS.md` review route after 3+ runs | Deferred; blocked on human design review |
| MEDIUM | `utils/README.md` has structural source changes including the new slug utility | Deferred by the 7-point budget |
| LOW | Maintain-docs intent companion had no recorded orphan exclusion | Fixed in this PR |
| LOW | Bugfix/refactor subagent prompts and design-review principles remain unclassified companion orphans | Deferred by the 7-point budget |

### Recommendations for separate work

- Review whether `src/snippet-engine/` needs its own concern or belongs under an existing concern in `docs/design/CONCERNS.md`.

### Validation checklist

- [x] All changed files are `.md` or `.mdc` (verified via `git diff --name-only`)
- [x] Phase 2.5 verification passed (sub-agent output reviewed and factual claims spot-checked)
- [x] `npm run prettier` passed
- [x] No source code files were modified