### PR TITLE
fix(ci): resolve Go version from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
         if: steps.check-for-backend.outputs.has-backend == 'true'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
@@ -224,7 +224,7 @@ jobs:
         if: steps.check-for-backend.outputs.has-backend == 'true'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
 
       - name: Build backend
         if: steps.check-for-backend.outputs.has-backend == 'true'


### PR DESCRIPTION
## Summary

The backend `Build` job fails intermittently with `go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)`, which breaks mage before it can parse the magefiles.

Root cause: both backend jobs asked `actions/setup-go` for `go-version: '1.26'` with the default `check-latest: false`, so setup-go satisfies that range from whatever 1.26.x already sits in the runner's hosted tool cache. `go.mod` requires `go >= 1.26.5` — raised by the `grafana-plugin-sdk-go` v0.293.0 bump, whose own `go` directive is `1.26.5` — and setup-go pins `GOTOOLCHAIN=local`, so a runner cached at 1.26.4 can't self-upgrade and the build dies. Whether a run passes depends on the runner image, which is why `Build` failed while `Test backend` passed in the same run.

The fix switches both steps to `go-version-file: go.mod`, so setup-go installs exactly the version the module requires and tracks future bumps to the directive automatically.

## What to look at

- `.github/workflows/ci.yml` — the `Setup Go environment` step in both `test-backend` and `build`. Nothing else in the Go setup changes; the action SHA pin is untouched.

## Why not the alternatives

Hardcoding `go-version: '1.26.5'` works but needs manual upkeep every time renovate raises the directive. Setting `GOTOOLCHAIN=auto` would let Go download a toolchain at build time, paying that cost on every run and defeating setup-go's caching.

## How to verify

1. In this PR's CI run, open the `Setup Go environment` step of both `Build` and `Test backend`; confirm it reports `Setup go version spec 1.26.5` and does not fall back to 1.26.4.
2. Confirm `Build backend` (`mage buildAll`) and `Test backend` (`mage coverage`) both complete.

## Breaking changes

None. Workflow-only change, fully reversible.
