### PR TITLE
fix(telemetry): redact embedded URLs from Faro exception/log content

### DIFF
--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -196,13 +196,14 @@ describe('isGrafanaCloud', () => {
 
 function exceptionItem(
   filenames: Array<string | undefined>,
-  context?: Record<string, string>
+  context?: Record<string, string>,
+  value = 'boom'
 ): TransportItem<APIEvent> {
   return {
     type: 'exception',
     payload: {
       type: 'Error',
-      value: 'boom',
+      value,
       timestamp: new Date().toISOString(),
       stacktrace: { frames: filenames.map((filename) => ({ filename, function: 'fn' })) },
       ...(context && { context }),
@@ -211,10 +212,10 @@ function exceptionItem(
   } as unknown as TransportItem<APIEvent>;
 }
 
-function exceptionItemWithoutStacktrace(context?: Record<string, string>): TransportItem<APIEvent> {
+function exceptionItemWithoutStacktrace(context?: Record<string, string>, value = 'boom'): TransportItem<APIEvent> {
   return {
     type: 'exception',
-    payload: { type: 'Error', value: 'boom', timestamp: new Date().toISOString(), ...(context && { context }) },
+    payload: { type: 'Error', value, timestamp: new Date().toISOString(), ...(context && { context }) },
     meta: {},
   } as unknown as TransportItem<APIEvent>;
 }
@@ -292,6 +293,42 @@ describe('filterPathfinderTelemetry', () => {
 
   it('drops a log message without the prefix', () => {
     expect(filterPathfinderTelemetry(logItem('something happened'))).toBeNull();
+  });
+
+  it('redacts a URL embedded in an attributed exception value', () => {
+    const item = exceptionItem(
+      ['webpack://grafana-pathfinder-app/./src/lib/faro.ts'],
+      undefined,
+      'No elements found matching selector: a[href="https://grafana.example/d/abc?token=S:sk-live-9f83b2&user=jdoe@corp.com"]'
+    );
+    const result = filterPathfinderTelemetry(item);
+    expect(result).not.toBeNull();
+    expect(result).not.toBe(item);
+    expect(result?.payload).toMatchObject({
+      value: 'No elements found matching selector: a[href="grafana.example/d/abc"]',
+    });
+  });
+
+  it('redacts a URL embedded in an explicitly-reported exception value', () => {
+    const item = exceptionItemWithoutStacktrace(
+      { pathfinder_reported: 'true' },
+      'dispatch failed for https://grafana.example/d/abc?token=secret'
+    );
+    const result = filterPathfinderTelemetry(item);
+    expect(result?.payload).toMatchObject({ value: 'dispatch failed for grafana.example/d/abc' });
+  });
+
+  it('leaves an attributed exception value untouched (same reference) when it carries no URL', () => {
+    const item = exceptionItem(['webpack://grafana-pathfinder-app/./src/lib/faro.ts'], undefined, 'boom');
+    expect(filterPathfinderTelemetry(item)).toBe(item);
+  });
+
+  it('redacts a URL embedded in a kept log message', () => {
+    const item = logItem('[pathfinder] fetch failed for https://grafana.example/d/abc?token=secret&user=jdoe@corp.com');
+    const result = filterPathfinderTelemetry(item);
+    expect(result).not.toBeNull();
+    expect(result).not.toBe(item);
+    expect(result?.payload).toMatchObject({ message: '[pathfinder] fetch failed for grafana.example/d/abc' });
   });
 
   it('passes through other item types unfiltered', () => {

--- a/src/lib/telemetry/filtering.ts
+++ b/src/lib/telemetry/filtering.ts
@@ -8,6 +8,7 @@ import {
   ALLOWED_RECOMMENDER_DOMAINS,
 } from '../../constants';
 import { isPathfinderOpen } from './surface';
+import { normalizeTelemetryUrl } from './url';
 
 const APP_NAME = packageJson.name;
 const LOCAL_OVERRIDE_KEY = 'pathfinder.faro.local';
@@ -130,6 +131,18 @@ function isTrackedResourceUrl(resourceUrl: string | undefined): boolean {
   }
 }
 
+// DOM/action failure text routinely embeds URLs with query-string secrets
+// (tokens, emails) — same leak normalizeTelemetryUrl closes for dedicated
+// URL attributes, applied here to any URL substring in free-text content.
+// Excludes quote/bracket/paren wrapping characters so an href like
+// `a[href="https://...token=x"]` doesn't swallow the closing `"]` into the
+// match and silently drop it along with the stripped query string.
+const EMBEDDED_URL_PATTERN = /https?:\/\/[^\s"'<>()[\]]+/g;
+
+function redactEmbeddedUrls(text: string): string {
+  return text.replace(EMBEDDED_URL_PATTERN, (match) => normalizeTelemetryUrl(match));
+}
+
 // Whitelist, not blocklist: Grafana core and other app plugins run their own
 // Faro instances on the same page, so exceptions/logs must be attributable to
 // Pathfinder, and PerformanceInstrumentation's resource entries must be
@@ -140,14 +153,20 @@ function isTrackedResourceUrl(resourceUrl: string | undefined): boolean {
 // through unfiltered.
 export function filterPathfinderTelemetry(item: TransportItem<APIEvent>): TransportItem<APIEvent> | null {
   if (isExceptionItem(item)) {
-    if (item.payload.context?.[EXPLICIT_REPORT_MARKER] === 'true') {
-      return item;
-    }
+    const isExplicit = item.payload.context?.[EXPLICIT_REPORT_MARKER] === 'true';
     const frames = item.payload.stacktrace?.frames ?? [];
-    return frames.some((frame) => isPathfinderStackFrame(frame.filename)) ? item : null;
+    if (!isExplicit && !frames.some((frame) => isPathfinderStackFrame(frame.filename))) {
+      return null;
+    }
+    const value = redactEmbeddedUrls(item.payload.value);
+    return value === item.payload.value ? item : { ...item, payload: { ...item.payload, value } };
   }
   if (isLogItem(item)) {
-    return item.payload.message.startsWith(LOG_PREFIX) ? item : null;
+    if (!item.payload.message.startsWith(LOG_PREFIX)) {
+      return null;
+    }
+    const message = redactEmbeddedUrls(item.payload.message);
+    return message === item.payload.message ? item : { ...item, payload: { ...item.payload, message } };
   }
   if (isEventItem(item)) {
     if (item.payload.name === 'faro.performance.navigation') {


### PR DESCRIPTION
## Summary

Follow-on to #1347, found while doing a final review pass on it. The `sequence_action_error` event fix in #1347 narrowed what reaches that one *custom event* — but the exact same secret-laden `Error` still leaks through an untouched sibling path: Faro *exceptions* and *logs*.

## Problem

`SequenceManager`'s retry loop calls `this.stateManager.logError(errorContext, error as Error, context.data)` on every retry, before `classifySequenceError` even runs. That raw `Error` flows through `logger.error` → `pushFaroError` → `faroInstance.api.pushError(error, ...)` untouched — only the wrapper message string gets `sanitizeForLogging()` (control-char stripping + length cap, no URL/secret redaction).

`filterPathfinderTelemetry`'s `beforeSend` exception branch only decides keep-vs-drop by stack-frame attribution; it never scrubs `payload.value`. So a DOM-selector-not-found message like:

```
No elements found matching selector: a[href="https://grafana.example/d/abc?token=S:sk-live-9f83b2&user=jdoe@corp.com"]
```

reaches Faro in full — full message, uncapped, on every retry. The same gap exists for log items when the thrown value isn't an `Error` instance (`logger.error` falls back to `pushFaroLog`).

## Fix

Redact at the shared choke point instead of patching the one call site: `filterPathfinderTelemetry` now runs any `https?://` substring found in an exception's `.value` or a kept log's `.message` through the existing `normalizeTelemetryUrl` (bounded `hostname/path`; userinfo, query, and fragment stripped) — the same rule already applied to dedicated URL-carrying telemetry attributes elsewhere in this codebase. This covers every current and future exception/log producer, not just this one retry loop, and it's a blanket rule (all query params dropped, not just ones that look sensitive), matching the existing `normalizeTelemetryUrl` policy.

Reference identity is preserved when nothing changes (no embedded URL), so existing `toBe(item)` assertions in `faro.test.ts` are untouched.

## What to look at

- `src/lib/telemetry/filtering.ts` — `redactEmbeddedUrls` + its two call sites in `filterPathfinderTelemetry`
- `src/lib/faro.test.ts` — new cases for attributed/explicit-report exceptions and kept logs with embedded URLs, plus a same-reference case confirming no-URL content is untouched

## How to verify

1. Run a guide with an interactive step whose selector cannot match (e.g. pointed at a URL with a query string) and let retries exhaust.
2. Inspect the outgoing Faro exception payload: `payload.value` should show `hostname/path` only, with no query string, token, or email.

## Breaking changes

None. This only changes what's redacted before send; no event/attribute shape changes.

## Reversibility

Fully reversible by revert — pure `beforeSend` content transform, no persisted state or contract dependency.

## Out of scope

- The `sequence_action_error` custom event itself — already fixed by #1347.
- General secret-pattern redaction (API keys not embedded in a URL) — this fix specifically closes the URL/query-string vector identified in review; a broader secret-scrubber would be new scope.

Fixes #1345 (exception/log path — the event-attribute path was already closed by #1347)