### PR TITLE
fix(interactive): stop highlights from auto-opening the nav sidebar

### DIFF
--- a/src/interactive-engine/navigation-manager.test.ts
+++ b/src/interactive-engine/navigation-manager.test.ts
@@ -734,4 +734,52 @@ describe('NavigationManager', () => {
       expect(dockClickSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('ensureNavigationOpen context check', () => {
+    let megaMenuToggle: HTMLButtonElement;
+    let toggleClickSpy: jest.Mock;
+
+    beforeEach(() => {
+      megaMenuToggle = document.createElement('button');
+      megaMenuToggle.id = 'mega-menu-toggle';
+      document.body.appendChild(megaMenuToggle);
+
+      toggleClickSpy = jest.fn();
+      megaMenuToggle.click = toggleClickSpy;
+    });
+
+    afterEach(() => {
+      megaMenuToggle.remove();
+    });
+
+    it('leaves the sidebar closed for a target inside a page toolbar <nav>', async () => {
+      // Grafana wraps page toolbars in <nav> (e.g. `nav.page-toolbar` in Explore), so
+      // targets like the data source picker must not trigger an open-and-dock.
+      const toolbar = document.createElement('nav');
+      toolbar.className = 'page-toolbar';
+      const target = document.createElement('div');
+      toolbar.appendChild(target);
+      document.body.appendChild(toolbar);
+
+      await navigationManager.ensureNavigationOpen(target);
+
+      expect(toggleClickSpy).not.toHaveBeenCalled();
+
+      toolbar.remove();
+    });
+
+    it('opens the sidebar for a target inside the mega menu', async () => {
+      const megaMenu = document.createElement('div');
+      megaMenu.setAttribute('data-testid', 'data-testid navigation mega-menu');
+      const target = document.createElement('a');
+      megaMenu.appendChild(target);
+      document.body.appendChild(megaMenu);
+
+      await navigationManager.ensureNavigationOpen(target);
+
+      expect(toggleClickSpy).toHaveBeenCalledTimes(1);
+
+      megaMenu.remove();
+    });
+  });
 });

--- a/src/interactive-engine/navigation-manager.ts
+++ b/src/interactive-engine/navigation-manager.ts
@@ -21,6 +21,7 @@ export interface NavigationOptions {
 }
 
 const NAV_ITEM_SELECTOR = 'a[data-testid="data-testid Nav menu item"]';
+const MEGA_MENU_SELECTOR = '[data-testid="data-testid navigation mega-menu"]';
 
 export class NavigationManager {
   private activeCleanupHandlers: Array<() => void> = [];
@@ -1268,7 +1269,7 @@ export class NavigationManager {
    */
   async ensureNavigationOpen(element: HTMLElement): Promise<void> {
     return this.openAndDockNavigation(element, {
-      checkContext: true, // Only run if element is in navigation
+      checkContext: true, // Only run if element is inside the mega menu
       logWarnings: false, // Silent operation
       ensureDocked: true, // Always dock if open
     });
@@ -1502,7 +1503,7 @@ export class NavigationManager {
    * that it's open so that other steps can be executed.
    * @param element - The element that may require navigation to be open
    * @param options - The options for the navigation
-   * @param options.checkContext - Whether to check if the element is within navigation (default false)
+   * @param options.checkContext - Whether to require that the element is inside the mega menu (default false)
    * @param options.logWarnings - Whether to log warnings (default true)
    * @param options.ensureDocked - Whether to ensure the navigation is docked when we're done. (default true)
    * @returns Promise that resolves when navigation is properly configured
@@ -1510,11 +1511,11 @@ export class NavigationManager {
   async openAndDockNavigation(element?: HTMLElement, options: NavigationOptions = {}): Promise<void> {
     const { checkContext = false, logWarnings = true, ensureDocked = true } = options;
 
-    if (checkContext && element) {
-      const isInNavigation = element.closest('nav, [class*="nav"], [class*="menu"], [class*="sidebar"]') !== null;
-      if (!isInNavigation) {
-        return;
-      }
+    // Only the mega menu counts as "navigation" — Grafana renders page toolbars and
+    // breadcrumbs as <nav> too, so a looser ancestor test opens the sidebar for
+    // ordinary page targets.
+    if (checkContext && element && !element.closest(MEGA_MENU_SELECTOR)) {
+      return;
     }
 
     const megaMenuToggle = document.querySelector('#mega-menu-toggle') as HTMLButtonElement;


### PR DESCRIPTION
## Summary

A `highlight` step whose target sits anywhere under a `<nav>` element made "Show me" / "Do it" open the Grafana mega menu and dock it to the side — even though the target had nothing to do with navigation.

Reproduced with [`explore-getting-started`](https://github.com/grafana/interactive-tutorials/blob/379d59cfb12b7db849f3b7900d9754fea4ac1b06/explore-getting-started/content.json), step `grafana:components.DataSourcePicker.container`.

## Why

`highlightWithComment` calls `ensureNavigationOpen(element)` on every highlight, which gates `openAndDockNavigation` behind this context check:

```ts
element.closest('nav, [class*="nav"], [class*="menu"], [class*="sidebar"]')
```

Grafana renders page toolbars and breadcrumbs as `<nav>`. In Explore the data source picker's ancestor chain is:

```
[data-testid="data-testid Data source picker select container"]
  └ <nav class="css-3ye0ev">
      └ <nav class="page-toolbar" data-testid="data-testid explore-toolbar">
```

So the check passed, no nav items were in the DOM (sidebar closed), and `openAndDockNavigation` clicked `#mega-menu-toggle` and then `#dock-menu-button`. The class-substring arms are just as loose — any emotion class containing `nav`, `menu`, or `sidebar` matched too.

The sidebar opening also destroyed the highlight the step was trying to show, because the resulting layout shift tripped the highlight's auto-cleanup.

## What changed

Scope the context check to the mega menu container (`[data-testid="data-testid navigation mega-menu"]`), which wraps the nav tree in both docked and overlay states. Targets outside it now return early, so genuine nav steps still open-and-dock and everything else is left alone.

## How to verify

Measured against a local Grafana 13.1.1 with the sidebar closed, clicking "Show me" on that step:

| | nav menu items | mega menu in DOM | highlights rendered |
|---|---|---|---|
| before | 10 | yes (docked) | 0 |
| after | 0 | no | 1 |

Also covered by two new specs in `navigation-manager.test.ts`: a target inside `nav.page-toolbar` must not click the toggle; a target inside the mega menu still must.

## Breaking changes

None.

## Reversibility

Single-predicate change, trivially revertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)