### PR TITLE
fix(context-panel): show short recommendation summaries inline

### DIFF
--- a/src/components/docs-panel/context-panel.test.tsx
+++ b/src/components/docs-panel/context-panel.test.tsx
@@ -230,6 +230,8 @@ describe('RecommendationsSection', () => {
 
   it('calls toggleSummaryExpansion with contentUrl for package-backed recommendations', () => {
     const toggleSummaryExpansion = jest.fn();
+    // 21+ words — above SUMMARY_COLLAPSE_WORD_THRESHOLD (20) so the Summary control appears.
+    const longSummary = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21';
 
     render(
       <RecommendationsSection
@@ -239,7 +241,7 @@ describe('RecommendationsSection', () => {
             url: '',
             contentUrl: 'https://interactive-learning.grafana.net/packages/alerting-101/content.json',
             type: 'package',
-            summary: 'Learn alerting basics.',
+            summary: longSummary,
             manifest: { id: 'alerting-101', type: 'guide' },
           },
         ]}
@@ -267,6 +269,82 @@ describe('RecommendationsSection', () => {
     expect(toggleSummaryExpansion).toHaveBeenCalledWith(
       'https://interactive-learning.grafana.net/packages/alerting-101/content.json'
     );
+  });
+
+  it('renders short summaries inline without a Summary collapse button', () => {
+    render(
+      <RecommendationsSection
+        recommendations={[
+          {
+            title: 'Alerting 101',
+            url: '',
+            contentUrl: 'https://interactive-learning.grafana.net/packages/alerting-101/content.json',
+            type: 'package',
+            summary: 'Learn alerting basics.',
+            manifest: { id: 'alerting-101', type: 'guide' },
+            completionPercentage: 10,
+          },
+        ]}
+        featuredRecommendations={[]}
+        customGuides={[]}
+        isLoadingCustomGuides={false}
+        customGuidesExpanded
+        suggestedGuidesExpanded
+        isLoadingRecommendations={false}
+        isLoadingContext={false}
+        recommendationsError={null}
+        otherDocsExpanded={false}
+        showEnableRecommenderBanner={false}
+        openLearningJourney={jest.fn()}
+        openDocsPage={jest.fn()}
+        toggleCustomGuidesExpansion={jest.fn()}
+        toggleSuggestedGuidesExpansion={jest.fn()}
+        toggleSummaryExpansion={jest.fn()}
+        toggleOtherDocsExpansion={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Summary' })).not.toBeInTheDocument();
+    expect(screen.getByText('Learn alerting basics.')).toBeInTheDocument();
+    expect(screen.getByText('{{percent}}% complete')).toBeInTheDocument();
+  });
+
+  it('keeps the Summary collapse button when short summary has expandable milestone details', () => {
+    render(
+      <RecommendationsSection
+        recommendations={[
+          {
+            title: 'Alerting 101',
+            url: '',
+            contentUrl: 'https://interactive-learning.grafana.net/packages/alerting-101/content.json',
+            type: 'package',
+            summary: 'Learn alerting basics.',
+            totalSteps: 3,
+            pendingMilestoneIds: ['intro', 'configure', 'verify'],
+            manifest: { id: 'alerting-101', type: 'guide' },
+          },
+        ]}
+        featuredRecommendations={[]}
+        customGuides={[]}
+        isLoadingCustomGuides={false}
+        customGuidesExpanded
+        suggestedGuidesExpanded
+        isLoadingRecommendations={false}
+        isLoadingContext={false}
+        recommendationsError={null}
+        otherDocsExpanded={false}
+        showEnableRecommenderBanner={false}
+        openLearningJourney={jest.fn()}
+        openDocsPage={jest.fn()}
+        toggleCustomGuidesExpansion={jest.fn()}
+        toggleSuggestedGuidesExpansion={jest.fn()}
+        toggleSummaryExpansion={jest.fn()}
+        toggleOtherDocsExpansion={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Summary' })).toBeInTheDocument();
+    expect(screen.queryByText('Learn alerting basics.')).not.toBeInTheDocument();
   });
 
   it('shows completion percentage for package with completionPercentage set', () => {

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -75,17 +75,6 @@ const getRecommendationButtonText = (type?: string, completionPercentage?: numbe
   return t('contextPanel.start', 'Start');
 };
 
-/** Get long CTA button text based on recommendation type */
-const getRecommendationCtaText = (type?: string): string => {
-  if (type === 'docs-page') {
-    return t('contextPanel.viewDocumentation', 'View documentation');
-  }
-  if (type === 'interactive') {
-    return t('contextPanel.startInteractiveGuide', 'Start interactive guide');
-  }
-  return t('contextPanel.startLearningJourney', 'Start learning path');
-};
-
 /** Get category label for display as a tag below the title */
 const getCategoryLabel = (type?: string): string => {
   if (type === 'interactive') {
@@ -110,6 +99,40 @@ const getCategoryTagStyle = (styles: ReturnType<typeof getStyles>, type?: string
 
 /** Check if recommendation type is docs-only (static documentation, not action-oriented) */
 const isDocsOnlyRecommendation = (type?: string): boolean => type === 'docs-page';
+
+/**
+ * Approximate two lines of bodySmall text in the recommendation card.
+ */
+const SUMMARY_COLLAPSE_WORD_THRESHOLD = 20;
+
+/** Whether the summary text alone is long enough to warrant a collapse control. */
+function isCollapsibleSummary(summary?: string): boolean {
+  const words = summary?.trim().split(/\s+/).filter(Boolean) ?? [];
+  return words.length > SUMMARY_COLLAPSE_WORD_THRESHOLD;
+}
+
+/** Whether unresolved or resolved content exists for the expansion panel. */
+function hasExpandableDetails(recommendation: Recommendation): boolean {
+  if (recommendation.type !== 'package') {
+    return false;
+  }
+
+  const hasPendingDetails =
+    Boolean(recommendation.pendingMilestoneIds?.length) ||
+    Boolean(recommendation.pendingRecommendIds?.length) ||
+    Boolean(recommendation.pendingSuggestIds?.length);
+  if (hasPendingDetails || Boolean(recommendation.milestones?.length)) {
+    return true;
+  }
+
+  const nav = getManifestNavigation(recommendation);
+  return nav.recommends.length > 0 || nav.suggests.length > 0;
+}
+
+/** Whether this card should render the Summary collapse control. */
+function isSummaryExpandable(recommendation: Recommendation): boolean {
+  return isCollapsibleSummary(recommendation.summary) || hasExpandableDetails(recommendation);
+}
 
 /**
  * Check if recommendation should use openDocsPage.
@@ -397,6 +420,8 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                 const contentUrl = getRecommendationContentUrl(recommendation);
                 const packageInfo = getRecommendationPackageInfo(recommendation);
                 const displayType = getEffectiveDisplayType(recommendation);
+                const isExpandable = isSummaryExpandable(recommendation);
+                const isExpanded = isExpandable && Boolean(recommendation.summaryExpanded);
                 return (
                   <Card
                     key={`featured-${index}`}
@@ -420,9 +445,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                             {getCategoryLabel(displayType)}
                           </span>
                         </div>
-                        <div
-                          className={`${styles.cardActions} ${recommendation.summaryExpanded ? styles.hiddenActions : ''}`}
-                        >
+                        <div className={styles.cardActions}>
                           <button
                             onClick={() => {
                               reportAppInteraction(UserInteraction.OpenResourceClick, {
@@ -458,30 +481,36 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                         <>
                           <div className={styles.cardMetadata}>
                             <div className={styles.summaryInfo}>
-                              <button
-                                onClick={() => {
-                                  reportAppInteraction(UserInteraction.SummaryClick, {
-                                    content_title: recommendation.title,
-                                    content_url: contentUrl,
-                                    content_type: getContentTypeForAnalytics(
-                                      contentUrl,
-                                      getContentTypeForDisplayType(displayType)
-                                    ),
-                                    action: recommendation.summaryExpanded ? 'collapse' : 'expand',
-                                    match_accuracy: recommendation.matchAccuracy || 0,
-                                    ...(displayType !== 'docs-page' && {
-                                      total_milestones: recommendation.totalSteps || 0,
-                                    }),
-                                  });
+                              {isExpandable ? (
+                                <button
+                                  onClick={() => {
+                                    reportAppInteraction(UserInteraction.SummaryClick, {
+                                      content_title: recommendation.title,
+                                      content_url: contentUrl,
+                                      content_type: getContentTypeForAnalytics(
+                                        contentUrl,
+                                        getContentTypeForDisplayType(displayType)
+                                      ),
+                                      action: isExpanded ? 'collapse' : 'expand',
+                                      match_accuracy: recommendation.matchAccuracy || 0,
+                                      ...(displayType !== 'docs-page' && {
+                                        total_milestones: recommendation.totalSteps || 0,
+                                      }),
+                                    });
 
-                                  toggleSummaryExpansion(contentUrl);
-                                }}
-                                className={styles.summaryButton}
-                              >
-                                <Icon name="info-circle" size="sm" />
-                                <span>{t('contextPanel.summary', 'Summary')}</span>
-                                <Icon name={recommendation.summaryExpanded ? 'angle-up' : 'angle-down'} size="sm" />
-                              </button>
+                                    toggleSummaryExpansion(contentUrl);
+                                  }}
+                                  className={styles.summaryButton}
+                                >
+                                  <Icon name="info-circle" size="sm" />
+                                  <span>{t('contextPanel.summary', 'Summary')}</span>
+                                  <Icon name={isExpanded ? 'angle-up' : 'angle-down'} size="sm" />
+                                </button>
+                              ) : (
+                                recommendation.summary && (
+                                  <p className={styles.inlineSummary}>{recommendation.summary}</p>
+                                )
+                              )}
                               {!isDocsOnlyRecommendation(displayType) &&
                                 typeof recommendation.completionPercentage === 'number' && (
                                   <div className={styles.completionInfo}>
@@ -498,7 +527,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                             </div>
                           </div>
 
-                          {recommendation.summaryExpanded && (
+                          {isExpanded && (
                             <div className={styles.summaryExpansion}>
                               {recommendation.summary && (
                                 <div className={styles.summaryContent}>
@@ -641,37 +670,6 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                                   </div>
                                 );
                               })()}
-
-                              <div className={styles.summaryCta}>
-                                <button
-                                  onClick={() => {
-                                    reportAppInteraction(UserInteraction.OpenResourceClick, {
-                                      content_title: recommendation.title,
-                                      content_url: contentUrl,
-                                      content_type: getContentTypeForAnalytics(
-                                        contentUrl,
-                                        getContentTypeForDisplayType(displayType)
-                                      ),
-                                      interaction_location: 'featured_summary_cta_button',
-                                      match_accuracy: recommendation.matchAccuracy || 0,
-                                      ...(displayType !== 'docs-page' && {
-                                        total_milestones: recommendation.totalSteps || 0,
-                                        completion_percentage: recommendation.completionPercentage ?? 0,
-                                      }),
-                                    });
-
-                                    if (shouldUseDocsPageOpener(recommendation.type)) {
-                                      openDocsPage(contentUrl, recommendation.title, packageInfo);
-                                    } else {
-                                      openLearningJourney(contentUrl, recommendation.title);
-                                    }
-                                  }}
-                                  className={styles.summaryCtaButton}
-                                >
-                                  <Icon name={getRecommendationIcon(displayType)} size="sm" />
-                                  {getRecommendationCtaText(displayType)}
-                                </button>
-                              </div>
                             </div>
                           )}
                         </>
@@ -691,6 +689,8 @@ export const RecommendationsSection = memo(function RecommendationsSection({
               const contentUrl = getRecommendationContentUrl(recommendation);
               const packageInfo = getRecommendationPackageInfo(recommendation);
               const displayType = getEffectiveDisplayType(recommendation);
+              const isExpandable = isSummaryExpandable(recommendation);
+              const isExpanded = isExpandable && Boolean(recommendation.summaryExpanded);
               return (
                 <Card
                   key={contentUrl || `rec-${index}`}
@@ -721,9 +721,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                           {getCategoryLabel(displayType)}
                         </span>
                       </div>
-                      <div
-                        className={`${styles.cardActions} ${recommendation.summaryExpanded ? styles.hiddenActions : ''}`}
-                      >
+                      <div className={styles.cardActions}>
                         <button
                           onClick={() => {
                             reportAppInteraction(UserInteraction.OpenResourceClick, {
@@ -760,31 +758,35 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                       <>
                         <div className={styles.cardMetadata}>
                           <div className={styles.summaryInfo}>
-                            <button
-                              onClick={() => {
-                                reportAppInteraction(UserInteraction.SummaryClick, {
-                                  content_title: recommendation.title,
-                                  content_url: contentUrl,
-                                  content_type: getContentTypeForAnalytics(
-                                    contentUrl,
-                                    getContentTypeForDisplayType(displayType)
-                                  ),
-                                  action: recommendation.summaryExpanded ? 'collapse' : 'expand',
-                                  match_accuracy: recommendation.matchAccuracy || 0,
-                                  ...(displayType !== 'docs-page' && {
-                                    total_milestones: recommendation.totalSteps || 0,
-                                  }),
-                                });
+                            {isExpandable ? (
+                              <button
+                                onClick={() => {
+                                  reportAppInteraction(UserInteraction.SummaryClick, {
+                                    content_title: recommendation.title,
+                                    content_url: contentUrl,
+                                    content_type: getContentTypeForAnalytics(
+                                      contentUrl,
+                                      getContentTypeForDisplayType(displayType)
+                                    ),
+                                    action: isExpanded ? 'collapse' : 'expand',
+                                    match_accuracy: recommendation.matchAccuracy || 0,
+                                    ...(displayType !== 'docs-page' && {
+                                      total_milestones: recommendation.totalSteps || 0,
+                                    }),
+                                  });
 
-                                toggleSummaryExpansion(contentUrl);
-                              }}
-                              className={styles.summaryButton}
-                              data-testid={testIds.contextPanel.recommendationSummaryButton(index)}
-                            >
-                              <Icon name="info-circle" size="sm" />
-                              <span>{t('contextPanel.summary', 'Summary')}</span>
-                              <Icon name={recommendation.summaryExpanded ? 'angle-up' : 'angle-down'} size="sm" />
-                            </button>
+                                  toggleSummaryExpansion(contentUrl);
+                                }}
+                                className={styles.summaryButton}
+                                data-testid={testIds.contextPanel.recommendationSummaryButton(index)}
+                              >
+                                <Icon name="info-circle" size="sm" />
+                                <span>{t('contextPanel.summary', 'Summary')}</span>
+                                <Icon name={isExpanded ? 'angle-up' : 'angle-down'} size="sm" />
+                              </button>
+                            ) : (
+                              recommendation.summary && <p className={styles.inlineSummary}>{recommendation.summary}</p>
+                            )}
                             {!isDocsOnlyRecommendation(displayType) &&
                               typeof recommendation.completionPercentage === 'number' && (
                                 <div className={styles.completionInfo}>
@@ -801,7 +803,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                           </div>
                         </div>
 
-                        {recommendation.summaryExpanded && (
+                        {isExpanded && (
                           <div
                             className={styles.summaryExpansion}
                             data-testid={testIds.contextPanel.recommendationSummaryContent(index)}
@@ -954,37 +956,6 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                                 </div>
                               );
                             })()}
-
-                            <div className={styles.summaryCta}>
-                              <button
-                                onClick={() => {
-                                  reportAppInteraction(UserInteraction.OpenResourceClick, {
-                                    content_title: recommendation.title,
-                                    content_url: contentUrl,
-                                    content_type: getContentTypeForAnalytics(
-                                      contentUrl,
-                                      getContentTypeForDisplayType(displayType)
-                                    ),
-                                    interaction_location: 'summary_cta_button',
-                                    match_accuracy: recommendation.matchAccuracy || 0,
-                                    ...(displayType !== 'docs-page' && {
-                                      total_milestones: recommendation.totalSteps || 0,
-                                      completion_percentage: recommendation.completionPercentage ?? 0,
-                                    }),
-                                  });
-
-                                  if (shouldUseDocsPageOpener(recommendation.type)) {
-                                    openDocsPage(contentUrl, recommendation.title, packageInfo);
-                                  } else {
-                                    openLearningJourney(contentUrl, recommendation.title);
-                                  }
-                                }}
-                                className={styles.summaryCtaButton}
-                              >
-                                <Icon name={getRecommendationIcon(displayType)} size="sm" />
-                                {getRecommendationCtaText(displayType)}
-                              </button>
-                            </div>
                           </div>
                         )}
                       </>

--- a/src/styles/context-panel.styles.ts
+++ b/src/styles/context-panel.styles.ts
@@ -203,11 +203,6 @@ export const getRecommendationCardStyles = (theme: GrafanaTheme2) => ({
     flexShrink: 0,
     width: '80px',
   }),
-  hiddenActions: css({
-    opacity: 0,
-    visibility: 'hidden',
-    transition: 'opacity 0.2s ease, visibility 0.2s ease',
-  }),
   startButton: css({
     display: 'flex',
     alignItems: 'center',
@@ -278,6 +273,7 @@ export const getCardMetadataStyles = (theme: GrafanaTheme2) => ({
   completionInfo: css({
     display: 'flex',
     alignItems: 'center',
+    alignSelf: 'flex-start',
     marginLeft: 'auto',
   }),
   completionPercentage: css({
@@ -315,6 +311,15 @@ export const getCardMetadataStyles = (theme: GrafanaTheme2) => ({
       cursor: 'not-allowed',
       color: theme.colors.text.secondary,
     },
+  }),
+  inlineSummary: css({
+    flex: 1,
+    margin: 0,
+    padding: `${theme.spacing(0.5)} ${theme.spacing(0.75)}`,
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontWeight: theme.typography.fontWeightRegular,
+    lineHeight: 1.4,
+    color: theme.colors.text.primary,
   }),
   stepsCount: css({
     display: 'flex',
@@ -354,11 +359,8 @@ export const getCardMetadataStyles = (theme: GrafanaTheme2) => ({
 // Summary and content expansion styles
 export const getSummaryStyles = (theme: GrafanaTheme2) => ({
   summaryExpansion: css({
-    marginTop: theme.spacing(1.5),
-    padding: theme.spacing(1.5),
-    backgroundColor: theme.colors.background.secondary,
-    borderRadius: theme.shape.radius.default,
-    border: `1px solid ${theme.colors.border.weak}`,
+    padding: theme.spacing(0.5),
+    paddingLeft: theme.spacing(3),
     position: 'relative',
   }),
   summaryContent: css({
@@ -369,51 +371,6 @@ export const getSummaryStyles = (theme: GrafanaTheme2) => ({
     color: theme.colors.text.primary,
     lineHeight: 1.4,
     margin: 0,
-  }),
-  summaryCta: css({
-    position: 'sticky',
-    bottom: 0,
-    marginTop: theme.spacing(2),
-    padding: theme.spacing(1.5),
-    backgroundColor: 'transparent',
-    borderTop: `1px solid ${theme.colors.border.weak}`,
-    borderRadius: `0 0 ${theme.shape.radius.default}px ${theme.shape.radius.default}px`,
-    display: 'flex',
-    justifyContent: 'center',
-    boxShadow: `0 -2px 8px ${theme.colors.background.secondary}`,
-    zIndex: 10,
-  }),
-  summaryCtaButton: css({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: theme.spacing(0.75),
-    padding: `${theme.spacing(1)} ${theme.spacing(2.5)}`,
-    backgroundColor: theme.colors.primary.main,
-    color: theme.colors.primary.contrastText,
-    border: 'none',
-    borderRadius: theme.shape.radius.default,
-    cursor: 'pointer',
-    fontSize: theme.typography.body.fontSize,
-    fontWeight: theme.typography.fontWeightMedium,
-    transition: 'all 0.2s ease',
-    minWidth: '120px',
-    boxShadow: theme.shadows.z1,
-
-    '&:hover': {
-      backgroundColor: theme.colors.primary.shade,
-      transform: 'translateY(-1px)',
-      boxShadow: theme.shadows.z2,
-    },
-
-    '&:active': {
-      transform: 'translateY(0)',
-      boxShadow: theme.shadows.z1,
-    },
-
-    '& svg': {
-      flexShrink: 0,
-    },
   }),
 });
 


### PR DESCRIPTION
## Summary

Recommendation cards no longer hide short summaries behind a Summary control. Concise copy renders inline; the expand control stays when the summary is long enough (~2 lines) or the package has milestone/nav details to show. The title-row Start/Resume/View action stays visible while expanded — the duplicate expanded-panel CTA is removed.

Aligns recommendation-card UX with Jess Matz’s Pathfinder UX review guidance ([Figma](https://www.figma.com/design/MuEIAafuIdrJOljvIy7E0T/Pathfinder-UX-review?node-id=0-1&p=f&t=388gwaK3E31FQFqa-0)).

## What to look at

- **Docs panel recommendations** ([`context-panel.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/989511b1c6dcc36b565136f6a0e07590c501fb97/src/components/docs-panel/context-panel.tsx)) — `isCollapsibleSummary` / `hasExpandableDetails` / `isSummaryExpandable` gate the Summary button vs inline `<p>`. Trace both featured and primary card maps (logic is mirrored). The expandable vs non-expandable branches use a ternary on purpose: the two layouts differ structurally, so a single shared tree would fight the styling.
- **Expandability stays in the panel** — word-count and package-detail checks live in the context panel, not as an upstream recommendation flag. That keeps rendering responsibility with the UI; more configurability can move onto props later if needed.
- **Word threshold is 20, not ~25** — calibrated so short copy more consistently lands near two `bodySmall` lines. If a summary still wraps, the container grows; if we later need a hard visual 2-line cap, we’d need a render-height probe (extra complexity we deferred).
- **Styles** ([`context-panel.styles.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/989511b1c6dcc36b565136f6a0e07590c501fb97/src/styles/context-panel.styles.ts)) — new `inlineSummary`; removed `hiddenActions` and `summaryCta*`; lighter `summaryExpansion` chrome.

## Why

Issue #1258: summaries always collapsed, even when short, adding a pointless click. Design asked to collapse only when content is roughly longer than two lines. We chose a plain word-count heuristic over measuring rendered height (CSS/`ResizeObserver`) to keep the first cut simple; we can add height-based expandability later if the heuristic isn’t enough.

## How to verify

1. Open Pathfinder recommendations with a **short** package summary and no milestone/nav details — confirm the summary text is visible inline and there is **no** Summary button.
2. Open a package with a **short** summary but pending milestones (or resolved milestones/nav) — confirm Summary still appears and expands to show details.
3. Open a package with a **long** summary (>20 words) — confirm Summary appears; expand/collapse works; expanded panel shows the summary text.
4. With a card expanded, confirm the title-row **Start/Resume/View** control remains visible and usable (no duplicate sticky CTA in the expansion).
5. Spot-check a featured recommendation card for the same short vs long / details behavior as the primary list.

## Breaking changes

None for end users. Analytics note: expansion-panel `OpenResourceClick` events with `interaction_location` `summary_cta_button` / `featured_summary_cta_button` are no longer emitted (CTA removed). Title-row open events are unchanged.

## Out of scope

- Height-/line-clamp-based expandability (deferred until word count proves insufficient).
- Passing an upstream “is expandable” flag on recommendation objects (kept as panel-local rendering logic for now).

Fixes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)
