### PR TITLE
docs: correct release runbook to reflect the real CD-based release flow

### DIFF
--- a/.cursor/skills/release-prep/SKILL.md
+++ b/.cursor/skills/release-prep/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: release-prep
-description: Orchestrate the pre-release flow for grafana-pathfinder-app — bump the version in package.json, draft a CHANGELOG entry (via the `changelog` skill), run `npm run check` and `npm run build`, then print the exact `git tag` command for the user to execute. Never creates or pushes the tag itself; tagging is a one-way door the user owns.
+description: Orchestrate the pre-release flow for grafana-pathfinder-app — bump the version in package.json + package-lock.json, draft a CHANGELOG entry (via the `changelog` skill), and run `npm run check` and `npm run build` under the repo's pinned Node (`.nvmrc`). Commits on a branch for a release-prep PR to protected `main`. The release itself is a manual CD deploy (the `Plugins - CD` workflow), NOT a git tag.
 ---
 
 # Release prep
 
-Pre-release orchestrator. Handles the safe, reversible parts of cutting a release (version bump, changelog, validation) and stops short of the irreversible step (tag push) so the user reviews everything before the GitHub release workflow fires.
+Pre-release orchestrator. Handles the safe, reversible parts of cutting a release (version bump, changelog, validation) and stops before merging the release-prep PR and running the CD deploy, so the user reviews everything first. Pathfinder is **not** released by pushing a `v*` tag — see `docs/developer/RELEASE_PROCESS.md`; the release is a manual `Plugins - CD` dispatch of `main` to each environment.
 
 This skill pairs with `.cursor/skills/changelog/SKILL.md`, which drafts the actual CHANGELOG entry. `release-prep` is the wrapper that runs `changelog` plus the surrounding validation.
 
@@ -13,8 +13,8 @@ This skill pairs with `.cursor/skills/changelog/SKILL.md`, which drafts the actu
 
 These constraints are absolute and override any other instructions:
 
-1. **Never create or push the git tag.** Print the exact command for the user to run. The user controls the moment of release.
-2. **Never push commits.** Stay on the local branch.
+1. **No git tag.** Pathfinder does not release via tags — the release is a manual CD deploy (`Plugins - CD`). Do not create or push a `v*` tag.
+2. **Never commit to or push `main` (it's protected).** Commit on a branch; the release-prep change lands via a PR the user merges. Do not deploy — the user runs the CD dispatch.
 3. **`npm run check` must pass before claiming "ready".** If it fails, abort with the failure log and stop. Do not "fix-up and retry" — a failing check is real signal.
 4. **Only edit `package.json` (version bump), `package-lock.json` (synced version fields), and `CHANGELOG.md`** (via the `changelog` skill). No other files. `src/plugin.json` carries `"%VERSION%"` and is substituted at build time — never edit it.
 5. **If the proposed tag already exists**, abort.
@@ -129,13 +129,13 @@ When the `changelog` skill is invoked from `release-prep`, override its Phase 3 
 
 ### Phase 4 — Validate
 
-1. **Run `npm run check`** — the canonical pre-merge gate:
+1. **Run `npm run check`** — the canonical pre-merge gate. **Run it under the repo's pinned Node** (`.nvmrc` = 24.18; the repo requires Node ≥ 24). On an older Node it fails spuriously (e.g. the `import-graph` `node:test` assertion, and the TS/webpack build). If a version manager isn't auto-switching, pin explicitly — e.g. `fnm exec --using 24.18 -- npm run check`.
 
    ```
    npm run check
    ```
 
-   This runs (per `package.json`): typecheck + lint + prettier-test + docs:sync-terms:check + lint:go + test:go + test:ci. If any step fails, **abort**. Print the failure log verbatim. Do not commit. Do not retry.
+   This runs (per `package.json`): typecheck + lint + prettier-test + docs:sync-terms:check + lint:go + test:go + test:coverage. If any step fails, **abort**. Print the failure log verbatim. Do not commit. Do not retry.
 
 2. **Run `npm run build`** — confirm the production bundle still builds:
 
@@ -147,7 +147,7 @@ When the `changelog` skill is invoked from `release-prep`, override its Phase 3 
 
 3. **Skip plugin signing.** Per `docs/developer/RELEASE_PROCESS.md`, signing is currently disabled (would require `policy_token` in repo secrets). If signing is re-enabled later, this skill should be updated to run `npm run sign` here.
 
-### Phase 5 — Commit and hand off
+### Phase 5 — Commit on a branch, open the PR, and hand off
 
 1. Verify only the expected files changed:
 
@@ -165,31 +165,31 @@ When the `changelog` skill is invoked from `release-prep`, override its Phase 3 
 
    If anything else appears, abort. The skill should never modify other files.
 
-2. **Commit** (do not push):
+2. **Commit on a release-prep branch** (never on `main` — it's protected):
 
    ```
+   git checkout -b chore/prep-v<version>
    git add CHANGELOG.md package.json package-lock.json
    git commit -m "chore: prep v<version> release"
+   git push -u origin chore/prep-v<version>
    ```
 
-3. **Print the release summary**:
+3. **Open the release-prep PR** to `main` (`gh pr create --base main`), then **print the summary**:
 
    ```
-   Ready to release v<version>.
+   Release-prep PR opened for v<version>.
 
    Previous: v<last-version>
    Included: <N> PRs (<X> added, <Y> fixed, <Z> chore)
 
-   To cut the release, run:
+   To release, once the PR is approved + merged to main:
+     1. Dispatch "Plugins - CD" (publish.yml): branch=main, environment=dev — verify.
+     2. Repeat for ops, then prod-canary, then prod.
+     3. For prod-canary + prod, click "Resume" on the paused approval step in the
+        Argo UI (argo-workflows.grafana.net, grafana-plugins-cd). Watch #pathfinder-app-release.
 
-     git push origin main
-     git tag -a v<version> -m "Release v<version>"
-     git push origin v<version>
-
-   The `release.yml` workflow triggers on `v*` tag push and creates the GitHub release.
+   No git tag is involved. See docs/developer/RELEASE_PROCESS.md.
    ```
-
-   Order matters: push the commit first so the tag points at an upstream-known SHA, then tag, then push the tag. Confirm this order with the user if they're unfamiliar.
 
 ## Reuses
 
@@ -201,7 +201,7 @@ When the `changelog` skill is invoked from `release-prep`, override its Phase 3 
 ## Integration
 
 - Invoked manually by the maintainer before each release.
-- Pairs with `release.yml` GitHub workflow (which fires on `v*` tag push) — the skill ends where the workflow begins.
+- The release is a manual `Plugins - CD` (`publish.yml`) dispatch of `main` to each environment — the skill ends where that deploy begins. It does **not** use the tag-based `release.yml` (see `docs/developer/RELEASE_PROCESS.md`).
 - Pairs with `/changelog` — release-prep calls it as a sub-step.
 
 ## Abort conditions
@@ -239,7 +239,7 @@ Total context per run: under 30k tokens for a typical release. Pull `npm run che
 
 ## What this skill does NOT do
 
-- Push commits or tags
+- Push to `main`, create git tags, merge the release-prep PR, or run the CD deploy
 - Sign the plugin (disabled per RELEASE_PROCESS.md)
 - Run E2E tests (`npm run e2e` is not part of `npm run check`; if needed, the user runs it separately)
 - Coordinate cross-repo releases (e.g., `grafana-recommender`) — out of scope
@@ -268,15 +268,15 @@ Reply with the version to proceed.
 ✓ CHANGELOG drafted (3 added, 7 fixed, 5 chore)
 ✓ npm run check (132 suites, 2511 tests, all passing)
 ✓ npm run build (bundle produced)
-✓ Committed: chore: prep v2.11.0 release
+✓ Committed on chore/prep-v2.11.0: chore: prep v2.11.0 release
+✓ Pushed branch + opened release-prep PR
 
-Ready to release v2.11.0.
+Release-prep PR opened for v2.11.0.
 
-To cut the release, run:
+To release, once the PR is approved + merged to main:
+  1. Dispatch "Plugins - CD": branch=main, environment=dev — verify.
+  2. Repeat for ops, then prod-canary, then prod.
+  3. For prod-canary + prod, click "Resume" on the paused Argo approval step. Watch #pathfinder-app-release.
 
-  git push origin main
-  git tag -a v2.11.0 -m "Release v2.11.0"
-  git push origin v2.11.0
-
-The `release.yml` workflow triggers on `v*` tag push and creates the GitHub release.
+No git tag is involved.
 ```

--- a/.cursor/skills/release-prep/SKILL.md
+++ b/.cursor/skills/release-prep/SKILL.md
@@ -17,7 +17,7 @@ These constraints are absolute and override any other instructions:
 2. **Never commit to or push `main` (it's protected).** Commit on a branch; the release-prep change lands via a PR the user merges. Do not deploy — the user runs the CD dispatch.
 3. **`npm run check` must pass before claiming "ready".** If it fails, abort with the failure log and stop. Do not "fix-up and retry" — a failing check is real signal.
 4. **Only edit `package.json` (version bump), `package-lock.json` (synced version fields), and `CHANGELOG.md`** (via the `changelog` skill). No other files. `src/plugin.json` carries `"%VERSION%"` and is substituted at build time — never edit it.
-5. **If the proposed tag already exists**, abort.
+5. **If a `v<version>` tag already exists, abort** — version numbers must be unique. Historical `v<version>` tags are used only as version markers / changelog-range boundaries; this skill never creates or pushes one.
 6. **If the working tree is dirty**, abort with `git status` output. Don't try to be clever about which dirt is safe.
 7. **One commit.** Title: `chore: prep v<version> release`. Contains the version bump (manifest + lockfile) + CHANGELOG draft.
 
@@ -68,7 +68,7 @@ If the user passed `/release-prep <version>`, use it. Otherwise suggest one.
 
 - Must be valid semver: `\d+\.\d+\.\d+` (no pre-release suffixes — the repo uses none).
 - Must be strictly greater than the last tag (no regressions).
-- Tag `v<version>` must not already exist: `git tag -l v<version>` returns nothing.
+- The version must be unused — no existing `v<version>` tag (`git tag -l v<version>` returns nothing). These tags are historical version markers used for the changelog range, not release triggers; the skill doesn't create one.
 
 **Auto-suggestion** (when no arg given):
 
@@ -208,15 +208,15 @@ When the `changelog` skill is invoked from `release-prep`, override its Phase 3 
 
 The skill must abort cleanly (no partial state, no commits) if any of these are true:
 
-| Condition                                     | Reason                                                                |
-| --------------------------------------------- | --------------------------------------------------------------------- |
-| Working tree dirty                            | Cannot reason about what state is being released                      |
-| Branch behind origin                          | Upstream commits would be missing from the release                    |
-| Tag `v<version>` already exists               | Cannot reuse a tag; double-tagging breaks GitHub releases             |
-| Version is not strictly > last tag            | Regression — semver violation                                         |
-| `npm run check` fails                         | Test suite or lint catches a real problem                             |
-| `npm run build` fails                         | Production bundle is broken                                           |
-| `git diff --name-only` shows unexpected paths | Skill must only touch package.json + package-lock.json + CHANGELOG.md |
+| Condition                                     | Reason                                                                     |
+| --------------------------------------------- | -------------------------------------------------------------------------- |
+| Working tree dirty                            | Cannot reason about what state is being released                           |
+| Branch behind origin                          | Upstream commits would be missing from the release                         |
+| `v<version>` version marker already exists    | Version numbers must be unique (these tags mark already-released versions) |
+| Version is not strictly > last tag            | Regression — semver violation                                              |
+| `npm run check` fails                         | Test suite or lint catches a real problem                                  |
+| `npm run build` fails                         | Production bundle is broken                                                |
+| `git diff --name-only` shows unexpected paths | Skill must only touch package.json + package-lock.json + CHANGELOG.md      |
 
 When aborting, print the failure reason clearly and (where applicable) the exact log line that triggered the abort. Do not leave partial commits behind.
 

--- a/docs/developer/RELEASE_PROCESS.md
+++ b/docs/developer/RELEASE_PROCESS.md
@@ -8,7 +8,7 @@ The project uses several GitHub Actions workflows for different release scenario
 
 ### 1. Tag-based build (`.github/workflows/release.yml`) — NOT the release path
 
-> **Do not release by pushing a tag.** This workflow builds a plugin zip + GitHub release on a `v*` tag push, but it is **not how Pathfinder ships** and is not exercised in practice — no v2.x tag has triggered it, and the v2.x GitHub releases are unpublished drafts. It also currently fails (the `build-plugin` action defaults to Node 20; the repo requires Node ≥ 24). Releases go out via the CD workflow (#2). The file is kept for reference only.
+> **Do not release by pushing a tag.** This workflow builds a plugin zip + GitHub release on a `v*` tag push, but it is **not how Pathfinder ships** and is not exercised in practice — no v2.x tag has triggered it, and the v2.x GitHub releases are unpublished drafts. It also currently fails: `release.yml` doesn't pin a Node version, while the repo requires Node ≥ 24 (`package.json` `engines` / `.nvmrc`), so the build runs on too old a Node. Releases go out via the CD workflow (#2). The file is kept for reference only.
 
 ### 2. Manual Publishing (`.github/workflows/publish.yml`)
 
@@ -115,7 +115,7 @@ Under the hood, CD opens a `grafana/deployment_tools` PR per environment that bu
 - **dev + ops** — the deployment_tools PR **auto-merges** once its CI passes; no manual action.
 - **prod-canary + prod** — the Argo workflow **pauses at an approval step**. Monitor the run in the Argo UI (`argo-workflows.grafana.net`, `grafana-plugins-cd`) and click **"Resume"** on each paused approval step to let it proceed. You approve in **Argo**, not in `deployment_tools` — CD handles the PR after approval.
 
-Deploy-start, per-environment PR links, and "waiting for manual approval… click Resume" prompts all post to Slack **`#pathfinder-app-release`**.
+Deploy start, per-environment PR links, and "waiting for manual approval… click Resume" prompts are all posted to Slack **`#pathfinder-app-release`**.
 
 ## Monitoring and Notifications
 

--- a/docs/developer/RELEASE_PROCESS.md
+++ b/docs/developer/RELEASE_PROCESS.md
@@ -6,14 +6,9 @@ This document describes how releases are created and managed for the Grafana Pat
 
 The project uses several GitHub Actions workflows for different release scenarios:
 
-### 1. Tag-Based Plugin Releases (`.github/workflows/release.yml`)
+### 1. Tag-based build (`.github/workflows/release.yml`) — NOT the release path
 
-- **Trigger**: Push of version tags matching pattern `v*` (e.g., `v1.0.0`)
-- **Process**:
-  - Uses `grafana/plugin-actions/build-plugin` action
-  - Builds the plugin for distribution
-  - Plugin signing is available but currently commented out
-  - Creates GitHub release with built artifacts
+> **Do not release by pushing a tag.** This workflow builds a plugin zip + GitHub release on a `v*` tag push, but it is **not how Pathfinder ships** and is not exercised in practice — no v2.x tag has triggered it, and the v2.x GitHub releases are unpublished drafts. It also currently fails (the `build-plugin` action defaults to Node 20; the repo requires Node ≥ 24). Releases go out via the CD workflow (#2). The file is kept for reference only.
 
 ### 2. Manual Publishing (`.github/workflows/publish.yml`)
 
@@ -74,9 +69,11 @@ npm run sign           # Sign plugin for distribution
 
 ### Environment Progression
 
-1. **Development** (`dev`) - Automatic on push to main
-2. **Operations** (`ops`) - Manual via publish workflow
-3. **Production** (`prod`) - Manual via publish workflow
+All environments deploy **manually** via the CD (`Plugins - CD`) workflow dispatch — **nothing auto-deploys on merge to `main`**:
+
+1. **Development** (`dev`) — manual CD dispatch; deployment_tools PR auto-merges.
+2. **Operations** (`ops`) — manual CD dispatch; deployment_tools PR auto-merges.
+3. **prod-canary / Production** (`prod`) — manual CD dispatch; requires clicking **"Resume"** on the paused approval step in the Argo UI.
 
 ### Plugin Scope
 
@@ -96,25 +93,29 @@ npm run sign           # Sign plugin for distribution
 
 ## Release Process Steps
 
-### For Official Releases
+A release is two phases: **(1)** prep the version + changelog on `main`, then **(2)** deploy `main` to each environment via the CD workflow. **There is no tag-based release.**
 
-1. Update version in `package.json`
-2. Create and push version tag (`git tag v1.1.32 && git push origin v1.1.32`)
-3. GitHub Actions automatically builds and creates release
-4. Optionally sign plugin for distribution
+### Phase 1 — Prepare the release (version + changelog)
 
-### For Development Deployments
+Use the `release-prep` skill (or do it by hand):
 
-1. Push changes to `main` branch
-2. Automatic deployment to `dev` environment
-3. Monitor via Slack channel `#pathfinder-app-release`
+1. Bump the version in `package.json` + `package-lock.json` (never `src/plugin.json` — it carries `%VERSION%`, substituted at build).
+2. Draft the `CHANGELOG.md` entry (via the `changelog` skill).
+3. Validate under the repo's pinned Node (`.nvmrc` = 24.18; e.g. `fnm use` / `nvm use`): `npm run check` and `npm run build`.
+4. Commit `chore: prep v<version> release` on a **branch** and open a **PR** to `main` — `main` is protected, so you cannot push to it directly. Merge once approved + green.
 
-### For Production Deployments
+No git tag is required. (If you want a GitHub release entry for the record, create it manually — the tag→`release.yml` build is not used.)
 
-1. Use manual publish workflow
-2. Select target environment (ops/prod)
-3. Choose branch to deploy from
-4. Monitor deployment via Argo Workflow
+### Phase 2 — Deploy via CD (`Plugins - CD` → `publish.yml`)
+
+Deploy `main` to each environment in order — **dev → ops → prod-canary → prod** — by dispatching the **"Plugins - CD"** workflow (`workflow_dispatch`) with `branch: main` and the target `environment`. **All environments are manual dispatches; nothing auto-deploys on merge to `main`.**
+
+Under the hood, CD opens a `grafana/deployment_tools` PR per environment that bumps the provisioned plugin version:
+
+- **dev + ops** — the deployment_tools PR **auto-merges** once its CI passes; no manual action.
+- **prod-canary + prod** — the Argo workflow **pauses at an approval step**. Monitor the run in the Argo UI (`argo-workflows.grafana.net`, `grafana-plugins-cd`) and click **"Resume"** on each paused approval step to let it proceed. You approve in **Argo**, not in `deployment_tools` — CD handles the PR after approval.
+
+Deploy-start, per-environment PR links, and "waiting for manual approval… click Resume" prompts all post to Slack **`#pathfinder-app-release`**.
 
 ## Monitoring and Notifications
 


### PR DESCRIPTION
Corrects `docs/developer/RELEASE_PROCESS.md` and `.cursor/skills/release-prep/SKILL.md` after cutting v2.15.0, where the documented flow didn't match reality.

**Fixes:**
1. **Release mechanism** — it's the **CD workflow** (`Plugins - CD` / `publish.yml`) deploying `main` per environment, **not** a `v*` tag → `release.yml`. Reframed `release.yml` as *not the release path* (kept for reference; it also currently fails on its Node-20 default). File left untouched.
2. **Branch + PR** — release-prep commits on a branch and lands via a PR; the old `git push origin main` + `git tag` steps can't work against protected `main`.
3. **Prod gating** — documented the real step: click **Resume** on the paused approval step in the **Argo UI** for prod-canary + prod. CD auto-merges the `deployment_tools` PRs for dev/ops under the hood; you approve in Argo, not in deployment_tools. Notifications in `#pathfinder-app-release`.
4. **Node 24** — `npm run check` must run under the repo's pinned Node (`.nvmrc` 24.18).
5. **No auto-deploy** — corrected 'dev is automatic on push to main'; all envs are manual CD dispatches.

Docs-only; `release.yml` and the `changelog` skill are unchanged.