### PR TITLE
fix(telemetry): align Faro event/action names with the analytics.ts convention

### DIFF
--- a/src/components/docs-panel/docs-panel.load-tab-content.test.ts
+++ b/src/components/docs-panel/docs-panel.load-tab-content.test.ts
@@ -89,7 +89,8 @@ jest.mock('../../lib/user-storage', () => ({
 jest.mock('../../lib/analytics', () => ({
   setupScrollTracking: jest.fn(),
   reportAppInteraction: jest.fn(),
-  UserInteraction: {},
+  createInteractionName: jest.fn((type: string) => `pathfinder_${type}`),
+  UserInteraction: { DocsPanelInteraction: 'docs_panel_interaction' },
   getContentTypeForAnalytics: jest.fn(),
 }));
 

--- a/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
+++ b/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
@@ -94,7 +94,8 @@ jest.mock('../../lib/user-storage', () => ({
 jest.mock('../../lib/analytics', () => ({
   setupScrollTracking: jest.fn(),
   reportAppInteraction: jest.fn(),
-  UserInteraction: {},
+  createInteractionName: jest.fn((type: string) => `pathfinder_${type}`),
+  UserInteraction: { DocsPanelInteraction: 'docs_panel_interaction' },
   getContentTypeForAnalytics: jest.fn(),
 }));
 

--- a/src/components/interactive-tutorial/interactive-section.runner.tripwire.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.runner.tripwire.test.tsx
@@ -198,7 +198,7 @@ describe('handleDoSection — Phase 0 tripwire (Tier C gate)', () => {
     });
   });
 
-  describe('pathfinder_section_run Faro outcome', () => {
+  describe('pathfinder_do_section_button_click Faro outcome', () => {
     it('reports outcome ok for a fully completed run', async () => {
       render(
         <InteractiveSection id="runner" title="Runner" autoCollapse={false}>
@@ -215,7 +215,9 @@ describe('handleDoSection — Phase 0 tripwire (Tier C gate)', () => {
       await waitFor(() => expect(screen.getByTestId(resetBtn(SECTION_ID))).toBeInTheDocument());
 
       const { withFaroUserAction } = require('../../lib/faro');
-      const sectionRunCall = withFaroUserAction.mock.calls.find((c: unknown[]) => c[0] === 'pathfinder_section_run');
+      const sectionRunCall = withFaroUserAction.mock.calls.find(
+        (c: unknown[]) => c[0] === 'pathfinder_do_section_button_click'
+      );
       expect(sectionRunCall[4].outcomeFrom).toBeInstanceOf(Function);
       expect(sectionRunCall[4].outcomeFrom()).toBe('ok');
     });
@@ -275,7 +277,9 @@ describe('handleDoSection — Phase 0 tripwire (Tier C gate)', () => {
 
       // mock.calls accumulates across tests in this file — take the latest call.
       const { withFaroUserAction } = require('../../lib/faro');
-      const sectionRunCalls = withFaroUserAction.mock.calls.filter((c: unknown[]) => c[0] === 'pathfinder_section_run');
+      const sectionRunCalls = withFaroUserAction.mock.calls.filter(
+        (c: unknown[]) => c[0] === 'pathfinder_do_section_button_click'
+      );
       const sectionRunCall = sectionRunCalls[sectionRunCalls.length - 1];
       expect(sectionRunCall[4].outcomeFrom()).toBe('action_error');
     });

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -66,7 +66,13 @@ function lookupStepSchema(child: React.ReactNode): StepTypeSchema | undefined {
   }
   return STEP_TYPE_LOOKUP.get(child.type as React.ComponentType<any>);
 }
-import { reportAppInteraction, UserInteraction, getSourceDocument, calculateStepCompletion } from '../../lib/analytics';
+import {
+  reportAppInteraction,
+  UserInteraction,
+  getSourceDocument,
+  calculateStepCompletion,
+  createInteractionName,
+} from '../../lib/analytics';
 import { StorageEvents } from '../../lib/event-names';
 import { sectionDoneStorage } from '../../lib/user-storage';
 import { INTERACTIVE_CONFIG, getInteractiveConfig } from '../../constants/interactive-config';
@@ -786,7 +792,7 @@ export function InteractiveSection({
     // unmount and silently lost the per-step writes.
 
     await withFaroUserAction(
-      'pathfinder_section_run',
+      createInteractionName(UserInteraction.DoSectionButtonClick),
       {
         section_id: sectionId,
         section_title: title || DEFAULT_INTERACTIVE_SECTION_TITLE,

--- a/src/integrations/cross-tab/live-tab-executor.ts
+++ b/src/integrations/cross-tab/live-tab-executor.ts
@@ -33,6 +33,7 @@ import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-side
 import pluginJson from '../../plugin.json';
 import { logger } from '../../lib/logging';
 import { setFaroUserActionAttributes, USER_ACTION_TIMEOUT_LONG_MS, withFaroUserAction } from '../../lib/faro';
+import { TELEMETRY_ACTIONS } from '../../lib/telemetry';
 
 // The verbs the guided handler can actually drive — narrower than the receive
 // gate's KNOWN_TARGET_ACTIONS, so runGuided checks against this before casting.
@@ -264,7 +265,7 @@ export function installLiveTabExecutor(
     const postProgress = (index: number) =>
       transport.post({ kind: 'step-progress', stepId, runId, index, total: internalActions?.length ?? 0 });
     await withFaroUserAction(
-      'pathfinder_remote_step',
+      TELEMETRY_ACTIONS.remoteStep,
       {
         target_action: command.action.targetAction,
         ref_target: command.action.refTarget ?? '',

--- a/src/interactive-engine/action-handlers/guided-handler.test.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.test.ts
@@ -153,7 +153,7 @@ describe('GuidedHandler', () => {
       );
 
       expect(withFaroUserAction).toHaveBeenCalledWith(
-        'pathfinder_guided_step',
+        'pathfinder_do_it_button_click',
         { target_action: 'highlight', ref_target: refTarget, step_index: 0, total_steps: 1 },
         expect.any(Function),
         10_005,

--- a/src/interactive-engine/action-handlers/guided-handler.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.ts
@@ -10,6 +10,7 @@ import {
 } from '../../lib/dom';
 import { logger } from '../../lib/logging';
 import { withFaroUserAction } from '../../lib/faro';
+import { createInteractionName, UserInteraction } from '../../lib/analytics';
 import { type CompletionResult, outcomeFromCompletionResult } from '../outcome-classifier';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 import { GuidedAction } from '../../types/interactive-actions.types';
@@ -88,7 +89,7 @@ export class GuidedHandler {
     timeout: number = INTERACTIVE_CONFIG.guided.stepTimeout
   ): Promise<CompletionResult> {
     return withFaroUserAction(
-      'pathfinder_guided_step',
+      createInteractionName(UserInteraction.DoItButtonClick),
       {
         target_action: action.targetAction,
         ref_target: action.refTarget ?? '',

--- a/src/interactive-engine/interactive.hook.test.ts
+++ b/src/interactive-engine/interactive.hook.test.ts
@@ -253,7 +253,7 @@ describe('useInteractiveElements', () => {
   });
 
   describe('Faro user action wiring', () => {
-    it('wraps show-mode execution in a pathfinder_step_show action', async () => {
+    it('wraps show-mode execution in a pathfinder_show_me_button_click action', async () => {
       const { result } = renderHook(() => useInteractiveElements({ containerRef }));
 
       await act(async () => {
@@ -261,7 +261,7 @@ describe('useInteractiveElements', () => {
       });
 
       expect(withFaroUserAction).toHaveBeenCalledWith(
-        'pathfinder_step_show',
+        'pathfinder_show_me_button_click',
         { target_action: 'highlight', ref_target: '#target' },
         expect.any(Function),
         undefined,
@@ -269,7 +269,7 @@ describe('useInteractiveElements', () => {
       );
     });
 
-    it('wraps do-mode execution in a pathfinder_step_do action', async () => {
+    it('wraps do-mode execution in a pathfinder_do_it_button_click action', async () => {
       const { result } = renderHook(() => useInteractiveElements({ containerRef }));
 
       await act(async () => {
@@ -277,7 +277,7 @@ describe('useInteractiveElements', () => {
       });
 
       expect(withFaroUserAction).toHaveBeenCalledWith(
-        'pathfinder_step_do',
+        'pathfinder_do_it_button_click',
         { target_action: 'button', ref_target: 'Save' },
         expect.any(Function),
         undefined,

--- a/src/interactive-engine/interactive.hook.ts
+++ b/src/interactive-engine/interactive.hook.ts
@@ -4,6 +4,7 @@ import { addGlobalInteractiveStyles, updateInteractiveThemeColors } from '../sty
 import { waitForReactUpdates } from '../lib/async-utils';
 import { logger } from '../lib/logging';
 import { USER_ACTION_TIMEOUT_LONG_MS, withFaroUserAction } from '../lib/faro';
+import { createInteractionName, UserInteraction } from '../lib/analytics';
 import type { SequenceRunResult, StepOutcome } from '../lib/telemetry';
 import { outcomeFromSequenceRun } from './outcome-classifier';
 // eslint-disable-next-line no-restricted-imports -- [ratchet] ALLOWED_LATERAL_VIOLATIONS: interactive-engine -> requirements-manager
@@ -164,7 +165,9 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
   const dispatchInteractiveAction = useCallback(
     async (data: InteractiveElementData, click: boolean) => {
       await withFaroUserAction(
-        click ? 'pathfinder_step_do' : 'pathfinder_step_show',
+        click
+          ? createInteractionName(UserInteraction.DoItButtonClick)
+          : createInteractionName(UserInteraction.ShowMeButtonClick),
         { target_action: data.targetAction, ref_target: data.refTarget },
         async () => {
           if (data.targetAction === 'highlight') {
@@ -411,7 +414,9 @@ export function useInteractiveElements(options: UseInteractiveElementsOptions = 
       // promise settlement — stamps the action outcome.
       let sequenceResult: SequenceRunResult | undefined;
       await withFaroUserAction(
-        isShowMode ? 'pathfinder_step_show' : 'pathfinder_step_do',
+        isShowMode
+          ? createInteractionName(UserInteraction.ShowMeButtonClick)
+          : createInteractionName(UserInteraction.DoItButtonClick),
         { target_action: targetAction, ref_target: refTarget },
         async () => {
           try {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -122,7 +122,7 @@ export enum UserInteraction {
 /**
  * Creates a properly namespaced interaction name for Grafana analytics
  */
-const createInteractionName = (type: UserInteraction): string => {
+export const createInteractionName = (type: UserInteraction): string => {
   return `pathfinder_${type}`;
 };
 

--- a/src/lib/telemetry/facade.test.ts
+++ b/src/lib/telemetry/facade.test.ts
@@ -26,12 +26,12 @@ beforeEach(() => {
 });
 
 describe('withGuideOpenAction', () => {
-  it('wraps the load in a critical pathfinder_guide_open action with a normalized URL', async () => {
+  it('wraps the load in a critical pathfinder_docs_panel_interaction action with a normalized URL', async () => {
     await withGuideOpenAction('https://grafana.com/docs/page/?token=secret#frag', async () => 'completed');
 
     expect(mockWithFaroUserAction).toHaveBeenCalledWith(
-      'pathfinder_guide_open',
-      { content_url: 'grafana.com/docs/page/' },
+      'pathfinder_docs_panel_interaction',
+      { action: 'open_guide', content_url: 'grafana.com/docs/page/' },
       expect.any(Function),
       USER_ACTION_TIMEOUT_MEDIUM_MS,
       expect.objectContaining({ critical: true })
@@ -65,7 +65,7 @@ describe('measurement and event domain operations', () => {
       { recommender_ms: 120 },
       { outcome: 'unavailable' }
     );
-    expect(mockPushFaroEvent).toHaveBeenCalledWith('recommender_fallback', {
+    expect(mockPushFaroEvent).toHaveBeenCalledWith('pathfinder_recommender_fallback', {
       fallback_tier: 'bundled+static',
       error_type: 'unavailable',
     });
@@ -89,7 +89,7 @@ describe('measurement and event domain operations', () => {
       { content_fetch_ms: 42 },
       { tier: 'content-json', outcome: 'ok', content_url: 'grafana.com/docs/x/' }
     );
-    expect(mockPushFaroEvent).toHaveBeenCalledWith('content_fetch_fallback', {
+    expect(mockPushFaroEvent).toHaveBeenCalledWith('pathfinder_content_fetch_fallback', {
       content_url: 'grafana.com/docs/x/',
       tier_used: 'unstyled-html',
       error_type: 'content-json-null',
@@ -100,11 +100,11 @@ describe('measurement and event domain operations', () => {
     recordRequirementsExhausted('has-role:admin', 3);
     recordSequenceActionError('has-role:admin', 3, { name: 'Error', category: 'timeout' });
 
-    expect(mockPushFaroEvent).toHaveBeenCalledWith('requirements_exhausted', {
+    expect(mockPushFaroEvent).toHaveBeenCalledWith('pathfinder_requirements_exhausted', {
       requirement: 'has-role:admin',
       retry_count: 3,
     });
-    expect(mockPushFaroEvent).toHaveBeenCalledWith('sequence_action_error', {
+    expect(mockPushFaroEvent).toHaveBeenCalledWith('pathfinder_sequence_action_error', {
       requirement: 'has-role:admin',
       retry_count: 3,
       error_name: 'Error',

--- a/src/lib/telemetry/facade.ts
+++ b/src/lib/telemetry/facade.ts
@@ -2,8 +2,8 @@
 // pushFaro* primitives, so the backing SDK stays an adapter concern.
 import { pushFaroEvent, pushFaroMeasurement, withFaroUserAction, USER_ACTION_TIMEOUT_MEDIUM_MS } from './faro-adapter';
 import { normalizeTelemetryUrl } from './url';
+import { createInteractionName, UserInteraction } from '../analytics';
 import {
-  TELEMETRY_ACTIONS,
   TELEMETRY_EVENTS,
   TELEMETRY_MEASUREMENTS,
   type ContentFetchOutcome,
@@ -19,8 +19,8 @@ import {
 // outcome — not promise settlement — stamps the action.
 export function withGuideOpenAction(url: string, work: () => Promise<GuideLoadOutcome>): Promise<GuideLoadOutcome> {
   return withFaroUserAction(
-    TELEMETRY_ACTIONS.guideOpen,
-    { content_url: normalizeTelemetryUrl(url) },
+    createInteractionName(UserInteraction.DocsPanelInteraction),
+    { action: 'open_guide', content_url: normalizeTelemetryUrl(url) },
     work,
     USER_ACTION_TIMEOUT_MEDIUM_MS,
     {

--- a/src/lib/telemetry/types.ts
+++ b/src/lib/telemetry/types.ts
@@ -21,10 +21,10 @@ export type ContentFetchTier = 'bundled' | 'backend-guide' | 'content-json' | 'u
 export type ContentFetchOutcome = 'ok' | 'error';
 
 export const TELEMETRY_EVENTS = {
-  recommenderFallback: 'recommender_fallback',
-  contentFetchFallback: 'content_fetch_fallback',
-  requirementsExhausted: 'requirements_exhausted',
-  sequenceActionError: 'sequence_action_error',
+  recommenderFallback: 'pathfinder_recommender_fallback',
+  contentFetchFallback: 'pathfinder_content_fetch_fallback',
+  requirementsExhausted: 'pathfinder_requirements_exhausted',
+  sequenceActionError: 'pathfinder_sequence_action_error',
 } as const;
 
 export const TELEMETRY_MEASUREMENTS = {
@@ -35,6 +35,9 @@ export const TELEMETRY_MEASUREMENTS = {
   panel: 'pathfinder_panel',
 } as const;
 
+// Faro-only spans with no real UserInteraction counterpart (unlike guide-open,
+// step-do/show, guided-step, and section-run, which reuse the real analytics
+// interaction name via analytics.ts's createInteractionName instead).
 export const TELEMETRY_ACTIONS = {
-  guideOpen: 'pathfinder_guide_open',
+  remoteStep: 'pathfinder_remote_step',
 } as const;

--- a/src/test-utils/interactive-section-harness.tsx
+++ b/src/test-utils/interactive-section-harness.tsx
@@ -335,11 +335,12 @@ export function createAlignmentContextMock() {
 export function createAnalyticsMock() {
   return {
     reportAppInteraction: jest.fn(),
+    createInteractionName: jest.fn((type: string) => `pathfinder_${type}`),
     UserInteraction: {
-      DoSectionButtonClick: 'do_section',
-      ShowMeButtonClick: 'show_me',
-      DoItButtonClick: 'do_it',
-      StepAutoCompleted: 'auto',
+      DoSectionButtonClick: 'do_section_button_click',
+      ShowMeButtonClick: 'show_me_button_click',
+      DoItButtonClick: 'do_it_button_click',
+      StepAutoCompleted: 'step_auto_completed',
     },
     getSourceDocument: jest.fn(() => ({})),
     calculateStepCompletion: jest.fn(() => undefined),


### PR DESCRIPTION
## Summary

Two distinct naming problems in the Faro-only telemetry path, both traced back to the `analytics.ts` convention (`pathfinder_<snake_case>`, applied via `createInteractionName`):

- **Missing prefix**: `TELEMETRY_EVENTS` in `src/lib/telemetry/types.ts` defined four Faro-only event names (`recommender_fallback`, `content_fetch_fallback`, `requirements_exhausted`, `sequence_action_error`) with no `pathfinder_` prefix — dropped when PR #1338 split them off the RudderStack pipeline into raw `pushFaroEvent(...)` calls. These stay Faro-only (that split was a deliberate, documented decision); this PR only adds the missing prefix.
- **Invented duplicate ("ghost") names**: five `withFaroUserAction(...)` call sites invented their own `pathfinder_`-prefixed name from scratch, even though the *same click* is already reported through `reportAppInteraction`/`UserInteraction` a few lines away:
  - `pathfinder_step_do` / `pathfinder_step_show` (`interactive.hook.ts`) → real name is `UserInteraction.DoItButtonClick` / `ShowMeButtonClick`
  - `pathfinder_section_run` (`interactive-section.tsx`) → real name is `UserInteraction.DoSectionButtonClick`
  - `pathfinder_guided_step` (`guided-handler.ts`) → real name is `UserInteraction.DoItButtonClick` (fired by `interactive-guided.tsx`'s `handleDoAction`)
  - `pathfinder_guide_open` (`facade.ts`'s `TELEMETRY_ACTIONS.guideOpen`) → the generic `UserInteraction.DocsPanelInteraction` action-bucket pattern (`{ action, source, ... }`) already used across the panel is the right fit; retargeted with `action: 'open_guide'`

`createInteractionName` is now exported from `analytics.ts` so these call sites can reuse the real name instead of inventing one.

One name investigated and found **not** to be a duplicate: `pathfinder_remote_step` (`live-tab-executor.ts`) times the two-tab controller's live-tab relay execution — the click is already reported as a real interaction on the *control* tab; this measures relay/execution latency on the *live* tab, a genuinely different signal. Moved into the `TELEMETRY_ACTIONS` registry instead of staying an inline literal, same treatment as the `TELEMETRY_EVENTS` funnel signals.

Sharing the real interaction name also means the fully-attributed `analytics.ts` Faro mirror (`step_id`, `section_id`, `current_step`, `completion_percentage`, etc. — flattened key-by-key by `stringifyAttributes`, not a nested JSON blob) is now discoverable under the same name as the engine's duration-tracked span, so these actions are searchable in Faro the same way they already are in RudderStack — no attribute mapping/threading needed, since that mirror already sends the full properties object.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run check` (348 suites, 5426 tests, all passing)
- [x] Grep sweep confirms no remaining un-prefixed/invented literal outside test fixtures and the unrelated `LoopExitReason`/`outcome-classifier.ts` vocabulary
- [ ] Manual sanity in a dev Grafana: trigger a "Show me"/"Do it" step, a guided step, a section run, and a guide open; confirm the Faro Frontend Observability "User actions" view shows the renamed actions

## Breaking changes

None for product behavior. Grafana-internal Faro event names change for 5 actions (`pathfinder_guide_open`→`pathfinder_docs_panel_interaction`, `pathfinder_step_do`→`pathfinder_do_it_button_click`, `pathfinder_step_show`→`pathfinder_show_me_button_click`, `pathfinder_guided_step`→`pathfinder_do_it_button_click`, `pathfinder_section_run`→`pathfinder_do_section_button_click`) plus a prefix added to 4 more (`pathfinder_recommender_fallback` etc.). All of this telemetry is very recent (PR #1338, merged 2026-07-15) — low blast radius for any existing dashboard/alert.