### PR TITLE
feat(e2e): support path (journey) packages

### DIFF
--- a/docs/developer/CONTEXT_INDEX.md
+++ b/docs/developer/CONTEXT_INDEX.md
@@ -30,14 +30,14 @@ Load these files **only when working in the relevant domain**.
 
 ## Security, review, and testing
 
-| File                       | When to load                                                                                                | Auto-triggered by globs                                  |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| `frontend-security.mdc`    | Frontend security (from security team)                                                                      | `*.ts`, `*.tsx`, `*.js`, `*.jsx`                         |
-| `react-antipatterns.mdc`   | PR reviews (on hit), hooks/effects/state. An index — routes each R-code to a themed file holding the detail | --                                                       |
-| `testingStrategy.mdc`      | Writing or reviewing tests                                                                                  | `*.test.ts`, `*.test.tsx`, `jest.config*`, `jest.setup*` |
-| `docs/design/PR_REVIEW.md` | PR review standards: pattern catalog (R1-R21, F1-F6, QC1-QC7, G1-G7), reviewer schema, comment prefixes     | --                                                       |
-| `E2E_TESTING_CONTRACT.md`  | E2E testing, `data-test-*` attributes                                                                       | --                                                       |
-| `E2E_TESTING.md`           | E2E guide test runner: CLI reference, options, troubleshooting, error classification, environment variables | --                                                       |
+| File                       | When to load                                                                                                                                                                                                                        | Auto-triggered by globs                                  |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `frontend-security.mdc`    | Frontend security (from security team)                                                                                                                                                                                              | `*.ts`, `*.tsx`, `*.js`, `*.jsx`                         |
+| `react-antipatterns.mdc`   | PR reviews (on hit), hooks/effects/state. An index — routes each R-code to a themed file holding the detail                                                                                                                         | --                                                       |
+| `testingStrategy.mdc`      | Writing or reviewing tests                                                                                                                                                                                                          | `*.test.ts`, `*.test.tsx`, `jest.config*`, `jest.setup*` |
+| `docs/design/PR_REVIEW.md` | PR review standards: pattern catalog (R1-R21, F1-F6, QC1-QC7, G1-G7), reviewer schema, comment prefixes                                                                                                                             | --                                                       |
+| `E2E_TESTING_CONTRACT.md`  | E2E testing, `data-test-*` attributes                                                                                                                                                                                               | --                                                       |
+| `E2E_TESTING.md`           | E2E guide test runner: CLI reference, package-aware testing (guides, paths/journeys), milestone expansion and dependency planning, report selection metadata, options, troubleshooting, error classification, environment variables | --                                                       |
 
 ## Release, flags, and CI
 

--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -15,8 +15,10 @@ This is the canonical implementation-backed reference for E2E CLI behavior. Veri
 ## Source map for agents
 
 - `src/cli/commands/e2e.ts` — Commander options, input resolution, dependency planning, pre-flight orchestration, clean-stack resets, cloud routing, and per-guide Playwright invocation.
+- `src/cli/e2e/e2e-local-package.ts` — local path/journey manifest validation, repository loading, milestone expansion, target gating, and guide hydration.
 - `src/cli/e2e/e2e-runner-contract.ts` — environment-variable contract between the CLI process and Playwright runner.
 - `src/cli/e2e/e2e-package.ts` — remote package and repository resolution, content fetch, schema validation, side-effect classification, and pre-run skip reasons.
+- `src/cli/e2e/guide-chains.ts` — pure package graph planning across hard dependencies, capabilities, and recursive milestones, followed by leaf-guide hydration.
 - `src/cli/e2e/e2e-targets.ts` — manifest `testEnvironment` to concrete target URL or skip reason.
 - `src/cli/e2e/cloud-provisioning.ts` and `src/cli/e2e/cloud-stack-pool-manager.ts` — shared-stack service-account isolation and pool-manager isolated stack leasing.
 - `tests/e2e-runner/guide-runner.spec.ts` — browser-side guide loading, pre-flight checks, DOM discovery, step execution, and result file writing.
@@ -62,7 +64,7 @@ npx pathfinder-cli e2e [options] [files...]
 | `--always-screenshot`                      | Capture screenshots on success and failure                                                                                                               | `false`                           |
 | `--clean`                                  | Run against an isolated docker-compose stack (project `pathfinder-e2e`, Grafana on `:3010`). Resets between dependency chains and tears down at the end. | `false`                           |
 | `--clean-ready-timeout-ms <ms>`            | How long to wait for the isolated Grafana to become healthy after a `--clean` reset                                                                      | `120000`                          |
-| `--package <dirOrId>`                      | Test a local package directory, or — when not an existing directory — a bare package ID resolved remotely via the recommender                            | None                              |
+| `--package <dirOrId>`                      | Test a local or remote guide, path, or journey package. Local paths/journeys also require `--repository` so milestone IDs resolve.                       | None                              |
 | `--tier <tier>`                            | Current environment tier (`local` or `cloud`); `cloud` guides are skipped on a `local` environment                                                       | `local`                           |
 | `--remote`                                 | Resolve and test every package from the CDN repository index                                                                                             | `false`                           |
 | `--repo-url <url>`                         | CDN base URL for `--remote`                                                                                                                              | Public package repository         |
@@ -81,8 +83,8 @@ The CLI accepts these input formats:
 1. **File paths**: `npx pathfinder-cli e2e ./my-guide.json ./another.json`
 2. **Bundled flag**: `npx pathfinder-cli e2e --bundled` (tests all guides in `src/bundled-interactives/`)
 3. **Bundled by name**: `npx pathfinder-cli e2e bundled:welcome-to-grafana`
-4. **Local package directory**: `npx pathfinder-cli e2e --package ./my-package/` (reads `content.json` + `manifest.json`)
-5. **Remote package ID**: `npx pathfinder-cli e2e --package alerting-101` (resolved via the recommender; see [Remote package-aware testing](#remote-package-aware-testing))
+4. **Local package directory**: `npx pathfinder-cli e2e --package ./my-package/` (reads `content.json` + `manifest.json`; add `--repository <path>` for a path or journey)
+5. **Remote package ID**: `npx pathfinder-cli e2e --package alerting-101` (guides, paths, and journeys resolve via the recommender; see [Remote package-aware testing](#remote-package-aware-testing))
 6. **Remote repository**: `npx pathfinder-cli e2e --remote` (every package in the CDN index)
 
 ## Exit codes
@@ -227,6 +229,7 @@ Key contract fields:
 - `errorCode`: structured failure code present on non-passing reports. Notable values: `TIER_MISMATCH` (guide requires a different environment tier), `SKIPPED_PREREQ` (a prerequisite guide failed), `REPORT_MISSING` (Playwright exited but wrote no results file), `AUTH_EXPIRED`, `NO_CAPACITY`, `PLAYWRIGHT_SPAWN_FAILED`.
 - `guide.contentDigest`: SHA-256 digest of the exact guide content executed
 - `guide.sourceUrl`: remote package source URL when available
+- `selection`: for an explicitly selected path or journey, the multi-guide report records the root package `id` and `type` separately from its executable leaf-guide reports
 
 ### Report validation
 
@@ -249,7 +252,7 @@ The emitted schema carries a stable `$id` (`https://grafana.com/schemas/pathfind
 
 The `e2e-report` and `e2e-multi-report` schemas are **open-world**: the exported JSON Schema does not include `additionalProperties: false`. This means additive optional fields introduced in a newer runner version are non-breaking — an orchestrator validating reports from a newer runner against an older schema copy will not reject the report. Consumers should configure their validators accordingly (for example, ajv's default behavior already allows extra fields unless explicitly set to strict mode). The `guide`, `manifest`, and other non-e2e schemas remain strict.
 
-Runs that execute more than one guide write a multi-guide report with aggregate summary fields plus the individual per-guide reports.
+Runs that execute more than one guide, or execute an explicitly selected path/journey with one milestone, write a multi-guide report with aggregate summary fields plus the individual per-guide reports.
 
 The dedicated `Dockerfile.e2e-runner` image contains the matching Playwright runner and Chromium, runs as a non-root user, and is published as a signed immutable `ghcr.io/grafana/pathfinder-e2e-runner:commit-<sha>` tag. Cloud Run Jobs should pin the resulting image digest rather than a mutable tag. The deterministic `always-passes` and `always-fails` package fixtures under `tests/e2e-runner/fixtures/` exercise the contract and artifact paths.
 
@@ -302,6 +305,14 @@ Before running, the CLI builds an execution plan from a `repository.json` index 
 - **Virtual capabilities**: a `depends` target may be a capability name; it resolves to whichever guide `provides` it.
 - **Failure propagation**: if a prerequisite fails, its dependents in the same chain are marked skipped (`prerequisite failed`) and not run; the runner continues with the next chain.
 - Only `depends` forms a chain. `recommends` and `suggests` are advisory and do not affect ordering. A `depends` cycle is a configuration error.
+  An explicitly selected `path` or `journey` recursively expands its `milestones` into executable leaf guides:
+
+- Milestones run in declared order and share one environment, including nested paths/journeys.
+- A metapackage or milestone can declare normal CNF `depends`, including a dependency on another path/journey or a virtual capability provider.
+- Milestone order is not an implicit hard dependency. If a milestone fails, later milestones continue unless their resolved `depends` includes the failed guide or metapackage.
+- A hard dependency on a metapackage requires all of that metapackage's executable leaves to pass before the dependent package can run.
+- Missing milestones, incompatible targets, and cycles crossing `depends` and `milestones` fail before Grafana provisioning or Playwright execution.
+- The metapackage cover `content.json` is not executed; only leaf guides are sent to Playwright.
 
 This ordering applies to every run. `--clean` additionally isolates each chain in its own environment (see below).
 
@@ -488,8 +499,8 @@ When the failure is not clearly a runner or contract bug, avoid changing Pathfin
 
 The CLI can resolve published guides instead of reading local files, then test them against the configured Grafana instance.
 
-- **By ID** (`--package <id>`): when the `--package` value is not an existing local directory, it is treated as a bare package ID and resolved through the recommender (`--resolver-url`, default `https://recommender.grafana.com`). The runner fetches the package's `content.json` and `manifest.json`, validates the content, and runs it.
-- **Whole repository** (`--remote`): fetches the CDN `repository.json` (`--repo-url`, default the public package repository) and tests every package in the index. Dependency-aware chaining still applies, driven by the remote index.
+- **By ID** (`--package <id>`): when the `--package` value is not an existing local directory, it is treated as a bare package ID and resolved through the recommender (`--resolver-url`, default `https://recommender.grafana.com`). Guides run directly. Paths and journeys expand recursively from the CDN `repository.json`, then fetch and run their leaf guides.
+- **Whole repository** (`--remote`): fetches the CDN `repository.json` (`--repo-url`, default the public package repository) and tests every leaf guide in the index. Dependency-aware chaining still applies. Metapackages are not expanded implicitly in a repository sweep; select one explicitly with `--package`.
 
 Guides are routed by their manifest's `testEnvironment.tier`:
 
@@ -519,7 +530,6 @@ Pool-backed run behavior:
 ### Known gaps and follow-up
 
 - Interactive SSO/Okta login (driving the identity provider's login UI) is not supported.
-- Path/journey (`milestones`) expansion is not yet implemented; `path` and `journey` packages are skipped as an unsupported type.
 
 ### Package outcomes
 
@@ -535,7 +545,7 @@ In remote modes a package can end in one of these states. `failed`, `provisionin
 | `skipped_unsafe_shared_stack` | Cloud guide requires an isolated stack, but none is configured | No            |
 | `resolution_failed`           | Recommender returned 404 or a network error                    | No            |
 | `fetch_failed`                | Could not fetch `content.json` from the CDN                    | No            |
-| `unsupported_type`            | Package is a `path` / `journey` (milestone expansion TODO)     | No            |
+| `unsupported_type`            | Repository sweep encountered a non-guide composition package   | No            |
 | `prerequisite_failed`         | A required prerequisite could not be resolved or run           | No            |
 | `skipped_prereq`              | A prerequisite in the same dependency chain failed             | No            |
 | `validation_failed`           | Fetched `content.json` failed guide schema validation          | **Yes**       |
@@ -545,6 +555,9 @@ With `--output`, pre-run skips are recorded under a `preRunSkipped` array, and e
 ```bash
 # Resolve and test a single published guide against local Grafana
 npx pathfinder-cli e2e --package alerting-101
+
+# Resolve and test every milestone in a published path
+npx pathfinder-cli e2e --package prometheus-lj
 
 # Test the whole published repository (local-tier guides run, cloud guides skip)
 npx pathfinder-cli e2e --remote --output results.json

--- a/src/cli/__tests__/schema-e2e-report.test.ts
+++ b/src/cli/__tests__/schema-e2e-report.test.ts
@@ -6,6 +6,8 @@
 
 import Ajv2020 from 'ajv/dist/2020';
 import { exportSchema, listSchemas } from '../commands/schema';
+import { ExecutionSelectionSchema, MultiGuideReportSchema } from '../e2e/schemas/e2e-report.schema';
+import { generateMultiGuideReport } from '../e2e/e2e-reporter';
 
 describe('schema command — e2e-report registration', () => {
   it('lists the e2e report schemas', () => {
@@ -23,7 +25,9 @@ describe('schema command — e2e-report registration', () => {
 
   it('exports the multi-guide report schema without throwing', () => {
     expect(() => exportSchema('e2e-multi-report', false)).not.toThrow();
-    expect(exportSchema('e2e-multi-report', false)).not.toBeNull();
+    const schema = exportSchema('e2e-multi-report', false);
+    expect(schema).not.toBeNull();
+    expect(JSON.stringify(schema)).toContain('"selection"');
   });
 
   it('produces ajv-compilable JSON Schema for e2e-report and e2e-multi-report', () => {
@@ -45,5 +49,25 @@ describe('schema command — e2e-report registration', () => {
     };
     expect(hasAdditionalPropertiesFalse(exportSchema('e2e-report', false))).toBe(false);
     expect(hasAdditionalPropertiesFalse(exportSchema('e2e-multi-report', false))).toBe(false);
+  });
+});
+
+describe('ExecutionSelection schema', () => {
+  it('is absent on non-metapackage multi-guide reports', () => {
+    const report = generateMultiGuideReport([]);
+    expect(report.selection).toBeUndefined();
+    expect(() => MultiGuideReportSchema.parse(report)).not.toThrow();
+  });
+
+  it('accepts a journey selection type', () => {
+    expect(() => ExecutionSelectionSchema.parse({ id: 'learn-grafana', type: 'journey' })).not.toThrow();
+    const result = ExecutionSelectionSchema.parse({ id: 'learn-grafana', type: 'journey' });
+    expect(result.type).toBe('journey');
+  });
+
+  it('rejects invalid selection types', () => {
+    expect(() => ExecutionSelectionSchema.parse({ id: 'x', type: 'guide' })).toThrow();
+    expect(() => ExecutionSelectionSchema.parse({ id: 'x', type: 'course' })).toThrow();
+    expect(() => ExecutionSelectionSchema.parse({ id: 'x' })).toThrow();
   });
 });

--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -6,28 +6,30 @@
  */
 
 import { existsSync } from 'fs';
-import { dirname, isAbsolute, join, resolve } from 'path';
+import { join } from 'path';
 
 import { Command, Option } from 'commander';
 
 import { validateGuideFromString, toLegacyResult } from '../../validation';
-import {
-  loadGuideFiles,
-  loadBundledGuides,
-  loadRepositoryIndex,
-  bundledRepositoryPath,
-  type LoadedGuide,
-} from '../utils/file-loader';
+import { loadGuideFiles, loadBundledGuides, type LoadedGuide } from '../utils/file-loader';
 import { planGuideExecution, type ExecutionPlan } from '../e2e/guide-chains';
-import { type E2EErrorCode, type E2EExecutionOutcome } from '../e2e/schemas/e2e-report.schema';
+import { type E2EErrorCode, type E2EExecutionOutcome, type ExecutionSelection } from '../e2e/schemas/e2e-report.schema';
 import {
   contentDigest,
   createMinimalResultsData,
+  generateMultiGuideReport,
   generateReport,
+  writeMultiGuideReport,
   writeReport,
   type TestResultsData,
 } from '../e2e/e2e-reporter';
 import { checkTier, loadManifestFromDir, runManifestPreflight, type CurrentTier } from '../e2e/manifest-preflight';
+import {
+  loadLocalRepositorySource,
+  LocalMetapackageResolutionError,
+  resolveLocalMetapackage,
+  type LocalRepositorySource,
+} from '../e2e/e2e-local-package';
 import {
   resolveRemotePackage,
   resolveRemoteRepository,
@@ -59,7 +61,7 @@ import {
   printSummary,
   writeJsonReport,
 } from '../e2e/e2e-console-reporter';
-import type { ManifestJson, RepositoryEntry, RepositoryJson } from '../../types/package.types';
+import type { ManifestJson, RepositoryEntry } from '../../types/package.types';
 
 import { randomUUID } from 'crypto';
 import { createCloudAuthPolicy, type CloudAuthPolicy } from '../e2e/cloud-auth';
@@ -115,12 +117,6 @@ const DEFAULT_GRAFANA_URL = 'http://localhost:3000';
 const DEFAULT_RESOLVER_URL = 'https://recommender.grafana.com';
 const DEFAULT_CLOUD_URL = 'https://learn.grafana.net/';
 
-/** Repository source for dependency-aware planning (local index or remote CDN index). */
-interface RepoSource {
-  repository: RepositoryJson;
-  loadGuideById: (id: string, entry: RepositoryEntry) => LoadedGuide | null;
-}
-
 /**
  * Everything the run pipeline needs, resolved from CLI inputs regardless of
  * source (local files/bundled, a remote package, or the remote repository).
@@ -131,8 +127,12 @@ interface RunInputs {
   mode: RunMode;
   /** Guides to validate, plan, and run. */
   guides: LoadedGuide[];
+  /** Hydrated package plan for an explicitly selected path or journey. */
+  executionPlan?: ExecutionPlan;
+  /** Explicit metapackage root represented by the multi-guide report. */
+  selection?: ExecutionSelection;
   /** Dependency-planning source; undefined falls back to the local/bundled index. */
-  repoSource?: RepoSource;
+  repoSource?: LocalRepositorySource;
   /** Packages skipped before execution (remote modes). */
   preRunSkipped: GuideRunResult[];
   /** Per-guide package metadata for report enrichment (remote modes). */
@@ -151,7 +151,8 @@ class E2ECommandError extends Error {
   constructor(
     message: string,
     readonly exitCode: number,
-    readonly errorCode: E2EErrorCode = 'CONFIGURATION_ERROR'
+    readonly errorCode: E2EErrorCode = 'CONFIGURATION_ERROR',
+    readonly selection?: ExecutionSelection
   ) {
     super(message);
     this.name = 'E2ECommandError';
@@ -161,12 +162,18 @@ class E2ECommandError extends Error {
 function failCommand(
   message: string,
   exitCode: number = ExitCode.CONFIGURATION_ERROR,
-  errorCode: E2EErrorCode = 'CONFIGURATION_ERROR'
+  errorCode: E2EErrorCode = 'CONFIGURATION_ERROR',
+  selection?: ExecutionSelection
 ): never {
-  throw new E2ECommandError(message, exitCode, errorCode);
+  throw new E2ECommandError(message, exitCode, errorCode, selection);
 }
 
-function writeCommandFailureReport(options: E2ECommandOptions, error: unknown, guide?: LoadedGuide): number {
+function writeCommandFailureReport(
+  options: E2ECommandOptions,
+  error: unknown,
+  guide?: LoadedGuide,
+  selection?: ExecutionSelection
+): number {
   const message = error instanceof Error ? error.message : 'Unknown error';
   const commandError = error instanceof E2ECommandError ? error : undefined;
   const exitCode = commandError?.exitCode ?? ExitCode.CONFIGURATION_ERROR;
@@ -181,10 +188,12 @@ function writeCommandFailureReport(options: E2ECommandOptions, error: unknown, g
     TIER_MISMATCH: 'skipped',
   };
   let guideId =
+    selection?.id ??
     guide?.path
       .split('/')
       .pop()
-      ?.replace(/\.json$/, '') ?? 'pathfinder-cli';
+      ?.replace(/\.json$/, '') ??
+    'pathfinder-cli';
   let guideTitle = guideId;
   if (guide) {
     try {
@@ -203,7 +212,7 @@ function writeCommandFailureReport(options: E2ECommandOptions, error: unknown, g
     guide: {
       id: guideId,
       title: guideTitle,
-      path: guide?.path ?? 'unknown',
+      path: guide?.path ?? selection?.id ?? 'unknown',
       targetUrl: options.grafanaUrl,
       ...(guide ? { contentDigest: contentDigest(guide.content) } : {}),
     },
@@ -211,7 +220,9 @@ function writeCommandFailureReport(options: E2ECommandOptions, error: unknown, g
     errorCode,
     errorMessage: message,
   });
-  const reportSchemaValid = writeReport(generateReport(data), outputPath);
+  const reportSchemaValid = selection
+    ? writeMultiGuideReport(generateMultiGuideReport([data], undefined, selection), outputPath)
+    : writeReport(generateReport(data), outputPath);
   if (!options.output) {
     console.error(`📄 JSON report written to: ${outputPath}`);
   }
@@ -418,14 +429,59 @@ function resolveValidGuides(files: string[], options: E2ECommandOptions): Loaded
   return valid;
 }
 
+function finalizeExecutionPlan(
+  plan: ExecutionPlan,
+  options: E2ECommandOptions,
+  validateAllGuidesInPlan = false,
+  selection?: ExecutionSelection
+): ExecutionPlan {
+  if (plan.errors.length > 0) {
+    console.error('\n❌ Failed to plan guide execution:');
+    for (const planError of plan.errors) {
+      console.error(`   • ${planError}`);
+    }
+    failCommand('Failed to plan guide execution.', ExitCode.CONFIGURATION_ERROR, 'CONFIGURATION_ERROR', selection);
+  }
+
+  const plannedGuides = plan.chains
+    .flat()
+    .filter((planned) => validateAllGuidesInPlan || planned.autoIncluded)
+    .map((planned) => planned.guide);
+  const validation = validateAllGuides(plannedGuides, options);
+  if (validation.hasErrors) {
+    const label = validateAllGuidesInPlan ? 'Planned guide' : 'Auto-included prerequisite';
+    console.error(`\n❌ ${label} validation failed:\n`);
+    console.error(formatGuideValidationErrors(validation.errors));
+    failCommand(`${label} validation failed.`, ExitCode.CONFIGURATION_ERROR, 'CONFIGURATION_ERROR', selection);
+  }
+  if (plan.autoIncludedIds.length > 0) {
+    console.log(
+      `\n➕ Auto-included ${plan.autoIncludedIds.length} prerequisite guide(s): ${plan.autoIncludedIds.join(', ')}`
+    );
+  }
+
+  if (options.verbose) {
+    console.log(`\n🔗 Execution plan: ${plan.chains.length} chain(s)`);
+    plan.chains.forEach((chain, idx) => {
+      const names = chain.map((planned) => `${planned.id}${planned.autoIncluded ? ' (auto)' : ''}`).join(' → ');
+      console.log(`   Chain ${idx + 1}: ${names}`);
+    });
+  }
+  return plan;
+}
+
 /**
  * Build a dependency-aware execution plan. Guides linked by `depends` run in
  * dependency order; under --clean each chain gets a fresh environment. Resolves
  * the repository index, validates any auto-included prerequisites, and prints
  * the plan in verbose mode. Exits on configuration errors.
  */
-function buildExecutionPlan(valid: LoadedGuide[], options: E2ECommandOptions, repoSource?: RepoSource): ExecutionPlan {
-  let repository: RepositoryJson;
+function buildExecutionPlan(
+  valid: LoadedGuide[],
+  options: E2ECommandOptions,
+  repoSource?: LocalRepositorySource
+): ExecutionPlan {
+  let repository: LocalRepositorySource['repository'];
   let loadGuideById: (id: string, entry: RepositoryEntry) => LoadedGuide | null;
 
   if (repoSource) {
@@ -434,76 +490,18 @@ function buildExecutionPlan(valid: LoadedGuide[], options: E2ECommandOptions, re
     repository = repoSource.repository;
     loadGuideById = repoSource.loadGuideById;
   } else {
-    const repositoryPath = options.repository
-      ? isAbsolute(options.repository)
-        ? options.repository
-        : resolve(process.cwd(), options.repository)
-      : bundledRepositoryPath();
-
-    if (options.repository && !existsSync(repositoryPath)) {
-      console.error(`\n❌ Repository index not found: ${repositoryPath}`);
-      failCommand(`Repository index not found: ${repositoryPath}`);
+    let localSource: LocalRepositorySource;
+    try {
+      localSource = loadLocalRepositorySource(options.repository);
+    } catch (error) {
+      failCommand(error instanceof Error ? error.message : 'Failed to load repository index.');
     }
-
-    repository = {};
-    if (existsSync(repositoryPath)) {
-      const loaded = loadRepositoryIndex(repositoryPath);
-      if (loaded.error) {
-        // An explicitly requested index that fails to load is a configuration
-        // error; a malformed default (bundled) index degrades to no planning.
-        if (options.repository) {
-          console.error(`\n❌ Failed to load repository index (${repositoryPath}): ${loaded.error}`);
-          failCommand(`Failed to load repository index (${repositoryPath}): ${loaded.error}`);
-        }
-        console.warn(`⚠️  Ignoring default repository index (${repositoryPath}): ${loaded.error}`);
-      }
-      repository = loaded.repository ?? {};
-    }
-
-    const repoBaseDir = dirname(repositoryPath);
-    loadGuideById = (id: string, entry: RepositoryEntry): LoadedGuide | null => {
-      const rel = entry.path || `${id}/`;
-      const contentPath = rel.endsWith('.json') ? join(repoBaseDir, rel) : join(repoBaseDir, rel, 'content.json');
-      return loadGuideFiles([contentPath])[0] ?? null;
-    };
+    repository = localSource.repository;
+    loadGuideById = localSource.loadGuideById;
   }
 
   const plan = planGuideExecution({ guides: valid, repository, loadGuideById });
-
-  if (plan.errors.length > 0) {
-    console.error('\n❌ Failed to plan guide execution:');
-    for (const planError of plan.errors) {
-      console.error(`   • ${planError}`);
-    }
-    failCommand('Failed to plan guide execution.');
-  }
-
-  // Validate prerequisites that were auto-included to satisfy dependencies.
-  const autoIncludedGuides = plan.chains
-    .flat()
-    .filter((p) => p.autoIncluded)
-    .map((p) => p.guide);
-  const { hasErrors: autoHasErrors, errors: autoErrors } = validateAllGuides(autoIncludedGuides, options);
-  if (autoHasErrors) {
-    console.error('\n❌ Auto-included prerequisite validation failed:\n');
-    console.error(formatGuideValidationErrors(autoErrors));
-    failCommand('Auto-included prerequisite validation failed.');
-  }
-  if (autoIncludedGuides.length > 0) {
-    console.log(
-      `\n➕ Auto-included ${autoIncludedGuides.length} prerequisite guide(s): ${plan.autoIncludedIds.join(', ')}`
-    );
-  }
-
-  if (options.verbose) {
-    console.log(`\n🔗 Execution plan: ${plan.chains.length} chain(s)`);
-    plan.chains.forEach((chain, idx) => {
-      const names = chain.map((p) => `${p.id}${p.autoIncluded ? ' (auto)' : ''}`).join(' → ');
-      console.log(`   Chain ${idx + 1}: ${names}`);
-    });
-  }
-
-  return plan;
+  return finalizeExecutionPlan(plan, options);
 }
 
 /**
@@ -854,11 +852,16 @@ function exitFromResults(results: GuideRunResult[], reportSchemaValid: boolean):
  * exit per the results' statuses. Shared by the normal path and the
  * nothing-to-run path so both report identically.
  */
-function reportResults(results: GuideRunResult[], options: E2ECommandOptions, cleanupWarnings: string[] = []): void {
+function reportResults(
+  results: GuideRunResult[],
+  options: E2ECommandOptions,
+  cleanupWarnings: string[] = [],
+  selection?: ExecutionSelection
+): void {
   printSummary(results, cleanupWarnings);
   const hasNonPassOutcome = results.length === 0 || results.some((result) => result.status !== 'passed');
   const outputPath = options.output ?? (hasNonPassOutcome ? join(options.artifacts, 'report.json') : undefined);
-  const reportSchemaValid = writeJsonReport(results, outputPath, cleanupWarnings);
+  const reportSchemaValid = writeJsonReport(results, outputPath, cleanupWarnings, selection);
   exitFromResults(results, reportSchemaValid);
 }
 
@@ -874,6 +877,37 @@ function remoteLoadGuideById(
   return (id: string) => byId.get(id) ?? null;
 }
 
+function resolveLocalRunInputs(files: string[], options: E2ECommandOptions): RunInputs {
+  if (options.package) {
+    try {
+      const metapackage = resolveLocalMetapackage({
+        packageDir: options.package,
+        repositoryPath: options.repository,
+        grafanaUrl: options.grafanaUrl,
+        currentTier: options.tier,
+        cloudUrl: options.cloudUrl,
+        verbose: options.verbose,
+      });
+      if (metapackage) {
+        return { mode: 'local', ...metapackage };
+      }
+    } catch (error) {
+      if (error instanceof LocalMetapackageResolutionError) {
+        throw new E2ECommandError(error.message, ExitCode.CONFIGURATION_ERROR, 'CONFIGURATION_ERROR', error.selection);
+      }
+      throw error;
+    }
+  }
+
+  return {
+    mode: 'local',
+    guides: resolveValidGuides(files, options),
+    preRunSkipped: [],
+    packageMetaById: new Map(),
+    localPackageDir: options.package,
+  };
+}
+
 /**
  * Resolve CLI inputs into a uniform, runnable set, hiding whether guides come
  * from local files/bundled content, a remote package ID, or the remote
@@ -884,13 +918,7 @@ async function resolveRunInputs(files: string[], options: E2ECommandOptions): Pr
   const mode = resolveRunMode(options);
 
   if (mode === 'local') {
-    return {
-      mode,
-      guides: resolveValidGuides(files, options),
-      preRunSkipped: [],
-      packageMetaById: new Map(),
-      localPackageDir: options.package,
-    };
+    return resolveLocalRunInputs(files, options);
   }
 
   const cloudAuth = createCloudAuthPolicy({
@@ -937,6 +965,8 @@ async function resolveRunInputs(files: string[], options: E2ECommandOptions): Pr
     packageMetaById: buildPackageMetaMap(loadable),
     cloudAuth,
     cloudStackPoolManagerConfig,
+    executionPlan: resolution.executionPlan,
+    selection: resolution.selection,
   };
 }
 
@@ -957,7 +987,7 @@ export const e2eCommand = new Command('e2e')
   .option('--bundled', 'Test all bundled guides')
   .option(
     '--package <dirOrId>',
-    'Test a package: a local directory (content.json + manifest.json), or — when not an existing directory — a bare package ID resolved via the recommender'
+    'Test a guide, path, or journey package: a local directory, or a bare package ID resolved via the recommender'
   )
   .addOption(new Option('--tier <tier>', 'Current test environment tier').choices(['local', 'cloud']).default('local'))
   .option('--trace', 'Generate Playwright trace file', false)
@@ -976,7 +1006,7 @@ export const e2eCommand = new Command('e2e')
   )
   .option(
     '--repository <path>',
-    'Path to a repository.json used for dependency-aware ordering (default: the bundled index when present)'
+    'Path to repository.json (default: bundled index for guide dependencies; required for local path/journey milestones)'
   )
   .option('--remote', 'Resolve and test every package from the CDN repository index', false)
   .option('--repo-url <url>', 'CDN base URL for --remote (default: the public Pathfinder package repository)')
@@ -1009,6 +1039,7 @@ export const e2eCommand = new Command('e2e')
     const cleanEnv = new CleanEnvironment(options.verbose);
     const cloudChainCleanup = new CloudChainCleanupRegistry();
     let reportGuide: LoadedGuide | undefined;
+    let reportSelection: ExecutionSelection | undefined;
 
     installTeardownHandlers(cleanEnv, cloudChainCleanup);
     if (options.clean && options.grafanaUrl === DEFAULT_GRAFANA_URL) {
@@ -1018,17 +1049,18 @@ export const e2eCommand = new Command('e2e')
     try {
       const inputs = await resolveRunInputs(files, options);
       reportGuide = inputs.guides.length === 1 ? inputs.guides[0] : undefined;
+      reportSelection = inputs.selection;
 
       // Remote runs can resolve to nothing runnable (e.g. all cloud-tier guides):
       // report the skips and exit without booting Grafana or Playwright.
       if (inputs.guides.length === 0) {
-        reportResults(inputs.preRunSkipped, options);
+        reportResults(inputs.preRunSkipped, options, [], inputs.selection);
         return;
       }
 
       printRunConfiguration(inputs.guides, options, inputs.mode);
 
-      const plan = buildExecutionPlan(inputs.guides, options, inputs.repoSource);
+      const plan = inputs.executionPlan ?? buildExecutionPlan(inputs.guides, options, inputs.repoSource);
       assertTierHomogeneousChains(plan, inputs.packageMetaById);
 
       await maybeCleanStart(cleanEnv, options);
@@ -1066,7 +1098,7 @@ export const e2eCommand = new Command('e2e')
         cloudChainCleanup
       );
 
-      reportResults([...inputs.preRunSkipped, ...outcome.results], options, outcome.cleanupWarnings);
+      reportResults([...inputs.preRunSkipped, ...outcome.results], options, outcome.cleanupWarnings, inputs.selection);
     } catch (error) {
       const isSuccessExit = error instanceof E2ECommandError && error.exitCode === ExitCode.SUCCESS;
       if (!isSuccessExit) {
@@ -1074,7 +1106,12 @@ export const e2eCommand = new Command('e2e')
       }
       let exitCode: number;
       try {
-        exitCode = writeCommandFailureReport(options, error, reportGuide);
+        exitCode = writeCommandFailureReport(
+          options,
+          error,
+          reportGuide,
+          reportSelection ?? (error instanceof E2ECommandError ? error.selection : undefined)
+        );
       } catch {
         exitCode = error instanceof E2ECommandError ? error.exitCode : ExitCode.CONFIGURATION_ERROR;
       }

--- a/src/cli/e2e/e2e-console-reporter.test.ts
+++ b/src/cli/e2e/e2e-console-reporter.test.ts
@@ -41,13 +41,14 @@ describe('writeJsonReport', () => {
       },
     ];
 
-    const schemaValid = writeJsonReport(results, outputPath);
+    const schemaValid = writeJsonReport(results, outputPath, [], { id: 'cloud-path', type: 'path' });
 
     const report = JSON.parse(readFileSync(outputPath, 'utf-8')) as MultiGuideReport;
     expect(schemaValid).toBe(true);
     expect(report.type).toBe('multi-guide');
     expect(report.summary.totalGuides).toBe(1);
     expect(report.summary.skippedGuides).toBe(1);
+    expect(report.selection).toEqual({ id: 'cloud-path', type: 'path' });
     expect(report.guides).toEqual([]);
     expect(report.reports).toEqual([]);
     expect(report.preRunSkipped).toEqual([
@@ -61,6 +62,38 @@ describe('writeJsonReport', () => {
       },
     ]);
     expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('No test results available'));
+  });
+
+  it('writes a multi-guide report for a one-milestone path', () => {
+    const outputPath = join(tempDir, 'results.json');
+    const results: GuideRunResult[] = [
+      {
+        guide: 'only/content.json',
+        id: 'only',
+        status: 'passed',
+        exitCode: ExitCode.SUCCESS,
+        autoIncluded: false,
+        resultsData: {
+          guide: {
+            id: 'only',
+            title: 'Only milestone',
+            path: 'only/content.json',
+            targetUrl: 'http://localhost:3000',
+          },
+          timestamp: '2026-01-01T00:00:00.000Z',
+          results: [],
+          aborted: false,
+        },
+      },
+    ];
+
+    const schemaValid = writeJsonReport(results, outputPath, [], { id: 'one-step-path', type: 'path' });
+
+    const report = JSON.parse(readFileSync(outputPath, 'utf-8')) as MultiGuideReport;
+    expect(schemaValid).toBe(true);
+    expect(report.type).toBe('multi-guide');
+    expect(report.selection).toEqual({ id: 'one-step-path', type: 'path' });
+    expect(report.reports).toHaveLength(1);
   });
 
   it('sets outcome to failed when a pre-run skip entry has failed: true', () => {

--- a/src/cli/e2e/e2e-console-reporter.ts
+++ b/src/cli/e2e/e2e-console-reporter.ts
@@ -10,7 +10,12 @@
  */
 
 import { CLEAN_COMPOSE_PROJECT } from './clean-environment';
-import { E2E_REPORT_SCHEMA_VERSION, type MultiGuideReport, type RunnerProvenance } from './schemas/e2e-report.schema';
+import {
+  E2E_REPORT_SCHEMA_VERSION,
+  type ExecutionSelection,
+  type MultiGuideReport,
+  type RunnerProvenance,
+} from './schemas/e2e-report.schema';
 import {
   generateReport,
   writeReport,
@@ -36,7 +41,8 @@ import type { SideEffectClassification } from './side-effects';
 
 function skipOnlyReport(
   preRunSkipped: MultiGuideReport['preRunSkipped'],
-  cleanupWarnings: string[] = []
+  cleanupWarnings: string[] = [],
+  selection?: ExecutionSelection
 ): MultiGuideReport {
   const timestamp = new Date().toISOString();
   const { failedGuides, skippedGuides } = countPreRunGuides(preRunSkipped);
@@ -53,6 +59,7 @@ function skipOnlyReport(
     startedAt: timestamp,
     endedAt: timestamp,
     type: 'multi-guide',
+    ...(selection ? { selection } : {}),
     config: { timestamp },
     summary: {
       totalGuides: (preRunSkipped ?? []).length,
@@ -232,19 +239,20 @@ export function printSummary(results: GuideRunResult[], cleanupWarnings: string[
 export function writeJsonReport(
   results: GuideRunResult[],
   outputPath: string | undefined,
-  cleanupWarnings: string[] = []
+  cleanupWarnings: string[] = [],
+  selection?: ExecutionSelection
 ): boolean {
   if (!outputPath) {
     return true;
   }
 
   const resultsWithData = results.filter((r) => r.resultsData).map((r) => r.resultsData!);
-  const isMultiGuide = results.length > 1;
+  const isMultiGuide = results.length > 1 || selection !== undefined;
   const preRunSkipped = preRunSkipsFromResults(results);
 
   if (resultsWithData.length === 0 && preRunSkipped.length > 0) {
     try {
-      const report = skipOnlyReport(preRunSkipped, cleanupWarnings);
+      const report = skipOnlyReport(preRunSkipped, cleanupWarnings, selection);
       const schemaValid = writeMultiGuideReport(report, outputPath);
       console.log(`\n📄 Multi-guide JSON report written to: ${outputPath}`);
       console.log(`   ${formatMultiGuideSummary(report)}`);
@@ -258,7 +266,7 @@ export function writeJsonReport(
     return true;
   } else if (isMultiGuide) {
     try {
-      const report = generateMultiGuideReport(resultsWithData);
+      const report = generateMultiGuideReport(resultsWithData, undefined, selection);
       if (preRunSkipped.length > 0) {
         report.preRunSkipped = preRunSkipped;
         const counts = countPreRunGuides(preRunSkipped);

--- a/src/cli/e2e/e2e-local-package.test.ts
+++ b/src/cli/e2e/e2e-local-package.test.ts
@@ -1,0 +1,314 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { resolveLocalMetapackage } from './e2e-local-package';
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function options(root: string, repository: string) {
+  return {
+    packageDir: join(root, 'path'),
+    repositoryPath: repository,
+    grafanaUrl: 'http://localhost:3000',
+    currentTier: 'local' as const,
+    cloudUrl: 'https://learn.grafana.net/',
+    verbose: false,
+  };
+}
+
+describe('local metapackage input resolution', () => {
+  let root: string;
+  let pathDir: string;
+  let stepDir: string;
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'pathfinder-local-metapackage-'));
+    pathDir = join(root, 'path');
+    stepDir = join(root, 'step');
+    mkdirSync(pathDir);
+    mkdirSync(stepDir);
+    writeJson(join(pathDir, 'manifest.json'), {
+      id: 'coverless-path',
+      type: 'path',
+      milestones: ['coverless-step'],
+      testEnvironment: { tier: 'local' },
+    });
+    writeJson(join(stepDir, 'content.json'), {
+      id: 'coverless-step',
+      title: 'Coverless step',
+      blocks: [],
+    });
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('expands a valid path without requiring cover content.json', () => {
+    const repository = join(root, 'repository.json');
+    writeJson(repository, {
+      'coverless-path': {
+        path: 'path/',
+        type: 'path',
+        milestones: ['coverless-step'],
+        testEnvironment: { tier: 'local' },
+      },
+      'coverless-step': {
+        path: 'step/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+    });
+
+    const inputs = resolveLocalMetapackage(options(root, repository))!;
+
+    expect(inputs.selection).toEqual({ id: 'coverless-path', type: 'path' });
+    expect(inputs.guides).toHaveLength(1);
+    expect(JSON.parse(inputs.guides[0]!.content).id).toBe('coverless-step');
+    expect(inputs.executionPlan?.chains[0]?.map((guide) => guide.id)).toEqual(['coverless-step']);
+  });
+
+  it('makes the root non-runnable when its own target is incompatible with the environment', () => {
+    const repository = join(root, 'repository.json');
+    writeJson(repository, {
+      'coverless-path': {
+        path: 'path/',
+        type: 'path',
+        milestones: ['coverless-step'],
+        testEnvironment: { tier: 'cloud' },
+      },
+      'coverless-step': {
+        path: 'step/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+    });
+
+    const inputs = resolveLocalMetapackage(options(root, repository))!;
+
+    expect(inputs.selection).toEqual({ id: 'coverless-path', type: 'path' });
+    expect(inputs.guides).toEqual([]);
+    expect(inputs.executionPlan).toBeUndefined();
+    expect(inputs.packageMetaById.size).toBe(0);
+    expect(inputs.preRunSkipped).toEqual([
+      expect.objectContaining({
+        id: 'coverless-path',
+        status: 'skipped_tier_mismatch',
+        abortMessage: expect.stringContaining('requires tier \"cloud\"'),
+      }),
+    ]);
+  });
+
+  it('rejects an otherwise-runnable milestone whose target differs from the root', () => {
+    const repository = join(root, 'repository.json');
+    writeJson(repository, {
+      'coverless-path': {
+        path: 'path/',
+        type: 'path',
+        milestones: ['coverless-step'],
+        testEnvironment: { tier: 'local', instance: 'root.example.com' },
+      },
+      'coverless-step': {
+        path: 'step/',
+        type: 'guide',
+        testEnvironment: { tier: 'local', instance: 'leaf.example.com' },
+      },
+    });
+
+    const inputs = resolveLocalMetapackage(options(root, repository))!;
+
+    expect(inputs.selection).toEqual({ id: 'coverless-path', type: 'path' });
+    expect(inputs.guides).toEqual([]);
+    expect(inputs.executionPlan).toBeUndefined();
+    expect(inputs.packageMetaById.size).toBe(0);
+    expect(inputs.preRunSkipped).toEqual([
+      expect.objectContaining({
+        id: 'coverless-path',
+        status: 'resolution_failed',
+        abortMessage: expect.stringContaining('mixes incompatible targets at guide \"coverless-step\"'),
+      }),
+    ]);
+  });
+
+  it('loads successful milestones in declared order', () => {
+    const repository = join(root, 'repository.json');
+    const secondStepDir = join(root, 'second-step');
+    mkdirSync(secondStepDir);
+    writeJson(join(secondStepDir, 'content.json'), {
+      id: 'second-step',
+      title: 'Second step',
+      blocks: [],
+    });
+    writeJson(repository, {
+      'coverless-path': {
+        path: 'path/',
+        type: 'path',
+        milestones: ['coverless-step', 'second-step'],
+        testEnvironment: { tier: 'local' },
+      },
+      'coverless-step': {
+        path: 'step/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+      'second-step': {
+        path: 'second-step/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+    });
+
+    const inputs = resolveLocalMetapackage(options(root, repository))!;
+
+    expect(inputs.guides.map((guide) => JSON.parse(guide.content).id)).toEqual(['coverless-step', 'second-step']);
+    expect(inputs.executionPlan?.chains[0]?.map((guide) => guide.id)).toEqual(['coverless-step', 'second-step']);
+    expect([...inputs.packageMetaById.keys()]).toEqual(['coverless-step', 'second-step']);
+    expect(inputs.preRunSkipped).toEqual([]);
+  });
+
+  it('reports manifest and repository root type mismatches with selection', () => {
+    const repository = join(root, 'repository.json');
+    writeJson(repository, {
+      'coverless-path': {
+        path: 'path/',
+        type: 'journey',
+        milestones: ['coverless-step'],
+        testEnvironment: { tier: 'local' },
+      },
+      'coverless-step': {
+        path: 'step/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+    });
+
+    try {
+      resolveLocalMetapackage(options(root, repository));
+      throw new Error('Expected local metapackage type validation to fail');
+    } catch (error) {
+      expect(error).toMatchObject({
+        message: expect.stringContaining('manifest declares "path", repository declares "journey"'),
+        selection: { id: 'coverless-path', type: 'path' },
+      });
+    }
+  });
+
+  it('makes the root non-runnable when any milestone is incompatible with the environment', () => {
+    const repository = join(root, 'repository.json');
+    const cloudStepDir = join(root, 'cloud-step');
+    mkdirSync(cloudStepDir);
+    writeJson(join(cloudStepDir, 'content.json'), {
+      id: 'cloud-step',
+      title: 'Cloud step',
+      blocks: [],
+    });
+    writeJson(repository, {
+      'coverless-path': {
+        path: 'path/',
+        type: 'path',
+        milestones: ['coverless-step', 'cloud-step'],
+        testEnvironment: { tier: 'local' },
+      },
+      'coverless-step': {
+        path: 'step/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+      'cloud-step': {
+        path: 'cloud-step/',
+        type: 'guide',
+        testEnvironment: { tier: 'cloud' },
+      },
+    });
+
+    const inputs = resolveLocalMetapackage(options(root, repository))!;
+
+    expect(inputs.selection).toEqual({ id: 'coverless-path', type: 'path' });
+    expect(inputs.guides).toEqual([]);
+    expect(inputs.executionPlan).toBeUndefined();
+    expect(inputs.packageMetaById.size).toBe(0);
+    expect(inputs.preRunSkipped).toEqual([
+      expect.objectContaining({ id: 'cloud-step', status: 'skipped_tier_mismatch' }),
+      expect.objectContaining({
+        id: 'coverless-path',
+        status: 'prerequisite_failed',
+        abortMessage: expect.stringContaining('cloud-step'),
+      }),
+    ]);
+  });
+
+  it('does not partially execute independent milestones when one required milestone is unrunnable', () => {
+    const repository = join(root, 'repository.json');
+    const cloudStepDir = join(root, 'cloud-step');
+    const independentStepDir = join(root, 'independent-step');
+    mkdirSync(cloudStepDir);
+    mkdirSync(independentStepDir);
+    writeJson(join(cloudStepDir, 'content.json'), {
+      id: 'cloud-step',
+      title: 'Cloud step',
+      blocks: [],
+    });
+    writeJson(join(independentStepDir, 'content.json'), {
+      id: 'independent-step',
+      title: 'Independent step',
+      blocks: [],
+    });
+    writeJson(repository, {
+      'coverless-path': {
+        path: 'path/',
+        type: 'path',
+        milestones: ['cloud-step', 'coverless-step', 'independent-step'],
+        testEnvironment: { tier: 'local' },
+      },
+      'cloud-step': {
+        path: 'cloud-step/',
+        type: 'guide',
+        testEnvironment: { tier: 'cloud' },
+      },
+      'coverless-step': {
+        path: 'step/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+      'independent-step': {
+        path: 'independent-step/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+    });
+
+    const inputs = resolveLocalMetapackage(options(root, repository))!;
+
+    expect(inputs.guides).toEqual([]);
+    expect(inputs.executionPlan).toBeUndefined();
+    expect(inputs.preRunSkipped.map((skip) => skip.id)).toEqual(['cloud-step', 'coverless-path']);
+  });
+
+  it('attaches root selection to a local milestone planning error', () => {
+    const repository = join(root, 'missing-repository.json');
+    writeJson(repository, {
+      'coverless-path': {
+        path: 'path/',
+        type: 'path',
+        milestones: ['coverless-step'],
+        testEnvironment: { tier: 'local' },
+      },
+    });
+
+    try {
+      resolveLocalMetapackage(options(root, repository));
+      throw new Error('Expected local metapackage planning to fail');
+    } catch (error) {
+      expect(error).toMatchObject({
+        message: expect.stringContaining('Failed to plan guide execution'),
+        selection: { id: 'coverless-path', type: 'path' },
+      });
+    }
+  });
+});

--- a/src/cli/e2e/e2e-local-package.ts
+++ b/src/cli/e2e/e2e-local-package.ts
@@ -1,0 +1,267 @@
+import { existsSync } from 'fs';
+import { dirname, isAbsolute, join, resolve } from 'path';
+
+import { toLegacyResult, validateGuideFromString } from '../../validation';
+import type { ManifestJson, RepositoryEntry, RepositoryJson } from '../../types/package.types';
+import { bundledRepositoryPath, loadGuideFiles, loadRepositoryIndex, type LoadedGuide } from '../utils/file-loader';
+import { classifyGuideSideEffectsFromString } from './side-effects';
+import { resolveTarget, sameOrigin } from './e2e-targets';
+import { ExitCode } from './exit-codes';
+import { hydrateExecutionPlan, planPackageExecution, type ExecutionPlan } from './guide-chains';
+import { loadManifestFromDir, type CurrentTier } from './manifest-preflight';
+import type { GuideRunResult, GuideStatus, PackageMeta } from './e2e-results';
+import type { ExecutionSelection } from './schemas/e2e-report.schema';
+
+export interface LocalRepositorySource {
+  repository: RepositoryJson;
+  loadGuideById: (id: string, entry: RepositoryEntry) => LoadedGuide | null;
+}
+
+export interface LocalMetapackageOptions {
+  packageDir: string;
+  repositoryPath?: string;
+  grafanaUrl: string;
+  currentTier: CurrentTier;
+  cloudUrl: string;
+  verbose: boolean;
+}
+
+export interface LocalMetapackageResolution {
+  guides: LoadedGuide[];
+  executionPlan?: ExecutionPlan;
+  selection: ExecutionSelection;
+  repoSource: LocalRepositorySource;
+  preRunSkipped: GuideRunResult[];
+  packageMetaById: Map<string, PackageMeta>;
+  localPackageDir: string;
+}
+
+export class LocalMetapackageResolutionError extends Error {
+  constructor(
+    message: string,
+    readonly selection?: ExecutionSelection
+  ) {
+    super(message);
+    this.name = 'LocalMetapackageResolutionError';
+  }
+}
+
+export function loadLocalRepositorySource(repositoryPath?: string): LocalRepositorySource {
+  const resolvedPath = repositoryPath
+    ? isAbsolute(repositoryPath)
+      ? repositoryPath
+      : resolve(process.cwd(), repositoryPath)
+    : bundledRepositoryPath();
+
+  if (repositoryPath && !existsSync(resolvedPath)) {
+    throw new Error(`Repository index not found: ${resolvedPath}`);
+  }
+
+  let repository: RepositoryJson = {};
+  if (existsSync(resolvedPath)) {
+    const loaded = loadRepositoryIndex(resolvedPath);
+    if (loaded.error) {
+      if (repositoryPath) {
+        throw new Error(`Failed to load repository index (${resolvedPath}): ${loaded.error}`);
+      }
+      console.warn(`⚠️  Ignoring default repository index (${resolvedPath}): ${loaded.error}`);
+    }
+    repository = loaded.repository ?? {};
+  }
+
+  const repoBaseDir = dirname(resolvedPath);
+  return {
+    repository,
+    loadGuideById(id: string, entry: RepositoryEntry): LoadedGuide | null {
+      const rel = entry.path || `${id}/`;
+      const contentPath = rel.endsWith('.json') ? join(repoBaseDir, rel) : join(repoBaseDir, rel, 'content.json');
+      return loadGuideFiles([contentPath])[0] ?? null;
+    },
+  };
+}
+
+function validatePlannedGuides(plan: ExecutionPlan, verbose: boolean, selection: ExecutionSelection): void {
+  const errors: Array<{ file: string; errors: string[] }> = [];
+  for (const planned of plan.chains.flat()) {
+    const result = validateGuideFromString(planned.guide.content);
+    if (verbose && result.isValid && result.warnings.length > 0) {
+      console.log(`⚠️  ${planned.guide.path}: ${result.warnings.length} warning(s)`);
+    }
+    if (!result.isValid) {
+      errors.push({ file: planned.guide.path, errors: toLegacyResult(result).errors });
+    }
+  }
+  if (errors.length > 0) {
+    const detail = errors
+      .map(({ file, errors: fileErrors }) => [`  ${file}:`, ...fileErrors.map((error) => `    - ${error}`)].join('\n'))
+      .join('\n');
+    throw new LocalMetapackageResolutionError(`Planned guide validation failed:\n${detail}`, selection);
+  }
+}
+
+function printPlan(plan: ExecutionPlan, verbose: boolean): void {
+  if (plan.autoIncludedIds.length > 0) {
+    console.log(
+      `\n➕ Auto-included ${plan.autoIncludedIds.length} prerequisite guide(s): ${plan.autoIncludedIds.join(', ')}`
+    );
+  }
+  if (verbose) {
+    console.log(`\n🔗 Execution plan: ${plan.chains.length} chain(s)`);
+    plan.chains.forEach((chain, index) => {
+      const names = chain.map((planned) => `${planned.id}${planned.autoIncluded ? ' (auto)' : ''}`).join(' → ');
+      console.log(`   Chain ${index + 1}: ${names}`);
+    });
+  }
+}
+
+export function resolveLocalMetapackage(options: LocalMetapackageOptions): LocalMetapackageResolution | undefined {
+  let manifest: ManifestJson | null;
+  try {
+    manifest = loadManifestFromDir(options.packageDir);
+  } catch (error) {
+    throw new LocalMetapackageResolutionError(
+      `Failed to load manifest.json: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+  if (!manifest || (manifest.type !== 'path' && manifest.type !== 'journey')) {
+    return undefined;
+  }
+
+  const selection: ExecutionSelection = { id: manifest.id, type: manifest.type };
+  if (!options.repositoryPath) {
+    throw new LocalMetapackageResolutionError(
+      `Local ${manifest.type} packages require --repository <path> to resolve milestones.`,
+      selection
+    );
+  }
+
+  try {
+    const repoSource = loadLocalRepositorySource(options.repositoryPath);
+    const rootEntry = repoSource.repository[manifest.id];
+    if (!rootEntry) {
+      throw new Error(`Root package "${manifest.id}" is missing from the repository index.`);
+    }
+    if (rootEntry.type !== manifest.type) {
+      throw new Error(
+        `Root package type mismatch: manifest declares "${manifest.type}", repository declares "${rootEntry.type}".`
+      );
+    }
+    const rootOnlySkip = (status: GuideStatus, abortMessage: string, tier?: string): LocalMetapackageResolution => ({
+      guides: [],
+      selection,
+      repoSource,
+      preRunSkipped: [
+        {
+          guide: options.packageDir,
+          id: manifest.id,
+          status,
+          exitCode: ExitCode.SUCCESS,
+          autoIncluded: false,
+          abortMessage,
+          tier,
+        },
+      ],
+      packageMetaById: new Map(),
+      localPackageDir: options.packageDir,
+    });
+    const targetOptions = {
+      grafanaUrl: options.grafanaUrl,
+      currentTier: options.currentTier,
+      cloudUrl: options.cloudUrl,
+    };
+    const rootTarget = resolveTarget(rootEntry.testEnvironment ?? {}, targetOptions);
+    if (!rootTarget.runnable) {
+      return rootOnlySkip(rootTarget.skipReason!, rootTarget.message ?? 'Package skipped', rootTarget.tier);
+    }
+
+    const packagePlan = planPackageExecution({ rootIds: [manifest.id], repository: repoSource.repository });
+    const executionPlan = hydrateExecutionPlan(packagePlan, new Map(), repoSource.repository, repoSource.loadGuideById);
+    if (executionPlan.errors.length > 0) {
+      throw new Error(`Failed to plan guide execution: ${executionPlan.errors.join('; ')}`);
+    }
+    validatePlannedGuides(executionPlan, options.verbose, selection);
+    printPlan(executionPlan, options.verbose);
+
+    const packageMetaById = new Map<string, PackageMeta>();
+    const preRunSkipped: GuideRunResult[] = [];
+    let incompatibleGuideId: string | undefined;
+    for (const planned of executionPlan.chains.flat()) {
+      const entry = repoSource.repository[planned.id];
+      const target = resolveTarget(entry?.testEnvironment ?? {}, targetOptions);
+      if (!target.runnable) {
+        preRunSkipped.push({
+          guide: planned.guide.path,
+          id: planned.id,
+          status: target.skipReason!,
+          exitCode: ExitCode.SUCCESS,
+          autoIncluded: planned.autoIncluded,
+          abortMessage: target.message ?? 'Guide skipped',
+          tier: target.tier,
+        });
+        continue;
+      }
+      if (
+        target.tier !== rootTarget.tier ||
+        target.instance !== rootTarget.instance ||
+        !sameOrigin(target.targetUrl, rootTarget.targetUrl)
+      ) {
+        incompatibleGuideId ??= planned.id;
+      }
+      packageMetaById.set(planned.id, {
+        packageId: planned.id,
+        tier: target.tier,
+        instance: target.instance,
+        targetUrl: target.targetUrl!,
+        sourceUrl: planned.guide.path,
+        startingLocation: entry?.startingLocation ?? '/',
+        sideEffects: classifyGuideSideEffectsFromString(planned.guide.content),
+        ...(entry?.testEnvironment?.plugins?.length ? { plugins: entry.testEnvironment.plugins } : {}),
+      });
+    }
+
+    if (preRunSkipped.length > 0) {
+      preRunSkipped.push({
+        guide: options.packageDir,
+        id: manifest.id,
+        status: 'prerequisite_failed',
+        exitCode: ExitCode.SUCCESS,
+        autoIncluded: false,
+        abortMessage: `Required guide(s) did not resolve: ${preRunSkipped.map((item) => item.id).join(', ')}`,
+        tier: rootEntry.testEnvironment?.tier,
+      });
+      return {
+        guides: [],
+        selection,
+        repoSource,
+        preRunSkipped,
+        packageMetaById: new Map(),
+        localPackageDir: options.packageDir,
+      };
+    }
+    if (incompatibleGuideId) {
+      return rootOnlySkip(
+        'resolution_failed',
+        `${manifest.type} package mixes incompatible targets at guide "${incompatibleGuideId}"`,
+        rootTarget.tier
+      );
+    }
+
+    return {
+      guides: executionPlan.chains.flatMap((chain) => chain.map((planned) => planned.guide)),
+      executionPlan,
+      selection,
+      repoSource,
+      preRunSkipped,
+      packageMetaById,
+      localPackageDir: options.packageDir,
+    };
+  } catch (error) {
+    if (error instanceof LocalMetapackageResolutionError) {
+      throw error;
+    }
+    throw new LocalMetapackageResolutionError(
+      error instanceof Error ? error.message : 'Unknown local metapackage resolution error',
+      selection
+    );
+  }
+}

--- a/src/cli/e2e/e2e-package.test.ts
+++ b/src/cli/e2e/e2e-package.test.ts
@@ -49,6 +49,15 @@ function mockFetch(body: { ok: true; text: string } | { ok: false; status: numbe
     ) as unknown as typeof fetch;
 }
 
+function mockGuideFetch(aliases: Record<string, string> = {}): void {
+  global.fetch = jest.fn((url: string) => {
+    const segments = new URL(url).pathname.split('/').filter(Boolean);
+    const packagePath = segments[segments.length - 2]!;
+    const id = aliases[packagePath] ?? packagePath;
+    return Promise.resolve({ ok: true, text: async () => JSON.stringify({ id }) } as Response);
+  }) as unknown as typeof fetch;
+}
+
 /** Configure the CDN index mock with the given packages. */
 function mockIndex(packages: unknown[]): void {
   (fetchRepositoryIndex as jest.Mock).mockResolvedValue({
@@ -123,20 +132,219 @@ describe('resolveRemotePackage (single, recommender)', () => {
     expect(result.skipped[0]).toMatchObject({ id: 'missing', reason: 'resolution_failed' });
   });
 
-  it('skips a non-guide package as unsupported_type', async () => {
+  it('expands a path package into an ordered leaf-guide execution plan', async () => {
     mockResolve({
       ok: true,
       id: 'prometheus-lj',
       contentUrl: 'https://cdn.test/prometheus-lj/content.json',
       manifestUrl: '',
       repository: 'r',
-      manifest: { id: 'prometheus-lj', type: 'path', milestones: ['a', 'b'] },
+      manifest: {
+        id: 'prometheus-lj',
+        type: 'path',
+        milestones: ['prometheus-a', 'prometheus-b'],
+        testEnvironment: { tier: 'local' },
+      },
     });
+    mockIndex([
+      {
+        id: 'prometheus-lj',
+        path: 'prometheus-lj/',
+        type: 'path',
+        milestones: ['prometheus-a', 'prometheus-b'],
+        testEnvironment: { tier: 'local' },
+      },
+      {
+        id: 'prometheus-a',
+        path: 'prometheus-lj/a/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+      {
+        id: 'prometheus-b',
+        path: 'prometheus-lj/b/',
+        type: 'guide',
+        depends: ['prometheus-a'],
+        testEnvironment: { tier: 'local' },
+      },
+    ]);
+    global.fetch = jest.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            id: url.includes('/a/') ? 'prometheus-a' : 'prometheus-b',
+            title: 'Guide',
+            blocks: [],
+          }),
+      } as Response)
+    ) as unknown as typeof fetch;
 
     const result = await resolveRemotePackage('prometheus-lj', OPTIONS);
 
-    expect(result.runnable).toHaveLength(0);
-    expect(result.skipped[0]).toMatchObject({ id: 'prometheus-lj', reason: 'unsupported_type' });
+    expect(result.skipped).toEqual([]);
+    expect(result.selection).toEqual({ id: 'prometheus-lj', type: 'path' });
+    expect(result.runnable.map((guide) => guide.id)).toEqual(['prometheus-a', 'prometheus-b']);
+    expect(result.executionPlan?.chains[0]?.map((guide) => guide.id)).toEqual(['prometheus-a', 'prometheus-b']);
+    expect(result.executionPlan?.chains[0]?.[1]?.dependencies).toEqual(['prometheus-a']);
+    expect(global.fetch).not.toHaveBeenCalledWith('https://cdn.test/prometheus-lj/content.json', expect.anything());
+  });
+
+  it('rejects a path whose repository root is declared as a journey', async () => {
+    mockResolve({
+      ok: true,
+      id: 'mismatched-path',
+      contentUrl: 'https://cdn.test/mismatched-path/content.json',
+      manifestUrl: 'https://cdn.test/mismatched-path/manifest.json',
+      repository: 'r',
+      manifest: {
+        id: 'mismatched-path',
+        type: 'path',
+        milestones: ['leaf'],
+        testEnvironment: { tier: 'local' },
+      },
+    });
+    mockIndex([
+      {
+        id: 'mismatched-path',
+        path: 'mismatched-path/',
+        type: 'journey',
+        milestones: ['leaf'],
+        testEnvironment: { tier: 'local' },
+      },
+      { id: 'leaf', path: 'mismatched-path/leaf/', type: 'guide', testEnvironment: { tier: 'local' } },
+    ]);
+
+    const result = await resolveRemotePackage('mismatched-path', OPTIONS);
+
+    expect(result.runnable).toEqual([]);
+    expect(result.selection).toEqual({ id: 'mismatched-path', type: 'path' });
+    expect(result.skipped).toEqual([
+      expect.objectContaining({
+        id: 'mismatched-path',
+        reason: 'resolution_failed',
+        message: expect.stringContaining(
+          'Root package type mismatch: recommender declared "path", repository declared "journey"'
+        ),
+      }),
+    ]);
+  });
+
+  it('preserves repository metapackage selection when recommender metadata declares a guide', async () => {
+    mockResolve({
+      ok: true,
+      id: 'repository-path',
+      contentUrl: 'https://cdn.test/repository-path/content.json',
+      manifestUrl: 'https://cdn.test/repository-path/manifest.json',
+      repository: 'r',
+      manifest: { id: 'repository-path', type: 'guide', testEnvironment: { tier: 'local' } },
+    });
+    mockIndex([
+      {
+        id: 'repository-path',
+        path: 'repository-path/',
+        type: 'path',
+        milestones: ['leaf'],
+        testEnvironment: { tier: 'local' },
+      },
+      { id: 'leaf', path: 'repository-path/leaf/', type: 'guide', testEnvironment: { tier: 'local' } },
+    ]);
+
+    const result = await resolveRemotePackage('repository-path', OPTIONS);
+
+    expect(result.runnable).toEqual([]);
+    expect(result.selection).toEqual({ id: 'repository-path', type: 'path' });
+    expect(result.skipped[0]).toMatchObject({
+      id: 'repository-path',
+      reason: 'resolution_failed',
+      message: expect.stringContaining('recommender declared "guide", repository declared "path"'),
+    });
+  });
+
+  it('skips an entire path before execution when a required leaf cannot be fetched', async () => {
+    mockResolve({
+      ok: true,
+      id: 'broken-path',
+      contentUrl: 'https://cdn.test/broken-path/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: {
+        id: 'broken-path',
+        type: 'path',
+        milestones: ['good-leaf', 'broken-leaf'],
+        testEnvironment: { tier: 'local' },
+      },
+    });
+    mockIndex([
+      {
+        id: 'broken-path',
+        path: 'broken-path/',
+        type: 'path',
+        milestones: ['good-leaf', 'broken-leaf'],
+        testEnvironment: { tier: 'local' },
+      },
+      { id: 'good-leaf', path: 'broken-path/good/', type: 'guide', testEnvironment: { tier: 'local' } },
+      { id: 'broken-leaf', path: 'broken-path/broken/', type: 'guide', testEnvironment: { tier: 'local' } },
+    ]);
+    global.fetch = jest.fn((url: string) =>
+      Promise.resolve(
+        url.includes('/broken/')
+          ? ({ ok: false, status: 503, statusText: 'Error' } as Response)
+          : ({ ok: true, text: async () => '{"id":"good-leaf","title":"Good","blocks":[]}' } as unknown as Response)
+      )
+    ) as unknown as typeof fetch;
+
+    const result = await resolveRemotePackage('broken-path', OPTIONS);
+
+    expect(result.runnable).toEqual([]);
+    expect(result.executionPlan).toBeUndefined();
+    expect(result.selection).toEqual({ id: 'broken-path', type: 'path' });
+    expect(Object.fromEntries(result.skipped.map((skip) => [skip.id, skip.reason]))).toEqual({
+      'broken-leaf': 'fetch_failed',
+      'broken-path': 'prerequisite_failed',
+    });
+  });
+
+  it('makes a mixed-tier remote path non-runnable instead of partially executing it', async () => {
+    mockResolve({
+      ok: true,
+      id: 'mixed-path',
+      contentUrl: 'https://cdn.test/mixed-path/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: {
+        id: 'mixed-path',
+        type: 'path',
+        milestones: ['local-leaf', 'cloud-leaf'],
+        testEnvironment: { tier: 'local' },
+      },
+    });
+    mockIndex([
+      {
+        id: 'mixed-path',
+        path: 'mixed-path/',
+        type: 'path',
+        milestones: ['local-leaf', 'cloud-leaf'],
+        testEnvironment: { tier: 'local' },
+      },
+      { id: 'local-leaf', path: 'mixed-path/local/', type: 'guide', testEnvironment: { tier: 'local' } },
+      { id: 'cloud-leaf', path: 'mixed-path/cloud/', type: 'guide', testEnvironment: { tier: 'cloud' } },
+    ]);
+    mockGuideFetch({ local: 'local-leaf' });
+
+    const result = await resolveRemotePackage('mixed-path', OPTIONS);
+
+    expect(result.runnable).toEqual([]);
+    expect(result.executionPlan).toBeUndefined();
+    expect(result.selection).toEqual({ id: 'mixed-path', type: 'path' });
+    expect(result.skipped).toEqual([
+      expect.objectContaining({ id: 'cloud-leaf', reason: 'skipped_tier_mismatch' }),
+      expect.objectContaining({
+        id: 'mixed-path',
+        reason: 'prerequisite_failed',
+        message: expect.stringContaining('cloud-leaf'),
+      }),
+    ]);
   });
 
   it('skips a cloud-tier package on a local environment', async () => {
@@ -186,6 +394,49 @@ describe('resolveRemotePackage (single, recommender)', () => {
     const result = await resolveRemotePackage('g', OPTIONS);
 
     expect(result.skipped[0]).toMatchObject({ id: 'g', reason: 'validation_failed' });
+  });
+
+  it('rejects fetched content whose id does not match the repository package', async () => {
+    mockResolve({
+      ok: true,
+      id: 'expected-id',
+      contentUrl: 'https://cdn.test/expected-id/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: { id: 'expected-id', type: 'guide', testEnvironment: { tier: 'local' } },
+    });
+    mockIndex([{ id: 'expected-id', path: 'expected-id/', type: 'guide', testEnvironment: { tier: 'local' } }]);
+    mockFetch({ ok: true, text: '{"id":"different-id"}' });
+
+    const result = await resolveRemotePackage('expected-id', OPTIONS);
+
+    expect(result.runnable).toEqual([]);
+    expect(result.skipped[0]).toMatchObject({
+      id: 'expected-id',
+      reason: 'validation_failed',
+      message: expect.stringContaining('does not match package id'),
+    });
+  });
+
+  it('fails closed when both manifest metadata and the repository index are unavailable', async () => {
+    mockResolve({
+      ok: true,
+      id: 'unknown-type',
+      contentUrl: 'https://cdn.test/unknown-type/content.json',
+      manifestUrl: '',
+      repository: 'r',
+      manifest: undefined,
+    });
+    (fetchRepositoryIndex as jest.Mock).mockResolvedValue({ ok: false, code: 'NETWORK_ERROR', message: 'offline' });
+
+    const result = await resolveRemotePackage('unknown-type', OPTIONS);
+
+    expect(result.runnable).toEqual([]);
+    expect(result.skipped[0]).toMatchObject({
+      id: 'unknown-type',
+      reason: 'resolution_failed',
+      message: expect.stringContaining('both unavailable'),
+    });
   });
 
   it('maps an invalid starting location to validation_failed before execution', async () => {
@@ -422,7 +673,7 @@ describe('resolveRemoteRepository (batch, CDN index)', () => {
       rawIndex: {},
       validation: { isValid: true, issues: [] },
     });
-    mockFetch({ ok: true, text: '{"id":"x"}' });
+    mockGuideFetch();
 
     const result = await resolveRemoteRepository(OPTIONS);
 
@@ -443,6 +694,108 @@ describe('resolveRemoteRepository (batch, CDN index)', () => {
 
     expect(result.error).toMatch(/repository index/i);
     expect(result.runnable).toHaveLength(0);
+  });
+
+  it('skips only dependents of an unavailable prerequisite and keeps independent guides runnable', async () => {
+    mockIndex([
+      {
+        id: 'dependent',
+        path: 'dependent/',
+        type: 'guide',
+        depends: ['cloud-prerequisite'],
+        testEnvironment: { tier: 'local' },
+      },
+      {
+        id: 'cloud-prerequisite',
+        path: 'cloud-prerequisite/',
+        type: 'guide',
+        testEnvironment: { tier: 'cloud' },
+      },
+      {
+        id: 'independent',
+        path: 'independent/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+    ]);
+    mockGuideFetch();
+
+    const result = await resolveRemoteRepository(OPTIONS);
+
+    expect(result.runnable.map((guide) => guide.id)).toEqual(['independent']);
+    expect(Object.fromEntries(result.skipped.map((skip) => [skip.id, skip.reason]))).toEqual({
+      'cloud-prerequisite': 'skipped_tier_mismatch',
+      dependent: 'prerequisite_failed',
+    });
+    expect(result.executionPlan?.chains.flat().map((guide) => guide.id)).toEqual(['independent']);
+  });
+
+  it('skips a root with a missing dependency while preserving an independent guide', async () => {
+    mockIndex([
+      {
+        id: 'broken-root',
+        path: 'broken-root/',
+        type: 'guide',
+        depends: ['ghost'],
+        testEnvironment: { tier: 'local' },
+      },
+      {
+        id: 'independent',
+        path: 'independent/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+    ]);
+    mockGuideFetch();
+
+    const result = await resolveRemoteRepository(OPTIONS);
+
+    expect(result.error).toBeUndefined();
+    expect(result.runnable.map((guide) => guide.id)).toEqual(['independent']);
+    expect(result.skipped).toEqual([
+      expect.objectContaining({
+        id: 'broken-root',
+        reason: 'prerequisite_failed',
+        message: expect.stringContaining('ghost'),
+      }),
+    ]);
+    expect(result.executionPlan?.chains.flat().map((guide) => guide.id)).toEqual(['independent']);
+  });
+
+  it('keeps independently valid roots runnable when their OR-provider closures are planned together', async () => {
+    mockIndex([
+      {
+        id: 'pkgx',
+        path: 'pkgx/',
+        type: 'guide',
+        depends: [['pkgp', 'pkgq']],
+        testEnvironment: { tier: 'local' },
+      },
+      { id: 'pkgp', path: 'pkgp/', type: 'guide', testEnvironment: { tier: 'local' } },
+      {
+        id: 'pkgq',
+        path: 'pkgq/',
+        type: 'guide',
+        depends: [['pkgz', 'pkgx']],
+        testEnvironment: { tier: 'local' },
+      },
+      { id: 'pkgz', path: 'pkgz/', type: 'guide', testEnvironment: { tier: 'local' } },
+      { id: 'pkgy2', path: 'pkgy2/', type: 'guide', depends: ['pkgq'], testEnvironment: { tier: 'local' } },
+    ]);
+    mockGuideFetch();
+
+    const result = await resolveRemoteRepository(OPTIONS);
+
+    expect(result.error).toBeUndefined();
+    expect(result.skipped).toEqual([]);
+    expect(result.runnable.map((guide) => guide.id)).toEqual(['pkgx', 'pkgp', 'pkgq', 'pkgz', 'pkgy2']);
+    expect(result.executionPlan?.chains.flat().map((guide) => guide.id)).toEqual([
+      'pkgp',
+      'pkgx',
+      'pkgz',
+      'pkgq',
+      'pkgy2',
+    ]);
   });
 });
 
@@ -465,7 +818,7 @@ describe('resolveRemotePackage (dependency resolution)', () => {
       { id: 'loki-101', path: 'loki-101/', type: 'guide', depends: ['prom-101'], testEnvironment: { tier: 'local' } },
       { id: 'prom-101', path: 'prom-101/', type: 'guide', testEnvironment: { tier: 'local' } },
     ]);
-    mockFetch({ ok: true, text: '{"id":"loki-101"}' });
+    mockGuideFetch();
 
     const result = await resolveRemotePackage('loki-101', OPTIONS);
 
@@ -482,7 +835,7 @@ describe('resolveRemotePackage (dependency resolution)', () => {
       { id: 'b-guide', path: 'b/', type: 'guide', depends: ['a-guide'], testEnvironment: { tier: 'local' } },
       { id: 'a-guide', path: 'a/', type: 'guide', testEnvironment: { tier: 'local' } },
     ]);
-    mockFetch({ ok: true, text: '{"id":"c-guide"}' });
+    mockGuideFetch({ a: 'a-guide', b: 'b-guide' });
 
     const result = await resolveRemotePackage('c-guide', OPTIONS);
 
@@ -496,7 +849,7 @@ describe('resolveRemotePackage (dependency resolution)', () => {
       { id: 'dependent', path: 'dependent/', type: 'guide', depends: ['db-ready'], testEnvironment: { tier: 'local' } },
       { id: 'provider', path: 'provider/', type: 'guide', provides: ['db-ready'], testEnvironment: { tier: 'local' } },
     ]);
-    mockFetch({ ok: true, text: '{"id":"dependent"}' });
+    mockGuideFetch();
 
     const result = await resolveRemotePackage('dependent', OPTIONS);
 
@@ -548,6 +901,35 @@ describe('resolveRemotePackage (dependency resolution)', () => {
     expect(result.skipped).toHaveLength(1);
     expect(result.skipped[0]).toMatchObject({ id: 'loki-101', reason: 'resolution_failed' });
     expect(result.skipped[0]!.message).toMatch(/unreachable/i);
+  });
+
+  it('preserves path selection when an unreachable index prevents milestone resolution', async () => {
+    mockResolve({
+      ok: true,
+      id: 'offline-path',
+      contentUrl: 'https://cdn.test/offline-path/content.json',
+      manifestUrl: 'https://cdn.test/offline-path/manifest.json',
+      repository: 'r',
+      manifest: {
+        id: 'offline-path',
+        type: 'path',
+        milestones: ['leaf'],
+        testEnvironment: { tier: 'local' },
+      },
+    });
+    (fetchRepositoryIndex as jest.Mock).mockResolvedValue({ ok: false, code: 'NETWORK_ERROR', message: 'offline' });
+
+    const result = await resolveRemotePackage('offline-path', OPTIONS);
+
+    expect(result.runnable).toEqual([]);
+    expect(result.selection).toEqual({ id: 'offline-path', type: 'path' });
+    expect(result.skipped).toEqual([
+      expect.objectContaining({
+        id: 'offline-path',
+        reason: 'resolution_failed',
+        message: expect.stringMatching(/unreachable.*milestones/i),
+      }),
+    ]);
   });
 
   it('cascades the skip to the target when a prerequisite cannot be fetched', async () => {

--- a/src/cli/e2e/e2e-package.ts
+++ b/src/cli/e2e/e2e-package.ts
@@ -17,12 +17,13 @@ import { validateGuideFromString } from '../../validation';
 import type { RepositoryEntry, RepositoryJson, TestEnvironment } from '../../types/package.types';
 import { resolvePackageById } from './recommender-resolver';
 import { fetchRepositoryIndex, buildPackageFileUrl, type RepositoryPackage } from '../mcp/lib/repository-client';
-import { planGuideExecution } from './guide-chains';
+import { hydrateExecutionPlan, planGuideExecution, planPackageExecution, type ExecutionPlan } from './guide-chains';
 import type { LoadedGuide } from '../utils/file-loader';
 import { resolveTarget, type CloudTargetCapabilities } from './e2e-targets';
 import type { CurrentTier } from './manifest-preflight';
 import { classifyGuideSideEffectsFromString, type SideEffectClassification } from './side-effects';
 import { resolveStartingPath } from './starting-location';
+import type { ExecutionSelection } from './schemas/e2e-report.schema';
 
 const FETCH_TIMEOUT_MS = 15_000;
 
@@ -85,6 +86,10 @@ export interface RemoteResolution {
   skipped: SkippedPackage[];
   /** Repository index for dependency chaining; empty when no index applies. */
   repository: RepositoryJson;
+  /** Precomputed leaf-guide plan for an explicitly selected path or journey. */
+  executionPlan?: ExecutionPlan;
+  /** Explicit metapackage root represented by a multi-guide report. */
+  selection?: ExecutionSelection;
   /** Set when the operation could not start at all (e.g. CDN index unreachable). */
   error?: string;
 }
@@ -133,13 +138,13 @@ async function buildGuideOrSkip(
   contentUrl: string,
   options: RemoteResolveOptions
 ): Promise<{ runnable?: ResolvedRemoteGuide; skipped?: SkippedPackage }> {
-  // Only single guides are testable; paths/journeys (milestone expansion) are deferred.
+  // Repository sweeps execute leaf guides only; explicit --package resolution expands metapackages first.
   if (type && type !== 'guide') {
     return {
       skipped: {
         id,
         reason: 'unsupported_type',
-        message: `Package type "${type}" is not yet testable`,
+        message: `Package type "${type}" is only testable through an explicit --package selection`,
         sourceUrl: contentUrl,
         tier: testEnvironment.tier,
       },
@@ -199,6 +204,18 @@ async function buildGuideOrSkip(
         id,
         reason: 'validation_failed',
         message: 'Fetched content.json failed guide schema validation',
+        sourceUrl: contentUrl,
+        tier: target.tier,
+      },
+    };
+  }
+  const parsedContent = JSON.parse(fetched.text) as { id?: unknown };
+  if (parsedContent.id !== id) {
+    return {
+      skipped: {
+        id,
+        reason: 'validation_failed',
+        message: `Fetched content.json id "${String(parsedContent.id)}" does not match package id "${id}"`,
         sourceUrl: contentUrl,
         tier: target.tier,
       },
@@ -290,8 +307,170 @@ function resolutionFailedSkip(target: ResolvedRemoteGuide, message: string): Ski
   };
 }
 
-function skippedResolution(skipped: SkippedPackage[], repository: RepositoryJson = {}): RemoteResolution {
-  return { runnable: [], prerequisites: [], skipped, repository };
+function skippedResolution(
+  skipped: SkippedPackage[],
+  repository: RepositoryJson = {},
+  selection?: ExecutionSelection
+): RemoteResolution {
+  return { runnable: [], prerequisites: [], skipped, repository, ...(selection ? { selection } : {}) };
+}
+
+function isMetapackageType(type: string | undefined): type is ExecutionSelection['type'] {
+  return type === 'path' || type === 'journey';
+}
+
+async function resolveRemoteMetapackage(
+  id: string,
+  type: ExecutionSelection['type'],
+  repository: RepositoryJson,
+  baseUrl: string,
+  options: RemoteResolveOptions
+): Promise<RemoteResolution> {
+  const selection: ExecutionSelection = { id, type };
+  const rootEntry = repository[id];
+  if (!rootEntry) {
+    return skippedResolution(
+      [{ id, reason: 'resolution_failed', message: `Root package "${id}" is missing from the repository index` }],
+      repository,
+      selection
+    );
+  }
+  if (rootEntry.type !== type) {
+    return skippedResolution(
+      [
+        {
+          id,
+          reason: 'resolution_failed',
+          message: `Root package type mismatch: recommender declared "${type}", repository declared "${rootEntry.type}"`,
+        },
+      ],
+      repository,
+      selection
+    );
+  }
+
+  const rootTarget = resolveTarget(rootEntry.testEnvironment ?? {}, {
+    grafanaUrl: options.grafanaUrl,
+    currentTier: options.currentTier,
+    cloudUrl: options.cloudUrl,
+    cloudTargetCapabilities: options.cloudTargetCapabilities,
+  });
+  if (!rootTarget.runnable) {
+    return skippedResolution(
+      [
+        {
+          id,
+          reason: rootTarget.skipReason!,
+          message: rootTarget.message ?? 'Package skipped',
+          tier: rootTarget.tier,
+        },
+      ],
+      repository,
+      selection
+    );
+  }
+
+  const packagePlan = planPackageExecution({ rootIds: [id], repository });
+  if (packagePlan.errors.length > 0) {
+    return skippedResolution(
+      [
+        {
+          id,
+          reason: 'prerequisite_failed',
+          message: `Could not expand ${type} package: ${packagePlan.errors.join('; ')}`,
+          tier: rootTarget.tier,
+        },
+      ],
+      repository,
+      selection
+    );
+  }
+
+  const leafIds = [...new Set(packagePlan.chains.flatMap((chain) => chain.map((planned) => planned.id)))];
+  const runnable: ResolvedRemoteGuide[] = [];
+  const skipped: SkippedPackage[] = [];
+  for (const leafId of leafIds) {
+    const entry = repository[leafId];
+    if (!entry) {
+      skipped.push({
+        id: leafId,
+        reason: 'resolution_failed',
+        message: 'Planned guide is missing from the repository index',
+      });
+      continue;
+    }
+    const built = await resolveIndexEntry(leafId, entry, baseUrl, options);
+    if (built.runnable) {
+      runnable.push(built.runnable);
+    }
+    if (built.skipped) {
+      skipped.push(built.skipped);
+    }
+  }
+  if (skipped.length > 0) {
+    return skippedResolution(
+      [
+        ...skipped,
+        {
+          id,
+          reason: 'prerequisite_failed',
+          message: `Required guide(s) did not resolve: ${skipped.map((item) => item.id).join(', ')}`,
+          tier: rootTarget.tier,
+        },
+      ],
+      repository,
+      selection
+    );
+  }
+
+  const incompatible = runnable.find(
+    (guide) =>
+      guide.tier !== rootTarget.tier ||
+      guide.instance !== rootTarget.instance ||
+      new URL(guide.targetUrl).origin !== new URL(rootTarget.targetUrl!).origin
+  );
+  if (incompatible) {
+    return skippedResolution(
+      [
+        {
+          id,
+          reason: 'resolution_failed',
+          message: `${type} package mixes incompatible targets at guide "${incompatible.id}"`,
+          tier: rootTarget.tier,
+        },
+      ],
+      repository,
+      selection
+    );
+  }
+
+  const executionPlan = hydrateExecutionPlan(
+    packagePlan,
+    new Map(runnable.map((guide) => [guide.id, guide.guide])),
+    repository
+  );
+  if (executionPlan.errors.length > 0) {
+    return skippedResolution(
+      [
+        {
+          id,
+          reason: 'resolution_failed',
+          message: `Could not hydrate ${type} package: ${executionPlan.errors.join('; ')}`,
+          tier: rootTarget.tier,
+        },
+      ],
+      repository,
+      selection
+    );
+  }
+  return {
+    runnable,
+    prerequisites: [],
+    skipped: [],
+    repository,
+    executionPlan,
+    selection,
+  };
 }
 
 /**
@@ -342,22 +521,46 @@ export async function resolveRemotePackage(id: string, options: RemoteResolveOpt
   if (!resolution.ok) {
     return skippedResolution([{ id, reason: 'resolution_failed', message: resolution.message }]);
   }
-
-  const built = await buildGuideOrSkip(
-    resolution.id || id,
-    resolution.manifest?.type,
-    resolution.manifest?.testEnvironment ?? {},
-    resolution.manifest?.startingLocation,
-    resolution.contentUrl,
-    options
-  );
-  if (!built.runnable) {
-    return skippedResolution(built.skipped ? [built.skipped] : []);
-  }
-  const target = built.runnable;
+  const targetId = resolution.id || id;
 
   const index = await fetchRepositoryIndex(options.repoUrl);
   if (!index.ok) {
+    if (!resolution.manifest) {
+      return skippedResolution([
+        {
+          id: targetId,
+          reason: 'resolution_failed',
+          message: `Manifest metadata and repository index are both unavailable (${index.message}); package type and prerequisites cannot be verified`,
+        },
+      ]);
+    }
+    if (isMetapackageType(resolution.manifest?.type)) {
+      const selection: ExecutionSelection = { id: targetId, type: resolution.manifest.type };
+      return skippedResolution(
+        [
+          {
+            id: targetId,
+            reason: 'resolution_failed',
+            message: `Repository index unreachable (${index.message}); ${selection.type} milestones cannot be resolved`,
+            tier: resolution.manifest.testEnvironment?.tier,
+          },
+        ],
+        {},
+        selection
+      );
+    }
+    const built = await buildGuideOrSkip(
+      targetId,
+      resolution.manifest?.type,
+      resolution.manifest?.testEnvironment ?? {},
+      resolution.manifest?.startingLocation,
+      resolution.contentUrl,
+      options
+    );
+    if (!built.runnable) {
+      return skippedResolution(built.skipped ? [built.skipped] : []);
+    }
+    const target = built.runnable;
     // Without an index we can only run safely if the manifest declares no prereqs.
     const declaredDepends = resolution.manifest?.depends ?? [];
     if (declaredDepends.length > 0) {
@@ -372,6 +575,45 @@ export async function resolveRemotePackage(id: string, options: RemoteResolveOpt
   }
 
   const repository = indexToRepository(index.packages);
+  const indexedEntry = repository[targetId];
+  if (
+    resolution.manifest?.type !== undefined &&
+    indexedEntry?.type !== undefined &&
+    resolution.manifest.type !== indexedEntry.type
+  ) {
+    if (isMetapackageType(resolution.manifest.type)) {
+      return resolveRemoteMetapackage(targetId, resolution.manifest.type, repository, index.baseUrl, options);
+    }
+    const metapackageType = isMetapackageType(indexedEntry.type) ? indexedEntry.type : undefined;
+    return skippedResolution(
+      [
+        {
+          id: targetId,
+          reason: 'resolution_failed',
+          message: `Package type mismatch: recommender declared "${resolution.manifest.type}", repository declared "${indexedEntry.type}"`,
+        },
+      ],
+      repository,
+      metapackageType ? { id: targetId, type: metapackageType } : undefined
+    );
+  }
+  const targetType = resolution.manifest?.type ?? indexedEntry?.type;
+  if (isMetapackageType(targetType)) {
+    return resolveRemoteMetapackage(targetId, targetType, repository, index.baseUrl, options);
+  }
+
+  const built = await buildGuideOrSkip(
+    targetId,
+    targetType,
+    resolution.manifest?.testEnvironment ?? indexedEntry?.testEnvironment ?? {},
+    resolution.manifest?.startingLocation ?? indexedEntry?.startingLocation,
+    resolution.contentUrl,
+    options
+  );
+  if (!built.runnable) {
+    return skippedResolution(built.skipped ? [built.skipped] : [], repository);
+  }
+  const target = built.runnable;
 
   // The recommender resolves across repos but this CLI checks deps against
   // one index. If the target's home repo isn't the one we fetched, its
@@ -434,6 +676,71 @@ export async function resolveRemoteRepository(options: RemoteResolveOptions): Pr
       skipped.push(built.skipped);
     }
   }
+  const structurallyUnavailable = new Set<string>();
+  for (const guide of runnable) {
+    const rootPlan = planPackageExecution({ rootIds: [guide.id], repository });
+    if (rootPlan.errors.length === 0) {
+      continue;
+    }
+    structurallyUnavailable.add(guide.id);
+    skipped.push({
+      id: guide.id,
+      reason: 'prerequisite_failed',
+      message: `Package planning failed: ${rootPlan.errors.join('; ')}`,
+      sourceUrl: guide.sourceUrl,
+      tier: guide.tier,
+      sideEffects: guide.sideEffects,
+    });
+  }
+  const plannable = runnable.filter((guide) => !structurallyUnavailable.has(guide.id));
+  const packagePlan = planPackageExecution({ rootIds: plannable.map((guide) => guide.id), repository });
+  if (packagePlan.errors.length > 0) {
+    return {
+      runnable: [],
+      prerequisites: [],
+      skipped,
+      repository,
+      error: `Could not build repository execution plan: ${packagePlan.errors.join('; ')}`,
+    };
+  }
 
-  return { runnable, prerequisites: [], skipped, repository };
+  const unavailable = new Set(skipped.map((item) => item.id));
+  const runnableById = new Map(plannable.map((guide) => [guide.id, guide]));
+  for (const planned of packagePlan.chains.flat()) {
+    const failedDependency = planned.dependencies.find((dependency) => unavailable.has(dependency));
+    if (!failedDependency || unavailable.has(planned.id) || !runnableById.has(planned.id)) {
+      continue;
+    }
+    unavailable.add(planned.id);
+    skipped.push({
+      id: planned.id,
+      reason: 'prerequisite_failed',
+      message: `Prerequisite "${failedDependency}" did not resolve`,
+      sourceUrl: runnableById.get(planned.id)?.sourceUrl,
+      tier: runnableById.get(planned.id)?.tier,
+      sideEffects: runnableById.get(planned.id)?.sideEffects,
+    });
+  }
+
+  const available = plannable.filter((guide) => !unavailable.has(guide.id));
+  const filteredPlan = {
+    chains: packagePlan.chains
+      .map((chain) =>
+        chain
+          .filter((planned) => !unavailable.has(planned.id))
+          .map((planned) => ({
+            ...planned,
+            dependencies: planned.dependencies.filter((dependency) => !unavailable.has(dependency)),
+          }))
+      )
+      .filter((chain) => chain.length > 0),
+    autoIncludedIds: packagePlan.autoIncludedIds.filter((id) => !unavailable.has(id)),
+    errors: [],
+  };
+  const executionPlan = hydrateExecutionPlan(
+    filteredPlan,
+    new Map(available.map((guide) => [guide.id, guide.guide])),
+    repository
+  );
+  return { runnable: available, prerequisites: [], skipped, repository, executionPlan };
 }

--- a/src/cli/e2e/e2e-reporter.test.ts
+++ b/src/cli/e2e/e2e-reporter.test.ts
@@ -10,7 +10,12 @@ import { mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import { E2E_REPORT_SCHEMA_VERSION, E2ETestReportSchema, type E2ETestReport } from './schemas/e2e-report.schema';
+import {
+  E2E_REPORT_SCHEMA_VERSION,
+  E2ETestReportSchema,
+  MultiGuideReportSchema,
+  type E2ETestReport,
+} from './schemas/e2e-report.schema';
 import {
   contentDigest,
   generateMultiGuideReport,
@@ -83,6 +88,16 @@ describe('generateMultiGuideReport — dependency-skipped guides', () => {
     expect(report.summary.totalGuides).toBe(2);
     expect(report.summary.skippedGuides).toBe(0);
     expect(report.guides.every((g) => g.abortReason === undefined)).toBe(true);
+  });
+
+  it('includes a schema-valid explicit metapackage selection', () => {
+    const report = generateMultiGuideReport([ranGuide('only-milestone')], undefined, {
+      id: 'single-milestone-path',
+      type: 'path',
+    });
+
+    expect(report.selection).toEqual({ id: 'single-milestone-path', type: 'path' });
+    expect(() => MultiGuideReportSchema.parse(report)).not.toThrow();
   });
 
   it('counts provisioning failures as failed guides', () => {

--- a/src/cli/e2e/e2e-reporter.ts
+++ b/src/cli/e2e/e2e-reporter.ts
@@ -27,6 +27,7 @@ import {
   type ReportConfig,
   type E2ETestReport,
   type GuideResult,
+  type ExecutionSelection,
   type MultiGuideSummary,
   type MultiGuideReport,
 } from './schemas/e2e-report.schema';
@@ -442,7 +443,11 @@ export function toGuideResult(report: E2ETestReport): GuideResult {
  * @param grafanaVersion - Optional Grafana version
  * @returns Complete multi-guide report
  */
-export function generateMultiGuideReport(resultsArray: TestResultsData[], grafanaVersion?: string): MultiGuideReport {
+export function generateMultiGuideReport(
+  resultsArray: TestResultsData[],
+  grafanaVersion?: string,
+  selection?: ExecutionSelection
+): MultiGuideReport {
   // Generate individual reports
   const reports = resultsArray.map((data) => generateReport(data, grafanaVersion));
 
@@ -488,6 +493,7 @@ export function generateMultiGuideReport(resultsArray: TestResultsData[], grafan
     startedAt,
     endedAt,
     type: 'multi-guide',
+    ...(selection ? { selection } : {}),
     config,
     summary,
     guides,

--- a/src/cli/e2e/guide-chains.test.ts
+++ b/src/cli/e2e/guide-chains.test.ts
@@ -8,7 +8,7 @@
 
 import type { RepositoryJson } from '../../types/package.types';
 import type { LoadedGuide } from '../utils/file-loader';
-import { deriveGuideId, planGuideExecution, type GuideChain } from './guide-chains';
+import { deriveGuideId, planGuideExecution, planPackageExecution, type GuideChain } from './guide-chains';
 
 function guide(id: string): LoadedGuide {
   return { path: `${id}/content.json`, content: JSON.stringify({ id, title: id, blocks: [] }) };
@@ -35,6 +35,180 @@ describe('deriveGuideId', () => {
 
   it('falls back to a flat file name without extension', () => {
     expect(deriveGuideId({ path: 'guides/legacy.json', content: 'not json' })).toBe('legacy');
+  });
+});
+
+describe('planPackageExecution', () => {
+  it('expands path milestones in declared order without making order a hard dependency', () => {
+    const repository: RepositoryJson = {
+      path: { path: 'path/', type: 'path', milestones: ['first', 'second', 'third'] },
+      first: { path: 'path/first/', type: 'guide' },
+      second: { path: 'path/second/', type: 'guide' },
+      third: { path: 'path/third/', type: 'guide', depends: ['first'] },
+    };
+
+    const plan = planPackageExecution({ rootIds: ['path'], repository });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.chains.map((chain) => chain.map((guide) => guide.id))).toEqual([['first', 'second', 'third']]);
+    expect(plan.chains[0]![0]!.dependencies).toEqual([]);
+    expect(plan.chains[0]![1]!.dependencies).toEqual([]);
+    expect(plan.chains[0]![2]!.dependencies).toEqual(['first']);
+    expect(plan.chains[0]!.every((guide) => !guide.autoIncluded)).toBe(true);
+  });
+
+  it('recursively expands journey and path milestones', () => {
+    const repository: RepositoryJson = {
+      journey: { path: 'journey/', type: 'journey', milestones: ['path-a', 'standalone', 'path-b'] },
+      'path-a': { path: 'path-a/', type: 'path', milestones: ['a-1', 'a-2'] },
+      'path-b': { path: 'path-b/', type: 'path', milestones: ['b-1'] },
+      'a-1': { path: 'path-a/a-1/', type: 'guide' },
+      'a-2': { path: 'path-a/a-2/', type: 'guide' },
+      standalone: { path: 'standalone/', type: 'guide' },
+      'b-1': { path: 'path-b/b-1/', type: 'guide' },
+    };
+
+    const plan = planPackageExecution({ rootIds: ['journey'], repository });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.chains[0]!.map((guide) => guide.id)).toEqual(['a-1', 'a-2', 'standalone', 'b-1']);
+  });
+
+  it('expands a path-level dependency on another path and gates every dependent milestone', () => {
+    const repository: RepositoryJson = {
+      prerequisite: { path: 'prerequisite/', type: 'path', milestones: ['setup-a', 'setup-b'] },
+      target: { path: 'target/', type: 'path', milestones: ['target-a', 'target-b'], depends: ['prerequisite'] },
+      'setup-a': { path: 'prerequisite/setup-a/', type: 'guide' },
+      'setup-b': { path: 'prerequisite/setup-b/', type: 'guide' },
+      'target-a': { path: 'target/target-a/', type: 'guide' },
+      'target-b': { path: 'target/target-b/', type: 'guide' },
+    };
+
+    const plan = planPackageExecution({ rootIds: ['target'], repository });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.chains[0]!.map((guide) => guide.id)).toEqual(['setup-a', 'setup-b', 'target-a', 'target-b']);
+    expect(plan.autoIncludedIds).toEqual(['setup-a', 'setup-b']);
+    expect(plan.chains[0]![2]!.dependencies).toEqual(['setup-a', 'setup-b']);
+    expect(plan.chains[0]![3]!.dependencies).toEqual(['setup-a', 'setup-b']);
+  });
+
+  it('can satisfy a dependency capability with a metapackage provider', () => {
+    const repository: RepositoryJson = {
+      target: { path: 'target/', type: 'path', milestones: ['target-step'], depends: ['environment-ready'] },
+      provider: {
+        path: 'provider/',
+        type: 'path',
+        milestones: ['provider-a', 'provider-b'],
+        provides: ['environment-ready'],
+      },
+      'target-step': { path: 'target/target-step/', type: 'guide' },
+      'provider-a': { path: 'provider/provider-a/', type: 'guide' },
+      'provider-b': { path: 'provider/provider-b/', type: 'guide' },
+    };
+
+    const plan = planPackageExecution({ rootIds: ['target'], repository });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.chains[0]!.map((guide) => guide.id)).toEqual(['provider-a', 'provider-b', 'target-step']);
+    expect(plan.chains[0]![2]!.dependencies).toEqual(['provider-a', 'provider-b']);
+  });
+
+  it('reuses a forced provider across milestones within the same root', () => {
+    const repository: RepositoryJson = {
+      path: { path: 'path/', type: 'path', milestones: ['x', 'y'] },
+      x: { path: 'path/x/', type: 'guide', depends: [['alt-a', 'alt-b']] },
+      y: { path: 'path/y/', type: 'guide', depends: ['alt-b'] },
+      'alt-a': { path: 'alt-a/', type: 'guide' },
+      'alt-b': { path: 'alt-b/', type: 'guide' },
+    };
+
+    const plan = planPackageExecution({ rootIds: ['path'], repository });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.autoIncludedIds).toEqual(['alt-b']);
+    expect(plan.chains[0]!.map((guide) => guide.id)).toEqual(['alt-b', 'x', 'y']);
+    expect(plan.chains[0]!.find((guide) => guide.id === 'x')?.dependencies).toEqual(['alt-b']);
+  });
+
+  it('executes a shared leaf once when composition reaches it through multiple milestones', () => {
+    const repository: RepositoryJson = {
+      root: { path: 'root/', type: 'journey', milestones: ['nested', 'shared'] },
+      nested: { path: 'nested/', type: 'path', milestones: ['shared', 'nested-only'] },
+      shared: { path: 'shared/', type: 'guide' },
+      'nested-only': { path: 'nested/nested-only/', type: 'guide' },
+    };
+
+    const plan = planPackageExecution({ rootIds: ['root'], repository });
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.chains[0]!.map((guide) => guide.id)).toEqual(['shared', 'nested-only']);
+  });
+
+  it('fails when a milestone is missing from the repository index', () => {
+    const repository: RepositoryJson = {
+      path: { path: 'path/', type: 'path', milestones: ['missing'] },
+    };
+
+    const plan = planPackageExecution({ rootIds: ['path'], repository });
+
+    expect(plan.chains).toEqual([]);
+    expect(plan.errors.some((error) => error.includes('missing from the repository index'))).toBe(true);
+  });
+
+  it('detects a cycle that crosses milestone and depends relationships', () => {
+    const repository: RepositoryJson = {
+      path: { path: 'path/', type: 'path', milestones: ['step'] },
+      step: { path: 'path/step/', type: 'guide', depends: ['path'] },
+    };
+
+    const plan = planPackageExecution({ rootIds: ['path'], repository });
+
+    expect(plan.chains).toEqual([]);
+    expect(plan.errors.some((error) => error.includes('Cycle across depends and milestones'))).toBe(true);
+  });
+
+  it('fails when a path has an empty milestones array', () => {
+    const plan = planPackageExecution({
+      rootIds: ['empty-path'],
+      repository: { 'empty-path': { path: 'empty-path/', type: 'path', milestones: [] } },
+    });
+
+    expect(plan.chains).toEqual([]);
+    expect(plan.errors.some((error) => error.includes('has no milestones'))).toBe(true);
+  });
+
+  it('detects a pure milestone-only cycle without any depends edges', () => {
+    const repository: RepositoryJson = {
+      'path-a': { path: 'path-a/', type: 'path', milestones: ['path-b'] },
+      'path-b': { path: 'path-b/', type: 'path', milestones: ['path-a'] },
+    };
+
+    const plan = planPackageExecution({ rootIds: ['path-a'], repository });
+
+    expect(plan.chains).toEqual([]);
+    expect(plan.errors.some((error) => error.includes('Cycle in milestones'))).toBe(true);
+  });
+
+  it('keeps OR-provider choices invariant when independently valid roots are batched', () => {
+    const repository: RepositoryJson = {
+      pkgx: { path: 'pkgx/', type: 'guide', depends: [['pkgp', 'pkgq']] },
+      pkgp: { path: 'pkgp/', type: 'guide' },
+      pkgq: { path: 'pkgq/', type: 'guide', depends: [['pkgz', 'pkgx']] },
+      pkgz: { path: 'pkgz/', type: 'guide' },
+      pkgy2: { path: 'pkgy2/', type: 'guide', depends: ['pkgq'] },
+    };
+
+    const xPlan = planPackageExecution({ rootIds: ['pkgx'], repository });
+    const yPlan = planPackageExecution({ rootIds: ['pkgy2'], repository });
+    const unionPlan = planPackageExecution({ rootIds: ['pkgx', 'pkgy2'], repository });
+
+    expect(xPlan.errors).toEqual([]);
+    expect(yPlan.errors).toEqual([]);
+    expect(unionPlan.errors).toEqual([]);
+    expect(unionPlan.chains.flat().map((guide) => guide.id)).toEqual(['pkgp', 'pkgx', 'pkgz', 'pkgq', 'pkgy2']);
+    expect(unionPlan.chains.flat().find((guide) => guide.id === 'pkgx')?.dependencies).toEqual(['pkgp']);
+    expect(unionPlan.chains.flat().find((guide) => guide.id === 'pkgq')?.dependencies).toEqual(['pkgz']);
   });
 });
 
@@ -169,7 +343,7 @@ describe('planGuideExecution', () => {
       'alt-b': { path: 'alt-b/', type: 'guide' },
     };
 
-    it('uses an already-selected alternative without auto-including', () => {
+    it('does not let a sibling root change the selected alternative', () => {
       const plan = planGuideExecution({
         guides: [guide('dependent'), guide('alt-b')],
         repository,
@@ -177,8 +351,8 @@ describe('planGuideExecution', () => {
       });
 
       expect(plan.errors).toEqual([]);
-      expect(plan.autoIncludedIds).toEqual([]);
-      expect(chainIds(plan.chains[0]!)).toEqual(['alt-b', 'dependent']);
+      expect(plan.autoIncludedIds).toEqual(['alt-a']);
+      expect(plan.chains.map((chain) => chainIds(chain))).toEqual([['alt-a', 'dependent'], ['alt-b']]);
     });
 
     it('auto-includes the first resolvable alternative when none are selected', () => {
@@ -235,7 +409,7 @@ describe('planGuideExecution', () => {
     expect(plan.errors.some((e) => e.includes('does-not-exist'))).toBe(true);
   });
 
-  it('resolves OR-groups as a pure function of the selection set', () => {
+  it('resolves OR-groups independently of sibling roots and selection order', () => {
     const repository: RepositoryJson = {
       x: { path: 'x/', type: 'guide', depends: [['alt-a', 'alt-b']] },
       y: { path: 'y/', type: 'guide', depends: ['alt-b'] },
@@ -250,11 +424,12 @@ describe('planGuideExecution', () => {
     const shape = (plan: ReturnType<typeof planGuideExecution>) => plan.chains.map((c) => chainIds(c));
     expect(shape(forward)).toEqual(shape(reverse));
 
-    // y's forced alt-b is resolved first, so x's OR-group reuses it: one chain.
     expect(forward.errors).toEqual([]);
-    expect(forward.autoIncludedIds).toEqual(['alt-b']);
-    expect(forward.chains).toHaveLength(1);
-    expect(chainIds(forward.chains[0]!)).toEqual(['alt-b', 'x', 'y']);
+    expect(forward.autoIncludedIds).toEqual(['alt-a', 'alt-b']);
+    expect(forward.chains.map((chain) => chainIds(chain))).toEqual([
+      ['alt-a', 'x'],
+      ['alt-b', 'y'],
+    ]);
   });
 
   it('fails the plan when two selected files derive the same id from different paths', () => {

--- a/src/cli/e2e/guide-chains.ts
+++ b/src/cli/e2e/guide-chains.ts
@@ -1,30 +1,46 @@
 /**
- * Dependency-aware guide execution planner.
+ * Package-aware guide execution planner.
  *
- * Groups guides into chains over their hard `depends` prerequisites and orders
- * each chain so prerequisites run first. Only `depends` participates;
- * `recommends`/`suggests` are advisory. Dependency targets may be real package
- * IDs or virtual capabilities resolved through `provides`.
+ * Hard `depends` relationships determine failure propagation. Ordered
+ * `milestones` keep path and journey members in one execution chain without
+ * turning presentation order into implicit hard dependencies.
  */
 
 import type { GraphEdge, GraphEdgeType, RepositoryEntry, RepositoryJson } from '../../types/package.types';
 import { detectCycles } from '../utils/graph-cycles';
 import type { LoadedGuide } from '../utils/file-loader';
 
-export interface PlannedGuide {
+export interface PlannedGuideRef {
   id: string;
-  guide: LoadedGuide;
   dependencies: string[];
   autoIncluded: boolean;
+}
+
+export interface PlannedGuide extends PlannedGuideRef {
+  guide: LoadedGuide;
 }
 
 /** Guides ordered so prerequisites run before dependents. */
 export type GuideChain = PlannedGuide[];
 
+/** Guide references ordered so prerequisites run before dependents. */
+export type GuideChainRef = PlannedGuideRef[];
+
+export interface PackageExecutionPlan {
+  chains: GuideChainRef[];
+  autoIncludedIds: string[];
+  errors: string[];
+}
+
 export interface ExecutionPlan {
   chains: GuideChain[];
   autoIncludedIds: string[];
   errors: string[];
+}
+
+export interface PlanPackageExecutionOptions {
+  rootIds: string[];
+  repository: RepositoryJson;
 }
 
 export interface PlanGuideExecutionOptions {
@@ -33,10 +49,7 @@ export interface PlanGuideExecutionOptions {
   loadGuideById?: (id: string, entry: RepositoryEntry) => LoadedGuide | null;
 }
 
-/**
- * Derive a guide's bare package ID. Prefers the `id` field in content.json,
- * falling back to the directory/file name for legacy guides.
- */
+/** Derive a guide's bare package ID, falling back to its file or directory name. */
 export function deriveGuideId(guide: LoadedGuide): string {
   try {
     const parsed = JSON.parse(guide.content) as { id?: unknown };
@@ -44,7 +57,7 @@ export function deriveGuideId(guide: LoadedGuide): string {
       return parsed.id;
     }
   } catch {
-    // Not JSON or no id — fall through to the path-derived name.
+    // Fall through to the path-derived name.
   }
 
   const segments = guide.path.split('/').filter(Boolean);
@@ -56,10 +69,10 @@ export function deriveGuideId(guide: LoadedGuide): string {
   return last.replace(/\.json$/, '');
 }
 
-/**
- * Build a capability → provider-IDs index from a repository, sorted for
- * deterministic provider selection.
- */
+function isMetapackage(entry: RepositoryEntry | undefined): boolean {
+  return entry?.type === 'path' || entry?.type === 'journey';
+}
+
 function buildProvidesIndex(repository: RepositoryJson): Map<string, string[]> {
   const index = new Map<string, string[]>();
   for (const [id, entry] of Object.entries(repository)) {
@@ -75,10 +88,6 @@ function buildProvidesIndex(repository: RepositoryJson): Map<string, string[]> {
   return index;
 }
 
-/**
- * Resolve a single dependency candidate (a real package ID or virtual
- * capability) to the concrete provider package IDs that could satisfy it.
- */
 function resolveCandidateProviders(
   candidate: string,
   repository: RepositoryJson,
@@ -94,191 +103,111 @@ function clauseCandidates(clause: string | string[]): string[] {
   return typeof clause === 'string' ? [clause] : clause;
 }
 
-/**
- * Plan guide execution: resolve dependencies, auto-include missing
- * prerequisites, detect cycles, and group guides into topologically ordered
- * dependency chains.
- */
-export function planGuideExecution(options: PlanGuideExecutionOptions): ExecutionPlan {
-  const { guides, repository, loadGuideById } = options;
-  const errors: string[] = [];
-
-  const providesIndex = buildProvidesIndex(repository);
-
-  const idToGuide = new Map<string, LoadedGuide>();
-  const directDeps = new Map<string, string[]>();
-  const autoIncluded = new Set<string>();
-  const runSet = new Set<string>();
-
-  for (const guide of guides) {
-    const id = deriveGuideId(guide);
-    const existing = idToGuide.get(id);
-    if (existing) {
-      if (existing.path !== guide.path) {
-        // Fail loudly on duplicate IDs from different paths
-        errors.push(`duplicate guide id "${id}" derived from "${existing.path}" and "${guide.path}"`);
-      }
-      continue;
-    }
-    idToGuide.set(id, guide);
-    runSet.add(id);
-  }
-
-  // Load a prereq into the run set on demand.
-  const ensureLoaded = (requesterId: string, providerId: string): boolean => {
-    if (runSet.has(providerId)) {
-      return true;
-    }
-    const providerEntry = repository[providerId];
-    const loaded = providerEntry ? (loadGuideById?.(providerId, providerEntry) ?? null) : null;
-    if (!loaded) {
-      errors.push(`${requesterId}: could not load auto-included prerequisite "${providerId}"`);
-      return false;
-    }
-    idToGuide.set(providerId, loaded);
-    runSet.add(providerId);
-    autoIncluded.add(providerId);
-    return true;
-  };
-
-  // Resolve one clause to a concrete provider: prefer an alternative already in
-  // the run set (so chains reuse it), otherwise the first resolvable candidate.
-  // Returns null when nothing satisfies the clause.
-  const resolveClauseProvider = (candidates: string[]): string | null => {
-    for (const candidate of candidates) {
-      const reused = resolveCandidateProviders(candidate, repository, providesIndex).find((p) => runSet.has(p));
-      if (reused) {
-        return reused;
-      }
-    }
-    for (const candidate of candidates) {
-      const [provider] = resolveCandidateProviders(candidate, repository, providesIndex);
-      if (provider) {
-        return provider;
-      }
-    }
-    return null;
-  };
-
-  // Resolve a single guide's clauses for one phase: `forced` handles
-  // single-target clauses, `!forced` handles OR-groups. Deps accumulate across
-  // the two phases.
-  const resolvePhase = (id: string, forced: boolean): void => {
-    const deps = directDeps.get(id) ?? [];
-    directDeps.set(id, deps);
-    const entry = repository[id];
-    if (!entry) {
-      return; // Unmanaged guide (no repository entry): dependency-free singleton.
-    }
-    for (const clause of entry.depends ?? []) {
-      const candidates = clauseCandidates(clause);
-      const isForced = candidates.length === 1;
-      if (candidates.length === 0 || isForced !== forced) {
-        continue;
-      }
-      const providerId = resolveClauseProvider(candidates);
-      if (providerId === null) {
-        errors.push(
-          `${id}: depends target "${candidates.join(' | ')}" does not resolve to a known package or capability`
-        );
-        continue;
-      }
-      if (ensureLoaded(id, providerId)) {
-        deps.push(providerId);
-      }
-    }
-  };
-
-  // Make the plan a pure function of the selection set: expand forced
-  // single-target prerequisites to a fixpoint, then resolve OR-group
-  // clauses against that now-stable run set, iterating ids in sorted order.
-  const forcedResolved = new Set<string>();
-  const orResolved = new Set<string>();
-  let progressed = true;
-  while (progressed) {
-    progressed = false;
-
-    let forcedProgress = true;
-    while (forcedProgress) {
-      forcedProgress = false;
-      for (const id of [...runSet].sort()) {
-        if (forcedResolved.has(id)) {
-          continue;
-        }
-        forcedResolved.add(id);
-        const before = runSet.size;
-        resolvePhase(id, true);
-        if (runSet.size !== before) {
-          forcedProgress = true;
-        }
-      }
-    }
-
-    for (const id of [...runSet].sort()) {
-      if (orResolved.has(id)) {
-        continue;
-      }
-      orResolved.add(id);
-      const before = runSet.size;
-      resolvePhase(id, false);
-      if (runSet.size !== before) {
-        progressed = true;
-      }
-    }
-  }
-
-  // Deduplicate accumulated provider ids per guide.
-  for (const [id, deps] of directDeps) {
-    directDeps.set(id, [...new Set(deps)]);
-  }
-
-  const allIds = new Set(runSet);
-  const edges: GraphEdge[] = [];
-  for (const [id, deps] of directDeps) {
-    for (const dep of deps) {
-      edges.push({ source: id, target: dep, type: 'depends' });
-    }
-  }
-
-  // A `depends` cycle is unsatisfiable. Fail the plan.
-  const cycles = detectCycles(allIds, edges, new Set<GraphEdgeType>(['depends']));
-  for (const cycle of cycles) {
-    errors.push(`Cycle in depends chain: ${cycle.join(' → ')}`);
-  }
-
-  const autoIncludedIds = [...autoIncluded].sort();
-  if (errors.length > 0) {
-    return { chains: [], autoIncludedIds, errors };
-  }
-
-  const chains = buildChains(allIds, edges, directDeps, idToGuide, autoIncluded);
-  return { chains, autoIncludedIds, errors };
+function cycleKey(cycle: string[]): string {
+  return [...new Set(cycle)].sort().join('\u0000');
 }
 
 /**
- * Group IDs into weakly connected components over `depends` edges, then
- * topologically sort each component so prerequisites come first.
+ * Resolve package metadata into executable leaf-guide chains.
+ *
+ * Design rationale:
+ * - **Leaf projection**: Metapackages (path/journey) are non-executable containers.
+ *   Only leaf guides run, so hard-dependency edges are projected from package
+ *   boundaries onto the constituent leaf sets.
+ * - **Ranking**: Guides are ranked by the order in which they are first reached
+ *   during a DFS over the dependency and milestone graph, providing deterministic
+ *   tiebreaking during topological sort so CI output is stable across runs.
+ * - **Two-phase resolution**: Forced single-candidate dependencies are resolved
+ *   to fixpoint before OR-group clauses see the selection set. This ensures
+ *   provider choice is deterministic regardless of selection order.
+ * - **Root isolation**: Each requested root is resolved independently before
+ *   leaf plans are merged. Sibling roots therefore cannot change one another's
+ *   OR-group provider choices; genuinely conflicting merged dependency edges
+ *   are still cycle-checked before execution.
+ * - **Milestone adjacency**: Milestones define presentation order but NOT hard
+ *   dependencies. Soft adjacency edges keep journey members in one execution
+ *   chain without turning ordering into failure propagation.
+ *
+ * Returns IDs only; callers hydrate leaf content after graph validation,
+ * keeping network and filesystem concerns out of the planner.
  */
-function buildChains(
-  allIds: Set<string>,
-  edges: GraphEdge[],
-  directDeps: Map<string, string[]>,
-  idToGuide: Map<string, LoadedGuide>,
-  autoIncluded: Set<string>
-): GuideChain[] {
-  // Undirected adjacency for component detection.
-  const adjacency = new Map<string, Set<string>>();
-  for (const id of allIds) {
-    adjacency.set(id, new Set());
+export function planPackageExecution(options: PlanPackageExecutionOptions): PackageExecutionPlan {
+  const rootIds = [...new Set(options.rootIds)].sort();
+  if (rootIds.length <= 1) {
+    return planRootPackageExecution({ ...options, rootIds });
   }
-  for (const edge of edges) {
-    adjacency.get(edge.source)?.add(edge.target);
-    adjacency.get(edge.target)?.add(edge.source);
+  const providesIndex = buildProvidesIndex(options.repository);
+
+  const rootPlans = rootIds.map((rootId) =>
+    planRootPackageExecution({ rootIds: [rootId], repository: options.repository }, providesIndex)
+  );
+  return mergeRootPackagePlans(rootPlans);
+}
+
+function mergeRootPackagePlans(rootPlans: PackageExecutionPlan[]): PackageExecutionPlan {
+  const errors = [...new Set(rootPlans.flatMap((plan) => plan.errors))];
+  if (errors.length > 0) {
+    return { chains: [], autoIncludedIds: [], errors };
   }
 
-  const visited = new Set<string>();
+  const plannedById = new Map<string, { dependencies: Set<string>; autoIncluded: boolean }>();
+  const rank = new Map<string, number>();
+  const rootChains: string[][] = [];
+  let nextRank = 0;
+
+  for (const plan of rootPlans) {
+    for (const chain of plan.chains) {
+      rootChains.push(chain.map((planned) => planned.id));
+      for (const planned of chain) {
+        if (!rank.has(planned.id)) {
+          rank.set(planned.id, nextRank++);
+        }
+        const merged = plannedById.get(planned.id) ?? {
+          dependencies: new Set<string>(),
+          autoIncluded: true,
+        };
+        for (const dependency of planned.dependencies) {
+          merged.dependencies.add(dependency);
+        }
+        merged.autoIncluded &&= planned.autoIncluded;
+        plannedById.set(planned.id, merged);
+      }
+    }
+  }
+
+  const allLeaves = new Set(plannedById.keys());
+  const dependencyEdges: GraphEdge[] = [];
+  for (const [id, planned] of plannedById) {
+    for (const dependency of planned.dependencies) {
+      dependencyEdges.push({ source: id, target: dependency, type: 'depends' });
+    }
+  }
+  for (const cycle of detectCycles(allLeaves, dependencyEdges, new Set<GraphEdgeType>(['depends']))) {
+    errors.push(`Cycle in depends chain: ${cycle.join(' → ')}`);
+  }
+  if (errors.length > 0) {
+    return { chains: [], autoIncludedIds: [], errors };
+  }
+
+  const adjacency = new Map<string, Set<string>>([...allLeaves].map((id) => [id, new Set<string>()]));
+  for (const [id, planned] of plannedById) {
+    for (const dependency of planned.dependencies) {
+      adjacency.get(id)?.add(dependency);
+      adjacency.get(dependency)?.add(id);
+    }
+  }
+  for (const rootChain of rootChains) {
+    for (let index = 1; index < rootChain.length; index++) {
+      const previous = rootChain[index - 1]!;
+      const current = rootChain[index]!;
+      adjacency.get(previous)?.add(current);
+      adjacency.get(current)?.add(previous);
+    }
+  }
+
   const components: string[][] = [];
-  for (const start of [...allIds].sort()) {
+  const visited = new Set<string>();
+  for (const start of [...allLeaves].sort()) {
     if (visited.has(start)) {
       continue;
     }
@@ -301,45 +230,453 @@ function buildChains(
     components.push(component);
   }
 
-  const chains = components.map((component) => {
-    const order = topologicalSort(component, directDeps);
-    return order.map<PlannedGuide>((id) => ({
+  const hardLeafDeps = new Map([...plannedById].map(([id, planned]) => [id, planned.dependencies] as const));
+  const chains = components.map((component) =>
+    stableTopologicalSort(component, hardLeafDeps, rank).map<PlannedGuideRef>((id) => ({
       id,
-      guide: idToGuide.get(id)!,
-      dependencies: directDeps.get(id) ?? [],
-      autoIncluded: autoIncluded.has(id),
-    }));
-  });
+      dependencies: [...(plannedById.get(id)?.dependencies ?? [])].sort(compareLeafOrder(rank)),
+      autoIncluded: plannedById.get(id)?.autoIncluded ?? true,
+    }))
+  );
+  chains.sort((left, right) => left[0]!.id.localeCompare(right[0]!.id));
 
-  // Deterministic chain ordering by the first (topologically earliest) guide.
-  chains.sort((a, b) => a[0]!.id.localeCompare(b[0]!.id));
-  return chains;
+  const autoIncludedIds = [...plannedById]
+    .filter(([, planned]) => planned.autoIncluded)
+    .map(([id]) => id)
+    .sort();
+  return { chains, autoIncludedIds, errors };
 }
 
-/**
- * Topologically sort so prerequisites come before their dependents.
- * A node is appended only after its prerequisites, and sorted iteration keeps
- * the result deterministic. The `visited` guard makes this terminate if a
- * cycle ever slipped through.
- */
-function topologicalSort(component: string[], directDeps: Map<string, string[]>): string[] {
-  const inComponent = new Set(component);
-  const visited = new Set<string>();
-  const order: string[] = [];
+function planRootPackageExecution(
+  options: PlanPackageExecutionOptions,
+  providesIndex: Map<string, string[]> = buildProvidesIndex(options.repository)
+): PackageExecutionPlan {
+  const { repository } = options;
+  const rootIds = [...new Set(options.rootIds)];
+  const rootSet = new Set(rootIds);
+  const errors: string[] = [];
+  const packageSet = new Set<string>();
+  const explicitPackages = new Set<string>();
+  const directDeps = new Map<string, string[]>();
 
-  const visit = (id: string): void => {
-    if (visited.has(id)) {
+  const markExplicit = (id: string, seen: Set<string> = new Set()): void => {
+    if (seen.has(id)) {
       return;
     }
-    visited.add(id);
-    for (const dep of [...(directDeps.get(id) ?? [])].filter((d) => inComponent.has(d)).sort()) {
-      visit(dep);
+    seen.add(id);
+    explicitPackages.add(id);
+    const entry = repository[id];
+    if (isMetapackage(entry)) {
+      for (const milestone of entry?.milestones ?? []) {
+        markExplicit(milestone, seen);
+      }
     }
-    order.push(id);
   };
 
-  for (const id of [...component].sort()) {
-    visit(id);
+  const addPackage = (requesterId: string, id: string, explicit: boolean): void => {
+    const entry = repository[id];
+    if (!entry && !rootSet.has(id)) {
+      errors.push(`${requesterId}: package "${id}" is missing from the repository index`);
+      return;
+    }
+    if (explicit) {
+      markExplicit(id);
+    }
+    if (packageSet.has(id)) {
+      return;
+    }
+    packageSet.add(id);
+    if (!isMetapackage(entry)) {
+      return;
+    }
+    const milestones = entry?.milestones ?? [];
+    if (milestones.length === 0) {
+      errors.push(`${id}: ${entry?.type} package has no milestones`);
+      return;
+    }
+    if (new Set(milestones).size !== milestones.length) {
+      errors.push(`${id}: milestones contains duplicate package IDs`);
+    }
+    for (const milestone of milestones) {
+      addPackage(id, milestone, explicit);
+    }
+  };
+
+  for (const id of [...rootIds].sort()) {
+    addPackage(id, id, true);
+  }
+
+  const ensureProvider = (requesterId: string, providerId: string): boolean => {
+    if (!repository[providerId]) {
+      errors.push(`${requesterId}: could not resolve prerequisite package "${providerId}"`);
+      return false;
+    }
+    addPackage(requesterId, providerId, false);
+    return true;
+  };
+
+  const resolveClauseProvider = (candidates: string[]): string | null => {
+    for (const candidate of candidates) {
+      const reused = resolveCandidateProviders(candidate, repository, providesIndex).find((id) => packageSet.has(id));
+      if (reused) {
+        return reused;
+      }
+    }
+    for (const candidate of candidates) {
+      const [provider] = resolveCandidateProviders(candidate, repository, providesIndex);
+      if (provider) {
+        return provider;
+      }
+    }
+    return null;
+  };
+
+  const resolvePhase = (id: string, forced: boolean): void => {
+    const deps = directDeps.get(id) ?? [];
+    directDeps.set(id, deps);
+    for (const clause of repository[id]?.depends ?? []) {
+      const candidates = clauseCandidates(clause);
+      if (candidates.length === 0 || (candidates.length === 1) !== forced) {
+        continue;
+      }
+      const providerId = resolveClauseProvider(candidates);
+      if (providerId === null) {
+        errors.push(
+          `${id}: depends target "${candidates.join(' | ')}" does not resolve to a known package or capability`
+        );
+        continue;
+      }
+      if (ensureProvider(id, providerId)) {
+        deps.push(providerId);
+      }
+    }
+  };
+
+  const forcedResolved = new Set<string>();
+  const alternativesResolved = new Set<string>();
+  let progressed = true;
+  while (progressed) {
+    progressed = false;
+    let forcedProgress = true;
+    while (forcedProgress) {
+      forcedProgress = false;
+      for (const id of [...packageSet].sort()) {
+        if (forcedResolved.has(id)) {
+          continue;
+        }
+        forcedResolved.add(id);
+        const before = packageSet.size;
+        resolvePhase(id, true);
+        if (packageSet.size !== before) {
+          forcedProgress = true;
+        }
+      }
+    }
+    for (const id of [...packageSet].sort()) {
+      if (alternativesResolved.has(id)) {
+        continue;
+      }
+      alternativesResolved.add(id);
+      const before = packageSet.size;
+      resolvePhase(id, false);
+      if (packageSet.size !== before) {
+        progressed = true;
+      }
+    }
+  }
+
+  for (const [id, deps] of directDeps) {
+    directDeps.set(id, [...new Set(deps)]);
+  }
+
+  const dependencyEdges: GraphEdge[] = [];
+  const milestoneEdges: GraphEdge[] = [];
+  for (const id of packageSet) {
+    for (const dependency of directDeps.get(id) ?? []) {
+      dependencyEdges.push({ source: id, target: dependency, type: 'depends' });
+    }
+    for (const milestone of repository[id]?.milestones ?? []) {
+      if (packageSet.has(milestone)) {
+        milestoneEdges.push({ source: id, target: milestone, type: 'milestones' });
+      }
+    }
+  }
+
+  const reportedCycleKeys = new Set<string>();
+  for (const cycle of detectCycles(packageSet, dependencyEdges, new Set<GraphEdgeType>(['depends']))) {
+    reportedCycleKeys.add(cycleKey(cycle));
+    errors.push(`Cycle in depends chain: ${cycle.join(' → ')}`);
+  }
+  for (const cycle of detectCycles(packageSet, milestoneEdges, new Set<GraphEdgeType>(['milestones']))) {
+    reportedCycleKeys.add(cycleKey(cycle));
+    errors.push(`Cycle in milestones chain: ${cycle.join(' → ')}`);
+  }
+  for (const cycle of detectCycles(
+    packageSet,
+    [...dependencyEdges, ...milestoneEdges],
+    new Set<GraphEdgeType>(['depends', 'milestones'])
+  )) {
+    const key = cycleKey(cycle);
+    if (!reportedCycleKeys.has(key)) {
+      reportedCycleKeys.add(key);
+      errors.push(`Cycle across depends and milestones: ${cycle.join(' → ')}`);
+    }
+  }
+
+  const leavesMemo = new Map<string, string[]>();
+  const packageLeaves = (id: string): string[] => {
+    const cached = leavesMemo.get(id);
+    if (cached) {
+      return cached;
+    }
+    const entry = repository[id];
+    const leaves = isMetapackage(entry)
+      ? (entry?.milestones ?? []).flatMap((milestone) => packageLeaves(milestone))
+      : [id];
+    const unique = [...new Set(leaves)];
+    leavesMemo.set(id, unique);
+    return unique;
+  };
+
+  if (errors.length > 0) {
+    return { chains: [], autoIncludedIds: [], errors };
+  }
+
+  const explicitLeafIds = new Set<string>();
+  for (const id of explicitPackages) {
+    if (!isMetapackage(repository[id])) {
+      explicitLeafIds.add(id);
+    }
+  }
+
+  const hardLeafDeps = new Map<string, Set<string>>();
+  for (const id of packageSet) {
+    for (const leaf of packageLeaves(id)) {
+      hardLeafDeps.set(leaf, hardLeafDeps.get(leaf) ?? new Set());
+    }
+  }
+  for (const [id, dependencies] of directDeps) {
+    const prerequisiteLeaves = dependencies.flatMap((dependency) => packageLeaves(dependency));
+    for (const leaf of packageLeaves(id)) {
+      const leafDeps = hardLeafDeps.get(leaf) ?? new Set<string>();
+      for (const prerequisite of prerequisiteLeaves) {
+        if (prerequisite !== leaf) {
+          leafDeps.add(prerequisite);
+        }
+      }
+      hardLeafDeps.set(leaf, leafDeps);
+    }
+  }
+
+  const rank = new Map<string, number>();
+  const rankedPackages = new Set<string>();
+  let nextRank = 0;
+  const rankPackage = (id: string): void => {
+    if (rankedPackages.has(id)) {
+      return;
+    }
+    rankedPackages.add(id);
+    for (const dependency of [...(directDeps.get(id) ?? [])].sort()) {
+      rankPackage(dependency);
+    }
+    const entry = repository[id];
+    if (isMetapackage(entry)) {
+      for (const milestone of entry?.milestones ?? []) {
+        rankPackage(milestone);
+      }
+      return;
+    }
+    if (!rank.has(id)) {
+      rank.set(id, nextRank++);
+    }
+  };
+  for (const id of [...rootIds].sort()) {
+    rankPackage(id);
+  }
+  for (const id of [...packageSet].sort()) {
+    rankPackage(id);
+  }
+
+  const allLeaves = new Set<string>([...packageSet].flatMap((id) => packageLeaves(id)));
+  const adjacency = new Map<string, Set<string>>([...allLeaves].map((id) => [id, new Set<string>()]));
+  for (const [id, dependencies] of hardLeafDeps) {
+    for (const dependency of dependencies) {
+      adjacency.get(id)?.add(dependency);
+      adjacency.get(dependency)?.add(id);
+    }
+  }
+
+  const closureLeaves = (rootId: string): string[] => {
+    const packages = new Set<string>();
+    const visit = (id: string): void => {
+      if (packages.has(id)) {
+        return;
+      }
+      packages.add(id);
+      for (const dependency of directDeps.get(id) ?? []) {
+        visit(dependency);
+      }
+      for (const milestone of repository[id]?.milestones ?? []) {
+        visit(milestone);
+      }
+    };
+    visit(rootId);
+    return [...new Set([...packages].flatMap((id) => packageLeaves(id)))].sort(compareLeafOrder(rank));
+  };
+  for (const rootId of rootIds) {
+    const leaves = closureLeaves(rootId);
+    for (let index = 1; index < leaves.length; index++) {
+      const previous = leaves[index - 1]!;
+      const current = leaves[index]!;
+      adjacency.get(previous)?.add(current);
+      adjacency.get(current)?.add(previous);
+    }
+  }
+
+  const components: string[][] = [];
+  const visited = new Set<string>();
+  for (const start of [...allLeaves].sort()) {
+    if (visited.has(start)) {
+      continue;
+    }
+    const component: string[] = [];
+    const stack = [start];
+    visited.add(start);
+    while (stack.length > 0) {
+      const node = stack.pop();
+      if (node === undefined) {
+        continue;
+      }
+      component.push(node);
+      for (const neighbor of [...(adjacency.get(node) ?? [])].sort()) {
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor);
+          stack.push(neighbor);
+        }
+      }
+    }
+    components.push(component);
+  }
+
+  const chains = components.map((component) =>
+    stableTopologicalSort(component, hardLeafDeps, rank).map<PlannedGuideRef>((id) => ({
+      id,
+      dependencies: [...(hardLeafDeps.get(id) ?? [])].sort(compareLeafOrder(rank)),
+      autoIncluded: !explicitLeafIds.has(id),
+    }))
+  );
+  chains.sort((left, right) => left[0]!.id.localeCompare(right[0]!.id));
+
+  const autoIncludedIds = [...allLeaves].filter((id) => !explicitLeafIds.has(id)).sort();
+  return { chains, autoIncludedIds, errors };
+}
+
+function compareLeafOrder(rank: Map<string, number>): (left: string, right: string) => number {
+  return (left, right) => {
+    const rankDifference = (rank.get(left) ?? Number.MAX_SAFE_INTEGER) - (rank.get(right) ?? Number.MAX_SAFE_INTEGER);
+    return rankDifference !== 0 ? rankDifference : left.localeCompare(right);
+  };
+}
+
+function stableTopologicalSort(
+  component: string[],
+  hardLeafDeps: Map<string, Set<string>>,
+  rank: Map<string, number>
+): string[] {
+  const inComponent = new Set(component);
+  const indegree = new Map<string, number>();
+  const dependents = new Map<string, Set<string>>();
+  for (const id of component) {
+    const dependencies = [...(hardLeafDeps.get(id) ?? [])].filter((dependency) => inComponent.has(dependency));
+    indegree.set(id, dependencies.length);
+    for (const dependency of dependencies) {
+      const values = dependents.get(dependency) ?? new Set<string>();
+      values.add(id);
+      dependents.set(dependency, values);
+    }
+  }
+
+  const compare = compareLeafOrder(rank);
+  const ready = component.filter((id) => indegree.get(id) === 0).sort(compare);
+  const order: string[] = [];
+  while (ready.length > 0) {
+    const id = ready.shift()!;
+    order.push(id);
+    for (const dependent of dependents.get(id) ?? []) {
+      const next = (indegree.get(dependent) ?? 0) - 1;
+      indegree.set(dependent, next);
+      if (next === 0) {
+        ready.push(dependent);
+        ready.sort(compare);
+      }
+    }
   }
   return order;
+}
+
+/** Hydrate an ID-only package plan with validated guide content. */
+export function hydrateExecutionPlan(
+  packagePlan: PackageExecutionPlan,
+  guidesById: Map<string, LoadedGuide>,
+  repository: RepositoryJson,
+  loadGuideById?: (id: string, entry: RepositoryEntry) => LoadedGuide | null
+): ExecutionPlan {
+  const errors = [...packagePlan.errors];
+  const loaded = new Map(guidesById);
+  for (const chain of packagePlan.chains) {
+    for (const planned of chain) {
+      if (loaded.has(planned.id)) {
+        continue;
+      }
+      const entry = repository[planned.id];
+      const guide = entry ? (loadGuideById?.(planned.id, entry) ?? null) : null;
+      if (!guide) {
+        errors.push(
+          planned.autoIncluded
+            ? `could not load auto-included prerequisite "${planned.id}"`
+            : `could not load planned guide "${planned.id}"`
+        );
+        continue;
+      }
+      loaded.set(planned.id, guide);
+    }
+  }
+  if (errors.length > 0) {
+    return { chains: [], autoIncludedIds: packagePlan.autoIncludedIds, errors };
+  }
+  return {
+    chains: packagePlan.chains.map((chain) =>
+      chain.map((planned) => ({
+        ...planned,
+        guide: loaded.get(planned.id)!,
+      }))
+    ),
+    autoIncludedIds: packagePlan.autoIncludedIds,
+    errors,
+  };
+}
+
+/** Plan selected guides and hydrate any dependency- or milestone-expanded leaves. */
+export function planGuideExecution(options: PlanGuideExecutionOptions): ExecutionPlan {
+  const idToGuide = new Map<string, LoadedGuide>();
+  const errors: string[] = [];
+  for (const guide of options.guides) {
+    const id = deriveGuideId(guide);
+    const existing = idToGuide.get(id);
+    if (existing) {
+      if (existing.path !== guide.path) {
+        errors.push(`duplicate guide id "${id}" derived from "${existing.path}" and "${guide.path}"`);
+      }
+      continue;
+    }
+    idToGuide.set(id, guide);
+  }
+  if (errors.length > 0) {
+    return { chains: [], autoIncludedIds: [], errors };
+  }
+  const packagePlan = planPackageExecution({
+    rootIds: [...idToGuide.keys()],
+    repository: options.repository,
+  });
+  return hydrateExecutionPlan(packagePlan, idToGuide, options.repository, options.loadGuideById);
 }

--- a/src/cli/e2e/schemas/e2e-report.schema.ts
+++ b/src/cli/e2e/schemas/e2e-report.schema.ts
@@ -118,6 +118,15 @@ export const GuideMetadataSchema = z.object({
   contentDigest: z.string().optional(),
   sideEffects: SideEffectClassificationSchema.optional(),
 });
+/**
+ * Identifies the explicitly selected milestone-based package.
+ * `path` and `journey` currently have identical execution semantics;
+ * `journey` is retained for package-format compatibility.
+ */
+export const ExecutionSelectionSchema = z.object({
+  id: z.string(),
+  type: z.enum(['path', 'journey']),
+});
 
 export const ReportConfigSchema = z.object({
   grafanaVersion: z.string().optional(),
@@ -197,6 +206,8 @@ export const MultiGuideReportSchema = z
     startedAt: z.iso.datetime(),
     endedAt: z.iso.datetime(),
     type: z.literal('multi-guide'),
+    /** Present when this report was produced by a metapackage (path/journey) run. */
+    selection: ExecutionSelectionSchema.optional(),
     config: ReportConfigSchema,
     summary: MultiGuideSummarySchema,
     guides: z.array(GuideResultSchema),
@@ -226,5 +237,6 @@ export type ReportConfig = z.infer<typeof ReportConfigSchema>;
 export type PreRunSkip = z.infer<typeof PreRunSkipSchema>;
 export type E2ETestReport = z.infer<typeof E2ETestReportSchema>;
 export type GuideResult = z.infer<typeof GuideResultSchema>;
+export type ExecutionSelection = z.infer<typeof ExecutionSelectionSchema>;
 export type MultiGuideSummary = z.infer<typeof MultiGuideSummarySchema>;
 export type MultiGuideReport = z.infer<typeof MultiGuideReportSchema>;


### PR DESCRIPTION
## Summary

Allows `pathfinder-cli e2e --package` to execute `path` packages by recursively expanding them into ordered leaf-guide chains. Hard `depends` relationships remain the only source of failure propagation, while the requested metapackage is recorded separately through additive multi-guide `selection` metadata.

Repository-wide runs also keep independent guides runnable when another root has an unavailable or structurally invalid prerequisite.

## What to look at

- [Package planning and hydration](https://github.com/grafana/grafana-pathfinder-app/blob/351da70bed0f1ca94c6ef0739cf51f927487937f/src/cli/e2e/guide-chains.ts) — trace how CNF dependencies, virtual providers, recursive milestones, mixed-edge cycles, and shared leaves become an ordered guide plan. Milestone order intentionally does not create hard dependency edges.
- [Local and remote package resolution](https://github.com/grafana/grafana-pathfinder-app/blob/351da70bed0f1ca94c6ef0739cf51f927487937f/src/cli/commands/e2e.ts) and [remote hydration](https://github.com/grafana/grafana-pathfinder-app/blob/351da70bed0f1ca94c6ef0739cf51f927487937f/src/cli/e2e/e2e-package.ts) — local metapackages are manifest-first so cover content stays optional, remote content identity is checked against the repository, and pre-run failures retain the selected root.
- [Multi-guide report contract](https://github.com/grafana/grafana-pathfinder-app/blob/351da70bed0f1ca94c6ef0739cf51f927487937f/src/cli/e2e/schemas/e2e-report.schema.ts) — `selection` is optional and additive, including for one-milestone and skip-only metapackage reports.

## Why

The E2E command previously understood only executable guides connected through hard dependencies. Selecting a path therefore tested neither its ordered milestones nor a path-level dependency on another metapackage, preventing scheduled E2E workers from treating a learning path as one execution root.

Courses were considered and deliberately excluded because their ordering is curatorial rather than an execution prerequisite and adds no unique leaf-guide coverage. Milestone ordering is likewise kept separate from `depends`: guides run in the declared learning order, but an unrelated milestone failure does not suppress later coverage.

## How to verify

1. Create a local path package with no cover `content.json`, two guide milestones, and a repository index beside the package tree. Run `pathfinder-cli e2e --package <path-directory> --repository <repository.json> --verbose` and confirm the plan contains the two leaf guides in milestone order.
2. Make the first milestone fail while leaving the second independent, then confirm the second still runs. Add a hard `depends` relationship from the second to the first and confirm it is instead reported as skipped because its prerequisite failed.
3. Resolve a published cloud path from a local-tier run with `--output <report.json>`. Confirm the skip-only multi-guide report contains `selection.id`, `selection.type`, and a structured pre-run skip for the root.
4. In a repository-wide run, make one guide depend on an unavailable package and include a separate independent guide. Confirm only the affected dependency chain receives `prerequisite_failed` while the independent guide remains in the execution plan.

## Breaking changes

None. The `selection` field is optional and additive to the open-world `1.0.0` multi-guide report contract. Existing guide runs and older multi-guide consumers continue to use leaf-guide or pre-run-skip identity.

## Reversibility

Reverting this PR stops path expansion and stops new reports from emitting `selection`. Reports already written with the optional field remain valid JSON for open-world consumers; there is no storage migration, persisted browser-state change, or cleanup requirement.

## Out of scope

- Course execution: courses are presentation-only compositions and do not add executable guide prerequisites.
- Implicit path expansion during `--remote`: repository sweeps remain leaf-guide populations; metapackages require explicit `--package` selection.
- Population-wide chain deduplication: shared-root optimization remains separate follow-up work.
- E2E-platform rollout: after merge, publish an immutable runner image, update the platform consumer, and refresh its imported schema provenance and image pins from that runner.
