### PR TITLE
feat(docs-panel): show Dev Tools as a strip tab and lift overflow z-index

### DIFF
--- a/src/components/block-editor/BlockEditor.tab-chrome.test.tsx
+++ b/src/components/block-editor/BlockEditor.tab-chrome.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * The editor tab's strip title and badge are owned by the docs panel, which
+ * renders outside this component. These cover the two channels that keep them
+ * in sync: the `onGuideTitleChange` callback and the published chrome status.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { StorageKeys } from '../../lib/storage-keys';
+import type { JsonGuide } from './types';
+import { BlockEditor } from './BlockEditor';
+import { DEFAULT_GUIDE_METADATA } from './constants';
+import {
+  getEditorChromeStatus,
+  resetEditorChromeStatus,
+  subscribeEditorChromeStatus,
+  type EditorChromeStatus,
+} from './editor-chrome-status';
+
+function storeGuide(guide: JsonGuide) {
+  localStorage.setItem(
+    StorageKeys.BLOCK_EDITOR_STATE,
+    JSON.stringify({ guide, blockIds: [], savedAt: new Date().toISOString(), version: 2 })
+  );
+}
+
+describe('BlockEditor tab chrome', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetEditorChromeStatus();
+  });
+
+  it('reports the working guide title on mount and after a rename', () => {
+    const onGuideTitleChange = jest.fn();
+    render(<BlockEditor onGuideTitleChange={onGuideTitleChange} />);
+
+    expect(onGuideTitleChange).toHaveBeenCalledWith(DEFAULT_GUIDE_METADATA.title);
+
+    const titleInput = screen.getByLabelText('Guide title');
+    fireEvent.change(titleInput, { target: { value: 'Renamed guide' } });
+    fireEvent.blur(titleInput);
+
+    expect(onGuideTitleChange).toHaveBeenLastCalledWith('Renamed guide');
+  });
+
+  it.each(['Restored guide', DEFAULT_GUIDE_METADATA.title])(
+    'reports the restored title without publishing the pre-restore default first: %s',
+    (title) => {
+      storeGuide({ id: 'restored-guide', title, blocks: [] });
+      const onGuideTitleChange = jest.fn();
+
+      render(<BlockEditor onGuideTitleChange={onGuideTitleChange} />);
+
+      expect(onGuideTitleChange).toHaveBeenCalledTimes(1);
+      expect(onGuideTitleChange).toHaveBeenCalledWith(title);
+    }
+  );
+
+  it('still reports chrome when a malformed stored draft fails to restore', () => {
+    localStorage.setItem(
+      StorageKeys.BLOCK_EDITOR_STATE,
+      JSON.stringify({ guide: { id: 'broken-guide', title: 'Broken guide' }, version: 2 })
+    );
+    const onGuideTitleChange = jest.fn();
+
+    render(<BlockEditor onGuideTitleChange={onGuideTitleChange} />);
+
+    expect(onGuideTitleChange).toHaveBeenCalledWith(DEFAULT_GUIDE_METADATA.title);
+  });
+
+  it('never publishes a dirty status from the pre-restore default guide', () => {
+    const guide: JsonGuide = { id: 'tracked-guide', title: 'Tracked guide', blocks: [] };
+    storeGuide(guide);
+    localStorage.setItem(
+      StorageKeys.BLOCK_EDITOR_BACKEND_TRACKING,
+      JSON.stringify({
+        resourceName: 'tracked-guide',
+        backendStatus: 'draft',
+        lastPublishedJson: JSON.stringify(guide),
+      })
+    );
+    const published: EditorChromeStatus[] = [];
+    const unsubscribe = subscribeEditorChromeStatus(() => published.push(getEditorChromeStatus()));
+
+    render(<BlockEditor />);
+    unsubscribe();
+
+    expect(published.every((s) => !s.hasUnsyncedChanges)).toBe(true);
+  });
+
+  it('publishes an unsaved guide as not-saved so the strip badge reads Draft', () => {
+    render(<BlockEditor />);
+
+    expect(getEditorChromeStatus()).toEqual({ publishedStatus: 'not-saved', hasUnsyncedChanges: false });
+  });
+
+  it('wakes the strip after the unmount draft flush, not before', () => {
+    const guide: JsonGuide = { id: 'tracked-guide', title: 'Tracked guide', blocks: [] };
+    storeGuide(guide);
+    localStorage.setItem(
+      StorageKeys.BLOCK_EDITOR_BACKEND_TRACKING,
+      JSON.stringify({
+        resourceName: 'tracked-guide',
+        backendStatus: 'draft',
+        lastPublishedJson: JSON.stringify(guide),
+      })
+    );
+    const { unmount } = render(<BlockEditor />);
+
+    const titleInput = screen.getByLabelText('Guide title');
+    fireEvent.change(titleInput, { target: { value: 'Renamed guide' } });
+    fireEvent.blur(titleInput);
+
+    // The rename is still inside the auto-save debounce, so only the unmount
+    // flush can put it in storage before subscribers read the fallback.
+    const seen: EditorChromeStatus[] = [];
+    const unsubscribe = subscribeEditorChromeStatus(() => seen.push(getEditorChromeStatus()));
+    unmount();
+    unsubscribe();
+
+    expect(seen[seen.length - 1]).toEqual({ publishedStatus: 'draft', hasUnsyncedChanges: true });
+  });
+});

--- a/src/components/block-editor/BlockEditor.tsx
+++ b/src/components/block-editor/BlockEditor.tsx
@@ -24,6 +24,7 @@ import { useBackendSaveFlow } from './hooks/useBackendSaveFlow';
 import { useGuidePreviewProgress } from './hooks/useGuidePreviewProgress';
 import { isBackendApiAvailable } from '../../utils/fetchBackendGuides';
 import { getBlockEditorStyles } from './block-editor.styles';
+import { publishEditorChromeStatus, readStoredEditorGuide, resetEditorChromeStatus } from './editor-chrome-status';
 import { BlockFormModal } from './BlockFormModal';
 import { RecordModeOverlay } from './RecordModeOverlay';
 import { GuideLibraryModal } from './GuideLibraryModal';
@@ -46,30 +47,7 @@ import {
   findSectionNestedBlockByInstanceId,
   readNestedInstanceId,
 } from './nestedBlockInstanceId';
-
-/** Converts a guide title to a URL-safe kebab-case slug */
-function slugifyTitle(title: string): string {
-  return (
-    title
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-|-$/g, '')
-      .slice(0, 40) || 'guide'
-  );
-}
-
-/** Generates a unique guide ID from a title, avoiding collisions with existing resource names */
-function generateUniqueId(title: string, existingNames: string[]): string {
-  const base = slugifyTitle(title);
-  for (let i = 0; i < 20; i++) {
-    const suffix = Math.random().toString(36).slice(2, 6);
-    const candidate = `${base}-${suffix}`;
-    if (!existingNames.includes(candidate)) {
-      return candidate;
-    }
-  }
-  return `${base}-${Date.now().toString(36).slice(-6)}`;
-}
+import { generateUniqueId } from './utils/guide-id';
 
 /**
  * Apply an author note to a block. When `note` is empty/undefined the
@@ -94,6 +72,8 @@ export interface BlockEditorProps {
   onCopy?: (json: string) => void;
   /** Called when download is requested */
   onDownload?: (guide: JsonGuide) => void;
+  /** Called when the working guide title changes (tab chrome). */
+  onGuideTitleChange?: (title: string) => void;
 }
 
 /**
@@ -234,11 +214,15 @@ function isSamePreviewTarget(a: PreviewTarget, b: PreviewTarget): boolean {
   return false;
 }
 
-function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockEditorProps) {
+function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload, onGuideTitleChange }: BlockEditorProps) {
   const styles = useStyles2(getBlockEditorStyles);
   const editor = useBlockEditor({ initialGuide, onChange });
   const { state } = editor;
   const hasLoadedFromStorage = useRef(false);
+  // Tab chrome (title + status badge) renders outside this component, so it must
+  // not publish this render's default guide over a stored draft. Flipped by the
+  // restore below, or already open when there is nothing to restore.
+  const [isChromeReady, setIsChromeReady] = useState(() => Boolean(initialGuide) || !readStoredEditorGuide());
 
   // Block editor context - replaces window globals for section/conditional editing
   const { sectionContext, conditionalContext, setGuideLintResult } = useBlockEditorContext();
@@ -252,6 +236,14 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
   useEffect(() => {
     setGuideLintResult(guideLint);
   }, [guideLint, setGuideLintResult]);
+
+  // Keep the owning editor tab's title in sync with the working guide.
+  useEffect(() => {
+    if (!isChromeReady) {
+      return;
+    }
+    onGuideTitleChange?.(state.guide.title);
+  }, [state.guide.title, onGuideTitleChange, isChromeReady]);
 
   // Modal state - useModalManager handles metadata, newGuideConfirm, import, githubPr, tour
   const modals = useModalManager();
@@ -569,13 +561,20 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
     autoSave: true,
     autoSavePaused: isBlockFormOpen,
     onLoad: (savedGuide, savedBlockIds, savedViewMode, savedJsonModeState) => {
-      if (!hasLoadedFromStorage.current && !initialGuide) {
-        hasLoadedFromStorage.current = true;
-        editor.loadGuide(savedGuide, savedBlockIds, savedViewMode);
-        if (savedViewMode === 'json') {
-          jsonMode.restoreJsonMode(savedGuide, savedBlockIds, savedJsonModeState);
+      try {
+        if (!hasLoadedFromStorage.current && !initialGuide) {
+          hasLoadedFromStorage.current = true;
+          editor.loadGuide(savedGuide, savedBlockIds, savedViewMode);
+          if (savedViewMode === 'json') {
+            jsonMode.restoreJsonMode(savedGuide, savedBlockIds, savedJsonModeState);
+          }
+          editor.markSaved();
         }
-        editor.markSaved();
+      } finally {
+        // A stored guide missing its `blocks` array throws in `loadGuide`, and
+        // persistence swallows that. Unlock chrome regardless, or the tab title
+        // and badge stay frozen for the rest of the session.
+        setIsChromeReady(true);
       }
     },
     onSave: handlePersistenceSave,
@@ -635,6 +634,26 @@ function BlockEditorInner({ initialGuide, onChange, onCopy, onDownload }: BlockE
   // stable pieces (trackLoadedGuide is a []-stable useCallback; the others are
   // primitives) and depend on those instead.
   const { trackLoadedGuide, publishedStatus, hasUnsyncedChanges } = backendSaveFlow;
+
+  // Publish status to the tab strip, which renders outside this component and
+  // has no other view of the save/publish lifecycle.
+  useEffect(() => {
+    if (!isChromeReady) {
+      return;
+    }
+    publishEditorChromeStatus({ publishedStatus, hasUnsyncedChanges });
+  }, [publishedStatus, hasUnsyncedChanges, isChromeReady]);
+
+  // The strip outlives this component, so hand it back to the persisted
+  // fallback on unmount — otherwise it keeps a frozen badge until a remount.
+  // Declared after `useBlockPersistence` so React runs that hook's draft flush
+  // first and subscribers wake to the newest draft, not the pre-edit one.
+  useEffect(() => {
+    return () => {
+      resetEditorChromeStatus();
+    };
+  }, []);
+
   const handleLoadGuideFromBackend = useCallback(
     (guide: JsonGuide, resourceName: string) => {
       editor.loadGuide(guide);

--- a/src/components/block-editor/BlockEditorHeader.tsx
+++ b/src/components/block-editor/BlockEditorHeader.tsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import { Button, Badge, Icon, IconButton, Tooltip, useStyles2 } from '@grafana/ui';
 import type { ViewMode } from './types';
+import { editorStatusBadge } from './editor-chrome-status';
 import { testIds } from '../../constants/testIds';
 import { getHeaderStyles } from './header/header.styles';
 import { HeaderTitleRow } from './header/HeaderTitleRow';
@@ -126,31 +127,17 @@ export function BlockEditorHeader({
   const styles = useStyles2(getHeaderStyles);
 
   const backendBadge = () => {
-    // The label sits in a [data-badge-label] span so `previewStatusWrap` can hide
-    // it at narrow preview widths — the badge collapses to its colored icon while
-    // the Tooltip keeps the full text, so status never disappears at 320px.
-    const badge = (
-      text: string,
-      color: 'blue' | 'orange' | 'green',
-      icon: 'circle' | 'exclamation-triangle' | 'cloud-upload',
-      tip: string
-    ) => (
-      <Tooltip content={tip}>
+    // Labels come from the shared status module so this badge and the docs-panel
+    // tab badge can't drift. The label sits in a [data-badge-label] span so
+    // `previewStatusWrap` can hide it at narrow preview widths — the badge
+    // collapses to its colored icon while the Tooltip keeps the full text, so
+    // status never disappears at 320px.
+    const { text, color, icon, tooltip } = editorStatusBadge({ publishedStatus, hasUnsyncedChanges });
+    return (
+      <Tooltip content={tooltip}>
         <Badge text={<span data-badge-label>{text}</span>} color={color} icon={icon} />
       </Tooltip>
     );
-
-    if (publishedStatus === 'not-saved') {
-      return badge('Draft', 'blue', 'circle', 'Not yet saved to library');
-    }
-    if (publishedStatus === 'draft') {
-      return hasUnsyncedChanges
-        ? badge('Draft (modified)', 'orange', 'exclamation-triangle', 'Draft has unsaved changes')
-        : badge('Draft', 'blue', 'circle', 'Saved to library but not published to users');
-    }
-    return hasUnsyncedChanges
-      ? badge('Published (modified)', 'orange', 'exclamation-triangle', 'Published guide has unsaved changes')
-      : badge('Published', 'green', 'cloud-upload', 'Published and visible to users');
   };
 
   const localSaveIndicator = !isBackendAvailable && (

--- a/src/components/block-editor/constants.ts
+++ b/src/components/block-editor/constants.ts
@@ -6,6 +6,7 @@
 
 import { StorageKeys } from '../../lib/storage-keys';
 
+import { DEFAULT_GUIDE_TITLE } from './editor-chrome-status';
 import type { BlockType, BlockTypeMetadata } from './types';
 
 /**
@@ -224,7 +225,7 @@ export const BACKEND_TRACKING_STORAGE_KEY = StorageKeys.BLOCK_EDITOR_BACKEND_TRA
  */
 export const DEFAULT_GUIDE_METADATA = {
   id: 'new-guide',
-  title: 'New guide',
+  title: DEFAULT_GUIDE_TITLE,
 };
 
 /**

--- a/src/components/block-editor/editor-chrome-status.test.ts
+++ b/src/components/block-editor/editor-chrome-status.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the status shared by the editor header badge and the tab strip.
+ */
+
+import {
+  editorStatusBadge,
+  editorTabStatusBadge,
+  getEditorChromeStatus,
+  getEditorChromeStatusVersion,
+  publishEditorChromeStatus,
+  resetEditorChromeStatus,
+  subscribeEditorChromeStatus,
+} from './editor-chrome-status';
+
+const GUIDE = { id: 'g', title: 'My Guide', blocks: [{ type: 'markdown', content: 'hi' }] };
+
+function persist(tracking: Record<string, unknown>, guide: unknown = GUIDE) {
+  localStorage.setItem('pathfinder-block-editor-state', JSON.stringify({ guide }));
+  localStorage.setItem('pathfinder-block-editor-backend-tracking', JSON.stringify(tracking));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetEditorChromeStatus();
+});
+
+describe('badge derivation', () => {
+  it('labels the header badge by publish state and dirtiness', () => {
+    expect(editorStatusBadge({ publishedStatus: 'not-saved', hasUnsyncedChanges: false }).text).toBe('Draft');
+    expect(editorStatusBadge({ publishedStatus: 'draft', hasUnsyncedChanges: true }).text).toBe('Draft (modified)');
+    expect(editorStatusBadge({ publishedStatus: 'published', hasUnsyncedChanges: false }).text).toBe('Published');
+    expect(editorStatusBadge({ publishedStatus: 'published', hasUnsyncedChanges: true }).text).toBe(
+      'Published (modified)'
+    );
+  });
+
+  it('drops the "(modified)" suffix for the strip, which italicizes the title instead', () => {
+    expect(editorTabStatusBadge({ publishedStatus: 'draft', hasUnsyncedChanges: true })).toEqual({
+      text: 'Draft',
+      color: 'blue',
+      tooltip: 'Draft has unsaved changes',
+    });
+    expect(editorTabStatusBadge({ publishedStatus: 'published', hasUnsyncedChanges: true }).text).toBe('Published');
+  });
+});
+
+describe('published status', () => {
+  it('prefers what the mounted editor published over persisted state', () => {
+    persist({ resourceName: 'g', backendStatus: 'published', lastPublishedJson: JSON.stringify(GUIDE) });
+
+    publishEditorChromeStatus({ publishedStatus: 'draft', hasUnsyncedChanges: true });
+
+    expect(getEditorChromeStatus()).toEqual({ publishedStatus: 'draft', hasUnsyncedChanges: true });
+  });
+
+  it('notifies subscribers only when the status actually changes', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeEditorChromeStatus(listener);
+
+    publishEditorChromeStatus({ publishedStatus: 'draft', hasUnsyncedChanges: false });
+    const versionAfterFirst = getEditorChromeStatusVersion();
+    publishEditorChromeStatus({ publishedStatus: 'draft', hasUnsyncedChanges: false });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(getEditorChromeStatusVersion()).toBe(versionAfterFirst);
+
+    unsubscribe();
+    publishEditorChromeStatus({ publishedStatus: 'published', hasUnsyncedChanges: false });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('persisted fallback', () => {
+  it('reads not-saved when no backend tracking exists', () => {
+    expect(getEditorChromeStatus()).toEqual({ publishedStatus: 'not-saved', hasUnsyncedChanges: false });
+  });
+
+  it('reports the persisted publish state when the draft matches the last save', () => {
+    persist({ resourceName: 'g', backendStatus: 'published', lastPublishedJson: JSON.stringify(GUIDE) });
+
+    expect(getEditorChromeStatus()).toEqual({ publishedStatus: 'published', hasUnsyncedChanges: false });
+  });
+
+  it('flags unsynced changes when the persisted draft has diverged', () => {
+    persist(
+      { resourceName: 'g', backendStatus: 'draft', lastPublishedJson: JSON.stringify(GUIDE) },
+      { ...GUIDE, title: 'Renamed' }
+    );
+
+    expect(getEditorChromeStatus()).toEqual({ publishedStatus: 'draft', hasUnsyncedChanges: true });
+  });
+
+  it('treats a missing sync baseline as clean rather than guessing', () => {
+    persist({ resourceName: 'g', backendStatus: 'draft' });
+
+    expect(getEditorChromeStatus()).toEqual({ publishedStatus: 'draft', hasUnsyncedChanges: false });
+  });
+
+  it('flags a tracked guide with no local draft, since the editor opens empty', () => {
+    localStorage.setItem(
+      'pathfinder-block-editor-backend-tracking',
+      JSON.stringify({ resourceName: 'g', backendStatus: 'published', lastPublishedJson: JSON.stringify(GUIDE) })
+    );
+
+    expect(getEditorChromeStatus()).toEqual({ publishedStatus: 'published', hasUnsyncedChanges: true });
+  });
+
+  it('ignores malformed tracking data', () => {
+    localStorage.setItem('pathfinder-block-editor-backend-tracking', 'not json');
+
+    expect(getEditorChromeStatus()).toEqual({ publishedStatus: 'not-saved', hasUnsyncedChanges: false });
+  });
+});

--- a/src/components/block-editor/editor-chrome-status.ts
+++ b/src/components/block-editor/editor-chrome-status.ts
@@ -1,0 +1,190 @@
+/**
+ * Editor chrome shared with the docs panel: the default guide title and the
+ * publish/dirty status behind the header badge and the editor tab badge, so
+ * none of them can drift.
+ *
+ * The tab strip renders outside the editor — and stays rendered while the
+ * editor is unmounted — so status arrives two ways: the mounted editor
+ * publishes it on every change, and a localStorage fallback derives it from the
+ * persisted draft plus backend tracking for strips rendered before the editor
+ * has mounted (e.g. right after a page reload).
+ *
+ * Deliberately imports only `StorageKeys` (pure data) so the docs-panel main
+ * chunk doesn't pull in the lazy-loaded block-editor bundle.
+ */
+
+import { StorageKeys } from '../../lib/storage-keys';
+
+/**
+ * Title of an untouched guide. The docs panel labels the editor tab with this
+ * before the editor mounts, and `DEFAULT_GUIDE_METADATA` carries it afterwards;
+ * they have to match or the tab visibly re-cases itself on mount.
+ */
+export const DEFAULT_GUIDE_TITLE = 'New guide';
+
+export interface EditorChromeStatus {
+  /**
+   * Backend publish status:
+   * - 'not-saved': guide exists only in localStorage
+   * - 'draft': saved to library but not visible to users
+   * - 'published': visible in the docs panel Custom guides section
+   */
+  publishedStatus: 'not-saved' | 'draft' | 'published';
+  /** True when local content differs from the last backend save. */
+  hasUnsyncedChanges: boolean;
+}
+
+export interface EditorStatusBadge {
+  text: string;
+  color: 'blue' | 'orange' | 'green';
+  icon: 'circle' | 'exclamation-triangle' | 'cloud-upload';
+  tooltip: string;
+}
+
+const NOT_SAVED: EditorChromeStatus = { publishedStatus: 'not-saved', hasUnsyncedChanges: false };
+
+/** Header badge labels (Draft / Published, with optional "(modified)"). */
+export function editorStatusBadge({ publishedStatus, hasUnsyncedChanges }: EditorChromeStatus): EditorStatusBadge {
+  if (publishedStatus === 'not-saved') {
+    return { text: 'Draft', color: 'blue', icon: 'circle', tooltip: 'Not yet saved to library' };
+  }
+
+  if (publishedStatus === 'draft') {
+    return hasUnsyncedChanges
+      ? {
+          text: 'Draft (modified)',
+          color: 'orange',
+          icon: 'exclamation-triangle',
+          tooltip: 'Draft has unsaved changes',
+        }
+      : {
+          text: 'Draft',
+          color: 'blue',
+          icon: 'circle',
+          tooltip: 'Saved to library but not published to users',
+        };
+  }
+
+  return hasUnsyncedChanges
+    ? {
+        text: 'Published (modified)',
+        color: 'orange',
+        icon: 'exclamation-triangle',
+        tooltip: 'Published guide has unsaved changes',
+      }
+    : {
+        text: 'Published',
+        color: 'green',
+        icon: 'cloud-upload',
+        tooltip: 'Published and visible to users',
+      };
+}
+
+/** Tab-strip badge: Draft / Published only — "modified" is carried by the italic title. */
+export function editorTabStatusBadge(status: EditorChromeStatus): Omit<EditorStatusBadge, 'icon'> {
+  const full = editorStatusBadge(status);
+  if (status.publishedStatus === 'published') {
+    return { text: 'Published', color: 'green', tooltip: full.tooltip };
+  }
+  return { text: 'Draft', color: 'blue', tooltip: full.tooltip };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** The working guide as last auto-saved by the editor, or null when absent. */
+export function readStoredEditorGuide(): Record<string, unknown> | null {
+  try {
+    const raw = localStorage.getItem(StorageKeys.BLOCK_EDITOR_STATE);
+    if (!raw) {
+      return null;
+    }
+    const parsed: unknown = JSON.parse(raw);
+    return isRecord(parsed) && isRecord(parsed.guide) ? parsed.guide : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Status derived from persisted state, for strips rendered while the editor is
+ * unmounted. Mirrors `useBackendSaveFlow`: dirty needs a sync baseline, so no
+ * `lastPublishedJson` reads as clean rather than guessing — but with a baseline
+ * and no draft, mounting the editor yields the empty default guide, which never
+ * matches it, so report that divergence instead of a false clean badge.
+ */
+function readPersistedEditorChromeStatus(): EditorChromeStatus {
+  try {
+    const raw = localStorage.getItem(StorageKeys.BLOCK_EDITOR_BACKEND_TRACKING);
+    if (!raw) {
+      return NOT_SAVED;
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || typeof parsed.resourceName !== 'string' || parsed.resourceName.length === 0) {
+      return NOT_SAVED;
+    }
+
+    const publishedStatus = parsed.backendStatus === 'published' ? 'published' : 'draft';
+    if (typeof parsed.lastPublishedJson !== 'string') {
+      return { publishedStatus, hasUnsyncedChanges: false };
+    }
+
+    const guide = readStoredEditorGuide();
+    return {
+      publishedStatus,
+      hasUnsyncedChanges: !guide || JSON.stringify(guide) !== parsed.lastPublishedJson,
+    };
+  } catch {
+    return NOT_SAVED;
+  }
+}
+
+let liveStatus: EditorChromeStatus | null = null;
+let statusVersion = 0;
+const listeners = new Set<() => void>();
+
+function notifyListeners(): void {
+  statusVersion += 1;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** Called by the mounted editor whenever its derived status changes. */
+export function publishEditorChromeStatus(next: EditorChromeStatus): void {
+  if (
+    liveStatus &&
+    liveStatus.publishedStatus === next.publishedStatus &&
+    liveStatus.hasUnsyncedChanges === next.hasUnsyncedChanges
+  ) {
+    return;
+  }
+  liveStatus = next;
+  notifyListeners();
+}
+
+/** Drop the published status so reads fall back to persisted state. */
+export function resetEditorChromeStatus(): void {
+  if (!liveStatus) {
+    return;
+  }
+  liveStatus = null;
+  notifyListeners();
+}
+
+export function subscribeEditorChromeStatus(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Monotonic counter — the `useSyncExternalStore` snapshot for the tab strip. */
+export function getEditorChromeStatusVersion(): number {
+  return statusVersion;
+}
+
+export function getEditorChromeStatus(): EditorChromeStatus {
+  return liveStatus ?? readPersistedEditorChromeStatus();
+}

--- a/src/components/block-editor/hooks/useBackendSaveFlow.test.ts
+++ b/src/components/block-editor/hooks/useBackendSaveFlow.test.ts
@@ -101,6 +101,25 @@ describe('useBackendSaveFlow — performSaveDraft', () => {
     );
   });
 
+  it('mints a unique id when saving a guide still on the default placeholder', async () => {
+    const g = guide({ id: 'new-guide', title: 'New guide' });
+    const updateGuideMetadata = jest.fn();
+    const editor = { getGuide: () => g, updateGuideMetadata };
+    const backendGuides = makeBackendGuides({ guides: [makeGuideEntry('new-guide', 'Someone else’s new guide')] });
+
+    const { result } = renderHook(() => useBackendSaveFlow({ editor, backendGuides }));
+
+    await act(async () => {
+      await result.current.performSaveDraft();
+    });
+
+    const [savedGuide] = (backendGuides.saveGuide as jest.Mock).mock.calls[0]!;
+    expect(savedGuide.id).toMatch(/^new-guide-.+/);
+    expect(updateGuideMetadata).toHaveBeenCalledWith({ id: savedGuide.id });
+    // A minted id means no collision, so the overwrite prompt stays closed.
+    expect(result.current.confirmModal.isOpen).toBe(false);
+  });
+
   it('rejects an empty guide without calling saveGuide', async () => {
     const editor = { getGuide: () => guide({ blocks: [] }) };
     const backendGuides = makeBackendGuides();

--- a/src/components/block-editor/hooks/useBackendSaveFlow.ts
+++ b/src/components/block-editor/hooks/useBackendSaveFlow.ts
@@ -10,9 +10,10 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import type { JsonGuide } from '../types';
-import { BACKEND_TRACKING_STORAGE_KEY } from '../constants';
+import { BACKEND_TRACKING_STORAGE_KEY, DEFAULT_GUIDE_METADATA } from '../constants';
 import { logger } from '../../../lib/logging';
 import { notify } from '../notify';
+import { generateUniqueId } from '../utils/guide-id';
 
 /**
  * Normalize a guide id or title into a Kubernetes-style resource name:
@@ -46,6 +47,8 @@ function readBackendTracking(): { resourceName: string | null; lastPublishedJson
 /** Minimal interface for editor functionality needed by this hook. */
 export interface BackendSaveFlowEditorInterface {
   getGuide: () => JsonGuide;
+  /** Used to write back an id minted at save time. */
+  updateGuideMetadata?: (updates: Partial<{ id: string; title: string }>) => void;
 }
 
 /** A backend-tracked guide entry, as returned by useBackendGuides. */
@@ -226,11 +229,23 @@ export function useBackendSaveFlow({ editor, backendGuides }: UseBackendSaveFlow
   const orchestrateSave = useCallback(
     async (status: 'draft' | 'published') => {
       try {
-        const guide = editor.getGuide();
+        let guide = editor.getGuide();
 
         if (!guide.blocks || guide.blocks.length === 0) {
           notify('error', 'Cannot save guide', 'Add at least one block before saving.');
           return;
+        }
+
+        // Renaming mints an id, but a guide saved under the untouched default
+        // title still carries `new-guide` — and so would every other one, all
+        // resolving to the same resource name. Mint here instead.
+        if (guide.id === DEFAULT_GUIDE_METADATA.id) {
+          const id = generateUniqueId(
+            guide.title || guide.id,
+            backendGuides.guides.map((g) => g.metadata.name)
+          );
+          guide = { ...guide, id };
+          editor.updateGuideMetadata?.({ id });
         }
 
         const isUpdate = !!currentGuideResourceName;

--- a/src/components/block-editor/hooks/useBlockPersistence.test.ts
+++ b/src/components/block-editor/hooks/useBlockPersistence.test.ts
@@ -122,6 +122,35 @@ describe('useBlockPersistence — debounced auto-save', () => {
   });
 });
 
+describe('useBlockPersistence — unmount flush', () => {
+  it('writes the pending draft when the editor unmounts mid-debounce', () => {
+    const { rerender, unmount } = renderHook(({ g }) => useBlockPersistence({ guide: g }), {
+      initialProps: { g: guide('a') },
+    });
+
+    rerender({ g: guide('edited') });
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    unmount();
+
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!).guide.title).toBe('edited');
+  });
+
+  it('writes nothing on unmount when no save is pending', () => {
+    const { unmount } = renderHook(({ g }) => useBlockPersistence({ guide: g }), {
+      initialProps: { g: guide('a') },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    localStorage.clear();
+    unmount();
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
 describe('useBlockPersistence — mount-time restore via onLoad', () => {
   it('calls onLoad with stored guide AND blockIds when both are present', () => {
     localStorage.setItem(
@@ -162,6 +191,21 @@ describe('useBlockPersistence — mount-time restore via onLoad', () => {
 });
 
 describe('useBlockPersistence — clear()', () => {
+  it('cancels a pending write so it cannot resurrect the cleared guide', () => {
+    const { result, rerender, unmount } = renderHook(({ g }) => useBlockPersistence({ guide: g }), {
+      initialProps: { g: guide('a') },
+    });
+
+    rerender({ g: guide('edited') });
+    act(() => result.current.clear());
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    unmount();
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
   it('clear() removes the storage key, and a subsequent mount finds nothing to restore', () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ guide: guide('a'), savedAt: '', version: 2 }));
     const { result } = renderHook(() => useBlockPersistence({ guide: guide('a') }));

--- a/src/components/block-editor/hooks/useBlockPersistence.ts
+++ b/src/components/block-editor/hooks/useBlockPersistence.ts
@@ -2,6 +2,7 @@
  * useBlockPersistence Hook
  *
  * Auto-save and restore functionality for the block editor using localStorage.
+ * Guide content writes are debounced; unmount flushes anything still pending.
  */
 
 import { useEffect, useCallback, useRef } from 'react';
@@ -106,6 +107,7 @@ export function useBlockPersistence({
   storageKey = BLOCK_EDITOR_STORAGE_KEY,
 }: UseBlockPersistenceOptions): UseBlockPersistenceReturn {
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingSaveRef = useRef(false);
   const lastGuideRef = useRef<string>('');
   const lastViewModeRef = useRef<ViewMode | undefined>(viewMode);
   const lastJsonModeStateRef = useRef<JsonModeState | null | undefined>(jsonModeState);
@@ -122,20 +124,52 @@ export function useBlockPersistence({
       };
       localStorage.setItem(storageKey, JSON.stringify(stored));
       lastGuideRef.current = JSON.stringify(guide);
+      pendingSaveRef.current = false;
       onSave?.();
     } catch (e) {
       logger.error('Failed to save guide to localStorage', { error: e });
     }
   }, [guide, blockIds, viewMode, jsonModeState, storageKey, onSave]);
 
+  // The debounced timeout closes over the `save` from the render that scheduled
+  // it; flushing must use the newest one so it writes the latest edit.
+  const latestSaveRef = useRef(save);
+  useEffect(() => {
+    latestSaveRef.current = save;
+  }, [save]);
+
+  const flush = useCallback(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+      saveTimeoutRef.current = null;
+    }
+    if (pendingSaveRef.current) {
+      latestSaveRef.current();
+    }
+  }, []);
+
   const clear = useCallback(() => {
     try {
+      // Drop the pending write too, or it would resurrect the guide we just removed.
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
+      }
+      pendingSaveRef.current = false;
       localStorage.removeItem(storageKey);
       lastGuideRef.current = '';
     } catch (e) {
       logger.error('Failed to clear guide from localStorage', { error: e });
     }
   }, [storageKey]);
+
+  // Switching tabs or handing off between surfaces unmounts the editor within
+  // the debounce window — write the pending draft instead of dropping it.
+  useEffect(() => {
+    return () => {
+      flush();
+    };
+  }, [flush]);
 
   useEffect(() => {
     if (!autoSave || autoSavePaused) {
@@ -145,6 +179,7 @@ export function useBlockPersistence({
     const currentGuideStr = JSON.stringify(guide);
 
     if (currentGuideStr === lastGuideRef.current) {
+      pendingSaveRef.current = false;
       onSave?.();
       return;
     }
@@ -153,13 +188,16 @@ export function useBlockPersistence({
       clearTimeout(saveTimeoutRef.current);
     }
 
+    pendingSaveRef.current = true;
     saveTimeoutRef.current = setTimeout(() => {
+      saveTimeoutRef.current = null;
       save();
     }, AUTO_SAVE_DELAY);
 
     return () => {
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
       }
     };
   }, [guide, autoSave, autoSavePaused, save, onSave]);

--- a/src/components/block-editor/utils/guide-id.ts
+++ b/src/components/block-editor/utils/guide-id.ts
@@ -1,0 +1,32 @@
+/**
+ * Guide ID derivation.
+ *
+ * The ID is what `toResourceName` turns into the backend resource name, so two
+ * guides that share an ID collide in the library. Both places that can leave a
+ * guide on the default placeholder — the title commit and the first save — mint
+ * through here.
+ */
+
+/** Converts a guide title to a URL-safe kebab-case slug. */
+export function slugifyTitle(title: string): string {
+  return (
+    title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 40) || 'guide'
+  );
+}
+
+/** Generates a unique guide ID from a title, avoiding collisions with existing resource names. */
+export function generateUniqueId(title: string, existingNames: string[] = []): string {
+  const base = slugifyTitle(title);
+  for (let i = 0; i < 20; i++) {
+    const suffix = Math.random().toString(36).slice(2, 6);
+    const candidate = `${base}-${suffix}`;
+    if (!existingNames.includes(candidate)) {
+      return candidate;
+    }
+  }
+  return `${base}-${Date.now().toString(36).slice(-6)}`;
+}

--- a/src/components/docs-panel/components/DocsPanelContentArea.tsx
+++ b/src/components/docs-panel/components/DocsPanelContentArea.tsx
@@ -128,6 +128,8 @@ export function DocsPanelContentArea(props: DocsPanelContentAreaProps): React.Re
   const pluginContext = usePluginContext();
   const twoTabControllerEnabled = getConfigWithDefaults(pluginContext?.meta?.jsonData || {}).enableTwoTabController;
 
+  const handleGuideTitleChange = React.useCallback((title: string) => model.updateEditorTabTitle(title), [model]);
+
   return (
     <div className={styles.content} data-testid={testIds.docsPanel.content}>
       {(() => {
@@ -167,7 +169,7 @@ export function DocsPanelContentArea(props: DocsPanelContentAreaProps): React.Re
           return (
             <div className={styles.devToolsContent} data-testid="editor-tab-content">
               <Suspense fallback={<SkeletonLoader type="recommendations" />}>
-                <BlockEditor />
+                <BlockEditor onGuideTitleChange={handleGuideTitleChange} />
               </Suspense>
             </div>
           );

--- a/src/components/docs-panel/components/DocsPanelTabBar.test.tsx
+++ b/src/components/docs-panel/components/DocsPanelTabBar.test.tsx
@@ -2,9 +2,15 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DocsPanelTabBar, type DocsPanelTabBarProps } from './DocsPanelTabBar';
 import { testIds } from '../../../constants/testIds';
+import { publishEditorChromeStatus, resetEditorChromeStatus } from '../../block-editor/editor-chrome-status';
 
 jest.mock('@grafana/i18n', () => ({
-  t: (_key: string, fallback: string) => fallback,
+  t: (_key: string, fallback: string, values?: Record<string, string>) => {
+    if (!values) {
+      return fallback;
+    }
+    return fallback.replace(/\{\{(\w+)\}\}/g, (_, name: string) => values[name] ?? '');
+  },
 }));
 
 jest.mock('@grafana/runtime', () => {
@@ -76,6 +82,8 @@ function makeProps(overrides: Partial<DocsPanelTabBarProps> = {}): DocsPanelTabB
 describe('DocsPanelTabBar', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    localStorage.clear();
+    resetEditorChromeStatus();
   });
 
   it('navigates to the My Learning page when the "My learning" button is clicked', () => {
@@ -93,6 +101,63 @@ describe('DocsPanelTabBar', () => {
   it('renders the "Interactive Learning" wordmark', () => {
     render(<DocsPanelTabBar {...makeProps()} />);
     expect(screen.getByText('Interactive Learning')).toBeInTheDocument();
+  });
+
+  describe('editor tab status badge', () => {
+    const editorTab: any = {
+      id: 'editor',
+      type: 'editor',
+      title: 'My Guide',
+      baseUrl: '',
+      currentUrl: '',
+      isLoading: false,
+    };
+
+    function renderWithEditor() {
+      const recommendationsTab: any = {
+        id: 'recommendations',
+        type: 'recommendations',
+        title: 'Recommendations',
+        baseUrl: '',
+        currentUrl: '',
+      };
+      render(
+        <DocsPanelTabBar
+          {...makeProps({
+            visibleTabs: [recommendationsTab, editorTab],
+            activeTabId: 'editor',
+            activeTab: editorTab,
+          })}
+        />
+      );
+    }
+
+    it('keeps the Draft badge and italicizes the title when a draft has diverged', () => {
+      publishEditorChromeStatus({ publishedStatus: 'draft', hasUnsyncedChanges: true });
+      renderWithEditor();
+
+      expect(screen.getByText('Draft')).toBeInTheDocument();
+      expect(screen.queryByText('Draft (modified)')).not.toBeInTheDocument();
+      expect(screen.getByText('My Guide').className).toContain('editorTabTitleModified');
+    });
+
+    it('derives status from persisted state before the editor has mounted', () => {
+      const guide = { id: 'g', title: 'My Guide', blocks: [{ type: 'markdown', content: 'hi' }] };
+      localStorage.setItem('pathfinder-block-editor-state', JSON.stringify({ guide }));
+      localStorage.setItem(
+        'pathfinder-block-editor-backend-tracking',
+        JSON.stringify({
+          resourceName: 'g',
+          backendStatus: 'published',
+          lastPublishedJson: JSON.stringify(guide),
+        })
+      );
+
+      renderWithEditor();
+
+      expect(screen.getByText('Published')).toBeInTheDocument();
+      expect(screen.getByText('My Guide').className).not.toContain('editorTabTitleModified');
+    });
   });
 
   describe('overflow chevron', () => {

--- a/src/components/docs-panel/components/DocsPanelTabBar.tsx
+++ b/src/components/docs-panel/components/DocsPanelTabBar.tsx
@@ -12,7 +12,7 @@
  * extraction moves the relevant references from docs-panel.tsx to this
  * file's entry in SOURCE_CONTRACT (updated in the same commit).
  */
-import React from 'react';
+import React, { useSyncExternalStore } from 'react';
 import { Icon, IconButton, Badge } from '@grafana/ui';
 import { t } from '@grafana/i18n';
 import type { LearningJourneyTab } from '../../../types/content-panel.types';
@@ -29,6 +29,13 @@ import {
   tabTypeToContentType,
 } from '../../../lib/analytics';
 import { getJourneyProgress } from '../../../docs-retrieval';
+import {
+  getEditorChromeStatus,
+  getEditorChromeStatusVersion,
+  subscribeEditorChromeStatus,
+  editorTabStatusBadge,
+  type EditorChromeStatus,
+} from '../../block-editor/editor-chrome-status';
 
 export interface DocsPanelTabBarProps {
   styles: DocsPanelStyles;
@@ -53,6 +60,11 @@ export interface DocsPanelTabBarProps {
   onOpenDevToolsTab: () => void;
 }
 
+/** Italics alone can't carry meaning, so the native tooltip spells it out. */
+function editorTabTooltip(title: string, status: EditorChromeStatus): string {
+  return status.hasUnsyncedChanges ? t('docsPanel.editorTabModified', '{{title}} — modified', { title }) : title;
+}
+
 export function DocsPanelTabBar({
   styles,
   activeTabId,
@@ -74,9 +86,13 @@ export function DocsPanelTabBar({
   onOpenEditorTab,
   onOpenDevToolsTab,
 }: DocsPanelTabBarProps): React.ReactElement {
-  // visibleTabs may still include strip-excluded chrome (recs, Dev Tools) on
-  // computeTabVisibility early returns; keep those out of the guide list.
+  // visibleTabs may still include recommendations on computeTabVisibility early
+  // returns; keep that rail-only chrome out of the guide list.
   const guideTabs = getGuideStripTabs(visibleTabs);
+
+  // One subscription for the whole strip: per-tab status is then a plain read,
+  // so an overflowed editor tab re-renders on draft/publish changes too.
+  useSyncExternalStore(subscribeEditorChromeStatus, getEditorChromeStatusVersion);
 
   return (
     <div className={styles.tabBar} ref={tabBarRef} data-testid={testIds.docsPanel.tabBar}>
@@ -99,23 +115,28 @@ export function DocsPanelTabBar({
 
       <div className={styles.tabList} ref={tabListRef} data-testid={testIds.docsPanel.tabList}>
         {guideTabs.map((tab) => {
+          const editorStatus = tab.type === 'editor' ? getEditorChromeStatus() : null;
+          const editorBadge = editorStatus ? editorTabStatusBadge(editorStatus) : null;
+          const modified = editorStatus?.hasUnsyncedChanges ? ` ${styles.editorTabTitleModified}` : '';
           return (
             <button
               key={tab.id}
               className={`${styles.tab} ${tab.id === activeTabId ? styles.activeTab : ''}`}
               onClick={() => onSetActiveTab(tab.id)}
-              title={getTranslatedTitle(tab.title)}
+              title={
+                editorStatus
+                  ? editorTabTooltip(getTranslatedTitle(tab.title), editorStatus)
+                  : getTranslatedTitle(tab.title)
+              }
               data-testid={testIds.docsPanel.tab(tab.id)}
             >
               <div className={styles.tabContent}>
-                {tab.type === 'editor' && !tab.isLoading && (
-                  <Badge
-                    text={t('docsPanel.editorDraftBadge', 'Draft')}
-                    color="orange"
-                    className={styles.editorTabDraftBadge}
-                  />
+                {editorBadge && !tab.isLoading && (
+                  <Badge text={editorBadge.text} color={editorBadge.color} className={styles.editorTabStatusBadge} />
                 )}
-                <span className={`${styles.tabTitle}${tab.type === 'editor' ? ` ${styles.editorTabTitle}` : ''}`}>
+                <span
+                  className={`${styles.tabTitle}${tab.type === 'editor' ? ` ${styles.editorTabTitle}` : ''}${modified}`}
+                >
                   {tab.isLoading ? (
                     <>
                       <Icon name="sync" size="xs" />
@@ -192,6 +213,9 @@ export function DocsPanelTabBar({
           data-testid={testIds.docsPanel.tabDropdown}
         >
           {overflowGuideTabs.map((tab) => {
+            const editorStatus = tab.type === 'editor' ? getEditorChromeStatus() : null;
+            const editorBadge = editorStatus ? editorTabStatusBadge(editorStatus) : null;
+            const modified = editorStatus?.hasUnsyncedChanges ? ` ${styles.editorTabTitleModified}` : '';
             return (
               <button
                 key={tab.id}
@@ -201,23 +225,20 @@ export function DocsPanelTabBar({
                   setIsDropdownOpen(false);
                 }}
                 role="menuitem"
+                title={editorStatus ? editorTabTooltip(getTranslatedTitle(tab.title), editorStatus) : undefined}
                 aria-label={t('docsPanel.switchToTab', 'Switch to {{title}}', {
                   title: getTranslatedTitle(tab.title),
                 })}
                 data-testid={testIds.docsPanel.tabDropdownItem(tab.id)}
               >
                 <div className={styles.dropdownItemContent}>
-                  {tab.type === 'editor' && !tab.isLoading && (
-                    <Badge
-                      text={t('docsPanel.editorDraftBadge', 'Draft')}
-                      color="orange"
-                      className={styles.editorTabDraftBadge}
-                    />
+                  {editorBadge && !tab.isLoading && (
+                    <Badge text={editorBadge.text} color={editorBadge.color} className={styles.editorTabStatusBadge} />
                   )}
                   <span
                     className={`${styles.dropdownItemTitle}${
                       tab.type === 'editor' ? ` ${styles.editorDropdownItemTitle}` : ''
-                    }`}
+                    }${modified}`}
                   >
                     {tab.isLoading ? (
                       <>

--- a/src/components/docs-panel/docs-panel.close-tab.test.ts
+++ b/src/components/docs-panel/docs-panel.close-tab.test.ts
@@ -1,10 +1,9 @@
 /**
  * Tests for CombinedLearningJourneyPanel.closeTab focus adjacency.
  *
- * The panel's `tabs` array is wider than the rendered strip: Dev Tools lives in
- * tab state for routing but claims no strip slot. Adjacency must therefore walk
- * strip-visible tabs, otherwise closing a guide can hand focus to Dev Tools and
- * leave no visible tab marked active.
+ * Recommendations uses the left-rail icon (not a strip slot). Adjacency walks
+ * strip-visible tabs via getGuideStripTabs, otherwise focus can land on a tab
+ * with no visible active marker.
  */
 
 // ---------------------------------------------------------------------------
@@ -272,21 +271,21 @@ describe('CombinedLearningJourneyPanel.closeTab — focus adjacency', () => {
     jest.clearAllMocks();
   });
 
-  it('skips Dev Tools when inheriting focus from the tab on the right', () => {
+  it('inherits the strip tab on the right, including Dev Tools', () => {
     // Open order: guide, Dev Tools, editor.
     const panel = panelWith([RECOMMENDATIONS, tab('guide-1', 'learning-journey'), DEVTOOLS, EDITOR], 'guide-1');
 
     panel.closeTab('guide-1');
 
-    expect(stateOf(panel)).toEqual({ tabIds: ['recommendations', 'devtools', 'editor'], activeTabId: 'editor' });
+    expect(stateOf(panel)).toEqual({ tabIds: ['recommendations', 'devtools', 'editor'], activeTabId: 'devtools' });
   });
 
-  it('falls back to recommendations when the last strip tab closes while Dev Tools remains', () => {
-    const panel = panelWith([RECOMMENDATIONS, DEVTOOLS, tab('guide-1', 'learning-journey')], 'guide-1');
+  it('falls back to recommendations when the last strip tab closes', () => {
+    const panel = panelWith([RECOMMENDATIONS, tab('guide-1', 'learning-journey')], 'guide-1');
 
     panel.closeTab('guide-1');
 
-    expect(stateOf(panel)).toEqual({ tabIds: ['recommendations', 'devtools'], activeTabId: 'recommendations' });
+    expect(stateOf(panel)).toEqual({ tabIds: ['recommendations'], activeTabId: 'recommendations' });
   });
 
   it('leaves focus alone when a background tab closes', () => {
@@ -299,7 +298,7 @@ describe('CombinedLearningJourneyPanel.closeTab — focus adjacency', () => {
     expect(stateOf(panel)).toEqual({ tabIds: ['recommendations', 'devtools'], activeTabId: 'devtools' });
   });
 
-  it('inherits the last strip tab when the active strip-excluded tab is closed via Ctrl+W', () => {
+  it('inherits the previous strip tab when the active last strip tab closes', () => {
     const panel = panelWith(
       [RECOMMENDATIONS, tab('guide-1', 'learning-journey'), tab('guide-2', 'learning-journey'), DEVTOOLS],
       'devtools'

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -93,6 +93,7 @@ import {
   didGateClose,
   type TabGates,
 } from './utils';
+import { DEFAULT_GUIDE_TITLE } from '../block-editor/editor-chrome-status';
 // Import extracted hooks
 import {
   useBadgeCelebrationQueue,
@@ -753,7 +754,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
 
     const newTab: LearningJourneyTab = {
       id: EDITOR_TAB_ID,
-      title: 'New Guide',
+      title: DEFAULT_GUIDE_TITLE,
       baseUrl: '',
       currentUrl: '',
       content: null,
@@ -767,6 +768,20 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       activeTabId: EDITOR_TAB_ID,
     });
 
+    this.saveTabsToStorage();
+  }
+
+  /** Update the editor tab's strip title from the working guide. */
+  public updateEditorTabTitle(title: string): void {
+    const trimmed = title.trim() || DEFAULT_GUIDE_TITLE;
+    const editorTab = this.state.tabs.find((t) => t.id === EDITOR_TAB_ID);
+    if (!editorTab || editorTab.title === trimmed) {
+      return;
+    }
+
+    this.setState({
+      tabs: this.state.tabs.map((t) => (t.id === EDITOR_TAB_ID ? { ...t, title: trimmed } : t)),
+    });
     this.saveTabsToStorage();
   }
 

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -629,13 +629,14 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     let newActiveTabId = this.state.activeTabId;
 
     // Closing a background tab must not move focus — the user may be sitting on
-    // a strip-excluded view (Dev Tools) and closing a guide from the overflow menu.
+    // another tab and closing a guide from the overflow menu.
     if (this.state.activeTabId === tabId) {
-      // Adjacency walks the rendered strip, not raw tab state: strip-excluded
-      // chrome holds no slot, so handing it focus would leave no visible tab
-      // marked active. A strip-excluded tab closed via Ctrl+W has no neighbours
-      // of its own, so it inherits the last strip tab instead of sending the
-      // user home to re-navigate. Recommendations is the empty-strip fallback.
+      // Adjacency walks the rendered strip, not raw tab state: the
+      // recommendations rail holds no strip slot, so handing it focus would
+      // leave no visible tab marked active. A tab outside the strip closed via
+      // Ctrl+W has no neighbours of its own, so it inherits the last strip tab
+      // instead of sending the user home. Recommendations is the empty-strip
+      // fallback.
       const stripTabs = getGuideStripTabs(currentTabs);
       const closedIndex = stripTabs.findIndex((t) => t.id === tabId);
       const replacement =
@@ -710,7 +711,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
 
   /**
    * Open the Dev Tools view (or switch to it if already open).
-   * Singleton lives in tab state for routing but is excluded from the guide strip.
+   * Singleton strip tab opened from the overflow menu when Dev Mode is on.
    */
   public openDevToolsTab(): void {
     const existingTab = this.state.tabs.find((t) => t.id === DEVTOOLS_TAB_ID);

--- a/src/components/docs-panel/keyboard-shortcuts.hook.test.ts
+++ b/src/components/docs-panel/keyboard-shortcuts.hook.test.ts
@@ -88,7 +88,7 @@ describe('useKeyboardShortcuts', () => {
     expect(mockModel.setActiveTab).toHaveBeenCalledWith('recommendations');
   });
 
-  it('should skip Dev Tools when cycling with Ctrl+Tab', () => {
+  it('should include Dev Tools when cycling with Ctrl+Tab', () => {
     const tabsWithDevTools = [
       {
         id: 'recommendations',
@@ -109,64 +109,24 @@ describe('useKeyboardShortcuts', () => {
         error: null,
       },
       { id: 'tab1', type: 'docs', title: 'Tab 1', baseUrl: '', content: null, isLoading: false, error: null },
-      { id: 'tab2', type: 'docs', title: 'Tab 2', baseUrl: '', content: null, isLoading: false, error: null },
     ] as LearningJourneyTab[];
 
     renderHook(() =>
       useKeyboardShortcuts({
         tabs: tabsWithDevTools,
-        activeTabId: 'tab1',
-        activeTab: tabsWithDevTools[2]!,
-        isRecommendationsTab: false,
+        activeTabId: 'recommendations',
+        activeTab: tabsWithDevTools[0]!,
+        isRecommendationsTab: true,
         model: mockModel,
       })
     );
 
     fireEvent.keyDown(document, { key: 'Tab', ctrlKey: true });
-    expect(mockModel.setActiveTab).toHaveBeenCalledWith('tab2');
-    expect(mockModel.setActiveTab).not.toHaveBeenCalledWith('devtools');
+    expect(mockModel.setActiveTab).toHaveBeenCalledWith('devtools');
 
     mockModel.setActiveTab.mockClear();
     fireEvent.keyDown(document, { key: 'Tab', ctrlKey: true, shiftKey: true });
-    // From tab1 backward → recommendations, skipping Dev Tools between them.
-    expect(mockModel.setActiveTab).toHaveBeenCalledWith('recommendations');
-  });
-
-  it('should leave Dev Tools via Ctrl+Tab onto a focusable tab', () => {
-    const tabsWithDevTools = [
-      {
-        id: 'recommendations',
-        type: 'recommendations',
-        title: 'Recommendations',
-        baseUrl: '',
-        content: null,
-        isLoading: false,
-        error: null,
-      },
-      {
-        id: 'devtools',
-        type: 'devtools',
-        title: 'Dev Tools',
-        baseUrl: '',
-        content: null,
-        isLoading: false,
-        error: null,
-      },
-      { id: 'tab1', type: 'docs', title: 'Tab 1', baseUrl: '', content: null, isLoading: false, error: null },
-    ] as LearningJourneyTab[];
-
-    renderHook(() =>
-      useKeyboardShortcuts({
-        tabs: tabsWithDevTools,
-        activeTabId: 'devtools',
-        activeTab: tabsWithDevTools[1]!,
-        isRecommendationsTab: false,
-        model: mockModel,
-      })
-    );
-
-    fireEvent.keyDown(document, { key: 'Tab', ctrlKey: true });
-    expect(mockModel.setActiveTab).toHaveBeenCalledWith('recommendations');
+    expect(mockModel.setActiveTab).toHaveBeenCalledWith('tab1');
   });
 
   it('should navigate milestones with Alt+Arrow keys when not in recommendations', () => {

--- a/src/components/docs-panel/keyboard-shortcuts.hook.ts
+++ b/src/components/docs-panel/keyboard-shortcuts.hook.ts
@@ -16,14 +16,8 @@ interface UseKeyboardShortcutsProps {
 }
 
 /**
- * Tabs Ctrl/Cmd+Tab may focus. Dev Tools is overflow-only with no strip/rail
- * active marker — cycling onto it leaves no visible tab marked active.
- * Recommendations stays (left-rail icon) alongside guide-strip tabs.
+ * Panel keyboard shortcuts. Ctrl/Cmd+Tab cycles every entry in `tabs`.
  */
-function getKeyboardCycleTabs(tabs: LearningJourneyTab[]): LearningJourneyTab[] {
-  return tabs.filter((tab) => tab.type !== 'devtools');
-}
-
 export function useKeyboardShortcuts({
   tabs,
   activeTabId,
@@ -44,16 +38,14 @@ export function useKeyboardShortcuts({
       // Ctrl/Cmd + Tab to switch between tabs
       if ((event.ctrlKey || event.metaKey) && event.key === 'Tab') {
         safeEventHandler(event, { preventDefault: true });
-        const cycleTabs = getKeyboardCycleTabs(tabs);
-        if (cycleTabs.length === 0) {
+        if (tabs.length === 0) {
           return;
         }
-        const currentIndex = cycleTabs.findIndex((tab) => tab.id === activeTabId);
-        // Active Dev Tools is outside the cycle (−1): forward → first, back → last.
+        const currentIndex = tabs.findIndex((tab) => tab.id === activeTabId);
         const nextIndex = event.shiftKey
-          ? ((currentIndex === -1 ? 0 : currentIndex) - 1 + cycleTabs.length) % cycleTabs.length
-          : (currentIndex + 1) % cycleTabs.length;
-        model.setActiveTab(cycleTabs[nextIndex]!.id);
+          ? ((currentIndex === -1 ? 0 : currentIndex) - 1 + tabs.length) % tabs.length
+          : ((currentIndex === -1 ? -1 : currentIndex) + 1) % tabs.length;
+        model.setActiveTab(tabs[nextIndex]!.id);
       }
 
       // Alt+Arrow keys for milestone navigation.

--- a/src/components/docs-panel/types.ts
+++ b/src/components/docs-panel/types.ts
@@ -96,6 +96,9 @@ export interface DocsPanelModelOperations {
   /** Open the editor tab (or switch to it if already open) */
   openEditorTab(): void;
 
+  /** Update the editor tab's strip title from the working guide */
+  updateEditorTabTitle(title: string): void;
+
   /** Get the currently active tab */
   getActiveTab(): LearningJourneyTab | null;
 

--- a/src/components/docs-panel/utils/index.ts
+++ b/src/components/docs-panel/utils/index.ts
@@ -10,7 +10,6 @@ export {
   RECOMMENDATIONS_TAB_ID,
   DEVTOOLS_TAB_ID,
   EDITOR_TAB_ID,
-  GUIDE_STRIP_EXCLUDED_TAB_TYPES,
   getGuideStripTabs,
   isNonContentTab,
   hasOnlyNonContentTabs,

--- a/src/components/docs-panel/utils/tab-kinds.test.ts
+++ b/src/components/docs-panel/utils/tab-kinds.test.ts
@@ -5,7 +5,7 @@
 import { getGuideStripTabs, hasOnlyNonContentTabs } from './tab-kinds';
 
 describe('getGuideStripTabs', () => {
-  it('keeps ordered strip tabs while excluding recommendations and Dev Tools', () => {
+  it('keeps ordered strip tabs while excluding recommendations', () => {
     expect(
       getGuideStripTabs([
         { type: 'recommendations' },
@@ -14,7 +14,7 @@ describe('getGuideStripTabs', () => {
         { type: 'devtools' },
         { type: 'docs' },
       ])
-    ).toEqual([{ type: 'editor' }, { type: 'learning-journey' }, { type: 'docs' }]);
+    ).toEqual([{ type: 'editor' }, { type: 'learning-journey' }, { type: 'devtools' }, { type: 'docs' }]);
   });
 });
 

--- a/src/components/docs-panel/utils/tab-kinds.ts
+++ b/src/components/docs-panel/utils/tab-kinds.ts
@@ -8,35 +8,35 @@ import type { LearningJourneyTab, LearningJourneyTabType } from '../../../types/
 /** Recommendations home (left-rail icon). Contract surface — do not rename. */
 export const RECOMMENDATIONS_TAB_ID = 'recommendations';
 
-/** Dev Tools singleton (overflow menu; strip-excluded). Contract surface. */
+/** Dev Tools singleton tab id (overflow menu → one closable strip tab). Contract surface. */
 export const DEVTOOLS_TAB_ID = 'devtools';
 
 /** Guide editor singleton (strip-included, no URL fetch). Contract surface. */
 export const EDITOR_TAB_ID = 'editor';
 
-/** Strip-excluded chrome: recommendations (left rail) and Dev Tools (overflow). */
-export const GUIDE_STRIP_EXCLUDED_TAB_TYPES = new Set<LearningJourneyTabType>(['recommendations', 'devtools']);
+/** Kinds with no content URL to fetch: panel chrome, the editor, and Dev Tools. */
+export const NON_CONTENT_TAB_TYPES = new Set<LearningJourneyTabType>(['recommendations', 'devtools', 'editor']);
 
 /**
  * Tabs that claim a guide-strip slot (rendered, closable, focusable).
  *
- * Raw `tabs` is wider than the strip: excluded chrome stays in state for
- * routing/content. Close adjacency, strip rendering, and overflow math must
- * use this projection — otherwise focus can land on a tab with no active marker.
+ * Recommendations stays in `tabs` for routing/content but uses the left-rail
+ * icon instead of a strip slot. Close adjacency, strip rendering, and overflow
+ * math must use this projection.
  */
 export function getGuideStripTabs<T extends Pick<LearningJourneyTab, 'type'>>(tabs: T[]): T[] {
-  return tabs.filter((tab) => !GUIDE_STRIP_EXCLUDED_TAB_TYPES.has(tab.type));
+  return tabs.filter((tab) => tab.type !== 'recommendations');
 }
 
-/** Panel chrome / editor: no content URL to fetch. */
+/** Panel chrome / editor / Dev Tools: no content URL to fetch. */
 export function isNonContentTab(tab: Pick<LearningJourneyTab, 'type'>): boolean {
-  return GUIDE_STRIP_EXCLUDED_TAB_TYPES.has(tab.type) || tab.type === 'editor';
+  return NON_CONTENT_TAB_TYPES.has(tab.type);
 }
 
 /**
  * True when tabStorage restore won't clobber in-memory content tabs.
- * Not the same as an empty strip: the editor is a strip tab but still
- * permits restore (it holds no fetched content).
+ * Not the same as an empty strip: the editor (and Dev Tools) are strip tabs
+ * but still permit restore (they hold no fetched content).
  */
 export function hasOnlyNonContentTabs(tabs: Array<Pick<LearningJourneyTab, 'type'>>): boolean {
   return tabs.every((t) => isNonContentTab(t));

--- a/src/components/docs-panel/utils/tab-storage-restore.ts
+++ b/src/components/docs-panel/utils/tab-storage-restore.ts
@@ -12,6 +12,7 @@ import type { LearningJourneyTab, LearningJourneyTabType, PersistedTabData } fro
 import { isAllowedContentUrl, isLocalhostUrl, isGitHubRawUrl } from '../../../security';
 import { logger } from '../../../lib/logging';
 import { DEVTOOLS_TAB_ID, EDITOR_TAB_ID, RECOMMENDATIONS_TAB_ID } from './tab-kinds';
+import { DEFAULT_GUIDE_TITLE } from '../../block-editor/editor-chrome-status';
 
 /**
  * Tab storage interface for dependency injection
@@ -157,7 +158,7 @@ export async function restoreTabsFromStorage(
       if (type === 'editor') {
         tabs.push({
           id: EDITOR_TAB_ID,
-          title: data.title || 'New Guide',
+          title: data.title || DEFAULT_GUIDE_TITLE,
           baseUrl: '',
           currentUrl: '',
           content: null,
@@ -228,7 +229,7 @@ export async function restoreActiveTabFromStorage(tabStorage: TabStorage, tabs: 
     if (activeTabId) {
       const tabExists = tabs.some((t) => t.id === activeTabId);
 
-      // Restore the stored tab if it exists (including Dev Tools — strip-excluded but persisted).
+      // Restore the stored tab if it exists.
       // closeTab ensures recommendations is saved when the strip is empty.
       return tabExists ? activeTabId : RECOMMENDATIONS_TAB_ID;
     }

--- a/src/components/docs-panel/utils/tab-visibility.ts
+++ b/src/components/docs-panel/utils/tab-visibility.ts
@@ -18,9 +18,8 @@ export interface TabVisibilityResult {
 
 /**
  * Computes which tabs fit in the visible area and which move to overflow.
- * Strip-excluded chrome stays out of the guide-tab competition; remaining
- * tabs share available width. Recommendations is prefixed into visibleTabs
- * for the rail (Dev Tools is strip-excluded and not shown there either).
+ * Recommendations stays out of the guide-tab competition (left-rail icon);
+ * remaining strip tabs share available width.
  */
 export function computeTabVisibility(
   tabs: LearningJourneyTab[],

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -372,7 +372,7 @@ function FloatingPanelInner() {
     >
       {isEditorTab ? (
         <Suspense fallback={<SkeletonLoader type="documentation" />}>
-          <BlockEditor />
+          <BlockEditor onGuideTitleChange={(newTitle) => panel.updateEditorTabTitle(newTitle)} />
         </Suspense>
       ) : (
         <FloatingPanelContent

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -412,7 +412,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     >
       {isEditorTab ? (
         <Suspense fallback={<SkeletonLoader type="documentation" />}>
-          <BlockEditor />
+          <BlockEditor onGuideTitleChange={(newTitle) => panel.updateEditorTabTitle(newTitle)} />
         </Suspense>
       ) : (
         <FloatingPanelContent

--- a/src/styles/docs-panel.styles.ts
+++ b/src/styles/docs-panel.styles.ts
@@ -403,12 +403,19 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
   }),
   editorTabTitle: css({
     label: 'combined-journey-editor-tab-title',
-    fontStyle: 'italic',
     fontWeight: theme.typography.fontWeightLight,
   }),
-  editorTabDraftBadge: css({
-    label: 'combined-journey-editor-tab-draft-badge',
-    flexShrink: 0,
+  // Italics mark a tab whose content has diverged from its saved remote entry.
+  editorTabTitleModified: css({
+    label: 'combined-journey-editor-tab-title-modified',
+    fontStyle: 'italic',
+  }),
+  editorTabStatusBadge: css({
+    label: 'combined-journey-editor-tab-status-badge',
+    // Shrink/clip under pressure so the close control stays in frame.
+    flexShrink: 1,
+    minWidth: 0,
+    overflow: 'hidden',
     // Compact so the badge fits tab chrome without dominating the title.
     fontSize: '10px',
     padding: `0 ${theme.spacing(0.5)}`,
@@ -546,7 +553,6 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
   }),
   editorDropdownItemTitle: css({
     label: 'combined-journey-editor-dropdown-item-title',
-    fontStyle: 'italic',
     fontWeight: theme.typography.fontWeightLight,
   }),
   dropdownItemClose: css({

--- a/src/styles/docs-panel.styles.ts
+++ b/src/styles/docs-panel.styles.ts
@@ -221,10 +221,14 @@ export const getTabStyles = (theme: GrafanaTheme2) => ({
     position: 'relative', // Positioning context for absolute dropdown
     flexShrink: 0, // Don't shrink, stay compact
     // container-type makes this a query container for the wordmark's narrow-width
-    // hide — which also makes it a stacking context, so lift the whole bar above
-    // page content (below modals) to keep the overflow dropdown painting on top.
+    // hide — which also makes it a stacking context. That traps the overflow
+    // dropdown: its own z-index only orders it *within* the bar, so the bar's
+    // level is what competes with the content below. Panel content pins its own
+    // chrome (block editor header, health bar) at `navbarFixed`, and those come
+    // later in the DOM — a tie there hid the dropdown behind the editor header.
+    // Outrank them here, while staying below tooltips, modals, and portals.
     containerType: 'inline-size',
-    zIndex: theme.zIndex.navbarFixed,
+    zIndex: theme.zIndex.dropdown,
   }),
   tabList: css({
     label: 'combined-journey-tab-list',


### PR DESCRIPTION
## Summary

Dev Tools is a normal closable strip tab instead of a chrome-less singleton view, so leaving it no longer feels like leaving the panel or flipping Dev Mode off. The tab bar also stacks above panel chrome so the overflow menu stays usable when the editor header is open.

## What to look at

- **Tab taxonomy** ([`tab-kinds.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/22521e678bfc2d99a4d0805aaf25dedec8545ef2/src/components/docs-panel/utils/tab-kinds.ts)) — `getGuideStripTabs` excludes only recommendations; Dev Tools claims a strip slot. `hasOnlyNonContentTabs` still treats Dev Tools as non-content so restore is not blocked by an open Dev Tools tab alone.
- **Close adjacency + keyboard cycle** ([`docs-panel.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/22521e678bfc2d99a4d0805aaf25dedec8545ef2/src/components/docs-panel/docs-panel.tsx), [`keyboard-shortcuts.hook.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/22521e678bfc2d99a4d0805aaf25dedec8545ef2/src/components/docs-panel/keyboard-shortcuts.hook.ts)) — closing a neighbor can land on Dev Tools, and Ctrl/Cmd+Tab includes it. That looks like a regression against the old “skip Dev Tools” tests, but it is the intended model now that the tab has a visible active marker.
- **Overflow stacking** ([`docs-panel.styles.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/22521e678bfc2d99a4d0805aaf25dedec8545ef2/src/styles/docs-panel.styles.ts)) — tab bar `zIndex` moves from `navbarFixed` to `dropdown` so the overflow menu is not trapped behind later `navbarFixed` chrome (editor header / health bar).

## Why

Without a strip tab, Dev Tools felt like a dead-end page: the exit path was unclear and users could mistake “leave this view” for “turn Dev Mode off.” Giving it a real tab also deletes the specialized “strip-excluded / skip in keyboard cycle” treatment.

An alternate close affordance on the Dev Tools page was considered; a strip tab is preferable because it removes that special-case logic and makes Dev Tools navigable like other strip tabs when that is useful.

## How to verify

1. Enable Dev Mode, open Dev Tools from the overflow menu — confirm it appears as a closable strip tab with a normal active marker.
2. Open a guide alongside Dev Tools, then close the guide — focus should move to Dev Tools (not skip over it).
3. From recommendations, press Ctrl/Cmd+Tab — Dev Tools should be in the cycle; Shift+Ctrl/Cmd+Tab should reverse through it.
4. Close the Dev Tools tab with the strip close control (and with Ctrl/Cmd+W while it is active) — confirm you return to another strip tab or recommendations without toggling Dev Mode.
5. With the guide editor open, open the overflow menu — confirm the dropdown paints above the editor header, not underneath it.

## Breaking changes

None. This change is additive and fully reversible. Existing persisted Dev Tools tabs remain valid; they now compete for strip width like other strip tabs.

## Out of scope

- Editor tab status badges and the badge-shrink fix that keeps the close control reachable when the badge overflows — those land in the follow-up chrome-lifecycle branch (`ui/editor-tab-chrome-lifecycle`), not this diff (this PR only lifts tab-bar z-index).
- Fullscreen/floating tab-storage overwrite on dock-back — follow-up (`ui/fix-surface-tab-storage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)