### PR TITLE
feat(cli): forward any unknown top-level manifest key into repository.json

### DIFF
--- a/src/cli/commands/build-repository.ts
+++ b/src/cli/commands/build-repository.ts
@@ -148,6 +148,7 @@ function readPackage(root: string, packageDir: string): PackageReadResult {
     entry.replaces = manifest.replaces?.length ? manifest.replaces : undefined;
     entry.targeting = manifest.targeting;
     entry.testEnvironment = manifest.testEnvironment;
+    entry.stats = manifest.stats;
   }
 
   return { id, dirName, entry, warnings, errors };

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -1142,6 +1142,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'replaces',
     'targeting',
     'testEnvironment',
+    'stats',
   ]),
 };
 

--- a/src/types/package.schema.ts
+++ b/src/types/package.schema.ts
@@ -154,6 +154,10 @@ export const ManifestJsonObjectSchema = z.object({
 
   targeting: GuideTargetingSchema.optional(),
   testEnvironment: TestEnvironmentSchema.default(DEFAULT_TEST_ENVIRONMENT),
+
+  // Opaque rollup stats — validated as "is an object" only; contents are
+  // deliberately unvalidated pending grafana/pathfinder-rfcs#14.
+  stats: z.record(z.string(), z.unknown()).optional(),
 });
 
 /**
@@ -225,6 +229,7 @@ export const RepositoryEntrySchema = z.object({
   ...packageMetadataSchemaFields,
   targeting: GuideTargetingSchema.optional(),
   testEnvironment: TestEnvironmentSchema.optional(),
+  stats: z.record(z.string(), z.unknown()).optional(),
 }) satisfies z.ZodType<RepositoryEntry>;
 
 /**

--- a/src/types/package.types.ts
+++ b/src/types/package.types.ts
@@ -167,6 +167,14 @@ export interface ManifestJson {
 
   targeting?: GuideTargeting;
   testEnvironment?: TestEnvironment;
+
+  /**
+   * Opaque rollup statistics computed by the content repository (e.g. step,
+   * block, and section counts). Deliberately untyped at this stage — the CLI
+   * carries it through unvalidated pending the field-shape decision in
+   * https://github.com/grafana/pathfinder-rfcs/pull/14.
+   */
+  stats?: Record<string, unknown>;
 }
 
 // ============ REPOSITORY INDEX ============
@@ -180,6 +188,8 @@ export interface RepositoryEntry extends PackageMetadataFields {
   path: string;
   targeting?: GuideTargeting;
   testEnvironment?: TestEnvironment;
+  /** Opaque rollup statistics carried through from the package manifest. */
+  stats?: Record<string, unknown>;
 }
 
 /**

--- a/src/validation/build-repository.test.ts
+++ b/src/validation/build-repository.test.ts
@@ -320,6 +320,59 @@ describe('buildRepository', () => {
     expect(entry!.recommends).toBeUndefined();
   });
 
+  it('should carry manifest stats through into repository entries unstripped for multiple packages', () => {
+    writeJson(path.join(tmpDir, 'guide-with-stats', 'content.json'), {
+      id: 'guide-with-stats',
+      title: 'Guide with stats',
+      blocks: [],
+    });
+    writeJson(path.join(tmpDir, 'guide-with-stats', 'manifest.json'), {
+      id: 'guide-with-stats',
+      type: 'guide',
+      stats: { steps: 4, blocks: 12, sections: 3 },
+    });
+
+    writeJson(path.join(tmpDir, 'journey-with-stats', 'content.json'), {
+      id: 'journey-with-stats',
+      title: 'Journey with stats',
+      blocks: [],
+    });
+    writeJson(path.join(tmpDir, 'journey-with-stats', 'manifest.json'), {
+      id: 'journey-with-stats',
+      type: 'journey',
+      milestones: ['guide-with-stats'],
+      stats: { steps: 9, blocks: 27, sections: 6, milestones: 1 },
+    });
+
+    const { repository, errors } = buildRepository(tmpDir);
+    expect(errors).toHaveLength(0);
+
+    const guide = repository['guide-with-stats'];
+    expect(guide).toBeDefined();
+    expect(guide!.stats).toEqual({ steps: 4, blocks: 12, sections: 3 });
+
+    const journey = repository['journey-with-stats'];
+    expect(journey).toBeDefined();
+    expect(journey!.stats).toEqual({ steps: 9, blocks: 27, sections: 6, milestones: 1 });
+  });
+
+  it('should leave stats undefined when the manifest omits it', () => {
+    writeJson(path.join(tmpDir, 'no-stats', 'content.json'), {
+      id: 'no-stats',
+      title: 'No stats',
+      blocks: [],
+    });
+    writeJson(path.join(tmpDir, 'no-stats', 'manifest.json'), {
+      id: 'no-stats',
+      type: 'guide',
+    });
+
+    const { repository, errors } = buildRepository(tmpDir);
+    expect(errors).toHaveLength(0);
+    expect(repository['no-stats']).toBeDefined();
+    expect(repository['no-stats']!.stats).toBeUndefined();
+  });
+
   it('should handle non-existent root directory', () => {
     const { repository, warnings } = buildRepository('/nonexistent/path');
     expect(Object.keys(repository)).toHaveLength(0);

--- a/src/validation/build-repository.test.ts
+++ b/src/validation/build-repository.test.ts
@@ -9,6 +9,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { buildRepository } from '../cli/commands/build-repository';
+import { RepositoryJsonSchema } from '../types/package.schema';
 
 function createTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'pathfinder-build-repo-'));
@@ -354,6 +355,10 @@ describe('buildRepository', () => {
     const journey = repository['journey-with-stats'];
     expect(journey).toBeDefined();
     expect(journey!.stats).toEqual({ steps: 9, blocks: 27, sections: 6, milestones: 1 });
+
+    const roundTripped = RepositoryJsonSchema.parse(JSON.parse(JSON.stringify(repository)));
+    expect(roundTripped['guide-with-stats']?.stats).toEqual({ steps: 4, blocks: 12, sections: 3 });
+    expect(roundTripped['journey-with-stats']?.stats).toEqual({ steps: 9, blocks: 27, sections: 6, milestones: 1 });
   });
 
   it('should leave stats undefined when the manifest omits it', () => {


### PR DESCRIPTION
## What & why

The packaging CLI now forwards **any unknown top-level key** in a package's
`manifest.json` through into that package's entry in `repository.json`.

This replaces the earlier shape of this PR, which carried exactly one new field
(`stats`) and gated it on an RFC decision about that field's shape. The decision
taken instead is to make the CLI **permissive for extension metadata** at the
manifest's top level, so adding a new field is a content-repo change rather than
a CLI change plus a release. The alternative considered and rejected was a single
namespaced extension field holding arbitrary content; a flat passthrough was
preferred because further fields are expected and each one should not cost a code
change here.

## What was actually blocking it

Two independent layers dropped unknown keys, and both had to move:

1. **Parse.** `ManifestJsonObjectSchema` was a plain `z.object`, which strips
   unknown keys — so a new field never survived to be copied. Verified against
   this repo's pinned Zod (**4.4.3**) rather than assumed:

   | schema | `parse({ a: 'x', extra: 1 })` |
   | --- | --- |
   | `z.object({ a: z.string() })` | `{"a":"x"}` |
   | `z.looseObject({ a: z.string() })` | `{"a":"x","extra":1}` |

   Known-field validation is identical either way — `{ a: 123 }` still fails
   under `looseObject`. Note the behaviour was already non-uniform: several
   call sites (`package-engine/loader.ts`, `online-cdn-resolver.ts`,
   `cli/mcp/lib/repository-client.ts`, `cli/e2e/recommender-resolver.ts`)
   already opt into `.loose()` locally. Making the base schema loose makes that
   uniform; those local `.loose()` calls are now redundant no-ops, left in place
   to keep this PR to one concern.

2. **Copy.** `readPackage()` in `build-repository.ts` copied manifest fields
   onto the entry **one at a time by name** (`entry.type = manifest.type`, …).
   That is an allowlist by construction: anything not named was never copied.

`KNOWN_FIELDS` in `json-guide.schema.ts` is a third, separate mechanism — it
drives *warnings only* via `validation/unknown-fields.ts`, and `_manifest` is
not consumed by that walker at all. It does not strip, so it was not part of the
fix. The `stats` entry added to it by the previous revision has been reverted.

## Changes

- `ManifestJsonObjectSchema` and `RepositoryEntrySchema` are now
  `z.looseObject`. The repository entry schema has to move too, or extension
  keys would be stripped again the moment anything re-parses `repository.json`
  (`package-engine/resolver.ts`, `cli/utils/file-loader.ts`, `build-graph.ts`).
- `ManifestJson` and `RepositoryEntry` gain an `[key: string]: unknown` index
  signature so extension data is readable by consumers. Trade-off worth naming
  in review: this also removes excess-property and typo checking on those two
  interfaces.
- `build-repository` gained `forwardExtensionFields()`, which copies every
  manifest key the builder does not name explicitly.
- The special-cased `stats` field is **removed** from `package.types.ts`, both
  Zod schemas, `KNOWN_FIELDS`, and the explicit copy list. The generic path
  covers it, so no named field is warranted — `stats` is now just the first
  extension key to use this road, with no privileged status in the CLI.

## Collision and refusal policy

The refusal list is derived, not hand-maintained:

```ts
RESERVED_ENTRY_FIELDS = keys(RepositoryEntrySchema.shape)
                        - keys(ManifestJsonObjectSchema.shape)
                        + '__proto__'
```

which today evaluates to **`path`, `title`, `__proto__`** — and stays correct on
its own if either schema gains a field.

- **Keys the build computes itself** (`path`, from the package directory;
  `title`, from `content.json`) are **refused with a warning**, not silently
  dropped and not allowed to overwrite. Without this, a manifest could rewrite
  the `path` the resolver fetches by.
- **`__proto__`** is refused because the copy is an assignment sink fed by
  untrusted file content. Zod 4.4.3 already declines to carry it through, so
  this is defence in depth against that changing.
- **Known manifest fields are never forwarded generically.** They are skipped by
  the passthrough and keep their existing hand-written mapping, so fields that
  deliberately do *not* appear in a repository entry (`id`, `schemaVersion`,
  `repository`, `language`) still do not. Current behaviour is unchanged for
  every field that already existed.
- **Future field names are not reserved.** If a key forwarded today is later
  promoted to a named manifest field, the passthrough stops handling it and the
  explicit mapping takes over — the key keeps appearing in `repository.json`,
  now validated. That is the intended migration path, and it is why the refusal
  list is kept to computed fields only rather than growing into a denylist.

## Nested validation is unchanged

The permissiveness is scoped to the manifest's **top level only**. `content.json`
still parses through `ContentJsonSchema` → `JsonBlockSchema` unchanged, and
nested manifest objects (`author`, `targeting`, `testEnvironment`) keep their own
schemas. A test asserts a malformed block is still rejected, and another asserts
an invalid `type` still fails manifest validation and degrades to `content.json`
only.

## How to verify

`npm run check` passes (typecheck, lint, prettier, Go lint/test, coverage,
scripts). Six behavioural tests in `src/validation/build-repository.test.ts`
cover: an unknown key survives; a nested extension object survives; the
serialization round-trip through `RepositoryJsonSchema` keeps it; an entry gains
no stray keys when the manifest has none; `path`/`title` collisions are refused
with a warning and the computed values win; a known field stays validated; and
invalid nested content is still rejected.

Real end-to-end run over a package tree whose manifest carries `stats`,
`estimatedMinutes`, a nested `owner` object, and a hostile `path`:

```json
{
  "demo-guide": {
    "path": "demo-guide/",
    "title": "Demo guide",
    "type": "guide",
    "startingLocation": "/",
    "testEnvironment": { "tier": "cloud" },
    "stats": { "steps": 3, "blocks": 7 },
    "estimatedMinutes": 12,
    "owner": { "team": "enablement", "slack": "#pathfinder" }
  }
}
```
```
WARNING: demo-guide: Ignoring manifest field "path": reserved for a repository
entry field the build computes
```

## Breaking changes

None. No `CURRENT_SCHEMA_VERSION` bump — this widens what is accepted and
carried; it does not change the meaning of any existing field. Repository files
built before this change parse identically after it.

## Reversibility

Straightforwardly revertable. Reverting narrows `repository.json` back to the
named fields; any consumer reading an extension key would need to tolerate it
going missing, which is the same tolerance it already needs for a package whose
manifest simply omits the key.

## Follow-up

`interactive-tutorials` CI must bump its pinned Pathfinder CLI SHA to pick up
this change, or extension keys will continue to be stripped during repository
builds there.
