### PR TITLE
fix(e2e): isolate selector resolution from browser runtime

### DIFF
--- a/src/lib/dom/grafana-selector-core.ts
+++ b/src/lib/dom/grafana-selector-core.ts
@@ -1,0 +1,175 @@
+import { resolveSelectors, versionedComponents, versionedPages } from '@grafana/e2e-selectors';
+
+import { toCssAttributeString } from './css-escape';
+
+type SelectorNode = { [key: string]: SelectorNode | string | ((...args: never[]) => unknown) };
+
+interface ReverseIndex {
+  exact: Map<string, string>;
+  templates: Array<{ regex: RegExp; path: string }>;
+}
+
+const selectorTrees = new Map<string, SelectorNode>();
+const reverseIndexes = new Map<SelectorNode, ReverseIndex>();
+const TEMPLATE_SENTINEL = 'PARAM';
+const TESTID_PREFIX = /^data-testid\s*/;
+
+function getResolvedSelectors(grafanaVersion: string): SelectorNode {
+  const version = grafanaVersion || 'latest';
+  const cached = selectorTrees.get(version);
+  if (cached) {
+    return cached;
+  }
+
+  const tree = resolveSelectors({ components: versionedComponents, pages: versionedPages }, version);
+  const selectorTree = tree as unknown as SelectorNode;
+  selectorTrees.set(version, selectorTree);
+  return selectorTree;
+}
+
+export function toGrafanaSelectorForVersion(selectorPath: string, grafanaVersion: string, selectorId?: string): string {
+  if (!selectorPath) {
+    throw new Error('Selector path is required');
+  }
+
+  const parts = selectorPath.split('.');
+  let current: SelectorNode[string] | undefined = getResolvedSelectors(grafanaVersion);
+
+  for (const part of parts) {
+    if (!current || typeof current !== 'object') {
+      throw new Error(`Invalid selector path: ${selectorPath} (failed at ${part})`);
+    }
+    current = current[part];
+    if (current === undefined) {
+      throw new Error(`Selector not found: ${selectorPath} (${part} is undefined)`);
+    }
+  }
+
+  let resolvedValue: string;
+  if (typeof current === 'function') {
+    if (!selectorId) {
+      throw new Error(`Selector ${selectorPath} requires an ID parameter`);
+    }
+    const result = (current as (id: string) => unknown)(selectorId);
+    if (typeof result !== 'string') {
+      throw new Error(`Invalid selector type at ${selectorPath}: ${typeof result}`);
+    }
+    resolvedValue = result;
+  } else if (typeof current === 'string') {
+    resolvedValue = current;
+  } else {
+    throw new Error(`Invalid selector type at ${selectorPath}: ${typeof current}`);
+  }
+
+  const cssValue = toCssAttributeString(resolvedValue);
+  return `:is([data-testid=${cssValue}], [aria-label=${cssValue}])`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildTemplate(fn: (...args: never[]) => unknown): { regex: RegExp; weight: number } | null {
+  let resolved: unknown;
+  try {
+    resolved = (fn as (id: string) => unknown)(TEMPLATE_SENTINEL);
+  } catch {
+    return null;
+  }
+  if (typeof resolved !== 'string') {
+    return null;
+  }
+
+  const first = resolved.indexOf(TEMPLATE_SENTINEL);
+  if (first === -1 || first !== resolved.lastIndexOf(TEMPLATE_SENTINEL) || resolved.includes('undefined')) {
+    return null;
+  }
+
+  const prefix = resolved.slice(0, first);
+  const suffix = resolved.slice(first + TEMPLATE_SENTINEL.length);
+  const discriminator = (prefix.replace(TESTID_PREFIX, '') + suffix).trim();
+  if (discriminator.length < 3) {
+    return null;
+  }
+
+  return { regex: new RegExp(`^${escapeRegExp(prefix)}(.+)${escapeRegExp(suffix)}$`), weight: discriminator.length };
+}
+
+function getReverseIndex(grafanaVersion: string): ReverseIndex {
+  const root = getResolvedSelectors(grafanaVersion);
+  const cached = reverseIndexes.get(root);
+  if (cached) {
+    return cached;
+  }
+
+  const exact = new Map<string, string>();
+  const ambiguous = new Set<string>();
+  const templates: Array<{ regex: RegExp; path: string; weight: number }> = [];
+
+  const walk = (node: SelectorNode, path: string): void => {
+    for (const key of Object.keys(node)) {
+      const value = node[key];
+      const childPath = path ? `${path}.${key}` : key;
+      if (typeof value === 'string') {
+        if (ambiguous.has(value)) {
+          continue;
+        }
+        if (exact.has(value)) {
+          exact.delete(value);
+          ambiguous.add(value);
+        } else {
+          exact.set(value, childPath);
+        }
+      } else if (typeof value === 'function') {
+        const template = buildTemplate(value);
+        if (template) {
+          templates.push({ regex: template.regex, path: childPath, weight: template.weight });
+        }
+      } else if (value && typeof value === 'object') {
+        walk(value, childPath);
+      }
+    }
+  };
+
+  walk(root.components as SelectorNode, 'components');
+  walk(root.pages as SelectorNode, 'pages');
+  templates.sort((a, b) => b.weight - a.weight);
+
+  const index = { exact, templates: templates.map(({ regex, path }) => ({ regex, path })) };
+  reverseIndexes.set(root, index);
+  return index;
+}
+
+export function findGrafanaSelectorPathForVersion(
+  selectorValues: readonly string[],
+  grafanaVersion: string
+): string | null {
+  const index = getReverseIndex(grafanaVersion);
+
+  for (const value of selectorValues) {
+    const exactPath = index.exact.get(value);
+    if (exactPath) {
+      return `grafana:${exactPath}`;
+    }
+  }
+
+  for (const value of selectorValues) {
+    let matched: string | null = null;
+    for (const template of index.templates) {
+      const match = template.regex.exec(value);
+      if (!match || !match[1]) {
+        continue;
+      }
+      if (matched) {
+        matched = null;
+        break;
+      }
+      matched = `grafana:${template.path}:${match[1]}`;
+    }
+    if (matched) {
+      return matched;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/dom/grafana-selector.ts
+++ b/src/lib/dom/grafana-selector.ts
@@ -1,283 +1,34 @@
-/**
- * Grafana E2E Selector utilities
- * Converts Grafana selector objects to CSS selector strings
- * Based on @grafana/plugin-e2e approach for cross-version compatibility
- */
-
-import { resolveSelectors, versionedComponents, versionedPages } from '@grafana/e2e-selectors';
 import { config } from '@grafana/runtime';
-import { toCssAttributeString } from './css-escape';
+
 import { querySelectorAllEnhanced } from './enhanced-selector';
+import { findGrafanaSelectorPathForVersion, toGrafanaSelectorForVersion } from './grafana-selector-core';
 
-type SelectorNode = { [key: string]: SelectorNode | string | ((...args: never[]) => unknown) };
-
-let resolvedSelectors: { version: string; tree: SelectorNode } | null = null;
-
-/**
- * The selector tree resolved for the running Grafana version, so both forward
- * resolution and reverse lookup use the values this instance actually renders,
- * not the newest values in the bundled package.
- */
-function getResolvedSelectors(): SelectorNode {
-  const version = config.buildInfo.version || 'latest';
-  if (resolvedSelectors?.version !== version) {
-    const tree = resolveSelectors({ components: versionedComponents, pages: versionedPages }, version);
-    resolvedSelectors = { version, tree: tree as unknown as SelectorNode };
-  }
-  return resolvedSelectors.tree;
+function getGrafanaVersion(): string {
+  return config.buildInfo.version || 'latest';
 }
 
-/**
- * Convert a Grafana selector path to a CSS selector string
- * Handles both aria-label and data-testid attributes based on the selector definition
- *
- * @param selectorPath - Dot-notation path to selector (e.g., 'components.RefreshPicker.runButtonV2')
- * @returns CSS selector string that can be used with querySelector
- *
- * @example
- * // Simple selector
- * const selector = toGrafanaSelector('components.Select.input');
- * // Returns: '[data-testid="data-testid Select input"], [aria-label="Select input"]'
- *
- * @example
- * // Parameterized selector with ID
- * const selector = toGrafanaSelector('pages.AddDashboard.itemButton', 'Panel');
- * // Returns: 'button[aria-label="Add new panel Panel"]'
- */
 export function toGrafanaSelector(selectorPath: string, selectorId?: string): string {
-  if (!selectorPath) {
-    throw new Error('Selector path is required');
-  }
-
-  // Navigate the selector object path
-  const parts = selectorPath.split('.');
-  let current: SelectorNode[string] | undefined = getResolvedSelectors();
-
-  for (const part of parts) {
-    if (!current || typeof current !== 'object') {
-      throw new Error(`Invalid selector path: ${selectorPath} (failed at ${part})`);
-    }
-    current = current[part];
-    if (current === undefined) {
-      throw new Error(`Selector not found: ${selectorPath} (${part} is undefined)`);
-    }
-  }
-
-  // Handle parameterized selectors (functions)
-  let resolvedValue: string;
-  if (typeof current === 'function') {
-    if (!selectorId) {
-      throw new Error(`Selector ${selectorPath} requires an ID parameter`);
-    }
-    const result = (current as (id: string) => unknown)(selectorId);
-    if (typeof result !== 'string') {
-      throw new Error(`Invalid selector type at ${selectorPath}: ${typeof result}`);
-    }
-    resolvedValue = result;
-  } else if (typeof current === 'string') {
-    resolvedValue = current;
-  } else {
-    throw new Error(`Invalid selector type at ${selectorPath}: ${typeof current}`);
-  }
-
-  // Most Grafana selectors use data-testid, but some older ones use aria-label.
-  // :is() keeps both alternatives in ONE compound selector, so the result can be
-  // scoped, prefixed, or embedded inside :has(...) — a bare top-level comma list
-  // cannot (`scope A, B` scopes only A).
-  const cssValue = toCssAttributeString(resolvedValue);
-  const dataTestIdSelector = `[data-testid=${cssValue}]`;
-  const ariaLabelSelector = `[aria-label=${cssValue}]`;
-
-  return `:is(${dataTestIdSelector}, ${ariaLabelSelector})`;
+  return toGrafanaSelectorForVersion(selectorPath, getGrafanaVersion(), selectorId);
 }
 
-/**
- * Find elements using a Grafana selector path
- * This is the primary function you should use when selecting Grafana UI elements
- *
- * @param selectorPath - Dot-notation path to selector
- * @param selectorId - Optional ID for parameterized selectors
- * @returns Array of matching HTMLElements
- *
- * @example
- * // Find the query editor
- * const editors = findByGrafanaSelector('components.CodeEditor.container');
- *
- * @example
- * // Find a specific menu item
- * const menuItem = findByGrafanaSelector('components.NavMenu.item', 'Dashboards');
- */
 export function findByGrafanaSelector(selectorPath: string, selectorId?: string): HTMLElement[] {
-  const cssSelector = toGrafanaSelector(selectorPath, selectorId);
-  const result = querySelectorAllEnhanced(cssSelector);
-  return result.elements;
+  return querySelectorAllEnhanced(toGrafanaSelector(selectorPath, selectorId)).elements;
 }
 
-/**
- * Find a single element using a Grafana selector path
- * Returns the first matching element or null
- * Internal helper - not part of public API (exported for testing only)
- *
- * @param selectorPath - Dot-notation path to selector
- * @param selectorId - Optional ID for parameterized selectors
- * @returns First matching HTMLElement or null
- */
 export function findOneByGrafanaSelector(selectorPath: string, selectorId?: string): HTMLElement | null {
-  const elements = findByGrafanaSelector(selectorPath, selectorId);
-  return elements.length > 0 ? elements[0]! : null;
+  return findByGrafanaSelector(selectorPath, selectorId)[0] ?? null;
 }
 
-/**
- * Check if an element matching the Grafana selector exists
- * Useful for requirement checking in interactive guides
- * Internal helper - not part of public API (exported for testing only)
- *
- * @param selectorPath - Dot-notation path to selector
- * @param selectorId - Optional ID for parameterized selectors
- * @returns true if at least one matching element exists
- */
 export function existsByGrafanaSelector(selectorPath: string, selectorId?: string): boolean {
-  const elements = findByGrafanaSelector(selectorPath, selectorId);
-  return elements.length > 0;
-}
-
-// ============================================================================
-// Reverse lookup: element → grafana: selector path
-// ============================================================================
-
-interface ReverseIndex {
-  exact: Map<string, string>;
-  templates: Array<{ regex: RegExp; path: string }>;
-}
-
-// Delimited by U+E000 private-use characters that never appear in a real
-// selector value, used to locate the parameter position inside a
-// parameterized selector's output.
-const TEMPLATE_SENTINEL = 'PARAM';
-const TESTID_PREFIX = /^data-testid\s*/;
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return findByGrafanaSelector(selectorPath, selectorId).length > 0;
 }
 
 /**
- * Turn a parameterized selector function into a matcher. Returns null when the
- * function ignores its argument, takes several, or is so generic that its only
- * literal text is the shared `data-testid` prefix (which would match almost any
- * element — `pages.AddDashboard.itemButton` is the canonical offender).
- */
-function buildTemplate(fn: (...args: never[]) => unknown): { regex: RegExp; weight: number } | null {
-  let resolved: unknown;
-  try {
-    resolved = (fn as (id: string) => unknown)(TEMPLATE_SENTINEL);
-  } catch {
-    return null;
-  }
-  if (typeof resolved !== 'string') {
-    return null;
-  }
-  const first = resolved.indexOf(TEMPLATE_SENTINEL);
-  if (first === -1 || first !== resolved.lastIndexOf(TEMPLATE_SENTINEL) || resolved.includes('undefined')) {
-    return null;
-  }
-  const prefix = resolved.slice(0, first);
-  const suffix = resolved.slice(first + TEMPLATE_SENTINEL.length);
-  const discriminator = (prefix.replace(TESTID_PREFIX, '') + suffix).trim();
-  if (discriminator.length < 3) {
-    return null;
-  }
-  return { regex: new RegExp(`^${escapeRegExp(prefix)}(.+)${escapeRegExp(suffix)}$`), weight: discriminator.length };
-}
-
-let reverseIndex: { source: SelectorNode; index: ReverseIndex } | null = null;
-
-function getReverseIndex(): ReverseIndex {
-  const root = getResolvedSelectors();
-  if (reverseIndex?.source === root) {
-    return reverseIndex.index;
-  }
-  const exact = new Map<string, string>();
-  const ambiguous = new Set<string>();
-  const templates: Array<{ regex: RegExp; path: string; weight: number }> = [];
-
-  const walk = (node: SelectorNode, path: string): void => {
-    for (const key of Object.keys(node)) {
-      const value = node[key];
-      const childPath = path ? `${path}.${key}` : key;
-      if (typeof value === 'string') {
-        if (ambiguous.has(value)) {
-          continue;
-        }
-        if (exact.has(value)) {
-          exact.delete(value);
-          ambiguous.add(value);
-        } else {
-          exact.set(value, childPath);
-        }
-      } else if (typeof value === 'function') {
-        const template = buildTemplate(value);
-        if (template) {
-          templates.push({ regex: template.regex, path: childPath, weight: template.weight });
-        }
-      } else if (value && typeof value === 'object') {
-        walk(value, childPath);
-      }
-    }
-  };
-
-  walk(root.components as SelectorNode, 'components');
-  walk(root.pages as SelectorNode, 'pages');
-
-  // Most specific templates first, so a generic pattern never shadows a precise one.
-  templates.sort((a, b) => b.weight - a.weight);
-  reverseIndex = { source: root, index: { exact, templates: templates.map(({ regex, path }) => ({ regex, path })) } };
-  return reverseIndex.index;
-}
-
-/**
- * Reverse of {@link toGrafanaSelector}: given a DOM element, return the
- * version-stable `grafana:` selector path that targets it, or null when the
- * element carries no recognized Grafana selector value.
- *
- * Covers both `components.*` and `pages.*`, matching on `data-testid` first and
- * `aria-label` second, and extracts the parameter for parameterized selectors
- * (e.g. `grafana:components.Breadcrumbs.breadcrumb:Home`).
- *
- * Lookups are resolved against the running Grafana version, and any ambiguous
- * value — one claimed by several selector paths, or matching several templates —
- * returns null so the picker degrades to its own CSS strategies rather than
- * emitting a confidently wrong path.
+ * Returns null for unknown or ambiguous values so callers can fall back to CSS generation.
  */
 export function findGrafanaSelectorPath(element: HTMLElement): string | null {
-  const index = getReverseIndex();
   const values = [element.getAttribute('data-testid'), element.getAttribute('aria-label')].filter(
     (value): value is string => Boolean(value)
   );
-
-  for (const value of values) {
-    const exactPath = index.exact.get(value);
-    if (exactPath) {
-      return `grafana:${exactPath}`;
-    }
-  }
-
-  for (const value of values) {
-    let matched: string | null = null;
-    for (const template of index.templates) {
-      const match = template.regex.exec(value);
-      if (!match || !match[1]) {
-        continue;
-      }
-      if (matched) {
-        matched = null;
-        break;
-      }
-      matched = `grafana:${template.path}:${match[1]}`;
-    }
-    if (matched) {
-      return matched;
-    }
-  }
-
-  return null;
+  return findGrafanaSelectorPathForVersion(values, getGrafanaVersion());
 }

--- a/src/lib/dom/grafana-selector.versioned.test.ts
+++ b/src/lib/dom/grafana-selector.versioned.test.ts
@@ -2,12 +2,11 @@
  * Version-aware resolution and ambiguity handling for grafana-selector.
  *
  * Uses a synthetic versioned selector tree with the package's real
- * `resolveSelectors`, so the wiring from `config.buildInfo.version` through
- * forward resolution and the reverse index is exercised end-to-end.
+ * `resolveSelectors`, so forward resolution and reverse lookup exercise
+ * explicit target versions end-to-end.
  */
 
 import { describe, it, expect } from '@jest/globals';
-
 jest.mock('@grafana/runtime', () => ({
   config: { buildInfo: { version: 'latest' } },
 }));
@@ -41,49 +40,48 @@ jest.mock('@grafana/e2e-selectors', () => {
     },
   };
 });
-
 import { config } from '@grafana/runtime';
-import { toGrafanaSelector, findGrafanaSelectorPath } from './grafana-selector';
+import { toGrafanaSelector } from './grafana-selector';
 
-function elementWithTestId(testId: string): HTMLElement {
-  const el = document.createElement('button');
-  el.setAttribute('data-testid', testId);
-  return el;
-}
-
-describe('grafana-selector — version-aware resolution', () => {
-  it('resolves forward against the running Grafana version, not latest', () => {
+import { findGrafanaSelectorPathForVersion, toGrafanaSelectorForVersion } from './grafana-selector-core';
+describe('grafana-selector browser adapter', () => {
+  it('resolves against the running Grafana version', () => {
     config.buildInfo.version = '9.0.0';
     expect(toGrafanaSelector('components.Thing.button')).toContain("[data-testid='old thing button']");
   });
+});
+
+describe('grafana-selector — version-aware resolution', () => {
+  it('resolves forward against the running Grafana version, not latest', () => {
+    expect(toGrafanaSelectorForVersion('components.Thing.button', '9.0.0')).toContain(
+      "[data-testid='old thing button']"
+    );
+  });
 
   it('resolves forward to the newer value once the running version reaches it', () => {
-    config.buildInfo.version = '12.0.0';
-    expect(toGrafanaSelector('components.Thing.button')).toContain("[data-testid='data-testid new thing button']");
+    expect(toGrafanaSelectorForVersion('components.Thing.button', '12.0.0')).toContain(
+      "[data-testid='data-testid new thing button']"
+    );
   });
 
   it('falls back to the latest values when the version is not valid semver', () => {
-    config.buildInfo.version = '1.0';
-    expect(toGrafanaSelector('components.Thing.button')).toContain("[data-testid='data-testid new thing button']");
+    expect(toGrafanaSelectorForVersion('components.Thing.button', '1.0')).toContain(
+      "[data-testid='data-testid new thing button']"
+    );
   });
 
   it('reverse-matches the value the running version renders', () => {
-    config.buildInfo.version = '9.0.0';
-    expect(findGrafanaSelectorPath(elementWithTestId('old thing button'))).toBe('grafana:components.Thing.button');
+    expect(findGrafanaSelectorPathForVersion(['old thing button'], '9.0.0')).toBe('grafana:components.Thing.button');
   });
 
   it('does not reverse-match a value from a different version', () => {
-    config.buildInfo.version = '9.0.0';
-    expect(findGrafanaSelectorPath(elementWithTestId('data-testid new thing button'))).toBeNull();
+    expect(findGrafanaSelectorPathForVersion(['data-testid new thing button'], '9.0.0')).toBeNull();
   });
 
   it('rebuilds the reverse index when the version changes', () => {
-    config.buildInfo.version = '9.0.0';
-    expect(findGrafanaSelectorPath(elementWithTestId('old thing button'))).toBe('grafana:components.Thing.button');
-
-    config.buildInfo.version = '12.0.0';
-    expect(findGrafanaSelectorPath(elementWithTestId('old thing button'))).toBeNull();
-    expect(findGrafanaSelectorPath(elementWithTestId('data-testid new thing button'))).toBe(
+    expect(findGrafanaSelectorPathForVersion(['old thing button'], '9.0.0')).toBe('grafana:components.Thing.button');
+    expect(findGrafanaSelectorPathForVersion(['old thing button'], '12.0.0')).toBeNull();
+    expect(findGrafanaSelectorPathForVersion(['data-testid new thing button'], '12.0.0')).toBe(
       'grafana:components.Thing.button'
     );
   });
@@ -91,20 +89,17 @@ describe('grafana-selector — version-aware resolution', () => {
 
 describe('grafana-selector — ambiguity rejection', () => {
   it('returns null for a value claimed by more than one selector path', () => {
-    config.buildInfo.version = '12.0.0';
-    expect(findGrafanaSelectorPath(elementWithTestId('data-testid shared value'))).toBeNull();
+    expect(findGrafanaSelectorPathForVersion(['data-testid shared value'], '12.0.0')).toBeNull();
   });
 
   it('returns a unique template match with its parameter', () => {
-    config.buildInfo.version = '12.0.0';
-    expect(findGrafanaSelectorPath(elementWithTestId('data-testid thing row alpha'))).toBe(
+    expect(findGrafanaSelectorPathForVersion(['data-testid thing row alpha'], '12.0.0')).toBe(
       'grafana:components.Tpl.row:alpha'
     );
   });
 
   it('returns null when a value matches more than one template', () => {
-    config.buildInfo.version = '12.0.0';
-    expect(findGrafanaSelectorPath(elementWithTestId('data-testid thing row alpha end'))).toBeNull();
+    expect(findGrafanaSelectorPathForVersion(['data-testid thing row alpha end'], '12.0.0')).toBeNull();
   });
 
   it('never treats an argument-ignoring selector function as a template', () => {
@@ -112,7 +107,6 @@ describe('grafana-selector — ambiguity rejection', () => {
     // appear in a probe's output unless the function interpolates its argument,
     // so Static.label ('data-testid PARAM label') must not become a template
     // matching unrelated values of the shape 'data-testid ... label'.
-    config.buildInfo.version = '12.0.0';
-    expect(findGrafanaSelectorPath(elementWithTestId('data-testid foo label'))).toBeNull();
+    expect(findGrafanaSelectorPathForVersion(['data-testid foo label'], '12.0.0')).toBeNull();
   });
 });

--- a/src/lib/dom/selector-resolver-core.ts
+++ b/src/lib/dom/selector-resolver-core.ts
@@ -1,0 +1,73 @@
+import { escapeCssAttributeValue } from './css-escape';
+import { toGrafanaSelectorForVersion } from './grafana-selector-core';
+
+export type SelectorResolutionErrorHandler = (message: string, error: unknown) => void;
+
+export function resolveSelectorForVersion(
+  reftarget: string,
+  grafanaVersion: string,
+  onError?: SelectorResolutionErrorHandler
+): string {
+  if (!reftarget) {
+    return reftarget;
+  }
+
+  if (reftarget.includes('{grafana:')) {
+    return resolveEmbeddedGrafanaTokens(reftarget, grafanaVersion, onError);
+  }
+
+  if (reftarget.startsWith('grafana:')) {
+    const { selectorPath, selectorId } = splitGrafanaPathParam(reftarget.substring(8));
+    try {
+      return toGrafanaSelectorForVersion(selectorPath, grafanaVersion, selectorId);
+    } catch (error) {
+      onError?.(`Failed to resolve Grafana selector: ${reftarget}`, error);
+      return reftarget;
+    }
+  }
+
+  if (reftarget.startsWith('panel:')) {
+    return resolvePanelSelector(reftarget);
+  }
+
+  return reftarget;
+}
+
+function splitGrafanaPathParam(pathWithParam: string): { selectorPath: string; selectorId?: string } {
+  const colonIndex = pathWithParam.indexOf(':');
+  if (colonIndex !== -1 && colonIndex < pathWithParam.length - 1) {
+    return {
+      selectorPath: pathWithParam.substring(0, colonIndex),
+      selectorId: pathWithParam.substring(colonIndex + 1),
+    };
+  }
+  return { selectorPath: pathWithParam };
+}
+
+function resolveEmbeddedGrafanaTokens(
+  reftarget: string,
+  grafanaVersion: string,
+  onError?: SelectorResolutionErrorHandler
+): string {
+  let failed = false;
+  const resolved = reftarget.replace(/\{grafana:([^}]+)\}/g, (match, pathWithParam: string) => {
+    const { selectorPath, selectorId } = splitGrafanaPathParam(pathWithParam);
+    try {
+      return toGrafanaSelectorForVersion(selectorPath, grafanaVersion, selectorId);
+    } catch (error) {
+      onError?.(`Failed to resolve embedded Grafana selector token: ${match}`, error);
+      failed = true;
+      return match;
+    }
+  });
+  return failed ? reftarget : resolved;
+}
+
+function resolvePanelSelector(reftarget: string): string {
+  const panelPart = reftarget.substring(6);
+  const childSeparator = panelPart.indexOf(' > ');
+  const panelTitle = childSeparator === -1 ? panelPart : panelPart.substring(0, childSeparator);
+  const childSelector = childSeparator === -1 ? null : panelPart.substring(childSeparator + 3);
+  const baseSelector = `[data-viz-panel-key]:has([data-testid*="Panel header ${escapeCssAttributeValue(panelTitle, '"')}"])`;
+  return childSelector ? `${baseSelector} ${childSelector}` : baseSelector;
+}

--- a/src/lib/dom/selector-resolver.ts
+++ b/src/lib/dom/selector-resolver.ts
@@ -1,11 +1,7 @@
-/**
- * Selector Resolver
- * Central resolver for handling different selector formats including Grafana e2e selectors
- */
+import { config } from '@grafana/runtime';
 
 import { logger } from '../logging';
-import { escapeCssAttributeValue } from './css-escape';
-import { toGrafanaSelector } from './grafana-selector';
+import { resolveSelectorForVersion } from './selector-resolver-core';
 
 /**
  * Resolve a selector string that may contain special prefixes
@@ -38,92 +34,7 @@ import { toGrafanaSelector } from './grafana-selector';
  * // Returns: ":is([data-testid='data-testid Panel header CPU Usage'], [aria-label='data-testid Panel header CPU Usage'])"
  */
 export function resolveSelector(reftarget: string): string {
-  if (!reftarget) {
-    return reftarget;
-  }
-
-  // Embedded `{grafana:path[:param]}` tokens inside an otherwise-plain CSS
-  // selector, e.g. `div[data-testid='panel'] {grafana:components.Select.input}`
-  if (reftarget.includes('{grafana:')) {
-    return resolveEmbeddedGrafanaTokens(reftarget);
-  }
-
-  // Check for grafana: prefix
-  if (reftarget.startsWith('grafana:')) {
-    const { selectorPath, selectorId } = splitGrafanaPathParam(reftarget.substring(8));
-    try {
-      return toGrafanaSelector(selectorPath, selectorId);
-    } catch (error) {
-      logger.error(`Failed to resolve Grafana selector: ${reftarget}`, { error });
-      // Return original selector as fallback
-      return reftarget;
-    }
-  }
-
-  // panel: prefix - resolves to panel container by title
-  if (reftarget.startsWith('panel:')) {
-    return resolvePanelSelector(reftarget);
-  }
-
-  // Return as-is if it's a regular CSS selector
-  return reftarget;
-}
-
-/**
- * Selector paths are dot-separated and never contain colons, so the first
- * colon unambiguously separates path from parameter (which may itself contain colons).
- */
-function splitGrafanaPathParam(pathWithParam: string): { selectorPath: string; selectorId?: string } {
-  const colonIndex = pathWithParam.indexOf(':');
-  if (colonIndex !== -1 && colonIndex < pathWithParam.length - 1) {
-    return {
-      selectorPath: pathWithParam.substring(0, colonIndex),
-      selectorId: pathWithParam.substring(colonIndex + 1),
-    };
-  }
-  return { selectorPath: pathWithParam };
-}
-
-/**
- * Replace every embedded `{grafana:path[:param]}` token with its
- * version-resolved :is() form. Parameters may contain colons but not `}`.
- * If any token fails to resolve, the whole reftarget is returned unchanged
- * (same safe degradation as the grafana: prefix fallback).
- */
-function resolveEmbeddedGrafanaTokens(reftarget: string): string {
-  let failed = false;
-  const resolved = reftarget.replace(/\{grafana:([^}]+)\}/g, (match, pathWithParam: string) => {
-    const { selectorPath, selectorId } = splitGrafanaPathParam(pathWithParam);
-    try {
-      return toGrafanaSelector(selectorPath, selectorId);
-    } catch (error) {
-      logger.error(`Failed to resolve embedded Grafana selector token: ${match}`, { error });
-      failed = true;
-      return match;
-    }
-  });
-  return failed ? reftarget : resolved;
-}
-
-/**
- * Resolve a panel: prefix selector to a CSS selector targeting a Grafana panel by title.
- * Format: "panel:Panel Title" or "panel:Panel Title > child-selector"
- */
-function resolvePanelSelector(reftarget: string): string {
-  const panelPart = reftarget.substring(6); // Remove 'panel:'
-  const childSeparator = panelPart.indexOf(' > ');
-
-  let panelTitle: string;
-  let childSelector: string | null = null;
-
-  if (childSeparator !== -1) {
-    panelTitle = panelPart.substring(0, childSeparator);
-    childSelector = panelPart.substring(childSeparator + 3);
-  } else {
-    panelTitle = panelPart;
-  }
-
-  // Grafana panels use [data-viz-panel-key] and have title in header
-  const baseSelector = `[data-viz-panel-key]:has([data-testid*="Panel header ${escapeCssAttributeValue(panelTitle, '"')}"])`;
-  return childSelector ? `${baseSelector} ${childSelector}` : baseSelector;
+  return resolveSelectorForVersion(reftarget, config.buildInfo.version || 'latest', (message, error) =>
+    logger.error(message, { error })
+  );
 }

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -49,7 +49,7 @@ import type {
   AllStepsResult,
   OnStepCompleteCallback,
 } from './types';
-import { resolveSelector } from '../../../../src/lib/dom';
+import { resolveSelector } from '../selector-resolver';
 import type { Locator } from '@playwright/test';
 
 // ============================================
@@ -244,7 +244,7 @@ const GUIDED_WAIT_EXECUTING_MS = 5000;
 /**
  * Resolve data-test-reftarget to a Playwright locator for the current substep.
  * Button: try getByRole('button', { name }) then locator(selector); others use locator(selector).
- * Handles grafana: prefix via resolveSelector.
+ * Handles grafana: prefix through the Node-safe E2E resolver.
  */
 async function resolveGuidedTarget(page: Page, reftarget: string, actionType: string): Promise<Locator> {
   const timeout = GUIDED_TARGET_RESOLUTION_TIMEOUT_MS;

--- a/tests/e2e-runner/utils/selector-resolver.test.ts
+++ b/tests/e2e-runner/utils/selector-resolver.test.ts
@@ -1,0 +1,11 @@
+/** @jest-environment node */
+
+import { resolveSelector } from './selector-resolver';
+
+describe('E2E selector resolver', () => {
+  it('resolves Grafana selectors without browser imports', () => {
+    expect(resolveSelector('grafana:components.RefreshPicker.runButtonV2')).toContain(
+      "[data-testid='data-testid RefreshPicker run button']"
+    );
+  });
+});

--- a/tests/e2e-runner/utils/selector-resolver.ts
+++ b/tests/e2e-runner/utils/selector-resolver.ts
@@ -1,0 +1,5 @@
+import { resolveSelectorForVersion } from '../../../src/lib/dom/selector-resolver-core';
+
+export function resolveSelector(reftarget: string): string {
+  return resolveSelectorForVersion(reftarget, 'latest');
+}


### PR DESCRIPTION
## Summary

A recent change made Grafana selector resolution version-aware by importing `@grafana/runtime` from the shared selector module. That change was breaking for local E2E runs: Playwright loads guide runner modules in Node before launching Chromium, so `@grafana/runtime` accessed `window` during test discovery and aborted with `ReferenceError: window is not defined`.

This PR separates selector logic into environment-neutral cores and thin browser/Node adapters, restoring local CLI E2E runs while preserving browser version-awareness and the runner's existing latest-selector behavior.

## What to look at

- **Selector boundary**: [`grafana-selector-core.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/e2706f70d36846807ece1cfd7fa6c499c4cbc14d/src/lib/dom/grafana-selector-core.ts) and [`selector-resolver-core.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/e2706f70d36846807ece1cfd7fa6c499c4cbc14d/src/lib/dom/selector-resolver-core.ts) own environment-neutral catalog and reference resolution. The browser-facing adapters continue to supply `config.buildInfo.version` from Grafana runtime.
- **E2E runner boundary**: [`selector-resolver.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/e2706f70d36846807ece1cfd7fa6c499c4cbc14d/tests/e2e-runner/utils/selector-resolver.ts) owns the runner's existing `latest` selector policy, and [`execution.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/e2706f70d36846807ece1cfd7fa6c499c4cbc14d/tests/e2e-runner/utils/guide-runner/execution.ts) imports that narrow Node-safe adapter instead of the browser-oriented DOM barrel.

## How to verify

1. Start Grafana with the Pathfinder plugin available at `http://localhost:3000`.
2. Run `npx playwright test tests/e2e-runner/guide-runner.spec.ts --config=tests/e2e-runner/playwright.config.ts --project=chromium --list`. Confirm Playwright lists the auth and guide tests without a `window is not defined` error.
3. Run `pathfinder-cli e2e bundled:welcome-to-grafana`. Confirm the command proceeds through Playwright discovery and executes the guide.

## Breaking changes

None. Browser selector behavior remains version-aware, and the E2E runner retains its existing latest-selector policy. The change is fully reversible.

## Out of scope

- Cross-version selector negotiation in the E2E CLI. This fix restores the Node/browser boundary without adding new version-resolution requirements to the runner.

🤖 Generated with [Warp](https://warp.dev)
