### PR TITLE
feat(learning-paths): land cloud paths on cover page with a table of contents

### DIFF
--- a/src/components/LearningPaths/GuideList.test.tsx
+++ b/src/components/LearningPaths/GuideList.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * Tests for the shared GuideList — the milestone/guide row list reused by the
+ * My Learning card expander and the cover-page table of contents.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { GuideList } from './GuideList';
+import type { PathGuide } from '../../types/learning-paths.types';
+
+jest.mock('@grafana/ui', () => ({
+  useStyles2: () => new Proxy({}, { get: (_t, p) => String(p) }),
+  Icon: ({ name }: { name: string }) => <span data-icon={name} />,
+}));
+
+const guides: PathGuide[] = [
+  { id: 'a', title: 'First module', completed: true, isCurrent: false },
+  { id: 'b', title: 'Second module', completed: false, isCurrent: true },
+  { id: 'c', title: 'Third module', completed: false, isCurrent: false },
+];
+
+describe('GuideList', () => {
+  it('renders a row per guide with a check icon for completed and a circle otherwise', () => {
+    render(<GuideList guides={guides} />);
+
+    expect(screen.getByText('First module')).toBeInTheDocument();
+    expect(screen.getByText('Second module')).toBeInTheDocument();
+    expect(screen.getByText('Third module')).toBeInTheDocument();
+
+    expect(document.querySelectorAll('[data-icon="check"]')).toHaveLength(1);
+    expect(document.querySelectorAll('[data-icon="circle"]')).toHaveLength(2);
+  });
+
+  it('shows a loading row instead of the list when isLoading is set', () => {
+    render(<GuideList guides={[]} isLoading loadingLabel="Loading…" />);
+
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+    expect(document.querySelector('[data-icon="fa fa-spinner"]')).toBeInTheDocument();
+  });
+});

--- a/src/components/LearningPaths/GuideList.test.tsx
+++ b/src/components/LearningPaths/GuideList.test.tsx
@@ -1,8 +1,3 @@
-/**
- * Tests for the shared GuideList — the milestone/guide row list reused by the
- * My Learning card expander and the cover-page table of contents.
- */
-
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { GuideList } from './GuideList';
@@ -11,6 +6,10 @@ import type { PathGuide } from '../../types/learning-paths.types';
 jest.mock('@grafana/ui', () => ({
   useStyles2: () => new Proxy({}, { get: (_t, p) => String(p) }),
   Icon: ({ name }: { name: string }) => <span data-icon={name} />,
+}));
+
+jest.mock('@grafana/i18n', () => ({
+  t: (_key: string, fallback: string) => fallback,
 }));
 
 const guides: PathGuide[] = [
@@ -32,9 +31,9 @@ describe('GuideList', () => {
   });
 
   it('shows a loading row instead of the list when isLoading is set', () => {
-    render(<GuideList guides={[]} isLoading loadingLabel="Loading…" />);
+    render(<GuideList guides={[]} isLoading />);
 
-    expect(screen.getByText('Loading…')).toBeInTheDocument();
+    expect(screen.getByText('Loading guides...')).toBeInTheDocument();
     expect(document.querySelector('[data-icon="fa fa-spinner"]')).toBeInTheDocument();
   });
 });

--- a/src/components/LearningPaths/GuideList.tsx
+++ b/src/components/LearningPaths/GuideList.tsx
@@ -1,0 +1,52 @@
+/**
+ * Guide list
+ *
+ * Renders an ordered list of a learning path's guides/milestones with a
+ * per-item completion icon. Shared by the My Learning card expander and the
+ * cover-page table of contents so both read identically.
+ */
+
+import React from 'react';
+import { useStyles2, Icon } from '@grafana/ui';
+import { cx } from '@emotion/css';
+
+import type { PathGuide } from '../../types/learning-paths.types';
+import { getLearningPathCardStyles } from './learning-paths.styles';
+
+export interface GuideListProps {
+  guides: PathGuide[];
+  /** Shows a spinner row instead of the list while guides resolve. */
+  isLoading?: boolean;
+  loadingLabel?: string;
+}
+
+export function GuideList({ guides, isLoading = false, loadingLabel = 'Loading guides...' }: GuideListProps) {
+  const styles = useStyles2(getLearningPathCardStyles);
+
+  return (
+    <div className={styles.guideList}>
+      {isLoading ? (
+        <div className={styles.guideItem}>
+          <Icon name="fa fa-spinner" size="sm" />
+          <span className={styles.guideTitle}>{loadingLabel}</span>
+        </div>
+      ) : (
+        guides.map((guide) => (
+          <div key={guide.id} className={cx(styles.guideItem, guide.isCurrent && styles.guideItemCurrent)}>
+            <span
+              className={cx(
+                styles.guideIcon,
+                guide.completed && styles.guideIconCompleted,
+                guide.isCurrent && styles.guideIconCurrent,
+                !guide.completed && !guide.isCurrent && styles.guideIconPending
+              )}
+            >
+              {guide.completed ? <Icon name="check" size="sm" /> : <Icon name="circle" size="sm" />}
+            </span>
+            <span className={styles.guideTitle}>{guide.title}</span>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/src/components/LearningPaths/GuideList.tsx
+++ b/src/components/LearningPaths/GuideList.tsx
@@ -1,34 +1,26 @@
-/**
- * Guide list
- *
- * Renders an ordered list of a learning path's guides/milestones with a
- * per-item completion icon. Shared by the My Learning card expander and the
- * cover-page table of contents so both read identically.
- */
-
 import React from 'react';
 import { useStyles2, Icon } from '@grafana/ui';
+import { t } from '@grafana/i18n';
 import { cx } from '@emotion/css';
 
 import type { PathGuide } from '../../types/learning-paths.types';
-import { getLearningPathCardStyles } from './learning-paths.styles';
+import { getGuideListStyles } from './learning-paths.styles';
 
 export interface GuideListProps {
   guides: PathGuide[];
-  /** Shows a spinner row instead of the list while guides resolve. */
   isLoading?: boolean;
-  loadingLabel?: string;
+  className?: string;
 }
 
-export function GuideList({ guides, isLoading = false, loadingLabel = 'Loading guides...' }: GuideListProps) {
-  const styles = useStyles2(getLearningPathCardStyles);
+export function GuideList({ guides, isLoading = false, className }: GuideListProps) {
+  const styles = useStyles2(getGuideListStyles);
 
   return (
-    <div className={styles.guideList}>
+    <div className={cx(styles.list, className)}>
       {isLoading ? (
         <div className={styles.guideItem}>
           <Icon name="fa fa-spinner" size="sm" />
-          <span className={styles.guideTitle}>{loadingLabel}</span>
+          <span className={styles.guideTitle}>{t('myLearning.loadingGuides', 'Loading guides...')}</span>
         </div>
       ) : (
         guides.map((guide) => (

--- a/src/components/LearningPaths/LearningPathCard.tsx
+++ b/src/components/LearningPaths/LearningPathCard.tsx
@@ -11,6 +11,7 @@ import { cx } from '@emotion/css';
 import type { LearningPathCardProps } from '../../types/learning-paths.types';
 import { testIds } from '../../constants/testIds';
 import { getLearningPathCardStyles } from './learning-paths.styles';
+import { GuideList } from './GuideList';
 import { ProgressRing } from './ProgressRing';
 
 /**
@@ -180,30 +181,7 @@ export function LearningPathCard({
       <div className={cx(styles.expandable, isExpanded && styles.expandableOpen)}>
         {path.description && <p className={styles.description}>{path.description}</p>}
 
-        <div className={styles.guideList}>
-          {isLoadingGuides ? (
-            <div className={styles.guideItem}>
-              <Icon name="fa fa-spinner" size="sm" />
-              <span className={styles.guideTitle}>Loading guides...</span>
-            </div>
-          ) : (
-            guides.map((guide) => (
-              <div key={guide.id} className={cx(styles.guideItem, guide.isCurrent && styles.guideItemCurrent)}>
-                <span
-                  className={cx(
-                    styles.guideIcon,
-                    guide.completed && styles.guideIconCompleted,
-                    guide.isCurrent && styles.guideIconCurrent,
-                    !guide.completed && !guide.isCurrent && styles.guideIconPending
-                  )}
-                >
-                  {guide.completed ? <Icon name="check" size="sm" /> : <Icon name="circle" size="sm" />}
-                </span>
-                <span className={styles.guideTitle}>{guide.title}</span>
-              </div>
-            ))
-          )}
-        </div>
+        <GuideList guides={guides} isLoading={isLoadingGuides} />
       </div>
     </div>
   );

--- a/src/components/LearningPaths/LearningPathCard.tsx
+++ b/src/components/LearningPaths/LearningPathCard.tsx
@@ -181,7 +181,7 @@ export function LearningPathCard({
       <div className={cx(styles.expandable, isExpanded && styles.expandableOpen)}>
         {path.description && <p className={styles.description}>{path.description}</p>}
 
-        <GuideList guides={guides} isLoading={isLoadingGuides} />
+        <GuideList guides={guides} isLoading={isLoadingGuides} className={styles.guideList} />
       </div>
     </div>
   );

--- a/src/components/LearningPaths/LearningPathTableOfContents.test.tsx
+++ b/src/components/LearningPaths/LearningPathTableOfContents.test.tsx
@@ -1,8 +1,3 @@
-/**
- * Tests for the cover-page table of contents: it lists journey milestones and
- * marks per-milestone completion resolved from storage (issue #1467).
- */
-
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { LearningPathTableOfContents } from './LearningPathTableOfContents';
@@ -20,17 +15,6 @@ jest.mock('@grafana/i18n', () => ({
 
 jest.mock('../../lib/user-storage', () => ({
   milestoneCompletionStorage: { getCompleted: jest.fn() },
-}));
-
-// The real docs-retrieval barrel drags content-fetcher (→ @grafana/runtime) at
-// import time; the slug rule under test is a stable one-liner.
-jest.mock('../../docs-retrieval', () => ({
-  getMilestoneSlug: (url: string) =>
-    url
-      .replace(/\/(content\.json|unstyled\.html)$/, '')
-      .replace(/\/+$/, '')
-      .split('/')
-      .pop() || '',
 }));
 
 const getCompletedMock = milestoneCompletionStorage.getCompleted as jest.MockedFunction<
@@ -53,7 +37,12 @@ describe('LearningPathTableOfContents', () => {
     expect(screen.getByText('In this path')).toBeInTheDocument();
     expect(screen.getByText('Set up')).toBeInTheDocument();
     expect(screen.getByText('Explore')).toBeInTheDocument();
-    await waitFor(() => expect(getCompletedMock).toHaveBeenCalledWith(baseUrl));
+    await waitFor(() =>
+      expect(getCompletedMock).toHaveBeenCalledWith(
+        baseUrl,
+        milestones.map((milestone) => milestone.url)
+      )
+    );
   });
 
   it('shows a check for milestones whose slug is in the completed set', async () => {

--- a/src/components/LearningPaths/LearningPathTableOfContents.test.tsx
+++ b/src/components/LearningPaths/LearningPathTableOfContents.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Tests for the cover-page table of contents: it lists journey milestones and
+ * marks per-milestone completion resolved from storage (issue #1467).
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { LearningPathTableOfContents } from './LearningPathTableOfContents';
+import { milestoneCompletionStorage } from '../../lib/user-storage';
+import type { Milestone } from '../../types/content.types';
+
+jest.mock('@grafana/ui', () => ({
+  useStyles2: () => new Proxy({}, { get: (_t, p) => String(p) }),
+  Icon: ({ name }: { name: string }) => <span data-icon={name} />,
+}));
+
+jest.mock('@grafana/i18n', () => ({
+  t: (_key: string, fallback: string) => fallback,
+}));
+
+jest.mock('../../lib/user-storage', () => ({
+  milestoneCompletionStorage: { getCompleted: jest.fn() },
+}));
+
+// The real docs-retrieval barrel drags content-fetcher (→ @grafana/runtime) at
+// import time; the slug rule under test is a stable one-liner.
+jest.mock('../../docs-retrieval', () => ({
+  getMilestoneSlug: (url: string) =>
+    url
+      .replace(/\/(content\.json|unstyled\.html)$/, '')
+      .replace(/\/+$/, '')
+      .split('/')
+      .pop() || '',
+}));
+
+const getCompletedMock = milestoneCompletionStorage.getCompleted as jest.MockedFunction<
+  typeof milestoneCompletionStorage.getCompleted
+>;
+
+const baseUrl = 'https://grafana.com/docs/learning-paths/demo/';
+const milestones: Milestone[] = [
+  { number: 1, title: 'Set up', duration: '', url: `${baseUrl}set-up/content.json`, isActive: false },
+  { number: 2, title: 'Explore', duration: '', url: `${baseUrl}explore/content.json`, isActive: false },
+];
+
+describe('LearningPathTableOfContents', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders every milestone title with a heading', async () => {
+    getCompletedMock.mockResolvedValue(new Set());
+    render(<LearningPathTableOfContents milestones={milestones} baseUrl={baseUrl} />);
+
+    expect(screen.getByText('In this path')).toBeInTheDocument();
+    expect(screen.getByText('Set up')).toBeInTheDocument();
+    expect(screen.getByText('Explore')).toBeInTheDocument();
+    await waitFor(() => expect(getCompletedMock).toHaveBeenCalledWith(baseUrl));
+  });
+
+  it('shows a check for milestones whose slug is in the completed set', async () => {
+    getCompletedMock.mockResolvedValue(new Set(['set-up']));
+    render(<LearningPathTableOfContents milestones={milestones} baseUrl={baseUrl} />);
+
+    await waitFor(() => expect(document.querySelectorAll('[data-icon="check"]')).toHaveLength(1));
+    expect(document.querySelectorAll('[data-icon="circle"]')).toHaveLength(1);
+  });
+});

--- a/src/components/LearningPaths/LearningPathTableOfContents.tsx
+++ b/src/components/LearningPaths/LearningPathTableOfContents.tsx
@@ -1,0 +1,67 @@
+/**
+ * Learning path table of contents
+ *
+ * Milestone list rendered on a learning path's cover page (milestone 0). Mirrors
+ * the My Learning card's guide expander via the shared GuideList, but sources its
+ * items from journey metadata and resolves per-milestone completion from storage
+ * (issue #1467). Display-only — the cover page's "Ready to begin" button and the
+ * milestone toolbar own navigation.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useStyles2, Icon } from '@grafana/ui';
+import { t } from '@grafana/i18n';
+
+import type { Milestone } from '../../types/content.types';
+import type { PathGuide } from '../../types/learning-paths.types';
+import { milestoneCompletionStorage } from '../../lib/user-storage';
+import { getMilestoneSlug } from '../../docs-retrieval';
+import { logger } from '../../lib/logging';
+import { testIds } from '../../constants/testIds';
+import { GuideList } from './GuideList';
+import { getTableOfContentsStyles } from './learning-paths.styles';
+
+export interface LearningPathTableOfContentsProps {
+  milestones: Milestone[];
+  /** Journey base URL — the completion-storage key for this path's milestones. */
+  baseUrl: string;
+}
+
+export function LearningPathTableOfContents({ milestones, baseUrl }: LearningPathTableOfContentsProps) {
+  const styles = useStyles2(getTableOfContentsStyles);
+  const [completedSlugs, setCompletedSlugs] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    milestoneCompletionStorage
+      .getCompleted(baseUrl)
+      .then((slugs) => {
+        if (!cancelled) {
+          setCompletedSlugs(slugs);
+        }
+      })
+      .catch((error) => {
+        logger.warn('[LearningPathTableOfContents] Failed to load milestone completion', { error });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [baseUrl]);
+
+  const guides: PathGuide[] = milestones.map((milestone) => ({
+    id: String(milestone.number),
+    title: milestone.title,
+    completed: completedSlugs.has(getMilestoneSlug(milestone.url)),
+    isCurrent: false,
+  }));
+
+  return (
+    <div className={styles.container} data-testid={testIds.learningPaths.tableOfContents}>
+      <h2 className={styles.heading}>
+        <Icon name="list-ul" size="md" className={styles.headingIcon} />
+        {t('coverPage.tableOfContents', 'In this path')}
+      </h2>
+      <GuideList guides={guides} />
+    </div>
+  );
+}

--- a/src/components/LearningPaths/LearningPathTableOfContents.tsx
+++ b/src/components/LearningPaths/LearningPathTableOfContents.tsx
@@ -1,13 +1,3 @@
-/**
- * Learning path table of contents
- *
- * Milestone list rendered on a learning path's cover page (milestone 0). Mirrors
- * the My Learning card's guide expander via the shared GuideList, but sources its
- * items from journey metadata and resolves per-milestone completion from storage
- * (issue #1467). Display-only — the cover page's "Ready to begin" button and the
- * milestone toolbar own navigation.
- */
-
 import React, { useEffect, useState } from 'react';
 import { useStyles2, Icon } from '@grafana/ui';
 import { t } from '@grafana/i18n';
@@ -15,15 +5,13 @@ import { t } from '@grafana/i18n';
 import type { Milestone } from '../../types/content.types';
 import type { PathGuide } from '../../types/learning-paths.types';
 import { milestoneCompletionStorage } from '../../lib/user-storage';
-import { getMilestoneSlug } from '../../docs-retrieval';
-import { logger } from '../../lib/logging';
+import { getMilestoneSlug } from '../../lib/learning-journey-url';
 import { testIds } from '../../constants/testIds';
 import { GuideList } from './GuideList';
 import { getTableOfContentsStyles } from './learning-paths.styles';
 
 export interface LearningPathTableOfContentsProps {
   milestones: Milestone[];
-  /** Journey base URL — the completion-storage key for this path's milestones. */
   baseUrl: string;
 }
 
@@ -33,20 +21,20 @@ export function LearningPathTableOfContents({ milestones, baseUrl }: LearningPat
 
   useEffect(() => {
     let cancelled = false;
-    milestoneCompletionStorage
-      .getCompleted(baseUrl)
+    void milestoneCompletionStorage
+      .getCompleted(
+        baseUrl,
+        milestones.map((milestone) => milestone.url)
+      )
       .then((slugs) => {
         if (!cancelled) {
           setCompletedSlugs(slugs);
         }
-      })
-      .catch((error) => {
-        logger.warn('[LearningPathTableOfContents] Failed to load milestone completion', { error });
       });
     return () => {
       cancelled = true;
     };
-  }, [baseUrl]);
+  }, [baseUrl, milestones]);
 
   const guides: PathGuide[] = milestones.map((milestone) => ({
     id: String(milestone.number),

--- a/src/components/LearningPaths/MyLearningTab.cover-launch.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.cover-launch.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tests for the cover-page launch routing (issue #1467): a fresh URL-based path
+ * lands on the cover page (base URL / milestone 0); an in-progress path resumes
+ * the current module's resolved URL.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
+import { MyLearningTab } from './MyLearningTab';
+import { prepareGuideLaunch, type PrepareGuideLaunchResult } from '../docs-panel/utils/prepare-guide-launch';
+import { testIds } from '../../constants/testIds';
+
+jest.mock('../docs-panel/utils/prepare-guide-launch', () => ({
+  prepareGuideLaunch: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime', () => ({ getAppEvents: () => ({ publish: jest.fn() }) }));
+jest.mock('@grafana/i18n', () => ({
+  t: (_key: string, fallback: string, vars?: Record<string, unknown>) =>
+    vars ? fallback.replace(/\{\{(\w+)\}\}/g, (_, k) => String(vars[k])) : fallback,
+}));
+jest.mock('@grafana/ui', () => ({
+  useStyles2: () => new Proxy({}, { get: () => 'style' }),
+  Icon: ({ name }: { name: string }) => <span data-icon={name} />,
+}));
+
+const pathBaseUrl = 'https://grafana.com/docs/learning-paths/path-1/';
+const moduleUrl = 'https://grafana.com/docs/learning-paths/path-1/guide-1/';
+
+// Mutable so each test picks the path's progress before rendering.
+let pathProgress = 0;
+
+jest.mock('../../learning-paths', () => ({
+  BADGES: [],
+  getPathsData: () => ({ guideMetadata: {} }),
+  useLearningPaths: () => ({
+    paths: [{ id: 'path-1', title: 'First path', guides: ['guide-1'], url: pathBaseUrl }],
+    badgesWithStatus: [],
+    progress: { completedGuides: [], earnedBadges: [], streakDays: 0 },
+    getPathGuides: () => [{ id: 'guide-1', title: 'Guide one', completed: false, isCurrent: true }],
+    getPathProgress: () => pathProgress,
+    isPathCompleted: () => false,
+    getGuideUrlForPath: () => moduleUrl,
+    resetPath: jest.fn(),
+    streakInfo: { days: 0 },
+    isLoading: false,
+  }),
+}));
+
+jest.mock('../SkeletonLoader', () => ({ SkeletonLoader: () => null }));
+jest.mock('../FeedbackButton/FeedbackButton', () => ({ FeedbackButton: () => null }));
+jest.mock('../../lib/analytics', () => ({
+  reportAppInteraction: jest.fn(),
+  UserInteraction: new Proxy({}, { get: (_t, p) => String(p) }),
+  AnalyticsContentType: new Proxy({}, { get: (_t, p) => String(p) }),
+}));
+jest.mock('../../lib/user-storage', () => ({
+  learningProgressStorage: { clear: jest.fn() },
+  journeyCompletionStorage: { getAll: jest.fn(async () => ({})), clear: jest.fn() },
+  interactiveStepStorage: { clearAll: jest.fn() },
+  interactiveCompletionStorage: { clearAll: jest.fn() },
+}));
+jest.mock('../../global-state/completion-store', () => ({ evictAllContentCaches: jest.fn() }));
+
+const prepareMock = prepareGuideLaunch as jest.MockedFunction<typeof prepareGuideLaunch>;
+
+const okResult: PrepareGuideLaunchResult = {
+  ok: true,
+  launch: {
+    url: pathBaseUrl,
+    title: 'First path',
+    type: 'learning-journey',
+    source: 'home_page',
+    preparedContent: {
+      content: '{}',
+      metadata: { title: 'First path' },
+      type: 'learning-journey',
+      url: pathBaseUrl,
+      lastFetched: '2026-07-29T00:00:00.000Z',
+    },
+    requiresGrafanaUi: false,
+  },
+} as PrepareGuideLaunchResult;
+
+describe('MyLearningTab cover-page launch routing', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('lands a fresh path on the cover page (base URL) with the path title', async () => {
+    pathProgress = 0;
+    prepareMock.mockResolvedValue(okResult);
+
+    render(<MyLearningTab onOpenGuide={jest.fn()} />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(testIds.learningPaths.continueButton('path-1')));
+    });
+
+    await waitFor(() => expect(prepareMock).toHaveBeenCalledTimes(1));
+    expect(prepareMock).toHaveBeenCalledWith(pathBaseUrl, expect.objectContaining({ title: 'First path' }));
+  });
+
+  it('resumes an in-progress path on the resolved module URL', async () => {
+    pathProgress = 40;
+    prepareMock.mockResolvedValue(okResult);
+
+    render(<MyLearningTab onOpenGuide={jest.fn()} />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId(testIds.learningPaths.continueButton('path-1')));
+    });
+
+    await waitFor(() => expect(prepareMock).toHaveBeenCalledTimes(1));
+    expect(prepareMock).toHaveBeenCalledWith(moduleUrl, expect.objectContaining({ title: 'Guide one' }));
+  });
+});

--- a/src/components/LearningPaths/MyLearningTab.cover-launch.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.cover-launch.test.tsx
@@ -9,6 +9,7 @@ import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import { MyLearningTab } from './MyLearningTab';
 import { prepareGuideLaunch, type PrepareGuideLaunchResult } from '../docs-panel/utils/prepare-guide-launch';
 import { testIds } from '../../constants/testIds';
+import { reportAppInteraction } from '../../lib/analytics';
 
 jest.mock('../docs-panel/utils/prepare-guide-launch', () => ({
   prepareGuideLaunch: jest.fn(),
@@ -63,6 +64,7 @@ jest.mock('../../lib/user-storage', () => ({
 jest.mock('../../global-state/completion-store', () => ({ evictAllContentCaches: jest.fn() }));
 
 const prepareMock = prepareGuideLaunch as jest.MockedFunction<typeof prepareGuideLaunch>;
+const reportMock = reportAppInteraction as jest.MockedFunction<typeof reportAppInteraction>;
 
 const okResult: PrepareGuideLaunchResult = {
   ok: true,
@@ -96,6 +98,10 @@ describe('MyLearningTab cover-page launch routing', () => {
 
     await waitFor(() => expect(prepareMock).toHaveBeenCalledTimes(1));
     expect(prepareMock).toHaveBeenCalledWith(pathBaseUrl, expect.objectContaining({ title: 'First path' }));
+    expect(reportMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ launch_target: 'cover_page' })
+    );
   });
 
   it('resumes an in-progress path on the resolved module URL', async () => {
@@ -109,5 +115,6 @@ describe('MyLearningTab cover-page launch routing', () => {
 
     await waitFor(() => expect(prepareMock).toHaveBeenCalledTimes(1));
     expect(prepareMock).toHaveBeenCalledWith(moduleUrl, expect.objectContaining({ title: 'Guide one' }));
+    expect(reportMock).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ launch_target: 'milestone' }));
   });
 });

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -369,9 +369,20 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
       // on the actual next module instead of the path base / first module
       // (issue #744). When dynamic data has not loaded yet, fall back to the
       // path's base URL.
+      //
+      // Fresh launch (no progress yet) lands on the path's cover page
+      // (milestone 0) instead of module 1 (issue #1467): the base URL is
+      // exactly the cover page, and its working Back button returns here so
+      // resuming users lose nothing. "Continue" (progress > 0) still resumes
+      // the current module below.
       if (parentPath?.url) {
-        const resolvedGuideUrl = getGuideUrlForPath(guideId, parentPath.id) ?? parentPath.url;
-        const guideTitle = getPathGuides(parentPath.id).find((g) => g.id === guideId)?.title;
+        const isFreshLaunch = getPathProgress(parentPath.id) === 0;
+        const resolvedGuideUrl = isFreshLaunch
+          ? parentPath.url
+          : (getGuideUrlForPath(guideId, parentPath.id) ?? parentPath.url);
+        const guideTitle = isFreshLaunch
+          ? parentPath.title
+          : getPathGuides(parentPath.id).find((g) => g.id === guideId)?.title;
         const title = guideTitle || parentPath.title;
 
         reportAppInteraction(UserInteraction.OpenResourceClick, {

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -359,24 +359,14 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
     [onOpenGuide]
   );
 
-  // Handle opening a guide
   const handleOpenGuide = useCallback(
     (guideId: string, pathId: string) => {
-      // Find the parent path by ID (not by guideId, since multiple paths may share the same guide slugs)
       const parentPath = paths.find((p) => p.id === pathId);
 
-      // URL-based path — open the per-guide URL when known so the user lands
-      // on the actual next module instead of the path base / first module
-      // (issue #744). When dynamic data has not loaded yet, fall back to the
-      // path's base URL.
-      //
-      // Fresh launch (no progress yet) lands on the path's cover page
-      // (milestone 0) instead of module 1 (issue #1467): the base URL is
-      // exactly the cover page, and its working Back button returns here so
-      // resuming users lose nothing. "Continue" (progress > 0) still resumes
-      // the current module below.
       if (parentPath?.url) {
         const isFreshLaunch = getPathProgress(parentPath.id) === 0;
+        const launchTarget = isFreshLaunch ? 'cover_page' : 'milestone';
+        // The path base URL is its cover page; continuing still resolves the current milestone.
         const resolvedGuideUrl = isFreshLaunch
           ? parentPath.url
           : (getGuideUrlForPath(guideId, parentPath.id) ?? parentPath.url);
@@ -390,6 +380,7 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
           content_url: resolvedGuideUrl,
           content_type: AnalyticsContentType.LearningJourney,
           interaction_location: 'my_learning_tab',
+          launch_target: launchTarget,
         });
 
         void launch(resolvedGuideUrl, title, parentPath.id);

--- a/src/components/LearningPaths/learning-paths.styles.ts
+++ b/src/components/LearningPaths/learning-paths.styles.ts
@@ -365,6 +365,34 @@ export const getLearningPathCardStyles = (theme: GrafanaTheme2) => {
 };
 
 // ============================================================================
+// COVER-PAGE TABLE OF CONTENTS STYLES
+// ============================================================================
+
+export const getTableOfContentsStyles = (theme: GrafanaTheme2) => {
+  return {
+    container: css({
+      margin: `${theme.spacing(2)} 0`,
+      padding: theme.spacing(2),
+      borderRadius: theme.shape.radius.default,
+      backgroundColor: theme.colors.background.secondary,
+      border: `1px solid ${theme.colors.border.weak}`,
+    }),
+    heading: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      margin: `0 0 ${theme.spacing(1.5)}`,
+      fontSize: theme.typography.h5.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+      color: theme.colors.text.primary,
+    }),
+    headingIcon: css({
+      color: theme.colors.text.secondary,
+    }),
+  };
+};
+
+// ============================================================================
 // BADGES DISPLAY STYLES
 // ============================================================================
 

--- a/src/components/LearningPaths/learning-paths.styles.ts
+++ b/src/components/LearningPaths/learning-paths.styles.ts
@@ -323,10 +323,19 @@ export const getLearningPathCardStyles = (theme: GrafanaTheme2) => {
       paddingTop: theme.spacing(1),
     }),
     guideList: css({
+      padding: `0 ${theme.spacing(1.5)} ${theme.spacing(1.5)}`,
+    }),
+  };
+};
+
+export const getGuideListStyles = (theme: GrafanaTheme2) => {
+  const colors = getColorPalette(theme);
+
+  return {
+    list: css({
       display: 'flex',
       flexDirection: 'column',
       gap: theme.spacing(0.5),
-      padding: `0 ${theme.spacing(1.5)} ${theme.spacing(1.5)}`,
     }),
     guideItem: css({
       display: 'flex',

--- a/src/components/content-renderer/content-renderer.cover-page-toc.test.tsx
+++ b/src/components/content-renderer/content-renderer.cover-page-toc.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import type { RawContent } from '../../types/content.types';
+import { testIds } from '../../constants/testIds';
+import { ContentRenderer } from './content-renderer';
+
+jest.mock('@grafana/i18n', () => ({
+  t: (_key: string, fallback: string) => fallback,
+}));
+
+const baseUrl = 'https://grafana.com/docs/learning-paths/demo';
+const milestones = [{ number: 1, title: 'Set up', duration: '', url: `${baseUrl}/set-up/`, isActive: false }];
+
+function makeContent(overrides: Partial<RawContent> = {}): RawContent {
+  return {
+    content: '<p>Body</p>',
+    type: 'learning-journey',
+    url: baseUrl,
+    lastFetched: '2026-07-31T00:00:00.000Z',
+    metadata: {
+      title: 'Demo',
+      learningJourney: {
+        currentMilestone: 0,
+        totalMilestones: milestones.length,
+        milestones,
+        baseUrl,
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('ContentRenderer cover-page table of contents', () => {
+  it('renders on a learning journey cover with milestones', () => {
+    render(<ContentRenderer content={makeContent()} />);
+
+    expect(screen.getByTestId(testIds.learningPaths.tableOfContents)).toBeInTheDocument();
+  });
+
+  it('renders for package-backed path covers', () => {
+    const content = makeContent({
+      metadata: {
+        ...makeContent().metadata,
+        packageManifest: { id: 'demo-path', type: 'path' },
+      },
+    });
+
+    render(<ContentRenderer content={content} />);
+
+    expect(screen.getByTestId(testIds.learningPaths.tableOfContents)).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      'a milestone page',
+      makeContent({
+        metadata: {
+          ...makeContent().metadata,
+          learningJourney: { ...makeContent().metadata.learningJourney!, currentMilestone: 1 },
+        },
+      }),
+    ],
+    [
+      'an empty journey',
+      makeContent({
+        metadata: {
+          ...makeContent().metadata,
+          learningJourney: { ...makeContent().metadata.learningJourney!, milestones: [], totalMilestones: 0 },
+        },
+      }),
+    ],
+    ['non-journey content', makeContent({ type: 'single-doc' })],
+  ])('does not render on %s', (_label, content) => {
+    render(<ContentRenderer content={content} />);
+
+    expect(screen.queryByTestId(testIds.learningPaths.tableOfContents)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -56,6 +56,7 @@ import {
 import { substituteVariables } from '../../utils/variable-substitution';
 import { STANDALONE_SECTION_ID } from '../../global-state/completion-store';
 import { subscribeProgressEvent } from '../../global-state/progress-events';
+import { LearningPathTableOfContents } from '../LearningPaths/LearningPathTableOfContents';
 
 /**
  * Scroll to and highlight an element with the given fragment ID
@@ -396,6 +397,19 @@ export const ContentRenderer = React.memo(function ContentRenderer({
     }
   }, [guideId]);
 
+  // On a learning-path cover page (milestone 0) render a milestone table of
+  // contents (issue #1467). Sourced from journey metadata + async completion
+  // storage, so it's a React sibling rather than injected HTML — the one shared
+  // mount point that reaches every surface (sidebar, floating, full-screen).
+  const journey = content.metadata.learningJourney;
+  const coverPageToc =
+    content.type === 'learning-journey' &&
+    journey &&
+    journey.currentMilestone === 0 &&
+    journey.milestones.length > 0 ? (
+      <LearningPathTableOfContents milestones={journey.milestones} baseUrl={journey.baseUrl} />
+    ) : null;
+
   return (
     <GuideResponseProvider guideId={guideId}>
       <ContentWithVariables
@@ -409,6 +423,7 @@ export const ContentRenderer = React.memo(function ContentRenderer({
         className={className}
         selectionState={selectionState}
         documentContext={documentContext}
+        coverPageToc={coverPageToc}
       />
     </GuideResponseProvider>
   );
@@ -426,6 +441,8 @@ interface ContentWithVariablesProps {
   className?: string;
   selectionState: TextSelectionState;
   documentContext: ReturnType<typeof buildDocumentContext>;
+  /** Cover-page milestone TOC, rendered above the content (null off the cover page). */
+  coverPageToc?: React.ReactNode;
 }
 
 function ContentWithVariables({
@@ -439,6 +456,7 @@ function ContentWithVariables({
   className,
   selectionState,
   documentContext,
+  coverPageToc,
 }: ContentWithVariablesProps) {
   // Get responses for variable substitution - passed to renderer, NOT used for pre-parsing
   // This avoids breaking JSON structure when user values contain special characters
@@ -514,6 +532,7 @@ function ContentWithVariables({
       }}
     >
       {title && isNativeJson && <h1 className={titleStyle}>{title}</h1>}
+      {coverPageToc}
       <ContentProcessor
         html={processedContent}
         contentType={contentType}

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -21,6 +21,7 @@ import {
   VimeoVideoRenderer,
   GuideResponseProvider,
   useGuideResponses,
+  isJourneyCoverPage,
 } from '../../docs-retrieval';
 import { guideHasSnippetRefs, inlineSnippetRefsInGuide } from '../../snippet-engine';
 import type { JsonGuide } from '../../types/json-guide.types';
@@ -397,16 +398,9 @@ export const ContentRenderer = React.memo(function ContentRenderer({
     }
   }, [guideId]);
 
-  // On a learning-path cover page (milestone 0) render a milestone table of
-  // contents (issue #1467). Sourced from journey metadata + async completion
-  // storage, so it's a React sibling rather than injected HTML — the one shared
-  // mount point that reaches every surface (sidebar, floating, full-screen).
   const journey = content.metadata.learningJourney;
-  const coverPageToc =
-    content.type === 'learning-journey' &&
-    journey &&
-    journey.currentMilestone === 0 &&
-    journey.milestones.length > 0 ? (
+  const beforeContent =
+    isJourneyCoverPage(content) && journey && journey.milestones.length > 0 ? (
       <LearningPathTableOfContents milestones={journey.milestones} baseUrl={journey.baseUrl} />
     ) : null;
 
@@ -423,7 +417,7 @@ export const ContentRenderer = React.memo(function ContentRenderer({
         className={className}
         selectionState={selectionState}
         documentContext={documentContext}
-        coverPageToc={coverPageToc}
+        beforeContent={beforeContent}
       />
     </GuideResponseProvider>
   );
@@ -441,8 +435,7 @@ interface ContentWithVariablesProps {
   className?: string;
   selectionState: TextSelectionState;
   documentContext: ReturnType<typeof buildDocumentContext>;
-  /** Cover-page milestone TOC, rendered above the content (null off the cover page). */
-  coverPageToc?: React.ReactNode;
+  beforeContent?: React.ReactNode;
 }
 
 function ContentWithVariables({
@@ -456,7 +449,7 @@ function ContentWithVariables({
   className,
   selectionState,
   documentContext,
-  coverPageToc,
+  beforeContent,
 }: ContentWithVariablesProps) {
   // Get responses for variable substitution - passed to renderer, NOT used for pre-parsing
   // This avoids breaking JSON structure when user values contain special characters
@@ -532,7 +525,7 @@ function ContentWithVariables({
       }}
     >
       {title && isNativeJson && <h1 className={titleStyle}>{title}</h1>}
-      {coverPageToc}
+      {beforeContent}
       <ContentProcessor
         html={processedContent}
         contentType={contentType}

--- a/src/components/docs-panel/components/DocsPanelContentArea.tsx
+++ b/src/components/docs-panel/components/DocsPanelContentArea.tsx
@@ -432,7 +432,7 @@ export function DocsPanelContentArea(props: DocsPanelContentAreaProps): React.Re
                         }
                         if (stableContent.type === 'learning-journey' && activeTab?.currentUrl) {
                           const slug = getMilestoneSlug(activeTab.currentUrl);
-                          const journeyBase = activeTab.baseUrl;
+                          const journeyBase = stableContent.metadata.learningJourney?.baseUrl;
                           if (slug && journeyBase) {
                             markMilestoneDone(
                               journeyBase,

--- a/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.test.tsx
+++ b/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.test.tsx
@@ -36,7 +36,7 @@ jest.mock('../../../lib/analytics', () => ({
 
 jest.mock('../../../docs-retrieval', () => ({
   getJourneyProgress: () => 0,
-  getMilestoneSlug: (url: string) => url.split('/').filter(Boolean).pop() ?? null,
+  getMilestoneSlug: jest.requireActual('../../../lib/learning-journey-url').getMilestoneSlug,
   markMilestoneDone: (...args: unknown[]) => markMilestoneDoneMock(...args),
 }));
 

--- a/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.test.tsx
+++ b/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.test.tsx
@@ -103,6 +103,7 @@ function makeJourneyTab(overrides: Partial<LearningJourneyTab> = {}): LearningJo
         learningJourney: {
           currentMilestone: 1,
           totalMilestones: 3,
+          baseUrl: 'https://grafana.com/docs/learning-journeys/foo-canonical',
           milestones: [
             { number: 1, title: 'm1', duration: '', url: 'm1', isActive: true, websiteUrl: 'https://grafana.com/m1' },
             { number: 2, title: 'm2', duration: '', url: 'm2', isActive: false },
@@ -188,7 +189,7 @@ describe('LearningJourneyMilestoneToolbar', () => {
     fireEvent.click(screen.getByLabelText('Next milestone'));
 
     expect(markMilestoneDoneMock).toHaveBeenCalledWith(
-      'https://grafana.com/docs/learning-journeys/foo',
+      'https://grafana.com/docs/learning-journeys/foo-canonical',
       'm1',
       3,
       expect.objectContaining({ packageManifest: undefined })

--- a/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
+++ b/src/components/docs-panel/components/LearningJourneyMilestoneToolbar.tsx
@@ -150,14 +150,14 @@ export function LearningJourneyMilestoneToolbar({
     // advances even though there's nothing to "complete". The DOM scope
     // comes from `contentRoot` (sidebar) or the global content attribute
     // (fullscreen) — both restrict the search to the active panel.
-    if (activeTab.currentUrl && activeTab.baseUrl) {
+    if (activeTab.currentUrl) {
       const root: ParentNode =
         contentRoot?.current ?? document.querySelector('[data-pathfinder-content="true"]') ?? document;
       const hasInteractiveSteps = root.querySelectorAll('[data-step-id]').length > 0;
       if (!hasInteractiveSteps) {
         const slug = getMilestoneSlug(activeTab.currentUrl);
         if (slug) {
-          void markMilestoneDone(activeTab.baseUrl, slug, lj.totalMilestones, {
+          void markMilestoneDone(lj.baseUrl, slug, lj.totalMilestones, {
             packageManifest: activeTab.content?.metadata?.packageManifest,
             guideTitle: activeTab.title,
           });

--- a/src/components/docs-panel/hooks/useLastMilestoneAutoComplete.test.ts
+++ b/src/components/docs-panel/hooks/useLastMilestoneAutoComplete.test.ts
@@ -24,7 +24,7 @@ function makeContent(overrides: Record<string, unknown> = {}): any {
   return {
     type: 'learning-journey',
     url: 'https://example.com/journey/final',
-    metadata: { learningJourney: { totalMilestones: 5 } },
+    metadata: { learningJourney: { baseUrl: 'https://example.com/journey-canonical', totalMilestones: 5 } },
     ...overrides,
   };
 }
@@ -119,7 +119,7 @@ describe('useLastMilestoneAutoComplete', () => {
     );
     jest.runAllTimers();
     expect(markMilestoneDoneMock).toHaveBeenCalledWith(
-      'https://example.com/journey/',
+      'https://example.com/journey-canonical',
       'final-slug',
       5,
       expect.objectContaining({ guideTitle: 'Journey' })

--- a/src/components/docs-panel/hooks/useLastMilestoneAutoComplete.ts
+++ b/src/components/docs-panel/hooks/useLastMilestoneAutoComplete.ts
@@ -34,7 +34,8 @@ export function useLastMilestoneAutoComplete({
   contentRef,
 }: UseLastMilestoneAutoCompleteParams): void {
   React.useEffect(() => {
-    if (!stableContent || stableContent.type !== 'learning-journey' || !activeTab?.currentUrl || !activeTab?.baseUrl) {
+    const journey = stableContent?.metadata.learningJourney;
+    if (!stableContent || stableContent.type !== 'learning-journey' || !journey || !activeTab?.currentUrl) {
       return;
     }
 
@@ -52,8 +53,8 @@ export function useLastMilestoneAutoComplete({
       if (!hasInteractiveSteps) {
         const slug = getMilestoneSlug(activeTab.currentUrl!);
         if (slug) {
-          void markMilestoneDone(activeTab.baseUrl!, slug, stableContent.metadata?.learningJourney?.totalMilestones, {
-            packageManifest: stableContent.metadata?.packageManifest,
+          void markMilestoneDone(journey.baseUrl, slug, journey.totalMilestones, {
+            packageManifest: stableContent.metadata.packageManifest,
             guideTitle: activeTab.title,
           });
         }
@@ -65,5 +66,5 @@ export function useLastMilestoneAutoComplete({
     // milestone-by-milestone `currentUrl` changes is the load-bearing trigger.
     // `activeTab.title` is only read to label the completion fact; re-arming
     // the timer on a title change is harmless.
-  }, [stableContent, activeTab?.currentUrl, activeTab?.baseUrl, activeTab?.title, contentRef]);
+  }, [stableContent, activeTab?.currentUrl, activeTab?.title, contentRef]);
 }

--- a/src/components/docs-panel/link-handler.hook.ts
+++ b/src/components/docs-panel/link-handler.hook.ts
@@ -525,13 +525,14 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
           });
 
           // Mark current milestone done if it has no interactive steps
-          if (activeTab?.content?.type === 'learning-journey' && activeTab?.currentUrl && activeTab?.baseUrl) {
+          const journey = activeTab?.content?.metadata.learningJourney;
+          if (activeTab?.content?.type === 'learning-journey' && activeTab.currentUrl && journey) {
             const hasInteractiveSteps = (contentRef?.current?.querySelectorAll('[data-step-id]').length ?? 0) > 0;
             if (!hasInteractiveSteps) {
               const slug = getMilestoneSlug(activeTab.currentUrl);
               if (slug) {
                 markMilestoneDone(
-                  activeTab.baseUrl,
+                  journey.baseUrl,
                   slug,
                   activeTab.content?.metadata?.learningJourney?.totalMilestones,
                   {

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -295,7 +295,7 @@ export const testIds = {
     resetProgressButton: 'learning-paths-reset-progress',
     badgeToast: 'learning-paths-badge-toast',
     badgeToastDismiss: 'learning-paths-badge-toast-dismiss',
-    tableOfContents: 'learning-path-toc',
+    tableOfContents: 'learning-paths-toc',
   },
 
   // Live Session

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -295,6 +295,7 @@ export const testIds = {
     resetProgressButton: 'learning-paths-reset-progress',
     badgeToast: 'learning-paths-badge-toast',
     badgeToastDismiss: 'learning-paths-badge-toast-dismiss',
+    tableOfContents: 'learning-path-toc',
   },
 
   // Live Session

--- a/src/docs-retrieval/content-fetcher/url-utils.test.ts
+++ b/src/docs-retrieval/content-fetcher/url-utils.test.ts
@@ -91,6 +91,9 @@ describe('url-utils', () => {
       expect(getLearningJourneyBaseUrl('https://grafana.com/docs/learning-paths/intro/')).toBe(
         'https://grafana.com/docs/learning-paths/intro'
       );
+      expect(getLearningJourneyBaseUrl('https://grafana.com/docs/learning-paths/intro/set-up/content.json')).toBe(
+        'https://grafana.com/docs/learning-paths/intro'
+      );
       expect(getLearningJourneyBaseUrl('https://grafana.com/tutorials/alerting-get-started/')).toBe(
         'https://grafana.com/tutorials/alerting-get-started'
       );

--- a/src/docs-retrieval/content-fetcher/url-utils.ts
+++ b/src/docs-retrieval/content-fetcher/url-utils.ts
@@ -1,5 +1,7 @@
 import { isInteractiveLearningUrl } from '../../security';
 
+export { getLearningJourneyBaseUrl } from '../../lib/learning-journey-url';
+
 /**
  * Generate a simple ID from a URL for use in wrapped JSON guides.
  */
@@ -67,35 +69,6 @@ export function getContentUrls(url: string): { jsonUrl: string; htmlUrl: string 
     jsonUrl: `${baseUrl}/content.json`,
     htmlUrl: `${baseUrl}/unstyled.html`,
   };
-}
-
-/**
- * Learning journey specific functions
- * These are simplified versions that focus on data extraction only
- */
-export function getLearningJourneyBaseUrl(url: string): string {
-  // Handle cases like:
-  // https://grafana.com/docs/learning-journeys/drilldown-logs/ -> https://grafana.com/docs/learning-journeys/drilldown-logs (legacy)
-  // https://grafana.com/docs/learning-paths/drilldown-logs/ -> https://grafana.com/docs/learning-paths/drilldown-logs (new)
-  // https://grafana.com/docs/learning-journeys/drilldown-logs/milestone-1/ -> https://grafana.com/docs/learning-journeys/drilldown-logs
-  // https://grafana.com/tutorials/alerting-get-started/ -> https://grafana.com/tutorials/alerting-get-started
-
-  const learningJourneyMatch = url.match(/^(https?:\/\/[^\/]+\/docs\/learning-journeys\/[^\/]+)/);
-  if (learningJourneyMatch) {
-    return learningJourneyMatch[1]!;
-  }
-
-  const learningPathMatch = url.match(/^(https?:\/\/[^\/]+\/docs\/learning-paths\/[^\/]+)/);
-  if (learningPathMatch) {
-    return learningPathMatch[1]!;
-  }
-
-  const tutorialMatch = url.match(/^(https?:\/\/[^\/]+\/tutorials\/[^\/]+)/);
-  if (tutorialMatch) {
-    return tutorialMatch[1]!;
-  }
-
-  return url.replace(/\/milestone-\d+.*$/, '').replace(/\/$/, '');
 }
 
 /**

--- a/src/docs-retrieval/learning-journey-helpers.nav-boundary.test.ts
+++ b/src/docs-retrieval/learning-journey-helpers.nav-boundary.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Boundary-nav invariants the cover-page landing relies on (issue #1467,
+ * feature 3): on the cover page (milestone 0) there is no previous milestone,
+ * and on the last milestone there is no next one. The shared milestone toolbar
+ * disables its arrows off these results, so landing on the cover disables Back
+ * with no extra nav code.
+ */
+
+import { getNextMilestoneUrl, getPreviousMilestoneUrl } from './learning-journey-helpers';
+import type { RawContent, Milestone } from '../types/content.types';
+
+const baseUrl = 'https://grafana.com/docs/learning-paths/demo/';
+const milestones: Milestone[] = [
+  { number: 1, title: 'One', duration: '', url: `${baseUrl}one/`, isActive: false },
+  { number: 2, title: 'Two', duration: '', url: `${baseUrl}two/`, isActive: false },
+];
+
+function contentAtMilestone(currentMilestone: number): RawContent {
+  return {
+    content: '{}',
+    url: baseUrl,
+    type: 'learning-journey',
+    lastFetched: '2026-07-30T00:00:00.000Z',
+    metadata: {
+      title: 'Demo',
+      learningJourney: { currentMilestone, totalMilestones: milestones.length, milestones, baseUrl },
+    },
+  } as RawContent;
+}
+
+describe('milestone navigation boundaries', () => {
+  it('has no previous milestone on the cover page (milestone 0)', () => {
+    expect(getPreviousMilestoneUrl(contentAtMilestone(0))).toBeNull();
+  });
+
+  it('returns the cover base URL as the previous target from milestone 1', () => {
+    expect(getPreviousMilestoneUrl(contentAtMilestone(1))).toBe(baseUrl);
+  });
+
+  it('has no next milestone on the last milestone', () => {
+    expect(getNextMilestoneUrl(contentAtMilestone(2))).toBeNull();
+  });
+
+  it('advances to the next milestone from the cover page', () => {
+    expect(getNextMilestoneUrl(contentAtMilestone(0))).toBe(`${baseUrl}one/`);
+  });
+});

--- a/src/docs-retrieval/learning-journey-helpers.nav-boundary.test.ts
+++ b/src/docs-retrieval/learning-journey-helpers.nav-boundary.test.ts
@@ -1,12 +1,4 @@
-/**
- * Boundary-nav invariants the cover-page landing relies on (issue #1467,
- * feature 3): on the cover page (milestone 0) there is no previous milestone,
- * and on the last milestone there is no next one. The shared milestone toolbar
- * disables its arrows off these results, so landing on the cover disables Back
- * with no extra nav code.
- */
-
-import { getNextMilestoneUrl, getPreviousMilestoneUrl } from './learning-journey-helpers';
+import { getMilestoneSlug, getNextMilestoneUrl, getPreviousMilestoneUrl } from './learning-journey-helpers';
 import type { RawContent, Milestone } from '../types/content.types';
 
 const baseUrl = 'https://grafana.com/docs/learning-paths/demo/';
@@ -43,5 +35,16 @@ describe('milestone navigation boundaries', () => {
 
   it('advances to the next milestone from the cover page', () => {
     expect(getNextMilestoneUrl(contentAtMilestone(0))).toBe(`${baseUrl}one/`);
+  });
+});
+
+describe('getMilestoneSlug', () => {
+  it.each([
+    ['https://grafana.com/docs/learning-paths/demo/set-up/', 'set-up'],
+    ['https://grafana.com/docs/learning-paths/demo/set-up/content.json', 'set-up'],
+    ['https://grafana.com/docs/learning-paths/demo/set-up/unstyled.html', 'set-up'],
+    ['', ''],
+  ])('extracts the milestone slug from %s', (url, expected) => {
+    expect(getMilestoneSlug(url)).toBe(expected);
   });
 });

--- a/src/docs-retrieval/learning-journey-helpers.ts
+++ b/src/docs-retrieval/learning-journey-helpers.ts
@@ -26,6 +26,8 @@ import {
 } from '../completion-records';
 import { escapeHtml, sanitizeHtmlUrl } from '../security/html-sanitizer';
 
+export { getMilestoneSlug } from '../lib/learning-journey-url';
+
 /**
  * Optional manifest/display context threaded from the completion call sites so
  * the recorder can key on `(guideSource, guideId) = (manifest.repository,
@@ -452,18 +454,6 @@ export async function getAllJourneyCompletionsAsync(): Promise<Record<string, nu
 // ============================================================================
 // MILESTONE COMPLETION HELPERS
 // ============================================================================
-
-/**
- * Extracts the milestone slug (guide ID) from a milestone URL.
- * e.g. "https://grafana.com/docs/learning-paths/linux-server-integration/select-platform/" -> "select-platform"
- * e.g. "https://grafana.com/docs/.../select-platform/content.json" -> "select-platform"
- */
-export function getMilestoneSlug(milestoneUrl: string): string {
-  // Strip content.json or unstyled.html suffixes added during content fetching
-  const cleanUrl = milestoneUrl.replace(/\/(content\.json|unstyled\.html)$/, '');
-  const segments = cleanUrl.replace(/\/+$/, '').split('/');
-  return segments[segments.length - 1] || '';
-}
 
 /**
  * Marks a learning journey milestone as completed.

--- a/src/lib/learning-journey-url.ts
+++ b/src/lib/learning-journey-url.ts
@@ -1,0 +1,21 @@
+const JOURNEY_BASE_URL_PATTERNS = [
+  /^(https?:\/\/[^/]+\/docs\/learning-journeys\/[^/]+)/,
+  /^(https?:\/\/[^/]+\/docs\/learning-paths\/[^/]+)/,
+  /^(https?:\/\/[^/]+\/tutorials\/[^/]+)/,
+];
+
+export function getLearningJourneyBaseUrl(url: string): string {
+  for (const pattern of JOURNEY_BASE_URL_PATTERNS) {
+    const match = url.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return url.replace(/\/milestone-\d+.*$/, '').replace(/\/$/, '');
+}
+
+export function getMilestoneSlug(url: string): string {
+  const withoutContentFile = url.replace(/\/(content\.json|unstyled\.html)$/, '');
+  return withoutContentFile.replace(/\/+$/, '').split('/').pop() || '';
+}

--- a/src/lib/user-storage.test.ts
+++ b/src/lib/user-storage.test.ts
@@ -5,6 +5,7 @@ import {
   interactiveCompletionStorage,
   interactiveStepStorage,
   journeyCompletionStorage,
+  milestoneCompletionStorage,
   sectionAcknowledgementStorage,
   tabStorage,
   unwrapEnvelope,
@@ -127,6 +128,51 @@ describe('unwrapEnvelope', () => {
     // A real envelope has a numeric timestamp
     const newFormat = JSON.stringify({ v: 'data', t: 42 });
     expect(unwrapEnvelope(newFormat)).toEqual({ v: 'data', t: 42 });
+  });
+});
+
+describe('milestoneCompletionStorage', () => {
+  const journeyUrl = 'https://grafana.com/docs/learning-paths/linux-server-integration';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('reads completions written with launch URL variants under the journey base URL', async () => {
+    await milestoneCompletionStorage.markCompleted(`${journeyUrl}/`, 'install-alloy');
+    await milestoneCompletionStorage.markCompleted(`${journeyUrl}/view-data/content.json`, 'view-data');
+
+    await expect(milestoneCompletionStorage.getCompleted(journeyUrl)).resolves.toEqual(
+      new Set(['install-alloy', 'view-data'])
+    );
+
+    const stored = JSON.parse(localStorage.getItem(StorageKeys.MILESTONE_COMPLETION) ?? '{}');
+    expect(stored[journeyUrl]).toEqual(['install-alloy', 'view-data']);
+    expect(stored[`${journeyUrl}/`]).toEqual(['install-alloy', 'view-data']);
+    expect(stored[`${journeyUrl}/view-data/content.json`]).toEqual(['install-alloy', 'view-data']);
+  });
+
+  it('reads non-HTTP milestone aliases supplied by journey metadata', async () => {
+    localStorage.setItem(
+      StorageKeys.MILESTONE_COMPLETION,
+      JSON.stringify({ 'bundled:demo-milestone/content.json': ['demo-milestone'] })
+    );
+
+    await expect(
+      milestoneCompletionStorage.getCompleted('bundled:demo-cover/content.json', [
+        'bundled:demo-milestone/content.json',
+      ])
+    ).resolves.toEqual(new Set(['demo-milestone']));
+  });
+
+  it('clears canonical and legacy URL variants together', async () => {
+    await milestoneCompletionStorage.markCompleted(`${journeyUrl}/`, 'install-alloy');
+    await milestoneCompletionStorage.markCompleted(`${journeyUrl}/view-data/content.json`, 'view-data');
+
+    await milestoneCompletionStorage.clear(journeyUrl);
+
+    await expect(milestoneCompletionStorage.getCompleted(journeyUrl)).resolves.toEqual(new Set());
+    expect(JSON.parse(localStorage.getItem(StorageKeys.MILESTONE_COMPLETION) ?? '{}')).toEqual({});
   });
 });
 

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -42,6 +42,7 @@ import { z } from 'zod';
 
 import type { LearningProgress, EarnedBadgeRecord } from '../types/learning-paths.types';
 import { StorageEvents } from './event-names';
+import { getLearningJourneyBaseUrl } from './learning-journey-url';
 import { logger } from './logging';
 import { createBoundedRecordStorage } from './storage/bounded-record-storage';
 import { StorageKeys } from './storage-keys';
@@ -757,6 +758,21 @@ export const journeyCompletionStorage = createBoundedRecordStorage({
   onQuotaExceeded: warnQuotaExceededOnce,
 });
 
+function getStoredMilestoneSlugs(
+  data: Record<string, string[]>,
+  journeyBaseUrl: string,
+  milestoneUrls: string[] = []
+): Set<string> {
+  const canonicalKey = getLearningJourneyBaseUrl(journeyBaseUrl);
+  const exactKeys = new Set([journeyBaseUrl, ...milestoneUrls].map((key) => key.replace(/\/+$/, '')));
+  const slugs = Object.entries(data).flatMap(([storedKey, storedSlugs]) =>
+    getLearningJourneyBaseUrl(storedKey) === canonicalKey || exactKeys.has(storedKey.replace(/\/+$/, ''))
+      ? storedSlugs
+      : []
+  );
+  return new Set(slugs);
+}
+
 /**
  * Milestone completion storage operations
  *
@@ -764,13 +780,13 @@ export const journeyCompletionStorage = createBoundedRecordStorage({
  * Stored as a map of journeyBaseUrl -> array of completed milestone slugs.
  */
 export const milestoneCompletionStorage = {
-  async getCompleted(journeyBaseUrl: string): Promise<Set<string>> {
+  async getCompleted(journeyBaseUrl: string, milestoneUrls: string[] = []): Promise<Set<string>> {
     try {
       const storage = createUserStorage();
       const data = await storage.getItem<Record<string, string[]>>(StorageKeys.MILESTONE_COMPLETION);
-      const slugs = data?.[journeyBaseUrl] || [];
-      return new Set(slugs);
-    } catch {
+      return getStoredMilestoneSlugs(data ?? {}, journeyBaseUrl, milestoneUrls);
+    } catch (error) {
+      logger.warn('Failed to load milestone completion', { error });
       return new Set();
     }
   },
@@ -779,9 +795,17 @@ export const milestoneCompletionStorage = {
     try {
       const storage = createUserStorage();
       const data = (await storage.getItem<Record<string, string[]>>(StorageKeys.MILESTONE_COMPLETION)) || {};
-      const existing = new Set(data[journeyBaseUrl] || []);
+      const canonicalKey = getLearningJourneyBaseUrl(journeyBaseUrl);
+      const existing = getStoredMilestoneSlugs(data, canonicalKey);
       existing.add(milestoneSlug);
-      data[journeyBaseUrl] = Array.from(existing);
+      const completedSlugs = Array.from(existing);
+      for (const storedKey of Object.keys(data)) {
+        if (getLearningJourneyBaseUrl(storedKey) === canonicalKey) {
+          data[storedKey] = completedSlugs;
+        }
+      }
+      data[canonicalKey] = completedSlugs;
+      data[journeyBaseUrl] = completedSlugs;
       await storage.setItem(StorageKeys.MILESTONE_COMPLETION, data);
     } catch (error) {
       logger.warn('Failed to save milestone completion', { error });
@@ -797,7 +821,12 @@ export const milestoneCompletionStorage = {
     try {
       const storage = createUserStorage();
       const data = (await storage.getItem<Record<string, string[]>>(StorageKeys.MILESTONE_COMPLETION)) || {};
-      delete data[journeyBaseUrl];
+      const canonicalKey = getLearningJourneyBaseUrl(journeyBaseUrl);
+      for (const storedKey of Object.keys(data)) {
+        if (getLearningJourneyBaseUrl(storedKey) === canonicalKey) {
+          delete data[storedKey];
+        }
+      }
       await storage.setItem(StorageKeys.MILESTONE_COMPLETION, data);
     } catch (error) {
       logger.warn('Failed to clear milestone completion', { error });

--- a/src/locales/en-US/grafana-pathfinder-app.json
+++ b/src/locales/en-US/grafana-pathfinder-app.json
@@ -1,4 +1,7 @@
 {
+  "coverPage": {
+    "tableOfContents": "In this path"
+  },
   "contextPanel": {
     "categoryDocsPage": "Docs page",
     "categoryInteractiveGuide": "Interactive guide",

--- a/src/locales/en-US/grafana-pathfinder-app.json
+++ b/src/locales/en-US/grafana-pathfinder-app.json
@@ -1,7 +1,4 @@
 {
-  "coverPage": {
-    "tableOfContents": "In this path"
-  },
   "contextPanel": {
     "categoryDocsPage": "Docs page",
     "categoryInteractiveGuide": "Interactive guide",
@@ -21,6 +18,9 @@
     "summary": "Summary",
     "view": "View",
     "viewDocumentation": "View documentation"
+  },
+  "coverPage": {
+    "tableOfContents": "In this path"
   },
   "docsPanel": {
     "closeTab": "Close {{title}}",
@@ -65,6 +65,7 @@
     "launchErrorMessage": "Something went wrong while loading the guide. Please try again.",
     "launchErrorTitle": "Could not open the guide",
     "learningPaths": "Learning paths",
+    "loadingGuides": "Loading guides...",
     "pathsDescription": "Structured guides to help you master Grafana step by step",
     "showLess": "Show less",
     "subtitle": "Track your progress, earn badges, and master Grafana",


### PR DESCRIPTION
## Summary

Launching a not-started URL-based (cloud) learning path from **My Learning** now opens the path's cover page (milestone 0) with an "In this path" table of contents showing per-milestone completion, instead of jumping straight to module 1. Because you now land on the cover, the shared toolbar's **Back** button is correctly disabled there with no new navigation code. A companion fix aligns milestone-completion storage keys so those table-of-contents checkmarks are accurate on the flow this feature targets.

## What to look at

- **`src/lib/user-storage.ts` + `src/lib/learning-journey-url.ts`** — the completion-key alignment, the load-bearing fix. `milestoneCompletionStorage` now canonicalizes keys through `getLearningJourneyBaseUrl` on both read and write: `getStoredMilestoneSlugs` matches any stored key whose canonical base (or trailing-slash-stripped launch URL) equals the lookup key, and `markCompleted` writes the canonical key, the raw launch URL, and any pre-existing matching rows. The URL helpers moved to a new tier-1 `lib/` module because tier-1 `user-storage` cannot import from tier-2 `docs-retrieval`; `url-utils.ts` and `learning-journey-helpers.ts` now re-export them.
- **The four completion writers** (`LearningJourneyMilestoneToolbar.tsx`, `DocsPanelContentArea.tsx`, `useLastMilestoneAutoComplete.ts`, `link-handler.hook.ts`) — all switched from the raw `activeTab.baseUrl` to the normalized `learningJourney.baseUrl`, so writes and reads agree on the key.
- **`src/components/content-renderer/content-renderer.tsx`** — the table-of-contents mount point. It renders `LearningPathTableOfContents` through a new generic `beforeContent` slot, gated on the existing `isJourneyCoverPage(content)` predicate plus `milestones.length > 0`. The gate is shape-based: it fires for any learning-journey cover with milestones — today that is cloud paths, and package/bundled `path` covers once they exist (see Out of scope).
- **`src/components/LearningPaths/`** — `GuideList` extracted from `LearningPathCard`'s inline list and reused by both the card and the new `LearningPathTableOfContents`; styles split into `getGuideListStyles` / `getTableOfContentsStyles` so the card owns its own gutter rather than the cover page inheriting card padding.
- **`src/components/LearningPaths/MyLearningTab.tsx`** — `handleOpenGuide` routes a fresh launch (`progress === 0`) to `parentPath.url` (the cover); "Continue" still resumes the current module. The `OpenResourceClick` event now carries a `launch_target: 'cover_page' | 'milestone'` discriminator.

## Why

Issue #1467: launching a learning path skipped its cover/landing page and dropped users on module 1, so they never saw the path overview or a milestone map, and Back appeared permanently enabled because there was nothing before module 1 to land on. Rendering the table of contents as a React sibling rather than injected HTML was deliberate — per-milestone completion comes from async storage, which is awkward and untestable in the HTML-string path, and a React component reaches every panel surface. The completion-key alignment was added after review found the table of contents read completions under a normalized key while every writer stored them under the raw launch URL (with a trailing slash), so freshly-completed milestones rendered unchecked on this feature's own surface.

## How to verify

1. In **My Learning**, open a not-started cloud path (e.g. "Monitor a Linux server"). Confirm it lands on the cover page showing an "In this path" milestone list, and the toolbar **Back** arrow is disabled.
2. Complete milestone 1, then click **Back** to return to the cover. Confirm the completed milestone now shows a green check — before the key-alignment fix it stayed an open circle.
3. Reload or reopen the tab and confirm completion state persists and still renders correctly.
4. Launch an **in-progress** path via "Continue" and confirm it resumes the current module, not the cover.
5. Confirm the table of contents does **not** appear on individual milestone pages, on an empty journey, or on single-doc content.

## Breaking changes

- **Milestone-completion storage keys**: completions are now canonicalized to the trailing-slash-free journey base URL. Reads reconcile legacy raw-URL rows and `markCompleted` continues to write the raw key too, so existing progress is preserved and no migration is required.
- **Analytics**: `OpenResourceClick` from `my_learning_tab` now emits `content_url` as the cover-page URL for fresh launches (previously module 1's URL) and adds a `launch_target` dimension. Downstream views that key on `content_url` to attribute a starting module will see a discontinuity from the cutover date; the new `launch_target` field is the intended discriminator.

## Reversibility

Reverting restores the previous launch and render behavior cleanly; the storage layer stays backward-compatible in both directions because `markCompleted` writes both canonical and raw keys. Emitted analytics rows are immutable, so the `content_url` / `launch_target` change on already-recorded events does not revert — confirm the cutover with the analytics owner.

## Out of scope

- **Static/bundled OSS paths** → #1469 (migrate to bundled `path` packages so they render through this pipeline). The shape-based gate will light up automatically for package `path` covers once they exist.
- **Nav-consistency nits** (bottom-nav hide-vs-disable; Alt+←/→ boundary gating) → separate follow-up noted in #1467.

Fixes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)
