### PR TITLE
fix(docs-panel): restore full-page navigation for the "My learning" header button

### DIFF
--- a/src/components/docs-panel/components/DocsPanelTabBar.test.tsx
+++ b/src/components/docs-panel/components/DocsPanelTabBar.test.tsx
@@ -1,12 +1,3 @@
-/**
- * Tests for DocsPanelTabBar.
- *
- * Focused on the "My learning" wiring seam: the tab bar must pass an in-panel
- * handler to TabBarActions so the button switches to the recommendations tab
- * (issue #1051) rather than navigating away. If this wiring is dropped, the
- * header button silently reverts to a full-page navigation.
- */
-
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DocsPanelTabBar, type DocsPanelTabBarProps } from './DocsPanelTabBar';
@@ -79,14 +70,14 @@ describe('DocsPanelTabBar', () => {
     jest.clearAllMocks();
   });
 
-  it('wires the "My learning" button to switch to the recommendations tab in place', () => {
+  it('navigates to the My Learning page when the "My learning" button is clicked', () => {
     const props = makeProps();
     render(<DocsPanelTabBar {...props} />);
 
     fireEvent.click(screen.getByTestId(testIds.docsPanel.myLearningTab));
 
-    expect(props.onSetActiveTab).toHaveBeenCalledWith('recommendations');
-    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalled();
+    expect(props.onSetActiveTab).not.toHaveBeenCalled();
   });
 
   describe('overflow chevron', () => {

--- a/src/components/docs-panel/components/DocsPanelTabBar.tsx
+++ b/src/components/docs-panel/components/DocsPanelTabBar.tsx
@@ -265,7 +265,6 @@ export function DocsPanelTabBar({
         activeTab={activeTab}
         isDevMode={isDevMode}
         onReloadActiveTab={reloadActiveTab}
-        onNavigateToRecommendations={() => onSetActiveTab('recommendations')}
       />
     </div>
   );

--- a/src/components/docs-panel/components/TabBarActions.test.tsx
+++ b/src/components/docs-panel/components/TabBarActions.test.tsx
@@ -147,17 +147,7 @@ describe('TabBarActions', () => {
   });
 
   describe('My learning button', () => {
-    it('switches to the recommendations tab in place when an in-panel handler is provided', () => {
-      const onNavigateToRecommendations = jest.fn();
-      render(<TabBarActions onNavigateToRecommendations={onNavigateToRecommendations} />);
-
-      fireEvent.click(screen.getByTestId(testIds.docsPanel.myLearningTab));
-
-      expect(onNavigateToRecommendations).toHaveBeenCalledTimes(1);
-      expect(mockPush).not.toHaveBeenCalled();
-    });
-
-    it('falls back to full-page navigation when no in-panel handler is provided', () => {
+    it('navigates to the My Learning page', () => {
       render(<TabBarActions />);
 
       fireEvent.click(screen.getByTestId(testIds.docsPanel.myLearningTab));

--- a/src/components/docs-panel/components/TabBarActions.tsx
+++ b/src/components/docs-panel/components/TabBarActions.tsx
@@ -29,13 +29,6 @@ export interface TabBarActionsProps {
   isDevMode?: boolean;
   /** Reload handler for the `Refresh (dev)` item. */
   onReloadActiveTab?: (tab: LearningJourneyTab) => void;
-  /**
-   * Switch the panel back to the recommendations tab in place. When supplied,
-   * the "My learning" button keeps the user in the sidebar instead of a
-   * full-page navigation to the plugin home. Falls back to navigation when
-   * absent (e.g. the component rendered outside the panel).
-   */
-  onNavigateToRecommendations?: () => void;
 }
 
 /**
@@ -47,7 +40,6 @@ export const TabBarActions: React.FC<TabBarActionsProps> = ({
   activeTab,
   isDevMode = false,
   onReloadActiveTab,
-  onNavigateToRecommendations,
 }) => {
   const user = config.bootData?.user;
   const canAccessPluginSettings = user?.isGrafanaAdmin === true || user?.orgRole === 'Admin';
@@ -100,13 +92,9 @@ export const TabBarActions: React.FC<TabBarActionsProps> = ({
 
   const handleMyLearningClick = () => {
     reportAppInteraction(UserInteraction.DocsPanelInteraction, {
-      action: 'navigate_to_recommendations',
+      action: 'navigate_to_my_learning',
       source: 'header_my_learning',
     });
-    if (onNavigateToRecommendations) {
-      onNavigateToRecommendations();
-      return;
-    }
     locationService.push(PLUGIN_BASE_URL);
   };
 


### PR DESCRIPTION
## Summary
- The header "My learning" icon button in the docs panel was rewired by #1286 to switch the panel to the in-panel recommendations tab instead of navigating to the plugin's actual My Learning page — leaving no way to reach that page from the sidebar.
- Reverts just that button to a full-page navigation (`locationService.push(PLUGIN_BASE_URL)`). "Return to my learning" (the content-area footer button, `DocsPanelContentArea.tsx`) is untouched and still switches to the in-panel recommendations tab.

## Test plan
- [x] `npx tsc --noEmit`
- [x] Updated `TabBarActions.test.tsx` and `DocsPanelTabBar.test.tsx` to assert full-page navigation; both suites pass
- [x] `docs-panel.contract.test.tsx` passes (testId ownership unaffected)
- [x] `npx eslint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)