### PR TITLE
feat(dom): compose grafana: selectors with ancestor/descendant anchoring

### DIFF
--- a/src/lib/dom/css-escape.test.ts
+++ b/src/lib/dom/css-escape.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { escapeCssAttributeValue } from './css-escape';
+import { escapeCssAttributeValue, toCssAttributeString } from './css-escape';
 
 describe('escapeCssAttributeValue', () => {
   it('returns plain values unchanged', () => {
@@ -47,6 +47,37 @@ describe('escapeCssAttributeValue', () => {
     const doubleQuoted = `[data-testid="${escapeCssAttributeValue(value, '"')}"]`;
     expect(Array.from(document.querySelectorAll(singleQuoted))).toContain(el);
     expect(Array.from(document.querySelectorAll(doubleQuoted))).toContain(el);
+
+    el.remove();
+  });
+});
+
+describe('toCssAttributeString', () => {
+  it('single-quotes plain values', () => {
+    expect(toCssAttributeString('data-testid Select input')).toBe("'data-testid Select input'");
+  });
+
+  it('double-quotes values containing a single quote instead of escaping', () => {
+    expect(toCssAttributeString("Mark's dashboard")).toBe('"Mark\'s dashboard"');
+  });
+
+  it('escapes only when the value contains both quote styles', () => {
+    expect(toCssAttributeString(`Mark's "big" dashboard`)).toBe(`'Mark\\'s "big" dashboard'`);
+  });
+
+  it('escapes backslashes in all quote modes', () => {
+    expect(toCssAttributeString('a\\b')).toBe("'a\\\\b'");
+    expect(toCssAttributeString("a\\'b")).toBe('"a\\\\\'b"');
+  });
+
+  it('quote-bearing values match inside :is() (nwsapi cannot parse escaped quotes there)', () => {
+    const value = "data-testid Mark's dashboard breadcrumb";
+    const el = document.createElement('span');
+    el.setAttribute('data-testid', value);
+    document.body.appendChild(el);
+
+    const selector = `:is([data-testid=${toCssAttributeString(value)}], [aria-label=${toCssAttributeString(value)}])`;
+    expect(Array.from(document.querySelectorAll(selector))).toContain(el);
 
     el.remove();
   });

--- a/src/lib/dom/css-escape.ts
+++ b/src/lib/dom/css-escape.ts
@@ -10,3 +10,22 @@ export function escapeCssAttributeValue(value: string, quote: "'" | '"' = "'"): 
   }
   return escaped.replace(/'/g, "\\'");
 }
+
+/**
+ * Render a value as a complete quoted CSS string (quotes included) for
+ * attribute selectors, picking the quote style that avoids escaped quotes:
+ * nwsapi (jsdom's selector engine) drops matches for backslash-escaped quotes
+ * inside functional pseudos like :is(), and this codebase's selector-parsing
+ * regexes ([^'"]+) mis-capture them everywhere. An escape is emitted only
+ * when the value contains both quote styles.
+ */
+export function toCssAttributeString(value: string): string {
+  const backslashEscaped = value.replace(/\\/g, '\\\\');
+  if (!value.includes("'")) {
+    return `'${backslashEscaped}'`;
+  }
+  if (!value.includes('"')) {
+    return `"${backslashEscaped}"`;
+  }
+  return `'${backslashEscaped.replace(/'/g, "\\'")}'`;
+}

--- a/src/lib/dom/grafana-selector.ts
+++ b/src/lib/dom/grafana-selector.ts
@@ -6,7 +6,7 @@
 
 import { resolveSelectors, versionedComponents, versionedPages } from '@grafana/e2e-selectors';
 import { config } from '@grafana/runtime';
-import { escapeCssAttributeValue } from './css-escape';
+import { toCssAttributeString } from './css-escape';
 import { querySelectorAllEnhanced } from './enhanced-selector';
 
 type SelectorNode = { [key: string]: SelectorNode | string | ((...args: never[]) => unknown) };
@@ -80,13 +80,15 @@ export function toGrafanaSelector(selectorPath: string, selectorId?: string): st
     throw new Error(`Invalid selector type at ${selectorPath}: ${typeof current}`);
   }
 
-  // Most Grafana selectors use data-testid, but some older ones use aria-label
-  // Return a compound selector that works with both
-  const escapedValue = escapeCssAttributeValue(resolvedValue);
-  const dataTestIdSelector = `[data-testid='${escapedValue}']`;
-  const ariaLabelSelector = `[aria-label='${escapedValue}']`;
+  // Most Grafana selectors use data-testid, but some older ones use aria-label.
+  // :is() keeps both alternatives in ONE compound selector, so the result can be
+  // scoped, prefixed, or embedded inside :has(...) — a bare top-level comma list
+  // cannot (`scope A, B` scopes only A).
+  const cssValue = toCssAttributeString(resolvedValue);
+  const dataTestIdSelector = `[data-testid=${cssValue}]`;
+  const ariaLabelSelector = `[aria-label=${cssValue}]`;
 
-  return `${dataTestIdSelector}, ${ariaLabelSelector}`;
+  return `:is(${dataTestIdSelector}, ${ariaLabelSelector})`;
 }
 
 /**

--- a/src/lib/dom/grafana-selector.ts
+++ b/src/lib/dom/grafana-selector.ts
@@ -31,7 +31,7 @@ function getResolvedSelectors(): SelectorNode {
  * Convert a Grafana selector path to a CSS selector string
  * Handles both aria-label and data-testid attributes based on the selector definition
  *
- * @param selectorPath - Dot-notation path to selector (e.g., 'components.RefreshPicker.runButton')
+ * @param selectorPath - Dot-notation path to selector (e.g., 'components.RefreshPicker.runButtonV2')
  * @returns CSS selector string that can be used with querySelector
  *
  * @example

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -599,17 +599,53 @@ describe('Selector Generator — Pipeline', () => {
     });
 
     it('rates a grafana: reftarget as good with the top stability score', () => {
-      const analysis = analyzeSelectorString('grafana:components.RefreshPicker.runButton');
+      const analysis = analyzeSelectorString('grafana:components.RefreshPicker.runButtonV2');
       expect(analysis.method).toBe('grafana');
       expect(analysis.quality).toBe('good');
       expect(analysis.stabilityScore).toBe(100);
     });
 
-    it('rates a panel: reftarget as good with the top stability score', () => {
+    it('rates a panel: reftarget as good but flags its free-text title as instance-bound', () => {
       const analysis = analyzeSelectorString('panel:CPU Usage');
       expect(analysis.method).toBe('grafana');
       expect(analysis.quality).toBe('good');
       expect(analysis.stabilityScore).toBe(100);
+      expect(analysis.flags).toContain('environment-unstable');
+    });
+
+    it('flags parameterized grafana: reftargets as instance-bound', () => {
+      const analysis = analyzeSelectorString('grafana:components.Breadcrumbs.breadcrumb:Home');
+      expect(analysis.quality).toBe('good');
+      expect(analysis.flags).toContain('environment-unstable');
+    });
+
+    it('rates an unresolvable grafana: path as poor', () => {
+      const analysis = analyzeSelectorString('grafana:components.RefreshPicker.runbutton');
+      expect(analysis.quality).toBe('poor');
+      expect(analysis.stabilityScore).toBe(0);
+      expect(analysis.warnings.some((w) => w.includes('Unknown grafana selector path'))).toBe(true);
+    });
+
+    it('rates an unresolvable embedded token as poor', () => {
+      const analysis = analyzeSelectorString("div[data-testid='panel'] {grafana:invalid.nonexistent.path}");
+      expect(analysis.quality).toBe('poor');
+      expect(analysis.stabilityScore).toBe(0);
+      expect(analysis.warnings.some((w) => w.includes('Unknown grafana selector path'))).toBe(true);
+    });
+
+    it('rates a resolvable scoped token as good', () => {
+      const analysis = analyzeSelectorString(
+        "div[data-testid='panel-B'] {grafana:components.RefreshPicker.runButtonV2}"
+      );
+      expect(analysis.method).toBe('scoped-grafana');
+      expect(analysis.quality).toBe('good');
+      expect(analysis.stabilityScore).toBe(100);
+    });
+
+    it('classifies a testid-subject :has() selector by its subject, not as has-descendant', () => {
+      const analysis = analyzeSelectorString("div[data-testid='wrapper']:has(a)");
+      expect(analysis.method).toBe('data-testid');
+      expect(analysis.quality).toBe('good');
     });
 
     it('recognizes a tag-attached id selector as an id method', () => {

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -808,7 +808,7 @@ describe('Selector Generator — CSS attribute-value escaping', () => {
     const selector = generateBestSelector(button);
     const resolved = resolveSelector(selector);
 
-    expect(resolved).toContain("\\'");
+    expect(resolved).toContain(`"Delete Mark's panel"`);
     const matches = querySelectorAllEnhanced(resolved);
     expect(matches.elements).toEqual([button]);
   });

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -859,6 +859,33 @@ describe('Selector Generator — CSS attribute-value escaping', () => {
     expect(matches.elements).toEqual([target]);
   });
 
+  it('emits version-stable {grafana:...} ancestor scopes when the ancestor reverse-maps', () => {
+    document.body.innerHTML = `
+      <nav data-testid="data-testid Home breadcrumb"><button></button></nav>
+      <nav data-testid="data-testid Alerts breadcrumb"><button></button></nav>
+    `;
+    const target = document.querySelectorAll('button')[1] as HTMLElement;
+
+    const selector = generateBestSelector(target);
+
+    expect(selector).toBe('{grafana:components.Breadcrumbs.breadcrumb:Alerts} button');
+    const matches = querySelectorAllEnhanced(resolveSelector(selector));
+    expect(matches.elements).toEqual([target]);
+  });
+
+  it('anchors an identity-less wrapper on a descendant via a {grafana:...} token inside :has()', () => {
+    document.body.innerHTML = `
+      <li><div class="css-abc123"><a data-testid="data-testid Home breadcrumb" href="/home">Home</a></div></li>
+    `;
+    const wrapper = document.querySelector('div') as HTMLElement;
+
+    const selector = generateBestSelector(wrapper);
+
+    expect(selector).toBe('div:has({grafana:components.Breadcrumbs.breadcrumb:Home})');
+    const matches = querySelectorAllEnhanced(resolveSelector(selector));
+    expect(matches.elements).toEqual([wrapper]);
+  });
+
   it('escapes quote-bearing ancestor testids used as disambiguation scopes', () => {
     document.body.innerHTML = '<div><span></span><span></span></div><section><em></em></section>';
     const scopeParent = document.querySelector('div')!;

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -886,6 +886,29 @@ describe('Selector Generator — CSS attribute-value escaping', () => {
     expect(matches.elements).toEqual([wrapper]);
   });
 
+  it('rescues an element via :has() when its only identity candidate dies at admission', () => {
+    // A long known aria-label value: candidateAriaLabel bails on length, so the
+    // grafana candidate is the element's ONLY identity candidate. Duplicated with
+    // no scoping ancestor it is dropped at admission — pre-rescue this element
+    // shipped as div:nth-of-type(2).
+    const longValue = `data-testid ${'X'.repeat(45)} breadcrumb`;
+    document.body.innerHTML = `
+      <div><a data-testid="unique-link-a" href="/a">A</a></div>
+      <div><a data-testid="unique-link-b" href="/b">B</a></div>
+    `;
+    const divs = document.querySelectorAll('body > div');
+    divs[0]!.setAttribute('aria-label', longValue);
+    divs[1]!.setAttribute('aria-label', longValue);
+    const target = divs[1] as HTMLElement;
+
+    const selector = generateBestSelector(target);
+
+    expect(selector).toContain(':has(');
+    expect(selector).not.toContain('nth-of-type');
+    const matches = querySelectorAllEnhanced(resolveSelector(selector));
+    expect(matches.elements).toEqual([target]);
+  });
+
   it('escapes quote-bearing ancestor testids used as disambiguation scopes', () => {
     document.body.innerHTML = '<div><span></span><span></span></div><section><em></em></section>';
     const scopeParent = document.querySelector('div')!;

--- a/src/lib/dom/selector-generator.test.ts
+++ b/src/lib/dom/selector-generator.test.ts
@@ -813,6 +813,52 @@ describe('Selector Generator — CSS attribute-value escaping', () => {
     expect(matches.elements).toEqual([button]);
   });
 
+  it('scopes a non-unique grafana: candidate under a stable ancestor as an embedded token', () => {
+    document.body.innerHTML = `
+      <div data-testid="panel-A"><button data-testid="data-testid RefreshPicker run button">A</button></div>
+      <div data-testid="panel-B"><button data-testid="data-testid RefreshPicker run button">B</button></div>
+    `;
+    const target = document.querySelectorAll('button')[1] as HTMLElement;
+
+    const selector = generateBestSelector(target);
+
+    expect(selector).toBe("div[data-testid='panel-B'] {grafana:components.RefreshPicker.runButtonV2}");
+    const matches = querySelectorAllEnhanced(resolveSelector(selector));
+    expect(matches.elements).toEqual([target]);
+  });
+
+  it('keeps the raw scoped testid available as a fallback alternative', () => {
+    document.body.innerHTML = `
+      <div data-testid="panel-A"><button data-testid="data-testid RefreshPicker run button">A</button></div>
+      <div data-testid="panel-B"><button data-testid="data-testid RefreshPicker run button">B</button></div>
+    `;
+    const target = document.querySelectorAll('button')[1] as HTMLElement;
+
+    const primary = generateBestSelector(target);
+    const fallbacks = generateFallbackSelectors(target, primary);
+
+    expect(primary).toContain('{grafana:');
+    expect(fallbacks).not.toContain(primary);
+    expect(fallbacks.some((s) => !s.includes('{grafana:') && s.includes('data-testid RefreshPicker run button'))).toBe(
+      true
+    );
+  });
+
+  it('drops the grafana: candidate when no ancestor scope disambiguates it', () => {
+    document.body.innerHTML = `
+      <div><button data-testid="data-testid RefreshPicker run button">A</button>
+      <button data-testid="data-testid RefreshPicker run button">B</button></div>
+    `;
+    const target = document.querySelectorAll('button')[1] as HTMLElement;
+
+    const selector = generateBestSelector(target);
+
+    expect(selector).not.toContain('{grafana:');
+    expect(selector).not.toContain('grafana:');
+    const matches = querySelectorAllEnhanced(resolveSelector(selector));
+    expect(matches.elements).toEqual([target]);
+  });
+
   it('escapes quote-bearing ancestor testids used as disambiguation scopes', () => {
     document.body.innerHTML = '<div><span></span><span></span></div><section><em></em></section>';
     const scopeParent = document.querySelector('div')!;

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -110,6 +110,10 @@ const DISAMBIGUATION_PENALTIES = {
   parentStableAttr: 70,
   overlayScope: 75,
   nthMatch: 1000,
+  // Small enough that a scoped grafana: token (5 + 7 = 12) still beats a raw
+  // scoped testid (15) and a disambiguated testid (10 + 50): half its identity
+  // stays version-resolved, so it must not lose to raw-literal alternatives.
+  scopedGrafana: 7,
 } as const;
 
 // Added to a descendant's own score when that descendant is used to anchor a
@@ -1037,11 +1041,47 @@ function admitCandidate(
     return candidate.method === 'scoped-bare-tag' ? [] : [{ ...candidate, matchCount }];
   }
 
-  if (candidate.method === 'button-text' || candidate.method === 'grafana') {
+  if (candidate.method === 'button-text') {
     return [];
   }
 
+  if (candidate.method === 'grafana') {
+    return admitScopedGrafana(candidate, element, ancestorScopes, inOverlay);
+  }
+
   return disambiguate(candidate, element, ancestorScopes, inOverlay).map((d) => ({ ...d, matchCount: 1 }));
+}
+
+/**
+ * A grafana: candidate that matches more than one element keeps its
+ * version-stable identity by re-emitting as an embedded token scoped under a
+ * stable ancestor: `div[data-testid='panel-A'] {grafana:components.Select.input}`.
+ * Only plain ancestor scoping is tried — positional hybrids (nth-child /
+ * nth-match around a grafana token) would undermine the stability the token
+ * exists to provide, so ranking falls through to the raw CSS candidates instead.
+ */
+function admitScopedGrafana(
+  candidate: Candidate,
+  element: HTMLElement,
+  ancestorScopes: AncestorScope[],
+  inOverlay: boolean
+): ScoredCandidate[] {
+  const token = `{${candidate.selector}}`;
+  for (const scope of ancestorScopes) {
+    const scoped = cleanDynamicAttributes(`${scope.selector} ${token}`);
+    const { matchCount, containsTarget } = testUniqueness(scoped, element, 'scoped-grafana', inOverlay);
+    if (matchCount === 1 && containsTarget) {
+      return [
+        {
+          selector: scoped,
+          score: candidate.score + DISAMBIGUATION_PENALTIES.scopedGrafana,
+          method: 'scoped-grafana',
+          matchCount: 1,
+        },
+      ];
+    }
+  }
+  return [];
 }
 
 function rankAndSelect(candidates: Candidate[], element: HTMLElement): ScoredCandidate {
@@ -1456,6 +1496,9 @@ function inferMethodAndScore(selector: string): { method: string; score: number 
   }
   if (selector.includes(':has(')) {
     return { method: 'has-descendant', score: CANDIDATE_SCORES.testId + HAS_DESCENDANT_PENALTY };
+  }
+  if (selector.includes('{grafana:')) {
+    return { method: 'scoped-grafana', score: CANDIDATE_SCORES.grafana + DISAMBIGUATION_PENALTIES.scopedGrafana };
   }
   if (SELECTOR_CONFIG.testIdAttrs.some((attr) => selector.includes(attr))) {
     return { method: 'data-testid', score: CANDIDATE_SCORES.testId };

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -114,6 +114,9 @@ const DISAMBIGUATION_PENALTIES = {
   // scoped testid (15) and a disambiguated testid (10 + 50): half its identity
   // stays version-resolved, so it must not lose to raw-literal alternatives.
   scopedGrafana: 7,
+  // Slightly below parentTestId so a version-resolvable ancestor scope wins
+  // when both it and a raw-testid scope would anchor uniquely.
+  parentGrafana: 45,
 } as const;
 
 // Added to a descendant's own score when that descendant is used to anchor a
@@ -837,7 +840,7 @@ function testUniqueness(
   }
 }
 
-type AncestorScopeType = 'testid' | 'id' | 'data-attr';
+type AncestorScopeType = 'grafana' | 'testid' | 'id' | 'data-attr';
 
 interface AncestorScope {
   selector: string;
@@ -856,8 +859,13 @@ function findAllAncestorScopes(element: HTMLElement): AncestorScope[] {
   let depth = 0;
 
   while (current && depth < SELECTOR_CONFIG.maxDisambiguationDepth) {
+    const grafanaPath = findGrafanaSelectorPath(current);
     const testId = getAnyTestId(current);
-    if (testId) {
+    if (grafanaPath) {
+      // The scope is often the longest-lived part of a composed selector, so a
+      // version-stable {grafana:...} token beats pinning the raw literal value.
+      scopes.push({ selector: `{${grafanaPath}}`, element: current, depth, type: 'grafana' });
+    } else if (testId) {
       const tag = current.tagName.toLowerCase();
       const attr = getTestIdAttr(current);
       scopes.push({
@@ -887,6 +895,16 @@ function findAllAncestorScopes(element: HTMLElement): AncestorScope[] {
   return scopes;
 }
 
+function scopePenalty(scope: AncestorScope): number {
+  if (scope.type === 'grafana') {
+    return DISAMBIGUATION_PENALTIES.parentGrafana;
+  }
+  if (scope.type === 'testid') {
+    return DISAMBIGUATION_PENALTIES.parentTestId;
+  }
+  return DISAMBIGUATION_PENALTIES.parentStableAttr;
+}
+
 /**
  * Find the direct child of `ancestor` that is an ancestor-or-self of `descendant`.
  */
@@ -912,11 +930,9 @@ function disambiguate(
     const scoped = `${scope.selector} ${candidate.selector}`;
     const { matchCount, containsTarget } = testUniqueness(scoped, element, candidate.method, inOverlay);
     if (matchCount === 1 && containsTarget) {
-      const penalty =
-        scope.type === 'testid' ? DISAMBIGUATION_PENALTIES.parentTestId : DISAMBIGUATION_PENALTIES.parentStableAttr;
       results.push({
         selector: cleanDynamicAttributes(scoped),
-        score: candidate.score + penalty,
+        score: candidate.score + scopePenalty(scope),
         method: candidate.method,
       });
       break;
@@ -937,11 +953,9 @@ function disambiguate(
         const nthChildScoped = `${scope.selector} > ${childTag}:nth-child(${childIndex})${suffix}`;
         const nthResult = testUniqueness(nthChildScoped, element, candidate.method, inOverlay);
         if (nthResult.matchCount === 1 && nthResult.containsTarget) {
-          const penalty =
-            scope.type === 'testid' ? DISAMBIGUATION_PENALTIES.parentTestId : DISAMBIGUATION_PENALTIES.parentStableAttr;
           results.push({
             selector: cleanDynamicAttributes(nthChildScoped),
-            score: candidate.score + penalty,
+            score: candidate.score + scopePenalty(scope),
             method: candidate.method,
           });
           break;
@@ -1121,18 +1135,26 @@ function rankAndSelect(candidates: Candidate[], element: HTMLElement): ScoredCan
 // Descendant-anchored :has() selectors
 // ============================================================================
 
-/** Pure-CSS candidate methods that are safe to embed inside `:has(...)`. */
+/** Candidate methods/shapes that are safe to embed inside `:has(...)`. */
 function isHasUsable(candidate: Candidate): boolean {
   if (STRUCTURAL_METHODS.has(candidate.method)) {
     return false;
   }
-  if (candidate.method === 'grafana' || candidate.method === 'button-text') {
+  if (candidate.method === 'button-text') {
     return false;
   }
   if (candidate.selector.includes(':text(') || candidate.selector.includes(':contains(')) {
     return false;
   }
   return true;
+}
+
+/** grafana: candidates embed as {grafana:...} tokens; everything else is already CSS. */
+function toHasEmbeddable(candidate: Candidate): Candidate {
+  if (candidate.method !== 'grafana') {
+    return candidate;
+  }
+  return { ...candidate, selector: `{${candidate.selector}}` };
 }
 
 function isInteractiveDescendant(element: HTMLElement): boolean {
@@ -1180,7 +1202,7 @@ function bestStableDescendant(element: HTMLElement): DescendantPick | null {
   let best: DescendantPick | null = null;
   for (const descendant of descendants) {
     const interactive = isInteractiveDescendant(descendant);
-    for (const candidate of generateIntrinsicCandidates(descendant)) {
+    for (const candidate of generateIntrinsicCandidates(descendant).map(toHasEmbeddable)) {
       if (!isHasUsable(candidate)) {
         continue;
       }

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -1103,6 +1103,19 @@ function rankAndSelect(candidates: Candidate[], element: HTMLElement): ScoredCan
   const inOverlay = findOverlayContext(element) !== null;
   const scored = candidates.flatMap((candidate) => admitCandidate(candidate, element, ancestorScopes, inOverlay));
 
+  // The generation-time gate only adds a :has() candidate when the element has
+  // no intrinsic identity at all. Identity candidates can also die at ADMISSION
+  // (a solitary grafana: candidate with no disambiguating ancestor, a candidate
+  // matching one element that isn't the target) — rescue those here before
+  // they degrade to a positional fallback.
+  const hasIdentitySurvivor = scored.some((s) => !STRUCTURAL_METHODS.has(s.method));
+  if (!hasIdentitySurvivor && !candidates.some((c) => c.method === 'has-descendant')) {
+    const rescue = candidateHasDescendant(element);
+    if (rescue) {
+      scored.push(...admitCandidate(rescue, element, ancestorScopes, inOverlay));
+    }
+  }
+
   if (scored.length === 0) {
     // No attribute / text / structural candidate matched — fall back to a positional
     // `:nth-of-type` selector. This is brittle (any sibling reorder breaks it) but

--- a/src/lib/dom/selector-generator.ts
+++ b/src/lib/dom/selector-generator.ts
@@ -1484,12 +1484,28 @@ function computeStabilityFlags(selector: string, method: string): StabilityFlag[
     /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i.test(selector) ||
     selector.includes('/d/') ||
     selector.includes('orgId=') ||
-    selector.includes('uid=')
+    selector.includes('uid=') ||
+    isParameterizedGrafanaIdentity(selector)
   ) {
     flags.push('environment-unstable');
   }
 
   return flags;
+}
+
+/**
+ * Parameterized grafana/panel identities embed free-text display values
+ * (panel titles, item labels) — stable across Grafana versions but bound to
+ * this instance's content.
+ */
+function isParameterizedGrafanaIdentity(selector: string): boolean {
+  if (selector.startsWith('panel:')) {
+    return true;
+  }
+  if (selector.startsWith('grafana:')) {
+    return selector.substring(8).includes(':');
+  }
+  return /\{grafana:[^}]*:[^}]*\}/.test(selector);
 }
 
 function computeQuality(stabilityScore: number, flags: StabilityFlag[]): SelectorQuality {
@@ -1530,6 +1546,17 @@ function inferMethodAndScore(selector: string): { method: string; score: number 
     return { method: 'grafana', score: CANDIDATE_SCORES.grafana };
   }
   if (selector.includes(':has(')) {
+    // A hand-typed selector whose SUBJECT carries a testid is a testid selector
+    // that happens to filter with :has(); the generator's has-descendant shape
+    // always has a bare-tag subject borrowing the descendant's identity.
+    const subject =
+      selector
+        .slice(0, selector.indexOf(':has('))
+        .split(/[\s>+~]+/)
+        .pop() ?? '';
+    if (SELECTOR_CONFIG.testIdAttrs.some((attr) => subject.includes(attr))) {
+      return { method: 'data-testid', score: CANDIDATE_SCORES.testId };
+    }
     return { method: 'has-descendant', score: CANDIDATE_SCORES.testId + HAS_DESCENDANT_PENALTY };
   }
   if (selector.includes('{grafana:')) {
@@ -1583,6 +1610,21 @@ export function analyzeSelectorString(selector: string): SelectorStringAnalysis 
   const stabilityScore = scoreToStability(score);
   const flags = computeStabilityFlags(selector, method);
   const quality = computeQuality(stabilityScore, flags);
+
+  // A grafana identity that doesn't resolve against this version's selector
+  // table will never match anywhere — resolveSelector returns the input
+  // unchanged on failure, so equality means unresolvable. Without this check a
+  // typo'd path reads good/100 with a "may work on the target page" warning.
+  const hasGrafanaIdentity = selector.startsWith('grafana:') || selector.includes('{grafana:');
+  if (hasGrafanaIdentity && resolveSelector(selector) === selector) {
+    return {
+      method,
+      stabilityScore: 0,
+      quality: 'poor',
+      flags,
+      warnings: ['Unknown grafana selector path for this Grafana version'],
+    };
+  }
 
   const warnings: string[] = [];
   if (flags.includes('structural')) {

--- a/src/lib/dom/selector-resolver.test.ts
+++ b/src/lib/dom/selector-resolver.test.ts
@@ -7,10 +7,10 @@ describe('selector-resolver', () => {
   });
 
   describe('resolveSelector', () => {
-    it('should resolve grafana: prefix to CSS selector', () => {
+    it('should resolve grafana: prefix to an embeddable :is() CSS selector', () => {
       const result = resolveSelector('grafana:components.RefreshPicker.runButtonV2');
       expect(result).toBe(
-        "[data-testid='data-testid RefreshPicker run button'], [aria-label='data-testid RefreshPicker run button']"
+        ":is([data-testid='data-testid RefreshPicker run button'], [aria-label='data-testid RefreshPicker run button'])"
       );
     });
 
@@ -67,9 +67,11 @@ describe('selector-resolver', () => {
       expect(result).toContain("[data-testid='data-testid Prod: Overview breadcrumb']");
     });
 
-    it('escapes quotes in resolved values so the emitted CSS stays valid', () => {
+    it('quotes resolved values safely so the emitted CSS stays valid and matchable', () => {
       const result = resolveSelector("grafana:components.Breadcrumbs.breadcrumb:Mark's dashboard");
-      expect(result).toContain("[data-testid='data-testid Mark\\'s dashboard breadcrumb']");
+      // Single-quote-bearing values are double-quoted rather than escaped:
+      // nwsapi (jsdom) drops matches for escaped quotes inside :is().
+      expect(result).toContain('[data-testid="data-testid Mark\'s dashboard breadcrumb"]');
 
       const el = document.createElement('span');
       el.setAttribute('data-testid', "data-testid Mark's dashboard breadcrumb");

--- a/src/lib/dom/selector-resolver.test.ts
+++ b/src/lib/dom/selector-resolver.test.ts
@@ -80,6 +80,53 @@ describe('selector-resolver', () => {
     });
   });
 
+  describe('resolveSelector with embedded {grafana:...} tokens', () => {
+    it('resolves a token after a scope in place', () => {
+      const result = resolveSelector("div[data-testid='panel-A'] {grafana:components.RefreshPicker.runButtonV2}");
+      expect(result).toBe(
+        "div[data-testid='panel-A'] :is([data-testid='data-testid RefreshPicker run button'], [aria-label='data-testid RefreshPicker run button'])"
+      );
+    });
+
+    it('resolves parameterized tokens whose parameter contains colons', () => {
+      const result = resolveSelector('{grafana:components.Breadcrumbs.breadcrumb:Prod: Overview} button');
+      expect(result).toContain("[data-testid='data-testid Prod: Overview breadcrumb']");
+      expect(result.endsWith(' button')).toBe(true);
+    });
+
+    it('resolves multiple tokens in one selector', () => {
+      const result = resolveSelector(
+        '{grafana:components.Breadcrumbs.breadcrumb:Home} {grafana:components.RefreshPicker.runButtonV2}'
+      );
+      expect(result).toContain("[data-testid='data-testid Home breadcrumb']");
+      expect(result).toContain("[data-testid='data-testid RefreshPicker run button']");
+      expect(result).not.toContain('{grafana:');
+    });
+
+    it('resolves tokens inside :has()', () => {
+      const result = resolveSelector('li > div:has({grafana:components.RefreshPicker.runButtonV2})');
+      expect(result).toBe(
+        "li > div:has(:is([data-testid='data-testid RefreshPicker run button'], [aria-label='data-testid RefreshPicker run button']))"
+      );
+    });
+
+    it('returns the reftarget unchanged when any token fails to resolve', () => {
+      const reftarget = "div[data-testid='panel-A'] {grafana:invalid.nonexistent.path}";
+      expect(resolveSelector(reftarget)).toBe(reftarget);
+    });
+
+    it('scoped tokens match only the element inside the scope', () => {
+      document.body.innerHTML = `
+        <div data-testid="panel-A"><button data-testid="data-testid RefreshPicker run button">A</button></div>
+        <div data-testid="panel-B"><button data-testid="data-testid RefreshPicker run button">B</button></div>
+      `;
+      const resolved = resolveSelector("div[data-testid='panel-B'] {grafana:components.RefreshPicker.runButtonV2}");
+      const matches = Array.from(document.querySelectorAll(resolved));
+      expect(matches).toHaveLength(1);
+      expect(matches[0]!.textContent).toBe('B');
+    });
+  });
+
   describe('resolveSelector with panel: prefix', () => {
     it('resolves a panel title to a panel container selector', () => {
       expect(resolveSelector('panel:CPU Usage')).toBe(

--- a/src/lib/dom/selector-resolver.ts
+++ b/src/lib/dom/selector-resolver.ts
@@ -23,7 +23,7 @@ import { toGrafanaSelector } from './grafana-selector';
  * // Grafana selector — one value resolved for the running Grafana version,
  * // mirrored onto both attributes
  * resolveSelector('grafana:components.RefreshPicker.runButton')
- * // Returns: "[data-testid='data-testid RefreshPicker run button'], [aria-label='data-testid RefreshPicker run button']"
+ * // Returns: ":is([data-testid='data-testid RefreshPicker run button'], [aria-label='data-testid RefreshPicker run button'])"
  *
  * @example
  * // Standard CSS selector
@@ -33,7 +33,7 @@ import { toGrafanaSelector } from './grafana-selector';
  * @example
  * // Grafana selector with parameter
  * resolveSelector('grafana:components.Panels.Panel.title:CPU Usage')
- * // Returns: "[data-testid='data-testid Panel header CPU Usage'], [aria-label='data-testid Panel header CPU Usage']"
+ * // Returns: ":is([data-testid='data-testid Panel header CPU Usage'], [aria-label='data-testid Panel header CPU Usage'])"
  */
 export function resolveSelector(reftarget: string): string {
   if (!reftarget) {

--- a/src/lib/dom/selector-resolver.ts
+++ b/src/lib/dom/selector-resolver.ts
@@ -14,6 +14,8 @@ import { toGrafanaSelector } from './grafana-selector';
  * - `grafana:components.RefreshPicker.runButton` - Grafana e2e selector path
  * - `grafana:components.NavMenu.item:Dashboards` - Grafana selector with parameter (split at the
  *   first colon after the prefix; the parameter itself may contain colons)
+ * - `div[data-testid='panel'] {grafana:components.Select.input}` - CSS selector with embedded
+ *   grafana tokens; each `{grafana:path[:param]}` resolves in place to its :is() form
  * - `button[data-testid="..."]` - Standard CSS selector (returned as-is)
  *
  * @param reftarget - The selector string from data-reftarget attribute
@@ -40,25 +42,15 @@ export function resolveSelector(reftarget: string): string {
     return reftarget;
   }
 
+  // Embedded `{grafana:path[:param]}` tokens inside an otherwise-plain CSS
+  // selector, e.g. `div[data-testid='panel'] {grafana:components.Select.input}`
+  if (reftarget.includes('{grafana:')) {
+    return resolveEmbeddedGrafanaTokens(reftarget);
+  }
+
   // Check for grafana: prefix
   if (reftarget.startsWith('grafana:')) {
-    // Remove prefix
-    const pathWithParam = reftarget.substring(8); // Remove 'grafana:'
-
-    // Selector paths are dot-separated and never contain colons, so the first
-    // colon unambiguously separates path from parameter (which may itself contain colons)
-    const colonIndex = pathWithParam.indexOf(':');
-    let selectorPath: string;
-    let selectorId: string | undefined;
-
-    if (colonIndex !== -1 && colonIndex < pathWithParam.length - 1) {
-      // Split path and parameter
-      selectorPath = pathWithParam.substring(0, colonIndex);
-      selectorId = pathWithParam.substring(colonIndex + 1);
-    } else {
-      selectorPath = pathWithParam;
-    }
-
+    const { selectorPath, selectorId } = splitGrafanaPathParam(reftarget.substring(8));
     try {
       return toGrafanaSelector(selectorPath, selectorId);
     } catch (error) {
@@ -75,6 +67,42 @@ export function resolveSelector(reftarget: string): string {
 
   // Return as-is if it's a regular CSS selector
   return reftarget;
+}
+
+/**
+ * Selector paths are dot-separated and never contain colons, so the first
+ * colon unambiguously separates path from parameter (which may itself contain colons).
+ */
+function splitGrafanaPathParam(pathWithParam: string): { selectorPath: string; selectorId?: string } {
+  const colonIndex = pathWithParam.indexOf(':');
+  if (colonIndex !== -1 && colonIndex < pathWithParam.length - 1) {
+    return {
+      selectorPath: pathWithParam.substring(0, colonIndex),
+      selectorId: pathWithParam.substring(colonIndex + 1),
+    };
+  }
+  return { selectorPath: pathWithParam };
+}
+
+/**
+ * Replace every embedded `{grafana:path[:param]}` token with its
+ * version-resolved :is() form. Parameters may contain colons but not `}`.
+ * If any token fails to resolve, the whole reftarget is returned unchanged
+ * (same safe degradation as the grafana: prefix fallback).
+ */
+function resolveEmbeddedGrafanaTokens(reftarget: string): string {
+  let failed = false;
+  const resolved = reftarget.replace(/\{grafana:([^}]+)\}/g, (match, pathWithParam: string) => {
+    const { selectorPath, selectorId } = splitGrafanaPathParam(pathWithParam);
+    try {
+      return toGrafanaSelector(selectorPath, selectorId);
+    } catch (error) {
+      logger.error(`Failed to resolve embedded Grafana selector token: ${match}`, { error });
+      failed = true;
+      return match;
+    }
+  });
+  return failed ? reftarget : resolved;
 }
 
 /**

--- a/src/lib/dom/selector-resolver.ts
+++ b/src/lib/dom/selector-resolver.ts
@@ -11,7 +11,7 @@ import { toGrafanaSelector } from './grafana-selector';
  * Resolve a selector string that may contain special prefixes
  *
  * Supported formats:
- * - `grafana:components.RefreshPicker.runButton` - Grafana e2e selector path
+ * - `grafana:components.RefreshPicker.runButtonV2` - Grafana e2e selector path
  * - `grafana:components.NavMenu.item:Dashboards` - Grafana selector with parameter (split at the
  *   first colon after the prefix; the parameter itself may contain colons)
  * - `div[data-testid='panel'] {grafana:components.Select.input}` - CSS selector with embedded
@@ -24,7 +24,7 @@ import { toGrafanaSelector } from './grafana-selector';
  * @example
  * // Grafana selector — one value resolved for the running Grafana version,
  * // mirrored onto both attributes
- * resolveSelector('grafana:components.RefreshPicker.runButton')
+ * resolveSelector('grafana:components.RefreshPicker.runButtonV2')
  * // Returns: ":is([data-testid='data-testid RefreshPicker run button'], [aria-label='data-testid RefreshPicker run button'])"
  *
  * @example


### PR DESCRIPTION
## What

Makes #1156 (version-stable `grafana:` selectors) and #1157 (stable-ancestor / `:has()` descendant anchoring) compose. Before this, the anchoring machinery pinned raw testid literals — the exact values #1156 exists to avoid — and non-unique `grafana:` candidates were dropped entirely. Plan reviewed via crit (5 rounds); built on the merged escaping/colon-split PR #1360.

One commit per step, reviewable independently:

1. **`:is()` keystone** — `toGrafanaSelector` returns `:is([data-testid=V], [aria-label=V])` instead of a top-level comma list, so the resolved form can be scoped, prefixed, and embedded. Values are quoted via `toCssAttributeString`, which picks the quote style avoiding escapes: nwsapi (jsdom) silently drops matches for backslash-escaped quotes inside `:is()`, and the codebase's selector-parsing regexes (`[^'"]+`) mis-capture them.
2. **`{grafana:path[:param]}` token grammar** — a pre-pass in `resolveSelector` resolves embedded tokens anywhere in a CSS string. All replay consumers already funnel through `resolveSelector`, so stored token reftargets version-resolve with no consumer changes. **Forward-compat:** plugin versions older than this change treat tokens as literal CSS (match nothing) when replaying newly-authored guides.
3. **Scoped grafana candidates** — a non-unique `grafana:` candidate re-emits as `div[data-testid='panel-B'] {grafana:components.RefreshPicker.runButtonV2}` (method `scoped-grafana`, score 12) instead of being dropped; no positional hybrids. Raw testid stays available in fallbacks.
4. **Version-stable anchors** — `findAllAncestorScopes` emits `{grafana:...}` token scopes when the ancestor reverse-maps (penalty 45, just under `parentTestId`), and `bestStableDescendant` embeds the grafana identity it previously computed and discarded: `div:has({grafana:components.Breadcrumbs.breadcrumb:Home})`.
5. **Admission-time `:has()` rescue** — identity candidates that die at admission (e.g. a solitary non-unique grafana candidate with no scoping ancestor) now retry descendant anchoring instead of degrading to positional `nth-of-type`.
6. **Badge resolvability validation** — `analyzeSelectorString` actually resolves grafana identities; a typo'd path now reads poor/0 with "Unknown grafana selector path for this Grafana version" instead of good/100. Parameterized grafana/`panel:` titles get the `environment-unstable` flag (free-text instance content). Testid-subject `:has()` selectors classify by subject. This check immediately caught the old pinned test and two docstrings referencing `components.RefreshPicker.runButton` — a path that doesn't exist in the resolved tree (only `runButtonV2` does).

## Verification

- `npm run check` fully green (5463 tests, 349 suites, Go, lint, prettier, coverage thresholds).
- New tests pin: token round-trip (params with colons, quotes), scoped-grafana emission with duplicated components, drop-when-unscopable, token ancestor scopes, token `:has()` anchors, admission-time rescue, badge poor-rating for unresolvable paths/tokens, instance-fragility flags.
- Suggested manual pass (`npm run server`): pick a Select/RefreshPicker inside one of several identical panels — primary selector should keep a `{grafana:...}` identity; type a bogus `grafana:` path in the block editor — badge should go red; replay a token selector with "Do it".

🤖 Generated with [Claude Code](https://claude.com/claude-code)