### PR TITLE
perf(telemetry): latch the cold-path surface read until the first report

### DIFF
--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -1174,10 +1174,11 @@ describe('passesActivityGate', () => {
   });
 
   it('latches open for the rest of the page load once Pathfinder was open', () => {
-    localStorage.setItem(PANEL_MODE_KEY, 'floating');
     const faro = freshFaro();
+    const surface: typeof import('./telemetry/surface') = require('./telemetry/surface');
+    surface.reportPathfinderSurface('floating');
     expect(faro.passesActivityGate(eventItem())).toBe(true);
-    localStorage.removeItem(PANEL_MODE_KEY);
+    surface.reportPathfinderSurfaceClosed('floating');
     expect(faro.passesActivityGate(eventItem())).toBe(true);
   });
 

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -1183,8 +1183,19 @@ describe('passesActivityGate', () => {
 
   it('opens on a later check after starting closed — closed does not latch', () => {
     const faro = freshFaro();
+    const surface: typeof import('./telemetry/surface') = require('./telemetry/surface');
+    expect(faro.passesActivityGate(eventItem())).toBe(false);
+    surface.reportPathfinderSurface('floating');
+    expect(faro.passesActivityGate(eventItem())).toBe(true);
+  });
+
+  it('an out-of-band localStorage write after a closed check does not open the gate — only a surface report does', () => {
+    const faro = freshFaro();
+    const surface: typeof import('./telemetry/surface') = require('./telemetry/surface');
     expect(faro.passesActivityGate(eventItem())).toBe(false);
     localStorage.setItem(PANEL_MODE_KEY, 'floating');
+    expect(faro.passesActivityGate(eventItem())).toBe(false);
+    surface.reportPathfinderSurface('floating');
     expect(faro.passesActivityGate(eventItem())).toBe(true);
   });
 
@@ -1216,7 +1227,8 @@ describe('beforeSend wiring', () => {
     expect(beforeSend(exceptionItem(['webpack://grafana-pathfinder-app/./src/lib/faro.ts']))).not.toBeNull();
     expect(beforeSend(exceptionItem(['webpack://grafana-core/./src/app.ts']))).toBeNull();
 
-    localStorage.setItem('grafana-pathfinder-app-panel-mode', 'floating');
+    const surface: typeof import('./telemetry/surface') = require('./telemetry/surface');
+    surface.reportPathfinderSurface('floating');
     expect(beforeSend(eventItem())).not.toBeNull();
   });
 });

--- a/src/lib/telemetry/surface.test.ts
+++ b/src/lib/telemetry/surface.test.ts
@@ -63,7 +63,7 @@ describe('surface owner', () => {
     expect(listener).toHaveBeenCalledWith('floating');
   });
 
-  it('double init: a second consumer cold-reading after the latch sees the latched value, not the changed DOM', () => {
+  it('a later cold-path caller sees the latched value, not the changed DOM', () => {
     const surface = freshSurface();
     expect(surface.isPathfinderOpen()).toBe(false);
 

--- a/src/lib/telemetry/surface.test.ts
+++ b/src/lib/telemetry/surface.test.ts
@@ -10,28 +10,84 @@ describe('surface owner', () => {
     document.body.innerHTML = '';
   });
 
-  it('falls back to the DOM/localStorage read until a surface is reported', () => {
-    const surface = freshSurface();
-    expect(surface.getPathfinderSurface()).toBe('closed');
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
+  it('falls back to the DOM/localStorage read until a surface is reported', () => {
     localStorage.setItem('grafana-pathfinder-app-panel-mode', 'floating');
+    const surface = freshSurface();
     expect(surface.getPathfinderSurface()).toBe('floating');
   });
 
-  it('cold-read fallback requires the visible kiosk overlay, not just its persistent mount root', () => {
+  it('performs the cold read once and answers subsequent calls from the latch', () => {
     const surface = freshSurface();
+    const getItem = jest.spyOn(Storage.prototype, 'getItem');
+    const querySelector = jest.spyOn(document, 'querySelector');
 
+    expect(surface.getPathfinderSurface()).toBe('closed');
+    const storageReads = getItem.mock.calls.length;
+    const domQueries = querySelector.mock.calls.length;
+    expect(storageReads).toBeGreaterThan(0);
+
+    surface.getPathfinderSurface();
+    surface.isPathfinderOpen();
+    expect(getItem).toHaveBeenCalledTimes(storageReads);
+    expect(querySelector).toHaveBeenCalledTimes(domQueries);
+  });
+
+  it('latches the cold read: an out-of-band localStorage write is not re-read, only a report supersedes it', () => {
+    const surface = freshSurface();
+    expect(surface.getPathfinderSurface()).toBe('closed');
+
+    // Cross-tab writes land without a report; same-tab opens always report
+    // (setMode / sidebar mount / kiosk open), so the report path suffices.
+    localStorage.setItem('grafana-pathfinder-app-panel-mode', 'floating');
+    expect(surface.getPathfinderSurface()).toBe('closed');
+    expect(surface.isPathfinderOpen()).toBe(false);
+
+    surface.reportPathfinderSurface('floating');
+    expect(surface.getPathfinderSurface()).toBe('floating');
+    expect(surface.isPathfinderOpen()).toBe(true);
+  });
+
+  it('notifies listeners on the first report even when it matches the latched cold value', () => {
+    localStorage.setItem('grafana-pathfinder-app-panel-mode', 'floating');
+    const surface = freshSurface();
+    expect(surface.getPathfinderSurface()).toBe('floating');
+
+    const listener = jest.fn();
+    surface.onPathfinderSurfaceChange(listener);
+    surface.reportPathfinderSurface('floating');
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith('floating');
+  });
+
+  it('double init: a second consumer cold-reading after the latch sees the latched value, not the changed DOM', () => {
+    const surface = freshSurface();
+    expect(surface.isPathfinderOpen()).toBe(false);
+
+    const el = document.createElement('div');
+    el.id = 'pathfinder-controller-root';
+    document.body.appendChild(el);
+    expect(surface.getPathfinderSurface()).toBe('closed');
+
+    surface.reportPathfinderSurface('controller');
+    expect(surface.getPathfinderSurface()).toBe('controller');
+  });
+
+  it('cold-read fallback requires the visible kiosk overlay, not just its persistent mount root', () => {
     const root = document.createElement('div');
     root.id = 'pathfinder-kiosk-root';
     document.body.appendChild(root);
     // The manager root mounts once kiosk mode is config-enabled and stays
     // in the DOM whether or not the overlay is actually open.
-    expect(surface.getPathfinderSurface()).toBe('closed');
+    expect(freshSurface().getPathfinderSurface()).toBe('closed');
 
     const overlay = document.createElement('div');
     overlay.setAttribute('data-testid', 'kiosk-mode-overlay');
     root.appendChild(overlay);
-    expect(surface.getPathfinderSurface()).toBe('kiosk');
+    expect(freshSurface().getPathfinderSurface()).toBe('kiosk');
   });
 
   it('prefers the reported surface over the cold-read fallback', () => {

--- a/src/lib/telemetry/surface.ts
+++ b/src/lib/telemetry/surface.ts
@@ -12,8 +12,10 @@ type SurfaceListener = (surface: PathfinderSurface) => void;
 
 // Single owner of "which Pathfinder surface is active": surfaces report
 // transitions here, telemetry subscribes. The DOM/localStorage read below is
-// only the cold-start fallback.
+// only the cold-start fallback, latched after its first read — every open
+// path reports on mount, so a report (never a re-read) supersedes it.
 let reportedSurface: PathfinderSurface | null = null;
+let latchedColdSurface: PathfinderSurface | null = null;
 const listeners = new Set<SurfaceListener>();
 
 // Mode literals mirror PanelMode in global-state/panel-mode — importing
@@ -43,7 +45,11 @@ export function readPathfinderSurface(): PathfinderSurface {
 }
 
 export function getPathfinderSurface(): PathfinderSurface {
-  return reportedSurface ?? readPathfinderSurface();
+  if (reportedSurface !== null) {
+    return reportedSurface;
+  }
+  latchedColdSurface ??= readPathfinderSurface();
+  return latchedColdSurface;
 }
 
 export function isPathfinderOpen(): boolean {
@@ -55,6 +61,7 @@ export function reportPathfinderSurface(surface: PathfinderSurface): void {
     return;
   }
   reportedSurface = surface;
+  latchedColdSurface = null;
   for (const listener of listeners) {
     try {
       listener(surface);


### PR DESCRIPTION
## Summary

While Pathfinder is closed, every Faro telemetry event (errors, web vitals, instrumentation) pays a full DOM + localStorage read chain: the `beforeSend` activity gate calls `getPathfinderSurface()`, which falls through to `readPathfinderSurface()` — a `localStorage.getItem` for panel mode, a docked-sidebar ownership check, a `document.querySelector` for the kiosk overlay, and a `document.getElementById` for the controller root — on every event until the first `reportPathfinderSurface()` lands. This PR latches that cold read once in a module-level cache, so the closed-state cost is a single read instead of per-event.

Follow-on to #1338, not a regression from it: the pre-#1338 `faro.ts` had identical per-event cost. #1338's `reportedSurface` cache already fixed the post-open half; this fixes the cold (pre-open) half.

## What to look at

- [`src/lib/telemetry/surface.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/0a46c12519f9eac89096429d76a014d2b185648a/src/lib/telemetry/surface.ts) — the latch/supersede interaction. Two things that look subtle but are deliberate:
  - A first report equal to the latched cold value **still notifies listeners**, because the dedup compares against `reportedSurface` (null until the first report), not the latch. `faro-adapter.ts`'s `stampSurface` listener depends on seeing that first transition.
  - An out-of-band localStorage write after the latch (e.g. a cross-tab `setMode`) no longer re-opens the activity gate via re-read — by design. Every same-tab open path reports on mount/open (`setMode` reports synchronously after its localStorage write, sidebar mount reports, kiosk `handleOpen` reports synchronously, controller reports at module init), so the report path alone preserves the gate-opens-when-Pathfinder-opens invariant. The decision is encoded in tests, not comments.
- Tests: pre-existing cases asserting per-event re-read semantics were rewritten to report-driven semantics (`surface.test.ts` fallback + kiosk-overlay tests; `faro.test.ts` "closed does not latch" gate test and the `beforeSend` wiring test), with original intent preserved via fresh-module cold reads or explicit reports. The second commit implements a mutation-verified self-review finding: the "latches open for the rest of the page load" gate test closed via an out-of-band `localStorage` removal the latch no longer observes, which made the `pathfinderWasOpen` coverage vacuous — it now closes via `reportPathfinderSurfaceClosed`, which kills that mutant.

## How to verify

1. In a dev Grafana with the plugin loaded and Pathfinder closed, instrument reads in DevTools (`const g = Storage.prototype.getItem; Storage.prototype.getItem = function (...a) { console.count('getItem'); return g.apply(this, a); }`) and generate telemetry events (navigate, trigger web vitals) — confirm no per-event panel-mode reads after the first.
2. Open Pathfinder (sidebar, floating, or kiosk) — confirm subsequent events pass the activity gate and the session's `surface` attribute stamps to the opened surface.
3. The pipeline's read-count evidence below (100 closed-state events through the real `beforeSend` gate): constant 2/1/1 reads with the latch vs linear 200/100/100 on the base commit.

## Breaking changes

None. No event names, payload shapes, or telemetry routing change — only when the surface value is derived.

## Reversibility

Fully reversible; no persisted state or external contract is touched. Revert restores the per-event read chain. The only observable behavior delta is the edge case above: an out-of-band localStorage write between the first closed-state event and the first surface report no longer opens the gate by itself — same-tab opens are unaffected because they always report.

Fixes #1344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<details>
<summary>Evidence: Before/after per-event surface read counts (issue #1344)</summary>

```text
Issue #1344 — latch cold-path surface read so Faro beforeSend stops re-reading
DOM/localStorage per telemetry event while Pathfinder is closed.

Measurement: 100 telemetry events pushed through the REAL Faro activity gate
(passesActivityGate -> isPathfinderOpen -> getPathfinderSurface) with Pathfinder
CLOSED the entire time. Spies count actual localStorage/DOM reads.

                          BASE (7810159, no latch)   TARGET (0a46c12, latched)
  localStorage.getItem      200  (2.00 / event)         2  (0.02 / event)
  document.querySelector    100  (1.00 / event)         1  (0.01 / event)
  document.getElementById   100  (1.00 / event)         1  (0.01 / event)

BASE:   reads scale linearly with event volume (the bug in #1344).
TARGET: one-time cold read, then 99/100 events answer from the module latch.
        A real open transition (reportPathfinderSurface) still flips the gate
        open exactly once, so no telemetry is lost.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx jest src/lib/telemetry/surface.test.ts src/lib/faro.test.ts` — 137 committed tests pass</code>
- <code>Temporary evidence test pushing 100 closed-state events through the real `passesActivityGate` path, counting `localStorage.getItem`/`document.querySelector`/`document.getElementById` calls on the target commit (constant one-time cold read)</code>
- `Same measurement against base commit 7810159's surface.ts (reads scale linearly: 200/100/100) to establish before/after contrast`
- <code>Mutation check: removed the `pathfinderWasOpen` latch in filtering.ts and ran the "latches open for the rest of the page load" test — it correctly failed, confirming the rewritten test kills the mutant</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
