### PR TITLE
feat: migrate interactive guides API to the new Grafana App Platform group

### DIFF
--- a/docs/design/APP-PLATFORM-PUBLISH-HANDOFF.md
+++ b/docs/design/APP-PLATFORM-PUBLISH-HANDOFF.md
@@ -27,7 +27,7 @@ The current Pathfinder custom-guide storage target is an App Platform resource:
 
 ```json
 {
-  "apiVersion": "pathfinderbackend.ext.grafana.com/v1alpha1",
+  "apiVersion": "pathfinderbackend.ext.grafana.app/v1alpha1",
   "kind": "InteractiveGuide",
   "metadata": {
     "name": "hello-world-x7q2k1"
@@ -76,17 +76,17 @@ The tool returns structured fields, not only prose instructions:
     "warnings": []
   },
   "appPlatform": {
-    "apiVersion": "pathfinderbackend.ext.grafana.com/v1alpha1",
+    "apiVersion": "pathfinderbackend.ext.grafana.app/v1alpha1",
     "kind": "InteractiveGuide",
     "resource": "interactiveguides",
     "namespacePlaceholder": "{namespace}",
-    "collectionPathTemplate": "/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/{namespace}/interactiveguides",
-    "itemPathTemplate": "/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/{namespace}/interactiveguides/hello-world-x7q2k1",
+    "collectionPathTemplate": "/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/{namespace}/interactiveguides",
+    "itemPathTemplate": "/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/{namespace}/interactiveguides/hello-world-x7q2k1",
     "createMethod": "POST",
     "updateMethod": "PUT"
   },
   "resource": {
-    "apiVersion": "pathfinderbackend.ext.grafana.com/v1alpha1",
+    "apiVersion": "pathfinderbackend.ext.grafana.app/v1alpha1",
     "kind": "InteractiveGuide",
     "metadata": {
       "name": "hello-world-x7q2k1"

--- a/docs/developer/CUSTOM_GUIDES.md
+++ b/docs/developer/CUSTOM_GUIDES.md
@@ -103,7 +103,7 @@ The library (**•••** → **Library**) lists all guides stored in the Pathf
 
 ## External import (CI / Terraform / scripts)
 
-Guides can also be pushed into a stack from outside the editor — useful for CI pipelines, Terraform, or one-off scripts. The Pathfinder backend's Kubernetes-style API at `/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/{namespace}/interactiveguides` accepts the same `spec` shape the editor reads and writes, and exposes the full lifecycle (`list`/`get`/`create`/`update`/`delete`).
+Guides can also be pushed into a stack from outside the editor — useful for CI pipelines, Terraform, or one-off scripts. The Pathfinder backend's Kubernetes-style API at `/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/{namespace}/interactiveguides` accepts the same `spec` shape the editor reads and writes, and exposes the full lifecycle (`list`/`get`/`create`/`update`/`delete`).
 
 Authentication is a Grafana service-account Bearer token; writes need the **Editor** or **Admin** role. The repo ships a small helper at [`scripts/upsert-guide.sh`](../../scripts/upsert-guide.sh) that handles the GET-then-create-or-update dance:
 
@@ -137,7 +137,7 @@ When the backend is unavailable the badge area instead shows a **Saved** / **Sav
 ## Technical notes
 
 - Guide IDs are auto-generated as `<title-slug>-<4-char-random>` when a new title is first committed. Later title edits do not change the ID or backend resource name.
-- The backend stores guides as `InteractiveGuide` custom resources in the `pathfinderbackend.ext.grafana.com/v1alpha1` API group.
+- The backend stores guides as `InteractiveGuide` custom resources in the `pathfinderbackend.ext.grafana.app/v1alpha1` API group.
 - `resourceVersion` is used for optimistic concurrency control — the editor always fetches the latest version after a save before allowing a subsequent write.
 - Backend tracking state (`resourceName` and the last backend-synced guide JSON) is persisted to localStorage. Draft or published status is derived from the refreshed backend guide list, so the correct button state survives a page refresh.
 

--- a/docs/developer/EXTERNAL_API.md
+++ b/docs/developer/EXTERNAL_API.md
@@ -20,7 +20,7 @@ For one-off authoring, the in-product editor is still the easier path.
 ## Prerequisites
 
 - **Grafana Cloud** (or any stack where the
-  `aggregation.pathfinderbackend-ext-grafana-com.enabled` feature
+  `aggregation.pathfinderbackend-ext-grafana-app.enabled` feature
   toggle is on). The aggregator does **not** run in OSS Grafana.
 - A **Grafana service-account token** with at least the **Editor**
   role on the stack. Create one in **Administration → Users and
@@ -32,7 +32,7 @@ For one-off authoring, the in-product editor is still the easier path.
 ## Endpoint
 
 ```
-{stack}/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/{namespace}/interactiveguides
+{stack}/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/{namespace}/interactiveguides
 ```
 
 | Operation | Method | Path                         |
@@ -99,7 +99,7 @@ The wire format is the standard Kubernetes envelope:
 
 ```json
 {
-  "apiVersion": "pathfinderbackend.ext.grafana.com/v1alpha1",
+  "apiVersion": "pathfinderbackend.ext.grafana.app/v1alpha1",
   "kind": "InteractiveGuide",
   "metadata": {
     "name": "intro-to-loki",
@@ -118,7 +118,7 @@ The wire format is the standard Kubernetes envelope:
 
 | Field                      | Required | Description                                                                                                                                                                                                                                                        |
 | -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `apiVersion`               | yes      | Always `pathfinderbackend.ext.grafana.com/v1alpha1`.                                                                                                                                                                                                               |
+| `apiVersion`               | yes      | Always `pathfinderbackend.ext.grafana.app/v1alpha1`.                                                                                                                                                                                                               |
 | `kind`                     | yes      | Always `InteractiveGuide`.                                                                                                                                                                                                                                         |
 | `metadata.name`            | yes      | Resource name, typically a slug — see [Resource-name slug rule](#resource-name-slug-rule).                                                                                                                                                                         |
 | `metadata.namespace`       | yes      | Must match the namespace in the URL (`stacks-<id>` in Cloud).                                                                                                                                                                                                      |
@@ -145,10 +145,10 @@ and `$TOKEN` is the service-account token.
 curl -sS -X POST \
   -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
-  "https://${STACK}/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${NS}/interactiveguides" \
+  "https://${STACK}/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/${NS}/interactiveguides" \
   -d @- <<'EOF'
 {
-  "apiVersion": "pathfinderbackend.ext.grafana.com/v1alpha1",
+  "apiVersion": "pathfinderbackend.ext.grafana.app/v1alpha1",
   "kind": "InteractiveGuide",
   "metadata": { "name": "intro-to-loki", "namespace": "stacks-12345" },
   "spec": {
@@ -169,14 +169,14 @@ Responds 201 with the persisted resource. The returned
 
 ```bash
 curl -sS -H "Authorization: Bearer $TOKEN" \
-  "https://${STACK}/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${NS}/interactiveguides/intro-to-loki"
+  "https://${STACK}/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/${NS}/interactiveguides/intro-to-loki"
 ```
 
 ### List
 
 ```bash
 curl -sS -H "Authorization: Bearer $TOKEN" \
-  "https://${STACK}/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${NS}/interactiveguides"
+  "https://${STACK}/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/${NS}/interactiveguides"
 ```
 
 ### Update
@@ -186,16 +186,16 @@ that version echoed in `metadata.resourceVersion`:
 
 ```bash
 RV=$(curl -sS -H "Authorization: Bearer $TOKEN" \
-  "https://${STACK}/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${NS}/interactiveguides/intro-to-loki" \
+  "https://${STACK}/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/${NS}/interactiveguides/intro-to-loki" \
   | jq -r .metadata.resourceVersion)
 
 curl -sS -X PUT \
   -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
-  "https://${STACK}/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${NS}/interactiveguides/intro-to-loki" \
+  "https://${STACK}/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/${NS}/interactiveguides/intro-to-loki" \
   -d @- <<EOF
 {
-  "apiVersion": "pathfinderbackend.ext.grafana.com/v1alpha1",
+  "apiVersion": "pathfinderbackend.ext.grafana.app/v1alpha1",
   "kind": "InteractiveGuide",
   "metadata": { "name": "intro-to-loki", "namespace": "${NS}", "resourceVersion": "${RV}" },
   "spec": {
@@ -219,7 +219,7 @@ you get a 409 telling you to re-fetch and retry:
   "status": "Failure",
   "code": 409,
   "reason": "Conflict",
-  "message": "Operation cannot be fulfilled on interactiveguides.pathfinderbackend.ext.grafana.com \"intro-to-loki\": the object has been modified; please apply your changes to the latest version and try again"
+  "message": "Operation cannot be fulfilled on interactiveguides.pathfinderbackend.ext.grafana.app \"intro-to-loki\": the object has been modified; please apply your changes to the latest version and try again"
 }
 ```
 
@@ -227,7 +227,7 @@ you get a 409 telling you to re-fetch and retry:
 
 ```bash
 curl -sS -X DELETE -H "Authorization: Bearer $TOKEN" \
-  "https://${STACK}/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${NS}/interactiveguides/intro-to-loki"
+  "https://${STACK}/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/${NS}/interactiveguides/intro-to-loki"
 ```
 
 ## Resource-name slug rule
@@ -256,7 +256,7 @@ The aggregator returns standard Kubernetes `Status` envelopes:
   "status": "Failure",
   "code": 422,
   "reason": "Invalid",
-  "message": "InteractiveGuide.pathfinderbackend.ext.grafana.com \"intro-to-loki\" is invalid: spec.blocks[0].type: …"
+  "message": "InteractiveGuide.pathfinderbackend.ext.grafana.app \"intro-to-loki\" is invalid: spec.blocks[0].type: …"
 }
 ```
 

--- a/docs/sources/architecture/_index.md
+++ b/docs/sources/architecture/_index.md
@@ -122,7 +122,7 @@ The [block editor](../block-editor/) lets editors and admins compose guides with
 | Draft     | Saved to the Pathfinder backend; visible only in the editor's library, not in the docs panel. |
 | Published | Saved to the Pathfinder backend; visible to all users of the Grafana instance.                |
 
-The backend stores guides as `InteractiveGuide` custom resources in the `pathfinderbackend.ext.grafana.com/v1alpha1` API group. The backend is shipped as part of the plugin's Go server — there is no external service to deploy. Custom guides are scoped to the Grafana stack they are published on; they are not shared between stacks.
+The backend stores guides as `InteractiveGuide` custom resources in the `pathfinderbackend.ext.grafana.app/v1alpha1` API group. The backend is shipped as part of the plugin's Go server — there is no external service to deploy. Custom guides are scoped to the Grafana stack they are published on; they are not shared between stacks.
 
 The block editor can also import and export the underlying JSON, which is useful for bringing a guide from a development stack to production, or for review through a GitHub pull request.
 

--- a/scripts/upsert-guide.sh
+++ b/scripts/upsert-guide.sh
@@ -3,7 +3,7 @@
 # Pathfinder Backend aggregator API.
 #
 # This is a convenience wrapper around the Kubernetes-style API at
-# `/apis/pathfinderbackend.ext.grafana.com/v1alpha1/.../interactiveguides`
+# `/apis/pathfinderbackend.ext.grafana.app/v1alpha1/.../interactiveguides`
 # served by Grafana Cloud. It does what callers would otherwise have
 # to write themselves: derive a slugified resource name, GET the
 # existing resource (if any) to discover its `resourceVersion`, then
@@ -32,7 +32,7 @@
 # Requirements:
 #   - curl, jq
 #   - A Grafana service-account token with at least the Editor role
-#   - The aggregator (`pathfinderbackend.ext.grafana.com/v1alpha1`)
+#   - The aggregator (`pathfinderbackend.ext.grafana.app/v1alpha1`)
 #     must be enabled on the stack — true for Grafana Cloud, not for
 #     OSS Grafana
 #
@@ -157,7 +157,7 @@ if [[ -z "$(echo "$SPEC_JSON" | jq -r '.id // ""')" ]]; then
   SPEC_JSON=$(echo "$SPEC_JSON" | jq --arg id "$NAME" '.id = $id')
 fi
 
-BASE="https://${STACK}/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${NAMESPACE}/interactiveguides"
+BASE="https://${STACK}/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/${NAMESPACE}/interactiveguides"
 
 # GET to decide between create and update. We intentionally accept any
 # status here so we can branch on it; -f would exit on non-2xx.
@@ -176,7 +176,7 @@ case "$HTTP_CODE" in
       --arg name "$NAME" --arg ns "$NAMESPACE" --arg rv "$RESOURCE_VERSION" \
       --argjson spec "$SPEC_JSON" \
       '{
-        apiVersion: "pathfinderbackend.ext.grafana.com/v1alpha1",
+        apiVersion: "pathfinderbackend.ext.grafana.app/v1alpha1",
         kind: "InteractiveGuide",
         metadata: { name: $name, namespace: $ns, resourceVersion: $rv },
         spec: $spec
@@ -192,7 +192,7 @@ case "$HTTP_CODE" in
       --arg name "$NAME" --arg ns "$NAMESPACE" \
       --argjson spec "$SPEC_JSON" \
       '{
-        apiVersion: "pathfinderbackend.ext.grafana.com/v1alpha1",
+        apiVersion: "pathfinderbackend.ext.grafana.app/v1alpha1",
         kind: "InteractiveGuide",
         metadata: { name: $name, namespace: $ns },
         spec: $spec

--- a/src/cli/mcp/__tests__/finalize.test.ts
+++ b/src/cli/mcp/__tests__/finalize.test.ts
@@ -104,11 +104,15 @@ describe('pathfinder_finalize_for_app_platform contract', () => {
     expect(payload).toMatchInlineSnapshot(`
       {
         "appPlatform": {
-          "apiVersion": "pathfinderbackend.ext.grafana.com/v1alpha1",
-          "collectionPathTemplate": "/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/{namespace}/interactiveguides",
+          "apiVersion": "pathfinderbackend.ext.grafana.app/v1alpha1",
+          "collectionPathTemplate": "/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/{namespace}/interactiveguides",
           "createMethod": "POST",
-          "itemPathTemplate": "/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/{namespace}/interactiveguides/snapshot-fixture",
+          "errorHandling": "During the CAP→GAP migration an instance may serve only the legacy group. On a 404 from the collection POST or item PUT against apiVersion, retry once against legacyApiVersion / legacyCollectionPathTemplate / legacyItemPathTemplate (swap resource.apiVersion to legacyApiVersion too) before falling through to grafanaOss.",
+          "itemPathTemplate": "/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/{namespace}/interactiveguides/snapshot-fixture",
           "kind": "InteractiveGuide",
+          "legacyApiVersion": "pathfinderbackend.ext.grafana.com/v1alpha1",
+          "legacyCollectionPathTemplate": "/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/{namespace}/interactiveguides",
+          "legacyItemPathTemplate": "/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/{namespace}/interactiveguides/snapshot-fixture",
           "namespacePlaceholder": "{namespace}",
           "resource": "interactiveguides",
           "updateMethod": "PUT",
@@ -136,7 +140,7 @@ describe('pathfinder_finalize_for_app_platform contract', () => {
         },
         "clientGuidance": {
           "grafanaAppPlatform": {
-            "appliesWhen": "You are a Grafana-aware client (e.g., Grafana Assistant) running inside a Grafana instance that has the Pathfinder backend aggregator enabled (featureToggles["aggregation.pathfinderbackend-ext-grafana-com.enabled"] === true). If you are unsure, try this branch first; on a 404 from the collection POST or from pathfinder_manage_guide_drafts, switch to grafanaOss.",
+            "appliesWhen": "You are a Grafana-aware client (e.g., Grafana Assistant) running inside a Grafana instance that has the Pathfinder backend aggregator enabled (featureToggles["aggregation.pathfinderbackend-ext-grafana-app.enabled"] === true, or the legacy featureToggles["aggregation.pathfinderbackend-ext-grafana-com.enabled"] during the CAP→GAP migration). If you are unsure, try this branch first; on a 404 from the collection POST or from pathfinder_manage_guide_drafts, retry against appPlatform.legacyApiVersion, then switch to grafanaOss.",
             "confirmationPrompt": "Publish guide "Snapshot Fixture" to <namespace> as <status>?",
             "errorHandling": [
               "pathfinder_manage_guide_drafts conflict response (concurrent edit): the tool returns the current server-side resourceVersion in its conflict artifact. Re-read it, ask the user to confirm overwrite, then call op=apply again. A second conflict means concurrent edits are racing — tell the user and offer localExport.",
@@ -228,7 +232,7 @@ describe('pathfinder_finalize_for_app_platform contract', () => {
           "summary": "Fallback used by the grafanaOss and nonGrafanaClient branches to preserve the authored guide as files on disk that the user can later import via the block editor.",
         },
         "resource": {
-          "apiVersion": "pathfinderbackend.ext.grafana.com/v1alpha1",
+          "apiVersion": "pathfinderbackend.ext.grafana.app/v1alpha1",
           "kind": "InteractiveGuide",
           "metadata": {
             "name": "snapshot-fixture",

--- a/src/cli/mcp/__tests__/finalize.test.ts
+++ b/src/cli/mcp/__tests__/finalize.test.ts
@@ -107,12 +107,8 @@ describe('pathfinder_finalize_for_app_platform contract', () => {
           "apiVersion": "pathfinderbackend.ext.grafana.app/v1alpha1",
           "collectionPathTemplate": "/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/{namespace}/interactiveguides",
           "createMethod": "POST",
-          "errorHandling": "During the CAP→GAP migration an instance may serve only the legacy group. On a 404 from the collection POST or item PUT against apiVersion, retry once against legacyApiVersion / legacyCollectionPathTemplate / legacyItemPathTemplate (swap resource.apiVersion to legacyApiVersion too) before falling through to grafanaOss.",
           "itemPathTemplate": "/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/{namespace}/interactiveguides/snapshot-fixture",
           "kind": "InteractiveGuide",
-          "legacyApiVersion": "pathfinderbackend.ext.grafana.com/v1alpha1",
-          "legacyCollectionPathTemplate": "/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/{namespace}/interactiveguides",
-          "legacyItemPathTemplate": "/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/{namespace}/interactiveguides/snapshot-fixture",
           "namespacePlaceholder": "{namespace}",
           "resource": "interactiveguides",
           "updateMethod": "PUT",
@@ -140,7 +136,7 @@ describe('pathfinder_finalize_for_app_platform contract', () => {
         },
         "clientGuidance": {
           "grafanaAppPlatform": {
-            "appliesWhen": "You are a Grafana-aware client (e.g., Grafana Assistant) running inside a Grafana instance that has the Pathfinder backend aggregator enabled (featureToggles["aggregation.pathfinderbackend-ext-grafana-app.enabled"] === true, or the legacy featureToggles["aggregation.pathfinderbackend-ext-grafana-com.enabled"] during the CAP→GAP migration). If you are unsure, try this branch first; on a 404 from the collection POST or from pathfinder_manage_guide_drafts, retry against appPlatform.legacyApiVersion, then switch to grafanaOss.",
+            "appliesWhen": "You are a Grafana-aware client (e.g., Grafana Assistant) running inside a Grafana instance that has the Pathfinder backend aggregator enabled (featureToggles["aggregation.pathfinderbackend-ext-grafana-app.enabled"] === true). If you are unsure, try this branch first; on a 404 from the collection POST or from pathfinder_manage_guide_drafts, switch to grafanaOss.",
             "confirmationPrompt": "Publish guide "Snapshot Fixture" to <namespace> as <status>?",
             "errorHandling": [
               "pathfinder_manage_guide_drafts conflict response (concurrent edit): the tool returns the current server-side resourceVersion in its conflict artifact. Re-read it, ask the user to confirm overwrite, then call op=apply again. A second conflict means concurrent edits are racing — tell the user and offer localExport.",

--- a/src/cli/mcp/tools/finalize.ts
+++ b/src/cli/mcp/tools/finalize.ts
@@ -38,8 +38,6 @@ import { textResult, withToolErrorEnvelope } from './result';
 import { ArtifactInputBase, SessionTokenBase } from './two-mode-input';
 
 const APP_PLATFORM_API_VERSION = 'pathfinderbackend.ext.grafana.app/v1alpha1';
-// Legacy Cloud App Platform group, still served during the CAP→GAP migration.
-const APP_PLATFORM_API_VERSION_LEGACY = 'pathfinderbackend.ext.grafana.com/v1alpha1';
 const APP_PLATFORM_KIND = 'InteractiveGuide';
 const APP_PLATFORM_RESOURCE = 'interactiveguides';
 const NAMESPACE_PLACEHOLDER = '{namespace}';
@@ -121,8 +119,6 @@ async function finalizeImpl(args: {
   const title = String(content.title ?? '');
   const collectionPathTemplate = `/apis/${APP_PLATFORM_API_VERSION}/namespaces/${NAMESPACE_PLACEHOLDER}/${APP_PLATFORM_RESOURCE}`;
   const itemPathTemplate = `${collectionPathTemplate}/${id}`;
-  const legacyCollectionPathTemplate = `/apis/${APP_PLATFORM_API_VERSION_LEGACY}/namespaces/${NAMESPACE_PLACEHOLDER}/${APP_PLATFORM_RESOURCE}`;
-  const legacyItemPathTemplate = `${legacyCollectionPathTemplate}/${id}`;
   const docParam = `api:${id}`;
   const encodedDoc = encodeURIComponent(docParam);
   const viewerPath = `${PLUGIN_VIEWER_BASE}?doc=${encodedDoc}`;
@@ -148,11 +144,6 @@ async function finalizeImpl(args: {
       itemPathTemplate,
       createMethod: 'POST',
       updateMethod: 'PUT',
-      legacyApiVersion: APP_PLATFORM_API_VERSION_LEGACY,
-      legacyCollectionPathTemplate,
-      legacyItemPathTemplate,
-      errorHandling:
-        'During the CAP→GAP migration an instance may serve only the legacy group. On a 404 from the collection POST or item PUT against apiVersion, retry once against legacyApiVersion / legacyCollectionPathTemplate / legacyItemPathTemplate (swap resource.apiVersion to legacyApiVersion too) before falling through to grafanaOss.',
     },
     resource: {
       apiVersion: APP_PLATFORM_API_VERSION,
@@ -173,7 +164,7 @@ async function finalizeImpl(args: {
     clientGuidance: {
       grafanaAppPlatform: {
         appliesWhen:
-          'You are a Grafana-aware client (e.g., Grafana Assistant) running inside a Grafana instance that has the Pathfinder backend aggregator enabled (featureToggles["aggregation.pathfinderbackend-ext-grafana-app.enabled"] === true, or the legacy featureToggles["aggregation.pathfinderbackend-ext-grafana-com.enabled"] during the CAP→GAP migration). If you are unsure, try this branch first; on a 404 from the collection POST or from pathfinder_manage_guide_drafts, retry against appPlatform.legacyApiVersion, then switch to grafanaOss.',
+          'You are a Grafana-aware client (e.g., Grafana Assistant) running inside a Grafana instance that has the Pathfinder backend aggregator enabled (featureToggles["aggregation.pathfinderbackend-ext-grafana-app.enabled"] === true). If you are unsure, try this branch first; on a 404 from the collection POST or from pathfinder_manage_guide_drafts, switch to grafanaOss.',
         confirmationPrompt,
         preferredTools: {
           drafts: {

--- a/src/cli/mcp/tools/finalize.ts
+++ b/src/cli/mcp/tools/finalize.ts
@@ -37,7 +37,9 @@ import { resolveReadOnlyInput } from './read-input';
 import { textResult, withToolErrorEnvelope } from './result';
 import { ArtifactInputBase, SessionTokenBase } from './two-mode-input';
 
-const APP_PLATFORM_API_VERSION = 'pathfinderbackend.ext.grafana.com/v1alpha1';
+const APP_PLATFORM_API_VERSION = 'pathfinderbackend.ext.grafana.app/v1alpha1';
+// Legacy Cloud App Platform group, still served during the CAP→GAP migration.
+const APP_PLATFORM_API_VERSION_LEGACY = 'pathfinderbackend.ext.grafana.com/v1alpha1';
 const APP_PLATFORM_KIND = 'InteractiveGuide';
 const APP_PLATFORM_RESOURCE = 'interactiveguides';
 const NAMESPACE_PLACEHOLDER = '{namespace}';
@@ -119,6 +121,8 @@ async function finalizeImpl(args: {
   const title = String(content.title ?? '');
   const collectionPathTemplate = `/apis/${APP_PLATFORM_API_VERSION}/namespaces/${NAMESPACE_PLACEHOLDER}/${APP_PLATFORM_RESOURCE}`;
   const itemPathTemplate = `${collectionPathTemplate}/${id}`;
+  const legacyCollectionPathTemplate = `/apis/${APP_PLATFORM_API_VERSION_LEGACY}/namespaces/${NAMESPACE_PLACEHOLDER}/${APP_PLATFORM_RESOURCE}`;
+  const legacyItemPathTemplate = `${legacyCollectionPathTemplate}/${id}`;
   const docParam = `api:${id}`;
   const encodedDoc = encodeURIComponent(docParam);
   const viewerPath = `${PLUGIN_VIEWER_BASE}?doc=${encodedDoc}`;
@@ -144,6 +148,11 @@ async function finalizeImpl(args: {
       itemPathTemplate,
       createMethod: 'POST',
       updateMethod: 'PUT',
+      legacyApiVersion: APP_PLATFORM_API_VERSION_LEGACY,
+      legacyCollectionPathTemplate,
+      legacyItemPathTemplate,
+      errorHandling:
+        'During the CAP→GAP migration an instance may serve only the legacy group. On a 404 from the collection POST or item PUT against apiVersion, retry once against legacyApiVersion / legacyCollectionPathTemplate / legacyItemPathTemplate (swap resource.apiVersion to legacyApiVersion too) before falling through to grafanaOss.',
     },
     resource: {
       apiVersion: APP_PLATFORM_API_VERSION,
@@ -164,7 +173,7 @@ async function finalizeImpl(args: {
     clientGuidance: {
       grafanaAppPlatform: {
         appliesWhen:
-          'You are a Grafana-aware client (e.g., Grafana Assistant) running inside a Grafana instance that has the Pathfinder backend aggregator enabled (featureToggles["aggregation.pathfinderbackend-ext-grafana-com.enabled"] === true). If you are unsure, try this branch first; on a 404 from the collection POST or from pathfinder_manage_guide_drafts, switch to grafanaOss.',
+          'You are a Grafana-aware client (e.g., Grafana Assistant) running inside a Grafana instance that has the Pathfinder backend aggregator enabled (featureToggles["aggregation.pathfinderbackend-ext-grafana-app.enabled"] === true, or the legacy featureToggles["aggregation.pathfinderbackend-ext-grafana-com.enabled"] during the CAP→GAP migration). If you are unsure, try this branch first; on a 404 from the collection POST or from pathfinder_manage_guide_drafts, retry against appPlatform.legacyApiVersion, then switch to grafanaOss.',
         confirmationPrompt,
         preferredTools: {
           drafts: {

--- a/src/components/block-editor/hooks/useBackendGuides.ts
+++ b/src/components/block-editor/hooks/useBackendGuides.ts
@@ -3,10 +3,10 @@
  */
 
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { getBackendSrv, config } from '@grafana/runtime';
-import { lastValueFrom } from 'rxjs';
+import { config } from '@grafana/runtime';
 import type { JsonGuide } from '../types';
 import { fetchBackendGuides } from '../../../utils/fetchBackendGuides';
+import { collectionUrl, dualWrite, itemUrl } from '../../../utils/interactive-guides-api';
 import { stripAuthorNotes } from '../utils/block-export';
 import { logger } from '../../../lib/logging';
 
@@ -156,9 +156,10 @@ export function useBackendGuides(): UseBackendGuidesReturn {
         // resource.
         const exportable = stripAuthorNotes(guide);
 
-        // Wrap guide in Kubernetes resource format
-        const k8sResource = {
-          apiVersion: 'pathfinderbackend.ext.grafana.com/v1alpha1',
+        // Wrap guide in Kubernetes resource format. apiVersion is injected per
+        // target group by dualWrite so the body always matches its destination.
+        const buildBody = (apiVersion: string) => ({
+          apiVersion,
           kind: 'InteractiveGuide',
           metadata,
           spec: {
@@ -168,31 +169,12 @@ export function useBackendGuides(): UseBackendGuidesReturn {
             blocks: exportable.blocks,
             status,
           },
-        };
-
-        const baseUrl = `/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${namespace}/interactiveguides`;
+        });
 
         if (existingResourceName) {
-          // Update existing guide (PUT)
-          const url = `${baseUrl}/${existingResourceName}`;
-          await lastValueFrom(
-            getBackendSrv().fetch({
-              url,
-              method: 'PUT',
-              data: k8sResource,
-              showErrorAlert: false,
-            })
-          );
+          await dualWrite({ method: 'PUT', buildUrl: (v) => itemUrl(v, namespace, existingResourceName), buildBody });
         } else {
-          // Create new guide (POST)
-          await lastValueFrom(
-            getBackendSrv().fetch({
-              url: baseUrl,
-              method: 'POST',
-              data: k8sResource,
-              showErrorAlert: false,
-            })
-          );
+          await dualWrite({ method: 'POST', buildUrl: (v) => collectionUrl(v, namespace), buildBody });
         }
 
         // Refresh the list after saving
@@ -226,25 +208,16 @@ export function useBackendGuides(): UseBackendGuidesReturn {
           resourceVersion: currentMetadata.resourceVersion,
         };
 
-        const k8sResource = {
-          apiVersion: 'pathfinderbackend.ext.grafana.com/v1alpha1',
-          kind: 'InteractiveGuide',
-          metadata,
-          spec: {
-            ...existing.spec,
-            status: 'published' as const,
-          },
-        };
-
-        const url = `/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${namespace}/interactiveguides/${resourceName}`;
-        await lastValueFrom(
-          getBackendSrv().fetch({
-            url,
-            method: 'PUT',
-            data: k8sResource,
-            showErrorAlert: false,
-          })
-        );
+        await dualWrite({
+          method: 'PUT',
+          buildUrl: (v) => itemUrl(v, namespace, resourceName),
+          buildBody: (apiVersion) => ({
+            apiVersion,
+            kind: 'InteractiveGuide',
+            metadata,
+            spec: { ...existing.spec, status: 'published' as const },
+          }),
+        });
 
         await refreshGuides();
       } finally {
@@ -276,25 +249,16 @@ export function useBackendGuides(): UseBackendGuidesReturn {
           resourceVersion: currentMetadata.resourceVersion,
         };
 
-        const k8sResource = {
-          apiVersion: 'pathfinderbackend.ext.grafana.com/v1alpha1',
-          kind: 'InteractiveGuide',
-          metadata,
-          spec: {
-            ...existing.spec,
-            status: 'draft' as const,
-          },
-        };
-
-        const url = `/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${namespace}/interactiveguides/${resourceName}`;
-        await lastValueFrom(
-          getBackendSrv().fetch({
-            url,
-            method: 'PUT',
-            data: k8sResource,
-            showErrorAlert: false,
-          })
-        );
+        await dualWrite({
+          method: 'PUT',
+          buildUrl: (v) => itemUrl(v, namespace, resourceName),
+          buildBody: (apiVersion) => ({
+            apiVersion,
+            kind: 'InteractiveGuide',
+            metadata,
+            spec: { ...existing.spec, status: 'draft' as const },
+          }),
+        });
 
         await refreshGuides();
       } finally {
@@ -314,15 +278,7 @@ export function useBackendGuides(): UseBackendGuidesReturn {
       }
 
       try {
-        const url = `/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${namespace}/interactiveguides/${resourceName}`;
-
-        await lastValueFrom(
-          getBackendSrv().fetch({
-            url,
-            method: 'DELETE',
-            showErrorAlert: false,
-          })
-        );
+        await dualWrite({ method: 'DELETE', buildUrl: (v) => itemUrl(v, namespace, resourceName) });
 
         // Refresh the list after deleting
         await refreshGuides();

--- a/src/components/block-editor/hooks/useBackendGuides.ts
+++ b/src/components/block-editor/hooks/useBackendGuides.ts
@@ -3,10 +3,11 @@
  */
 
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { config } from '@grafana/runtime';
+import { getBackendSrv, config } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
 import type { JsonGuide } from '../types';
 import { fetchBackendGuides } from '../../../utils/fetchBackendGuides';
-import { collectionUrl, dualWrite, itemUrl } from '../../../utils/interactive-guides-api';
+import { APP_PLATFORM_API_VERSION, collectionUrl, itemUrl } from '../../../utils/interactive-guides-api';
 import { stripAuthorNotes } from '../utils/block-export';
 import { logger } from '../../../lib/logging';
 
@@ -156,10 +157,9 @@ export function useBackendGuides(): UseBackendGuidesReturn {
         // resource.
         const exportable = stripAuthorNotes(guide);
 
-        // Wrap guide in Kubernetes resource format. apiVersion is injected per
-        // target group by dualWrite so the body always matches its destination.
-        const buildBody = (apiVersion: string) => ({
-          apiVersion,
+        // Wrap guide in Kubernetes resource format
+        const k8sResource = {
+          apiVersion: APP_PLATFORM_API_VERSION,
           kind: 'InteractiveGuide',
           metadata,
           spec: {
@@ -169,13 +169,16 @@ export function useBackendGuides(): UseBackendGuidesReturn {
             blocks: exportable.blocks,
             status,
           },
-        });
+        };
 
-        if (existingResourceName) {
-          await dualWrite({ method: 'PUT', buildUrl: (v) => itemUrl(v, namespace, existingResourceName), buildBody });
-        } else {
-          await dualWrite({ method: 'POST', buildUrl: (v) => collectionUrl(v, namespace), buildBody });
-        }
+        await lastValueFrom(
+          getBackendSrv().fetch({
+            url: existingResourceName ? itemUrl(namespace, existingResourceName) : collectionUrl(namespace),
+            method: existingResourceName ? 'PUT' : 'POST',
+            data: k8sResource,
+            showErrorAlert: false,
+          })
+        );
 
         // Refresh the list after saving
         await refreshGuides();
@@ -208,16 +211,19 @@ export function useBackendGuides(): UseBackendGuidesReturn {
           resourceVersion: currentMetadata.resourceVersion,
         };
 
-        await dualWrite({
-          method: 'PUT',
-          buildUrl: (v) => itemUrl(v, namespace, resourceName),
-          buildBody: (apiVersion) => ({
-            apiVersion,
-            kind: 'InteractiveGuide',
-            metadata,
-            spec: { ...existing.spec, status: 'published' as const },
-          }),
-        });
+        await lastValueFrom(
+          getBackendSrv().fetch({
+            url: itemUrl(namespace, resourceName),
+            method: 'PUT',
+            data: {
+              apiVersion: APP_PLATFORM_API_VERSION,
+              kind: 'InteractiveGuide',
+              metadata,
+              spec: { ...existing.spec, status: 'published' as const },
+            },
+            showErrorAlert: false,
+          })
+        );
 
         await refreshGuides();
       } finally {
@@ -249,16 +255,19 @@ export function useBackendGuides(): UseBackendGuidesReturn {
           resourceVersion: currentMetadata.resourceVersion,
         };
 
-        await dualWrite({
-          method: 'PUT',
-          buildUrl: (v) => itemUrl(v, namespace, resourceName),
-          buildBody: (apiVersion) => ({
-            apiVersion,
-            kind: 'InteractiveGuide',
-            metadata,
-            spec: { ...existing.spec, status: 'draft' as const },
-          }),
-        });
+        await lastValueFrom(
+          getBackendSrv().fetch({
+            url: itemUrl(namespace, resourceName),
+            method: 'PUT',
+            data: {
+              apiVersion: APP_PLATFORM_API_VERSION,
+              kind: 'InteractiveGuide',
+              metadata,
+              spec: { ...existing.spec, status: 'draft' as const },
+            },
+            showErrorAlert: false,
+          })
+        );
 
         await refreshGuides();
       } finally {
@@ -278,7 +287,13 @@ export function useBackendGuides(): UseBackendGuidesReturn {
       }
 
       try {
-        await dualWrite({ method: 'DELETE', buildUrl: (v) => itemUrl(v, namespace, resourceName) });
+        await lastValueFrom(
+          getBackendSrv().fetch({
+            url: itemUrl(namespace, resourceName),
+            method: 'DELETE',
+            showErrorAlert: false,
+          })
+        );
 
         // Refresh the list after deleting
         await refreshGuides();

--- a/src/context-engine/context.init.ts
+++ b/src/context-engine/context.init.ts
@@ -1,6 +1,7 @@
-import { config } from '@grafana/runtime';
+import { getBackendSrv, config } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
 import { initializeEchoLogging, initializeFromRecentEvents } from './context-event-bus';
-import { collectionUrl, readListMerged } from '../utils/interactive-guides-api';
+import { collectionUrl } from '../utils/interactive-guides-api';
 import { logger } from '../lib/logging';
 
 /**
@@ -14,10 +15,25 @@ export async function fetchInteractiveGuidesFromBackend(): Promise<void> {
   }
 
   try {
-    // Dormant warm/probe: result discarded. readListMerged swallows
-    // "not rolled out" statuses and re-throws only genuine errors.
-    await readListMerged((apiVersion) => collectionUrl(apiVersion, namespace));
+    await lastValueFrom(
+      getBackendSrv().fetch({
+        url: collectionUrl(namespace),
+        method: 'GET',
+        // Optional rollout endpoint: don't show global toast when absent.
+        showErrorAlert: false,
+      })
+    );
   } catch (error) {
+    const status =
+      (error as { status?: number; statusCode?: number; data?: { statusCode?: number } })?.status ??
+      (error as { statusCode?: number })?.statusCode ??
+      (error as { data?: { statusCode?: number } })?.data?.statusCode;
+    const unavailableStatuses = new Set([400, 403, 404, 405, 501, 503]);
+
+    if (status && unavailableStatuses.has(status)) {
+      return;
+    }
+
     logger.error('[Pathfinder] Failed to fetch interactive guides', { error });
   }
 }

--- a/src/context-engine/context.init.ts
+++ b/src/context-engine/context.init.ts
@@ -1,6 +1,6 @@
-import { getBackendSrv, config } from '@grafana/runtime';
-import { lastValueFrom } from 'rxjs';
+import { config } from '@grafana/runtime';
 import { initializeEchoLogging, initializeFromRecentEvents } from './context-event-bus';
+import { collectionUrl, readListMerged } from '../utils/interactive-guides-api';
 import { logger } from '../lib/logging';
 
 /**
@@ -14,26 +14,10 @@ export async function fetchInteractiveGuidesFromBackend(): Promise<void> {
   }
 
   try {
-    const url = `/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${namespace}/interactiveguides`;
-    await lastValueFrom(
-      getBackendSrv().fetch({
-        url,
-        method: 'GET',
-        // Optional rollout endpoint: don't show global toast when absent.
-        showErrorAlert: false,
-      })
-    );
+    // Dormant warm/probe: result discarded. readListMerged swallows
+    // "not rolled out" statuses and re-throws only genuine errors.
+    await readListMerged((apiVersion) => collectionUrl(apiVersion, namespace));
   } catch (error) {
-    const status =
-      (error as { status?: number; statusCode?: number; data?: { statusCode?: number } })?.status ??
-      (error as { statusCode?: number })?.statusCode ??
-      (error as { data?: { statusCode?: number } })?.data?.statusCode;
-    const unavailableStatuses = new Set([400, 403, 404, 405, 501, 503]);
-
-    if (status && unavailableStatuses.has(status)) {
-      return;
-    }
-
     logger.error('[Pathfinder] Failed to fetch interactive guides', { error });
   }
 }

--- a/src/docs-retrieval/content-fetcher/backend-guide.test.ts
+++ b/src/docs-retrieval/content-fetcher/backend-guide.test.ts
@@ -10,7 +10,6 @@ jest.mock('@grafana/runtime', () => ({
     get namespace() {
       return mockNamespace;
     },
-    featureToggles: { 'aggregation.pathfinderbackend-ext-grafana-app.enabled': true },
   },
   getBackendSrv: () => ({ fetch: mockFetch }),
 }));
@@ -155,14 +154,14 @@ describe('fetchBackendInteractive — path traversal guard (F3)', () => {
 });
 
 describe('fetchBackendInteractive — transport failure', () => {
-  it('maps a genuine (non-"unavailable") thrown request to a load error and surfaces the status code', async () => {
-    mockFetch.mockReturnValue(throwError(() => ({ status: 500 })));
+  it('maps a thrown request to a load error and surfaces the status code', async () => {
+    mockFetch.mockReturnValue(throwError(() => ({ status: 503 })));
 
     const result = await fetchBackendInteractive('backend-guide:my-guide');
 
     expect(result.content).toBeNull();
     expect(result.error).toBe('Failed to load custom guide: my-guide');
     expect(result.errorType).toBe('other');
-    expect(result.statusCode).toBe(500);
+    expect(result.statusCode).toBe(503);
   });
 });

--- a/src/docs-retrieval/content-fetcher/backend-guide.test.ts
+++ b/src/docs-retrieval/content-fetcher/backend-guide.test.ts
@@ -10,6 +10,7 @@ jest.mock('@grafana/runtime', () => ({
     get namespace() {
       return mockNamespace;
     },
+    featureToggles: { 'aggregation.pathfinderbackend-ext-grafana-app.enabled': true },
   },
   getBackendSrv: () => ({ fetch: mockFetch }),
 }));
@@ -154,14 +155,14 @@ describe('fetchBackendInteractive — path traversal guard (F3)', () => {
 });
 
 describe('fetchBackendInteractive — transport failure', () => {
-  it('maps a thrown request to a load error and surfaces the status code', async () => {
-    mockFetch.mockReturnValue(throwError(() => ({ status: 503 })));
+  it('maps a genuine (non-"unavailable") thrown request to a load error and surfaces the status code', async () => {
+    mockFetch.mockReturnValue(throwError(() => ({ status: 500 })));
 
     const result = await fetchBackendInteractive('backend-guide:my-guide');
 
     expect(result.content).toBeNull();
     expect(result.error).toBe('Failed to load custom guide: my-guide');
     expect(result.errorType).toBe('other');
-    expect(result.statusCode).toBe(503);
+    expect(result.statusCode).toBe(500);
   });
 });

--- a/src/docs-retrieval/content-fetcher/backend-guide.ts
+++ b/src/docs-retrieval/content-fetcher/backend-guide.ts
@@ -2,8 +2,9 @@
 // by the Pathfinder backend's Kubernetes-style resource API, scoped to the
 // current Grafana namespace.
 import { ContentFetchResult } from '../../types/content.types';
-import { config } from '@grafana/runtime';
-import { itemUrl, readItemWithFallback } from '../../utils/interactive-guides-api';
+import { config, getBackendSrv } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
+import { itemUrl } from '../../utils/interactive-guides-api';
 import { validateGuide } from '../../validation';
 
 interface BackendGuideResource {
@@ -31,17 +32,16 @@ export async function fetchBackendInteractive(url: string): Promise<ContentFetch
   }
 
   try {
-    // itemUrl encodes resourceName to prevent path traversal (F3). Reads the new
-    // App Platform group first, falling back to the legacy group during migration.
-    const result = await readItemWithFallback<BackendGuideResource>((apiVersion) =>
-      itemUrl(apiVersion, namespace, resourceName)
+    // itemUrl encodes resourceName to prevent path traversal (F3).
+    const response = await lastValueFrom(
+      getBackendSrv().fetch<BackendGuideResource>({
+        url: itemUrl(namespace, resourceName),
+        method: 'GET',
+        // Optional rollout endpoint: don't show a global toast when unavailable.
+        showErrorAlert: false,
+      })
     );
-
-    if (!result.ok) {
-      return { content: null, error: `Failed to load custom guide: ${resourceName}`, errorType: 'other' };
-    }
-
-    const guideResource = result.data;
+    const guideResource = response.data;
 
     if (!guideResource?.spec?.blocks || !guideResource.spec.title) {
       return {

--- a/src/docs-retrieval/content-fetcher/backend-guide.ts
+++ b/src/docs-retrieval/content-fetcher/backend-guide.ts
@@ -2,8 +2,8 @@
 // by the Pathfinder backend's Kubernetes-style resource API, scoped to the
 // current Grafana namespace.
 import { ContentFetchResult } from '../../types/content.types';
-import { config, getBackendSrv } from '@grafana/runtime';
-import { lastValueFrom } from 'rxjs';
+import { config } from '@grafana/runtime';
+import { itemUrl, readItemWithFallback } from '../../utils/interactive-guides-api';
 import { validateGuide } from '../../validation';
 
 interface BackendGuideResource {
@@ -31,17 +31,17 @@ export async function fetchBackendInteractive(url: string): Promise<ContentFetch
   }
 
   try {
-    // SECURITY: Encode resourceName to prevent path traversal (F3)
-    const endpoint = `/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${namespace}/interactiveguides/${encodeURIComponent(resourceName)}`;
-    const response = await lastValueFrom(
-      getBackendSrv().fetch<BackendGuideResource>({
-        url: endpoint,
-        method: 'GET',
-        // Optional rollout endpoint: don't show a global toast when unavailable.
-        showErrorAlert: false,
-      })
+    // itemUrl encodes resourceName to prevent path traversal (F3). Reads the new
+    // App Platform group first, falling back to the legacy group during migration.
+    const result = await readItemWithFallback<BackendGuideResource>((apiVersion) =>
+      itemUrl(apiVersion, namespace, resourceName)
     );
-    const guideResource = response.data;
+
+    if (!result.ok) {
+      return { content: null, error: `Failed to load custom guide: ${resourceName}`, errorType: 'other' };
+    }
+
+    const guideResource = result.data;
 
     if (!guideResource?.spec?.blocks || !guideResource.spec.title) {
       return {

--- a/src/utils/fetchBackendGuides.ts
+++ b/src/utils/fetchBackendGuides.ts
@@ -1,67 +1,26 @@
 /**
- * Shared utility for fetching backend guides
+ * Shared utility for fetching backend guides.
+ *
+ * Group resolution, availability, and read semantics live in
+ * `./interactive-guides-api`; this module is the guide-list read on top of it.
  */
 
-import { config, getBackendSrv } from '@grafana/runtime';
-import { lastValueFrom } from 'rxjs';
+import { collectionUrl, isBackendApiAvailable, readListMerged } from './interactive-guides-api';
 
-interface BackendGuidesList {
-  items?: any[];
-}
+// Re-exported so existing importers (e.g. BlockEditor) keep a stable path.
+export { isBackendApiAvailable };
 
 /**
- * Returns true when the Pathfinder backend API is available in this Grafana instance.
- * Reads the boot-time feature toggle set by the aggregation layer.
- */
-export function isBackendApiAvailable(): boolean {
-  const featureToggles = config.featureToggles as Record<string, boolean> | undefined;
-  return featureToggles?.['aggregation.pathfinderbackend-ext-grafana-com.enabled'] === true;
-}
-
-/** HTTP status codes that indicate the optional backend API is not yet rolled out */
-const UNAVAILABLE_STATUSES = new Set([400, 403, 404, 405, 501, 503]);
-
-/**
- * Fetch guides from the backend API
- * Returns empty array if endpoint is unavailable or on error.
- * When publishedOnly is true, only guides with spec.status === 'published' are returned;
- * guides with missing/undefined status are treated as draft and excluded.
+ * Fetch guides from the backend API. Returns an empty array when the endpoint
+ * is unavailable; genuine (non-"not rolled out") errors propagate to the caller.
+ * When publishedOnly is true, only guides with spec.status === 'published' are
+ * returned; guides with missing/undefined status are treated as draft and excluded.
  */
 export async function fetchBackendGuides(namespace: string, publishedOnly?: boolean): Promise<any[]> {
-  if (!isBackendApiAvailable()) {
-    return [];
+  const items = await readListMerged<any>((apiVersion) => collectionUrl(apiVersion, namespace));
+
+  if (publishedOnly) {
+    return items.filter((item: any) => item.spec?.status === 'published');
   }
-
-  try {
-    const url = `/apis/pathfinderbackend.ext.grafana.com/v1alpha1/namespaces/${namespace}/interactiveguides`;
-
-    const response = await lastValueFrom(
-      getBackendSrv().fetch<BackendGuidesList>({
-        url,
-        method: 'GET',
-        showErrorAlert: false,
-      })
-    );
-
-    const items = response.data?.items || [];
-
-    if (publishedOnly) {
-      return items.filter((item: any) => item.spec?.status === 'published');
-    }
-
-    return items;
-  } catch (err) {
-    const status =
-      (err as { status?: number; statusCode?: number; data?: { statusCode?: number } })?.status ??
-      (err as { statusCode?: number })?.statusCode ??
-      (err as { data?: { statusCode?: number } })?.data?.statusCode;
-
-    // Endpoint may not be rolled out yet - treat as unavailable
-    if (status && UNAVAILABLE_STATUSES.has(status)) {
-      return [];
-    }
-
-    // Re-throw for caller to handle
-    throw err;
-  }
+  return items;
 }

--- a/src/utils/fetchBackendGuides.ts
+++ b/src/utils/fetchBackendGuides.ts
@@ -1,26 +1,61 @@
 /**
- * Shared utility for fetching backend guides.
- *
- * Group resolution, availability, and read semantics live in
- * `./interactive-guides-api`; this module is the guide-list read on top of it.
+ * Shared utility for fetching backend guides from the App Platform (GAP) group.
  */
 
-import { collectionUrl, isBackendApiAvailable, readListMerged } from './interactive-guides-api';
+import { getBackendSrv } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
+
+import { collectionUrl, isBackendApiAvailable } from './interactive-guides-api';
 
 // Re-exported so existing importers (e.g. BlockEditor) keep a stable path.
 export { isBackendApiAvailable };
 
+interface BackendGuidesList {
+  items?: any[];
+}
+
+/** HTTP status codes that indicate the optional backend API is not yet rolled out. */
+const UNAVAILABLE_STATUSES = new Set([400, 403, 404, 405, 501, 503]);
+
 /**
- * Fetch guides from the backend API. Returns an empty array when the endpoint
- * is unavailable; genuine (non-"not rolled out") errors propagate to the caller.
- * When publishedOnly is true, only guides with spec.status === 'published' are
- * returned; guides with missing/undefined status are treated as draft and excluded.
+ * Fetch guides from the backend API. Returns an empty array if the endpoint is
+ * unavailable or on error. When publishedOnly is true, only guides with
+ * spec.status === 'published' are returned; guides with missing/undefined
+ * status are treated as draft and excluded.
  */
 export async function fetchBackendGuides(namespace: string, publishedOnly?: boolean): Promise<any[]> {
-  const items = await readListMerged<any>((apiVersion) => collectionUrl(apiVersion, namespace));
-
-  if (publishedOnly) {
-    return items.filter((item: any) => item.spec?.status === 'published');
+  if (!isBackendApiAvailable() || !namespace) {
+    return [];
   }
-  return items;
+
+  try {
+    const response = await lastValueFrom(
+      getBackendSrv().fetch<BackendGuidesList>({
+        url: collectionUrl(namespace),
+        method: 'GET',
+        showErrorAlert: false,
+      })
+    );
+
+    const items = response.data?.items || [];
+
+    if (publishedOnly) {
+      return items.filter((item: any) => item.spec?.status === 'published');
+    }
+
+    return items;
+  } catch (err) {
+    const status =
+      (err as { status?: number; statusCode?: number; data?: { statusCode?: number } })?.status ??
+      (err as { statusCode?: number })?.statusCode ??
+      (err as { data?: { statusCode?: number } })?.data?.statusCode;
+
+    // Endpoint may not be rolled out yet - treat as unavailable.
+    if (status && UNAVAILABLE_STATUSES.has(status)) {
+      return [];
+    }
+
+    // Re-throw for caller to handle.
+    throw err;
+  }
 }

--- a/src/utils/interactive-guides-api.test.ts
+++ b/src/utils/interactive-guides-api.test.ts
@@ -1,0 +1,214 @@
+import { of, throwError } from 'rxjs';
+
+let mockToggles: Record<string, boolean> = {};
+const mockFetch = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  config: {
+    get featureToggles() {
+      return mockToggles;
+    },
+  },
+  getBackendSrv: () => ({ fetch: mockFetch }),
+}));
+
+const mockWarn = jest.fn();
+jest.mock('../lib/logging', () => ({
+  logger: { warn: (...args: unknown[]) => mockWarn(...args) },
+}));
+
+import {
+  apiVersionFor,
+  collectionUrl,
+  dualWrite,
+  isBackendApiAvailable,
+  itemUrl,
+  readItemWithFallback,
+  readListMerged,
+  resolveAvailability,
+} from './interactive-guides-api';
+
+const NEW_TOGGLE = 'aggregation.pathfinderbackend-ext-grafana-app.enabled';
+const OLD_TOGGLE = 'aggregation.pathfinderbackend-ext-grafana-com.enabled';
+const NEW_V = 'pathfinderbackend.ext.grafana.app/v1alpha1';
+const OLD_V = 'pathfinderbackend.ext.grafana.com/v1alpha1';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockToggles = {};
+});
+
+describe('availability resolution', () => {
+  it.each([
+    [{ [NEW_TOGGLE]: true, [OLD_TOGGLE]: true }, true, true],
+    [{ [NEW_TOGGLE]: true }, true, false],
+    [{ [OLD_TOGGLE]: true }, false, true],
+    [{}, false, false],
+  ])('toggles %o → new=%s old=%s', (toggles, newAvailable, oldAvailable) => {
+    mockToggles = toggles as Record<string, boolean>;
+    expect(resolveAvailability()).toEqual({ newAvailable, oldAvailable });
+    expect(isBackendApiAvailable()).toBe(newAvailable || oldAvailable);
+  });
+});
+
+describe('url + apiVersion builders', () => {
+  it('derives apiVersion per group', () => {
+    expect(apiVersionFor('new')).toBe(NEW_V);
+    expect(apiVersionFor('old')).toBe(OLD_V);
+  });
+
+  it('builds collection and item URLs, encoding the name', () => {
+    expect(collectionUrl(NEW_V, 'stacks-1')).toBe(`/apis/${NEW_V}/namespaces/stacks-1/interactiveguides`);
+    expect(itemUrl(NEW_V, 'stacks-1', '../x')).toBe(
+      `/apis/${NEW_V}/namespaces/stacks-1/interactiveguides/${encodeURIComponent('../x')}`
+    );
+  });
+});
+
+describe('readItemWithFallback', () => {
+  const build = (v: string) => itemUrl(v, 'ns', 'g1');
+
+  it('returns unavailable when neither group is on, without fetching', async () => {
+    const result = await readItemWithFallback(build);
+    expect(result).toEqual({ ok: false, reason: 'unavailable' });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('reads the new group first when available', async () => {
+    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
+    mockFetch.mockReturnValueOnce(of({ data: { id: 'from-new' } }));
+
+    const result = await readItemWithFallback<{ id: string }>(build);
+
+    expect(result).toEqual({ ok: true, data: { id: 'from-new' }, group: 'new' });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]![0].url).toContain(NEW_V);
+  });
+
+  it('falls back to the old group when new returns an unavailable status (404)', async () => {
+    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
+    mockFetch
+      .mockReturnValueOnce(throwError(() => ({ status: 404 })))
+      .mockReturnValueOnce(of({ data: { id: 'from-old' } }));
+
+    const result = await readItemWithFallback<{ id: string }>(build);
+
+    expect(result).toEqual({ ok: true, data: { id: 'from-old' }, group: 'old' });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[1]![0].url).toContain(OLD_V);
+  });
+
+  it('re-throws a genuine (non-unavailable) error instead of falling back', async () => {
+    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
+    mockFetch.mockReturnValueOnce(throwError(() => ({ status: 500 })));
+
+    await expect(readItemWithFallback(build)).rejects.toEqual({ status: 500 });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns unavailable when both groups 404', async () => {
+    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
+    mockFetch
+      .mockReturnValueOnce(throwError(() => ({ status: 404 })))
+      .mockReturnValueOnce(throwError(() => ({ status: 404 })));
+
+    expect(await readItemWithFallback(build)).toEqual({ ok: false, reason: 'unavailable' });
+  });
+});
+
+describe('readListMerged', () => {
+  const build = (v: string) => collectionUrl(v, 'ns');
+
+  it('returns [] when neither group is available', async () => {
+    expect(await readListMerged(build)).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('unions both groups deduped by metadata.name, new winning', async () => {
+    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
+    mockFetch
+      .mockReturnValueOnce(of({ data: { items: [{ metadata: { name: 'a' }, v: 'new' }] } }))
+      .mockReturnValueOnce(
+        of({ data: { items: [{ metadata: { name: 'a' }, v: 'old' }, { metadata: { name: 'b' } }] } })
+      );
+
+    const items = await readListMerged<{ metadata: { name: string }; v?: string }>(build);
+
+    expect(items).toHaveLength(2);
+    expect(items.find((i) => i.metadata.name === 'a')!.v).toBe('new');
+    expect(items.some((i) => i.metadata.name === 'b')).toBe(true);
+  });
+
+  it('surfaces old-group items when the new group is available but empty (pre-backfill)', async () => {
+    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
+    mockFetch
+      .mockReturnValueOnce(of({ data: { items: [] } }))
+      .mockReturnValueOnce(of({ data: { items: [{ metadata: { name: 'b' } }] } }));
+
+    const items = await readListMerged<{ metadata: { name: string } }>(build);
+    expect(items).toEqual([{ metadata: { name: 'b' } }]);
+  });
+
+  it('re-throws a genuine error', async () => {
+    mockToggles = { [NEW_TOGGLE]: true };
+    mockFetch.mockReturnValueOnce(throwError(() => ({ status: 500 })));
+    await expect(readListMerged(build)).rejects.toEqual({ status: 500 });
+  });
+});
+
+describe('dualWrite', () => {
+  const build = (v: string) => itemUrl(v, 'ns', 'g1');
+
+  it('throws when neither group is available', async () => {
+    await expect(dualWrite({ method: 'PUT', buildUrl: build })).rejects.toThrow('not available');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('writes to both groups new-first with the correct apiVersion per body', async () => {
+    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
+    mockFetch.mockReturnValue(of({ data: {} }));
+
+    const result = await dualWrite({
+      method: 'POST',
+      buildUrl: (v) => collectionUrl(v, 'ns'),
+      buildBody: (v) => ({ apiVersion: v }),
+    });
+
+    expect(result).toEqual({ primaryGroup: 'new', secondaryFailures: [] });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]![0].data.apiVersion).toBe(NEW_V);
+    expect(mockFetch.mock.calls[0]![0].url).toContain(NEW_V);
+    expect(mockFetch.mock.calls[1]![0].data.apiVersion).toBe(OLD_V);
+  });
+
+  it('writes only the old group when only old is available (old is primary)', async () => {
+    mockToggles = { [OLD_TOGGLE]: true };
+    mockFetch.mockReturnValue(of({ data: {} }));
+
+    const result = await dualWrite({ method: 'DELETE', buildUrl: build });
+
+    expect(result.primaryGroup).toBe('old');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]![0].url).toContain(OLD_V);
+  });
+
+  it('tolerates a secondary failure: resolves, records it, and warns', async () => {
+    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
+    mockFetch
+      .mockReturnValueOnce(of({ data: {} })) // new (primary) ok
+      .mockReturnValueOnce(throwError(() => ({ status: 409 }))); // old (secondary) fails
+
+    const result = await dualWrite({ method: 'PUT', buildUrl: build });
+
+    expect(result).toEqual({ primaryGroup: 'new', secondaryFailures: ['old'] });
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws on primary failure and never attempts the secondary', async () => {
+    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
+    mockFetch.mockReturnValueOnce(throwError(() => ({ status: 500 })));
+
+    await expect(dualWrite({ method: 'PUT', buildUrl: build })).rejects.toEqual({ status: 500 });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/interactive-guides-api.test.ts
+++ b/src/utils/interactive-guides-api.test.ts
@@ -1,7 +1,4 @@
-import { of, throwError } from 'rxjs';
-
 let mockToggles: Record<string, boolean> = {};
-const mockFetch = jest.fn();
 
 jest.mock('@grafana/runtime', () => ({
   config: {
@@ -9,206 +6,43 @@ jest.mock('@grafana/runtime', () => ({
       return mockToggles;
     },
   },
-  getBackendSrv: () => ({ fetch: mockFetch }),
 }));
 
-const mockWarn = jest.fn();
-jest.mock('../lib/logging', () => ({
-  logger: { warn: (...args: unknown[]) => mockWarn(...args) },
-}));
+import { APP_PLATFORM_API_VERSION, collectionUrl, isBackendApiAvailable, itemUrl } from './interactive-guides-api';
 
-import {
-  apiVersionFor,
-  collectionUrl,
-  dualWrite,
-  isBackendApiAvailable,
-  itemUrl,
-  readItemWithFallback,
-  readListMerged,
-  resolveAvailability,
-} from './interactive-guides-api';
-
-const NEW_TOGGLE = 'aggregation.pathfinderbackend-ext-grafana-app.enabled';
-const OLD_TOGGLE = 'aggregation.pathfinderbackend-ext-grafana-com.enabled';
-const NEW_V = 'pathfinderbackend.ext.grafana.app/v1alpha1';
-const OLD_V = 'pathfinderbackend.ext.grafana.com/v1alpha1';
+const GAP_TOGGLE = 'aggregation.pathfinderbackend-ext-grafana-app.enabled';
 
 beforeEach(() => {
-  jest.clearAllMocks();
   mockToggles = {};
 });
 
-describe('availability resolution', () => {
-  it.each([
-    [{ [NEW_TOGGLE]: true, [OLD_TOGGLE]: true }, true, true],
-    [{ [NEW_TOGGLE]: true }, true, false],
-    [{ [OLD_TOGGLE]: true }, false, true],
-    [{}, false, false],
-  ])('toggles %o → new=%s old=%s', (toggles, newAvailable, oldAvailable) => {
-    mockToggles = toggles as Record<string, boolean>;
-    expect(resolveAvailability()).toEqual({ newAvailable, oldAvailable });
-    expect(isBackendApiAvailable()).toBe(newAvailable || oldAvailable);
+describe('isBackendApiAvailable', () => {
+  it('is true only when the GAP aggregation toggle is on', () => {
+    mockToggles = { [GAP_TOGGLE]: true };
+    expect(isBackendApiAvailable()).toBe(true);
+  });
+
+  it('is false when the toggle is absent', () => {
+    expect(isBackendApiAvailable()).toBe(false);
+  });
+
+  it('does not treat the legacy CAP toggle as availability', () => {
+    mockToggles = { 'aggregation.pathfinderbackend-ext-grafana-com.enabled': true };
+    expect(isBackendApiAvailable()).toBe(false);
   });
 });
 
-describe('url + apiVersion builders', () => {
-  it('derives apiVersion per group', () => {
-    expect(apiVersionFor('new')).toBe(NEW_V);
-    expect(apiVersionFor('old')).toBe(OLD_V);
-  });
-
-  it('builds collection and item URLs, encoding the name', () => {
-    expect(collectionUrl(NEW_V, 'stacks-1')).toBe(`/apis/${NEW_V}/namespaces/stacks-1/interactiveguides`);
-    expect(itemUrl(NEW_V, 'stacks-1', '../x')).toBe(
-      `/apis/${NEW_V}/namespaces/stacks-1/interactiveguides/${encodeURIComponent('../x')}`
+describe('url builders', () => {
+  it('targets the GAP group/version', () => {
+    expect(APP_PLATFORM_API_VERSION).toBe('pathfinderbackend.ext.grafana.app/v1alpha1');
+    expect(collectionUrl('stacks-1')).toBe(
+      '/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/stacks-1/interactiveguides'
     );
   });
-});
 
-describe('readItemWithFallback', () => {
-  const build = (v: string) => itemUrl(v, 'ns', 'g1');
-
-  it('returns unavailable when neither group is on, without fetching', async () => {
-    const result = await readItemWithFallback(build);
-    expect(result).toEqual({ ok: false, reason: 'unavailable' });
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it('reads the new group first when available', async () => {
-    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
-    mockFetch.mockReturnValueOnce(of({ data: { id: 'from-new' } }));
-
-    const result = await readItemWithFallback<{ id: string }>(build);
-
-    expect(result).toEqual({ ok: true, data: { id: 'from-new' }, group: 'new' });
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch.mock.calls[0]![0].url).toContain(NEW_V);
-  });
-
-  it('falls back to the old group when new returns an unavailable status (404)', async () => {
-    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
-    mockFetch
-      .mockReturnValueOnce(throwError(() => ({ status: 404 })))
-      .mockReturnValueOnce(of({ data: { id: 'from-old' } }));
-
-    const result = await readItemWithFallback<{ id: string }>(build);
-
-    expect(result).toEqual({ ok: true, data: { id: 'from-old' }, group: 'old' });
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch.mock.calls[1]![0].url).toContain(OLD_V);
-  });
-
-  it('re-throws a genuine (non-unavailable) error instead of falling back', async () => {
-    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
-    mockFetch.mockReturnValueOnce(throwError(() => ({ status: 500 })));
-
-    await expect(readItemWithFallback(build)).rejects.toEqual({ status: 500 });
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('returns unavailable when both groups 404', async () => {
-    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
-    mockFetch
-      .mockReturnValueOnce(throwError(() => ({ status: 404 })))
-      .mockReturnValueOnce(throwError(() => ({ status: 404 })));
-
-    expect(await readItemWithFallback(build)).toEqual({ ok: false, reason: 'unavailable' });
-  });
-});
-
-describe('readListMerged', () => {
-  const build = (v: string) => collectionUrl(v, 'ns');
-
-  it('returns [] when neither group is available', async () => {
-    expect(await readListMerged(build)).toEqual([]);
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it('unions both groups deduped by metadata.name, new winning', async () => {
-    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
-    mockFetch
-      .mockReturnValueOnce(of({ data: { items: [{ metadata: { name: 'a' }, v: 'new' }] } }))
-      .mockReturnValueOnce(
-        of({ data: { items: [{ metadata: { name: 'a' }, v: 'old' }, { metadata: { name: 'b' } }] } })
-      );
-
-    const items = await readListMerged<{ metadata: { name: string }; v?: string }>(build);
-
-    expect(items).toHaveLength(2);
-    expect(items.find((i) => i.metadata.name === 'a')!.v).toBe('new');
-    expect(items.some((i) => i.metadata.name === 'b')).toBe(true);
-  });
-
-  it('surfaces old-group items when the new group is available but empty (pre-backfill)', async () => {
-    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
-    mockFetch
-      .mockReturnValueOnce(of({ data: { items: [] } }))
-      .mockReturnValueOnce(of({ data: { items: [{ metadata: { name: 'b' } }] } }));
-
-    const items = await readListMerged<{ metadata: { name: string } }>(build);
-    expect(items).toEqual([{ metadata: { name: 'b' } }]);
-  });
-
-  it('re-throws a genuine error', async () => {
-    mockToggles = { [NEW_TOGGLE]: true };
-    mockFetch.mockReturnValueOnce(throwError(() => ({ status: 500 })));
-    await expect(readListMerged(build)).rejects.toEqual({ status: 500 });
-  });
-});
-
-describe('dualWrite', () => {
-  const build = (v: string) => itemUrl(v, 'ns', 'g1');
-
-  it('throws when neither group is available', async () => {
-    await expect(dualWrite({ method: 'PUT', buildUrl: build })).rejects.toThrow('not available');
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it('writes to both groups new-first with the correct apiVersion per body', async () => {
-    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
-    mockFetch.mockReturnValue(of({ data: {} }));
-
-    const result = await dualWrite({
-      method: 'POST',
-      buildUrl: (v) => collectionUrl(v, 'ns'),
-      buildBody: (v) => ({ apiVersion: v }),
-    });
-
-    expect(result).toEqual({ primaryGroup: 'new', secondaryFailures: [] });
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch.mock.calls[0]![0].data.apiVersion).toBe(NEW_V);
-    expect(mockFetch.mock.calls[0]![0].url).toContain(NEW_V);
-    expect(mockFetch.mock.calls[1]![0].data.apiVersion).toBe(OLD_V);
-  });
-
-  it('writes only the old group when only old is available (old is primary)', async () => {
-    mockToggles = { [OLD_TOGGLE]: true };
-    mockFetch.mockReturnValue(of({ data: {} }));
-
-    const result = await dualWrite({ method: 'DELETE', buildUrl: build });
-
-    expect(result.primaryGroup).toBe('old');
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch.mock.calls[0]![0].url).toContain(OLD_V);
-  });
-
-  it('tolerates a secondary failure: resolves, records it, and warns', async () => {
-    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
-    mockFetch
-      .mockReturnValueOnce(of({ data: {} })) // new (primary) ok
-      .mockReturnValueOnce(throwError(() => ({ status: 409 }))); // old (secondary) fails
-
-    const result = await dualWrite({ method: 'PUT', buildUrl: build });
-
-    expect(result).toEqual({ primaryGroup: 'new', secondaryFailures: ['old'] });
-    expect(mockWarn).toHaveBeenCalledTimes(1);
-  });
-
-  it('throws on primary failure and never attempts the secondary', async () => {
-    mockToggles = { [NEW_TOGGLE]: true, [OLD_TOGGLE]: true };
-    mockFetch.mockReturnValueOnce(throwError(() => ({ status: 500 })));
-
-    await expect(dualWrite({ method: 'PUT', buildUrl: build })).rejects.toEqual({ status: 500 });
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+  it('encodes the resource name to guard against path traversal', () => {
+    expect(itemUrl('stacks-1', '../x')).toBe(
+      `/apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/stacks-1/interactiveguides/${encodeURIComponent('../x')}`
+    );
   });
 });

--- a/src/utils/interactive-guides-api.ts
+++ b/src/utils/interactive-guides-api.ts
@@ -1,235 +1,38 @@
 /**
- * Shared client for the InteractiveGuide App Platform API.
+ * Shared definitions for the InteractiveGuide App Platform API.
  *
- * Owns the API group/version, toggle-derived availability, URL building, and
- * the migration shims (read-with-fallback + dual-write) for the transition from
- * the old Cloud App Platform group (`pathfinderbackend.ext.grafana.com`) to the
- * new Grafana App Platform group (`pathfinderbackend.ext.grafana.app`).
+ * The plugin talks only to the Grafana App Platform (GAP) group
+ * `pathfinderbackend.ext.grafana.app`. `isBackendApiAvailable` gates the feature
+ * on the aggregation toggle, so on a stack where GAP isn't rolled out yet the
+ * feature cleanly hides (same as any not-yet-available backend).
  *
- * During the transition both groups may be live: reads union both, writes go to
- * both (new is authoritative, old is best-effort). Once the old group is retired
- * (its toggle off) the dual paths collapse to the single available group with no
- * code change; the dual-write can then be dropped.
+ * Migration of pre-existing guides from the retired Cloud App Platform group
+ * (`pathfinderbackend.ext.grafana.com`) is handled out-of-band by the GAP team's
+ * data migration (an idempotent CAP→GAP sweep run until CAP retirement), NOT by
+ * this client — so there is no dual-write or legacy-fallback here.
  */
-import { config, getBackendSrv } from '@grafana/runtime';
-import { lastValueFrom } from 'rxjs';
+import { config } from '@grafana/runtime';
 
-import { logger } from '../lib/logging';
-
-export const GROUP_NEW = 'pathfinderbackend.ext.grafana.app';
-export const GROUP_OLD = 'pathfinderbackend.ext.grafana.com';
-const API_VERSION = 'v1alpha1';
+export const APP_PLATFORM_GROUP = 'pathfinderbackend.ext.grafana.app';
+export const APP_PLATFORM_API_VERSION = `${APP_PLATFORM_GROUP}/v1alpha1`;
 const RESOURCE = 'interactiveguides';
 
-export type GroupKey = 'new' | 'old';
-
-const GROUP_STRING: Record<GroupKey, string> = { new: GROUP_NEW, old: GROUP_OLD };
-
-/** `<group>/<version>` — for a resource body's `apiVersion` and the URL path. */
-export function apiVersionFor(group: GroupKey): string {
-  return `${GROUP_STRING[group]}/${API_VERSION}`;
-}
+// Grafana derives the aggregation toggle from the group name, dots→dashes.
+const AGGREGATION_TOGGLE = `aggregation.${APP_PLATFORM_GROUP.replace(/\./g, '-')}.enabled`;
 
 /**
- * Aggregation feature-toggle name for a group. Grafana derives it from the group
- * by replacing dots with dashes, e.g.
- * `pathfinderbackend.ext.grafana.app` → `aggregation.pathfinderbackend-ext-grafana-app.enabled`.
- * NOTE: the new-group toggle name is assumed to follow this derivation; confirm
- * with the GAP team. Availability is resilient regardless (see resolveAvailability).
- */
-function toggleNameForGroup(group: GroupKey): string {
-  return `aggregation.${GROUP_STRING[group].replace(/\./g, '-')}.enabled`;
-}
-
-function isGroupToggleOn(group: GroupKey): boolean {
-  const featureToggles = config.featureToggles as Record<string, boolean> | undefined;
-  return featureToggles?.[toggleNameForGroup(group)] === true;
-}
-
-export interface GroupAvailability {
-  newAvailable: boolean;
-  oldAvailable: boolean;
-}
-
-export function resolveAvailability(): GroupAvailability {
-  return { newAvailable: isGroupToggleOn('new'), oldAvailable: isGroupToggleOn('old') };
-}
-
-/** Groups to target, new first, for the current stack. */
-function activeGroups(): GroupKey[] {
-  const { newAvailable, oldAvailable } = resolveAvailability();
-  const groups: GroupKey[] = [];
-  if (newAvailable) {
-    groups.push('new');
-  }
-  if (oldAvailable) {
-    groups.push('old');
-  }
-  return groups;
-}
-
-/**
- * True when the InteractiveGuide backend API is reachable on this instance via
- * either the new or the legacy aggregation toggle — resilient to the exact new
- * toggle name.
+ * True when the InteractiveGuide backend API is available on this instance
+ * (the GAP aggregation toggle is on). Reads the boot-time feature toggles.
  */
 export function isBackendApiAvailable(): boolean {
-  const { newAvailable, oldAvailable } = resolveAvailability();
-  return newAvailable || oldAvailable;
+  const featureToggles = config.featureToggles as Record<string, boolean> | undefined;
+  return featureToggles?.[AGGREGATION_TOGGLE] === true;
 }
 
-/** HTTP statuses meaning a group's API isn't rolled out — fall through to the next. */
-export const UNAVAILABLE_STATUSES = new Set([400, 403, 404, 405, 501, 503]);
-
-export function extractStatus(err: unknown): number | undefined {
-  const e = err as { status?: number; statusCode?: number; data?: { statusCode?: number } };
-  return e?.status ?? e?.statusCode ?? e?.data?.statusCode;
+export function collectionUrl(namespace: string): string {
+  return `/apis/${APP_PLATFORM_API_VERSION}/namespaces/${namespace}/${RESOURCE}`;
 }
 
-function isUnavailableError(err: unknown): boolean {
-  const status = extractStatus(err);
-  return status !== undefined && UNAVAILABLE_STATUSES.has(status);
-}
-
-export function collectionUrl(apiVersion: string, namespace: string): string {
-  return `/apis/${apiVersion}/namespaces/${namespace}/${RESOURCE}`;
-}
-
-export function itemUrl(apiVersion: string, namespace: string, name: string): string {
-  return `${collectionUrl(apiVersion, namespace)}/${encodeURIComponent(name)}`;
-}
-
-type UrlBuilder = (apiVersion: string) => string;
-
-export type ReadItemResult<T> = { ok: true; data: T; group: GroupKey } | { ok: false; reason: 'unavailable' };
-
-/**
- * GET a single resource, new group first, falling back to old on an
- * "unavailable" status (or 404). Genuine errors (5xx/network) are re-thrown so
- * callers can distinguish "not rolled out" from "broken".
- */
-export async function readItemWithFallback<T>(buildUrl: UrlBuilder): Promise<ReadItemResult<T>> {
-  const groups = activeGroups();
-  if (groups.length === 0) {
-    return { ok: false, reason: 'unavailable' };
-  }
-  for (const group of groups) {
-    try {
-      const response = await lastValueFrom(
-        getBackendSrv().fetch<T>({ url: buildUrl(apiVersionFor(group)), method: 'GET', showErrorAlert: false })
-      );
-      return { ok: true, data: response.data, group };
-    } catch (err) {
-      if (isUnavailableError(err)) {
-        continue;
-      }
-      throw err;
-    }
-  }
-  return { ok: false, reason: 'unavailable' };
-}
-
-interface K8sList<I> {
-  items?: I[];
-}
-
-interface NamedItem {
-  metadata?: { name?: string };
-}
-
-/**
- * LIST from every available group and union the items, deduped by
- * `metadata.name` (new wins). Union — not new-first-fallback — is required
- * during the migration: a successful *empty* 200 from the new group (before the
- * old→new backfill runs) wouldn't trigger a fallback, and best-effort writes to
- * the old group can silently fail, so neither group is a guaranteed superset.
- */
-export async function readListMerged<I extends NamedItem>(buildUrl: UrlBuilder): Promise<I[]> {
-  const groups = activeGroups(); // new first
-  if (groups.length === 0) {
-    return [];
-  }
-  const byName = new Map<string, I>();
-  const unnamed: I[] = [];
-  for (const group of groups) {
-    let items: I[] = [];
-    try {
-      const response = await lastValueFrom(
-        getBackendSrv().fetch<K8sList<I>>({ url: buildUrl(apiVersionFor(group)), method: 'GET', showErrorAlert: false })
-      );
-      items = response.data?.items ?? [];
-    } catch (err) {
-      if (isUnavailableError(err)) {
-        continue;
-      }
-      throw err;
-    }
-    for (const item of items) {
-      const name = item.metadata?.name;
-      if (!name) {
-        unnamed.push(item);
-      } else if (!byName.has(name)) {
-        // First writer wins; groups are new-first, so the new group's copy wins.
-        byName.set(name, item);
-      }
-    }
-  }
-  return [...byName.values(), ...unnamed];
-}
-
-export interface DualWriteArgs {
-  method: 'POST' | 'PUT' | 'DELETE';
-  buildUrl: UrlBuilder;
-  /** Receives the target group's apiVersion so the body's `apiVersion` matches its destination. */
-  buildBody?: (apiVersion: string) => unknown;
-}
-
-export interface DualWriteResult {
-  primaryGroup: GroupKey;
-  secondaryFailures: GroupKey[];
-}
-
-/**
- * Write to every available group. The primary (new if available, else old) is
- * authoritative — its failure throws and is the user-visible error. Secondary
- * writes are best-effort: failures are logged and collected, never thrown, so a
- * group-scoped `resourceVersion` 409 or a not-yet-backfilled 404 on the old
- * group can't block a successful primary write.
- */
-export async function dualWrite(args: DualWriteArgs): Promise<DualWriteResult> {
-  const groups = activeGroups(); // new first
-  if (groups.length === 0) {
-    throw new Error('Pathfinder backend API is not available');
-  }
-  const primary = groups[0]!;
-  const secondaries = groups.slice(1);
-
-  await writeOne(primary, args);
-
-  const secondaryFailures: GroupKey[] = [];
-  for (const group of secondaries) {
-    try {
-      await writeOne(group, args);
-    } catch (err) {
-      secondaryFailures.push(group);
-      logger.warn('[interactive-guides-api] secondary dual-write failed', {
-        group,
-        method: args.method,
-        status: extractStatus(err),
-      });
-    }
-  }
-  return { primaryGroup: primary, secondaryFailures };
-}
-
-async function writeOne(group: GroupKey, args: DualWriteArgs): Promise<void> {
-  const apiVersion = apiVersionFor(group);
-  await lastValueFrom(
-    getBackendSrv().fetch({
-      url: args.buildUrl(apiVersion),
-      method: args.method,
-      data: args.buildBody ? args.buildBody(apiVersion) : undefined,
-      showErrorAlert: false,
-    })
-  );
+export function itemUrl(namespace: string, name: string): string {
+  return `${collectionUrl(namespace)}/${encodeURIComponent(name)}`;
 }

--- a/src/utils/interactive-guides-api.ts
+++ b/src/utils/interactive-guides-api.ts
@@ -1,15 +1,8 @@
 /**
- * Shared definitions for the InteractiveGuide App Platform API.
- *
- * The plugin talks only to the Grafana App Platform (GAP) group
- * `pathfinderbackend.ext.grafana.app`. `isBackendApiAvailable` gates the feature
- * on the aggregation toggle, so on a stack where GAP isn't rolled out yet the
- * feature cleanly hides (same as any not-yet-available backend).
- *
- * Migration of pre-existing guides from the retired Cloud App Platform group
- * (`pathfinderbackend.ext.grafana.com`) is handled out-of-band by the GAP team's
- * data migration (an idempotent CAP→GAP sweep run until CAP retirement), NOT by
- * this client — so there is no dual-write or legacy-fallback here.
+ * Shared definitions for the InteractiveGuide App Platform API (Grafana App
+ * Platform group `pathfinderbackend.ext.grafana.app`). `isBackendApiAvailable`
+ * gates the feature on the aggregation toggle, so it cleanly hides where GAP
+ * isn't enabled.
  */
 import { config } from '@grafana/runtime';
 
@@ -30,7 +23,7 @@ export function isBackendApiAvailable(): boolean {
 }
 
 export function collectionUrl(namespace: string): string {
-  return `/apis/${APP_PLATFORM_API_VERSION}/namespaces/${namespace}/${RESOURCE}`;
+  return `/apis/${APP_PLATFORM_API_VERSION}/namespaces/${encodeURIComponent(namespace)}/${RESOURCE}`;
 }
 
 export function itemUrl(namespace: string, name: string): string {

--- a/src/utils/interactive-guides-api.ts
+++ b/src/utils/interactive-guides-api.ts
@@ -1,0 +1,235 @@
+/**
+ * Shared client for the InteractiveGuide App Platform API.
+ *
+ * Owns the API group/version, toggle-derived availability, URL building, and
+ * the migration shims (read-with-fallback + dual-write) for the transition from
+ * the old Cloud App Platform group (`pathfinderbackend.ext.grafana.com`) to the
+ * new Grafana App Platform group (`pathfinderbackend.ext.grafana.app`).
+ *
+ * During the transition both groups may be live: reads union both, writes go to
+ * both (new is authoritative, old is best-effort). Once the old group is retired
+ * (its toggle off) the dual paths collapse to the single available group with no
+ * code change; the dual-write can then be dropped.
+ */
+import { config, getBackendSrv } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
+
+import { logger } from '../lib/logging';
+
+export const GROUP_NEW = 'pathfinderbackend.ext.grafana.app';
+export const GROUP_OLD = 'pathfinderbackend.ext.grafana.com';
+const API_VERSION = 'v1alpha1';
+const RESOURCE = 'interactiveguides';
+
+export type GroupKey = 'new' | 'old';
+
+const GROUP_STRING: Record<GroupKey, string> = { new: GROUP_NEW, old: GROUP_OLD };
+
+/** `<group>/<version>` — for a resource body's `apiVersion` and the URL path. */
+export function apiVersionFor(group: GroupKey): string {
+  return `${GROUP_STRING[group]}/${API_VERSION}`;
+}
+
+/**
+ * Aggregation feature-toggle name for a group. Grafana derives it from the group
+ * by replacing dots with dashes, e.g.
+ * `pathfinderbackend.ext.grafana.app` → `aggregation.pathfinderbackend-ext-grafana-app.enabled`.
+ * NOTE: the new-group toggle name is assumed to follow this derivation; confirm
+ * with the GAP team. Availability is resilient regardless (see resolveAvailability).
+ */
+function toggleNameForGroup(group: GroupKey): string {
+  return `aggregation.${GROUP_STRING[group].replace(/\./g, '-')}.enabled`;
+}
+
+function isGroupToggleOn(group: GroupKey): boolean {
+  const featureToggles = config.featureToggles as Record<string, boolean> | undefined;
+  return featureToggles?.[toggleNameForGroup(group)] === true;
+}
+
+export interface GroupAvailability {
+  newAvailable: boolean;
+  oldAvailable: boolean;
+}
+
+export function resolveAvailability(): GroupAvailability {
+  return { newAvailable: isGroupToggleOn('new'), oldAvailable: isGroupToggleOn('old') };
+}
+
+/** Groups to target, new first, for the current stack. */
+function activeGroups(): GroupKey[] {
+  const { newAvailable, oldAvailable } = resolveAvailability();
+  const groups: GroupKey[] = [];
+  if (newAvailable) {
+    groups.push('new');
+  }
+  if (oldAvailable) {
+    groups.push('old');
+  }
+  return groups;
+}
+
+/**
+ * True when the InteractiveGuide backend API is reachable on this instance via
+ * either the new or the legacy aggregation toggle — resilient to the exact new
+ * toggle name.
+ */
+export function isBackendApiAvailable(): boolean {
+  const { newAvailable, oldAvailable } = resolveAvailability();
+  return newAvailable || oldAvailable;
+}
+
+/** HTTP statuses meaning a group's API isn't rolled out — fall through to the next. */
+export const UNAVAILABLE_STATUSES = new Set([400, 403, 404, 405, 501, 503]);
+
+export function extractStatus(err: unknown): number | undefined {
+  const e = err as { status?: number; statusCode?: number; data?: { statusCode?: number } };
+  return e?.status ?? e?.statusCode ?? e?.data?.statusCode;
+}
+
+function isUnavailableError(err: unknown): boolean {
+  const status = extractStatus(err);
+  return status !== undefined && UNAVAILABLE_STATUSES.has(status);
+}
+
+export function collectionUrl(apiVersion: string, namespace: string): string {
+  return `/apis/${apiVersion}/namespaces/${namespace}/${RESOURCE}`;
+}
+
+export function itemUrl(apiVersion: string, namespace: string, name: string): string {
+  return `${collectionUrl(apiVersion, namespace)}/${encodeURIComponent(name)}`;
+}
+
+type UrlBuilder = (apiVersion: string) => string;
+
+export type ReadItemResult<T> = { ok: true; data: T; group: GroupKey } | { ok: false; reason: 'unavailable' };
+
+/**
+ * GET a single resource, new group first, falling back to old on an
+ * "unavailable" status (or 404). Genuine errors (5xx/network) are re-thrown so
+ * callers can distinguish "not rolled out" from "broken".
+ */
+export async function readItemWithFallback<T>(buildUrl: UrlBuilder): Promise<ReadItemResult<T>> {
+  const groups = activeGroups();
+  if (groups.length === 0) {
+    return { ok: false, reason: 'unavailable' };
+  }
+  for (const group of groups) {
+    try {
+      const response = await lastValueFrom(
+        getBackendSrv().fetch<T>({ url: buildUrl(apiVersionFor(group)), method: 'GET', showErrorAlert: false })
+      );
+      return { ok: true, data: response.data, group };
+    } catch (err) {
+      if (isUnavailableError(err)) {
+        continue;
+      }
+      throw err;
+    }
+  }
+  return { ok: false, reason: 'unavailable' };
+}
+
+interface K8sList<I> {
+  items?: I[];
+}
+
+interface NamedItem {
+  metadata?: { name?: string };
+}
+
+/**
+ * LIST from every available group and union the items, deduped by
+ * `metadata.name` (new wins). Union — not new-first-fallback — is required
+ * during the migration: a successful *empty* 200 from the new group (before the
+ * old→new backfill runs) wouldn't trigger a fallback, and best-effort writes to
+ * the old group can silently fail, so neither group is a guaranteed superset.
+ */
+export async function readListMerged<I extends NamedItem>(buildUrl: UrlBuilder): Promise<I[]> {
+  const groups = activeGroups(); // new first
+  if (groups.length === 0) {
+    return [];
+  }
+  const byName = new Map<string, I>();
+  const unnamed: I[] = [];
+  for (const group of groups) {
+    let items: I[] = [];
+    try {
+      const response = await lastValueFrom(
+        getBackendSrv().fetch<K8sList<I>>({ url: buildUrl(apiVersionFor(group)), method: 'GET', showErrorAlert: false })
+      );
+      items = response.data?.items ?? [];
+    } catch (err) {
+      if (isUnavailableError(err)) {
+        continue;
+      }
+      throw err;
+    }
+    for (const item of items) {
+      const name = item.metadata?.name;
+      if (!name) {
+        unnamed.push(item);
+      } else if (!byName.has(name)) {
+        // First writer wins; groups are new-first, so the new group's copy wins.
+        byName.set(name, item);
+      }
+    }
+  }
+  return [...byName.values(), ...unnamed];
+}
+
+export interface DualWriteArgs {
+  method: 'POST' | 'PUT' | 'DELETE';
+  buildUrl: UrlBuilder;
+  /** Receives the target group's apiVersion so the body's `apiVersion` matches its destination. */
+  buildBody?: (apiVersion: string) => unknown;
+}
+
+export interface DualWriteResult {
+  primaryGroup: GroupKey;
+  secondaryFailures: GroupKey[];
+}
+
+/**
+ * Write to every available group. The primary (new if available, else old) is
+ * authoritative — its failure throws and is the user-visible error. Secondary
+ * writes are best-effort: failures are logged and collected, never thrown, so a
+ * group-scoped `resourceVersion` 409 or a not-yet-backfilled 404 on the old
+ * group can't block a successful primary write.
+ */
+export async function dualWrite(args: DualWriteArgs): Promise<DualWriteResult> {
+  const groups = activeGroups(); // new first
+  if (groups.length === 0) {
+    throw new Error('Pathfinder backend API is not available');
+  }
+  const primary = groups[0]!;
+  const secondaries = groups.slice(1);
+
+  await writeOne(primary, args);
+
+  const secondaryFailures: GroupKey[] = [];
+  for (const group of secondaries) {
+    try {
+      await writeOne(group, args);
+    } catch (err) {
+      secondaryFailures.push(group);
+      logger.warn('[interactive-guides-api] secondary dual-write failed', {
+        group,
+        method: args.method,
+        status: extractStatus(err),
+      });
+    }
+  }
+  return { primaryGroup: primary, secondaryFailures };
+}
+
+async function writeOne(group: GroupKey, args: DualWriteArgs): Promise<void> {
+  const apiVersion = apiVersionFor(group);
+  await lastValueFrom(
+    getBackendSrv().fetch({
+      url: args.buildUrl(apiVersion),
+      method: args.method,
+      data: args.buildBody ? args.buildBody(apiVersion) : undefined,
+      showErrorAlert: false,
+    })
+  );
+}


### PR DESCRIPTION
## What

Migrates the plugin's existing InteractiveGuide App Platform integration from the old Cloud App Platform group `pathfinderbackend.ext.grafana.com` to the new Grafana App Platform group `pathfinderbackend.ext.grafana.app`. CAP is being deprecated. This is a **hard cutover** — the plugin talks only to GAP.

## Why a hard cutover (not dual-write)

The release is sequenced so the plugin never faces a GAP backend without data: GAP is rolled out to all stacks and the GAP team's idempotent CAP→GAP backfill runs **before** the plugin release. The availability toggle already hides the feature cleanly on any stack where GAP isn't rolled out yet. So there's no transition window to bridge — an earlier dual-write/read-fallback design (see history) was over-engineered and was the source of the blocking review issues; it's been removed.

## How

- New shared `src/utils/interactive-guides-api.ts` — single source of truth for the GAP group/version/resource, `isBackendApiAvailable()` (gates on `aggregation.pathfinderbackend-ext-grafana-app.enabled`, confirmed with the GAP team), and URL builders. No dual-write, union, or fallback.
- All call sites do single-group GAP reads/writes: `fetchBackendGuides`, the block-editor guide CRUD (save/publish/unpublish/delete), the `backend-guide:` loader, and the context-init probe.
- MCP `finalize` handoff points at GAP only, with its original "GAP → grafanaOss on 404" guidance unchanged.
- Migrated the CAP-only external tooling + reference docs to `.app`: `scripts/upsert-guide.sh`, `docs/developer/EXTERNAL_API.md`, `docs/developer/CUSTOM_GUIDES.md`, `docs/sources/architecture/_index.md`, and the App Platform handoff contract.

## Scope

Frontend-only — **no `pkg/plugin` changes**. Does not touch the completion-records proxy or the deferred custom-guide-repository catalogue proxy: both remain on the old group and are documented as such in `docs/design/BACKEND_PROXY_PATTERN.md` (out of scope here, so its `.com` references stay accurate). Design/phase archive docs likewise retain their historical `.com` references.

## Laggard handling (out-of-band)

A stack that stays on the old plugin and keeps authoring against CAP after release, then upgrades, briefly won't see those guides — **no data loss** (CAP is additive, never deleted). Resolved by re-running the idempotent CAP→GAP migration sweep until CAP retirement; retirement is gated on a final reconciliation sweep. Kept in the migration script rather than the plugin (a plugin read-fallback reintroduces write/delete asymmetries).

## Verification

- New `src/utils/interactive-guides-api.test.ts` (availability matrix + URL builders); existing `backend-guide` and `finalize` tests updated / snapshot regenerated.
- typecheck · eslint · prettier · architecture/import-graph governance all pass; full suite green apart from a pre-existing Node-version test artifact unrelated to this change.
- E2E on a GAP dev stack: author + publish via the block editor → reads/writes hit the `.app` group; feature hides cleanly on a stack without the GAP toggle.
