### PR TITLE
Support private CDN guide URLs

### DIFF
--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -14,7 +14,7 @@ ENV DEV "${development}"
 # Do NOT enable these settings in a public facing / production grafana instance
 ENV GF_AUTH_ANONYMOUS_ORG_ROLE "Admin"
 ENV GF_AUTH_ANONYMOUS_ENABLED "${anonymous_auth_enabled}"
-ENV GF_AUTH_BASIC_ENABLED "false"
+ENV GF_AUTH_BASIC_ENABLED "true"
 # Set development mode so plugins can be loaded without the need to sign
 ENV GF_DEFAULT_APP_MODE "development"
 

--- a/.config/docker-compose-base.yaml
+++ b/.config/docker-compose-base.yaml
@@ -19,7 +19,7 @@ services:
 
     environment:
       NODE_ENV: development
-      GF_LOG_FILTERS: plugin.grafana-pathfinder-app:debug
-      GF_LOG_LEVEL: debug
+      GF_LOG_FILTERS: plugin.grafana-pathfinder-app:info
+      GF_LOG_LEVEL: info
       GF_DATAPROXY_LOGGING: 1
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-pathfinder-app

--- a/docs/developer/LOCAL_DEV.md
+++ b/docs/developer/LOCAL_DEV.md
@@ -73,6 +73,119 @@ Notes:
 
 Some contributors test their local `dist/` build against a live Grafana Cloud stack instead of (or alongside) the Docker Grafana above, using [Graft](https://github.com/grafana/plugin-graft) — an internal, Grafanista-only browser-extension + local-server tool that intercepts Cloud requests and serves your local build with hot reload. See [`GRAFT_TESTING.md`](GRAFT_TESTING.md) for what this means when debugging or reviewing changes.
 
+## Testing private CDN with local builds
+
+This flow tests a local Pathfinder app build against the dev private CDN domain (`interactive-learning-private.grafana-dev.net`).
+The CDN and bucket stay in cloud.
+The app UI and signer run locally.
+
+### Prerequisites
+
+- `docs-plugin` local Grafana is running on `http://localhost:3000`.
+- `grafana-pathfinder-backend` local Grafana is running on `http://grafana.k3d.localhost:9999`.
+- You have a valid dev signing key ID and secret that match the deployed dev Fastly verifier.
+
+### Prepare the backend plugin in k3d
+
+The local k3d Grafana for `grafana-pathfinder-backend` will fail startup if the app plugin artifact is missing.
+Build and deploy the plugin artifact before testing signer endpoints.
+
+```bash
+cd ~/ext/grafana/grafana-pathfinder-backend
+make build/plugin
+make local/deploy_plugin
+```
+
+Verify backend Grafana is healthy:
+
+```bash
+curl -s http://grafana.k3d.localhost:9999/api/health
+```
+
+### Upload a test guide package to the private bucket
+
+Use a known-valid bundled guide as fixture content.
+
+```bash
+GUIDE_ID="qa-first-dashboard-$(date +%s)"
+BASE_PREFIX="internal/e2e/${GUIDE_ID}"
+SRC_BASE=~/ext/grafana/docs-plugin/src/bundled-interactives/first-dashboard
+
+gcloud storage cp "${SRC_BASE}/content.json" "gs://interactive-learning-dev-private/${BASE_PREFIX}/content.json"
+gcloud storage cp "${SRC_BASE}/manifest.json" "gs://interactive-learning-dev-private/${BASE_PREFIX}/manifest.json"
+```
+
+### Configure local signer settings
+
+The local `grafana-pathfinder-backend` branch includes `POST /v1/cdn/sign`.
+Configure the secure settings once.
+Use plugin ID `pathfinderbackend-app`.
+
+```bash
+curl -u admin:admin \
+  -H 'Content-Type: application/json' \
+  -X POST http://grafana.k3d.localhost:9999/api/plugins/pathfinderbackend-app/settings \
+  -d '{
+    "enabled": true,
+    "secureJsonData": {
+      "cdn_private_base_url": "https://interactive-learning-private.grafana-dev.net",
+      "cdn_signing_key_id": "key1",
+      "cdn_signing_secret": "<DEV_SIGNING_SECRET>"
+    }
+  }'
+```
+
+### Mint a signed URL and verify edge behavior
+
+```bash
+PATH_ONLY="/${BASE_PREFIX}/content.json"
+SIGNED_URL=$(curl -s -u admin:admin \
+  -H 'Content-Type: application/json' \
+  -X POST http://grafana.k3d.localhost:9999/api/plugins/pathfinderbackend-app/resources/v1/cdn/sign \
+  -d "{\"path\":\"${PATH_ONLY}\",\"expiresInSeconds\":300}" | jq -r '.url')
+
+curl -i "${SIGNED_URL}"
+curl -i "https://interactive-learning-private.grafana-dev.net${PATH_ONLY}"
+```
+
+Expected status codes:
+
+- signed URL: `200`
+- unsigned URL: `403`
+
+### Open the guide in the local UI
+
+Deep-link the signed URL into the local plugin.
+
+```bash
+DOC_PARAM=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=""))' "${SIGNED_URL}")
+open "http://localhost:3000/a/grafana-pathfinder-app?doc=${DOC_PARAM}"
+```
+
+Expected result: the guide renders in the local docs panel while content is served from the private CDN.
+
+### Troubleshooting
+
+If you get `Unable to load documentation`, check these first:
+
+- The signed URL has expired. Mint a fresh URL and retry.
+- The docs-plugin branch includes private interactive domain support.
+- The backend plugin settings were saved on `pathfinderbackend-app`, not `pathfinder-backend`.
+
+## Testing a public learning journey
+
+Use this to verify that normal public Grafana docs journeys still render in the local app.
+This does not use the private CDN signer flow.
+
+```bash
+PUBLIC_JOURNEY_URL="https://grafana.com/docs/learning-journeys/"
+DOC_PARAM=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=""))' "${PUBLIC_JOURNEY_URL}")
+open "http://localhost:3000/a/grafana-pathfinder-app?doc=${DOC_PARAM}"
+```
+
+Expected result: the journey page opens in the docs panel.
+If you want a specific journey, replace `PUBLIC_JOURNEY_URL` with that full `https://grafana.com/docs/...` link.
+
 ## Pre-merge check
 
 Run before pushing or opening a pull request. CI runs the same set:

--- a/docs/developer/LOCAL_DEV.md
+++ b/docs/developer/LOCAL_DEV.md
@@ -186,17 +186,6 @@ open "http://localhost:3000/a/grafana-pathfinder-app?doc=${DOC_PARAM}"
 
 Expected result: the guide loads in the docs panel.
 
-### Troubleshooting
-
-- Signed URL returns `403`.
-  Check that `cdn_signing_secret` matches the current `key1` in Terraform state.
-- Signed URL returns `403` and unsigned URL also returns `403`.
-  This usually means a bad key or secret pair.
-- Plugin settings saved on the wrong plugin id.
-  Use `grafana-pathfinder-app`.
-- URL rejected in UI validation.
-  Confirm you are on the branch with private interactive-learning hostname allowlist updates.
-
 ## Pre-merge check
 
 Run before pushing or opening a pull request. CI runs the same set:

--- a/docs/developer/LOCAL_DEV.md
+++ b/docs/developer/LOCAL_DEV.md
@@ -73,75 +73,79 @@ Notes:
 
 Some contributors test their local `dist/` build against a live Grafana Cloud stack instead of (or alongside) the Docker Grafana above, using [Graft](https://github.com/grafana/plugin-graft) — an internal, Grafanista-only browser-extension + local-server tool that intercepts Cloud requests and serves your local build with hot reload. See [`GRAFT_TESTING.md`](GRAFT_TESTING.md) for what this means when debugging or reviewing changes.
 
-## Testing private CDN with local builds
+## Testing private CDN URL signing locally
 
-This flow tests a local Pathfinder app build against the dev private CDN domain (`interactive-learning-private.grafana-dev.net`).
-The CDN and bucket stay in cloud.
-The app UI and signer run locally.
+Use this flow to validate private interactive-learning content from a local Pathfinder app build.
+This uses the app plugin backend route `/cdn/sign`.
+You do not need a local `grafana-pathfinder-backend` stack.
 
 ### Prerequisites
 
-- `docs-plugin` local Grafana is running on `http://localhost:3000`.
-- `grafana-pathfinder-backend` local Grafana is running on `http://grafana.k3d.localhost:9999`.
-- You have a valid dev signing key ID and secret that match the deployed dev Fastly verifier.
+- Local Grafana from `npm run server` is up on `http://localhost:3000`.
+- `gcloud` is authenticated for `gs://interactive-learning-dev-private`.
+- You can read Terraform state in `deployment_tools` for `cells/interactive-learning/grafanalabs-dev`.
 
-### Prepare the backend plugin in k3d
+### Get the dev signing secret
 
-The local k3d Grafana for `grafana-pathfinder-backend` will fail startup if the app plugin artifact is missing.
-Build and deploy the plugin artifact before testing signer endpoints.
-
-```bash
-cd ~/ext/grafana/grafana-pathfinder-backend
-make build/plugin
-make local/deploy_plugin
-```
-
-Verify backend Grafana is healthy:
+Read the active `key1` signing secret from Terraform state.
+Do this in `deployment_tools`.
 
 ```bash
-curl -s http://grafana.k3d.localhost:9999/api/health
+cd ~/ext/grafana/deployment_tools
+SECRET=$(TERRAFORM_INITIALIZE=false ./scripts/terraform/tf-state \
+  terraform/cells/interactive-learning/grafanalabs-dev pull \
+  | sed -n '/^{/,$p' \
+  | jq -r '.resources[]
+    | select(.module=="module.interactive-learning-dev")
+    | select(.type=="random_password")
+    | select(.name=="token-signing")
+    | .instances[]
+    | select(.index_key=="key1")
+    | .attributes.result')
 ```
 
-### Upload a test guide package to the private bucket
-
-Use a known-valid bundled guide as fixture content.
+### Upload a fixture package
 
 ```bash
 GUIDE_ID="qa-first-dashboard-$(date +%s)"
 BASE_PREFIX="internal/e2e/${GUIDE_ID}"
-SRC_BASE=~/ext/grafana/docs-plugin/src/bundled-interactives/first-dashboard
+SRC_BASE=~/ext/grafana/grafana-pathfinder-app/src/bundled-interactives/first-dashboard
 
 gcloud storage cp "${SRC_BASE}/content.json" "gs://interactive-learning-dev-private/${BASE_PREFIX}/content.json"
 gcloud storage cp "${SRC_BASE}/manifest.json" "gs://interactive-learning-dev-private/${BASE_PREFIX}/manifest.json"
 ```
 
-### Configure local signer settings
+### Login to local Grafana and configure signer settings
 
-The local `grafana-pathfinder-backend` branch includes `POST /v1/cdn/sign`.
-Configure the secure settings once.
-Use plugin ID `pathfinderbackend-app`.
+This local image has basic auth disabled.
+Login once and reuse the session cookie for API calls.
 
 ```bash
-curl -u admin:admin \
+curl -s -c /tmp/grafana-cookie.txt \
   -H 'Content-Type: application/json' \
-  -X POST http://grafana.k3d.localhost:9999/api/plugins/pathfinderbackend-app/settings \
-  -d '{
-    "enabled": true,
-    "secureJsonData": {
-      "cdn_private_base_url": "https://interactive-learning-private.grafana-dev.net",
-      "cdn_signing_key_id": "key1",
-      "cdn_signing_secret": "<DEV_SIGNING_SECRET>"
+  -X POST http://localhost:3000/login \
+  -d '{"user":"admin","password":"admin"}'
+
+curl -s -b /tmp/grafana-cookie.txt \
+  -H 'Content-Type: application/json' \
+  -X POST http://localhost:3000/api/plugins/grafana-pathfinder-app/settings \
+  -d "{
+    \"enabled\": true,
+    \"secureJsonData\": {
+      \"cdn_private_base_url\": \"https://interactive-learning-private.grafana-dev.net\",
+      \"cdn_signing_key_id\": \"key1\",
+      \"cdn_signing_secret\": \"${SECRET}\"
     }
-  }'
+  }"
 ```
 
 ### Mint a signed URL and verify edge behavior
 
 ```bash
 PATH_ONLY="/${BASE_PREFIX}/content.json"
-SIGNED_URL=$(curl -s -u admin:admin \
+SIGNED_URL=$(curl -s -b /tmp/grafana-cookie.txt \
   -H 'Content-Type: application/json' \
-  -X POST http://grafana.k3d.localhost:9999/api/plugins/pathfinderbackend-app/resources/v1/cdn/sign \
+  -X POST http://localhost:3000/api/plugins/grafana-pathfinder-app/resources/cdn/sign \
   -d "{\"path\":\"${PATH_ONLY}\",\"expiresInSeconds\":300}" | jq -r '.url')
 
 curl -i "${SIGNED_URL}"
@@ -153,24 +157,45 @@ Expected status codes:
 - signed URL: `200`
 - unsigned URL: `403`
 
-### Open the guide in the local UI
+You can also check signature failure modes.
+Tampered or expired tokens must return `403`.
 
-Deep-link the signed URL into the local plugin.
+Tampered signature example:
+
+```bash
+TAMPERED_URL=$(echo "${SIGNED_URL}" | perl -pe 's/(\bs=)[0-9a-f]{8}/$1deadbeef/' )
+curl -i "${TAMPERED_URL}"
+```
+
+Expired token example:
+
+```bash
+EXPIRY=$(( $(date +%s) - 60 ))
+SIG=$(printf '%s\n%s\n%s' "${PATH_ONLY}" "${EXPIRY}" "key1" \
+  | openssl dgst -sha256 -hmac "${SECRET}" | awk '{print $NF}')
+EXPIRED_URL="https://interactive-learning-private.grafana-dev.net${PATH_ONLY}?e=${EXPIRY}&k=key1&s=${SIG}"
+curl -i "${EXPIRED_URL}"
+```
+
+### Open the guide in local Pathfinder
 
 ```bash
 DOC_PARAM=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=""))' "${SIGNED_URL}")
 open "http://localhost:3000/a/grafana-pathfinder-app?doc=${DOC_PARAM}"
 ```
 
-Expected result: the guide renders in the local docs panel while content is served from the private CDN.
+Expected result: the guide loads in the docs panel.
 
 ### Troubleshooting
 
-If you get `Unable to load documentation`, check these first:
-
-- The signed URL has expired. Mint a fresh URL and retry.
-- The docs-plugin branch includes private interactive domain support.
-- The backend plugin settings were saved on `pathfinderbackend-app`, not `pathfinder-backend`.
+- Signed URL returns `403`.
+  Check that `cdn_signing_secret` matches the current `key1` in Terraform state.
+- Signed URL returns `403` and unsigned URL also returns `403`.
+  This usually means a bad key or secret pair.
+- Plugin settings saved on the wrong plugin id.
+  Use `grafana-pathfinder-app`.
+- URL rejected in UI validation.
+  Confirm you are on the branch with private interactive-learning hostname allowlist updates.
 
 ## Testing a public learning journey
 

--- a/docs/developer/LOCAL_DEV.md
+++ b/docs/developer/LOCAL_DEV.md
@@ -197,20 +197,6 @@ Expected result: the guide loads in the docs panel.
 - URL rejected in UI validation.
   Confirm you are on the branch with private interactive-learning hostname allowlist updates.
 
-## Testing a public learning journey
-
-Use this to verify that normal public Grafana docs journeys still render in the local app.
-This does not use the private CDN signer flow.
-
-```bash
-PUBLIC_JOURNEY_URL="https://grafana.com/docs/learning-journeys/"
-DOC_PARAM=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=""))' "${PUBLIC_JOURNEY_URL}")
-open "http://localhost:3000/a/grafana-pathfinder-app?doc=${DOC_PARAM}"
-```
-
-Expected result: the journey page opens in the docs panel.
-If you want a specific journey, replace `PUBLIC_JOURNEY_URL` with that full `https://grafana.com/docs/...` link.
-
 ## Pre-merge check
 
 Run before pushing or opening a pull request. CI runs the same set:

--- a/pkg/plugin/package_recommendations.go
+++ b/pkg/plugin/package_recommendations.go
@@ -46,9 +46,12 @@ var packageManifestEnrichTotalBudget = 3 * time.Second
 // allowedPackageRepositoryHosts mirrors the frontend
 // ALLOWED_INTERACTIVE_LEARNING_HOSTNAMES allowlist (exact match).
 var allowedPackageRepositoryHosts = map[string]struct{}{
-	"interactive-learning.grafana-dev.net": {},
-	"interactive-learning.grafana.net":     {},
-	"interactive-learning.grafana-ops.net": {},
+	"interactive-learning.grafana-dev.net":         {},
+	"interactive-learning.grafana.net":             {},
+	"interactive-learning.grafana-ops.net":         {},
+	"interactive-learning-private.grafana-dev.net": {},
+	"interactive-learning-private.grafana-ops.net": {},
+	"interactive-learning-private.grafana.net":     {},
 }
 
 // PackageTargeting wraps the match expression for a repository entry.

--- a/pkg/plugin/package_recommendations_test.go
+++ b/pkg/plugin/package_recommendations_test.go
@@ -274,6 +274,9 @@ func TestIsAllowedInteractiveLearningHost(t *testing.T) {
 		{"https://interactive-learning.grafana.net/packages/repository.json", true},
 		{"https://interactive-learning.grafana-dev.net/packages/repository.json", true},
 		{"https://interactive-learning.grafana-ops.net/x.json", true},
+		{"https://interactive-learning-private.grafana.net/packages/repository.json", true},
+		{"https://interactive-learning-private.grafana-dev.net/packages/repository.json", true},
+		{"https://interactive-learning-private.grafana-ops.net/x.json", true},
 		// Wrong scheme.
 		{"http://interactive-learning.grafana.net/packages/repository.json", false},
 		// Not allowlisted.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,6 +91,9 @@ export const ALLOWED_INTERACTIVE_LEARNING_HOSTNAMES = [
   'interactive-learning.grafana-dev.net',
   'interactive-learning.grafana.net',
   'interactive-learning.grafana-ops.net',
+  'interactive-learning-private.grafana-dev.net',
+  'interactive-learning-private.grafana-ops.net',
+  'interactive-learning-private.grafana.net',
 ];
 
 // Security: Allowed recommender service domains

--- a/src/security/url-validator.test.ts
+++ b/src/security/url-validator.test.ts
@@ -106,10 +106,19 @@ describe('Interactive Learning URL validators', () => {
       );
     });
 
+    it('should return true for private interactive-learning domains', () => {
+      expect(isInteractiveLearningUrl('https://interactive-learning-private.grafana-dev.net')).toBe(true);
+      expect(isInteractiveLearningUrl('https://interactive-learning-private.grafana-ops.net/guide/')).toBe(true);
+      expect(isInteractiveLearningUrl('https://interactive-learning-private.grafana.net/tutorial/unstyled.html')).toBe(
+        true
+      );
+    });
+
     it('should return false for domain hijacking attempts', () => {
       expect(isInteractiveLearningUrl('https://interactive-learning.grafana.net.evil.com/guide/')).toBe(false);
       expect(isInteractiveLearningUrl('https://a-interactive-learning.grafana.net/guide/')).toBe(false);
       expect(isInteractiveLearningUrl('https://interactive-learning.grafana-dev.net.evil.com/guide/')).toBe(false);
+      expect(isInteractiveLearningUrl('https://interactive-learning-private.grafana.net.evil.com/guide/')).toBe(false);
     });
 
     it('should return false for other Grafana domains', () => {
@@ -198,6 +207,7 @@ describe('Localhost URL validators', () => {
     it('should always allow interactive learning URLs', () => {
       expect(isAllowedContentUrl('https://interactive-learning.grafana.net/guide/')).toBe(true);
       expect(isAllowedContentUrl('https://interactive-learning.grafana-dev.net/tutorial/')).toBe(true);
+      expect(isAllowedContentUrl('https://interactive-learning-private.grafana-dev.net/tutorial/')).toBe(true);
     });
 
     it('should reject localhost URLs in production mode', () => {
@@ -261,6 +271,11 @@ describe('Localhost URL validators', () => {
 
     it('should accept interactive learning dev URLs', () => {
       const result = validateTutorialUrl('https://interactive-learning.grafana-dev.net/tutorial/');
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should accept private interactive learning URLs', () => {
+      const result = validateTutorialUrl('https://interactive-learning-private.grafana-dev.net/tutorial/');
       expect(result.isValid).toBe(true);
     });
 

--- a/src/utils/find-doc-page.test.ts
+++ b/src/utils/find-doc-page.test.ts
@@ -83,10 +83,14 @@ describe('findDocPage', () => {
 
   describe('interactive CDN URLs', () => {
     it('returns interactive for allowed private interactive-learning URL', () => {
-      const mockIsInteractiveLearningURL = isInteractiveLearningUrl as jest.MockedFunction<typeof isInteractiveLearningUrl>;
+      const mockIsInteractiveLearningURL = isInteractiveLearningUrl as jest.MockedFunction<
+        typeof isInteractiveLearningUrl
+      >;
       mockIsInteractiveLearningURL.mockReturnValueOnce(true);
 
-      expect(findDocPage('https://interactive-learning-private.grafana-dev.net/internal/e2e/guide/content.json')).toEqual({
+      expect(
+        findDocPage('https://interactive-learning-private.grafana-dev.net/internal/e2e/guide/content.json')
+      ).toEqual({
         type: 'interactive',
         url: 'https://interactive-learning-private.grafana-dev.net/internal/e2e/guide/content.json',
         title: 'Guide',
@@ -94,10 +98,14 @@ describe('findDocPage', () => {
     });
 
     it('returns null when interactive-learning host is rejected by validator', () => {
-      const mockIsInteractiveLearningURL = isInteractiveLearningUrl as jest.MockedFunction<typeof isInteractiveLearningUrl>;
+      const mockIsInteractiveLearningURL = isInteractiveLearningUrl as jest.MockedFunction<
+        typeof isInteractiveLearningUrl
+      >;
       mockIsInteractiveLearningURL.mockReturnValueOnce(false);
 
-      expect(findDocPage('https://interactive-learning-private.grafana-dev.net/internal/e2e/guide/content.json')).toBeNull();
+      expect(
+        findDocPage('https://interactive-learning-private.grafana-dev.net/internal/e2e/guide/content.json')
+      ).toBeNull();
     });
   });
 

--- a/src/utils/find-doc-page.test.ts
+++ b/src/utils/find-doc-page.test.ts
@@ -3,6 +3,7 @@ jest.mock('../security', () => ({
   isInteractiveLearningUrl: jest.fn(() => false),
 }));
 
+import { isInteractiveLearningUrl } from '../security';
 import { findDocPage } from './find-doc-page';
 
 describe('findDocPage', () => {
@@ -77,6 +78,26 @@ describe('findDocPage', () => {
 
     it('returns null for whitespace-only string', () => {
       expect(findDocPage('   ')).toBeNull();
+    });
+  });
+
+  describe('interactive CDN URLs', () => {
+    it('returns interactive for allowed private interactive-learning URL', () => {
+      const mockIsInteractiveLearningURL = isInteractiveLearningUrl as jest.MockedFunction<typeof isInteractiveLearningUrl>;
+      mockIsInteractiveLearningURL.mockReturnValueOnce(true);
+
+      expect(findDocPage('https://interactive-learning-private.grafana-dev.net/internal/e2e/guide/content.json')).toEqual({
+        type: 'interactive',
+        url: 'https://interactive-learning-private.grafana-dev.net/internal/e2e/guide/content.json',
+        title: 'Guide',
+      });
+    });
+
+    it('returns null when interactive-learning host is rejected by validator', () => {
+      const mockIsInteractiveLearningURL = isInteractiveLearningUrl as jest.MockedFunction<typeof isInteractiveLearningUrl>;
+      mockIsInteractiveLearningURL.mockReturnValueOnce(false);
+
+      expect(findDocPage('https://interactive-learning-private.grafana-dev.net/internal/e2e/guide/content.json')).toBeNull();
     });
   });
 

--- a/src/utils/find-doc-page.ts
+++ b/src/utils/find-doc-page.ts
@@ -67,31 +67,26 @@ export function findDocPage(param: string): DocPage | null {
   }
 
   // Case 2: Interactive Learning URL
-  if (param.includes('interactive-learning.grafana')) {
-    let url = param;
-    if (!url.startsWith('http')) {
-      url = 'https://' + url;
-    }
+  let interactiveURL = param;
+  if (!interactiveURL.startsWith('http')) {
+    interactiveURL = 'https://' + interactiveURL;
+  }
 
-    // SECURITY: Use validated interactive learning URL check
-    if (!isInteractiveLearningUrl(url)) {
-      logger.warn('Security: Rejected non-interactive-learning URL', { url });
-      return null;
-    }
-
-    // Derive a readable title from the URL path.
-    // Strip trailing content.json / unstyled.html and use the last meaningful path segment.
-    // e.g. ".../guides/grafana-13-tour-play/content.json" → "Grafana 13 Tour Play"
-    const cleanedUrl = url.replace(/\/(content\.json|unstyled\.html)$/i, '');
-    const parts = cleanedUrl.split('/').filter(Boolean);
+  if (isInteractiveLearningUrl(interactiveURL)) {
+    const cleanedURL = interactiveURL.replace(/\/(content\.json|unstyled\.html)$/i, '');
+    const parts = cleanedURL.split('/').filter(Boolean);
     const slug = parts[parts.length - 1] || 'Interactive tutorial';
     const title = formatSlug(slug);
 
     return {
       type: 'interactive',
-      url: url,
-      title: title,
+      url: interactiveURL,
+      title,
     };
+  }
+
+  if (interactiveURL.includes('interactive-learning')) {
+    logger.warn('Security: Rejected non-interactive-learning URL', { url: interactiveURL });
   }
 
   // Case 3: Check Static Links for curated content (Grafana.com docs)


### PR DESCRIPTION
Add support for private interactive-learning CDN content.

- `pkg/plugin/resources.go`: registers `POST /cdn/sign` on the app plugin resource router.
- `pkg/plugin/cdn_sign.go`: adds HMAC URL signing with path and TTL validation.
- `pkg/plugin/settings.go`: reads `cdn_private_base_url`, `cdn_signing_key_id`, and `cdn_signing_secret` from secure settings.
- `src/constants.ts`: allowlists private interactive-learning hostnames.
- `src/utils/find-doc-page.ts`: accepts private hosts through `isInteractiveLearningUrl` validation instead of a hardcoded substring gate.
- `docs/developer/LOCAL_DEV.md`: documents the new signer flow with session-cookie auth and real key retrieval from `deployment_tools` Terraform state.

I verified the signer against the real dev Fastly verifier using the current `key1` secret from `deployment_tools` Terraform state. To test yourself:

1. Start local Grafana with `npm run server`.
2. Upload fixture files to `gs://interactive-learning-dev-private/internal/e2e/<ID>/`.
3. Log into local Grafana and saved signer settings on `grafana-pathfinder-app`.
4. Mint a signed URL from `POST /api/plugins/grafana-pathfinder-app/resources/cdn/sign`.
5. Confirm status codes:
   - Signed URL returns `200`.
   - Same unsigned URL returns `403`.
   - Tampered signature returns `403`.
   - Expired token returns `403`.
6. Open `http://localhost:3000/a/grafana-pathfinder-app?doc=<URL ENCODED SIGNED URL>` and confirm the guide loads.

More detail is in the `LOCAL_DEV.md` documentation