### PR TITLE
refactor(interactive): single owner for UserActionOutcome classification

### DIFF
--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -2,7 +2,12 @@ import React, { useState, useCallback, useMemo, useEffect, useReducer, useRef } 
 import { Button } from '@grafana/ui';
 import { usePluginContext } from '@grafana/data';
 
-import { useInteractiveElements, ActionMonitor } from '../../interactive-engine';
+import {
+  useInteractiveElements,
+  ActionMonitor,
+  outcomeFromLoopExit,
+  type LoopExitReason,
+} from '../../interactive-engine';
 import { useStepChecker, stripTabLocalRequirements } from '../../requirements-manager';
 import { useIsAlignmentPaused, useAlignmentStartingLocation } from '../../global-state/alignment-pending-context';
 import { useInteractiveMode } from '../../global-state/interactive-mode-context';
@@ -770,10 +775,7 @@ export function InteractiveSection({
     };
     startSectionBlocking(sectionId, dummyData, handleSectionCancel);
 
-    let stoppedDueToRequirements = false;
-    // Distinct from stoppedDueToRequirements: the step's requirements passed but the
-    // action itself (or its post-verify) failed — a real action_error, not exhausted retries.
-    let stoppedDueToActionError = false;
+    let loopExitReason: LoopExitReason = 'ok';
     let completedStepsCount = startIndex; // Track number of completed steps for analytics (starts at startIndex since those are already done)
     // The completion store handles per-step persistence synchronously via
     // `markStepCompleted` — every write hits the store + storage immediately,
@@ -871,11 +873,7 @@ export function InteractiveSection({
                           }
                           continue; // Continue to next step
                         } else {
-                          // Priority 4: Stop execution if not skippable.
-                          // (cursor is already at `i` via the prior
-                          // COMPLETE_STEP dispatches — no explicit setter
-                          // needed.)
-                          stoppedDueToRequirements = true;
+                          loopExitReason = 'requirements_exhausted';
                           break;
                         }
                       }
@@ -893,8 +891,7 @@ export function InteractiveSection({
                         }
                         continue;
                       } else {
-                        // Stop execution (cursor already at `i`)
-                        stoppedDueToRequirements = true;
+                        loopExitReason = 'requirements_exhausted';
                         break;
                       }
                     }
@@ -910,16 +907,14 @@ export function InteractiveSection({
                       }
                       continue; // Continue to next step
                     } else {
-                      // Priority 4: Stop execution if not skippable and no fix available
-                      // (cursor already at `i`)
-                      stoppedDueToRequirements = true;
+                      loopExitReason = 'requirements_exhausted';
                       break;
                     }
                   }
                 }
               } catch (error) {
                 logger.warn(`Step ${i + 1} requirements check failed, stopping section execution`, { error });
-                stoppedDueToRequirements = true;
+                loopExitReason = 'requirements_exhausted';
                 break;
               }
             }
@@ -977,8 +972,7 @@ export function InteractiveSection({
               }
             } else {
               // Step execution failed after retries - stop and don't auto-complete remaining steps
-              // (cursor already at `i` via the prior COMPLETE_STEP dispatches)
-              stoppedDueToActionError = true;
+              loopExitReason = 'action_error';
 
               // Wait for state to settle, then trigger reactive check
               // This ensures remaining steps update their eligibility based on completed steps
@@ -994,7 +988,7 @@ export function InteractiveSection({
           }
 
           // Section sequence completed or cancelled
-          if (!isCancelledRef.current && !stoppedDueToRequirements && !stoppedDueToActionError) {
+          if (!isCancelledRef.current && loopExitReason === 'ok') {
             // Belt-and-braces bulk write so any steps that didn't go through the
             // per-step path (e.g. skipped via fix → `markSkipped` → `handleStepComplete`)
             // also end up in the store. `markStepsCompleted` is idempotent.
@@ -1017,7 +1011,7 @@ export function InteractiveSection({
           // Keep isCancelled state for UI feedback, will be reset on next run
 
           // Track "Do Section" analytics after completion (success or cancel)
-          const wasCanceled = isCancelledRef.current || stoppedDueToRequirements || stoppedDueToActionError;
+          const wasCanceled = isCancelledRef.current || loopExitReason !== 'ok';
           setFaroUserActionAttributes({ steps_completed: completedStepsCount, canceled: wasCanceled });
           const docInfo = getSourceDocument(sectionId);
 
@@ -1057,16 +1051,9 @@ export function InteractiveSection({
       {
         critical: true,
         // The work callback swallows errors and always resolves — cancellation
-        // and requirement-stops must be read from the refs/flags it sets,
-        // not inferred from settlement.
-        outcomeFrom: () =>
-          isCancelledRef.current
-            ? 'cancelled'
-            : stoppedDueToActionError
-              ? 'action_error'
-              : stoppedDueToRequirements
-                ? 'requirements_exhausted'
-                : 'ok',
+        // and the loop exit reason must be read from the refs/flags it sets,
+        // not inferred from settlement. Cancellation wins over the loop reason.
+        outcomeFrom: () => outcomeFromLoopExit(isCancelledRef.current ? 'cancelled' : loopExitReason),
       }
     );
   }, [

--- a/src/components/interactive-tutorial/interactive-step.test.tsx
+++ b/src/components/interactive-tutorial/interactive-step.test.tsx
@@ -13,13 +13,13 @@ describe('executeWithLazyScroll: step outcome propagation', () => {
 
   it('propagates the action result for non-DOM actions instead of assuming success', async () => {
     const failed = await executeWithLazyScroll('', false, undefined, async () => false, 'noop');
-    expect(failed).toEqual({ success: true, actionSucceeded: false, elementFound: true });
+    expect(failed).toEqual({ outcome: 'error', elementFound: true });
 
     const passed = await executeWithLazyScroll('', false, undefined, async () => true, 'noop');
-    expect(passed).toEqual({ success: true, actionSucceeded: true, elementFound: true });
+    expect(passed).toEqual({ outcome: 'ok', elementFound: true });
   });
 
-  it('reports actionSucceeded: false when the element is found but the step itself fails', async () => {
+  it('reports outcome: error when the element is found but the step itself fails', async () => {
     const target = document.createElement('div');
     target.id = 'step-target';
     document.body.appendChild(target);
@@ -29,17 +29,15 @@ describe('executeWithLazyScroll: step outcome propagation', () => {
     const result = await executeWithLazyScroll('#step-target', false, undefined, async () => false, 'highlight');
 
     expect(result.elementFound).toBe(true);
-    expect(result.success).toBe(true);
-    expect(result.actionSucceeded).toBe(false);
+    expect(result.outcome).toBe('error');
   });
 
-  it('reports element-not-found failures with actionSucceeded: false and an error', async () => {
+  it('reports element-not-found failures with outcome: error and an error message', async () => {
     const action = jest.fn(async () => true);
     const result = await executeWithLazyScroll('#missing', false, undefined, action, 'highlight');
 
     expect(result).toEqual({
-      success: false,
-      actionSucceeded: false,
+      outcome: 'error',
       elementFound: false,
       error: 'Element not found: #missing',
     });

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../requirements-manager';
 import { reportAppInteraction, UserInteraction, buildInteractiveStepProperties } from '../../lib/analytics';
 import { logger } from '../../lib/logging';
-import { recordStepExecution } from '../../lib/telemetry';
+import { recordStepExecution, type StepOutcome } from '../../lib/telemetry';
 import type { InteractiveStepProps } from '../../types/component-props.types';
 import {
   type DetectedActionEvent,
@@ -36,10 +36,8 @@ import { useControllerChannel } from '../../global-state/controller-channel';
  * Result type for lazy scroll execution wrapper
  */
 interface LazyScrollResult {
-  /** Element discovery + dispatch ran (drives the UI error state). */
-  success: boolean;
-  /** The action's own result — a found element can still fail execution or verification. */
-  actionSucceeded: boolean;
+  /** `ok` only when the element was found and the action itself succeeded. */
+  outcome: StepOutcome;
   error?: string;
   elementFound: boolean;
 }
@@ -64,7 +62,7 @@ export async function executeWithLazyScroll(
 ): Promise<LazyScrollResult> {
   // Navigate, noop, and popout actions don't target DOM elements - execute immediately without element checking
   if (targetAction === 'navigate' || targetAction === 'noop' || targetAction === 'popout') {
-    return { success: true, actionSucceeded: await action(), elementFound: true };
+    return { outcome: (await action()) ? 'ok' : 'error', elementFound: true };
   }
 
   // DOM-targeting actions: quick synchronous check if element exists (provides user feedback if missing)
@@ -75,7 +73,7 @@ export async function executeWithLazyScroll(
 
   if (elementExists) {
     // Element found - execute action immediately
-    return { success: true, actionSucceeded: await action(), elementFound: true };
+    return { outcome: (await action()) ? 'ok' : 'error', elementFound: true };
   }
 
   // Element not found - try lazy scroll discovery only if enabled
@@ -87,13 +85,12 @@ export async function executeWithLazyScroll(
 
     if (foundElement) {
       // Element discovered after scroll - execute action
-      return { success: true, actionSucceeded: await action(), elementFound: true };
+      return { outcome: (await action()) ? 'ok' : 'error', elementFound: true };
     }
 
     // Scroll completed but element still not found
     return {
-      success: false,
-      actionSucceeded: false,
+      outcome: 'error',
       elementFound: false,
       error: 'Element not found after scrolling dashboard',
     };
@@ -101,8 +98,7 @@ export async function executeWithLazyScroll(
 
   // lazyRender not enabled and element not found - return clear error
   return {
-    success: false,
-    actionSucceeded: false,
+    outcome: 'error',
     elementFound: false,
     error: `Element not found: ${refTarget}`,
   };
@@ -731,7 +727,7 @@ export const InteractiveStep = forwardRef<
           targetAction
         );
 
-        if (!result.success) {
+        if (!result.elementFound) {
           // Lazy scroll failed to find element
           setLazyScrollError(result.error || 'Element not found');
           return;
@@ -845,8 +841,8 @@ export const InteractiveStep = forwardRef<
         // Use lazy scroll wrapper to ensure element is found before executing
         const result = await executeWithLazyScroll(refTarget, lazyRender, scrollContainer, executeStep, targetAction);
 
-        stepOutcome = result.success && result.actionSucceeded ? 'ok' : 'error';
-        if (!result.success) {
+        stepOutcome = result.outcome;
+        if (!result.elementFound) {
           // Lazy scroll failed to find element
           setLazyScrollError(result.error || 'Element not found');
         }

--- a/src/interactive-engine/action-handlers/guided-handler.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.ts
@@ -10,7 +10,7 @@ import {
 } from '../../lib/dom';
 import { logger } from '../../lib/logging';
 import { withFaroUserAction } from '../../lib/faro';
-import type { UserActionOutcome } from '../../lib/telemetry';
+import { type CompletionResult, outcomeFromCompletionResult } from '../outcome-classifier';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 import { GuidedAction } from '../../types/interactive-actions.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
@@ -18,17 +18,7 @@ import { sanitizeDocumentationHTML } from '../../security/html-sanitizer';
 import { matchFormValue } from '../auto-completion/action-matcher';
 import { applyE2ECommentBoxAttributes } from '../e2e-attributes';
 
-export type CompletionResult = 'completed' | 'timeout' | 'cancelled' | 'skipped' | 'error';
-
-// Every branch of runGuidedStep resolves, so the resolved value — not
-// promise settlement — maps to the stamped outcome.
-const GUIDED_STEP_OUTCOMES: Record<CompletionResult, UserActionOutcome> = {
-  completed: 'ok',
-  timeout: 'timeout',
-  cancelled: 'cancelled',
-  skipped: 'skipped',
-  error: 'action_error',
-};
+export type { CompletionResult };
 
 /**
  * Handler for guided interactions where users manually perform actions
@@ -108,7 +98,7 @@ export class GuidedHandler {
       () => this.runGuidedStep(action, stepIndex, totalSteps, timeout),
       // Internal waits are bounded by `timeout`; the margin only catches a hung step.
       timeout + 10_000,
-      { critical: true, outcomeFrom: (result) => GUIDED_STEP_OUTCOMES[result] }
+      { critical: true, outcomeFrom: outcomeFromCompletionResult }
     );
   }
 

--- a/src/interactive-engine/index.ts
+++ b/src/interactive-engine/index.ts
@@ -25,6 +25,10 @@ export { default as GlobalInteractionBlocker } from './global-interaction-blocke
 // Sequential step state hook
 export { useSequentialStepState } from './use-sequential-step-state.hook';
 
+// UserActionOutcome classification
+export { outcomeFromCompletionResult, outcomeFromSequenceRun, outcomeFromLoopExit } from './outcome-classifier';
+export type { CompletionResult, LoopExitReason } from './outcome-classifier';
+
 // Action handlers (re-export only handlers used externally)
 export {
   GuidedHandler,

--- a/src/interactive-engine/interactive.hook.ts
+++ b/src/interactive-engine/interactive.hook.ts
@@ -5,6 +5,7 @@ import { waitForReactUpdates } from '../lib/async-utils';
 import { logger } from '../lib/logging';
 import { USER_ACTION_TIMEOUT_LONG_MS, withFaroUserAction } from '../lib/faro';
 import type { SequenceRunResult, StepOutcome } from '../lib/telemetry';
+import { outcomeFromSequenceRun } from './outcome-classifier';
 // eslint-disable-next-line no-restricted-imports -- [ratchet] ALLOWED_LATERAL_VIOLATIONS: interactive-engine -> requirements-manager
 import { checkRequirements, checkPostconditions, RequirementsCheckOptions } from '../requirements-manager';
 import { extractInteractiveDataFromElement } from '../lib/dom';
@@ -472,7 +473,7 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
         targetAction === 'sequence' ? USER_ACTION_TIMEOUT_LONG_MS : undefined,
         {
           critical: !isShowMode,
-          outcomeFrom: () => (sequenceResult === undefined || sequenceResult === 'completed' ? 'ok' : sequenceResult),
+          outcomeFrom: () => outcomeFromSequenceRun(sequenceResult),
         }
       );
       // Sequence runs resolve rather than throw on requirements-exhausted/

--- a/src/interactive-engine/outcome-classifier.test.ts
+++ b/src/interactive-engine/outcome-classifier.test.ts
@@ -1,0 +1,50 @@
+import type { SequenceRunResult, UserActionOutcome } from '../lib/telemetry';
+import {
+  type CompletionResult,
+  type LoopExitReason,
+  outcomeFromCompletionResult,
+  outcomeFromLoopExit,
+  outcomeFromSequenceRun,
+} from './outcome-classifier';
+
+describe('outcome-classifier', () => {
+  describe('outcomeFromCompletionResult', () => {
+    const cases: Array<[CompletionResult, UserActionOutcome]> = [
+      ['completed', 'ok'],
+      ['timeout', 'timeout'],
+      ['cancelled', 'cancelled'],
+      ['skipped', 'skipped'],
+      ['error', 'action_error'],
+    ];
+
+    it.each(cases)('maps %s -> %s', (result, expected) => {
+      expect(outcomeFromCompletionResult(result)).toBe(expected);
+    });
+  });
+
+  describe('outcomeFromSequenceRun', () => {
+    const cases: Array<[SequenceRunResult | undefined, UserActionOutcome]> = [
+      [undefined, 'ok'],
+      ['completed', 'ok'],
+      ['requirements_exhausted', 'requirements_exhausted'],
+      ['action_error', 'action_error'],
+    ];
+
+    it.each(cases)('maps %s -> %s', (result, expected) => {
+      expect(outcomeFromSequenceRun(result)).toBe(expected);
+    });
+  });
+
+  describe('outcomeFromLoopExit', () => {
+    const cases: Array<[LoopExitReason, UserActionOutcome]> = [
+      ['ok', 'ok'],
+      ['cancelled', 'cancelled'],
+      ['requirements_exhausted', 'requirements_exhausted'],
+      ['action_error', 'action_error'],
+    ];
+
+    it.each(cases)('maps %s -> %s', (reason, expected) => {
+      expect(outcomeFromLoopExit(reason)).toBe(expected);
+    });
+  });
+});

--- a/src/interactive-engine/outcome-classifier.ts
+++ b/src/interactive-engine/outcome-classifier.ts
@@ -1,0 +1,35 @@
+import type { SequenceRunResult, UserActionOutcome } from '../lib/telemetry';
+
+export type CompletionResult = 'completed' | 'timeout' | 'cancelled' | 'skipped' | 'error';
+
+export type LoopExitReason = 'ok' | 'cancelled' | 'requirements_exhausted' | 'action_error';
+
+const COMPLETION_RESULT_OUTCOMES: Record<CompletionResult, UserActionOutcome> = {
+  completed: 'ok',
+  timeout: 'timeout',
+  cancelled: 'cancelled',
+  skipped: 'skipped',
+  error: 'action_error',
+};
+
+const LOOP_EXIT_OUTCOMES: Record<LoopExitReason, UserActionOutcome> = {
+  ok: 'ok',
+  cancelled: 'cancelled',
+  requirements_exhausted: 'requirements_exhausted',
+  action_error: 'action_error',
+};
+
+export function outcomeFromCompletionResult(result: CompletionResult): UserActionOutcome {
+  return COMPLETION_RESULT_OUTCOMES[result];
+}
+
+export function outcomeFromSequenceRun(result: SequenceRunResult | undefined): UserActionOutcome {
+  if (result === undefined || result === 'completed') {
+    return 'ok';
+  }
+  return result;
+}
+
+export function outcomeFromLoopExit(reason: LoopExitReason): UserActionOutcome {
+  return LOOP_EXIT_OUTCOMES[reason];
+}

--- a/src/test-utils/interactive-section-harness.tsx
+++ b/src/test-utils/interactive-section-harness.tsx
@@ -273,6 +273,7 @@ export function createInteractiveEngineMock() {
       fixLocationRequirement: jest.fn().mockResolvedValue(undefined),
       expandParentNavigationSection: jest.fn().mockResolvedValue(undefined),
     })),
+    ...require('../interactive-engine/outcome-classifier'),
   };
 }
 


### PR DESCRIPTION
## Summary

Follow-on to #1338. The result→`UserActionOutcome` classification was duplicated across three independent sites with no shared owner, so adding a new outcome variant (or changing precedence) required updating all three in lockstep — a miss at any one silently misclassified funnel metrics with no compile error and no spanning test.

This extracts a single classifier and points all three sites at it.

## Changes

- **New `src/interactive-engine/outcome-classifier.ts`** — the single owner of the mapping into `UserActionOutcome`, exposing three total, exhaustive lookups:
  - `outcomeFromCompletionResult(CompletionResult)`
  - `outcomeFromSequenceRun(SequenceRunResult | undefined)`
  - `outcomeFromLoopExit(LoopExitReason)`
  - Placed in tier 2 (`interactive-engine/`), importing `UserActionOutcome` from tier 1 (`lib/telemetry`) — a legal downward edge (architecture test passes). `CompletionResult` now lives here; `guided-handler` re-exports it for compatibility.
- **`guided-handler.ts`** — replaced the local `GUIDED_STEP_OUTCOMES` map with `outcomeFromCompletionResult`.
- **`interactive.hook.ts`** — replaced the inline `SequenceRunResult` ternary with `outcomeFromSequenceRun`.
- **`interactive-section.tsx`** — replaced the two mutually-exclusive booleans (`stoppedDueToRequirements` / `stoppedDueToActionError`) with a single `LoopExitReason` enum, making the impossible both-true state unrepresentable and collapsing the nested outcome ternary into `outcomeFromLoopExit` (cancellation still wins over the loop reason, read from the ref).
- **`interactive-step.tsx`** — collapsed `LazyScrollResult`'s `success` + `actionSucceeded` boolean pair into a single `outcome: StepOutcome` field (`actionSucceeded` was fully determined — `false` whenever `success` was false), removing the caller-side `result.success && result.actionSucceeded` recombination. The element-not-found branch now keys off `elementFound`.

## Tests

- New `outcome-classifier.test.ts` spans the full mapping for all three classifiers (the whole point — a miss at any site is now a single-file test failure).
- Updated `interactive-step.test.tsx` and the section harness mock for the new shapes.
- `npm run check` passes (typecheck, lint, prettier, go, full coverage).

Closes #1343

🤖 Generated with [Claude Code](https://claude.com/claude-code)
