### PR TITLE
test(architecture): file-level circular-dependency ratchet

### DIFF
--- a/src/global-state/link-interception.ts
+++ b/src/global-state/link-interception.ts
@@ -1,12 +1,7 @@
 import { getDocsLinkFromEvent } from 'global-state/utils.link-interception';
 import { sidebarState } from 'global-state/sidebar';
 import { reportAppInteraction, UserInteraction } from 'lib/analytics';
-
-export interface QueuedDocsLink {
-  url: string;
-  title: string;
-  timestamp: number;
-}
+import type { QueuedDocsLink } from 'types/link-interception.types';
 
 /**
  * Global state manager for the Pathfinder plugin's link interception.

--- a/src/global-state/utils.link-interception.ts
+++ b/src/global-state/utils.link-interception.ts
@@ -1,4 +1,4 @@
-import { QueuedDocsLink } from 'global-state/link-interception';
+import type { QueuedDocsLink } from 'types/link-interception.types';
 import { isAllowedContentUrl, isLocalhostUrl, isGitHubRawUrl } from 'security/url-validator';
 import { isDevModeEnabledGlobal } from '../utils/dev-mode';
 

--- a/src/lib/storage/bounded-record-storage.test.ts
+++ b/src/lib/storage/bounded-record-storage.test.ts
@@ -1,12 +1,18 @@
 import { getAppEvents } from '@grafana/runtime';
 
-import { __resetQuotaWarningForTests } from '../user-storage';
-import { createBoundedRecordStorage } from './bounded-record-storage';
+import { createUserStorage, warnQuotaExceededOnce, __resetQuotaWarningForTests } from '../user-storage';
+import { createBoundedRecordStorage, type BoundedRecordStorageConfig } from './bounded-record-storage';
 
 jest.mock('@grafana/runtime', () => ({
   usePluginUserStorage: jest.fn(),
   getAppEvents: jest.fn(),
 }));
+
+// The building block takes its storage backend and quota notifier by injection
+// (that's how the user-storage import cycle is broken). Wire in the real
+// implementations so these tests exercise the same behavior as production.
+const makeStore = (config: Omit<BoundedRecordStorageConfig, 'createStorage' | 'onQuotaExceeded'>) =>
+  createBoundedRecordStorage({ ...config, createStorage: createUserStorage, onQuotaExceeded: warnQuotaExceededOnce });
 
 describe('createBoundedRecordStorage', () => {
   const TEST_KEY = 'pathfinder.bounded-record-test';
@@ -18,18 +24,18 @@ describe('createBoundedRecordStorage', () => {
   });
 
   it('returns 0 when the underlying record is empty', async () => {
-    const store = createBoundedRecordStorage({ storageKey: TEST_KEY, limit: 100, label: 'test' });
+    const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
     expect(await store.get('missing')).toBe(0);
   });
 
   it('round-trips a percentage value', async () => {
-    const store = createBoundedRecordStorage({ storageKey: TEST_KEY, limit: 100, label: 'test' });
+    const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
     await store.set('a', 42);
     expect(await store.get('a')).toBe(42);
   });
 
   it('clamps values to [0, 100]', async () => {
-    const store = createBoundedRecordStorage({ storageKey: TEST_KEY, limit: 100, label: 'test' });
+    const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
     await store.set('low', -10);
     await store.set('high', 999);
     expect(await store.get('low')).toBe(0);
@@ -37,7 +43,7 @@ describe('createBoundedRecordStorage', () => {
   });
 
   it('clear() removes a single entry without touching others', async () => {
-    const store = createBoundedRecordStorage({ storageKey: TEST_KEY, limit: 100, label: 'test' });
+    const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
     await store.set('a', 25);
     await store.set('b', 75);
     await store.clear('a');
@@ -46,14 +52,14 @@ describe('createBoundedRecordStorage', () => {
   });
 
   it('getAll() returns the full record', async () => {
-    const store = createBoundedRecordStorage({ storageKey: TEST_KEY, limit: 100, label: 'test' });
+    const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
     await store.set('a', 10);
     await store.set('b', 20);
     expect(await store.getAll()).toEqual({ a: 10, b: 20 });
   });
 
   it('cleanup() trims to the most-recent `limit` entries', async () => {
-    const store = createBoundedRecordStorage({ storageKey: TEST_KEY, limit: 3, label: 'test' });
+    const store = makeStore({ storageKey: TEST_KEY, limit: 3, label: 'test' });
     await store.set('a', 1);
     await store.set('b', 2);
     await store.set('c', 3);
@@ -69,7 +75,7 @@ describe('createBoundedRecordStorage', () => {
   });
 
   it('clearAll() removes the underlying storage key entirely', async () => {
-    const store = createBoundedRecordStorage({ storageKey: TEST_KEY, limit: 100, label: 'test' });
+    const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
     await store.set('a', 10);
     await store.clearAll();
     expect(localStorage.getItem(TEST_KEY)).toBeNull();
@@ -77,7 +83,7 @@ describe('createBoundedRecordStorage', () => {
   });
 
   it('retries set() once after cleanup when the first write hits QuotaExceededError', async () => {
-    const store = createBoundedRecordStorage({ storageKey: TEST_KEY, limit: 100, label: 'test' });
+    const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
 
     // Seed an existing entry so the test exercises the merge-then-write path.
     await store.set('seed', 50);
@@ -108,7 +114,7 @@ describe('createBoundedRecordStorage', () => {
   });
 
   it('does not loop forever when QuotaExceededError persists after cleanup', async () => {
-    const store = createBoundedRecordStorage({ storageKey: TEST_KEY, limit: 100, label: 'test' });
+    const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
 
     const setItemSpy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       const err = new Error('Quota exceeded');
@@ -129,8 +135,8 @@ describe('createBoundedRecordStorage', () => {
   });
 
   it('isolates state between two instances with different storage keys', async () => {
-    const journeys = createBoundedRecordStorage({ storageKey: 'pathfinder.journeys-test', limit: 100, label: 'j' });
-    const interactives = createBoundedRecordStorage({
+    const journeys = makeStore({ storageKey: 'pathfinder.journeys-test', limit: 100, label: 'j' });
+    const interactives = makeStore({
       storageKey: 'pathfinder.interactives-test',
       limit: 100,
       label: 'i',

--- a/src/lib/storage/bounded-record-storage.ts
+++ b/src/lib/storage/bounded-record-storage.ts
@@ -1,5 +1,5 @@
 import { logger } from '../logging';
-import { createUserStorage, warnQuotaExceededOnce } from '../user-storage';
+import type { UserStorage } from '../../types/storage.types';
 
 export interface BoundedRecordStorage {
   get(key: string): Promise<number>;
@@ -17,13 +17,23 @@ export interface BoundedRecordStorageConfig {
   limit: number;
   /** Short label used in diagnostic console messages, e.g. `'journey completion'`. */
   label: string;
+  /**
+   * Storage backend factory, injected rather than imported. This building
+   * block is a lower layer than the user-storage module that supplies the
+   * backend; importing it directly would form an import cycle
+   * (user-storage → bounded-record-storage → user-storage), so callers pass
+   * the factory in.
+   */
+  createStorage: () => UserStorage;
+  /** Quota-exceeded notifier, injected for the same reason as `createStorage`. */
+  onQuotaExceeded: () => void;
 }
 
 export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): BoundedRecordStorage {
-  const { storageKey, limit, label } = config;
+  const { storageKey, limit, label, createStorage, onQuotaExceeded } = config;
 
   const writeWithCap = async (data: Record<string, number>): Promise<void> => {
-    const storage = createUserStorage();
+    const storage = createStorage();
     const entries = Object.entries(data);
     const payload = entries.length > limit ? Object.fromEntries(entries.slice(-limit)) : data;
     await storage.setItem(storageKey, payload);
@@ -31,7 +41,7 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
 
   const setInternal = async (key: string, percentage: number, hasRetried: boolean): Promise<void> => {
     try {
-      const storage = createUserStorage();
+      const storage = createStorage();
       const data = (await storage.getItem<Record<string, number>>(storageKey)) || {};
       data[key] = Math.max(0, Math.min(100, percentage));
       await writeWithCap(data);
@@ -44,7 +54,7 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
           return;
         }
         logger.warn(`Storage quota exceeded, clearing old ${label} data`);
-        warnQuotaExceededOnce();
+        onQuotaExceeded();
         await api.cleanup();
         await setInternal(key, percentage, true);
       } else {
@@ -56,7 +66,7 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
   const api: BoundedRecordStorage = {
     async get(key: string): Promise<number> {
       try {
-        const storage = createUserStorage();
+        const storage = createStorage();
         const data = await storage.getItem<Record<string, number>>(storageKey);
         return data?.[key] || 0;
       } catch {
@@ -70,7 +80,7 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
 
     async clear(key: string): Promise<void> {
       try {
-        const storage = createUserStorage();
+        const storage = createStorage();
         const data = (await storage.getItem<Record<string, number>>(storageKey)) || {};
         delete data[key];
         await storage.setItem(storageKey, data);
@@ -81,7 +91,7 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
 
     async getAll(): Promise<Record<string, number>> {
       try {
-        const storage = createUserStorage();
+        const storage = createStorage();
         return (await storage.getItem<Record<string, number>>(storageKey)) || {};
       } catch {
         return {};
@@ -90,7 +100,7 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
 
     async cleanup(): Promise<void> {
       try {
-        const storage = createUserStorage();
+        const storage = createStorage();
         const data = (await storage.getItem<Record<string, number>>(storageKey)) || {};
         if (Object.keys(data).length > limit) {
           await writeWithCap(data);
@@ -102,7 +112,7 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
 
     async clearAll(): Promise<void> {
       try {
-        const storage = createUserStorage();
+        const storage = createStorage();
         await storage.removeItem(storageKey);
       } catch (error) {
         logger.warn(`Failed to clear all ${label} entries`, { error });

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -753,6 +753,8 @@ export const journeyCompletionStorage = createBoundedRecordStorage({
   storageKey: StorageKeys.JOURNEY_COMPLETION,
   limit: LIMITS.MAX_JOURNEY_COMPLETIONS,
   label: 'journey completion',
+  createStorage: createUserStorage,
+  onQuotaExceeded: warnQuotaExceededOnce,
 });
 
 /**
@@ -813,6 +815,8 @@ export const interactiveCompletionStorage = createBoundedRecordStorage({
   storageKey: StorageKeys.INTERACTIVE_COMPLETION,
   limit: LIMITS.MAX_INTERACTIVE_COMPLETIONS,
   label: 'interactive completion',
+  createStorage: createUserStorage,
+  onQuotaExceeded: warnQuotaExceededOnce,
 });
 
 /**

--- a/src/types/link-interception.types.ts
+++ b/src/types/link-interception.types.ts
@@ -1,0 +1,11 @@
+/**
+ * A docs link captured from an intercepted navigation event, queued for the
+ * sidebar to open. Lives in Tier 0 so the link-interception state manager and
+ * its event-parsing helpers can share the shape without importing each other
+ * (which would form an import cycle).
+ */
+export interface QueuedDocsLink {
+  url: string;
+  title: string;
+  timestamp: number;
+}

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -24,6 +24,7 @@ import {
   TIER_MAP,
   assertRatchet,
   findCycles,
+  validateAllowedCycleEntries,
   getAllFileImports,
   getRootLevelSourceFiles,
   getSourceTier,
@@ -32,6 +33,7 @@ import {
   readJsoncFile,
   resolveImportToRelative,
   toPosixPath,
+  type AllowedCycleEntry,
 } from './import-graph';
 
 interface ResolvedImportContext {
@@ -140,28 +142,57 @@ const ALLOWED_BARREL_VIOLATIONS = new Set<string>([]);
 
 /**
  * Known circular-dependency clusters (strongly-connected components of the
- * file-level import graph). Each entry is the SCC's member files, sorted and
- * joined by ' <-> '. This list should only shrink — breaking any edge in a
- * cluster splits or dissolves the SCC and changes/removes its key, which the
+ * file-level import graph). This list should only shrink — breaking any edge in
+ * a cluster splits or dissolves the SCC and changes/removes its key, which the
  * ratchet's stale-entry check surfaces.
  *
+ * Each entry must carry a real `reason` and a `tracking` issue: a sibling test
+ * ('every ALLOWED_CYCLES entry is justified and tracked') enforces both so a new
+ * cycle can't be silenced with an empty rubber-stamp. `cycle` is the SCC's
+ * member files, sorted and joined by ' <-> ' (must match findCycles() output).
+ *
  * Populated with the baseline that existed when cycle detection was added, so
- * CI stays green while we decide how to pay these down.
+ * CI stays green while these are paid down opportunistically. See #1359.
  */
-const ALLOWED_CYCLES = new Set<string>([
-  // Tier 1 telemetry + OpenFeature tangle spanning lib/security/utils. Largest
-  // cluster; the telemetry bridge, url-validator, and openfeature tracking
-  // mutually reach each other.
-  'lib/analytics.ts <-> lib/logging.ts <-> lib/telemetry/bridge.ts <-> lib/telemetry/faro-adapter.ts <-> lib/telemetry/session.ts <-> security/url-validator.ts <-> utils/dev-mode.ts <-> utils/openfeature-tracking.ts <-> utils/openfeature.ts',
-  // requirements-manager check modules + shared utils reach each other.
-  'requirements-manager/checks/coda.ts <-> requirements-manager/checks/env.ts <-> requirements-manager/checks/grafana-api.ts <-> requirements-manager/checks/location.ts <-> requirements-manager/checks/terminal.ts <-> requirements-manager/checks/vars.ts <-> requirements-manager/requirements-checker.utils.ts',
-  // interactive-engine <-> requirements-manager (overlaps ALLOWED_LATERAL_VIOLATIONS cluster A).
-  'interactive-engine/index.ts <-> interactive-engine/interactive.hook.ts <-> interactive-engine/use-sequential-step-state.hook.ts <-> requirements-manager/index.ts <-> requirements-manager/step-checker.hook.ts',
-  // components/interactive-tutorial section rendering + requirements hook.
-  'components/interactive-tutorial/hooks/use-section-requirements.ts <-> components/interactive-tutorial/interactive-conditional.tsx <-> components/interactive-tutorial/interactive-section.tsx <-> components/interactive-tutorial/section-numbering.tsx',
-  // docs-panel content area <-> milestone toolbar via the components barrel.
-  'components/docs-panel/components/DocsPanelContentArea.tsx <-> components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx <-> components/docs-panel/components/index.ts <-> components/docs-panel/docs-panel.tsx',
-]);
+const ALLOWED_CYCLES: readonly AllowedCycleEntry[] = [
+  {
+    cycle:
+      'lib/analytics.ts <-> lib/logging.ts <-> lib/telemetry/bridge.ts <-> lib/telemetry/faro-adapter.ts <-> lib/telemetry/session.ts <-> security/url-validator.ts <-> utils/dev-mode.ts <-> utils/openfeature-tracking.ts <-> utils/openfeature.ts',
+    reason:
+      'Tier 1 telemetry + OpenFeature tangle spanning lib/security/utils; largest cluster, needs a dedicated extraction pass rather than a one-edge fix.',
+    tracking: '#1359',
+  },
+  {
+    cycle:
+      'requirements-manager/checks/coda.ts <-> requirements-manager/checks/env.ts <-> requirements-manager/checks/grafana-api.ts <-> requirements-manager/checks/location.ts <-> requirements-manager/checks/terminal.ts <-> requirements-manager/checks/vars.ts <-> requirements-manager/requirements-checker.utils.ts',
+    reason:
+      'requirements-manager check modules and their shared utils mutually reach each other; needs a shared-seam extraction.',
+    tracking: '#1359',
+  },
+  {
+    cycle:
+      'interactive-engine/index.ts <-> interactive-engine/interactive.hook.ts <-> interactive-engine/use-sequential-step-state.hook.ts <-> requirements-manager/index.ts <-> requirements-manager/step-checker.hook.ts',
+    reason:
+      'Cross-engine interactive-engine <-> requirements-manager coupling; already tracked in ALLOWED_LATERAL_VIOLATIONS cluster A, structural.',
+    tracking: '#1359',
+  },
+  {
+    cycle:
+      'components/interactive-tutorial/hooks/use-section-requirements.ts <-> components/interactive-tutorial/interactive-conditional.tsx <-> components/interactive-tutorial/interactive-section.tsx <-> components/interactive-tutorial/section-numbering.tsx',
+    reason:
+      'interactive-tutorial section rendering and its requirements hook cross-reference; contained within one component subtree.',
+    tracking: '#1359',
+  },
+  {
+    cycle:
+      'components/docs-panel/components/DocsPanelContentArea.tsx <-> components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx <-> components/docs-panel/components/index.ts <-> components/docs-panel/docs-panel.tsx',
+    reason:
+      'Barrel-routed docs-panel cluster; back-edges are the shared CombinedLearningJourneyPanel type, likely a shared-type extraction.',
+    tracking: '#1359',
+  },
+];
+
+const ALLOWED_CYCLE_KEYS = new Set(ALLOWED_CYCLES.map((entry) => entry.cycle));
 
 // Violation key formatters — kept adjacent to allowlists so format changes
 // are visible in the same diff as allowlist updates.
@@ -339,15 +370,36 @@ describe('Import graph: circular dependencies', () => {
 
     assertRatchet(
       violations,
-      ALLOWED_CYCLES,
+      ALLOWED_CYCLE_KEYS,
       'circular dependencies',
       'ALLOWED_CYCLES',
       `A circular dependency (strongly-connected cluster of files that mutually import each other) ` +
-        `was detected. Break at least one edge in the cluster — commonly by extracting the shared ` +
-        `symbol to a lower tier (src/types/, src/lib/), inverting a dependency, or using a dynamic ` +
-        `import at the call site. If the cycle is genuinely unavoidable, add its key to ALLOWED_CYCLES ` +
-        `with a comment explaining why. Each key is the cluster's member files joined by ' <-> '.`
+        `was detected. Prefer breaking an edge over allowlisting — two worked examples live in this repo:\n` +
+        `  • Extract the shared type to a Tier-0 leaf when the closing edge is a type/interface — see\n` +
+        `    src/types/link-interception.types.ts (imported by global-state/link-interception.ts and\n` +
+        `    global-state/utils.link-interception.ts instead of them importing each other).\n` +
+        `  • Inject the dependency when a lower-level module reaches up to a higher one — see\n` +
+        `    createBoundedRecordStorage in src/lib/storage/bounded-record-storage.ts (its callers in\n` +
+        `    src/lib/user-storage.ts pass the storage backend in rather than it importing user-storage).\n` +
+        `  Other options: invert the dependency, or use a dynamic import at the call site.\n\n` +
+        `Only if the cycle is genuinely unavoidable, add an entry to ALLOWED_CYCLES. A sibling test ` +
+        `requires a substantive 'reason' and a 'tracking' issue on every entry, so an empty rubber-stamp ` +
+        `will not pass. 'cycle' is the cluster's member files joined by ' <-> '.`
     );
+  });
+
+  it('every ALLOWED_CYCLES entry is justified and tracked', () => {
+    const errors = validateAllowedCycleEntries(ALLOWED_CYCLES);
+
+    if (errors.length > 0) {
+      throw new Error(
+        `ALLOWED_CYCLES entries must each carry a justification and a paydown tracking issue:\n` +
+          errors.map((e) => `  - ${e}`).join('\n') +
+          `\n\nThis exists so a new cycle can't be silenced by pasting its key in with an empty comment. ` +
+          `Fill in a real 'reason' and 'tracking' issue, or — better — break the cycle instead (see the ` +
+          `worked examples referenced by the sibling ratchet test).`
+      );
+    }
   });
 });
 
@@ -357,7 +409,7 @@ describe('Architecture ratchet progress', () => {
       `[architecture-ratchet] vertical=${ALLOWED_VERTICAL_VIOLATIONS.size}` +
         ` lateral=${ALLOWED_LATERAL_VIOLATIONS.size}` +
         ` barrel=${ALLOWED_BARREL_VIOLATIONS.size}` +
-        ` cycles=${ALLOWED_CYCLES.size}`
+        ` cycles=${ALLOWED_CYCLES.length}`
     );
   });
 });

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -23,6 +23,7 @@ import {
   TIER_2_ENGINES,
   TIER_MAP,
   assertRatchet,
+  findCycles,
   getAllFileImports,
   getRootLevelSourceFiles,
   getSourceTier,
@@ -137,11 +138,42 @@ const ALLOWED_LATERAL_VIOLATIONS = new Set([
  */
 const ALLOWED_BARREL_VIOLATIONS = new Set<string>([]);
 
+/**
+ * Known circular-dependency clusters (strongly-connected components of the
+ * file-level import graph). Each entry is the SCC's member files, sorted and
+ * joined by ' <-> '. This list should only shrink — breaking any edge in a
+ * cluster splits or dissolves the SCC and changes/removes its key, which the
+ * ratchet's stale-entry check surfaces.
+ *
+ * Populated with the baseline that existed when cycle detection was added, so
+ * CI stays green while we decide how to pay these down.
+ */
+const ALLOWED_CYCLES = new Set<string>([
+  // Tier 1 telemetry + OpenFeature tangle spanning lib/security/utils. Largest
+  // cluster; the telemetry bridge, url-validator, and openfeature tracking
+  // mutually reach each other.
+  'lib/analytics.ts <-> lib/logging.ts <-> lib/telemetry/bridge.ts <-> lib/telemetry/faro-adapter.ts <-> lib/telemetry/session.ts <-> security/url-validator.ts <-> utils/dev-mode.ts <-> utils/openfeature-tracking.ts <-> utils/openfeature.ts',
+  // requirements-manager check modules + shared utils reach each other.
+  'requirements-manager/checks/coda.ts <-> requirements-manager/checks/env.ts <-> requirements-manager/checks/grafana-api.ts <-> requirements-manager/checks/location.ts <-> requirements-manager/checks/terminal.ts <-> requirements-manager/checks/vars.ts <-> requirements-manager/requirements-checker.utils.ts',
+  // interactive-engine <-> requirements-manager (overlaps ALLOWED_LATERAL_VIOLATIONS cluster A).
+  'interactive-engine/index.ts <-> interactive-engine/interactive.hook.ts <-> interactive-engine/use-sequential-step-state.hook.ts <-> requirements-manager/index.ts <-> requirements-manager/step-checker.hook.ts',
+  // components/interactive-tutorial section rendering + requirements hook.
+  'components/interactive-tutorial/hooks/use-section-requirements.ts <-> components/interactive-tutorial/interactive-conditional.tsx <-> components/interactive-tutorial/interactive-section.tsx <-> components/interactive-tutorial/section-numbering.tsx',
+  // docs-panel content area <-> milestone toolbar via the components barrel.
+  'components/docs-panel/components/DocsPanelContentArea.tsx <-> components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx <-> components/docs-panel/components/index.ts <-> components/docs-panel/docs-panel.tsx',
+  // global-state link-interception split across two mutually-importing files.
+  'global-state/link-interception.ts <-> global-state/utils.link-interception.ts',
+  // lib storage: bounded-record-storage <-> user-storage.
+  'lib/storage/bounded-record-storage.ts <-> lib/user-storage.ts',
+]);
+
 // Violation key formatters — kept adjacent to allowlists so format changes
 // are visible in the same diff as allowlist updates.
 const directionKey = (relPath: string, targetTopLevel: string) => `${toPosixPath(relPath)} -> ${targetTopLevel}`;
 
 const barrelKey = (relPath: string, resolved: string) => `${toPosixPath(relPath)} -> ${toPosixPath(resolved)}`;
+
+const cycleKey = (scc: string[]) => scc.join(' <-> ');
 
 // ---------------------------------------------------------------------------
 // Tests (mechanism — edit these only when adding new constraint categories)
@@ -293,12 +325,43 @@ describe('Barrel export discipline', () => {
   });
 });
 
+describe('Import graph: circular dependencies', () => {
+  it('reports the current circular-dependency footprint', () => {
+    const cycles = findCycles();
+    const filesInCycles = cycles.reduce((sum, scc) => sum + scc.length, 0);
+    const largest = cycles.reduce((max, scc) => Math.max(max, scc.length), 0);
+    console.log(
+      `[architecture-ratchet] cycles: clusters=${cycles.length} filesInCycles=${filesInCycles} largestCluster=${largest}`
+    );
+    for (const scc of [...cycles].sort((a, b) => b.length - a.length)) {
+      console.log(`  cluster(${scc.length}): ${scc.join(' <-> ')}`);
+    }
+  });
+
+  it('should not introduce new circular dependencies beyond the ratchet allowlist', () => {
+    const violations = new Set(findCycles().map(cycleKey));
+
+    assertRatchet(
+      violations,
+      ALLOWED_CYCLES,
+      'circular dependencies',
+      'ALLOWED_CYCLES',
+      `A circular dependency (strongly-connected cluster of files that mutually import each other) ` +
+        `was detected. Break at least one edge in the cluster — commonly by extracting the shared ` +
+        `symbol to a lower tier (src/types/, src/lib/), inverting a dependency, or using a dynamic ` +
+        `import at the call site. If the cycle is genuinely unavoidable, add its key to ALLOWED_CYCLES ` +
+        `with a comment explaining why. Each key is the cluster's member files joined by ' <-> '.`
+    );
+  });
+});
+
 describe('Architecture ratchet progress', () => {
   it('should report current violation counts', () => {
     console.log(
       `[architecture-ratchet] vertical=${ALLOWED_VERTICAL_VIOLATIONS.size}` +
         ` lateral=${ALLOWED_LATERAL_VIOLATIONS.size}` +
-        ` barrel=${ALLOWED_BARREL_VIOLATIONS.size}`
+        ` barrel=${ALLOWED_BARREL_VIOLATIONS.size}` +
+        ` cycles=${ALLOWED_CYCLES.size}`
     );
   });
 });

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -161,10 +161,6 @@ const ALLOWED_CYCLES = new Set<string>([
   'components/interactive-tutorial/hooks/use-section-requirements.ts <-> components/interactive-tutorial/interactive-conditional.tsx <-> components/interactive-tutorial/interactive-section.tsx <-> components/interactive-tutorial/section-numbering.tsx',
   // docs-panel content area <-> milestone toolbar via the components barrel.
   'components/docs-panel/components/DocsPanelContentArea.tsx <-> components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx <-> components/docs-panel/components/index.ts <-> components/docs-panel/docs-panel.tsx',
-  // global-state link-interception split across two mutually-importing files.
-  'global-state/link-interception.ts <-> global-state/utils.link-interception.ts',
-  // lib storage: bounded-record-storage <-> user-storage.
-  'lib/storage/bounded-record-storage.ts <-> lib/user-storage.ts',
 ]);
 
 // Violation key formatters — kept adjacent to allowlists so format changes

--- a/src/validation/import-graph.test.ts
+++ b/src/validation/import-graph.test.ts
@@ -18,6 +18,7 @@ import {
   extractRelativeImports,
   findCycles,
   findStronglyConnectedComponents,
+  validateAllowedCycleEntries,
   getNewViolations,
   getRootLevelSourceFiles,
   getSourceTier,
@@ -595,5 +596,53 @@ describe('buildModuleGraph', () => {
     for (const [node, edges] of graph.adjacency) {
       expect(edges.has(node)).toBe(false);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateAllowedCycleEntries
+// ---------------------------------------------------------------------------
+
+describe('validateAllowedCycleEntries', () => {
+  const valid = { cycle: 'a.ts <-> b.ts', reason: 'shared type extraction pending', tracking: '#1359' };
+
+  it('accepts a well-formed entry with a #-issue', () => {
+    expect(validateAllowedCycleEntries([valid])).toEqual([]);
+  });
+
+  it('accepts a GitHub issues URL as tracking', () => {
+    const url = 'https://github.com/grafana/grafana-pathfinder-app/issues/1359';
+    expect(validateAllowedCycleEntries([{ ...valid, tracking: url }])).toEqual([]);
+  });
+
+  it('flags a reason that is missing or too short', () => {
+    const errors = validateAllowedCycleEntries([{ ...valid, reason: 'too short' }]);
+    expect(errors.some((e) => e.includes("'reason'"))).toBe(true);
+  });
+
+  it('flags whitespace-only reasons (trimmed before length check)', () => {
+    const errors = validateAllowedCycleEntries([{ ...valid, reason: '                          ' }]);
+    expect(errors.some((e) => e.includes("'reason'"))).toBe(true);
+  });
+
+  it('flags a tracking value that is neither #-issue nor issues URL', () => {
+    const errors = validateAllowedCycleEntries([{ ...valid, tracking: 'later' }]);
+    expect(errors.some((e) => e.includes("'tracking'"))).toBe(true);
+  });
+
+  it('rejects a PR URL (must be an issues URL, not pull)', () => {
+    const prUrl = 'https://github.com/grafana/grafana-pathfinder-app/pull/1358';
+    const errors = validateAllowedCycleEntries([{ ...valid, tracking: prUrl }]);
+    expect(errors.some((e) => e.includes("'tracking'"))).toBe(true);
+  });
+
+  it('flags duplicate cycle keys', () => {
+    const errors = validateAllowedCycleEntries([valid, { ...valid }]);
+    expect(errors.some((e) => e.includes('Duplicate'))).toBe(true);
+  });
+
+  it('labels errors by the first file in the offending cycle', () => {
+    const errors = validateAllowedCycleEntries([{ cycle: 'x.ts <-> y.ts', reason: 'x', tracking: 'x' }]);
+    expect(errors.every((e) => e.startsWith('x.ts:'))).toBe(true);
   });
 });

--- a/src/validation/import-graph.test.ts
+++ b/src/validation/import-graph.test.ts
@@ -16,6 +16,8 @@ import {
   TIER_2_ENGINES,
   EXCLUDED_TOP_LEVEL,
   extractRelativeImports,
+  findCycles,
+  findStronglyConnectedComponents,
   getNewViolations,
   getRootLevelSourceFiles,
   getSourceTier,
@@ -24,12 +26,14 @@ import {
   getTopLevelDir,
   isTestFile,
   assertRatchet,
+  buildModuleGraph,
   collectSourceFiles,
   loadTsconfigPaths,
   readJsoncFile,
   resolveImportToRelative,
   resolvePathAlias,
   toPosixPath,
+  type ModuleGraph,
 } from './import-graph';
 
 // ---------------------------------------------------------------------------
@@ -498,5 +502,98 @@ describe('assertRatchet', () => {
     const violations = new Set(['new -> one']);
     const allowlist = new Set(['stale -> old']);
     expect(() => assertRatchet(violations, allowlist, 'test', 'CONST', advice)).toThrow(/New test detected/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cycle detection: findStronglyConnectedComponents / findCycles
+// ---------------------------------------------------------------------------
+
+function graphFromAdjacency(adjacency: Record<string, string[]>): ModuleGraph {
+  const map = new Map<string, Set<string>>();
+  for (const [node, edges] of Object.entries(adjacency)) {
+    map.set(node, new Set(edges));
+  }
+  return { nodes: Object.keys(adjacency), adjacency: map };
+}
+
+function sortedComponents(components: string[][]): string[][] {
+  return components.map((c) => [...c].sort()).sort((a, b) => (a[0]! < b[0]! ? -1 : a[0]! > b[0]! ? 1 : 0));
+}
+
+describe('findStronglyConnectedComponents', () => {
+  it('returns a singleton component for each node in an acyclic graph', () => {
+    const graph = graphFromAdjacency({ a: ['b'], b: ['c'], c: [] });
+    const sccs = findStronglyConnectedComponents(graph);
+    expect(sccs.every((c) => c.length === 1)).toBe(true);
+    expect(sccs).toHaveLength(3);
+  });
+
+  it('detects a simple two-node cycle', () => {
+    const graph = graphFromAdjacency({ a: ['b'], b: ['a'] });
+    const cyclic = findStronglyConnectedComponents(graph).filter((c) => c.length >= 2);
+    expect(sortedComponents(cyclic)).toEqual([['a', 'b']]);
+  });
+
+  it('detects a longer cycle', () => {
+    const graph = graphFromAdjacency({ a: ['b'], b: ['c'], c: ['a'] });
+    const cyclic = findStronglyConnectedComponents(graph).filter((c) => c.length >= 2);
+    expect(sortedComponents(cyclic)).toEqual([['a', 'b', 'c']]);
+  });
+
+  it('separates two independent cycles', () => {
+    const graph = graphFromAdjacency({ a: ['b'], b: ['a'], c: ['d'], d: ['c'], e: [] });
+    const cyclic = findStronglyConnectedComponents(graph).filter((c) => c.length >= 2);
+    expect(sortedComponents(cyclic)).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ]);
+  });
+
+  it('merges nested cycles that mutually reach into one component', () => {
+    // a->b->c->a and b->d->b: all of a,b,c,d are mutually reachable.
+    const graph = graphFromAdjacency({ a: ['b'], b: ['c', 'd'], c: ['a'], d: ['b'] });
+    const cyclic = findStronglyConnectedComponents(graph).filter((c) => c.length >= 2);
+    expect(sortedComponents(cyclic)).toEqual([['a', 'b', 'c', 'd']]);
+  });
+
+  it('does not overflow on a long acyclic chain', () => {
+    const adjacency: Record<string, string[]> = {};
+    for (let i = 0; i < 5000; i++) {
+      adjacency[`n${i}`] = i < 4999 ? [`n${i + 1}`] : [];
+    }
+    const sccs = findStronglyConnectedComponents(graphFromAdjacency(adjacency));
+    expect(sccs).toHaveLength(5000);
+    expect(sccs.every((c) => c.length === 1)).toBe(true);
+  });
+});
+
+describe('findCycles', () => {
+  it('returns only components of size >= 2, with members sorted', () => {
+    const graph = graphFromAdjacency({ b: ['a'], a: ['b'], z: [] });
+    expect(findCycles(graph)).toEqual([['a', 'b']]);
+  });
+
+  it('returns an empty array for an acyclic graph', () => {
+    expect(findCycles(graphFromAdjacency({ a: ['b'], b: [] }))).toEqual([]);
+  });
+});
+
+describe('buildModuleGraph', () => {
+  it('produces a graph whose edges are all real nodes (no dangling targets)', () => {
+    const graph = buildModuleGraph();
+    const nodeSet = new Set(graph.nodes);
+    for (const [, edges] of graph.adjacency) {
+      for (const target of edges) {
+        expect(nodeSet.has(target)).toBe(true);
+      }
+    }
+  });
+
+  it('excludes self-edges', () => {
+    const graph = buildModuleGraph();
+    for (const [node, edges] of graph.adjacency) {
+      expect(edges.has(node)).toBe(false);
+    }
   });
 });

--- a/src/validation/import-graph.ts
+++ b/src/validation/import-graph.ts
@@ -473,6 +473,49 @@ export function findCycles(graph: ModuleGraph = buildModuleGraph()): string[][] 
     .map((component) => [...component].sort());
 }
 
+/**
+ * A grandfathered cycle in the ratchet allowlist. Beyond the SCC key, each
+ * carries a justification and a paydown tracking issue so a new cycle can't be
+ * silenced by pasting its key in with an empty rubber-stamp comment.
+ */
+export interface AllowedCycleEntry {
+  cycle: string;
+  reason: string;
+  tracking: string;
+}
+
+const CYCLE_REASON_MIN_LENGTH = 20;
+const CYCLE_TRACKING_RE = /^#\d+$/;
+const CYCLE_TRACKING_URL_RE = /github\.com\/[^/]+\/[^/]+\/issues\/\d+/;
+
+/**
+ * Validates that every allowlisted cycle is justified and tracked: unique key,
+ * a substantive `reason`, and a `tracking` issue (either `#1234` or a GitHub
+ * issues URL). Returns a list of human-readable errors (empty when all pass).
+ */
+export function validateAllowedCycleEntries(entries: readonly AllowedCycleEntry[]): string[] {
+  const errors: string[] = [];
+
+  const keys = new Set(entries.map((entry) => entry.cycle));
+  if (keys.size !== entries.length) {
+    errors.push(`Duplicate 'cycle' keys in ALLOWED_CYCLES (${entries.length} entries, ${keys.size} unique).`);
+  }
+
+  for (const entry of entries) {
+    const label = entry.cycle.split(' <-> ')[0] || '(empty cycle key)';
+    if (entry.reason.trim().length < CYCLE_REASON_MIN_LENGTH) {
+      errors.push(`${label}: 'reason' is missing or too short — explain why the cycle is tolerated.`);
+    }
+    if (!CYCLE_TRACKING_RE.test(entry.tracking) && !CYCLE_TRACKING_URL_RE.test(entry.tracking)) {
+      errors.push(
+        `${label}: 'tracking' must be an issue reference ('#1234') or a GitHub issues URL, got '${entry.tracking}'.`
+      );
+    }
+  }
+
+  return errors;
+}
+
 // ---------------------------------------------------------------------------
 // Ratchet mechanism
 // ---------------------------------------------------------------------------

--- a/src/validation/import-graph.ts
+++ b/src/validation/import-graph.ts
@@ -319,6 +319,161 @@ export function resetCache(): void {
 }
 
 // ---------------------------------------------------------------------------
+// Module graph & cycle detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves an import specifier to the src-relative path of the real file it
+ * points at (with extension), or null if it resolves outside src/ or to no
+ * file on disk. Unlike resolveImportToRelative (which returns an extension-
+ * less path and never touches the filesystem), this collapses `./foo`,
+ * `./foo.ts`, and `./foo/index.ts` onto the same canonical node key so the
+ * graph has one node per module.
+ */
+export function resolveImportToFileNode(fileDir: string, importPath: string): string | null {
+  const absoluteNoExt = path.resolve(fileDir, importPath);
+  const found = findExistingSourceFile(absoluteNoExt);
+  if (!found) {
+    return null;
+  }
+  const relative = path.relative(SRC_DIR, found);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    return null;
+  }
+  return toPosixPath(relative);
+}
+
+export interface ModuleGraph {
+  /** src-relative posix paths of every non-test source file (with extension). */
+  nodes: string[];
+  /** node -> set of nodes it imports (intra-src, non-test edges only). */
+  adjacency: Map<string, Set<string>>;
+}
+
+/**
+ * Builds the file-level import graph over production source (test files are
+ * excluded as both nodes and edge targets). Self-edges are dropped. Edges to
+ * unresolvable / external / test targets are dropped.
+ */
+export function buildModuleGraph(): ModuleGraph {
+  const all = getAllFileImports();
+  const adjacency = new Map<string, Set<string>>();
+
+  for (const { file, relPath, imports } of all) {
+    if (isTestFile(file)) {
+      continue;
+    }
+    let edges = adjacency.get(relPath);
+    if (!edges) {
+      edges = new Set<string>();
+      adjacency.set(relPath, edges);
+    }
+    const fileDir = path.dirname(file);
+    for (const imp of imports) {
+      const target = resolveImportToFileNode(fileDir, imp);
+      if (!target || target === relPath || isTestFile(path.join(SRC_DIR, target))) {
+        continue;
+      }
+      edges.add(target);
+    }
+  }
+
+  // Close the graph over production source: drop edges into excluded dirs
+  // (cli/, bundled-interactives/, …) which are never iterated as nodes and so
+  // are always acyclic sinks anyway. Keeps every edge target a real node.
+  const nodes = new Set(adjacency.keys());
+  for (const edges of adjacency.values()) {
+    for (const target of edges) {
+      if (!nodes.has(target)) {
+        edges.delete(target);
+      }
+    }
+  }
+
+  return { nodes: [...nodes], adjacency };
+}
+
+/**
+ * Tarjan's strongly-connected-components algorithm. Every returned component
+ * of size >= 2 is a set of files that mutually reach each other — i.e. a
+ * circular-dependency cluster. Size-1 components are acyclic singletons (self
+ * edges are already excluded by buildModuleGraph), so callers filter to
+ * length >= 2 to get the cycles.
+ *
+ * Iterative (explicit work stack) so a deep chain in a ~600-node graph can't
+ * overflow the JS call stack.
+ */
+export function findStronglyConnectedComponents(graph: ModuleGraph): string[][] {
+  const indices = new Map<string, number>();
+  const lowlink = new Map<string, number>();
+  const onStack = new Set<string>();
+  const sccStack: string[] = [];
+  const result: string[][] = [];
+  let counter = 0;
+
+  interface Frame {
+    node: string;
+    neighbors: string[];
+    next: number;
+  }
+
+  for (const start of graph.nodes) {
+    if (indices.has(start)) {
+      continue;
+    }
+    const work: Frame[] = [{ node: start, neighbors: [...(graph.adjacency.get(start) ?? [])], next: 0 }];
+    indices.set(start, counter);
+    lowlink.set(start, counter);
+    counter++;
+    sccStack.push(start);
+    onStack.add(start);
+
+    while (work.length > 0) {
+      const frame = work[work.length - 1]!;
+      if (frame.next < frame.neighbors.length) {
+        const w = frame.neighbors[frame.next]!;
+        frame.next++;
+        if (!indices.has(w)) {
+          indices.set(w, counter);
+          lowlink.set(w, counter);
+          counter++;
+          sccStack.push(w);
+          onStack.add(w);
+          work.push({ node: w, neighbors: [...(graph.adjacency.get(w) ?? [])], next: 0 });
+        } else if (onStack.has(w)) {
+          lowlink.set(frame.node, Math.min(lowlink.get(frame.node)!, indices.get(w)!));
+        }
+      } else {
+        if (lowlink.get(frame.node) === indices.get(frame.node)) {
+          const component: string[] = [];
+          let w: string;
+          do {
+            w = sccStack.pop()!;
+            onStack.delete(w);
+            component.push(w);
+          } while (w !== frame.node);
+          result.push(component);
+        }
+        work.pop();
+        const parent = work[work.length - 1];
+        if (parent) {
+          lowlink.set(parent.node, Math.min(lowlink.get(parent.node)!, lowlink.get(frame.node)!));
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+/** SCCs of size >= 2 — the circular-dependency clusters, each members sorted. */
+export function findCycles(graph: ModuleGraph = buildModuleGraph()): string[][] {
+  return findStronglyConnectedComponents(graph)
+    .filter((component) => component.length >= 2)
+    .map((component) => [...component].sort());
+}
+
+// ---------------------------------------------------------------------------
 // Ratchet mechanism
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What this does

Extends the architecture invariant tests (`src/validation/architecture.test.ts`) with **general, file-level circular-dependency detection** over the whole import graph — complementing the existing Tier-2-only lateral-cycle check — plus **two sample paydown refactors** and **anti-gaming safeguards** on the allowlist.

## Mechanism

- `buildModuleGraph()` reuses the existing AST import scanner to build a file-level graph over production source (test files, `.d.ts`, and excluded dirs dropped; edges closed over real nodes).
- `findStronglyConnectedComponents()` — iterative Tarjan (stack-safe on the ~600-node graph). `findCycles()` returns SCCs of size ≥ 2.
- New ratchet test with an `ALLOWED_CYCLES` allowlist — the same shrink-only mechanism the tier/lateral/barrel checks already use. Counts **all** imports (including `import type`). An informational test logs the full footprint on every run.

## Footprint: 7 → 5 clusters

Baseline was `clusters=7 filesInCycles=33 largestCluster=9`. This PR pays down two, leaving **5** grandfathered in `ALLOWED_CYCLES`, tracked for opportunistic paydown in #1359.

## Sample paydown patterns (copy these)

**1. Extract the shared type** — `global-state/link-interception` ↔ `utils.link-interception`. The closing edge was a shared `QueuedDocsLink` type; moved to `src/types/link-interception.types.ts` (Tier 0). *Use when the back-edge is a type/interface.*

**2. Dependency injection** — `lib/storage/bounded-record-storage` ↔ `lib/user-storage`. The low-level building block imported the higher-level `user-storage` for its backend + quota notifier; now `createBoundedRecordStorage` receives them by injection from its two callers. *Use when a lower module reaches up to a higher one.* (A re-export shim can't break this cycle — it re-forms through `bounded-record-storage`; and moving the completion instances would churn 8 consumers + ~16 test mocks. Injection touches only the 2 files in the cycle.)

## Anti-gaming safeguards on the allowlist

The failure hands agents an escape hatch ("add its key to ALLOWED_CYCLES"), and the shrink-only ratchet doesn't stop *additions*. Two guards make silent rubber-stamping hard:

**A. Enforced justification + tracking.** `ALLOWED_CYCLES` entries are now `{ cycle, reason, tracking }`. A sibling test (`validateAllowedCycleEntries`, pure + unit-tested) fails unless every entry has a substantive `reason` and a `tracking` issue (`#1234` or a GitHub issues URL) — so a new cycle can't be silenced with an empty comment.

**B. Guidance toward the fix.** The new-cycle failure message now points at the two worked examples above and notes the enforced fields, steering agents to break the cycle rather than allowlist it.

> These raise the bar; they don't make the allowlist unforgeable (an agent can still write a plausible fake reason). The stronger mechanism-level lock — CODEOWNERS on `architecture.test.ts` or a frozen grandfathered-vs-new split — is deferred for separate discussion.

## Testing

- SCC algorithm: unit tests for simple/long/nested/independent cycles + deep-chain stack-safety.
- `validateAllowedCycleEntries`: unit tests for short/blank reason, bad tracking (incl. rejecting a PR URL), duplicate keys, valid `#`/URL forms.
- Building-block test wires the real backend via a `makeStore` helper — behavior unchanged.
- Full suite green (347 suites / 5416 tests); lint, prettier, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
