### PR TITLE
test(cross-tab): close the pairOverBus controller-binding race behind the CI flake

### DIFF
--- a/src/integrations/cross-tab/cross-tab-protocol.acceptance.test.tsx
+++ b/src/integrations/cross-tab/cross-tab-protocol.acceptance.test.tsx
@@ -227,6 +227,13 @@ async function pairOverBus(): Promise<PairedHarness> {
   await waitFor(() => expect(getAcceptedSession()).not.toBeNull());
   await waitFor(() => expect(channel).not.toBeNull());
 
+  // The above only proves LIVE-side acceptance. The controller binds its
+  // liveTabId after two more async crypto hops (pairing-accept post + proof
+  // verify), and until then signForLive silently drops signed commands. The
+  // controller's post-binding sidebar-handoff is the observable that the
+  // binding landed — without this wait, channel.post races the handshake.
+  await waitFor(() => expect(controller.postedPayloads.some((p) => p.kind === 'sidebar-handoff')).toBe(true));
+
   return {
     bus,
     controller,


### PR DESCRIPTION
## Summary

Fixes the CI flake that broke main on docs-only commit 8d670a9d ([failing Test job in run 29931130300](https://github.com/grafana/grafana-pathfinder-app/actions/runs/29931130300/job/88960834949#step:6:19951)): `cross-tab pairing protocol acceptance › 3. user consent › runs a signed command end-to-end once the user accepts`.

Root cause: [`pairOverBus()`](https://github.com/grafana/grafana-pathfinder-app/blob/ede239f754f794a3668f5fbdea9b12b4a1df8009/src/integrations/cross-tab/cross-tab-protocol.acceptance.test.tsx#L192) returned after waiting only on live-side acceptance (`getAcceptedSession()`) and channel mount. The controller binds its `pairedLiveIdRef` two async WebCrypto hops later (the live executor posts `pairing-accept`, then the controller verifies the accept proof). A `step-command` posted before that binding lands is silently dropped by `signForLive` in [`controller-channel.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/ede239f754f794a3668f5fbdea9b12b4a1df8009/src/global-state/controller-channel.tsx#L98-L120) — there is no queue and no retry — so the `waitFor` on `ButtonHandler.execute` times out. Under CI load the crypto promises occasionally lose that race.

The fix adds one wait to the test harness: `pairOverBus` now also waits for the controller's post-binding `sidebar-handoff` post, which is strictly ordered after `pairedLiveIdRef` is set. This hardens all six `pairOverBus` call sites, not just the consent test.

## What to look at

- `src/integrations/cross-tab/` (test harness only) — the new `waitFor` keys on `controller.postedPayloads` containing a `sidebar-handoff`. That payload is posted by the controller immediately after it binds `pairedLiveIdRef`, so it is a reliable observable for controller-side pairing completion. No production code changes; the cross-tab trust boundary (per-kind validators, signature gate, pairing gesture requirement) is untouched.

## How to verify

1. Reproduce the original race deterministically on `main`: in `src/global-state/controller-channel.tsx`, delay the `verifyPairingAcceptProof(...)` resolution by ~100 ms (chain `.then((ok) => new Promise((resolve) => setTimeout(() => resolve(ok), 100)))` before the binding `.then`), then run `npx jest src/integrations/cross-tab/cross-tab-protocol.acceptance.test.tsx -t "runs a signed command end-to-end"`. It fails with the exact CI signature: `Expected number of calls: >= 1, Received: 0` at the `waitFor(executeOf(ButtonHandler))` assertion.
2. Apply the same injected delay on top of this branch and run the full file — all 35 tests should pass, because the harness now waits out the delayed binding instead of racing it.
3. Remove the injected delay.

## Breaking changes

None. Test-only change; fully reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
