### PR TITLE
fix(e2e): preserve guide execution context

### DIFF
--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -434,6 +434,7 @@ These variables are consumed by the CLI or passed to the spawned Playwright proc
 | ----------------------- | ------------------------------------------------------------------------------ | ----------------------- |
 | `GUIDE_JSON_PATH`       | Path to JSON guide file                                                        | Required                |
 | `GRAFANA_URL`           | Grafana instance URL                                                           | `http://localhost:3000` |
+| `STARTING_LOCATION`     | Same-origin path where the guide should begin (set from manifest or `/`)       | `/`                     |
 | `AUTH_STATE_FILE`       | Per-guide Playwright storage-state path for form-login auth                    | Temporary CLI path      |
 | `E2E_VERBOSE`           | Enable verbose logging                                                         | `false`                 |
 | `E2E_TRACE`             | Generate Playwright trace file                                                 | `false`                 |

--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -45,6 +45,7 @@ import {
   provisioningErrorCode,
   provisioningFailureResults,
   resolveRunMode,
+  runnerFailureResult,
   skipToResult,
   type GuideRunResult,
   type GuideStatus,
@@ -773,7 +774,18 @@ async function runChains(
           token: isCloudTarget ? provisionedTargets.tokenForGuide(planned.id, meta?.targetUrl) : undefined,
         };
 
-        const result = await runPlaywrightTests(planned.guide, runGuideOptions);
+        let result: Awaited<ReturnType<typeof runPlaywrightTests>>;
+        try {
+          result = await runPlaywrightTests(planned.guide, runGuideOptions);
+        } catch (error) {
+          const failure = runnerFailureResult(planned, meta, targetUrl, error);
+          results.push(failure);
+          allPassed = false;
+          chainHadFailure = true;
+          blocked.add(planned.id);
+          console.error(`   ❌ ${failure.abortMessage}`);
+          continue;
+        }
         applyPackageMeta(result.resultsData, meta);
         const status: GuideStatus = result.success
           ? 'passed'

--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -532,7 +532,7 @@ async function runPreflightChecks(
   options: E2ECommandOptions,
   targetUrls: string[],
   packageDir?: string
-): Promise<void> {
+): Promise<ManifestJson | null> {
   console.log('\n🔍 Running pre-flight checks...');
 
   // Manifest pre-flight applies to a local package directory only. Remote modes
@@ -641,6 +641,7 @@ async function runPreflightChecks(
   } else {
     console.log('   → Auth and plugin checks will run in Playwright context');
   }
+  return packageManifest;
 }
 
 /**
@@ -763,6 +764,7 @@ async function runChains(
         const targetUrl = provisionedTargets.targetUrlForGuide(planned.id, meta?.targetUrl ?? options.grafanaUrl);
         const runGuideOptions: RunGuideOptions = {
           targetUrl,
+          startingLocation: meta?.startingLocation ?? '/',
           verbose: options.verbose,
           trace: options.trace,
           headed: options.headed,
@@ -1024,7 +1026,7 @@ export const e2eCommand = new Command('e2e')
         cloudAuth: inputs.cloudAuth,
         verbose: options.verbose,
       });
-      await runPreflightChecks(
+      const localManifest = await runPreflightChecks(
         options,
         preflightTargetUrlsForPlan({
           plan,
@@ -1035,6 +1037,12 @@ export const e2eCommand = new Command('e2e')
         }),
         inputs.localPackageDir
       );
+      if (localManifest) {
+        inputs.packageMetaById.set(localManifest.id, {
+          packageId: localManifest.id,
+          startingLocation: localManifest.startingLocation ?? '/',
+        });
+      }
 
       const outcome = await runChains(
         plan,

--- a/src/cli/e2e/e2e-package.test.ts
+++ b/src/cli/e2e/e2e-package.test.ts
@@ -188,6 +188,31 @@ describe('resolveRemotePackage (single, recommender)', () => {
     expect(result.skipped[0]).toMatchObject({ id: 'g', reason: 'validation_failed' });
   });
 
+  it('maps an invalid starting location to validation_failed before execution', async () => {
+    mockResolve({
+      ok: true,
+      id: 'invalid-start',
+      contentUrl: 'https://cdn.test/invalid-start/content.json',
+      manifestUrl: 'https://cdn.test/invalid-start/manifest.json',
+      repository: 'r',
+      manifest: {
+        id: 'invalid-start',
+        type: 'guide',
+        startingLocation: 'https://example.com/dashboard',
+        testEnvironment: { tier: 'local' },
+      },
+    });
+
+    const result = await resolveRemotePackage('invalid-start', OPTIONS);
+
+    expect(result.runnable).toHaveLength(0);
+    expect(result.skipped[0]).toMatchObject({
+      id: 'invalid-start',
+      reason: 'validation_failed',
+      message: expect.stringMatching(/startingLocation.*same origin/i),
+    });
+  });
+
   it('resolves a runnable cloud guide against the cloud target URL when credentials are present', async () => {
     mockResolve({
       ok: true,

--- a/src/cli/e2e/e2e-package.test.ts
+++ b/src/cli/e2e/e2e-package.test.ts
@@ -76,9 +76,22 @@ describe('resolveRemotePackage (single, recommender)', () => {
       contentUrl: 'https://cdn.test/alerting-101/content.json',
       manifestUrl: 'https://cdn.test/alerting-101/manifest.json',
       repository: 'r',
-      manifest: { id: 'alerting-101', type: 'guide', testEnvironment: { tier: 'local' } },
+      manifest: {
+        id: 'alerting-101',
+        type: 'guide',
+        startingLocation: '/alerting',
+        testEnvironment: { tier: 'local' },
+      },
     });
-    mockIndex([{ id: 'alerting-101', path: 'alerting-101/', type: 'guide', testEnvironment: { tier: 'local' } }]);
+    mockIndex([
+      {
+        id: 'alerting-101',
+        path: 'alerting-101/',
+        type: 'guide',
+        startingLocation: '/alerting',
+        testEnvironment: { tier: 'local' },
+      },
+    ]);
     mockFetch({
       ok: true,
       text: '{"id":"alerting-101","title":"Alerting","blocks":[{"type":"markdown","content":"Read this"}]}',
@@ -93,6 +106,7 @@ describe('resolveRemotePackage (single, recommender)', () => {
       tier: 'local',
       targetUrl: 'http://localhost:3000',
       sourceUrl: 'https://cdn.test/alerting-101/content.json',
+      startingLocation: '/alerting',
       sideEffects: { level: 'readonly', reasons: [] },
     });
     expect(result.runnable[0]!.guide.content).toBe(

--- a/src/cli/e2e/e2e-package.ts
+++ b/src/cli/e2e/e2e-package.ts
@@ -22,6 +22,7 @@ import type { LoadedGuide } from '../utils/file-loader';
 import { resolveTarget, type CloudTargetCapabilities } from './e2e-targets';
 import type { CurrentTier } from './manifest-preflight';
 import { classifyGuideSideEffectsFromString, type SideEffectClassification } from './side-effects';
+import { resolveStartingPath } from './starting-location';
 
 const FETCH_TIMEOUT_MS = 15_000;
 
@@ -163,6 +164,21 @@ async function buildGuideOrSkip(
     };
   }
 
+  let resolvedStartingLocation: string;
+  try {
+    resolvedStartingLocation = resolveStartingPath(target.targetUrl!, startingLocation);
+  } catch (error) {
+    return {
+      skipped: {
+        id,
+        reason: 'validation_failed',
+        message: `Invalid startingLocation: ${error instanceof Error ? error.message : 'unknown error'}`,
+        sourceUrl: contentUrl,
+        tier: target.tier,
+      },
+    };
+  }
+
   const fetched = await fetchText(contentUrl);
   if (!fetched.ok) {
     return {
@@ -198,7 +214,7 @@ async function buildGuideOrSkip(
       instance: target.instance,
       targetUrl: target.targetUrl!,
       sourceUrl: contentUrl,
-      startingLocation: startingLocation ?? '/',
+      startingLocation: resolvedStartingLocation,
       sideEffects,
       ...(testEnvironment.plugins?.length ? { plugins: testEnvironment.plugins } : {}),
     },

--- a/src/cli/e2e/e2e-package.ts
+++ b/src/cli/e2e/e2e-package.ts
@@ -56,6 +56,7 @@ export interface ResolvedRemoteGuide {
   targetUrl: string;
   /** The content.json URL the guide was fetched from. */
   sourceUrl: string;
+  startingLocation: string;
   /** Conservative side-effect classification for the fetched content. */
   sideEffects: SideEffectClassification;
   /** Plugin IDs required by this guide, from testEnvironment.plugins. */
@@ -127,6 +128,7 @@ async function buildGuideOrSkip(
   id: string,
   type: string | undefined,
   testEnvironment: TestEnvironment,
+  startingLocation: string | undefined,
   contentUrl: string,
   options: RemoteResolveOptions
 ): Promise<{ runnable?: ResolvedRemoteGuide; skipped?: SkippedPackage }> {
@@ -196,6 +198,7 @@ async function buildGuideOrSkip(
       instance: target.instance,
       targetUrl: target.targetUrl!,
       sourceUrl: contentUrl,
+      startingLocation: startingLocation ?? '/',
       sideEffects,
       ...(testEnvironment.plugins?.length ? { plugins: testEnvironment.plugins } : {}),
     },
@@ -230,7 +233,7 @@ async function resolveIndexEntry(
       },
     };
   }
-  return buildGuideOrSkip(id, entry.type, entry.testEnvironment ?? {}, contentUrl, options);
+  return buildGuideOrSkip(id, entry.type, entry.testEnvironment ?? {}, entry.startingLocation, contentUrl, options);
 }
 
 /**
@@ -328,6 +331,7 @@ export async function resolveRemotePackage(id: string, options: RemoteResolveOpt
     resolution.id || id,
     resolution.manifest?.type,
     resolution.manifest?.testEnvironment ?? {},
+    resolution.manifest?.startingLocation,
     resolution.contentUrl,
     options
   );

--- a/src/cli/e2e/e2e-results.test.ts
+++ b/src/cli/e2e/e2e-results.test.ts
@@ -122,6 +122,7 @@ describe('buildPackageMetaMap', () => {
         instance: 'play.grafana.org',
         targetUrl: 'http://localhost:3000',
         sourceUrl: 'https://cdn.test/a/content.json',
+        startingLocation: '/d/example/example',
         sideEffects: READONLY_SIDE_EFFECTS,
       },
     ];
@@ -132,6 +133,7 @@ describe('buildPackageMetaMap', () => {
       instance: 'play.grafana.org',
       targetUrl: 'http://localhost:3000',
       sourceUrl: 'https://cdn.test/a/content.json',
+      startingLocation: '/d/example/example',
       sideEffects: READONLY_SIDE_EFFECTS,
     });
   });
@@ -156,6 +158,7 @@ describe('applyPackageMeta', () => {
       instance: 'play.grafana.org',
       targetUrl: 'http://should-not-overwrite:3000',
       sourceUrl: 'https://cdn.test/a/content.json',
+      startingLocation: '/d/example/example',
       sideEffects: READONLY_SIDE_EFFECTS,
     });
 
@@ -167,6 +170,7 @@ describe('applyPackageMeta', () => {
       tier: 'local',
       instance: 'play.grafana.org',
       sourceUrl: 'https://cdn.test/a/content.json',
+      startingLocation: '/d/example/example',
       sideEffects: READONLY_SIDE_EFFECTS,
     });
   });

--- a/src/cli/e2e/e2e-results.test.ts
+++ b/src/cli/e2e/e2e-results.test.ts
@@ -25,6 +25,7 @@ import {
   preRunSkipsFromResults,
   provisioningErrorCode,
   provisioningFailureResults,
+  runnerFailureResult,
   resolveRunMode,
   skipToResult,
   summarizeSteps,
@@ -257,6 +258,40 @@ describe('provisioningFailureResults', () => {
     expect(report).toMatchObject({
       outcome: 'infrastructure_error',
       errorCode: 'PROVISIONING_FAILED',
+    });
+  });
+});
+
+describe('runnerFailureResult', () => {
+  it('converts a thrown runner error into a retained per-guide configuration failure', () => {
+    const result = runnerFailureResult(
+      {
+        id: 'bad-guide',
+        guide: { path: 'https://cdn.test/bad-guide/content.json', content: '{"id":"bad-guide"}' },
+        autoIncluded: false,
+      },
+      {
+        packageId: 'bad-guide',
+        tier: 'cloud',
+        targetUrl: 'https://play.grafana.org/',
+        sourceUrl: 'https://cdn.test/bad-guide/content.json',
+      },
+      'http://localhost:3000',
+      new Error('Invalid starting location')
+    );
+
+    expect(result).toMatchObject({
+      id: 'bad-guide',
+      status: 'failed',
+      exitCode: ExitCode.CONFIGURATION_ERROR,
+      abortMessage: 'Runner setup failed: Invalid starting location',
+      resultsData: {
+        outcome: 'configuration_error',
+        errorCode: 'CONFIGURATION_ERROR',
+        errorMessage: 'Runner setup failed: Invalid starting location',
+        guide: { targetUrl: 'http://localhost:3000' },
+        results: [],
+      },
     });
   });
 });

--- a/src/cli/e2e/e2e-results.ts
+++ b/src/cli/e2e/e2e-results.ts
@@ -18,7 +18,7 @@ import {
   type SkippedPackage,
 } from './e2e-package';
 import type { E2EErrorCode, E2EExecutionOutcome, PreRunSkip } from './schemas/e2e-report.schema';
-import { contentDigest, type TestResultsData } from './e2e-reporter';
+import { contentDigest, createMinimalResultsData, type TestResultsData } from './e2e-reporter';
 import { ExitCode } from './exit-codes';
 import type { AbortReason } from './playwright-runner';
 import type { SideEffectClassification } from './side-effects';
@@ -193,6 +193,39 @@ interface PlannedGuideForResult {
   id: string;
   guide: { path: string; content?: string };
   autoIncluded: boolean;
+}
+
+export function runnerFailureResult(
+  planned: PlannedGuideForResult,
+  meta: PackageMeta | undefined,
+  fallbackTargetUrl: string,
+  error: unknown
+): GuideRunResult {
+  const message = `Runner setup failed: ${error instanceof Error ? error.message : 'Unknown error'}`;
+  const resultsData = createMinimalResultsData({
+    guide: {
+      id: planned.id,
+      title: planned.id,
+      path: planned.guide.path,
+      targetUrl: fallbackTargetUrl,
+      ...(planned.guide.content ? { contentDigest: contentDigest(planned.guide.content) } : {}),
+    },
+    outcome: 'configuration_error',
+    errorCode: 'CONFIGURATION_ERROR',
+    errorMessage: message,
+  });
+  applyPackageMeta(resultsData, meta);
+  return {
+    guide: planned.guide.path,
+    id: planned.id,
+    status: 'failed',
+    exitCode: ExitCode.CONFIGURATION_ERROR,
+    autoIncluded: planned.autoIncluded,
+    abortMessage: message,
+    tier: meta?.tier,
+    sideEffects: meta?.sideEffects,
+    resultsData,
+  };
 }
 export function provisioningErrorCode(error: unknown): E2EErrorCode {
   const code =

--- a/src/cli/e2e/e2e-results.ts
+++ b/src/cli/e2e/e2e-results.ts
@@ -33,6 +33,7 @@ export interface PackageMeta {
   instance?: string;
   targetUrl?: string;
   sourceUrl?: string;
+  startingLocation?: string;
   sideEffects?: SideEffectClassification;
   plugins?: string[];
 }
@@ -161,6 +162,7 @@ export function buildPackageMetaMap(runnable: ResolvedRemoteGuide[]): Map<string
         instance: g.instance,
         targetUrl: g.targetUrl,
         sourceUrl: g.sourceUrl,
+        startingLocation: g.startingLocation,
         sideEffects: g.sideEffects,
         ...(g.plugins?.length ? { plugins: g.plugins } : {}),
       },
@@ -182,6 +184,7 @@ export function applyPackageMeta(data: TestResultsData | undefined, meta: Packag
     tier: meta.tier,
     instance: meta.instance,
     sourceUrl: meta.sourceUrl,
+    startingLocation: meta.startingLocation,
     sideEffects: meta.sideEffects,
   };
 }

--- a/src/cli/e2e/e2e-runner-contract.ts
+++ b/src/cli/e2e/e2e-runner-contract.ts
@@ -17,6 +17,8 @@ export const E2E_ENV = {
   GUIDE_JSON_PATH: 'GUIDE_JSON_PATH',
   /** Grafana base URL under test. */
   GRAFANA_URL: 'GRAFANA_URL',
+  /** Same-origin path where the guide should begin. */
+  STARTING_LOCATION: 'STARTING_LOCATION',
   /**
    * Absolute path the form-login auth setup writes storage state to, and the
    * test project reads in non-token mode. Per-guide and ephemeral.

--- a/src/cli/e2e/playwright-runner.test.ts
+++ b/src/cli/e2e/playwright-runner.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 
 import { ExitCode } from './exit-codes';
-import { findRunnerRoot, processPlaywrightResults, runPlaywrightTests } from './playwright-runner';
+import { findRunnerRoot, processPlaywrightResults, resolveStartingUrl, runPlaywrightTests } from './playwright-runner';
 
 jest.mock('child_process', () => ({
   spawn: jest.fn(),
@@ -36,6 +36,22 @@ describe('findRunnerRoot', () => {
     writeFileSync(join(runnerTestDir, 'guide-runner.spec.ts'), '');
 
     expect(findRunnerRoot(compiledModuleDir)).toBe(tempRoot);
+  });
+});
+
+describe('resolveStartingUrl', () => {
+  it('resolves a relative manifest location against the selected target', () => {
+    expect(resolveStartingUrl('https://play.grafana.org/', '/d/example/example?orgId=1')).toBe(
+      'https://play.grafana.org/d/example/example?orgId=1'
+    );
+  });
+
+  it('rejects a starting location on another origin', () => {
+    expect(() => resolveStartingUrl('https://play.grafana.org/', 'https://example.com/')).toThrow(/same origin/i);
+  });
+
+  it('rejects non-HTTP protocols', () => {
+    expect(() => resolveStartingUrl('https://play.grafana.org/', 'javascript:alert(1)')).toThrow(/protocol/i);
   });
 });
 
@@ -143,6 +159,7 @@ describe('runPlaywrightTests', () => {
         headed: false,
         artifacts: 'artifacts',
         alwaysScreenshot: false,
+        startingLocation: '/d/example/example',
       }
     );
     child.emit('close', 1);
@@ -176,6 +193,7 @@ describe('runPlaywrightTests', () => {
         headed: false,
         artifacts: join('output', 'artifacts'),
         alwaysScreenshot: false,
+        startingLocation: '/d/example/example',
       }
     );
     const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
@@ -183,6 +201,7 @@ describe('runPlaywrightTests', () => {
     await resultPromise;
 
     expect(spawnOptions.env?.ARTIFACTS_DIR).toBe(resolve(process.cwd(), 'output', 'artifacts'));
+    expect(spawnOptions.env?.STARTING_LOCATION).toBe('/d/example/example');
   });
 
   it.each([
@@ -206,6 +225,7 @@ describe('runPlaywrightTests', () => {
         headed: false,
         artifacts: 'artifacts',
         alwaysScreenshot: false,
+        startingLocation: '/',
       }
     );
 

--- a/src/cli/e2e/playwright-runner.test.ts
+++ b/src/cli/e2e/playwright-runner.test.ts
@@ -53,6 +53,20 @@ describe('resolveStartingUrl', () => {
   it('rejects non-HTTP protocols', () => {
     expect(() => resolveStartingUrl('https://play.grafana.org/', 'javascript:alert(1)')).toThrow(/protocol/i);
   });
+
+  it('defaults an empty starting location to the target root', () => {
+    expect(resolveStartingUrl('http://localhost:3000', '')).toBe('http://localhost:3000/');
+  });
+
+  it('preserves query parameters and fragments', () => {
+    expect(resolveStartingUrl('http://localhost:3000', '/explore?orgId=1#panel-2')).toBe(
+      'http://localhost:3000/explore?orgId=1#panel-2'
+    );
+  });
+
+  it('rejects malformed absolute URLs', () => {
+    expect(() => resolveStartingUrl('http://localhost:3000', 'http://[invalid')).toThrow();
+  });
 });
 
 describe('processPlaywrightResults', () => {

--- a/src/cli/e2e/playwright-runner.test.ts
+++ b/src/cli/e2e/playwright-runner.test.ts
@@ -218,6 +218,36 @@ describe('runPlaywrightTests', () => {
     expect(spawnOptions.env?.STARTING_LOCATION).toBe('/d/example/example');
   });
 
+  it('cleans up the temp directory when starting-location validation rejects', async () => {
+    const fsModule = jest.requireActual<typeof import('fs')>('fs');
+    const rmSpy = jest.spyOn(fsModule, 'rmSync');
+
+    try {
+      await expect(
+        runPlaywrightTests(
+          { path: 'fixture.json', content: '{}' },
+          {
+            targetUrl: 'https://play.grafana.org',
+            startingLocation: 'https://example.com',
+            verbose: false,
+            trace: false,
+            headed: false,
+            artifacts: 'artifacts',
+            alwaysScreenshot: false,
+          }
+        )
+      ).rejects.toThrow(/same origin/i);
+
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(rmSpy).toHaveBeenCalledWith(
+        expect.stringContaining('pathfinder-e2e-'),
+        expect.objectContaining({ recursive: true, force: true })
+      );
+    } finally {
+      rmSpy.mockRestore();
+    }
+  });
+
   it.each([
     ['AUTH_EXPIRED', 'aborted'],
     ['MANDATORY_FAILURE', 'failed'],

--- a/src/cli/e2e/playwright-runner.ts
+++ b/src/cli/e2e/playwright-runner.ts
@@ -220,10 +220,10 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
   const resultsFilePath = join(tempDir, 'results.json');
   const authStateFile = join(tempDir, 'auth.json');
   const traceOutputFilePath = join(tempDir, 'trace-path.txt');
-  const startingUrl = new URL(resolveStartingUrl(options.targetUrl, options.startingLocation));
-  const startingPath = `${startingUrl.pathname}${startingUrl.search}${startingUrl.hash}`;
 
   try {
+    const startingUrl = new URL(resolveStartingUrl(options.targetUrl, options.startingLocation));
+    const startingPath = `${startingUrl.pathname}${startingUrl.search}${startingUrl.hash}`;
     writeFileSync(guidePath, guide.content);
 
     if (options.verbose) {

--- a/src/cli/e2e/playwright-runner.ts
+++ b/src/cli/e2e/playwright-runner.ts
@@ -13,6 +13,9 @@ import { E2E_ENV, encodeEnvFlag } from './e2e-runner-contract';
 import type { LoadedGuide } from '../utils/file-loader';
 import type { E2EErrorCode } from './schemas/e2e-report.schema';
 import { contentDigest, createMinimalResultsData, type TestResultsData } from './e2e-reporter';
+import { resolveStartingPath } from './starting-location';
+
+export { resolveStartingUrl } from './starting-location';
 
 const PLAYWRIGHT_CONFIG_PATH = join('tests', 'e2e-runner', 'playwright.config.ts');
 const GUIDE_RUNNER_SPEC_PATH = join('tests', 'e2e-runner', 'guide-runner.spec.ts');
@@ -35,18 +38,6 @@ function tryFindRunnerRoot(startDir: string): string | undefined {
     }
     candidate = parent;
   }
-}
-
-export function resolveStartingUrl(targetUrl: string, startingLocation: string): string {
-  const target = new URL(targetUrl);
-  const resolved = new URL(startingLocation || '/', target);
-  if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
-    throw new Error(`Guide starting location protocol must be HTTP or HTTPS, received ${resolved.protocol}`);
-  }
-  if (resolved.origin !== target.origin) {
-    throw new Error(`Guide starting location must use the same origin as ${target.origin}`);
-  }
-  return resolved.toString();
 }
 
 export function findRunnerRoot(startDir: string): string {
@@ -222,8 +213,7 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
   const traceOutputFilePath = join(tempDir, 'trace-path.txt');
 
   try {
-    const startingUrl = new URL(resolveStartingUrl(options.targetUrl, options.startingLocation));
-    const startingPath = `${startingUrl.pathname}${startingUrl.search}${startingUrl.hash}`;
+    const startingPath = resolveStartingPath(options.targetUrl, options.startingLocation);
     writeFileSync(guidePath, guide.content);
 
     if (options.verbose) {

--- a/src/cli/e2e/playwright-runner.ts
+++ b/src/cli/e2e/playwright-runner.ts
@@ -37,6 +37,18 @@ function tryFindRunnerRoot(startDir: string): string | undefined {
   }
 }
 
+export function resolveStartingUrl(targetUrl: string, startingLocation: string): string {
+  const target = new URL(targetUrl);
+  const resolved = new URL(startingLocation || '/', target);
+  if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
+    throw new Error(`Guide starting location protocol must be HTTP or HTTPS, received ${resolved.protocol}`);
+  }
+  if (resolved.origin !== target.origin) {
+    throw new Error(`Guide starting location must use the same origin as ${target.origin}`);
+  }
+  return resolved.toString();
+}
+
 export function findRunnerRoot(startDir: string): string {
   const fromStart = tryFindRunnerRoot(startDir);
   if (fromStart !== undefined) {
@@ -103,6 +115,7 @@ export interface PlaywrightResult {
 export interface RunGuideOptions {
   /** Resolved Grafana base URL this guide is tested against. */
   targetUrl: string;
+  startingLocation: string;
   verbose: boolean;
   trace: boolean;
   headed: boolean;
@@ -207,6 +220,8 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
   const resultsFilePath = join(tempDir, 'results.json');
   const authStateFile = join(tempDir, 'auth.json');
   const traceOutputFilePath = join(tempDir, 'trace-path.txt');
+  const startingUrl = new URL(resolveStartingUrl(options.targetUrl, options.startingLocation));
+  const startingPath = `${startingUrl.pathname}${startingUrl.search}${startingUrl.hash}`;
 
   try {
     writeFileSync(guidePath, guide.content);
@@ -238,6 +253,7 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
           ...process.env,
           [E2E_ENV.GUIDE_JSON_PATH]: guidePath,
           [E2E_ENV.GRAFANA_URL]: options.targetUrl,
+          [E2E_ENV.STARTING_LOCATION]: startingPath,
           [E2E_ENV.AUTH_STATE_FILE]: authStateFile,
           ...(options.token ? { [E2E_ENV.GRAFANA_TOKEN]: options.token } : {}),
           [E2E_ENV.TRACE]: encodeEnvFlag(options.trace),

--- a/src/cli/e2e/schemas/e2e-report.schema.ts
+++ b/src/cli/e2e/schemas/e2e-report.schema.ts
@@ -114,6 +114,7 @@ export const GuideMetadataSchema = z.object({
   instance: z.string().optional(),
   targetUrl: z.string().optional(),
   sourceUrl: z.string().optional(),
+  startingLocation: z.string().optional(),
   contentDigest: z.string().optional(),
   sideEffects: SideEffectClassificationSchema.optional(),
 });

--- a/src/cli/e2e/starting-location.ts
+++ b/src/cli/e2e/starting-location.ts
@@ -1,0 +1,16 @@
+export function resolveStartingUrl(targetUrl: string, startingLocation: string): string {
+  const target = new URL(targetUrl);
+  const resolved = new URL(startingLocation || '/', target);
+  if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
+    throw new Error(`Guide starting location protocol must be HTTP or HTTPS, received ${resolved.protocol}`);
+  }
+  if (resolved.origin !== target.origin) {
+    throw new Error(`Guide starting location must use the same origin as ${target.origin}`);
+  }
+  return resolved.toString();
+}
+
+export function resolveStartingPath(targetUrl: string, startingLocation: string | undefined): string {
+  const resolved = new URL(resolveStartingUrl(targetUrl, startingLocation ?? '/'));
+  return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+}

--- a/tests/e2e-runner/guide-runner.spec.ts
+++ b/tests/e2e-runner/guide-runner.spec.ts
@@ -29,6 +29,8 @@ import { runPlaywrightPreflightChecks, formatPreflightResults } from './utils/pr
 import {
   discoverStepsFromDOM,
   executeAllSteps,
+  calculateGuideTimeout,
+  GUIDE_SETUP_TIMEOUT_MS,
   ensureDocsPanelOpen,
   summarizeResults,
   AllStepsResult,
@@ -78,6 +80,7 @@ function writeResultsFile(
   results: StepTestResult[],
   guide: { id: string; title: string; path: string },
   targetUrl: string,
+  startingLocation: string,
   timestamp: string,
   allStepsResult: AllStepsResult,
   guideContent: string,
@@ -89,7 +92,7 @@ function writeResultsFile(
   }
 
   const data: TestResultsData = {
-    guide: { ...guide, targetUrl, contentDigest: contentDigest(guideContent) },
+    guide: { ...guide, targetUrl, startingLocation, contentDigest: contentDigest(guideContent) },
     timestamp,
     startedAt: timestamp,
     endedAt: new Date().toISOString(),
@@ -133,11 +136,7 @@ function writeTracePathFile(outputDir: string): void {
 
 test.describe('Guide Runner', () => {
   test('loads and displays guide from JSON', async ({ page }, testInfo) => {
-    // Guide tests may take longer due to fix button attempts and multi-step execution.
-    // Per L3-3C timing design: 30s base + 5s per internal action for multisteps,
-    // plus additional time for fix attempts (up to 3 × 10s each).
-    // Set a generous 2-minute timeout to accommodate complex guides.
-    test.setTimeout(120000);
+    test.setTimeout(GUIDE_SETUP_TIMEOUT_MS * 2);
 
     // L3-5B: Capture timestamp at test start for JSON report
     const testStartTimestamp = new Date().toISOString();
@@ -145,6 +144,7 @@ test.describe('Guide Runner', () => {
     // Read guide JSON from environment variable path
     const guidePath = process.env[E2E_ENV.GUIDE_JSON_PATH];
     const targetUrl = process.env[E2E_ENV.GRAFANA_URL] ?? 'http://localhost:3000';
+    const startingLocation = process.env[E2E_ENV.STARTING_LOCATION] ?? '/';
     const bearerToken = process.env[E2E_ENV.GRAFANA_TOKEN];
     const isVerbose = isEnvFlagEnabled(process.env[E2E_ENV.VERBOSE]);
     // L3-5D: Artifacts directory for artifact collection
@@ -207,9 +207,8 @@ test.describe('Guide Runner', () => {
     // Guide loading and verification
     // ============================================
 
-    // Navigate to Grafana home (pre-flight may have left us on a different page)
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.goto(startingLocation, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.locator('button[aria-label="Help"]').waitFor({ state: 'visible', timeout: 30000 });
 
     const injectGuide = () =>
       page.evaluate(
@@ -222,7 +221,8 @@ test.describe('Guide Runner', () => {
 
     await ensureDocsPanelOpen(page, {
       beforeRetry: async () => {
-        await page.reload({ waitUntil: 'networkidle', timeout: 10_000 });
+        await page.reload({ waitUntil: 'domcontentloaded', timeout: 10000 });
+        await page.locator('button[aria-label="Help"]').waitFor({ state: 'visible', timeout: 10000 });
         await injectGuide();
       },
     });
@@ -252,6 +252,7 @@ test.describe('Guide Runner', () => {
     // Step discovery: DOM-based step enumeration
     // ============================================
     const discoveryResult = await discoverStepsFromDOM(page);
+    test.setTimeout(calculateGuideTimeout(discoveryResult.steps));
 
     // Verify step discovery found steps
     expect(discoveryResult.totalSteps).toBeGreaterThan(0);
@@ -305,6 +306,7 @@ test.describe('Guide Runner', () => {
       executionResult.results,
       guideMetadata,
       targetUrl,
+      startingLocation,
       testStartTimestamp,
       executionResult,
       guideJson,

--- a/tests/e2e-runner/guide-runner.spec.ts
+++ b/tests/e2e-runner/guide-runner.spec.ts
@@ -30,7 +30,7 @@ import {
   discoverStepsFromDOM,
   executeAllSteps,
   calculateGuideTimeout,
-  GUIDE_SETUP_TIMEOUT_MS,
+  GUIDE_INITIAL_TIMEOUT_MS,
   ensureDocsPanelOpen,
   summarizeResults,
   AllStepsResult,
@@ -136,7 +136,7 @@ function writeTracePathFile(outputDir: string): void {
 
 test.describe('Guide Runner', () => {
   test('loads and displays guide from JSON', async ({ page }, testInfo) => {
-    test.setTimeout(GUIDE_SETUP_TIMEOUT_MS * 2);
+    test.setTimeout(GUIDE_INITIAL_TIMEOUT_MS);
 
     // L3-5B: Capture timestamp at test start for JSON report
     const testStartTimestamp = new Date().toISOString();

--- a/tests/e2e-runner/utils/guide-runner/constants.ts
+++ b/tests/e2e-runner/utils/guide-runner/constants.ts
@@ -37,6 +37,7 @@ export const SECTION_SELECTOR = '[data-testid^="interactive-section-"]';
  */
 export const DEFAULT_STEP_TIMEOUT_MS = 30000;
 export const GUIDE_SETUP_TIMEOUT_MS = 60000;
+export const GUIDE_INITIAL_TIMEOUT_MS = GUIDE_SETUP_TIMEOUT_MS * 2;
 export const STEP_OVERHEAD_TIMEOUT_MS = 20000;
 
 /**

--- a/tests/e2e-runner/utils/guide-runner/constants.ts
+++ b/tests/e2e-runner/utils/guide-runner/constants.ts
@@ -36,6 +36,8 @@ export const SECTION_SELECTOR = '[data-testid^="interactive-section-"]';
  * Per design doc: 30 seconds as a generous default.
  */
 export const DEFAULT_STEP_TIMEOUT_MS = 30000;
+export const GUIDE_SETUP_TIMEOUT_MS = 60000;
+export const STEP_OVERHEAD_TIMEOUT_MS = 20000;
 
 /**
  * Additional timeout per internal action for multisteps.

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -13,7 +13,7 @@ import { Page, expect } from '@playwright/test';
 import { testIds } from '../../../../src/constants/testIds';
 import {
   DEFAULT_STEP_TIMEOUT_MS,
-  GUIDE_SETUP_TIMEOUT_MS,
+  GUIDE_INITIAL_TIMEOUT_MS,
   STEP_OVERHEAD_TIMEOUT_MS,
   TIMEOUT_PER_MULTISTEP_ACTION_MS,
   TIMEOUT_PER_GUIDED_SUBSTEP_MS,
@@ -156,7 +156,7 @@ export function calculateStepTimeout(step: TestableStep): number {
 
 export function calculateGuideTimeout(steps: TestableStep[]): number {
   return (
-    GUIDE_SETUP_TIMEOUT_MS +
+    GUIDE_INITIAL_TIMEOUT_MS +
     steps.reduce((total, step) => total + calculateStepTimeout(step) + STEP_OVERHEAD_TIMEOUT_MS, 0)
   );
 }

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -13,6 +13,8 @@ import { Page, expect } from '@playwright/test';
 import { testIds } from '../../../../src/constants/testIds';
 import {
   DEFAULT_STEP_TIMEOUT_MS,
+  GUIDE_SETUP_TIMEOUT_MS,
+  STEP_OVERHEAD_TIMEOUT_MS,
   TIMEOUT_PER_MULTISTEP_ACTION_MS,
   TIMEOUT_PER_GUIDED_SUBSTEP_MS,
   BUTTON_ENABLE_TIMEOUT_MS,
@@ -150,6 +152,13 @@ export function calculateStepTimeout(step: TestableStep): number {
     return DEFAULT_STEP_TIMEOUT_MS + step.internalActionCount * TIMEOUT_PER_MULTISTEP_ACTION_MS;
   }
   return DEFAULT_STEP_TIMEOUT_MS;
+}
+
+export function calculateGuideTimeout(steps: TestableStep[]): number {
+  return (
+    GUIDE_SETUP_TIMEOUT_MS +
+    steps.reduce((total, step) => total + calculateStepTimeout(step) + STEP_OVERHEAD_TIMEOUT_MS, 0)
+  );
 }
 
 /**

--- a/tests/e2e-runner/utils/guide-runner/index.ts
+++ b/tests/e2e-runner/utils/guide-runner/index.ts
@@ -31,7 +31,13 @@ export type {
 // ============================================
 // Constants
 // ============================================
-export { DEFAULT_STEP_TIMEOUT_MS, TIMEOUT_PER_MULTISTEP_ACTION_MS, TIMEOUT_PER_GUIDED_SUBSTEP_MS } from './constants';
+export {
+  DEFAULT_STEP_TIMEOUT_MS,
+  GUIDE_SETUP_TIMEOUT_MS,
+  STEP_OVERHEAD_TIMEOUT_MS,
+  TIMEOUT_PER_MULTISTEP_ACTION_MS,
+  TIMEOUT_PER_GUIDED_SUBSTEP_MS,
+} from './constants';
 
 // ============================================
 // Error Classification
@@ -74,6 +80,7 @@ export {
   scrollStepIntoView,
   waitForDoItButtonEnabled,
   waitForDoItButtonToAppear,
+  calculateGuideTimeout,
   calculateStepTimeout,
   waitForStepCompletion,
   checkObjectiveCompletion,

--- a/tests/e2e-runner/utils/guide-runner/index.ts
+++ b/tests/e2e-runner/utils/guide-runner/index.ts
@@ -33,6 +33,7 @@ export type {
 // ============================================
 export {
   DEFAULT_STEP_TIMEOUT_MS,
+  GUIDE_INITIAL_TIMEOUT_MS,
   GUIDE_SETUP_TIMEOUT_MS,
   STEP_OVERHEAD_TIMEOUT_MS,
   TIMEOUT_PER_MULTISTEP_ACTION_MS,

--- a/tests/e2e-runner/utils/guide-test-runner.test.ts
+++ b/tests/e2e-runner/utils/guide-test-runner.test.ts
@@ -22,6 +22,7 @@ import {
   logStepResult,
   logExecutionSummary,
   DEFAULT_STEP_TIMEOUT_MS,
+  GUIDE_INITIAL_TIMEOUT_MS,
   TIMEOUT_PER_MULTISTEP_ACTION_MS,
   TIMEOUT_PER_GUIDED_SUBSTEP_MS,
 } from './guide-runner';
@@ -181,6 +182,9 @@ describe('calculateStepTimeout', () => {
 });
 
 describe('calculateGuideTimeout', () => {
+  it('preserves the full initial setup allowance after discovery', () => {
+    expect(calculateGuideTimeout([])).toBe(GUIDE_INITIAL_TIMEOUT_MS);
+  });
   it('allows the aggregate budget for multiple simple steps to exceed two minutes', () => {
     const steps = Array.from({ length: 5 }, (_, index) => createTestableStep({ stepId: `step-${index}`, index }));
 

--- a/tests/e2e-runner/utils/guide-test-runner.test.ts
+++ b/tests/e2e-runner/utils/guide-test-runner.test.ts
@@ -16,6 +16,7 @@ jest.mock('@playwright/test', () => ({
 }));
 
 import {
+  calculateGuideTimeout,
   calculateStepTimeout,
   summarizeResults,
   logStepResult,
@@ -176,6 +177,21 @@ describe('calculateStepTimeout', () => {
     const timeout = calculateStepTimeout(step);
 
     expect(timeout).toBe(DEFAULT_STEP_TIMEOUT_MS + 4 * TIMEOUT_PER_GUIDED_SUBSTEP_MS);
+  });
+});
+
+describe('calculateGuideTimeout', () => {
+  it('allows the aggregate budget for multiple simple steps to exceed two minutes', () => {
+    const steps = Array.from({ length: 5 }, (_, index) => createTestableStep({ stepId: `step-${index}`, index }));
+
+    expect(calculateGuideTimeout(steps)).toBeGreaterThan(120000);
+  });
+
+  it('includes guided substep budgets', () => {
+    const simple = calculateGuideTimeout([createTestableStep()]);
+    const guided = calculateGuideTimeout([createTestableStep({ isGuided: true, guidedStepCount: 3 })]);
+
+    expect(guided).toBeGreaterThan(simple);
   });
 });
 


### PR DESCRIPTION
## Summary

Remote package runs discarded the manifest’s `startingLocation`, causing guides to execute from `/` and report misleading selector failures. This change carries validated start context into Playwright, records it in reports, replaces network-idle startup with bounded DOM readiness, and derives the test deadline from discovered step budgets.

## What to look at

- [Package resolution](https://github.com/grafana/grafana-pathfinder-app/blob/cde0de27196d0ad2940406f5b2010ac0899ac8ae/src/cli/e2e/e2e-package.ts) — verify local and remote manifests preserve `startingLocation`.
- [Playwright runner](https://github.com/grafana/grafana-pathfinder-app/blob/cde0de27196d0ad2940406f5b2010ac0899ac8ae/src/cli/e2e/playwright-runner.ts) — starting paths are resolved with `URL`, restricted to the selected Grafana origin, and passed through the runner environment.
- [Guide runner setup](https://github.com/grafana/grafana-pathfinder-app/blob/cde0de27196d0ad2940406f5b2010ac0899ac8ae/tests/e2e-runner/guide-runner.spec.ts) — startup waits for bounded DOM readiness and expands the deadline from discovered step budgets.

## How to verify

1. Run a remote package whose manifest starts on a non-root dashboard and confirm its first step executes on that dashboard.
2. Inspect the JSON report and confirm `guide.startingLocation` matches the manifest.
3. Try an absolute starting URL on another origin and confirm the runner rejects it before launching Playwright.
4. Run a telemetry-active dashboard and confirm startup does not wait indefinitely for network silence.

## Breaking changes

None. The report field is additive, and packages without a starting location continue to use `/`.

## Out of scope

- Rendered step-control semantics are handled in PR #1441.
- Guided UI state and viewport behavior are handled in PR #1442.
- Trace security and reporting integrity are handled in PR #1443.

🤖 Generated with Warp

Co-Authored-By: Oz <oz-agent@warp.dev>



