### PR TITLE
fix(telemetry): route remaining raw-URL log paths through normalizeTelemetryUrl

### DIFF
--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -403,7 +403,6 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       const tab = this.state.tabs.find((t) => t.id === tabId);
       const result = await fetchContent(url);
 
-      // Check if fetch succeeded or failed
       if (result.content) {
         let content = result.content;
 

--- a/src/docs-retrieval/content-fetcher/fetch-raw.test.ts
+++ b/src/docs-retrieval/content-fetcher/fetch-raw.test.ts
@@ -218,6 +218,24 @@ describe('fetchRawHtml — telemetry log hygiene', () => {
     }
   });
 
+  it('normalizes both URLs in context when an ok response redirects to an untrusted URL', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(htmlResponse('<html>x</html>', 'https://evil.com/x?leak=zzz'));
+
+    await fetchRawHtml(SECRET_URL, {});
+
+    for (const message of loggedMessages()) {
+      expect(message).not.toContain('token=secret123');
+      expect(message).not.toContain('leak=zzz');
+    }
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Redirect target not in trusted domain list',
+      expect.objectContaining({
+        content_url: 'grafana.com/docs/grafana/latest/panels/',
+        final_url: 'evil.com/x',
+      })
+    );
+  });
+
   it('keeps the original URL out of the manual-redirect log message', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(redirectResponse(301, 'https://evil.com/phishing'));
 

--- a/src/docs-retrieval/content-fetcher/fetch-raw.test.ts
+++ b/src/docs-retrieval/content-fetcher/fetch-raw.test.ts
@@ -1,4 +1,5 @@
 import { fetchRawHtml, enforceHttps, generateUserFriendlyError } from './fetch-raw';
+import { logger } from '../../lib/logging';
 
 // Mock AbortSignal.timeout for Node environments that don't support it
 if (!AbortSignal.timeout) {
@@ -164,6 +165,71 @@ describe('fetchRawHtml — trust re-validation and error classification', () => 
 
     const result = await fetchRawHtml(DOC_URL, {});
     expect(result.error?.errorType).toBe('network');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// telemetry log hygiene — URL redaction has one owner (normalizeTelemetryUrl)
+// ---------------------------------------------------------------------------
+describe('fetchRawHtml — telemetry log hygiene', () => {
+  const SECRET_URL = 'https://grafana.com/docs/grafana/latest/panels/?token=secret123#fragment';
+
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  const loggedMessages = () => [...warnSpy.mock.calls, ...errorSpy.mock.calls].map((call) => String(call[0]));
+
+  it('keeps query and fragment out of log messages on HTTP errors and normalizes the context URL', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      headers: new Headers(),
+      text: async () => '',
+    });
+
+    await fetchRawHtml(SECRET_URL, {});
+
+    expect(loggedMessages().length).toBeGreaterThan(0);
+    for (const message of loggedMessages()) {
+      expect(message).not.toContain('token=secret123');
+      expect(message).not.toContain('#fragment');
+    }
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ content_url: 'grafana.com/docs/grafana/latest/panels/' })
+    );
+  });
+
+  it('keeps query and fragment out of log messages when the fetch throws', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    await fetchRawHtml(SECRET_URL, {});
+
+    expect(loggedMessages().length).toBeGreaterThan(0);
+    for (const message of loggedMessages()) {
+      expect(message).not.toContain('token=secret123');
+      expect(message).not.toContain('#fragment');
+    }
+  });
+
+  it('keeps the original URL out of the manual-redirect log message', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(redirectResponse(301, 'https://evil.com/phishing'));
+
+    await fetchRawHtml(SECRET_URL, {});
+
+    for (const message of loggedMessages()) {
+      expect(message).not.toContain('token=secret123');
+    }
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Manual redirect detected',
+      expect.objectContaining({ content_url: 'grafana.com/docs/grafana/latest/panels/' })
+    );
   });
 });
 

--- a/src/docs-retrieval/content-fetcher/fetch-raw.ts
+++ b/src/docs-retrieval/content-fetcher/fetch-raw.ts
@@ -349,7 +349,10 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
             const redirectUrl = new URL(location, originalUrl.origin);
 
             if (redirectUrl.origin !== originalUrl.origin) {
-              logger.warn(`Blocked redirect to different origin: ${redirectUrl.origin}`);
+              logger.warn('Blocked redirect to different origin', {
+                redirect_origin: redirectUrl.origin,
+                content_url: normalizeTelemetryUrl(url),
+              });
               lastError = {
                 message: `Cross-origin redirect blocked for security: ${redirectUrl.origin}`,
                 errorType: 'other',
@@ -359,6 +362,7 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
 
               if (!isRedirectTrusted) {
                 logger.warn('Redirect target not in trusted domain list', {
+                  content_url: normalizeTelemetryUrl(url),
                   final_url: normalizeTelemetryUrl(redirectUrl.href),
                 });
                 lastError = {

--- a/src/docs-retrieval/content-fetcher/fetch-raw.ts
+++ b/src/docs-retrieval/content-fetcher/fetch-raw.ts
@@ -111,7 +111,10 @@ async function tryUrlVariations(urls: string[], options: ContentFetchOptions): P
           const isFinalUrlTrusted = isTrustedFinalUrl(finalUrl);
 
           if (!isFinalUrlTrusted) {
-            logger.warn(`URL variation ${urlVariation} redirected to untrusted URL: ${finalUrl}`);
+            logger.warn('URL variation redirected to untrusted URL', {
+              content_url: normalizeTelemetryUrl(urlVariation),
+              final_url: normalizeTelemetryUrl(finalUrl),
+            });
             continue; // Try next variation
           }
 
@@ -285,13 +288,12 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
         const isFinalUrlTrusted = isTrustedFinalUrl(finalUrl);
 
         if (!isFinalUrlTrusted) {
-          logger.warn(
-            `Redirect target not in trusted domain list.\n` +
-              `Original URL: ${url}\n` +
-              `Final URL: ${finalUrl}\n` +
-              `response.url: ${response.url}\n` +
-              `isAllowedContentUrl: ${isAllowedContentUrl(finalUrl)}`
-          );
+          logger.warn('Redirect target not in trusted domain list', {
+            content_url: normalizeTelemetryUrl(url),
+            final_url: normalizeTelemetryUrl(finalUrl),
+            response_url_empty: !response.url,
+            is_allowed_content_url: isAllowedContentUrl(finalUrl),
+          });
           lastError = {
             message: 'Redirect target is not in trusted domain list',
             errorType: 'other',
@@ -336,7 +338,10 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
           errorType: 'other',
           statusCode: response.status,
         };
-        logger.warn(`Manual redirect detected from ${url}`, { lastErrorMessage: lastError.message });
+        logger.warn('Manual redirect detected', {
+          content_url: normalizeTelemetryUrl(url),
+          lastErrorMessage: lastError.message,
+        });
 
         if (location.startsWith('/')) {
           try {
@@ -353,7 +358,9 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
               const isRedirectTrusted = isTrustedFinalUrl(redirectUrl.href);
 
               if (!isRedirectTrusted) {
-                logger.warn(`Redirect target not in trusted domain list: ${redirectUrl.href}`);
+                logger.warn('Redirect target not in trusted domain list', {
+                  final_url: normalizeTelemetryUrl(redirectUrl.href),
+                });
                 lastError = {
                   message: 'Redirect target is not in trusted domain list',
                   errorType: 'other',
@@ -394,7 +401,7 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
         errorType,
         statusCode: response.status,
       };
-      logger.warn(`Failed to fetch from ${url}: ${lastError.message}`, {
+      logger.warn(`Failed to fetch content: ${lastError.message}`, {
         content_url: normalizeTelemetryUrl(url),
         error_type: errorType,
       });
@@ -412,11 +419,11 @@ export async function fetchRawHtml(url: string, options: ContentFetchOptions): P
       message: errorMessage,
       errorType: isTimeout ? 'timeout' : isNetwork ? 'network' : 'other',
     };
-    logger.warn(`Failed to fetch from ${url}`, { error, content_url: normalizeTelemetryUrl(url) });
+    logger.warn('Failed to fetch content', { error, content_url: normalizeTelemetryUrl(url) });
   }
 
   if (lastError) {
-    logger.error(`Failed to fetch content from ${url}`, {
+    logger.error('Failed to fetch content', {
       lastErrorMessage: lastError.message,
       content_url: normalizeTelemetryUrl(url),
       error_type: lastError.errorType,

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -1253,6 +1253,28 @@ describe('setFaroView', () => {
     });
     expect(() => faro.setFaroView('https://grafana.com/docs/')).not.toThrow();
   });
+
+  it('sets internal content identifiers as the view instead of dropping them', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.setFaroView('bundled:welcome-to-pathfinder');
+    expect(mockSetView).toHaveBeenCalledWith({ name: 'bundled:welcome-to-pathfinder' });
+
+    faro.setFaroView('backend-guide:my-guide');
+    expect(mockSetView).toHaveBeenCalledWith({ name: 'backend-guide:my-guide' });
+  });
+
+  it('bounds the view name length', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.setFaroView(`https://grafana.com/docs/${'a'.repeat(500)}`);
+
+    const { name } = mockSetView.mock.calls[0]![0] as { name: string };
+    expect(name.length).toBeLessThanOrEqual(200);
+    expect(name.startsWith('grafana.com/docs/')).toBe(true);
+  });
 });
 
 describe('setFaroViewName', () => {

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -1254,7 +1254,7 @@ describe('setFaroView', () => {
     expect(() => faro.setFaroView('https://grafana.com/docs/')).not.toThrow();
   });
 
-  it('sets internal content identifiers as the view instead of dropping them', async () => {
+  it('keeps the internal scheme prefix in the view name (previously the bare slug)', async () => {
     const faro = freshFaro();
     await faro.initFaro();
 
@@ -1274,6 +1274,14 @@ describe('setFaroView', () => {
     const { name } = mockSetView.mock.calls[0]![0] as { name: string };
     expect(name.length).toBeLessThanOrEqual(200);
     expect(name.startsWith('grafana.com/docs/')).toBe(true);
+  });
+
+  it('sets the invalid-url sentinel for unparsable URLs instead of keeping the previous view', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+
+    faro.setFaroView('http://');
+    expect(mockSetView).toHaveBeenCalledWith({ name: 'invalid-url' });
   });
 });
 

--- a/src/lib/telemetry/faro-adapter.ts
+++ b/src/lib/telemetry/faro-adapter.ts
@@ -324,8 +324,8 @@ export function setFaroView(url: string): void {
 }
 
 // For surfaces with no URL to derive a view name from (e.g. the
-// recommendations tab) — setFaroView's hostname+pathname derivation doesn't
-// apply there, so the view would otherwise stay unset/stale until a doc opens.
+// recommendations tab) — setFaroView's URL normalization doesn't apply
+// there, so the view would otherwise stay unset/stale until a doc opens.
 export function setFaroViewName(name: string): void {
   guardTelemetry(() => {
     if (name && faroInstance) {

--- a/src/lib/telemetry/faro-adapter.ts
+++ b/src/lib/telemetry/faro-adapter.ts
@@ -15,6 +15,7 @@ import { buildTelemetryIdentity } from './identity';
 import { getPathfinderSurface, onPathfinderSurfaceChange } from './surface';
 import { stampSessionExperiments } from './session';
 import { registerTelemetryBridge } from './bridge';
+import { normalizeTelemetryUrl } from './url';
 
 const COLLECTOR_URL = 'https://faro-collector-ops-eu-south-0.grafana-ops.net/collect/d6ec87b657b65de6e363de05623d9c57';
 const APP_NAME = packageJson.name;
@@ -318,8 +319,7 @@ export function setFaroView(url: string): void {
     if (!url || !faroInstance) {
       return;
     }
-    const { hostname, pathname } = new URL(url, window.location.origin);
-    faroInstance.api.setView({ name: `${hostname}${pathname}` });
+    faroInstance.api.setView({ name: normalizeTelemetryUrl(url) });
   });
 }
 


### PR DESCRIPTION
## Summary

Follow-on to #1338, which made `normalizeTelemetryUrl` ([src/lib/telemetry/url.ts](https://github.com/grafana/grafana-pathfinder-app/blob/35368d913987a6e544ed49a5297396a497b76224/src/lib/telemetry/url.ts)) the single owner of URL redaction for telemetry (bounded `hostname/path`, userinfo/query/fragment stripped, internal `bundled:`/`backend-guide:` schemes handled). The final review of that PR found two straggler paths in the content fetcher and the Faro adapter that still derived or emitted telemetry URLs on their own; this PR closes them. Raw fetch URLs no longer reach Faro through log message strings, and `setFaroView` now applies the same bounding and scheme handling as every other telemetry URL.

## What to look at

- `src/docs-retrieval/content-fetcher/fetch-raw.ts` — log messages interpolated the raw `${url}` while the structured `content_url` context field was already normalized. Messages ship to Faro (`logging.ts` → `pushFaroLog`), and `sanitizeForLogging` only escapes control characters — it does not strip query params — so a URL with sensitive query content leaked via the message. Raw URLs are now removed from all message templates in this file (the three sites named in the issue plus the same-class interpolations in the redirect/variation paths); normalized structured context fields carry the URLs instead. The diff is logging-only: no control flow, return value, or caller-facing error shape changes.
- `src/lib/telemetry/faro-adapter.ts` — `setFaroView` had its own `new URL()` → `hostname+pathname` derivation with two divergences from the normalizer: no 200-char bound, and internal-scheme URLs were reduced to the bare slug (`new URL('bundled:x', origin)` parses with an empty hostname, so a bundled guide's view name was `x`, indistinguishable from a docs path with the same tail). It now delegates to `normalizeTelemetryUrl`, imported directly from `./url` (not the barrel) per the entry-bundle boundary pinned by `entry-bundle-boundary.test.ts`. Output for regular http(s) URLs is identical (`hostname/pathname`), so docs-URL view names are unchanged.
- `src/components/docs-panel/docs-panel.tsx` — ride-along requested by the issue: deletes one narrating comment inside `loadTabContent`. No code change.

## How to verify

1. Open the docs panel and load a guide URL that fails (e.g. a 404 docs page with a query string appended). In the Faro collector (or a `pushFaroLog` breakpoint), confirm the warn/error log messages contain no query string and the `content_url` context field is the bounded `hostname/path` form.
2. Open a bundled guide (`bundled:welcome-to-pathfinder`) and confirm the Faro view name is the scheme-prefixed identifier (`bundled:welcome-to-pathfinder`), not the bare slug.

## Breaking changes

None for product behavior. Two observability notes for Grafana-internal Faro consumers:

- Log message strings for content-fetch failures no longer embed the URL — dashboards or alerts matching on `Failed to fetch from <url>` message text should match on the constant message prefix and read the `content_url` context field instead.
- Faro view names for internal-scheme guides are **renamed**, not newly set: previously the bare slug (`welcome-to-pathfinder` — the old `new URL()` derivation dropped the scheme), now the full identifier (`bundled:welcome-to-pathfinder`). Queries keyed on old bundled-guide view names will see a series break. Docs-URL view names are unchanged apart from a new 200-char cap; unparsable URLs now set the sentinel view `invalid-url` instead of retaining the previous view.

## Reversibility

Reversible by revert. Telemetry already collected before this change retains raw URLs in historical log messages; revert would resume emitting them and would create a second view-name series break for bundled guides.

## Out of scope

- `lastErrorMessage` context fields that carry fetch-layer error strings (e.g. `Redirect to <location>`) are unchanged — consistent with what #1338 shipped, the error text is pinned by existing tests, and the manual-redirect branch is only reachable through proxied/synthetic fetch responses (the fetch uses `redirect: 'follow'`). Candidate for a small follow-up.
- The one-owner contract is now complete for `fetch-raw.ts` and `setFaroView` — the surfaces this issue names. A repo-wide sweep found a few remaining Faro-bound raw-URL context values outside this PR's scope (`src/utils/find-doc-page.ts`, `src/components/docs-panel/link-handler.hook.ts`, `src/docs-retrieval/content-fetcher/metadata-extract.ts`, `src/learning-paths/fetch-path-guides.ts`); those belong in a follow-up rather than widening this diff.
- The similar narrating comment at ~line 725 of `docs-panel.tsx` sits in a function #1338 did not touch; trim-on-touch leaves it for whoever next edits that function.

Fixes #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)
