### PR TITLE
fix(dom): escape CSS attribute values and split grafana: params at first colon

### DIFF
--- a/src/integrations/workshop/action-replay.ts
+++ b/src/integrations/workshop/action-replay.ts
@@ -15,6 +15,7 @@ import type {
   InteractiveAction,
 } from '../../types/collaboration.types';
 import { isCssSelector } from '../../lib/dom/selector-detector';
+import { escapeCssAttributeValue } from '../../lib/dom/css-escape';
 import { querySelectorAllEnhanced } from '../../lib/dom/enhanced-selector';
 import { logger } from '../../lib/logging';
 
@@ -269,14 +270,14 @@ export class ActionReplaySystem {
    */
   private findStepElement(stepId: string, action: InteractiveAction): HTMLElement | null {
     // Try by step ID first
-    const byId = document.querySelector(`[data-step-id="${stepId}"]`) as HTMLElement;
+    const byId = document.querySelector(`[data-step-id="${escapeCssAttributeValue(stepId, '"')}"]`) as HTMLElement;
     if (byId) {
       return byId;
     }
 
-    // Try by action attributes
+    // Try by action attributes; refTarget is a CSS selector or button text, so it can contain quotes
     const byAttributes = document.querySelector(
-      `[data-targetaction="${action.targetAction}"][data-reftarget="${action.refTarget}"]`
+      `[data-targetaction="${escapeCssAttributeValue(action.targetAction, '"')}"][data-reftarget="${escapeCssAttributeValue(action.refTarget, '"')}"]`
     ) as HTMLElement;
 
     return byAttributes;

--- a/src/interactive-engine/navigation-manager.ts
+++ b/src/interactive-engine/navigation-manager.ts
@@ -3,6 +3,7 @@ import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import logoSvg from '../img/logo.svg';
 import {
   describeElement,
+  escapeCssAttributeValue,
   isElementVisible,
   getScrollParent,
   getStickyHeaderOffset,
@@ -1406,7 +1407,7 @@ export class NavigationManager {
     const capitalizedName = sectionName.charAt(0).toUpperCase() + sectionName.slice(1);
 
     const expandButton = document.querySelector(
-      `button[aria-label*="Expand section: ${capitalizedName}"]`
+      `button[aria-label*="Expand section: ${escapeCssAttributeValue(capitalizedName, '"')}"]`
     ) as HTMLButtonElement;
     if (expandButton) {
       return expandButton;

--- a/src/lib/dom/action-detector.ts
+++ b/src/lib/dom/action-detector.ts
@@ -15,7 +15,7 @@
  * @module action-detector
  */
 
-import { findButtonByText, isElementVisible, isPathfinderContent } from '.';
+import { escapeCssAttributeValue, findButtonByText, isElementVisible, isPathfinderContent } from '.';
 
 export type DetectedAction = 'highlight' | 'button' | 'formfill' | 'navigate' | 'hover';
 
@@ -243,7 +243,7 @@ export function extractElementSelector(element: HTMLElement): string | undefined
   if (tag === 'input' || tag === 'textarea' || tag === 'select') {
     const name = element.getAttribute('name');
     if (name) {
-      return `[name="${name}"]`;
+      return `[name="${escapeCssAttributeValue(name, '"')}"]`;
     }
   }
 

--- a/src/lib/dom/css-escape.test.ts
+++ b/src/lib/dom/css-escape.test.ts
@@ -22,6 +22,21 @@ describe('escapeCssAttributeValue', () => {
     expect(escapeCssAttributeValue("a\\'b")).toBe("a\\\\\\'b");
   });
 
+  it('handles mixed and consecutive quotes', () => {
+    expect(escapeCssAttributeValue(`He said 'hello' and "goodbye"`)).toBe(`He said \\'hello\\' and "goodbye"`);
+    expect(escapeCssAttributeValue(`''`)).toBe(`\\'\\'`);
+  });
+
+  it('handles quotes at value boundaries', () => {
+    expect(escapeCssAttributeValue("'start")).toBe("\\'start");
+    expect(escapeCssAttributeValue("end'")).toBe("end\\'");
+  });
+
+  it('passes through empty strings and unicode unchanged', () => {
+    expect(escapeCssAttributeValue('')).toBe('');
+    expect(escapeCssAttributeValue('François™ Dashboard')).toBe('François™ Dashboard');
+  });
+
   it('round-trips through querySelectorAll', () => {
     const value = `quote ' double " and backslash \\ value`;
     const el = document.createElement('div');

--- a/src/lib/dom/css-escape.test.ts
+++ b/src/lib/dom/css-escape.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from '@jest/globals';
+import { escapeCssAttributeValue } from './css-escape';
+
+describe('escapeCssAttributeValue', () => {
+  it('returns plain values unchanged', () => {
+    expect(escapeCssAttributeValue('data-testid RefreshPicker run button')).toBe(
+      'data-testid RefreshPicker run button'
+    );
+  });
+
+  it('escapes single quotes for the default single-quote delimiter', () => {
+    expect(escapeCssAttributeValue("Mark's dashboard")).toBe("Mark\\'s dashboard");
+    expect(escapeCssAttributeValue("Mark's dashboard")).not.toContain('\\"');
+  });
+
+  it('escapes double quotes for the double-quote delimiter and leaves single quotes alone', () => {
+    expect(escapeCssAttributeValue('He said "hi"', '"')).toBe('He said \\"hi\\"');
+    expect(escapeCssAttributeValue("Mark's dashboard", '"')).toBe("Mark's dashboard");
+  });
+
+  it('escapes backslashes before quotes so existing backslashes are not double-processed', () => {
+    expect(escapeCssAttributeValue("a\\'b")).toBe("a\\\\\\'b");
+  });
+
+  it('round-trips through querySelectorAll', () => {
+    const value = `quote ' double " and backslash \\ value`;
+    const el = document.createElement('div');
+    el.setAttribute('data-testid', value);
+    document.body.appendChild(el);
+
+    const singleQuoted = `[data-testid='${escapeCssAttributeValue(value)}']`;
+    const doubleQuoted = `[data-testid="${escapeCssAttributeValue(value, '"')}"]`;
+    expect(Array.from(document.querySelectorAll(singleQuoted))).toContain(el);
+    expect(Array.from(document.querySelectorAll(doubleQuoted))).toContain(el);
+
+    el.remove();
+  });
+});

--- a/src/lib/dom/css-escape.ts
+++ b/src/lib/dom/css-escape.ts
@@ -1,0 +1,12 @@
+/**
+ * Escape a raw attribute value for interpolation into a quoted CSS attribute
+ * selector: `[data-testid='${escapeCssAttributeValue(value)}']`.
+ * Inside a CSS string only the backslash and the delimiting quote need escaping.
+ */
+export function escapeCssAttributeValue(value: string, quote: "'" | '"' = "'"): string {
+  const escaped = value.replace(/\\/g, '\\\\');
+  if (quote === '"') {
+    return escaped.replace(/"/g, '\\"');
+  }
+  return escaped.replace(/'/g, "\\'");
+}

--- a/src/lib/dom/enhanced-selector.ts
+++ b/src/lib/dom/enhanced-selector.ts
@@ -5,6 +5,7 @@
  */
 
 import { logger } from '../logging';
+import { escapeCssAttributeValue } from './css-escape';
 
 export interface SelectorResult {
   elements: HTMLElement[];
@@ -671,7 +672,10 @@ function handleTestIdSelector(selector: string): SelectorResult {
     const fullTestId = testIdAttrMatch[1]!;
     const stablePrefix = extractStableTestIdPrefix(fullTestId);
     if (stablePrefix) {
-      const prefixSelector = selector.replace(/\[data-testid=['"][^'"]+['"]\]/, `[data-testid^='${stablePrefix}']`);
+      const prefixSelector = selector.replace(
+        /\[data-testid=['"][^'"]+['"]\]/,
+        `[data-testid^='${escapeCssAttributeValue(stablePrefix)}']`
+      );
       try {
         const prefixResults = document.querySelectorAll(prefixSelector);
         // Only accept if exactly 1 visible element matches

--- a/src/lib/dom/grafana-selector.ts
+++ b/src/lib/dom/grafana-selector.ts
@@ -6,6 +6,7 @@
 
 import { resolveSelectors, versionedComponents, versionedPages } from '@grafana/e2e-selectors';
 import { config } from '@grafana/runtime';
+import { escapeCssAttributeValue } from './css-escape';
 import { querySelectorAllEnhanced } from './enhanced-selector';
 
 type SelectorNode = { [key: string]: SelectorNode | string | ((...args: never[]) => unknown) };
@@ -81,8 +82,9 @@ export function toGrafanaSelector(selectorPath: string, selectorId?: string): st
 
   // Most Grafana selectors use data-testid, but some older ones use aria-label
   // Return a compound selector that works with both
-  const dataTestIdSelector = `[data-testid='${resolvedValue}']`;
-  const ariaLabelSelector = `[aria-label='${resolvedValue}']`;
+  const escapedValue = escapeCssAttributeValue(resolvedValue);
+  const dataTestIdSelector = `[data-testid='${escapedValue}']`;
+  const ariaLabelSelector = `[aria-label='${escapedValue}']`;
 
   return `${dataTestIdSelector}, ${ariaLabelSelector}`;
 }

--- a/src/lib/dom/index.ts
+++ b/src/lib/dom/index.ts
@@ -4,6 +4,7 @@
  */
 
 // Re-export all DOM utilities
+export * from './css-escape';
 export * from './dom-utils';
 export * from './pathfinder-content';
 export * from './enhanced-selector';

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -14,6 +14,7 @@ import {
   analyzeSelectorString,
 } from './selector-generator';
 import { querySelectorAllEnhanced } from './enhanced-selector';
+import { resolveSelector } from './selector-resolver';
 
 describe('Selector Generator — Pipeline', () => {
   beforeEach(() => {
@@ -774,5 +775,53 @@ describe('Selector Generator — Pipeline', () => {
       const m3 = querySelectorAllEnhanced(s3);
       expect(m3.elements).toContain(inputs[2]);
     });
+  });
+});
+
+describe('Selector Generator — CSS attribute-value escaping', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('emits a valid, matching selector for a testid containing a single quote', () => {
+    const button = document.createElement('button');
+    button.setAttribute('data-testid', "Panel menu item Mark's dashboard");
+    document.body.appendChild(button);
+
+    const selector = generateBestSelector(button);
+
+    expect(selector).toContain("Mark\\'s");
+    const matches = querySelectorAllEnhanced(selector);
+    expect(matches.elements).toEqual([button]);
+  });
+
+  it('emits a resolvable, matching selector for an aria-label containing a single quote', () => {
+    const button = document.createElement('button');
+    button.setAttribute('aria-label', "Delete Mark's panel");
+    document.body.appendChild(button);
+
+    // The winner may be a grafana: path (the reverse index matches this label
+    // against the legacy `${title} panel` template) — resolve like replay does.
+    const selector = generateBestSelector(button);
+    const resolved = resolveSelector(selector);
+
+    expect(resolved).toContain("\\'");
+    const matches = querySelectorAllEnhanced(resolved);
+    expect(matches.elements).toEqual([button]);
+  });
+
+  it('escapes quote-bearing ancestor testids used as disambiguation scopes', () => {
+    document.body.innerHTML = '<div><span></span><span></span></div><section><em></em></section>';
+    const scopeParent = document.querySelector('div')!;
+    scopeParent.setAttribute('data-testid', "Mark's section");
+    const target = scopeParent.querySelector('span')!;
+
+    const selector = generateBestSelector(target as HTMLElement);
+
+    const matches = querySelectorAllEnhanced(selector);
+    expect(matches.elements).toEqual([target]);
   });
 });

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -9,6 +9,7 @@
  * @module selector-generator
  */
 
+import { escapeCssAttributeValue } from './css-escape';
 import { findButtonByText } from './dom-utils';
 import { querySelectorAllEnhanced, querySelectorAllEnhancedVisible } from './enhanced-selector';
 import { findGrafanaSelectorPath } from './grafana-selector';
@@ -382,7 +383,7 @@ function findOverlayContext(element: HTMLElement): HTMLElement | null {
 function buildOverlayScopedSelector(overlay: HTMLElement, baseSelector: string): string {
   const role = overlay.getAttribute('role');
   if (role) {
-    return `[role="${role}"] ${baseSelector}`;
+    return `[role="${escapeCssAttributeValue(role, '"')}"] ${baseSelector}`;
   }
   if (overlay.tagName === 'DIALOG') {
     return `dialog ${baseSelector}`;
@@ -482,7 +483,7 @@ function candidateTestId(element: HTMLElement): Candidate | null {
   }
   const tag = element.tagName.toLowerCase();
   const attr = getTestIdAttr(element);
-  return { selector: `${tag}[${attr}='${testId}']`, score: CANDIDATE_SCORES.testId, method: 'data-testid' };
+  return { selector: `${tag}[${attr}='${escapeCssAttributeValue(testId)}']`, score: CANDIDATE_SCORES.testId, method: 'data-testid' };
 }
 
 function candidateScopedTestId(element: HTMLElement): Candidate | null {
@@ -492,7 +493,7 @@ function candidateScopedTestId(element: HTMLElement): Candidate | null {
   }
   const tag = element.tagName.toLowerCase();
   const attr = getTestIdAttr(element);
-  const base = `${tag}[${attr}='${testId}']`;
+  const base = `${tag}[${attr}='${escapeCssAttributeValue(testId)}']`;
 
   let current = element.parentElement;
   let depth = 0;
@@ -502,7 +503,7 @@ function candidateScopedTestId(element: HTMLElement): Candidate | null {
       const pTag = current.tagName.toLowerCase();
       const pAttr = getTestIdAttr(current);
       return {
-        selector: `${pTag}[${pAttr}='${parentTestId}'] ${base}`,
+        selector: `${pTag}[${pAttr}='${escapeCssAttributeValue(parentTestId)}'] ${base}`,
         score: CANDIDATE_SCORES.scopedTestId,
         method: 'scoped-testid',
       };
@@ -525,7 +526,7 @@ function candidateTestIdPlusHref(element: HTMLElement): Candidate | null {
   const attr = getTestIdAttr(element);
   const href = normalizeHref(rawHref);
   return {
-    selector: `a[${attr}='${testId}'][href='${href}']`,
+    selector: `a[${attr}='${escapeCssAttributeValue(testId)}'][href='${escapeCssAttributeValue(href)}']`,
     score: CANDIDATE_SCORES.testId + 2,
     method: 'testid-href',
   };
@@ -546,13 +547,20 @@ function candidateRoleName(element: HTMLElement): Candidate | null {
   const text = normalizeText(element.textContent || '');
   if (text.length === 0 || text.length > SELECTOR_CONFIG.maxTextLength) {
     const tag = element.tagName.toLowerCase();
-    return { selector: `${tag}[role='${role}']`, score: CANDIDATE_SCORES.roleContains + 50, method: 'role' };
+    return { selector: `${tag}[role='${escapeCssAttributeValue(role)}']`, score: CANDIDATE_SCORES.roleContains + 50, method: 'role' };
   }
+  // The :text()/:contains() arguments stay raw: the custom-pseudo parser in
+  // enhanced-selector.ts reads them with a regex that cannot handle backslash
+  // escapes, so only the attribute-selector part is escaped here.
   if (text.length < 20) {
-    return { selector: `[role='${role}']:text('${text}')`, score: CANDIDATE_SCORES.roleText, method: 'role-text' };
+    return {
+      selector: `[role='${escapeCssAttributeValue(role)}']:text('${text}')`,
+      score: CANDIDATE_SCORES.roleText,
+      method: 'role-text',
+    };
   }
   return {
-    selector: `[role='${role}']:contains('${text}')`,
+    selector: `[role='${escapeCssAttributeValue(role)}']:contains('${text}')`,
     score: CANDIDATE_SCORES.roleContains,
     method: 'role-contains',
   };
@@ -564,7 +572,11 @@ function candidateAriaLabel(element: HTMLElement): Candidate | null {
     return null;
   }
   const tag = element.tagName.toLowerCase();
-  return { selector: `${tag}[aria-label='${ariaLabel}']`, score: CANDIDATE_SCORES.ariaLabel, method: 'aria-label' };
+  return {
+    selector: `${tag}[aria-label='${escapeCssAttributeValue(ariaLabel)}']`,
+    score: CANDIDATE_SCORES.ariaLabel,
+    method: 'aria-label',
+  };
 }
 
 function candidateButtonText(element: HTMLElement): Candidate[] {
@@ -616,7 +628,7 @@ function candidatePlaceholder(element: HTMLElement): Candidate | null {
   }
   const tag = element.tagName.toLowerCase();
   return {
-    selector: `${tag}[placeholder='${placeholder}']`,
+    selector: `${tag}[placeholder='${escapeCssAttributeValue(placeholder)}']`,
     score: CANDIDATE_SCORES.placeholder,
     method: 'placeholder',
   };
@@ -628,7 +640,7 @@ function candidateTitle(element: HTMLElement): Candidate | null {
     return null;
   }
   const tag = element.tagName.toLowerCase();
-  return { selector: `${tag}[title='${title}']`, score: CANDIDATE_SCORES.title, method: 'title' };
+  return { selector: `${tag}[title='${escapeCssAttributeValue(title)}']`, score: CANDIDATE_SCORES.title, method: 'title' };
 }
 
 function candidateLabelText(element: HTMLElement): Candidate | null {
@@ -657,7 +669,7 @@ function candidateName(element: HTMLElement): Candidate | null {
       return null;
     }
   }
-  return { selector: `${tag}[name='${name}']`, score: CANDIDATE_SCORES.name, method: 'name' };
+  return { selector: `${tag}[name='${escapeCssAttributeValue(name)}']`, score: CANDIDATE_SCORES.name, method: 'name' };
 }
 
 function candidateHref(element: HTMLElement): Candidate | null {
@@ -669,7 +681,7 @@ function candidateHref(element: HTMLElement): Candidate | null {
     return null;
   }
   const href = normalizeHref(rawHref);
-  return { selector: `a[href='${href}']`, score: CANDIDATE_SCORES.href, method: 'href' };
+  return { selector: `a[href='${escapeCssAttributeValue(href)}']`, score: CANDIDATE_SCORES.href, method: 'href' };
 }
 
 function candidateCompound(element: HTMLElement): Candidate | null {
@@ -690,14 +702,14 @@ function candidateCompound(element: HTMLElement): Candidate | null {
       attr.value !== 'false' &&
       !/^\d+$/.test(attr.value)
     ) {
-      parts.push(`[${attr.name}='${attr.value}']`);
+      parts.push(`[${attr.name}='${escapeCssAttributeValue(attr.value)}']`);
       break;
     }
   }
 
   if (tag === 'a' && element.hasAttribute('href')) {
     const href = normalizeHref(element.getAttribute('href')!);
-    parts.push(`[href='${href}']`);
+    parts.push(`[href='${escapeCssAttributeValue(href)}']`);
   }
 
   if (parts.length <= 1) {
@@ -832,7 +844,12 @@ function findAllAncestorScopes(element: HTMLElement): AncestorScope[] {
     if (testId) {
       const tag = current.tagName.toLowerCase();
       const attr = getTestIdAttr(current);
-      scopes.push({ selector: `${tag}[${attr}='${testId}']`, element: current, depth, type: 'testid' });
+      scopes.push({
+        selector: `${tag}[${attr}='${escapeCssAttributeValue(testId)}']`,
+        element: current,
+        depth,
+        type: 'testid',
+      });
     } else if (current.id && !isAutoGeneratedId(current.id)) {
       scopes.push({ selector: `#${current.id}`, element: current, depth, type: 'id' });
     } else {
@@ -840,7 +857,7 @@ function findAllAncestorScopes(element: HTMLElement): AncestorScope[] {
       if (stableAttr) {
         const tag = current.tagName.toLowerCase();
         scopes.push({
-          selector: `${tag}[${stableAttr.name}='${stableAttr.value}']`,
+          selector: `${tag}[${stableAttr.name}='${escapeCssAttributeValue(stableAttr.value)}']`,
           element: current,
           depth,
           type: 'data-attr',

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -483,7 +483,11 @@ function candidateTestId(element: HTMLElement): Candidate | null {
   }
   const tag = element.tagName.toLowerCase();
   const attr = getTestIdAttr(element);
-  return { selector: `${tag}[${attr}='${escapeCssAttributeValue(testId)}']`, score: CANDIDATE_SCORES.testId, method: 'data-testid' };
+  return {
+    selector: `${tag}[${attr}='${escapeCssAttributeValue(testId)}']`,
+    score: CANDIDATE_SCORES.testId,
+    method: 'data-testid',
+  };
 }
 
 function candidateScopedTestId(element: HTMLElement): Candidate | null {
@@ -547,7 +551,11 @@ function candidateRoleName(element: HTMLElement): Candidate | null {
   const text = normalizeText(element.textContent || '');
   if (text.length === 0 || text.length > SELECTOR_CONFIG.maxTextLength) {
     const tag = element.tagName.toLowerCase();
-    return { selector: `${tag}[role='${escapeCssAttributeValue(role)}']`, score: CANDIDATE_SCORES.roleContains + 50, method: 'role' };
+    return {
+      selector: `${tag}[role='${escapeCssAttributeValue(role)}']`,
+      score: CANDIDATE_SCORES.roleContains + 50,
+      method: 'role',
+    };
   }
   // The :text()/:contains() arguments stay raw: the custom-pseudo parser in
   // enhanced-selector.ts reads them with a regex that cannot handle backslash
@@ -640,7 +648,11 @@ function candidateTitle(element: HTMLElement): Candidate | null {
     return null;
   }
   const tag = element.tagName.toLowerCase();
-  return { selector: `${tag}[title='${escapeCssAttributeValue(title)}']`, score: CANDIDATE_SCORES.title, method: 'title' };
+  return {
+    selector: `${tag}[title='${escapeCssAttributeValue(title)}']`,
+    score: CANDIDATE_SCORES.title,
+    method: 'title',
+  };
 }
 
 function candidateLabelText(element: HTMLElement): Candidate | null {

--- a/src/lib/dom/selector-resolver.test.ts
+++ b/src/lib/dom/selector-resolver.test.ts
@@ -1,25 +1,9 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { describe, it, expect, beforeEach } from '@jest/globals';
 import { resolveSelector } from './selector-resolver';
-
-// Mock the grafana-selector module
-jest.mock('./grafana-selector', () => ({
-  toGrafanaSelector: jest.fn((path: string, id?: string) => {
-    if (path === 'components.RefreshPicker.runButtonV2') {
-      return "[data-testid='data-testid RefreshPicker run button'], [aria-label='data-testid RefreshPicker run button']";
-    }
-    if (path === 'pages.AddDashboard.itemButton' && id === 'Panel') {
-      return "button[aria-label='Add new panel Panel']";
-    }
-    if (path === 'invalid.path') {
-      throw new Error('Selector not found');
-    }
-    return `[data-testid='mock-${path}']`;
-  }),
-}));
 
 describe('selector-resolver', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    document.body.innerHTML = '';
   });
 
   describe('resolveSelector', () => {
@@ -31,11 +15,8 @@ describe('selector-resolver', () => {
     });
 
     it('should handle grafana: prefix with parameter', () => {
-      // The mock should handle this case
-      const result = resolveSelector('grafana:pages.AddDashboard.itemButton:Panel');
-      // Due to jest mocking issues in this context, the actual selector will be generated
-      // but this test verifies the colon-separated parameter logic works
-      expect(result).toContain('testid');
+      const result = resolveSelector('grafana:components.Breadcrumbs.breadcrumb:Home');
+      expect(result).toContain("[data-testid='data-testid Home breadcrumb']");
     });
 
     it('should return standard CSS selector unchanged', () => {
@@ -81,11 +62,39 @@ describe('selector-resolver', () => {
       expect(result).toBe(cssSelector);
     });
 
-    it('should handle multiple colons in selector path', () => {
-      const result = resolveSelector('grafana:components.Select.option:value:name');
-      // The last colon should be treated as parameter separator
-      // If the selector is invalid, it should fallback to the original selector
-      expect(result).toBe('grafana:components.Select.option:value:name');
+    it('splits path and parameter at the first colon so parameters may contain colons', () => {
+      const result = resolveSelector('grafana:components.Breadcrumbs.breadcrumb:Prod: Overview');
+      expect(result).toContain("[data-testid='data-testid Prod: Overview breadcrumb']");
+    });
+
+    it('escapes quotes in resolved values so the emitted CSS stays valid', () => {
+      const result = resolveSelector("grafana:components.Breadcrumbs.breadcrumb:Mark's dashboard");
+      expect(result).toContain("[data-testid='data-testid Mark\\'s dashboard breadcrumb']");
+
+      const el = document.createElement('span');
+      el.setAttribute('data-testid', "data-testid Mark's dashboard breadcrumb");
+      document.body.appendChild(el);
+      expect(Array.from(document.querySelectorAll(result))).toContain(el);
+    });
+  });
+
+  describe('resolveSelector with panel: prefix', () => {
+    it('resolves a panel title to a panel container selector', () => {
+      expect(resolveSelector('panel:CPU Usage')).toBe(
+        '[data-viz-panel-key]:has([data-testid*="Panel header CPU Usage"])'
+      );
+    });
+
+    it('appends the child selector after the panel container', () => {
+      expect(resolveSelector('panel:CPU Usage > .menu')).toBe(
+        '[data-viz-panel-key]:has([data-testid*="Panel header CPU Usage"]) .menu'
+      );
+    });
+
+    it('escapes double quotes in the panel title', () => {
+      expect(resolveSelector('panel:He said "hi"')).toBe(
+        '[data-viz-panel-key]:has([data-testid*="Panel header He said \\"hi\\""])'
+      );
     });
   });
 });

--- a/src/lib/dom/selector-resolver.ts
+++ b/src/lib/dom/selector-resolver.ts
@@ -4,6 +4,7 @@
  */
 
 import { logger } from '../logging';
+import { escapeCssAttributeValue } from './css-escape';
 import { toGrafanaSelector } from './grafana-selector';
 
 /**
@@ -11,16 +12,18 @@ import { toGrafanaSelector } from './grafana-selector';
  *
  * Supported formats:
  * - `grafana:components.RefreshPicker.runButton` - Grafana e2e selector path
- * - `grafana:components.NavMenu.item:Dashboards` - Grafana selector with parameter (colon-separated)
+ * - `grafana:components.NavMenu.item:Dashboards` - Grafana selector with parameter (split at the
+ *   first colon after the prefix; the parameter itself may contain colons)
  * - `button[data-testid="..."]` - Standard CSS selector (returned as-is)
  *
  * @param reftarget - The selector string from data-reftarget attribute
  * @returns Resolved CSS selector string
  *
  * @example
- * // Grafana selector
+ * // Grafana selector — one value resolved for the running Grafana version,
+ * // mirrored onto both attributes
  * resolveSelector('grafana:components.RefreshPicker.runButton')
- * // Returns: '[data-testid="data-testid RefreshPicker run button"], [aria-label="RefreshPicker run button"]'
+ * // Returns: "[data-testid='data-testid RefreshPicker run button'], [aria-label='data-testid RefreshPicker run button']"
  *
  * @example
  * // Standard CSS selector
@@ -29,8 +32,8 @@ import { toGrafanaSelector } from './grafana-selector';
  *
  * @example
  * // Grafana selector with parameter
- * resolveSelector('grafana:pages.AddDashboard.itemButton:Panel')
- * // Returns: 'button[aria-label="Add new panel Panel"]'
+ * resolveSelector('grafana:components.Panels.Panel.title:CPU Usage')
+ * // Returns: "[data-testid='data-testid Panel header CPU Usage'], [aria-label='data-testid Panel header CPU Usage']"
  */
 export function resolveSelector(reftarget: string): string {
   if (!reftarget) {
@@ -42,8 +45,9 @@ export function resolveSelector(reftarget: string): string {
     // Remove prefix
     const pathWithParam = reftarget.substring(8); // Remove 'grafana:'
 
-    // Check if there's a parameter (separated by colon)
-    const colonIndex = pathWithParam.lastIndexOf(':');
+    // Selector paths are dot-separated and never contain colons, so the first
+    // colon unambiguously separates path from parameter (which may itself contain colons)
+    const colonIndex = pathWithParam.indexOf(':');
     let selectorPath: string;
     let selectorId: string | undefined;
 
@@ -92,6 +96,6 @@ function resolvePanelSelector(reftarget: string): string {
   }
 
   // Grafana panels use [data-viz-panel-key] and have title in header
-  const baseSelector = `[data-viz-panel-key]:has([data-testid*="Panel header ${panelTitle}"])`;
+  const baseSelector = `[data-viz-panel-key]:has([data-testid*="Panel header ${escapeCssAttributeValue(panelTitle, '"')}"])`;
   return childSelector ? `${baseSelector} ${childSelector}` : baseSelector;
 }


### PR DESCRIPTION
## What

Fixes the two selector bugs deferred during the #1156 review, plus the wider unescaped-interpolation class (scope confirmed in plan review):

1. **Colon-split**: `resolveSelector` split `grafana:path:param` at the *last* colon, so parameters containing colons (e.g. a breadcrumb `Prod: Overview`) mis-split, threw inside `toGrafanaSelector`, and silently resolved to nothing at replay. Selector paths are dot-separated and never contain colons, so the first colon is unambiguously the separator.

2. **CSS attribute-value escaping**: live-DOM attribute values were interpolated unescaped into quoted CSS attribute selectors at ~20 sites (`toGrafanaSelector`, `resolvePanelSelector`, every candidate/scope builder in `selector-generator.ts`, `enhanced-selector.ts`'s prefix fallback, `action-detector.ts`, `navigation-manager.ts`). A value containing a quote produced malformed CSS that silently matched nothing — the picker degraded quote-bearing titles to positional `nth-of-type` selectors, and a crafted value like `x'], [data-foo='y` could rewrite selector structure. Fixed with a new shared `escapeCssAttributeValue` (escapes backslash + the delimiting quote, per CSS string syntax).

Out of scope: `:text('…')`/`:contains('…')` pseudo arguments stay raw — their parser in `enhanced-selector.ts` reads them with a regex that cannot handle backslash escapes.

## Notes for review

- The `jest.mock` in `selector-resolver.test.ts` was removed: it demonstrably never applied (its default branch *returns* instead of throwing, which the old multi-colon test's pass depended on), so the suite already exercised the real `toGrafanaSelector`. The multi-colon test that encoded the last-colon bug is rewritten against the real parameterized `components.Breadcrumbs.breadcrumb` selector.
- First test coverage for `resolvePanelSelector` (basic, child selector, quote-bearing title).
- New end-to-end picker test showed the escaper restoring a `grafana:` selector that previously died at the uniqueness gate: an aria-label `Delete Mark's panel` now correctly reverse-matches the legacy `${title} panel` template and survives resolution.

## Verification

- `npm run test:ci` — 338 suites / 5278 tests green
- `npx tsc --noEmit` clean; lint 0 errors (23 pre-existing warnings in unrelated files)

Prerequisite for the upcoming `{grafana:...}` token-grammar work (making #1156 + #1157 compose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)