### PR TITLE
fix(e2e-runner): pass with 0 steps for markdown-only guides

### DIFF
--- a/src/components/docs-panel/utils/requires-grafana-ui.ts
+++ b/src/components/docs-panel/utils/requires-grafana-ui.ts
@@ -21,7 +21,14 @@
  * `prepareGuideLaunch` handles that case separately via the inliner's status.
  */
 
+import { isInteractiveBlockType, type InteractiveBlockType } from '../../../constants/json-guide-classification';
 import type { JsonBlock, JsonGuide, JsonInteractiveAction, JsonStep } from '../../../types/json-guide.types';
+
+type InteractiveBlock = Extract<JsonBlock, { type: InteractiveBlockType }>;
+
+function isInteractiveBlock(block: JsonBlock): block is InteractiveBlock {
+  return isInteractiveBlockType(block.type);
+}
 
 /** The action values that require the live Grafana UI. */
 const GRAFANA_DRIVING_ACTIONS: ReadonlySet<JsonInteractiveAction> = new Set<JsonInteractiveAction>([
@@ -44,40 +51,45 @@ function stepDrivesGrafana(step: Pick<JsonStep, 'action' | 'targetAction'>): boo
 function blocksRequireGrafanaUi(blocks: JsonBlock[]): boolean {
   return blocks.some(blockRequiresGrafanaUi);
 }
-
-function blockRequiresGrafanaUi(block: JsonBlock): boolean {
+function interactiveBlockRequiresGrafanaUi(block: InteractiveBlock): boolean {
   switch (block.type) {
     case 'interactive':
       return stepDrivesGrafana(block);
     case 'multistep':
     case 'guided':
       return block.steps.some(stepDrivesGrafana);
-    case 'section':
-    case 'assistant':
-    case 'collapsible':
-      return blocksRequireGrafanaUi(block.blocks);
-    case 'conditional':
-      return blocksRequireGrafanaUi(block.whenTrue) || blocksRequireGrafanaUi(block.whenFalse);
     case 'code-block':
       // `reftarget` is schema-required and targets a live Grafana Monaco
       // editor; without the Grafana UI both "Show me" and "Insert" are dead.
       return true;
-    case 'snippet-ref':
-      return true;
-    // Interactive inside Pathfinder or purely presentational — none drive
-    // the live Grafana page. Enumerated (no default) so a new JsonBlock
-    // member is a compile error here instead of silently classifying as
-    // non-interactive and hiding any Grafana-driving action it may nest.
-    case 'markdown':
-    case 'html':
-    case 'image':
-    case 'video':
+    // Interactive inside Pathfinder, but self-contained; none drive the live Grafana page.
     case 'quiz':
     case 'input':
     case 'terminal':
     case 'terminal-connect':
     case 'challenge':
     case 'grot-guide':
+      return false;
+  }
+}
+
+function blockRequiresGrafanaUi(block: JsonBlock): boolean {
+  if (isInteractiveBlock(block)) {
+    return interactiveBlockRequiresGrafanaUi(block);
+  }
+  switch (block.type) {
+    case 'section':
+    case 'assistant':
+    case 'collapsible':
+      return blocksRequireGrafanaUi(block.blocks);
+    case 'conditional':
+      return blocksRequireGrafanaUi(block.whenTrue) || blocksRequireGrafanaUi(block.whenFalse);
+    case 'snippet-ref':
+      return true;
+    case 'markdown':
+    case 'html':
+    case 'image':
+    case 'video':
       return false;
     default: {
       // Exhaustiveness: adding a JsonBlock member without classifying it here

--- a/src/constants/json-guide-classification.test.ts
+++ b/src/constants/json-guide-classification.test.ts
@@ -1,0 +1,27 @@
+import { INTERACTIVE_BLOCK_TYPES, isInteractiveBlockType } from './json-guide-classification';
+
+describe('JSON guide classification', () => {
+  it('defines every Pathfinder interactive block type', () => {
+    expect(INTERACTIVE_BLOCK_TYPES).toEqual([
+      'interactive',
+      'multistep',
+      'guided',
+      'quiz',
+      'input',
+      'terminal',
+      'terminal-connect',
+      'code-block',
+      'challenge',
+      'grot-guide',
+    ]);
+  });
+
+  it('distinguishes interactive blocks from content and containers', () => {
+    expect(isInteractiveBlockType('quiz')).toBe(true);
+    expect(isInteractiveBlockType('code-block')).toBe(true);
+    expect(isInteractiveBlockType('markdown')).toBe(false);
+    expect(isInteractiveBlockType('section')).toBe(false);
+    expect(isInteractiveBlockType('conditional')).toBe(false);
+    expect(isInteractiveBlockType('snippet-ref')).toBe(false);
+  });
+});

--- a/src/constants/json-guide-classification.ts
+++ b/src/constants/json-guide-classification.ts
@@ -11,7 +11,7 @@ export const INTERACTIVE_BLOCK_TYPES = [
   'code-block',
   'challenge',
   'grot-guide',
-] as const satisfies readonly JsonBlock['type'][];
+] as const satisfies ReadonlyArray<JsonBlock['type']>;
 
 export type InteractiveBlockType = (typeof INTERACTIVE_BLOCK_TYPES)[number];
 

--- a/src/constants/json-guide-classification.ts
+++ b/src/constants/json-guide-classification.ts
@@ -1,0 +1,22 @@
+import type { JsonBlock } from '../types/json-guide.types';
+
+export const INTERACTIVE_BLOCK_TYPES = [
+  'interactive',
+  'multistep',
+  'guided',
+  'quiz',
+  'input',
+  'terminal',
+  'terminal-connect',
+  'code-block',
+  'challenge',
+  'grot-guide',
+] as const satisfies readonly JsonBlock['type'][];
+
+export type InteractiveBlockType = (typeof INTERACTIVE_BLOCK_TYPES)[number];
+
+const INTERACTIVE_BLOCK_TYPE_SET: ReadonlySet<string> = new Set(INTERACTIVE_BLOCK_TYPES);
+
+export function isInteractiveBlockType(type: unknown): type is InteractiveBlockType {
+  return typeof type === 'string' && INTERACTIVE_BLOCK_TYPE_SET.has(type);
+}

--- a/tests/e2e-runner/fixtures/markdown-only/content.json
+++ b/tests/e2e-runner/fixtures/markdown-only/content.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "markdown-only",
+  "title": "Markdown Only (Synthetic Fixture)",
+  "blocks": [
+    {
+      "type": "markdown",
+      "content": "# Read-only guide\n\nThis fixture contains no interactive steps. It is used to verify the E2E runner handles markdown-only guides correctly."
+    },
+    {
+      "type": "image",
+      "src": "https://grafana.com/static/img/grafana_logo.svg",
+      "alt": "Grafana logo"
+    }
+  ]
+}

--- a/tests/e2e-runner/guide-runner.spec.ts
+++ b/tests/e2e-runner/guide-runner.spec.ts
@@ -45,7 +45,7 @@ import {
   printDiscoveryResults,
 } from './utils/console-reporter';
 import { contentDigest, type TestResultsData } from '../../src/cli/e2e/e2e-reporter';
-import { countDiscoverableSteps } from './utils/guide-runner/static-analysis';
+import { countInteractiveBlocks } from './utils/guide-runner/static-analysis';
 import { E2E_ENV, isEnvFlagEnabled } from '../../src/cli/e2e/e2e-runner-contract';
 import {
   createScopedBearerTokenAuthStrategy,
@@ -166,7 +166,7 @@ test.describe('Guide Runner', () => {
 
     const guideJson = readFileSync(guidePath, 'utf-8');
     const guide = JSON.parse(guideJson) as { title?: string; id?: string };
-    const hasDiscoverableSteps = countDiscoverableSteps(guide) > 0;
+    const hasInteractiveSteps = countInteractiveBlocks(guide) > 0;
     const guideTitle = guide.title ?? 'E2E Test Guide';
 
     // L3-5B: Extract guide ID from path or use provided id
@@ -244,15 +244,14 @@ test.describe('Guide Runner', () => {
     // Wait for content to load
     await page.waitForTimeout(1000);
 
-    // Unsupported/read-only blocks never render the runner's `interactive-step-*` contract.
     const guideMetadata = {
       id: guideId,
       title: guideTitle,
       path: guidePath ?? 'unknown',
     };
-    if (!hasDiscoverableSteps) {
+    if (!hasInteractiveSteps) {
       printHeader(guideTitle);
-      console.log('   ⊘ No E2E-discoverable steps (0 steps, pass)');
+      console.log('   ⊘ No interactive steps — guide is read-only content (0 steps, pass)');
       const emptyResult: AllStepsResult = { results: [], aborted: false };
       writeResultsFile(
         [],

--- a/tests/e2e-runner/guide-runner.spec.ts
+++ b/tests/e2e-runner/guide-runner.spec.ts
@@ -261,7 +261,16 @@ test.describe('Guide Runner', () => {
       printHeader(guideTitle);
       console.log('   ⊘ No interactive steps — guide is read-only content (0 steps, pass)');
       const emptyResult: AllStepsResult = { results: [], aborted: false };
-      writeResultsFile([], guideMetadata, targetUrl, startingLocation, testStartTimestamp, emptyResult, guideJson, 'passed');
+      writeResultsFile(
+        [],
+        guideMetadata,
+        targetUrl,
+        startingLocation,
+        testStartTimestamp,
+        emptyResult,
+        guideJson,
+        'passed'
+      );
       return;
     }
 

--- a/tests/e2e-runner/guide-runner.spec.ts
+++ b/tests/e2e-runner/guide-runner.spec.ts
@@ -45,6 +45,7 @@ import {
   printDiscoveryResults,
 } from './utils/console-reporter';
 import { contentDigest, type TestResultsData } from '../../src/cli/e2e/e2e-reporter';
+import { countInteractiveBlocks } from './utils/guide-runner/static-analysis';
 import { E2E_ENV, isEnvFlagEnabled } from '../../src/cli/e2e/e2e-runner-contract';
 import {
   createScopedBearerTokenAuthStrategy,
@@ -165,6 +166,7 @@ test.describe('Guide Runner', () => {
 
     const guideJson = readFileSync(guidePath, 'utf-8');
     const guide = JSON.parse(guideJson) as { title?: string; id?: string };
+    const hasInteractiveSteps = countInteractiveBlocks(guide) > 0;
     const guideTitle = guide.title ?? 'E2E Test Guide';
 
     // L3-5B: Extract guide ID from path or use provided id
@@ -242,6 +244,27 @@ test.describe('Guide Runner', () => {
     // Wait for content to load
     await page.waitForTimeout(1000);
 
+    // ============================================
+    // Markdown-only guides: skip DOM interaction
+    // ============================================
+    // Determine upfront — before any DOM wait — whether this guide has
+    // interactive steps. Guides with no interactive blocks (markdown,
+    // image, video only) never produce any [data-testid^="interactive-step-"]
+    // elements; waiting for them would time out after 15 s. Instead, pass
+    // immediately with 0 steps once the guide is confirmed to have loaded.
+    const guideMetadata = {
+      id: guideId,
+      title: guideTitle,
+      path: guidePath ?? 'unknown',
+    };
+    if (!hasInteractiveSteps) {
+      printHeader(guideTitle);
+      console.log('   ⊘ No interactive steps — guide is read-only content (0 steps, pass)');
+      const emptyResult: AllStepsResult = { results: [], aborted: false };
+      writeResultsFile([], guideMetadata, targetUrl, startingLocation, testStartTimestamp, emptyResult, guideJson, 'passed');
+      return;
+    }
+
     // Verify guide content loaded (first step visible indicates interactive content rendered)
     // Use a more general selector since step IDs vary by guide
     const firstStep = page.locator('[data-testid^="interactive-step-"]').first();
@@ -296,11 +319,6 @@ test.describe('Guide Runner', () => {
     printDetailedSummary(executionResult.results, executionResult, isVerbose);
 
     // L3-5B: Write results file for CLI to generate JSON report
-    const guideMetadata = {
-      id: guideId,
-      title: guideTitle,
-      path: guidePath ?? 'unknown',
-    };
     writeResultsFile(
       executionResult.results,
       guideMetadata,

--- a/tests/e2e-runner/guide-runner.spec.ts
+++ b/tests/e2e-runner/guide-runner.spec.ts
@@ -45,7 +45,7 @@ import {
   printDiscoveryResults,
 } from './utils/console-reporter';
 import { contentDigest, type TestResultsData } from '../../src/cli/e2e/e2e-reporter';
-import { countInteractiveBlocks } from './utils/guide-runner/static-analysis';
+import { countDiscoverableSteps } from './utils/guide-runner/static-analysis';
 import { E2E_ENV, isEnvFlagEnabled } from '../../src/cli/e2e/e2e-runner-contract';
 import {
   createScopedBearerTokenAuthStrategy,
@@ -166,7 +166,7 @@ test.describe('Guide Runner', () => {
 
     const guideJson = readFileSync(guidePath, 'utf-8');
     const guide = JSON.parse(guideJson) as { title?: string; id?: string };
-    const hasInteractiveSteps = countInteractiveBlocks(guide) > 0;
+    const hasDiscoverableSteps = countDiscoverableSteps(guide) > 0;
     const guideTitle = guide.title ?? 'E2E Test Guide';
 
     // L3-5B: Extract guide ID from path or use provided id
@@ -244,22 +244,15 @@ test.describe('Guide Runner', () => {
     // Wait for content to load
     await page.waitForTimeout(1000);
 
-    // ============================================
-    // Markdown-only guides: skip DOM interaction
-    // ============================================
-    // Determine upfront — before any DOM wait — whether this guide has
-    // interactive steps. Guides with no interactive blocks (markdown,
-    // image, video only) never produce any [data-testid^="interactive-step-"]
-    // elements; waiting for them would time out after 15 s. Instead, pass
-    // immediately with 0 steps once the guide is confirmed to have loaded.
+    // Unsupported/read-only blocks never render the runner's `interactive-step-*` contract.
     const guideMetadata = {
       id: guideId,
       title: guideTitle,
       path: guidePath ?? 'unknown',
     };
-    if (!hasInteractiveSteps) {
+    if (!hasDiscoverableSteps) {
       printHeader(guideTitle);
-      console.log('   ⊘ No interactive steps — guide is read-only content (0 steps, pass)');
+      console.log('   ⊘ No E2E-discoverable steps (0 steps, pass)');
       const emptyResult: AllStepsResult = { results: [], aborted: false };
       writeResultsFile(
         [],

--- a/tests/e2e-runner/utils/guide-runner/static-analysis.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/static-analysis.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for static guide content analysis.
  *
- * countInteractiveBlocks lets the runner determine before Playwright starts
+ * countDiscoverableSteps lets the runner determine before Playwright starts
  * whether a guide has any interactive steps to execute. Markdown-only guides
  * should produce a 0-step pass rather than timing out waiting for DOM elements.
  */
@@ -9,7 +9,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-import { countInteractiveBlocks } from './static-analysis';
+import { countDiscoverableSteps } from './static-analysis';
 
 const FIXTURES = join(__dirname, '../../fixtures');
 
@@ -17,16 +17,30 @@ function loadFixture(name: string): string {
   return readFileSync(join(FIXTURES, name, 'content.json'), 'utf-8');
 }
 
-describe('countInteractiveBlocks', () => {
+describe('countDiscoverableSteps', () => {
   it('returns 0 for a markdown-only guide', () => {
     const json = loadFixture('markdown-only');
-    expect(countInteractiveBlocks(JSON.parse(json))).toBe(0);
+    expect(countDiscoverableSteps(JSON.parse(json))).toBe(0);
   });
 
   it('returns the correct count for a guide with interactive steps', () => {
     const json = loadFixture('always-passes');
-    // always-passes has 2 interactive blocks nested inside a section
-    expect(countInteractiveBlocks(JSON.parse(json))).toBe(2);
+    expect(countDiscoverableSteps(JSON.parse(json))).toBe(2);
+  });
+
+  it('counts all E2E-discoverable block types and excludes unsupported block types', () => {
+    const guide = {
+      blocks: [
+        { type: 'interactive' },
+        { type: 'multistep' },
+        { type: 'guided' },
+        { type: 'code-block' },
+        { type: 'terminal' },
+        { type: 'terminal-connect' },
+        { type: 'grot-guide' },
+      ],
+    };
+    expect(countDiscoverableSteps(guide)).toBe(3);
   });
 
   it('counts interactive blocks nested inside conditional whenTrue and whenFalse', () => {
@@ -40,7 +54,7 @@ describe('countInteractiveBlocks', () => {
         },
       ],
     };
-    expect(countInteractiveBlocks(guide)).toBe(2);
+    expect(countDiscoverableSteps(guide)).toBe(2);
   });
 
   it('counts interactive blocks nested inside assistant blocks', () => {
@@ -52,10 +66,39 @@ describe('countInteractiveBlocks', () => {
         },
       ],
     };
-    expect(countInteractiveBlocks(guide)).toBe(1);
+    expect(countDiscoverableSteps(guide)).toBe(1);
   });
 
   it('returns 0 for an empty blocks array', () => {
-    expect(countInteractiveBlocks({ blocks: [] })).toBe(0);
+    expect(countDiscoverableSteps({ blocks: [] })).toBe(0);
+  });
+
+  it('returns 0 for null and malformed guide values', () => {
+    expect(countDiscoverableSteps(null)).toBe(0);
+    expect(countDiscoverableSteps(undefined)).toBe(0);
+    expect(countDiscoverableSteps('not-a-guide')).toBe(0);
+  });
+
+  it('counts deeply nested mixed content', () => {
+    const guide = {
+      blocks: [
+        {
+          type: 'section',
+          blocks: [
+            {
+              type: 'assistant',
+              blocks: [
+                {
+                  type: 'conditional',
+                  whenTrue: [{ type: 'markdown' }, { type: 'guided' }],
+                  whenFalse: [{ type: 'terminal' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(countDiscoverableSteps(guide)).toBe(1);
   });
 });

--- a/tests/e2e-runner/utils/guide-runner/static-analysis.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/static-analysis.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for static guide content analysis.
+ *
+ * countInteractiveBlocks lets the runner determine before Playwright starts
+ * whether a guide has any interactive steps to execute. Markdown-only guides
+ * should produce a 0-step pass rather than timing out waiting for DOM elements.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { countInteractiveBlocks } from './static-analysis';
+
+const FIXTURES = join(__dirname, '../../fixtures');
+
+function loadFixture(name: string): string {
+  return readFileSync(join(FIXTURES, name, 'content.json'), 'utf-8');
+}
+
+describe('countInteractiveBlocks', () => {
+  it('returns 0 for a markdown-only guide', () => {
+    const json = loadFixture('markdown-only');
+    expect(countInteractiveBlocks(JSON.parse(json))).toBe(0);
+  });
+
+  it('returns the correct count for a guide with interactive steps', () => {
+    const json = loadFixture('always-passes');
+    // always-passes has 2 interactive blocks nested inside a section
+    expect(countInteractiveBlocks(JSON.parse(json))).toBe(2);
+  });
+
+  it('counts interactive blocks nested inside conditional whenTrue and whenFalse', () => {
+    const guide = {
+      blocks: [
+        {
+          type: 'conditional',
+          conditions: ['has-datasource:prometheus'],
+          whenTrue: [{ type: 'interactive', action: 'highlight', reftarget: '.a', content: '' }],
+          whenFalse: [{ type: 'interactive', action: 'button', reftarget: 'Set up', content: '' }],
+        },
+      ],
+    };
+    expect(countInteractiveBlocks(guide)).toBe(2);
+  });
+
+  it('counts interactive blocks nested inside assistant blocks', () => {
+    const guide = {
+      blocks: [
+        {
+          type: 'assistant',
+          blocks: [{ type: 'interactive', action: 'highlight', reftarget: '.b', content: '' }],
+        },
+      ],
+    };
+    expect(countInteractiveBlocks(guide)).toBe(1);
+  });
+
+  it('returns 0 for an empty blocks array', () => {
+    expect(countInteractiveBlocks({ blocks: [] })).toBe(0);
+  });
+});

--- a/tests/e2e-runner/utils/guide-runner/static-analysis.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/static-analysis.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for static guide content analysis.
  *
- * countDiscoverableSteps lets the runner determine before Playwright starts
+ * countInteractiveBlocks lets the runner determine before Playwright starts
  * whether a guide has any interactive steps to execute. Markdown-only guides
  * should produce a 0-step pass rather than timing out waiting for DOM elements.
  */
@@ -9,7 +9,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-import { countDiscoverableSteps } from './static-analysis';
+import { countInteractiveBlocks } from './static-analysis';
 
 const FIXTURES = join(__dirname, '../../fixtures');
 
@@ -17,30 +17,37 @@ function loadFixture(name: string): string {
   return readFileSync(join(FIXTURES, name, 'content.json'), 'utf-8');
 }
 
-describe('countDiscoverableSteps', () => {
+describe('countInteractiveBlocks', () => {
   it('returns 0 for a markdown-only guide', () => {
     const json = loadFixture('markdown-only');
-    expect(countDiscoverableSteps(JSON.parse(json))).toBe(0);
+    expect(countInteractiveBlocks(JSON.parse(json))).toBe(0);
   });
 
   it('returns the correct count for a guide with interactive steps', () => {
     const json = loadFixture('always-passes');
-    expect(countDiscoverableSteps(JSON.parse(json))).toBe(2);
+    expect(countInteractiveBlocks(JSON.parse(json))).toBe(2);
   });
 
-  it('counts all E2E-discoverable block types and excludes unsupported block types', () => {
+  it('counts every Pathfinder interactive block type', () => {
     const guide = {
       blocks: [
         { type: 'interactive' },
         { type: 'multistep' },
         { type: 'guided' },
+        { type: 'quiz' },
+        { type: 'input' },
         { type: 'code-block' },
         { type: 'terminal' },
         { type: 'terminal-connect' },
+        { type: 'challenge' },
         { type: 'grot-guide' },
       ],
     };
-    expect(countDiscoverableSteps(guide)).toBe(3);
+    expect(countInteractiveBlocks(guide)).toBe(10);
+  });
+
+  it('treats a surviving snippet reference as potentially interactive', () => {
+    expect(countInteractiveBlocks({ blocks: [{ type: 'snippet-ref' }] })).toBe(1);
   });
 
   it('counts interactive blocks nested inside conditional whenTrue and whenFalse', () => {
@@ -54,7 +61,7 @@ describe('countDiscoverableSteps', () => {
         },
       ],
     };
-    expect(countDiscoverableSteps(guide)).toBe(2);
+    expect(countInteractiveBlocks(guide)).toBe(2);
   });
 
   it('counts interactive blocks nested inside assistant blocks', () => {
@@ -66,17 +73,17 @@ describe('countDiscoverableSteps', () => {
         },
       ],
     };
-    expect(countDiscoverableSteps(guide)).toBe(1);
+    expect(countInteractiveBlocks(guide)).toBe(1);
   });
 
   it('returns 0 for an empty blocks array', () => {
-    expect(countDiscoverableSteps({ blocks: [] })).toBe(0);
+    expect(countInteractiveBlocks({ blocks: [] })).toBe(0);
   });
 
   it('returns 0 for null and malformed guide values', () => {
-    expect(countDiscoverableSteps(null)).toBe(0);
-    expect(countDiscoverableSteps(undefined)).toBe(0);
-    expect(countDiscoverableSteps('not-a-guide')).toBe(0);
+    expect(countInteractiveBlocks(null)).toBe(0);
+    expect(countInteractiveBlocks(undefined)).toBe(0);
+    expect(countInteractiveBlocks('not-a-guide')).toBe(0);
   });
 
   it('counts deeply nested mixed content', () => {
@@ -99,6 +106,6 @@ describe('countDiscoverableSteps', () => {
         },
       ],
     };
-    expect(countDiscoverableSteps(guide)).toBe(1);
+    expect(countInteractiveBlocks(guide)).toBe(2);
   });
 });

--- a/tests/e2e-runner/utils/guide-runner/static-analysis.ts
+++ b/tests/e2e-runner/utils/guide-runner/static-analysis.ts
@@ -1,22 +1,7 @@
-const INTERACTIVE_TYPES = new Set([
-  'interactive',
-  'multistep',
-  'guided',
-  'code-block',
-  'terminal',
-  'terminal-connect',
-  'grot-guide',
-]);
+const INTERACTIVE_TYPES = new Set(['interactive', 'multistep', 'guided']);
 
-/**
- * Count interactive blocks in a guide recursively.
- *
- * Walks the full nested block tree, including section, assistant, and
- * conditional containers (both whenTrue and whenFalse branches). The count
- * lets the runner skip the DOM wait entirely for markdown-only guides rather
- * than timing out after 15 s waiting for elements that never appear.
- */
-export function countInteractiveBlocks(guide: unknown): number {
+/** Count blocks discoverable through the runner's `interactive-step-*` selector. */
+export function countDiscoverableSteps(guide: unknown): number {
   let count = 0;
 
   function walk(node: unknown): void {

--- a/tests/e2e-runner/utils/guide-runner/static-analysis.ts
+++ b/tests/e2e-runner/utils/guide-runner/static-analysis.ts
@@ -1,7 +1,6 @@
-const INTERACTIVE_TYPES = new Set(['interactive', 'multistep', 'guided']);
+import { isInteractiveBlockType } from '../../../../src/constants/json-guide-classification';
 
-/** Count blocks discoverable through the runner's `interactive-step-*` selector. */
-export function countDiscoverableSteps(guide: unknown): number {
+export function countInteractiveBlocks(guide: unknown): number {
   let count = 0;
 
   function walk(node: unknown): void {
@@ -18,7 +17,7 @@ export function countDiscoverableSteps(guide: unknown): number {
 
     const block = node as Record<string, unknown>;
 
-    if (typeof block.type === 'string' && INTERACTIVE_TYPES.has(block.type)) {
+    if (isInteractiveBlockType(block.type) || block.type === 'snippet-ref') {
       count++;
     }
 

--- a/tests/e2e-runner/utils/guide-runner/static-analysis.ts
+++ b/tests/e2e-runner/utils/guide-runner/static-analysis.ts
@@ -1,0 +1,47 @@
+const INTERACTIVE_TYPES = new Set([
+  'interactive',
+  'multistep',
+  'guided',
+  'code-block',
+  'terminal',
+  'terminal-connect',
+  'grot-guide',
+]);
+
+/**
+ * Count interactive blocks in a guide recursively.
+ *
+ * Walks the full nested block tree, including section, assistant, and
+ * conditional containers (both whenTrue and whenFalse branches). The count
+ * lets the runner skip the DOM wait entirely for markdown-only guides rather
+ * than timing out after 15 s waiting for elements that never appear.
+ */
+export function countInteractiveBlocks(guide: unknown): number {
+  let count = 0;
+
+  function walk(node: unknown): void {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        walk(item);
+      }
+      return;
+    }
+
+    const block = node as Record<string, unknown>;
+
+    if (typeof block.type === 'string' && INTERACTIVE_TYPES.has(block.type)) {
+      count++;
+    }
+
+    walk(block.blocks);
+    walk(block.whenTrue);
+    walk(block.whenFalse);
+  }
+
+  walk(guide);
+  return count;
+}


### PR DESCRIPTION
## Summary

Guides with no interactive blocks (markdown, image, video only) previously caused the runner to wait 15 s for `[data-testid^="interactive-step-"]` elements that never appear, then exit without writing a results file. The CLI reported `infrastructure_error / REPORT_MISSING`, which cascaded into `SKIPPED_PREREQ` for every subsequent milestone with a hard dependency.

53% of the interactive-tutorials guide population (280 of 529) is markdown-only. This affected all learning path runs that include bookend milestones (business-value intros, end-journey wrap-ups).

## What to look at

- [`tests/e2e-runner/utils/guide-runner/static-analysis.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/d7eef6b0cab0a81e4b6a11e9cd7ed5f5e3c2e28e/tests/e2e-runner/utils/guide-runner/static-analysis.ts) — `countInteractiveBlocks()` walks the full nested block tree (section, conditional both branches, assistant) before Playwright starts.
- [`tests/e2e-runner/guide-runner.spec.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/d7eef6b0cab0a81e4b6a11e9cd7ed5f5e3c2e28e/tests/e2e-runner/guide-runner.spec.ts) — immediately after reading the guide JSON, check the count; if zero, write a passed result with 0 steps and return without touching the DOM wait or step-discovery path. Pre-flight checks (auth, plugin) still run.

## Why

The runner was designed for guides with at least one interactive step. Learning paths expose a large class of read-only milestone pages that are correct content but have no actionable steps. Failing them as infrastructure errors and blocking all downstream milestones is wrong; 0 steps passed is the correct outcome.

## How to verify

Run the CLI against any markdown-only milestone in a local learning path:

```bash
node dist/cli/cli/index.js e2e \
  --package /path/to/interactive-tutorials/alloy-configuration-basics-lj/configuration-file-anatomy \
  --tier local --output /tmp/result.json
```

Confirm the result is `outcome: "passed"` with `summary.total = 0` rather than `infrastructure_error / REPORT_MISSING`.

## Breaking changes

None. The fix is additive: guides with interactive steps follow the existing code path unchanged.
