### PR TITLE
feat(block-editor): editor header redesign — two-row toolbar, labeled rocker + Save (#1256)

### DIFF
--- a/src/components/block-editor/BlockEditor.persistence.test.tsx
+++ b/src/components/block-editor/BlockEditor.persistence.test.tsx
@@ -31,7 +31,7 @@ describe('BlockEditor persistence', () => {
   it('writes preview mode immediately when selected', () => {
     render(<BlockEditor />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Preview' }));
 
     expect(screen.queryByTestId(testIds.blockEditor.palette)).not.toBeInTheDocument();
     expect(JSON.parse(localStorage.getItem(StorageKeys.BLOCK_EDITOR_STATE)!).viewMode).toBe('preview');
@@ -40,7 +40,7 @@ describe('BlockEditor persistence', () => {
   it('restores preview mode after a remount', () => {
     const { unmount } = render(<BlockEditor />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Preview' }));
     unmount();
     render(<BlockEditor />);
 

--- a/src/components/block-editor/BlockEditorHeader.test.tsx
+++ b/src/components/block-editor/BlockEditorHeader.test.tsx
@@ -215,3 +215,38 @@ describe('BlockEditorHeader: selection mode (in the more-actions kebab)', () => 
     expect(onToggleSelectionMode).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('BlockEditorHeader: toolbar row + undo/redo', () => {
+  it('renders the view-mode rocker as radios', () => {
+    render(<BlockEditorHeader {...baseProps} viewMode="edit" />);
+    expect(screen.getByRole('radio', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Preview' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'JSON' })).toBeInTheDocument();
+  });
+
+  it('shows undo/redo in edit mode, disabled when there is no history', () => {
+    render(<BlockEditorHeader {...baseProps} viewMode="edit" canUndo={false} canRedo={false} />);
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Redo' })).toBeDisabled();
+  });
+
+  it('does not render undo/redo outside edit mode', () => {
+    render(<BlockEditorHeader {...baseProps} viewMode="preview" />);
+    expect(screen.queryByRole('button', { name: 'Undo' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Redo' })).not.toBeInTheDocument();
+  });
+});
+
+describe('BlockEditorHeader: preview mode', () => {
+  it('renders a spacer instead of the editable title input in preview', () => {
+    render(<BlockEditorHeader {...baseProps} viewMode="preview" />);
+    expect(screen.queryByLabelText('Guide title')).not.toBeInTheDocument();
+  });
+
+  it('keeps the local-save indicator visible in preview when the backend is unavailable', () => {
+    render(<BlockEditorHeader {...baseProps} viewMode="preview" isBackendAvailable={false} isDirty={false} />);
+    // The Saved-to-local-storage indicator lives in the title row, which stays
+    // rendered in preview — no-backend users don't lose save-state feedback.
+    expect(screen.getByLabelText('Saved')).toBeInTheDocument();
+  });
+});

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -225,11 +225,11 @@ export function BlockEditorHeader({
           {viewMode === 'preview' && isBackendAvailable && backendBadge()}
           {previewResetButton}
 
-          {/* Undo / redo — edit mode only; hidden below the narrow tier (still
-              reachable via keyboard). The curved-arrow glyphs are the
-              conventional undo/redo icons. */}
+          {/* Undo / redo — edit mode only. Always visible (no keyboard fallback
+              exists, and they fit even at the floating minimum width). The
+              curved-arrow glyphs are the conventional undo/redo icons. */}
           {viewMode === 'edit' && (
-            <div className={styles.undoRedo}>
+            <>
               <IconButton
                 name="corner-up-left"
                 size="sm"
@@ -250,7 +250,7 @@ export function BlockEditorHeader({
                 tooltip={redoLabel ? `Redo: ${redoLabel}` : 'Redo'}
                 data-testid="pathfinder-block-editor-redo"
               />
-            </div>
+            </>
           )}
 
           {isBackendAvailable && (

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -92,10 +92,6 @@ export interface BlockEditorHeaderProps {
   redoLabel: string | null;
 }
 
-/**
- * Header component for the block editor.
- * Compact single-row design with better organization.
- */
 export function BlockEditorHeader({
   guideTitle,
   guideId,
@@ -214,8 +210,8 @@ export function BlockEditorHeader({
         </div>
       </div>
 
-      {/* Toolbar row: view-mode rocker on the left, actions on the right.
-          Single-line, never wraps (see toolbarRow / the container-query tiers). */}
+      {/* Single-line — never wraps; the rocker and Save collapse to icons via
+          the container-query tiers instead (see toolbarRow). */}
       <div className={styles.toolbarRow}>
         <ViewModeRocker viewMode={viewMode} onSetViewMode={onSetViewMode} />
 

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -168,55 +168,68 @@ export function BlockEditorHeader({
     );
   };
 
+  const localSaveIndicator = !isBackendAvailable && (
+    <>
+      {isDirty ? (
+        <Tooltip content="Saving changes to local storage">
+          <span className={styles.savingIndicator} aria-label="Saving">
+            <Icon name="fa fa-spinner" size="sm" />
+          </span>
+        </Tooltip>
+      ) : (
+        <Tooltip content="All changes saved to local storage">
+          <span className={styles.savedIndicator} aria-label="Saved">
+            <Icon name="save" size="sm" />
+          </span>
+        </Tooltip>
+      )}
+    </>
+  );
+
+  const previewResetButton = viewMode === 'preview' && hasPreviewProgress && onResetPreviewProgress && (
+    <Button
+      variant="secondary"
+      size="sm"
+      icon="history-alt"
+      onClick={onResetPreviewProgress}
+      tooltip="Resets all interactive steps"
+      data-testid={testIds.blockEditor.previewResetButton}
+    >
+      Reset guide
+    </Button>
+  );
+
   return (
     <div className={styles.header}>
-      <div className={styles.row}>
-        <HeaderTitleRow guideTitle={guideTitle} guideId={guideId} viewMode={viewMode} onTitleCommit={onTitleCommit} />
+      {/* Title row: editable title + guide id on the left, publish status on the
+          right. Hidden in preview — the rendered guide shows its own <h1>, and
+          the badge moves to the toolbar row so publish status stays visible. */}
+      {viewMode !== 'preview' && (
+        <div className={styles.titleRow}>
+          <HeaderTitleRow guideTitle={guideTitle} guideId={guideId} viewMode={viewMode} onTitleCommit={onTitleCommit} />
+          <div className={styles.rightCluster}>
+            {localSaveIndicator}
+            {isBackendAvailable && backendBadge()}
+          </div>
+        </div>
+      )}
 
-        <div className={styles.actions}>
-          {!isBackendAvailable &&
-            (isDirty ? (
-              <Tooltip content="Saving changes to local storage">
-                <span className={styles.savingIndicator} aria-label="Saving">
-                  <Icon name="fa fa-spinner" size="sm" />
-                </span>
-              </Tooltip>
-            ) : (
-              <Tooltip content="All changes saved to local storage">
-                <span className={styles.savedIndicator} aria-label="Saved">
-                  <Icon name="save" size="sm" />
-                </span>
-              </Tooltip>
-            ))}
+      {/* Toolbar row: view-mode rocker on the left, actions on the right.
+          Single-line, never wraps (see toolbarRow / the container-query tiers). */}
+      <div className={styles.toolbarRow}>
+        <ViewModeRocker viewMode={viewMode} onSetViewMode={onSetViewMode} />
 
-          {/* Backend publish status — kept as a Badge since the
-              Draft/Published distinction is genuinely informative. */}
-          {isBackendAvailable && backendBadge()}
+        <div className={styles.rightCluster}>
+          {/* Preview mode: badge lives here (titleRow is hidden) alongside the
+              "Reset guide" affordance lifted out of the preview content area. */}
+          {viewMode === 'preview' && isBackendAvailable && backendBadge()}
+          {previewResetButton}
 
-          {/* Preview-mode "Reset guide" trigger. Mirrors the affordance that
-              previously lived inside the preview content area, but lifted into
-              the header so the rendered guide stays free of editor chrome. */}
-          {viewMode === 'preview' && hasPreviewProgress && onResetPreviewProgress && (
-            <Button
-              variant="secondary"
-              size="sm"
-              icon="history-alt"
-              onClick={onResetPreviewProgress}
-              tooltip="Resets all interactive steps"
-              data-testid={testIds.blockEditor.previewResetButton}
-            >
-              Reset guide
-            </Button>
-          )}
-
-          {/* Undo / redo for the in-session history ring buffer. The
-              labels (when present) describe the next operation in the
-              stack — useful for tooltip-driven discoverability. The
-              `corner-up-left` / `corner-up-right` icons are the
-              conventional curved-arrow glyphs every word processor /
-              editor uses for undo/redo. */}
+          {/* Undo / redo — edit mode only; hidden below the narrow tier (still
+              reachable via keyboard). The curved-arrow glyphs are the
+              conventional undo/redo icons. */}
           {viewMode === 'edit' && (
-            <>
+            <div className={styles.undoRedo}>
               <IconButton
                 name="corner-up-left"
                 size="sm"
@@ -237,10 +250,8 @@ export function BlockEditorHeader({
                 tooltip={redoLabel ? `Redo: ${redoLabel}` : 'Redo'}
                 data-testid="pathfinder-block-editor-redo"
               />
-            </>
+            </div>
           )}
-
-          <ViewModeRocker viewMode={viewMode} onSetViewMode={onSetViewMode} />
 
           {isBackendAvailable && (
             <SaveActions

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -202,7 +202,7 @@ export function BlockEditorHeader({
           (the rendered guide shows its own <h1>), so the row stays put without
           duplicating the title. Fully hiding the row in preview is deferred to
           the title-row PR. */}
-      <div className={styles.titleRow}>
+      <div className={styles.titleRow} data-testid={testIds.blockEditor.titleRow}>
         <HeaderTitleRow guideTitle={guideTitle} guideId={guideId} viewMode={viewMode} onTitleCommit={onTitleCommit} />
         <div className={styles.rightCluster}>
           {localSaveIndicator}

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -202,17 +202,17 @@ export function BlockEditorHeader({
   return (
     <div className={styles.header}>
       {/* Title row: editable title + guide id on the left, publish status on the
-          right. Hidden in preview — the rendered guide shows its own <h1>, and
-          the badge moves to the toolbar row so publish status stays visible. */}
-      {viewMode !== 'preview' && (
-        <div className={styles.titleRow}>
-          <HeaderTitleRow guideTitle={guideTitle} guideId={guideId} viewMode={viewMode} onTitleCommit={onTitleCommit} />
-          <div className={styles.rightCluster}>
-            {localSaveIndicator}
-            {isBackendAvailable && backendBadge()}
-          </div>
+          right. In preview HeaderTitleRow renders a spacer instead of the input
+          (the rendered guide shows its own <h1>), so the row stays put without
+          duplicating the title. Fully hiding the row in preview is deferred to
+          the title-row PR. */}
+      <div className={styles.titleRow}>
+        <HeaderTitleRow guideTitle={guideTitle} guideId={guideId} viewMode={viewMode} onTitleCommit={onTitleCommit} />
+        <div className={styles.rightCluster}>
+          {localSaveIndicator}
+          {isBackendAvailable && backendBadge()}
         </div>
-      )}
+      </div>
 
       {/* Toolbar row: view-mode rocker on the left, actions on the right.
           Single-line, never wraps (see toolbarRow / the container-query tiers). */}
@@ -220,14 +220,11 @@ export function BlockEditorHeader({
         <ViewModeRocker viewMode={viewMode} onSetViewMode={onSetViewMode} />
 
         <div className={styles.rightCluster}>
-          {/* Preview mode: badge lives here (titleRow is hidden) alongside the
-              "Reset guide" affordance lifted out of the preview content area. */}
-          {viewMode === 'preview' && isBackendAvailable && backendBadge()}
+          {/* "Reset guide" affordance, lifted out of the preview content area. */}
           {previewResetButton}
 
-          {/* Undo / redo — edit mode only. Always visible (no keyboard fallback
-              exists, and they fit even at the floating minimum width). The
-              curved-arrow glyphs are the conventional undo/redo icons. */}
+          {/* Undo / redo — edit mode only. Kept visible at all widths: there's no
+              keyboard shortcut, so hiding them would strand the action. */}
           {viewMode === 'edit' && (
             <>
               <IconButton

--- a/src/components/block-editor/GuideLibraryModal.tsx
+++ b/src/components/block-editor/GuideLibraryModal.tsx
@@ -225,7 +225,7 @@ export function GuideLibraryModal({
             <div className={styles.emptyState}>
               <div className={styles.emptyStateIcon}>📚</div>
               <p>No guides in library.</p>
-              <p>Use &ldquo;Save as draft&rdquo; in the editor to save your first guide.</p>
+              <p>Use &ldquo;Save&rdquo; in the editor to save your first guide.</p>
             </div>
           ) : (
             guides.map((guide) => {

--- a/src/components/block-editor/block-editor.styles.ts
+++ b/src/components/block-editor/block-editor.styles.ts
@@ -51,10 +51,6 @@ export const getBlockEditorStyles = (theme: GrafanaTheme2) => ({
     gap: theme.spacing(0.5),
   }),
 
-  viewModeToggle: css({
-    marginRight: theme.spacing(1.5),
-  }),
-
   guideTitle: css({
     fontSize: theme.typography.h4.fontSize,
     fontWeight: theme.typography.fontWeightMedium,

--- a/src/components/block-editor/header/HeaderKebab.tsx
+++ b/src/components/block-editor/header/HeaderKebab.tsx
@@ -72,7 +72,8 @@ export function HeaderKebab({
       return <Menu.Item label="Publish" icon="cloud-upload" onClick={onPostToBackend} disabled={isPosting} />;
     }
     if (publishedStatus === 'draft' && hasUnsyncedChanges) {
-      // Main save action is "Save" → offer "Publish" as a shortcut here
+      // Draft with unsynced changes: the toolbar's primary button saves the
+      // draft, so surface Publish here as a shortcut.
       return <Menu.Item label="Publish" icon="cloud-upload" onClick={onPostToBackend} disabled={isPosting} />;
     }
     if (publishedStatus === 'draft' && !hasUnsyncedChanges) {

--- a/src/components/block-editor/header/HeaderKebab.tsx
+++ b/src/components/block-editor/header/HeaderKebab.tsx
@@ -72,7 +72,7 @@ export function HeaderKebab({
       return <Menu.Item label="Publish" icon="cloud-upload" onClick={onPostToBackend} disabled={isPosting} />;
     }
     if (publishedStatus === 'draft' && hasUnsyncedChanges) {
-      // Main save action is "Update draft" → offer "Publish" as a shortcut here
+      // Main save action is "Save" → offer "Publish" as a shortcut here
       return <Menu.Item label="Publish" icon="cloud-upload" onClick={onPostToBackend} disabled={isPosting} />;
     }
     if (publishedStatus === 'draft' && !hasUnsyncedChanges) {

--- a/src/components/block-editor/header/SaveActions.test.tsx
+++ b/src/components/block-editor/header/SaveActions.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SaveActions } from './SaveActions';
+
+describe('SaveActions: smart label + routing', () => {
+  it('not-saved → "Save" (secondary), routes to onSaveDraft', () => {
+    const onSaveDraft = jest.fn();
+    const onPostToBackend = jest.fn();
+    render(
+      <SaveActions
+        publishedStatus="not-saved"
+        hasUnsyncedChanges={false}
+        isPosting={false}
+        onSaveDraft={onSaveDraft}
+        onPostToBackend={onPostToBackend}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSaveDraft).toHaveBeenCalledTimes(1);
+    expect(onPostToBackend).not.toHaveBeenCalled();
+  });
+
+  it('draft with unsynced changes → "Save", routes to onSaveDraft (never publishes)', () => {
+    const onSaveDraft = jest.fn();
+    const onPostToBackend = jest.fn();
+    render(
+      <SaveActions
+        publishedStatus="draft"
+        hasUnsyncedChanges={true}
+        isPosting={false}
+        onSaveDraft={onSaveDraft}
+        onPostToBackend={onPostToBackend}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSaveDraft).toHaveBeenCalledTimes(1);
+    expect(onPostToBackend).not.toHaveBeenCalled();
+  });
+
+  it('draft, synced → "Publish", routes to onPostToBackend', () => {
+    const onSaveDraft = jest.fn();
+    const onPostToBackend = jest.fn();
+    render(
+      <SaveActions
+        publishedStatus="draft"
+        hasUnsyncedChanges={false}
+        isPosting={false}
+        onSaveDraft={onSaveDraft}
+        onPostToBackend={onPostToBackend}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Publish' }));
+    expect(onPostToBackend).toHaveBeenCalledTimes(1);
+    expect(onSaveDraft).not.toHaveBeenCalled();
+  });
+
+  it('published → "Update", routes to onPostToBackend', () => {
+    const onSaveDraft = jest.fn();
+    const onPostToBackend = jest.fn();
+    render(
+      <SaveActions
+        publishedStatus="published"
+        hasUnsyncedChanges={false}
+        isPosting={false}
+        onSaveDraft={onSaveDraft}
+        onPostToBackend={onPostToBackend}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }));
+    expect(onPostToBackend).toHaveBeenCalledTimes(1);
+    expect(onSaveDraft).not.toHaveBeenCalled();
+  });
+
+  it('disables the button and drops the click while a backend operation is in progress', () => {
+    const onSaveDraft = jest.fn();
+    render(
+      <SaveActions
+        publishedStatus="not-saved"
+        hasUnsyncedChanges={false}
+        isPosting={true}
+        onSaveDraft={onSaveDraft}
+        onPostToBackend={jest.fn()}
+      />
+    );
+    // Grafana's Button keeps a tooltipped button focusable via aria-disabled
+    // (rather than the native disabled attribute) and drops its onClick.
+    const btn = screen.getByRole('button', { name: 'Save' });
+    expect(btn).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(btn);
+    expect(onSaveDraft).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/block-editor/header/SaveActions.tsx
+++ b/src/components/block-editor/header/SaveActions.tsx
@@ -22,9 +22,10 @@ export interface SaveActionsProps {
 }
 
 /**
- * Single smart save/publish action button whose label and variant follow the
- * backend publish state: Save as draft / Update draft (secondary) or
- * Publish / Update (primary).
+ * Single smart save/publish button whose label and variant follow the backend
+ * publish state: "Save" (secondary — an unsaved guide or a draft with local
+ * changes) or "Publish" / "Update" (primary). Label-only at full width;
+ * collapses to icon-only when the toolbar narrows (see `saveButton`).
  */
 export function SaveActions({
   publishedStatus,
@@ -44,11 +45,11 @@ export function SaveActions({
         onClick={onSaveDraft}
         disabled={isPosting}
         tooltip="Save as draft without publishing"
-        aria-label="Save as draft"
-        className={styles.collapsibleLabel}
+        aria-label="Save"
+        className={styles.saveButton}
         data-testid={testIds.blockEditor.saveDraftButton}
       >
-        Save as draft
+        Save
       </Button>
     );
   }
@@ -62,12 +63,12 @@ export function SaveActions({
           icon="save"
           onClick={onSaveDraft}
           disabled={isPosting}
-          tooltip="Save current changes to library draft"
-          aria-label="Update draft"
-          className={styles.collapsibleLabel}
+          tooltip="Save current changes to the library draft"
+          aria-label="Save"
+          className={styles.saveButton}
           data-testid={testIds.blockEditor.saveDraftButton}
         >
-          Update draft
+          Save
         </Button>
       );
     }
@@ -80,7 +81,7 @@ export function SaveActions({
         disabled={isPosting}
         tooltip="Publish and make visible to users"
         aria-label="Publish"
-        className={styles.collapsibleLabel}
+        className={styles.saveButton}
         data-testid={testIds.blockEditor.publishButton}
       >
         Publish
@@ -98,7 +99,7 @@ export function SaveActions({
       disabled={isPosting}
       tooltip="Save changes and keep published"
       aria-label="Update"
-      className={styles.collapsibleLabel}
+      className={styles.saveButton}
       data-testid={testIds.blockEditor.publishButton}
     >
       Update

--- a/src/components/block-editor/header/ViewModeRocker.tsx
+++ b/src/components/block-editor/header/ViewModeRocker.tsx
@@ -1,42 +1,58 @@
 import React from 'react';
-import { Button, ButtonGroup } from '@grafana/ui';
+import { RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import type { SelectableValue } from '@grafana/data';
 import type { ViewMode } from '../types';
 import { testIds } from '../../../constants/testIds';
+import { getHeaderStyles } from './header.styles';
 
 export interface ViewModeRockerProps {
   viewMode: ViewMode;
   onSetViewMode: (mode: ViewMode) => void;
 }
 
-/** Edit / Preview / JSON view-mode toggle. */
+const LABELED_OPTIONS: Array<SelectableValue<ViewMode>> = [
+  { value: 'edit', label: 'Edit', icon: 'pen' },
+  { value: 'preview', label: 'Preview', icon: 'eye' },
+  { value: 'json', label: 'JSON', icon: 'brackets-curly' },
+];
+
+// Same options without visible labels. `ariaLabel` keeps each radio named for
+// screen readers and e2e locators when the labeled group is collapsed away.
+const ICON_ONLY_OPTIONS: Array<SelectableValue<ViewMode>> = [
+  { value: 'edit', icon: 'pen', ariaLabel: 'Edit' },
+  { value: 'preview', icon: 'eye', ariaLabel: 'Preview' },
+  { value: 'json', icon: 'brackets-curly', ariaLabel: 'JSON' },
+];
+
+/**
+ * Edit / Preview / JSON view-mode toggle.
+ *
+ * Renders two sibling `RadioButtonGroup`s — one labeled, one icon-only — inside a
+ * single testid wrapper, and swaps between them purely with a container query
+ * (see `getHeaderStyles`). `RadioButtonGroup` has no built-in label collapse, and
+ * hiding its internal label spans via CSS would couple us to `@grafana/ui`'s
+ * markup; two groups toggled by `display: none` keep that decoupled and drop the
+ * hidden group from the accessibility tree, so only one set of radios is exposed.
+ */
 export function ViewModeRocker({ viewMode, onSetViewMode }: ViewModeRockerProps) {
+  const styles = useStyles2(getHeaderStyles);
   return (
-    <ButtonGroup data-testid={testIds.blockEditor.viewModeToggle}>
-      <Button
-        variant={viewMode === 'edit' ? 'primary' : 'secondary'}
+    <div className={styles.viewModeRocker} data-testid={testIds.blockEditor.viewModeToggle}>
+      <RadioButtonGroup
+        className={styles.viewModeRockerLabeled}
         size="sm"
-        icon="pen"
-        onClick={() => onSetViewMode('edit')}
-        tooltip="Edit"
-        aria-label="Edit"
+        options={LABELED_OPTIONS}
+        value={viewMode}
+        onChange={onSetViewMode}
       />
-      <Button
-        variant={viewMode === 'preview' ? 'primary' : 'secondary'}
+      <RadioButtonGroup
+        className={styles.viewModeRockerIconOnly}
         size="sm"
-        icon="eye"
-        onClick={() => onSetViewMode('preview')}
-        tooltip="Preview"
-        aria-label="Preview"
+        options={ICON_ONLY_OPTIONS}
+        value={viewMode}
+        onChange={onSetViewMode}
       />
-      <Button
-        variant={viewMode === 'json' ? 'primary' : 'secondary'}
-        size="sm"
-        icon="brackets-curly"
-        onClick={() => onSetViewMode('json')}
-        tooltip="JSON"
-        aria-label="JSON"
-      />
-    </ButtonGroup>
+    </div>
   );
 }
 

--- a/src/components/block-editor/header/ViewModeRocker.tsx
+++ b/src/components/block-editor/header/ViewModeRocker.tsx
@@ -16,12 +16,14 @@ const LABELED_OPTIONS: Array<SelectableValue<ViewMode>> = [
   { value: 'json', label: 'JSON', icon: 'brackets-curly' },
 ];
 
-// Same options without visible labels. `ariaLabel` keeps each radio named for
-// screen readers and e2e locators when the labeled group is collapsed away.
+// Same options without visible labels. `ariaLabel` names each radio for screen
+// readers and e2e locators; `description` restores the hover tooltip that the
+// old icon rocker had (RadioButton renders `description` as a Tooltip), so the
+// collapsed icon-only rocker stays discoverable for sighted users.
 const ICON_ONLY_OPTIONS: Array<SelectableValue<ViewMode>> = [
-  { value: 'edit', icon: 'pen', ariaLabel: 'Edit' },
-  { value: 'preview', icon: 'eye', ariaLabel: 'Preview' },
-  { value: 'json', icon: 'brackets-curly', ariaLabel: 'JSON' },
+  { value: 'edit', icon: 'pen', ariaLabel: 'Edit', description: 'Edit' },
+  { value: 'preview', icon: 'eye', ariaLabel: 'Preview', description: 'Preview' },
+  { value: 'json', icon: 'brackets-curly', ariaLabel: 'JSON', description: 'JSON' },
 ];
 
 /**

--- a/src/components/block-editor/header/header.styles.ts
+++ b/src/components/block-editor/header/header.styles.ts
@@ -97,17 +97,24 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
     padding: '0 2px',
     flexShrink: 0,
   }),
-  // Opt-in collapse for Grafana `Button` components that carry a text label.
-  // Under 500px we hide Button's content `<span>` (its direct child) and
-  // tighten horizontal padding, leaving the icon visible. Tooltips and
-  // aria-labels carry the meaning. Targets `& > span` so it only affects
-  // the labeled span that Grafana renders as a direct child of the
-  // `<button>` element this class is applied to — never any descendants.
-  // Container query fires off `toolbarRow`'s `containerType: inline-size`.
-  collapsibleLabel: css({
+  // Save/publish button: label-only at full width, icon-only once the toolbar
+  // collapses below 500px (mirrors the rocker's collapse). Grafana's Button
+  // renders the icon as its only `<svg>` and the label as a direct-child
+  // `<span>`, so we toggle those directly. Container query fires off
+  // `toolbarRow`'s `containerType: inline-size`; the aria-label carries the
+  // action name when the label is hidden.
+  saveButton: css({
+    // Full width: show the label, hide the icon glyph.
+    '& svg': {
+      display: 'none',
+    },
     '@container (max-width: 500px)': {
+      // Collapsed: icon-only — show the icon, hide the label, tighten padding.
       paddingLeft: theme.spacing(0.75),
       paddingRight: theme.spacing(0.75),
+      '& svg': {
+        display: 'inline-block',
+      },
       '& > span': {
         display: 'none',
       },

--- a/src/components/block-editor/header/header.styles.ts
+++ b/src/components/block-editor/header/header.styles.ts
@@ -43,14 +43,16 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
     marginLeft: 'auto',
     flexShrink: 0,
   }),
-  // Reserves ~180px min and grows to fill the title row. The input inside keeps
-  // `minWidth: 0 + flex: 1` so long titles ellipsis within the reserved space
-  // rather than overflowing.
+  // Grows to fill the title row but can shrink below its ~180px preferred width
+  // when space is tight (e.g. the 320px floating-panel minimum), so the status
+  // badge in `rightCluster` stays visible instead of overflowing the row. The
+  // input inside keeps `minWidth: 0` so long titles truncate rather than push
+  // the row wider.
   titleArea: css({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(0.5),
-    minWidth: 180,
+    minWidth: 0,
     flex: '1 1 180px',
     '&:hover .guide-id': {
       opacity: 1,

--- a/src/components/block-editor/header/header.styles.ts
+++ b/src/components/block-editor/header/header.styles.ts
@@ -16,17 +16,42 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
     zIndex: theme.zIndex.navbarFixed,
     flexShrink: 0,
   }),
-  // Single-row toolbar: title (flex 1) + actions cluster on the right.
-  // `containerType: inline-size` lets the per-button `@container` rule in
-  // `collapsibleLabel` collapse button labels to icon-only when the row gets
-  // narrow. Wraps to a second line when the cluster still doesn't fit.
-  row: css({
+  // Title row (top): editable title + guide id, then status/badge on the right.
+  titleRow: css({
     display: 'flex',
     alignItems: 'center',
-    padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
+    padding: `${theme.spacing(1)} ${theme.spacing(1.5)} ${theme.spacing(0.5)}`,
     gap: theme.spacing(1),
-    flexWrap: 'wrap',
+  }),
+  // Toolbar row (bottom): view-mode rocker on the left, action cluster on the
+  // right. Single-line — never wraps. `containerType: inline-size` drives the
+  // rocker's icon-only swap, the `collapsibleLabel` save collapse, and the
+  // undo/redo narrow-tier hide, all keyed off this row's width.
+  toolbarRow: css({
+    display: 'flex',
+    alignItems: 'center',
+    padding: `0 ${theme.spacing(1.5)} ${theme.spacing(1)}`,
+    gap: theme.spacing(0.5),
+    flexWrap: 'nowrap',
     containerType: 'inline-size',
+  }),
+  // Right-aligned cluster (used on both rows).
+  rightCluster: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    marginLeft: 'auto',
+    flexShrink: 0,
+  }),
+  // Undo/redo disappear entirely below the narrow tier (still reachable via
+  // keyboard shortcuts). Keyed off `toolbarRow`'s container width.
+  undoRedo: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    '@container (max-width: 420px)': {
+      display: 'none',
+    },
   }),
   // Title is guaranteed at least ~180px so the actions cluster has to wrap
   // to a new row when the row gets narrow, instead of crushing the title to
@@ -73,34 +98,13 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
     padding: '0 2px',
     flexShrink: 0,
   }),
-  // Right-side action cluster.
-  // - `marginLeft: auto` pushes the cluster to the right edge of the row,
-  //   and — when the cluster wraps onto its own line — keeps it right-aligned
-  //   on that line as well.
-  // - `flexWrap` + `rowGap` let the buttons inside the cluster spill onto a
-  //   second line once even the icon-only collapse can't keep them on one row.
-  // - Label collapse below 640px is opt-in via the `collapsibleLabel` class
-  //   on each Button that wants it (rather than a broad `& button > span`
-  //   rule scoped to the whole cluster). That avoids accidentally hiding
-  //   spans nested inside Badges, IconButtons, or future Grafana `Button`
-  //   internals that might add their own child `<span>`s.
-  actions: css({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    gap: theme.spacing(0.5),
-    flexShrink: 0,
-    flexWrap: 'wrap',
-    rowGap: theme.spacing(0.5),
-    marginLeft: 'auto',
-  }),
   // Opt-in collapse for Grafana `Button` components that carry a text label.
   // Under 640px we hide Button's content `<span>` (its direct child) and
   // tighten horizontal padding, leaving the icon visible. Tooltips and
   // aria-labels carry the meaning. Targets `& > span` so it only affects
   // the labeled span that Grafana renders as a direct child of the
   // `<button>` element this class is applied to — never any descendants.
-  // Container query fires off `row`'s `containerType: inline-size`.
+  // Container query fires off `toolbarRow`'s `containerType: inline-size`.
   collapsibleLabel: css({
     '@container (max-width: 640px)': {
       paddingLeft: theme.spacing(0.75),
@@ -118,8 +122,8 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'center',
   }),
   // Labeled group is the default; it collapses to the icon-only sibling below
-  // the toolbar's collapse breakpoint. The `@container` rule fires off `row`'s
-  // `containerType: inline-size`.
+  // the toolbar's collapse breakpoint. The `@container` rule fires off
+  // `toolbarRow`'s `containerType: inline-size`.
   viewModeRockerLabeled: css({
     '@container (max-width: 640px)': {
       display: 'none',

--- a/src/components/block-editor/header/header.styles.ts
+++ b/src/components/block-editor/header/header.styles.ts
@@ -110,6 +110,28 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
       },
     },
   }),
+  // View-mode rocker wrapper: holds the labeled + icon-only RadioButtonGroups
+  // and carries the viewModeToggle testid (the tour anchors on it). Exactly one
+  // group is visible at a time — see the two classes below.
+  viewModeRocker: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+  }),
+  // Labeled group is the default; it collapses to the icon-only sibling below
+  // the toolbar's collapse breakpoint. The `@container` rule fires off `row`'s
+  // `containerType: inline-size`.
+  viewModeRockerLabeled: css({
+    '@container (max-width: 640px)': {
+      display: 'none',
+    },
+  }),
+  // Icon-only fallback: hidden until the toolbar is too narrow for labels.
+  viewModeRockerIconOnly: css({
+    display: 'none',
+    '@container (max-width: 640px)': {
+      display: 'inline-flex',
+    },
+  }),
   // Subtler "Saved" indicator (replaces the green chip) — small floppy
   // `save` icon. Tooltip preserved for context.
   savedIndicator: css({

--- a/src/components/block-editor/header/header.styles.ts
+++ b/src/components/block-editor/header/header.styles.ts
@@ -25,8 +25,8 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
   }),
   // Toolbar row (bottom): view-mode rocker on the left, action cluster on the
   // right. Single-line — never wraps. `containerType: inline-size` drives the
-  // rocker's icon-only swap, the `collapsibleLabel` save collapse, and the
-  // undo/redo narrow-tier hide, all keyed off this row's width.
+  // rocker's icon-only swap and the `saveButton` label/icon collapse, both
+  // keyed off this row's width.
   toolbarRow: css({
     display: 'flex',
     alignItems: 'center',
@@ -42,16 +42,6 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
     gap: theme.spacing(0.5),
     marginLeft: 'auto',
     flexShrink: 0,
-  }),
-  // Undo/redo disappear entirely below the narrow tier (still reachable via
-  // keyboard shortcuts). Keyed off `toolbarRow`'s container width.
-  undoRedo: css({
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: theme.spacing(0.5),
-    '@container (max-width: 420px)': {
-      display: 'none',
-    },
   }),
   // Reserves ~180px min and grows to fill the title row. The input inside keeps
   // `minWidth: 0 + flex: 1` so long titles ellipsis within the reserved space
@@ -98,7 +88,7 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
     flexShrink: 0,
   }),
   // Save/publish button: label-only at full width, icon-only once the toolbar
-  // collapses below 500px (mirrors the rocker's collapse). Grafana's Button
+  // collapses below 420px (mirrors the rocker's collapse). Grafana's Button
   // renders the icon as its only `<svg>` and the label as a direct-child
   // `<span>`, so we toggle those directly. Container query fires off
   // `toolbarRow`'s `containerType: inline-size`; the aria-label carries the
@@ -108,7 +98,7 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
     '& svg': {
       display: 'none',
     },
-    '@container (max-width: 500px)': {
+    '@container (max-width: 420px)': {
       // Collapsed: icon-only — show the icon, hide the label, tighten padding.
       paddingLeft: theme.spacing(0.75),
       paddingRight: theme.spacing(0.75),
@@ -131,14 +121,14 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
   // the toolbar's collapse breakpoint. The `@container` rule fires off
   // `toolbarRow`'s `containerType: inline-size`.
   viewModeRockerLabeled: css({
-    '@container (max-width: 500px)': {
+    '@container (max-width: 420px)': {
       display: 'none',
     },
   }),
   // Icon-only fallback: hidden until the toolbar is too narrow for labels.
   viewModeRockerIconOnly: css({
     display: 'none',
-    '@container (max-width: 500px)': {
+    '@container (max-width: 420px)': {
       display: 'inline-flex',
     },
   }),

--- a/src/components/block-editor/header/header.styles.ts
+++ b/src/components/block-editor/header/header.styles.ts
@@ -53,10 +53,9 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
       display: 'none',
     },
   }),
-  // Title is guaranteed at least ~180px so the actions cluster has to wrap
-  // to a new row when the row gets narrow, instead of crushing the title to
-  // zero. The input inside still keeps `minWidth: 0 + flex: 1` so long
-  // titles ellipsis within the reserved 180px rather than overflowing.
+  // Reserves ~180px min and grows to fill the title row. The input inside keeps
+  // `minWidth: 0 + flex: 1` so long titles ellipsis within the reserved space
+  // rather than overflowing.
   titleArea: css({
     display: 'flex',
     alignItems: 'center',
@@ -99,14 +98,14 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
     flexShrink: 0,
   }),
   // Opt-in collapse for Grafana `Button` components that carry a text label.
-  // Under 640px we hide Button's content `<span>` (its direct child) and
+  // Under 500px we hide Button's content `<span>` (its direct child) and
   // tighten horizontal padding, leaving the icon visible. Tooltips and
   // aria-labels carry the meaning. Targets `& > span` so it only affects
   // the labeled span that Grafana renders as a direct child of the
   // `<button>` element this class is applied to — never any descendants.
   // Container query fires off `toolbarRow`'s `containerType: inline-size`.
   collapsibleLabel: css({
-    '@container (max-width: 640px)': {
+    '@container (max-width: 500px)': {
       paddingLeft: theme.spacing(0.75),
       paddingRight: theme.spacing(0.75),
       '& > span': {
@@ -125,14 +124,14 @@ export const getHeaderStyles = (theme: GrafanaTheme2) => ({
   // the toolbar's collapse breakpoint. The `@container` rule fires off
   // `toolbarRow`'s `containerType: inline-size`.
   viewModeRockerLabeled: css({
-    '@container (max-width: 640px)': {
+    '@container (max-width: 500px)': {
       display: 'none',
     },
   }),
   // Icon-only fallback: hidden until the toolbar is too narrow for labels.
   viewModeRockerIconOnly: css({
     display: 'none',
-    '@container (max-width: 640px)': {
+    '@container (max-width: 500px)': {
       display: 'inline-flex',
     },
   }),

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -218,6 +218,7 @@ export const testIds = {
   blockEditor: {
     container: 'block-editor-container',
     content: 'block-editor-content',
+    titleRow: 'block-editor-title-row',
     palette: 'block-editor-palette',
     jsonEditor: 'block-editor-json-editor',
     // Modals

--- a/tests/block-editor-title-row.spec.ts
+++ b/tests/block-editor-title-row.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from './fixtures';
+import { openBlockEditor, clearBlockEditorState } from './helpers/block-editor.helpers';
+import { testIds } from '../src/constants/testIds';
+
+/**
+ * Title-row responsive regression (header redesign, #1256 / PR #1429).
+ *
+ * At the 320px floating-panel minimum the title row must not overflow
+ * horizontally when the widest status badge ("Published (modified)") is shown,
+ * and the status must stay visible. Regression guard for the title-area shrink
+ * fix in `header.styles.ts`.
+ *
+ * The "published (modified)" backend state can't be reached without a live
+ * backend, so we (1) force the optional-backend feature toggle client-side so
+ * the status badge renders at all, and (2) rewrite the rendered badge's label to
+ * the widest value. The real title-row flex layout is what's under test.
+ */
+
+// Forces the aggregation backend toggle on before boot so `isBackendApiAvailable()`
+// returns true and the header renders the publish-status badge.
+function forceBackendToggle() {
+  let bootData: unknown;
+  Object.defineProperty(window, 'grafanaBootData', {
+    configurable: true,
+    get() {
+      return bootData;
+    },
+    set(value: unknown) {
+      try {
+        const toggles = (value as { settings?: { featureToggles?: Record<string, boolean> } })?.settings
+          ?.featureToggles;
+        if (toggles) {
+          toggles['aggregation.pathfinderbackend-ext-grafana-com.enabled'] = true;
+        }
+      } catch {
+        // ignore
+      }
+      bootData = value;
+    },
+  });
+}
+
+test.describe('Block editor header — title row responsive', () => {
+  test.beforeAll(async ({ request }) => {
+    await request.post('/api/plugins/grafana-pathfinder-app/settings', {
+      data: { enabled: true, jsonData: {} },
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(forceBackendToggle);
+    await page.goto('/');
+    await clearBlockEditorState(page);
+  });
+
+  test('title row does not overflow at 320px with the widest status badge', async ({ page }) => {
+    await openBlockEditor(page);
+
+    const titleRow = page.getByTestId(testIds.blockEditor.titleRow);
+    await expect(titleRow).toBeVisible();
+
+    // Force the status badge to its widest label ("Published (modified)").
+    const badgeForced = await titleRow.evaluate((row) => {
+      const candidates = Array.from(row.querySelectorAll('*')).filter((el) =>
+        /^(Draft|Published)/.test((el.textContent || '').trim())
+      );
+      const badge = candidates[candidates.length - 1];
+      if (!badge) {
+        return false;
+      }
+      let changed = false;
+      badge.childNodes.forEach((node) => {
+        if (node.nodeType === Node.TEXT_NODE && (node.textContent || '').trim()) {
+          node.textContent = 'Published (modified)';
+          changed = true;
+        }
+      });
+      if (!changed) {
+        badge.textContent = 'Published (modified)';
+      }
+      return true;
+    });
+    expect(badgeForced).toBe(true);
+
+    // Constrain the editor to the 320px floating-panel minimum.
+    await page.getByTestId(testIds.blockEditor.container).evaluate((container) => {
+      const el = container as HTMLElement;
+      el.style.width = '320px';
+      el.style.maxWidth = '320px';
+      void el.offsetWidth; // force reflow
+    });
+
+    // 1. No horizontal overflow.
+    const overflow = await titleRow.evaluate((el) => el.scrollWidth - el.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(0);
+
+    // 2. Status stays visible within the row (not clipped past the right edge).
+    const statusVisible = await titleRow.evaluate((row) => {
+      const badge = Array.from(row.querySelectorAll('*')).find(
+        (el) => (el.textContent || '').trim() === 'Published (modified)'
+      );
+      if (!badge) {
+        return false;
+      }
+      const b = badge.getBoundingClientRect();
+      const r = row.getBoundingClientRect();
+      return b.width > 0 && b.right <= r.right + 1;
+    });
+    expect(statusVisible).toBe(true);
+  });
+});

--- a/tests/block-editor-title-row.spec.ts
+++ b/tests/block-editor-title-row.spec.ts
@@ -3,17 +3,16 @@ import { openBlockEditor, clearBlockEditorState } from './helpers/block-editor.h
 import { testIds } from '../src/constants/testIds';
 
 /**
- * Title-row responsive regression (header redesign, #1256 / PR #1429).
- *
- * At the 320px floating-panel minimum the title row must not overflow
- * horizontally when the widest status badge ("Published (modified)") is shown,
- * and the status must stay visible. Regression guard for the title-area shrink
- * fix in `header.styles.ts`.
+ * Title-row responsive regression: at the 320px floating-panel minimum the
+ * title row must not overflow horizontally when the widest status badge
+ * ("Published (modified)") is shown, and the status must stay visible. Guards
+ * the title-area shrink behavior in `header.styles.ts`.
  *
  * The "published (modified)" backend state can't be reached without a live
- * backend, so we (1) force the optional-backend feature toggle client-side so
- * the status badge renders at all, and (2) rewrite the rendered badge's label to
- * the widest value. The real title-row flex layout is what's under test.
+ * backend, so the test (1) forces the optional-backend feature toggle
+ * client-side so the status badge renders at all, and (2) rewrites the rendered
+ * badge's label to the widest value. The real title-row flex layout is what's
+ * under test.
  */
 
 // Forces the aggregation backend toggle on before boot so `isBackendApiAvailable()`

--- a/tests/block-editor-title-row.spec.ts
+++ b/tests/block-editor-title-row.spec.ts
@@ -4,82 +4,63 @@ import { testIds } from '../src/constants/testIds';
 
 /**
  * Title-row responsive regression: at the 320px floating-panel minimum the
- * title row must not overflow horizontally when the widest status badge
- * ("Published (modified)") is shown, and the status must stay visible. Guards
- * the title-area shrink behavior in `header.styles.ts`.
+ * title row must not overflow horizontally when a wide status badge is shown,
+ * and the status must stay visible. Guards the title-area shrink behavior in
+ * `header.styles.ts` — `titleArea` must shrink below its ~180px preferred width
+ * so a non-shrinking status cluster fits instead of pushing the row into
+ * overflow.
  *
- * The "published (modified)" backend state can't be reached without a live
- * backend, so the test (1) forces the optional-backend feature toggle
- * client-side so the status badge renders at all, and (2) rewrites the rendered
- * badge's label to the widest value. The real title-row flex layout is what's
- * under test.
+ * The real "Published (modified)" badge only renders with a live backend, which
+ * isn't available in e2e, so the test injects a stand-in the width of that
+ * badge into the real status cluster. The title-row / titleArea / rightCluster
+ * flex layout under test is exercised for real; only the badge's content is
+ * synthetic.
  */
 
-// Forces the aggregation backend toggle on before boot so `isBackendApiAvailable()`
-// returns true and the header renders the publish-status badge.
-function forceBackendToggle() {
-  let bootData: unknown;
-  Object.defineProperty(window, 'grafanaBootData', {
-    configurable: true,
-    get() {
-      return bootData;
-    },
-    set(value: unknown) {
-      try {
-        const toggles = (value as { settings?: { featureToggles?: Record<string, boolean> } })?.settings
-          ?.featureToggles;
-        if (toggles) {
-          toggles['aggregation.pathfinderbackend-ext-grafana-com.enabled'] = true;
-        }
-      } catch {
-        // ignore
-      }
-      bootData = value;
-    },
-  });
-}
+// Approximate rendered width of the widest status badge ("Published (modified)").
+const WIDEST_BADGE_PX = 150;
+const STANDIN_TESTID = 'title-row-status-standin';
 
 test.describe('Block editor header — title row responsive', () => {
+  // Ensure the plugin is enabled. Keep devMode on so this doesn't clobber the
+  // parallel block-editor spec, which needs it for its recording test.
   test.beforeAll(async ({ request }) => {
     await request.post('/api/plugins/grafana-pathfinder-app/settings', {
-      data: { enabled: true, jsonData: {} },
+      data: { enabled: true, jsonData: { devMode: true, devModeUserIds: [1] } },
     });
   });
 
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript(forceBackendToggle);
     await page.goto('/');
     await clearBlockEditorState(page);
   });
 
-  test('title row does not overflow at 320px with the widest status badge', async ({ page }) => {
+  test('title row does not overflow at 320px with a wide status badge', async ({ page }) => {
     await openBlockEditor(page);
 
     const titleRow = page.getByTestId(testIds.blockEditor.titleRow);
     await expect(titleRow).toBeVisible();
 
-    // Force the status badge to its widest label ("Published (modified)").
-    const badgeForced = await titleRow.evaluate((row) => {
-      const candidates = Array.from(row.querySelectorAll('*')).filter((el) =>
-        /^(Draft|Published)/.test((el.textContent || '').trim())
-      );
-      const badge = candidates[candidates.length - 1];
-      if (!badge) {
-        return false;
-      }
-      let changed = false;
-      badge.childNodes.forEach((node) => {
-        if (node.nodeType === Node.TEXT_NODE && (node.textContent || '').trim()) {
-          node.textContent = 'Published (modified)';
-          changed = true;
+    // Inject a stand-in the width of the widest status badge into the real
+    // status cluster (rightCluster = the title row's last element child).
+    const injected = await titleRow.evaluate(
+      (row, args) => {
+        const cluster = row.lastElementChild as HTMLElement | null;
+        if (!cluster) {
+          return false;
         }
-      });
-      if (!changed) {
-        badge.textContent = 'Published (modified)';
-      }
-      return true;
-    });
-    expect(badgeForced).toBe(true);
+        const standin = document.createElement('span');
+        standin.setAttribute('data-testid', args.testId);
+        standin.textContent = 'Published (modified)';
+        standin.style.flexShrink = '0';
+        standin.style.width = `${args.widthPx}px`;
+        standin.style.whiteSpace = 'nowrap';
+        cluster.appendChild(standin);
+        return true;
+      },
+      { widthPx: WIDEST_BADGE_PX, testId: STANDIN_TESTID }
+    );
+    expect(injected).toBe(true);
 
     // Constrain the editor to the 320px floating-panel minimum.
     await page.getByTestId(testIds.blockEditor.container).evaluate((container) => {
@@ -94,16 +75,14 @@ test.describe('Block editor header — title row responsive', () => {
     expect(overflow).toBeLessThanOrEqual(0);
 
     // 2. Status stays visible within the row (not clipped past the right edge).
-    const statusVisible = await titleRow.evaluate((row) => {
-      const badge = Array.from(row.querySelectorAll('*')).find(
-        (el) => (el.textContent || '').trim() === 'Published (modified)'
-      );
-      if (!badge) {
+    const statusVisible = await page.getByTestId(STANDIN_TESTID).evaluate((standin) => {
+      const row = standin.closest('[data-testid="block-editor-title-row"]');
+      if (!row) {
         return false;
       }
-      const b = badge.getBoundingClientRect();
+      const s = standin.getBoundingClientRect();
       const r = row.getBoundingClientRect();
-      return b.width > 0 && b.right <= r.right + 1;
+      return s.width > 0 && s.right <= r.right + 1;
     });
     expect(statusVisible).toBe(true);
   });

--- a/tests/block-editor.spec.ts
+++ b/tests/block-editor.spec.ts
@@ -85,17 +85,19 @@ test.describe.serial('Block Editor', () => {
     const viewModeToggle = page.getByTestId(testIds.blockEditor.viewModeToggle);
     await expect(viewModeToggle).toBeVisible();
 
-    // Click preview mode button (eye icon) - Grafana Button uses tooltip which becomes aria-label
-    const previewButton = viewModeToggle.locator('button[aria-label="Preview"]');
-    await previewButton.click();
+    // The rocker is a RadioButtonGroup: each mode is a radio named by its label
+    // (or aria-label in the collapsed icon-only variant). The hidden variant is
+    // display:none, so only the visible group's radios are in the a11y tree.
+    const previewRadio = viewModeToggle.getByRole('radio', { name: 'Preview' });
+    await previewRadio.check();
 
     // Block palette should be hidden in preview mode
     const blockPalette = page.getByTestId(testIds.blockEditor.palette);
     await expect(blockPalette).not.toBeVisible();
 
-    // Click edit mode button (pen icon) to go back - tooltip is "Edit" not "Edit blocks"
-    const editButton = viewModeToggle.locator('button[aria-label="Edit"]');
-    await editButton.click();
+    // Switch back to edit mode.
+    const editRadio = viewModeToggle.getByRole('radio', { name: 'Edit' });
+    await editRadio.check();
 
     // Block palette should be visible again
     await expect(blockPalette).toBeVisible();


### PR DESCRIPTION
## What & why

Editor header redesign ([#1256](https://github.com/grafana/grafana-pathfinder-app/issues/1256)) — rows 2–3 of Jess's mockup: a labeled view-mode rocker on its own line, a two-row title/toolbar layout, and a labeled Save, with a measured responsive collapse.

> **Stacked on the kebab consolidation ([#1428](https://github.com/grafana/grafana-pathfinder-app/pull/1428)).** Base retargets to `main` once #1428 merges — review #1428 first. Doing the kebab first shrank the toolbar, which is what makes this bar's responsive behavior work.

## Changes

- **Rocker** — `ButtonGroup` → labeled `RadioButtonGroup<ViewMode>` (Edit/Preview/JSON) with an icon-only container-query fallback (two sibling groups toggled by `display:none`, so it doesn't depend on `@grafana/ui` internal markup). `viewModeToggle` testid stays on the wrapper (tour anchor); `onChange` still routes through `onSetViewMode` (preserves viewMode persistence).
- **Two-row layout** — the single header row splits into `titleRow` (title + guide id + publish status) and `toolbarRow` (rocker left; undo/redo, Save, kebab right). `containerType` moves to `toolbarRow`; single-line, never wraps.
- **Save** — label-only at width, icon-only when collapsed. The two draft-save states ("Save as draft"/"Update draft") both simplify to **"Save"** (mirroring the already-simple Publish/Update); smart routing (save vs publish) unchanged.
- **Collapse breakpoint 420px** — measured: the labeled toolbar needs ~370–386px, so the rocker + Save collapse to icons at ≤420px (one breakpoint, not two).
- **Undo/redo always visible** — the plan hid them below 420px "via keyboard shortcuts", but no such shortcut exists (`useGuideHistory` has none), so hiding stranded the action. They fit even at the 320px floating minimum, so they stay.

## Deferred / out of scope
- **Title-row polish → PR 5**: Draft badge recolor (purple → blue) and the gradient underline. Preview keeps the title row rendered (spacer, no duplicate `<h1>`); fully hiding it in preview is PR-5 work.
- **Tab-bar chrome (wordmark + book/editor tabs) → PR 6**; search / link / resize stay out (per #1256).

## Testing
- `npm run test:ci`: **5688 pass** (+10 new). New `SaveActions.test.tsx` pins the 4-state label + save-vs-publish routing (a private draft must never publish); `BlockEditorHeader.test.tsx` now covers the rocker radios, undo/redo visibility, and preview mode. The one unrelated failure (`schema-e2e-report.test.ts`) is a pre-existing missing `ajv` dep.
- Typecheck / lint / prettier clean.
- Ran a max-effort `/code-review`: it caught preview-mode regressions from the two-row split (local-save indicator dropped for no-backend users, missing top padding, potential narrow-width overflow) — all fixed here by not special-casing preview.

## Screenshots
#### Action row with labels
<img width="474" height="250" alt="actions-with-labels" src="https://github.com/user-attachments/assets/febed9f5-686c-4a0a-ac59-33cfeaec8082" />

#### Action row collapsed to icon only
<img width="436" height="237" alt="actions-icon-only" src="https://github.com/user-attachments/assets/3f42f1f6-d669-4bf6-b36b-84e53af3362f" />

#### Before and after of action row (full width and collapsed)
<img width="1036" height="463" alt="save-matrix" src="https://github.com/user-attachments/assets/f98b6185-2d41-457d-a5ea-da2d11e8ba08" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
