### PR TITLE
fix(floating-panel): render Grafana overlays above the popped-out panel

### DIFF
--- a/docs/developer/constants/README.md
+++ b/docs/developer/constants/README.md
@@ -157,6 +157,7 @@ The constants directory is organized into specialized files that separate concer
 **Key Exports**:
 
 - `INTERACTIVE_Z_INDEX` - Object containing:
+  - `FLOATING_PANEL` - 1045 (popped-out guide panel; deliberately sits _below_ Grafana's overlay layer so menus, tooltips, and modals opened from within it stay on top — see the doc comment in `interactive-z-index.ts` and issue #1439)
   - `BLOCKING_OVERLAY` - 9999 (blocks interaction with specific elements)
   - `HIGHLIGHT_OUTLINE` - 9999 (visual highlight around target elements)
   - `COMMENT_BOX` - 10002 (explanation tooltips for interactive steps)
@@ -172,10 +173,10 @@ The constants directory is organized into specialized files that separate concer
 
 **Critical Dependencies**:
 
-- **Grafana UI**: Values must exceed Grafana's z-index ranges (modals, portals, tooltips up to ~2000)
+- **Grafana UI**: Interactive overlays must exceed Grafana's z-index ranges (modals, portals, tooltips up to ~2000); `FLOATING_PANEL` is the deliberate exception and sits below them
 - **Interactive Styles**: Must coordinate with other styling systems to prevent stacking context issues
 
-**Why It Exists**: Pathfinder runs as a Grafana plugin and must render interactive overlays above all Grafana UI elements (modals, navigation, tooltips). These intentionally high z-index values (9999+) ensure guides remain visible and functional regardless of Grafana's own UI state. Centralizing these values prevents z-index conflicts and makes stacking order explicit.
+**Why It Exists**: Pathfinder runs as a Grafana plugin and must render interactive overlays (highlights, blocking overlay, comment boxes) above all Grafana UI elements (modals, navigation, tooltips). These intentionally high z-index values (9999+) ensure guides remain visible and functional regardless of Grafana's own UI state. `FLOATING_PANEL` is the one exception — it portals into the shared Grafana portal container and must yield to Grafana's overlay layer, so it sits below it (see the doc comment in `interactive-z-index.ts`). Centralizing these values prevents z-index conflicts and makes stacking order explicit.
 
 ---
 

--- a/src/components/floating-panel/MinimizedPill.tsx
+++ b/src/components/floating-panel/MinimizedPill.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { Badge, useStyles2 } from '@grafana/ui';
 import { getFloatingPanelStyles } from './floating-panel.styles';
+import { INTERACTIVE_Z_INDEX } from '../../constants/interactive-z-index';
 import logoSvg from '../../img/logo.svg';
 
 export interface MinimizedPillProps {
@@ -66,7 +67,10 @@ export function MinimizedPill({ hasActiveGuide, stepProgress, onRestore }: Minim
   // No <Portal> needed — the parent (FloatingPanel) already renders
   // via createPortal into document.body
   return (
-    <div className={styles.pillWrapper} style={{ position: 'fixed', left: pos.x, top: pos.y, zIndex: 9990 }}>
+    <div
+      className={styles.pillWrapper}
+      style={{ position: 'fixed', left: pos.x, top: pos.y, zIndex: INTERACTIVE_Z_INDEX.FLOATING_PANEL }}
+    >
       <button
         className={`${styles.pill} ${hasActiveGuide ? styles.pillActive : ''}`}
         style={{ position: 'relative' }}

--- a/src/components/floating-panel/MinimizedPill.tsx
+++ b/src/components/floating-panel/MinimizedPill.tsx
@@ -64,8 +64,10 @@ export function MinimizedPill({ hasActiveGuide, stepProgress, onRestore }: Minim
     }
   }, [onRestore]);
 
-  // No <Portal> needed — the parent (FloatingPanel) already renders
-  // via createPortal into document.body
+  // No <Portal> needed — the parent (FloatingPanel) already portals this into
+  // Grafana's shared portal container (getPortalContainer), which is
+  // position: fixed; z-index: 1061, so the pill clears app chrome regardless of
+  // its own z-index value.
   return (
     <div
       className={styles.pillWrapper}

--- a/src/constants/interactive-z-index.test.ts
+++ b/src/constants/interactive-z-index.test.ts
@@ -1,0 +1,30 @@
+import { createTheme } from '@grafana/data';
+import { INTERACTIVE_Z_INDEX } from './interactive-z-index';
+
+// Regression guard for #1439: the floating panel portals into the shared
+// `#grafana-portal-container`, so it stacks as a sibling of every Grafana
+// Dropdown/Menu/Tooltip/Modal. If its z-index is above Grafana's overlay layer,
+// menus and modals opened from within the popped-out panel render behind it and
+// become unusable. It must sit below the overlay band but above app chrome.
+describe('INTERACTIVE_Z_INDEX floating panel layering', () => {
+  const { zIndex } = createTheme();
+
+  it('keeps the floating panel below every Grafana overlay layer', () => {
+    expect(INTERACTIVE_Z_INDEX.FLOATING_PANEL).toBeLessThan(zIndex.portal);
+    expect(INTERACTIVE_Z_INDEX.FLOATING_PANEL).toBeLessThan(zIndex.modal);
+    expect(INTERACTIVE_Z_INDEX.FLOATING_PANEL).toBeLessThan(zIndex.modalBackdrop);
+  });
+
+  it('keeps the floating panel above Grafana app chrome', () => {
+    expect(INTERACTIVE_Z_INDEX.FLOATING_PANEL).toBeGreaterThan(zIndex.navbarFixed);
+    expect(INTERACTIVE_Z_INDEX.FLOATING_PANEL).toBeGreaterThan(zIndex.sidemenu);
+  });
+
+  it('keeps interactive guide overlays above the panel and the Grafana overlay layer', () => {
+    // Highlights, blocking overlay and comment boxes are appended to document.body
+    // and must remain visible above both the panel and any Grafana overlay.
+    expect(INTERACTIVE_Z_INDEX.BLOCKING_OVERLAY).toBeGreaterThan(INTERACTIVE_Z_INDEX.FLOATING_PANEL);
+    expect(INTERACTIVE_Z_INDEX.COMMENT_BOX).toBeGreaterThan(zIndex.portal);
+    expect(INTERACTIVE_Z_INDEX.HIGHLIGHT_OUTLINE).toBeGreaterThan(zIndex.portal);
+  });
+});

--- a/src/constants/interactive-z-index.ts
+++ b/src/constants/interactive-z-index.ts
@@ -1,15 +1,28 @@
 /**
  * Z-Index constants for interactive overlays and highlights.
  *
- * IMPORTANT: These values are intentionally very high (9999+) because:
+ * IMPORTANT: The interactive overlays are intentionally very high (9999+) because:
  * 1. Pathfinder runs as a Grafana plugin and needs to appear above ALL Grafana UI
  * 2. Grafana's own z-index values (modals, portals, tooltips) range up to ~2000
  * 3. Interactive highlights/comments must be visible above everything for guides to work
  * 4. These elements are appended to document.body, outside the normal stacking context
+ *
+ * FLOATING_PANEL is the deliberate exception — see its note below.
  */
 export const INTERACTIVE_Z_INDEX = {
-  /** Floating panel for guide content — above Grafana UI, below interactive overlays */
-  FLOATING_PANEL: 9990,
+  /**
+   * Floating panel for guide content. Unlike the other constants, this must sit
+   * BELOW Grafana's overlay layer, not above it. The panel portals into the
+   * shared `#grafana-portal-container`, so it becomes a stacking-context sibling
+   * of every Grafana Dropdown/Menu/Tooltip/Modal — which portal at
+   * `theme.zIndex.portal` (1061) and `modal` (1060) / `modalBackdrop` (1050).
+   * A high value here (the old 9990) made overlays opened from within the panel —
+   * the header kebab, tooltips, the editor's own modals — render *behind* it and
+   * become unusable (#1439). 1045 keeps the panel above all Grafana app chrome
+   * (the container is already `position: fixed; z-index: 1061`) while letting any
+   * overlay it spawns stack above it.
+   */
+  FLOATING_PANEL: 1045,
   /** Overlay that blocks interaction with specific elements during guides */
   BLOCKING_OVERLAY: 9999,
   /** Visual highlight outline around target elements */


### PR DESCRIPTION
## Summary

When the guide editor is popped out into the floating panel, opening the header kebab ("More actions") menu — or any Grafana `Dropdown`, `Menu`, `Tooltip`, or `Modal` — rendered *behind* the floating panel, invisible and unusable (#1439). Root cause: the panel portals into the shared `#grafana-portal-container`, making it a stacking-context sibling of every Grafana overlay, but at `z-index: 9990` it out-stacked them all (Grafana's overlays cap at `theme.zIndex.portal` = 1061). The fix lowers `FLOATING_PANEL` to `1045` so the panel sits below Grafana's overlay/modal band while remaining above app chrome — fixing the entire overlay class in one constant, not just the kebab.

## What to look at

- **[`src/constants/interactive-z-index.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/374f0aa2b5bc23063e3a73ca585dcd95f9e5bb48/src/constants/interactive-z-index.ts)** — the load-bearing change: `FLOATING_PANEL: 9990 → 1045`. The value looks surprisingly low next to the neighbouring `9999+` constants; that's deliberate, and the doc comment explains why. Invariant to preserve: `FLOATING_PANEL` must stay **below** `theme.zIndex.portal`/`modal`/`modalBackdrop` (so overlays it spawns stack above it) yet **above** `navbarFixed`/`sidemenu`. The panel doesn't need a high value to float over the app — its portal container is already `position: fixed; z-index: 1061`, so any positive value clears app chrome. The interactive overlays (blocking/highlight/comment box) are unchanged: they're appended to `document.body` and stay above everything.
- **[`src/components/floating-panel/MinimizedPill.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/374f0aa2b5bc23063e3a73ca585dcd95f9e5bb48/src/components/floating-panel/MinimizedPill.tsx)** — the pill previously hardcoded `9990`; now references the same constant for a single source of truth, and its portal-container comment is corrected (it said `document.body`; it's actually `getPortalContainer()` — the distinction is why the fix works).
- **[`src/constants/interactive-z-index.test.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/374f0aa2b5bc23063e3a73ca585dcd95f9e5bb48/src/constants/interactive-z-index.test.ts)** — regression guard reading Grafana's *live* `createTheme().zIndex` values rather than hardcoding `1061`, so it keeps holding if Grafana renumbers its scale.

## Why

Three fix directions were on the table:

1. **Lower the panel below the overlay layer (chosen).** One constant, and it covers *every* Grafana overlay — dropdowns, menus, tooltips, and the editor's own modals — because they all portal at ≤1061. Minimal surface, no new plumbing.
2. **Pass `Dropdown root={panelEl}` so the menu portals inside the panel's subtree.** Rejected: it only fixes the kebab. Tooltips and the ~10 editor `Modal`s stay broken, so it fails the issue's explicit ask to cover dropdowns, menus, and tooltips generally. It also needs a panel-DOM ref threaded through several layers.
3. **Wrap menus in a custom `Portal` with a z-index above 9990.** Rejected: Grafana's `Dropdown` exposes `root` but not `zIndex`, so this means abandoning `Dropdown`; per-instance and doesn't generalize to tooltips.

**Deliberate tradeoff:** the floating panel now **yields** to Grafana overlays — a stray tooltip or modal from the underlying app could paint over it. For a guide panel that is correct (a modal owns focus by definition; the panel isn't a system-critical always-on-top layer), and it also fixes the latent case where the editor's *own* modals opened while popped out were hidden behind the panel.

## How to verify

1. Open the guide editor and pop it out into the floating panel.
2. Click the kebab ("More actions") button in the panel header — the menu now opens *in front of* the panel and every item is clickable. (Before: it opened behind and was unusable.)
3. Hover a header icon button — its tooltip renders above the panel.
4. From the kebab, open an editor modal (e.g. "Library" or "Create GitHub PR") — the modal and its backdrop cover the panel cleanly, rather than appearing behind it.
5. Confirm the panel still floats above dashboard content, and that running a guide still shows the highlight outline / "Show me / Do it" comment boxes *above* the panel (the interactive overlay layer is unchanged).

<details>
<summary>Live stacking order (low → high) from <code>createTheme().zIndex</code> + <code>INTERACTIVE_Z_INDEX</code></summary>

```text
1000  app chrome: navbarFixed
1020  app chrome: sidemenu
1045  >> FLOATING_PANEL (was 9990)
1050  overlay: modalBackdrop
1060  overlay: modal
1061  overlay: portal (Dropdown / Menu / Tooltip)
9999  guide: BLOCKING_OVERLAY
9999  guide: HIGHLIGHT_OUTLINE
10002 guide: COMMENT_BOX
```
The panel (1045) lands in the narrow gap between app chrome and Grafana's overlay band, with the guide-interactive overlays still on top.
</details>

## Breaking changes

None to any API, storage, or test contract. One intentional behavior change: the popped-out floating panel now stacks below Grafana overlays and modals instead of above them (see Why).

## Reversibility

Fully reversible — the fix is a single numeric constant plus a shared-constant tie-up. Reverting restores the prior stacking with no migration or persisted state involved.

Closes #1439

🤖 Generated with [Claude Code](https://claude.com/claude-code)
