### PR TITLE
fix(telemetry): derive panel-ready readiness from scene state, not a one-shot event

### DIFF
--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -18,7 +18,6 @@ import { useContextPanel, Recommendation } from '../../context-engine';
 import type { ResolvedNavLink } from '../../types/context.types';
 import { reportAppInteraction, UserInteraction, getContentTypeForAnalytics } from '../../lib/analytics';
 import { logger } from '../../lib/logging';
-import { RECOMMENDATIONS_READY_EVENT } from '../../lib/event-names';
 import { getConfigWithDefaults, PLUGIN_BASE_URL } from '../../constants';
 import { isDevModeEnabled } from '../../utils/dev-mode';
 import { testIds } from '../../constants/testIds';
@@ -1122,14 +1121,13 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
 
   // Signals docs-panel's panel_lcp_ms that recommendations are actually
   // showing (reuses the same readiness the scroll-position hook uses).
-  // Deferred to a microtask since effects commit child-before-parent —
-  // dispatching synchronously on first mount could race ahead of the
-  // ancestor's listener-registration effect.
+  // Written to scene state — a replayable observable the parent reads on
+  // any render, so it survives this renderer remounting on tab changes.
   useEffect(() => {
-    if (recommendationsScrollReady) {
-      queueMicrotask(() => document.dispatchEvent(new CustomEvent(RECOMMENDATIONS_READY_EVENT)));
+    if (recommendationsScrollReady && !model.state.recommendationsReady) {
+      model.setState({ recommendationsReady: true });
     }
-  }, [recommendationsScrollReady]);
+  }, [recommendationsScrollReady, model]);
 
   return (
     <div className={styles.container} data-testid={testIds.contextPanel.container}>

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -815,6 +815,7 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   }, [pluginConfig]);
 
   const { tabs, activeTabId, contextPanel } = model.useState();
+  const { recommendationsReady = false } = contextPanel.useState();
   React.useEffect(() => {
     addGlobalModalStyles();
   }, []);
@@ -943,7 +944,12 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   // when other tab properties change (isLoading, error, etc.)
   const stableContent = React.useMemo(() => activeTab?.content, [activeTab?.content]);
 
-  usePanelReadyMeasurement({ hasContent: !!stableContent, isRecommendationsTab, surface: panelMode });
+  usePanelReadyMeasurement({
+    hasContent: !!stableContent,
+    isRecommendationsTab,
+    recommendationsReady,
+    surface: panelMode,
+  });
 
   // STABILITY: Memoize the AlignmentPendingContext value keyed on the two
   // underlying primitives so consumers (`useStepChecker` in every interactive

--- a/src/components/docs-panel/hooks/usePanelReadyMeasurement.test.ts
+++ b/src/components/docs-panel/hooks/usePanelReadyMeasurement.test.ts
@@ -1,8 +1,6 @@
-import * as React from 'react';
-import { act, render, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { usePanelReadyMeasurement } from './usePanelReadyMeasurement';
 import { recordPanelReady } from '../../../lib/telemetry';
-import { RECOMMENDATIONS_READY_EVENT } from '../../../lib/event-names';
 
 jest.mock('../../../lib/telemetry', () => ({
   recordPanelReady: jest.fn(),
@@ -21,7 +19,13 @@ describe('usePanelReadyMeasurement', () => {
     const nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => now);
 
     const { rerender } = renderHook(
-      ({ hasContent }) => usePanelReadyMeasurement({ hasContent, isRecommendationsTab: false, surface: 'sidebar' }),
+      ({ hasContent }) =>
+        usePanelReadyMeasurement({
+          hasContent,
+          isRecommendationsTab: false,
+          recommendationsReady: false,
+          surface: 'sidebar',
+        }),
       { initialProps: { hasContent: false } }
     );
 
@@ -34,7 +38,14 @@ describe('usePanelReadyMeasurement', () => {
   });
 
   it('records a measurement for content that is already ready at mount', () => {
-    renderHook(() => usePanelReadyMeasurement({ hasContent: true, isRecommendationsTab: false, surface: 'sidebar' }));
+    renderHook(() =>
+      usePanelReadyMeasurement({
+        hasContent: true,
+        isRecommendationsTab: false,
+        recommendationsReady: false,
+        surface: 'sidebar',
+      })
+    );
 
     expect(mockRecordPanelReady).toHaveBeenCalledTimes(1);
     expect(mockRecordPanelReady).toHaveBeenCalledWith(expect.any(Number), 'sidebar');
@@ -42,7 +53,13 @@ describe('usePanelReadyMeasurement', () => {
 
   it('waits for content before recording, then records exactly once', () => {
     const { rerender } = renderHook(
-      ({ hasContent }) => usePanelReadyMeasurement({ hasContent, isRecommendationsTab: false, surface: 'floating' }),
+      ({ hasContent }) =>
+        usePanelReadyMeasurement({
+          hasContent,
+          isRecommendationsTab: false,
+          recommendationsReady: false,
+          surface: 'floating',
+        }),
       { initialProps: { hasContent: false } }
     );
 
@@ -56,37 +73,50 @@ describe('usePanelReadyMeasurement', () => {
     expect(mockRecordPanelReady).toHaveBeenCalledTimes(1);
   });
 
-  it('records for the recommendations tab only once the recommendations-ready event fires', () => {
-    renderHook(() => usePanelReadyMeasurement({ hasContent: false, isRecommendationsTab: true, surface: 'sidebar' }));
+  it('records for the recommendations tab once recommendations become ready', () => {
+    const { rerender } = renderHook(
+      ({ recommendationsReady }) =>
+        usePanelReadyMeasurement({
+          hasContent: false,
+          isRecommendationsTab: true,
+          recommendationsReady,
+          surface: 'sidebar',
+        }),
+      { initialProps: { recommendationsReady: false } }
+    );
 
     expect(mockRecordPanelReady).not.toHaveBeenCalled();
 
-    act(() => {
-      document.dispatchEvent(new CustomEvent(RECOMMENDATIONS_READY_EVENT));
-    });
+    rerender({ recommendationsReady: true });
 
     expect(mockRecordPanelReady).toHaveBeenCalledTimes(1);
     expect(mockRecordPanelReady).toHaveBeenCalledWith(expect.any(Number), 'sidebar');
   });
 
-  it('is not missed when a descendant dispatches the ready event from its own mount effect (child-before-parent effect ordering)', async () => {
-    // Mirrors context-panel.tsx's real dispatch site (microtask-deferred)
-    // so this fails if that deferral regresses.
-    function ReadySignalChild() {
-      React.useEffect(() => {
-        queueMicrotask(() => document.dispatchEvent(new CustomEvent(RECOMMENDATIONS_READY_EVENT)));
-      }, []);
-      return null;
-    }
-    function Parent() {
-      usePanelReadyMeasurement({ hasContent: false, isRecommendationsTab: true, surface: 'sidebar' });
-      return React.createElement(ReadySignalChild);
-    }
-
-    await act(async () => {
-      render(React.createElement(Parent));
-    });
+  it('records when recommendations are already ready at mount (synchronous cache hit, the previously-racy path)', () => {
+    renderHook(() =>
+      usePanelReadyMeasurement({
+        hasContent: false,
+        isRecommendationsTab: true,
+        recommendationsReady: true,
+        surface: 'sidebar',
+      })
+    );
 
     expect(mockRecordPanelReady).toHaveBeenCalledTimes(1);
+    expect(mockRecordPanelReady).toHaveBeenCalledWith(expect.any(Number), 'sidebar');
+  });
+
+  it('ignores recommendations readiness when the recommendations tab is not active', () => {
+    renderHook(() =>
+      usePanelReadyMeasurement({
+        hasContent: false,
+        isRecommendationsTab: false,
+        recommendationsReady: true,
+        surface: 'sidebar',
+      })
+    );
+
+    expect(mockRecordPanelReady).not.toHaveBeenCalled();
   });
 });

--- a/src/components/docs-panel/hooks/usePanelReadyMeasurement.ts
+++ b/src/components/docs-panel/hooks/usePanelReadyMeasurement.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { RECOMMENDATIONS_READY_EVENT } from '../../../lib/event-names';
 import { recordPanelReady } from '../../../lib/telemetry';
 
 // Panel-scoped analog of LCP, fired once per mount. Not Faro's page-level
@@ -7,21 +6,15 @@ import { recordPanelReady } from '../../../lib/telemetry';
 export function usePanelReadyMeasurement(params: {
   hasContent: boolean;
   isRecommendationsTab: boolean;
+  recommendationsReady: boolean;
   surface: string;
 }): void {
   // Clock starts in the render pass, not the effect — effects run after
   // commit, which would measure already-ready content as ~0.
   const [renderStart] = React.useState(() => performance.now());
   const recordedRef = React.useRef(false);
-  const [recommendationsReady, setRecommendationsReady] = React.useState(false);
 
-  React.useEffect(() => {
-    const onReady = () => setRecommendationsReady(true);
-    document.addEventListener(RECOMMENDATIONS_READY_EVENT, onReady);
-    return () => document.removeEventListener(RECOMMENDATIONS_READY_EVENT, onReady);
-  }, []);
-
-  const { hasContent, isRecommendationsTab, surface } = params;
+  const { hasContent, isRecommendationsTab, recommendationsReady, surface } = params;
   React.useEffect(() => {
     if (recordedRef.current) {
       return;

--- a/src/lib/event-names.ts
+++ b/src/lib/event-names.ts
@@ -10,10 +10,6 @@ export type StorageEventName = (typeof StorageEvents)[keyof typeof StorageEvents
 // detail { mode, previous }; consumed by every Pathfinder surface.
 export const PANEL_MODE_CHANGE_EVENT = 'pathfinder-panel-mode-change';
 
-// Dispatched by ContextPanelRenderer when the recommendations list has
-// finished loading; consumed by docs-panel's panel_lcp_ms measurement.
-export const RECOMMENDATIONS_READY_EVENT = 'pathfinder-recommendations-ready';
-
 export const FloatingPanelEvents = {
   Dodge: 'pathfinder-floating-dodge',
   Compact: 'pathfinder-floating-compact',

--- a/src/types/content-panel.types.ts
+++ b/src/types/content-panel.types.ts
@@ -83,6 +83,7 @@ export interface ContextPanelState extends SceneObjectState {
   onOpenLearningJourney?: (url: string, title: string) => void;
   onOpenDocsPage?: (url: string, title: string, packageInfo?: PackageOpenInfo) => void;
   onOpenEditor?: () => void;
+  recommendationsReady?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-on to #1338. The panel-ready (`panel_lcp_ms`) measurement's readiness signal was a two-phase `RECOMMENDATIONS_READY_EVENT` CustomEvent with no replay. If the dispatch ever beat listener registration — the risky path when recommendations resolve synchronously from cache — the event was lost and `panel_ready` silently never recorded for that session, biasing the metric toward the fastest, cache-hit sessions. The `queueMicrotask` deferral only mitigated this by leaning on effect-flush timing, which is fragile given `ContextPanelRenderer` remounts on tab changes.

## Change

Drop the CustomEvent indirection in favor of replayable observable state:

- `ContextPanelRenderer` writes `recommendationsReady: true` onto the `ContextPanel` scene object's state when `recommendationsScrollReady` becomes true (idempotent).
- `CombinedPanelRendererInner` reads it via `contextPanel.useState()` and passes `recommendationsReady` into `usePanelReadyMeasurement`.
- `usePanelReadyMeasurement` accepts `recommendationsReady` as a prop; the window-listener effect and the local event state are removed.
- `RECOMMENDATIONS_READY_EVENT` is deleted from `event-names.ts` (no other consumers — grep-confirmed).

Scene state is observable on any render regardless of mount order, so it survives `ContextPanelRenderer` remounting and cannot be "missed" the way a one-shot event can. The LCP-anchoring semantics from #1338 are preserved — the measurement still completes exactly once when recommendations become ready.

Telemetry-only; no user-facing behavior changes.

## Tests

`usePanelReadyMeasurement.test.ts` updated to drive readiness via the prop, adding explicit coverage for the previously-racy path (recommendations already ready at mount / synchronous cache hit) and for readiness being ignored when the recommendations tab is not active. `npm run typecheck` and the docs-panel test suites pass.

Closes #1342

🤖 Generated with [Claude Code](https://claude.com/claude-code)
