### PR TITLE
chore: prep v2.14.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 2.14.1
+## 2.14.2
 
 ### Fixed
 
+- **"My learning" header button opens the My Learning page again**: #1286 rewired the docs panel's header "My learning" icon to switch to the in-panel recommendations tab, leaving no way to reach the actual My Learning page from the sidebar. The header button navigates there again; the guide footer's "Return to my learning" button is unchanged. (#1368)
 - **Block editor preserves view mode and JSON drafts across remounts**: Switching to Preview or JSON mode and popping the panel out or docking it back no longer resets to Edit mode or drops an unapplied JSON draft. (#1314)
 - **Secondary step buttons size to their label**: The "Show me" and "Do it" buttons on interactive steps no longer render inside an oversized fixed-width button. (#1323)
 - **Resume/do section button uses correct singular and plural step counts**: The catch-all section action button and its tooltip no longer read "(1 steps)" when exactly one step remains. (#1325)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-pathfinder-app",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-pathfinder-app",
-      "version": "2.14.1",
+      "version": "2.14.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-pathfinder-app",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "bin": {
     "pathfinder-cli": "./dist/cli/cli/index.js"
   },


### PR DESCRIPTION
## Summary
- v2.14.1 was staged (version bump + changelog) but never tagged/released.
- Folds its contents plus the "My learning" header-button navigation fix (#1368) into v2.14.2, since the previously-attempted dev release can't be reused under the same version number.
- Renames the `## 2.14.1` CHANGELOG section to `## 2.14.2` and adds the new fix entry; bumps `package.json` / `package-lock.json` to `2.14.2`.

## Test plan
- [x] `npm run check` (typecheck, lint, prettier, docs:sync-terms:check, lint:go, test:go, test:coverage) — 350 suites / 5466 tests passing
- [x] `npm run build` — production bundle compiles
- [x] `git diff --name-only` confined to `CHANGELOG.md`, `package.json`, `package-lock.json`

## After merge
```
git tag -a v2.14.2 -m "Release v2.14.2"
git push origin v2.14.2
```
The `release.yml` workflow triggers on `v*` tag push and creates the GitHub release. Tagging is left to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)