### PR TITLE
fix(e2e): secure runner artifacts and reporting

### DIFF
--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -257,7 +257,7 @@ When a step fails, the runner captures:
 - **DOM snapshot**: `{stepId}-dom.html` for selector debugging
 - **Console errors**: `{stepId}-console.json` when the step records console errors
 
-Artifacts are saved to the `--artifacts` directory (or a temp directory by default). With `--always-screenshot`, the runner also captures pre-step screenshots, success screenshots, and a final screenshot. `--trace` records a Playwright trace in a per-invocation output directory and surfaces the trace path in CLI output. Trace capture is disabled for bearer-token-authenticated cloud runs because Playwright traces can contain authorization headers, cookies, and temporary credentials.
+Artifacts are saved to the `--artifacts` directory (or a temp directory by default). With `--always-screenshot`, the runner also captures pre-step screenshots, success screenshots, and a final screenshot. `--trace` records a Playwright trace in a retained per-invocation output directory and surfaces the trace path in CLI output. Non-trace Playwright output directories are removed after each invocation. Trace capture is disabled for bearer-token-authenticated cloud runs because Playwright traces can contain authorization headers, cookies, and temporary credentials.
 
 ## Guided-block test guide
 

--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -255,7 +255,7 @@ When a step fails, the runner captures:
 - **DOM snapshot**: `{stepId}-dom.html` for selector debugging
 - **Console errors**: `{stepId}-console.json` when the step records console errors
 
-Artifacts are saved to the `--artifacts` directory (or a temp directory by default). With `--always-screenshot`, the runner also captures pre-step screenshots, success screenshots, and a final screenshot. `--trace` records a Playwright trace and surfaces the trace path in CLI output.
+Artifacts are saved to the `--artifacts` directory (or a temp directory by default). With `--always-screenshot`, the runner also captures pre-step screenshots, success screenshots, and a final screenshot. `--trace` records a Playwright trace in a per-invocation output directory and surfaces the trace path in CLI output. Trace capture is disabled for bearer-token-authenticated cloud runs because Playwright traces can contain authorization headers, cookies, and temporary credentials.
 
 ## Guided-block test guide
 
@@ -455,11 +455,11 @@ When a step fails, the runner assigns an error classification to help with triag
 | `SELECTOR_NOT_FOUND` | `unknown`        | Could be content-drift OR product-regression |
 | `ACTION_FAILED`      | `unknown`        | Needs human triage                           |
 | `REQUIREMENT_FAILED` | `unknown`        | Could be content-drift OR missing setup      |
-| `TIMEOUT`            | `infrastructure` | Likely environmental                         |
+| `TIMEOUT`            | `unknown`        | Could be content, product, or performance    |
 | `NETWORK_ERROR`      | `infrastructure` | Definitely environmental                     |
 | `AUTH_EXPIRED`       | `infrastructure` | Definitely environmental                     |
 
-Only `infrastructure` failures are auto-classified. `SELECTOR_NOT_FOUND`, `ACTION_FAILED`, and `REQUIREMENT_FAILED` default to `unknown` and require human triage — they could indicate content drift, a product regression, or a missing test environment setup.
+Only high-confidence network, authentication, browser-crash, and closed-target failures are auto-classified as `infrastructure`. Selector, action, requirement, and step timeout failures default to `unknown` and require human triage.
 
 The implemented classifier lives in `tests/e2e-runner/utils/guide-runner/classification.ts`.
 

--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -169,6 +169,8 @@ Requirements met? → Execute step
 
 **Skippable steps** (those with a Skip button) allow the test to continue when requirements cannot be met. **Mandatory steps** cause the test to abort on failure, marking remaining steps as `not_reached`.
 
+Overall success requires zero mandatory failures and either at least one verified pass or zero failed steps. A run where every step is skipped cleanly succeeds; a run with no verified pass and any failed skippable step fails.
+
 ## Artifacts and reporting
 
 ### Console output

--- a/src/cli/e2e/e2e-console-reporter.test.ts
+++ b/src/cli/e2e/e2e-console-reporter.test.ts
@@ -46,6 +46,8 @@ describe('writeJsonReport', () => {
     const report = JSON.parse(readFileSync(outputPath, 'utf-8')) as MultiGuideReport;
     expect(schemaValid).toBe(true);
     expect(report.type).toBe('multi-guide');
+    expect(report.summary.totalGuides).toBe(1);
+    expect(report.summary.skippedGuides).toBe(1);
     expect(report.guides).toEqual([]);
     expect(report.reports).toEqual([]);
     expect(report.preRunSkipped).toEqual([

--- a/src/cli/e2e/e2e-console-reporter.test.ts
+++ b/src/cli/e2e/e2e-console-reporter.test.ts
@@ -104,6 +104,38 @@ describe('writeJsonReport', () => {
     expect(report.outcome).toBe('skipped');
   });
 
+  it('counts mixed failed and skipped pre-run guides', () => {
+    const outputPath = join(tempDir, 'results.json');
+    const results: GuideRunResult[] = [
+      {
+        guide: 'https://cdn.test/failed-guide/content.json',
+        id: 'failed-guide',
+        status: 'validation_failed',
+        exitCode: ExitCode.TEST_FAILURE,
+        autoIncluded: false,
+        abortMessage: 'Validation failed',
+        tier: 'cloud',
+      },
+      {
+        guide: 'https://cdn.test/skipped-guide/content.json',
+        id: 'skipped-guide',
+        status: 'skipped_no_auth',
+        exitCode: ExitCode.SUCCESS,
+        autoIncluded: false,
+        abortMessage: 'No auth',
+        tier: 'cloud',
+      },
+    ];
+
+    writeJsonReport(results, outputPath);
+
+    const report = JSON.parse(readFileSync(outputPath, 'utf-8')) as MultiGuideReport;
+    expect(report.outcome).toBe('failed');
+    expect(report.summary.totalGuides).toBe(2);
+    expect(report.summary.failedGuides).toBe(1);
+    expect(report.summary.skippedGuides).toBe(1);
+  });
+
   it('preserves an aborted outcome when a pre-run skip entry failed', () => {
     const outputPath = join(tempDir, 'results.json');
     const results: GuideRunResult[] = [

--- a/src/cli/e2e/e2e-console-reporter.test.ts
+++ b/src/cli/e2e/e2e-console-reporter.test.ts
@@ -136,6 +136,67 @@ describe('writeJsonReport', () => {
     expect(report.summary.skippedGuides).toBe(1);
   });
 
+  it('includes pre-run failures and skips in a mixed executed report summary', () => {
+    const outputPath = join(tempDir, 'results.json');
+    const results: GuideRunResult[] = [
+      {
+        guide: 'executed-guide/content.json',
+        id: 'executed-guide',
+        status: 'passed',
+        exitCode: ExitCode.SUCCESS,
+        autoIncluded: false,
+        resultsData: {
+          guide: {
+            id: 'executed-guide',
+            title: 'Executed guide',
+            path: 'executed-guide/content.json',
+            targetUrl: 'http://localhost:3000',
+          },
+          timestamp: '2026-01-01T00:00:00.000Z',
+          outcome: 'passed',
+          results: [
+            {
+              stepId: 'verified-step',
+              status: 'passed',
+              durationMs: 1,
+              currentUrl: 'http://localhost:3000',
+              consoleErrors: [],
+              skippable: false,
+            },
+          ],
+          aborted: false,
+        },
+      },
+      {
+        guide: 'https://cdn.test/failed-guide/content.json',
+        id: 'failed-guide',
+        status: 'validation_failed',
+        exitCode: ExitCode.TEST_FAILURE,
+        autoIncluded: false,
+        abortMessage: 'Validation failed',
+        tier: 'cloud',
+      },
+      {
+        guide: 'https://cdn.test/skipped-guide/content.json',
+        id: 'skipped-guide',
+        status: 'skipped_no_auth',
+        exitCode: ExitCode.SUCCESS,
+        autoIncluded: false,
+        abortMessage: 'No auth',
+        tier: 'cloud',
+      },
+    ];
+
+    writeJsonReport(results, outputPath);
+
+    const report = JSON.parse(readFileSync(outputPath, 'utf-8')) as MultiGuideReport;
+    expect(report.outcome).toBe('failed');
+    expect(report.summary.totalGuides).toBe(3);
+    expect(report.summary.passedGuides).toBe(1);
+    expect(report.summary.failedGuides).toBe(1);
+    expect(report.summary.skippedGuides).toBe(1);
+  });
+
   it('preserves an aborted outcome when a pre-run skip entry failed', () => {
     const outputPath = join(tempDir, 'results.json');
     const results: GuideRunResult[] = [

--- a/src/cli/e2e/e2e-console-reporter.ts
+++ b/src/cli/e2e/e2e-console-reporter.ts
@@ -39,8 +39,7 @@ function skipOnlyReport(
   cleanupWarnings: string[] = []
 ): MultiGuideReport {
   const timestamp = new Date().toISOString();
-  const failedGuides = (preRunSkipped ?? []).filter((entry) => entry.failed).length;
-  const skippedGuides = (preRunSkipped ?? []).length - failedGuides;
+  const { failedGuides, skippedGuides } = countPreRunGuides(preRunSkipped);
   const runner: RunnerProvenance = {
     name: 'pathfinder-e2e-runner',
     version: process.env.PATHFINDER_E2E_RUNNER_VERSION ?? 'source',
@@ -77,6 +76,14 @@ function skipOnlyReport(
     preRunSkipped,
     cleanupWarnings: cleanupWarnings.length > 0 ? cleanupWarnings : undefined,
   };
+}
+
+function countPreRunGuides(preRunSkipped: MultiGuideReport['preRunSkipped']): {
+  failedGuides: number;
+  skippedGuides: number;
+} {
+  const failedGuides = (preRunSkipped ?? []).filter((entry) => entry.failed).length;
+  return { failedGuides, skippedGuides: (preRunSkipped ?? []).length - failedGuides };
 }
 
 function formatSideEffects(sideEffects: SideEffectClassification | undefined): string {
@@ -254,8 +261,12 @@ export function writeJsonReport(
       const report = generateMultiGuideReport(resultsWithData);
       if (preRunSkipped.length > 0) {
         report.preRunSkipped = preRunSkipped;
+        const counts = countPreRunGuides(preRunSkipped);
+        report.summary.totalGuides += preRunSkipped.length;
+        report.summary.failedGuides += counts.failedGuides;
+        report.summary.skippedGuides += counts.skippedGuides;
         const failureOutcomes: string[] = ['infrastructure_error', 'configuration_error', 'aborted', 'failed'];
-        if (preRunSkipped.some((e) => e.failed) && !failureOutcomes.includes(report.outcome)) {
+        if (counts.failedGuides > 0 && !failureOutcomes.includes(report.outcome)) {
           report.outcome = 'failed';
         }
       }

--- a/src/cli/e2e/e2e-console-reporter.ts
+++ b/src/cli/e2e/e2e-console-reporter.ts
@@ -39,6 +39,8 @@ function skipOnlyReport(
   cleanupWarnings: string[] = []
 ): MultiGuideReport {
   const timestamp = new Date().toISOString();
+  const failedGuides = (preRunSkipped ?? []).filter((entry) => entry.failed).length;
+  const skippedGuides = (preRunSkipped ?? []).length - failedGuides;
   const runner: RunnerProvenance = {
     name: 'pathfinder-e2e-runner',
     version: process.env.PATHFINDER_E2E_RUNNER_VERSION ?? 'source',
@@ -54,11 +56,11 @@ function skipOnlyReport(
     type: 'multi-guide',
     config: { timestamp },
     summary: {
-      totalGuides: 0,
+      totalGuides: (preRunSkipped ?? []).length,
       passedGuides: 0,
-      failedGuides: 0,
+      failedGuides,
       authExpiredGuides: 0,
-      skippedGuides: 0,
+      skippedGuides,
       steps: {
         total: 0,
         passed: 0,

--- a/src/cli/e2e/playwright-runner.test.ts
+++ b/src/cli/e2e/playwright-runner.test.ts
@@ -219,6 +219,35 @@ describe('runPlaywrightTests', () => {
     expect(spawnOptions.env?.STARTING_LOCATION).toBe('/d/example/example');
   });
 
+  it('cleans the per-invocation Playwright output when tracing is disabled', async () => {
+    const child = new EventEmitter();
+    const fsModule = jest.requireActual<typeof import('fs')>('fs');
+    const rmSpy = jest.spyOn(fsModule, 'rmSync');
+    spawnMock.mockImplementation(() => child as never);
+    try {
+      const resultPromise = runPlaywrightTests(
+        { path: 'fixture.json', content: '{}' },
+        {
+          targetUrl: 'http://localhost:3000',
+          verbose: false,
+          trace: false,
+          headed: false,
+          artifacts: 'artifacts',
+          alwaysScreenshot: false,
+          startingLocation: '/',
+        }
+      );
+      const args = spawnMock.mock.calls[0]?.[1] as string[];
+      const outputDir = args.find((arg) => arg.startsWith('--output='))?.slice('--output='.length);
+      child.emit('close', 1);
+      await resultPromise;
+
+      expect(rmSpy).toHaveBeenCalledWith(outputDir, expect.objectContaining({ recursive: true, force: true }));
+    } finally {
+      rmSpy.mockRestore();
+    }
+  });
+
   it('cleans up the temp directory when starting-location validation rejects', async () => {
     const fsModule = jest.requireActual<typeof import('fs')>('fs');
     const rmSpy = jest.spyOn(fsModule, 'rmSync');
@@ -244,6 +273,38 @@ describe('runPlaywrightTests', () => {
         expect.stringContaining('pathfinder-e2e-'),
         expect.objectContaining({ recursive: true, force: true })
       );
+    } finally {
+      rmSpy.mockRestore();
+    }
+  });
+
+  it('enables Playwright tracing when bearer-token authentication is absent', async () => {
+    const child = new EventEmitter();
+    const fsModule = jest.requireActual<typeof import('fs')>('fs');
+    const rmSpy = jest.spyOn(fsModule, 'rmSync');
+    spawnMock.mockImplementation(() => child as never);
+    try {
+      const resultPromise = runPlaywrightTests(
+        { path: 'fixture.json', content: '{}' },
+        {
+          targetUrl: 'http://localhost:3000',
+          verbose: false,
+          trace: true,
+          headed: false,
+          artifacts: 'artifacts',
+          alwaysScreenshot: false,
+          startingLocation: '/',
+        }
+      );
+      const args = spawnMock.mock.calls[0]?.[1] as string[];
+      const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+      const outputDir = args.find((arg) => arg.startsWith('--output='))?.slice('--output='.length);
+      child.emit('close', 1);
+      await resultPromise;
+
+      expect(args).toEqual(expect.arrayContaining(['--trace', 'on']));
+      expect(spawnOptions.env?.E2E_TRACE).toBe('true');
+      expect(rmSpy).not.toHaveBeenCalledWith(outputDir, expect.objectContaining({ recursive: true, force: true }));
     } finally {
       rmSpy.mockRestore();
     }

--- a/src/cli/e2e/playwright-runner.test.ts
+++ b/src/cli/e2e/playwright-runner.test.ts
@@ -251,27 +251,35 @@ describe('runPlaywrightTests', () => {
 
   it('disables Playwright tracing when bearer-token authentication is active', async () => {
     const child = new EventEmitter();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     spawnMock.mockImplementation(() => child as never);
+    try {
+      const resultPromise = runPlaywrightTests(
+        { path: 'fixture.json', content: '{}' },
+        {
+          targetUrl: 'https://play.grafana.org',
+          verbose: false,
+          trace: true,
+          headed: false,
+          artifacts: 'artifacts',
+          alwaysScreenshot: false,
+          startingLocation: '/',
+          token: 'test-token',
+        }
+      );
+      const args = spawnMock.mock.calls[0]?.[1] as string[];
+      const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+      child.emit('close', 1);
+      await resultPromise;
 
-    const resultPromise = runPlaywrightTests(
-      { path: 'fixture.json', content: '{}' },
-      {
-        targetUrl: 'https://play.grafana.org',
-        verbose: false,
-        trace: true,
-        headed: false,
-        artifacts: 'artifacts',
-        alwaysScreenshot: false,
-        token: 'test-token',
-      }
-    );
-    const args = spawnMock.mock.calls[0]?.[1] as string[];
-    const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
-    child.emit('close', 1);
-    await resultPromise;
-
-    expect(args).not.toContain('--trace');
-    expect(spawnOptions.env?.E2E_TRACE).toBe('false');
+      expect(args).not.toContain('--trace');
+      expect(spawnOptions.env?.E2E_TRACE).toBe('false');
+      expect(warnSpy).toHaveBeenCalledWith(
+        '   ⚠ Trace disabled for bearer-token authentication because traces can contain credentials'
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it.each([

--- a/src/cli/e2e/playwright-runner.test.ts
+++ b/src/cli/e2e/playwright-runner.test.ts
@@ -187,6 +187,7 @@ describe('runPlaywrightTests', () => {
         join(runnerRoot, 'tests/e2e-runner/guide-runner.spec.ts'),
         `--config=${join(runnerRoot, 'tests/e2e-runner/playwright.config.ts')}`,
         '--project=chromium',
+        expect.stringMatching(/^--output=/),
       ],
       expect.objectContaining({
         cwd: runnerRoot,
@@ -246,6 +247,31 @@ describe('runPlaywrightTests', () => {
     } finally {
       rmSpy.mockRestore();
     }
+  });
+
+  it('disables Playwright tracing when bearer-token authentication is active', async () => {
+    const child = new EventEmitter();
+    spawnMock.mockImplementation(() => child as never);
+
+    const resultPromise = runPlaywrightTests(
+      { path: 'fixture.json', content: '{}' },
+      {
+        targetUrl: 'https://play.grafana.org',
+        verbose: false,
+        trace: true,
+        headed: false,
+        artifacts: 'artifacts',
+        alwaysScreenshot: false,
+        token: 'test-token',
+      }
+    );
+    const args = spawnMock.mock.calls[0]?.[1] as string[];
+    const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+    child.emit('close', 1);
+    await resultPromise;
+
+    expect(args).not.toContain('--trace');
+    expect(spawnOptions.env?.E2E_TRACE).toBe('false');
   });
 
   it.each([

--- a/src/cli/e2e/playwright-runner.ts
+++ b/src/cli/e2e/playwright-runner.ts
@@ -328,6 +328,13 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
     }
     return result;
   } finally {
+    if (!traceEnabled) {
+      try {
+        rmSync(playwrightOutputDir, { recursive: true, force: true });
+      } catch {
+        console.warn(`Warning: Failed to clean up Playwright output directory: ${playwrightOutputDir}`);
+      }
+    }
     try {
       rmSync(tempDir, { recursive: true, force: true });
       if (options.verbose) {

--- a/src/cli/e2e/playwright-runner.ts
+++ b/src/cli/e2e/playwright-runner.ts
@@ -231,7 +231,7 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
       `--output=${playwrightOutputDir}`,
     ];
 
-    if (options.trace && options.token && options.verbose) {
+    if (options.trace && options.token) {
       console.warn('   ⚠ Trace disabled for bearer-token authentication because traces can contain credentials');
     }
     if (traceEnabled) {

--- a/src/cli/e2e/playwright-runner.ts
+++ b/src/cli/e2e/playwright-runner.ts
@@ -5,7 +5,7 @@
 
 import { spawn } from 'child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
-import { dirname, join, resolve } from 'path';
+import { basename, dirname, join, resolve } from 'path';
 import { tmpdir } from 'os';
 
 import { ExitCode } from './exit-codes';
@@ -211,6 +211,8 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
   const resultsFilePath = join(tempDir, 'results.json');
   const authStateFile = join(tempDir, 'auth.json');
   const traceOutputFilePath = join(tempDir, 'trace-path.txt');
+  const playwrightOutputDir = join(artifactsDir, `playwright-${basename(tempDir)}`);
+  const traceEnabled = options.trace && !options.token;
 
   try {
     const startingPath = resolveStartingPath(options.targetUrl, options.startingLocation);
@@ -226,9 +228,13 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
       join(runnerRoot, GUIDE_RUNNER_SPEC_PATH),
       `--config=${join(runnerRoot, PLAYWRIGHT_CONFIG_PATH)}`,
       '--project=chromium',
+      `--output=${playwrightOutputDir}`,
     ];
 
-    if (options.trace) {
+    if (options.trace && options.token && options.verbose) {
+      console.warn('   ⚠ Trace disabled for bearer-token authentication because traces can contain credentials');
+    }
+    if (traceEnabled) {
       playwrightArgs.push('--trace', 'on');
     }
 
@@ -246,7 +252,7 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
           [E2E_ENV.STARTING_LOCATION]: startingPath,
           [E2E_ENV.AUTH_STATE_FILE]: authStateFile,
           ...(options.token ? { [E2E_ENV.GRAFANA_TOKEN]: options.token } : {}),
-          [E2E_ENV.TRACE]: encodeEnvFlag(options.trace),
+          [E2E_ENV.TRACE]: encodeEnvFlag(traceEnabled),
           [E2E_ENV.VERBOSE]: encodeEnvFlag(options.verbose),
           [E2E_ENV.ABORT_FILE_PATH]: abortFilePath,
           [E2E_ENV.RESULTS_FILE_PATH]: resultsFilePath,
@@ -261,7 +267,7 @@ export async function runPlaywrightTests(guide: LoadedGuide, options: RunGuideOp
       proc.on('close', (code) => {
         const result = processPlaywrightResults(
           code ?? 1,
-          { trace: options.trace },
+          { trace: traceEnabled },
           {
             abortFilePath,
             resultsFilePath,

--- a/tests/e2e-runner/guide-runner.spec.ts
+++ b/tests/e2e-runner/guide-runner.spec.ts
@@ -97,7 +97,7 @@ function writeResultsFile(
     startedAt: timestamp,
     endedAt: new Date().toISOString(),
     outcome,
-    errorCode: allStepsResult.abortReason,
+    errorCode: allStepsResult.abortReason ?? (outcome === 'failed' ? 'UNKNOWN' : undefined),
     errorMessage: allStepsResult.abortMessage,
     results: results.map((r) => ({
       stepId: r.stepId,
@@ -218,7 +218,6 @@ test.describe('Guide Runner', () => {
         { key: StorageKeys.E2E_TEST_GUIDE, json: guideJson }
       );
     await injectGuide();
-
     await ensureDocsPanelOpen(page, {
       beforeRetry: async () => {
         await page.reload({ waitUntil: 'domcontentloaded', timeout: 10000 });
@@ -312,7 +311,7 @@ test.describe('Guide Runner', () => {
       guideJson,
       executionResult.abortReason === 'AUTH_EXPIRED'
         ? 'aborted'
-        : executionResult.abortReason === 'MANDATORY_FAILURE' || summary.mandatoryFailed > 0
+        : executionResult.abortReason === 'MANDATORY_FAILURE' || !summary.success
           ? 'failed'
           : 'passed'
     );
@@ -326,8 +325,6 @@ test.describe('Guide Runner', () => {
       throw new Error(`AUTH_EXPIRED: ${executionResult.abortMessage}`);
     }
 
-    // L3-4C: Verify no mandatory failures occurred
-    // Per design doc: skippable step failures do NOT fail the overall test
-    expect(summary.mandatoryFailed).toBe(0);
+    expect(summary.success).toBe(true);
   });
 });

--- a/tests/e2e-runner/utils/console-reporter.ts
+++ b/tests/e2e-runner/utils/console-reporter.ts
@@ -274,7 +274,11 @@ export function printDetailedSummary(
         console.log(`  └─ Mandatory failures: ${summary.mandatoryFailed} (affects overall result)`);
       }
       if (summary.skippableFailed > 0) {
-        console.log(`  └─ Skippable failures: ${summary.skippableFailed} (does not affect overall result)`);
+        const impact =
+          summary.mandatoryFailed === 0 && summary.passed === 0
+            ? 'affects overall result: no verified pass'
+            : 'does not affect overall result';
+        console.log(`  └─ Skippable failures: ${summary.skippableFailed} (${impact})`);
       }
     }
 

--- a/tests/e2e-runner/utils/console-reporter.ts
+++ b/tests/e2e-runner/utils/console-reporter.ts
@@ -7,7 +7,7 @@
  * @see docs/developer/E2E_TESTING.md#console-output
  */
 
-import { StepTestResult, AllStepsResult, summarizeResults } from './guide-runner';
+import { StepTestResult, AllStepsResult, summarizeResults, skippableFailuresAffectSuccess } from './guide-runner';
 
 // ============================================
 // Constants
@@ -274,10 +274,9 @@ export function printDetailedSummary(
         console.log(`  └─ Mandatory failures: ${summary.mandatoryFailed} (affects overall result)`);
       }
       if (summary.skippableFailed > 0) {
-        const impact =
-          summary.mandatoryFailed === 0 && summary.passed === 0
-            ? 'affects overall result: no verified pass'
-            : 'does not affect overall result';
+        const impact = skippableFailuresAffectSuccess(summary)
+          ? 'affects overall result: no verified pass'
+          : 'does not affect overall result';
         console.log(`  └─ Skippable failures: ${summary.skippableFailed} (${impact})`);
       }
     }

--- a/tests/e2e-runner/utils/guide-runner/classification.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/classification.test.ts
@@ -1,0 +1,22 @@
+jest.mock('@playwright/test', () => ({
+  Page: jest.fn(),
+  Locator: jest.fn(),
+  expect: jest.fn(),
+  test: jest.fn(),
+}));
+
+import { classifyError } from './classification';
+
+describe('classifyError', () => {
+  it('keeps step completion timeouts out of infrastructure classification', () => {
+    expect(classifyError('Timeout waiting for data-test-step-state="completed"')).toBe('unknown');
+  });
+
+  it('classifies network failures as infrastructure', () => {
+    expect(classifyError('net::ERR_CONNECTION_REFUSED')).toBe('infrastructure');
+  });
+
+  it('classifies closed browser targets as infrastructure', () => {
+    expect(classifyError('Target page, context or browser has been closed')).toBe('infrastructure');
+  });
+});

--- a/tests/e2e-runner/utils/guide-runner/classification.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/classification.test.ts
@@ -8,8 +8,13 @@ jest.mock('@playwright/test', () => ({
 import { classifyError } from './classification';
 
 describe('classifyError', () => {
-  it('keeps step completion timeouts out of infrastructure classification', () => {
-    expect(classifyError('Timeout waiting for data-test-step-state="completed"')).toBe('unknown');
+  it.each([
+    'Timeout waiting for data-test-step-state="completed"',
+    'Operation timed out after 30s',
+    'Timeout exceeded while waiting for selector',
+    'Request timeout',
+  ])('keeps timeout pattern "%s" out of infrastructure classification', (errorMessage) => {
+    expect(classifyError(errorMessage)).toBe('unknown');
   });
 
   it('classifies network failures as infrastructure', () => {

--- a/tests/e2e-runner/utils/guide-runner/classification.ts
+++ b/tests/e2e-runner/utils/guide-runner/classification.ts
@@ -14,7 +14,7 @@ import { INFRASTRUCTURE_ERROR_PATTERNS } from './constants';
  * Classify an error for failure triage (L3-5C).
  *
  * Per design doc MVP approach:
- * - TIMEOUT, NETWORK_ERROR, AUTH_EXPIRED → `infrastructure`
+ * - High-confidence network, authentication, and browser failures → `infrastructure`
  * - Everything else → `unknown` (requires human triage)
  *
  * This function analyzes error messages to determine classification.
@@ -27,7 +27,7 @@ import { INFRASTRUCTURE_ERROR_PATTERNS } from './constants';
  *
  * @example
  * ```typescript
- * classifyError('Timeout waiting for step completion')  // → 'infrastructure'
+ * classifyError('Timeout waiting for step completion')  // → 'unknown'
  * classifyError('net::ERR_CONNECTION_REFUSED')          // → 'infrastructure'
  * classifyError('Element not found')                    // → 'unknown'
  * classifyError(undefined, 'AUTH_EXPIRED')              // → 'infrastructure'

--- a/tests/e2e-runner/utils/guide-runner/constants.ts
+++ b/tests/e2e-runner/utils/guide-runner/constants.ts
@@ -198,12 +198,6 @@ export const NAVIGATION_FIX_SETTLE_DELAY_MS = 2000;
  * are unlikely to be caused by guide content or product code changes.
  */
 export const INFRASTRUCTURE_ERROR_PATTERNS = [
-  // Timeout patterns - environmental/performance issues
-  /timeout/i,
-  /timed out/i,
-  /waiting for/i, // "Timeout waiting for X"
-  /exceeded/i, // "Timeout exceeded"
-
   // Network patterns - connectivity issues
   /network/i,
   /net::/i, // Chrome network errors like net::ERR_*

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -1208,8 +1208,9 @@ export function logStepResult(result: StepTestResult): void {
  * Summarize execution results (L3-4C enhanced).
  *
  * Per design doc, overall test success is determined by:
- * - Skippable step failures do NOT fail the overall test
- * - Only mandatory step failures count against success
+ * - Mandatory step failures always fail the overall test
+ * - Skippable step failures fail the test only when no step has a verified pass
+ * - A clean all-skipped run succeeds
  *
  * @param results - Array of step test results
  * @returns Summary object with counts and overall status
@@ -1222,7 +1223,7 @@ export function summarizeResults(results: StepTestResult[]): {
   notReached: number;
   /** L3-4C: Count of mandatory step failures (determines overall success) */
   mandatoryFailed: number;
-  /** L3-4C: Count of skippable step failures (do not affect overall success) */
+  /** L3-4C: Count of skippable failures (affect success when no step passed) */
   skippableFailed: number;
   success: boolean;
   totalDurationMs: number;
@@ -1272,7 +1273,11 @@ export function logExecutionSummary(results: StepTestResult[]): void {
       console.log(`      └─ Mandatory: ${summary.mandatoryFailed} (affects result)`);
     }
     if (summary.skippableFailed > 0) {
-      console.log(`      └─ Skippable: ${summary.skippableFailed} (does not affect result)`);
+      const impact =
+        summary.mandatoryFailed === 0 && summary.passed === 0
+          ? 'affects result: no verified pass'
+          : 'does not affect result';
+      console.log(`      └─ Skippable: ${summary.skippableFailed} (${impact})`);
     }
   } else {
     console.log(`   ✗ Failed: 0`);

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -1215,7 +1215,7 @@ export function logStepResult(result: StepTestResult): void {
  * @param results - Array of step test results
  * @returns Summary object with counts and overall status
  */
-export function summarizeResults(results: StepTestResult[]): {
+export interface ExecutionSummary {
   total: number;
   passed: number;
   failed: number;
@@ -1227,7 +1227,9 @@ export function summarizeResults(results: StepTestResult[]): {
   skippableFailed: number;
   success: boolean;
   totalDurationMs: number;
-} {
+}
+
+export function summarizeResults(results: StepTestResult[]): ExecutionSummary {
   const failedResults = results.filter((r) => r.status === 'failed');
 
   // L3-4C: Separate mandatory vs skippable failures
@@ -1249,6 +1251,10 @@ export function summarizeResults(results: StepTestResult[]): {
     success: mandatoryFailed === 0 && (counts.passed > 0 || counts.failed === 0),
     totalDurationMs: results.reduce((sum, r) => sum + r.durationMs, 0),
   };
+}
+
+export function skippableFailuresAffectSuccess(summary: ExecutionSummary): boolean {
+  return !summary.success && summary.mandatoryFailed === 0 && summary.skippableFailed > 0;
 }
 
 /**
@@ -1273,10 +1279,9 @@ export function logExecutionSummary(results: StepTestResult[]): void {
       console.log(`      └─ Mandatory: ${summary.mandatoryFailed} (affects result)`);
     }
     if (summary.skippableFailed > 0) {
-      const impact =
-        summary.mandatoryFailed === 0 && summary.passed === 0
-          ? 'affects result: no verified pass'
-          : 'does not affect result';
+      const impact = skippableFailuresAffectSuccess(summary)
+        ? 'affects result: no verified pass'
+        : 'does not affect result';
       console.log(`      └─ Skippable: ${summary.skippableFailed} (${impact})`);
     }
   } else {

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -1245,7 +1245,7 @@ export function summarizeResults(results: StepTestResult[]): {
 
   return {
     ...counts,
-    success: mandatoryFailed === 0,
+    success: mandatoryFailed === 0 && (counts.passed > 0 || counts.failed === 0),
     totalDurationMs: results.reduce((sum, r) => sum + r.durationMs, 0),
   };
 }

--- a/tests/e2e-runner/utils/guide-runner/index.ts
+++ b/tests/e2e-runner/utils/guide-runner/index.ts
@@ -92,5 +92,6 @@ export {
   executeAllSteps,
   logStepResult,
   summarizeResults,
+  skippableFailuresAffectSuccess,
   logExecutionSummary,
 } from './execution';

--- a/tests/e2e-runner/utils/guide-runner/types.ts
+++ b/tests/e2e-runner/utils/guide-runner/types.ts
@@ -266,7 +266,7 @@ export interface ArtifactPaths {
  * Classification types (for future use):
  * - `content-drift`: Selector/requirement issues → Content team
  * - `product-regression`: Action failures → Product team
- * - `infrastructure`: TIMEOUT/NETWORK/AUTH → Environmental
+ * - `infrastructure`: high-confidence network/auth/browser failures → Environmental
  * - `unknown`: Default for anything that can't be reliably classified
  *
  * @see docs/developer/E2E_TESTING.md
@@ -274,7 +274,7 @@ export interface ArtifactPaths {
 export type ErrorClassification =
   | 'content-drift' // Selector/requirement issues (requires human validation)
   | 'product-regression' // Action failures (requires human validation)
-  | 'infrastructure' // TIMEOUT, NETWORK_ERROR, AUTH_EXPIRED
+  | 'infrastructure' // Network, authentication, browser-crash, and closed-target failures
   | 'unknown'; // Default - cannot be reliably classified
 
 // ============================================
@@ -318,8 +318,7 @@ export interface StepTestResult {
 
   /**
    * Whether the step was skippable (L3-4C).
-   * Used to determine if failures count against overall test success.
-   * Per design doc: skippable step failures do NOT fail the overall test.
+   * Skippable failures continue execution, but fail a run with no verified pass.
    */
   skippable: boolean;
 

--- a/tests/e2e-runner/utils/guide-test-runner.test.ts
+++ b/tests/e2e-runner/utils/guide-test-runner.test.ts
@@ -31,7 +31,8 @@ import {
   TIMEOUT_PER_MULTISTEP_ACTION_MS,
   TIMEOUT_PER_GUIDED_SUBSTEP_MS,
 } from './guide-runner';
-import type { StepTestResult, TestableStep } from './guide-runner';
+import { printDetailedSummary } from './console-reporter';
+import type { AllStepsResult, StepTestResult, TestableStep } from './guide-runner';
 
 // ============================================
 // Test Fixtures
@@ -184,6 +185,31 @@ describe('calculateStepTimeout', () => {
     const timeout = calculateStepTimeout(step);
 
     expect(timeout).toBe(DEFAULT_STEP_TIMEOUT_MS + 4 * TIMEOUT_PER_GUIDED_SUBSTEP_MS);
+  });
+});
+
+describe('printDetailedSummary', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('explains that skippable failures affect a zero-pass result', () => {
+    const results = [
+      createStepResult({ stepId: 'step-1', status: 'failed', skippable: true }),
+      createStepResult({ stepId: 'step-2', status: 'skipped', skipReason: 'requirements_unmet' }),
+    ];
+    const allStepsResult: AllStepsResult = { results, aborted: false };
+
+    printDetailedSummary(results, allStepsResult, true);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('affects overall result: no verified pass'));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('❌ FAILURE'));
   });
 });
 
@@ -679,6 +705,18 @@ describe('logExecutionSummary', () => {
 
     logExecutionSummary(results);
 
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('❌ FAILURE'));
+  });
+
+  it('explains that skippable failures affect a zero-pass result', () => {
+    const results = [
+      createStepResult({ stepId: 'step-1', status: 'failed', skippable: true }),
+      createStepResult({ stepId: 'step-2', status: 'skipped', skipReason: 'requirements_unmet' }),
+    ];
+
+    logExecutionSummary(results);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('affects result: no verified pass'));
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('❌ FAILURE'));
   });
 

--- a/tests/e2e-runner/utils/guide-test-runner.test.ts
+++ b/tests/e2e-runner/utils/guide-test-runner.test.ts
@@ -363,6 +363,15 @@ describe('summarizeResults', () => {
     expect(summary.mandatoryFailed).toBe(0);
   });
 
+  it('does not pass when no step was verified and a skippable step failed', () => {
+    const results = [
+      createStepResult({ stepId: 'step-1', status: 'failed', skippable: true }),
+      createStepResult({ stepId: 'step-2', status: 'skipped', skipReason: 'requirements_unmet' }),
+    ];
+
+    expect(summarizeResults(results).success).toBe(false);
+  });
+
   it('success is false when any mandatory step fails', () => {
     const results = [
       createStepResult({ stepId: 'step-1', status: 'passed' }),

--- a/tests/e2e-runner/utils/guide-test-runner.test.ts
+++ b/tests/e2e-runner/utils/guide-test-runner.test.ts
@@ -372,6 +372,15 @@ describe('summarizeResults', () => {
     expect(summarizeResults(results).success).toBe(false);
   });
 
+  it('passes when all steps are skipped cleanly', () => {
+    const results = [
+      createStepResult({ stepId: 'step-1', status: 'skipped', skipReason: 'requirements_unmet' }),
+      createStepResult({ stepId: 'step-2', status: 'skipped', skipReason: 'requirements_unmet' }),
+    ];
+
+    expect(summarizeResults(results).success).toBe(true);
+  });
+
   it('success is false when any mandatory step fails', () => {
     const results = [
       createStepResult({ stepId: 'step-1', status: 'passed' }),


### PR DESCRIPTION
## Summary

Concurrent runs shared Playwright output paths, bearer-authenticated traces persisted credentials, broad timeout matching misclassified guide failures as infrastructure, and skip-only or zero-pass runs could report misleading summaries. This change isolates output, disables traces when bearer authentication is active, narrows automatic infrastructure classification, and makes report outcomes reflect verified execution.

## What to look at

- `src/cli/e2e/playwright-runner.ts` — each invocation gets a unique output directory, bearer-token runs explicitly disable tracing, and the security warning is always visible.
- `src/cli/e2e/e2e-console-reporter.ts` — pre-run skips contribute to total, failed, and skipped guide counts.
- `tests/e2e-runner/utils/guide-runner/constants.ts` — only high-confidence network, authentication, browser-crash, and closed-target failures are automatically infrastructure.
- `tests/e2e-runner/utils/guide-runner/execution.ts` — a run with failures and no verified pass cannot report success, while an all-skipped clean run still succeeds.

## How to verify

1. Run two local guide tests with trace enabled and confirm their Playwright outputs use different `playwright-{invocation-id}` directories.
2. Run a bearer-authenticated cloud guide with `--trace` and confirm the runner warns that tracing is disabled and creates no trace archive.
3. Run a credential-safe local or form-login guide with tracing and confirm the trace path is still reported.
4. Produce all-skipped and mixed failed/skipped pre-run reports and confirm their guide counts and outcomes.
5. Trigger messages containing `timeout`, `timed out`, `waiting for`, and `exceeded`; confirm they remain `unknown` unless a high-confidence infrastructure pattern also matches.
6. Produce a run with an optional failure and zero verified passes and confirm the overall outcome is failed.

## Breaking changes

- Bearer-token-authenticated runs no longer emit Playwright traces, even when `--trace` is requested. Screenshots, DOM snapshots, console artifacts, and credential-safe local traces remain available.
- Success now requires zero mandatory failures and either at least one verified passed step or zero failed steps. Previously, a guide with only failed skippable steps could report success.
  - **Impact:** optional-only guides and CI pipelines may see new failures.
  - **Migration:** ensure a guide has at least one step that verifies core functionality, or that all skipped steps are clean skips rather than failed optional executions.
- Generic timeout failures are no longer automatically classified as `infrastructure`; they default to `unknown` unless they also match a high-confidence network, authentication, browser-crash, or closed-target pattern.
  - **Impact:** automated triage and dashboards may route timeout failures differently.
  - **Migration:** update filters and alert routing to account for timeout failures under `unknown`.
- Playwright artifacts now use a per-invocation `playwright-{invocation-id}` subdirectory instead of sharing a flat output path.

## Historical discontinuity

Pass-rate and failure-classification metrics will show a step change at this commit. Reports generated after this change should not be compared directly with earlier reports without accounting for the stricter verified-pass rule and timeout reclassification. Artifact consumers must also follow the new per-invocation output directory.

## Reversibility

The code changes are reversible and do not migrate application state. A revert restores future trace, classification, success, and output-directory behavior, but it cannot remove credential-bearing traces already captured after a revert or erase the historical metrics discontinuity created while this version was active.

## Out of scope

- Semantic-layer shared-stack safety classification remains unchanged.
- Guide execution context and rendered control behavior are handled in PRs #1440–#1442.
- Splitting the security, reporting, and classification changes into separate deployments is not planned for this PR; the added tests and explicit migration guidance provide the rollout boundary.

🤖 Generated with Warp

Co-Authored-By: Oz <oz-agent@warp.dev>