### PR TITLE
refactor(architecture): dissolve three import-cycle clusters via leaf extractions

### DIFF
--- a/src/components/docs-panel/components/DocsPanelContentArea.tsx
+++ b/src/components/docs-panel/components/DocsPanelContentArea.tsx
@@ -48,8 +48,7 @@ import { LoadingIndicator } from './LoadingIndicator';
 import { LearningJourneyMilestoneToolbar } from './LearningJourneyMilestoneToolbar';
 import { PanelModeActionButtons } from './PanelModeActionButtons';
 import type { SceneObject } from '@grafana/scenes';
-import type { OpenDocsOptions } from '../types';
-import type { CombinedLearningJourneyPanel } from '../docs-panel';
+import type { DocsPanelModelOperations, OpenDocsOptions } from '../types';
 
 // Kept inside the component file so webpack sees the same dynamic-import
 // module specifiers used pre-refactor. See pre-mortem H8.
@@ -74,7 +73,7 @@ export interface DocsPanelContentAreaProps {
   interactiveStyles: string;
   prismStyles: string;
 
-  model: CombinedLearningJourneyPanel;
+  model: DocsPanelModelOperations;
   contextPanel: SceneObject<ContextPanelState>;
 
   isFullScreenActive: boolean;

--- a/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.test.tsx
+++ b/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.test.tsx
@@ -16,7 +16,7 @@ import {
   type LearningJourneyMilestoneToolbarProps,
 } from './LearningJourneyMilestoneToolbar';
 import type { LearningJourneyTab } from '../../../types/content-panel.types';
-import type { CombinedLearningJourneyPanel } from '../docs-panel';
+import type { DocsPanelModelOperations } from '../types';
 
 const reportAppInteractionMock = jest.fn();
 const markMilestoneDoneMock = jest.fn();
@@ -78,7 +78,7 @@ function makePanel() {
     navigateToNextMilestone: jest.fn(),
     canNavigatePrevious: jest.fn(() => true),
     canNavigateNext: jest.fn(() => true),
-  } as unknown as CombinedLearningJourneyPanel & {
+  } as unknown as DocsPanelModelOperations & {
     navigateToPreviousMilestone: jest.Mock;
     navigateToNextMilestone: jest.Mock;
     canNavigatePrevious: jest.Mock;

--- a/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
+++ b/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
@@ -35,13 +35,13 @@ import {
 import { getJourneyProgress, getMilestoneSlug, markMilestoneDone } from '../../../docs-retrieval';
 import { getMilestoneStyles } from '../../../styles/docs-panel.styles';
 import type { LearningJourneyTab } from '../../../types/content-panel.types';
-import type { CombinedLearningJourneyPanel } from '../docs-panel';
+import type { DocsPanelModelOperations } from '../types';
 import { cleanDocsUrl } from '../utils';
 
 export type MilestoneToolbarSurface = 'sidebar' | 'fullscreen' | 'floating';
 
 export interface LearningJourneyMilestoneToolbarProps {
-  panel: CombinedLearningJourneyPanel;
+  panel: DocsPanelModelOperations;
   activeTab: LearningJourneyTab;
   /**
    * Where this toolbar lives — drives the analytics `interaction_location`

--- a/src/components/docs-panel/types.ts
+++ b/src/components/docs-panel/types.ts
@@ -88,6 +88,12 @@ export interface DocsPanelModelOperations {
   /** Get the currently active tab */
   getActiveTab(): LearningJourneyTab | null;
 
+  /** Accept the implied-0th-step alignment prompt for a tab */
+  confirmAlignment(tabId: string): Promise<void>;
+
+  /** Dismiss the implied-0th-step alignment prompt for a tab */
+  dismissAlignment(tabId: string): void;
+
   /**
    * Record the launch source for the next `loadDocsTabContent` call so the
    * implied-0th-step evaluator classifies it correctly. Consumed once by the

--- a/src/components/interactive-tutorial/hooks/use-section-requirements.ts
+++ b/src/components/interactive-tutorial/hooks/use-section-requirements.ts
@@ -28,7 +28,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { getRequirementExplanation, dispatchFix } from '../../../requirements-manager';
 import { subscribeProgressEvent } from '../../../global-state/progress-events';
 import { logger } from '../../../lib/logging';
-import { DEFAULT_INTERACTIVE_SECTION_TITLE } from '../interactive-section';
+import { DEFAULT_INTERACTIVE_SECTION_TITLE } from '../section-titles';
 
 interface SectionRequirementsResult {
   pass: boolean;

--- a/src/components/interactive-tutorial/index.ts
+++ b/src/components/interactive-tutorial/index.ts
@@ -5,9 +5,8 @@ export {
   registerSectionSteps,
   getDocumentStepPosition,
   getTotalDocumentSteps,
-  DEFAULT_INTERACTIVE_SECTION_TITLE,
-  PASSIVE_SECTION_TITLE,
 } from './interactive-section';
+export { DEFAULT_INTERACTIVE_SECTION_TITLE, PASSIVE_SECTION_TITLE } from './section-titles';
 export { InteractiveStep } from './interactive-step';
 export { InteractiveMultiStep } from './interactive-multi-step';
 export { InteractiveGuided } from './interactive-guided';

--- a/src/components/interactive-tutorial/interactive-conditional.tsx
+++ b/src/components/interactive-tutorial/interactive-conditional.tsx
@@ -16,6 +16,7 @@ import type { ConditionalDisplayMode, ConditionalSectionConfig } from '../../typ
 import { InteractiveSection } from './interactive-section';
 import { subscribeProgressEvent } from '../../global-state/progress-events';
 import { logger } from '../../lib/logging';
+import { markSkipsSectionNumbering } from './skip-section-numbering';
 
 export interface InteractiveConditionalProps {
   /** Conditions to evaluate (uses same syntax as requirements) */
@@ -342,3 +343,6 @@ export function InteractiveConditional({
 
 // Add display name for debugging
 InteractiveConditional.displayName = 'InteractiveConditional';
+
+// Wrapper block: sits in a section's list without a step number.
+markSkipsSectionNumbering(InteractiveConditional);

--- a/src/components/interactive-tutorial/interactive-conditional.tsx
+++ b/src/components/interactive-tutorial/interactive-conditional.tsx
@@ -341,7 +341,6 @@ export function InteractiveConditional({
   );
 }
 
-// Add display name for debugging
 InteractiveConditional.displayName = 'InteractiveConditional';
 
 // Wrapper block: sits in a section's list without a step number.

--- a/src/components/interactive-tutorial/interactive-section.display-title.test.tsx
+++ b/src/components/interactive-tutorial/interactive-section.display-title.test.tsx
@@ -93,12 +93,8 @@ jest.mock('./interactive-conditional', () => {
 // ─── Imports after mocks ────────────────────────────────────────────────────
 
 import { InteractiveStep } from './interactive-step';
-import {
-  DEFAULT_INTERACTIVE_SECTION_TITLE,
-  InteractiveSection,
-  PASSIVE_SECTION_TITLE,
-  resetInteractiveCounters,
-} from './interactive-section';
+import { InteractiveSection, resetInteractiveCounters } from './interactive-section';
+import { DEFAULT_INTERACTIVE_SECTION_TITLE, PASSIVE_SECTION_TITLE } from './section-titles';
 import { resetSectionHarness, silenceSectionWarnings } from '../../test-utils/interactive-section-harness';
 
 let warnSpy: jest.SpyInstance;

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -120,10 +120,6 @@ export {
   getDocumentStepPosition,
 } from '../../global-state/section-registry';
 
-// Re-exports preserved for back-compat with tests and the barrel. New code
-// should import directly from `./section-titles`.
-export { DEFAULT_INTERACTIVE_SECTION_TITLE, PASSIVE_SECTION_TITLE } from './section-titles';
-
 // Reset every counter (registry + offsets + per-step-type anonymous-ID
 // counters). Called when new content loads. The registry's own state
 // lives in `./section-registry`; this function adds the step-module

--- a/src/components/interactive-tutorial/interactive-section.tsx
+++ b/src/components/interactive-tutorial/interactive-section.tsx
@@ -105,6 +105,7 @@ import {
 } from '../../global-state/completion-store';
 import { dispatchProgress } from '../../global-state/progress-events';
 import { computeCursor, deriveSectionState, initialSectionState, sectionReducer } from './section-state';
+import { DEFAULT_INTERACTIVE_SECTION_TITLE, PASSIVE_SECTION_TITLE } from './section-titles';
 import {
   getDocumentStepPosition,
   nextSectionCounter,
@@ -119,11 +120,9 @@ export {
   getDocumentStepPosition,
 } from '../../global-state/section-registry';
 
-// Interactive Section title fallback
-export const DEFAULT_INTERACTIVE_SECTION_TITLE = 'Interactive section';
-
-// Interactive Section title fallback for sections with no interactive steps (passive content only)
-export const PASSIVE_SECTION_TITLE = 'Steps';
+// Re-exports preserved for back-compat with tests and the barrel. New code
+// should import directly from `./section-titles`.
+export { DEFAULT_INTERACTIVE_SECTION_TITLE, PASSIVE_SECTION_TITLE } from './section-titles';
 
 // Reset every counter (registry + offsets + per-step-type anonymous-ID
 // counters). Called when new content loads. The registry's own state

--- a/src/components/interactive-tutorial/section-numbering.tsx
+++ b/src/components/interactive-tutorial/section-numbering.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 
 import { ImageRenderer, VideoRenderer, YouTubeVideoRenderer, VimeoVideoRenderer } from '../../docs-retrieval';
-import { InteractiveConditional } from './interactive-conditional';
+import { skipsSectionNumbering } from './skip-section-numbering';
 
 /** Returns `true` if the child should receive a step number in the
  *  section's ordered list. Media (image/video/youtube) and wrapper
@@ -34,7 +34,7 @@ export function shouldNumberSectionChild(child: React.ReactNode): boolean {
     t !== VideoRenderer &&
     t !== YouTubeVideoRenderer &&
     t !== VimeoVideoRenderer &&
-    t !== InteractiveConditional
+    !skipsSectionNumbering(t)
   );
 }
 

--- a/src/components/interactive-tutorial/section-titles.ts
+++ b/src/components/interactive-tutorial/section-titles.ts
@@ -1,0 +1,5 @@
+// Interactive Section title fallback
+export const DEFAULT_INTERACTIVE_SECTION_TITLE = 'Interactive section';
+
+// Interactive Section title fallback for sections with no interactive steps (passive content only)
+export const PASSIVE_SECTION_TITLE = 'Steps';

--- a/src/components/interactive-tutorial/section-titles.ts
+++ b/src/components/interactive-tutorial/section-titles.ts
@@ -1,4 +1,3 @@
-// Interactive Section title fallback
 export const DEFAULT_INTERACTIVE_SECTION_TITLE = 'Interactive section';
 
 // Interactive Section title fallback for sections with no interactive steps (passive content only)

--- a/src/components/interactive-tutorial/skip-section-numbering.ts
+++ b/src/components/interactive-tutorial/skip-section-numbering.ts
@@ -1,0 +1,22 @@
+/**
+ * Opt-out marker for section child numbering.
+ *
+ * `section-numbering.tsx` excludes wrapper components from the `1. 2. 3.`
+ * sequence. Components tag themselves at definition time instead of
+ * `section-numbering` importing them for identity checks — importing
+ * `InteractiveConditional` there closed an import cycle through
+ * `interactive-section.tsx` (#1359).
+ */
+
+import type React from 'react';
+
+const SKIP_SECTION_NUMBERING = Symbol.for('pathfinder.skipSectionNumbering');
+
+export function markSkipsSectionNumbering<T extends React.ComponentType<any>>(component: T): T {
+  (component as unknown as Record<symbol, boolean>)[SKIP_SECTION_NUMBERING] = true;
+  return component;
+}
+
+export function skipsSectionNumbering(type: unknown): boolean {
+  return typeof type === 'function' && (type as unknown as Record<symbol, boolean>)[SKIP_SECTION_NUMBERING] === true;
+}

--- a/src/components/interactive-tutorial/skip-section-numbering.ts
+++ b/src/components/interactive-tutorial/skip-section-numbering.ts
@@ -18,5 +18,8 @@ export function markSkipsSectionNumbering<T extends React.ComponentType<any>>(co
 }
 
 export function skipsSectionNumbering(type: unknown): boolean {
-  return typeof type === 'function' && (type as unknown as Record<symbol, boolean>)[SKIP_SECTION_NUMBERING] === true;
+  // memo/forwardRef components are exotic objects, not functions — the marker
+  // survives wrapping only if we read it off objects too.
+  const canCarryMarker = typeof type === 'function' || (typeof type === 'object' && type !== null);
+  return canCarryMarker && (type as unknown as Record<symbol, boolean>)[SKIP_SECTION_NUMBERING] === true;
 }

--- a/src/requirements-manager/checks/coda.ts
+++ b/src/requirements-manager/checks/coda.ts
@@ -13,7 +13,7 @@
  * to exit-code semantics rather than a separate regex matcher type.
  */
 
-import type { CheckResultError } from '../requirements-checker.utils';
+import type { CheckResultError } from '../../types/requirements.types';
 import { getBackendSrv } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
 

--- a/src/requirements-manager/checks/env.ts
+++ b/src/requirements-manager/checks/env.ts
@@ -4,7 +4,7 @@
  */
 
 import { config } from '@grafana/runtime';
-import type { CheckResultError } from '../requirements-checker.utils';
+import type { CheckResultError } from '../../types/requirements.types';
 
 /**
  * Feature toggle: `has-feature:<name>`.

--- a/src/requirements-manager/checks/grafana-api.ts
+++ b/src/requirements-manager/checks/grafana-api.ts
@@ -8,7 +8,7 @@
 import { config, hasPermission, getDataSourceSrv, getBackendSrv } from '@grafana/runtime';
 // eslint-disable-next-line no-restricted-imports -- [ratchet] ALLOWED_LATERAL_VIOLATIONS: requirements-manager -> context-engine
 import { ContextService } from '../../context-engine';
-import type { CheckResultError } from '../requirements-checker.utils';
+import type { CheckResultError } from '../../types/requirements.types';
 
 /**
  * Permission checking via Grafana's hasPermission helper.

--- a/src/requirements-manager/checks/location.ts
+++ b/src/requirements-manager/checks/location.ts
@@ -6,7 +6,7 @@
  */
 
 import { locationService } from '@grafana/runtime';
-import type { CheckResultError } from '../requirements-checker.utils';
+import type { CheckResultError } from '../../types/requirements.types';
 
 export async function onPageCheck(check: string): Promise<CheckResultError> {
   try {

--- a/src/requirements-manager/checks/terminal.ts
+++ b/src/requirements-manager/checks/terminal.ts
@@ -6,7 +6,7 @@
  * dependency between requirements-manager and integrations/coda).
  */
 
-import type { CheckResultError } from '../requirements-checker.utils';
+import type { CheckResultError } from '../../types/requirements.types';
 
 export async function terminalActiveCheck(check: string): Promise<CheckResultError> {
   try {

--- a/src/requirements-manager/checks/vars.ts
+++ b/src/requirements-manager/checks/vars.ts
@@ -6,7 +6,7 @@
  */
 
 import { guideResponseStorage } from '../../lib/user-storage';
-import type { CheckResultError } from '../requirements-checker.utils';
+import type { CheckResultError } from '../../types/requirements.types';
 
 /**
  * Get the current guide ID from the global context set by ContentRenderer.

--- a/src/requirements-manager/index.ts
+++ b/src/requirements-manager/index.ts
@@ -28,7 +28,8 @@ export type { UseStepCheckerProps, UseStepCheckerReturn } from '../types/hooks.t
 // Pure requirements checking utilities
 export { checkRequirements, checkPostconditions, validateInteractiveRequirements } from './requirements-checker.utils';
 
-export type { RequirementsCheckResult, CheckResultError, RequirementsCheckOptions } from './requirements-checker.utils';
+export type { RequirementsCheckResult, RequirementsCheckOptions } from './requirements-checker.utils';
+export type { CheckResultError } from '../types/requirements.types';
 
 // Requirement explanations and messages
 export {

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -17,7 +17,7 @@
 
 import { reftargetExistsCheck, navmenuOpenCheck, formValidCheck } from '../lib/dom';
 import { sectionCompletedCheck } from './checks/section-completed-check';
-import { isValidRequirement } from '../types/requirements.types';
+import { isValidRequirement, type CheckResultError } from '../types/requirements.types';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import { logger } from '../lib/logging';
 import { TimeoutManager } from '../utils/timeout-manager';
@@ -42,24 +42,12 @@ import { guideVariableCheck } from './checks/vars';
 import { terminalActiveCheck } from './checks/terminal';
 import { codaExitZeroCheck } from './checks/coda';
 
-// Re-export types for convenience
+export type { CheckResultError };
+
 export interface RequirementsCheckResult {
   requirements: string;
   pass: boolean;
   error: CheckResultError[];
-}
-
-export interface CheckResultError {
-  requirement: string;
-  pass: boolean;
-  error?: string;
-  /** Diagnostic context for debugging. Should be included when available. */
-  context?: Record<string, unknown> | null;
-  canFix?: boolean;
-  fixType?: string;
-  targetHref?: string;
-  /** Scroll container selector for lazy-scroll fixes */
-  scrollContainer?: string;
 }
 
 export interface RequirementsCheckOptions {

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -42,8 +42,6 @@ import { guideVariableCheck } from './checks/vars';
 import { terminalActiveCheck } from './checks/terminal';
 import { codaExitZeroCheck } from './checks/coda';
 
-export type { CheckResultError };
-
 export interface RequirementsCheckResult {
   requirements: string;
   pass: boolean;

--- a/src/test-utils/interactive-section-harness.tsx
+++ b/src/test-utils/interactive-section-harness.tsx
@@ -28,6 +28,8 @@
 
 import React from 'react';
 
+import { markSkipsSectionNumbering } from '../components/interactive-tutorial/skip-section-numbering';
+
 export const memoryStore = new Map<string, unknown>();
 
 /** Configurable return value for `checkRequirementsFromData`. Override per-test
@@ -241,7 +243,8 @@ export function createCodeBlockStepMock() {
   return { CodeBlockStep: () => null, resetCodeBlockStepCounter: jest.fn() };
 }
 export function createInteractiveConditionalMock() {
-  return { InteractiveConditional: () => null };
+  // Mirror production: the real component self-tags as skip-numbering.
+  return { InteractiveConditional: markSkipsSectionNumbering(() => null) };
 }
 
 /** Factory for `jest.mock('../../interactive-engine', ...)`. */

--- a/src/types/cross-tab.types.test.ts
+++ b/src/types/cross-tab.types.test.ts
@@ -1,4 +1,5 @@
-import { validateCrossTabMessage } from './cross-tab.types';
+import { validateCrossTabMessage, type RemoteRequirementError } from './cross-tab.types';
+import type { CheckResultError } from './requirements.types';
 
 function envelope(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return { source: 'pathfinder', senderId: 'sender-1', timestamp: 1, ...overrides };
@@ -199,5 +200,18 @@ describe('validateCrossTabMessage', () => {
     expect(
       validateCrossTabMessage(envelope({ kind: 'requirement-result', requestId: 'req-1', stepId: 's1', result }))
     ).toBeNull();
+  });
+});
+
+describe('RemoteRequirementError wire mirror', () => {
+  // Compile-time guard for the deliberate re-statement in cross-tab.types.ts:
+  // if CheckResultError and the wire type stop being mutually assignable
+  // (field added/removed/retyped on either side), these lines stop compiling
+  // and force a conscious decision about the wire contract.
+  it('stays mutually assignable with CheckResultError', () => {
+    const local: CheckResultError = { requirement: 'r', pass: true };
+    const wire: RemoteRequirementError = local;
+    const back: CheckResultError = wire;
+    expect(back).toBe(local);
   });
 });

--- a/src/types/cross-tab.types.ts
+++ b/src/types/cross-tab.types.ts
@@ -23,9 +23,11 @@ interface CrossTabEnvelope {
   timestamp: number;
 }
 
-// Tier-0 structural mirror of requirements-manager's CheckResultError /
-// RequirementsCheckResult, so a live-tab result crosses the channel without an
-// upward import.
+// Deliberate re-statement (not an alias) of CheckResultError /
+// RequirementsCheckResult: this is a wire contract, and the two tabs on a
+// channel may run different plugin versions, so the internal type must not be
+// able to reshape the wire silently. A compile-time guard in
+// cross-tab.types.test.ts forces a conscious update here when they diverge.
 export interface RemoteRequirementError {
   requirement: string;
   pass: boolean;

--- a/src/types/requirements.types.ts
+++ b/src/types/requirements.types.ts
@@ -57,6 +57,24 @@ export const isValidRequirement = (req: string): req is ValidRequirement => {
   return isFixedRequirement(req) || isParameterizedRequirement(req);
 };
 
+/**
+ * Result of a single requirement check. Lives here (Tier 0) so
+ * `requirements-manager/checks/*` and the check router can share it without
+ * importing each other (#1359).
+ */
+export interface CheckResultError {
+  requirement: string;
+  pass: boolean;
+  error?: string;
+  /** Diagnostic context for debugging. Should be included when available. */
+  context?: Record<string, unknown> | null;
+  canFix?: boolean;
+  fixType?: string;
+  targetHref?: string;
+  /** Scroll container selector for lazy-scroll fixes */
+  scrollContainer?: string;
+}
+
 // Type-safe requirement checker options
 export interface TypeSafeRequirementsCheckOptions {
   requirements: string; // We keep this as string for backward compatibility, but validate at runtime

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -164,30 +164,9 @@ const ALLOWED_CYCLES: readonly AllowedCycleEntry[] = [
   },
   {
     cycle:
-      'requirements-manager/checks/coda.ts <-> requirements-manager/checks/env.ts <-> requirements-manager/checks/grafana-api.ts <-> requirements-manager/checks/location.ts <-> requirements-manager/checks/terminal.ts <-> requirements-manager/checks/vars.ts <-> requirements-manager/requirements-checker.utils.ts',
-    reason:
-      'requirements-manager check modules and their shared utils mutually reach each other; needs a shared-seam extraction.',
-    tracking: '#1359',
-  },
-  {
-    cycle:
       'interactive-engine/index.ts <-> interactive-engine/interactive.hook.ts <-> interactive-engine/use-sequential-step-state.hook.ts <-> requirements-manager/index.ts <-> requirements-manager/step-checker.hook.ts',
     reason:
       'Cross-engine interactive-engine <-> requirements-manager coupling; already tracked in ALLOWED_LATERAL_VIOLATIONS cluster A, structural.',
-    tracking: '#1359',
-  },
-  {
-    cycle:
-      'components/interactive-tutorial/hooks/use-section-requirements.ts <-> components/interactive-tutorial/interactive-conditional.tsx <-> components/interactive-tutorial/interactive-section.tsx <-> components/interactive-tutorial/section-numbering.tsx',
-    reason:
-      'interactive-tutorial section rendering and its requirements hook cross-reference; contained within one component subtree.',
-    tracking: '#1359',
-  },
-  {
-    cycle:
-      'components/docs-panel/components/DocsPanelContentArea.tsx <-> components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx <-> components/docs-panel/components/index.ts <-> components/docs-panel/docs-panel.tsx',
-    reason:
-      'Barrel-routed docs-panel cluster; back-edges are the shared CombinedLearningJourneyPanel type, likely a shared-type extraction.',
     tracking: '#1359',
   },
 ];


### PR DESCRIPTION
## What

Pays down three of the five grandfathered `ALLOWED_CYCLES` clusters from the #1358 baseline, using the two patterns demonstrated on that PR (extract the shared symbol to a leaf; don't import upward for identity/type access). Their allowlist entries are removed; the ratchet's stale-entry check confirms the SCCs are gone.

**Part of #1359 — does not close it.** The two remaining clusters (telemetry + OpenFeature across `lib`/`security`/`utils`, and the `interactive-engine <-> requirements-manager` lateral) need runtime inversions and are left for follow-up PRs.

## Per-cluster changes

### `requirements-manager/checks/*` (7 files)

Every `checks/* -> requirements-checker.utils.ts` back-edge was the same single `import type { CheckResultError }`. The type moves to the Tier-0 `types/requirements.types.ts` leaf; the `requirements-manager` barrel exports it from there, so the public surface is unchanged.

### `components/interactive-tutorial` (4 files)

Two cuts:

- `use-section-requirements.ts` imported only `DEFAULT_INTERACTIVE_SECTION_TITLE` from `interactive-section.tsx`. The title constants move to a new `section-titles.ts` leaf; the barrel and tests import it directly.
- `section-numbering.tsx` imported `InteractiveConditional` solely for a component-identity check. The conditional now tags itself via a shared marker leaf (`skip-section-numbering.ts`) and the numbering helper checks the marker. This also removes the conditional from the cycle-load-order hazard documented in `section-numbering.tsx`'s header. The genuine render recursion (conditional renders `InteractiveSection`) is untouched and is now a one-way edge.

### `components/docs-panel` (4 files)

`DocsPanelContentArea` and `LearningJourneyMilestoneToolbar` imported the `CombinedLearningJourneyPanel` class from `docs-panel.tsx` as a prop type. Both now type against the existing `DocsPanelModelOperations` interface in `components/docs-panel/types.ts` (extended with `confirmAlignment`/`dismissAlignment`, which the class already exposes publicly — this was the interface's stated purpose, "Pattern E: interface-first decoupling").

## Verification

- `src/validation/architecture.test.ts`: 23/23 pass; ratchet log now reports `cycles: clusters=2` (down from 5)
- `tsc --noEmit` clean, lint 0 errors, prettier clean
- Full suite: 356 suites / 5,530 tests pass

## Review pass

An independent tech-debt-focused review (per `.cursor/skills/review/SKILL.md` + the techdebt lens) found 0 blockers and confirmed all three clusters are genuine graph surgery rather than allowlist appeasement. Its 7 minor/nit findings are addressed in the second commit: marker survives `React.memo`/`forwardRef` wrapping, the test-harness conditional mock self-tags like production, the `RemoteRequirementError` wire mirror got an honest rationale + a compile-time assignability guard, both single-consumer back-compat re-exports were dropped in favor of direct leaf imports, two QC8 narration comments removed, and the toolbar test mock now types against the operations interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
