### PR TITLE
feat: add collapsible block for gating solutions in guides (#1054)

### DIFF
--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -340,14 +340,14 @@ Hides its nested blocks behind a toggle. Use it to gate solutions or example out
 }
 ````
 
-| Field       | Type        | Required | Description                                         |
-| ----------- | ----------- | -------- | --------------------------------------------------- |
-| `id`        | string      | ❌       | HTML id for the collapsible                         |
-| `title`     | string      | ❌       | Label shown on the toggle (defaults to "Show more") |
-| `collapsed` | boolean     | ❌       | Whether it starts collapsed (defaults to `true`)    |
-| `blocks`    | JsonBlock[] | ✅       | Nested content hidden behind the toggle             |
+| Field       | Type                | Required | Description                                         |
+| ----------- | ------------------- | -------- | --------------------------------------------------- |
+| `id`        | string              | ❌       | HTML id for the collapsible (usable as a deep-link) |
+| `title`     | string              | ❌       | Label shown on the toggle (defaults to "Show more") |
+| `collapsed` | boolean             | ❌       | Whether it starts collapsed (defaults to `true`)    |
+| `blocks`    | content block array | ✅       | Content hidden behind the toggle                    |
 
-> Use presentational blocks (markdown — including fenced code — and images). Avoid nesting interactive steps for now: the guide-completion counter does not descend into collapsibles, so a nested step still records its own completion but is excluded from the guide's step total, skewing the progress percentage. Counting nested steps is planned as a follow-up.
+> A collapsible is presentational: it accepts content blocks only — `markdown` (including fenced code), `html`, `image`, and `video`. Interactive steps and containers (`section`, `collapsible`, `conditional`) are rejected, so a collapsible never carries completion state. To gate interactive steps, use a `section`.
 
 #### Conditional Block
 

--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -322,6 +322,33 @@ Groups related interactive steps into a sequence with "Do Section" functionality
 | `requirements` | string[]    | ❌       | Section-level requirements          |
 | `objectives`   | string[]    | ❌       | Objectives for the entire section   |
 
+#### Collapsible Block
+
+Hides its nested blocks behind a toggle. Use it to gate solutions or example outputs so learners attempt an exercise before revealing the answer. Unlike a section, it is purely presentational and tracks no completion state.
+
+````json
+{
+  "type": "collapsible",
+  "title": "Show solution",
+  "collapsed": true,
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "Here's one approach:\n\n```logql\n{app=\"foo\"} |= \"error\" | json\n```"
+    }
+  ]
+}
+````
+
+| Field       | Type        | Required | Description                                         |
+| ----------- | ----------- | -------- | --------------------------------------------------- |
+| `id`        | string      | ❌       | HTML id for the collapsible                         |
+| `title`     | string      | ❌       | Label shown on the toggle (defaults to "Show more") |
+| `collapsed` | boolean     | ❌       | Whether it starts collapsed (defaults to `true`)    |
+| `blocks`    | JsonBlock[] | ✅       | Nested content hidden behind the toggle             |
+
+> Use presentational blocks (markdown — including fenced code — and images). Avoid nesting interactive steps for now: the guide-completion counter does not descend into collapsibles, so a nested step still records its own completion but is excluded from the guide's step total, skewing the progress percentage. Counting nested steps is planned as a follow-up.
+
 #### Conditional Block
 
 Shows different content based on runtime condition evaluation. Conditions use the same syntax as requirements (e.g., `has-datasource:prometheus`, `is-admin`). When ALL conditions pass, the `whenTrue` branch is shown; otherwise, the `whenFalse` branch is shown.
@@ -896,6 +923,7 @@ Each screen has `id`, `title`, `body` (markdown), and an `options[]` array. Each
 | `video`            | Content     | YouTube or native HTML5 video embeds                                            |
 | `code-block`       | Content     | Code snippet with copy and optional Monaco-editor insert                        |
 | `section`          | Structure   | Container for grouped interactive steps with "Do Section"                       |
+| `collapsible`      | Structure   | Hides nested content behind a toggle                                            |
 | `conditional`      | Structure   | Shows different content based on runtime conditions                             |
 | `assistant`        | Structure   | Wraps blocks with AI-powered customization                                      |
 | `interactive`      | Interactive | Single-action step (highlight, button, formfill, navigate, hover, noop, popout) |

--- a/src/cli/__tests__/package-io.test.ts
+++ b/src/cli/__tests__/package-io.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import type {
   JsonBlock,
   JsonInteractiveBlock,
+  JsonMarkdownBlock,
   JsonMultistepBlock,
   JsonQuizBlock,
   JsonSectionBlock,
@@ -69,7 +70,7 @@ function baseManifest(): ManifestJson {
   } as ManifestJson;
 }
 
-const markdown = (id?: string): JsonBlock => ({ type: 'markdown', content: 'hi', ...(id ? { id } : {}) });
+const markdown = (id?: string): JsonMarkdownBlock => ({ type: 'markdown', content: 'hi', ...(id ? { id } : {}) });
 const interactiveBlock = (overrides: Partial<JsonInteractiveBlock> = {}): JsonInteractiveBlock => ({
   type: 'interactive',
   action: 'navigate',
@@ -213,6 +214,23 @@ describe('walkBlocks / findBlockById / findContainerById / collectAllIds', () =>
       }
     }
     expect(seen).toEqual(['cond', 'a', 'b']);
+  });
+
+  it('walks into a collapsible container', () => {
+    const content = baseContent([{ type: 'collapsible', id: 'panel', title: 'More', blocks: [markdown('hidden')] }]);
+    const seen: string[] = [];
+    for (const { block } of walkBlocks(content)) {
+      if (typeof block.id === 'string') {
+        seen.push(block.id);
+      }
+    }
+    expect(seen).toEqual(['panel', 'hidden']);
+  });
+
+  it('findBlockById and collectAllIds see blocks nested in a collapsible', () => {
+    const content = baseContent([{ type: 'collapsible', id: 'panel', blocks: [markdown('answer')] }]);
+    expect(findBlockById(content, 'answer')).not.toBeNull();
+    expect(collectAllIds(content)).toEqual(new Set(['panel', 'answer']));
   });
 
   it('findBlockById returns null when no match', () => {

--- a/src/cli/utils/block-registry.ts
+++ b/src/cli/utils/block-registry.ts
@@ -77,12 +77,16 @@ export const BLOCK_SCHEMA_MAP = {
  * flow for snippet refs is a follow-up — for v1, authors who want to insert
  * a snippet should use the editor's Reusable palette group.
  *
+ * `collapsible` is a presentational container authored through the block
+ * editor (Structure palette group). A CLI flow for its nested content is a
+ * follow-up; for now authors should use the editor.
+ *
  * The completeness test asserts that this set, unioned with the keys of
  * `BLOCK_SCHEMA_MAP`, exactly matches `VALID_BLOCK_TYPES`. Adding a new block
  * type to `VALID_BLOCK_TYPES` therefore forces a deliberate decision: register
  * it for CLI authoring or document why it's excluded.
  */
-export const CLI_EXCLUDED_BLOCK_TYPES: ReadonlySet<string> = new Set(['grot-guide', 'snippet-ref']);
+export const CLI_EXCLUDED_BLOCK_TYPES: ReadonlySet<string> = new Set(['grot-guide', 'snippet-ref', 'collapsible']);
 
 /**
  * Block-type discriminator strings the CLI knows how to create. Sourced

--- a/src/cli/utils/package-io/tree.ts
+++ b/src/cli/utils/package-io/tree.ts
@@ -23,6 +23,7 @@ import { PackageIOError } from './errors';
 export const CONTAINER_CHILD_KEYS: Record<string, string[]> = {
   section: ['blocks'],
   assistant: ['blocks'],
+  collapsible: ['blocks'],
   conditional: ['whenTrue', 'whenFalse'],
 };
 

--- a/src/components/block-editor/BlockFormModal.tsx
+++ b/src/components/block-editor/BlockFormModal.tsx
@@ -38,6 +38,7 @@ import { HtmlBlockForm } from './forms/HtmlBlockForm';
 import { ImageBlockForm } from './forms/ImageBlockForm';
 import { VideoBlockForm } from './forms/VideoBlockForm';
 import { SectionBlockForm } from './forms/SectionBlockForm';
+import { CollapsibleBlockForm } from './forms/CollapsibleBlockForm';
 import { ConditionalBlockForm } from './forms/ConditionalBlockForm';
 import { InteractiveBlockForm } from './forms/InteractiveBlockForm';
 import { MultistepBlockForm } from './forms/MultistepBlockForm';
@@ -115,6 +116,7 @@ const FORM_COMPONENTS: Record<BlockType, React.ComponentType<BlockFormProps>> = 
   image: ImageBlockForm,
   video: VideoBlockForm,
   section: SectionBlockForm,
+  collapsible: CollapsibleBlockForm,
   conditional: ConditionalBlockForm,
   interactive: InteractiveBlockForm,
   multistep: MultistepBlockForm,

--- a/src/components/block-editor/constants.ts
+++ b/src/components/block-editor/constants.ts
@@ -48,6 +48,13 @@ export const BLOCK_TYPE_METADATA: Record<BlockType, BlockTypeMetadata> = {
     name: 'Section',
     description: 'Container for grouped interactive steps',
   },
+  collapsible: {
+    type: 'collapsible',
+    icon: '📖',
+    grafanaIcon: 'angle-down',
+    name: 'Collapsible',
+    description: 'Hide content behind a toggle',
+  },
   conditional: {
     type: 'conditional',
     icon: '🔀',
@@ -143,6 +150,7 @@ export const BLOCK_TYPE_ORDER: BlockType[] = [
   'image',
   'video',
   'section',
+  'collapsible',
   'conditional',
   'interactive',
   'multistep',
@@ -184,7 +192,7 @@ export const BLOCK_TYPE_GROUPS: ReadonlyArray<{
   {
     id: 'structure',
     label: 'Structure',
-    types: ['section', 'conditional', 'grot-guide'],
+    types: ['section', 'collapsible', 'conditional', 'grot-guide'],
   },
   {
     id: 'reusable',

--- a/src/components/block-editor/forms/BranchBlocksEditor.tsx
+++ b/src/components/block-editor/forms/BranchBlocksEditor.tsx
@@ -272,8 +272,10 @@ function createDefaultBlock(type: BlockType): JsonBlock {
   }
 }
 
-// Block types allowed in conditional branches (no sections or conditionals)
-const ALLOWED_BRANCH_BLOCK_TYPES: BlockType[] = BLOCK_TYPE_ORDER.filter((t) => t !== 'section' && t !== 'conditional');
+// Block types allowed in conditional branches (no nested containers)
+const ALLOWED_BRANCH_BLOCK_TYPES: BlockType[] = BLOCK_TYPE_ORDER.filter(
+  (t) => t !== 'section' && t !== 'collapsible' && t !== 'conditional'
+);
 
 // Block types that support inline form editing in BranchBlocksEditor
 // quiz, multistep, and guided require the dedicated editors and cannot be edited inline

--- a/src/components/block-editor/forms/BranchBlocksEditor.tsx
+++ b/src/components/block-editor/forms/BranchBlocksEditor.tsx
@@ -336,11 +336,20 @@ export interface BranchBlocksEditorProps {
   blocks: JsonBlock[];
   /** Called when blocks change */
   onChange: (blocks: JsonBlock[]) => void;
+  /** Block types offered in the add menu. Defaults to ALLOWED_BRANCH_BLOCK_TYPES. */
+  addableBlockTypes?: BlockType[];
   /** Called to start/stop the element picker */
   onPickerModeChange?: BlockFormProps['onPickerModeChange'];
 }
 
-export function BranchBlocksEditor({ label, variant, blocks, onChange, onPickerModeChange }: BranchBlocksEditorProps) {
+export function BranchBlocksEditor({
+  label,
+  variant,
+  blocks,
+  onChange,
+  addableBlockTypes = ALLOWED_BRANCH_BLOCK_TYPES,
+  onPickerModeChange,
+}: BranchBlocksEditorProps) {
   const styles = useStyles2(getStyles);
 
   // Expansion state
@@ -846,7 +855,7 @@ export function BranchBlocksEditor({ label, variant, blocks, onChange, onPickerM
               <div className={styles.addBlockForm}>
                 <Field label="Block type">
                   <Combobox
-                    options={ALLOWED_BRANCH_BLOCK_TYPES.map((t) => ({
+                    options={addableBlockTypes.map((t) => ({
                       value: t,
                       label: BLOCK_TYPE_METADATA[t]?.name ?? t,
                       description: BLOCK_TYPE_METADATA[t]?.description,

--- a/src/components/block-editor/forms/CollapsibleBlockForm.tsx
+++ b/src/components/block-editor/forms/CollapsibleBlockForm.tsx
@@ -1,0 +1,98 @@
+/**
+ * Collapsible Block Form
+ *
+ * Form for creating/editing collapsible blocks. The nested content is edited
+ * inline via BranchBlocksEditor, so a collapsible is fully authored in one
+ * place without the main editor's section drag-and-drop.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { Button, Field, Input, Switch, useStyles2 } from '@grafana/ui';
+import { getBlockFormStyles } from '../block-editor.styles';
+import { BranchBlocksEditor } from './BranchBlocksEditor';
+import { testIds } from '../../../constants/testIds';
+import type { BlockFormProps, JsonBlock } from '../types';
+import type { JsonCollapsibleBlock } from '../../../types/json-guide.types';
+
+function isCollapsibleBlock(block: JsonBlock): block is JsonCollapsibleBlock {
+  return block.type === 'collapsible';
+}
+
+export function CollapsibleBlockForm({
+  initialData,
+  onSubmit,
+  onCancel,
+  isEditing = false,
+  onPickerModeChange,
+}: BlockFormProps) {
+  const styles = useStyles2(getBlockFormStyles);
+
+  const initial = initialData && isCollapsibleBlock(initialData) ? initialData : null;
+  const initialId = initial?.id;
+  const [title, setTitle] = useState(initial?.title ?? '');
+  const [collapsed, setCollapsed] = useState(initial?.collapsed ?? true);
+  const [blocks, setBlocks] = useState<JsonBlock[]>(initial?.blocks ?? []);
+
+  const buildBlock = useCallback((): JsonCollapsibleBlock => {
+    return {
+      type: 'collapsible',
+      blocks,
+      ...(title.trim() && { title: title.trim() }),
+      // Persist only when it differs from the `true` default.
+      ...(collapsed === false && { collapsed: false }),
+      ...(initialId && { id: initialId }),
+    };
+  }, [title, collapsed, blocks, initialId]);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      onSubmit(buildBlock());
+    },
+    [buildBlock, onSubmit]
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.form}>
+      <Field label="Toggle label" description="Text shown on the control that reveals the content">
+        <Input
+          value={title}
+          onChange={(e) => setTitle(e.currentTarget.value)}
+          placeholder="e.g., Show solution"
+          autoFocus
+          data-testid={testIds.blockEditor.collapsibleTitleInput}
+        />
+      </Field>
+
+      <Field
+        label="Start collapsed"
+        description="When enabled, the content is hidden until the learner clicks the toggle"
+      >
+        <Switch
+          value={collapsed}
+          onChange={(e) => setCollapsed(e.currentTarget.checked)}
+          data-testid={testIds.blockEditor.collapsibleCollapsedToggle}
+        />
+      </Field>
+
+      <BranchBlocksEditor
+        label="Hidden content"
+        variant="success"
+        blocks={blocks}
+        onChange={setBlocks}
+        onPickerModeChange={onPickerModeChange}
+      />
+
+      <div className={styles.footer}>
+        <Button variant="secondary" onClick={onCancel} type="button">
+          Cancel
+        </Button>
+        <Button variant="primary" type="submit" data-testid={testIds.blockEditor.submitButton}>
+          {isEditing ? 'Update block' : 'Add block'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+CollapsibleBlockForm.displayName = 'CollapsibleBlockForm';

--- a/src/components/block-editor/forms/CollapsibleBlockForm.tsx
+++ b/src/components/block-editor/forms/CollapsibleBlockForm.tsx
@@ -12,7 +12,7 @@ import { getBlockFormStyles } from '../block-editor.styles';
 import { BranchBlocksEditor } from './BranchBlocksEditor';
 import { testIds } from '../../../constants/testIds';
 import type { BlockFormProps, JsonBlock } from '../types';
-import type { JsonCollapsibleBlock } from '../../../types/json-guide.types';
+import type { JsonCollapsibleBlock, NonContainerBlock } from '../../../types/json-guide.types';
 
 function isCollapsibleBlock(block: JsonBlock): block is JsonCollapsibleBlock {
   return block.type === 'collapsible';
@@ -36,7 +36,9 @@ export function CollapsibleBlockForm({
   const buildBlock = useCallback((): JsonCollapsibleBlock => {
     return {
       type: 'collapsible',
-      blocks,
+      // BranchBlocksEditor's add menu (ALLOWED_BRANCH_BLOCK_TYPES) excludes all
+      // container types, so the edited list only ever holds non-container blocks.
+      blocks: blocks as NonContainerBlock[],
       ...(title.trim() && { title: title.trim() }),
       // Persist only when it differs from the `true` default.
       ...(collapsed === false && { collapsed: false }),

--- a/src/components/block-editor/forms/CollapsibleBlockForm.tsx
+++ b/src/components/block-editor/forms/CollapsibleBlockForm.tsx
@@ -11,8 +11,13 @@ import { Button, Field, Input, Switch, useStyles2 } from '@grafana/ui';
 import { getBlockFormStyles } from '../block-editor.styles';
 import { BranchBlocksEditor } from './BranchBlocksEditor';
 import { testIds } from '../../../constants/testIds';
-import type { BlockFormProps, JsonBlock } from '../types';
-import type { JsonCollapsibleBlock, NonContainerBlock } from '../../../types/json-guide.types';
+import type { BlockFormProps, BlockType, JsonBlock } from '../types';
+import type { JsonCollapsibleBlock, PresentationalBlock } from '../../../types/json-guide.types';
+
+// Content-only block types offered in a collapsible's add menu. Mirrors
+// PresentationalBlock in json-guide.types.ts (html is authored via markdown,
+// not the palette).
+const PRESENTATIONAL_ADDABLE_TYPES: BlockType[] = ['markdown', 'image', 'video'];
 
 function isCollapsibleBlock(block: JsonBlock): block is JsonCollapsibleBlock {
   return block.type === 'collapsible';
@@ -36,9 +41,9 @@ export function CollapsibleBlockForm({
   const buildBlock = useCallback((): JsonCollapsibleBlock => {
     return {
       type: 'collapsible',
-      // BranchBlocksEditor's add menu (ALLOWED_BRANCH_BLOCK_TYPES) excludes all
-      // container types, so the edited list only ever holds non-container blocks.
-      blocks: blocks as NonContainerBlock[],
+      // The add menu below is restricted to PRESENTATIONAL_ADDABLE_TYPES, so
+      // the edited list only ever holds content blocks.
+      blocks: blocks as PresentationalBlock[],
       ...(title.trim() && { title: title.trim() }),
       // Persist only when it differs from the `true` default.
       ...(collapsed === false && { collapsed: false }),
@@ -82,6 +87,7 @@ export function CollapsibleBlockForm({
         variant="success"
         blocks={blocks}
         onChange={setBlocks}
+        addableBlockTypes={PRESENTATIONAL_ADDABLE_TYPES}
         onPickerModeChange={onPickerModeChange}
       />
 

--- a/src/components/block-editor/types.ts
+++ b/src/components/block-editor/types.ts
@@ -21,6 +21,7 @@ export type BlockType =
   | 'image'
   | 'video'
   | 'section'
+  | 'collapsible'
   | 'conditional'
   | 'interactive'
   | 'multistep'

--- a/src/components/block-editor/utils/block-preview.ts
+++ b/src/components/block-editor/utils/block-preview.ts
@@ -11,6 +11,7 @@ import {
   isImageBlock,
   isVideoBlock,
   isSectionBlock,
+  isCollapsibleBlock,
   isInteractiveBlock,
   isMultistepBlock,
   isGuidedBlock,
@@ -76,6 +77,10 @@ export function getBlockPreview(block: JsonBlock, options: BlockPreviewOptions =
 
   if (isSectionBlock(block)) {
     return block.title || block.id || `${block.blocks.length} blocks`;
+  }
+
+  if (isCollapsibleBlock(block)) {
+    return block.title || `${block.blocks.length} hidden blocks`;
   }
 
   if (isInteractiveBlock(block)) {

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -1324,7 +1324,12 @@ function renderParsedElement(
       );
     case 'collapsible':
       return (
-        <CollapsibleBlock key={key} title={sub(element.props.title)} collapsed={element.props.collapsed}>
+        <CollapsibleBlock
+          key={key}
+          id={element.props.id}
+          title={sub(element.props.title)}
+          collapsed={element.props.collapsed}
+        >
           {renderChildren(element.children)}
         </CollapsibleBlock>
       );

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -12,6 +12,7 @@ import {
   isJsonGuideContent,
   resolveRelativeUrls,
   CodeBlock,
+  CollapsibleBlock,
   ExpandableTable,
   ImageRenderer,
   ContentParsingError,
@@ -1320,6 +1321,12 @@ function renderParsedElement(
           showCopy={element.props.showCopy}
           inline={element.props.inline}
         />
+      );
+    case 'collapsible':
+      return (
+        <CollapsibleBlock key={key} title={sub(element.props.title)} collapsed={element.props.collapsed}>
+          {renderChildren(element.children)}
+        </CollapsibleBlock>
       );
     case 'expandable-table':
       return (

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -236,6 +236,9 @@ export const testIds = {
     sectionTitleInput: 'block-editor-section-title-input',
     sectionIdInput: 'block-editor-section-id-input',
     sectionAutoCollapseToggle: 'block-editor-section-auto-collapse-toggle',
+    // Collapsible form
+    collapsibleTitleInput: 'block-editor-collapsible-title-input',
+    collapsibleCollapsedToggle: 'block-editor-collapsible-collapsed-toggle',
     addAndRecordButton: 'block-editor-add-and-record-button',
     // Section empty state and nested add button
     sectionEmptyState: 'block-editor-section-empty-state',

--- a/src/docs-retrieval/components/docs/collapsible-block.test.tsx
+++ b/src/docs-retrieval/components/docs/collapsible-block.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CollapsibleBlock } from './collapsible-block';
+
+describe('CollapsibleBlock', () => {
+  it('hides children by default (collapsed)', () => {
+    render(
+      <CollapsibleBlock title="Show solution">
+        <p>secret answer</p>
+      </CollapsibleBlock>
+    );
+    expect(screen.queryByText('secret answer')).not.toBeInTheDocument();
+    expect(screen.getByTestId('collapsible-toggle')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('reveals children when the toggle is clicked', () => {
+    render(
+      <CollapsibleBlock title="Show solution">
+        <p>secret answer</p>
+      </CollapsibleBlock>
+    );
+    fireEvent.click(screen.getByTestId('collapsible-toggle'));
+    expect(screen.getByText('secret answer')).toBeInTheDocument();
+    expect(screen.getByTestId('collapsible-toggle')).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('renders children immediately when collapsed=false', () => {
+    render(
+      <CollapsibleBlock title="Notes" collapsed={false}>
+        <p>always visible</p>
+      </CollapsibleBlock>
+    );
+    expect(screen.getByText('always visible')).toBeInTheDocument();
+  });
+
+  it('falls back to a default label when no title is given', () => {
+    render(
+      <CollapsibleBlock>
+        <p>content</p>
+      </CollapsibleBlock>
+    );
+    expect(screen.getByTestId('collapsible-toggle')).toHaveTextContent('Show more');
+  });
+});

--- a/src/docs-retrieval/components/docs/collapsible-block.test.tsx
+++ b/src/docs-retrieval/components/docs/collapsible-block.test.tsx
@@ -24,6 +24,22 @@ describe('CollapsibleBlock', () => {
     expect(screen.getByTestId('collapsible-toggle')).toHaveAttribute('aria-expanded', 'true');
   });
 
+  it('only sets aria-controls while the content region is in the DOM', () => {
+    render(
+      <CollapsibleBlock title="Show solution">
+        <p>secret answer</p>
+      </CollapsibleBlock>
+    );
+    const toggle = screen.getByTestId('collapsible-toggle');
+    // Collapsed: content is unmounted, so aria-controls must not dangle
+    expect(toggle).not.toHaveAttribute('aria-controls');
+    fireEvent.click(toggle);
+    // Expanded: aria-controls points at the rendered content region
+    const controls = toggle.getAttribute('aria-controls');
+    expect(controls).toBeTruthy();
+    expect(document.getElementById(controls!)).toBeInTheDocument();
+  });
+
   it('renders children immediately when collapsed=false', () => {
     render(
       <CollapsibleBlock title="Notes" collapsed={false}>

--- a/src/docs-retrieval/components/docs/collapsible-block.tsx
+++ b/src/docs-retrieval/components/docs/collapsible-block.tsx
@@ -1,6 +1,8 @@
 import React, { useId, useState } from 'react';
 
 export interface CollapsibleBlockProps {
+  /** Author-supplied HTML id, emitted on the wrapper for deep-linking */
+  id?: string;
   /** Label shown on the toggle control */
   title?: string;
   /** Whether the block starts collapsed. Defaults to true. */
@@ -15,12 +17,12 @@ const DEFAULT_TITLE = 'Show more';
  * guide authors can gate solutions or answers until a learner reveals them.
  * Reuses the shared `journey-collapse` styles (see content-html.styles.ts).
  */
-export function CollapsibleBlock({ title, collapsed = true, children }: CollapsibleBlockProps) {
+export function CollapsibleBlock({ id, title, collapsed = true, children }: CollapsibleBlockProps) {
   const [isCollapsed, setIsCollapsed] = useState(collapsed);
   const contentId = useId();
 
   return (
-    <div className="journey-collapse" data-testid="collapsible-block">
+    <div className="journey-collapse" id={id} data-testid="collapsible-block">
       <button
         onClick={() => setIsCollapsed((prev) => !prev)}
         className="journey-collapse-trigger"

--- a/src/docs-retrieval/components/docs/collapsible-block.tsx
+++ b/src/docs-retrieval/components/docs/collapsible-block.tsx
@@ -28,7 +28,9 @@ export function CollapsibleBlock({ id, title, collapsed = true, children }: Coll
         className="journey-collapse-trigger"
         type="button"
         aria-expanded={!isCollapsed}
-        aria-controls={contentId}
+        // Only reference the content region while it's in the DOM (it's
+        // unmounted when collapsed) so the IDREF never dangles.
+        aria-controls={isCollapsed ? undefined : contentId}
         data-testid="collapsible-toggle"
       >
         <span>{title || DEFAULT_TITLE}</span>

--- a/src/docs-retrieval/components/docs/collapsible-block.tsx
+++ b/src/docs-retrieval/components/docs/collapsible-block.tsx
@@ -1,0 +1,44 @@
+import React, { useId, useState } from 'react';
+
+export interface CollapsibleBlockProps {
+  /** Label shown on the toggle control */
+  title?: string;
+  /** Whether the block starts collapsed. Defaults to true. */
+  collapsed?: boolean;
+  children?: React.ReactNode;
+}
+
+const DEFAULT_TITLE = 'Show more';
+
+/**
+ * Presentational collapsible container. Hides its children behind a toggle so
+ * guide authors can gate solutions or answers until a learner reveals them.
+ * Reuses the shared `journey-collapse` styles (see content-html.styles.ts).
+ */
+export function CollapsibleBlock({ title, collapsed = true, children }: CollapsibleBlockProps) {
+  const [isCollapsed, setIsCollapsed] = useState(collapsed);
+  const contentId = useId();
+
+  return (
+    <div className="journey-collapse" data-testid="collapsible-block">
+      <button
+        onClick={() => setIsCollapsed((prev) => !prev)}
+        className="journey-collapse-trigger"
+        type="button"
+        aria-expanded={!isCollapsed}
+        aria-controls={contentId}
+        data-testid="collapsible-toggle"
+      >
+        <span>{title || DEFAULT_TITLE}</span>
+        <span className={`journey-collapse-icon${isCollapsed ? ' collapsed' : ''}`} aria-hidden="true">
+          ▼
+        </span>
+      </button>
+      {!isCollapsed && (
+        <div className="journey-collapse-content" id={contentId}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/docs-retrieval/components/docs/index.ts
+++ b/src/docs-retrieval/components/docs/index.ts
@@ -1,5 +1,6 @@
 // Documentation components
 export { CodeBlock } from './code-block';
+export { CollapsibleBlock } from './collapsible-block';
 export { ExpandableTable } from './expandable-table';
 export { ImageRenderer } from './image-renderer';
 export { VideoRenderer } from './video-renderer';
@@ -11,6 +12,7 @@ export { ContentParsingError } from './content-parsing-error';
 
 // Types
 export type { CodeBlockProps } from './code-block';
+export type { CollapsibleBlockProps } from './collapsible-block';
 export type { ExpandableTableProps } from './expandable-table';
 export type { ImageRendererProps } from './image-renderer';
 export type { VideoRendererProps } from './video-renderer';

--- a/src/docs-retrieval/index.ts
+++ b/src/docs-retrieval/index.ts
@@ -56,6 +56,7 @@ export { parseMarkdownToElements } from './json-parser';
 // Docs components
 export {
   CodeBlock,
+  CollapsibleBlock,
   ExpandableTable,
   ImageRenderer,
   ContentParsingError,

--- a/src/docs-retrieval/json-parser-collapsible.test.ts
+++ b/src/docs-retrieval/json-parser-collapsible.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for collapsible block conversion in the JSON parser.
+ */
+
+import { parseJsonGuide } from './json-parser';
+
+// Mock Grafana runtime
+jest.mock('@grafana/runtime', () => ({
+  config: { bootData: { user: null }, buildInfo: { version: '10.0.0' } },
+}));
+
+// Mock @grafana/data renderMarkdown
+jest.mock('@grafana/data', () => ({
+  renderMarkdown: (md: string) => `<p>${md}</p>`,
+}));
+
+describe('json-parser collapsible block', () => {
+  it('converts a collapsible block to a collapsible ParsedElement with nested children', () => {
+    const guide = JSON.stringify({
+      id: 'test-collapsible',
+      title: 'Collapsible test',
+      blocks: [
+        {
+          type: 'collapsible',
+          title: 'Show solution',
+          blocks: [{ type: 'markdown', content: 'The answer is 42.' }],
+        },
+      ],
+    });
+
+    const result = parseJsonGuide(guide);
+
+    expect(result.isValid).toBe(true);
+    const collapsible = result.data!.elements.find((el) => el.type === 'collapsible');
+    expect(collapsible).toBeDefined();
+    expect(collapsible!.props.title).toBe('Show solution');
+    expect(collapsible!.children.length).toBe(1);
+  });
+
+  it('defaults collapsed to true when omitted', () => {
+    const guide = JSON.stringify({
+      id: 'test-collapsible-default',
+      title: 'Collapsible default',
+      blocks: [{ type: 'collapsible', blocks: [{ type: 'markdown', content: 'hidden' }] }],
+    });
+
+    const result = parseJsonGuide(guide);
+    const collapsible = result.data!.elements.find((el) => el.type === 'collapsible');
+    expect(collapsible!.props.collapsed).toBe(true);
+  });
+
+  it('preserves an explicit collapsed=false', () => {
+    const guide = JSON.stringify({
+      id: 'test-collapsible-open',
+      title: 'Collapsible open',
+      blocks: [{ type: 'collapsible', collapsed: false, blocks: [{ type: 'markdown', content: 'shown' }] }],
+    });
+
+    const result = parseJsonGuide(guide);
+    const collapsible = result.data!.elements.find((el) => el.type === 'collapsible');
+    expect(collapsible!.props.collapsed).toBe(false);
+  });
+
+  it('does not mark the guide as interactive for a presentational collapsible', () => {
+    const guide = JSON.stringify({
+      id: 'test-collapsible-presentational',
+      title: 'Presentational',
+      blocks: [{ type: 'collapsible', blocks: [{ type: 'markdown', content: 'text' }] }],
+    });
+
+    const result = parseJsonGuide(guide);
+    expect(result.data!.hasInteractiveElements).toBe(false);
+  });
+});

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -548,11 +548,9 @@ function convertSectionBlock(block: JsonSectionBlock, path: string, baseUrl?: st
 
 /**
  * Convert a collapsible block to a ParsedElement.
- * Presentational container — children render as ordinary content with no step
- * context. ContentProcessor's document-layout pass does not descend into
- * collapsibles, so nested interactive steps are excluded from the guide step
- * total and skew the completion percentage; content is expected to be
- * presentational. `collapsed` defaults to true.
+ * Presentational container — children are content blocks (the schema forbids
+ * interactive/step and container types), so there is no completion state to
+ * track. `collapsed` defaults to true.
  */
 function convertCollapsibleBlock(block: JsonCollapsibleBlock, path: string, baseUrl?: string): ConversionResult {
   const children: ParsedElement[] = [];

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -19,6 +19,7 @@ import {
   type JsonMarkdownBlock,
   type JsonHtmlBlock,
   type JsonSectionBlock,
+  type JsonCollapsibleBlock,
   type JsonConditionalBlock,
   type JsonInteractiveBlock,
   type JsonMultistepBlock,
@@ -280,6 +281,8 @@ function convertBlockByType(
       return convertHtmlBlock(block, path, baseUrl);
     case 'section':
       return convertSectionBlock(block, path, baseUrl);
+    case 'collapsible':
+      return convertCollapsibleBlock(block, path, baseUrl);
     case 'conditional':
       return convertConditionalBlock(block, path, baseUrl);
     case 'interactive':
@@ -540,6 +543,38 @@ function convertSectionBlock(block: JsonSectionBlock, path: string, baseUrl?: st
       children,
     },
     hasInteractive: true,
+  };
+}
+
+/**
+ * Convert a collapsible block to a ParsedElement.
+ * Presentational container — children render as ordinary content with no step
+ * context. ContentProcessor's document-layout pass does not descend into
+ * collapsibles, so nested interactive steps are excluded from the guide step
+ * total and skew the completion percentage; content is expected to be
+ * presentational. `collapsed` defaults to true.
+ */
+function convertCollapsibleBlock(block: JsonCollapsibleBlock, path: string, baseUrl?: string): ConversionResult {
+  const children: ParsedElement[] = [];
+
+  for (let i = 0; i < block.blocks.length; i++) {
+    const childBlock = block.blocks[i]!;
+    const result = convertBlockToParsedElement(childBlock, `${path}.blocks[${i}]`, baseUrl);
+    if (result.element) {
+      children.push(result.element);
+    }
+  }
+
+  return {
+    element: {
+      type: 'collapsible',
+      props: {
+        title: block.title,
+        id: block.id,
+        collapsed: block.collapsed ?? true,
+      },
+      children,
+    },
   };
 }
 

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -862,26 +862,33 @@ function createBlockSchemaWithDepth(currentDepth: number): z.ZodType {
 
   const nestedBlockSchema = z.lazy(() => createBlockSchemaWithDepth(currentDepth + 1));
 
+  // Each container arm spreads AuthorAnnotatedSchema.shape so `authorNote`
+  // survives validation (Zod's default strip would otherwise drop it — leaf
+  // block schemas already include it, so containers must too).
   return z.union([
     NonRecursiveBlockSchema,
     z.object({
       ...SectionProps,
       blocks: z.array(nestedBlockSchema),
+      ...AuthorAnnotatedSchema.shape,
     }),
     // Collapsible is presentational: it holds only content blocks (no
     // interactive/step types, no containers). See PresentationalBlockSchema.
     z.object({
       ...CollapsibleProps,
       blocks: z.array(PresentationalBlockSchema),
+      ...AuthorAnnotatedSchema.shape,
     }),
     z.object({
       ...AssistantProps,
       blocks: z.array(nestedBlockSchema),
+      ...AuthorAnnotatedSchema.shape,
     }),
     z.object({
       ...ConditionalProps,
       whenTrue: z.array(nestedBlockSchema),
       whenFalse: z.array(nestedBlockSchema),
+      ...AuthorAnnotatedSchema.shape,
     }),
   ]);
 }
@@ -902,26 +909,32 @@ function createBlockSchemaWithDepthNoRef(currentDepth: number): z.ZodType {
 
   const nestedBlockSchema = z.lazy(() => createBlockSchemaWithDepthNoRef(currentDepth + 1));
 
+  // See createBlockSchemaWithDepth: container arms spread
+  // AuthorAnnotatedSchema.shape so `authorNote` is preserved, not stripped.
   return z.union([
     NonRecursiveBlockSchemaNoRef,
     z.object({
       ...SectionProps,
       blocks: z.array(nestedBlockSchema),
+      ...AuthorAnnotatedSchema.shape,
     }),
     // Collapsible holds only content blocks (PresentationalBlockSchema has no
     // snippet-ref, so the NoRef variant needs no separate union here).
     z.object({
       ...CollapsibleProps,
       blocks: z.array(PresentationalBlockSchema),
+      ...AuthorAnnotatedSchema.shape,
     }),
     z.object({
       ...AssistantProps,
       blocks: z.array(nestedBlockSchema),
+      ...AuthorAnnotatedSchema.shape,
     }),
     z.object({
       ...ConditionalProps,
       whenTrue: z.array(nestedBlockSchema),
       whenFalse: z.array(nestedBlockSchema),
+      ...AuthorAnnotatedSchema.shape,
     }),
   ]);
 }

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -766,6 +766,19 @@ const NonRecursiveBlockSchemaNoRef = z.union([
   JsonGrotGuideBlockSchema,
 ]);
 
+/**
+ * Blocks a collapsible may hold: pure content only — no interactive/step
+ * types and no containers. Keeps the collapsible presentational (see
+ * `JsonCollapsibleBlock`), which is why nested-step completion never arises.
+ * @coupling Type: PresentationalBlock in json-guide.types.ts
+ */
+export const PresentationalBlockSchema = z.union([
+  JsonMarkdownBlockSchema,
+  JsonHtmlBlockSchema,
+  JsonImageBlockSchema,
+  JsonVideoBlockSchema,
+]);
+
 // ============ RECURSIVE BLOCK SCHEMAS ============
 
 // Common properties for recursive blocks to avoid duplication
@@ -855,12 +868,11 @@ function createBlockSchemaWithDepth(currentDepth: number): z.ZodType {
       ...SectionProps,
       blocks: z.array(nestedBlockSchema),
     }),
-    // Collapsible is presentational: it may hold leaf/step blocks but not
-    // other containers (section, collapsible, conditional). Using the
-    // non-recursive union enforces that and keeps its subtree shallow.
+    // Collapsible is presentational: it holds only content blocks (no
+    // interactive/step types, no containers). See PresentationalBlockSchema.
     z.object({
       ...CollapsibleProps,
-      blocks: z.array(NonRecursiveBlockSchema),
+      blocks: z.array(PresentationalBlockSchema),
     }),
     z.object({
       ...AssistantProps,
@@ -896,11 +908,11 @@ function createBlockSchemaWithDepthNoRef(currentDepth: number): z.ZodType {
       ...SectionProps,
       blocks: z.array(nestedBlockSchema),
     }),
-    // See the non-NoRef variant above: collapsible holds only non-container
-    // blocks (here, the snippet-ref-free union).
+    // Collapsible holds only content blocks (PresentationalBlockSchema has no
+    // snippet-ref, so the NoRef variant needs no separate union here).
     z.object({
       ...CollapsibleProps,
-      blocks: z.array(NonRecursiveBlockSchemaNoRef),
+      blocks: z.array(PresentationalBlockSchema),
     }),
     z.object({
       ...AssistantProps,
@@ -932,14 +944,13 @@ export const JsonSectionBlockSchema = z.object({
 });
 
 /**
- * Schema for collapsible block. Presentational container — holds only
- * non-container blocks (no section/collapsible/conditional), so it does not
- * recurse through JsonBlockSchema.
+ * Schema for collapsible block. Presentational container — holds only content
+ * blocks (see PresentationalBlockSchema), so it does not recurse.
  * @coupling Type: JsonCollapsibleBlock
  */
 export const JsonCollapsibleBlockSchema = z.object({
   ...CollapsibleProps,
-  blocks: z.array(NonRecursiveBlockSchema),
+  blocks: z.array(PresentationalBlockSchema),
   ...AuthorAnnotatedSchema.shape,
 });
 

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -855,9 +855,12 @@ function createBlockSchemaWithDepth(currentDepth: number): z.ZodType {
       ...SectionProps,
       blocks: z.array(nestedBlockSchema),
     }),
+    // Collapsible is presentational: it may hold leaf/step blocks but not
+    // other containers (section, collapsible, conditional). Using the
+    // non-recursive union enforces that and keeps its subtree shallow.
     z.object({
       ...CollapsibleProps,
-      blocks: z.array(nestedBlockSchema),
+      blocks: z.array(NonRecursiveBlockSchema),
     }),
     z.object({
       ...AssistantProps,
@@ -893,9 +896,11 @@ function createBlockSchemaWithDepthNoRef(currentDepth: number): z.ZodType {
       ...SectionProps,
       blocks: z.array(nestedBlockSchema),
     }),
+    // See the non-NoRef variant above: collapsible holds only non-container
+    // blocks (here, the snippet-ref-free union).
     z.object({
       ...CollapsibleProps,
-      blocks: z.array(nestedBlockSchema),
+      blocks: z.array(NonRecursiveBlockSchemaNoRef),
     }),
     z.object({
       ...AssistantProps,
@@ -927,13 +932,14 @@ export const JsonSectionBlockSchema = z.object({
 });
 
 /**
- * Schema for collapsible block (contains nested blocks).
- * Uses JsonBlockSchema which enforces depth limit globally.
+ * Schema for collapsible block. Presentational container — holds only
+ * non-container blocks (no section/collapsible/conditional), so it does not
+ * recurse through JsonBlockSchema.
  * @coupling Type: JsonCollapsibleBlock
  */
 export const JsonCollapsibleBlockSchema = z.object({
   ...CollapsibleProps,
-  blocks: z.lazy(() => z.array(JsonBlockSchema)),
+  blocks: z.array(NonRecursiveBlockSchema),
   ...AuthorAnnotatedSchema.shape,
 });
 
@@ -1185,6 +1191,7 @@ export const VALID_BLOCK_TYPES = new Set([
   'multistep',
   'guided',
   'section',
+  'collapsible',
   'conditional',
   'quiz',
   'input',

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -778,6 +778,13 @@ const SectionProps = {
   autoCollapse: z.boolean().optional().describe('Collapse the section after the user completes its contents'),
 };
 
+const CollapsibleProps = {
+  type: z.literal('collapsible'),
+  id: z.string().optional().describe('Stable identifier for the collapsible (required for container blocks via CLI)'),
+  title: z.string().optional().describe('Label shown on the toggle control'),
+  collapsed: z.boolean().optional().describe('Whether the block starts collapsed'),
+};
+
 const AssistantProps = {
   type: z.literal('assistant'),
   id: z
@@ -849,6 +856,10 @@ function createBlockSchemaWithDepth(currentDepth: number): z.ZodType {
       blocks: z.array(nestedBlockSchema),
     }),
     z.object({
+      ...CollapsibleProps,
+      blocks: z.array(nestedBlockSchema),
+    }),
+    z.object({
       ...AssistantProps,
       blocks: z.array(nestedBlockSchema),
     }),
@@ -883,6 +894,10 @@ function createBlockSchemaWithDepthNoRef(currentDepth: number): z.ZodType {
       blocks: z.array(nestedBlockSchema),
     }),
     z.object({
+      ...CollapsibleProps,
+      blocks: z.array(nestedBlockSchema),
+    }),
+    z.object({
       ...AssistantProps,
       blocks: z.array(nestedBlockSchema),
     }),
@@ -907,6 +922,17 @@ export const JsonBlockSchemaNoRef = createBlockSchemaWithDepthNoRef(0);
  */
 export const JsonSectionBlockSchema = z.object({
   ...SectionProps,
+  blocks: z.lazy(() => z.array(JsonBlockSchema)),
+  ...AuthorAnnotatedSchema.shape,
+});
+
+/**
+ * Schema for collapsible block (contains nested blocks).
+ * Uses JsonBlockSchema which enforces depth limit globally.
+ * @coupling Type: JsonCollapsibleBlock
+ */
+export const JsonCollapsibleBlockSchema = z.object({
+  ...CollapsibleProps,
   blocks: z.lazy(() => z.array(JsonBlockSchema)),
   ...AuthorAnnotatedSchema.shape,
 });
@@ -1041,6 +1067,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
     'authorNote',
   ]),
   section: new Set(['type', 'id', 'title', 'blocks', 'requirements', 'objectives', 'autoCollapse', 'authorNote']),
+  collapsible: new Set(['type', 'id', 'title', 'collapsed', 'blocks', 'authorNote']),
   conditional: new Set([
     'type',
     'id',

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -793,7 +793,7 @@ const SectionProps = {
 
 const CollapsibleProps = {
   type: z.literal('collapsible'),
-  id: z.string().optional().describe('Stable identifier for the collapsible (required for container blocks via CLI)'),
+  id: z.string().optional().describe('HTML id for the collapsible (usable as a deep-link anchor)'),
   title: z.string().optional().describe('Label shown on the toggle control'),
   collapsed: z.boolean().optional().describe('Whether the block starts collapsed'),
 };

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -32,6 +32,7 @@ export type JsonBlock =
   | JsonMarkdownBlock
   | JsonHtmlBlock
   | JsonSectionBlock
+  | JsonCollapsibleBlock
   | JsonConditionalBlock
   | JsonInteractiveBlock
   | JsonMultistepBlock
@@ -183,6 +184,27 @@ export interface JsonSectionBlock extends AuthorAnnotated {
   objectives?: string[];
   /** Whether to auto-collapse this section on completion. Defaults to true. */
   autoCollapse?: boolean;
+}
+
+/**
+ * Collapsible content block.
+ * A presentational container that hides its nested blocks behind a toggle —
+ * used to gate solutions or answers until a learner chooses to reveal them.
+ * Content should stay presentational: the guide-completion counter does not
+ * descend into collapsibles, so a nested interactive step still records its
+ * own completion but is excluded from the guide's step total, skewing the
+ * progress percentage.
+ */
+export interface JsonCollapsibleBlock extends AuthorAnnotated {
+  type: 'collapsible';
+  /** Optional HTML id for the collapsible */
+  id?: string;
+  /** Label shown on the toggle control */
+  title?: string;
+  /** Whether the block starts collapsed. Defaults to true. */
+  collapsed?: boolean;
+  /** Nested blocks hidden behind the toggle */
+  blocks: JsonBlock[];
 }
 
 // ============ CONDITIONAL BLOCK ============
@@ -811,6 +833,13 @@ export function isHtmlBlock(block: JsonBlock): block is JsonHtmlBlock {
  */
 export function isSectionBlock(block: JsonBlock): block is JsonSectionBlock {
   return block.type === 'section';
+}
+
+/**
+ * Type guard for JsonCollapsibleBlock
+ */
+export function isCollapsibleBlock(block: JsonBlock): block is JsonCollapsibleBlock {
+  return block.type === 'collapsible';
 }
 
 /**

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -190,10 +190,8 @@ export interface JsonSectionBlock extends AuthorAnnotated {
  * Collapsible content block.
  * A presentational container that hides its nested blocks behind a toggle —
  * used to gate solutions or answers until a learner chooses to reveal them.
- * Content should stay presentational: the guide-completion counter does not
- * descend into collapsibles, so a nested interactive step still records its
- * own completion but is excluded from the guide's step total, skewing the
- * progress percentage.
+ * Holds content blocks only (no interactive/step types, no containers), so it
+ * carries no completion state.
  */
 export interface JsonCollapsibleBlock extends AuthorAnnotated {
   type: 'collapsible';
@@ -203,19 +201,15 @@ export interface JsonCollapsibleBlock extends AuthorAnnotated {
   title?: string;
   /** Whether the block starts collapsed. Defaults to true. */
   collapsed?: boolean;
-  /** Nested blocks hidden behind the toggle. Non-container blocks only. */
-  blocks: NonContainerBlock[];
+  /** Content blocks hidden behind the toggle */
+  blocks: PresentationalBlock[];
 }
 
 /**
- * Blocks that are not containers — the only blocks a collapsible may hold.
- * Mirrors `NonRecursiveBlockSchema` in json-guide.schema.ts: everything in
- * `JsonBlock` except the block types that nest other blocks.
+ * Content-only blocks — the only blocks a collapsible may hold.
+ * Mirrors `PresentationalBlockSchema` in json-guide.schema.ts.
  */
-export type NonContainerBlock = Exclude<
-  JsonBlock,
-  JsonSectionBlock | JsonCollapsibleBlock | JsonConditionalBlock | JsonAssistantBlock
->;
+export type PresentationalBlock = JsonMarkdownBlock | JsonHtmlBlock | JsonImageBlock | JsonVideoBlock;
 
 // ============ CONDITIONAL BLOCK ============
 

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -203,9 +203,19 @@ export interface JsonCollapsibleBlock extends AuthorAnnotated {
   title?: string;
   /** Whether the block starts collapsed. Defaults to true. */
   collapsed?: boolean;
-  /** Nested blocks hidden behind the toggle */
-  blocks: JsonBlock[];
+  /** Nested blocks hidden behind the toggle. Non-container blocks only. */
+  blocks: NonContainerBlock[];
 }
+
+/**
+ * Blocks that are not containers — the only blocks a collapsible may hold.
+ * Mirrors `NonRecursiveBlockSchema` in json-guide.schema.ts: everything in
+ * `JsonBlock` except the block types that nest other blocks.
+ */
+export type NonContainerBlock = Exclude<
+  JsonBlock,
+  JsonSectionBlock | JsonCollapsibleBlock | JsonConditionalBlock | JsonAssistantBlock
+>;
 
 // ============ CONDITIONAL BLOCK ============
 

--- a/src/validation/type-coupling.test.ts
+++ b/src/validation/type-coupling.test.ts
@@ -9,6 +9,7 @@ import {
   JsonMultistepBlockSchema,
   JsonGuidedBlockSchema,
   JsonSectionBlockSchema,
+  JsonCollapsibleBlockSchema,
   JsonQuizBlockSchema,
   JsonAssistantBlockSchema,
   JsonInputBlockSchema,
@@ -135,6 +136,10 @@ describe('KNOWN_FIELDS sync', () => {
 
   it('should match section schema fields', () => {
     verifyFields(JsonSectionBlockSchema, 'section');
+  });
+
+  it('should match collapsible schema fields', () => {
+    verifyFields(JsonCollapsibleBlockSchema, 'collapsible');
   });
 
   it('should match quiz schema fields', () => {

--- a/src/validation/type-coupling.test.ts
+++ b/src/validation/type-coupling.test.ts
@@ -10,6 +10,7 @@ import {
   JsonGuidedBlockSchema,
   JsonSectionBlockSchema,
   JsonCollapsibleBlockSchema,
+  PresentationalBlockSchema,
   JsonQuizBlockSchema,
   JsonAssistantBlockSchema,
   JsonInputBlockSchema,
@@ -140,6 +141,37 @@ describe('KNOWN_FIELDS sync', () => {
 
   it('should match collapsible schema fields', () => {
     verifyFields(JsonCollapsibleBlockSchema, 'collapsible');
+  });
+
+  // Drift guard: PresentationalBlockSchema (collapsible children) and the
+  // PresentationalBlock type must list the same block types. If the union
+  // gains/loses a member on one side only, one of these assertions fails.
+  describe('PresentationalBlockSchema membership', () => {
+    it('accepts the content block types', () => {
+      const accepted: unknown[] = [
+        { type: 'markdown', content: 'x' },
+        { type: 'html', content: '<p>x</p>' },
+        { type: 'image', src: 'https://example.com/x.png' },
+        { type: 'video', src: 'https://example.com/x.mp4', provider: 'native' },
+      ];
+      for (const block of accepted) {
+        expect(PresentationalBlockSchema.safeParse(block).success).toBe(true);
+      }
+    });
+
+    it('rejects interactive, step, and container types', () => {
+      const rejected: unknown[] = [
+        { type: 'interactive', action: 'highlight', reftarget: 'x', content: 'y' },
+        { type: 'code-block', reftarget: 'x', code: 'y' },
+        { type: 'quiz', question: 'q', choices: [{ id: 'a', text: 'a', correct: true }] },
+        { type: 'section', blocks: [] },
+        { type: 'collapsible', blocks: [] },
+        { type: 'conditional', conditions: ['is-admin'], whenTrue: [], whenFalse: [] },
+      ];
+      for (const block of rejected) {
+        expect(PresentationalBlockSchema.safeParse(block).success).toBe(false);
+      }
+    });
   });
 
   it('should match quiz schema fields', () => {

--- a/src/validation/validate-guide.test.ts
+++ b/src/validation/validate-guide.test.ts
@@ -795,19 +795,26 @@ describe('JsonGuideSchema', () => {
     });
   });
 
-  describe('collapsible block - non-container restriction', () => {
+  describe('collapsible block - presentational-only restriction', () => {
     const wrap = (blocks: unknown[]) =>
       JSON.stringify({ id: 'test', title: 'Test', blocks: [{ type: 'collapsible', title: 'More', blocks }] });
 
-    it('accepts leaf and step blocks inside a collapsible', () => {
+    it('accepts content blocks inside a collapsible', () => {
       const result = validateGuideFromString(
         wrap([
           { type: 'markdown', content: 'note' },
-          { type: 'interactive', action: 'highlight', reftarget: 'button', content: 'do it' },
+          { type: 'image', src: 'https://example.com/x.png' },
         ])
       );
       expect(result.isValid).toBe(true);
       expect(result.errors).toHaveLength(0);
+    });
+
+    it('rejects an interactive step nested inside a collapsible', () => {
+      const result = validateGuideFromString(
+        wrap([{ type: 'interactive', action: 'highlight', reftarget: 'button', content: 'do it' }])
+      );
+      expect(result.isValid).toBe(false);
     });
 
     it('rejects a section nested inside a collapsible', () => {

--- a/src/validation/validate-guide.test.ts
+++ b/src/validation/validate-guide.test.ts
@@ -834,4 +834,31 @@ describe('JsonGuideSchema', () => {
       expect(result.isValid).toBe(false);
     });
   });
+
+  describe('authorNote is preserved on container blocks', () => {
+    const firstBlock = (json: string) => {
+      const result = validateGuideFromString(json);
+      expect(result.isValid).toBe(true);
+      return (result.guide?.blocks?.[0] ?? {}) as { authorNote?: string };
+    };
+    const guideWith = (block: unknown) => JSON.stringify({ id: 'g', title: 't', blocks: [block] });
+
+    it('preserves authorNote on section, collapsible, assistant, and conditional', () => {
+      expect(firstBlock(guideWith({ type: 'section', title: 'S', authorNote: 'n', blocks: [] })).authorNote).toBe('n');
+      expect(
+        firstBlock(
+          guideWith({ type: 'collapsible', title: 'C', authorNote: 'n', blocks: [{ type: 'markdown', content: 'x' }] })
+        ).authorNote
+      ).toBe('n');
+      expect(
+        firstBlock(guideWith({ type: 'assistant', authorNote: 'n', blocks: [{ type: 'markdown', content: 'x' }] }))
+          .authorNote
+      ).toBe('n');
+      expect(
+        firstBlock(
+          guideWith({ type: 'conditional', conditions: ['is-admin'], authorNote: 'n', whenTrue: [], whenFalse: [] })
+        ).authorNote
+      ).toBe('n');
+    });
+  });
 });

--- a/src/validation/validate-guide.test.ts
+++ b/src/validation/validate-guide.test.ts
@@ -794,4 +794,37 @@ describe('JsonGuideSchema', () => {
       expect(result.warnings.some((w) => w.message.includes('duplicates the guide title'))).toBe(true);
     });
   });
+
+  describe('collapsible block - non-container restriction', () => {
+    const wrap = (blocks: unknown[]) =>
+      JSON.stringify({ id: 'test', title: 'Test', blocks: [{ type: 'collapsible', title: 'More', blocks }] });
+
+    it('accepts leaf and step blocks inside a collapsible', () => {
+      const result = validateGuideFromString(
+        wrap([
+          { type: 'markdown', content: 'note' },
+          { type: 'interactive', action: 'highlight', reftarget: 'button', content: 'do it' },
+        ])
+      );
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('rejects a section nested inside a collapsible', () => {
+      const result = validateGuideFromString(wrap([{ type: 'section', title: 'S', blocks: [] }]));
+      expect(result.isValid).toBe(false);
+    });
+
+    it('rejects a collapsible nested inside a collapsible', () => {
+      const result = validateGuideFromString(wrap([{ type: 'collapsible', title: 'Inner', blocks: [] }]));
+      expect(result.isValid).toBe(false);
+    });
+
+    it('rejects a conditional nested inside a collapsible', () => {
+      const result = validateGuideFromString(
+        wrap([{ type: 'conditional', conditions: ['is-admin'], whenTrue: [], whenFalse: [] }])
+      );
+      expect(result.isValid).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## What
Adds a first-class `collapsible` JSON guide block that hides its nested content behind a toggle, so guide authors can gate solutions or answers until a learner chooses to reveal them.

Closes #1054.

## Changes
- **Types + schema:** `JsonCollapsibleBlock` + `JsonCollapsibleBlockSchema`; registered in `VALID_BLOCK_TYPES`; type guard and known-fields entry.
- **Presentational-only:** a collapsible accepts **content blocks only** (`markdown`, `html`, `image`, `video`) via `PresentationalBlockSchema`. Interactive/step blocks and containers (`section`/`collapsible`/`conditional`) are rejected, so a collapsible carries no completion state. A drift-guard test ties the `PresentationalBlock` type to the schema.
- **Parser:** `convertCollapsibleBlock` → `collapsible` element.
- **Rendering:** `CollapsibleBlock` component (themed via the shared `journey-collapse` styles; `aria-expanded`/`aria-controls`; author `id` emitted on the wrapper so `#id` deep-links resolve) + renderer case.
- **Block editor:** palette entry under "Structure" + `CollapsibleBlockForm`; nested content is edited in-form via `BranchBlocksEditor`, whose add menu is restricted to content blocks (new `addableBlockTypes` prop).
- **CLI/MCP:** the tree walk descends into a collapsible's `blocks` (`CONTAINER_CHILD_KEYS`) so nested ids are collected and addressable (fixes duplicate-id / broken edit-remove for nested blocks); `collapsible` is excluded from CLI authoring (block-editor only, like `grot-guide`).
- **Docs + tests:** documented in `json-guide-format.md`; parser, schema, component, and CLI-traversal tests.

## Scope
Presentational by design: a collapsible hides/reveals **content**; to gate **interactive** steps use a `section`. Nesting interactives in a collapsible is rejected by the schema, so there is no completion-tracking edge case and no follow-up PR required. The door is left open to a purpose-built "collapsible interactive container" in the future if that need arises.

## Incidental fix (rides along)
Surfaced by review of this change: the depth-limited block union arms for **all** container types (`section`, `collapsible`, `assistant`, `conditional`) built their objects without `...AuthorAnnotatedSchema.shape`, so Zod's default strip dropped the editor-only `authorNote` during validation — while leaf blocks preserved it. This was **pre-existing** for the three sibling containers. Fixed by spreading `AuthorAnnotatedSchema.shape` into every container arm (both the standard and `NoRef` unions), with a test asserting `authorNote` survives on each container type.

## Verification
- typecheck, ESLint (0 errors), prettier, terms-sync ✅
- full frontend suite: 359 suites, 5554 tests ✅
- production build clean ✅
- (Go steps skipped — no `pkg/**` changes)

## Screenshots

#### Collapsible Preview
<img width="529" height="429" alt="collapsible-preview" src="https://github.com/user-attachments/assets/a3a1a60c-4457-46f9-9c59-b2ec55686f96" />

#### Collapsible Preview Expanded
<img width="530" height="536" alt="collapsible-preview-expanded" src="https://github.com/user-attachments/assets/d0f58762-0848-4b97-9ff9-243ad38e4ab4" />

#### Collapsible Editor
<img width="705" height="590" alt="collapsible-editor" src="https://github.com/user-attachments/assets/70da9b50-b568-490b-b4c2-175a2a83fee4" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
