### PR TITLE
feat(docs-panel): choose launch surface from guide content for My Learning

### DIFF
--- a/src/components/Home/HomePanel.test.tsx
+++ b/src/components/Home/HomePanel.test.tsx
@@ -16,6 +16,7 @@ import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-side
 import { locationService } from '@grafana/runtime';
 import type { PreparedGuideLaunch } from '../docs-panel/utils/prepare-guide-launch';
 import type { RawContent } from '../../types/content.types';
+import type { PackageOpenInfo } from '../../types/content-panel.types';
 import { testIds } from '../../constants/testIds';
 
 // ---------------------------------------------------------------------------
@@ -175,7 +176,8 @@ describe('HomePanelRenderer', () => {
           }),
         })
       );
-      expect(panelModeManager.setModeTransient).not.toHaveBeenCalled();
+      expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('sidebar');
+      expect(panelModeManager.setModeTransient).not.toHaveBeenCalledWith('fullscreen');
       dispatchSpy.mockRestore();
     });
 
@@ -206,6 +208,52 @@ describe('HomePanelRenderer', () => {
       );
       expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('floating');
       expect(sidebarState.openSidebar).not.toHaveBeenCalled();
+    });
+
+    it('carries packageInfo on both the dispatched event and the queued link', () => {
+      const packageInfo: PackageOpenInfo = { packageId: 'pkg-1', packageManifest: { kind: 'package' } };
+
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
+      const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+      render(<HomePanelRenderer />);
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true, packageInfo }));
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: expect.objectContaining({ packageInfo }) })
+      );
+      dispatchSpy.mockRestore();
+
+      jest.clearAllMocks();
+      (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(false);
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(false);
+      render(<HomePanelRenderer />);
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true, packageInfo }));
+
+      expect(linkInterceptionState.addToQueue).toHaveBeenCalledWith(expect.objectContaining({ packageInfo }));
+    });
+  });
+
+  describe('launches are independent — no cross-launch surface leakage', () => {
+    it('reading-only then interactive: the interactive launch resets the surface to sidebar (A→B)', () => {
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
+      render(<HomePanelRenderer />);
+
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: false }));
+      expect(panelModeManager.setModeTransient).toHaveBeenLastCalledWith('fullscreen');
+
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true }));
+      expect(panelModeManager.setModeTransient).toHaveBeenLastCalledWith('sidebar');
+    });
+
+    it('interactive then reading-only: the reading-only launch still enters full screen (B→A)', () => {
+      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
+      render(<HomePanelRenderer />);
+
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true }));
+      expect(panelModeManager.setModeTransient).toHaveBeenLastCalledWith('sidebar');
+
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: false }));
+      expect(panelModeManager.setModeTransient).toHaveBeenLastCalledWith('fullscreen');
     });
   });
 });

--- a/src/components/Home/HomePanel.test.tsx
+++ b/src/components/Home/HomePanel.test.tsx
@@ -88,6 +88,7 @@ jest.mock('../../global-state/link-interception', () => ({
 
 jest.mock('../../global-state/panel-mode', () => ({
   panelModeManager: {
+    getMode: jest.fn(() => 'sidebar'),
     setPendingGuide: jest.fn(),
     setModeTransient: jest.fn(),
     capturePriorPath: jest.fn(),
@@ -131,6 +132,7 @@ describe('HomePanelRenderer', () => {
     jest.clearAllMocks();
     capturedOnOpenGuide = undefined;
     (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(false);
+    (panelModeManager.getMode as jest.Mock).mockReturnValue('sidebar');
   });
 
   describe('composition', () => {
@@ -226,6 +228,28 @@ describe('HomePanelRenderer', () => {
         expect.objectContaining({ url: 'bundled:first-dashboard', preparedContent: rawContent })
       );
       expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('floating');
+      expect(sidebarState.openSidebar).not.toHaveBeenCalled();
+    });
+
+    it('delivers to the floating panel when it is the current surface, instead of tearing it down', () => {
+      // Nothing is docked in floating mode (module.tsx clears the key), so the
+      // owned-by-other check alone would force 'sidebar' — unmounting the
+      // floating panel while `isSidebarMounted` stays true, dropping the guide.
+      (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(false);
+      (panelModeManager.getMode as jest.Mock).mockReturnValue('floating');
+      const requestGuideListener = jest.fn();
+      document.addEventListener(REQUEST_FLOATING_GUIDE_EVENT, requestGuideListener);
+
+      render(<HomePanelRenderer />);
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true }));
+
+      document.removeEventListener(REQUEST_FLOATING_GUIDE_EVENT, requestGuideListener);
+      expect(panelModeManager.setPendingGuide).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'bundled:first-dashboard', preparedContent: rawContent })
+      );
+      expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('floating');
+      expect(panelModeManager.setModeTransient).not.toHaveBeenCalledWith('sidebar');
+      expect(requestGuideListener).toHaveBeenCalledTimes(1);
       expect(sidebarState.openSidebar).not.toHaveBeenCalled();
     });
 

--- a/src/components/Home/HomePanel.test.tsx
+++ b/src/components/Home/HomePanel.test.tsx
@@ -14,6 +14,7 @@ import { guideLaunchStore } from '../../global-state/guide-launch';
 import { linkInterceptionState } from '../../global-state/link-interception';
 import { panelModeManager } from '../../global-state/panel-mode';
 import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
+import { REQUEST_FLOATING_GUIDE_EVENT } from '../../lib/event-names';
 import { locationService } from '@grafana/runtime';
 import type { PreparedGuideLaunch } from '../docs-panel/utils/prepare-guide-launch';
 import type { RawContent } from '../../types/content.types';
@@ -226,6 +227,25 @@ describe('HomePanelRenderer', () => {
       );
       expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('floating');
       expect(sidebarState.openSidebar).not.toHaveBeenCalled();
+    });
+
+    it('signals an already-mounted floating panel to consume, once per launch, after staging', () => {
+      // A repeat launch leaves the mode at 'floating', so no mode-change event
+      // fires and the panel never remounts — without this signal the second
+      // guide would be staged but never consumed (silently dropped).
+      (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(true);
+      const stagedWhenHeard: number[] = [];
+      const listener = () => {
+        stagedWhenHeard.push((panelModeManager.setPendingGuide as jest.Mock).mock.calls.length);
+      };
+      document.addEventListener(REQUEST_FLOATING_GUIDE_EVENT, listener);
+
+      render(<HomePanelRenderer />);
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true }));
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true }));
+
+      document.removeEventListener(REQUEST_FLOATING_GUIDE_EVENT, listener);
+      expect(stagedWhenHeard).toEqual([1, 2]);
     });
 
     it('carries packageInfo through the staged payload on both the event and the queued-link paths', () => {

--- a/src/components/Home/HomePanel.test.tsx
+++ b/src/components/Home/HomePanel.test.tsx
@@ -1,6 +1,8 @@
 /**
- * Tests for HomePanelRenderer (composition root).
- * Verifies that MyLearningTab is rendered and guide-open callbacks work correctly.
+ * Tests for HomePanelRenderer (composition root + launch-surface selection).
+ * Verifies that MyLearningTab is rendered and that a prepared guide launch is
+ * routed to the right surface (full screen for reading-only content, sidebar /
+ * floating for content that drives the Grafana UI) without a second fetch.
  * MyLearningTab internals are tested separately in the LearningPaths domain.
  */
 
@@ -9,23 +11,29 @@ import { render, screen } from '@testing-library/react';
 import { HomePanelRenderer } from './HomePanel';
 import { sidebarState } from '../../global-state/sidebar';
 import { linkInterceptionState } from '../../global-state/link-interception';
+import { panelModeManager } from '../../global-state/panel-mode';
+import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
+import { locationService } from '@grafana/runtime';
+import type { PreparedGuideLaunch } from '../docs-panel/utils/prepare-guide-launch';
+import type { RawContent } from '../../types/content.types';
 import { testIds } from '../../constants/testIds';
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
-// Mock @grafana/scenes to avoid transitive @grafana/runtime dependency
 jest.mock('@grafana/scenes', () => ({
   SceneObjectBase: class SceneObjectBase {},
 }));
 
-// Mock @grafana/ui - provide simple stand-ins
+jest.mock('@grafana/runtime', () => ({
+  locationService: { push: jest.fn() },
+}));
+
 jest.mock('@grafana/ui', () => ({
   useStyles2: (fn: any) => fn(mockTheme),
 }));
 
-// Minimal GrafanaTheme2-shaped object for style functions
 const mockTheme = {
   isDark: false,
   spacing: (n: number) => `${n * 8}px`,
@@ -48,11 +56,10 @@ const mockTheme = {
   zIndex: { modal: 1000 },
 };
 
-// Capture onOpenGuide prop passed to MyLearningTab
-let capturedOnOpenGuide: ((url: string, title: string) => void) | undefined;
+let capturedOnOpenGuide: ((launch: PreparedGuideLaunch) => void) | undefined;
 
 jest.mock('../LearningPaths', () => ({
-  MyLearningTab: ({ onOpenGuide }: { onOpenGuide: (url: string, title: string) => void }) => {
+  MyLearningTab: ({ onOpenGuide }: { onOpenGuide: (launch: PreparedGuideLaunch) => void }) => {
     capturedOnOpenGuide = onOpenGuide;
     return <div data-testid="my-learning-tab">MyLearningTab</div>;
   },
@@ -62,7 +69,6 @@ jest.mock('../docs-panel/components', () => ({
   MyLearningErrorBoundary: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
-// Mock global state
 jest.mock('../../global-state/sidebar', () => ({
   sidebarState: {
     getIsSidebarMounted: jest.fn(),
@@ -77,6 +83,42 @@ jest.mock('../../global-state/link-interception', () => ({
   },
 }));
 
+jest.mock('../../global-state/panel-mode', () => ({
+  panelModeManager: {
+    setPendingGuide: jest.fn(),
+    setModeTransient: jest.fn(),
+    capturePriorPath: jest.fn(),
+  },
+}));
+
+jest.mock('../../lib/storage/extension-sidebar', () => ({
+  isExtensionSidebarOwnedByOther: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const rawContent: RawContent = {
+  content: '{"id":"g","title":"g","blocks":[]}',
+  metadata: { title: 'g' },
+  type: 'interactive',
+  url: 'bundled:first-dashboard',
+  lastFetched: '2026-07-28T00:00:00.000Z',
+};
+
+function preparedLaunch(overrides: Partial<PreparedGuideLaunch> = {}): PreparedGuideLaunch {
+  return {
+    url: 'bundled:first-dashboard',
+    title: 'Create your first dashboard',
+    type: 'docs',
+    source: 'home_page',
+    preparedContent: rawContent,
+    requiresGrafanaUi: false,
+    ...overrides,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -85,9 +127,8 @@ describe('HomePanelRenderer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedOnOpenGuide = undefined;
+    (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(false);
   });
-
-  // ---------- Composition ---------------------------------------------------
 
   describe('composition', () => {
     it('renders MyLearningTab', () => {
@@ -101,33 +142,48 @@ describe('HomePanelRenderer', () => {
     });
   });
 
-  // ---------- Guide opening -----------------------------------------------
+  describe('reading-only content opens full screen', () => {
+    it('carries the prepared content into a pending guide and enters full screen transiently', () => {
+      render(<HomePanelRenderer />);
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: false }));
 
-  describe('opening a guide', () => {
-    it('dispatches pathfinder-auto-open-docs when sidebar is mounted', () => {
+      expect(panelModeManager.setPendingGuide).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'bundled:first-dashboard', preparedContent: rawContent })
+      );
+      expect(panelModeManager.capturePriorPath).toHaveBeenCalled();
+      expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('fullscreen');
+      expect(locationService.push).toHaveBeenCalledWith(expect.stringContaining('doc=bundled'));
+    });
+  });
+
+  describe('content that drives the Grafana UI opens beside Grafana', () => {
+    it('dispatches pathfinder-auto-open-docs (with prepared content) when the sidebar is mounted', () => {
       (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
       const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
 
       render(<HomePanelRenderer />);
-      expect(capturedOnOpenGuide).toBeDefined();
-      capturedOnOpenGuide!('bundled:first-dashboard', 'Create your first dashboard');
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true }));
 
       expect(dispatchSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'pathfinder-auto-open-docs',
-          detail: { url: 'bundled:first-dashboard', title: 'Create your first dashboard', source: 'home_page' },
+          detail: expect.objectContaining({
+            url: 'bundled:first-dashboard',
+            title: 'Create your first dashboard',
+            source: 'home_page',
+            preparedContent: rawContent,
+          }),
         })
       );
-
+      expect(panelModeManager.setModeTransient).not.toHaveBeenCalled();
       dispatchSpy.mockRestore();
     });
 
-    it('opens sidebar and queues link when sidebar is NOT mounted', () => {
+    it('opens the sidebar and queues the prepared link when the sidebar is NOT mounted', () => {
       (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(false);
 
       render(<HomePanelRenderer />);
-      expect(capturedOnOpenGuide).toBeDefined();
-      capturedOnOpenGuide!('bundled:first-dashboard', 'Create your first dashboard');
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true }));
 
       expect(sidebarState.setPendingOpenSource).toHaveBeenCalledWith('home_page');
       expect(sidebarState.openSidebar).toHaveBeenCalledWith(
@@ -135,28 +191,21 @@ describe('HomePanelRenderer', () => {
         expect.objectContaining({ url: 'bundled:first-dashboard', title: 'Create your first dashboard' })
       );
       expect(linkInterceptionState.addToQueue).toHaveBeenCalledWith(
-        expect.objectContaining({ url: 'bundled:first-dashboard', title: 'Create your first dashboard' })
+        expect.objectContaining({ url: 'bundled:first-dashboard', preparedContent: rawContent })
       );
     });
 
-    it('supports URL-based (remote) guides', () => {
-      (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
-      const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+    it('falls back to a floating overlay when another plugin owns the sidebar', () => {
+      (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(true);
 
       render(<HomePanelRenderer />);
-      expect(capturedOnOpenGuide).toBeDefined();
+      capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true }));
 
-      const remoteUrl = 'https://interactive-learning.grafana.net/guides/prometheus-lj/add-data-source/content.json';
-      capturedOnOpenGuide!(remoteUrl, 'Add the Prometheus data source');
-
-      expect(dispatchSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'pathfinder-auto-open-docs',
-          detail: { url: remoteUrl, title: 'Add the Prometheus data source', source: 'home_page' },
-        })
+      expect(panelModeManager.setPendingGuide).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'bundled:first-dashboard', preparedContent: rawContent })
       );
-
-      dispatchSpy.mockRestore();
+      expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('floating');
+      expect(sidebarState.openSidebar).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Home/HomePanel.test.tsx
+++ b/src/components/Home/HomePanel.test.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { HomePanelRenderer } from './HomePanel';
 import { sidebarState } from '../../global-state/sidebar';
+import { guideLaunchStore } from '../../global-state/guide-launch';
 import { linkInterceptionState } from '../../global-state/link-interception';
 import { panelModeManager } from '../../global-state/panel-mode';
 import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
@@ -158,7 +159,7 @@ describe('HomePanelRenderer', () => {
   });
 
   describe('content that drives the Grafana UI opens beside Grafana', () => {
-    it('dispatches pathfinder-auto-open-docs (with prepared content) when the sidebar is mounted', () => {
+    it('dispatches pathfinder-auto-open-docs with a redeemable launch key (payload stays off the event) when the sidebar is mounted', () => {
       (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
       const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
 
@@ -172,16 +173,28 @@ describe('HomePanelRenderer', () => {
             url: 'bundled:first-dashboard',
             title: 'Create your first dashboard',
             source: 'home_page',
-            preparedContent: rawContent,
+            launchKey: expect.any(String),
           }),
         })
+      );
+      // The forgeable event never carries the payload itself…
+      const detail = (
+        dispatchSpy.mock.calls.find(
+          (c) => (c[0] as CustomEvent).type === 'pathfinder-auto-open-docs'
+        )![0] as CustomEvent
+      ).detail;
+      expect(detail.preparedContent).toBeUndefined();
+      expect(detail.packageInfo).toBeUndefined();
+      // …but the key redeems it from the module-owned store.
+      expect(guideLaunchStore.consume(detail.launchKey, 'bundled:first-dashboard')).toEqual(
+        expect.objectContaining({ preparedContent: rawContent })
       );
       expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('sidebar');
       expect(panelModeManager.setModeTransient).not.toHaveBeenCalledWith('fullscreen');
       dispatchSpy.mockRestore();
     });
 
-    it('opens the sidebar and queues the prepared link when the sidebar is NOT mounted', () => {
+    it('opens the sidebar and queues a redeemable launch key when the sidebar is NOT mounted', () => {
       (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(false);
 
       render(<HomePanelRenderer />);
@@ -193,7 +206,12 @@ describe('HomePanelRenderer', () => {
         expect.objectContaining({ url: 'bundled:first-dashboard', title: 'Create your first dashboard' })
       );
       expect(linkInterceptionState.addToQueue).toHaveBeenCalledWith(
-        expect.objectContaining({ url: 'bundled:first-dashboard', preparedContent: rawContent })
+        expect.objectContaining({ url: 'bundled:first-dashboard', launchKey: expect.any(String) })
+      );
+      const queued = (linkInterceptionState.addToQueue as jest.Mock).mock.calls[0][0];
+      expect(queued.preparedContent).toBeUndefined();
+      expect(guideLaunchStore.consume(queued.launchKey, 'bundled:first-dashboard')).toEqual(
+        expect.objectContaining({ preparedContent: rawContent })
       );
     });
 
@@ -210,7 +228,7 @@ describe('HomePanelRenderer', () => {
       expect(sidebarState.openSidebar).not.toHaveBeenCalled();
     });
 
-    it('carries packageInfo on both the dispatched event and the queued link', () => {
+    it('carries packageInfo through the staged payload on both the event and the queued-link paths', () => {
       const packageInfo: PackageOpenInfo = { packageId: 'pkg-1', packageManifest: { kind: 'package' } };
 
       (sidebarState.getIsSidebarMounted as jest.Mock).mockReturnValue(true);
@@ -218,8 +236,14 @@ describe('HomePanelRenderer', () => {
       render(<HomePanelRenderer />);
       capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true, packageInfo }));
 
-      expect(dispatchSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ detail: expect.objectContaining({ packageInfo }) })
+      const detail = (
+        dispatchSpy.mock.calls.find(
+          (c) => (c[0] as CustomEvent).type === 'pathfinder-auto-open-docs'
+        )![0] as CustomEvent
+      ).detail;
+      expect(detail.packageInfo).toBeUndefined();
+      expect(guideLaunchStore.consume(detail.launchKey, 'bundled:first-dashboard')).toEqual(
+        expect.objectContaining({ packageInfo })
       );
       dispatchSpy.mockRestore();
 
@@ -229,7 +253,11 @@ describe('HomePanelRenderer', () => {
       render(<HomePanelRenderer />);
       capturedOnOpenGuide!(preparedLaunch({ requiresGrafanaUi: true, packageInfo }));
 
-      expect(linkInterceptionState.addToQueue).toHaveBeenCalledWith(expect.objectContaining({ packageInfo }));
+      const queued = (linkInterceptionState.addToQueue as jest.Mock).mock.calls[0][0];
+      expect(queued.packageInfo).toBeUndefined();
+      expect(guideLaunchStore.consume(queued.launchKey, 'bundled:first-dashboard')).toEqual(
+        expect.objectContaining({ packageInfo })
+      );
     });
   });
 

--- a/src/components/Home/HomePanel.tsx
+++ b/src/components/Home/HomePanel.tsx
@@ -58,6 +58,7 @@ function pendingGuideFrom(launch: PreparedGuideLaunch): PendingGuide {
     type: launch.type,
     packageInfo: launch.packageInfo,
     preparedContent: launch.preparedContent,
+    source: launch.source,
   };
 }
 

--- a/src/components/Home/HomePanel.tsx
+++ b/src/components/Home/HomePanel.tsx
@@ -30,7 +30,7 @@ import { guideLaunchStore } from '../../global-state/guide-launch';
 import { linkInterceptionState } from '../../global-state/link-interception';
 import { panelModeManager, type PendingGuide } from '../../global-state/panel-mode';
 import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
-import { REQUEST_FLOATING_GUIDE_EVENT } from '../../lib/event-names';
+import { AUTO_OPEN_DOCS_EVENT, REQUEST_FLOATING_GUIDE_EVENT } from '../../lib/event-names';
 import { PLUGIN_BASE_URL, ROUTES } from '../../constants';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
 import { buildFullScreenRouteUrl } from '../../utils/pathfinder-search-params';
@@ -113,7 +113,7 @@ export function HomePanelRenderer() {
     });
     if (sidebarState.getIsSidebarMounted()) {
       document.dispatchEvent(
-        new CustomEvent('pathfinder-auto-open-docs', {
+        new CustomEvent(AUTO_OPEN_DOCS_EVENT, {
           detail: { url: launch.url, title: launch.title, source: launch.source, launchKey },
         })
       );

--- a/src/components/Home/HomePanel.tsx
+++ b/src/components/Home/HomePanel.tsx
@@ -29,6 +29,7 @@ import { guideLaunchStore } from '../../global-state/guide-launch';
 import { linkInterceptionState } from '../../global-state/link-interception';
 import { panelModeManager, type PendingGuide } from '../../global-state/panel-mode';
 import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
+import { REQUEST_FLOATING_GUIDE_EVENT } from '../../lib/event-names';
 import { PLUGIN_BASE_URL, ROUTES } from '../../constants';
 import { buildFullScreenRouteUrl } from '../../utils/pathfinder-search-params';
 import pluginJson from '../../plugin.json';
@@ -73,6 +74,10 @@ export function HomePanelRenderer() {
     if (isExtensionSidebarOwnedByOther(pluginJson.id)) {
       panelModeManager.setPendingGuide(pendingGuideFrom(launch));
       panelModeManager.setModeTransient('floating');
+      // A same-mode transient launch dispatches no mode-change event, so an
+      // already-mounted floating panel never remounts to consume. Signal it
+      // directly; unheard when the panel isn't up yet (mount consumes then).
+      document.dispatchEvent(new CustomEvent(REQUEST_FLOATING_GUIDE_EVENT));
       return;
     }
 

--- a/src/components/Home/HomePanel.tsx
+++ b/src/components/Home/HomePanel.tsx
@@ -3,16 +3,36 @@
  *
  * SceneObjectBase wrapper + React composition root for the home page.
  * Renders MyLearningTab as the full-page learning hub at /a/grafana-pathfinder-app.
- * Guide opens are dispatched to the sidebar panel.
+ *
+ * When a guide is launched from My Learning it arrives here already fetched,
+ * snippet-expanded, and classified (see `prepareGuideLaunch`). This handler
+ * picks the display surface from that classification:
+ *
+ * - reading-only content (no Grafana-driving action) → full screen, so the
+ *   whole viewport is used for reading;
+ * - content that drives the Grafana UI → the sidebar, so its "show me / do it"
+ *   actions have the Grafana main area to work on — or a floating overlay when
+ *   another plugin owns the extension sidebar.
+ *
+ * The surface choice is transient: it never overwrites the user's persisted
+ * panel-mode preference. The prepared content is carried through to the
+ * destination so no second fetch happens.
  */
 
 import React, { useCallback } from 'react';
 import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
+import { locationService } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 
 import { sidebarState } from '../../global-state/sidebar';
 import { linkInterceptionState } from '../../global-state/link-interception';
+import { panelModeManager, type PendingGuide } from '../../global-state/panel-mode';
+import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
+import { PLUGIN_BASE_URL, ROUTES } from '../../constants';
+import { buildFullScreenRouteUrl } from '../../utils/pathfinder-search-params';
+import pluginJson from '../../plugin.json';
 import { MyLearningTab } from '../LearningPaths';
+import type { PreparedGuideLaunch } from '../docs-panel/utils/prepare-guide-launch';
 import { MyLearningErrorBoundary } from '../docs-panel/components';
 import { getHomePageStyles } from './home.styles';
 import { testIds } from '../../constants/testIds';
@@ -31,12 +51,35 @@ export class HomePanel extends SceneObjectBase<HomePanelState> {
 // RENDERER
 // ============================================================================
 
+function pendingGuideFrom(launch: PreparedGuideLaunch): PendingGuide {
+  return {
+    url: launch.url,
+    title: launch.title,
+    type: launch.type,
+    packageInfo: launch.packageInfo,
+    preparedContent: launch.preparedContent,
+  };
+}
+
 export function HomePanelRenderer() {
   const styles = useStyles2(getHomePageStyles);
 
-  const handleOpenGuide = useCallback((url: string, title: string) => {
-    const detail = { url, title, source: 'home_page' };
+  // Open beside Grafana: sidebar, or a floating overlay when another plugin
+  // owns the extension sidebar. Carries the prepared content so the tab opens
+  // without a second fetch.
+  const openBesideGrafana = useCallback((launch: PreparedGuideLaunch) => {
+    if (isExtensionSidebarOwnedByOther(pluginJson.id)) {
+      panelModeManager.setPendingGuide(pendingGuideFrom(launch));
+      panelModeManager.setModeTransient('floating');
+      return;
+    }
 
+    const detail = {
+      url: launch.url,
+      title: launch.title,
+      source: launch.source,
+      preparedContent: launch.preparedContent,
+    };
     if (sidebarState.getIsSidebarMounted()) {
       document.dispatchEvent(new CustomEvent('pathfinder-auto-open-docs', { detail }));
     } else {
@@ -46,9 +89,42 @@ export function HomePanelRenderer() {
         title: detail.title,
         timestamp: Date.now(),
       });
-      linkInterceptionState.addToQueue({ ...detail, timestamp: Date.now() });
+      linkInterceptionState.addToQueue({
+        url: launch.url,
+        title: launch.title,
+        timestamp: Date.now(),
+        preparedContent: launch.preparedContent,
+      });
     }
   }, []);
+
+  // Open full screen for reading-only content. Mirrors the sidebar→full-screen
+  // handoff order (pending guide → prior path → mode → route), but selects the
+  // mode transiently so the user's stored preference is untouched.
+  const openFullScreen = useCallback((launch: PreparedGuideLaunch) => {
+    panelModeManager.setPendingGuide(pendingGuideFrom(launch));
+    panelModeManager.capturePriorPath(window.location.pathname + window.location.search);
+    panelModeManager.setModeTransient('fullscreen');
+    locationService.push(
+      buildFullScreenRouteUrl({
+        pluginBaseUrl: PLUGIN_BASE_URL,
+        fullScreenRoute: ROUTES.FullScreen,
+        doc: launch.url,
+        guideType: launch.type,
+      })
+    );
+  }, []);
+
+  const handleOpenGuide = useCallback(
+    (launch: PreparedGuideLaunch) => {
+      if (launch.requiresGrafanaUi) {
+        openBesideGrafana(launch);
+      } else {
+        openFullScreen(launch);
+      }
+    },
+    [openBesideGrafana, openFullScreen]
+  );
 
   return (
     <div className={styles.container} data-testid={testIds.homePage.container}>

--- a/src/components/Home/HomePanel.tsx
+++ b/src/components/Home/HomePanel.tsx
@@ -25,6 +25,7 @@ import { locationService } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 
 import { sidebarState } from '../../global-state/sidebar';
+import { guideLaunchStore } from '../../global-state/guide-launch';
 import { linkInterceptionState } from '../../global-state/link-interception';
 import { panelModeManager, type PendingGuide } from '../../global-state/panel-mode';
 import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
@@ -77,28 +78,31 @@ export function HomePanelRenderer() {
 
     panelModeManager.setModeTransient('sidebar');
 
-    const detail = {
+    // The event and the cold-sidebar queue are public channels — stage the
+    // prepared payload in module-owned memory and send only the opaque key.
+    const launchKey = guideLaunchStore.stage({
       url: launch.url,
-      title: launch.title,
-      source: launch.source,
       preparedContent: launch.preparedContent,
       packageInfo: launch.packageInfo,
-    };
+    });
     if (sidebarState.getIsSidebarMounted()) {
-      document.dispatchEvent(new CustomEvent('pathfinder-auto-open-docs', { detail }));
+      document.dispatchEvent(
+        new CustomEvent('pathfinder-auto-open-docs', {
+          detail: { url: launch.url, title: launch.title, source: launch.source, launchKey },
+        })
+      );
     } else {
       sidebarState.setPendingOpenSource('home_page');
       sidebarState.openSidebar('Interactive learning', {
-        url: detail.url,
-        title: detail.title,
+        url: launch.url,
+        title: launch.title,
         timestamp: Date.now(),
       });
       linkInterceptionState.addToQueue({
         url: launch.url,
         title: launch.title,
         timestamp: Date.now(),
-        preparedContent: launch.preparedContent,
-        packageInfo: launch.packageInfo,
+        launchKey,
       });
     }
   }, []);

--- a/src/components/Home/HomePanel.tsx
+++ b/src/components/Home/HomePanel.tsx
@@ -74,11 +74,14 @@ export function HomePanelRenderer() {
       return;
     }
 
+    panelModeManager.setModeTransient('sidebar');
+
     const detail = {
       url: launch.url,
       title: launch.title,
       source: launch.source,
       preparedContent: launch.preparedContent,
+      packageInfo: launch.packageInfo,
     };
     if (sidebarState.getIsSidebarMounted()) {
       document.dispatchEvent(new CustomEvent('pathfinder-auto-open-docs', { detail }));
@@ -94,6 +97,7 @@ export function HomePanelRenderer() {
         title: launch.title,
         timestamp: Date.now(),
         preparedContent: launch.preparedContent,
+        packageInfo: launch.packageInfo,
       });
     }
   }, []);

--- a/src/components/Home/HomePanel.tsx
+++ b/src/components/Home/HomePanel.tsx
@@ -12,7 +12,8 @@
  *   whole viewport is used for reading;
  * - content that drives the Grafana UI → the sidebar, so its "show me / do it"
  *   actions have the Grafana main area to work on — or a floating overlay when
- *   another plugin owns the extension sidebar.
+ *   another plugin owns the extension sidebar or the floating panel is already
+ *   the current surface.
  *
  * The surface choice is transient: it never overwrites the user's persisted
  * panel-mode preference. The prepared content is carried through to the
@@ -71,7 +72,13 @@ export function HomePanelRenderer() {
   // owns the extension sidebar. Carries the prepared content so the tab opens
   // without a second fetch.
   const openBesideGrafana = useCallback((launch: PreparedGuideLaunch) => {
-    if (isExtensionSidebarOwnedByOther(pluginJson.id)) {
+    // A floating panel already IS beside Grafana — deliver the guide there.
+    // Forcing 'sidebar' would unmount the floating panel without anything
+    // opening the extension sidebar: `isSidebarMounted` stays true (the
+    // floating cleanup leaves it for the expected sidebar mount), so the
+    // auto-open event below would fire with no listener and the guide would
+    // be lost. See #1450 for the listener-ownership gap.
+    if (isExtensionSidebarOwnedByOther(pluginJson.id) || panelModeManager.getMode() === 'floating') {
       panelModeManager.setPendingGuide(pendingGuideFrom(launch));
       panelModeManager.setModeTransient('floating');
       // A same-mode transient launch dispatches no mode-change event, so an

--- a/src/components/Home/HomePanel.tsx
+++ b/src/components/Home/HomePanel.tsx
@@ -32,6 +32,7 @@ import { panelModeManager, type PendingGuide } from '../../global-state/panel-mo
 import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
 import { REQUEST_FLOATING_GUIDE_EVENT } from '../../lib/event-names';
 import { PLUGIN_BASE_URL, ROUTES } from '../../constants';
+import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
 import { buildFullScreenRouteUrl } from '../../utils/pathfinder-search-params';
 import pluginJson from '../../plugin.json';
 import { MyLearningTab } from '../LearningPaths';
@@ -53,6 +54,17 @@ export class HomePanel extends SceneObjectBase<HomePanelState> {
 // ============================================================================
 // RENDERER
 // ============================================================================
+
+// Answers "is the classifier picking the right surface in the wild?" — the
+// surface itself is also reported by mounts/mode changes, but only this event
+// ties it to the content and the classification that chose it.
+function reportSurfaceChoice(surface: 'sidebar' | 'floating' | 'fullscreen', launch: PreparedGuideLaunch): void {
+  reportAppInteraction(UserInteraction.GuideLaunchSurfaceChosen, {
+    surface,
+    requires_grafana_ui: launch.requiresGrafanaUi,
+    content_url: launch.url,
+  });
+}
 
 function pendingGuideFrom(launch: PreparedGuideLaunch): PendingGuide {
   return {
@@ -79,6 +91,7 @@ export function HomePanelRenderer() {
     // auto-open event below would fire with no listener and the guide would
     // be lost. See #1450 for the listener-ownership gap.
     if (isExtensionSidebarOwnedByOther(pluginJson.id) || panelModeManager.getMode() === 'floating') {
+      reportSurfaceChoice('floating', launch);
       panelModeManager.setPendingGuide(pendingGuideFrom(launch));
       panelModeManager.setModeTransient('floating');
       // A same-mode transient launch dispatches no mode-change event, so an
@@ -88,6 +101,7 @@ export function HomePanelRenderer() {
       return;
     }
 
+    reportSurfaceChoice('sidebar', launch);
     panelModeManager.setModeTransient('sidebar');
 
     // The event and the cold-sidebar queue are public channels — stage the
@@ -123,6 +137,7 @@ export function HomePanelRenderer() {
   // handoff order (pending guide → prior path → mode → route), but selects the
   // mode transiently so the user's stored preference is untouched.
   const openFullScreen = useCallback((launch: PreparedGuideLaunch) => {
+    reportSurfaceChoice('fullscreen', launch);
     panelModeManager.setPendingGuide(pendingGuideFrom(launch));
     panelModeManager.capturePriorPath(window.location.pathname + window.location.search);
     panelModeManager.setModeTransient('fullscreen');

--- a/src/components/LearningPaths/LearningPathCard.tsx
+++ b/src/components/LearningPaths/LearningPathCard.tsx
@@ -24,6 +24,8 @@ export function LearningPathCard({
   onContinue,
   onReset,
   defaultExpanded = false,
+  isLaunching = false,
+  launchDisabled = false,
 }: LearningPathCardProps & { defaultExpanded?: boolean }) {
   const styles = useStyles2(getLearningPathCardStyles);
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
@@ -125,10 +127,11 @@ export function LearningPathCard({
             <button
               className={styles.actionButton}
               onClick={handleContinue}
+              disabled={launchDisabled}
               data-testid={testIds.learningPaths.continueButton(path.id)}
             >
-              <Icon name="play" size="sm" />
-              {getButtonText()}
+              <Icon name={isLaunching ? 'fa fa-spinner' : 'play'} size="sm" />
+              {isLaunching ? 'Opening…' : getButtonText()}
             </button>
           )}
           {isCompleted && onReset && !isConfirmingReset && (

--- a/src/components/LearningPaths/MyLearningTab.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Tests for the MyLearningTab launch flow: the pending affordance while
+ * `prepareGuideLaunch` runs, and the unmount guard that stops a resolved
+ * launch from navigating the user after they've left the page.
+ * Badge/path presentation is covered by badge-utils tests.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
+import { MyLearningTab } from './MyLearningTab';
+import { prepareGuideLaunch, type PrepareGuideLaunchResult } from '../docs-panel/utils/prepare-guide-launch';
+import { testIds } from '../../constants/testIds';
+
+jest.mock('../docs-panel/utils/prepare-guide-launch', () => ({
+  prepareGuideLaunch: jest.fn(),
+}));
+
+const publishMock = jest.fn();
+jest.mock('@grafana/runtime', () => ({
+  getAppEvents: () => ({ publish: publishMock }),
+}));
+
+jest.mock('@grafana/i18n', () => ({
+  t: (_key: string, fallback: string, vars?: Record<string, unknown>) =>
+    vars ? fallback.replace(/\{\{(\w+)\}\}/g, (_, k) => String(vars[k])) : fallback,
+}));
+
+jest.mock('@grafana/ui', () => ({
+  useStyles2: () => new Proxy({}, { get: () => 'style' }),
+  Icon: ({ name }: { name: string }) => <span data-icon={name} />,
+}));
+
+jest.mock('../../learning-paths', () => ({
+  BADGES: [],
+  getPathsData: () => ({ guideMetadata: {} }),
+  useLearningPaths: () => ({
+    paths: [
+      {
+        id: 'path-1',
+        title: 'First path',
+        guides: ['guide-1'],
+        url: 'https://grafana.com/docs/learning-paths/path-1/',
+      },
+    ],
+    badgesWithStatus: [],
+    progress: { completedGuides: [], earnedBadges: [], streakDays: 0 },
+    getPathGuides: () => [{ id: 'guide-1', title: 'Guide one', completed: false, isCurrent: true }],
+    getPathProgress: () => 0,
+    isPathCompleted: () => false,
+    getGuideUrlForPath: () => 'https://grafana.com/docs/learning-paths/path-1/guide-1/',
+    resetPath: jest.fn(),
+    streakInfo: { days: 0 },
+    isLoading: false,
+  }),
+}));
+
+jest.mock('../SkeletonLoader', () => ({ SkeletonLoader: () => null }));
+jest.mock('../FeedbackButton/FeedbackButton', () => ({ FeedbackButton: () => null }));
+jest.mock('../../lib/analytics', () => ({
+  reportAppInteraction: jest.fn(),
+  UserInteraction: new Proxy({}, { get: (_t, p) => String(p) }),
+  AnalyticsContentType: new Proxy({}, { get: (_t, p) => String(p) }),
+}));
+jest.mock('../../lib/user-storage', () => ({
+  learningProgressStorage: { clear: jest.fn() },
+  journeyCompletionStorage: { getAll: jest.fn(async () => ({})), clear: jest.fn() },
+  interactiveStepStorage: { clearAll: jest.fn() },
+  interactiveCompletionStorage: { clearAll: jest.fn() },
+}));
+jest.mock('../../global-state/completion-store', () => ({ evictAllContentCaches: jest.fn() }));
+
+const prepareMock = prepareGuideLaunch as jest.MockedFunction<typeof prepareGuideLaunch>;
+
+function deferred() {
+  let resolve!: (r: PrepareGuideLaunchResult) => void;
+  const promise = new Promise<PrepareGuideLaunchResult>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const okResult: PrepareGuideLaunchResult = {
+  ok: true,
+  launch: {
+    url: 'https://grafana.com/docs/learning-paths/path-1/guide-1/',
+    title: 'Guide one',
+    type: 'learning-journey',
+    source: 'home_page',
+    preparedContent: {
+      content: '{}',
+      metadata: { title: 'Guide one' },
+      type: 'learning-journey',
+      url: 'https://grafana.com/docs/learning-paths/path-1/guide-1/',
+      lastFetched: '2026-07-29T00:00:00.000Z',
+    },
+    requiresGrafanaUi: false,
+  },
+} as PrepareGuideLaunchResult;
+
+describe('MyLearningTab launch flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows a pending affordance on the launching card and re-enables after resolve', async () => {
+    const { promise, resolve } = deferred();
+    prepareMock.mockReturnValue(promise);
+    const onOpenGuide = jest.fn();
+
+    render(<MyLearningTab onOpenGuide={onOpenGuide} />);
+    const continueButton = screen.getByTestId(testIds.learningPaths.continueButton('path-1'));
+    fireEvent.click(continueButton);
+
+    expect(continueButton).toBeDisabled();
+    expect(continueButton).toHaveTextContent('Opening…');
+
+    await act(async () => resolve(okResult));
+
+    await waitFor(() => expect(onOpenGuide).toHaveBeenCalledTimes(1));
+    expect(continueButton).not.toBeDisabled();
+    expect(continueButton).not.toHaveTextContent('Opening…');
+  });
+
+  it('drops a launch that resolves after unmount instead of opening the guide', async () => {
+    const { promise, resolve } = deferred();
+    prepareMock.mockReturnValue(promise);
+    const onOpenGuide = jest.fn();
+
+    const { unmount } = render(<MyLearningTab onOpenGuide={onOpenGuide} />);
+    fireEvent.click(screen.getByTestId(testIds.learningPaths.continueButton('path-1')));
+    unmount();
+
+    await act(async () => resolve(okResult));
+
+    expect(onOpenGuide).not.toHaveBeenCalled();
+    expect(publishMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed prepare as an error alert without opening a guide', async () => {
+    prepareMock.mockResolvedValue({ ok: false, error: 'Failed to load content' });
+    const onOpenGuide = jest.fn();
+
+    render(<MyLearningTab onOpenGuide={onOpenGuide} />);
+    fireEvent.click(screen.getByTestId(testIds.learningPaths.continueButton('path-1')));
+
+    await waitFor(() => expect(publishMock).toHaveBeenCalledTimes(1));
+    expect(publishMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'alert-error' }));
+    expect(onOpenGuide).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -18,6 +18,7 @@ import { BadgeIcon } from './BadgeIcon';
 import { SkeletonLoader } from '../SkeletonLoader';
 import { FeedbackButton } from '../FeedbackButton/FeedbackButton';
 import { reportAppInteraction, UserInteraction, AnalyticsContentType } from '../../lib/analytics';
+import { logger } from '../../lib/logging';
 import { StorageEvents } from '../../lib/event-names';
 import {
   learningProgressStorage,
@@ -336,9 +337,16 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
         if (result.ok) {
           onOpenGuide(result.launch);
         } else {
+          // The raw error is internal-shaped — keep it for the logs (Faro
+          // bridge makes launch failures countable) and show a translated
+          // generic message.
+          logger.error('[MyLearning] Guide launch preparation failed', { url, error: result.error });
           getAppEvents().publish({
             type: 'alert-error',
-            payload: ['Could not open the guide', result.error],
+            payload: [
+              t('myLearning.launchErrorTitle', 'Could not open the guide'),
+              t('myLearning.launchErrorMessage', 'Something went wrong while loading the guide. Please try again.'),
+            ],
           });
         }
       } finally {

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -5,7 +5,7 @@
  * Provides a unified experience for users to explore and track their learning journey.
  */
 
-import React, { useState, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useStyles2, Icon } from '@grafana/ui';
 import { getAppEvents } from '@grafana/runtime';
 import { t } from '@grafana/i18n';
@@ -222,6 +222,16 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
   const styles = useStyles2(getMyLearningStyles);
   // Guards against a second launch while the first is still fetching/classifying.
   const launchInFlightRef = useRef(false);
+  // Drives the pending affordance on the launching card while the ref above
+  // stays the correctness guard.
+  const [launchingPathId, setLaunchingPathId] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
   const [showAllBadges, setShowAllBadges] = useState(false);
   const [showAllPaths, setShowAllPaths] = useState(false);
   const [selectedBadge, setSelectedBadge] = useState<EarnedBadge | null>(null);
@@ -308,13 +318,21 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
   // fetch happens while My Learning stays mounted; on failure My Learning stays
   // visible and the error is surfaced rather than committing a surface.
   const launch = useCallback(
-    async (url: string, title: string) => {
+    async (url: string, title: string, pathId: string) => {
       if (launchInFlightRef.current) {
         return;
       }
       launchInFlightRef.current = true;
+      setLaunchingPathId(pathId);
       try {
         const result = await prepareGuideLaunch(url, { title, source: 'home_page' });
+        // The prepare step can outlive this page (the fetches are bounded but
+        // slow-CDN cases run tens of seconds). If the user navigated away,
+        // drop the result — launching now would yank them to /fullscreen from
+        // wherever they landed.
+        if (!mountedRef.current) {
+          return;
+        }
         if (result.ok) {
           onOpenGuide(result.launch);
         } else {
@@ -325,6 +343,9 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
         }
       } finally {
         launchInFlightRef.current = false;
+        if (mountedRef.current) {
+          setLaunchingPathId(null);
+        }
       }
     },
     [onOpenGuide]
@@ -352,7 +373,7 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
           interaction_location: 'my_learning_tab',
         });
 
-        void launch(resolvedGuideUrl, title);
+        void launch(resolvedGuideUrl, title, parentPath.id);
         return;
       }
 
@@ -383,7 +404,7 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
         });
       }
 
-      void launch(guideUrl, title);
+      void launch(guideUrl, title, pathId);
     },
     [launch, paths, getPathProgress, getPathGuides, getGuideUrlForPath]
   );
@@ -554,6 +575,8 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
                 onContinue={handleOpenGuide}
                 onReset={resetPath}
                 defaultExpanded={isFirstInProgress}
+                isLaunching={launchingPathId === path.id}
+                launchDisabled={launchingPathId !== null}
               />
             );
           })}

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -5,10 +5,12 @@
  * Provides a unified experience for users to explore and track their learning journey.
  */
 
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useRef } from 'react';
 import { useStyles2, Icon } from '@grafana/ui';
+import { getAppEvents } from '@grafana/runtime';
 import { t } from '@grafana/i18n';
 
+import { prepareGuideLaunch, type PreparedGuideLaunch } from '../docs-panel/utils/prepare-guide-launch';
 import { useLearningPaths, BADGES, getPathsData } from '../../learning-paths';
 import { testIds } from '../../constants/testIds';
 import { LearningPathCard } from './LearningPathCard';
@@ -34,7 +36,13 @@ import { getBadgeDetailStyles } from './BadgeDetailCard.styles';
 import { getMyLearningStyles } from './MyLearningTab.styles';
 
 interface MyLearningTabProps {
-  onOpenGuide: (url: string, title: string) => void;
+  /**
+   * Called once the guide has been fetched, snippet-expanded, and classified,
+   * so the host can choose the display surface (full-screen for reading-only
+   * content, sidebar/floating when it drives the Grafana UI) and open the tab
+   * without a second fetch.
+   */
+  onOpenGuide: (launch: PreparedGuideLaunch) => void;
 }
 
 // ============================================================================
@@ -212,6 +220,8 @@ function BadgeGridItem({ badge, index, completedGuides, streakDays, paths, style
 
 export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
   const styles = useStyles2(getMyLearningStyles);
+  // Guards against a second launch while the first is still fetching/classifying.
+  const launchInFlightRef = useRef(false);
   const [showAllBadges, setShowAllBadges] = useState(false);
   const [showAllPaths, setShowAllPaths] = useState(false);
   const [selectedBadge, setSelectedBadge] = useState<EarnedBadge | null>(null);
@@ -293,6 +303,33 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
     );
   }, [selectedBadge, progress.completedGuides, progress.streakDays, paths]);
 
+  // Fetch + snippet-expand + classify the target, then hand the prepared
+  // launch to the host so it can pick the surface without re-fetching. The
+  // fetch happens while My Learning stays mounted; on failure My Learning stays
+  // visible and the error is surfaced rather than committing a surface.
+  const launch = useCallback(
+    async (url: string, title: string) => {
+      if (launchInFlightRef.current) {
+        return;
+      }
+      launchInFlightRef.current = true;
+      try {
+        const result = await prepareGuideLaunch(url, { title, source: 'home_page' });
+        if (result.ok) {
+          onOpenGuide(result.launch);
+        } else {
+          getAppEvents().publish({
+            type: 'alert-error',
+            payload: ['Could not open the guide', result.error],
+          });
+        }
+      } finally {
+        launchInFlightRef.current = false;
+      }
+    },
+    [onOpenGuide]
+  );
+
   // Handle opening a guide
   const handleOpenGuide = useCallback(
     (guideId: string, pathId: string) => {
@@ -315,7 +352,7 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
           interaction_location: 'my_learning_tab',
         });
 
-        onOpenGuide(resolvedGuideUrl, title);
+        void launch(resolvedGuideUrl, title);
         return;
       }
 
@@ -346,9 +383,9 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
         });
       }
 
-      onOpenGuide(guideUrl, title);
+      void launch(guideUrl, title);
     },
-    [onOpenGuide, paths, getPathProgress, getPathGuides, getGuideUrlForPath]
+    [launch, paths, getPathProgress, getPathGuides, getGuideUrlForPath]
   );
 
   // Handle reset all progress (for testing)

--- a/src/components/docs-panel/components/FullScreenModeNotice.tsx
+++ b/src/components/docs-panel/components/FullScreenModeNotice.tsx
@@ -80,7 +80,11 @@ export function FullScreenModeNotice() {
     // re-mount the extension sidebar; that's what triggers the sidebar's
     // panel restoration from storage (without the re-mount, `setMode`
     // alone won't bring the user's tab back).
-    panelModeManager.setMode('sidebar');
+    if (panelModeManager.isTransientMode()) {
+      panelModeManager.setModeTransient('sidebar');
+    } else {
+      panelModeManager.setMode('sidebar');
+    }
     sidebarState.setPendingOpenSource('fullscreen_handoff', 'open');
     sidebarState.openSidebar('Interactive learning');
     const priorPath = panelModeManager.consumePriorPath();

--- a/src/components/docs-panel/components/FullScreenModeNotice.tsx
+++ b/src/components/docs-panel/components/FullScreenModeNotice.tsx
@@ -80,11 +80,7 @@ export function FullScreenModeNotice() {
     // re-mount the extension sidebar; that's what triggers the sidebar's
     // panel restoration from storage (without the re-mount, `setMode`
     // alone won't bring the user's tab back).
-    if (panelModeManager.isTransientMode()) {
-      panelModeManager.setModeTransient('sidebar');
-    } else {
-      panelModeManager.setMode('sidebar');
-    }
+    panelModeManager.setMode('sidebar');
     sidebarState.setPendingOpenSource('fullscreen_handoff', 'open');
     sidebarState.openSidebar('Interactive learning');
     const priorPath = panelModeManager.consumePriorPath();

--- a/src/components/docs-panel/docs-panel.auto-open-event.test.tsx
+++ b/src/components/docs-panel/docs-panel.auto-open-event.test.tsx
@@ -37,12 +37,12 @@ const PANEL_ROOT = path.join(__dirname);
 const TRACKED_FILES = ['docs-panel.tsx', 'hooks/useAutoOpenListener.ts'];
 
 const REQUIRED_REFERENCES = {
-  listenerRegistration: "addEventListener('pathfinder-auto-open-docs'",
-  listenerCleanup: "removeEventListener('pathfinder-auto-open-docs'",
+  listenerRegistration: 'addEventListener(AUTO_OPEN_DOCS_EVENT',
+  listenerCleanup: 'removeEventListener(AUTO_OPEN_DOCS_EVENT',
   routeLearningJourney: 'openLearningJourney(',
   routeDocsPage: 'openDocsPage(',
   sourceCoercion: 'coerceLaunchSource(',
-  journeyUrlMatcher: '/learning-journeys/',
+  journeyUrlMatcher: 'isLearningJourneyUrl(',
 };
 
 function loadTrackedSources(): Array<{ file: string; src: string | null }> {
@@ -56,6 +56,20 @@ function loadTrackedSources(): Array<{ file: string; src: string | null }> {
 }
 
 describe('Phase 0 tripwire: pathfinder-auto-open-docs CustomEvent contract', () => {
+  it('the event name constant still carries the wire-contract string', () => {
+    // Dispatchers and the listener share AUTO_OPEN_DOCS_EVENT; the string
+    // itself is the cross-surface contract (external guides may dispatch it),
+    // so renaming the VALUE is a breaking change even if every import compiles.
+    const eventNames = fs.readFileSync(path.join(PANEL_ROOT, '..', '..', 'lib', 'event-names.ts'), 'utf-8');
+    expect(eventNames).toContain("AUTO_OPEN_DOCS_EVENT = 'pathfinder-auto-open-docs'");
+  });
+
+  it('the shared routing predicate still tests journey pathnames', () => {
+    const urlValidation = fs.readFileSync(path.join(PANEL_ROOT, 'utils', 'url-validation.ts'), 'utf-8');
+    expect(urlValidation).toContain('/learning-journeys/');
+    expect(urlValidation).toContain('/learning-paths/');
+  });
+
   it('listener registration exists in exactly one tracked file', () => {
     const matches = loadTrackedSources().filter(
       ({ src }) => src && src.includes(REQUIRED_REFERENCES.listenerRegistration)

--- a/src/components/docs-panel/docs-panel.load-tab-content.test.ts
+++ b/src/components/docs-panel/docs-panel.load-tab-content.test.ts
@@ -220,6 +220,8 @@ jest.mock('../../hooks', () => ({}));
 // ---------------------------------------------------------------------------
 
 import { CombinedLearningJourneyPanel } from './docs-panel';
+import { loadDocsTabContentResult, shouldUseDocsLoader } from './utils';
+import type { RawContent } from '../../types/content.types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -234,6 +236,16 @@ const makeTab = (id: string) => ({
   isLoading: false,
   error: null,
 });
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const preparedContent: RawContent = {
+  content: '{"id":"g","title":"g","blocks":[]}',
+  metadata: { title: 'g' },
+  type: 'interactive',
+  url: 'bundled:prepared',
+  lastFetched: '2026-07-28T00:00:00.000Z',
+};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -264,5 +276,51 @@ describe('CombinedLearningJourneyPanel.loadTab — empty tab URL', () => {
 
     const tab = (panel as any).state.tabs.find((t: any) => t.id === 'broken-tab');
     expect(tab.error).toBeTruthy();
+  });
+});
+
+describe('CombinedLearningJourneyPanel.openDocsPage — prepared (one-fetch) launch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('commits prepared content with no second fetch on the journey loader path', async () => {
+    (shouldUseDocsLoader as jest.Mock).mockReturnValue(false);
+    const panel = new CombinedLearningJourneyPanel();
+    panel.setState({ tabs: [], activeTabId: 'recommendations' });
+
+    const tabId = await panel.openDocsPage('bundled:prepared', 'Prepared', {
+      source: 'home_page',
+      preparedContent,
+    });
+    await flush();
+
+    expect(mockFetchContent).not.toHaveBeenCalled();
+    expect(loadDocsTabContentResult as jest.Mock).not.toHaveBeenCalled();
+
+    const tab = (panel as any).state.tabs.find((t: any) => t.id === tabId);
+    expect(tab.content).toBe(preparedContent);
+    expect(tab.isLoading).toBe(false);
+    expect(tab.error).toBeNull();
+  });
+
+  it('commits prepared content with no second fetch on the docs/package loader path', async () => {
+    (shouldUseDocsLoader as jest.Mock).mockReturnValue(true);
+    const panel = new CombinedLearningJourneyPanel();
+    panel.setState({ tabs: [], activeTabId: 'recommendations' });
+
+    const tabId = await panel.openDocsPage('bundled:prepared', 'Prepared', {
+      source: 'home_page',
+      preparedContent,
+    });
+    await flush();
+
+    expect(mockFetchContent).not.toHaveBeenCalled();
+    expect(loadDocsTabContentResult as jest.Mock).not.toHaveBeenCalled();
+
+    const tab = (panel as any).state.tabs.find((t: any) => t.id === tabId);
+    expect(tab.content).toBe(preparedContent);
+    expect(tab.isLoading).toBe(false);
+    expect(tab.error).toBeNull();
   });
 });

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -112,6 +112,7 @@ import {
   PackageOpenInfo,
 } from '../../types/content-panel.types';
 import { getPackageRenderType } from '../../types/package.types';
+import type { RawContent } from '../../types/content.types';
 import type { DocsPanelModelOperations, OpenDocsOptions, OpenLearningJourneyOptions } from './types';
 
 class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> implements DocsPanelModelOperations {
@@ -342,7 +343,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     // Route through the unified dispatcher so future docs-like or
     // package-backed learning-journey openings pick the docs loader
     // without an extra branch here.
-    this.loadTab(tabId, url);
+    this.loadTab(tabId, url, { prefetched: options?.preparedContent });
 
     return tabId;
   }
@@ -380,7 +381,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
   public async loadTab(
     tabId: string,
     url: string,
-    options?: { skipReadyToBegin?: boolean; packageInfo?: PackageOpenInfo }
+    options?: { skipReadyToBegin?: boolean; packageInfo?: PackageOpenInfo; prefetched?: RawContent }
   ): Promise<void> {
     // Loaders resolve on failure (failTab stores the error in tab state), so
     // their returned outcome — not promise settlement — stamps the action.
@@ -388,13 +389,19 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       const tab = this.state.tabs.find((t) => t.id === tabId);
       const needsDocsLoader = options?.packageInfo != null || (tab ? shouldUseDocsLoader(tab) : false);
       if (needsDocsLoader) {
-        return this.loadDocsTabContent(tabId, url, options?.skipReadyToBegin, options?.packageInfo);
+        return this.loadDocsTabContent(
+          tabId,
+          url,
+          options?.skipReadyToBegin,
+          options?.packageInfo,
+          options?.prefetched
+        );
       }
-      return this.loadTabContent(tabId, url);
+      return this.loadTabContent(tabId, url, options?.prefetched);
     });
   }
 
-  private async loadTabContent(tabId: string, url: string): Promise<GuideLoadOutcome> {
+  private async loadTabContent(tabId: string, url: string, prefetched?: RawContent): Promise<GuideLoadOutcome> {
     // Empty/corrupted tab URL — nothing to load, and not a successful open.
     if (!url || url.trim() === '') {
       logger.error(`loadTabContent called with an empty URL for tab ${tabId}`);
@@ -406,7 +413,9 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
 
     try {
       const tab = this.state.tabs.find((t) => t.id === tabId);
-      const result = await fetchContent(url);
+      // Prefetched content skips the network fetch (one-fetch launch) but runs
+      // the identical finalization below so journey/completion parity holds.
+      const result = prefetched ? { content: prefetched } : await fetchContent(url);
 
       if (result.content) {
         let content = result.content;
@@ -664,7 +673,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
   }
 
   public async openDocsPage(url: string, title?: string, options?: OpenDocsOptions): Promise<string> {
-    const { source, skipReadyToBegin, packageInfo } = options ?? {};
+    const { source, skipReadyToBegin, packageInfo, preparedContent } = options ?? {};
 
     // Make the launch source explicit at the call site if provided. This
     // narrows the surface area of the legacy `_recordAutoLaunchSource` flag —
@@ -699,7 +708,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     // Save tabs to storage immediately after creating
     this.saveTabsToStorage();
 
-    this.loadTab(tabId, url, { skipReadyToBegin, packageInfo });
+    this.loadTab(tabId, url, { skipReadyToBegin, packageInfo, prefetched: preparedContent });
 
     return tabId;
   }
@@ -708,7 +717,8 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     tabId: string,
     url: string,
     skipReadyToBegin?: boolean,
-    packageInfoArg?: PackageOpenInfo
+    packageInfoArg?: PackageOpenInfo,
+    prefetched?: RawContent
   ): Promise<GuideLoadOutcome> {
     // No early return for empty URLs — loadDocsTabContentResult handles all
     // edge cases (empty URL with packageInfo falls back to fetchPackageById;
@@ -723,11 +733,17 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       // Auto-derive packageInfo when opening a package URL via deep-link or
       // handoff (no recommender). Without the manifest, downstream rendering
       // falls through to plain fetchContent and the milestone toolbar never
-      // appears. See package-info-from-url.ts for the URL pattern.
-      if (!packageInfo && isPackageContentUrl(url)) {
+      // appears. See package-info-from-url.ts for the URL pattern. Skipped for
+      // prefetched launches — `prepareGuideLaunch` already derived it.
+      if (!prefetched && !packageInfo && isPackageContentUrl(url)) {
         packageInfo = await fetchPackageInfoFromUrl(url);
       }
-      const result = await loadDocsTabContentResult(url, { skipReadyToBegin, packageInfo });
+      // Prefetched content skips the network fetch (one-fetch launch) but runs
+      // the identical finalization below so alignment / journey / package
+      // parity holds.
+      const result = prefetched
+        ? { content: prefetched }
+        : await loadDocsTabContentResult(url, { skipReadyToBegin, packageInfo });
 
       // Check if fetch succeeded or failed
       if (result.content) {

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -740,7 +740,13 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       }
       // Prefetched content skips the network fetch (one-fetch launch) but runs
       // the identical finalization below so alignment / journey / package
-      // parity holds.
+      // parity holds. skipReadyToBegin only exists inside that skipped fetch —
+      // prefetched content was built without it (prepareGuideLaunch doesn't
+      // pass it), so the combination cannot be honored; surface the conflict
+      // instead of silently rendering the wrong variant.
+      if (prefetched && skipReadyToBegin) {
+        logger.warn('[DocsPanel] skipReadyToBegin ignored for prefetched content', { url });
+      }
       const result = prefetched
         ? { content: prefetched }
         : await loadDocsTabContentResult(url, { skipReadyToBegin, packageInfo });

--- a/src/components/docs-panel/hooks/useAutoOpenListener.cold-sidebar-relay.test.ts
+++ b/src/components/docs-panel/hooks/useAutoOpenListener.cold-sidebar-relay.test.ts
@@ -1,5 +1,5 @@
 /**
- * Cold-sidebar payload-relay boundary test (PR #1446 review finding 5).
+ * Cold-sidebar payload-relay boundary test.
  *
  * A prepared (one-fetch) launch from My Learning with the sidebar unmounted
  * crosses several independently owned seams:

--- a/src/components/docs-panel/hooks/useAutoOpenListener.cold-sidebar-relay.test.ts
+++ b/src/components/docs-panel/hooks/useAutoOpenListener.cold-sidebar-relay.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Cold-sidebar payload-relay boundary test (PR #1446 review finding 5).
+ *
+ * A prepared (one-fetch) launch from My Learning with the sidebar unmounted
+ * crosses several independently owned seams:
+ *
+ *   HomePanel stage+queue → linkInterceptionState.processQueuedLinks →
+ *   `pathfinder-auto-open-docs` → useAutoOpenListener → model open method
+ *
+ * Unit tests of each seam can all stay green while a handoff silently drops
+ * the payload, so this test runs the REAL queue, REAL store, and REAL
+ * listener (only the model is mocked) and asserts the staged payload
+ * arrives intact with no network fetch along the way. The final hop —
+ * the loader consuming `preparedContent` without calling `fetchContent` —
+ * is pinned separately in `docs-panel.load-tab-content.test.ts`.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useAutoOpenListener } from './useAutoOpenListener';
+import { guideLaunchStore } from '../../../global-state/guide-launch';
+import { linkInterceptionState } from '../../../global-state/link-interception';
+import type { RawContent } from '../../../types/content.types';
+import type { PackageOpenInfo } from '../../../types/content-panel.types';
+import type { DocsPanelModelOperations } from '../types';
+
+const DOC_URL = 'https://grafana.com/docs/grafana/latest/';
+
+const preparedContent: RawContent = {
+  content: '{"id":"g","title":"g","blocks":[]}',
+  metadata: { title: 'g' },
+  type: 'interactive',
+  url: DOC_URL,
+  lastFetched: '2026-07-28T00:00:00.000Z',
+};
+
+const packageInfo: PackageOpenInfo = { packageId: 'pkg-1', packageManifest: { kind: 'package' } };
+
+function makeModel(): DocsPanelModelOperations {
+  return {
+    openLearningJourney: jest.fn(),
+    openDocsPage: jest.fn(),
+  } as unknown as DocsPanelModelOperations;
+}
+
+describe('cold-sidebar relay: queued prepared launch reaches the model intact', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // Drain anything a previous test left in the shared queue singleton.
+    while (linkInterceptionState.hasQueuedLinks()) {
+      linkInterceptionState.shiftFromQueue();
+    }
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('delivers preparedContent and packageInfo through queue → drain → event → listener without a network fetch', () => {
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    // 1. What HomePanel does when the sidebar is unmounted: stage the trusted
+    //    payload, queue only the redeemable key.
+    const launchKey = guideLaunchStore.stage({ url: DOC_URL, preparedContent, packageInfo });
+    linkInterceptionState.addToQueue({ url: DOC_URL, title: 'Guide', timestamp: 0, launchKey });
+
+    // 2. The sidebar mounts: the listener registers, then drains the queue on
+    //    the next tick (the H2 ordering the hook deliberately preserves).
+    const model = makeModel();
+    renderHook(() => useAutoOpenListener(model));
+    expect(model.openDocsPage).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+
+    // 3. The model receives the exact staged payload, once, with no fetch.
+    expect(model.openDocsPage).toHaveBeenCalledTimes(1);
+    expect(model.openDocsPage).toHaveBeenCalledWith(DOC_URL, 'Guide', {
+      source: 'queued_link',
+      preparedContent,
+      packageInfo,
+    });
+    expect(model.openLearningJourney).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(linkInterceptionState.hasQueuedLinks()).toBe(false);
+  });
+
+  it('routes a queued journey URL through openLearningJourney with the payload intact', () => {
+    const journeyUrl = 'https://grafana.com/docs/learning-journeys/intro/';
+    const journeyContent = { ...preparedContent, url: journeyUrl };
+
+    const launchKey = guideLaunchStore.stage({ url: journeyUrl, preparedContent: journeyContent });
+    linkInterceptionState.addToQueue({ url: journeyUrl, title: 'Journey', timestamp: 0, launchKey });
+
+    const model = makeModel();
+    renderHook(() => useAutoOpenListener(model));
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+
+    expect(model.openLearningJourney).toHaveBeenCalledWith(
+      journeyUrl,
+      'Journey',
+      expect.objectContaining({ preparedContent: journeyContent })
+    );
+    expect(model.openDocsPage).not.toHaveBeenCalled();
+  });
+
+  it('a queued link without a key still opens — via the normal fetch path', () => {
+    linkInterceptionState.addToQueue({ url: DOC_URL, title: 'Plain', timestamp: 0 });
+
+    const model = makeModel();
+    renderHook(() => useAutoOpenListener(model));
+    act(() => {
+      jest.advanceTimersByTime(0);
+    });
+
+    expect(model.openDocsPage).toHaveBeenCalledTimes(1);
+    expect((model.openDocsPage as jest.Mock).mock.calls[0][2].preparedContent).toBeUndefined();
+  });
+});

--- a/src/components/docs-panel/hooks/useAutoOpenListener.test.ts
+++ b/src/components/docs-panel/hooks/useAutoOpenListener.test.ts
@@ -108,7 +108,7 @@ describe('useAutoOpenListener', () => {
     removeSpy.mockRestore();
   });
 
-  describe('prepared-launch trust boundary (PR #1446 review finding 1)', () => {
+  describe('prepared-launch trust boundary', () => {
     // The document-level event is dispatchable by any same-page script, so
     // the prepared (one-fetch) payload must never be read from it: the
     // listener redeems an opaque `launchKey` from the module-owned

--- a/src/components/docs-panel/hooks/useAutoOpenListener.test.ts
+++ b/src/components/docs-panel/hooks/useAutoOpenListener.test.ts
@@ -1,6 +1,8 @@
 import { renderHook, act } from '@testing-library/react';
 import { useAutoOpenListener } from './useAutoOpenListener';
+import { guideLaunchStore } from '../../../global-state/guide-launch';
 import { linkInterceptionState } from '../../../global-state/link-interception';
+import type { RawContent } from '../../../types/content.types';
 import type { DocsPanelModelOperations } from '../types';
 
 function makeModel(): DocsPanelModelOperations {
@@ -10,7 +12,7 @@ function makeModel(): DocsPanelModelOperations {
   } as unknown as DocsPanelModelOperations;
 }
 
-function dispatchAutoOpen(detail: { url: string; title: string; source?: string }) {
+function dispatchAutoOpen(detail: Record<string, unknown>) {
   act(() => {
     document.dispatchEvent(new CustomEvent('pathfinder-auto-open-docs', { detail }));
   });
@@ -104,5 +106,79 @@ describe('useAutoOpenListener', () => {
     unmount();
     expect(removeSpy).toHaveBeenCalledWith('pathfinder-auto-open-docs', expect.any(Function));
     removeSpy.mockRestore();
+  });
+
+  describe('prepared-launch trust boundary (PR #1446 review finding 1)', () => {
+    // The document-level event is dispatchable by any same-page script, so
+    // the prepared (one-fetch) payload must never be read from it: the
+    // listener redeems an opaque `launchKey` from the module-owned
+    // guideLaunchStore, and anything beyond {url, title, source, launchKey}
+    // in the detail is ignored.
+    const DOC_URL = 'https://grafana.com/docs/grafana/latest/';
+    const rawContent: RawContent = {
+      content: '{"id":"g","title":"g","blocks":[]}',
+      metadata: { title: 'g' },
+      type: 'interactive',
+      url: DOC_URL,
+      lastFetched: '2026-07-28T00:00:00.000Z',
+    };
+
+    it('ignores preparedContent and packageInfo smuggled directly in the event detail', () => {
+      const model = makeModel();
+      renderHook(() => useAutoOpenListener(model));
+
+      // A forged event carrying the payload inline — the shape that would
+      // bypass the fetch pipeline's URL/HTTPS/package validation.
+      dispatchAutoOpen({
+        url: DOC_URL,
+        title: 'Forged',
+        source: 'home_page',
+        preparedContent: { ...rawContent, content: '{"id":"evil","title":"evil","blocks":[]}' },
+        packageInfo: { packageId: 'evil', packageManifest: { kind: 'package' } },
+      });
+
+      expect(model.openDocsPage).toHaveBeenCalledTimes(1);
+      const options = (model.openDocsPage as jest.Mock).mock.calls[0][2];
+      expect(options.preparedContent).toBeUndefined();
+      expect(options.packageInfo).toBeUndefined();
+    });
+
+    it('falls back to the normal fetch path on a forged or unknown launchKey', () => {
+      const model = makeModel();
+      renderHook(() => useAutoOpenListener(model));
+
+      dispatchAutoOpen({ url: DOC_URL, title: 'Guide', source: 'home_page', launchKey: 'forged-key' });
+
+      expect(model.openDocsPage).toHaveBeenCalledTimes(1);
+      expect((model.openDocsPage as jest.Mock).mock.calls[0][2].preparedContent).toBeUndefined();
+    });
+
+    it('redeems a genuinely staged key into the prepared payload', () => {
+      const model = makeModel();
+      renderHook(() => useAutoOpenListener(model));
+
+      const launchKey = guideLaunchStore.stage({ url: DOC_URL, preparedContent: rawContent });
+      dispatchAutoOpen({ url: DOC_URL, title: 'Guide', source: 'home_page', launchKey });
+
+      expect(model.openDocsPage).toHaveBeenCalledWith(
+        DOC_URL,
+        'Guide',
+        expect.objectContaining({ source: 'home_page', preparedContent: rawContent })
+      );
+    });
+
+    it('refuses a genuine key re-attached to a different URL', () => {
+      const model = makeModel();
+      renderHook(() => useAutoOpenListener(model));
+
+      const launchKey = guideLaunchStore.stage({
+        url: 'https://grafana.com/docs/other/',
+        preparedContent: rawContent,
+      });
+      dispatchAutoOpen({ url: DOC_URL, title: 'Guide', source: 'home_page', launchKey });
+
+      expect(model.openDocsPage).toHaveBeenCalledTimes(1);
+      expect((model.openDocsPage as jest.Mock).mock.calls[0][2].preparedContent).toBeUndefined();
+    });
   });
 });

--- a/src/components/docs-panel/hooks/useAutoOpenListener.ts
+++ b/src/components/docs-panel/hooks/useAutoOpenListener.ts
@@ -29,6 +29,7 @@ import * as React from 'react';
 import { guideLaunchStore } from '../../../global-state/guide-launch';
 import { linkInterceptionState } from '../../../global-state/link-interception';
 import { coerceLaunchSource } from '../../../recovery';
+import { AUTO_OPEN_DOCS_EVENT } from '../../../lib/event-names';
 import { isLearningJourneyUrl } from '../utils/url-validation';
 import type { DocsPanelModelOperations } from '../types';
 
@@ -70,13 +71,13 @@ export function useAutoOpenListener(model: DocsPanelModelOperations): void {
     };
 
     // Listen for all auto-open events
-    document.addEventListener('pathfinder-auto-open-docs', handleAutoOpen);
+    document.addEventListener(AUTO_OPEN_DOCS_EVENT, handleAutoOpen);
 
     // todo: investigate why this needs to be kicked to the end of the event loop
     setTimeout(() => linkInterceptionState.processQueuedLinks(), 0);
 
     return () => {
-      document.removeEventListener('pathfinder-auto-open-docs', handleAutoOpen);
+      document.removeEventListener(AUTO_OPEN_DOCS_EVENT, handleAutoOpen);
     };
   }, [model]); // Only model as dependency - this component doesn't remount on tab changes
 }

--- a/src/components/docs-panel/hooks/useAutoOpenListener.ts
+++ b/src/components/docs-panel/hooks/useAutoOpenListener.ts
@@ -27,6 +27,7 @@ import { linkInterceptionState } from '../../../global-state/link-interception';
 import { coerceLaunchSource } from '../../../recovery';
 import { parseUrlSafely } from '../../../security';
 import type { RawContent } from '../../../types/content.types';
+import type { PackageOpenInfo } from '../../../types/content-panel.types';
 import type { DocsPanelModelOperations } from '../types';
 
 export function useAutoOpenListener(model: DocsPanelModelOperations): void {
@@ -37,8 +38,9 @@ export function useAutoOpenListener(model: DocsPanelModelOperations): void {
         title: string;
         source?: string;
         preparedContent?: RawContent;
+        packageInfo?: PackageOpenInfo;
       }>;
-      const { url, title, source, preparedContent } = customEvent.detail;
+      const { url, title, source, preparedContent, packageInfo } = customEvent.detail;
 
       // Coerce the untrusted event.detail.source to a typed LaunchSource at
       // the boundary. Unknown literals fall through to `null` ("needs check"),
@@ -55,9 +57,9 @@ export function useAutoOpenListener(model: DocsPanelModelOperations): void {
       // `preparedContent`, when present (My Learning launch), lets the tab open
       // without a second fetch.
       if (isLearningJourney) {
-        model.openLearningJourney(url, title, { source: typedSource ?? undefined, preparedContent });
+        model.openLearningJourney(url, title, { source: typedSource ?? undefined, preparedContent, packageInfo });
       } else {
-        model.openDocsPage(url, title, { source: typedSource ?? undefined, preparedContent });
+        model.openDocsPage(url, title, { source: typedSource ?? undefined, preparedContent, packageInfo });
       }
     };
 

--- a/src/components/docs-panel/hooks/useAutoOpenListener.ts
+++ b/src/components/docs-panel/hooks/useAutoOpenListener.ts
@@ -18,16 +18,18 @@
  * Contract surfaces preserved (Pattern J — pinned by
  * docs-panel.auto-open-event.test.tsx):
  *   - CustomEvent name: `pathfinder-auto-open-docs`
- *   - Detail shape: `{ url: string; title: string; source?: string }`
+ *   - Detail shape: `{ url: string; title: string; source?: string }`,
+ *     plus an optional opaque `launchKey` redeeming a prepared launch from
+ *     the module-owned `guideLaunchStore` (the payload itself never rides
+ *     this forgeable event)
  *   - Routing predicate: `/learning-journeys/` or `/learning-paths/` pathname
  *   - Source coercion via `coerceLaunchSource`
  */
 import * as React from 'react';
+import { guideLaunchStore } from '../../../global-state/guide-launch';
 import { linkInterceptionState } from '../../../global-state/link-interception';
 import { coerceLaunchSource } from '../../../recovery';
 import { parseUrlSafely } from '../../../security';
-import type { RawContent } from '../../../types/content.types';
-import type { PackageOpenInfo } from '../../../types/content-panel.types';
 import type { DocsPanelModelOperations } from '../types';
 
 export function useAutoOpenListener(model: DocsPanelModelOperations): void {
@@ -37,15 +39,20 @@ export function useAutoOpenListener(model: DocsPanelModelOperations): void {
         url: string;
         title: string;
         source?: string;
-        preparedContent?: RawContent;
-        packageInfo?: PackageOpenInfo;
+        launchKey?: string;
       }>;
-      const { url, title, source, preparedContent, packageInfo } = customEvent.detail;
+      const { url, title, source, launchKey } = customEvent.detail;
 
       // Coerce the untrusted event.detail.source to a typed LaunchSource at
       // the boundary. Unknown literals fall through to `null` ("needs check"),
       // which is the safer default than passing typo'd strings into the model.
       const typedSource = coerceLaunchSource(source);
+
+      // Redeem a prepared (one-fetch) launch at the trusted boundary. The
+      // document-level event is forgeable, so it carries only an opaque key;
+      // the payload never crosses it. A forged/replayed/mismatched key
+      // redeems to null and the loader runs its normal validated fetch.
+      const staged = guideLaunchStore.consume(launchKey, url);
 
       // Always create a new tab for each intercepted link
       // Call the model method directly to ensure new tabs are created
@@ -54,12 +61,18 @@ export function useAutoOpenListener(model: DocsPanelModelOperations): void {
       const isLearningJourney =
         urlObj?.pathname.includes('/learning-journeys/') || urlObj?.pathname.includes('/learning-paths/');
 
-      // `preparedContent`, when present (My Learning launch), lets the tab open
-      // without a second fetch.
       if (isLearningJourney) {
-        model.openLearningJourney(url, title, { source: typedSource ?? undefined, preparedContent, packageInfo });
+        model.openLearningJourney(url, title, {
+          source: typedSource ?? undefined,
+          preparedContent: staged?.preparedContent,
+          packageInfo: staged?.packageInfo,
+        });
       } else {
-        model.openDocsPage(url, title, { source: typedSource ?? undefined, preparedContent, packageInfo });
+        model.openDocsPage(url, title, {
+          source: typedSource ?? undefined,
+          preparedContent: staged?.preparedContent,
+          packageInfo: staged?.packageInfo,
+        });
       }
     };
 

--- a/src/components/docs-panel/hooks/useAutoOpenListener.ts
+++ b/src/components/docs-panel/hooks/useAutoOpenListener.ts
@@ -29,7 +29,7 @@ import * as React from 'react';
 import { guideLaunchStore } from '../../../global-state/guide-launch';
 import { linkInterceptionState } from '../../../global-state/link-interception';
 import { coerceLaunchSource } from '../../../recovery';
-import { parseUrlSafely } from '../../../security';
+import { isLearningJourneyUrl } from '../utils/url-validation';
 import type { DocsPanelModelOperations } from '../types';
 
 export function useAutoOpenListener(model: DocsPanelModelOperations): void {
@@ -54,14 +54,7 @@ export function useAutoOpenListener(model: DocsPanelModelOperations): void {
       // redeems to null and the loader runs its normal validated fetch.
       const staged = guideLaunchStore.consume(launchKey, url);
 
-      // Always create a new tab for each intercepted link
-      // Call the model method directly to ensure new tabs are created
-      // Use proper URL parsing for security (defense in depth)
-      const urlObj = parseUrlSafely(url);
-      const isLearningJourney =
-        urlObj?.pathname.includes('/learning-journeys/') || urlObj?.pathname.includes('/learning-paths/');
-
-      if (isLearningJourney) {
+      if (isLearningJourneyUrl(url)) {
         model.openLearningJourney(url, title, {
           source: typedSource ?? undefined,
           preparedContent: staged?.preparedContent,

--- a/src/components/docs-panel/hooks/useAutoOpenListener.ts
+++ b/src/components/docs-panel/hooks/useAutoOpenListener.ts
@@ -26,13 +26,19 @@ import * as React from 'react';
 import { linkInterceptionState } from '../../../global-state/link-interception';
 import { coerceLaunchSource } from '../../../recovery';
 import { parseUrlSafely } from '../../../security';
+import type { RawContent } from '../../../types/content.types';
 import type { DocsPanelModelOperations } from '../types';
 
 export function useAutoOpenListener(model: DocsPanelModelOperations): void {
   React.useEffect(() => {
     const handleAutoOpen = (event: Event) => {
-      const customEvent = event as CustomEvent<{ url: string; title: string; source?: string }>;
-      const { url, title, source } = customEvent.detail;
+      const customEvent = event as CustomEvent<{
+        url: string;
+        title: string;
+        source?: string;
+        preparedContent?: RawContent;
+      }>;
+      const { url, title, source, preparedContent } = customEvent.detail;
 
       // Coerce the untrusted event.detail.source to a typed LaunchSource at
       // the boundary. Unknown literals fall through to `null` ("needs check"),
@@ -46,10 +52,12 @@ export function useAutoOpenListener(model: DocsPanelModelOperations): void {
       const isLearningJourney =
         urlObj?.pathname.includes('/learning-journeys/') || urlObj?.pathname.includes('/learning-paths/');
 
+      // `preparedContent`, when present (My Learning launch), lets the tab open
+      // without a second fetch.
       if (isLearningJourney) {
-        model.openLearningJourney(url, title, { source: typedSource ?? undefined });
+        model.openLearningJourney(url, title, { source: typedSource ?? undefined, preparedContent });
       } else {
-        model.openDocsPage(url, title, { source: typedSource ?? undefined });
+        model.openDocsPage(url, title, { source: typedSource ?? undefined, preparedContent });
       }
     };
 

--- a/src/components/docs-panel/hooks/useFullScreenHandoff.test.ts
+++ b/src/components/docs-panel/hooks/useFullScreenHandoff.test.ts
@@ -39,13 +39,13 @@ function dispatchFullScreen() {
 }
 
 describe('useFullScreenHandoff', () => {
-  let setModeSpy: jest.SpyInstance;
+  let setModePersistedSpy: jest.SpyInstance;
   let setPendingGuideSpy: jest.SpyInstance;
   let capturePriorPathSpy: jest.SpyInstance;
   let publishMock: jest.Mock;
 
   beforeEach(() => {
-    setModeSpy = jest.spyOn(panelModeManager, 'setMode').mockImplementation(() => {});
+    setModePersistedSpy = jest.spyOn(panelModeManager, 'setModePersisted').mockImplementation(() => {});
     setPendingGuideSpy = jest.spyOn(panelModeManager, 'setPendingGuide').mockImplementation(() => {});
     capturePriorPathSpy = jest.spyOn(panelModeManager, 'capturePriorPath').mockImplementation(() => {});
     publishMock = jest.fn();
@@ -78,7 +78,7 @@ describe('useFullScreenHandoff', () => {
       type: 'alert-info',
       payload: ['Leave the live session before switching to full screen.'],
     });
-    expect(setModeSpy).not.toHaveBeenCalled();
+    expect(setModePersistedSpy).not.toHaveBeenCalled();
     expect(locationService.push).not.toHaveBeenCalled();
   });
 
@@ -92,7 +92,7 @@ describe('useFullScreenHandoff', () => {
 
     expect(setPendingGuideSpy).toHaveBeenCalledWith({ title: 'Block editor', type: 'editor' });
     expect(capturePriorPathSpy).toHaveBeenCalledTimes(1);
-    expect(setModeSpy).toHaveBeenCalledWith('fullscreen');
+    expect(setModePersistedSpy).toHaveBeenCalledWith('fullscreen');
     expect(locationService.push).toHaveBeenCalledWith(expect.stringContaining('/fullscreen'));
     expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.FullScreenEnter, {
       guide_url: '',
@@ -113,7 +113,7 @@ describe('useFullScreenHandoff', () => {
       type: 'alert-info',
       payload: ['Open a guide before switching to full screen.'],
     });
-    expect(setModeSpy).not.toHaveBeenCalled();
+    expect(setModePersistedSpy).not.toHaveBeenCalled();
   });
 
   it('refuses devtools tab with an alert', () => {
@@ -128,7 +128,7 @@ describe('useFullScreenHandoff', () => {
       type: 'alert-info',
       payload: ['Open a guide before switching to full screen.'],
     });
-    expect(setModeSpy).not.toHaveBeenCalled();
+    expect(setModePersistedSpy).not.toHaveBeenCalled();
   });
 
   it('hands off the active learning-journey using currentUrl with doc + guideType in the URL', () => {
@@ -155,7 +155,7 @@ describe('useFullScreenHandoff', () => {
       packageInfo: { packageId: 'pkg-y' },
     });
     expect(capturePriorPathSpy).toHaveBeenCalledTimes(1);
-    expect(setModeSpy).toHaveBeenCalledWith('fullscreen');
+    expect(setModePersistedSpy).toHaveBeenCalledWith('fullscreen');
     const pushedUrl = (locationService.push as jest.Mock).mock.calls[0][0];
     expect(pushedUrl).toContain('doc=');
     expect(pushedUrl).toContain('type=learning-journey');

--- a/src/components/docs-panel/hooks/useFullScreenHandoff.ts
+++ b/src/components/docs-panel/hooks/useFullScreenHandoff.ts
@@ -24,18 +24,18 @@
  *   - Live session active: alert "Leave the live session before switching
  *     to full screen." and return.
  *   - Editor tab: capturePriorPath → setPendingGuide({ title, type: 'editor' })
- *     → setMode('fullscreen') → push the bare FullScreen route. No
+ *     → setModePersisted('fullscreen') → push the bare FullScreen route. No
  *     snapshot, no guideUrl in the route.
  *   - No supported guide (no tab, recommendations, devtools, or no URL):
  *     alert "Open a guide before switching to full screen." and return.
  *   - Active guide: setPendingGuide({ url, title, type, packageInfo }),
- *     capturePriorPath, setMode('fullscreen'), push the full-screen route
+ *     capturePriorPath, setModePersisted('fullscreen'), push the full-screen route
  *     with `doc` and `guideType` query params (so a refresh rehydrates
  *     the right tab kind via the URL fallback in FullScreenPanel).
  *
  * Contract surfaces preserved (Pattern J):
  *   - CustomEvent name: `pathfinder-request-full-screen`
- *   - `panelModeManager.setMode('fullscreen')`
+ *   - `panelModeManager.setModePersisted('fullscreen')`
  *   - `panelModeManager.setPendingGuide(...)` payload shapes (editor vs guide)
  *   - `panelModeManager.capturePriorPath(...)`
  *   - Full-screen route built via `buildFullScreenRouteUrl` (URL contract
@@ -76,7 +76,7 @@ export function useFullScreenHandoff(model: FullScreenModel, isSessionActive: bo
       // Editor tab: the block editor itself moves into full screen.
       // We set a pending editor handoff so when the user clicks "Full screen"
       // on the editor while another guide is already in fullscreen
-      // (`setMode('fullscreen')` no-ops in that case), the receiving panel
+      // (`setModePersisted('fullscreen')` no-ops in that case), the receiving panel
       // still switches its active tab to the editor — replacing the journey.
       if (activeTab?.type === 'editor') {
         reportAppInteraction(UserInteraction.FullScreenEnter, {
@@ -88,7 +88,7 @@ export function useFullScreenHandoff(model: FullScreenModel, isSessionActive: bo
         // user's prior Grafana page instead of the plugin home.
         panelModeManager.capturePriorPath(window.location.pathname + window.location.search);
         panelModeManager.setPendingGuide({ title: activeTab.title, type: 'editor' });
-        panelModeManager.setMode('fullscreen');
+        panelModeManager.setModePersisted('fullscreen');
         locationService.push(`${PLUGIN_BASE_URL}/${ROUTES.FullScreen}`);
         return;
       }
@@ -129,7 +129,7 @@ export function useFullScreenHandoff(model: FullScreenModel, isSessionActive: bo
       // Remember where we came from so explicit Exit can land back on the
       // user's prior Grafana page instead of the plugin home.
       panelModeManager.capturePriorPath(window.location.pathname + window.location.search);
-      panelModeManager.setMode('fullscreen');
+      panelModeManager.setModePersisted('fullscreen');
       // Encode the tab type in the URL so a refresh / shared link rehydrates
       // the right kind of tab. Without this, FullScreenPanel's URL fallback
       // would call findDocPage and classify a journey package URL as

--- a/src/components/docs-panel/hooks/usePopOutHandoff.test.ts
+++ b/src/components/docs-panel/hooks/usePopOutHandoff.test.ts
@@ -50,11 +50,11 @@ async function dispatchPopOut() {
 }
 
 describe('usePopOutHandoff', () => {
-  let setModeSpy: jest.SpyInstance;
+  let setModePersistedSpy: jest.SpyInstance;
   let publishMock: jest.Mock;
 
   beforeEach(() => {
-    setModeSpy = jest.spyOn(panelModeManager, 'setMode').mockImplementation(() => {});
+    setModePersistedSpy = jest.spyOn(panelModeManager, 'setModePersisted').mockImplementation(() => {});
     publishMock = jest.fn();
     (getAppEvents as jest.Mock).mockReturnValue({ publish: publishMock });
     (reportAppInteraction as jest.Mock).mockClear();
@@ -83,7 +83,7 @@ describe('usePopOutHandoff', () => {
     await dispatchPopOut();
 
     expect(saveTabsToStorage).toHaveBeenCalledTimes(1);
-    expect(setModeSpy).toHaveBeenCalledWith('floating');
+    expect(setModePersistedSpy).toHaveBeenCalledWith('floating');
     expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.FloatingPanelPopOut, {
       guide_url: 'https://example.com/a/milestone-3',
       guide_title: 'Journey A',
@@ -115,9 +115,9 @@ describe('usePopOutHandoff', () => {
       document.dispatchEvent(new CustomEvent('pathfinder-request-pop-out'));
     });
 
-    // Without resolving the save, setMode must not have fired.
+    // Without resolving the save, the mode flip must not have fired.
     await Promise.resolve();
-    expect(setModeSpy).not.toHaveBeenCalled();
+    expect(setModePersistedSpy).not.toHaveBeenCalled();
 
     await act(async () => {
       resolveSave();
@@ -125,7 +125,7 @@ describe('usePopOutHandoff', () => {
       await Promise.resolve();
     });
 
-    expect(setModeSpy).toHaveBeenCalledWith('floating');
+    expect(setModePersistedSpy).toHaveBeenCalledWith('floating');
   });
 
   it('editor branch: flushes storage and switches to floating with empty guide_url', async () => {
@@ -138,7 +138,7 @@ describe('usePopOutHandoff', () => {
     await dispatchPopOut();
 
     expect(saveTabsToStorage).toHaveBeenCalledTimes(1);
-    expect(setModeSpy).toHaveBeenCalledWith('floating');
+    expect(setModePersistedSpy).toHaveBeenCalledWith('floating');
     expect(reportAppInteraction).toHaveBeenCalledWith(UserInteraction.FloatingPanelPopOut, {
       guide_url: '',
       guide_title: 'Block editor',
@@ -159,7 +159,7 @@ describe('usePopOutHandoff', () => {
       payload: ['Open a guide before popping out the panel.'],
     });
     expect(saveTabsToStorage).not.toHaveBeenCalled();
-    expect(setModeSpy).not.toHaveBeenCalled();
+    expect(setModePersistedSpy).not.toHaveBeenCalled();
   });
 
   it('refuses pop-out when there is no active tab', async () => {
@@ -172,7 +172,7 @@ describe('usePopOutHandoff', () => {
       type: 'alert-info',
       payload: ['Open a guide before popping out the panel.'],
     });
-    expect(setModeSpy).not.toHaveBeenCalled();
+    expect(setModePersistedSpy).not.toHaveBeenCalled();
   });
 
   it('H1 — re-reads model.state inside the handler (tab switched after mount)', async () => {

--- a/src/components/docs-panel/hooks/usePopOutHandoff.ts
+++ b/src/components/docs-panel/hooks/usePopOutHandoff.ts
@@ -30,7 +30,7 @@
  *
  * Contract surfaces preserved (Pattern J):
  *   - CustomEvent name: `pathfinder-request-pop-out`
- *   - `panelModeManager.setMode('floating')`
+ *   - `panelModeManager.setModePersisted('floating')`
  *   - `model.saveTabsToStorage()` awaited before the mode flip
  */
 import * as React from 'react';
@@ -57,7 +57,7 @@ export function usePopOutHandoff(model: PopOutModel): void {
           guide_title: activeTab.title,
         });
         await model.saveTabsToStorage();
-        panelModeManager.setMode('floating');
+        panelModeManager.setModePersisted('floating');
         return;
       }
 
@@ -75,7 +75,7 @@ export function usePopOutHandoff(model: PopOutModel): void {
       });
 
       await model.saveTabsToStorage();
-      panelModeManager.setMode('floating');
+      panelModeManager.setModePersisted('floating');
     };
 
     document.addEventListener('pathfinder-request-pop-out', handlePopOut);

--- a/src/components/docs-panel/pendingGuideRouter.test.ts
+++ b/src/components/docs-panel/pendingGuideRouter.test.ts
@@ -10,9 +10,10 @@
  * journeys whose URL is a raw GitHub URL).
  */
 
-import { openPendingGuide } from './pendingGuideRouter';
+import { consumePendingGuideOnMount, openPendingGuide } from './pendingGuideRouter';
 import type { CombinedLearningJourneyPanel } from './docs-panel';
-import type { PendingGuide } from '../../global-state/panel-mode';
+import { panelModeManager, type PendingGuide } from '../../global-state/panel-mode';
+import type { RawContent } from '../../types/content.types';
 
 function makePanel() {
   return {
@@ -121,5 +122,85 @@ describe('openPendingGuide', () => {
       pending.title,
       expect.objectContaining({ source: 'fullscreen_handoff' })
     );
+  });
+});
+
+describe('consumePendingGuideOnMount (PR #1446 review finding 3)', () => {
+  // State-level test of the occupied-sidebar launch: HomePanel sets a
+  // prepared pending guide and flips to transient floating; the floating
+  // surface must consume it on mount or the launch is silently dropped
+  // (stale restored tabs, or the empty-state fallback bouncing back to
+  // sidebar mode). Mounting FloatingPanelInner itself is not feasible in
+  // Jest (Scenes + theme provider), so this exercises the shared consume
+  // step against the real panelModeManager singleton.
+  const preparedContent: RawContent = {
+    content: '{"id":"g","title":"g","blocks":[]}',
+    metadata: { title: 'g' },
+    type: 'interactive',
+    url: 'bundled:first-dashboard',
+    lastFetched: '2026-07-28T00:00:00.000Z',
+  };
+
+  afterEach(() => {
+    // Drain any pending guide a test left behind (consume-once slot).
+    panelModeManager.consumePendingGuide();
+  });
+
+  it('consumes the prepared guide exactly once, marking in-flight BEFORE routing', () => {
+    const order: string[] = [];
+    const panel = makePanel();
+    panel.openDocsPage.mockImplementation(() => order.push('open'));
+    const markInFlight = jest.fn(() => order.push('in-flight'));
+
+    panelModeManager.setPendingGuide({
+      url: 'bundled:first-dashboard',
+      title: 'Create your first dashboard',
+      type: 'docs',
+      preparedContent,
+      source: 'home_page',
+    });
+
+    expect(consumePendingGuideOnMount(asPanel(panel), 'floating_panel_dock', markInFlight)).toBe(true);
+
+    // The original launch source wins over the surface's fallback so the
+    // starting-location alignment check behaves the same as it would have
+    // in the sidebar; the prepared content survives so no second fetch runs.
+    expect(panel.openDocsPage).toHaveBeenCalledWith(
+      'bundled:first-dashboard',
+      'Create your first dashboard',
+      expect.objectContaining({ source: 'home_page', preparedContent })
+    );
+    // In-flight must be marked before the open so the empty-state fallback
+    // and restoration gates can never observe "nothing happening".
+    expect(order).toEqual(['in-flight', 'open']);
+
+    // Consume-once: a second mount (or another surface) gets nothing.
+    expect(consumePendingGuideOnMount(asPanel(panel), 'floating_panel_dock', markInFlight)).toBe(false);
+    expect(panel.openDocsPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the surface handoff source when the pending guide carries none', () => {
+    const panel = makePanel();
+    panelModeManager.setPendingGuide({ url: 'bundled:foo', title: 'Foo', type: 'docs' });
+
+    consumePendingGuideOnMount(asPanel(panel), 'floating_panel_dock', jest.fn());
+
+    expect(panel.openDocsPage).toHaveBeenCalledWith(
+      'bundled:foo',
+      'Foo',
+      expect.objectContaining({ source: 'floating_panel_dock' })
+    );
+  });
+
+  it('is a no-op when no guide is pending', () => {
+    const panel = makePanel();
+    const markInFlight = jest.fn();
+
+    expect(consumePendingGuideOnMount(asPanel(panel), 'floating_panel_dock', markInFlight)).toBe(false);
+
+    expect(markInFlight).not.toHaveBeenCalled();
+    expect(panel.openDocsPage).not.toHaveBeenCalled();
+    expect(panel.openLearningJourney).not.toHaveBeenCalled();
+    expect(panel.openEditorTab).not.toHaveBeenCalled();
   });
 });

--- a/src/components/docs-panel/pendingGuideRouter.test.ts
+++ b/src/components/docs-panel/pendingGuideRouter.test.ts
@@ -125,7 +125,7 @@ describe('openPendingGuide', () => {
   });
 });
 
-describe('consumePendingGuideOnMount (PR #1446 review finding 3)', () => {
+describe('consumePendingGuideOnMount', () => {
   // State-level test of the occupied-sidebar launch: HomePanel sets a
   // prepared pending guide and flips to transient floating; the floating
   // surface must consume it on mount or the launch is silently dropped

--- a/src/components/docs-panel/pendingGuideRouter.ts
+++ b/src/components/docs-panel/pendingGuideRouter.ts
@@ -58,9 +58,12 @@ export function openPendingGuide(
 }
 
 /**
- * Consume any pending guide at surface mount: consume-once read → mark the
- * open as in-flight (BEFORE routing, so the surface's empty-state fallback
- * and tab restoration cannot race the open) → route via `openPendingGuide`.
+ * Consume any pending guide: consume-once read → mark the open as in-flight
+ * (BEFORE routing, so the surface's empty-state fallback and tab restoration
+ * cannot race the open) → route via `openPendingGuide`. Called from surface
+ * mount effects and from already-mounted consume signals (the floating
+ * panel's `REQUEST_FLOATING_GUIDE_EVENT` listener, the fullscreen swap
+ * handler); the consume-once read makes overlapping consumers safe.
  *
  * The guide's own `source` (carried from the original launch so alignment
  * semantics survive the handoff) wins over `fallbackSource`, which is the

--- a/src/components/docs-panel/pendingGuideRouter.ts
+++ b/src/components/docs-panel/pendingGuideRouter.ts
@@ -10,12 +10,15 @@
  * `packageInfo`, breaking the milestone toolbar for synthetic PR-tester
  * journeys whose URL is a raw GitHub URL rather than a recognised package URL).
  *
- * The receiving surface still owns the in-flight bookkeeping
- * (`guideOpenInFlightRef`) and reads `panelModeManager.consumePendingGuide()`
- * itself; this helper is just the routing decision so it stays consistent.
+ * `consumePendingGuideOnMount` bundles the full consume step (consume →
+ * mark in-flight → route) for surface mount effects, so a surface cannot
+ * forget one of the three parts — the floating panel shipped exactly that
+ * bug once: it set pending guides but never consumed them, so an
+ * occupied-sidebar launch showed stale restored tabs or fell back to
+ * sidebar mode (PR #1446 review finding 3).
  */
 
-import type { PendingGuide } from '../../global-state/panel-mode';
+import { panelModeManager, type PendingGuide } from '../../global-state/panel-mode';
 import type { CombinedLearningJourneyPanel } from './docs-panel';
 import type { LaunchSource } from '../../recovery';
 
@@ -52,4 +55,30 @@ export function openPendingGuide(
   } else {
     panel.openDocsPage(pending.url, pending.title, { source, preparedContent });
   }
+}
+
+/**
+ * Consume any pending guide at surface mount: consume-once read → mark the
+ * open as in-flight (BEFORE routing, so the surface's empty-state fallback
+ * and tab restoration cannot race the open) → route via `openPendingGuide`.
+ *
+ * The guide's own `source` (carried from the original launch so alignment
+ * semantics survive the handoff) wins over `fallbackSource`, which is the
+ * surface's legacy handoff source for pending guides set before the field
+ * existed.
+ *
+ * Returns true when a pending guide was consumed.
+ */
+export function consumePendingGuideOnMount(
+  panel: CombinedLearningJourneyPanel,
+  fallbackSource: LaunchSource,
+  markInFlight: () => void
+): boolean {
+  const pending = panelModeManager.consumePendingGuide();
+  if (!pending) {
+    return false;
+  }
+  markInFlight();
+  openPendingGuide(panel, pending, pending.source ?? fallbackSource);
+  return true;
 }

--- a/src/components/docs-panel/pendingGuideRouter.ts
+++ b/src/components/docs-panel/pendingGuideRouter.ts
@@ -15,7 +15,7 @@
  * forget one of the three parts — the floating panel shipped exactly that
  * bug once: it set pending guides but never consumed them, so an
  * occupied-sidebar launch showed stale restored tabs or fell back to
- * sidebar mode (PR #1446 review finding 3).
+ * sidebar mode.
  */
 
 import { panelModeManager, type PendingGuide } from '../../global-state/panel-mode';

--- a/src/components/docs-panel/pendingGuideRouter.ts
+++ b/src/components/docs-panel/pendingGuideRouter.ts
@@ -44,11 +44,12 @@ export function openPendingGuide(
   if (!pending.url) {
     return;
   }
+  const preparedContent = pending.preparedContent;
   if (pending.packageInfo) {
-    panel.openDocsPage(pending.url, pending.title, { source, packageInfo: pending.packageInfo });
+    panel.openDocsPage(pending.url, pending.title, { source, packageInfo: pending.packageInfo, preparedContent });
   } else if (pending.type === 'learning-journey') {
-    panel.openLearningJourney(pending.url, pending.title, { source });
+    panel.openLearningJourney(pending.url, pending.title, { source, preparedContent });
   } else {
-    panel.openDocsPage(pending.url, pending.title, { source });
+    panel.openDocsPage(pending.url, pending.title, { source, preparedContent });
   }
 }

--- a/src/components/docs-panel/types.ts
+++ b/src/components/docs-panel/types.ts
@@ -29,11 +29,20 @@ export interface OpenDocsOptions {
   skipReadyToBegin?: boolean;
   /** Optional package context for bundled or remote package guides. */
   packageInfo?: PackageOpenInfo;
+  /**
+   * Content already fetched + snippet-expanded by `prepareGuideLaunch`. When
+   * present the loader skips its network fetch (one-fetch launch) but runs the
+   * identical finalization, so alignment / journey / package parity holds.
+   * One-shot memory state — never persisted to tab storage.
+   */
+  preparedContent?: RawContent;
 }
 
 /** @see OpenDocsOptions */
 export interface OpenLearningJourneyOptions {
   source?: LaunchSource;
+  /** @see OpenDocsOptions.preparedContent */
+  preparedContent?: RawContent;
 }
 
 /**
@@ -58,7 +67,7 @@ export interface DocsPanelModelOperations {
   loadTab(
     tabId: string,
     url: string,
-    options?: { skipReadyToBegin?: boolean; packageInfo?: PackageOpenInfo }
+    options?: { skipReadyToBegin?: boolean; packageInfo?: PackageOpenInfo; prefetched?: RawContent }
   ): Promise<void>;
 
   /** Close a tab by ID */

--- a/src/components/docs-panel/types.ts
+++ b/src/components/docs-panel/types.ts
@@ -43,6 +43,8 @@ export interface OpenLearningJourneyOptions {
   source?: LaunchSource;
   /** @see OpenDocsOptions.preparedContent */
   preparedContent?: RawContent;
+  /** @see OpenDocsOptions.packageInfo */
+  packageInfo?: PackageOpenInfo;
 }
 
 /**

--- a/src/components/docs-panel/utils/index.ts
+++ b/src/components/docs-panel/utils/index.ts
@@ -8,7 +8,7 @@ export { computeTabVisibility, PERMANENT_TAB_IDS } from './tab-visibility';
 export type { TabVisibilityResult } from './tab-visibility';
 export { restoreTabsFromStorage, restoreActiveTabFromStorage, createUrlValidator } from './tab-storage-restore';
 export type { UrlValidator, TabRestoreOptions } from './tab-storage-restore';
-export { isGrafanaDocsUrl, cleanDocsUrl } from './url-validation';
+export { isGrafanaDocsUrl, cleanDocsUrl, isLearningJourneyUrl } from './url-validation';
 export { loadDocsTabContentResult, UNRESOLVED_PACKAGE_ERROR } from './docs-tab-loader';
 export { findCurrentMilestoneIndex } from './milestone-index';
 export { pickGrafanaDocsOpenAction } from './grafana-docs-open-action';

--- a/src/components/docs-panel/utils/prepare-guide-launch.test.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.test.ts
@@ -1,0 +1,153 @@
+import { prepareGuideLaunch } from './prepare-guide-launch';
+import { loadDocsTabContentResult } from './docs-tab-loader';
+import { fetchPackageInfoFromUrl, isPackageContentUrl } from '../../../docs-retrieval';
+import { inlineSnippetRefsInGuideWithStatus } from '../../../snippet-engine';
+import type { JsonGuide } from '../../../types/json-guide.types';
+import type { RawContent } from '../../../types/content.types';
+
+jest.mock('./docs-tab-loader', () => ({
+  loadDocsTabContentResult: jest.fn(),
+}));
+
+jest.mock('../../../docs-retrieval', () => ({
+  fetchPackageInfoFromUrl: jest.fn(),
+  isPackageContentUrl: jest.fn(() => false),
+}));
+
+jest.mock('../../../snippet-engine', () => ({
+  // Default: passthrough with no failed refs. Individual tests override.
+  inlineSnippetRefsInGuideWithStatus: jest.fn(async (guide: JsonGuide) => ({ guide, unresolvedSnippetIds: [] })),
+}));
+
+const mockLoad = loadDocsTabContentResult as jest.Mock;
+const mockIsPackage = isPackageContentUrl as jest.Mock;
+const mockFetchPackageInfo = fetchPackageInfoFromUrl as jest.Mock;
+const mockInline = inlineSnippetRefsInGuideWithStatus as jest.Mock;
+
+function rawContentFor(guide: JsonGuide, url = 'https://grafana.com/docs/x'): RawContent {
+  return {
+    content: JSON.stringify(guide),
+    metadata: { title: guide.title },
+    type: 'interactive',
+    url,
+    lastFetched: '2026-07-28T00:00:00.000Z',
+  };
+}
+
+function fetchResolves(guide: JsonGuide, url?: string) {
+  mockLoad.mockResolvedValue({ content: rawContentFor(guide, url) });
+}
+
+describe('prepareGuideLaunch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsPackage.mockReturnValue(false);
+    mockInline.mockImplementation(async (guide: JsonGuide) => ({ guide, unresolvedSnippetIds: [] }));
+  });
+
+  it('fetches the content exactly once', async () => {
+    fetchResolves({ id: 'g', title: 'g', blocks: [{ type: 'markdown', content: 'hi' }] });
+    await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies prose as not requiring the Grafana UI and re-serializes the expanded guide', async () => {
+    const guide: JsonGuide = { id: 'g', title: 'g', blocks: [{ type: 'markdown', content: 'read me' }] };
+    fetchResolves(guide);
+
+    const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.launch.requiresGrafanaUi).toBe(false);
+      expect(result.launch.source).toBe('home_page');
+      expect(JSON.parse(result.launch.preparedContent.content)).toEqual(guide);
+    }
+  });
+
+  it('classifies a guide with a Grafana-driving action as requiring the Grafana UI', async () => {
+    fetchResolves({ id: 'g', title: 'g', blocks: [{ type: 'interactive', action: 'button', content: 'go' }] });
+
+    const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.launch.requiresGrafanaUi).toBe(true);
+    }
+  });
+
+  it('fails safe to requiresGrafanaUi when a snippet could not be resolved', async () => {
+    const proseGuide: JsonGuide = { id: 'g', title: 'g', blocks: [{ type: 'markdown', content: 'prose only' }] };
+    fetchResolves(proseGuide);
+    // Expanded guide is pure prose, but a ref failed — never hide a possible action.
+    mockInline.mockResolvedValue({ guide: proseGuide, unresolvedSnippetIds: ['missing-snippet'] });
+
+    const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.launch.requiresGrafanaUi).toBe(true);
+    }
+  });
+
+  it('returns a failure result (no surface committed) when the fetch fails', async () => {
+    mockLoad.mockResolvedValue({ content: null, error: 'not found' });
+
+    const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('not found');
+    }
+  });
+
+  it('returns a failure result when the fetched content is not parseable JSON', async () => {
+    mockLoad.mockResolvedValue({
+      content: { content: 'not json', metadata: { title: 'x' }, type: 'interactive', url: 'u', lastFetched: 't' },
+    });
+
+    const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('derives package info for a package URL and fetches only once', async () => {
+    mockIsPackage.mockReturnValue(true);
+    const packageInfo = { packageId: 'pkg', packageManifest: { type: 'path' } };
+    mockFetchPackageInfo.mockResolvedValue(packageInfo);
+    fetchResolves({ id: 'g', title: 'g', blocks: [] }, 'https://interactive-learning.grafana.net/x/content.json');
+
+    const result = await prepareGuideLaunch('https://interactive-learning.grafana.net/x/content.json', {
+      title: 'X',
+      source: 'home_page',
+    });
+
+    expect(mockFetchPackageInfo).toHaveBeenCalledTimes(1);
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+    expect(mockLoad).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ packageInfo }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.launch.packageInfo).toBe(packageInfo);
+    }
+  });
+
+  it('does not derive package info for a non-package URL', async () => {
+    fetchResolves({ id: 'g', title: 'g', blocks: [] });
+    await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+    expect(mockFetchPackageInfo).not.toHaveBeenCalled();
+  });
+
+  it('marks a learning-journey URL with the journey type discriminator', async () => {
+    fetchResolves({ id: 'g', title: 'g', blocks: [] }, 'https://grafana.com/docs/learning-journeys/x/');
+
+    const result = await prepareGuideLaunch('https://grafana.com/docs/learning-journeys/x/', {
+      title: 'X',
+      source: 'home_page',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.launch.type).toBe('learning-journey');
+    }
+  });
+});

--- a/src/components/docs-panel/utils/prepare-guide-launch.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.ts
@@ -24,6 +24,7 @@ import type { JsonGuide } from '../../../types/json-guide.types';
 
 import { loadDocsTabContentResult } from './docs-tab-loader';
 import { requiresGrafanaUi } from './requires-grafana-ui';
+import { isLearningJourneyUrl } from './url-validation';
 
 /**
  * An in-memory, consume-once launch payload. Carries the resolved content plus
@@ -32,7 +33,7 @@ import { requiresGrafanaUi } from './requires-grafana-ui';
 export interface PreparedGuideLaunch {
   url: string;
   title: string;
-  /** Routing discriminator, computed from the URL — mirrors the auto-open listener's rule. */
+  /** Routing discriminator — `isLearningJourneyUrl`, shared with the auto-open listener. */
   type: 'learning-journey' | 'docs';
   source: LaunchSource;
   /** Snippet-expanded content, ready for the renderer's synchronous parse path. */
@@ -50,11 +51,6 @@ interface PrepareGuideLaunchContext {
   source: LaunchSource;
   /** Pre-resolved package context (recommender path); otherwise derived from the URL. */
   packageInfo?: PackageOpenInfo;
-}
-
-/** Mirrors the routing predicate in `useAutoOpenListener` so the surface handoff picks the same open method. */
-function isLearningJourneyUrl(url: string): boolean {
-  return url.includes('/learning-journeys/') || url.includes('/learning-paths/');
 }
 
 /**

--- a/src/components/docs-panel/utils/prepare-guide-launch.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.ts
@@ -16,6 +16,7 @@
  */
 
 import { fetchPackageInfoFromUrl, isPackageContentUrl } from '../../../docs-retrieval';
+import { logger } from '../../../lib/logging';
 import { inlineSnippetRefsInGuideWithStatus } from '../../../snippet-engine';
 import type { LaunchSource } from '../../../recovery';
 import type { PackageOpenInfo } from '../../../types/content-panel.types';
@@ -81,7 +82,10 @@ export async function prepareGuideLaunch(
     guide = JSON.parse(rawContent.content) as JsonGuide;
   } catch {
     // fetchContent validates native JSON guides, so this is not expected;
-    // fail safe rather than commit a surface for uninspectable content.
+    // fail safe rather than commit a surface for uninspectable content. The
+    // log is the only aggregate signal for this branch — the fetch ladder's
+    // own telemetry saw a successful fetch.
+    logger.error('[PrepareGuideLaunch] Guide content could not be parsed', { url });
     return { ok: false, error: 'Guide content could not be parsed' };
   }
 

--- a/src/components/docs-panel/utils/prepare-guide-launch.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.ts
@@ -1,0 +1,109 @@
+/**
+ * One-shot launch preparation: fetch a guide's content once, expand its snippet
+ * refs, and classify whether it drives the Grafana UI — all BEFORE a display
+ * surface is committed. The result carries the resolved content so the
+ * destination renders it without a second fetch.
+ *
+ * The classification runs on the snippet-EXPANDED guide (so actions hidden
+ * inside snippets count) and fails safe: a snippet that could not be resolved
+ * forces `requiresGrafanaUi: true` so an action is never hidden behind a
+ * placeholder.
+ *
+ * `preparedContent` re-serializes the expanded guide back into the fetched
+ * `RawContent`, so the renderer takes its synchronous parse path and issues no
+ * post-mount snippet requests. It is one-shot memory state — carried through a
+ * launch handoff and consumed once, never persisted to tab storage.
+ */
+
+import { fetchPackageInfoFromUrl, isPackageContentUrl } from '../../../docs-retrieval';
+import { inlineSnippetRefsInGuideWithStatus } from '../../../snippet-engine';
+import type { LaunchSource } from '../../../recovery';
+import type { PackageOpenInfo } from '../../../types/content-panel.types';
+import type { RawContent } from '../../../types/content.types';
+import type { JsonGuide } from '../../../types/json-guide.types';
+
+import { loadDocsTabContentResult } from './docs-tab-loader';
+import { requiresGrafanaUi } from './requires-grafana-ui';
+
+/**
+ * An in-memory, consume-once launch payload. Carries the resolved content plus
+ * the surface decision so the destination tab opens without re-fetching.
+ */
+export interface PreparedGuideLaunch {
+  url: string;
+  title: string;
+  /** Routing discriminator, computed from the URL — mirrors the auto-open listener's rule. */
+  type: 'learning-journey' | 'docs';
+  source: LaunchSource;
+  /** Snippet-expanded content, ready for the renderer's synchronous parse path. */
+  preparedContent: RawContent;
+  /** True when any reachable step drives the live Grafana UI (or a snippet failed to resolve). */
+  requiresGrafanaUi: boolean;
+  /** Preserved so journey/package rendering (milestone toolbar) survives the handoff. */
+  packageInfo?: PackageOpenInfo;
+}
+
+export type PrepareGuideLaunchResult = { ok: true; launch: PreparedGuideLaunch } | { ok: false; error: string };
+
+interface PrepareGuideLaunchContext {
+  title: string;
+  source: LaunchSource;
+  /** Pre-resolved package context (recommender path); otherwise derived from the URL. */
+  packageInfo?: PackageOpenInfo;
+}
+
+/** Mirrors the routing predicate in `useAutoOpenListener` so the surface handoff picks the same open method. */
+function isLearningJourneyUrl(url: string): boolean {
+  return url.includes('/learning-journeys/') || url.includes('/learning-paths/');
+}
+
+/**
+ * Fetch, expand, and classify a guide for launch. Returns a failure result
+ * (leaving the caller's origin visible) when the fetch fails — the caller must
+ * NOT commit a surface and re-fetch in that case.
+ */
+export async function prepareGuideLaunch(
+  url: string,
+  context: PrepareGuideLaunchContext
+): Promise<PrepareGuideLaunchResult> {
+  // Mirror loadDocsTabContent's package derivation so the single fetch here is
+  // identical to the one the destination loader would otherwise perform.
+  let packageInfo = context.packageInfo;
+  if (!packageInfo && isPackageContentUrl(url)) {
+    packageInfo = await fetchPackageInfoFromUrl(url);
+  }
+
+  const result = await loadDocsTabContentResult(url, { packageInfo });
+  if (!result.content) {
+    return { ok: false, error: result.error || 'Failed to load content' };
+  }
+
+  const rawContent = result.content;
+
+  let guide: JsonGuide;
+  try {
+    guide = JSON.parse(rawContent.content) as JsonGuide;
+  } catch {
+    // fetchContent validates native JSON guides, so this is not expected;
+    // fail safe rather than commit a surface for uninspectable content.
+    return { ok: false, error: 'Guide content could not be parsed' };
+  }
+
+  const { guide: expandedGuide, unresolvedSnippetIds } = await inlineSnippetRefsInGuideWithStatus(guide);
+  const needsGrafanaUi = requiresGrafanaUi(expandedGuide) || unresolvedSnippetIds.length > 0;
+
+  const preparedContent: RawContent = { ...rawContent, content: JSON.stringify(expandedGuide) };
+
+  return {
+    ok: true,
+    launch: {
+      url,
+      title: context.title,
+      type: isLearningJourneyUrl(url) ? 'learning-journey' : 'docs',
+      source: context.source,
+      preparedContent,
+      requiresGrafanaUi: needsGrafanaUi,
+      packageInfo,
+    },
+  };
+}

--- a/src/components/docs-panel/utils/requires-grafana-ui.test.ts
+++ b/src/components/docs-panel/utils/requires-grafana-ui.test.ts
@@ -38,7 +38,7 @@ describe('requiresGrafanaUi', () => {
       expect(requiresGrafanaUi(guide([{ type: 'interactive', action, content: 'x' }]))).toBe(false);
     });
 
-    it('quiz / input / terminal / challenge / code-block / grot-guide do not trigger it', () => {
+    it('quiz / input / terminal / challenge / grot-guide do not trigger it', () => {
       expect(
         requiresGrafanaUi(
           guide([
@@ -47,7 +47,6 @@ describe('requiresGrafanaUi', () => {
             { type: 'terminal', command: 'ls', content: 'run it' },
             { type: 'terminal-connect', content: 'connect' },
             { type: 'challenge', title: 't', brief: 'b', successCriteria: 'coda-exit-zero:true' },
-            { type: 'code-block', reftarget: '#editor', code: 'x = 1' },
             {
               type: 'grot-guide',
               welcome: { title: 'w', body: 'b', ctas: [] },
@@ -56,6 +55,24 @@ describe('requiresGrafanaUi', () => {
           ])
         )
       ).toBe(false);
+    });
+  });
+
+  describe('code-block drives the Grafana UI', () => {
+    // Regression for PR #1446 review finding 2: reftarget is schema-required
+    // and targets a live Monaco editor ("Show me" highlights it, "Insert"
+    // mutates it), so a guide that is ONLY a code block must still open
+    // beside Grafana, never full screen.
+    it('a guide containing only a code block opens beside Grafana', () => {
+      expect(requiresGrafanaUi(guide([{ type: 'code-block', reftarget: '#editor', code: 'x = 1' }]))).toBe(true);
+    });
+
+    it('detects a code block nested in a section', () => {
+      expect(
+        requiresGrafanaUi(
+          guide([{ type: 'section', title: 's', blocks: [{ type: 'code-block', reftarget: '#editor', code: 'y' }] }])
+        )
+      ).toBe(true);
     });
   });
 

--- a/src/components/docs-panel/utils/requires-grafana-ui.test.ts
+++ b/src/components/docs-panel/utils/requires-grafana-ui.test.ts
@@ -59,7 +59,7 @@ describe('requiresGrafanaUi', () => {
   });
 
   describe('code-block drives the Grafana UI', () => {
-    // Regression for PR #1446 review finding 2: reftarget is schema-required
+    // reftarget is schema-required
     // and targets a live Monaco editor ("Show me" highlights it, "Insert"
     // mutates it), so a guide that is ONLY a code block must still open
     // beside Grafana, never full screen.

--- a/src/components/docs-panel/utils/requires-grafana-ui.test.ts
+++ b/src/components/docs-panel/utils/requires-grafana-ui.test.ts
@@ -1,0 +1,169 @@
+import { requiresGrafanaUi } from './requires-grafana-ui';
+import type { JsonBlock, JsonGuide, JsonInteractiveAction } from '../../../types/json-guide.types';
+
+function guide(blocks: JsonBlock[]): JsonGuide {
+  return { id: 'g', title: 'g', blocks };
+}
+
+const GRAFANA_DRIVING: JsonInteractiveAction[] = ['highlight', 'button', 'formfill', 'navigate', 'hover'];
+const NON_DRIVING: JsonInteractiveAction[] = ['noop', 'popout'];
+
+describe('requiresGrafanaUi', () => {
+  it('returns false for a prose-only guide', () => {
+    expect(
+      requiresGrafanaUi(
+        guide([
+          { type: 'markdown', content: 'hello' },
+          { type: 'html', content: '<p>hi</p>' },
+          { type: 'image', src: 'a.png' },
+        ])
+      )
+    ).toBe(false);
+  });
+
+  describe('the five Grafana-driving actions each trigger it', () => {
+    it.each(GRAFANA_DRIVING)('interactive block with action=%s', (action) => {
+      expect(requiresGrafanaUi(guide([{ type: 'interactive', action, content: 'do', reftarget: '#x' }]))).toBe(true);
+    });
+
+    it.each(GRAFANA_DRIVING)('reads the camelCase targetAction alias (=%s)', (action) => {
+      expect(
+        requiresGrafanaUi(guide([{ type: 'interactive', action: 'noop', targetAction: action, content: 'do' }]))
+      ).toBe(true);
+    });
+  });
+
+  describe('non-Grafana-driving actions and in-panel controls do NOT trigger it', () => {
+    it.each(NON_DRIVING)('interactive block with action=%s stays full-screen', (action) => {
+      expect(requiresGrafanaUi(guide([{ type: 'interactive', action, content: 'x' }]))).toBe(false);
+    });
+
+    it('quiz / input / terminal / challenge / code-block / grot-guide do not trigger it', () => {
+      expect(
+        requiresGrafanaUi(
+          guide([
+            { type: 'quiz', question: 'q', choices: [{ id: 'a', text: 'a', correct: true }] },
+            { type: 'input', prompt: 'p', inputType: 'text', variableName: 'v' },
+            { type: 'terminal', command: 'ls', content: 'run it' },
+            { type: 'terminal-connect', content: 'connect' },
+            { type: 'challenge', title: 't', brief: 'b', successCriteria: 'coda-exit-zero:true' },
+            { type: 'code-block', reftarget: '#editor', code: 'x = 1' },
+            {
+              type: 'grot-guide',
+              welcome: { title: 'w', body: 'b', ctas: [] },
+              screens: [{ type: 'result', id: 'r', title: 'done', body: 'b' }],
+            },
+          ])
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('nesting', () => {
+    it('detects an action inside a section', () => {
+      expect(
+        requiresGrafanaUi(
+          guide([{ type: 'section', title: 's', blocks: [{ type: 'interactive', action: 'button', content: 'go' }] }])
+        )
+      ).toBe(true);
+    });
+
+    it('detects an action inside an assistant block', () => {
+      expect(
+        requiresGrafanaUi(
+          guide([{ type: 'assistant', blocks: [{ type: 'interactive', action: 'highlight', content: 'go' }] }])
+        )
+      ).toBe(true);
+    });
+
+    it('detects an action in a multistep step', () => {
+      expect(
+        requiresGrafanaUi(
+          guide([
+            {
+              type: 'multistep',
+              content: 'seq',
+              steps: [{ action: 'noop' }, { action: 'formfill', reftarget: '#in', targetvalue: 'v' }],
+            },
+          ])
+        )
+      ).toBe(true);
+    });
+
+    it('detects an action in a guided step', () => {
+      expect(
+        requiresGrafanaUi(guide([{ type: 'guided', content: 'tour', steps: [{ action: 'hover', reftarget: '#el' }] }]))
+      ).toBe(true);
+    });
+
+    it('detects an action in EITHER conditional branch', () => {
+      const inWhenTrue = guide([
+        {
+          type: 'conditional',
+          conditions: ['has-datasource:prometheus'],
+          whenTrue: [{ type: 'interactive', action: 'navigate', content: 'go', reftarget: '/x' }],
+          whenFalse: [{ type: 'markdown', content: 'prose' }],
+        },
+      ]);
+      const inWhenFalse = guide([
+        {
+          type: 'conditional',
+          conditions: ['has-datasource:prometheus'],
+          whenTrue: [{ type: 'markdown', content: 'prose' }],
+          whenFalse: [{ type: 'interactive', action: 'button', content: 'go' }],
+        },
+      ]);
+      expect(requiresGrafanaUi(inWhenTrue)).toBe(true);
+      expect(requiresGrafanaUi(inWhenFalse)).toBe(true);
+    });
+
+    it('returns false when both conditional branches are prose', () => {
+      expect(
+        requiresGrafanaUi(
+          guide([
+            {
+              type: 'conditional',
+              conditions: ['has-datasource:prometheus'],
+              whenTrue: [{ type: 'markdown', content: 'a' }],
+              whenFalse: [{ type: 'markdown', content: 'b' }],
+            },
+          ])
+        )
+      ).toBe(false);
+    });
+
+    it('detects a deeply nested action (section > conditional > multistep)', () => {
+      expect(
+        requiresGrafanaUi(
+          guide([
+            {
+              type: 'section',
+              blocks: [
+                {
+                  type: 'conditional',
+                  conditions: ['x'],
+                  whenTrue: [],
+                  whenFalse: [
+                    { type: 'multistep', content: 'm', steps: [{ action: 'highlight', reftarget: '#deep' }] },
+                  ],
+                },
+              ],
+            },
+          ])
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('snippet-ref fail-safe', () => {
+    it('treats a surviving snippet-ref as Grafana-driving (never hide an action)', () => {
+      expect(requiresGrafanaUi(guide([{ type: 'snippet-ref', snippetId: 'maybe-interactive' }]))).toBe(true);
+    });
+
+    it('treats a snippet-ref nested in a section as Grafana-driving', () => {
+      expect(requiresGrafanaUi(guide([{ type: 'section', blocks: [{ type: 'snippet-ref', snippetId: 's' }] }]))).toBe(
+        true
+      );
+    });
+  });
+});

--- a/src/components/docs-panel/utils/requires-grafana-ui.ts
+++ b/src/components/docs-panel/utils/requires-grafana-ui.ts
@@ -64,8 +64,31 @@ function blockRequiresGrafanaUi(block: JsonBlock): boolean {
       return true;
     case 'snippet-ref':
       return true;
-    default:
+    // Interactive inside Pathfinder or purely presentational — none drive
+    // the live Grafana page. Enumerated (no default) so a new JsonBlock
+    // member is a compile error here instead of silently classifying as
+    // non-interactive and hiding any Grafana-driving action it may nest.
+    case 'markdown':
+    case 'html':
+    case 'image':
+    case 'video':
+    case 'quiz':
+    case 'input':
+    case 'terminal':
+    case 'terminal-connect':
+    case 'challenge':
+    case 'grot-guide':
       return false;
+    default: {
+      // Exhaustiveness: adding a JsonBlock member without classifying it here
+      // is a compile error. At runtime (untyped CDN JSON can still carry an
+      // unknown block type) fail safe in the never-hide-an-action direction:
+      // an unknown container may nest Grafana-driving steps, so keep the
+      // guide beside Grafana rather than full screen with dead buttons.
+      const unhandled: never = block;
+      void unhandled;
+      return true;
+    }
   }
 }
 

--- a/src/components/docs-panel/utils/requires-grafana-ui.ts
+++ b/src/components/docs-panel/utils/requires-grafana-ui.ts
@@ -1,0 +1,73 @@
+/**
+ * Launch-surface classifier: does this guide contain an action that drives the
+ * live Grafana UI?
+ *
+ * A guide "requires the Grafana UI" when any reachable step performs one of the
+ * five Grafana-driving actions — `highlight`, `button`, `formfill`, `navigate`,
+ * `hover`. Those actions manipulate or point at the real Grafana page, so the
+ * guide must render beside Grafana (sidebar / floating), not full screen.
+ *
+ * Deliberately NARROWER than `ParsedContent.hasInteractiveElements`: `noop`,
+ * `popout`, quizzes, inputs, terminals, challenges, code blocks, and grot guides
+ * are interactive inside Pathfinder but do not need the Grafana main area, so
+ * they do not force the sidebar.
+ *
+ * Operates on the snippet-EXPANDED guide so actions hidden inside snippets are
+ * counted. A surviving `snippet-ref` (should not happen after expansion) is
+ * treated as Grafana-driving — fail safe, never hide an action. Snippet refs
+ * that failed to resolve become markdown placeholders and are invisible here;
+ * `prepareGuideLaunch` handles that case separately via the inliner's status.
+ */
+
+import type { JsonBlock, JsonGuide, JsonInteractiveAction, JsonStep } from '../../../types/json-guide.types';
+
+/** The action values that require the live Grafana UI. */
+const GRAFANA_DRIVING_ACTIONS: ReadonlySet<JsonInteractiveAction> = new Set<JsonInteractiveAction>([
+  'highlight',
+  'button',
+  'formfill',
+  'navigate',
+  'hover',
+]);
+
+function isGrafanaDrivingAction(action: JsonInteractiveAction | undefined): boolean {
+  return action !== undefined && GRAFANA_DRIVING_ACTIONS.has(action);
+}
+
+/** A single interactive block or step carries the action in `action` (canonical) or `targetAction` (alias). */
+function stepDrivesGrafana(step: Pick<JsonStep, 'action' | 'targetAction'>): boolean {
+  return isGrafanaDrivingAction(step.action) || isGrafanaDrivingAction(step.targetAction);
+}
+
+function blocksRequireGrafanaUi(blocks: JsonBlock[]): boolean {
+  return blocks.some(blockRequiresGrafanaUi);
+}
+
+function blockRequiresGrafanaUi(block: JsonBlock): boolean {
+  switch (block.type) {
+    case 'interactive':
+      return stepDrivesGrafana(block);
+    case 'multistep':
+    case 'guided':
+      return block.steps.some(stepDrivesGrafana);
+    case 'section':
+    case 'assistant':
+    case 'collapsible':
+      return blocksRequireGrafanaUi(block.blocks);
+    case 'conditional':
+      return blocksRequireGrafanaUi(block.whenTrue) || blocksRequireGrafanaUi(block.whenFalse);
+    case 'snippet-ref':
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * True when the guide contains any reachable Grafana-driving action, recursing
+ * through sections, assistants, collapsibles, multistep/guided steps, and BOTH
+ * conditional branches.
+ */
+export function requiresGrafanaUi(guide: JsonGuide): boolean {
+  return blocksRequireGrafanaUi(guide.blocks);
+}

--- a/src/components/docs-panel/utils/requires-grafana-ui.ts
+++ b/src/components/docs-panel/utils/requires-grafana-ui.ts
@@ -4,12 +4,14 @@
  *
  * A guide "requires the Grafana UI" when any reachable step performs one of the
  * five Grafana-driving actions — `highlight`, `button`, `formfill`, `navigate`,
- * `hover`. Those actions manipulate or point at the real Grafana page, so the
- * guide must render beside Grafana (sidebar / floating), not full screen.
+ * `hover` — or is a `code-block`, whose required `reftarget` points at a live
+ * Monaco editor that "Show me" highlights and "Insert" mutates. Those blocks
+ * manipulate or point at the real Grafana page, so the guide must render
+ * beside Grafana (sidebar / floating), not full screen.
  *
  * Deliberately NARROWER than `ParsedContent.hasInteractiveElements`: `noop`,
- * `popout`, quizzes, inputs, terminals, challenges, code blocks, and grot guides
- * are interactive inside Pathfinder but do not need the Grafana main area, so
+ * `popout`, quizzes, inputs, terminals, challenges, and grot guides are
+ * interactive inside Pathfinder but do not need the Grafana main area, so
  * they do not force the sidebar.
  *
  * Operates on the snippet-EXPANDED guide so actions hidden inside snippets are
@@ -56,6 +58,10 @@ function blockRequiresGrafanaUi(block: JsonBlock): boolean {
       return blocksRequireGrafanaUi(block.blocks);
     case 'conditional':
       return blocksRequireGrafanaUi(block.whenTrue) || blocksRequireGrafanaUi(block.whenFalse);
+    case 'code-block':
+      // `reftarget` is schema-required and targets a live Grafana Monaco
+      // editor; without the Grafana UI both "Show me" and "Insert" are dead.
+      return true;
     case 'snippet-ref':
       return true;
     default:

--- a/src/components/docs-panel/utils/tab-translations.test.ts
+++ b/src/components/docs-panel/utils/tab-translations.test.ts
@@ -19,7 +19,7 @@ describe('getTranslatedTitle', () => {
 
     it('translates "Learning Path" (uppercase P)', () => {
       const result = getTranslatedTitle('Learning Path');
-      expect(result).toBe('[translated:docsPanel.learningJourney]Learning Path');
+      expect(result).toBe('[translated:docsPanel.learningJourney]Learning path');
     });
 
     it('translates legacy "Learning journey" (lowercase j) for backwards compatibility', () => {
@@ -29,7 +29,7 @@ describe('getTranslatedTitle', () => {
 
     it('translates legacy "Learning Journey" (uppercase J) for backwards compatibility', () => {
       const result = getTranslatedTitle('Learning Journey');
-      expect(result).toBe('[translated:docsPanel.learningJourney]Learning Path');
+      expect(result).toBe('[translated:docsPanel.learningJourney]Learning path');
     });
 
     it('translates "Documentation"', () => {

--- a/src/components/docs-panel/utils/tab-translations.ts
+++ b/src/components/docs-panel/utils/tab-translations.ts
@@ -19,7 +19,7 @@ export const getTranslatedTitle = (title: string): string => {
   }
   // Handle 'Learning Path' (with uppercase 'P') from older data or translations
   if (title === 'Learning Path') {
-    return t('docsPanel.learningJourney', 'Learning Path');
+    return t('docsPanel.learningJourney', 'Learning path');
   }
   // Handle old 'Learning journey' (with lowercase 'j') for backwards compatibility
   if (title === 'Learning journey') {
@@ -27,7 +27,7 @@ export const getTranslatedTitle = (title: string): string => {
   }
   // Handle old 'Learning Journey' (with uppercase 'J') for backwards compatibility
   if (title === 'Learning Journey') {
-    return t('docsPanel.learningJourney', 'Learning Path');
+    return t('docsPanel.learningJourney', 'Learning path');
   }
   if (title === 'Documentation') {
     return t('docsPanel.documentation', 'Documentation');

--- a/src/components/docs-panel/utils/url-validation.test.ts
+++ b/src/components/docs-panel/utils/url-validation.test.ts
@@ -1,4 +1,4 @@
-import { isGrafanaDocsUrl, cleanDocsUrl } from './url-validation';
+import { isGrafanaDocsUrl, cleanDocsUrl, isLearningJourneyUrl } from './url-validation';
 
 // Mock the constants
 jest.mock('../../../constants', () => ({
@@ -89,6 +89,25 @@ describe('url-validation', () => {
     it('does not modify URLs without known suffixes', () => {
       const url = 'https://grafana.com/docs/learning-paths/my-path';
       expect(cleanDocsUrl(url)).toBe(url);
+    });
+  });
+
+  describe('isLearningJourneyUrl', () => {
+    it('matches journey and path pathnames', () => {
+      expect(isLearningJourneyUrl('https://grafana.com/docs/learning-journeys/drilldown/')).toBe(true);
+      expect(isLearningJourneyUrl('https://grafana.com/learning-paths/grafana-basics/')).toBe(true);
+    });
+
+    it('routes plain docs pages to the docs loader', () => {
+      expect(isLearningJourneyUrl('https://grafana.com/docs/grafana/latest/')).toBe(false);
+    });
+
+    it('tests the pathname only — a journey path echoed in the query string does not misroute', () => {
+      expect(isLearningJourneyUrl('https://grafana.com/docs/foo/?ref=/learning-paths/x')).toBe(false);
+    });
+
+    it('treats bundled URLs as docs', () => {
+      expect(isLearningJourneyUrl('bundled:first-dashboard')).toBe(false);
     });
   });
 });

--- a/src/components/docs-panel/utils/url-validation.ts
+++ b/src/components/docs-panel/utils/url-validation.ts
@@ -4,6 +4,19 @@
  */
 
 import { ALLOWED_GRAFANA_DOCS_HOSTNAMES } from '../../../constants';
+import { parseUrlSafely } from '../../../security';
+
+/**
+ * Routing predicate shared by the auto-open listener and `prepareGuideLaunch`:
+ * journey URLs open via `openLearningJourney`, everything else via
+ * `openDocsPage`. Tests the PATHNAME only, so a journey path echoed in a query
+ * string (`/docs/foo/?ref=/learning-paths/x`) does not misroute, and both
+ * consumers stay consistent by construction.
+ */
+export function isLearningJourneyUrl(url: string): boolean {
+  const urlObj = parseUrlSafely(url);
+  return Boolean(urlObj?.pathname.includes('/learning-journeys/') || urlObj?.pathname.includes('/learning-paths/'));
+}
 
 /**
  * Checks if a URL is from an allowed Grafana documentation domain.

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -232,7 +232,7 @@ function FloatingPanelInner() {
       // Remember where the user was so explicit Exit can land back there.
       panelModeManager.capturePriorPath(window.location.pathname + window.location.search);
       panelModeManager.setPendingGuide({ title, type: 'editor' });
-      panelModeManager.setMode('fullscreen');
+      panelModeManager.setModePersisted('fullscreen');
       locationService.push(`${PLUGIN_BASE_URL}/${ROUTES.FullScreen}`);
       return;
     }
@@ -258,7 +258,7 @@ function FloatingPanelInner() {
     });
     // Remember where the user was so explicit Exit can land back there.
     panelModeManager.capturePriorPath(window.location.pathname + window.location.search);
-    panelModeManager.setMode('fullscreen');
+    panelModeManager.setModePersisted('fullscreen');
     // Include type in the URL so refresh/share rehydrates as a journey
     // even if findDocPage's URL-based classification can't tell.
     locationService.push(

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -12,7 +12,7 @@ import { panelModeManager, type PanelMode } from '../../global-state/panel-mode'
 import { sidebarState } from '../../global-state/sidebar';
 import { getConfigWithDefaults, PLUGIN_BASE_URL, ROUTES } from '../../constants';
 import { reportAppInteraction, UserInteraction, AnalyticsContentType } from '../../lib/analytics';
-import { PANEL_MODE_CHANGE_EVENT } from '../../lib/event-names';
+import { PANEL_MODE_CHANGE_EVENT, REQUEST_FLOATING_GUIDE_EVENT } from '../../lib/event-names';
 import { buildFullScreenRouteUrl } from '../../utils/pathfinder-search-params';
 import { FloatingPanel } from './FloatingPanel';
 import { FloatingPanelContent } from './FloatingPanelContent';
@@ -133,6 +133,22 @@ function FloatingPanelInner() {
       if (panelModeManager.getMode() !== 'sidebar') {
         sidebarState.setIsSidebarMounted(false);
       }
+    };
+  }, [panel]);
+
+  // A launch targeting an already-mounted floating panel changes no mode, so
+  // the mount effect above never re-runs — HomePanel signals with this event
+  // instead. Consume-once semantics make double delivery with the mount path
+  // safe: whichever consumer runs first gets the guide, the other a null.
+  useEffect(() => {
+    const handleRequestGuide = () => {
+      consumePendingGuideOnMount(panel, 'floating_panel_dock', () => {
+        guideOpenInFlightRef.current = true;
+      });
+    };
+    document.addEventListener(REQUEST_FLOATING_GUIDE_EVENT, handleRequestGuide);
+    return () => {
+      document.removeEventListener(REQUEST_FLOATING_GUIDE_EVENT, handleRequestGuide);
     };
   }, [panel]);
 

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -2,6 +2,7 @@ import React, { lazy, Suspense, useState, useEffect, useCallback, useMemo, useRe
 import { ThemeContext } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { CombinedLearningJourneyPanel } from '../docs-panel/docs-panel';
+import { consumePendingGuideOnMount } from '../docs-panel/pendingGuideRouter';
 import { useContentReset } from '../docs-panel/hooks';
 import { useKeyboardShortcuts } from '../docs-panel/keyboard-shortcuts.hook';
 import { PERMANENT_TAB_IDS } from '../docs-panel/utils';
@@ -116,6 +117,14 @@ function FloatingPanelInner() {
     document.dispatchEvent(new CustomEvent('pathfinder-panel-mounted', { detail: { timestamp: Date.now() } }));
     sidebarState.setIsSidebarMounted(true);
 
+    // Handoff from HomePanel's occupied-sidebar launch path (and any other
+    // setPendingGuide caller targeting the floating surface): consume the
+    // pending guide and mark the open in-flight BEFORE the restoration and
+    // empty-state-fallback effects below can run. Mirrors FullScreenPanel.
+    consumePendingGuideOnMount(panel, 'floating_panel_dock', () => {
+      guideOpenInFlightRef.current = true;
+    });
+
     return () => {
       document.removeEventListener('pathfinder-auto-launch-pending', handlePending);
       // Only clear if we're still the active owner — during dock-back the
@@ -134,11 +143,17 @@ function FloatingPanelInner() {
   const [restorationDone, setRestorationDone] = useState(false);
 
   useEffect(() => {
+    // Read live model state instead of closure'd `tabs`: the pending-guide
+    // consumption in the mount effect above mutates `panel.state.tabs`
+    // synchronously in the same commit, before this render's snapshot
+    // updates — restoring on top of the just-opened guide would await
+    // tabStorage and clobber it. Mirrors FullScreenPanel's gate.
     // Permanent system tabs (`recommendations`, `devtools`, `editor`) don't
     // count as user content — restoring on top of them is safe. Mirrors the
     // sidebar's gate at `docs-panel.tsx` so all three surfaces agree on
     // when "the panel is empty".
-    const hasOnlyDefaultTabs = tabs.every((t) => PERMANENT_TAB_IDS.has(t.id));
+    const liveTabs = panel.state.tabs;
+    const hasOnlyDefaultTabs = liveTabs.every((t) => PERMANENT_TAB_IDS.has(t.id));
     const restore = hasOnlyDefaultTabs ? panel.restoreTabsAsync() : Promise.resolve();
     restore.then(() => setRestorationDone(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/floating-panel/floating-panel.pending-guide.test.ts
+++ b/src/components/floating-panel/floating-panel.pending-guide.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tripwire (Pattern J — contract-surface preservation)
  *
- * Pins the floating surface's pending-guide consumption, added for PR #1446
- * review finding 3: HomePanel's occupied-sidebar launch path hands the
+ * Pins the floating surface's pending-guide consumption:
+ * HomePanel's occupied-sidebar launch path hands the
  * prepared guide off via `panelModeManager.setPendingGuide` + transient
  * floating mode, and `FloatingPanelInner` must consume it on mount or the
  * launch is silently dropped (the panel restores stale tabs, or the

--- a/src/components/floating-panel/floating-panel.pending-guide.test.ts
+++ b/src/components/floating-panel/floating-panel.pending-guide.test.ts
@@ -28,8 +28,10 @@ describe('FloatingPanelInner consumes the pending guide on mount', () => {
 
   it('consumes before the tab-restoration effect runs', () => {
     // Effects run in declaration order; consumption must be declared first
-    // so the restoration gate sees the just-opened tab.
-    expect(src.indexOf('consumePendingGuideOnMount')).toBeLessThan(src.indexOf('restoreTabsAsync'));
+    // so the restoration gate sees the just-opened tab. Anchor on the call
+    // site `(panel,` — a bare name match would hit the import statement and
+    // pass regardless of effect order.
+    expect(src.indexOf('consumePendingGuideOnMount(panel,')).toBeLessThan(src.indexOf('restoreTabsAsync'));
   });
 
   it('gates restoration on LIVE model tabs, not the render snapshot', () => {

--- a/src/components/floating-panel/floating-panel.pending-guide.test.ts
+++ b/src/components/floating-panel/floating-panel.pending-guide.test.ts
@@ -38,3 +38,14 @@ describe('FloatingPanelInner consumes the pending guide on mount', () => {
     expect(src).toMatch(/const liveTabs = panel\.state\.tabs/);
   });
 });
+
+describe('FloatingPanelInner consumes staged guides while already mounted', () => {
+  // A same-mode transient launch fires no PANEL_MODE_CHANGE_EVENT, so the
+  // mount effect never re-runs; HomePanel signals the mounted panel instead.
+  it('listens for the request-floating-guide signal and routes through the shared consume step', () => {
+    expect(src).toContain('addEventListener(REQUEST_FLOATING_GUIDE_EVENT');
+    expect(src).toContain('removeEventListener(REQUEST_FLOATING_GUIDE_EVENT');
+    const listenerEffect = src.slice(src.indexOf('handleRequestGuide'));
+    expect(listenerEffect).toContain('consumePendingGuideOnMount(panel,');
+  });
+});

--- a/src/components/floating-panel/floating-panel.pending-guide.test.ts
+++ b/src/components/floating-panel/floating-panel.pending-guide.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tripwire (Pattern J — contract-surface preservation)
+ *
+ * Pins the floating surface's pending-guide consumption, added for PR #1446
+ * review finding 3: HomePanel's occupied-sidebar launch path hands the
+ * prepared guide off via `panelModeManager.setPendingGuide` + transient
+ * floating mode, and `FloatingPanelInner` must consume it on mount or the
+ * launch is silently dropped (the panel restores stale tabs, or the
+ * empty-state fallback bounces straight back to sidebar mode).
+ *
+ * Why a tripwire (not a runtime mount test):
+ *   `@grafana/scenes` + `@grafana/ui` require a theme provider that is
+ *   not available in the Jest environment — the established shape for this
+ *   surface (see `floating-panel.shared-tabstorage.test.ts`). The consume
+ *   step's behavior is unit-tested in `pendingGuideRouter.test.ts`; this
+ *   file pins only the wiring the mount test would otherwise cover.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const src = fs.readFileSync(path.resolve(__dirname, 'FloatingPanelManager.tsx'), 'utf-8');
+
+describe('FloatingPanelInner consumes the pending guide on mount', () => {
+  it('calls the shared consume step (consume → in-flight → route)', () => {
+    expect(src).toContain('consumePendingGuideOnMount(panel,');
+  });
+
+  it('consumes before the tab-restoration effect runs', () => {
+    // Effects run in declaration order; consumption must be declared first
+    // so the restoration gate sees the just-opened tab.
+    expect(src.indexOf('consumePendingGuideOnMount')).toBeLessThan(src.indexOf('restoreTabsAsync'));
+  });
+
+  it('gates restoration on LIVE model tabs, not the render snapshot', () => {
+    // The pending-guide open mutates panel.state.tabs synchronously in the
+    // same commit; a closure'd snapshot would restore on top of it.
+    expect(src).toMatch(/const liveTabs = panel\.state\.tabs/);
+  });
+});

--- a/src/components/floating-panel/floating-panel.shared-tabstorage.test.ts
+++ b/src/components/floating-panel/floating-panel.shared-tabstorage.test.ts
@@ -46,7 +46,7 @@ describe('floating panel shares tabStorage with the sidebar', () => {
       expect(src).not.toContain(method);
     }
     expect(src).toMatch(/await\s+model\.saveTabsToStorage\(\)/);
-    expect(src).toContain("setMode('floating')");
+    expect(src).toContain("setModePersisted('floating')");
   });
 
   it('full-screen-autodock does not snapshot or set a pending guide for the floating branch', () => {

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -245,7 +245,11 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
       guide_url: guideUrl || '',
       guide_title: title,
     });
-    panelModeManager.setMode('sidebar');
+    if (panelModeManager.isTransientMode()) {
+      panelModeManager.setModeTransient('sidebar');
+    } else {
+      panelModeManager.setMode('sidebar');
+    }
     sidebarState.setPendingOpenSource('fullscreen_handoff', 'open');
     sidebarState.openSidebar('Interactive learning');
     // Land the user back on the page they were on before they entered full

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -60,9 +60,16 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
   // the extension sidebar is closed. Idempotent — safe on refresh of
   // /fullscreen where mode may already be 'fullscreen' but a stale Grafana
   // dock could otherwise re-mount the sidebar in parallel.
+  //
+  // Transient, not plain setMode: this effect only fires when the route and
+  // the mode disagree, i.e. a cold load / reload of a /fullscreen URL after
+  // the in-memory transient state was lost. Aligning mode to a route we
+  // already landed on is not a preference expression — a persisting write
+  // here would overwrite the user's stored preference with whatever surface
+  // an auto-launch chose before the reload.
   useEffect(() => {
     if (panelModeManager.getMode() !== 'fullscreen') {
-      panelModeManager.setMode('fullscreen');
+      panelModeManager.setModeTransient('fullscreen');
     } else {
       getAppEvents().publish({ type: 'close-extension-sidebar', payload: {} });
     }

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -245,11 +245,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
       guide_url: guideUrl || '',
       guide_title: title,
     });
-    if (panelModeManager.isTransientMode()) {
-      panelModeManager.setModeTransient('sidebar');
-    } else {
-      panelModeManager.setMode('sidebar');
-    }
+    panelModeManager.setMode('sidebar');
     sidebarState.setPendingOpenSource('fullscreen_handoff', 'open');
     sidebarState.openSidebar('Interactive learning');
     // Land the user back on the page they were on before they entered full

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -6,7 +6,7 @@ import { useStyles2 } from '@grafana/ui';
 import { CombinedLearningJourneyPanel } from '../docs-panel/docs-panel';
 import { useContentReset } from '../docs-panel/hooks';
 import { useKeyboardShortcuts } from '../docs-panel/keyboard-shortcuts.hook';
-import { openPendingGuide } from '../docs-panel/pendingGuideRouter';
+import { consumePendingGuideOnMount } from '../docs-panel/pendingGuideRouter';
 import { LearningJourneyMilestoneToolbar } from '../docs-panel/components';
 import { PERMANENT_TAB_IDS } from '../docs-panel/utils';
 import { FloatingPanelContent } from '../floating-panel/FloatingPanelContent';
@@ -87,11 +87,9 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     // `openSidebar`, which now no-ops in fullscreen mode).
     sidebarState.setIsSidebarMounted(true);
 
-    const pendingGuide = panelModeManager.consumePendingGuide();
-    if (pendingGuide) {
+    consumePendingGuideOnMount(panel, 'fullscreen_handoff', () => {
       guideOpenInFlightRef.current = true;
-      openPendingGuide(panel, pendingGuide, 'fullscreen_handoff');
-    }
+    });
 
     return () => {
       document.removeEventListener('pathfinder-auto-launch-pending', handlePending);
@@ -358,12 +356,9 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
   // happens — typically used to replace a journey with the editor or vice versa.
   useEffect(() => {
     const handleFullScreenRequest = () => {
-      const pendingGuide = panelModeManager.consumePendingGuide();
-      if (!pendingGuide) {
-        return;
-      }
-      guideOpenInFlightRef.current = true;
-      openPendingGuide(panel, pendingGuide, 'fullscreen_handoff');
+      consumePendingGuideOnMount(panel, 'fullscreen_handoff', () => {
+        guideOpenInFlightRef.current = true;
+      });
     };
     document.addEventListener('pathfinder-request-full-screen', handleFullScreenRequest);
     return () => {

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -271,7 +271,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
         guide_title: title,
       });
       panelModeManager.setPendingGuide({ title, type: 'editor' });
-      panelModeManager.setMode('floating');
+      panelModeManager.setModePersisted('floating');
       locationService.push(PLUGIN_BASE_URL);
       return;
     }
@@ -296,7 +296,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
       // direction: raw GitHub URLs aren't recognised package URLs.
       packageInfo: activeTab?.packageInfo,
     });
-    panelModeManager.setMode('floating');
+    panelModeManager.setModePersisted('floating');
     locationService.push(PLUGIN_BASE_URL);
   }, [isEditorTab, guideUrl, title, activeTab?.type, activeTab?.packageInfo]);
 
@@ -353,7 +353,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
   // In-fullscreen swap: when something dispatches `pathfinder-request-full-screen`
   // while we're already on the fullscreen route (e.g. the BlockEditor toolbar
   // in a sidebar that's still mounted alongside fullscreen, see Issue 3), the
-  // host-side handler's `setMode('fullscreen')` is a no-op and the route push
+  // host-side handler's `setModePersisted('fullscreen')` is a no-op and the route push
   // doesn't remount us. Consume any pending guide here too so the swap still
   // happens — typically used to replace a journey with the editor or vice versa.
   useEffect(() => {

--- a/src/components/full-screen/full-screen-autodock.test.ts
+++ b/src/components/full-screen/full-screen-autodock.test.ts
@@ -14,6 +14,8 @@ jest.mock('../../global-state/panel-mode', () => ({
   panelModeManager: {
     getMode: jest.fn(),
     setMode: jest.fn(),
+    setModeTransient: jest.fn(),
+    isTransientMode: jest.fn(),
     setPendingGuide: jest.fn(),
   },
 }));
@@ -64,6 +66,7 @@ describe('dockOnLeavingFullScreen', () => {
     // side effects in the same test.
     jest.useFakeTimers();
     (panelModeManager.getMode as jest.Mock).mockReturnValue('fullscreen');
+    (panelModeManager.isTransientMode as jest.Mock).mockReturnValue(false);
     (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(false);
   });
 
@@ -165,6 +168,32 @@ describe('dockOnLeavingFullScreen', () => {
         guide_title: baseTab.title,
         reason: 'navigation_away_sidebar_occupied',
       });
+    });
+  });
+
+  describe('transient full screen (automatic My Learning launch) docks without persisting', () => {
+    beforeEach(() => {
+      (panelModeManager.isTransientMode as jest.Mock).mockReturnValue(true);
+    });
+
+    it('docks to sidebar via the non-persisting setModeTransient', () => {
+      const outcome = dockOnLeavingFullScreen(defaultInputs());
+      jest.runAllTimers();
+
+      expect(outcome).toBe('sidebar');
+      expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('sidebar');
+      expect(panelModeManager.setMode).not.toHaveBeenCalled();
+    });
+
+    it('docks to floating via the non-persisting setModeTransient when the sidebar is occupied', () => {
+      (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(true);
+
+      const outcome = dockOnLeavingFullScreen(defaultInputs());
+      jest.runAllTimers();
+
+      expect(outcome).toBe('floating');
+      expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('floating');
+      expect(panelModeManager.setMode).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/full-screen/full-screen-autodock.test.ts
+++ b/src/components/full-screen/full-screen-autodock.test.ts
@@ -14,8 +14,6 @@ jest.mock('../../global-state/panel-mode', () => ({
   panelModeManager: {
     getMode: jest.fn(),
     setMode: jest.fn(),
-    setModeTransient: jest.fn(),
-    isTransientMode: jest.fn(),
     setPendingGuide: jest.fn(),
   },
 }));
@@ -66,7 +64,6 @@ describe('dockOnLeavingFullScreen', () => {
     // side effects in the same test.
     jest.useFakeTimers();
     (panelModeManager.getMode as jest.Mock).mockReturnValue('fullscreen');
-    (panelModeManager.isTransientMode as jest.Mock).mockReturnValue(false);
     (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(false);
   });
 
@@ -168,32 +165,6 @@ describe('dockOnLeavingFullScreen', () => {
         guide_title: baseTab.title,
         reason: 'navigation_away_sidebar_occupied',
       });
-    });
-  });
-
-  describe('transient full screen (automatic My Learning launch) docks without persisting', () => {
-    beforeEach(() => {
-      (panelModeManager.isTransientMode as jest.Mock).mockReturnValue(true);
-    });
-
-    it('docks to sidebar via the non-persisting setModeTransient', () => {
-      const outcome = dockOnLeavingFullScreen(defaultInputs());
-      jest.runAllTimers();
-
-      expect(outcome).toBe('sidebar');
-      expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('sidebar');
-      expect(panelModeManager.setMode).not.toHaveBeenCalled();
-    });
-
-    it('docks to floating via the non-persisting setModeTransient when the sidebar is occupied', () => {
-      (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(true);
-
-      const outcome = dockOnLeavingFullScreen(defaultInputs());
-      jest.runAllTimers();
-
-      expect(outcome).toBe('floating');
-      expect(panelModeManager.setModeTransient).toHaveBeenCalledWith('floating');
-      expect(panelModeManager.setMode).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/full-screen/full-screen-autodock.ts
+++ b/src/components/full-screen/full-screen-autodock.ts
@@ -69,12 +69,6 @@ export function dockOnLeavingFullScreen(inputs: AutoDockInputs): AutoDockOutcome
   // pending `await markAsCompleted()` chain can settle first.
   const deferred = (fn: () => void) => setTimeout(fn, 0);
 
-  // A transiently-entered full screen (automatic My Learning launch) must
-  // dock without persisting, so the auto-launch never overwrites the user's
-  // durable preference; a manually-entered full screen persists as before.
-  const dockTo = (mode: 'sidebar' | 'floating') =>
-    panelModeManager.isTransientMode() ? panelModeManager.setModeTransient(mode) : panelModeManager.setMode(mode);
-
   if (isExtensionSidebarOwnedByOther(myPluginId)) {
     // Sidebar is taken — pop out as a floating overlay so we co-exist
     // with whatever plugin owns the sidebar instead of stealing it.
@@ -84,7 +78,7 @@ export function dockOnLeavingFullScreen(inputs: AutoDockInputs): AutoDockOutcome
       guide_title: title,
       reason: 'navigation_away_sidebar_occupied',
     });
-    deferred(() => dockTo('floating'));
+    deferred(() => panelModeManager.setMode('floating'));
     return 'floating';
   }
 
@@ -99,7 +93,7 @@ export function dockOnLeavingFullScreen(inputs: AutoDockInputs): AutoDockOutcome
   // latest milestone URL full-screen wrote during the session, not the
   // pre-fullscreen position.
   deferred(() => {
-    dockTo('sidebar');
+    panelModeManager.setMode('sidebar');
     sidebarState.setPendingOpenSource('fullscreen_handoff', 'open');
     sidebarState.openSidebar('Interactive learning');
   });

--- a/src/components/full-screen/full-screen-autodock.ts
+++ b/src/components/full-screen/full-screen-autodock.ts
@@ -69,6 +69,12 @@ export function dockOnLeavingFullScreen(inputs: AutoDockInputs): AutoDockOutcome
   // pending `await markAsCompleted()` chain can settle first.
   const deferred = (fn: () => void) => setTimeout(fn, 0);
 
+  // A transiently-entered full screen (automatic My Learning launch) must
+  // dock without persisting, so the auto-launch never overwrites the user's
+  // durable preference; a manually-entered full screen persists as before.
+  const dockTo = (mode: 'sidebar' | 'floating') =>
+    panelModeManager.isTransientMode() ? panelModeManager.setModeTransient(mode) : panelModeManager.setMode(mode);
+
   if (isExtensionSidebarOwnedByOther(myPluginId)) {
     // Sidebar is taken — pop out as a floating overlay so we co-exist
     // with whatever plugin owns the sidebar instead of stealing it.
@@ -78,7 +84,7 @@ export function dockOnLeavingFullScreen(inputs: AutoDockInputs): AutoDockOutcome
       guide_title: title,
       reason: 'navigation_away_sidebar_occupied',
     });
-    deferred(() => panelModeManager.setMode('floating'));
+    deferred(() => dockTo('floating'));
     return 'floating';
   }
 
@@ -93,7 +99,7 @@ export function dockOnLeavingFullScreen(inputs: AutoDockInputs): AutoDockOutcome
   // latest milestone URL full-screen wrote during the session, not the
   // pre-fullscreen position.
   deferred(() => {
-    panelModeManager.setMode('sidebar');
+    dockTo('sidebar');
     sidebarState.setPendingOpenSource('fullscreen_handoff', 'open');
     sidebarState.openSidebar('Interactive learning');
   });

--- a/src/components/full-screen/panel-mode-surface-toggles.contract.test.ts
+++ b/src/components/full-screen/panel-mode-surface-toggles.contract.test.ts
@@ -83,9 +83,17 @@ describe('panel-mode surface-toggle persistence classification', () => {
       const usePanelMode = read('components/docs-panel/hooks/usePanelMode.ts');
       expect(usePanelMode).toContain("setMode('sidebar')");
       expect(usePanelMode).not.toContain('setModePersisted');
+    });
 
-      // FullScreenPanel cold-load sync keeps plain setMode('fullscreen').
-      expect(read('components/full-screen/FullScreenPanel.tsx')).toContain("setMode('fullscreen')");
+    it('FullScreenPanel cold-load route sync is transient, never a persisting write', () => {
+      // The reconcile effect only fires when route and mode disagree — a cold
+      // load / reload of /fullscreen after in-memory transient state was lost.
+      // Aligning mode to the route is not a preference expression: a plain
+      // setMode here persists 'fullscreen' over the user's stored preference
+      // the moment they reload a transient full-screen launch.
+      const src = read('components/full-screen/FullScreenPanel.tsx');
+      expect(src).toContain("setModeTransient('fullscreen')");
+      expect(src).not.toContain("setMode('fullscreen')");
     });
   });
 });

--- a/src/components/full-screen/panel-mode-surface-toggles.contract.test.ts
+++ b/src/components/full-screen/panel-mode-surface-toggles.contract.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tripwire (Pattern J — contract-surface preservation)
+ *
+ * Pins the panel-mode persistence classification (locked decision 2 + the A2
+ * mechanism): every `panelModeManager.setMode` call site must match the single
+ * rule —
+ *
+ *   Use `setModePersisted` (persist + END the transient session) IFF the call
+ *   is an explicit USER choice ADOPTING a NON-SIDEBAR surface (floating or
+ *   fullscreen). Everything else (automatic teardown / auto-dock / self-heal /
+ *   cold-load, and every return-to-base sidebar dock) stays plain `setMode`,
+ *   which is non-persisting while an auto-launch round-trip is active and
+ *   persists otherwise.
+ *
+ * Why source-assertion (not runtime mount):
+ *   `@grafana/scenes` + `@grafana/ui` require a theme provider that is not
+ *   available in the Jest environment, so these surfaces use tracked-file
+ *   substring tripwires (see `docs-panel.panel-mode.test.tsx`).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+function read(rel: string): string {
+  return fs.readFileSync(path.resolve(__dirname, '..', '..', rel), 'utf-8');
+}
+
+describe('panel-mode surface-toggle persistence classification', () => {
+  describe('deliberate non-sidebar adoptions persist via setModePersisted', () => {
+    it('FullScreenPanel switch-to-floating persists, never plain setMode', () => {
+      const src = read('components/full-screen/FullScreenPanel.tsx');
+      expect(src).toContain("setModePersisted('floating')");
+      expect(src).not.toContain("setMode('floating')");
+    });
+
+    it('FloatingPanelManager switch-to-fullscreen persists, never plain setMode', () => {
+      const src = read('components/floating-panel/FloatingPanelManager.tsx');
+      expect(src).toContain("setModePersisted('fullscreen')");
+      expect(src).not.toContain("setMode('fullscreen')");
+    });
+
+    it('the sidebar-owned pop-out / full-screen controls and deep link stay persisted', () => {
+      expect(read('components/docs-panel/hooks/usePopOutHandoff.ts')).toContain("setModePersisted('floating')");
+      const fullScreenHandoff = read('components/docs-panel/hooks/useFullScreenHandoff.ts');
+      expect(fullScreenHandoff).toContain("setModePersisted('fullscreen')");
+      expect(fullScreenHandoff).not.toContain("setMode('fullscreen')");
+      const deepLink = read('utils/pathfinder-deep-link-handler.ts');
+      expect(deepLink).toContain("setModePersisted('floating')");
+      expect(deepLink).toContain("setModePersisted('fullscreen')");
+    });
+  });
+
+  describe('automatic and return-to-base sites stay plain setMode', () => {
+    it('full-screen auto-dock (sidebar OR floating) never persists', () => {
+      const src = read('components/full-screen/full-screen-autodock.ts');
+      expect(src).not.toContain('setModePersisted');
+      expect(src).toContain("setMode('sidebar')");
+      expect(src).toContain("setMode('floating')");
+    });
+
+    it('return-to-base sidebar docks and closes never adopt the base via setModePersisted', () => {
+      // Base sidebar is never a deliberate non-sidebar adoption, so it must
+      // never be forced-persisted; plain setMode gives the correct behavior
+      // (suppressed during a transient round-trip, persists otherwise).
+      const fullScreen = read('components/full-screen/FullScreenPanel.tsx');
+      expect(fullScreen).toContain("setMode('sidebar')");
+      expect(fullScreen).not.toContain("setModePersisted('sidebar')");
+
+      const floating = read('components/floating-panel/FloatingPanelManager.tsx');
+      expect(floating).toContain("setMode('sidebar')");
+      expect(floating).not.toContain("setModePersisted('sidebar')");
+
+      const notice = read('components/docs-panel/components/FullScreenModeNotice.tsx');
+      expect(notice).toContain("setMode('sidebar')");
+      expect(notice).not.toContain('setModePersisted');
+    });
+
+    it('self-heal and cold-load mode-sync stay plain setMode', () => {
+      const contextPanel = read('components/App/ContextPanel.tsx');
+      expect(contextPanel).toContain("setMode('sidebar')");
+      expect(contextPanel).not.toContain('setModePersisted');
+
+      const usePanelMode = read('components/docs-panel/hooks/usePanelMode.ts');
+      expect(usePanelMode).toContain("setMode('sidebar')");
+      expect(usePanelMode).not.toContain('setModePersisted');
+
+      // FullScreenPanel cold-load sync keeps plain setMode('fullscreen').
+      expect(read('components/full-screen/FullScreenPanel.tsx')).toContain("setMode('fullscreen')");
+    });
+  });
+});

--- a/src/components/interactive-tutorial/grot-guide-block.tsx
+++ b/src/components/interactive-tutorial/grot-guide-block.tsx
@@ -5,6 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 
 import { substituteVariables } from '../../utils/variable-substitution';
 import { escapeHtml } from '../../security/html-sanitizer';
+import { AUTO_OPEN_DOCS_EVENT } from '../../lib/event-names';
 import type {
   GrotGuideWelcome,
   GrotGuideQuestionScreen,
@@ -216,7 +217,7 @@ const ResultScreen: React.FC<ResultScreenProps> = ({ screen, sub, subHtml, onBac
 
           const openInSidebar = () => {
             document.dispatchEvent(
-              new CustomEvent('pathfinder-auto-open-docs', {
+              new CustomEvent(AUTO_OPEN_DOCS_EVENT, {
                 detail: { url: href, title, source: 'grot_guide_block' },
               })
             );

--- a/src/global-state/guide-launch.test.ts
+++ b/src/global-state/guide-launch.test.ts
@@ -13,7 +13,7 @@ function payload(overrides: Partial<StagedLaunchPayload> = {}): StagedLaunchPayl
   return { url: 'bundled:first-dashboard', preparedContent: rawContent, ...overrides };
 }
 
-describe('guideLaunchStore (PR #1446 review finding 1)', () => {
+describe('guideLaunchStore', () => {
   it('redeems a staged payload exactly once for the URL it was staged for', () => {
     const key = guideLaunchStore.stage(payload());
 
@@ -49,6 +49,27 @@ describe('guideLaunchStore (PR #1446 review finding 1)', () => {
     nowSpy.mockReturnValue(now + 61_000);
     expect(guideLaunchStore.consume(key, 'bundled:first-dashboard')).toBeNull();
 
+    nowSpy.mockRestore();
+  });
+
+  it('sweeps expired entries on stage so abandoned launches do not accumulate', () => {
+    // Redemption is the only other eviction path, and an abandoned launch's
+    // key is exactly the one that is never redeemed — the sweep keeps memory
+    // bounded by construction instead of by the redeemer's good behaviour.
+    const now = Date.now();
+    const nowSpy = jest.spyOn(Date, 'now');
+    const staged = (guideLaunchStore as unknown as { _staged: Map<string, unknown> })._staged;
+
+    nowSpy.mockReturnValue(now);
+    guideLaunchStore.stage(payload());
+
+    nowSpy.mockReturnValue(now + 61_000);
+    const freshKey = guideLaunchStore.stage(payload());
+
+    // Everything staged before the deadline (including leftovers from other
+    // tests) is expired at this point — only the fresh entry survives.
+    expect(staged.size).toBe(1);
+    guideLaunchStore.consume(freshKey, 'bundled:first-dashboard');
     nowSpy.mockRestore();
   });
 

--- a/src/global-state/guide-launch.test.ts
+++ b/src/global-state/guide-launch.test.ts
@@ -1,0 +1,67 @@
+import { guideLaunchStore, type StagedLaunchPayload } from './guide-launch';
+import type { RawContent } from '../types/content.types';
+
+const rawContent: RawContent = {
+  content: '{"id":"g","title":"g","blocks":[]}',
+  metadata: { title: 'g' },
+  type: 'interactive',
+  url: 'bundled:first-dashboard',
+  lastFetched: '2026-07-28T00:00:00.000Z',
+};
+
+function payload(overrides: Partial<StagedLaunchPayload> = {}): StagedLaunchPayload {
+  return { url: 'bundled:first-dashboard', preparedContent: rawContent, ...overrides };
+}
+
+describe('guideLaunchStore (PR #1446 review finding 1)', () => {
+  it('redeems a staged payload exactly once for the URL it was staged for', () => {
+    const key = guideLaunchStore.stage(payload());
+
+    expect(guideLaunchStore.consume(key, 'bundled:first-dashboard')).toEqual(payload());
+    // Consume-once: a replayed key gets nothing.
+    expect(guideLaunchStore.consume(key, 'bundled:first-dashboard')).toBeNull();
+  });
+
+  it('returns null for a forged or absent key (caller falls back to a normal fetch)', () => {
+    guideLaunchStore.stage(payload());
+
+    expect(guideLaunchStore.consume('not-a-real-key', 'bundled:first-dashboard')).toBeNull();
+    expect(guideLaunchStore.consume(undefined, 'bundled:first-dashboard')).toBeNull();
+  });
+
+  it('refuses to redeem a genuine key against a different URL', () => {
+    // A same-page script that observed a real key must not be able to attach
+    // it to attacker-chosen content coordinates.
+    const key = guideLaunchStore.stage(payload());
+
+    expect(guideLaunchStore.consume(key, 'https://evil.example/content.json')).toBeNull();
+    // The mismatch also burns the key — no second try at the right URL.
+    expect(guideLaunchStore.consume(key, 'bundled:first-dashboard')).toBeNull();
+  });
+
+  it('treats entries older than the redemption deadline as abandoned', () => {
+    const now = Date.now();
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    nowSpy.mockReturnValue(now);
+    const key = guideLaunchStore.stage(payload());
+
+    nowSpy.mockReturnValue(now + 61_000);
+    expect(guideLaunchStore.consume(key, 'bundled:first-dashboard')).toBeNull();
+
+    nowSpy.mockRestore();
+  });
+
+  it('issues unguessable, non-repeating keys', () => {
+    const first = guideLaunchStore.stage(payload());
+    const second = guideLaunchStore.stage(payload());
+
+    expect(first).not.toEqual(second);
+    // UUID shape — the key must not be derivable from the payload.
+    expect(first).toMatch(/^[0-9a-f-]{36}$/);
+
+    // Drain what this test staged.
+    guideLaunchStore.consume(first, 'bundled:first-dashboard');
+    guideLaunchStore.consume(second, 'bundled:first-dashboard');
+  });
+});

--- a/src/global-state/guide-launch.ts
+++ b/src/global-state/guide-launch.ts
@@ -45,11 +45,21 @@ class GuideLaunchStore {
 
   /**
    * Stage a prepared payload and get back the opaque key to send over the
-   * public channel. Keys are single-use.
+   * public channel. Keys are single-use. Expired entries are swept here —
+   * redemption is the only other eviction path, and an abandoned launch's
+   * key is exactly the one that never gets redeemed, so without the sweep
+   * each abandoned launch would retain a full expanded guide for the life
+   * of the page.
    */
   public stage(payload: StagedLaunchPayload): string {
+    const now = Date.now();
+    for (const [key, entry] of this._staged) {
+      if (now - entry.stagedAt > STALE_AFTER_MS) {
+        this._staged.delete(key);
+      }
+    }
     const key = crypto.randomUUID();
-    this._staged.set(key, { payload, stagedAt: Date.now() });
+    this._staged.set(key, { payload, stagedAt: now });
     return key;
   }
 

--- a/src/global-state/guide-launch.ts
+++ b/src/global-state/guide-launch.ts
@@ -1,0 +1,83 @@
+/**
+ * Module-owned staging area for prepared (one-fetch) launch payloads.
+ *
+ * `prepareGuideLaunch` produces trusted, already-validated content. The
+ * launch handoff sometimes has to cross PUBLIC channels — the
+ * `pathfinder-auto-open-docs` CustomEvent and the cold-sidebar link queue —
+ * that any same-page script can also write to. The payload itself must never
+ * ride those channels: a forged `preparedContent` would bypass the fetch
+ * pipeline's URL/HTTPS/package validation, and a forged `packageInfo` is
+ * persisted with the tab and controls render type.
+ *
+ * Instead, the producer stages the payload here and sends only an opaque,
+ * unguessable `launchKey` over the public channel. The consumer redeems the
+ * key at the trusted boundary. A forged, replayed, stale, or URL-mismatched
+ * key redeems to `null`, and the loader falls back to its normal validated
+ * fetch — exactly the pre-prepared-launch behavior.
+ *
+ * (The `panelModeManager.setPendingGuide` handoff channel is already
+ * module-owned memory and never crosses a public boundary, so it carries its
+ * payload directly.)
+ */
+
+import type { PackageOpenInfo } from '../types/content-panel.types';
+import type { RawContent } from '../types/content.types';
+
+export interface StagedLaunchPayload {
+  /** URL the payload was prepared for — redemption requires an exact match. */
+  url: string;
+  /** @see OpenDocsOptions.preparedContent */
+  preparedContent: RawContent;
+  /** @see OpenDocsOptions.packageInfo */
+  packageInfo?: PackageOpenInfo;
+}
+
+/**
+ * Redemption deadline. The public channels drain within milliseconds (event)
+ * or as soon as the cold sidebar mounts and replays its queue (seconds); a
+ * minute-old key means the launch was abandoned, and falling back to a fresh
+ * fetch is safer than rendering stale content.
+ */
+const STALE_AFTER_MS = 60_000;
+
+class GuideLaunchStore {
+  private _staged = new Map<string, { payload: StagedLaunchPayload; stagedAt: number }>();
+
+  /**
+   * Stage a prepared payload and get back the opaque key to send over the
+   * public channel. Keys are single-use.
+   */
+  public stage(payload: StagedLaunchPayload): string {
+    const key = crypto.randomUUID();
+    this._staged.set(key, { payload, stagedAt: Date.now() });
+    return key;
+  }
+
+  /**
+   * Redeem a key received from a public channel. Consume-once: the entry is
+   * removed whether or not redemption succeeds. Returns `null` (caller falls
+   * back to a normal fetch) for unknown/forged keys, replays, stale entries,
+   * and keys redeemed against a different URL than they were staged for —
+   * that last check stops a same-page script from re-attaching a genuine
+   * key to attacker-chosen content coordinates.
+   */
+  public consume(key: string | undefined, url: string): StagedLaunchPayload | null {
+    if (!key) {
+      return null;
+    }
+    const entry = this._staged.get(key);
+    if (!entry) {
+      return null;
+    }
+    this._staged.delete(key);
+    if (Date.now() - entry.stagedAt > STALE_AFTER_MS) {
+      return null;
+    }
+    if (entry.payload.url !== url) {
+      return null;
+    }
+    return entry.payload;
+  }
+}
+
+export const guideLaunchStore = new GuideLaunchStore();

--- a/src/global-state/link-interception.ts
+++ b/src/global-state/link-interception.ts
@@ -91,6 +91,8 @@ class GlobalLinkInterceptionState {
               url: docsLink.url,
               title: docsLink.title,
               source: 'queued_link',
+              // Preserve a prepared (one-fetch) launch through the cold-sidebar queue.
+              preparedContent: docsLink.preparedContent,
             },
           })
         );

--- a/src/global-state/link-interception.ts
+++ b/src/global-state/link-interception.ts
@@ -91,9 +91,10 @@ class GlobalLinkInterceptionState {
               url: docsLink.url,
               title: docsLink.title,
               source: 'queued_link',
-              // Preserve a prepared (one-fetch) launch through the cold-sidebar queue.
-              preparedContent: docsLink.preparedContent,
-              packageInfo: docsLink.packageInfo,
+              // Preserve a prepared (one-fetch) launch through the cold-sidebar
+              // queue: the key redeems the payload from guideLaunchStore at the
+              // listener's trusted boundary.
+              launchKey: docsLink.launchKey,
             },
           })
         );

--- a/src/global-state/link-interception.ts
+++ b/src/global-state/link-interception.ts
@@ -1,6 +1,7 @@
 import { getDocsLinkFromEvent } from 'global-state/utils.link-interception';
 import { sidebarState } from 'global-state/sidebar';
 import { reportAppInteraction, UserInteraction } from 'lib/analytics';
+import { AUTO_OPEN_DOCS_EVENT } from 'lib/event-names';
 import type { QueuedDocsLink } from 'types/link-interception.types';
 
 /**
@@ -32,7 +33,7 @@ class GlobalLinkInterceptionState {
     // if sidebar is mounted, auto-open the link
     if (sidebarState.getIsSidebarMounted()) {
       document.dispatchEvent(
-        new CustomEvent('pathfinder-auto-open-docs', {
+        new CustomEvent(AUTO_OPEN_DOCS_EVENT, {
           detail: { ...docsLink, source: 'link_interception' },
         })
       );
@@ -86,7 +87,7 @@ class GlobalLinkInterceptionState {
 
       if (docsLink) {
         document.dispatchEvent(
-          new CustomEvent('pathfinder-auto-open-docs', {
+          new CustomEvent(AUTO_OPEN_DOCS_EVENT, {
             detail: {
               url: docsLink.url,
               title: docsLink.title,

--- a/src/global-state/link-interception.ts
+++ b/src/global-state/link-interception.ts
@@ -93,6 +93,7 @@ class GlobalLinkInterceptionState {
               source: 'queued_link',
               // Preserve a prepared (one-fetch) launch through the cold-sidebar queue.
               preparedContent: docsLink.preparedContent,
+              packageInfo: docsLink.packageInfo,
             },
           })
         );

--- a/src/global-state/panel-mode.test.ts
+++ b/src/global-state/panel-mode.test.ts
@@ -187,62 +187,54 @@ describe('panelModeManager', () => {
       expect(publishMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'close-extension-sidebar' }));
     });
 
-    it('is cleared by a subsequent explicit setMode, which then persists', () => {
-      panelModeManager.setModeTransient('fullscreen');
-      panelModeManager.setMode('sidebar');
-      expect(panelModeManager.getMode()).toBe('sidebar');
-      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('sidebar');
-    });
-  });
-
-  describe('isTransientMode', () => {
-    afterEach(() => {
-      panelModeManager.setMode('sidebar');
-      localStorage.clear();
-    });
-
-    it('is false with no override active', () => {
-      expect(panelModeManager.isTransientMode()).toBe(false);
-    });
-
-    it('is true after a transient launch and false after an explicit setMode', () => {
-      panelModeManager.setModeTransient('fullscreen');
-      expect(panelModeManager.isTransientMode()).toBe(true);
-      panelModeManager.setMode('sidebar');
-      expect(panelModeManager.isTransientMode()).toBe(false);
-    });
-  });
-
-  describe('auto-launch round-trip (entry + transient exit)', () => {
-    afterEach(() => {
-      panelModeManager.setMode('sidebar');
-      localStorage.clear();
-    });
-
-    it('never overwrites a non-default persisted preference across a transient full-screen round-trip', () => {
+    it('keeps a subsequent setMode non-persisting while the transient session is active', () => {
       localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
-
-      // Entry: My Learning auto-launches a reading-only guide full screen.
       panelModeManager.setModeTransient('fullscreen');
-      expect(panelModeManager.getMode()).toBe('fullscreen');
-
-      // Exit: a transient full screen must dock via the non-persisting path.
-      expect(panelModeManager.isTransientMode()).toBe(true);
-      panelModeManager.setModeTransient('sidebar');
-
+      // A teardown/exit still calls setMode, but must not persist during a
+      // transient session — the stored preference stays 'floating'.
+      panelModeManager.setMode('sidebar');
       expect(panelModeManager.getMode()).toBe('sidebar');
-      // The user's durable preference is still 'floating' — never rewritten.
       expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
     });
+  });
 
-    it('a manually entered full screen still persists sidebar on exit (fix stays scoped)', () => {
+  describe('transient-session persistence suppression (locked decision 2)', () => {
+    // A transient session only ends on page reload, so the singleton would leak
+    // its in-memory override across tests. Load a fresh instance per test to
+    // simulate a clean page load.
+    let manager!: typeof panelModeManager;
+    beforeEach(() => {
+      jest.isolateModules(() => {
+        manager = jest.requireActual('./panel-mode').panelModeManager;
+      });
+    });
+
+    // Each surface: stored pref = floating → auto-launch enter → teardown via the
+    // real, persistence-agnostic setMode('sidebar') exit call (as every exit /
+    // close / restoration site does) → stored pref STILL floating.
+    it.each(['fullscreen', 'floating', 'sidebar'] as const)(
+      'never overwrites a non-default preference across a transient %s launch round-trip',
+      (surface) => {
+        localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
+
+        manager.setModeTransient(surface);
+        expect(manager.getMode()).toBe(surface);
+
+        manager.setMode('sidebar');
+
+        expect(manager.getMode()).toBe('sidebar');
+        expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
+      }
+    );
+
+    it('persists a manually entered surface on exit (no transient session)', () => {
       localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
 
-      panelModeManager.setMode('fullscreen');
-      expect(panelModeManager.isTransientMode()).toBe(false);
-      panelModeManager.setMode('sidebar');
+      manager.setMode('fullscreen');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('fullscreen');
+      manager.setMode('sidebar');
 
-      expect(panelModeManager.getMode()).toBe('sidebar');
+      expect(manager.getMode()).toBe('sidebar');
       expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('sidebar');
     });
   });

--- a/src/global-state/panel-mode.test.ts
+++ b/src/global-state/panel-mode.test.ts
@@ -159,4 +159,39 @@ describe('panelModeManager', () => {
       expect(panelModeManager.consumePriorPath()).toBe('/connections');
     });
   });
+
+  describe('setModeTransient', () => {
+    // Clear any in-memory transient override left by a test (the manager is a
+    // singleton) so the next test reads its persisted preference.
+    afterEach(() => {
+      panelModeManager.setMode('sidebar');
+      localStorage.clear();
+    });
+
+    it('does NOT persist the mode to localStorage (user preference untouched)', () => {
+      panelModeManager.setModeTransient('fullscreen');
+      expect(panelModeManager.getMode()).toBe('fullscreen');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBeNull();
+    });
+
+    it('preserves an existing persisted preference under the transient override', () => {
+      localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
+      panelModeManager.setModeTransient('fullscreen');
+      expect(panelModeManager.getMode()).toBe('fullscreen');
+      // The stored preference is still 'floating' — only the in-memory override changed.
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
+    });
+
+    it('runs the same side effects as setMode (close-extension-sidebar)', () => {
+      panelModeManager.setModeTransient('fullscreen');
+      expect(publishMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'close-extension-sidebar' }));
+    });
+
+    it('is cleared by a subsequent explicit setMode, which then persists', () => {
+      panelModeManager.setModeTransient('fullscreen');
+      panelModeManager.setMode('sidebar');
+      expect(panelModeManager.getMode()).toBe('sidebar');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('sidebar');
+    });
+  });
 });

--- a/src/global-state/panel-mode.test.ts
+++ b/src/global-state/panel-mode.test.ts
@@ -161,9 +161,12 @@ describe('panelModeManager', () => {
   });
 
   describe('setModeTransient', () => {
-    // Clear any in-memory transient override left by a test (the manager is a
-    // singleton) so the next test reads its persisted preference.
+    // The manager is a singleton: end any open round-trip and clear the
+    // in-memory override so the next test reads a clean localStorage state. The
+    // first setMode ends the round-trip (keeps 'sidebar' as the override); the
+    // second, no longer in a round-trip, clears the override.
     afterEach(() => {
+      panelModeManager.setMode('sidebar');
       panelModeManager.setMode('sidebar');
       localStorage.clear();
     });
@@ -187,11 +190,9 @@ describe('panelModeManager', () => {
       expect(publishMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'close-extension-sidebar' }));
     });
 
-    it('keeps a subsequent setMode non-persisting while the transient session is active', () => {
+    it('does not persist the base sidebar teardown of a round-trip', () => {
       localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
       panelModeManager.setModeTransient('fullscreen');
-      // A teardown/exit still calls setMode, but must not persist during a
-      // transient session — the stored preference stays 'floating'.
       panelModeManager.setMode('sidebar');
       expect(panelModeManager.getMode()).toBe('sidebar');
       expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
@@ -226,6 +227,31 @@ describe('panelModeManager', () => {
         expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
       }
     );
+
+    it('resumes persistence for a deliberate surface change after a round-trip ends', () => {
+      localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
+
+      // Auto-launch a reading-only guide (transient) and exit to sidebar.
+      manager.setModeTransient('fullscreen');
+      manager.setMode('sidebar');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
+
+      // A deliberate change AFTER the round-trip persists as normal.
+      manager.setMode('fullscreen');
+      expect(manager.getMode()).toBe('fullscreen');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('fullscreen');
+    });
+
+    it('persists a deliberate non-base surface change made mid-round-trip', () => {
+      localStorage.setItem(StorageKeys.PANEL_MODE, 'sidebar');
+
+      manager.setModeTransient('fullscreen');
+      // User deliberately pops out to floating before the base teardown.
+      manager.setMode('floating');
+
+      expect(manager.getMode()).toBe('floating');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
+    });
 
     it('persists a manually entered surface on exit (no transient session)', () => {
       localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');

--- a/src/global-state/panel-mode.test.ts
+++ b/src/global-state/panel-mode.test.ts
@@ -241,6 +241,24 @@ describe('panelModeManager', () => {
       expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('sidebar');
     });
 
+    it('reloading a transient full-screen launch keeps the stored preference intact', () => {
+      // A transient launch pushes a real, reloadable /fullscreen?doc=… URL but
+      // transiency lives in memory only. After a reload (fresh manager,
+      // preserved localStorage) FullScreenPanel's reconcile effect sees the
+      // mode mismatch and re-aligns to the route — that write must be
+      // transient, or the reload persists 'fullscreen' over the preference.
+      localStorage.setItem(StorageKeys.PANEL_MODE, 'sidebar');
+
+      // FullScreenPanel reconcile on a cold /fullscreen load (see the
+      // panel-mode-surface-toggles contract test pinning the call site).
+      if (manager.getMode() !== 'fullscreen') {
+        manager.setModeTransient('fullscreen');
+      }
+
+      expect(manager.getMode()).toBe('fullscreen');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('sidebar');
+    });
+
     it('resumes persistence for a deliberate surface change after a round-trip', () => {
       localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
 

--- a/src/global-state/panel-mode.test.ts
+++ b/src/global-state/panel-mode.test.ts
@@ -71,6 +71,9 @@ describe('panelModeManager', () => {
       localStorage.setItem(StorageKeys.PANEL_MODE, 'fullscreen');
       panelModeManager.setMode('fullscreen');
       expect(publishMock).not.toHaveBeenCalled();
+      // commit() runs before the same-mode early return, so pin the stored
+      // VALUE too (it is legitimately rewritten, but must not change).
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('fullscreen');
     });
 
     it('dispatches pathfinder-panel-mode-change with previous and next modes', () => {

--- a/src/global-state/panel-mode.test.ts
+++ b/src/global-state/panel-mode.test.ts
@@ -161,13 +161,11 @@ describe('panelModeManager', () => {
   });
 
   describe('setModeTransient', () => {
-    // The manager is a singleton: end any open round-trip and clear the
-    // in-memory override so the next test reads a clean localStorage state. The
-    // first setMode ends the round-trip (keeps 'sidebar' as the override); the
-    // second, no longer in a round-trip, clears the override.
+    // The manager is a singleton: end any open round-trip (only the deliberate
+    // setModePersisted does that) and clear the in-memory override so the next
+    // test reads a clean localStorage state.
     afterEach(() => {
-      panelModeManager.setMode('sidebar');
-      panelModeManager.setMode('sidebar');
+      panelModeManager.setModePersisted('sidebar');
       localStorage.clear();
     });
 
@@ -200,9 +198,10 @@ describe('panelModeManager', () => {
   });
 
   describe('transient-session persistence suppression (locked decision 2)', () => {
-    // A transient session only ends on page reload, so the singleton would leak
-    // its in-memory override across tests. Load a fresh instance per test to
-    // simulate a clean page load.
+    // An auto-launch round-trip's automatic teardown never ends the session
+    // (only a deliberate setModePersisted or a reload does), so the singleton
+    // would leak its in-memory override across tests. Load a fresh instance per
+    // test to simulate a clean page load.
     let manager!: typeof panelModeManager;
     beforeEach(() => {
       jest.isolateModules(() => {
@@ -211,8 +210,8 @@ describe('panelModeManager', () => {
     });
 
     // Each surface: stored pref = floating → auto-launch enter → teardown via the
-    // real, persistence-agnostic setMode('sidebar') exit call (as every exit /
-    // close / restoration site does) → stored pref STILL floating.
+    // persistence-agnostic setMode('sidebar') exit call (as every exit / close /
+    // restoration site does) → stored pref STILL floating.
     it.each(['fullscreen', 'floating', 'sidebar'] as const)(
       'never overwrites a non-default preference across a transient %s launch round-trip',
       (surface) => {
@@ -228,7 +227,21 @@ describe('panelModeManager', () => {
       }
     );
 
-    it('resumes persistence for a deliberate surface change after a round-trip ends', () => {
+    it('never persists an automatic auto-dock to FLOATING (full-screen → floating when sidebar occupied)', () => {
+      // review-4: stored pref = sidebar; a reading-only guide auto-launches
+      // full screen; navigating away auto-docks to FLOATING (another plugin owns
+      // the extension sidebar). That automatic teardown must not overwrite the
+      // stored 'sidebar' preference with 'floating'.
+      localStorage.setItem(StorageKeys.PANEL_MODE, 'sidebar');
+
+      manager.setModeTransient('fullscreen');
+      manager.setMode('floating');
+
+      expect(manager.getMode()).toBe('floating');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('sidebar');
+    });
+
+    it('resumes persistence for a deliberate surface change after a round-trip', () => {
       localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
 
       // Auto-launch a reading-only guide (transient) and exit to sidebar.
@@ -236,21 +249,25 @@ describe('panelModeManager', () => {
       manager.setMode('sidebar');
       expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
 
-      // A deliberate change AFTER the round-trip persists as normal.
-      manager.setMode('fullscreen');
+      // A deliberate change goes through the persisting path and persists.
+      manager.setModePersisted('fullscreen');
       expect(manager.getMode()).toBe('fullscreen');
       expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('fullscreen');
     });
 
-    it('persists a deliberate non-base surface change made mid-round-trip', () => {
+    it('setModePersisted persists, ends the session, and lets subsequent setMode persist', () => {
       localStorage.setItem(StorageKeys.PANEL_MODE, 'sidebar');
 
+      // Deliberate pop-out mid-round-trip persists and ends the session.
       manager.setModeTransient('fullscreen');
-      // User deliberately pops out to floating before the base teardown.
-      manager.setMode('floating');
-
+      manager.setModePersisted('floating');
       expect(manager.getMode()).toBe('floating');
       expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
+
+      // Session ended → a plain setMode now persists as a normal user choice.
+      manager.setMode('fullscreen');
+      expect(manager.getMode()).toBe('fullscreen');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('fullscreen');
     });
 
     it('persists a manually entered surface on exit (no transient session)', () => {

--- a/src/global-state/panel-mode.test.ts
+++ b/src/global-state/panel-mode.test.ts
@@ -194,4 +194,56 @@ describe('panelModeManager', () => {
       expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('sidebar');
     });
   });
+
+  describe('isTransientMode', () => {
+    afterEach(() => {
+      panelModeManager.setMode('sidebar');
+      localStorage.clear();
+    });
+
+    it('is false with no override active', () => {
+      expect(panelModeManager.isTransientMode()).toBe(false);
+    });
+
+    it('is true after a transient launch and false after an explicit setMode', () => {
+      panelModeManager.setModeTransient('fullscreen');
+      expect(panelModeManager.isTransientMode()).toBe(true);
+      panelModeManager.setMode('sidebar');
+      expect(panelModeManager.isTransientMode()).toBe(false);
+    });
+  });
+
+  describe('auto-launch round-trip (entry + transient exit)', () => {
+    afterEach(() => {
+      panelModeManager.setMode('sidebar');
+      localStorage.clear();
+    });
+
+    it('never overwrites a non-default persisted preference across a transient full-screen round-trip', () => {
+      localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
+
+      // Entry: My Learning auto-launches a reading-only guide full screen.
+      panelModeManager.setModeTransient('fullscreen');
+      expect(panelModeManager.getMode()).toBe('fullscreen');
+
+      // Exit: a transient full screen must dock via the non-persisting path.
+      expect(panelModeManager.isTransientMode()).toBe(true);
+      panelModeManager.setModeTransient('sidebar');
+
+      expect(panelModeManager.getMode()).toBe('sidebar');
+      // The user's durable preference is still 'floating' — never rewritten.
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
+    });
+
+    it('a manually entered full screen still persists sidebar on exit (fix stays scoped)', () => {
+      localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
+
+      panelModeManager.setMode('fullscreen');
+      expect(panelModeManager.isTransientMode()).toBe(false);
+      panelModeManager.setMode('sidebar');
+
+      expect(panelModeManager.getMode()).toBe('sidebar');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('sidebar');
+    });
+  });
 });

--- a/src/global-state/panel-mode.ts
+++ b/src/global-state/panel-mode.ts
@@ -56,10 +56,11 @@ class PanelModeManager {
   private _priorPath: string | null = null;
   /**
    * In-memory surface override for an automatic launch (see `setModeTransient`).
-   * When set, it wins over the persisted preference for `getMode()` but is
-   * never written to localStorage, so an automatic surface choice does not
-   * overwrite the user's durable preference. Cleared by any explicit
-   * (persisting) `setMode` and does not survive a page reload.
+   * When set, a transient session is active: it wins over the persisted
+   * preference for `getMode()`, is never written to localStorage, and
+   * suppresses persistence for every subsequent `setMode` (so no teardown /
+   * exit path can overwrite the user's durable preference). Does not survive a
+   * page reload.
    */
   private _transientMode: PanelMode | null = null;
 
@@ -83,29 +84,25 @@ class PanelModeManager {
   }
 
   /**
-   * Whether an automatic-launch surface override is currently active. Exit
-   * paths use this to keep a transiently-entered surface's teardown
-   * non-persisting, so an automatic launch never overwrites the user's
-   * durable preference at exit (locked decision 2).
-   */
-  public isTransientMode(): boolean {
-    return this._transientMode !== null;
-  }
-
-  /**
-   * Switch panel mode. Persists to localStorage and dispatches a
-   * `pathfinder-panel-mode-change` event so both the sidebar and
-   * floating panel can react.
+   * Switch panel mode. Dispatches a `pathfinder-panel-mode-change` event so
+   * both the sidebar and floating panel can react.
    *
    * When switching to 'floating', closes the extension sidebar.
    * When switching to 'sidebar', notifies the floating panel to unmount.
+   *
+   * Persistence is the single enforcement point for locked decision 2: outside
+   * a transient session this writes the user's durable choice to localStorage;
+   * while a transient (auto-launch) session is active it updates the in-memory
+   * surface only, so no teardown / exit path can overwrite the stored
+   * preference. The session stays transient until a page reload.
    */
   public setMode(mode: PanelMode): void {
-    // An explicit mode change is the user's durable choice: persist it and drop
-    // any transient launch override.
     this.applyModeChange(mode, (next) => {
-      this._transientMode = null;
-      localStorage.setItem(StorageKeys.PANEL_MODE, next);
+      if (this._transientMode !== null) {
+        this._transientMode = next;
+      } else {
+        localStorage.setItem(StorageKeys.PANEL_MODE, next);
+      }
     });
   }
 
@@ -125,11 +122,17 @@ class PanelModeManager {
 
   private applyModeChange(mode: PanelMode, commit: (mode: PanelMode) => void): void {
     const previous = this.getMode();
+
+    // Record the new state first (idempotent) so a transient session is marked
+    // even when the surface does not visibly change — e.g. an auto-launch to the
+    // surface that already matches the stored preference. Otherwise the session
+    // would not be flagged transient and a later teardown would persist over the
+    // user's preference.
+    commit(mode);
+
     if (mode === previous) {
       return;
     }
-
-    commit(mode);
 
     if (mode === 'floating' || mode === 'fullscreen') {
       // Close the Grafana extension sidebar to free the slot. Full screen

--- a/src/global-state/panel-mode.ts
+++ b/src/global-state/panel-mode.ts
@@ -83,6 +83,16 @@ class PanelModeManager {
   }
 
   /**
+   * Whether an automatic-launch surface override is currently active. Exit
+   * paths use this to keep a transiently-entered surface's teardown
+   * non-persisting, so an automatic launch never overwrites the user's
+   * durable preference at exit (locked decision 2).
+   */
+  public isTransientMode(): boolean {
+    return this._transientMode !== null;
+  }
+
+  /**
    * Switch panel mode. Persists to localStorage and dispatches a
    * `pathfinder-panel-mode-change` event so both the sidebar and
    * floating panel can react.

--- a/src/global-state/panel-mode.ts
+++ b/src/global-state/panel-mode.ts
@@ -55,19 +55,26 @@ class PanelModeManager {
   private _pendingGuide: PendingGuide | null = null;
   private _priorPath: string | null = null;
   /**
-   * In-memory surface override for an automatic launch (see `setModeTransient`).
-   * When set, a transient session is active: it wins over the persisted
-   * preference for `getMode()`, is never written to localStorage, and
-   * suppresses persistence for every subsequent `setMode` (so no teardown /
-   * exit path can overwrite the user's durable preference). Does not survive a
-   * page reload.
+   * In-memory current surface. When non-null it wins over the persisted
+   * preference for `getMode()` and mount decisions; it is never written to
+   * localStorage. Set by an automatic launch (`setModeTransient`) and updated
+   * by its non-persisting teardown; cleared once persistence resumes so
+   * localStorage governs again. Does not survive a page reload.
    */
   private _transientMode: PanelMode | null = null;
+  /**
+   * Whether an auto-launch round-trip is in progress. Gates ONLY persistence:
+   * while active, the round-trip's teardown does not overwrite the user's
+   * stored preference (locked decision 2). The first `setMode` after entry
+   * ends the round-trip, so genuine, deliberate surface changes made afterwards
+   * persist as normal.
+   */
+  private _transientActive = false;
 
   /**
-   * Get the current panel mode. A transient (automatic-launch) override wins
-   * over the persisted preference; otherwise read from localStorage.
-   * Defaults to 'sidebar' for backward compatibility.
+   * Get the current panel mode. The in-memory surface override wins over the
+   * persisted preference; otherwise read from localStorage. Defaults to
+   * 'sidebar' for backward compatibility.
    */
   public getMode(): PanelMode {
     if (this._transientMode) {
@@ -90,17 +97,22 @@ class PanelModeManager {
    * When switching to 'floating', closes the extension sidebar.
    * When switching to 'sidebar', notifies the floating panel to unmount.
    *
-   * Persistence is the single enforcement point for locked decision 2: outside
-   * a transient session this writes the user's durable choice to localStorage;
-   * while a transient (auto-launch) session is active it updates the in-memory
-   * surface only, so no teardown / exit path can overwrite the stored
-   * preference. The session stays transient until a page reload.
+   * Persistence is the single enforcement point for locked decision 2:
+   * - Outside an auto-launch round-trip this writes the user's durable choice
+   *   to localStorage and drops any in-memory override.
+   * - The first call during a round-trip ENDS it. The base 'sidebar' teardown
+   *   is non-persisting (the stored preference is preserved and 'sidebar' is
+   *   kept as the in-memory current surface); any other, deliberate choice
+   *   (e.g. the user pops out to floating/fullscreen mid-round-trip) persists.
    */
   public setMode(mode: PanelMode): void {
     this.applyModeChange(mode, (next) => {
-      if (this._transientMode !== null) {
-        this._transientMode = next;
+      const endingRoundTrip = this._transientActive;
+      this._transientActive = false;
+      if (endingRoundTrip && next === 'sidebar') {
+        this._transientMode = 'sidebar';
       } else {
+        this._transientMode = null;
         localStorage.setItem(StorageKeys.PANEL_MODE, next);
       }
     });
@@ -111,11 +123,13 @@ class PanelModeManager {
    * same side effects as `setMode` (close sidebar, telemetry, mode-change
    * event) but records the choice in memory only, so the user's stored
    * preference is untouched (locked decision: an automatic launch selection
-   * must not overwrite the persisted preference). Cleared by the next explicit
-   * `setMode` (e.g. exit / auto-dock) and does not survive a reload.
+   * must not overwrite the persisted preference). Opens an auto-launch
+   * round-trip that the next `setMode` (exit / auto-dock / close) ends; does
+   * not survive a reload.
    */
   public setModeTransient(mode: PanelMode): void {
     this.applyModeChange(mode, (next) => {
+      this._transientActive = true;
       this._transientMode = next;
     });
   }

--- a/src/global-state/panel-mode.ts
+++ b/src/global-state/panel-mode.ts
@@ -56,18 +56,19 @@ class PanelModeManager {
   private _priorPath: string | null = null;
   /**
    * In-memory current surface. When non-null it wins over the persisted
-   * preference for `getMode()` and mount decisions; it is never written to
-   * localStorage. Set by an automatic launch (`setModeTransient`) and updated
-   * by its non-persisting teardown; cleared once persistence resumes so
-   * localStorage governs again. Does not survive a page reload.
+   * preference for `getMode()` and mount decisions and is never written to
+   * localStorage. Set by an automatic launch (`setModeTransient`) and updated by
+   * each non-persisting `setMode` during the round-trip; cleared when a
+   * persisting write (`setModePersisted`, or `setMode` outside a round-trip)
+   * takes over so localStorage governs again. Does not survive a page reload.
    */
   private _transientMode: PanelMode | null = null;
   /**
    * Whether an auto-launch round-trip is in progress. Gates ONLY persistence:
-   * while active, the round-trip's teardown does not overwrite the user's
-   * stored preference (locked decision 2). The first `setMode` after entry
-   * ends the round-trip, so genuine, deliberate surface changes made afterwards
-   * persist as normal.
+   * while active, plain `setMode` (every automatic teardown / exit / auto-dock,
+   * to sidebar OR floating) does not overwrite the user's stored preference
+   * (locked decision 2). The round-trip ends only when a deliberate
+   * `setModePersisted` runs or the page reloads.
    */
   private _transientActive = false;
 
@@ -94,27 +95,39 @@ class PanelModeManager {
    * Switch panel mode. Dispatches a `pathfinder-panel-mode-change` event so
    * both the sidebar and floating panel can react.
    *
-   * When switching to 'floating', closes the extension sidebar.
-   * When switching to 'sidebar', notifies the floating panel to unmount.
+   * When switching to 'floating' or 'fullscreen', closes the extension sidebar.
    *
-   * Persistence is the single enforcement point for locked decision 2:
-   * - Outside an auto-launch round-trip this writes the user's durable choice
-   *   to localStorage and drops any in-memory override.
-   * - The first call during a round-trip ENDS it. The base 'sidebar' teardown
-   *   is non-persisting (the stored preference is preserved and 'sidebar' is
-   *   kept as the in-memory current surface); any other, deliberate choice
-   *   (e.g. the user pops out to floating/fullscreen mid-round-trip) persists.
+   * This is the AUTOMATIC path and the single enforcement point for locked
+   * decision 2: while an auto-launch round-trip is active it is non-persisting
+   * for EVERY destination (teardown, exit, auto-dock to sidebar OR floating) and
+   * keeps the round-trip open, so no automatic surface change overwrites the
+   * user's stored preference. Outside a round-trip it persists the mode and
+   * drops any in-memory override. Deliberate user surface choices must use
+   * `setModePersisted`.
    */
   public setMode(mode: PanelMode): void {
     this.applyModeChange(mode, (next) => {
-      const endingRoundTrip = this._transientActive;
-      this._transientActive = false;
-      if (endingRoundTrip && next === 'sidebar') {
-        this._transientMode = 'sidebar';
+      if (this._transientActive) {
+        this._transientMode = next;
       } else {
         this._transientMode = null;
         localStorage.setItem(StorageKeys.PANEL_MODE, next);
       }
+    });
+  }
+
+  /**
+   * Switch panel mode for a DELIBERATE user surface choice (the pop-out /
+   * full-screen controls, a deep-link `panelMode=`). Always persists to
+   * localStorage, ends any active auto-launch round-trip, and drops the
+   * in-memory override so localStorage governs again. Runs the same side effects
+   * as `setMode`.
+   */
+  public setModePersisted(mode: PanelMode): void {
+    this.applyModeChange(mode, (next) => {
+      this._transientActive = false;
+      this._transientMode = null;
+      localStorage.setItem(StorageKeys.PANEL_MODE, next);
     });
   }
 

--- a/src/global-state/panel-mode.ts
+++ b/src/global-state/panel-mode.ts
@@ -7,6 +7,7 @@ import { reportPathfinderSurface, reportPathfinderSurfaceClosed } from '../lib/t
 import { type FloatingPanelGeometry, getDefaultFloatingPanelGeometry } from '../constants/floating-panel';
 import type { PackageOpenInfo } from '../types/content-panel.types';
 import type { RawContent } from '../types/content.types';
+import type { LaunchSource } from '../recovery';
 
 export type PanelMode = 'sidebar' | 'floating' | 'fullscreen';
 
@@ -42,6 +43,14 @@ export interface PendingGuide {
    * persisted to tab storage.
    */
   preparedContent?: RawContent;
+  /**
+   * Launch source of the ORIGINAL launch, carried so alignment semantics
+   * survive the surface handoff — a `home_page` launch needs the same
+   * starting-location check whether it lands in the sidebar (event path)
+   * or a floating overlay (this path). Consumers fall back to their legacy
+   * handoff source when absent.
+   */
+  source?: LaunchSource;
 }
 
 /**

--- a/src/global-state/panel-mode.ts
+++ b/src/global-state/panel-mode.ts
@@ -137,8 +137,9 @@ class PanelModeManager {
    * event) but records the choice in memory only, so the user's stored
    * preference is untouched (locked decision: an automatic launch selection
    * must not overwrite the persisted preference). Opens an auto-launch
-   * round-trip that the next `setMode` (exit / auto-dock / close) ends; does
-   * not survive a reload.
+   * round-trip during which every plain `setMode` (exit / auto-dock / close) is
+   * non-persisting; the round-trip ends only when a deliberate
+   * `setModePersisted` runs or the page reloads. Does not survive a reload.
    */
   public setModeTransient(mode: PanelMode): void {
     this.applyModeChange(mode, (next) => {

--- a/src/global-state/panel-mode.ts
+++ b/src/global-state/panel-mode.ts
@@ -6,6 +6,7 @@ import { PANEL_MODE_CHANGE_EVENT } from '../lib/event-names';
 import { reportPathfinderSurface, reportPathfinderSurfaceClosed } from '../lib/telemetry/surface';
 import { type FloatingPanelGeometry, getDefaultFloatingPanelGeometry } from '../constants/floating-panel';
 import type { PackageOpenInfo } from '../types/content-panel.types';
+import type { RawContent } from '../types/content.types';
 
 export type PanelMode = 'sidebar' | 'floating' | 'fullscreen';
 
@@ -34,6 +35,13 @@ export interface PendingGuide {
    * milestone toolbar / Alt+arrow navigation never appear.
    */
   packageInfo?: PackageOpenInfo;
+  /**
+   * Content already fetched + snippet-expanded by `prepareGuideLaunch`, carried
+   * so the receiving surface renders it without a second fetch (one-fetch
+   * launch). One-shot memory state — consumed with the pending guide, never
+   * persisted to tab storage.
+   */
+  preparedContent?: RawContent;
 }
 
 /**
@@ -47,10 +55,23 @@ class PanelModeManager {
   private _pendingGuide: PendingGuide | null = null;
   private _priorPath: string | null = null;
   /**
-   * Get the current panel mode from localStorage.
+   * In-memory surface override for an automatic launch (see `setModeTransient`).
+   * When set, it wins over the persisted preference for `getMode()` but is
+   * never written to localStorage, so an automatic surface choice does not
+   * overwrite the user's durable preference. Cleared by any explicit
+   * (persisting) `setMode` and does not survive a page reload.
+   */
+  private _transientMode: PanelMode | null = null;
+
+  /**
+   * Get the current panel mode. A transient (automatic-launch) override wins
+   * over the persisted preference; otherwise read from localStorage.
    * Defaults to 'sidebar' for backward compatibility.
    */
   public getMode(): PanelMode {
+    if (this._transientMode) {
+      return this._transientMode;
+    }
     const stored = localStorage.getItem(StorageKeys.PANEL_MODE);
     if (stored === 'floating') {
       return 'floating';
@@ -70,12 +91,35 @@ class PanelModeManager {
    * When switching to 'sidebar', notifies the floating panel to unmount.
    */
   public setMode(mode: PanelMode): void {
+    // An explicit mode change is the user's durable choice: persist it and drop
+    // any transient launch override.
+    this.applyModeChange(mode, (next) => {
+      this._transientMode = null;
+      localStorage.setItem(StorageKeys.PANEL_MODE, next);
+    });
+  }
+
+  /**
+   * Switch panel mode for an automatic launch WITHOUT persisting it. Runs the
+   * same side effects as `setMode` (close sidebar, telemetry, mode-change
+   * event) but records the choice in memory only, so the user's stored
+   * preference is untouched (locked decision: an automatic launch selection
+   * must not overwrite the persisted preference). Cleared by the next explicit
+   * `setMode` (e.g. exit / auto-dock) and does not survive a reload.
+   */
+  public setModeTransient(mode: PanelMode): void {
+    this.applyModeChange(mode, (next) => {
+      this._transientMode = next;
+    });
+  }
+
+  private applyModeChange(mode: PanelMode, commit: (mode: PanelMode) => void): void {
     const previous = this.getMode();
     if (mode === previous) {
       return;
     }
 
-    localStorage.setItem(StorageKeys.PANEL_MODE, mode);
+    commit(mode);
 
     if (mode === 'floating' || mode === 'fullscreen') {
       // Close the Grafana extension sidebar to free the slot. Full screen

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -79,6 +79,7 @@ export enum UserInteraction {
   // Learning Paths & Gamification
   LearningPathProgress = 'learning_path_progress',
   BadgeUnlocked = 'badge_unlocked',
+  GuideLaunchSurfaceChosen = 'guide_launch_surface_chosen',
 
   // Feature Flag Tracking
   FeatureFlagEvaluated = 'feature_flag_evaluated',

--- a/src/lib/event-names.ts
+++ b/src/lib/event-names.ts
@@ -10,6 +10,11 @@ export type StorageEventName = (typeof StorageEvents)[keyof typeof StorageEvents
 // detail { mode, previous }; consumed by every Pathfinder surface.
 export const PANEL_MODE_CHANGE_EVENT = 'pathfinder-panel-mode-change';
 
+// Dispatched by launch paths after panelModeManager.setPendingGuide: a
+// same-mode transient launch fires no PANEL_MODE_CHANGE_EVENT, so an
+// already-mounted floating panel must be signalled to consume directly.
+export const REQUEST_FLOATING_GUIDE_EVENT = 'pathfinder-request-floating-guide';
+
 export const FloatingPanelEvents = {
   Dodge: 'pathfinder-floating-dodge',
   Compact: 'pathfinder-floating-compact',

--- a/src/lib/event-names.ts
+++ b/src/lib/event-names.ts
@@ -15,6 +15,13 @@ export const PANEL_MODE_CHANGE_EVENT = 'pathfinder-panel-mode-change';
 // already-mounted floating panel must be signalled to consume directly.
 export const REQUEST_FLOATING_GUIDE_EVENT = 'pathfinder-request-floating-guide';
 
+// Ask the docs panel to open a URL in a new tab. Dispatched by the global
+// link interceptor, HomePanel's beside-Grafana launch path, and grot guides;
+// handled by useAutoOpenListener. Detail: { url, title, source?, launchKey? }
+// — the optional launchKey redeems a prepared launch from guideLaunchStore;
+// the payload itself never rides this forgeable event.
+export const AUTO_OPEN_DOCS_EVENT = 'pathfinder-auto-open-docs';
+
 export const FloatingPanelEvents = {
   Dodge: 'pathfinder-floating-dodge',
   Compact: 'pathfinder-floating-compact',

--- a/src/snippet-engine/index.ts
+++ b/src/snippet-engine/index.ts
@@ -9,7 +9,13 @@ export {
   createOnlineSnippetResolver,
   deriveSnippetsBaseUrl,
 } from './online-snippet-resolver';
-export { guideHasSnippetRefs, inlineSnippetRefsInBlocks, inlineSnippetRefsInGuide } from './inline-refs';
+export {
+  guideHasSnippetRefs,
+  inlineSnippetRefsInBlocks,
+  inlineSnippetRefsInGuide,
+  inlineSnippetRefsInGuideWithStatus,
+} from './inline-refs';
+export type { InlineWithStatusResult } from './inline-refs';
 export type {
   SnippetCatalogProvider,
   SnippetResolution,

--- a/src/snippet-engine/inline-refs.test.ts
+++ b/src/snippet-engine/inline-refs.test.ts
@@ -1,4 +1,4 @@
-import { inlineSnippetRefsInGuide } from './inline-refs';
+import { inlineSnippetRefsInGuide, inlineSnippetRefsInGuideWithStatus } from './inline-refs';
 import type { SnippetResolution, SnippetResolver } from './types';
 import type { JsonBlock, JsonGuide } from '../types/json-guide.types';
 
@@ -116,5 +116,37 @@ describe('inlineSnippetRefsInGuide', () => {
     const placeholder = out.blocks[0]!;
     expect(placeholder.type).toBe('markdown');
     expect((placeholder as { content: string }).content).toMatch(/missing/);
+  });
+});
+
+describe('inlineSnippetRefsInGuideWithStatus', () => {
+  it('reports no unresolved ids and returns the guide unchanged when there are no refs', async () => {
+    const g: JsonGuide = { id: 'g', title: 'g', blocks: [{ type: 'markdown', content: 'hi' }] };
+    const out = await inlineSnippetRefsInGuideWithStatus(g, new StubResolver({}));
+    expect(out.unresolvedSnippetIds).toEqual([]);
+    expect(out.guide).toEqual(g);
+  });
+
+  it('reports the ids of refs that failed to resolve while still splicing placeholders', async () => {
+    const g: JsonGuide = {
+      id: 'g',
+      title: 'g',
+      blocks: [
+        { type: 'snippet-ref', snippetId: 'ok-one' },
+        { type: 'section', title: 's', blocks: [{ type: 'snippet-ref', snippetId: 'missing' }] },
+      ],
+    };
+    const resolver = new StubResolver({ 'ok-one': ok('ok-one', [{ type: 'markdown', content: 'resolved' }]) });
+    const out = await inlineSnippetRefsInGuideWithStatus(g, resolver);
+    expect(out.unresolvedSnippetIds).toEqual(['missing']);
+    expect(out.guide.blocks[0]).toEqual({ type: 'markdown', content: 'resolved' });
+  });
+
+  it('reports an empty list when every ref resolves', async () => {
+    const g: JsonGuide = { id: 'g', title: 'g', blocks: [{ type: 'snippet-ref', snippetId: 's' }] };
+    const resolver = new StubResolver({ s: ok('s', [{ type: 'interactive', action: 'button', content: 'go' }]) });
+    const out = await inlineSnippetRefsInGuideWithStatus(g, resolver);
+    expect(out.unresolvedSnippetIds).toEqual([]);
+    expect(out.guide.blocks[0]).toMatchObject({ type: 'interactive', action: 'button' });
   });
 });

--- a/src/snippet-engine/inline-refs.ts
+++ b/src/snippet-engine/inline-refs.ts
@@ -25,21 +25,10 @@ export async function inlineSnippetRefsInBlocks(
   blocks: JsonBlock[],
   resolver: SnippetResolver = getSnippetResolver()
 ): Promise<JsonBlock[]> {
-  // Resolve all unique ref ids in parallel before the synchronous splice walk.
-  const ids = new Set<string>();
-  collectRefIds(blocks, ids);
-
-  if (ids.size === 0) {
+  const resolutions = await resolveRefs(blocks, resolver);
+  if (resolutions.size === 0) {
     return blocks;
   }
-
-  const resolutions = new Map<string, SnippetResolution>();
-  await Promise.all(
-    [...ids].map(async (id) => {
-      resolutions.set(id, await resolver.resolve(id));
-    })
-  );
-
   return spliceBlocks(blocks, resolutions);
 }
 
@@ -49,6 +38,43 @@ export async function inlineSnippetRefsInGuide(
 ): Promise<JsonGuide> {
   const blocks = await inlineSnippetRefsInBlocks(guide.blocks, resolver);
   return { ...guide, blocks };
+}
+
+/** Result of an expansion that also reports which refs could not be resolved. */
+export interface InlineWithStatusResult {
+  guide: JsonGuide;
+  /** IDs of snippet refs that failed to resolve (rendered as inert placeholders). */
+  unresolvedSnippetIds: string[];
+}
+
+/**
+ * Like {@link inlineSnippetRefsInGuide} but also reports the ids that failed to
+ * resolve. A failed ref is spliced in as an inert markdown placeholder (same as
+ * the plain path), so its id would otherwise be invisible to a downstream
+ * classifier — callers that must fail safe on a hidden action use this.
+ */
+export async function inlineSnippetRefsInGuideWithStatus(
+  guide: JsonGuide,
+  resolver: SnippetResolver = getSnippetResolver()
+): Promise<InlineWithStatusResult> {
+  const resolutions = await resolveRefs(guide.blocks, resolver);
+  const unresolvedSnippetIds = [...resolutions.values()].filter((r) => !r.ok).map((r) => r.id);
+  const blocks = resolutions.size === 0 ? guide.blocks : spliceBlocks(guide.blocks, resolutions);
+  return { guide: { ...guide, blocks }, unresolvedSnippetIds };
+}
+
+/** Resolve every unique ref id in the tree in parallel. Empty map when there are no refs. */
+async function resolveRefs(blocks: JsonBlock[], resolver: SnippetResolver): Promise<Map<string, SnippetResolution>> {
+  const ids = new Set<string>();
+  collectRefIds(blocks, ids);
+
+  const resolutions = new Map<string, SnippetResolution>();
+  await Promise.all(
+    [...ids].map(async (id) => {
+      resolutions.set(id, await resolver.resolve(id));
+    })
+  );
+  return resolutions;
 }
 
 /** True if any block in the guide tree is a `snippet-ref`. */

--- a/src/snippet-engine/online-snippet-resolver.test.ts
+++ b/src/snippet-engine/online-snippet-resolver.test.ts
@@ -57,7 +57,10 @@ describe('OnlineCdnSnippetResolver.resolve', () => {
 
     const result = await createOnlineSnippetResolver().resolve('datasource-picker');
 
-    expect(global.fetch).toHaveBeenCalledWith(`${SNIPPETS_BASE}/datasource-picker.json`);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${SNIPPETS_BASE}/datasource-picker.json`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
     expect(result).toMatchObject({ ok: true, id: 'datasource-picker', source: 'online-cdn' });
   });
 
@@ -66,7 +69,7 @@ describe('OnlineCdnSnippetResolver.resolve', () => {
 
     await createOnlineSnippetResolver().resolve('../../etc/passwd');
 
-    expect(global.fetch).toHaveBeenCalledWith(`${SNIPPETS_BASE}/..%2F..%2Fetc%2Fpasswd.json`);
+    expect(global.fetch).toHaveBeenCalledWith(`${SNIPPETS_BASE}/..%2F..%2Fetc%2Fpasswd.json`, expect.anything());
   });
 
   it('returns a network-error failure on a non-ok HTTP response (no throw)', async () => {
@@ -117,7 +120,10 @@ describe('OnlineCdnSnippetResolver.list', () => {
 
     const result = await createOnlineSnippetResolver().list();
 
-    expect(global.fetch).toHaveBeenCalledWith(`${SNIPPETS_BASE}/index.json`);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${SNIPPETS_BASE}/index.json`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
     expect(result).toEqual(catalog);
   });
 
@@ -130,5 +136,55 @@ describe('OnlineCdnSnippetResolver.list', () => {
 
     global.fetch = jest.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
     expect(await createOnlineSnippetResolver().list()).toEqual({});
+  });
+});
+
+describe('OnlineCdnSnippetResolver deadline (PR #1446 review finding 4)', () => {
+  // A CDN request that never settles must not hang the caller forever:
+  // prepareGuideLaunch awaits snippet resolution before committing a launch
+  // surface, and MyLearningTab's in-flight guard blocks all later launches
+  // until it returns. Both fetches carry AbortSignal.timeout; an abort flows
+  // through the existing catch into the unresolved-snippet fail-safe.
+  beforeEach(() => {
+    mockRecommendations.mockResolvedValue({ baseUrl: PACKAGES_BASE, packages: [] });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockNeverSettlingFetch(): AbortController {
+    const controller = new AbortController();
+    jest.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal);
+    global.fetch = jest.fn(
+      (_url: unknown, options?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          const abort = () => reject(new DOMException('This operation was aborted', 'AbortError'));
+          if (options?.signal?.aborted) {
+            abort();
+            return;
+          }
+          options?.signal?.addEventListener('abort', abort);
+        })
+    ) as unknown as typeof fetch;
+    return controller;
+  }
+
+  it('a never-settling snippet fetch resolves to a network-error failure when the deadline fires', async () => {
+    const controller = mockNeverSettlingFetch();
+
+    const pending = createOnlineSnippetResolver().resolve('datasource-picker');
+    controller.abort();
+
+    expect(await pending).toMatchObject({ ok: false, error: { code: 'network-error' } });
+  });
+
+  it('a never-settling catalog fetch resolves to an empty catalog when the deadline fires', async () => {
+    const controller = mockNeverSettlingFetch();
+
+    const pending = createOnlineSnippetResolver().list();
+    controller.abort();
+
+    expect(await pending).toEqual({});
   });
 });

--- a/src/snippet-engine/online-snippet-resolver.test.ts
+++ b/src/snippet-engine/online-snippet-resolver.test.ts
@@ -139,7 +139,7 @@ describe('OnlineCdnSnippetResolver.list', () => {
   });
 });
 
-describe('OnlineCdnSnippetResolver deadline (PR #1446 review finding 4)', () => {
+describe('OnlineCdnSnippetResolver deadline', () => {
   // A CDN request that never settles must not hang the caller forever:
   // prepareGuideLaunch awaits snippet resolution before committing a launch
   // surface, and MyLearningTab's in-flight guard blocks all later launches

--- a/src/snippet-engine/online-snippet-resolver.ts
+++ b/src/snippet-engine/online-snippet-resolver.ts
@@ -7,6 +7,7 @@
  * `deriveSnippetsBaseUrl`).
  */
 
+import { DEFAULT_CONTENT_FETCH_TIMEOUT } from '../constants';
 import { fetchOnlinePackageRecommendations } from '../lib/package-recommendations-client';
 import { JsonSnippetSchema, SnippetCatalogSchema } from '../types/json-snippet.schema';
 import type { JsonSnippet, SnippetCatalog } from '../types/json-snippet.types';
@@ -41,7 +42,7 @@ export class OnlineCdnSnippetResolver implements SnippetResolver, SnippetCatalog
 
     const url = `${baseUrl}/${encodeURIComponent(snippetId)}.json`;
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, { signal: AbortSignal.timeout(DEFAULT_CONTENT_FETCH_TIMEOUT) });
       if (!response.ok) {
         return {
           ok: false,
@@ -72,7 +73,9 @@ export class OnlineCdnSnippetResolver implements SnippetResolver, SnippetCatalog
     }
 
     try {
-      const response = await fetch(`${baseUrl}/index.json`);
+      const response = await fetch(`${baseUrl}/index.json`, {
+        signal: AbortSignal.timeout(DEFAULT_CONTENT_FETCH_TIMEOUT),
+      });
       if (!response.ok) {
         return {};
       }

--- a/src/types/learning-paths.types.ts
+++ b/src/types/learning-paths.types.ts
@@ -169,6 +169,10 @@ export interface LearningPathCardProps {
   onContinue: (guideId: string, pathId: string) => void;
   /** Callback when user clicks to reset the path (optional) */
   onReset?: (pathId: string) => void;
+  /** A launch from THIS card is being prepared (fetch + classify) */
+  isLaunching?: boolean;
+  /** Any launch is in flight — continue is disabled so clicks aren't silently dropped */
+  launchDisabled?: boolean;
 }
 
 /**

--- a/src/types/link-interception.types.ts
+++ b/src/types/link-interception.types.ts
@@ -1,6 +1,3 @@
-import type { RawContent } from './content.types';
-import type { PackageOpenInfo } from './content-panel.types';
-
 /**
  * A docs link captured from an intercepted navigation event, queued for the
  * sidebar to open. Lives in Tier 0 so the link-interception state manager and
@@ -12,17 +9,11 @@ export interface QueuedDocsLink {
   title: string;
   timestamp: number;
   /**
-   * Content already fetched + snippet-expanded by `prepareGuideLaunch`, carried
-   * through the cold-sidebar open queue so the tab renders without a second
-   * fetch (one-fetch launch). One-shot memory state — the queue is never
-   * persisted, so this never reaches storage.
+   * Opaque key redeeming a prepared (one-fetch) launch payload from the
+   * module-owned `guideLaunchStore`. The queue is writable by any same-page
+   * script, so the payload itself never rides it — only this key, which the
+   * auto-open listener redeems at the trusted boundary (a forged or stale
+   * key falls back to a normal fetch).
    */
-  preparedContent?: RawContent;
-  /**
-   * Package context derived by `prepareGuideLaunch`, carried through the queue
-   * so a package-backed guide keeps its milestone toolbar / package render type
-   * on the cold-sidebar path (the destination loader skips re-derivation for
-   * prefetched launches). One-shot memory state — never persisted.
-   */
-  packageInfo?: PackageOpenInfo;
+  launchKey?: string;
 }

--- a/src/types/link-interception.types.ts
+++ b/src/types/link-interception.types.ts
@@ -1,4 +1,5 @@
 import type { RawContent } from './content.types';
+import type { PackageOpenInfo } from './content-panel.types';
 
 /**
  * A docs link captured from an intercepted navigation event, queued for the
@@ -17,4 +18,11 @@ export interface QueuedDocsLink {
    * persisted, so this never reaches storage.
    */
   preparedContent?: RawContent;
+  /**
+   * Package context derived by `prepareGuideLaunch`, carried through the queue
+   * so a package-backed guide keeps its milestone toolbar / package render type
+   * on the cold-sidebar path (the destination loader skips re-derivation for
+   * prefetched launches). One-shot memory state — never persisted.
+   */
+  packageInfo?: PackageOpenInfo;
 }

--- a/src/types/link-interception.types.ts
+++ b/src/types/link-interception.types.ts
@@ -1,3 +1,5 @@
+import type { RawContent } from './content.types';
+
 /**
  * A docs link captured from an intercepted navigation event, queued for the
  * sidebar to open. Lives in Tier 0 so the link-interception state manager and
@@ -8,4 +10,11 @@ export interface QueuedDocsLink {
   url: string;
   title: string;
   timestamp: number;
+  /**
+   * Content already fetched + snippet-expanded by `prepareGuideLaunch`, carried
+   * through the cold-sidebar open queue so the tab renders without a second
+   * fetch (one-fetch launch). One-shot memory state — the queue is never
+   * persisted, so this never reaches storage.
+   */
+  preparedContent?: RawContent;
 }

--- a/src/utils/pathfinder-deep-link-handler.test.ts
+++ b/src/utils/pathfinder-deep-link-handler.test.ts
@@ -30,10 +30,12 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 const mockSetMode = jest.fn();
+const mockSetModePersisted = jest.fn();
 const mockGetMode = jest.fn().mockReturnValue('sidebar');
 jest.mock('../global-state/panel-mode', () => ({
   panelModeManager: {
     setMode: (mode: string) => mockSetMode(mode),
+    setModePersisted: (mode: string) => mockSetModePersisted(mode),
     getMode: () => mockGetMode(),
   },
 }));
@@ -166,7 +168,7 @@ describe('handlePathfinderDeepLink', () => {
     const deps = mkDeps();
 
     expect(handlePathfinderDeepLink(deps)).toBe(true);
-    expect(mockSetMode).toHaveBeenCalledWith('floating');
+    expect(mockSetModePersisted).toHaveBeenCalledWith('floating');
     expect(window.location.search).toBe('?keep=this');
   });
 
@@ -175,7 +177,7 @@ describe('handlePathfinderDeepLink', () => {
     const deps = mkDeps();
 
     expect(handlePathfinderDeepLink(deps)).toBe(true);
-    expect(mockSetMode).toHaveBeenCalledWith('fullscreen');
+    expect(mockSetModePersisted).toHaveBeenCalledWith('fullscreen');
 
     const target = mockLocationServiceReplace.mock.calls[0][0] as string;
     expect(target).toContain('/a/grafana-pathfinder-app/fullscreen?');
@@ -243,7 +245,7 @@ describe('handlePathfinderDeepLink', () => {
     const deps = mkDeps();
 
     expect(handlePathfinderDeepLink(deps)).toBe(true);
-    expect(mockSetMode).toHaveBeenCalledWith('floating');
+    expect(mockSetModePersisted).toHaveBeenCalledWith('floating');
 
     await flushPromises();
     // panelMode is consumed; doc survives for FullScreenPanel rehydration.

--- a/src/utils/pathfinder-deep-link-handler.ts
+++ b/src/utils/pathfinder-deep-link-handler.ts
@@ -82,10 +82,10 @@ export function handlePathfinderDeepLink(deps: DeepLinkHandlerDeps): boolean {
   }
 
   if (panelModeParam === 'floating') {
-    panelModeManager.setMode('floating');
+    panelModeManager.setModePersisted('floating');
     rewriteCurrentUrl((url) => url.searchParams.delete('panelMode'));
   } else if (panelModeParam === 'fullscreen') {
-    panelModeManager.setMode('fullscreen');
+    panelModeManager.setModePersisted('fullscreen');
     rewriteCurrentUrl((url) => url.searchParams.delete('panelMode'));
     let target = `${PLUGIN_BASE_URL}/${ROUTES.FullScreen}`;
     if (docsParam) {


### PR DESCRIPTION
## Intent

A large amount of **non-interactive** content is coming to Pathfinder, and it will be launched from the **My Learning** page. Non-interactive content — prose, images, video — is a poor fit for the sidebar: it doesn't use the available screen real estate, and the sidebar's whole reason for being is to let you _use Grafana while a guide runs beside it_. That benefit means nothing for content you only read or watch.

So this began with one question: **how do we make sure non-interactive content launches in full-screen mode, since it needs no app interaction?**

Answering it honestly pulled in the other half of the problem: sometimes you launch content that **is** interactive, and that content genuinely needs the sidebar so its "show me / do it" steps can drive the real Grafana UI. A launch therefore has to decide, per guide, which surface fits — without a jarring switch, and without trampling a preference the user set themselves.

That gives three requirements:

1. **Determine whether a guide needs the Grafana UI.** We deliberately did **not** add another manifest metadata field for this. Whether a guide drives the Grafana UI is _computable from the guide's own content_ — so we compute it, and a value derived from the content it describes can never drift out of sync with that content. A hand-maintained flag inevitably would (an author adds an interactive step, forgets the flag → wrong surface). The classifier is `src/components/docs-panel/utils/requires-grafana-ui.ts`; it detects the Grafana-driving actions `highlight`, `button`, `formfill`, `navigate`, `hover`, plus `code-block` (whose required `reftarget` targets a live Monaco editor) (`src/types/json-guide.schema.ts`), recursing through sections, multistep/guided steps, conditionals, and resolved snippet references.
2. **Decide the launch surface as the guide loads.** `src/components/docs-panel/utils/prepare-guide-launch.ts` fetches the guide, resolves its snippets, classifies it, and carries that _same_ fetched content into the chosen surface — one fetch, surface committed before render, so there's no second load and no visible bounce. Wired into the My Learning launch path (`src/components/LearningPaths/MyLearningTab.tsx`, `src/components/Home/HomePanel.tsx`, `src/components/docs-panel/docs-panel.tsx`).
3. **Respect the user's own preference.** An automatic launch choice is _transient_ — it never overwrites the panel-mode preference the user set deliberately; only genuine user surface choices (pop-out, switch to full-screen/floating, `panelMode=` deep link) persist. Enforced centrally in `src/global-state/panel-mode.ts`.

## What changes

- A **non-interactive** guide launched from My Learning now opens **full-screen** automatically, using the whole content area for reading (previously: sidebar).
- An **interactive** guide launched from My Learning opens in the **sidebar** (or a floating panel if another plugin owns the sidebar), chosen from the guide's real content rather than a fixed default.
- The surface is decided **as the guide loads**, from a single fetch — no switch after render.
- **Code blocks count as interactive**: a guide whose only interactivity is a `code-block` still opens beside Grafana, because its "Show me" highlights and "Insert" mutates a live Monaco editor that doesn't exist in full-screen mode.

## How the prepared content travels (hardened after review)

The launch handoff crosses two kinds of channel, and after the review pass they are treated differently:

- **Trusted, module-owned memory** — `panelModeManager.setPendingGuide` (full-screen and occupied-sidebar→floating handoffs). Carries the prepared payload directly; consumed once on the receiving surface's mount via the shared `consumePendingGuideOnMount` router, so all surfaces route identically. The pending guide also carries the original launch `source`, so the starting-location alignment check behaves the same regardless of which surface the guide lands in.
- **Public channels** — the `pathfinder-auto-open-docs` CustomEvent and the cold-sidebar link queue, both writable by any same-page script. These never carry the payload. The producer stages it in a module-owned, consume-once store (`src/global-state/guide-launch.ts`) and sends only an opaque `launchKey`; the listener redeems the key at the trusted boundary. Redemption requires the key to be genuine, unused, less than 60s old, and presented with the exact URL it was staged for. **Any miss falls back to the loader's normal validated fetch** — the optimization's failure mode is the pre-existing two-fetch behavior, never trust in unvalidated content.

Snippet resolution during launch preparation is deadline-bounded (`AbortSignal.timeout` on the CDN fetches); a timeout flows into the existing unresolved-snippet fail-safe, which forces the sidebar rather than hiding a possibly-interactive guide in full-screen mode.

## What does NOT change

- **Your saved panel-mode preference is never overwritten by an auto-launch.** Reading a prose guide (transient full-screen) and exiting leaves your saved preference untouched. Deliberately choosing a surface still persists as before.
- **Manual full-screen entry/exit** behaves exactly as it always did.
- **Guides launched from anywhere other than My Learning** are unaffected — this is scoped to the My Learning launch path.
- **Cold `/fullscreen?doc=` deep links** are honored exactly as before.
- **The interactive engine is untouched** — "show me / do it / do section", section completion, starting-location alignment, journey navigation, and completion tracking all behave as before. This PR decides _which surface a guide opens in_, not how guides run.
- **No new manifest field, no authoring burden** — authors tag nothing; the behavior falls out of the content.
- **The `pathfinder-auto-open-docs` event keeps its pinned pre-PR detail shape** (`{url, title, source}`), extended only by the opaque `launchKey`.

## Testing

- **Classifier** (`requires-grafana-ui.test.ts`): the five Grafana-driving actions detected through sections, multistep/guided steps, conditionals, and snippet-refs; regression tests prove a `code-block`-only guide (top-level and nested) forces the sidebar; negative cases confirm `noop`, `popout`, quiz/input/terminal/etc. do **not**.
- **Prepared launch** (`prepare-guide-launch.test.ts`): fetch → resolve snippets → classify → carry, verifying a single content fetch.
- **Trust boundary** (`guide-launch.test.ts`, `useAutoOpenListener.test.ts`): consume-once redemption; forged, replayed, stale, and URL-mismatched keys all fall back to the normal fetch; a forged event smuggling `preparedContent`/`packageInfo` inline is ignored.
- **Cold-sidebar relay** (`useAutoOpenListener.cold-sidebar-relay.test.ts`): the real queue, real store, and real listener relay a staged payload end to end (queue → drain → event → listener → model) with zero network fetches; the loader's no-fetch consumption of `preparedContent` is pinned in `docs-panel.load-tab-content.test.ts`.
- **Occupied-sidebar → floating handoff** (`pendingGuideRouter.test.ts`, `floating-panel.pending-guide.test.ts`): the floating surface consumes the pending guide exactly once on mount, marks the open in-flight before the restoration/empty-state gates can run, and preserves the original launch source.
- **Launch deadline** (`online-snippet-resolver.test.ts`): a never-settling snippet CDN fetch resolves into the existing failure shapes instead of hanging the launch.
- **Acceptance criteria:**
  - **A** — a non-interactive guide launched from My Learning opens full-screen.
  - **B** — an interactive guide launched from My Learning opens in the sidebar.
  - **C** — launch independence: B opens in the sidebar regardless of whether A launched first, and A opens full-screen regardless of whether B launched first (both orderings).
- **Preference round-trip invariant** (`panel-mode.test.ts`): a stored non-default preference (e.g. `floating`) survives an auto-launch enter + teardown across sidebar, full-screen exit, and floating teardown (including the auto-dock-to-floating path); a deliberate mode change after a round-trip still persists.
- **CI:** all checks green on the head commit, including the six-image Playwright e2e matrix.

## Review response

All six findings from the [review](https://github.com/grafana/grafana-pathfinder-app/pull/1446#issuecomment-5110518588) are dispositioned ([full mapping](https://github.com/grafana/grafana-pathfinder-app/pull/1446#issuecomment-5111106120)): findings 1–5 fixed in dedicated commits (`8b9c47b6`, `5c92ccdf`, `74cfec0a`, `5849d59b`, `c41bdbbe` — one per finding, rationale in each message); finding 6 explicitly deferred to #1448 (needs a new panel-mode primitive and touches the race-sensitive auto-dock — split so this PR's surface stays reviewable). Adjacent debt discovered while verifying the review is tracked in #1449 and #1450, both out of scope here.
