### PR TITLE
feat(block-editor): consolidate pop out / full screen / selection into the kebab (#1256)

### DIFF
--- a/src/components/block-editor/BlockEditorHeader.test.tsx
+++ b/src/components/block-editor/BlockEditorHeader.test.tsx
@@ -36,7 +36,7 @@ const baseProps = {
   redoLabel: null,
 };
 
-describe('BlockEditorHeader: pop out / dock button', () => {
+describe('BlockEditorHeader: pop out / dock (in the more-actions kebab)', () => {
   let getModeSpy: jest.SpyInstance<PanelMode, []>;
 
   beforeEach(() => {
@@ -47,19 +47,23 @@ describe('BlockEditorHeader: pop out / dock button', () => {
     getModeSpy.mockRestore();
   });
 
-  it('renders "Pop out" when the panel is currently in sidebar mode', () => {
+  const openKebab = () => fireEvent.click(screen.getByTestId(testIds.blockEditor.moreActionsButton));
+  const popOutItem = () => screen.getByTestId('pathfinder-block-editor-toggle-popout');
+
+  it('shows "Pop out" in the kebab when the panel is in sidebar mode', () => {
     getModeSpy.mockReturnValue('sidebar');
     render(<BlockEditorHeader {...baseProps} />);
-    expect(screen.getByRole('button', { name: 'Pop out editor' })).toBeInTheDocument();
+    openKebab();
+    expect(popOutItem()).toHaveTextContent('Pop out');
   });
 
-  it("dispatches 'pathfinder-request-pop-out' when clicked from sidebar mode", () => {
+  it("dispatches 'pathfinder-request-pop-out' when the kebab item is clicked from sidebar mode", () => {
     getModeSpy.mockReturnValue('sidebar');
     const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
     try {
       render(<BlockEditorHeader {...baseProps} />);
-      const button = screen.getByRole('button', { name: 'Pop out editor' });
-      button.click();
+      openKebab();
+      fireEvent.click(popOutItem());
       const popOutCall = dispatchSpy.mock.calls.find(
         (call) => (call[0] as Event).type === 'pathfinder-request-pop-out'
       );
@@ -69,19 +73,20 @@ describe('BlockEditorHeader: pop out / dock button', () => {
     }
   });
 
-  it('renders "Dock" when the panel is currently in floating mode', () => {
+  it('shows "Dock" in the kebab when the panel is in floating mode', () => {
     getModeSpy.mockReturnValue('floating');
     render(<BlockEditorHeader {...baseProps} />);
-    expect(screen.getByRole('button', { name: 'Dock editor' })).toBeInTheDocument();
+    openKebab();
+    expect(popOutItem()).toHaveTextContent('Dock');
   });
 
-  it("dispatches 'pathfinder-request-dock' when clicked from floating mode", () => {
+  it("dispatches 'pathfinder-request-dock' when the kebab item is clicked from floating mode", () => {
     getModeSpy.mockReturnValue('floating');
     const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
     try {
       render(<BlockEditorHeader {...baseProps} />);
-      const button = screen.getByRole('button', { name: 'Dock editor' });
-      button.click();
+      openKebab();
+      fireEvent.click(popOutItem());
       const dockCall = dispatchSpy.mock.calls.find((call) => (call[0] as Event).type === 'pathfinder-request-dock');
       expect(dockCall).toBeDefined();
     } finally {
@@ -92,14 +97,15 @@ describe('BlockEditorHeader: pop out / dock button', () => {
   it("reacts to 'pathfinder-panel-mode-change' events at runtime", () => {
     getModeSpy.mockReturnValue('sidebar');
     render(<BlockEditorHeader {...baseProps} />);
+    openKebab();
 
-    expect(screen.getByRole('button', { name: 'Pop out editor' })).toBeInTheDocument();
+    expect(popOutItem()).toHaveTextContent('Pop out');
 
     act(() => {
       document.dispatchEvent(new CustomEvent('pathfinder-panel-mode-change', { detail: { mode: 'floating' } }));
     });
 
-    expect(screen.getByRole('button', { name: 'Dock editor' })).toBeInTheDocument();
+    expect(popOutItem()).toHaveTextContent('Dock');
   });
 });
 

--- a/src/components/block-editor/BlockEditorHeader.test.tsx
+++ b/src/components/block-editor/BlockEditorHeader.test.tsx
@@ -128,3 +128,90 @@ describe('BlockEditorHeader: Library menu item visibility', () => {
     expect(screen.queryByText('Library')).not.toBeInTheDocument();
   });
 });
+
+describe('BlockEditorHeader: full screen (in the more-actions kebab)', () => {
+  let getModeSpy: jest.SpyInstance<PanelMode, []>;
+
+  beforeEach(() => {
+    getModeSpy = jest.spyOn(panelModeManager, 'getMode');
+  });
+
+  afterEach(() => {
+    getModeSpy.mockRestore();
+  });
+
+  const openKebab = () => fireEvent.click(screen.getByTestId(testIds.blockEditor.moreActionsButton));
+  const fullScreenItem = () => screen.queryByTestId('pathfinder-block-editor-go-fullscreen');
+
+  it('shows the Full screen item when not already in fullscreen', () => {
+    getModeSpy.mockReturnValue('sidebar');
+    render(<BlockEditorHeader {...baseProps} />);
+    openKebab();
+    expect(fullScreenItem()).toBeInTheDocument();
+  });
+
+  it('hides the Full screen item when already in fullscreen mode', () => {
+    getModeSpy.mockReturnValue('fullscreen');
+    render(<BlockEditorHeader {...baseProps} />);
+    openKebab();
+    expect(fullScreenItem()).not.toBeInTheDocument();
+  });
+
+  it("dispatches 'pathfinder-request-full-screen' when the Full screen item is clicked", () => {
+    getModeSpy.mockReturnValue('sidebar');
+    const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+    try {
+      render(<BlockEditorHeader {...baseProps} />);
+      openKebab();
+      fireEvent.click(fullScreenItem()!);
+      const call = dispatchSpy.mock.calls.find((c) => (c[0] as Event).type === 'pathfinder-request-full-screen');
+      expect(call).toBeDefined();
+    } finally {
+      dispatchSpy.mockRestore();
+    }
+  });
+});
+
+describe('BlockEditorHeader: selection mode (in the more-actions kebab)', () => {
+  const openKebab = () => fireEvent.click(screen.getByTestId(testIds.blockEditor.moreActionsButton));
+  const selectionItem = () => screen.queryByTestId(testIds.blockEditor.toggleSelectionButton);
+
+  it('shows the selection item only in edit mode with blocks', () => {
+    render(<BlockEditorHeader {...baseProps} viewMode="edit" hasBlocks={true} />);
+    openKebab();
+    expect(selectionItem()).toHaveTextContent('Select blocks for merging');
+  });
+
+  it('hides the selection item when the guide has no blocks', () => {
+    render(<BlockEditorHeader {...baseProps} viewMode="edit" hasBlocks={false} />);
+    openKebab();
+    expect(selectionItem()).not.toBeInTheDocument();
+  });
+
+  it('hides the selection item outside edit mode', () => {
+    render(<BlockEditorHeader {...baseProps} viewMode="preview" hasBlocks={true} />);
+    openKebab();
+    expect(selectionItem()).not.toBeInTheDocument();
+  });
+
+  it('labels the item "Exit selection mode" while selection mode is active', () => {
+    render(<BlockEditorHeader {...baseProps} viewMode="edit" hasBlocks={true} isSelectionMode={true} />);
+    openKebab();
+    expect(selectionItem()).toHaveTextContent('Exit selection mode');
+  });
+
+  it('calls onToggleSelectionMode when the item is clicked', () => {
+    const onToggleSelectionMode = jest.fn();
+    render(
+      <BlockEditorHeader
+        {...baseProps}
+        viewMode="edit"
+        hasBlocks={true}
+        onToggleSelectionMode={onToggleSelectionMode}
+      />
+    );
+    openKebab();
+    fireEvent.click(selectionItem()!);
+    expect(onToggleSelectionMode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -172,13 +172,10 @@ export function BlockEditorHeader({
 
   return (
     <div className={styles.header}>
-      {/* Single-row toolbar: title area on the left, right-aligned actions
-          cluster on the right. */}
       <div className={styles.row}>
         <HeaderTitleRow guideTitle={guideTitle} guideId={guideId} viewMode={viewMode} onTitleCommit={onTitleCommit} />
 
         <div className={styles.actions}>
-          {/* Local-save indicator, shown only when the backend is unavailable. */}
           {!isBackendAvailable &&
             (isDirty ? (
               <Tooltip content="Saving changes to local storage">

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -3,7 +3,7 @@
  *
  * Header section of the block editor. Orchestrates the title row, view-mode
  * rocker, smart save action, and the "more actions" kebab (each extracted into
- * its own component under `header/`), plus the inline status/undo/redo/panel
+ * its own component under `header/`), plus the inline status and undo/redo
  * controls that live directly on the toolbar.
  */
 
@@ -11,7 +11,6 @@ import React from 'react';
 import { Button, Badge, Icon, IconButton, Tooltip, useStyles2 } from '@grafana/ui';
 import type { ViewMode } from './types';
 import { testIds } from '../../constants/testIds';
-import { usePanelModeControls } from '../../global-state/use-panel-mode';
 import { getHeaderStyles } from './header/header.styles';
 import { HeaderTitleRow } from './header/HeaderTitleRow';
 import { ViewModeRocker } from './header/ViewModeRocker';
@@ -133,9 +132,6 @@ export function BlockEditorHeader({
 }: BlockEditorHeaderProps) {
   const styles = useStyles2(getHeaderStyles);
 
-  // Panel mode drives the Pop out / Dock swap and the full-screen affordance.
-  const { panelMode, handleTogglePanelMode, handleGoFullScreen } = usePanelModeControls();
-
   // Derive backend status badge
   const backendBadge = () => {
     if (publishedStatus === 'not-saved') {
@@ -177,17 +173,12 @@ export function BlockEditorHeader({
   return (
     <div className={styles.header}>
       {/* Single-row toolbar: title area on the left, right-aligned actions
-          cluster (status, selection toggle, undo/redo, view-mode rocker, save,
-          pop out / full screen, more-actions kebab) on the right. */}
+          cluster on the right. */}
       <div className={styles.row}>
         <HeaderTitleRow guideTitle={guideTitle} guideId={guideId} viewMode={viewMode} onTitleCommit={onTitleCommit} />
 
         <div className={styles.actions}>
-          {/* Local-save indicator — subtle icon (replaces the green
-              chip). Only shown when backend isn't available. The icon
-              is deliberately a floppy `save` so it doesn't visually
-              clash with the `check-square` selection trigger that
-              follows. */}
+          {/* Local-save indicator, shown only when the backend is unavailable. */}
           {!isBackendAvailable &&
             (isDirty ? (
               <Tooltip content="Saving changes to local storage">
@@ -221,26 +212,6 @@ export function BlockEditorHeader({
             >
               Reset guide
             </Button>
-          )}
-
-          {/* Selection-mode trigger — only meaningful in edit mode
-              with at least one block. The preceding divider exists
-              specifically to break the visual pairing between the
-              status icon and this `check-square` button, so it only
-              appears when the trigger does. */}
-          {viewMode === 'edit' && hasBlocks && (
-            <>
-              <div className={styles.divider} />
-              <IconButton
-                name="check-square"
-                size="sm"
-                variant={isSelectionMode ? 'primary' : 'secondary'}
-                onClick={onToggleSelectionMode}
-                aria-label={isSelectionMode ? 'Exit selection mode' : 'Select blocks for merging'}
-                tooltip={isSelectionMode ? 'Exit selection mode' : 'Select blocks for merging'}
-                data-testid={testIds.blockEditor.toggleSelectionButton}
-              />
-            </>
           )}
 
           {/* Undo / redo for the in-session history ring buffer. The
@@ -286,46 +257,16 @@ export function BlockEditorHeader({
             />
           )}
 
-          <Button
-            variant="secondary"
-            size="sm"
-            icon={panelMode === 'sidebar' ? 'corner-up-right' : 'corner-down-right-alt'}
-            onClick={handleTogglePanelMode}
-            tooltip={
-              panelMode === 'sidebar'
-                ? 'Pop out the editor into a floating window'
-                : 'Dock the editor back into the sidebar'
-            }
-            aria-label={panelMode === 'sidebar' ? 'Pop out editor' : 'Dock editor'}
-            className={styles.collapsibleLabel}
-            data-testid="pathfinder-block-editor-toggle-popout"
-          >
-            {panelMode === 'sidebar' ? 'Pop out' : 'Dock'}
-          </Button>
-
-          {/* Full-screen affordance — hidden when already in fullscreen
-              because the FullScreenLayout's back-arrow handles the inverse. */}
-          {panelMode !== 'fullscreen' && (
-            <Button
-              variant="secondary"
-              size="sm"
-              icon="expand-arrows"
-              onClick={handleGoFullScreen}
-              tooltip="Open the editor in full screen"
-              aria-label="Open editor in full screen"
-              className={styles.collapsibleLabel}
-              data-testid="pathfinder-block-editor-go-fullscreen"
-            >
-              Full screen
-            </Button>
-          )}
-
           <HeaderKebab
             isBackendAvailable={isBackendAvailable}
             hasBackendGuides={hasBackendGuides}
             publishedStatus={publishedStatus}
             hasUnsyncedChanges={hasUnsyncedChanges}
             isPosting={isPostingToBackend}
+            viewMode={viewMode}
+            hasBlocks={hasBlocks}
+            isSelectionMode={isSelectionMode}
+            onToggleSelectionMode={onToggleSelectionMode}
             onNewGuide={onNewGuide}
             onOpenGuideLibrary={onOpenGuideLibrary}
             onOpenImport={onOpenImport}

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -132,7 +132,6 @@ export function BlockEditorHeader({
 }: BlockEditorHeaderProps) {
   const styles = useStyles2(getHeaderStyles);
 
-  // Derive backend status badge
   const backendBadge = () => {
     if (publishedStatus === 'not-saved') {
       return (
@@ -155,7 +154,6 @@ export function BlockEditorHeader({
         </Tooltip>
       );
     }
-    // published
     if (hasUnsyncedChanges) {
       return (
         <Tooltip content="Published guide has unsaved changes">

--- a/src/components/block-editor/BlockEditorTour.tsx
+++ b/src/components/block-editor/BlockEditorTour.tsx
@@ -42,7 +42,7 @@ const TOUR_STEPS: TourStep[] = [
     target: `[data-testid="${testIds.blockEditor.moreActionsButton}"]`,
     title: 'More actions',
     content:
-      'This menu holds panel and file actions: pop out or go full screen, toggle block-selection mode, import a guide, copy or download the guide JSON, and create a GitHub PR.',
+      "This menu holds the editor's secondary actions — create or load a guide, pop out or go full screen, toggle block selection, and import, export, or share the guide JSON.",
   },
   {
     target: `[data-testid="${testIds.blockEditor.content}"]`,

--- a/src/components/block-editor/BlockEditorTour.tsx
+++ b/src/components/block-editor/BlockEditorTour.tsx
@@ -42,7 +42,7 @@ const TOUR_STEPS: TourStep[] = [
     target: `[data-testid="${testIds.blockEditor.moreActionsButton}"]`,
     title: 'More actions',
     content:
-      'This menu contains import, export, and sharing options. Use it to copy or download the guide JSON, create a GitHub PR, or import an existing guide.',
+      'This menu holds panel and file actions: pop out or go full screen, toggle block-selection mode, import a guide, copy or download the guide JSON, and create a GitHub PR.',
   },
   {
     target: `[data-testid="${testIds.blockEditor.content}"]`,

--- a/src/components/block-editor/header/HeaderKebab.tsx
+++ b/src/components/block-editor/header/HeaderKebab.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Button, Dropdown, Menu, useStyles2 } from '@grafana/ui';
+import type { ViewMode } from '../types';
 import { testIds } from '../../../constants/testIds';
+import { usePanelModeControls } from '../../../global-state/use-panel-mode';
 import { getHeaderStyles } from './header.styles';
 
 export interface HeaderKebabProps {
@@ -14,6 +16,13 @@ export interface HeaderKebabProps {
   hasUnsyncedChanges: boolean;
   /** Whether a backend operation is in progress. */
   isPosting: boolean;
+  /** Current view mode — the selection-mode item only shows in edit mode. */
+  viewMode: ViewMode;
+  /** Whether the guide has any blocks — gates the selection-mode item. */
+  hasBlocks: boolean;
+  /** Whether block-selection mode is currently active. */
+  isSelectionMode: boolean;
+  onToggleSelectionMode: () => void;
   onNewGuide: () => void;
   onOpenGuideLibrary: () => void;
   onOpenImport: () => void;
@@ -26,8 +35,9 @@ export interface HeaderKebabProps {
 }
 
 /**
- * "More actions" kebab menu for less-used editor actions (New, Library, Import,
- * Copy/Download JSON, GitHub PR, tour) plus a context-sensitive publish shortcut.
+ * "More actions" kebab menu: guide actions (New, Library, block selection), a
+ * context-sensitive publish shortcut, view controls (pop out / dock, full
+ * screen), and file actions (import, copy/download JSON, GitHub PR, tour).
  */
 export function HeaderKebab({
   isBackendAvailable,
@@ -35,6 +45,10 @@ export function HeaderKebab({
   publishedStatus,
   hasUnsyncedChanges,
   isPosting,
+  viewMode,
+  hasBlocks,
+  isSelectionMode,
+  onToggleSelectionMode,
   onNewGuide,
   onOpenGuideLibrary,
   onOpenImport,
@@ -46,6 +60,8 @@ export function HeaderKebab({
   onUnpublish,
 }: HeaderKebabProps) {
   const styles = useStyles2(getHeaderStyles);
+
+  const { panelMode, handleTogglePanelMode, handleGoFullScreen } = usePanelModeControls();
 
   // Context-sensitive publish/unpublish shortcut, rendered after the New/Library section.
   const moreMenuContextItem = () => {
@@ -70,39 +86,58 @@ export function HeaderKebab({
         icon="times-circle"
         onClick={onUnpublish}
         disabled={isPosting}
-        data-testid={testIds.blockEditor.unpublishButton}
+        testId={testIds.blockEditor.unpublishButton}
       />
     );
   };
 
-  // New + Library live here (moved from the toolbar) — both are infrequent and
-  // "New" is destructive, so it's an improvement to guard them behind a menu.
   // The context item can return null (backend available, draft, no unsynced
   // changes) — gate its trailing divider on the item itself, not on backend
   // availability, to avoid an orphan double-divider.
   const contextItem = moreMenuContextItem();
+  const showSelectionItem = viewMode === 'edit' && hasBlocks;
   const moreMenu = (
     <Menu>
-      <Menu.Item
-        label="New guide"
-        icon="file-blank"
-        onClick={onNewGuide}
-        data-testid={testIds.blockEditor.newGuideButton}
-      />
+      <Menu.Item label="New guide" icon="file-blank" onClick={onNewGuide} testId={testIds.blockEditor.newGuideButton} />
+      {showSelectionItem && (
+        <Menu.Item
+          label={isSelectionMode ? 'Exit selection mode' : 'Select blocks for merging'}
+          icon="check-square"
+          onClick={onToggleSelectionMode}
+          testId={testIds.blockEditor.toggleSelectionButton}
+        />
+      )}
       {isBackendAvailable && hasBackendGuides && (
         <Menu.Item
           label="Library"
           icon="book-open"
           onClick={onOpenGuideLibrary}
-          data-testid={testIds.blockEditor.libraryButton}
+          testId={testIds.blockEditor.libraryButton}
         />
       )}
       <Menu.Divider />
       {contextItem}
       {contextItem && <Menu.Divider />}
+      {/* Full screen is hidden when already fullscreen (the FullScreenLayout
+          back-arrow handles the inverse). */}
+      <Menu.Item
+        label={panelMode === 'sidebar' ? 'Pop out' : 'Dock'}
+        icon={panelMode === 'sidebar' ? 'corner-up-right' : 'corner-down-right-alt'}
+        onClick={handleTogglePanelMode}
+        testId="pathfinder-block-editor-toggle-popout"
+      />
+      {panelMode !== 'fullscreen' && (
+        <Menu.Item
+          label="Full screen"
+          icon="expand-arrows"
+          onClick={handleGoFullScreen}
+          testId="pathfinder-block-editor-go-fullscreen"
+        />
+      )}
+      <Menu.Divider />
       <Menu.Item label="Import" icon="upload" onClick={onOpenImport} />
       <Menu.Divider />
-      <Menu.Item label="Copy JSON" icon="copy" onClick={onCopy} data-testid={testIds.blockEditor.copyJsonButton} />
+      <Menu.Item label="Copy JSON" icon="copy" onClick={onCopy} testId={testIds.blockEditor.copyJsonButton} />
       <Menu.Item label="Download JSON" icon="download-alt" onClick={onDownload} />
       <Menu.Item label="Create GitHub PR" icon="github" onClick={onOpenGitHubPR} />
       <Menu.Divider />

--- a/src/components/block-editor/header/HeaderKebab.tsx
+++ b/src/components/block-editor/header/HeaderKebab.tsx
@@ -122,6 +122,7 @@ export function HeaderKebab({
           back-arrow handles the inverse). */}
       <Menu.Item
         label={panelMode === 'sidebar' ? 'Pop out' : 'Dock'}
+        ariaLabel={panelMode === 'sidebar' ? 'Pop out editor' : 'Dock editor'}
         icon={panelMode === 'sidebar' ? 'corner-up-right' : 'corner-down-right-alt'}
         onClick={handleTogglePanelMode}
         testId="pathfinder-block-editor-toggle-popout"
@@ -129,6 +130,7 @@ export function HeaderKebab({
       {panelMode !== 'fullscreen' && (
         <Menu.Item
           label="Full screen"
+          ariaLabel="Open editor in full screen"
           icon="expand-arrows"
           onClick={handleGoFullScreen}
           testId="pathfinder-block-editor-go-fullscreen"

--- a/src/components/block-editor/header/header.styles.ts
+++ b/src/components/block-editor/header/header.styles.ts
@@ -124,13 +124,6 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
     color: theme.colors.warning.text,
     flexShrink: 0,
   }),
-  divider: css({
-    width: '1px',
-    height: '20px',
-    backgroundColor: theme.colors.border.weak,
-    margin: `0 ${theme.spacing(0.25)}`,
-    flexShrink: 0,
-  }),
   moreButton: css({
     '& > button': {
       padding: '4px 8px',


### PR DESCRIPTION
## What & why

PR 4 of the block-editor chrome redesign ([#1256](https://github.com/grafana/grafana-pathfinder-app/issues/1256)), on top of the merged extract (#1406). Folds the **pop out / dock**, **full screen**, and **block-selection** controls off the toolbar and into the **"more actions" kebab**, shrinking the action cluster to `save · undo/redo · rocker · kebab`.

> **Sequencing note:** the plan ordered this after the rocker, but consolidating the kebab first *reduces the toolbar width*, making the rocker + responsive-tiers work (a later PR) far easier to reason about. This is independent of the rocker (disjoint files).

## Changes

- `HeaderKebab` consumes the shared `usePanelModeControls()` hook (removed from `BlockEditorHeader`) and renders three new `Menu.Item`s:
  - **Pop out / Dock** (panelMode-aware) and **Full screen** (hidden in fullscreen) — a view-controls group.
  - **Select blocks for merging** (gated to edit mode with blocks) — grouped with the guide actions near *New guide*, since it's a guide-editing operation, not a view control.
- **`testId` vs `data-testid`:** Grafana's `MenuItem` has no rest-spread — a plain `data-testid` is silently dropped; the real API is the `testId` prop. The pre-existing kebab items' `data-testid`s therefore never rendered (nothing referenced them). Converting all kebab items to `testId` makes them actually appear; the `<Button>` trigger keeps `data-testid` (it forwards correctly).
- `BlockEditorHeader.test.tsx`: pop out / dock assertions rewritten as kebab-menu interactions (open the kebab, act on the item), preserving the dispatch + runtime mode-change-reaction assertions.
- `BlockEditorTour`: "More actions" step copy updated for the relocated actions.
- Removed the now-dead `divider` style.

## Safety / sweep
- The **popout interactive step dispatches events**, not button clicks, so relocating the button doesn't affect it. No other code/e2e targets the relocated controls (full source sweep clean).
- Behavior of each moved control (gates, handlers, panelMode-aware labels) preserved byte-for-byte.

## Testing
- Block-editor jest suites: **555 pass** (header test drives the kebab menu).
- Typecheck / lint / prettier clean.
- Screenshotted the open kebab in live Grafana to confirm grouping + the shrunken toolbar.
- Ran a max-effort self-review (`/code-review max`): correctness clean across 3 independent angles; 6 comment-hygiene trims applied.

## Screenshots
<img width="559" height="497" alt="fold-editor-actions" src="https://github.com/user-attachments/assets/d0a1fa2e-dc6f-4cdb-b743-1b5e8343dff6" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
