### PR TITLE
feat(docs-panel): tab-bar chrome — Pathfinder wordmark + My learning tab (#1256)

### DIFF
--- a/src/components/docs-panel/components/DocsPanelTabBar.test.tsx
+++ b/src/components/docs-panel/components/DocsPanelTabBar.test.tsx
@@ -80,6 +80,13 @@ describe('DocsPanelTabBar', () => {
     expect(props.onSetActiveTab).not.toHaveBeenCalled();
   });
 
+  // jsdom can't evaluate the @container query that hides the wordmark at narrow
+  // widths, so this asserts presence only — the responsive hide isn't unit-testable.
+  it('renders the "Interactive Learning" wordmark', () => {
+    render(<DocsPanelTabBar {...makeProps()} />);
+    expect(screen.getByText('Interactive Learning')).toBeInTheDocument();
+  });
+
   describe('overflow chevron', () => {
     const overflowTab: any = { id: 'overflow-1', title: 'overflow-1', baseUrl: '', currentUrl: '' };
 

--- a/src/components/docs-panel/components/DocsPanelTabBar.tsx
+++ b/src/components/docs-panel/components/DocsPanelTabBar.tsx
@@ -74,6 +74,10 @@ export function DocsPanelTabBar({
     <div className={styles.tabBar} ref={tabBarRef} data-testid={testIds.docsPanel.tabBar}>
       {/* Permanent icon-only tabs */}
       <div className={styles.permanentTabs}>
+        <div className={styles.wordmarkGroup}>
+          <span className={styles.wordmark}>{t('docsPanel.wordmark', 'Interactive Learning')}</span>
+          <div className={styles.tabDivider} aria-hidden="true" />
+        </div>
         <button
           className={`${styles.iconTab} ${activeTabId === 'recommendations' ? styles.iconTabActive : ''}`}
           onClick={() => onSetActiveTab('recommendations')}

--- a/src/locales/en-US/grafana-pathfinder-app.json
+++ b/src/locales/en-US/grafana-pathfinder-app.json
@@ -50,7 +50,8 @@
     "settings": "Settings",
     "showMoreTabs_one": "Show {{count}} more tab",
     "showMoreTabs_other": "Show {{count}} more tabs",
-    "switchToTab": "Switch to {{title}}"
+    "switchToTab": "Switch to {{title}}",
+    "wordmark": "Interactive Learning"
   },
   "myLearning": {
     "badges": "Badges",

--- a/src/styles/docs-panel.styles.ts
+++ b/src/styles/docs-panel.styles.ts
@@ -220,6 +220,11 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
     overflow: 'visible', // Allow dropdown to extend below tab bar
     position: 'relative', // Positioning context for absolute dropdown
     flexShrink: 0, // Don't shrink, stay compact
+    // container-type makes this a query container for the wordmark's narrow-width
+    // hide — which also makes it a stacking context, so lift the whole bar above
+    // page content (below modals) to keep the overflow dropdown painting on top.
+    containerType: 'inline-size',
+    zIndex: theme.zIndex.navbarFixed,
   }),
   tabList: css({
     label: 'combined-journey-tab-list',
@@ -238,6 +243,25 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
     alignItems: 'center',
     gap: theme.spacing(0.5),
     flexShrink: 0,
+  }),
+  // "Interactive Learning" wordmark + divider — the plugin's external name.
+  // Branding is the first thing to drop when the bar is narrow.
+  wordmarkGroup: css({
+    label: 'combined-journey-wordmark-group',
+    display: 'inline-flex',
+    alignItems: 'center',
+    flexShrink: 0,
+    '@container (max-width: 360px)': {
+      display: 'none',
+    },
+  }),
+  wordmark: css({
+    label: 'combined-journey-wordmark',
+    paddingLeft: theme.spacing(0.5),
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+    color: theme.colors.text.secondary,
+    whiteSpace: 'nowrap',
   }),
   iconTab: css({
     label: 'combined-journey-icon-tab',
@@ -419,7 +443,7 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
     position: 'absolute',
     top: '100%',
     right: 0, // Align with the right edge of the chevron button
-    zIndex: 9999, // High z-index to appear above content
+    zIndex: 9999, // Stack above other tab-bar items (the bar's z-index lifts the dropdown above page content)
     minWidth: '220px',
     maxWidth: '320px',
     backgroundColor: theme.colors.background.primary,

--- a/src/styles/docs-panel.styles.ts
+++ b/src/styles/docs-panel.styles.ts
@@ -251,6 +251,7 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
     display: 'inline-flex',
     alignItems: 'center',
     flexShrink: 0,
+    gap: theme.spacing(1),
     '@container (max-width: 360px)': {
       display: 'none',
     },


### PR DESCRIPTION
PR 6 (final) of the block-editor header redesign stack (issue #1256, change 7). **Independent of the editor header** — branches off `main`.

## What this does

Adds the **"Interactive Learning" wordmark** (the plugin's external name) + a vertical divider to the docs-panel tab bar. The wordmark hides below a 360px container width so branding yields first when the bar is narrow.

`container-type: inline-size` (the wordmark's query container) makes the tab bar a stacking context, so the bar takes `theme.zIndex.navbarFixed` to keep the tab-overflow dropdown painting above page content (below modals).

## Scope note — reduced from the original change-7 plan

Parallel work is removing the editor/devtools permanent tabs (leaving a single, non-dismissable Recommendations tab, so no in-panel navigation is needed) and separately owns the "My learning" affordance. To avoid conflicts and wasted effort, this PR was reduced to **just the wordmark + divider** and leaves the following to that parallel work:

- The recommendations tab's icon and title — a new "recommendations" icon is wanted (TBD; a book icon would conflate it with My learning), so it's left as-is here.
- The "My learning" book button and its placement (stays right-justified per design; not moved into a kebab).
- The tab-overflow reserve calc.

## Verification

- Unit (`DocsPanelTabBar` + contract), lint, prettier, `tsc` — green.
- The wordmark's responsive hide is a container query (not unit-testable in jsdom); the unit test asserts presence.

## Screenshots
<img width="536" height="155" alt="pathfinder-header-wordmark" src="https://github.com/user-attachments/assets/5bb40121-b042-4232-8800-1bf733813c76" />

