### PR TITLE
refactor(block-editor): extract header into focused components (#1256)

### DIFF
--- a/src/components/block-editor/BlockEditor.tsx
+++ b/src/components/block-editor/BlockEditor.tsx
@@ -630,10 +630,11 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
     selection.clearSelection();
   }, [selection, editor]);
 
-  // Load guide from backend. `trackLoadedGuide` is a stable useCallback, so
-  // destructuring it keeps this callback from being recreated every render
-  // (the whole backendSaveFlow return is a fresh object literal per render).
-  const { trackLoadedGuide } = backendSaveFlow;
+  // useBackendSaveFlow returns a fresh object literal every render, so depending
+  // on `backendSaveFlow` directly defeats the memoization below. Destructure the
+  // stable pieces (trackLoadedGuide is a []-stable useCallback; the others are
+  // primitives) and depend on those instead.
+  const { trackLoadedGuide, publishedStatus, hasUnsyncedChanges } = backendSaveFlow;
   const handleLoadGuideFromBackend = useCallback(
     (guide: JsonGuide, resourceName: string) => {
       editor.loadGuide(guide);
@@ -654,8 +655,7 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
     const currentGuide = editor.getGuide();
     const hasBlocksNow = currentGuide.blocks && currentGuide.blocks.length > 0;
     // Has content, and either never saved to backend or diverged from the last backend save
-    const hasChanges =
-      hasBlocksNow && (backendSaveFlow.publishedStatus === 'not-saved' || backendSaveFlow.hasUnsyncedChanges);
+    const hasChanges = hasBlocksNow && (publishedStatus === 'not-saved' || hasUnsyncedChanges);
 
     if (hasChanges) {
       // Show warning modal
@@ -664,7 +664,7 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
       // No changes to lose, just create new guide
       guideOps.handleNewGuide();
     }
-  }, [editor, backendSaveFlow.publishedStatus, backendSaveFlow.hasUnsyncedChanges, modals, guideOps]);
+  }, [editor, publishedStatus, hasUnsyncedChanges, modals, guideOps]);
 
   // Modified form submit to handle section insertions, nested block edits, and conditional branch blocks
   const handleBlockFormSubmitWithSection = useCallback(

--- a/src/components/block-editor/BlockEditor.tsx
+++ b/src/components/block-editor/BlockEditor.tsx
@@ -630,14 +630,17 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
     selection.clearSelection();
   }, [selection, editor]);
 
-  // Load guide from backend
+  // Load guide from backend. `trackLoadedGuide` is a stable useCallback, so
+  // destructuring it keeps this callback from being recreated every render
+  // (the whole backendSaveFlow return is a fresh object literal per render).
+  const { trackLoadedGuide } = backendSaveFlow;
   const handleLoadGuideFromBackend = useCallback(
     (guide: JsonGuide, resourceName: string) => {
       editor.loadGuide(guide);
-      backendSaveFlow.trackLoadedGuide(guide, resourceName);
+      trackLoadedGuide(guide, resourceName);
       editor.markSaved();
     },
-    [editor, backendSaveFlow]
+    [editor, trackLoadedGuide]
   );
 
   // Open guide library
@@ -661,7 +664,7 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
       // No changes to lose, just create new guide
       guideOps.handleNewGuide();
     }
-  }, [editor, backendSaveFlow, modals, guideOps]);
+  }, [editor, backendSaveFlow.publishedStatus, backendSaveFlow.hasUnsyncedChanges, modals, guideOps]);
 
   // Modified form submit to handle section insertions, nested block edits, and conditional branch blocks
   const handleBlockFormSubmitWithSection = useCallback(

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -176,9 +176,9 @@ export function BlockEditorHeader({
 
   return (
     <div className={styles.header}>
-      {/* Single-row toolbar: title (flex 1) + actions on the right.
-          New / Library moved into the kebab menu; selection-mode
-          trigger is a small icon button next to the view-mode toggle. */}
+      {/* Single-row toolbar: title area on the left, right-aligned actions
+          cluster (status, selection toggle, undo/redo, view-mode rocker, save,
+          pop out / full screen, more-actions kebab) on the right. */}
       <div className={styles.row}>
         <HeaderTitleRow guideTitle={guideTitle} guideId={guideId} viewMode={viewMode} onTitleCommit={onTitleCommit} />
 

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -1,21 +1,22 @@
 /**
  * BlockEditorHeader Component
  *
- * Header section of the block editor containing:
- * - Guide title, ID, and status indicators
- * - View mode toggle
- * - Import/export actions
- * - Publishing controls
+ * Header section of the block editor. Orchestrates the title row, view-mode
+ * rocker, smart save action, and the "more actions" kebab (each extracted into
+ * its own component under `header/`), plus the inline status/undo/redo/panel
+ * controls that live directly on the toolbar.
  */
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Button, Badge, ButtonGroup, Icon, IconButton, Tooltip, Dropdown, Menu, useStyles2 } from '@grafana/ui';
-import { css } from '@emotion/css';
-import { GrafanaTheme2 } from '@grafana/data';
+import React from 'react';
+import { Button, Badge, Icon, IconButton, Tooltip, useStyles2 } from '@grafana/ui';
 import type { ViewMode } from './types';
 import { testIds } from '../../constants/testIds';
-import { panelModeManager, type PanelMode } from '../../global-state/panel-mode';
-import { PANEL_MODE_CHANGE_EVENT } from '../../lib/event-names';
+import { usePanelModeControls } from '../../global-state/use-panel-mode';
+import { getHeaderStyles } from './header/header.styles';
+import { HeaderTitleRow } from './header/HeaderTitleRow';
+import { ViewModeRocker } from './header/ViewModeRocker';
+import { SaveActions } from './header/SaveActions';
+import { HeaderKebab } from './header/HeaderKebab';
 
 export interface BlockEditorHeaderProps {
   /** Guide title to display */
@@ -92,143 +93,6 @@ export interface BlockEditorHeaderProps {
   redoLabel: string | null;
 }
 
-const getHeaderStyles = (theme: GrafanaTheme2) => ({
-  // Sticky so the toolbar stays pinned to the top of the editor's scroll
-  // container — same belt-and-braces approach used by the fullscreen layout
-  // (`full-screen.styles.ts:stickyTopBar`). `flexShrink: 0` keeps it from
-  // collapsing inside a flex parent.
-  header: css({
-    display: 'flex',
-    flexDirection: 'column',
-    borderBottom: `1px solid ${theme.colors.border.weak}`,
-    backgroundColor: theme.colors.background.primary,
-    position: 'sticky',
-    top: 0,
-    zIndex: theme.zIndex.navbarFixed,
-    flexShrink: 0,
-  }),
-  // Single-row toolbar: title (flex 1) + actions cluster on the right.
-  // `containerType: inline-size` lets the `@container` rule on `actions`
-  // collapse button labels to icon-only when the row gets narrow. Wraps
-  // to a second line when the cluster still doesn't fit.
-  row: css({
-    display: 'flex',
-    alignItems: 'center',
-    padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
-    gap: theme.spacing(1),
-    flexWrap: 'wrap',
-    containerType: 'inline-size',
-  }),
-  // Title is guaranteed at least ~180px so the actions cluster has to wrap
-  // to a new row when the row gets narrow, instead of crushing the title to
-  // zero. The input inside still keeps `minWidth: 0 + flex: 1` so long
-  // titles ellipsis within the reserved 180px rather than overflowing.
-  titleArea: css({
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing(0.5),
-    minWidth: 180,
-    flex: '1 1 180px',
-    '&:hover .guide-id': {
-      opacity: 1,
-    },
-  }),
-  guideTitleInput: css({
-    background: 'transparent',
-    border: 'none',
-    borderBottom: `1px solid transparent`,
-    borderRadius: 0,
-    color: theme.colors.text.primary,
-    fontSize: theme.typography.h5.fontSize,
-    fontWeight: theme.typography.fontWeightMedium,
-    fontFamily: theme.typography.fontFamily,
-    padding: '0 2px',
-    margin: 0,
-    outline: 'none',
-    minWidth: 0,
-    flex: 1,
-    '&:hover': {
-      borderBottomColor: theme.colors.border.medium,
-    },
-    '&:focus': {
-      borderBottomColor: theme.colors.primary.main,
-      background: theme.colors.background.secondary,
-    },
-  }),
-  guideId: css({
-    fontSize: theme.typography.bodySmall.fontSize,
-    color: theme.colors.text.secondary,
-    fontFamily: theme.typography.fontFamilyMonospace,
-    opacity: 0,
-    transition: 'opacity 0.15s',
-    padding: '0 2px',
-    flexShrink: 0,
-  }),
-  // Right-side action cluster.
-  // - `marginLeft: auto` pushes the cluster to the right edge of the row,
-  //   and — when the cluster wraps onto its own line — keeps it right-aligned
-  //   on that line as well.
-  // - `flexWrap` + `rowGap` let the buttons inside the cluster spill onto a
-  //   second line once even the icon-only collapse can't keep them on one row.
-  // - Label collapse below 640px is opt-in via the `collapsibleLabel` class
-  //   on each Button that wants it (rather than a broad `& button > span`
-  //   rule scoped to the whole cluster). That avoids accidentally hiding
-  //   spans nested inside Badges, IconButtons, or future Grafana `Button`
-  //   internals that might add their own child `<span>`s.
-  actions: css({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    gap: theme.spacing(0.5),
-    flexShrink: 0,
-    flexWrap: 'wrap',
-    rowGap: theme.spacing(0.5),
-    marginLeft: 'auto',
-  }),
-  // Opt-in collapse for Grafana `Button` components that carry a text label.
-  // Under 640px we hide Button's content `<span>` (its direct child) and
-  // tighten horizontal padding, leaving the icon visible. Tooltips and
-  // aria-labels carry the meaning. Targets `& > span` so it only affects
-  // the labeled span that Grafana renders as a direct child of the
-  // `<button>` element this class is applied to — never any descendants.
-  // Container query fires off `row`'s `containerType: inline-size`.
-  collapsibleLabel: css({
-    '@container (max-width: 640px)': {
-      paddingLeft: theme.spacing(0.75),
-      paddingRight: theme.spacing(0.75),
-      '& > span': {
-        display: 'none',
-      },
-    },
-  }),
-  // Subtler "Saved" indicator (replaces the green chip) — small
-  // check-circle icon. Tooltip preserved for context.
-  savedIndicator: css({
-    display: 'inline-flex',
-    alignItems: 'center',
-    color: theme.colors.success.text,
-    flexShrink: 0,
-  }),
-  savingIndicator: css({
-    display: 'inline-flex',
-    alignItems: 'center',
-    color: theme.colors.warning.text,
-    flexShrink: 0,
-  }),
-  divider: css({
-    width: '1px',
-    height: '20px',
-    backgroundColor: theme.colors.border.weak,
-    margin: `0 ${theme.spacing(0.25)}`,
-    flexShrink: 0,
-  }),
-  moreButton: css({
-    '& > button': {
-      padding: '4px 8px',
-    },
-  }),
-});
-
 /**
  * Header component for the block editor.
  * Compact single-row design with better organization.
@@ -269,130 +133,8 @@ export function BlockEditorHeader({
 }: BlockEditorHeaderProps) {
   const styles = useStyles2(getHeaderStyles);
 
-  // Inline title editing
-  const [titleDraft, setTitleDraft] = useState(guideTitle);
-  // Keep the draft in sync when the title changes externally (e.g. guide loaded
-  // from library) — the "adjust state during render" pattern, no effect needed.
-  const [lastSyncedTitle, setLastSyncedTitle] = useState(guideTitle);
-  if (guideTitle !== lastSyncedTitle) {
-    setLastSyncedTitle(guideTitle);
-    setTitleDraft(guideTitle);
-  }
-  const titleInputRef = useRef<HTMLInputElement>(null);
-
-  // Track the current panel mode so the Pop out button can swap between
-  // "Pop out" (sidebar) and "Dock" (floating) at runtime.
-  const [panelMode, setPanelMode] = useState<PanelMode>(() => panelModeManager.getMode());
-  useEffect(() => {
-    const handleModeChange = (e: CustomEvent<{ mode: PanelMode }>) => {
-      setPanelMode(e.detail.mode);
-    };
-    document.addEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
-    return () => {
-      document.removeEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
-    };
-  }, []);
-
-  // Dispatch the same document-level events used by interactive popout steps.
-  // The sidebar's docs-panel handler picks up pop-out for the editor tab; the
-  // FloatingPanelManager handles dock requests.
-  const handleTogglePanelMode = useCallback(() => {
-    if (panelMode === 'sidebar') {
-      document.dispatchEvent(new CustomEvent('pathfinder-request-pop-out'));
-    } else {
-      document.dispatchEvent(new CustomEvent('pathfinder-request-dock'));
-    }
-  }, [panelMode]);
-
-  // Symmetric to docs-panel / FloatingPanelManager — both listen for this
-  // event to swap the active surface to full screen.
-  const handleGoFullScreen = useCallback(() => {
-    document.dispatchEvent(new CustomEvent('pathfinder-request-full-screen'));
-  }, []);
-
-  const commitTitle = () => {
-    const trimmed = titleDraft.trim();
-    if (!trimmed) {
-      setTitleDraft(guideTitle); // revert if cleared
-      return;
-    }
-    if (trimmed !== guideTitle) {
-      onTitleCommit(trimmed);
-    }
-  };
-
-  const handleTitleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      titleInputRef.current?.blur();
-    } else if (e.key === 'Escape') {
-      setTitleDraft(guideTitle);
-      titleInputRef.current?.blur();
-    }
-  };
-
-  // Context-sensitive item at the top of the more menu
-  const moreMenuContextItem = () => {
-    if (!isBackendAvailable) {
-      return null;
-    }
-    if (publishedStatus === 'not-saved') {
-      return <Menu.Item label="Publish" icon="cloud-upload" onClick={onPostToBackend} disabled={isPostingToBackend} />;
-    }
-    if (publishedStatus === 'draft' && hasUnsyncedChanges) {
-      // Primary = "Update draft" → offer "Publish" as shortcut
-      return <Menu.Item label="Publish" icon="cloud-upload" onClick={onPostToBackend} disabled={isPostingToBackend} />;
-    }
-    if (publishedStatus === 'draft' && !hasUnsyncedChanges) {
-      // Draft with no changes — nothing extra to show
-      return null;
-    }
-    // published
-    return (
-      <Menu.Item
-        label="Unpublish"
-        icon="times-circle"
-        onClick={onUnpublish}
-        disabled={isPostingToBackend}
-        data-testid={testIds.blockEditor.unpublishButton}
-      />
-    );
-  };
-
-  // More menu for less-used actions. New + Library moved here (from
-  // the toolbar) — both are infrequent and "New" is destructive, so
-  // it's an improvement to guard them behind a menu.
-  // Context item can return null (backend available, draft, no
-  // unsynced changes) — gate its trailing divider on the item itself,
-  // not on backend availability, to avoid an orphan double-divider.
-  const contextItem = moreMenuContextItem();
-  const moreMenu = (
-    <Menu>
-      <Menu.Item
-        label="New guide"
-        icon="file-blank"
-        onClick={onNewGuide}
-        data-testid={testIds.blockEditor.newGuideButton}
-      />
-      {isBackendAvailable && hasBackendGuides && (
-        <Menu.Item
-          label="Library"
-          icon="book-open"
-          onClick={onOpenGuideLibrary}
-          data-testid={testIds.blockEditor.libraryButton}
-        />
-      )}
-      <Menu.Divider />
-      {contextItem}
-      {contextItem && <Menu.Divider />}
-      <Menu.Item label="Import" icon="upload" onClick={onOpenImport} />
-      <Menu.Divider />
-      <Menu.Item label="Copy JSON" icon="copy" onClick={onCopy} data-testid={testIds.blockEditor.copyJsonButton} />
-      <Menu.Item label="Download JSON" icon="download-alt" onClick={onDownload} />
-      <Menu.Item label="Create GitHub PR" icon="github" onClick={onOpenGitHubPR} />
-      <Menu.Divider />
-      <Menu.Item label="Take tour" icon="question-circle" onClick={onOpenTour} />
-    </Menu>
-  );
+  // Panel mode drives the Pop out / Dock swap and the full-screen affordance.
+  const { panelMode, handleTogglePanelMode, handleGoFullScreen } = usePanelModeControls();
 
   // Derive backend status badge
   const backendBadge = () => {
@@ -432,101 +174,13 @@ export function BlockEditorHeader({
     );
   };
 
-  // Single smart primary action button based on publishedStatus and hasUnsyncedChanges
-  const renderBackendButton = () => {
-    if (publishedStatus === 'not-saved') {
-      return (
-        <Button
-          variant="secondary"
-          size="sm"
-          icon="save"
-          onClick={onSaveDraft}
-          disabled={isPostingToBackend}
-          tooltip="Save as draft without publishing"
-          className={styles.collapsibleLabel}
-          data-testid={testIds.blockEditor.saveDraftButton}
-        >
-          Save as draft
-        </Button>
-      );
-    }
-
-    if (publishedStatus === 'draft') {
-      if (hasUnsyncedChanges) {
-        return (
-          <Button
-            variant="secondary"
-            size="sm"
-            icon="save"
-            onClick={onSaveDraft}
-            disabled={isPostingToBackend}
-            tooltip="Save current changes to library draft"
-            className={styles.collapsibleLabel}
-            data-testid={testIds.blockEditor.saveDraftButton}
-          >
-            Update draft
-          </Button>
-        );
-      }
-      return (
-        <Button
-          variant="primary"
-          size="sm"
-          icon="cloud-upload"
-          onClick={onPostToBackend}
-          disabled={isPostingToBackend}
-          tooltip="Publish and make visible to users"
-          className={styles.collapsibleLabel}
-          data-testid={testIds.blockEditor.publishButton}
-        >
-          Publish
-        </Button>
-      );
-    }
-
-    // published
-    return (
-      <Button
-        variant="primary"
-        size="sm"
-        icon="cloud-upload"
-        onClick={onPostToBackend}
-        disabled={isPostingToBackend}
-        tooltip="Save changes and keep published"
-        className={styles.collapsibleLabel}
-        data-testid={testIds.blockEditor.publishButton}
-      >
-        Update
-      </Button>
-    );
-  };
-
   return (
     <div className={styles.header}>
       {/* Single-row toolbar: title (flex 1) + actions on the right.
           New / Library moved into the kebab menu; selection-mode
           trigger is a small icon button next to the view-mode toggle. */}
       <div className={styles.row}>
-        {/* In preview mode the rendered content already shows the guide title
-            as an <h1> (matching how it appears in production). Rendering the
-            editable title input here too would duplicate that heading, so we
-            collapse the title area to a flex spacer. */}
-        {viewMode === 'preview' ? (
-          <div className={styles.titleArea} aria-hidden="true" />
-        ) : (
-          <div className={styles.titleArea}>
-            <input
-              ref={titleInputRef}
-              className={styles.guideTitleInput}
-              value={titleDraft}
-              onChange={(e) => setTitleDraft(e.target.value)}
-              onBlur={commitTitle}
-              onKeyDown={handleTitleKeyDown}
-              aria-label="Guide title"
-            />
-            {guideId && <div className={`${styles.guideId} guide-id`}>({guideId})</div>}
-          </div>
-        )}
+        <HeaderTitleRow guideTitle={guideTitle} guideId={guideId} viewMode={viewMode} onTitleCommit={onTitleCommit} />
 
         <div className={styles.actions}>
           {/* Local-save indicator — subtle icon (replaces the green
@@ -620,31 +274,17 @@ export function BlockEditorHeader({
             </>
           )}
 
-          <ButtonGroup data-testid={testIds.blockEditor.viewModeToggle}>
-            <Button
-              variant={viewMode === 'edit' ? 'primary' : 'secondary'}
-              size="sm"
-              icon="pen"
-              onClick={() => onSetViewMode('edit')}
-              tooltip="Edit"
-            />
-            <Button
-              variant={viewMode === 'preview' ? 'primary' : 'secondary'}
-              size="sm"
-              icon="eye"
-              onClick={() => onSetViewMode('preview')}
-              tooltip="Preview"
-            />
-            <Button
-              variant={viewMode === 'json' ? 'primary' : 'secondary'}
-              size="sm"
-              icon="brackets-curly"
-              onClick={() => onSetViewMode('json')}
-              tooltip="JSON"
-            />
-          </ButtonGroup>
+          <ViewModeRocker viewMode={viewMode} onSetViewMode={onSetViewMode} />
 
-          {isBackendAvailable && renderBackendButton()}
+          {isBackendAvailable && (
+            <SaveActions
+              publishedStatus={publishedStatus}
+              hasUnsyncedChanges={hasUnsyncedChanges}
+              isPosting={isPostingToBackend}
+              onSaveDraft={onSaveDraft}
+              onPostToBackend={onPostToBackend}
+            />
+          )}
 
           <Button
             variant="secondary"
@@ -680,17 +320,22 @@ export function BlockEditorHeader({
             </Button>
           )}
 
-          <div className={styles.moreButton}>
-            <Dropdown overlay={moreMenu} placement="bottom-end">
-              <Button
-                variant="secondary"
-                size="sm"
-                icon="ellipsis-v"
-                tooltip="More actions"
-                data-testid={testIds.blockEditor.moreActionsButton}
-              />
-            </Dropdown>
-          </div>
+          <HeaderKebab
+            isBackendAvailable={isBackendAvailable}
+            hasBackendGuides={hasBackendGuides}
+            publishedStatus={publishedStatus}
+            hasUnsyncedChanges={hasUnsyncedChanges}
+            isPosting={isPostingToBackend}
+            onNewGuide={onNewGuide}
+            onOpenGuideLibrary={onOpenGuideLibrary}
+            onOpenImport={onOpenImport}
+            onCopy={onCopy}
+            onDownload={onDownload}
+            onOpenGitHubPR={onOpenGitHubPR}
+            onOpenTour={onOpenTour}
+            onPostToBackend={onPostToBackend}
+            onUnpublish={onUnpublish}
+          />
         </div>
       </div>
     </div>

--- a/src/components/block-editor/header/HeaderKebab.tsx
+++ b/src/components/block-editor/header/HeaderKebab.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { Button, Dropdown, Menu, useStyles2 } from '@grafana/ui';
+import { testIds } from '../../../constants/testIds';
+import { getHeaderStyles } from './header.styles';
+
+export interface HeaderKebabProps {
+  /** Whether the Pathfinder backend API is available; gates publish shortcut + Library. */
+  isBackendAvailable: boolean;
+  /** Whether the guide Library entry should be offered. */
+  hasBackendGuides: boolean;
+  /** Backend publish status, drives the context-sensitive top menu item. */
+  publishedStatus: 'not-saved' | 'draft' | 'published';
+  /** Whether the guide has local changes not yet sent to the backend. */
+  hasUnsyncedChanges: boolean;
+  /** Whether a backend operation is in progress. */
+  isPosting: boolean;
+  onNewGuide: () => void;
+  onOpenGuideLibrary: () => void;
+  onOpenImport: () => void;
+  onCopy: () => void;
+  onDownload: () => void;
+  onOpenGitHubPR: () => void;
+  onOpenTour: () => void;
+  onPostToBackend: () => void;
+  onUnpublish: () => void;
+}
+
+/**
+ * "More actions" kebab menu for less-used editor actions (New, Library, Import,
+ * Copy/Download JSON, GitHub PR, tour) plus a context-sensitive publish shortcut.
+ */
+export function HeaderKebab({
+  isBackendAvailable,
+  hasBackendGuides,
+  publishedStatus,
+  hasUnsyncedChanges,
+  isPosting,
+  onNewGuide,
+  onOpenGuideLibrary,
+  onOpenImport,
+  onCopy,
+  onDownload,
+  onOpenGitHubPR,
+  onOpenTour,
+  onPostToBackend,
+  onUnpublish,
+}: HeaderKebabProps) {
+  const styles = useStyles2(getHeaderStyles);
+
+  // Context-sensitive item at the top of the more menu
+  const moreMenuContextItem = () => {
+    if (!isBackendAvailable) {
+      return null;
+    }
+    if (publishedStatus === 'not-saved') {
+      return <Menu.Item label="Publish" icon="cloud-upload" onClick={onPostToBackend} disabled={isPosting} />;
+    }
+    if (publishedStatus === 'draft' && hasUnsyncedChanges) {
+      // Primary = "Update draft" → offer "Publish" as shortcut
+      return <Menu.Item label="Publish" icon="cloud-upload" onClick={onPostToBackend} disabled={isPosting} />;
+    }
+    if (publishedStatus === 'draft' && !hasUnsyncedChanges) {
+      // Draft with no changes — nothing extra to show
+      return null;
+    }
+    // published
+    return (
+      <Menu.Item
+        label="Unpublish"
+        icon="times-circle"
+        onClick={onUnpublish}
+        disabled={isPosting}
+        data-testid={testIds.blockEditor.unpublishButton}
+      />
+    );
+  };
+
+  // New + Library live here (moved from the toolbar) — both are infrequent and
+  // "New" is destructive, so it's an improvement to guard them behind a menu.
+  // The context item can return null (backend available, draft, no unsynced
+  // changes) — gate its trailing divider on the item itself, not on backend
+  // availability, to avoid an orphan double-divider.
+  const contextItem = moreMenuContextItem();
+  const moreMenu = (
+    <Menu>
+      <Menu.Item
+        label="New guide"
+        icon="file-blank"
+        onClick={onNewGuide}
+        data-testid={testIds.blockEditor.newGuideButton}
+      />
+      {isBackendAvailable && hasBackendGuides && (
+        <Menu.Item
+          label="Library"
+          icon="book-open"
+          onClick={onOpenGuideLibrary}
+          data-testid={testIds.blockEditor.libraryButton}
+        />
+      )}
+      <Menu.Divider />
+      {contextItem}
+      {contextItem && <Menu.Divider />}
+      <Menu.Item label="Import" icon="upload" onClick={onOpenImport} />
+      <Menu.Divider />
+      <Menu.Item label="Copy JSON" icon="copy" onClick={onCopy} data-testid={testIds.blockEditor.copyJsonButton} />
+      <Menu.Item label="Download JSON" icon="download-alt" onClick={onDownload} />
+      <Menu.Item label="Create GitHub PR" icon="github" onClick={onOpenGitHubPR} />
+      <Menu.Divider />
+      <Menu.Item label="Take tour" icon="question-circle" onClick={onOpenTour} />
+    </Menu>
+  );
+
+  return (
+    <div className={styles.moreButton}>
+      <Dropdown overlay={moreMenu} placement="bottom-end">
+        <Button
+          variant="secondary"
+          size="sm"
+          icon="ellipsis-v"
+          tooltip="More actions"
+          data-testid={testIds.blockEditor.moreActionsButton}
+        />
+      </Dropdown>
+    </div>
+  );
+}
+
+HeaderKebab.displayName = 'HeaderKebab';

--- a/src/components/block-editor/header/HeaderKebab.tsx
+++ b/src/components/block-editor/header/HeaderKebab.tsx
@@ -47,7 +47,7 @@ export function HeaderKebab({
 }: HeaderKebabProps) {
   const styles = useStyles2(getHeaderStyles);
 
-  // Context-sensitive item at the top of the more menu
+  // Context-sensitive publish/unpublish shortcut, rendered after the New/Library section.
   const moreMenuContextItem = () => {
     if (!isBackendAvailable) {
       return null;
@@ -56,7 +56,7 @@ export function HeaderKebab({
       return <Menu.Item label="Publish" icon="cloud-upload" onClick={onPostToBackend} disabled={isPosting} />;
     }
     if (publishedStatus === 'draft' && hasUnsyncedChanges) {
-      // Primary = "Update draft" → offer "Publish" as shortcut
+      // Main save action is "Update draft" → offer "Publish" as a shortcut here
       return <Menu.Item label="Publish" icon="cloud-upload" onClick={onPostToBackend} disabled={isPosting} />;
     }
     if (publishedStatus === 'draft' && !hasUnsyncedChanges) {
@@ -118,6 +118,7 @@ export function HeaderKebab({
           size="sm"
           icon="ellipsis-v"
           tooltip="More actions"
+          aria-label="More actions"
           data-testid={testIds.blockEditor.moreActionsButton}
         />
       </Dropdown>

--- a/src/components/block-editor/header/HeaderTitleRow.tsx
+++ b/src/components/block-editor/header/HeaderTitleRow.tsx
@@ -1,0 +1,73 @@
+import React, { useRef, useState } from 'react';
+import { useStyles2 } from '@grafana/ui';
+import type { ViewMode } from '../types';
+import { getHeaderStyles } from './header.styles';
+
+export interface HeaderTitleRowProps {
+  guideTitle: string;
+  /** Guide ID — null means not yet assigned (hides the ID display). */
+  guideId: string | null;
+  viewMode: ViewMode;
+  /** Called when the title is committed (blur or Enter). */
+  onTitleCommit: (title: string) => void;
+}
+
+/**
+ * Editable guide title + id. In preview mode the rendered content already shows
+ * the guide title as an `<h1>` (matching production), so the editable input is
+ * replaced by a flex spacer to avoid duplicating that heading.
+ */
+export function HeaderTitleRow({ guideTitle, guideId, viewMode, onTitleCommit }: HeaderTitleRowProps) {
+  const styles = useStyles2(getHeaderStyles);
+
+  const [titleDraft, setTitleDraft] = useState(guideTitle);
+  // Keep the draft in sync when the title changes externally (e.g. guide loaded
+  // from library) — the "adjust state during render" pattern, no effect needed.
+  const [lastSyncedTitle, setLastSyncedTitle] = useState(guideTitle);
+  if (guideTitle !== lastSyncedTitle) {
+    setLastSyncedTitle(guideTitle);
+    setTitleDraft(guideTitle);
+  }
+  const titleInputRef = useRef<HTMLInputElement>(null);
+
+  const commitTitle = () => {
+    const trimmed = titleDraft.trim();
+    if (!trimmed) {
+      setTitleDraft(guideTitle); // revert if cleared
+      return;
+    }
+    if (trimmed !== guideTitle) {
+      onTitleCommit(trimmed);
+    }
+  };
+
+  const handleTitleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      titleInputRef.current?.blur();
+    } else if (e.key === 'Escape') {
+      setTitleDraft(guideTitle);
+      titleInputRef.current?.blur();
+    }
+  };
+
+  if (viewMode === 'preview') {
+    return <div className={styles.titleArea} aria-hidden="true" />;
+  }
+
+  return (
+    <div className={styles.titleArea}>
+      <input
+        ref={titleInputRef}
+        className={styles.guideTitleInput}
+        value={titleDraft}
+        onChange={(e) => setTitleDraft(e.target.value)}
+        onBlur={commitTitle}
+        onKeyDown={handleTitleKeyDown}
+        aria-label="Guide title"
+      />
+      {guideId && <div className={`${styles.guideId} guide-id`}>({guideId})</div>}
+    </div>
+  );
+}
+
+HeaderTitleRow.displayName = 'HeaderTitleRow';

--- a/src/components/block-editor/header/SaveActions.tsx
+++ b/src/components/block-editor/header/SaveActions.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Button, useStyles2 } from '@grafana/ui';
+import { testIds } from '../../../constants/testIds';
+import { getHeaderStyles } from './header.styles';
+
+export interface SaveActionsProps {
+  /**
+   * Backend publish status:
+   * - 'not-saved': guide exists only in localStorage
+   * - 'draft': saved to library but not visible to users
+   * - 'published': visible in docs panel Custom guides section
+   */
+  publishedStatus: 'not-saved' | 'draft' | 'published';
+  /** Whether the guide (draft or published) has local changes not yet sent to the backend. */
+  hasUnsyncedChanges: boolean;
+  /** Whether a backend operation is in progress. */
+  isPosting: boolean;
+  /** Save the current guide as a draft (not visible to users). */
+  onSaveDraft: () => void;
+  /** Publish/update the guide (makes it visible to users). */
+  onPostToBackend: () => void;
+}
+
+/**
+ * Single smart primary action button whose label/variant follow the backend
+ * publish state: Save as draft / Update draft / Publish / Update.
+ */
+export function SaveActions({
+  publishedStatus,
+  hasUnsyncedChanges,
+  isPosting,
+  onSaveDraft,
+  onPostToBackend,
+}: SaveActionsProps) {
+  const styles = useStyles2(getHeaderStyles);
+
+  if (publishedStatus === 'not-saved') {
+    return (
+      <Button
+        variant="secondary"
+        size="sm"
+        icon="save"
+        onClick={onSaveDraft}
+        disabled={isPosting}
+        tooltip="Save as draft without publishing"
+        className={styles.collapsibleLabel}
+        data-testid={testIds.blockEditor.saveDraftButton}
+      >
+        Save as draft
+      </Button>
+    );
+  }
+
+  if (publishedStatus === 'draft') {
+    if (hasUnsyncedChanges) {
+      return (
+        <Button
+          variant="secondary"
+          size="sm"
+          icon="save"
+          onClick={onSaveDraft}
+          disabled={isPosting}
+          tooltip="Save current changes to library draft"
+          className={styles.collapsibleLabel}
+          data-testid={testIds.blockEditor.saveDraftButton}
+        >
+          Update draft
+        </Button>
+      );
+    }
+    return (
+      <Button
+        variant="primary"
+        size="sm"
+        icon="cloud-upload"
+        onClick={onPostToBackend}
+        disabled={isPosting}
+        tooltip="Publish and make visible to users"
+        className={styles.collapsibleLabel}
+        data-testid={testIds.blockEditor.publishButton}
+      >
+        Publish
+      </Button>
+    );
+  }
+
+  // published
+  return (
+    <Button
+      variant="primary"
+      size="sm"
+      icon="cloud-upload"
+      onClick={onPostToBackend}
+      disabled={isPosting}
+      tooltip="Save changes and keep published"
+      className={styles.collapsibleLabel}
+      data-testid={testIds.blockEditor.publishButton}
+    >
+      Update
+    </Button>
+  );
+}
+
+SaveActions.displayName = 'SaveActions';

--- a/src/components/block-editor/header/SaveActions.tsx
+++ b/src/components/block-editor/header/SaveActions.tsx
@@ -22,8 +22,9 @@ export interface SaveActionsProps {
 }
 
 /**
- * Single smart primary action button whose label/variant follow the backend
- * publish state: Save as draft / Update draft / Publish / Update.
+ * Single smart save/publish action button whose label and variant follow the
+ * backend publish state: Save as draft / Update draft (secondary) or
+ * Publish / Update (primary).
  */
 export function SaveActions({
   publishedStatus,
@@ -43,6 +44,7 @@ export function SaveActions({
         onClick={onSaveDraft}
         disabled={isPosting}
         tooltip="Save as draft without publishing"
+        aria-label="Save as draft"
         className={styles.collapsibleLabel}
         data-testid={testIds.blockEditor.saveDraftButton}
       >
@@ -61,6 +63,7 @@ export function SaveActions({
           onClick={onSaveDraft}
           disabled={isPosting}
           tooltip="Save current changes to library draft"
+          aria-label="Update draft"
           className={styles.collapsibleLabel}
           data-testid={testIds.blockEditor.saveDraftButton}
         >
@@ -76,6 +79,7 @@ export function SaveActions({
         onClick={onPostToBackend}
         disabled={isPosting}
         tooltip="Publish and make visible to users"
+        aria-label="Publish"
         className={styles.collapsibleLabel}
         data-testid={testIds.blockEditor.publishButton}
       >
@@ -93,6 +97,7 @@ export function SaveActions({
       onClick={onPostToBackend}
       disabled={isPosting}
       tooltip="Save changes and keep published"
+      aria-label="Update"
       className={styles.collapsibleLabel}
       data-testid={testIds.blockEditor.publishButton}
     >

--- a/src/components/block-editor/header/ViewModeRocker.tsx
+++ b/src/components/block-editor/header/ViewModeRocker.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Button, ButtonGroup } from '@grafana/ui';
+import type { ViewMode } from '../types';
+import { testIds } from '../../../constants/testIds';
+
+export interface ViewModeRockerProps {
+  viewMode: ViewMode;
+  onSetViewMode: (mode: ViewMode) => void;
+}
+
+/** Edit / Preview / JSON view-mode toggle. */
+export function ViewModeRocker({ viewMode, onSetViewMode }: ViewModeRockerProps) {
+  return (
+    <ButtonGroup data-testid={testIds.blockEditor.viewModeToggle}>
+      <Button
+        variant={viewMode === 'edit' ? 'primary' : 'secondary'}
+        size="sm"
+        icon="pen"
+        onClick={() => onSetViewMode('edit')}
+        tooltip="Edit"
+      />
+      <Button
+        variant={viewMode === 'preview' ? 'primary' : 'secondary'}
+        size="sm"
+        icon="eye"
+        onClick={() => onSetViewMode('preview')}
+        tooltip="Preview"
+      />
+      <Button
+        variant={viewMode === 'json' ? 'primary' : 'secondary'}
+        size="sm"
+        icon="brackets-curly"
+        onClick={() => onSetViewMode('json')}
+        tooltip="JSON"
+      />
+    </ButtonGroup>
+  );
+}
+
+ViewModeRocker.displayName = 'ViewModeRocker';

--- a/src/components/block-editor/header/ViewModeRocker.tsx
+++ b/src/components/block-editor/header/ViewModeRocker.tsx
@@ -18,6 +18,7 @@ export function ViewModeRocker({ viewMode, onSetViewMode }: ViewModeRockerProps)
         icon="pen"
         onClick={() => onSetViewMode('edit')}
         tooltip="Edit"
+        aria-label="Edit"
       />
       <Button
         variant={viewMode === 'preview' ? 'primary' : 'secondary'}
@@ -25,6 +26,7 @@ export function ViewModeRocker({ viewMode, onSetViewMode }: ViewModeRockerProps)
         icon="eye"
         onClick={() => onSetViewMode('preview')}
         tooltip="Preview"
+        aria-label="Preview"
       />
       <Button
         variant={viewMode === 'json' ? 'primary' : 'secondary'}
@@ -32,6 +34,7 @@ export function ViewModeRocker({ viewMode, onSetViewMode }: ViewModeRockerProps)
         icon="brackets-curly"
         onClick={() => onSetViewMode('json')}
         tooltip="JSON"
+        aria-label="JSON"
       />
     </ButtonGroup>
   );

--- a/src/components/block-editor/header/header.styles.ts
+++ b/src/components/block-editor/header/header.styles.ts
@@ -17,9 +17,9 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
     flexShrink: 0,
   }),
   // Single-row toolbar: title (flex 1) + actions cluster on the right.
-  // `containerType: inline-size` lets the `@container` rule on `actions`
-  // collapse button labels to icon-only when the row gets narrow. Wraps
-  // to a second line when the cluster still doesn't fit.
+  // `containerType: inline-size` lets the per-button `@container` rule in
+  // `collapsibleLabel` collapse button labels to icon-only when the row gets
+  // narrow. Wraps to a second line when the cluster still doesn't fit.
   row: css({
     display: 'flex',
     alignItems: 'center',
@@ -110,8 +110,8 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
       },
     },
   }),
-  // Subtler "Saved" indicator (replaces the green chip) — small
-  // check-circle icon. Tooltip preserved for context.
+  // Subtler "Saved" indicator (replaces the green chip) — small floppy
+  // `save` icon. Tooltip preserved for context.
   savedIndicator: css({
     display: 'inline-flex',
     alignItems: 'center',

--- a/src/components/block-editor/header/header.styles.ts
+++ b/src/components/block-editor/header/header.styles.ts
@@ -1,0 +1,139 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+
+export const getHeaderStyles = (theme: GrafanaTheme2) => ({
+  // Sticky so the toolbar stays pinned to the top of the editor's scroll
+  // container — same belt-and-braces approach used by the fullscreen layout
+  // (`full-screen.styles.ts:stickyTopBar`). `flexShrink: 0` keeps it from
+  // collapsing inside a flex parent.
+  header: css({
+    display: 'flex',
+    flexDirection: 'column',
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
+    backgroundColor: theme.colors.background.primary,
+    position: 'sticky',
+    top: 0,
+    zIndex: theme.zIndex.navbarFixed,
+    flexShrink: 0,
+  }),
+  // Single-row toolbar: title (flex 1) + actions cluster on the right.
+  // `containerType: inline-size` lets the `@container` rule on `actions`
+  // collapse button labels to icon-only when the row gets narrow. Wraps
+  // to a second line when the cluster still doesn't fit.
+  row: css({
+    display: 'flex',
+    alignItems: 'center',
+    padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
+    gap: theme.spacing(1),
+    flexWrap: 'wrap',
+    containerType: 'inline-size',
+  }),
+  // Title is guaranteed at least ~180px so the actions cluster has to wrap
+  // to a new row when the row gets narrow, instead of crushing the title to
+  // zero. The input inside still keeps `minWidth: 0 + flex: 1` so long
+  // titles ellipsis within the reserved 180px rather than overflowing.
+  titleArea: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    minWidth: 180,
+    flex: '1 1 180px',
+    '&:hover .guide-id': {
+      opacity: 1,
+    },
+  }),
+  guideTitleInput: css({
+    background: 'transparent',
+    border: 'none',
+    borderBottom: `1px solid transparent`,
+    borderRadius: 0,
+    color: theme.colors.text.primary,
+    fontSize: theme.typography.h5.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+    fontFamily: theme.typography.fontFamily,
+    padding: '0 2px',
+    margin: 0,
+    outline: 'none',
+    minWidth: 0,
+    flex: 1,
+    '&:hover': {
+      borderBottomColor: theme.colors.border.medium,
+    },
+    '&:focus': {
+      borderBottomColor: theme.colors.primary.main,
+      background: theme.colors.background.secondary,
+    },
+  }),
+  guideId: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    fontFamily: theme.typography.fontFamilyMonospace,
+    opacity: 0,
+    transition: 'opacity 0.15s',
+    padding: '0 2px',
+    flexShrink: 0,
+  }),
+  // Right-side action cluster.
+  // - `marginLeft: auto` pushes the cluster to the right edge of the row,
+  //   and — when the cluster wraps onto its own line — keeps it right-aligned
+  //   on that line as well.
+  // - `flexWrap` + `rowGap` let the buttons inside the cluster spill onto a
+  //   second line once even the icon-only collapse can't keep them on one row.
+  // - Label collapse below 640px is opt-in via the `collapsibleLabel` class
+  //   on each Button that wants it (rather than a broad `& button > span`
+  //   rule scoped to the whole cluster). That avoids accidentally hiding
+  //   spans nested inside Badges, IconButtons, or future Grafana `Button`
+  //   internals that might add their own child `<span>`s.
+  actions: css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: theme.spacing(0.5),
+    flexShrink: 0,
+    flexWrap: 'wrap',
+    rowGap: theme.spacing(0.5),
+    marginLeft: 'auto',
+  }),
+  // Opt-in collapse for Grafana `Button` components that carry a text label.
+  // Under 640px we hide Button's content `<span>` (its direct child) and
+  // tighten horizontal padding, leaving the icon visible. Tooltips and
+  // aria-labels carry the meaning. Targets `& > span` so it only affects
+  // the labeled span that Grafana renders as a direct child of the
+  // `<button>` element this class is applied to — never any descendants.
+  // Container query fires off `row`'s `containerType: inline-size`.
+  collapsibleLabel: css({
+    '@container (max-width: 640px)': {
+      paddingLeft: theme.spacing(0.75),
+      paddingRight: theme.spacing(0.75),
+      '& > span': {
+        display: 'none',
+      },
+    },
+  }),
+  // Subtler "Saved" indicator (replaces the green chip) — small
+  // check-circle icon. Tooltip preserved for context.
+  savedIndicator: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    color: theme.colors.success.text,
+    flexShrink: 0,
+  }),
+  savingIndicator: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    color: theme.colors.warning.text,
+    flexShrink: 0,
+  }),
+  divider: css({
+    width: '1px',
+    height: '20px',
+    backgroundColor: theme.colors.border.weak,
+    margin: `0 ${theme.spacing(0.25)}`,
+    flexShrink: 0,
+  }),
+  moreButton: css({
+    '& > button': {
+      padding: '4px 8px',
+    },
+  }),
+});

--- a/src/global-state/use-panel-mode.ts
+++ b/src/global-state/use-panel-mode.ts
@@ -1,0 +1,51 @@
+/**
+ * Tracks the panel mode (`sidebar` / `floating` / `fullscreen`) and exposes the
+ * two surface-coordination dispatchers used across Pathfinder chrome.
+ *
+ * This is the plain listener: it mirrors `pathfinder-panel-mode-change` into
+ * React state and offers pop-out/dock and full-screen requests. It deliberately
+ * carries no fullscreen self-heal — that behavior is sidebar-specific and lives
+ * in `docs-panel/hooks/usePanelMode.ts`; the block editor legitimately mounts on
+ * the fullscreen surface and must not reset itself off it.
+ */
+import * as React from 'react';
+import { PANEL_MODE_CHANGE_EVENT } from '../lib/event-names';
+import { panelModeManager, type PanelMode } from './panel-mode';
+
+export interface PanelModeControls {
+  panelMode: PanelMode;
+  /** Pop out to a floating window (from sidebar) or dock back (from floating). */
+  handleTogglePanelMode: () => void;
+  /** Request a switch to the full-screen surface. */
+  handleGoFullScreen: () => void;
+}
+
+export function usePanelModeControls(): PanelModeControls {
+  const [panelMode, setPanelMode] = React.useState<PanelMode>(() => panelModeManager.getMode());
+
+  React.useEffect(() => {
+    const handleModeChange = (e: CustomEvent<{ mode: PanelMode }>) => {
+      setPanelMode(e.detail.mode);
+    };
+    document.addEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
+    return () => {
+      document.removeEventListener(PANEL_MODE_CHANGE_EVENT, handleModeChange as EventListener);
+    };
+  }, []);
+
+  // The sidebar's docs-panel handler picks up pop-out for the editor tab; the
+  // FloatingPanelManager handles dock requests.
+  const handleTogglePanelMode = React.useCallback(() => {
+    if (panelMode === 'sidebar') {
+      document.dispatchEvent(new CustomEvent('pathfinder-request-pop-out'));
+    } else {
+      document.dispatchEvent(new CustomEvent('pathfinder-request-dock'));
+    }
+  }, [panelMode]);
+
+  const handleGoFullScreen = React.useCallback(() => {
+    document.dispatchEvent(new CustomEvent('pathfinder-request-full-screen'));
+  }, []);
+
+  return { panelMode, handleTogglePanelMode, handleGoFullScreen };
+}

--- a/src/global-state/use-panel-mode.ts
+++ b/src/global-state/use-panel-mode.ts
@@ -14,7 +14,7 @@ import { panelModeManager, type PanelMode } from './panel-mode';
 
 export interface PanelModeControls {
   panelMode: PanelMode;
-  /** Pop out to a floating window (from sidebar) or dock back (from floating). */
+  /** Pop out to a floating window (from sidebar) or dock back (from floating or full screen). */
   handleTogglePanelMode: () => void;
   /** Request a switch to the full-screen surface. */
   handleGoFullScreen: () => void;
@@ -34,7 +34,7 @@ export function usePanelModeControls(): PanelModeControls {
   }, []);
 
   // The sidebar's docs-panel handler picks up pop-out for the editor tab; the
-  // FloatingPanelManager handles dock requests.
+  // FloatingPanelManager handles dock requests (from floating or full screen).
   const handleTogglePanelMode = React.useCallback(() => {
     if (panelMode === 'sidebar') {
       document.dispatchEvent(new CustomEvent('pathfinder-request-pop-out'));


### PR DESCRIPTION
## What & why

PR 2 of the **block-editor chrome redesign stack** ([#1256](https://github.com/grafana/grafana-pathfinder-app/issues/1256)) — the behavior-neutral decomposition that unblocks the rocker/save/kebab/title-row PRs.

Splits the 700-line `BlockEditorHeader` **by concern** (not by row) into small components under `header/`:

| Component | Responsibility |
| --- | --- |
| `HeaderTitleRow` | editable title input + guide id + commit logic + preview-mode spacer |
| `ViewModeRocker` | Edit/Preview/JSON `ButtonGroup` |
| `SaveActions` | smart Save-as-draft / Update draft / Publish / Update button |
| `HeaderKebab` | "more actions" menu + context-sensitive publish shortcut |

`getHeaderStyles` moves to `header/header.styles.ts`. `BlockEditorHeader` (700 → 345 lines) stays the orchestrator: same single-row layout, and the inline status badge / local-save indicator / preview-reset / selection trigger / undo-redo / pop-out / full-screen controls are unchanged (they relocate in PRs 4/5).

### Shared panel-mode hook
Lifts the panel-mode listener + `handleTogglePanelMode`/`handleGoFullScreen` dispatchers into `global-state/use-panel-mode.ts` (`usePanelModeControls`) so later PRs (kebab consolidation) don't duplicate the listener.

**Deviation from the plan:** docs-panel's `usePanelMode` is left as its own implementation rather than wrapping the shared hook. Its self-heal test (`usePanelMode.test.ts:73-81`) mocks `setMode` to a no-op and asserts local state flips to `sidebar`, so the self-heal must own a local `setPanelMode` — a wrapper over the shared listener can't satisfy that cleanly. The plan's real constraint (self-heal must not leak into the editor, which legitimately mounts on the fullscreen surface) is fully met.

### #1331 leave-behind resolved
Destructures the stable `trackLoadedGuide` and narrows the `useCallback` deps in `BlockEditor.tsx` so they no longer recreate every render off the fresh `useBackendSaveFlow` return literal.

## Behavior-neutral guarantee
- External `BlockEditorHeaderProps` interface unchanged.
- All `data-testid`s preserved.
- `BlockEditorHeader.test.tsx` and `tests/block-editor.spec.ts` are **unmodified** and green.

## Testing
- `npm run test:ci`: 5,664 passed (block-editor, docs-panel contract/panel-mode, architecture, persistence all green). The one unrelated failure — `schema-e2e-report.test.ts` — is a pre-existing missing `ajv/dist/2020` dependency in the environment, not touched by this branch.
- Typecheck / ESLint / Prettier clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)