### PR TITLE
chore(ci): alert #grafana-pathfinder-alerts on main branch CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,11 +351,12 @@ jobs:
             ["Test backend"]="$TEST_BACKEND_RESULT"
           )
 
-          text="*CI failed on \`main\`*\n*Failed jobs:*"
+          nl=$'\n'
+          text="*CI failed on \`main\`*${nl}*Failed jobs:*"
           for name in "Lint" "Typecheck" "Prettier" "Test" "Validate packages" "Test backend"; do
             if [[ "${results[$name]}" == "failure" ]]; then
               url=$(echo "$jobs_json" | jq -r --arg n "$name" '.jobs[] | select(.name == $n) | .html_url')
-              text="${text}\n• <${url}|${name}>"
+              text="${text}${nl}• <${url}|${name}>"
             fi
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
   # Alerts #grafana-pathfinder-alerts on main-branch CI failures only.
   notify-ci-failure:
     name: Notify CI failure
-    needs: [lint, typecheck, prettier, test, validate-packages, test-backend]
+    needs: [lint, typecheck, prettier, test, validate-packages, build, test-backend]
     if: >-
       always() &&
       github.event_name == 'push' &&
@@ -319,6 +319,7 @@ jobs:
        needs.prettier.result == 'failure' ||
        needs.test.result == 'failure' ||
        needs.validate-packages.result == 'failure' ||
+       needs.build.result == 'failure' ||
        needs.test-backend.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
@@ -335,6 +336,7 @@ jobs:
           PRETTIER_RESULT: ${{ needs.prettier.result }}
           TEST_RESULT: ${{ needs.test.result }}
           VALIDATE_RESULT: ${{ needs.validate-packages.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
           TEST_BACKEND_RESULT: ${{ needs.test-backend.result }}
           RUN_ID: ${{ github.run_id }}
           SHA: ${{ github.sha }}
@@ -348,12 +350,13 @@ jobs:
             ["Prettier"]="$PRETTIER_RESULT"
             ["Test"]="$TEST_RESULT"
             ["Validate packages"]="$VALIDATE_RESULT"
+            ["Build"]="$BUILD_RESULT"
             ["Test backend"]="$TEST_BACKEND_RESULT"
           )
 
           nl=$'\n'
           text="*CI failed on \`main\`*${nl}*Failed jobs:*"
-          for name in "Lint" "Typecheck" "Prettier" "Test" "Validate packages" "Test backend"; do
+          for name in "Lint" "Typecheck" "Prettier" "Test" "Validate packages" "Build" "Test backend"; do
             if [[ "${results[$name]}" == "failure" ]]; then
               url=$(echo "$jobs_json" | jq -r --arg n "$name" '.jobs[] | select(.name == $n) | .html_url')
               text="${text}${nl}• <${url}|${name}>"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,89 @@ jobs:
 
           echo "All required jobs passed!"
 
+  # Alerts #grafana-pathfinder-alerts on main-branch CI failures only.
+  notify-ci-failure:
+    name: Notify CI failure
+    needs: [lint, typecheck, prettier, test, validate-packages, test-backend]
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      (needs.lint.result == 'failure' ||
+       needs.typecheck.result == 'failure' ||
+       needs.prettier.result == 'failure' ||
+       needs.test.result == 'failure' ||
+       needs.validate-packages.result == 'failure' ||
+       needs.test-backend.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # required by the shared action's checkout step
+      id-token: write # required by get-vault-secrets for OIDC auth to Vault
+      actions: read   # required to fetch job URLs from the GitHub API
+    steps:
+      - name: Build Slack payload
+        id: payload
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          TYPECHECK_RESULT: ${{ needs.typecheck.result }}
+          PRETTIER_RESULT: ${{ needs.prettier.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          VALIDATE_RESULT: ${{ needs.validate-packages.result }}
+          TEST_BACKEND_RESULT: ${{ needs.test-backend.result }}
+          RUN_ID: ${{ github.run_id }}
+          SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          jobs_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs")
+
+          declare -A results=(
+            ["Lint"]="$LINT_RESULT"
+            ["Typecheck"]="$TYPECHECK_RESULT"
+            ["Prettier"]="$PRETTIER_RESULT"
+            ["Test"]="$TEST_RESULT"
+            ["Validate packages"]="$VALIDATE_RESULT"
+            ["Test backend"]="$TEST_BACKEND_RESULT"
+          )
+
+          text="*CI failed on \`main\`*\n*Failed jobs:*"
+          for name in "Lint" "Typecheck" "Prettier" "Test" "Validate packages" "Test backend"; do
+            if [[ "${results[$name]}" == "failure" ]]; then
+              url=$(echo "$jobs_json" | jq -r --arg n "$name" '.jobs[] | select(.name == $n) | .html_url')
+              text="${text}\n• <${url}|${name}>"
+            fi
+          done
+
+          payload=$(jq -n \
+            --arg text "$text" \
+            --arg run_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" \
+            --arg sha "${SHA}" \
+            --arg actor "${ACTOR}" \
+            '{
+              channel: "C0A2VAPHCBT",
+              text: "CI failed on main",
+              blocks: [
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: $text }
+                },
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: "<\($run_url)|Open CI run>\nCommit: `\($sha)` \u00b7 triggered by `\($actor)`" }
+                }
+              ]
+            }')
+
+          echo "payload<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$payload" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack
+        uses: grafana/shared-workflows/actions/send-slack-message@551bc8d50017d3e95d5da3f8a4826e733a208dc0 # send-slack-message/v3.0.2
+        with:
+          method: chat.postMessage
+          payload: ${{ steps.payload.outputs.payload }}
+
   # Resolve E2E versions runs in parallel (no dependency on build)
   resolve-versions:
     name: Resolve e2e images


### PR DESCRIPTION
## Summary

Adds a `notify-ci-failure` job to `.github/workflows/ci.yml` that posts a Slack message to `#grafana-pathfinder-alerts` when any of the seven critical CI jobs (`lint`, `typecheck`, `prettier`, `test`, `validate-packages`, `build`, `test-backend`) fail on `main`. The message lists only the failing jobs as direct links to their GitHub Actions log pages, fetched from the GitHub Jobs API at alert time. Success, cancellation, and skip results do not trigger the alert.

Example message will look like this:

> **CI failed on `main`**
*Failed jobs:*
• [Test](https://github.com/org/grafana-pathfinder-app/actions/runs/12345678/job/111111111)
• [Test backend](https://github.com/org/grafana-pathfinder-app/actions/runs/12345678/job/222222222)
>
> [Open CI run](https://github.com/org/grafana-pathfinder-app/actions/runs/12345678)
Commit: `a1b2c3d4` · triggered by `leslieheinzen`

## What to look at

- [**`.github/workflows/ci.yml` — `notify-ci-failure` job**](https://github.com/grafana/grafana-pathfinder-app/blob/854f793854e71ad603661fea42925031b8934d79/.github/workflows/ci.yml#L309): The `if` expression checks `github.event_name == 'push'` and `github.ref == 'refs/heads/main'` before checking for `'failure'` results, so PR runs and branch runs are excluded. The script step calls `gh api` to get per-job `html_url` values, builds the payload with `jq` (safe against injection), and writes it to `GITHUB_OUTPUT`. The `send-slack-message` action is pinned to commit SHA `551bc8d5` (v3.0.2) consistent with repo pinning conventions.

## How to verify

1. Review the `if:` expression — confirm it will not fire for `cancelled` results (e.g. when the concurrency policy cancels a run mid-flight) or `skipped` results (e.g. `test-backend` when no `Magefile.go` is present).
2. Confirm `id-token: write` is scoped solely to Vault OIDC auth via `get-vault-secrets`, and `actions: read` is the minimum scope needed to call the GitHub Jobs API.
3. Confirm the Slack channel ID `C0A2VAPHCBT` maps to `#grafana-pathfinder-alerts`.

## Breaking changes

None. This change is additive and fully reversible.
