### PR TITLE
fix(telemetry): replace raw error_message with low-cardinality classification in sequence action errors

### DIFF
--- a/src/interactive-engine/sequence-manager.test.ts
+++ b/src/interactive-engine/sequence-manager.test.ts
@@ -1,4 +1,4 @@
-import { SequenceManager } from './sequence-manager';
+import { SequenceManager, classifySequenceError } from './sequence-manager';
 import { InteractiveStateManager } from './interactive-state-manager';
 import { InteractiveElementData } from '../types/interactive.types';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
@@ -153,12 +153,23 @@ describe('SequenceManager', () => {
       const result = await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
 
       expect(result).toBe('action_error');
-      expect(mockRecordSequenceActionError).toHaveBeenCalledWith(
-        'test-requirements',
-        INTERACTIVE_CONFIG.maxRetries,
-        'click failed'
-      );
+      expect(mockRecordSequenceActionError).toHaveBeenCalledWith('test-requirements', INTERACTIVE_CONFIG.maxRetries, {
+        name: 'Error',
+        category: 'dispatch_failed',
+      });
       expect(mockRecordRequirementsExhausted).not.toHaveBeenCalled();
+    });
+
+    it('reports a classification instead of the raw error message', async () => {
+      mockDispatchInteractiveAction.mockRejectedValue(
+        new Error('No elements found matching selector: div[data-secret="token=abc123"]')
+      );
+
+      await sequenceManager.runInteractiveSequence([mockElements[0]!], false);
+
+      const [, , classification] = mockRecordSequenceActionError.mock.calls[0];
+      expect(classification).toEqual({ name: 'Error', category: 'not_found' });
+      expect(JSON.stringify(mockRecordSequenceActionError.mock.calls)).not.toContain('token=abc123');
     });
 
     it('does not report exhaustion when a step eventually succeeds', async () => {
@@ -277,11 +288,10 @@ describe('SequenceManager', () => {
       const result = await sequenceManager.runStepByStepSequence([mockElements[0]!]);
 
       expect(result).toBe('action_error');
-      expect(mockRecordSequenceActionError).toHaveBeenCalledWith(
-        'test-requirements',
-        INTERACTIVE_CONFIG.maxRetries,
-        'click failed'
-      );
+      expect(mockRecordSequenceActionError).toHaveBeenCalledWith('test-requirements', INTERACTIVE_CONFIG.maxRetries, {
+        name: 'Error',
+        category: 'dispatch_failed',
+      });
       expect(mockRecordRequirementsExhausted).not.toHaveBeenCalled();
     });
 
@@ -373,6 +383,52 @@ describe('SequenceManager', () => {
         testError,
         expect.any(Object)
       );
+    });
+  });
+
+  describe('classifySequenceError', () => {
+    it('maps timeout messages to the timeout category', () => {
+      expect(classifySequenceError(new Error('Timeout finding element: div.panel'))).toEqual({
+        name: 'Error',
+        category: 'timeout',
+      });
+      expect(classifySequenceError(new Error('operation timed out'))).toEqual({
+        name: 'Error',
+        category: 'timeout',
+      });
+    });
+
+    it('maps missing-element messages to the not_found category', () => {
+      expect(classifySequenceError(new Error('No elements found matching selector: #x'))).toEqual({
+        name: 'Error',
+        category: 'not_found',
+      });
+      expect(classifySequenceError(new Error('No element found for ref'))).toEqual({
+        name: 'Error',
+        category: 'not_found',
+      });
+    });
+
+    it('maps other Error instances to dispatch_failed, preserving the error name', () => {
+      expect(classifySequenceError(new TypeError('x is not a function'))).toEqual({
+        name: 'TypeError',
+        category: 'dispatch_failed',
+      });
+    });
+
+    it('maps non-Error throws to other with a stable name', () => {
+      expect(classifySequenceError('boom')).toEqual({ name: 'UnknownError', category: 'other' });
+      expect(classifySequenceError(undefined)).toEqual({ name: 'UnknownError', category: 'other' });
+    });
+
+    it('bounds the error name and never emits an empty one', () => {
+      const longName = new Error('x');
+      longName.name = 'A'.repeat(200);
+      expect(classifySequenceError(longName).name).toHaveLength(64);
+
+      const emptyName = new Error('x');
+      emptyName.name = '';
+      expect(classifySequenceError(emptyName).name).toBe('Error');
     });
   });
 

--- a/src/interactive-engine/sequence-manager.ts
+++ b/src/interactive-engine/sequence-manager.ts
@@ -2,10 +2,29 @@ import { InteractiveElementData } from '../types/interactive.types';
 import { InteractiveStateManager } from './interactive-state-manager';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import { logger } from '../lib/logging';
-import { recordRequirementsExhausted, recordSequenceActionError, type SequenceRunResult } from '../lib/telemetry';
+import {
+  recordRequirementsExhausted,
+  recordSequenceActionError,
+  type SequenceErrorClassification,
+  type SequenceRunResult,
+} from '../lib/telemetry';
 
 const MAX_REQUIREMENT_CONTEXT_LENGTH = 200;
-const MAX_ERROR_CONTEXT_LENGTH = 200;
+const MAX_ERROR_NAME_LENGTH = 64;
+
+export function classifySequenceError(error: unknown): SequenceErrorClassification {
+  if (!(error instanceof Error)) {
+    return { name: 'UnknownError', category: 'other' };
+  }
+  const name = error.name.slice(0, MAX_ERROR_NAME_LENGTH) || 'Error';
+  if (/timeout|timed out/i.test(error.message)) {
+    return { name, category: 'timeout' };
+  }
+  if (/no elements? found|not found/i.test(error.message)) {
+    return { name, category: 'not_found' };
+  }
+  return { name, category: 'dispatch_failed' };
+}
 
 // Exhaustion is classified by what the *last* attempt failed on: an unmet
 // requirements check vs the action itself throwing.
@@ -47,7 +66,7 @@ export class SequenceManager {
   ): Promise<RetryResult> {
     let retryCount = 0;
     let lastFailure: 'requirements' | 'action' = 'requirements';
-    let lastErrorMessage = '';
+    let lastError: unknown;
 
     while (retryCount < this.MAX_RETRIES) {
       try {
@@ -63,7 +82,7 @@ export class SequenceManager {
       } catch (error) {
         this.stateManager.logError(errorContext, error as Error, context.data);
         lastFailure = 'action';
-        lastErrorMessage = error instanceof Error ? error.message : String(error);
+        lastError = error;
         retryCount++;
         if (retryCount < this.MAX_RETRIES) {
           await this.sleep(this.RETRY_DELAY);
@@ -76,7 +95,7 @@ export class SequenceManager {
     );
     const requirement = (context.data.requirements ?? '').slice(0, MAX_REQUIREMENT_CONTEXT_LENGTH);
     if (lastFailure === 'action') {
-      recordSequenceActionError(requirement, this.MAX_RETRIES, lastErrorMessage.slice(0, MAX_ERROR_CONTEXT_LENGTH));
+      recordSequenceActionError(requirement, this.MAX_RETRIES, classifySequenceError(lastError));
       return 'failed_action';
     }
     recordRequirementsExhausted(requirement, this.MAX_RETRIES);

--- a/src/lib/telemetry/facade.test.ts
+++ b/src/lib/telemetry/facade.test.ts
@@ -98,7 +98,7 @@ describe('measurement and event domain operations', () => {
 
   it('recordRequirementsExhausted and recordSequenceActionError emit distinct event names', () => {
     recordRequirementsExhausted('has-role:admin', 3);
-    recordSequenceActionError('has-role:admin', 3, 'click failed');
+    recordSequenceActionError('has-role:admin', 3, { name: 'Error', category: 'timeout' });
 
     expect(mockPushFaroEvent).toHaveBeenCalledWith('requirements_exhausted', {
       requirement: 'has-role:admin',
@@ -107,8 +107,17 @@ describe('measurement and event domain operations', () => {
     expect(mockPushFaroEvent).toHaveBeenCalledWith('sequence_action_error', {
       requirement: 'has-role:admin',
       retry_count: 3,
-      error_message: 'click failed',
+      error_name: 'Error',
+      error_category: 'timeout',
     });
+  });
+
+  it('recordSequenceActionError never ships a free-text error message attribute', () => {
+    recordSequenceActionError('exists-reftarget', 3, { name: 'TypeError', category: 'dispatch_failed' });
+
+    const [, attributes] = mockPushFaroEvent.mock.calls[0];
+    expect(attributes).not.toHaveProperty('error_message');
+    expect(Object.keys(attributes).sort()).toEqual(['error_category', 'error_name', 'requirement', 'retry_count']);
   });
 
   it('recordPanelReady emits the panel measurement with the surface context', () => {

--- a/src/lib/telemetry/facade.ts
+++ b/src/lib/telemetry/facade.ts
@@ -11,6 +11,7 @@ import {
   type GuideLoadOutcome,
   type RecommenderErrorType,
   type RecommenderOutcome,
+  type SequenceErrorClassification,
   type StepOutcome,
 } from './types';
 
@@ -78,12 +79,19 @@ export function recordRequirementsExhausted(requirement: string, retryCount: num
   pushFaroEvent(TELEMETRY_EVENTS.requirementsExhausted, { requirement, retry_count: retryCount });
 }
 
-export function recordSequenceActionError(requirement: string, retryCount: number, errorMessage: string): void {
+// Takes a classification, not the raw error: free-text messages embed URLs,
+// selectors, and echoed input, and nothing downstream scrubs event attributes.
+export function recordSequenceActionError(
+  requirement: string,
+  retryCount: number,
+  error: SequenceErrorClassification
+): void {
   pushFaroMeasurement(TELEMETRY_MEASUREMENTS.requirements, { retry_count: retryCount }, { requirement });
   pushFaroEvent(TELEMETRY_EVENTS.sequenceActionError, {
     requirement,
     retry_count: retryCount,
-    error_message: errorMessage,
+    error_name: error.name,
+    error_category: error.category,
   });
 }
 

--- a/src/lib/telemetry/types.ts
+++ b/src/lib/telemetry/types.ts
@@ -7,6 +7,13 @@ export type StepOutcome = 'ok' | 'error';
 
 export type SequenceRunResult = 'completed' | 'requirements_exhausted' | 'action_error';
 
+export type SequenceErrorCategory = 'timeout' | 'not_found' | 'dispatch_failed' | 'other';
+
+export interface SequenceErrorClassification {
+  name: string;
+  category: SequenceErrorCategory;
+}
+
 export type RecommenderErrorType = 'unavailable' | 'rate-limit' | 'other';
 export type RecommenderOutcome = 'ok' | RecommenderErrorType;
 


### PR DESCRIPTION
## Summary

Follow-on to #1338. The `sequence_action_error` telemetry event no longer ships the raw JavaScript `error.message` to Faro — it now records a bounded `error_name` plus a coarse `error_category` (`timeout | not_found | dispatch_failed | other`), so free-text failure content never leaves the client.

## Why

The #1338 review found that `recordSequenceActionError` forwarded `error.message` with only length truncation (200 chars at the call site, 500 in the Faro adapter), and nothing downstream scrubs regular event attributes — `filterPathfinderTelemetry` passes them through unchanged. DOM/action failure messages routinely embed URLs with query strings, CSS selectors, fetch response text, or echoed user input. Faro data is Grafana-internal, so this is privacy hygiene rather than an external leak, but it bypassed the content scrubbing the logging path gets. Of the two fixes the issue proposed (sanitize the string vs. classify), classification is stronger and matches the facade's own direction of typed, low-cardinality outcomes over free-form strings.

## What to look at

- [`src/interactive-engine/sequence-manager.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/179308e0c71e556a1c52ce5e6be1c4cd81aaccf1/src/interactive-engine/sequence-manager.ts) — new `classifySequenceError` at the catch site: timeout and not-found keyword matches first, other `Error` instances map to `dispatch_failed` (the throw source in this retry path is the action dispatch), non-`Error` throws map to `other`. `verify_failed` from the issue's example set was deliberately omitted — post-action verification failures return `false` and flow to `requirements_exhausted`, never through this throw path, so the category would be dead.
- [`src/lib/telemetry/facade.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/179308e0c71e556a1c52ce5e6be1c4cd81aaccf1/src/lib/telemetry/facade.ts) + [`types.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/179308e0c71e556a1c52ce5e6be1c4cd81aaccf1/src/lib/telemetry/types.ts) — `recordSequenceActionError` now takes a typed `SequenceErrorClassification` instead of a string, making the low-cardinality contract explicit at the boundary.

## How to verify

1. Run a guide with an interactive step whose selector cannot match (or point a step at a URL that will time out) and let retries exhaust.
2. In the browser network tab, inspect the outgoing Faro payload for the `sequence_action_error` event: it should carry `error_name` and `error_category` only — no `error_message` attribute and no fragment of the underlying selector/URL anywhere in the event.

## Breaking changes

None externally. The event attribute shape changes (`error_message` → `error_name` + `error_category`), but the event is brand-new — it merged earlier today in #1338 — so no dashboards or queries depend on the old shape. During rollout, clients still on the #1338 build emit the old `error_message` shape into the same event stream; treat `error_message` as retired when querying Faro — the window is self-healing as clients update.

## Reversibility

Reversible by revert. Telemetry already emitted with the old shape is Grafana-internal Faro data with a hard 200-char cap, and no stored state or contract depends on either shape.

## Out of scope

- `faro-adapter.ts`, `surface.ts`, `filtering.ts`, `src/docs-retrieval/**`, and `src/components/**` — owned by sibling PRs in flight; this PR deliberately touches only the sequence-manager and facade seam.
- Content sanitization via `src/security/log-sanitizer.ts` — not needed once the free-text message is dropped entirely.

Fixes #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<details>
<summary>Evidence: Faro sequence_action_error wire shape — secret-laden error is scrubbed to a low-cardinality classification</summary>

```text
raw error.message (thrown at the action call site — NEVER sent to Faro):
  No elements found matching selector:
  a[href="https://grafana.example/d/abc?token=S:sk-live-9f83b2&user=jdoe@corp.com"]

classifySequenceError(raw)  [src/interactive-engine/sequence-manager.ts]:
  { "name": "Error", "category": "not_found" }

Faro event pushed by recordSequenceActionError [src/lib/telemetry/facade.ts]:
  event name: sequence_action_error
  attributes:
    {
      "requirement":    "has-role:admin",
      "retry_count":    3,
      "error_name":     "Error",
      "error_category": "not_found"
    }

Privacy checks on the serialized outgoing event:
  attributes has "error_message"?              false   (attribute removed entirely)
  serialized event contains "token=S..."?      false
  serialized event contains "sk-live"?         false   (API-key-shaped secret)
  serialized event contains "@corp.com"?       false   (echoed user email)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm run test:ci -- src/interactive-engine/sequence-manager.test.ts src/lib/telemetry/facade.test.ts` (43 passed: classifier mapping timeout/not_found/dispatch_failed/other, name bounding to 64 chars + non-empty default, event wire shape, absence of error_message, and secrets never reaching the telemetry call)</code>
- <code>Wrote a temporary end-to-end evidence test that fed a secret-laden DOM error through `classifySequenceError` -&gt; `recordSequenceActionError` and captured the exact mocked `pushFaroEvent` payload; asserted no `error_message` key and that the token/API-key/email substrings are absent from the serialized event (removed the temp file afterward)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
