### PR TITLE
feat: custom guide repository catalogue proxy (App Platform proxy pattern)

### DIFF
--- a/pkg/plugin/app_platform_client.go
+++ b/pkg/plugin/app_platform_client.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -170,4 +171,27 @@ func isTransientUpstreamStatus(status int) bool {
 // condition. Identity-scoped failures must never enter a shared cache (§4).
 func isIdentityScopedUpstreamStatus(status int) bool {
 	return status == http.StatusUnauthorized || status == http.StatusForbidden
+}
+
+// isTerminalUpstreamError reports whether an upstream failure is terminal (a
+// non-transient 4xx per §5). Network/timeout/decode errors carry no HTTP
+// status and are treated as transient (retryable). Error-level companion to
+// isTransientUpstreamStatus, shared by every proxy route.
+func isTerminalUpstreamError(err error) bool {
+	var ue *appPlatformUpstreamError
+	if errors.As(err, &ue) {
+		return !isTransientUpstreamStatus(ue.status)
+	}
+	return false
+}
+
+// isIdentityScopedUpstreamError reports whether an upstream failure means the
+// aggregator rejected this caller's forwarded identity (401/403). Error-level
+// companion to isIdentityScopedUpstreamStatus, shared by every proxy route.
+func isIdentityScopedUpstreamError(err error) bool {
+	var ue *appPlatformUpstreamError
+	if errors.As(err, &ue) {
+		return isIdentityScopedUpstreamStatus(ue.status)
+	}
+	return false
 }

--- a/pkg/plugin/completion_records.go
+++ b/pkg/plugin/completion_records.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"sort"
 	"strconv"
@@ -582,21 +581,15 @@ func (a *App) resolveCompletionBackend(r *http.Request) (lister completionRecord
 
 // isTerminalCompletionError reports whether an upstream failure is terminal
 // (a non-transient 4xx per RFC §6.9). Network/timeout/decoding errors have no
-// HTTP status and are treated as transient (retryable).
+// HTTP status and are treated as transient (retryable). Thin domain alias over
+// the shared classifier so both proxies share one definition of the logic.
 func isTerminalCompletionError(err error) bool {
-	var ue *appPlatformUpstreamError
-	if errors.As(err, &ue) {
-		return !isTransientUpstreamStatus(ue.status)
-	}
-	return false
+	return isTerminalUpstreamError(err)
 }
 
 // isIdentityScopedCompletionError reports whether an upstream failure means
-// the aggregator rejected this caller's forwarded identity (401/403).
+// the aggregator rejected this caller's forwarded identity (401/403). Thin
+// domain alias over the shared classifier.
 func isIdentityScopedCompletionError(err error) bool {
-	var ue *appPlatformUpstreamError
-	if errors.As(err, &ue) {
-		return isIdentityScopedUpstreamStatus(ue.status)
-	}
-	return false
+	return isIdentityScopedUpstreamError(err)
 }

--- a/pkg/plugin/custom_guide_repository.go
+++ b/pkg/plugin/custom_guide_repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -17,44 +16,47 @@ import (
 // The Custom Guides sidebar and My Learning surfaces need a slim catalogue of a
 // stack's private InteractiveGuide packages. The aggregated LIST returns
 // full-fidelity guides (spec.blocks and all), so this proxy drains the
-// namespace LIST once, strips each guide to a slim entry, and serves the shaped
-// catalogue from a short-lived in-process cache. Unlike completion records this
-// is a SHARED-BLOB catalogue, not per-user (see the identity-invariance note on
-// the cache below).
+// namespace LIST, strips each guide to a slim entry, and returns the shaped
+// catalogue.
+//
+// DELIBERATE DEVIATION from the pattern's cache-centric §4/§5: this proxy does
+// NOT cache across requests, and does NOT single-flight across callers. Every
+// request performs its own upstream LIST under the caller's own forwarded
+// identity, so per-caller list authorization is always enforced at the source.
+//
+// Why not the pattern's shared-blob cache: a namespace-global catalogue is a
+// shared blob, and a shared cache is only sound if the upstream LIST is
+// identity-invariant — i.e. every caller who can reach this route can also list
+// interactiveguides. That invariant is unproven (it depends on the stack's
+// interactiveguides RBAC, and would silently break if a future role change let
+// a token-bearing caller reach the plugin without list permission). A warm
+// shared entry — or a shared in-flight LIST — would then serve one user's
+// catalogue to an unauthorized caller for the cache window. Rather than rely on
+// an unverifiable invariant for cross-user data, we skip cross-request/cross-
+// caller sharing entirely. The pattern's §3 forbids the alternative safe cache
+// (per-user partitioning needs `sub`, which a namespace-global route must not
+// extract), so "no shared cache" is the conservative in-pattern choice here.
+// This data is low-traffic (a small enablement catalogue read on panel load),
+// so a LIST per request is an acceptable cost. If load ever justifies caching,
+// the safe reintroduction is a per-identity-partitioned cache — a deliberate
+// future change. With no warm data to serve, the pattern's stale-serve and
+// negative-cache-cooldown clauses (§5) do not apply.
 
 const (
-	// customGuideCacheTTL is short because App Platform guides are an
-	// edited-in-place repository — an author publishes a guide and expects it to
-	// appear promptly. 30s absorbs the near-simultaneous Custom Guides + My
-	// Learning reads on a page load without serving meaningfully stale data.
-	customGuideCacheTTL = 30 * time.Second
-
-	// customGuideForcedRefreshInterval rate-limits ?refresh=1 (used by the
-	// author flow: publish a guide, immediately re-list) to at most one forced
-	// upstream LIST per namespace per window, so it can't become a load lever.
-	customGuideForcedRefreshInterval = 30 * time.Second
-
-	// customGuideFailureCooldown is a negative-cache window, deliberately a
-	// separate constant from the success TTL: after an upstream refresh fails,
-	// TTL-expired re-attempts are suppressed for this long so a sustained outage
-	// doesn't re-trigger a full-namespace LIST on every sequential request.
-	// Identity-scoped (401/403) failures never enter this shared negative cache.
-	customGuideFailureCooldown = 30 * time.Second
-
-	// customGuideRetryAfterSeconds is the Retry-After hint on a cold 503.
+	// customGuideRetryAfterSeconds is the Retry-After hint on a transient 503.
 	customGuideRetryAfterSeconds = 30
 
-	// customGuideAggregateDeadline bounds a whole multi-page drain. The refresh
-	// runs detached from the request (context.WithoutCancel), so without this an
-	// N-page drain would be bounded only by N × per-page timeout — detached must
-	// not mean unkillable.
+	// customGuideAggregateDeadline bounds a whole multi-page drain. The drain is
+	// detached from the request (context.WithoutCancel) so a canceled request
+	// (panel closed mid-flight) doesn't abort a fetch partway and log spurious
+	// errors; the deadline ensures detached never means unkillable.
 	customGuideAggregateDeadline = 60 * time.Second
 )
 
 // customGuideListMaxTotalEntries is the aggregate budget across all LIST pages
 // of one drain (the per-page byte cap alone does not bound total memory). When
-// the budget trips, the drain stops and logs the truncation — never silently.
-// A var so tests can exercise the budget path.
+// the budget trips, the drain caps the result and logs the truncation — never
+// silently. A var so tests can exercise the budget path.
 var customGuideListMaxTotalEntries = 50_000
 
 // customGuideCapability is the availability signal the front-end gates the
@@ -69,257 +71,19 @@ type customGuideCapability struct {
 
 // customGuideRepositoryResponse is the GET /custom-guide-repository envelope
 // (BACKEND_PROXY_PATTERN.md §6): a capability object, the always-non-null data
-// array, and asOf — the staleness contract telling the front-end when the
-// underlying LIST completed.
+// array, and asOf — when this request's underlying LIST completed.
 type customGuideRepositoryResponse struct {
 	Capability customGuideCapability        `json:"capability"`
 	Guides     []customGuideRepositoryEntry `json:"guides"`
 	AsOf       string                       `json:"asOf,omitempty"`
 }
 
-// customGuideIndex is the shaped, block-stripped catalogue for a namespace.
-//
-// SHARED-BLOB identity model (BACKEND_PROXY_PATTERN.md §4): authorization is
-// enforced at cache-fill (the LIST rides the filling caller's forwarded
-// identity) and the result is shared for the TTL across every authorized
-// caller in the namespace. This is sound ONLY because the upstream LIST is
-// identity-invariant here: Kubernetes list RBAC on interactiveguides is
-// namespace-scoped, not object-scoped, so any caller permitted to list sees
-// the same full set — no caller's richer view can leak to another. The cache
-// is not partitioned by user because there is nothing per-user to partition.
-type customGuideIndex struct {
-	entries []customGuideRepositoryEntry
-	asOf    time.Time
-}
-
-type customGuideCacheEntry struct {
-	index *customGuideIndex
-}
-
-// customGuideFailure records the most recent namespace-global upstream refresh
-// failure so the cooldown can suppress re-probes and cold callers can still
-// distinguish terminal from transient while throttled.
-type customGuideFailure struct {
-	at  time.Time
-	err error
-}
-
-// customGuideRefreshFlight is a single-flight handle: concurrent cache-miss
-// callers for a namespace wait on `done` and share one upstream LIST.
-type customGuideRefreshFlight struct {
-	done  chan struct{}
-	index *customGuideIndex
-	err   error
-}
-
-// customGuideCacheStats are per-namespace vital signs, included in refresh-time
-// structured logs so the cache is diagnosable on-call.
-type customGuideCacheStats struct {
-	hits            int
-	misses          int
-	staleServes     int
-	refreshes       int
-	refreshFailures int
-}
-
-// All maps below are keyed by the trusted-context namespace (never
-// caller-supplied — see resolveCustomGuideBackend), so on hosted Grafana the
-// key space is one entry per process; the maps need no eviction.
-var (
-	customGuideCacheMu      sync.Mutex
-	customGuideCacheEntries map[string]*customGuideCacheEntry
-	customGuideFlights      map[string]*customGuideRefreshFlight
-	customGuideLastForced   map[string]time.Time
-	customGuideLastFailure  map[string]customGuideFailure
-	customGuideStats        map[string]*customGuideCacheStats
-
-	// customGuideListerOverride injects a fake lister in tests. nil selects the
-	// real per-request HTTP client. Config resolution (feature toggle, app URL,
-	// namespace) is checked BEFORE this override so the structural-
-	// unavailability path stays testable.
-	customGuideListerOverride customGuideLister
-)
-
-func customGuideCacheInit() {
-	if customGuideCacheEntries == nil {
-		customGuideCacheEntries = map[string]*customGuideCacheEntry{}
-	}
-	if customGuideFlights == nil {
-		customGuideFlights = map[string]*customGuideRefreshFlight{}
-	}
-	if customGuideLastForced == nil {
-		customGuideLastForced = map[string]time.Time{}
-	}
-	if customGuideLastFailure == nil {
-		customGuideLastFailure = map[string]customGuideFailure{}
-	}
-	if customGuideStats == nil {
-		customGuideStats = map[string]*customGuideCacheStats{}
-	}
-}
-
-func customGuideStatsFor(namespace string) *customGuideCacheStats {
-	s := customGuideStats[namespace]
-	if s == nil {
-		s = &customGuideCacheStats{}
-		customGuideStats[namespace] = s
-	}
-	return s
-}
-
-// resetCustomGuideRepositoryCache clears all cached state. Test-only.
-func resetCustomGuideRepositoryCache() {
-	customGuideCacheMu.Lock()
-	defer customGuideCacheMu.Unlock()
-	customGuideCacheEntries = nil
-	customGuideFlights = nil
-	customGuideLastForced = nil
-	customGuideLastFailure = nil
-	customGuideStats = nil
-}
-
-// getCustomGuideIndex returns the shaped catalogue for a namespace, refreshing
-// at most once per TTL (or immediately for a rate-limit-permitted forced
-// refresh). On refresh failure it serves a warm (stale) index when one exists;
-// a cold failure returns (nil, err). After a namespace-global failure a short
-// cooldown suppresses TTL-driven re-attempts; identity-scoped (401/403)
-// failures are per-request and never enter that shared negative cache — caller
-// A's denied token must not become a cached error served to caller B.
-// Concurrent refreshes single-flight.
-func getCustomGuideIndex(ctx context.Context, namespace string, lister customGuideLister, forced bool, logger log.Logger) (*customGuideIndex, error) {
-	customGuideCacheMu.Lock()
-	customGuideCacheInit()
-
-	entry := customGuideCacheEntries[namespace]
-	stats := customGuideStatsFor(namespace)
-
-	effectiveForced := false
-	if forced {
-		last, seen := customGuideLastForced[namespace]
-		if !seen || timeNow().Sub(last) >= customGuideForcedRefreshInterval {
-			effectiveForced = true
-			customGuideLastForced[namespace] = timeNow()
-		}
-	}
-
-	if entry != nil && !effectiveForced && timeNow().Sub(entry.index.asOf) < customGuideCacheTTL {
-		stats.hits++
-		idx := entry.index
-		customGuideCacheMu.Unlock()
-		return idx, nil
-	}
-	stats.misses++
-
-	// Negative-cache cooldown: after a recent namespace-global refresh failure,
-	// don't re-probe a struggling upstream on every TTL-expired request. Serve
-	// the stale index when warm, or replay the sticky error when cold, until the
-	// cooldown elapses. A rate-limit-permitted ?refresh=1 bypasses this.
-	if !effectiveForced {
-		if fail, ok := customGuideLastFailure[namespace]; ok && timeNow().Sub(fail.at) < customGuideFailureCooldown {
-			if entry != nil {
-				stats.staleServes++
-				idx := entry.index
-				customGuideCacheMu.Unlock()
-				return idx, nil
-			}
-			err := fail.err
-			customGuideCacheMu.Unlock()
-			return nil, err
-		}
-	}
-
-	if fl := customGuideFlights[namespace]; fl != nil {
-		customGuideCacheMu.Unlock()
-		select {
-		case <-fl.done:
-			return fl.index, fl.err
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
-
-	fl := &customGuideRefreshFlight{done: make(chan struct{})}
-	customGuideFlights[namespace] = fl
-	customGuideCacheMu.Unlock()
-
-	// Detach from the caller's cancellation so a canceled request (panel closed
-	// mid-flight) doesn't abort a refresh other waiters depend on, bounded by
-	// the aggregate deadline so detached never means unkillable.
-	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), customGuideAggregateDeadline)
-	idx, pages, err := buildCustomGuideIndex(fetchCtx, namespace, lister, logger)
-	cancel()
-
-	customGuideCacheMu.Lock()
-	stats = customGuideStatsFor(namespace)
-	if err == nil {
-		stats.refreshes++
-		if _, hadFailure := customGuideLastFailure[namespace]; hadFailure {
-			logger.Info("custom guide catalogue recovered", "namespace", namespace)
-		}
-		customGuideCacheEntries[namespace] = &customGuideCacheEntry{index: idx}
-		delete(customGuideLastFailure, namespace)
-		fl.index = idx
-		logger.Debug("custom guide catalogue refreshed",
-			"namespace", namespace, "pages", pages, "guides", len(idx.entries),
-			"hits", stats.hits, "misses", stats.misses,
-			"staleServes", stats.staleServes, "refreshFailures", stats.refreshFailures)
-	} else {
-		stats.refreshFailures++
-		identityScoped := isIdentityScopedUpstreamError(err)
-		if !identityScoped {
-			customGuideLastFailure[namespace] = customGuideFailure{at: timeNow(), err: err}
-		}
-		// Refresh attempts are throttled by TTL + cooldown, so this logs state
-		// transitions, not every request.
-		logger.Info("custom guide catalogue refresh failed",
-			"namespace", namespace, "error", err,
-			"identityScoped", identityScoped, "servingStale", entry != nil,
-			"refreshFailures", stats.refreshFailures)
-		if entry != nil {
-			// Warm cache + upstream failure: serve stale. asOf reflects true age.
-			stats.staleServes++
-			fl.index = entry.index
-			fl.err = err
-		} else {
-			fl.err = err
-		}
-	}
-	delete(customGuideFlights, namespace)
-	customGuideCacheMu.Unlock()
-	close(fl.done)
-
-	return fl.index, fl.err
-}
-
-// buildCustomGuideIndex drains the namespace LIST across pages — up to the
-// aggregate entry budget — and shapes the guides into the catalogue index.
-func buildCustomGuideIndex(ctx context.Context, namespace string, lister customGuideLister, logger log.Logger) (*customGuideIndex, int, error) {
-	var entries []customGuideRepositoryEntry
-	continueToken := ""
-	pages := 0
-	for {
-		page, err := lister.ListPage(ctx, namespace, continueToken)
-		if err != nil {
-			return nil, pages, err
-		}
-		pages++
-		entries = append(entries, page.Entries...)
-		if len(entries) >= customGuideListMaxTotalEntries && page.Continue != "" {
-			logger.Warn("custom guide catalogue LIST truncated at aggregate budget",
-				"namespace", namespace, "maxTotalEntries", customGuideListMaxTotalEntries, "pages", pages)
-			break
-		}
-		if page.Continue == "" {
-			break
-		}
-		continueToken = page.Continue
-	}
-
-	if entries == nil {
-		entries = []customGuideRepositoryEntry{}
-	}
-	return &customGuideIndex{entries: entries, asOf: timeNow()}, pages, nil
-}
+// customGuideListerOverride injects a fake lister in tests. nil selects the
+// real per-request HTTP client. Config resolution (feature toggle, app URL,
+// namespace) is checked BEFORE this override so the structural-unavailability
+// path stays testable. This is the only package-level state in the proxy —
+// there is no cross-request cache (see the deviation note above).
+var customGuideListerOverride customGuideLister
 
 // handleCustomGuideRepository serves GET /custom-guide-repository.
 func (a *App) handleCustomGuideRepository(w http.ResponseWriter, r *http.Request) {
@@ -328,8 +92,7 @@ func (a *App) handleCustomGuideRepository(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Identity gate first — cache hit or miss, warm bytes are never served to an
-	// unauthenticated caller. This is a namespace-global catalogue, so we only
+	// Identity gate first. This is a namespace-global catalogue, so we only
 	// STRUCTURALLY validate the ID token (validIDToken); there is no per-user
 	// need, so we deliberately do not extract `sub`. Missing/invalid identity on
 	// a GET read is a soft-200 capability envelope (not 401): these routes gate
@@ -352,29 +115,75 @@ func (a *App) handleCustomGuideRepository(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	forced := r.URL.Query().Get("refresh") == "1"
-	idx, err := getCustomGuideIndex(r.Context(), namespace, lister, forced, a.ctxLogger(r.Context()))
-	if idx == nil {
-		// Cold failure: no cache to fall back on.
+	// Detach the drain from the caller's cancellation, bounded by the aggregate
+	// deadline. Per-request (no cross-caller sharing): this fetch rides this
+	// caller's identity and is never handed to another caller.
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), customGuideAggregateDeadline)
+	entries, pages, err := drainCustomGuides(fetchCtx, namespace, lister)
+	cancel()
+
+	logger := a.ctxLogger(r.Context())
+	if err != nil {
 		if isTerminalUpstreamError(err) {
-			// Structurally can't serve for this caller ("never works here").
+			// Structurally can't serve for this caller ("never works here") —
+			// includes identity-scoped 401/403 for this caller's token.
+			logger.Info("custom guide catalogue unavailable (terminal)", "namespace", namespace, "error", err)
 			a.writeJSON(w, customGuideRepositoryResponse{
 				Capability: customGuideCapability{Available: false, Reason: reasonBackendUnavailable},
 				Guides:     []customGuideRepositoryEntry{},
 			}, http.StatusOK)
 			return
 		}
-		a.ctxLogger(r.Context()).Debug("custom guide catalogue unavailable (cold)", "error", err)
+		// Transient: a retry might fix it, so signal a hiccup rather than
+		// darkening the feature.
+		logger.Debug("custom guide catalogue unavailable (transient)", "namespace", namespace, "error", err)
 		w.Header().Set("Retry-After", strconv.Itoa(customGuideRetryAfterSeconds))
 		a.writeError(w, "custom-guide-repository-unavailable", http.StatusServiceUnavailable)
 		return
 	}
 
+	logger.Debug("custom guide catalogue served", "namespace", namespace, "pages", pages, "guides", len(entries))
 	a.writeJSON(w, customGuideRepositoryResponse{
 		Capability: customGuideCapability{Available: true},
-		Guides:     idx.entries,
-		AsOf:       idx.asOf.UTC().Format(time.RFC3339),
+		Guides:     entries,
+		AsOf:       timeNow().UTC().Format(time.RFC3339),
 	}, http.StatusOK)
+}
+
+// drainCustomGuides drains the namespace LIST across pages — up to the
+// aggregate entry budget — and returns the shaped catalogue entries.
+func drainCustomGuides(ctx context.Context, namespace string, lister customGuideLister) ([]customGuideRepositoryEntry, int, error) {
+	entries := []customGuideRepositoryEntry{}
+	continueToken := ""
+	pages := 0
+	for {
+		page, err := lister.ListPage(ctx, namespace, continueToken)
+		if err != nil {
+			return nil, pages, err
+		}
+		pages++
+		entries = append(entries, page.Entries...)
+		if len(entries) >= customGuideListMaxTotalEntries {
+			// Strict budget: cap the accumulated slice so the memory bound holds
+			// exactly (a page can push us past the limit), and log whenever the
+			// cap actually drops data — either we trimmed an overshoot or more
+			// pages remained undrained.
+			truncated := len(entries) > customGuideListMaxTotalEntries || page.Continue != ""
+			if len(entries) > customGuideListMaxTotalEntries {
+				entries = entries[:customGuideListMaxTotalEntries]
+			}
+			if truncated {
+				log.DefaultLogger.Warn("custom guide catalogue LIST truncated at aggregate budget",
+					"namespace", namespace, "maxTotalEntries", customGuideListMaxTotalEntries, "pages", pages)
+			}
+			break
+		}
+		if page.Continue == "" {
+			break
+		}
+		continueToken = page.Continue
+	}
+	return entries, pages, nil
 }
 
 // resolveCustomGuideBackend determines whether the aggregated CRUD API is

--- a/pkg/plugin/custom_guide_repository.go
+++ b/pkg/plugin/custom_guide_repository.go
@@ -1,0 +1,408 @@
+package plugin
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/config"
+)
+
+// Custom guide repository catalogue proxy (docs/design/BACKEND_PROXY_PATTERN.md).
+//
+// The Custom Guides sidebar and My Learning surfaces need a slim catalogue of a
+// stack's private InteractiveGuide packages. The aggregated LIST returns
+// full-fidelity guides (spec.blocks and all), so this proxy drains the
+// namespace LIST once, strips each guide to a slim entry, and serves the shaped
+// catalogue from a short-lived in-process cache. Unlike completion records this
+// is a SHARED-BLOB catalogue, not per-user (see the identity-invariance note on
+// the cache below).
+
+const (
+	// customGuideCacheTTL is short because App Platform guides are an
+	// edited-in-place repository — an author publishes a guide and expects it to
+	// appear promptly. 30s absorbs the near-simultaneous Custom Guides + My
+	// Learning reads on a page load without serving meaningfully stale data.
+	customGuideCacheTTL = 30 * time.Second
+
+	// customGuideForcedRefreshInterval rate-limits ?refresh=1 (used by the
+	// author flow: publish a guide, immediately re-list) to at most one forced
+	// upstream LIST per namespace per window, so it can't become a load lever.
+	customGuideForcedRefreshInterval = 30 * time.Second
+
+	// customGuideFailureCooldown is a negative-cache window, deliberately a
+	// separate constant from the success TTL: after an upstream refresh fails,
+	// TTL-expired re-attempts are suppressed for this long so a sustained outage
+	// doesn't re-trigger a full-namespace LIST on every sequential request.
+	// Identity-scoped (401/403) failures never enter this shared negative cache.
+	customGuideFailureCooldown = 30 * time.Second
+
+	// customGuideRetryAfterSeconds is the Retry-After hint on a cold 503.
+	customGuideRetryAfterSeconds = 30
+
+	// customGuideAggregateDeadline bounds a whole multi-page drain. The refresh
+	// runs detached from the request (context.WithoutCancel), so without this an
+	// N-page drain would be bounded only by N × per-page timeout — detached must
+	// not mean unkillable.
+	customGuideAggregateDeadline = 60 * time.Second
+)
+
+// customGuideListMaxTotalEntries is the aggregate budget across all LIST pages
+// of one drain (the per-page byte cap alone does not bound total memory). When
+// the budget trips, the drain stops and logs the truncation — never silently.
+// A var so tests can exercise the budget path.
+var customGuideListMaxTotalEntries = 50_000
+
+// customGuideCapability is the availability signal the front-end gates the
+// Custom Guides / My Learning surfaces on. `available` is read-derived: it
+// measures identity presence plus read-path reachability of the
+// interactiveguides API on this stack. Reasons use the shared machine tokens
+// reasonIdentityUnavailable / reasonBackendUnavailable (completion_records.go).
+type customGuideCapability struct {
+	Available bool   `json:"available"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// customGuideRepositoryResponse is the GET /custom-guide-repository envelope
+// (BACKEND_PROXY_PATTERN.md §6): a capability object, the always-non-null data
+// array, and asOf — the staleness contract telling the front-end when the
+// underlying LIST completed.
+type customGuideRepositoryResponse struct {
+	Capability customGuideCapability        `json:"capability"`
+	Guides     []customGuideRepositoryEntry `json:"guides"`
+	AsOf       string                       `json:"asOf,omitempty"`
+}
+
+// customGuideIndex is the shaped, block-stripped catalogue for a namespace.
+//
+// SHARED-BLOB identity model (BACKEND_PROXY_PATTERN.md §4): authorization is
+// enforced at cache-fill (the LIST rides the filling caller's forwarded
+// identity) and the result is shared for the TTL across every authorized
+// caller in the namespace. This is sound ONLY because the upstream LIST is
+// identity-invariant here: Kubernetes list RBAC on interactiveguides is
+// namespace-scoped, not object-scoped, so any caller permitted to list sees
+// the same full set — no caller's richer view can leak to another. The cache
+// is not partitioned by user because there is nothing per-user to partition.
+type customGuideIndex struct {
+	entries []customGuideRepositoryEntry
+	asOf    time.Time
+}
+
+type customGuideCacheEntry struct {
+	index *customGuideIndex
+}
+
+// customGuideFailure records the most recent namespace-global upstream refresh
+// failure so the cooldown can suppress re-probes and cold callers can still
+// distinguish terminal from transient while throttled.
+type customGuideFailure struct {
+	at  time.Time
+	err error
+}
+
+// customGuideRefreshFlight is a single-flight handle: concurrent cache-miss
+// callers for a namespace wait on `done` and share one upstream LIST.
+type customGuideRefreshFlight struct {
+	done  chan struct{}
+	index *customGuideIndex
+	err   error
+}
+
+// customGuideCacheStats are per-namespace vital signs, included in refresh-time
+// structured logs so the cache is diagnosable on-call.
+type customGuideCacheStats struct {
+	hits            int
+	misses          int
+	staleServes     int
+	refreshes       int
+	refreshFailures int
+}
+
+// All maps below are keyed by the trusted-context namespace (never
+// caller-supplied — see resolveCustomGuideBackend), so on hosted Grafana the
+// key space is one entry per process; the maps need no eviction.
+var (
+	customGuideCacheMu      sync.Mutex
+	customGuideCacheEntries map[string]*customGuideCacheEntry
+	customGuideFlights      map[string]*customGuideRefreshFlight
+	customGuideLastForced   map[string]time.Time
+	customGuideLastFailure  map[string]customGuideFailure
+	customGuideStats        map[string]*customGuideCacheStats
+
+	// customGuideListerOverride injects a fake lister in tests. nil selects the
+	// real per-request HTTP client. Config resolution (feature toggle, app URL,
+	// namespace) is checked BEFORE this override so the structural-
+	// unavailability path stays testable.
+	customGuideListerOverride customGuideLister
+)
+
+func customGuideCacheInit() {
+	if customGuideCacheEntries == nil {
+		customGuideCacheEntries = map[string]*customGuideCacheEntry{}
+	}
+	if customGuideFlights == nil {
+		customGuideFlights = map[string]*customGuideRefreshFlight{}
+	}
+	if customGuideLastForced == nil {
+		customGuideLastForced = map[string]time.Time{}
+	}
+	if customGuideLastFailure == nil {
+		customGuideLastFailure = map[string]customGuideFailure{}
+	}
+	if customGuideStats == nil {
+		customGuideStats = map[string]*customGuideCacheStats{}
+	}
+}
+
+func customGuideStatsFor(namespace string) *customGuideCacheStats {
+	s := customGuideStats[namespace]
+	if s == nil {
+		s = &customGuideCacheStats{}
+		customGuideStats[namespace] = s
+	}
+	return s
+}
+
+// resetCustomGuideRepositoryCache clears all cached state. Test-only.
+func resetCustomGuideRepositoryCache() {
+	customGuideCacheMu.Lock()
+	defer customGuideCacheMu.Unlock()
+	customGuideCacheEntries = nil
+	customGuideFlights = nil
+	customGuideLastForced = nil
+	customGuideLastFailure = nil
+	customGuideStats = nil
+}
+
+// getCustomGuideIndex returns the shaped catalogue for a namespace, refreshing
+// at most once per TTL (or immediately for a rate-limit-permitted forced
+// refresh). On refresh failure it serves a warm (stale) index when one exists;
+// a cold failure returns (nil, err). After a namespace-global failure a short
+// cooldown suppresses TTL-driven re-attempts; identity-scoped (401/403)
+// failures are per-request and never enter that shared negative cache — caller
+// A's denied token must not become a cached error served to caller B.
+// Concurrent refreshes single-flight.
+func getCustomGuideIndex(ctx context.Context, namespace string, lister customGuideLister, forced bool, logger log.Logger) (*customGuideIndex, error) {
+	customGuideCacheMu.Lock()
+	customGuideCacheInit()
+
+	entry := customGuideCacheEntries[namespace]
+	stats := customGuideStatsFor(namespace)
+
+	effectiveForced := false
+	if forced {
+		last, seen := customGuideLastForced[namespace]
+		if !seen || timeNow().Sub(last) >= customGuideForcedRefreshInterval {
+			effectiveForced = true
+			customGuideLastForced[namespace] = timeNow()
+		}
+	}
+
+	if entry != nil && !effectiveForced && timeNow().Sub(entry.index.asOf) < customGuideCacheTTL {
+		stats.hits++
+		idx := entry.index
+		customGuideCacheMu.Unlock()
+		return idx, nil
+	}
+	stats.misses++
+
+	// Negative-cache cooldown: after a recent namespace-global refresh failure,
+	// don't re-probe a struggling upstream on every TTL-expired request. Serve
+	// the stale index when warm, or replay the sticky error when cold, until the
+	// cooldown elapses. A rate-limit-permitted ?refresh=1 bypasses this.
+	if !effectiveForced {
+		if fail, ok := customGuideLastFailure[namespace]; ok && timeNow().Sub(fail.at) < customGuideFailureCooldown {
+			if entry != nil {
+				stats.staleServes++
+				idx := entry.index
+				customGuideCacheMu.Unlock()
+				return idx, nil
+			}
+			err := fail.err
+			customGuideCacheMu.Unlock()
+			return nil, err
+		}
+	}
+
+	if fl := customGuideFlights[namespace]; fl != nil {
+		customGuideCacheMu.Unlock()
+		select {
+		case <-fl.done:
+			return fl.index, fl.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	fl := &customGuideRefreshFlight{done: make(chan struct{})}
+	customGuideFlights[namespace] = fl
+	customGuideCacheMu.Unlock()
+
+	// Detach from the caller's cancellation so a canceled request (panel closed
+	// mid-flight) doesn't abort a refresh other waiters depend on, bounded by
+	// the aggregate deadline so detached never means unkillable.
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), customGuideAggregateDeadline)
+	idx, pages, err := buildCustomGuideIndex(fetchCtx, namespace, lister, logger)
+	cancel()
+
+	customGuideCacheMu.Lock()
+	stats = customGuideStatsFor(namespace)
+	if err == nil {
+		stats.refreshes++
+		if _, hadFailure := customGuideLastFailure[namespace]; hadFailure {
+			logger.Info("custom guide catalogue recovered", "namespace", namespace)
+		}
+		customGuideCacheEntries[namespace] = &customGuideCacheEntry{index: idx}
+		delete(customGuideLastFailure, namespace)
+		fl.index = idx
+		logger.Debug("custom guide catalogue refreshed",
+			"namespace", namespace, "pages", pages, "guides", len(idx.entries),
+			"hits", stats.hits, "misses", stats.misses,
+			"staleServes", stats.staleServes, "refreshFailures", stats.refreshFailures)
+	} else {
+		stats.refreshFailures++
+		identityScoped := isIdentityScopedUpstreamError(err)
+		if !identityScoped {
+			customGuideLastFailure[namespace] = customGuideFailure{at: timeNow(), err: err}
+		}
+		// Refresh attempts are throttled by TTL + cooldown, so this logs state
+		// transitions, not every request.
+		logger.Info("custom guide catalogue refresh failed",
+			"namespace", namespace, "error", err,
+			"identityScoped", identityScoped, "servingStale", entry != nil,
+			"refreshFailures", stats.refreshFailures)
+		if entry != nil {
+			// Warm cache + upstream failure: serve stale. asOf reflects true age.
+			stats.staleServes++
+			fl.index = entry.index
+			fl.err = err
+		} else {
+			fl.err = err
+		}
+	}
+	delete(customGuideFlights, namespace)
+	customGuideCacheMu.Unlock()
+	close(fl.done)
+
+	return fl.index, fl.err
+}
+
+// buildCustomGuideIndex drains the namespace LIST across pages — up to the
+// aggregate entry budget — and shapes the guides into the catalogue index.
+func buildCustomGuideIndex(ctx context.Context, namespace string, lister customGuideLister, logger log.Logger) (*customGuideIndex, int, error) {
+	var entries []customGuideRepositoryEntry
+	continueToken := ""
+	pages := 0
+	for {
+		page, err := lister.ListPage(ctx, namespace, continueToken)
+		if err != nil {
+			return nil, pages, err
+		}
+		pages++
+		entries = append(entries, page.Entries...)
+		if len(entries) >= customGuideListMaxTotalEntries && page.Continue != "" {
+			logger.Warn("custom guide catalogue LIST truncated at aggregate budget",
+				"namespace", namespace, "maxTotalEntries", customGuideListMaxTotalEntries, "pages", pages)
+			break
+		}
+		if page.Continue == "" {
+			break
+		}
+		continueToken = page.Continue
+	}
+
+	if entries == nil {
+		entries = []customGuideRepositoryEntry{}
+	}
+	return &customGuideIndex{entries: entries, asOf: timeNow()}, pages, nil
+}
+
+// handleCustomGuideRepository serves GET /custom-guide-repository.
+func (a *App) handleCustomGuideRepository(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Identity gate first — cache hit or miss, warm bytes are never served to an
+	// unauthenticated caller. This is a namespace-global catalogue, so we only
+	// STRUCTURALLY validate the ID token (validIDToken); there is no per-user
+	// need, so we deliberately do not extract `sub`. Missing/invalid identity on
+	// a GET read is a soft-200 capability envelope (not 401): these routes gate
+	// whether a feature renders at all, and a bare error status conflates "never
+	// works here" with a transient blip (BACKEND_PROXY_PATTERN.md §3, §7).
+	if !validIDToken(r) {
+		a.writeJSON(w, customGuideRepositoryResponse{
+			Capability: customGuideCapability{Available: false, Reason: reasonIdentityUnavailable},
+			Guides:     []customGuideRepositoryEntry{},
+		}, http.StatusOK)
+		return
+	}
+
+	lister, namespace, available, reason := a.resolveCustomGuideBackend(r)
+	if !available {
+		a.writeJSON(w, customGuideRepositoryResponse{
+			Capability: customGuideCapability{Available: false, Reason: reason},
+			Guides:     []customGuideRepositoryEntry{},
+		}, http.StatusOK)
+		return
+	}
+
+	forced := r.URL.Query().Get("refresh") == "1"
+	idx, err := getCustomGuideIndex(r.Context(), namespace, lister, forced, a.ctxLogger(r.Context()))
+	if idx == nil {
+		// Cold failure: no cache to fall back on.
+		if isTerminalUpstreamError(err) {
+			// Structurally can't serve for this caller ("never works here").
+			a.writeJSON(w, customGuideRepositoryResponse{
+				Capability: customGuideCapability{Available: false, Reason: reasonBackendUnavailable},
+				Guides:     []customGuideRepositoryEntry{},
+			}, http.StatusOK)
+			return
+		}
+		a.ctxLogger(r.Context()).Debug("custom guide catalogue unavailable (cold)", "error", err)
+		w.Header().Set("Retry-After", strconv.Itoa(customGuideRetryAfterSeconds))
+		a.writeError(w, "custom-guide-repository-unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	a.writeJSON(w, customGuideRepositoryResponse{
+		Capability: customGuideCapability{Available: true},
+		Guides:     idx.entries,
+		AsOf:       idx.asOf.UTC().Format(time.RFC3339),
+	}, http.StatusOK)
+}
+
+// resolveCustomGuideBackend determines whether the aggregated CRUD API is
+// structurally reachable for this request and returns a lister to use.
+// "Structurally unavailable" (feature toggle off, no app URL, no namespace) is
+// a "never works here" condition surfaced as capability=false, distinct from a
+// transient LIST failure. The namespace comes from the trusted plugin context,
+// never from a query parameter. Config resolution runs before the test-only
+// lister override so the structural-unavailability branch stays testable.
+func (a *App) resolveCustomGuideBackend(r *http.Request) (lister customGuideLister, namespace string, available bool, reason string) {
+	namespace = backend.PluginConfigFromContext(r.Context()).Namespace
+
+	cfg := config.GrafanaConfigFromContext(r.Context())
+	if cfg == nil {
+		return nil, namespace, false, reasonBackendUnavailable
+	}
+	if !cfg.FeatureToggles().IsEnabled(pathfinderBackendAggregationToggle) {
+		return nil, namespace, false, reasonBackendUnavailable
+	}
+	appURL, err := cfg.AppURL()
+	if err != nil || appURL == "" || namespace == "" {
+		return nil, namespace, false, reasonBackendUnavailable
+	}
+
+	if customGuideListerOverride != nil {
+		return customGuideListerOverride, namespace, true, ""
+	}
+
+	idToken := r.Header.Get(backend.GrafanaUserSignInTokenHeaderName)
+	return newCustomGuideHTTPClient(appURL, idToken, a.ctxLogger(r.Context())), namespace, true, ""
+}

--- a/pkg/plugin/custom_guide_repository_client.go
+++ b/pkg/plugin/custom_guide_repository_client.go
@@ -1,0 +1,117 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+// customGuideGroupVersion is the App Platform API group/version that serves the
+// InteractiveGuide kind; the plural resource is "interactiveguides". Tracks
+// grafana-pathfinder-backend kinds/interactiveguide.cue (groupOverride
+// pathfinderbackend.ext.grafana.com).
+const (
+	customGuideGroupVersion = "pathfinderbackend.ext.grafana.com/v1alpha1"
+	customGuideResource     = "interactiveguides"
+
+	// customGuideListPageSize bounds each upstream LIST page. The proxy drains
+	// all pages, so this only trades round-trips against per-response size.
+	customGuideListPageSize = 500
+
+	// customGuideListMaxBytes bounds an individual page body so a pathological
+	// namespace can't exhaust plugin memory. The aggregate budget across pages
+	// is customGuideListMaxTotalEntries (custom_guide_repository.go). Each page
+	// carries full InteractiveGuide specs (blocks included) off the wire — they
+	// are stripped in-process during shaping — so the per-page cap is generous.
+	customGuideListMaxBytes = 8 * 1024 * 1024
+)
+
+// customGuideManifest mirrors #Manifest in pathfinder-backend's
+// kinds/interactiveguide.cue. Decoded loosely (a plain struct, not the
+// generated client type) since this repo doesn't vendor pathfinder-backend's
+// generated Go types.
+type customGuideManifest struct {
+	Type        string   `json:"type"`
+	Repository  string   `json:"repository,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Milestones  []string `json:"milestones,omitempty"`
+	Category    string   `json:"category,omitempty"`
+	Author      *struct {
+		Name string `json:"name,omitempty"`
+		Team string `json:"team,omitempty"`
+	} `json:"author,omitempty"`
+	Depends []json.RawMessage `json:"depends,omitempty"`
+}
+
+// customGuideRepositoryEntry is the slim, block-stripped view of an
+// InteractiveGuide — the App Platform analogue of a repository.json entry (see
+// PackageEntry in package_recommendations.go). This is the shaped/collated
+// unit the cache stores; the heavy spec.blocks never survives shaping, so
+// steady-state memory is bounded by guide count, not guide size.
+type customGuideRepositoryEntry struct {
+	ID       string               `json:"id"`
+	Title    string               `json:"title,omitempty"`
+	Status   string               `json:"status,omitempty"`
+	Manifest *customGuideManifest `json:"manifest,omitempty"`
+}
+
+// customGuidePage is one page of a namespace LIST: the shaped entries plus the
+// Kubernetes continue token (empty when the listing is drained).
+type customGuidePage struct {
+	Entries  []customGuideRepositoryEntry
+	Continue string
+}
+
+// customGuideLister abstracts a single upstream LIST page so the cache can
+// drain pagination while tests inject a fake without an HTTP server. The
+// production implementation is customGuideHTTPClient.
+type customGuideLister interface {
+	ListPage(ctx context.Context, namespace, continueToken string) (*customGuidePage, error)
+}
+
+// customGuideHTTPClient is the per-kind wrapper over the shared App Platform
+// LIST client: it supplies the interactiveguides coordinates and shapes each
+// `items[].spec` into a slim, block-stripped customGuideRepositoryEntry.
+type customGuideHTTPClient struct {
+	inner *appPlatformListClient
+}
+
+// newCustomGuideHTTPClient builds a lister that calls appURL with identity
+// derived from the caller's ID token (forwardIdentityHeaders). A
+// namespace-scoped LIST returns every InteractiveGuide in the namespace
+// (Kubernetes RBAC is namespace-, not object-, scoped), which is what lets one
+// refresh serve every caller (see the identity-invariance note in
+// custom_guide_repository.go). A caller lacking list permission gets a 401/403,
+// surfaced as an identity-scoped terminal error.
+func newCustomGuideHTTPClient(appURL, idToken string, logger log.Logger) *customGuideHTTPClient {
+	return &customGuideHTTPClient{inner: newAppPlatformListClient(appURL, idToken, logger)}
+}
+
+// ListPage fetches one page of InteractiveGuides for the namespace and shapes
+// each spec into a slim entry, dropping spec.blocks.
+func (c *customGuideHTTPClient) ListPage(ctx context.Context, namespace, continueToken string) (*customGuidePage, error) {
+	page, err := c.inner.listPage(ctx, customGuideGroupVersion, namespace,
+		customGuideResource, continueToken, customGuideListPageSize, customGuideListMaxBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decode each spec directly into the slim entry: spec.blocks has no field
+	// here, so encoding/json drops it — that omission IS the block-stripping.
+	entries := make([]customGuideRepositoryEntry, 0, len(page.Specs))
+	for _, raw := range page.Specs {
+		var entry customGuideRepositoryEntry
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return nil, fmt.Errorf("custom guide repository: decode spec: %w", err)
+		}
+		if entry.ID == "" {
+			// id is required by the CRD schema; skip anything malformed rather
+			// than surface an entry with no stable identifier.
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return &customGuidePage{Entries: entries, Continue: page.Continue}, nil
+}

--- a/pkg/plugin/custom_guide_repository_test.go
+++ b/pkg/plugin/custom_guide_repository_test.go
@@ -1,0 +1,570 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	sdkconfig "github.com/grafana/grafana-plugin-sdk-go/config"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/featuretoggles"
+)
+
+// Shared test helpers reused from the package: withFrozenTime
+// (package_recommendations_test.go), makeIDToken (app_platform_identity_test.go),
+// testNamespace + testGrafanaConfig (completion_records_test.go), newTestApp
+// (helpers_test.go).
+
+// fakeGuideLister is an injectable customGuideLister. respond maps an incoming
+// continue token to a page or error; calls counts invocations.
+type fakeGuideLister struct {
+	respond func(token string) (*customGuidePage, error)
+	calls   int32
+}
+
+func (f *fakeGuideLister) ListPage(_ context.Context, _ string, token string) (*customGuidePage, error) {
+	atomic.AddInt32(&f.calls, 1)
+	return f.respond(token)
+}
+
+func (f *fakeGuideLister) callCount() int { return int(atomic.LoadInt32(&f.calls)) }
+
+func guideEntry(id, title, status, manifestType string) customGuideRepositoryEntry {
+	e := customGuideRepositoryEntry{ID: id, Title: title, Status: status}
+	if manifestType != "" {
+		e.Manifest = &customGuideManifest{Type: manifestType, Repository: "app-platform"}
+	}
+	return e
+}
+
+// singlePageGuideLister serves all entries in one page.
+func singlePageGuideLister(entries ...customGuideRepositoryEntry) *fakeGuideLister {
+	return &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
+		return &customGuidePage{Entries: entries, Continue: ""}, nil
+	}}
+}
+
+func withGuideLister(t *testing.T, l customGuideLister) {
+	t.Helper()
+	resetCustomGuideRepositoryCache()
+	prev := customGuideListerOverride
+	customGuideListerOverride = l
+	t.Cleanup(func() {
+		customGuideListerOverride = prev
+		resetCustomGuideRepositoryCache()
+	})
+}
+
+// customGuideRequestWithConfig builds a GET request carrying an ID-token
+// identity (valid future exp), a namespace in the plugin context, and the given
+// Grafana config. `sub` may be empty: the catalogue only structurally validates
+// the token, so a subjectless-but-valid token is still authorized.
+func customGuideRequestWithConfig(t *testing.T, target, sub string, cfg map[string]string) *http.Request {
+	t.Helper()
+	r, _ := http.NewRequest(http.MethodGet, target, nil)
+	r.Header.Set(backend.GrafanaUserSignInTokenHeaderName, makeIDToken(t, sub, timeNow().Add(time.Hour).Unix()))
+	ctx := backend.WithPluginContext(r.Context(), backend.PluginContext{Namespace: testNamespace})
+	ctx = sdkconfig.WithGrafanaConfig(ctx, sdkconfig.NewGrafanaCfg(cfg))
+	return r.WithContext(ctx)
+}
+
+func customGuideRequest(t *testing.T, target, sub string) *http.Request {
+	t.Helper()
+	return customGuideRequestWithConfig(t, target, sub, testGrafanaConfig())
+}
+
+func doCustomGuideReq(t *testing.T, r *http.Request) (*httptest.ResponseRecorder, customGuideRepositoryResponse) {
+	t.Helper()
+	app := newTestApp(t)
+	rec := httptest.NewRecorder()
+	app.handleCustomGuideRepository(rec, r)
+	var body customGuideRepositoryResponse
+	if rec.Body.Len() > 0 {
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode body: %v (raw: %s)", err, rec.Body.String())
+		}
+	}
+	return rec, body
+}
+
+func doCustomGuide(t *testing.T, target, sub string) (*httptest.ResponseRecorder, customGuideRepositoryResponse) {
+	t.Helper()
+	return doCustomGuideReq(t, customGuideRequest(t, target, sub))
+}
+
+// --- Happy path / shaping ----------------------------------------------------
+
+func TestCustomGuide_ServesShapedCatalogue(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	withGuideLister(t, singlePageGuideLister(
+		guideEntry("fe-alerting-path", "Alerting enablement", "published", "path"),
+		guideEntry("fe-alerting-01", "Alerting module 1", "published", "guide"),
+	))
+
+	rr, body := doCustomGuide(t, "/custom-guide-repository", "user:1")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if !body.Capability.Available {
+		t.Fatalf("expected capability available, got %+v", body.Capability)
+	}
+	if len(body.Guides) != 2 {
+		t.Fatalf("expected 2 guides, got %d", len(body.Guides))
+	}
+	if body.Guides[0].ID != "fe-alerting-path" || body.Guides[0].Manifest == nil || body.Guides[0].Manifest.Type != "path" {
+		t.Errorf("first guide not shaped as expected: %+v", body.Guides[0])
+	}
+	if body.AsOf == "" {
+		t.Error("expected asOf to be set on a successful serve")
+	}
+}
+
+// A structurally valid token with no `sub` claim is still authorized: the
+// catalogue is namespace-global and must not depend on subject extraction.
+func TestCustomGuide_SubjectlessTokenStillServes(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	withGuideLister(t, singlePageGuideLister(guideEntry("fe-01", "One", "published", "guide")))
+
+	rr, body := doCustomGuide(t, "/custom-guide-repository", "")
+
+	if rr.Code != http.StatusOK || !body.Capability.Available {
+		t.Fatalf("subjectless-but-valid token should serve; status=%d cap=%+v", rr.Code, body.Capability)
+	}
+	if len(body.Guides) != 1 {
+		t.Fatalf("expected 1 guide, got %d", len(body.Guides))
+	}
+}
+
+// Two different callers share one upstream LIST — the shared-blob model: the
+// catalogue is identity-invariant, so a warm entry serves every authorized
+// caller in the namespace.
+func TestCustomGuide_SharedBlobServesAllCallers(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	l := singlePageGuideLister(guideEntry("fe-01", "One", "published", "guide"))
+	withGuideLister(t, l)
+
+	_, b1 := doCustomGuide(t, "/custom-guide-repository", "user:1")
+	_, b2 := doCustomGuide(t, "/custom-guide-repository", "user:2")
+
+	if len(b1.Guides) != 1 || len(b2.Guides) != 1 {
+		t.Fatalf("both callers should see the catalogue; got %d and %d", len(b1.Guides), len(b2.Guides))
+	}
+	if l.callCount() != 1 {
+		t.Errorf("expected one shared upstream LIST for two callers, got %d", l.callCount())
+	}
+}
+
+func TestCustomGuide_EmptyNamespaceIsAvailableNotUnavailable(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	withGuideLister(t, singlePageGuideLister())
+
+	_, body := doCustomGuide(t, "/custom-guide-repository", "user:1")
+
+	if !body.Capability.Available {
+		t.Fatalf("empty result must still be available=true, got %+v", body.Capability)
+	}
+	if body.Guides == nil {
+		t.Error("guides must serialize as [] not null")
+	}
+	if len(body.Guides) != 0 {
+		t.Errorf("expected 0 guides, got %d", len(body.Guides))
+	}
+}
+
+// --- Pagination --------------------------------------------------------------
+
+func TestCustomGuide_PaginationDrainsAllPages(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	l := &fakeGuideLister{respond: func(token string) (*customGuidePage, error) {
+		switch token {
+		case "":
+			return &customGuidePage{Entries: []customGuideRepositoryEntry{guideEntry("a", "A", "published", "guide")}, Continue: "tok-2"}, nil
+		case "tok-2":
+			return &customGuidePage{Entries: []customGuideRepositoryEntry{guideEntry("b", "B", "published", "guide")}, Continue: "tok-3"}, nil
+		default:
+			return &customGuidePage{Entries: []customGuideRepositoryEntry{guideEntry("c", "C", "published", "guide")}, Continue: ""}, nil
+		}
+	}}
+	withGuideLister(t, l)
+
+	_, body := doCustomGuide(t, "/custom-guide-repository", "user:1")
+
+	if len(body.Guides) != 3 {
+		t.Fatalf("expected 3 guides drained across pages, got %d", len(body.Guides))
+	}
+	if l.callCount() != 3 {
+		t.Errorf("expected 3 page fetches, got %d", l.callCount())
+	}
+}
+
+func TestCustomGuide_AggregateBudgetStopsDrain(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	prev := customGuideListMaxTotalEntries
+	customGuideListMaxTotalEntries = 2
+	t.Cleanup(func() { customGuideListMaxTotalEntries = prev })
+
+	page := 0
+	l := &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
+		page++
+		return &customGuidePage{
+			Entries:  []customGuideRepositoryEntry{guideEntry(fmt.Sprintf("g-%d", page), "G", "published", "guide")},
+			Continue: fmt.Sprintf("tok-%d", page+1), // never drains naturally
+		}, nil
+	}}
+	withGuideLister(t, l)
+
+	_, body := doCustomGuide(t, "/custom-guide-repository", "user:1")
+
+	if len(body.Guides) < 2 {
+		t.Fatalf("expected the budget to stop the drain with >=2 entries, got %d", len(body.Guides))
+	}
+	if l.callCount() > 5 {
+		t.Errorf("budget did not stop the drain: %d page fetches", l.callCount())
+	}
+}
+
+// --- Cache -------------------------------------------------------------------
+
+func TestCustomGuide_WithinTTLServesFromCache(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	l := singlePageGuideLister(guideEntry("a", "A", "published", "guide"))
+	withGuideLister(t, l)
+
+	doCustomGuide(t, "/custom-guide-repository", "user:1")
+	doCustomGuide(t, "/custom-guide-repository", "user:1")
+
+	if l.callCount() != 1 {
+		t.Errorf("expected 1 upstream LIST within TTL, got %d", l.callCount())
+	}
+}
+
+func TestCustomGuide_TTLExpiryTriggersRefresh(t *testing.T) {
+	advance := withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	l := singlePageGuideLister(guideEntry("a", "A", "published", "guide"))
+	withGuideLister(t, l)
+
+	doCustomGuide(t, "/custom-guide-repository", "user:1")
+	advance(customGuideCacheTTL + time.Second)
+	doCustomGuide(t, "/custom-guide-repository", "user:1")
+
+	if l.callCount() != 2 {
+		t.Errorf("expected a refresh after TTL expiry, got %d LISTs", l.callCount())
+	}
+}
+
+func TestCustomGuide_Singleflight(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	release := make(chan struct{})
+	var calls int32
+	l := &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
+		atomic.AddInt32(&calls, 1)
+		<-release
+		return &customGuidePage{Entries: []customGuideRepositoryEntry{guideEntry("a", "A", "published", "guide")}, Continue: ""}, nil
+	}}
+	withGuideLister(t, l)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			doCustomGuide(t, "/custom-guide-repository", "user:1")
+		}()
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("expected concurrent callers to single-flight one LIST, got %d", got)
+	}
+}
+
+func TestCustomGuide_ForcedRefreshBypassAndRateLimit(t *testing.T) {
+	advance := withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	l := singlePageGuideLister(guideEntry("a", "A", "published", "guide"))
+	withGuideLister(t, l)
+
+	doCustomGuide(t, "/custom-guide-repository", "user:1")           // 1: cold
+	doCustomGuide(t, "/custom-guide-repository?refresh=1", "user:1") // 2: forced bypass
+	if l.callCount() != 2 {
+		t.Fatalf("refresh=1 should bypass the fresh cache; got %d LISTs", l.callCount())
+	}
+	// Second forced refresh within the rate-limit window is suppressed (cache hit).
+	doCustomGuide(t, "/custom-guide-repository?refresh=1", "user:1")
+	if l.callCount() != 2 {
+		t.Errorf("forced refresh should be rate-limited within the window; got %d LISTs", l.callCount())
+	}
+	// After the window, a forced refresh is permitted again.
+	advance(customGuideForcedRefreshInterval + time.Second)
+	doCustomGuide(t, "/custom-guide-repository?refresh=1", "user:1")
+	if l.callCount() != 3 {
+		t.Errorf("forced refresh after the window should LIST again; got %d", l.callCount())
+	}
+}
+
+// --- Failure matrix ----------------------------------------------------------
+
+func TestCustomGuide_ColdTransientReturns503WithRetryAfter(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	withGuideLister(t, &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
+		return nil, &appPlatformUpstreamError{status: http.StatusServiceUnavailable, msg: "upstream 503"}
+	}})
+
+	rr, _ := doCustomGuide(t, "/custom-guide-repository", "user:1")
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("cold transient failure = %d, want 503", rr.Code)
+	}
+	if rr.Header().Get("Retry-After") == "" {
+		t.Error("expected Retry-After header on cold 503")
+	}
+}
+
+func TestCustomGuide_ColdTerminalReturnsCapabilityFalse(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	withGuideLister(t, &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
+		return nil, &appPlatformUpstreamError{status: http.StatusForbidden, msg: "upstream 403"}
+	}})
+
+	rr, body := doCustomGuide(t, "/custom-guide-repository", "user:1")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("cold terminal failure should be soft-200, got %d", rr.Code)
+	}
+	if body.Capability.Available || body.Capability.Reason != reasonBackendUnavailable {
+		t.Errorf("expected capability false/backend-unavailable, got %+v", body.Capability)
+	}
+}
+
+func TestCustomGuide_WarmCacheServesStaleOnUpstreamFailure(t *testing.T) {
+	advance := withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	fail := false
+	l := &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
+		if fail {
+			return nil, &appPlatformUpstreamError{status: http.StatusServiceUnavailable, msg: "hiccup"}
+		}
+		return &customGuidePage{Entries: []customGuideRepositoryEntry{guideEntry("a", "A", "published", "guide")}, Continue: ""}, nil
+	}}
+	withGuideLister(t, l)
+
+	_, warm := doCustomGuide(t, "/custom-guide-repository", "user:1")
+	warmAsOf := warm.AsOf
+
+	fail = true
+	advance(customGuideCacheTTL + time.Second)
+	rr, stale := doCustomGuide(t, "/custom-guide-repository", "user:1")
+
+	if rr.Code != http.StatusOK || len(stale.Guides) != 1 {
+		t.Fatalf("warm failure should serve stale 200 with data; got %d / %d guides", rr.Code, len(stale.Guides))
+	}
+	if stale.AsOf != warmAsOf {
+		t.Errorf("stale serve asOf should reflect the original (stale) fill time: got %q want %q", stale.AsOf, warmAsOf)
+	}
+}
+
+func TestCustomGuide_ColdOutageThrottledByCooldown(t *testing.T) {
+	advance := withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	l := &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
+		return nil, &appPlatformUpstreamError{status: http.StatusServiceUnavailable, msg: "down"}
+	}}
+	withGuideLister(t, l)
+
+	rr, _ := doCustomGuide(t, "/custom-guide-repository", "user:1")
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("first cold failure = %d, want 503", rr.Code)
+	}
+	// Sequential requests INSIDE the cooldown window must not re-probe, yet
+	// still return the sticky 503 so the client keeps its Retry-After semantics.
+	for i := 0; i < 3; i++ {
+		advance(time.Second)
+		rr, _ := doCustomGuide(t, "/custom-guide-repository", "user:1")
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("throttled status = %d, want 503", rr.Code)
+		}
+	}
+	if l.callCount() != 1 {
+		t.Errorf("cooldown should suppress re-probes; got %d LISTs", l.callCount())
+	}
+	// After the cooldown, a re-probe is allowed.
+	advance(customGuideFailureCooldown + time.Second)
+	doCustomGuide(t, "/custom-guide-repository", "user:1")
+	if l.callCount() != 2 {
+		t.Errorf("expected a re-probe after the cooldown; got %d", l.callCount())
+	}
+}
+
+// An identity-scoped (401/403) failure must NOT enter the shared negative
+// cache: the next request still attempts upstream rather than replaying a
+// sticky error that belongs to one caller's token.
+func TestCustomGuide_IdentityScopedFailureNotCachedShared(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	var calls int32
+	l := &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			return nil, &appPlatformUpstreamError{status: http.StatusForbidden, msg: "403 for this caller"}
+		}
+		return &customGuidePage{Entries: []customGuideRepositoryEntry{guideEntry("a", "A", "published", "guide")}, Continue: ""}, nil
+	}}
+	withGuideLister(t, l)
+
+	doCustomGuide(t, "/custom-guide-repository", "user:1") // 403, must not be cached
+	_, body := doCustomGuide(t, "/custom-guide-repository", "user:2")
+
+	if !body.Capability.Available || len(body.Guides) != 1 {
+		t.Fatalf("second caller should get a fresh attempt, not a cached 403; cap=%+v guides=%d", body.Capability, len(body.Guides))
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Errorf("expected the second request to re-attempt upstream, got %d LISTs", calls)
+	}
+}
+
+// --- Identity + config gates -------------------------------------------------
+
+func TestCustomGuide_MissingIdentityEnvelope(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	withGuideLister(t, singlePageGuideLister())
+
+	r, _ := http.NewRequest(http.MethodGet, "/custom-guide-repository", nil) // no ID token
+	ctx := backend.WithPluginContext(r.Context(), backend.PluginContext{Namespace: testNamespace})
+	ctx = sdkconfig.WithGrafanaConfig(ctx, sdkconfig.NewGrafanaCfg(testGrafanaConfig()))
+	rr, body := doCustomGuideReq(t, r.WithContext(ctx))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("missing identity on a GET read should be soft-200, got %d", rr.Code)
+	}
+	if body.Capability.Available || body.Capability.Reason != reasonIdentityUnavailable {
+		t.Errorf("expected capability false/identity-unavailable, got %+v", body.Capability)
+	}
+}
+
+func TestCustomGuide_ExpiredOrExplessTokenRejected(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	withGuideLister(t, singlePageGuideLister(guideEntry("a", "A", "published", "guide")))
+	app := newTestApp(t)
+
+	cases := map[string]string{
+		"no exp claim":  makeIDToken(t, "user:1", 0),
+		"expired token": makeIDToken(t, "user:1", timeNow().Add(-time.Hour).Unix()),
+	}
+	for name, token := range cases {
+		t.Run(name, func(t *testing.T) {
+			r, _ := http.NewRequest(http.MethodGet, "/custom-guide-repository", nil)
+			r.Header.Set(backend.GrafanaUserSignInTokenHeaderName, token)
+			ctx := backend.WithPluginContext(r.Context(), backend.PluginContext{Namespace: testNamespace})
+			ctx = sdkconfig.WithGrafanaConfig(ctx, sdkconfig.NewGrafanaCfg(testGrafanaConfig()))
+			rec := httptest.NewRecorder()
+			app.handleCustomGuideRepository(rec, r.WithContext(ctx))
+			var body customGuideRepositoryResponse
+			_ = json.Unmarshal(rec.Body.Bytes(), &body)
+			if body.Capability.Available || body.Capability.Reason != reasonIdentityUnavailable {
+				t.Errorf("%s: expected identity-unavailable, got %+v", name, body.Capability)
+			}
+		})
+	}
+}
+
+func TestCustomGuide_ToggleOffStructurallyUnavailable(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	l := singlePageGuideLister()
+	withGuideLister(t, l)
+
+	cfg := map[string]string{sdkconfig.AppURL: "http://grafana.example"} // toggle absent
+	rr, body := doCustomGuideReq(t, customGuideRequestWithConfig(t, "/custom-guide-repository", "user:1", cfg))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("toggle-off should be soft-200, got %d", rr.Code)
+	}
+	if body.Capability.Available || body.Capability.Reason != reasonBackendUnavailable {
+		t.Errorf("expected backend-unavailable, got %+v", body.Capability)
+	}
+	if l.callCount() != 0 {
+		t.Errorf("structurally unavailable must not hit upstream; got %d LISTs", l.callCount())
+	}
+}
+
+func TestCustomGuide_NoAppURLStructurallyUnavailable(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	l := singlePageGuideLister()
+	withGuideLister(t, l)
+
+	cfg := map[string]string{featuretoggles.EnabledFeatures: pathfinderBackendAggregationToggle} // no app URL
+	_, body := doCustomGuideReq(t, customGuideRequestWithConfig(t, "/custom-guide-repository", "user:1", cfg))
+
+	if body.Capability.Available || body.Capability.Reason != reasonBackendUnavailable {
+		t.Errorf("expected backend-unavailable with no app URL, got %+v", body.Capability)
+	}
+	if l.callCount() != 0 {
+		t.Errorf("structurally unavailable must not hit upstream; got %d LISTs", l.callCount())
+	}
+}
+
+func TestCustomGuide_MethodNotAllowed(t *testing.T) {
+	app := newTestApp(t)
+	r, _ := http.NewRequest(http.MethodPost, "/custom-guide-repository", nil)
+	rec := httptest.NewRecorder()
+	app.handleCustomGuideRepository(rec, r)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST should be 405, got %d", rec.Code)
+	}
+}
+
+// --- HTTP-level shaping (block-stripping through the real client) ------------
+
+// Proves the headline behavior end-to-end through customGuideHTTPClient: full
+// InteractiveGuide specs on the wire (blocks included) are shaped to slim
+// entries with blocks dropped and the manifest (incl. depends) preserved.
+func TestCustomGuideHTTPClient_StripsBlocksPreservesManifest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"metadata": map[string]any{"continue": ""},
+			"items": []map[string]any{
+				{"spec": map[string]any{
+					"id":     "fe-alerting-path",
+					"title":  "Alerting enablement",
+					"status": "published",
+					"blocks": []map[string]any{{"type": "markdown", "content": "a very large cover body"}},
+					"manifest": map[string]any{
+						"type":       "path",
+						"repository": "app-platform",
+						"milestones": []string{"fe-alerting-01", "fe-alerting-02"},
+						"depends":    []any{[]string{"fe-intro"}},
+					},
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := newCustomGuideHTTPClient(srv.URL, "id-token-abc", log.DefaultLogger)
+	page, err := c.ListPage(context.Background(), testNamespace, "")
+	if err != nil {
+		t.Fatalf("ListPage: %v", err)
+	}
+	if len(page.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(page.Entries))
+	}
+	e := page.Entries[0]
+	if e.ID != "fe-alerting-path" || e.Title != "Alerting enablement" || e.Status != "published" {
+		t.Errorf("entry core fields not shaped: %+v", e)
+	}
+	if e.Manifest == nil || e.Manifest.Type != "path" || len(e.Manifest.Milestones) != 2 || len(e.Manifest.Depends) != 1 {
+		t.Errorf("manifest not preserved through shaping: %+v", e.Manifest)
+	}
+
+	// The block content must not appear anywhere in the shaped, re-serialized entry.
+	raw, _ := json.Marshal(e)
+	if strings.Contains(string(raw), "a very large cover body") {
+		t.Errorf("blocks leaked into the shaped entry: %s", raw)
+	}
+}

--- a/pkg/plugin/custom_guide_repository_test.go
+++ b/pkg/plugin/custom_guide_repository_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,6 +21,10 @@ import (
 // (package_recommendations_test.go), makeIDToken (app_platform_identity_test.go),
 // testNamespace + testGrafanaConfig (completion_records_test.go), newTestApp
 // (helpers_test.go).
+//
+// This proxy has no cross-request cache (see the deviation note in
+// custom_guide_repository.go): every request performs its own identity-scoped
+// LIST, so the tests assert per-request behavior, not caching.
 
 // fakeGuideLister is an injectable customGuideLister. respond maps an incoming
 // continue token to a page or error; calls counts invocations.
@@ -54,13 +57,9 @@ func singlePageGuideLister(entries ...customGuideRepositoryEntry) *fakeGuideList
 
 func withGuideLister(t *testing.T, l customGuideLister) {
 	t.Helper()
-	resetCustomGuideRepositoryCache()
 	prev := customGuideListerOverride
 	customGuideListerOverride = l
-	t.Cleanup(func() {
-		customGuideListerOverride = prev
-		resetCustomGuideRepositoryCache()
-	})
+	t.Cleanup(func() { customGuideListerOverride = prev })
 }
 
 // customGuideRequestWithConfig builds a GET request carrying an ID-token
@@ -144,25 +143,6 @@ func TestCustomGuide_SubjectlessTokenStillServes(t *testing.T) {
 	}
 }
 
-// Two different callers share one upstream LIST — the shared-blob model: the
-// catalogue is identity-invariant, so a warm entry serves every authorized
-// caller in the namespace.
-func TestCustomGuide_SharedBlobServesAllCallers(t *testing.T) {
-	withFrozenTime(t, time.Unix(1_700_000_000, 0))
-	l := singlePageGuideLister(guideEntry("fe-01", "One", "published", "guide"))
-	withGuideLister(t, l)
-
-	_, b1 := doCustomGuide(t, "/custom-guide-repository", "user:1")
-	_, b2 := doCustomGuide(t, "/custom-guide-repository", "user:2")
-
-	if len(b1.Guides) != 1 || len(b2.Guides) != 1 {
-		t.Fatalf("both callers should see the catalogue; got %d and %d", len(b1.Guides), len(b2.Guides))
-	}
-	if l.callCount() != 1 {
-		t.Errorf("expected one shared upstream LIST for two callers, got %d", l.callCount())
-	}
-}
-
 func TestCustomGuide_EmptyNamespaceIsAvailableNotUnavailable(t *testing.T) {
 	withFrozenTime(t, time.Unix(1_700_000_000, 0))
 	withGuideLister(t, singlePageGuideLister())
@@ -177,6 +157,51 @@ func TestCustomGuide_EmptyNamespaceIsAvailableNotUnavailable(t *testing.T) {
 	}
 	if len(body.Guides) != 0 {
 		t.Errorf("expected 0 guides, got %d", len(body.Guides))
+	}
+}
+
+// --- No cross-request / cross-caller sharing (the safety property) -----------
+
+// Each request performs its own identity-scoped LIST — there is no shared
+// cache, so two callers produce two upstream LISTs and neither is ever served
+// data fetched under the other's identity.
+func TestCustomGuide_EachRequestListsIndependently(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	l := singlePageGuideLister(guideEntry("fe-01", "One", "published", "guide"))
+	withGuideLister(t, l)
+
+	doCustomGuide(t, "/custom-guide-repository", "user:1")
+	doCustomGuide(t, "/custom-guide-repository", "user:2")
+	doCustomGuide(t, "/custom-guide-repository", "user:1") // even the same caller re-LISTs
+
+	if l.callCount() != 3 {
+		t.Errorf("expected one upstream LIST per request (no cross-request cache), got %d", l.callCount())
+	}
+}
+
+// An identity-scoped (401/403) failure for one caller is a per-request terminal
+// result and cannot affect another caller: there is no shared negative cache to
+// poison, so a later authorized caller is served normally.
+func TestCustomGuide_IdentityScopedFailureIsPerRequest(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	var calls int32
+	l := &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return nil, &appPlatformUpstreamError{status: http.StatusForbidden, msg: "403 for this caller"}
+		}
+		return &customGuidePage{Entries: []customGuideRepositoryEntry{guideEntry("a", "A", "published", "guide")}, Continue: ""}, nil
+	}}
+	withGuideLister(t, l)
+
+	// Caller 1 is denied by the aggregator → soft-200 capability false.
+	rr1, b1 := doCustomGuide(t, "/custom-guide-repository", "user:1")
+	if rr1.Code != http.StatusOK || b1.Capability.Available || b1.Capability.Reason != reasonBackendUnavailable {
+		t.Fatalf("denied caller should get soft-200 backend-unavailable; status=%d cap=%+v", rr1.Code, b1.Capability)
+	}
+	// Caller 2 is authorized and served normally — no poisoning from caller 1.
+	_, b2 := doCustomGuide(t, "/custom-guide-repository", "user:2")
+	if !b2.Capability.Available || len(b2.Guides) != 1 {
+		t.Fatalf("authorized caller should be served; cap=%+v guides=%d", b2.Capability, len(b2.Guides))
 	}
 }
 
@@ -224,97 +249,18 @@ func TestCustomGuide_AggregateBudgetStopsDrain(t *testing.T) {
 
 	_, body := doCustomGuide(t, "/custom-guide-repository", "user:1")
 
-	if len(body.Guides) < 2 {
-		t.Fatalf("expected the budget to stop the drain with >=2 entries, got %d", len(body.Guides))
+	// Strict budget: the result is capped exactly at the limit, never overshot.
+	if len(body.Guides) != 2 {
+		t.Fatalf("expected the budget to cap the drain at exactly 2 entries, got %d", len(body.Guides))
 	}
 	if l.callCount() > 5 {
 		t.Errorf("budget did not stop the drain: %d page fetches", l.callCount())
 	}
 }
 
-// --- Cache -------------------------------------------------------------------
+// --- Failure classification --------------------------------------------------
 
-func TestCustomGuide_WithinTTLServesFromCache(t *testing.T) {
-	withFrozenTime(t, time.Unix(1_700_000_000, 0))
-	l := singlePageGuideLister(guideEntry("a", "A", "published", "guide"))
-	withGuideLister(t, l)
-
-	doCustomGuide(t, "/custom-guide-repository", "user:1")
-	doCustomGuide(t, "/custom-guide-repository", "user:1")
-
-	if l.callCount() != 1 {
-		t.Errorf("expected 1 upstream LIST within TTL, got %d", l.callCount())
-	}
-}
-
-func TestCustomGuide_TTLExpiryTriggersRefresh(t *testing.T) {
-	advance := withFrozenTime(t, time.Unix(1_700_000_000, 0))
-	l := singlePageGuideLister(guideEntry("a", "A", "published", "guide"))
-	withGuideLister(t, l)
-
-	doCustomGuide(t, "/custom-guide-repository", "user:1")
-	advance(customGuideCacheTTL + time.Second)
-	doCustomGuide(t, "/custom-guide-repository", "user:1")
-
-	if l.callCount() != 2 {
-		t.Errorf("expected a refresh after TTL expiry, got %d LISTs", l.callCount())
-	}
-}
-
-func TestCustomGuide_Singleflight(t *testing.T) {
-	withFrozenTime(t, time.Unix(1_700_000_000, 0))
-	release := make(chan struct{})
-	var calls int32
-	l := &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
-		atomic.AddInt32(&calls, 1)
-		<-release
-		return &customGuidePage{Entries: []customGuideRepositoryEntry{guideEntry("a", "A", "published", "guide")}, Continue: ""}, nil
-	}}
-	withGuideLister(t, l)
-
-	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			doCustomGuide(t, "/custom-guide-repository", "user:1")
-		}()
-	}
-	time.Sleep(50 * time.Millisecond)
-	close(release)
-	wg.Wait()
-
-	if got := atomic.LoadInt32(&calls); got != 1 {
-		t.Errorf("expected concurrent callers to single-flight one LIST, got %d", got)
-	}
-}
-
-func TestCustomGuide_ForcedRefreshBypassAndRateLimit(t *testing.T) {
-	advance := withFrozenTime(t, time.Unix(1_700_000_000, 0))
-	l := singlePageGuideLister(guideEntry("a", "A", "published", "guide"))
-	withGuideLister(t, l)
-
-	doCustomGuide(t, "/custom-guide-repository", "user:1")           // 1: cold
-	doCustomGuide(t, "/custom-guide-repository?refresh=1", "user:1") // 2: forced bypass
-	if l.callCount() != 2 {
-		t.Fatalf("refresh=1 should bypass the fresh cache; got %d LISTs", l.callCount())
-	}
-	// Second forced refresh within the rate-limit window is suppressed (cache hit).
-	doCustomGuide(t, "/custom-guide-repository?refresh=1", "user:1")
-	if l.callCount() != 2 {
-		t.Errorf("forced refresh should be rate-limited within the window; got %d LISTs", l.callCount())
-	}
-	// After the window, a forced refresh is permitted again.
-	advance(customGuideForcedRefreshInterval + time.Second)
-	doCustomGuide(t, "/custom-guide-repository?refresh=1", "user:1")
-	if l.callCount() != 3 {
-		t.Errorf("forced refresh after the window should LIST again; got %d", l.callCount())
-	}
-}
-
-// --- Failure matrix ----------------------------------------------------------
-
-func TestCustomGuide_ColdTransientReturns503WithRetryAfter(t *testing.T) {
+func TestCustomGuide_TransientReturns503WithRetryAfter(t *testing.T) {
 	withFrozenTime(t, time.Unix(1_700_000_000, 0))
 	withGuideLister(t, &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
 		return nil, &appPlatformUpstreamError{status: http.StatusServiceUnavailable, msg: "upstream 503"}
@@ -323,109 +269,26 @@ func TestCustomGuide_ColdTransientReturns503WithRetryAfter(t *testing.T) {
 	rr, _ := doCustomGuide(t, "/custom-guide-repository", "user:1")
 
 	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("cold transient failure = %d, want 503", rr.Code)
+		t.Fatalf("transient failure = %d, want 503", rr.Code)
 	}
 	if rr.Header().Get("Retry-After") == "" {
-		t.Error("expected Retry-After header on cold 503")
+		t.Error("expected Retry-After header on a transient 503")
 	}
 }
 
-func TestCustomGuide_ColdTerminalReturnsCapabilityFalse(t *testing.T) {
+func TestCustomGuide_TerminalReturnsCapabilityFalse(t *testing.T) {
 	withFrozenTime(t, time.Unix(1_700_000_000, 0))
 	withGuideLister(t, &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
-		return nil, &appPlatformUpstreamError{status: http.StatusForbidden, msg: "upstream 403"}
+		return nil, &appPlatformUpstreamError{status: http.StatusNotFound, msg: "upstream 404"}
 	}})
 
 	rr, body := doCustomGuide(t, "/custom-guide-repository", "user:1")
 
 	if rr.Code != http.StatusOK {
-		t.Fatalf("cold terminal failure should be soft-200, got %d", rr.Code)
+		t.Fatalf("terminal failure should be soft-200, got %d", rr.Code)
 	}
 	if body.Capability.Available || body.Capability.Reason != reasonBackendUnavailable {
 		t.Errorf("expected capability false/backend-unavailable, got %+v", body.Capability)
-	}
-}
-
-func TestCustomGuide_WarmCacheServesStaleOnUpstreamFailure(t *testing.T) {
-	advance := withFrozenTime(t, time.Unix(1_700_000_000, 0))
-	fail := false
-	l := &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
-		if fail {
-			return nil, &appPlatformUpstreamError{status: http.StatusServiceUnavailable, msg: "hiccup"}
-		}
-		return &customGuidePage{Entries: []customGuideRepositoryEntry{guideEntry("a", "A", "published", "guide")}, Continue: ""}, nil
-	}}
-	withGuideLister(t, l)
-
-	_, warm := doCustomGuide(t, "/custom-guide-repository", "user:1")
-	warmAsOf := warm.AsOf
-
-	fail = true
-	advance(customGuideCacheTTL + time.Second)
-	rr, stale := doCustomGuide(t, "/custom-guide-repository", "user:1")
-
-	if rr.Code != http.StatusOK || len(stale.Guides) != 1 {
-		t.Fatalf("warm failure should serve stale 200 with data; got %d / %d guides", rr.Code, len(stale.Guides))
-	}
-	if stale.AsOf != warmAsOf {
-		t.Errorf("stale serve asOf should reflect the original (stale) fill time: got %q want %q", stale.AsOf, warmAsOf)
-	}
-}
-
-func TestCustomGuide_ColdOutageThrottledByCooldown(t *testing.T) {
-	advance := withFrozenTime(t, time.Unix(1_700_000_000, 0))
-	l := &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
-		return nil, &appPlatformUpstreamError{status: http.StatusServiceUnavailable, msg: "down"}
-	}}
-	withGuideLister(t, l)
-
-	rr, _ := doCustomGuide(t, "/custom-guide-repository", "user:1")
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("first cold failure = %d, want 503", rr.Code)
-	}
-	// Sequential requests INSIDE the cooldown window must not re-probe, yet
-	// still return the sticky 503 so the client keeps its Retry-After semantics.
-	for i := 0; i < 3; i++ {
-		advance(time.Second)
-		rr, _ := doCustomGuide(t, "/custom-guide-repository", "user:1")
-		if rr.Code != http.StatusServiceUnavailable {
-			t.Fatalf("throttled status = %d, want 503", rr.Code)
-		}
-	}
-	if l.callCount() != 1 {
-		t.Errorf("cooldown should suppress re-probes; got %d LISTs", l.callCount())
-	}
-	// After the cooldown, a re-probe is allowed.
-	advance(customGuideFailureCooldown + time.Second)
-	doCustomGuide(t, "/custom-guide-repository", "user:1")
-	if l.callCount() != 2 {
-		t.Errorf("expected a re-probe after the cooldown; got %d", l.callCount())
-	}
-}
-
-// An identity-scoped (401/403) failure must NOT enter the shared negative
-// cache: the next request still attempts upstream rather than replaying a
-// sticky error that belongs to one caller's token.
-func TestCustomGuide_IdentityScopedFailureNotCachedShared(t *testing.T) {
-	withFrozenTime(t, time.Unix(1_700_000_000, 0))
-	var calls int32
-	l := &fakeGuideLister{respond: func(string) (*customGuidePage, error) {
-		n := atomic.AddInt32(&calls, 1)
-		if n == 1 {
-			return nil, &appPlatformUpstreamError{status: http.StatusForbidden, msg: "403 for this caller"}
-		}
-		return &customGuidePage{Entries: []customGuideRepositoryEntry{guideEntry("a", "A", "published", "guide")}, Continue: ""}, nil
-	}}
-	withGuideLister(t, l)
-
-	doCustomGuide(t, "/custom-guide-repository", "user:1") // 403, must not be cached
-	_, body := doCustomGuide(t, "/custom-guide-repository", "user:2")
-
-	if !body.Capability.Available || len(body.Guides) != 1 {
-		t.Fatalf("second caller should get a fresh attempt, not a cached 403; cap=%+v guides=%d", body.Capability, len(body.Guides))
-	}
-	if atomic.LoadInt32(&calls) != 2 {
-		t.Errorf("expected the second request to re-attempt upstream, got %d LISTs", calls)
 	}
 }
 

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -20,6 +20,7 @@ func (a *App) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/package-recommendations", a.handlePackageRecommendations)
 	mux.HandleFunc("/completion-records/my", a.handleMyCompletions)
 	mux.HandleFunc("/completion-records/capability", a.handleCompletionCapability)
+	mux.HandleFunc("/custom-guide-repository", a.handleCustomGuideRepository)
 	mux.HandleFunc("/health", a.handleHealth)
 }
 


### PR DESCRIPTION
## Summary

A GET `/custom-guide-repository` plugin-backend route that serves a slim, block-stripped catalogue of a stack's private `InteractiveGuide` packages for the Custom Guides sidebar and My Learning surfaces. Follows [`docs/design/BACKEND_PROXY_PATTERN.md`](https://github.com/grafana/grafana-pathfinder-app/blob/main/docs/design/BACKEND_PROXY_PATTERN.md) (#1401), **consuming the shared plumbing landed by #1398** rather than re-deriving it.

## Conformance to the pattern

- **§1 Upstream / pagination** — drains `metadata.continue` via the shared `appPlatformListClient`; per-page byte cap + **strict** aggregate entry budget (capped exactly, logged, never silent truncation) + an aggregate deadline bounding the detached drain.
- **§2 Namespace** — from the trusted plugin context (`PluginConfigFromContext().Namespace`). No `?namespace=` query param.
- **§3 Identity** — inbound: structural ID-token validation via the shared `validIDToken`, fail-closed. Namespace-global catalogue, so it deliberately does **not** extract `sub`. Outbound: the shared `forwardIdentityHeaders` (`Authorization: Bearer <id-token>` + `X-Grafana-Id`); never `Cookie`, never a replayed inbound `Authorization`.
- **§6/§7 Envelope** — `{ capability, guides, asOf }`: soft-200 capability object (`identity-unavailable` / `backend-unavailable` via the shared reason tokens), `guides` always `[]` never `null`, `asOf`, stable machine error token, `Retry-After` on transient 503.
- **§8 Shared plumbing** — consumes the shared identity helpers, LIST client, URL builder, toggle constant, and `timeNow` seam. Also promotes the error-level classifiers `isTerminalUpstreamError` / `isIdentityScopedUpstreamError` into the shared `app_platform_client.go` (one definition); `completion_records.go`'s domain-named wrappers delegate to them — no behavior/signature change, so #1398's tests are unaffected.
- **§10 Tests** — per-request behavior (each request LISTs independently; identity-scoped failure is per-request, no poisoning), pagination drain + strict budget, identity fail-closed incl. `exp == 0` / expired, config-resolution branch (toggle off / no app URL), transient→503+Retry-After, terminal→soft-200, plus an HTTP-level block-stripping test.

## Deliberate deviations (documented per the pattern's "divergence should be deliberate")

- **No cross-request cache (deviates from §4/§5).** A namespace-global catalogue is a shared blob, and the pattern's shared-blob cache is only sound if the upstream LIST is identity-invariant — i.e. every caller who can reach the route can also list `interactiveguides`. That invariant is unproven (depends on the stack's RBAC, and would silently break if a future role change let a token-bearing caller reach the plugin without list permission); a warm shared entry — or a shared in-flight LIST — would then serve one user's catalogue to an unauthorized caller for the cache window. Rather than rely on an unverifiable invariant for cross-user data, **every request performs its own identity-scoped LIST**, so per-caller authz is always enforced at the source. The pattern's §3 forbids the alternative safe cache (per-user partitioning needs `sub`, which a namespace-global route must not extract), so "no shared cache" is the conservative in-pattern choice. This is low-traffic catalogue data (~66 guides, read on panel load), so a LIST per request is acceptable; a per-identity-partitioned cache is the safe way to reintroduce caching if load ever warrants. With no warm data, the pattern's stale-serve and negative-cache-cooldown clauses (§5) don't apply. _(This resolves the High-severity shared-cache identity flag from the automated review.)_
- **No separate capability-probe route.** The Custom Guides / My Learning surfaces read the data route and branch on its in-envelope `capability` object; a second route would be speculative. Easy to add later if a consumer needs it.

## Test plan

- [x] `go build ./...`, `go vet ./pkg/...` clean
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./pkg/...` green
- [ ] **Runtime smoke (gates dependent frontend work AND the final outbound header set, per §3/§10):** on a dev stack with `idForwarding` + the aggregation toggle on, create an `InteractiveGuide` upstream, hit `/custom-guide-repository`, confirm a slim shaped catalogue (no `blocks`), and confirm the first-request credential diagnostics log shows the upstream LIST authenticating. Narrow the outbound headers to `X-Grafana-Id` alone only if that smoke proves it suffices.

## Downstream note

The frontend catalogue client (on the unmerged `custom-guide-packages` branch) currently expects `{ namespace, guides }`; it will need updating to the `{ capability, guides, asOf }` envelope when it rebases. No consumer binds this on `main` yet.

Refs #1401, #1398.