### PR TITLE
docs: add agent context for Graft (plugin-graft) dev workflow

### DIFF
--- a/docs/developer/CONTEXT_INDEX.md
+++ b/docs/developer/CONTEXT_INDEX.md
@@ -56,15 +56,16 @@ Load these files **only when working in the relevant domain**.
 
 ## Dev mode, local dev, live sessions
 
-| File                       | When to load                                                                                          | Auto-triggered by globs                                                   |
-| -------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `DEV_MODE.md`              | Dev mode configuration and debugging tools                                                            | `src/utils/dev-mode.ts`                                                   |
-| `LOCAL_DEV.md`             | Local development setup, prerequisites, Docker workflow                                               | --                                                                        |
-| `LIVE_SESSIONS.md`         | Live sessions feature (WebRTC, PeerJS)                                                                | `src/components/LiveSession/*`                                            |
-| `KNOWN_ISSUES.md`          | Known bugs and workarounds                                                                            | --                                                                        |
-| `integrations/workshop.md` | Workshop mode, action capture and replay                                                              | `src/integrations/workshop/*`                                             |
-| `CROSS_TAB_CONTROLLER.md`  | Two-tab interactive controller — a popped-out guide drives the live Grafana tab over BroadcastChannel | `src/integrations/cross-tab/*`, `src/global-state/controller-channel.tsx` |
-| `SCALE_TESTING.md`         | Live session scale testing procedures                                                                 | --                                                                        |
+| File                       | When to load                                                                                                                                 | Auto-triggered by globs                                                   |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `DEV_MODE.md`              | Dev mode configuration and debugging tools                                                                                                   | `src/utils/dev-mode.ts`                                                   |
+| `LOCAL_DEV.md`             | Local development setup, prerequisites, Docker workflow                                                                                      | --                                                                        |
+| `GRAFT_TESTING.md`         | Testing the local build against a live Grafana Cloud stack via Graft (internal, Grafanista-only) instead of the Docker `npm run server` flow | --                                                                        |
+| `LIVE_SESSIONS.md`         | Live sessions feature (WebRTC, PeerJS)                                                                                                       | `src/components/LiveSession/*`                                            |
+| `KNOWN_ISSUES.md`          | Known bugs and workarounds                                                                                                                   | --                                                                        |
+| `integrations/workshop.md` | Workshop mode, action capture and replay                                                                                                     | `src/integrations/workshop/*`                                             |
+| `CROSS_TAB_CONTROLLER.md`  | Two-tab interactive controller — a popped-out guide drives the live Grafana tab over BroadcastChannel                                        | `src/integrations/cross-tab/*`, `src/global-state/controller-channel.tsx` |
+| `SCALE_TESTING.md`         | Live session scale testing procedures                                                                                                        | --                                                                        |
 
 ## Subsystem references
 

--- a/docs/developer/GRAFT_TESTING.md
+++ b/docs/developer/GRAFT_TESTING.md
@@ -1,0 +1,27 @@
+# Testing against Grafana Cloud with Graft
+
+[Graft](https://github.com/grafana/plugin-graft) (`grafana/plugin-graft`, **Grafanista-only**) is an internal dev tool: a browser extension paired with a local server/binary that intercepts Grafana Cloud requests and serves a locally-built plugin from disk, with hot reload. Some Pathfinder contributors use it instead of, or alongside, this repo's Docker-based `npm run server` workflow (see [`LOCAL_DEV.md`](LOCAL_DEV.md)).
+
+## Why a dev would reach for it here
+
+- Test the `dist/` build (from `npm run dev` or `npm run build`) against a **real** Grafana Cloud stack — real data, real feature flags, hundreds of capabilities a local Docker stack doesn't have.
+- Reproduce and fix a customer escalation directly on their stack, if authorized.
+- Pair with an AI coding agent for rapid debug loops against a live stack — this is part of how Jay develops Pathfinder day to day.
+
+## What this means when helping with this repo
+
+- **No running `docker compose` container doesn't mean the plugin isn't running.** It may be served into a Cloud stack via Graft instead. Don't assume `npm run server` is the only way a dev is seeing their changes.
+- **Graft's config and logs live outside this repo** — in `~/.config/graft/` and `~/.local/state/graft/`, not under this project. There's nothing to find here.
+- **Graft's per-domain feature flag overrides are unrelated to Pathfinder's own flag system.** If a dev mentions flipping a flag while using Graft, that's Grafana Cloud's feature toggles via Graft, not Pathfinder's OpenFeature/experiment system (see [`FEATURE_FLAGS.md`](FEATURE_FLAGS.md), [`EXPERIMENT_TESTING.md`](EXPERIMENT_TESTING.md)).
+- **The plugin ID Graft is configured with is `grafana-pathfinder-app`** (from `src/plugin.json`), pointed at this repo's `dist/` directory.
+
+## Where to look for more
+
+This repo doesn't own or document Graft itself — for install, setup, and feature detail, use plugin-graft's own docs rather than this file drifting out of date:
+
+- [Is Graft for you?](https://github.com/grafana/plugin-graft/blob/main/docs/is-graft-for-you.md)
+- [Graft features](https://github.com/grafana/plugin-graft/blob/main/docs/graft-features.md)
+- [Setup guide](https://github.com/grafana/plugin-graft/blob/main/docs/setup.md)
+- [Observability / logs](https://github.com/grafana/plugin-graft/blob/main/docs/observability.md)
+
+Don't attempt to install or configure Graft on a user's behalf — point them at plugin-graft's README quick-install if asked.

--- a/docs/developer/LOCAL_DEV.md
+++ b/docs/developer/LOCAL_DEV.md
@@ -69,6 +69,10 @@ Notes:
 - Default credentials: `admin` / `admin`.
 - The sidebar **Help** icon opens the docs panel.
 
+## Testing against Grafana Cloud (Graft)
+
+Some contributors test their local `dist/` build against a live Grafana Cloud stack instead of (or alongside) the Docker Grafana above, using [Graft](https://github.com/grafana/plugin-graft) — an internal, Grafanista-only browser-extension + local-server tool that intercepts Cloud requests and serves your local build with hot reload. See [`GRAFT_TESTING.md`](GRAFT_TESTING.md) for what this means when debugging or reviewing changes.
+
 ## Pre-merge check
 
 Run before pushing or opening a pull request. CI runs the same set:


### PR DESCRIPTION
## Summary
- Some Grafanistas test Pathfinder by serving the local `dist/` build into a live Grafana Cloud stack via [Graft](https://github.com/grafana/plugin-graft) (internal, Grafanista-only), instead of/alongside this repo's Docker-based `npm run server` workflow.
- Adds `docs/developer/GRAFT_TESTING.md` so agents recognize the term, don't assume "no docker container" means "plugin isn't running," and don't confuse Graft's Cloud feature-flag overrides with Pathfinder's own flag system.
- Routes it from `CONTEXT_INDEX.md` and links it from `LOCAL_DEV.md`, following this repo's existing on-demand-context pattern (no new skill — Graft has no CLI surface invoked from within this repo).

## Test plan
- [x] Docs-only change; no build/test impact.
- [x] `npx prettier --check` passes on all three files.
- [x] Pre-commit hooks (typecheck + governance tests) passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)