### PR TITLE
fix(full-screen): quiet exit on browser Back from a content-only guide

### DIFF
--- a/docs/design/PANEL-MODE-PERSISTENCE.md
+++ b/docs/design/PANEL-MODE-PERSISTENCE.md
@@ -1,9 +1,10 @@
 # Panel-mode persistence
 
 > Canonical rationale for `src/global-state/panel-mode.ts`. The persistence
-> contract is enforced in code by three mutators + one predicate, pinned
-> behaviourally by `panel-mode.test.ts` and by the source tripwire
-> `components/full-screen/panel-mode-surface-toggles.contract.test.ts`.
+> contract is enforced in code by three mode mutators, a non-persisting
+> transient-session closer (`endTransientSession`), and the transient predicate
+> (`isTransient`), pinned behaviourally by `panel-mode.test.ts` and by the source
+> tripwire `components/full-screen/panel-mode-surface-toggles.contract.test.ts`.
 
 ## Purpose
 
@@ -101,6 +102,31 @@ to make the dock persist (decision 3) rather than making it never persist.
 The conditional `setMode` is intentional. Do **not** "simplify" it into an
 unconditional in-memory write; doing so silently reintroduces this regression.
 
+### Decision 4 (#1448) — browser Back out of a transient prose launch exits quietly
+
+A prose guide launched from My Learning auto-picks full screen
+(`setModeTransient('fullscreen')`), expressing no durable surface preference.
+Browser **Back** out of that launch previously fell through to the auto-dock's
+return-to-sidebar path, reopening a closed extension sidebar with the prose
+squeezed in.
+
+**Decision.** On a history **POP** while a transient session is active, the
+auto-dock (`dockOnLeavingFullScreen`) ends the session via `endTransientSession`
+— which drops the in-memory override so `getMode()` falls back to the stored
+preference — and forces no surface open (outcome `'transient_back'`). The exit
+is **always** quiet: the prior surface is deliberately never captured or
+restored, so Back never reopens a surface the launch didn't durably choose.
+PUSH/REPLACE keep today's dock (an interactive `navigate` step leaving full
+screen still needs a panel to continue in), and a non-transient POP (a
+deliberately-adopted full screen) docks too. history v4 cannot tell Back from
+Forward — both are POP — which is accepted for this quiet exit.
+
+`endTransientSession` neither persists (the launch never chose a preference —
+decision 2) nor dispatches `PANEL_MODE_CHANGE_EVENT` (the surface is already
+unmounted, so no live listener). Its call is deferred so `FullScreenPanel`'s
+unmount cleanup runs first while `getMode()` is still `'fullscreen'`; see the
+code comments for that hazard and the dead-state hazard it also avoids.
+
 ## What is safe to change vs. load-bearing
 
 - **Safe:** collapsing bookkeeping that is provably redundant. `_transientActive`
@@ -113,5 +139,8 @@ unconditional in-memory write; doing so silently reintroduces this regression.
 
 ## Related
 
-- Return-path interaction with browser Back on a transient prose launch: **#1448**.
+- Return-path interaction with browser Back on a transient prose launch:
+  **#1448** (resolved — see decision 4). The Grafana nav-click-with-prose
+  annoyance is a separate follow-up needing an interactive-step-in-progress
+  signal, still to be filed.
 - Auto-open listener ownership across surfaces: **#1450**.

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -50,6 +50,22 @@ export function FloatingPanelManager() {
     };
   }, []);
 
+  // Re-sync from the singleton on a floating launch. A quiet transient-Back exit
+  // (#1448) clears the session without emitting PANEL_MODE_CHANGE_EVENT, so our
+  // cached mode can be stale-'fullscreen' while getMode() has reverted to a
+  // persisted 'floating'. Without this, the next floating launch's
+  // REQUEST_FLOATING_GUIDE_EVENT fires into a void — FloatingPanelInner (its only
+  // listener) is unmounted — and the guide is stranded. Re-deriving here remounts
+  // the inner, which then consumes the pending guide on mount (a no-op when the
+  // cached mode already matches).
+  useEffect(() => {
+    const resync = () => setMode(panelModeManager.getMode());
+    document.addEventListener(REQUEST_FLOATING_GUIDE_EVENT, resync);
+    return () => {
+      document.removeEventListener(REQUEST_FLOATING_GUIDE_EVENT, resync);
+    };
+  }, []);
+
   if (mode !== 'floating') {
     return null;
   }

--- a/src/components/floating-panel/floating-panel.pending-guide.test.ts
+++ b/src/components/floating-panel/floating-panel.pending-guide.test.ts
@@ -51,3 +51,24 @@ describe('FloatingPanelInner consumes staged guides while already mounted', () =
     expect(listenerEffect).toContain('consumePendingGuideOnMount(panel,');
   });
 });
+
+describe('outer FloatingPanelManager re-syncs a stale cached mode on a floating launch (#1448)', () => {
+  // A quiet transient-Back exit clears the session without emitting
+  // PANEL_MODE_CHANGE_EVENT, so the always-mounted outer manager can be cached
+  // stale-'fullscreen' while getMode() has reverted to a persisted 'floating'.
+  // The next floating launch's REQUEST_FLOATING_GUIDE_EVENT must remount the
+  // inner (its only consumer) instead of firing into a void and stranding the
+  // guide. The remount then consumes the pending guide via the mount path pinned
+  // above. Anchor on the OUTER component (before FloatingPanelInner) so this
+  // can't be satisfied by the inner's same-named listener.
+  const outer = src.slice(0, src.indexOf('function FloatingPanelInner'));
+
+  it('the outer manager listens for REQUEST_FLOATING_GUIDE_EVENT', () => {
+    expect(outer).toContain('addEventListener(REQUEST_FLOATING_GUIDE_EVENT');
+    expect(outer).toContain('removeEventListener(REQUEST_FLOATING_GUIDE_EVENT');
+  });
+
+  it('re-derives its rendered mode from the singleton (not the stale event cache)', () => {
+    expect(outer).toContain('setMode(panelModeManager.getMode())');
+  });
+});

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -21,7 +21,7 @@ import { parsePathfinderDeepLink, shouldOpenAsLearningJourney } from '../../util
 import pluginJson from '../../plugin.json';
 import { FullScreenLayout } from './FullScreenLayout';
 import { getFullScreenStyles } from './full-screen.styles';
-import { dockOnLeavingFullScreen } from './full-screen-autodock';
+import { dockOnLeavingFullScreen, type HistoryAction } from './full-screen-autodock';
 
 // Lazy-loaded so the editor only ships when the user actually opens it full screen.
 const BlockEditor = lazy(() =>
@@ -214,7 +214,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
   useEffect(() => {
     const fullScreenPathname = `${PLUGIN_BASE_URL}/${ROUTES.FullScreen}`;
     const history = locationService.getHistory();
-    const unlisten = history.listen((location: { pathname: string }) => {
+    const unlisten = history.listen((location: { pathname: string }, action: HistoryAction) => {
       const { guideUrl: latestGuideUrl, title: latestTitle } = dockInputsRef.current;
       dockOnLeavingFullScreen({
         pathname: location.pathname,
@@ -222,6 +222,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
         myPluginId: pluginJson.id,
         guideUrl: latestGuideUrl,
         title: latestTitle,
+        action,
       });
     });
     return unlisten;

--- a/src/components/full-screen/full-screen-autodock.test.ts
+++ b/src/components/full-screen/full-screen-autodock.test.ts
@@ -15,6 +15,8 @@ jest.mock('../../global-state/panel-mode', () => ({
     getMode: jest.fn(),
     setMode: jest.fn(),
     setPendingGuide: jest.fn(),
+    isTransient: jest.fn(),
+    endTransientSession: jest.fn(),
   },
 }));
 
@@ -50,6 +52,9 @@ function defaultInputs(overrides: Partial<Parameters<typeof dockOnLeavingFullScr
     myPluginId: PLUGIN_ID,
     guideUrl: baseTab.baseUrl,
     title: baseTab.title,
+    // Default to PUSH (an interactive `navigate` step): exercises the dock
+    // branches. The transient-Back branch is opted into per-test.
+    action: 'PUSH' as const,
     ...overrides,
   };
 }
@@ -64,6 +69,7 @@ describe('dockOnLeavingFullScreen', () => {
     // side effects in the same test.
     jest.useFakeTimers();
     (panelModeManager.getMode as jest.Mock).mockReturnValue('fullscreen');
+    (panelModeManager.isTransient as jest.Mock).mockReturnValue(false);
     (isExtensionSidebarOwnedByOther as jest.Mock).mockReturnValue(false);
   });
 
@@ -165,6 +171,71 @@ describe('dockOnLeavingFullScreen', () => {
         guide_title: baseTab.title,
         reason: 'navigation_away_sidebar_occupied',
       });
+    });
+  });
+
+  describe('transient Back branch (browser Back out of a transient prose launch)', () => {
+    beforeEach(() => {
+      (panelModeManager.isTransient as jest.Mock).mockReturnValue(true);
+    });
+
+    it('quietly ends the transient session without opening the sidebar (deferred)', () => {
+      const outcome = dockOnLeavingFullScreen(defaultInputs({ action: 'POP' }));
+
+      // Session end is deferred so FullScreenPanel's unmount cleanup runs first
+      // (while mode is still fullscreen) and clears isSidebarMounted.
+      expect(panelModeManager.endTransientSession).not.toHaveBeenCalled();
+
+      jest.runAllTimers();
+
+      expect(outcome).toBe('transient_back');
+      expect(panelModeManager.endTransientSession).toHaveBeenCalledTimes(1);
+      // Never forces a surface open and never docks.
+      expect(panelModeManager.setMode).not.toHaveBeenCalled();
+      expect(sidebarState.openSidebar).not.toHaveBeenCalled();
+      expect(sidebarState.setPendingOpenSource).not.toHaveBeenCalled();
+    });
+
+    it('reports analytics with destination=none and reason=transient_back', () => {
+      dockOnLeavingFullScreen(defaultInputs({ action: 'POP' }));
+
+      expect(reportAppInteraction).toHaveBeenCalledWith('full_screen_exit', {
+        destination: 'none',
+        guide_url: baseTab.baseUrl,
+        guide_title: baseTab.title,
+        reason: 'transient_back',
+      });
+    });
+
+    it('leaves PUSH (interactive navigate step) on the docking path even mid-session', () => {
+      const outcome = dockOnLeavingFullScreen(defaultInputs({ action: 'PUSH' }));
+      jest.runAllTimers();
+
+      expect(outcome).toBe('sidebar');
+      expect(panelModeManager.endTransientSession).not.toHaveBeenCalled();
+      expect(panelModeManager.setMode).toHaveBeenCalledWith('sidebar');
+      expect(sidebarState.openSidebar).toHaveBeenCalledWith('Interactive learning');
+    });
+
+    it('leaves REPLACE on the docking path (POP-only rule)', () => {
+      const outcome = dockOnLeavingFullScreen(defaultInputs({ action: 'REPLACE' }));
+      jest.runAllTimers();
+
+      expect(outcome).toBe('sidebar');
+      expect(panelModeManager.endTransientSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Back branch does not fire for a deliberate (non-transient) full screen', () => {
+    it('a POP with no transient session docks as today (deliberate adoption exit)', () => {
+      // isTransient() defaults to false in beforeEach.
+      const outcome = dockOnLeavingFullScreen(defaultInputs({ action: 'POP' }));
+      jest.runAllTimers();
+
+      expect(outcome).toBe('sidebar');
+      expect(panelModeManager.endTransientSession).not.toHaveBeenCalled();
+      expect(panelModeManager.setMode).toHaveBeenCalledWith('sidebar');
+      expect(sidebarState.openSidebar).toHaveBeenCalledWith('Interactive learning');
     });
   });
 });

--- a/src/components/full-screen/full-screen-autodock.ts
+++ b/src/components/full-screen/full-screen-autodock.ts
@@ -22,7 +22,10 @@ import { sidebarState } from '../../global-state/sidebar';
 import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
 
-export type AutoDockOutcome = 'sidebar' | 'floating' | 'noop';
+export type AutoDockOutcome = 'sidebar' | 'floating' | 'noop' | 'transient_back';
+
+/** history@4 navigation actions (`history.listen`'s second argument). */
+export type HistoryAction = 'PUSH' | 'REPLACE' | 'POP';
 
 export interface AutoDockInputs {
   /** New pathname after the navigation. */
@@ -34,6 +37,8 @@ export interface AutoDockInputs {
   /** Captured from `FullScreenPanel`'s active tab — reported as analytics context. */
   guideUrl: string | undefined;
   title: string;
+  /** history action driving the navigation — `'POP'` is the browser Back path. */
+  action: HistoryAction;
 }
 
 /**
@@ -57,7 +62,7 @@ export function dockOnLeavingFullScreen(inputs: AutoDockInputs): AutoDockOutcome
     return 'noop';
   }
 
-  const { guideUrl, title, myPluginId } = inputs;
+  const { guideUrl, title, myPluginId, action } = inputs;
 
   // Defer the actual mode/sidebar side effects to the next macrotask.
   // The history listener fires synchronously on `locationService.push`,
@@ -66,8 +71,35 @@ export function dockOnLeavingFullScreen(inputs: AutoDockInputs): AutoDockOutcome
   // the FullScreenPanel React tree here, `markAsCompleted` is racing
   // against unmount and the step's persistence write may never happen.
   // A `setTimeout(0)` delay yields the microtask queue so the handler's
-  // pending `await markAsCompleted()` chain can settle first.
+  // pending `await markAsCompleted()` chain can settle first. The Back
+  // branch below relies on the same deferral for a second reason (see there).
   const deferred = (fn: () => void) => setTimeout(fn, 0);
+
+  // Guard 3: browser Back (history POP) out of a transient prose full-screen
+  // launch. The launch picked full screen automatically and never expressed a
+  // durable surface preference, so the return gesture must not force the
+  // extension sidebar open with the prose squeezed in (#1448) — quietly end
+  // the transient session so `getMode()` falls back to the stored preference.
+  // PUSH/REPLACE keep today's dock (an interactive `navigate` step leaving full
+  // screen still needs a panel to continue in); a non-transient POP (a
+  // deliberately-adopted full screen) docks too. history v4 can't tell Back
+  // from Forward — both are POP — which is acceptable for this quiet exit.
+  //
+  // Deferring `endTransientSession` is load-bearing: `FullScreenPanel`'s unmount
+  // cleanup must run first, while `getMode()` is still `'fullscreen'`, so it
+  // clears `isSidebarMounted`. Ending the session synchronously would flip
+  // `getMode()` to the stored preference before the cleanup's mode check and
+  // strand the mount flag stale-true with no surface.
+  if (action === 'POP' && panelModeManager.isTransient()) {
+    reportAppInteraction(UserInteraction.FullScreenExit, {
+      destination: 'none',
+      guide_url: guideUrl || '',
+      guide_title: title,
+      reason: 'transient_back',
+    });
+    deferred(() => panelModeManager.endTransientSession());
+    return 'transient_back';
+  }
 
   if (isExtensionSidebarOwnedByOther(myPluginId)) {
     // Sidebar is taken — pop out as a floating overlay so we co-exist

--- a/src/components/full-screen/transient-back-quiet-exit.integration.test.ts
+++ b/src/components/full-screen/transient-back-quiet-exit.integration.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Integration proof for #1448 — browser Back out of a transient prose
+ * full-screen launch is a QUIET exit.
+ *
+ * Unlike `full-screen-autodock.test.ts`, this wires the REAL
+ * `panelModeManager`, REAL `dockOnLeavingFullScreen`, and REAL `sidebarState`
+ * together and observes the one side effect the end user actually feels: does
+ * the plugin publish an `OpenExtensionSidebarEvent` (the extension sidebar
+ * reopening with the prose squeezed in)? Only `@grafana/runtime`'s event bus,
+ * telemetry, analytics, and the sidebar-ownership probe are stubbed at the
+ * edges.
+ */
+
+const publishedEvents: Array<{ type: string }> = [];
+
+jest.mock('@grafana/runtime', () => ({
+  getAppEvents: () => ({
+    publish: (event: { type: string }) => {
+      publishedEvents.push(event);
+    },
+  }),
+}));
+
+jest.mock('../../lib/telemetry/surface', () => ({
+  reportPathfinderSurface: jest.fn(),
+  reportPathfinderSurfaceClosed: jest.fn(),
+}));
+
+jest.mock('../../lib/analytics', () => ({
+  reportAppInteraction: jest.fn(),
+  UserInteraction: new Proxy({}, { get: (_t, prop) => String(prop) }),
+}));
+
+jest.mock('../../lib/storage/extension-sidebar', () => ({
+  isExtensionSidebarOwnedByOther: jest.fn().mockReturnValue(false),
+}));
+
+import { OpenExtensionSidebarEvent } from '../../global-state/sidebar';
+import { StorageKeys } from '../../lib/storage-keys';
+
+const FULL_SCREEN_PATHNAME = '/a/grafana-pathfinder-app/fullscreen';
+
+interface Wired {
+  panelModeManager: typeof import('../../global-state/panel-mode').panelModeManager;
+  sidebarState: typeof import('../../global-state/sidebar').sidebarState;
+  dockOnLeavingFullScreen: typeof import('./full-screen-autodock').dockOnLeavingFullScreen;
+}
+
+// Fresh singleton graph per test so `_transientMode` never leaks across cases.
+function wireRealModules(): Wired {
+  let wired!: Wired;
+  jest.isolateModules(() => {
+    wired = {
+      panelModeManager: require('../../global-state/panel-mode').panelModeManager,
+      sidebarState: require('../../global-state/sidebar').sidebarState,
+      dockOnLeavingFullScreen: require('./full-screen-autodock').dockOnLeavingFullScreen,
+    };
+  });
+  return wired;
+}
+
+function sidebarOpenRequests() {
+  return publishedEvents.filter((e) => e.type === OpenExtensionSidebarEvent.type);
+}
+
+describe('#1448 quiet exit — real panel-mode + auto-dock + sidebar', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorage.clear();
+    publishedEvents.length = 0;
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('browser Back (POP) from a transient full-screen launch does NOT reopen the sidebar and reverts to the stored preference', () => {
+    const { panelModeManager, dockOnLeavingFullScreen } = wireRealModules();
+
+    // User's durable preference before the excursion.
+    localStorage.setItem(StorageKeys.PANEL_MODE, 'sidebar');
+    // My Learning opens a prose guide that auto-picks full screen (transient).
+    panelModeManager.setModeTransient('fullscreen');
+    expect(panelModeManager.getMode()).toBe('fullscreen');
+    publishedEvents.length = 0; // ignore the launch's close-sidebar event
+
+    const outcome = dockOnLeavingFullScreen({
+      pathname: '/a/grafana-pathfinder-app/journeys',
+      fullScreenPathname: FULL_SCREEN_PATHNAME,
+      myPluginId: 'grafana-pathfinder-app',
+      guideUrl: 'https://example.com/guide.json',
+      title: 'My journey',
+      action: 'POP',
+    });
+    jest.runAllTimers();
+
+    expect(outcome).toBe('transient_back');
+    // The bug: sidebar reopened with prose squeezed in. The fix: it does not.
+    expect(sidebarOpenRequests()).toHaveLength(0);
+    // No dead-state stuck on 'fullscreen'; falls back to the stored preference.
+    expect(panelModeManager.getMode()).toBe('sidebar');
+    expect(panelModeManager.isTransient()).toBe(false);
+    // Preference the launch never expressed is left untouched (no persist).
+    expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('sidebar');
+  });
+
+  it('a PUSH mid-session (interactive navigate step) still docks and DOES reopen the sidebar', () => {
+    const { panelModeManager, dockOnLeavingFullScreen } = wireRealModules();
+
+    localStorage.setItem(StorageKeys.PANEL_MODE, 'sidebar');
+    panelModeManager.setModeTransient('fullscreen');
+    publishedEvents.length = 0;
+
+    const outcome = dockOnLeavingFullScreen({
+      pathname: '/a/grafana-pathfinder-app/journeys',
+      fullScreenPathname: FULL_SCREEN_PATHNAME,
+      myPluginId: 'grafana-pathfinder-app',
+      guideUrl: 'https://example.com/guide.json',
+      title: 'My journey',
+      action: 'PUSH',
+    });
+    jest.runAllTimers();
+
+    expect(outcome).toBe('sidebar');
+    expect(sidebarOpenRequests()).toHaveLength(1);
+  });
+});

--- a/src/components/full-screen/transient-back-quiet-exit.integration.test.ts
+++ b/src/components/full-screen/transient-back-quiet-exit.integration.test.ts
@@ -103,6 +103,40 @@ describe('#1448 quiet exit — real panel-mode + auto-dock + sidebar', () => {
     expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('sidebar');
   });
 
+  it('browser Back (POP) with a persisted floating preference reverts to floating, not sidebar', () => {
+    const { panelModeManager, dockOnLeavingFullScreen } = wireRealModules();
+
+    // Durable preference is floating; the prose launch still auto-picks full
+    // screen transiently (previous='floating' ≠ 'fullscreen', so this DOES emit
+    // the mode-change event that caches the outer FloatingPanelManager stale).
+    localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
+    panelModeManager.setModeTransient('fullscreen');
+    expect(panelModeManager.getMode()).toBe('fullscreen');
+    publishedEvents.length = 0;
+
+    const outcome = dockOnLeavingFullScreen({
+      pathname: '/a/grafana-pathfinder-app/journeys',
+      fullScreenPathname: FULL_SCREEN_PATHNAME,
+      myPluginId: 'grafana-pathfinder-app',
+      guideUrl: 'https://example.com/guide.json',
+      title: 'My journey',
+      action: 'POP',
+    });
+    jest.runAllTimers();
+
+    expect(outcome).toBe('transient_back');
+    expect(sidebarOpenRequests()).toHaveLength(0);
+    // The launch never expressed a preference, so Back reverts to the stored
+    // floating one. getMode() reporting 'floating' is what routes the NEXT
+    // launch down HomePanel's floating branch (REQUEST_FLOATING_GUIDE_EVENT),
+    // which the outer manager's resync listener remounts to consume — the
+    // stranding path Leslie flagged. Wiring pinned in
+    // floating-panel.pending-guide.test.ts.
+    expect(panelModeManager.getMode()).toBe('floating');
+    expect(panelModeManager.isTransient()).toBe(false);
+    expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
+  });
+
   it('a PUSH mid-session (interactive navigate step) still docks and DOES reopen the sidebar', () => {
     const { panelModeManager, dockOnLeavingFullScreen } = wireRealModules();
 

--- a/src/global-state/panel-mode.test.ts
+++ b/src/global-state/panel-mode.test.ts
@@ -343,4 +343,58 @@ describe('panelModeManager', () => {
       expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
     });
   });
+
+  describe('endTransientSession (browser Back quiet exit, #1448)', () => {
+    // The manager is a singleton and only setModePersisted / endTransientSession
+    // close a session, so load a fresh instance per test to avoid leaking the
+    // in-memory override across cases.
+    let manager!: typeof panelModeManager;
+    beforeEach(() => {
+      jest.isolateModules(() => {
+        manager = jest.requireActual('./panel-mode').panelModeManager;
+      });
+    });
+
+    it('isTransient tracks the session: false → true after a transient launch → false after end', () => {
+      expect(manager.isTransient()).toBe(false);
+      manager.setModeTransient('fullscreen');
+      expect(manager.isTransient()).toBe(true);
+      manager.endTransientSession();
+      expect(manager.isTransient()).toBe(false);
+    });
+
+    it('drops the override so getMode reverts to the stored preference, without persisting', () => {
+      localStorage.setItem(StorageKeys.PANEL_MODE, 'sidebar');
+      manager.setModeTransient('fullscreen');
+      expect(manager.getMode()).toBe('fullscreen');
+
+      manager.endTransientSession();
+
+      // Reverts to the stored preference (not stuck on fullscreen — the dead-state
+      // hazard) and leaves the preference untouched (no persisting write).
+      expect(manager.getMode()).toBe('sidebar');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('sidebar');
+    });
+
+    it('is a no-op when no transient session is active', () => {
+      localStorage.setItem(StorageKeys.PANEL_MODE, 'floating');
+      manager.endTransientSession();
+      expect(manager.isTransient()).toBe(false);
+      expect(manager.getMode()).toBe('floating');
+      expect(localStorage.getItem(StorageKeys.PANEL_MODE)).toBe('floating');
+    });
+
+    it('does not dispatch pathfinder-panel-mode-change (surface already unmounted)', () => {
+      const handler = jest.fn();
+      document.addEventListener('pathfinder-panel-mode-change', handler);
+      try {
+        manager.setModeTransient('fullscreen');
+        handler.mockClear();
+        manager.endTransientSession();
+        expect(handler).not.toHaveBeenCalled();
+      } finally {
+        document.removeEventListener('pathfinder-panel-mode-change', handler);
+      }
+    });
+  });
 });

--- a/src/global-state/panel-mode.ts
+++ b/src/global-state/panel-mode.ts
@@ -120,6 +120,39 @@ class PanelModeManager {
   }
 
   /**
+   * Whether a transient auto-launch session is active (`_transientMode !== null`;
+   * see the persistence contract). Public accessor consulted by the full-screen
+   * auto-dock to tell a transient launch's return path apart from a deliberate
+   * full-screen adoption. Past the auto-dock's `getMode() === 'fullscreen'`
+   * guard a true value necessarily means a transient _fullscreen_ session.
+   */
+  public isTransient(): boolean {
+    return this._transientMode !== null;
+  }
+
+  /**
+   * End a transient auto-launch session WITHOUT persisting or forcing a surface
+   * open — drops the in-memory override so `getMode()` falls back to the stored
+   * preference. The quiet counterpart to `setModeTransient`, used when the user
+   * leaves a transient full-screen excursion via browser Back (#1448): we must
+   * neither reopen a surface nor overwrite the preference the launch never
+   * expressed. No-ops when no session is active.
+   *
+   * Reports `reportPathfinderSurfaceClosed('fullscreen')` for parity with the
+   * other full-screen exits. Deliberately does NOT dispatch
+   * `PANEL_MODE_CHANGE_EVENT`: the caller has already navigated away and
+   * unmounted the surface, so no live listener consumes the transition (unlike
+   * the three mutators, which drive a visible surface change).
+   */
+  public endTransientSession(): void {
+    if (this._transientMode === null) {
+      return;
+    }
+    this._transientMode = null;
+    reportPathfinderSurfaceClosed('fullscreen');
+  }
+
+  /**
    * Conditional mode change — the default path for automatic transitions
    * (teardown, auto-dock, self-heal, cold-load sync) and for deliberate
    * RETURN-to-base gestures (fullscreen back-arrow, floating close). Persists


### PR DESCRIPTION
## Intent

Fix issue #1448: browser Back from a transient prose full-screen launch (My Learning → prose guide → auto full screen) reopens a closed extension sidebar with the prose squeezed in. Goal is a QUIET exit on browser Back only.

Settled product decisions (constraints, not mistakes): Q1 quiet exit ALWAYS — never force the sidebar open on Back regardless of whether it was open before launch; deliberately NO prior-surface capture and NO tabStorage snapshot/restore. Q2 browser Back (history POP) only — all PUSH paths keep today's dock behavior, including the interactive navigate-step continuation and the Grafana nav-click-with-prose annoyance (that is a separate follow-up needing an interactive-step-in-progress signal, to be filed, not folded in). history v4 cannot distinguish Back from Forward (both POP) — accepted.

Implementation: 3 source files. panel-mode.ts gains isTransient() (public accessor for the private _transientMode) and endTransientSession() which nulls _transientMode WITHOUT persisting so getMode() falls back to the stored preference (fixes the dead-state hazard H1 where mode would otherwise stay stuck on 'fullscreen'), and emits reportPathfinderSurfaceClosed('fullscreen') for telemetry parity. It deliberately does NOT dispatch PANEL_MODE_CHANGE_EVENT because the surface is already unmounted on the Back path (no live listener). full-screen-autodock.ts threads a new history 'action' input and adds a guard: action==='POP' && isTransient() → report FullScreenExit with destination='none'/reason='transient_back', defer endTransientSession, return new outcome 'transient_back'. The endTransientSession call is DEFERRED via the existing setTimeout(0) (hazard H2): FullScreenPanel's unmount cleanup must run first while getMode() is still 'fullscreen' so it clears isSidebarMounted. FullScreenPanel.tsx captures the second 'action' arg from history.listen and passes it through.

Telemetry values destination='none' and reason='transient_back' are low-cardinality, non-user-derived — no privacy review needed per TELEMETRY.md. Contract tripwire panel-mode-surface-toggles.contract.test.ts is preserved (autodock still contains literal setMode('sidebar')/setMode('floating'), never setModePersisted). Updated full-screen-autodock.test.ts and panel-mode.test.ts. Typecheck and the 3 affected suites pass locally.

## What Changed

- Added `isTransient()` and `endTransientSession()` to `panel-mode.ts`: the latter clears `_transientMode` without persisting so `getMode()` falls back to the stored preference (avoiding a stuck `'fullscreen'` state) and emits `reportPathfinderSurfaceClosed('fullscreen')` for telemetry parity, deliberately without dispatching `PANEL_MODE_CHANGE_EVENT` since the surface is already unmounted.
- Threaded a history `action` argument through `FullScreenPanel.tsx` into `full-screen-autodock.ts`, which now guards on `action === 'POP' && isTransient()` to report a `FullScreenExit` (`destination='none'`, `reason='transient_back'`), return the new `'transient_back'` outcome, and defer `endTransientSession()` via the existing `setTimeout(0)` so unmount cleanup runs while the mode is still `'fullscreen'`; PUSH paths keep today's dock behavior.
- Extended `full-screen-autodock.test.ts` and `panel-mode.test.ts`, added a `transient-back-quiet-exit.integration.test.ts` suite, and documented the browser-Back quiet exit in `docs/design/PANEL-MODE-PERSISTENCE.md`.

## Risk Assessment

✅ Low: A small, well-bounded three-file fix that matches the settled product decisions exactly, preserves the surface-toggle contract, and whose load-bearing deferral/ordering and revert-target invariants all hold with no reachable dead state.

## Testing

Baseline: installed deps (node_modules absent; gitignored). Ran the three affected Jest suites plus the preserved contract tripwire (56 pass) and confirmed the autodock still uses literal setMode('sidebar')/setMode('floating') with no setModePersisted. Verified the load-bearing library contract directly in the history v4 source — the history.listen callback receives (location, action) and a browser Back emits action='POP' — which validates the one untested piece, FullScreenPanel.tsx's action passthrough. To demonstrate the intent end-to-end rather than via mocks, I added and ran an integration test that wires the real panelModeManager, dockOnLeavingFullScreen, and sidebarState together and observes the genuine end-user side effect (whether an OpenExtensionSidebarEvent is published): a POP out of a transient full-screen launch publishes no sidebar-open event and getMode() falls back to the stored preference with no persist write (the quiet exit, no dead-state), whereas a PUSH mid-session still docks and reopens the sidebar. No visual screenshot was captured because the user-visible manifestation (the extension sidebar reopening with prose squeezed in) is Grafana host chrome, not plugin-rendered UI — the plugin's sole contribution is whether it emits the open-sidebar request, which the integration test observes directly at the real boundary; a full Docker build + multi-hop manual reproduction would only re-exercise host chrome driven by that same event. All checks pass; no actionable findings.

<details>
<summary>Evidence: #1448 quiet-exit targeted test transcript (58/58 pass across 4 suites)</summary>

```text
#1448 quiet-exit on browser Back — targeted test run
58/58 tests passed across 4 suites

● src/components/full-screen/transient-back-quiet-exit.integration.test.ts
   PASS  #1448 quiet exit — real panel-mode + auto-dock + sidebar › browser Back (POP) from a transient full-screen launch does NOT reopen the sidebar and reverts to the stored preference
   PASS  #1448 quiet exit — real panel-mode + auto-dock + sidebar › a PUSH mid-session (interactive navigate step) still docks and DOES reopen the sidebar

● src/global-state/panel-mode.test.ts
   PASS  panelModeManager › getMode › defaults to sidebar when nothing is stored
   PASS  panelModeManager › getMode › returns floating when stored value is "floating"
   PASS  panelModeManager › getMode › returns fullscreen when stored value is "fullscreen"
   PASS  panelModeManager › getMode › falls back to sidebar for any unknown stored value
   PASS  panelModeManager › setMode › persists fullscreen to storage
   PASS  panelModeManager › setMode › publishes close-extension-sidebar when entering fullscreen
   PASS  panelModeManager › setMode › publishes close-extension-sidebar when entering floating (regression)
   PASS  panelModeManager › setMode › does not publish close-extension-sidebar when returning to sidebar
   PASS  panelModeManager › setMode › is a no-op when target mode equals current mode
   PASS  panelModeManager › setMode › dispatches pathfinder-panel-mode-change with previous and next modes
   PASS  panelModeManager › pendingGuide handoff › round-trips a pending guide once via consume
   PASS  panelModeManager › pendingGuide handoff › round-trips an editor handoff with no url
   PASS  panelModeManager › pendingGuide handoff › preserves packageInfo across the handoff (synthetic PR-tester journeys)
   PASS  panelModeManager › priorPath capture › round-trips a captured prior path once via consume
   PASS  panelModeManager › priorPath capture › returns null when nothing was captured (cold-loaded /fullscreen URL)
   PASS  panelModeManager › priorPath capture › overwrites a previously captured path on second capture
   PASS  panelModeManager › setModeTransient › does NOT persist the mode to localStorage (user preference untouched)
   PASS  panelModeManager › setModeTransient › preserves an existing persisted preference under the transient override
   PASS  panelModeManager › setModeTransient › runs the same side effects as setMode (close-extension-sidebar)
   PASS  panelModeManager › setModeTransient › does not persist the base sidebar teardown of a round-trip
   PASS  panelModeManager › transient-session persistence suppression (locked decision 2) › never overwrites a non-default preference across a transient fullscreen launch round-trip
   PASS  panelModeManager › transient-session persistence suppression (locked decision 2) › never overwrites a non-default preference across a transient floating launch round-trip
   PASS  panelModeManager › transient-session persistence suppression (locked decision 2) › never overwrites a non-default preference across a transient sidebar launch round-trip
   PASS  panelModeManager › transient-session persistence suppression (locked decision 2) › never persists an automatic auto-dock to FLOATING (full-screen → floating when sidebar occupied)
   PASS  panelModeManager › transient-session persistence suppression (locked decision 2) › reloading a transient full-screen launch keeps the stored preference intact
   PASS  panelModeManager › transient-session persistence suppression (locked decision 2) › resumes persistence for a deliberate surface change after a round-trip
   PASS  panelModeManager › transient-session persistence suppression (locked decision 2) › setModePersisted persists, ends the session, and lets subsequent setMode persist
   PASS  panelModeManager › transient-session persistence suppression (locked decision 2) › persists a manually entered surface on exit (no transient session)
   PASS  panelModeManager › deliberate dock to sidebar persists consistently (decision 3, #1449) › persists sidebar for a floating-preference user in a fresh session
   PASS  panelModeManager › deliberate dock to sidebar persists consistently (decision 3, #1449) › persists sidebar even mid transient session (no invisible-history dependence)
   PASS  panelModeManager › deliberate dock to sidebar persists consistently (decision 3, #1449) › contrasts with the conditional fullscreen return, which stays transient-safe
   PASS  panelModeManager › endTransientSession (browser Back quiet exit, #1448) › isTransient tracks the session: false → true after a transient launch → false after end
   PASS  panelModeManager › endTransientSession (browser Back quiet exit, #1448) › drops the override so getMode reverts to the stored preference, without persisting
   PASS  panelModeManager › endTransientSession (browser Back quiet exit, #1448) › is a no-op when no transient session is active
   PASS  panelModeManager › endTransientSession (browser Back quiet exit, #1448) › does not dispatch pathfinder-panel-mode-change (surface already unmounted)

● src/components/full-screen/full-screen-autodock.test.ts
   PASS  dockOnLeavingFullScreen › guards › no-ops when panel mode is no longer fullscreen (explicit Exit ran first)
   PASS  dockOnLeavingFullScreen › guards › no-ops when only search/hash changed (pathname still on fullscreen route)
   PASS  dockOnLeavingFullScreen › sidebar branch (sidebar free or owned by us) › switches to sidebar mode and opens the extension sidebar (deferred to next macrotask)
   PASS  dockOnLeavingFullScreen › sidebar branch (sidebar free or owned by us) › reports analytics with destination=sidebar and reason=navigation_away
   PASS  dockOnLeavingFullScreen › sidebar branch (sidebar free or owned by us) › uses an empty guide_url when none is available (e.g. recommendations tab)
   PASS  dockOnLeavingFullScreen › floating branch (sidebar owned by another plugin) › switches to floating mode without opening the sidebar (deferred)
   PASS  dockOnLeavingFullScreen › floating branch (sidebar owned by another plugin) › does not set a pending guide — the floating panel restores from tabStorage
   PASS  dockOnLeavingFullScreen › floating branch (sidebar owned by another plugin) › reports analytics with destination=floating and reason=navigation_away_sidebar_occupied
   PASS  dockOnLeavingFullScreen › transient Back branch (browser Back out of a transient prose launch) › quietly ends the transient session without opening the sidebar (deferred)
   PASS  dockOnLeavingFullScreen › transient Back branch (browser Back out of a transient prose launch) › reports analytics with destination=none and reason=transient_back
   PASS  dockOnLeavingFullScreen › transient Back branch (browser Back out of a transient prose launch) › leaves PUSH (interactive navigate step) on the docking path even mid-session
   PASS  dockOnLeavingFullScreen › transient Back branch (browser Back out of a transient prose launch) › leaves REPLACE on the docking path (POP-only rule)
   PASS  dockOnLeavingFullScreen › Back branch does not fire for a deliberate (non-transient) full screen › a POP with no transient session docks as today (deliberate adoption exit)

● src/components/full-screen/panel-mode-surface-toggles.contract.test.ts
   PASS  panel-mode surface-toggle persistence classification › deliberate non-sidebar adoptions persist via setModePersisted › FullScreenPanel switch-to-floating persists, never plain setMode
   PASS  panel-mode surface-toggle persistence classification › deliberate non-sidebar adoptions persist via setModePersisted › FloatingPanelManager switch-to-fullscreen persists, never plain setMode
   PASS  panel-mode surface-toggle persistence classification › deliberate non-sidebar adoptions persist via setModePersisted › the sidebar-owned pop-out / full-screen controls and deep link stay persisted
   PASS  panel-mode surface-toggle persistence classification › the floating dock-to-sidebar pill is a deliberate adoption (decision 3) › the pill persists (dockToSidebar(true)) while the programmatic dock request stays transient (dockToSidebar(false))
   PASS  panel-mode surface-toggle persistence classification › automatic and return-to-base sites stay conditional setMode › full-screen auto-dock (sidebar OR floating) never persists
   PASS  panel-mode surface-toggle persistence classification › automatic and return-to-base sites stay conditional setMode › the fullscreen RETURN-to-sidebar exit stays conditional, never a forced sidebar adoption
   PASS  panel-mode surface-toggle persistence classification › automatic and return-to-base sites stay conditional setMode › self-heal and cold-load mode-sync stay plain setMode
   PASS  panel-mode surface-toggle persistence classification › automatic and return-to-base sites stay conditional setMode › FullScreenPanel cold-load route sync is transient, never a persisting write
```
</details>
<details>
<summary>Evidence: Integration proof: POP+transient → no sidebar reopen + revert to stored pref; PUSH → docks + reopens</summary>

```text
● transient-back-quiet-exit.integration.test.ts
PASS browser Back (POP) from a transient full-screen launch does NOT reopen the sidebar and reverts to the stored preference
PASS a PUSH mid-session (interactive navigate step) still docks and DOES reopen the sidebar
```
</details>
- Outcome: ⚠️ 1 info across 1 run (6m0s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `src/components/full-screen/transient-back-quiet-exit.integration.test.ts` - new test file written by agent: src/components/full-screen/transient-back-quiet-exit.integration.test.ts
- <code>`npx jest --coverage=false` on the 3 affected suites + contract tripwire</code>
- `new integration test transient-back-quiet-exit.integration.test.ts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
