### PR TITLE
fix(docs-panel): stop surface handoffs from overwriting sibling tabs

### DIFF
--- a/src/components/docs-panel/docs-panel.alignment.test.ts
+++ b/src/components/docs-panel/docs-panel.alignment.test.ts
@@ -207,6 +207,7 @@ jest.mock('./utils', () => ({
   getTranslatedTitle: jest.fn((t: string) => t),
   restoreTabsFromStorage: jest.fn(),
   restoreActiveTabFromStorage: jest.fn(),
+  mergeRestoredTabsWithExisting: jest.requireActual('./utils/tab-storage-restore').mergeRestoredTabsWithExisting,
   isGrafanaDocsUrl: jest.fn(),
   cleanDocsUrl: jest.fn((url: string) => url),
   loadDocsTabContentResult: (...args: unknown[]) => mockLoadDocsTabContentResult(...args),

--- a/src/components/docs-panel/docs-panel.close-tab.test.ts
+++ b/src/components/docs-panel/docs-panel.close-tab.test.ts
@@ -188,6 +188,7 @@ jest.mock('./utils', () => ({
   getTranslatedTitle: jest.fn((t: string) => t),
   restoreTabsFromStorage: jest.fn(),
   restoreActiveTabFromStorage: jest.fn(),
+  mergeRestoredTabsWithExisting: jest.requireActual('./utils/tab-storage-restore').mergeRestoredTabsWithExisting,
   isGrafanaDocsUrl: jest.fn(),
   cleanDocsUrl: jest.fn((url: string) => url),
   loadDocsTabContentResult: jest.fn(),

--- a/src/components/docs-panel/docs-panel.load-tab-content.test.ts
+++ b/src/components/docs-panel/docs-panel.load-tab-content.test.ts
@@ -184,6 +184,7 @@ jest.mock('./utils', () => ({
   getTranslatedTitle: jest.fn((t: string) => t),
   restoreTabsFromStorage: jest.fn(),
   restoreActiveTabFromStorage: jest.fn(),
+  mergeRestoredTabsWithExisting: jest.requireActual('./utils/tab-storage-restore').mergeRestoredTabsWithExisting,
   isGrafanaDocsUrl: jest.fn(),
   cleanDocsUrl: jest.fn((url: string) => url),
   loadDocsTabContentResult: jest.fn(),

--- a/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
+++ b/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
@@ -226,6 +226,7 @@ jest.mock('../../hooks', () => ({}));
 // ---------------------------------------------------------------------------
 
 import { isDevModeEnabled } from '../../utils/dev-mode';
+import { tabStorage } from '../../lib/user-storage';
 import { CombinedLearningJourneyPanel } from './docs-panel';
 
 // ---------------------------------------------------------------------------
@@ -308,6 +309,41 @@ describe('CombinedLearningJourneyPanel — tab restoration guard (#782)', () => 
     expect(mockRestoreTabsFromStorage).toHaveBeenCalledTimes(2);
     expect((panel as any).state.activeTabId).toBe('tab-guide-2');
     expect((panel as any).state.tabs.map((tab: { id: string }) => tab.id)).toContain('tab-guide-2');
+  });
+
+  it('waits for an in-flight save before restoring, so return paths that cannot flush still see the latest strip', async () => {
+    // Tab mutations save fire-and-forget, and the return paths that cannot
+    // await that write — the sidebar's "Return to sidebar" notice (no handle on
+    // the full-screen model) and auto-dock on navigation — would otherwise let
+    // this force restore read the pre-handoff strip.
+    let writeLanded = false;
+    let resolveWrite!: () => void;
+    (tabStorage.setTabs as jest.Mock).mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveWrite = () => {
+          writeLanded = true;
+          resolve();
+        };
+      })
+    );
+    mockRestoreTabsFromStorage.mockImplementation(async () =>
+      writeLanded ? [RESTORED_TABS[0], { ...RESTORED_TABS[1], id: 'tab-from-fullscreen' }] : [RESTORED_TABS[0]]
+    );
+    mockRestoreActiveTabFromStorage.mockImplementation(async () =>
+      writeLanded ? 'tab-from-fullscreen' : 'recommendations'
+    );
+
+    const outgoing = new CombinedLearningJourneyPanel();
+    void outgoing.saveTabsToStorage();
+
+    const sidebar = new CombinedLearningJourneyPanel();
+    // Land the write a macrotask later so restore's own microtask-resolved
+    // storage reads would win the race if the barrier were removed.
+    const restore = sidebar.restoreTabsAsync({ force: true });
+    setTimeout(resolveWrite, 0);
+    await restore;
+
+    expect((sidebar as any).state.tabs.map((tab: { id: string }) => tab.id)).toContain('tab-from-fullscreen');
   });
 
   it('should allow a NEW instance to restore tabs after the first instance already restored', async () => {

--- a/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
+++ b/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
@@ -189,6 +189,7 @@ jest.mock('./utils', () => ({
   getTranslatedTitle: jest.fn((t: string) => t),
   restoreTabsFromStorage: (...args: unknown[]) => mockRestoreTabsFromStorage(...args),
   restoreActiveTabFromStorage: (...args: unknown[]) => mockRestoreActiveTabFromStorage(...args),
+  mergeRestoredTabsWithExisting: jest.requireActual('./utils/tab-storage-restore').mergeRestoredTabsWithExisting,
   isGrafanaDocsUrl: jest.fn(),
   cleanDocsUrl: jest.fn((url: string) => url),
   loadDocsTabContentResult: jest.fn(),
@@ -311,11 +312,69 @@ describe('CombinedLearningJourneyPanel — tab restoration guard (#782)', () => 
     expect((panel as any).state.tabs.map((tab: { id: string }) => tab.id)).toContain('tab-guide-2');
   });
 
+  it('keeps loaded content on force restore when id and currentUrl still match', async () => {
+    // Storage never persists content. Without a merge, every fullscreen/floating
+    // round trip would blank the strip and refetch — same cost as a reload.
+    const panel = new CombinedLearningJourneyPanel();
+    await panel.restoreTabsAsync();
+
+    const loadedContent = { content: '# still here', meta: {}, type: 'html' as const };
+    (panel as any).setState({
+      tabs: (panel as any).state.tabs.map((tab: { id: string }) =>
+        tab.id === 'tab-guide-1'
+          ? {
+              ...tab,
+              content: loadedContent,
+              pathContext: { learningJourney: { milestones: [] } },
+            }
+          : tab
+      ),
+    });
+
+    mockRestoreTabsFromStorage.mockResolvedValueOnce([
+      RESTORED_TABS[0],
+      { ...RESTORED_TABS[1], title: 'Renamed in full screen' },
+    ]);
+    mockRestoreActiveTabFromStorage.mockResolvedValueOnce('tab-guide-1');
+
+    await panel.restoreTabsAsync({ force: true });
+
+    const guide = (panel as any).state.tabs.find((tab: { id: string }) => tab.id === 'tab-guide-1');
+    expect(guide.title).toBe('Renamed in full screen');
+    expect(guide.content).toBe(loadedContent);
+    expect(guide.pathContext).toEqual({ learningJourney: { milestones: [] } });
+  });
+
+  it('drops in-memory content on force restore when currentUrl changed in storage', async () => {
+    const panel = new CombinedLearningJourneyPanel();
+    await panel.restoreTabsAsync();
+
+    (panel as any).setState({
+      tabs: (panel as any).state.tabs.map((tab: { id: string }) =>
+        tab.id === 'tab-guide-1' ? { ...tab, content: { content: '# stale page', meta: {}, type: 'html' } } : tab
+      ),
+    });
+
+    mockRestoreTabsFromStorage.mockResolvedValueOnce([
+      RESTORED_TABS[0],
+      {
+        ...RESTORED_TABS[1],
+        currentUrl: 'https://grafana.com/docs/grafana/latest/test/other-page/',
+      },
+    ]);
+    mockRestoreActiveTabFromStorage.mockResolvedValueOnce('tab-guide-1');
+
+    await panel.restoreTabsAsync({ force: true });
+
+    const guide = (panel as any).state.tabs.find((tab: { id: string }) => tab.id === 'tab-guide-1');
+    expect(guide.content).toBeNull();
+    expect(guide.currentUrl).toBe('https://grafana.com/docs/grafana/latest/test/other-page/');
+  });
+
   it('waits for an in-flight save before restoring, so return paths that cannot flush still see the latest strip', async () => {
-    // Tab mutations save fire-and-forget, and the return paths that cannot
-    // await that write — the sidebar's "Return to sidebar" notice (no handle on
-    // the full-screen model) and auto-dock on navigation — would otherwise let
-    // this force restore read the pre-handoff strip.
+    // Covers fire-and-forget returns (Return to sidebar notice; auto-dock):
+    // restore waits for the newest write already pending when the await
+    // starts, not for a save issued after that.
     let writeLanded = false;
     let resolveWrite!: () => void;
     (tabStorage.setTabs as jest.Mock).mockReturnValueOnce(

--- a/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
+++ b/src/components/docs-panel/docs-panel.tab-restore-guard.test.ts
@@ -291,6 +291,25 @@ describe('CombinedLearningJourneyPanel — tab restoration guard (#782)', () => 
     expect(mockRestoreTabsFromStorage).toHaveBeenCalledTimes(1);
   });
 
+  it('force-refreshes an existing model after another surface updates storage', async () => {
+    // Fullscreen/floating own separate models. Without the force escape hatch
+    // the returning sidebar keeps its pre-handoff snapshot and their tab work
+    // looks discarded.
+    const panel = new CombinedLearningJourneyPanel();
+    await panel.restoreTabsAsync();
+    mockRestoreTabsFromStorage.mockResolvedValueOnce([
+      RESTORED_TABS[0],
+      { ...RESTORED_TABS[1], id: 'tab-guide-2', title: 'Opened in full screen' },
+    ]);
+    mockRestoreActiveTabFromStorage.mockResolvedValueOnce('tab-guide-2');
+
+    await panel.restoreTabsAsync({ force: true });
+
+    expect(mockRestoreTabsFromStorage).toHaveBeenCalledTimes(2);
+    expect((panel as any).state.activeTabId).toBe('tab-guide-2');
+    expect((panel as any).state.tabs.map((tab: { id: string }) => tab.id)).toContain('tab-guide-2');
+  });
+
   it('should allow a NEW instance to restore tabs after the first instance already restored', async () => {
     // Simulate: sidebar mounts, panel A restores tabs
     const panelA = new CombinedLearningJourneyPanel();

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -223,11 +223,13 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     // to avoid race condition with useUserStorage hook
   }
 
-  public async restoreTabsAsync(): Promise<void> {
+  public async restoreTabsAsync(options?: { force?: boolean }): Promise<void> {
     // Guard: only restore once per model lifetime to prevent double-restore race condition
     // where a second restore (triggered by component remount or React Strict Mode) replaces
-    // tabs that already had content loaded, leaving them in {content: null} blank state
-    if (this._hasRestoredTabs) {
+    // tabs that already had content loaded, leaving them in {content: null} blank state.
+    // `force` is reserved for a surface ownership handover: floating/fullscreen own
+    // separate models, so a returning sidebar must re-read the shared workspace.
+    if (this._hasRestoredTabs && !options?.force) {
       return;
     }
     this._hasRestoredTabs = true;

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -81,6 +81,7 @@ import {
   shouldUseDocsLoader,
   restoreTabsFromStorage,
   restoreActiveTabFromStorage,
+  mergeRestoredTabsWithExisting,
   loadDocsTabContentResult,
   RECOMMENDATIONS_TAB_ID,
   DEVTOOLS_TAB_ID,
@@ -124,13 +125,13 @@ import type { RawContent } from '../../types/content.types';
 import type { DocsPanelModelOperations, OpenDocsOptions, OpenLearningJourneyOptions } from './types';
 
 /**
- * Newest in-flight `saveTabsToStorage`, shared by every panel model.
+ * Newest in-flight `saveTabsToStorage`, shared across panel models.
  *
- * Surfaces own separate models but one `tabStorage`. Tab mutations save
- * fire-and-forget, and not every return path can await that write first: the
- * sidebar's "Return to sidebar" notice has no handle on the full-screen model,
- * and auto-dock on navigation flips mode from a history listener. Readers wait
- * on this instead, so a handover can never restore the pre-handoff strip.
+ * Explicit handoffs await their own save before flipping mode. This barrier
+ * only covers the fire-and-forget return paths that cannot (sidebar
+ * "Return to sidebar" notice; auto-dock on navigation): restore waits for
+ * the newest write already pending when the await starts — not for a save
+ * issued after that.
  */
 let pendingTabStorageWrite: Promise<void> | null = null;
 
@@ -245,9 +246,8 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     }
     this._hasRestoredTabs = true;
 
-    // The surface handing the workspace back may still have a write in flight,
-    // so read after it lands — otherwise we restore its pre-handoff strip and
-    // its opens, closes, renames, and milestone position look discarded.
+    // Newest write pending when this await starts (see pendingTabStorageWrite).
+    // Saves begun after that are not waited on.
     await pendingTabStorageWrite;
 
     // `isDevMode` here only widens URL validation (localhost / GitHub raw).
@@ -263,13 +263,16 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     const pruned = this.pruneUnauthorizedGatedTabs(restoredTabs, activeTabId);
     restoredTabs = pruned.tabs;
     activeTabId = pruned.activeTabId;
+    // Keep loaded snapshots for tabs storage still lists at the same id +
+    // currentUrl so a force restore does not refetch every guide.
+    restoredTabs = mergeRestoredTabsWithExisting(restoredTabs, this.state.tabs);
 
     this.setState({
       tabs: restoredTabs,
       activeTabId,
     });
 
-    // Initialize the active tab if needed
+    // Initialize the active tab if needed (no-op when merge kept content)
     this.initializeRestoredActiveTab();
   }
 

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -123,6 +123,17 @@ import { getPackageRenderType } from '../../types/package.types';
 import type { RawContent } from '../../types/content.types';
 import type { DocsPanelModelOperations, OpenDocsOptions, OpenLearningJourneyOptions } from './types';
 
+/**
+ * Newest in-flight `saveTabsToStorage`, shared by every panel model.
+ *
+ * Surfaces own separate models but one `tabStorage`. Tab mutations save
+ * fire-and-forget, and not every return path can await that write first: the
+ * sidebar's "Return to sidebar" notice has no handle on the full-screen model,
+ * and auto-dock on navigation flips mode from a history listener. Readers wait
+ * on this instead, so a handover can never restore the pre-handoff strip.
+ */
+let pendingTabStorageWrite: Promise<void> | null = null;
+
 class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> implements DocsPanelModelOperations {
   public static Component = CombinedPanelRenderer;
 
@@ -233,6 +244,11 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
       return;
     }
     this._hasRestoredTabs = true;
+
+    // The surface handing the workspace back may still have a write in flight,
+    // so read after it lands — otherwise we restore its pre-handoff strip and
+    // its opens, closes, renames, and milestone position look discarded.
+    await pendingTabStorageWrite;
 
     // `isDevMode` here only widens URL validation (localhost / GitHub raw).
     // Tab-level gating is applied below, after the storage awaits.
@@ -360,7 +376,20 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     }
   }
 
-  public async saveTabsToStorage(): Promise<void> {
+  public saveTabsToStorage(): Promise<void> {
+    const write = this.writeTabsToStorage();
+    pendingTabStorageWrite = write;
+    // Only the newest write clears the barrier; an older one settling late must
+    // not retire a save that is still in flight.
+    void write.finally(() => {
+      if (pendingTabStorageWrite === write) {
+        pendingTabStorageWrite = null;
+      }
+    });
+    return write;
+  }
+
+  private async writeTabsToStorage(): Promise<void> {
     try {
       // Save user-opened tabs (recommendations home is always present and not persisted)
       const tabsToSave: PersistedTabData[] = this.state.tabs

--- a/src/components/docs-panel/hooks/useFullScreenHandoff.test.ts
+++ b/src/components/docs-panel/hooks/useFullScreenHandoff.test.ts
@@ -20,20 +20,23 @@ jest.mock('@grafana/runtime', () => {
 
 function makeModel(initial: { tabs: any[]; activeTabId: string }) {
   const state = { ...initial };
+  const saveTabsToStorage = jest.fn().mockResolvedValue(undefined);
   return {
     model: {
       get state() {
         return state;
       },
+      saveTabsToStorage,
     } as any,
+    saveTabsToStorage,
     setActive(id: string) {
       state.activeTabId = id;
     },
   };
 }
 
-function dispatchFullScreen() {
-  act(() => {
+async function dispatchFullScreen() {
+  await act(async () => {
     document.dispatchEvent(new CustomEvent('pathfinder-request-full-screen'));
   });
 }
@@ -58,7 +61,7 @@ describe('useFullScreenHandoff', () => {
     jest.restoreAllMocks();
   });
 
-  it('refuses when a live session is active and surfaces an alert', () => {
+  it('refuses when a live session is active and surfaces an alert', async () => {
     const { model } = makeModel({
       tabs: [
         {
@@ -72,7 +75,7 @@ describe('useFullScreenHandoff', () => {
       activeTabId: 'tab-a',
     });
     renderHook(() => useFullScreenHandoff(model, true));
-    dispatchFullScreen();
+    await dispatchFullScreen();
 
     expect(publishMock).toHaveBeenCalledWith({
       type: 'alert-info',
@@ -82,15 +85,16 @@ describe('useFullScreenHandoff', () => {
     expect(locationService.push).not.toHaveBeenCalled();
   });
 
-  it('editor branch: pushes the bare full-screen route with no doc query', () => {
-    const { model } = makeModel({
+  it('editor branch: pushes the bare full-screen route with no doc query', async () => {
+    const { model, saveTabsToStorage } = makeModel({
       tabs: [{ id: 'editor', type: 'editor', title: 'Block editor', baseUrl: 'bundled:editor' }],
       activeTabId: 'editor',
     });
     renderHook(() => useFullScreenHandoff(model, false));
-    dispatchFullScreen();
+    await dispatchFullScreen();
 
     expect(setPendingGuideSpy).toHaveBeenCalledWith({ title: 'Block editor', type: 'editor' });
+    expect(saveTabsToStorage).toHaveBeenCalledTimes(1);
     expect(capturePriorPathSpy).toHaveBeenCalledTimes(1);
     expect(setModePersistedSpy).toHaveBeenCalledWith('fullscreen');
     expect(locationService.push).toHaveBeenCalledWith(expect.stringContaining('/fullscreen'));
@@ -101,37 +105,26 @@ describe('useFullScreenHandoff', () => {
     });
   });
 
-  it('refuses recommendations tab with an alert', () => {
-    const { model } = makeModel({
-      tabs: [{ id: 'recommendations', type: 'recommendations', title: 'Recs', baseUrl: '' }],
-      activeTabId: 'recommendations',
+  it.each([
+    ['recommendations', 'Recs'],
+    ['devtools', 'Dev Tools'],
+  ])('refuses the unsupported %s tab without touching storage', async (type, title) => {
+    const { model, saveTabsToStorage } = makeModel({
+      tabs: [{ id: type, type, title, baseUrl: '' }],
+      activeTabId: type,
     });
     renderHook(() => useFullScreenHandoff(model, false));
-    dispatchFullScreen();
+    await dispatchFullScreen();
 
     expect(publishMock).toHaveBeenCalledWith({
       type: 'alert-info',
       payload: ['Open a guide before switching to full screen.'],
     });
+    expect(saveTabsToStorage).not.toHaveBeenCalled();
     expect(setModePersistedSpy).not.toHaveBeenCalled();
   });
 
-  it('refuses devtools tab with an alert', () => {
-    const { model } = makeModel({
-      tabs: [{ id: 'devtools', type: 'devtools', title: 'Devtools', baseUrl: '' }],
-      activeTabId: 'devtools',
-    });
-    renderHook(() => useFullScreenHandoff(model, false));
-    dispatchFullScreen();
-
-    expect(publishMock).toHaveBeenCalledWith({
-      type: 'alert-info',
-      payload: ['Open a guide before switching to full screen.'],
-    });
-    expect(setModePersistedSpy).not.toHaveBeenCalled();
-  });
-
-  it('hands off the active learning-journey using currentUrl with doc + guideType in the URL', () => {
+  it('hands off the active learning-journey using currentUrl with doc + guideType in the URL', async () => {
     const { model } = makeModel({
       tabs: [
         {
@@ -146,7 +139,7 @@ describe('useFullScreenHandoff', () => {
       activeTabId: 'tab-a',
     });
     renderHook(() => useFullScreenHandoff(model, false));
-    dispatchFullScreen();
+    await dispatchFullScreen();
 
     expect(setPendingGuideSpy).toHaveBeenCalledWith({
       url: 'https://example.com/a/milestone-2',
@@ -161,7 +154,7 @@ describe('useFullScreenHandoff', () => {
     expect(pushedUrl).toContain('type=learning-journey');
   });
 
-  it('treats docs-type tabs as type "docs" in payload and URL', () => {
+  it('treats docs-type tabs as type "docs" in payload and URL', async () => {
     const { model } = makeModel({
       tabs: [
         {
@@ -175,14 +168,14 @@ describe('useFullScreenHandoff', () => {
       activeTabId: 'tab-d',
     });
     renderHook(() => useFullScreenHandoff(model, false));
-    dispatchFullScreen();
+    await dispatchFullScreen();
 
     expect(setPendingGuideSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'docs' }));
     const pushedUrl = (locationService.push as jest.Mock).mock.calls[0][0];
     expect(pushedUrl).toContain('type=docs');
   });
 
-  it('H1 — re-reads model.state inside the handler (tab switched after mount)', () => {
+  it('H1 — re-reads model.state inside the handler (tab switched after mount)', async () => {
     const { model, setActive } = makeModel({
       tabs: [
         {
@@ -204,14 +197,48 @@ describe('useFullScreenHandoff', () => {
     });
     renderHook(() => useFullScreenHandoff(model, false));
     setActive('tab-b');
-    dispatchFullScreen();
+    await dispatchFullScreen();
 
     expect(setPendingGuideSpy).toHaveBeenCalledWith(
       expect.objectContaining({ url: 'https://example.com/b', title: 'Journey B' })
     );
   });
 
-  it('removes the listener on unmount', () => {
+  it('awaits saveTabsToStorage before flipping the mode, so full screen restores the current tabs', async () => {
+    const { model } = makeModel({
+      tabs: [
+        {
+          id: 'tab-a',
+          type: 'learning-journey',
+          title: 'Journey A',
+          baseUrl: 'https://example.com/a',
+          currentUrl: 'https://example.com/a/milestone-3',
+        },
+      ],
+      activeTabId: 'tab-a',
+    });
+    let resolveSave!: () => void;
+    (model.saveTabsToStorage as jest.Mock).mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveSave = resolve;
+      })
+    );
+
+    renderHook(() => useFullScreenHandoff(model, false));
+    await dispatchFullScreen();
+
+    expect(setModePersistedSpy).not.toHaveBeenCalled();
+    expect(locationService.push).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveSave();
+    });
+
+    expect(setModePersistedSpy).toHaveBeenCalledWith('fullscreen');
+    expect(locationService.push).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the listener on unmount', async () => {
     const { model } = makeModel({ tabs: [], activeTabId: 'x' });
     const removeSpy = jest.spyOn(document, 'removeEventListener');
     const { unmount } = renderHook(() => useFullScreenHandoff(model, false));

--- a/src/components/docs-panel/hooks/useFullScreenHandoff.test.ts
+++ b/src/components/docs-panel/hooks/useFullScreenHandoff.test.ts
@@ -144,6 +144,9 @@ describe('useFullScreenHandoff', () => {
     expect(setPendingGuideSpy).toHaveBeenCalledWith({
       url: 'https://example.com/a/milestone-2',
       title: 'Journey A',
+      // Identity travels with the handoff: the full-screen page restores this
+      // same tab from storage and focuses it rather than opening a second copy.
+      tabId: 'tab-a',
       type: 'learning-journey',
       packageInfo: { packageId: 'pkg-y' },
     });

--- a/src/components/docs-panel/hooks/useFullScreenHandoff.ts
+++ b/src/components/docs-panel/hooks/useFullScreenHandoff.ts
@@ -35,6 +35,7 @@
  *
  * Contract surfaces preserved (Pattern J):
  *   - CustomEvent name: `pathfinder-request-full-screen`
+ *   - `model.saveTabsToStorage()` awaited before the mode flip
  *   - `panelModeManager.setModePersisted('fullscreen')`
  *   - `panelModeManager.setPendingGuide(...)` payload shapes (editor vs guide)
  *   - `panelModeManager.capturePriorPath(...)`
@@ -57,11 +58,12 @@ import type { CombinedPanelState } from '../../../types/content-panel.types';
 
 interface FullScreenModel {
   state: CombinedPanelState;
+  saveTabsToStorage(): Promise<void>;
 }
 
 export function useFullScreenHandoff(model: FullScreenModel, isSessionActive: boolean): void {
   React.useEffect(() => {
-    const handleFullScreenRequest = () => {
+    const handleFullScreenRequest = async () => {
       if (isSessionActive) {
         getAppEvents().publish({
           type: 'alert-info',
@@ -84,10 +86,14 @@ export function useFullScreenHandoff(model: FullScreenModel, isSessionActive: bo
           guide_title: activeTab.title,
           content_type: AnalyticsContentType.Editor,
         });
+        // The full-screen page rebuilds its tabs from storage, so the write has
+        // to land before the mode flip or it restores the pre-handoff state.
+        const saveTabs = model.saveTabsToStorage();
         // Remember where we came from so explicit Exit can land back on the
         // user's prior Grafana page instead of the plugin home.
         panelModeManager.capturePriorPath(window.location.pathname + window.location.search);
         panelModeManager.setPendingGuide({ title: activeTab.title, type: 'editor' });
+        await saveTabs;
         panelModeManager.setModePersisted('fullscreen');
         locationService.push(`${PLUGIN_BASE_URL}/${ROUTES.FullScreen}`);
         return;
@@ -111,6 +117,7 @@ export function useFullScreenHandoff(model: FullScreenModel, isSessionActive: bo
         return;
       }
 
+      const saveTabs = model.saveTabsToStorage();
       panelModeManager.setPendingGuide({
         url: guideUrl,
         title: activeTab.title,
@@ -121,6 +128,7 @@ export function useFullScreenHandoff(model: FullScreenModel, isSessionActive: bo
         packageInfo: activeTab.packageInfo,
       });
 
+      await saveTabs;
       reportAppInteraction(UserInteraction.FullScreenEnter, {
         guide_url: guideUrl,
         guide_title: activeTab.title,

--- a/src/components/docs-panel/hooks/useFullScreenHandoff.ts
+++ b/src/components/docs-panel/hooks/useFullScreenHandoff.ts
@@ -121,6 +121,9 @@ export function useFullScreenHandoff(model: FullScreenModel, isSessionActive: bo
       panelModeManager.setPendingGuide({
         url: guideUrl,
         title: activeTab.title,
+        // The full-screen page restores this same tab from storage, so hand
+        // over its identity and let it focus rather than open a second copy.
+        tabId: activeTab.id,
         type: activeTab.type === 'learning-journey' ? 'learning-journey' : 'docs',
         // Forward synthetic packageInfo (e.g. PR-tester journeys whose URL
         // is a raw GitHub URL, not a recognised package URL) so the

--- a/src/components/docs-panel/hooks/useTabRestoration.test.ts
+++ b/src/components/docs-panel/hooks/useTabRestoration.test.ts
@@ -30,7 +30,7 @@ describe('useTabRestoration', () => {
     expect(model.restoreTabsAsync).toHaveBeenCalledTimes(1);
   });
 
-  it('calls restoreTabsAsync when only the editor tab is open (handoff-safe)', () => {
+  it('does NOT restore when an editor tab is already in the strip', () => {
     const model = makeModel();
     renderHook(() =>
       useTabRestoration({
@@ -39,7 +39,7 @@ describe('useTabRestoration', () => {
         tabs: [tab('recommendations', 'recommendations'), tab('editor', 'editor')],
       })
     );
-    expect(model.restoreTabsAsync).toHaveBeenCalledTimes(1);
+    expect(model.restoreTabsAsync).not.toHaveBeenCalled();
   });
 
   it('does NOT restore when a user-opened guide tab is present', () => {
@@ -62,7 +62,7 @@ describe('useTabRestoration', () => {
     expect(model.restoreTabsAsync).not.toHaveBeenCalled();
   });
 
-  it('re-fires when panelMode transitions away from fullscreen', () => {
+  it('force-refreshes the sidebar model when returning from fullscreen', () => {
     const model = makeModel();
     const { rerender } = renderHook(
       (props: { panelMode: PanelMode; tabs: any[] }) =>
@@ -72,7 +72,32 @@ describe('useTabRestoration', () => {
     expect(model.restoreTabsAsync).not.toHaveBeenCalled();
 
     rerender({ panelMode: 'sidebar', tabs: [tab('recommendations', 'recommendations')] });
-    expect(model.restoreTabsAsync).toHaveBeenCalledTimes(1);
+    expect(model.restoreTabsAsync).toHaveBeenCalledWith({ force: true });
+  });
+
+  it('force-refreshes over a populated strip, so fullscreen tab work is not dropped', () => {
+    const model = makeModel();
+    const tabs = [tab('recommendations', 'recommendations'), tab('user-guide-1')];
+    const { rerender } = renderHook(
+      ({ panelMode }: { panelMode: PanelMode }) => useTabRestoration({ model, panelMode, tabs }),
+      { initialProps: { panelMode: 'fullscreen' as PanelMode } }
+    );
+
+    rerender({ panelMode: 'sidebar' });
+    expect(model.restoreTabsAsync).toHaveBeenCalledWith({ force: true });
+  });
+
+  it('force-refreshes the sidebar model when returning from floating mode', () => {
+    const model = makeModel();
+    const tabs = [tab('recommendations', 'recommendations'), tab('editor', 'editor')];
+    const { rerender } = renderHook(
+      ({ panelMode }: { panelMode: PanelMode }) => useTabRestoration({ model, panelMode, tabs }),
+      { initialProps: { panelMode: 'floating' as PanelMode } }
+    );
+    expect(model.restoreTabsAsync).not.toHaveBeenCalled();
+
+    rerender({ panelMode: 'sidebar' });
+    expect(model.restoreTabsAsync).toHaveBeenCalledWith({ force: true });
   });
 
   it('does NOT re-fire on tab or model changes when panelMode is unchanged (preserves [panelMode]-only dep array)', () => {

--- a/src/components/docs-panel/hooks/useTabRestoration.ts
+++ b/src/components/docs-panel/hooks/useTabRestoration.ts
@@ -1,8 +1,11 @@
 /**
- * Triggers tab restoration from storage when the sidebar instance is
- * actually responsible for owning the tab surface — gated by `panelMode`
- * and by the "only non-content tabs" predicate so we don't overwrite
- * user-opened guide/docs tabs on a remount (editor chrome alone is OK).
+ * Keeps the sidebar model aligned with the shared tab workspace.
+ *
+ * Initial mount restores only an empty strip. Returning from floating or
+ * fullscreen force-refreshes even a populated strip, because those surfaces
+ * own separate models and may have opened, closed, or renamed tabs while
+ * they held the workspace — without the refresh the sidebar keeps its
+ * pre-handoff snapshot and their work looks discarded.
  *
  * Why the dep array is `[panelMode]` only (preserved verbatim — Pattern J
  * boundary touching the `_hasRestoredTabs` instance guard, deferred to a
@@ -13,16 +16,17 @@
  *     re-fire on every tab open/close — but the in-class `_hasRestoredTabs`
  *     guard makes those re-fires no-ops, so it'd be wasted work, not a
  *     bug.
- *   - The non-content check reads `tabs` via closure capture from
+ *   - The strip-empty check reads `tabs` via closure capture from
  *     the render that registered the effect. That's safe because the
  *     restoration trigger only matters at the boundary where `panelMode`
  *     flips away from `'fullscreen'`. The `tabs` snapshot at that moment
  *     is whatever the renderer last rendered.
  *
- * Full-screen mode skip (preserved verbatim):
- *   When the full-screen panel owns the session, the sidebar instance
+ * Non-sidebar mode skip:
+ *   While floating or full screen owns the session, the sidebar instance
  *   must NOT call restoreTabsAsync — otherwise both instances race on
- *   tabStorage and drift the saved tab content.
+ *   tabStorage and drift the saved tab content. Those surfaces flush
+ *   storage before they hand the workspace back.
  *
  * Restore-once guard (preserved — Pattern I, deferred):
  *   `_hasRestoredTabs` lives on the model instance, not the hook. The
@@ -31,20 +35,17 @@
  *   guard into a hook would change StrictMode and fullscreen-remount
  *   semantics — see the deferred-work note in the refactor plan.
  *
- * Contract surfaces preserved (Pattern J — pinned by
- * docs-panel.tab-restore-guard.test.ts and utils/tab-storage-restore.test.ts):
- *   - hasOnlyNonContentTabs predicate (does NOT touch tabStorage)
- *   - model.restoreTabsAsync() entry point (unchanged)
- *   - `_hasRestoredTabs` guard semantics (untouched on the class)
+ * The model's restore-once guard still protects the initial StrictMode
+ * replay; `{ force: true }` is reserved for a surface ownership transition.
  */
 import * as React from 'react';
-import { hasOnlyNonContentTabs } from '../utils';
+import { getGuideStripTabs } from '../utils';
 import type { LearningJourneyTab, CombinedPanelState } from '../../../types/content-panel.types';
 import type { PanelMode } from '../../../global-state/panel-mode';
 
 interface TabRestorationModel {
   state: CombinedPanelState;
-  restoreTabsAsync(): Promise<void>;
+  restoreTabsAsync(options?: { force?: boolean }): Promise<void>;
 }
 
 export interface UseTabRestorationArgs {
@@ -54,17 +55,27 @@ export interface UseTabRestorationArgs {
 }
 
 export function useTabRestoration({ model, panelMode, tabs }: UseTabRestorationArgs): void {
+  const previousModeRef = React.useRef(panelMode);
+
   // Restore tabs after storage is initialized (fixes race condition)
   React.useEffect(() => {
-    // Restore when only chrome / editor are present. Content tabs mean live
-    // user state we must not clobber; a lone Create Guide tab must not block
-    // pulling guides written by fullscreen/floating into shared tabStorage.
-    if (panelMode === 'fullscreen') {
+    const previousMode = previousModeRef.current;
+    previousModeRef.current = panelMode;
+
+    if (panelMode !== 'sidebar') {
       return;
     }
 
-    if (hasOnlyNonContentTabs(tabs)) {
-      model.restoreTabsAsync();
+    // Floating/fullscreen own separate models. Reconcile their saved strip
+    // when this long-lived sidebar model becomes the owner again.
+    if (previousMode !== 'sidebar') {
+      void model.restoreTabsAsync({ force: true });
+      return;
+    }
+
+    // Empty strip → hydrate from tabStorage. Any strip tab is live state.
+    if (getGuideStripTabs(tabs).length === 0) {
+      void model.restoreTabsAsync();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [panelMode]);

--- a/src/components/docs-panel/pendingGuideRouter.test.ts
+++ b/src/components/docs-panel/pendingGuideRouter.test.ts
@@ -10,7 +10,7 @@
  * journeys whose URL is a raw GitHub URL).
  */
 
-import { consumePendingGuideOnMount, openPendingGuide } from './pendingGuideRouter';
+import { consumePendingGuideOnMount, initializePanelTabsOnMount, openPendingGuide } from './pendingGuideRouter';
 import type { CombinedLearningJourneyPanel } from './docs-panel';
 import { panelModeManager, type PendingGuide } from '../../global-state/panel-mode';
 import type { RawContent } from '../../types/content.types';
@@ -20,6 +20,7 @@ function makePanel() {
     openEditorTab: jest.fn(),
     openLearningJourney: jest.fn(),
     openDocsPage: jest.fn(),
+    restoreTabsAsync: jest.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -122,6 +123,42 @@ describe('openPendingGuide', () => {
       pending.title,
       expect.objectContaining({ source: 'fullscreen_handoff' })
     );
+  });
+});
+
+describe('initializePanelTabsOnMount', () => {
+  afterEach(() => {
+    panelModeManager.consumePendingGuide();
+  });
+
+  it('restores the full strip before opening the pending guide', async () => {
+    // Reversing this order is what erased sibling tabs: the handoff tab made
+    // the strip non-empty, restore was skipped, and the surface's next
+    // `saveTabsToStorage()` persisted its one-tab model over the workspace.
+    const order: string[] = [];
+    const panel = makePanel();
+    panel.restoreTabsAsync.mockImplementation(async () => {
+      order.push('restore');
+    });
+    panel.openDocsPage.mockImplementation(() => order.push('open'));
+    panelModeManager.setPendingGuide({ url: 'bundled:b', title: 'B', type: 'docs' });
+
+    await expect(
+      initializePanelTabsOnMount(asPanel(panel), 'fullscreen_handoff', () => order.push('in-flight'))
+    ).resolves.toBe(true);
+
+    expect(order).toEqual(['in-flight', 'restore', 'open']);
+  });
+
+  it('restores without marking an open in-flight when nothing was handed off', async () => {
+    const panel = makePanel();
+    const markInFlight = jest.fn();
+
+    await expect(initializePanelTabsOnMount(asPanel(panel), 'fullscreen_handoff', markInFlight)).resolves.toBe(false);
+
+    expect(panel.restoreTabsAsync).toHaveBeenCalledTimes(1);
+    expect(markInFlight).not.toHaveBeenCalled();
+    expect(panel.openDocsPage).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/docs-panel/pendingGuideRouter.test.ts
+++ b/src/components/docs-panel/pendingGuideRouter.test.ts
@@ -15,8 +15,10 @@ import type { CombinedLearningJourneyPanel } from './docs-panel';
 import { panelModeManager, type PendingGuide } from '../../global-state/panel-mode';
 import type { RawContent } from '../../types/content.types';
 
-function makePanel() {
+function makePanel(state: { tabs: Array<{ id: string }>; activeTabId: string } = { tabs: [], activeTabId: '' }) {
   return {
+    state,
+    setActiveTab: jest.fn(),
     openEditorTab: jest.fn(),
     openLearningJourney: jest.fn(),
     openDocsPage: jest.fn(),
@@ -31,6 +33,53 @@ function asPanel(panel: ReturnType<typeof makePanel>): CombinedLearningJourneyPa
 }
 
 describe('openPendingGuide', () => {
+  // The receiving surface restores the whole strip before applying the
+  // handoff, so the guide being handed off is already a tab. Every open
+  // method below mints a fresh id and appends, so without the tabId guard a
+  // sidebar → fullscreen switch shows the guide twice and persists the
+  // duplicate back into the shared workspace.
+  it('focuses the restored tab named by tabId instead of opening a duplicate', () => {
+    const panel = makePanel({ tabs: [{ id: 'recommendations' }, { id: 'tab-a' }], activeTabId: 'recommendations' });
+    const pending: PendingGuide = {
+      url: 'https://grafana.com/docs/learning-journeys/foo/milestone-2',
+      title: 'Foo',
+      type: 'learning-journey',
+      tabId: 'tab-a',
+    };
+
+    openPendingGuide(asPanel(panel), pending, 'fullscreen_handoff');
+
+    expect(panel.setActiveTab).toHaveBeenCalledWith('tab-a');
+    expect(panel.openLearningJourney).not.toHaveBeenCalled();
+    expect(panel.openDocsPage).not.toHaveBeenCalled();
+  });
+
+  it('leaves an already-active restored tab alone so its in-flight load is not duplicated', () => {
+    const panel = makePanel({ tabs: [{ id: 'tab-a' }], activeTabId: 'tab-a' });
+    const pending: PendingGuide = { url: 'bundled:foo', title: 'Foo', type: 'docs', tabId: 'tab-a' };
+
+    openPendingGuide(asPanel(panel), pending, 'fullscreen_handoff');
+
+    expect(panel.setActiveTab).not.toHaveBeenCalled();
+    expect(panel.openDocsPage).not.toHaveBeenCalled();
+  });
+
+  it('opens normally when tabId names a tab this surface does not have', () => {
+    // Mounted-surface swaps (the fullscreen `pathfinder-request-full-screen`
+    // handler) route without restoring, so the handoff target can be absent.
+    const panel = makePanel({ tabs: [{ id: 'recommendations' }], activeTabId: 'recommendations' });
+    const pending: PendingGuide = { url: 'bundled:foo', title: 'Foo', type: 'docs', tabId: 'tab-gone' };
+
+    openPendingGuide(asPanel(panel), pending, 'fullscreen_handoff');
+
+    expect(panel.setActiveTab).not.toHaveBeenCalled();
+    expect(panel.openDocsPage).toHaveBeenCalledWith(
+      'bundled:foo',
+      'Foo',
+      expect.objectContaining({ source: 'fullscreen_handoff' })
+    );
+  });
+
   it('routes editor handoffs to openEditorTab and ignores any URL/packageInfo', () => {
     const panel = makePanel();
     const pending: PendingGuide = { type: 'editor', title: 'Guide editor' };
@@ -148,6 +197,20 @@ describe('initializePanelTabsOnMount', () => {
     ).resolves.toBe(true);
 
     expect(order).toEqual(['in-flight', 'restore', 'open']);
+  });
+
+  it('does not duplicate a handoff guide that restore just brought back', async () => {
+    const panel = makePanel({ tabs: [{ id: 'recommendations' }], activeTabId: 'recommendations' });
+    panel.restoreTabsAsync.mockImplementation(async () => {
+      panel.state.tabs = [{ id: 'recommendations' }, { id: 'tab-a' }, { id: 'tab-b' }];
+      panel.state.activeTabId = 'tab-a';
+    });
+    panelModeManager.setPendingGuide({ url: 'bundled:a', title: 'A', type: 'docs', tabId: 'tab-a' });
+
+    await initializePanelTabsOnMount(asPanel(panel), 'fullscreen_handoff', jest.fn());
+
+    expect(panel.openDocsPage).not.toHaveBeenCalled();
+    expect(panel.state.tabs).toHaveLength(3);
   });
 
   it('restores without marking an open in-flight when nothing was handed off', async () => {

--- a/src/components/docs-panel/pendingGuideRouter.ts
+++ b/src/components/docs-panel/pendingGuideRouter.ts
@@ -85,3 +85,33 @@ export function consumePendingGuideOnMount(
   openPendingGuide(panel, pending, pending.source ?? fallbackSource);
   return true;
 }
+
+/**
+ * Restore the complete workspace before applying a one-tab launch intent.
+ *
+ * Order is the whole point. Opening the handoff first makes the strip
+ * non-empty, which skips restore — the surface then owns a single-tab model
+ * and the next `saveTabsToStorage()` erases every sibling tab from the shared
+ * workspace. Consuming the pending guide up front (before the await) keeps the
+ * consume-once read synchronous with mount, so the in-flight flag is set
+ * before the empty-state fallback can look at it.
+ *
+ * Returns true when a pending guide was consumed.
+ */
+export async function initializePanelTabsOnMount(
+  panel: CombinedLearningJourneyPanel,
+  fallbackSource: LaunchSource,
+  markInFlight: () => void
+): Promise<boolean> {
+  const pending = panelModeManager.consumePendingGuide();
+  if (pending) {
+    markInFlight();
+  }
+
+  await panel.restoreTabsAsync();
+
+  if (pending) {
+    openPendingGuide(panel, pending, pending.source ?? fallbackSource);
+  }
+  return pending !== null;
+}

--- a/src/components/docs-panel/pendingGuideRouter.ts
+++ b/src/components/docs-panel/pendingGuideRouter.ts
@@ -26,6 +26,9 @@ import type { LaunchSource } from '../../recovery';
  * Apply a consumed pending guide to the receiving panel model.
  *
  * The branch order is load-bearing:
+ * 0. `tabId` naming a tab that already exists — the surface restored the strip
+ *    first, so the handoff target is a tab we already have. Focus it; every
+ *    open method below appends unconditionally and would duplicate the guide.
  * 1. `editor` handoffs carry no URL — switch the active tab to the editor.
  * 2. URL + `packageInfo` → `openDocsPage` with the manifest, so synthetic
  *    journeys (PR-tester) get a journey tab with the milestone toolbar even
@@ -40,6 +43,15 @@ export function openPendingGuide(
   pending: PendingGuide,
   source: LaunchSource
 ): void {
+  if (pending.tabId && panel.state.tabs.some((tab) => tab.id === pending.tabId)) {
+    // Restore already made it active and kicked off its content load, so
+    // re-selecting it would only risk a second fetch for the same tab.
+    if (panel.state.activeTabId !== pending.tabId) {
+      panel.setActiveTab(pending.tabId);
+    }
+    return;
+  }
+
   if (pending.type === 'editor') {
     panel.openEditorTab();
     return;
@@ -95,6 +107,10 @@ export function consumePendingGuideOnMount(
  * workspace. Consuming the pending guide up front (before the await) keeps the
  * consume-once read synchronous with mount, so the in-flight flag is set
  * before the empty-state fallback can look at it.
+ *
+ * The flip side of restoring first is that the handoff target is now already
+ * in the strip — `openPendingGuide` relies on `pending.tabId` to focus it
+ * rather than append a duplicate.
  *
  * Returns true when a pending guide was consumed.
  */

--- a/src/components/docs-panel/utils/index.ts
+++ b/src/components/docs-panel/utils/index.ts
@@ -15,7 +15,12 @@ export {
 } from './tab-kinds';
 export { isCurrentUserEditor, resolveTabGates, didGateClose } from './tab-gates';
 export type { TabGates } from './tab-gates';
-export { restoreTabsFromStorage, restoreActiveTabFromStorage, createUrlValidator } from './tab-storage-restore';
+export {
+  restoreTabsFromStorage,
+  restoreActiveTabFromStorage,
+  mergeRestoredTabsWithExisting,
+  createUrlValidator,
+} from './tab-storage-restore';
 export type { UrlValidator, TabRestoreOptions } from './tab-storage-restore';
 export { isGrafanaDocsUrl, cleanDocsUrl, isLearningJourneyUrl } from './url-validation';
 export { loadDocsTabContentResult, UNRESOLVED_PACKAGE_ERROR } from './docs-tab-loader';

--- a/src/components/docs-panel/utils/index.ts
+++ b/src/components/docs-panel/utils/index.ts
@@ -12,7 +12,6 @@ export {
   EDITOR_TAB_ID,
   getGuideStripTabs,
   isNonContentTab,
-  hasOnlyNonContentTabs,
 } from './tab-kinds';
 export { isCurrentUserEditor, resolveTabGates, didGateClose } from './tab-gates';
 export type { TabGates } from './tab-gates';

--- a/src/components/docs-panel/utils/tab-kinds.test.ts
+++ b/src/components/docs-panel/utils/tab-kinds.test.ts
@@ -2,7 +2,7 @@
  * Tests for docs-panel tab taxonomy helpers.
  */
 
-import { getGuideStripTabs, hasOnlyNonContentTabs } from './tab-kinds';
+import { getGuideStripTabs } from './tab-kinds';
 
 describe('getGuideStripTabs', () => {
   it('keeps ordered strip tabs while excluding recommendations', () => {
@@ -15,13 +15,5 @@ describe('getGuideStripTabs', () => {
         { type: 'docs' },
       ])
     ).toEqual([{ type: 'editor' }, { type: 'learning-journey' }, { type: 'devtools' }, { type: 'docs' }]);
-  });
-});
-
-describe('hasOnlyNonContentTabs', () => {
-  it('allows restore for chrome/editor state but blocks it when content is open', () => {
-    expect(hasOnlyNonContentTabs([{ type: 'recommendations' }])).toBe(true);
-    expect(hasOnlyNonContentTabs([{ type: 'recommendations' }, { type: 'devtools' }, { type: 'editor' }])).toBe(true);
-    expect(hasOnlyNonContentTabs([{ type: 'recommendations' }, { type: 'learning-journey' }])).toBe(false);
   });
 });

--- a/src/components/docs-panel/utils/tab-kinds.ts
+++ b/src/components/docs-panel/utils/tab-kinds.ts
@@ -32,12 +32,3 @@ export function getGuideStripTabs<T extends Pick<LearningJourneyTab, 'type'>>(ta
 export function isNonContentTab(tab: Pick<LearningJourneyTab, 'type'>): boolean {
   return NON_CONTENT_TAB_TYPES.has(tab.type);
 }
-
-/**
- * True when tabStorage restore won't clobber in-memory content tabs.
- * Not the same as an empty strip: the editor (and Dev Tools) are strip tabs
- * but still permit restore (they hold no fetched content).
- */
-export function hasOnlyNonContentTabs(tabs: Array<Pick<LearningJourneyTab, 'type'>>): boolean {
-  return tabs.every((t) => isNonContentTab(t));
-}

--- a/src/components/docs-panel/utils/tab-storage-restore.test.ts
+++ b/src/components/docs-panel/utils/tab-storage-restore.test.ts
@@ -5,10 +5,17 @@
 import {
   restoreTabsFromStorage,
   restoreActiveTabFromStorage,
+  mergeRestoredTabsWithExisting,
   createUrlValidator,
   TabStorage,
 } from './tab-storage-restore';
-import { PersistedTabData } from '../../../types/content-panel.types';
+import {
+  LearningJourneyTab,
+  PathContext,
+  PendingAlignment,
+  PersistedTabData,
+} from '../../../types/content-panel.types';
+import type { RawContent } from '../../../types/content.types';
 
 // Mock TabStorage
 const createMockTabStorage = (tabs: PersistedTabData[] | null = null, activeTab: string | null = null): TabStorage => ({
@@ -477,6 +484,118 @@ describe('tab-storage-restore', () => {
 
       const activeTabId = await restoreActiveTabFromStorage(storage, tabs);
       expect(activeTabId).toBe('recommendations');
+    });
+  });
+
+  describe('mergeRestoredTabsWithExisting', () => {
+    const blank = (overrides: Partial<LearningJourneyTab> = {}): LearningJourneyTab => ({
+      id: 'tab-1',
+      type: 'docs',
+      title: 'From storage',
+      baseUrl: 'https://grafana.com/docs/a/',
+      currentUrl: 'https://grafana.com/docs/a/page/',
+      content: null,
+      isLoading: false,
+      error: null,
+      ...overrides,
+    });
+
+    it('returns restored tabs unchanged when nothing is loaded in memory', () => {
+      const restored = [blank()];
+      expect(mergeRestoredTabsWithExisting(restored, [])).toBe(restored);
+      expect(mergeRestoredTabsWithExisting(restored, [blank({ title: 'Old' })])).toEqual(restored);
+    });
+
+    it('keeps content and pathContext when id and currentUrl match', () => {
+      const content: RawContent = {
+        content: '# guide',
+        metadata: { title: 'guide' },
+        type: 'single-doc',
+        url: 'https://grafana.com/docs/a/page/',
+        lastFetched: '2026-01-01T00:00:00.000Z',
+      };
+      const pathContext: PathContext = {
+        learningJourney: {
+          currentMilestone: 1,
+          totalMilestones: 1,
+          baseUrl: 'https://grafana.com/docs/a/',
+          milestones: [
+            {
+              number: 1,
+              title: 'Page',
+              duration: '',
+              url: 'https://grafana.com/docs/a/page/',
+              isActive: true,
+            },
+          ],
+        },
+      };
+      const pendingAlignment: PendingAlignment = {
+        startingLocation: '/old',
+        currentPath: '/old',
+        launchSource: 'test',
+        decidedAt: 0,
+      };
+      const existing = [
+        blank({
+          title: 'Old title',
+          content,
+          pathContext,
+          pendingAlignment,
+          error: 'stale',
+          isLoading: true,
+        }),
+      ];
+      const restored = [blank({ title: 'Renamed elsewhere' })];
+
+      const merged = mergeRestoredTabsWithExisting(restored, existing);
+
+      expect(merged[0]).toMatchObject({
+        title: 'Renamed elsewhere',
+        content,
+        pathContext,
+        isLoading: false,
+        error: null,
+      });
+      expect(merged[0]!.pendingAlignment).toBeUndefined();
+    });
+
+    it('does not keep error or pendingAlignment without content', () => {
+      const existing = [
+        blank({
+          error: 'load failed',
+          pendingAlignment: {
+            startingLocation: '/x',
+            currentPath: '/x',
+            launchSource: 'test',
+            decidedAt: 0,
+          },
+        }),
+      ];
+      const restored = [blank()];
+
+      expect(mergeRestoredTabsWithExisting(restored, existing)[0]).toEqual(restored[0]);
+    });
+
+    it('does not keep content when currentUrl diverged', () => {
+      const existing = [
+        blank({
+          content: {
+            content: '# old page',
+            metadata: { title: 'old' },
+            type: 'single-doc',
+            url: 'https://grafana.com/docs/a/page/',
+            lastFetched: '2026-01-01T00:00:00.000Z',
+          },
+          currentUrl: 'https://grafana.com/docs/a/page/',
+        }),
+      ];
+      const restored = [blank({ currentUrl: 'https://grafana.com/docs/a/other/' })];
+
+      expect(mergeRestoredTabsWithExisting(restored, existing)[0]!.content).toBeNull();
+      expect(mergeRestoredTabsWithExisting(restored, existing)[0]!.currentUrl).toBe(
+        'https://grafana.com/docs/a/other/'
+      );
     });
   });
 });

--- a/src/components/docs-panel/utils/tab-storage-restore.ts
+++ b/src/components/docs-panel/utils/tab-storage-restore.ts
@@ -216,6 +216,45 @@ export async function restoreTabsFromStorage(
 }
 
 /**
+ * Reconcile a storage-built tab strip with the model's current in-memory tabs.
+ *
+ * `restoreTabsFromStorage` always emits `content: null`. A wholesale
+ * `setState({ tabs })` on force restore would drop every loaded snapshot and
+ * refetch — same cost as a reload, on every fullscreen/floating round trip.
+ *
+ * When a restored tab shares an id and `currentUrl` with an existing tab that
+ * already has content, keep that content (and `pathContext`) and take the rest
+ * from storage. Do not carry `pendingAlignment`, `error`, or a mid-flight
+ * `isLoading`: those are surface-local, and preserving them would block the
+ * normal retry / `browser_restore` paths that a blank restore used to hit.
+ */
+export function mergeRestoredTabsWithExisting(
+  restoredTabs: LearningJourneyTab[],
+  existingTabs: LearningJourneyTab[]
+): LearningJourneyTab[] {
+  if (existingTabs.length === 0) {
+    return restoredTabs;
+  }
+
+  const existingById = new Map(existingTabs.map((tab) => [tab.id, tab]));
+
+  return restoredTabs.map((restored) => {
+    const existing = existingById.get(restored.id);
+    if (!existing || existing.currentUrl !== restored.currentUrl || existing.content == null) {
+      return restored;
+    }
+
+    return {
+      ...restored,
+      content: existing.content,
+      pathContext: existing.pathContext,
+      isLoading: false,
+      error: null,
+    };
+  });
+}
+
+/**
  * Restore active tab ID from storage
  *
  * @param tabStorage - Storage interface for persisted tabs

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -2,10 +2,10 @@ import React, { lazy, Suspense, useState, useEffect, useCallback, useMemo, useRe
 import { ThemeContext } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { CombinedLearningJourneyPanel } from '../docs-panel/docs-panel';
-import { consumePendingGuideOnMount } from '../docs-panel/pendingGuideRouter';
+import { consumePendingGuideOnMount, initializePanelTabsOnMount } from '../docs-panel/pendingGuideRouter';
 import { useContentReset, useAutoOpenListener } from '../docs-panel/hooks';
 import { useKeyboardShortcuts } from '../docs-panel/keyboard-shortcuts.hook';
-import { hasOnlyNonContentTabs, isNonContentTab } from '../docs-panel/utils';
+import { isNonContentTab } from '../docs-panel/utils';
 import { PathfinderFeatureProvider } from '../OpenFeatureProvider';
 import { useGuideProgressState, useAutoLaunchTutorial, useStepProgressFromEvents } from '../../hooks';
 import { panelModeManager, type PanelMode } from '../../global-state/panel-mode';
@@ -119,6 +119,7 @@ function FloatingPanelInner() {
   // Track whether a guide open is in-flight (pending guide consumed or auto-launch received).
   // Prevents the fallback from firing before the guide has loaded.
   const guideOpenInFlightRef = useRef(false);
+  const initializationRef = useRef<Promise<boolean> | null>(null);
 
   // Fire panel-mounted event so auto-launch and MCP flows work
   useEffect(() => {
@@ -132,14 +133,6 @@ function FloatingPanelInner() {
 
     document.dispatchEvent(new CustomEvent('pathfinder-panel-mounted', { detail: { timestamp: Date.now() } }));
     sidebarState.setIsSidebarMounted(true);
-
-    // Handoff from HomePanel's occupied-sidebar launch path (and any other
-    // setPendingGuide caller targeting the floating surface): consume the
-    // pending guide and mark the open in-flight BEFORE the restoration and
-    // empty-state-fallback effects below can run. Mirrors FullScreenPanel.
-    consumePendingGuideOnMount(panel, 'floating_panel_dock', () => {
-      guideOpenInFlightRef.current = true;
-    });
 
     return () => {
       document.removeEventListener('pathfinder-auto-launch-pending', handlePending);
@@ -175,15 +168,12 @@ function FloatingPanelInner() {
   const [restorationDone, setRestorationDone] = useState(false);
 
   useEffect(() => {
-    // Read live model state instead of closure'd `tabs`: the pending-guide
-    // consumption in the mount effect above mutates `panel.state.tabs`
-    // synchronously in the same commit, before this render's snapshot
-    // updates — restoring on top of the just-opened guide would await
-    // tabStorage and clobber it. Mirrors FullScreenPanel's gate.
-    // Only restore when no content tabs are open (editor chrome alone is OK).
-    const liveTabs = panel.state.tabs;
-    const restore = hasOnlyNonContentTabs(liveTabs) ? panel.restoreTabsAsync() : Promise.resolve();
-    restore.then(() => setRestorationDone(true));
+    // Restore the complete strip before applying the pending handoff — see
+    // `initializePanelTabsOnMount`. Mirrors FullScreenPanel.
+    initializationRef.current ??= initializePanelTabsOnMount(panel, 'floating_panel_dock', () => {
+      guideOpenInFlightRef.current = true;
+    });
+    initializationRef.current.then(() => setRestorationDone(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run once on mount
 
@@ -242,11 +232,14 @@ function FloatingPanelInner() {
   // docs/design/PANEL-MODE-PERSISTENCE.md (decisions 2 and 3); mechanics in
   // global-state/panel-mode.ts.
   const dockToSidebar = useCallback(
-    (persist: boolean) => {
+    async (persist: boolean) => {
       reportAppInteraction(UserInteraction.FloatingPanelDock, {
         guide_url: guideUrl || '',
         guide_title: title,
       });
+      // Flush before the mode flip: the sidebar force-restores from tabStorage
+      // when it takes the workspace back.
+      await panel.saveTabsToStorage();
       if (persist) {
         panelModeManager.setModePersisted('sidebar');
       } else {
@@ -255,11 +248,11 @@ function FloatingPanelInner() {
       sidebarState.setPendingOpenSource('floating_panel_dock', 'open');
       sidebarState.openSidebar('Interactive learning');
     },
-    [guideUrl, title]
+    [guideUrl, title, panel]
   );
 
-  const handleSwitchToSidebar = useCallback(() => {
-    dockToSidebar(true);
+  const handleSwitchToSidebar = useCallback(async () => {
+    await dockToSidebar(true);
   }, [dockToSidebar]);
 
   // Symmetric counterpart to `pathfinder-request-pop-out` (see docs-panel.tsx).
@@ -267,7 +260,7 @@ function FloatingPanelInner() {
   // dock the floating panel back into the sidebar.
   useEffect(() => {
     const handleDockRequest = () => {
-      dockToSidebar(false);
+      void dockToSidebar(false);
     };
     document.addEventListener('pathfinder-request-dock', handleDockRequest);
     return () => {
@@ -275,11 +268,12 @@ function FloatingPanelInner() {
     };
   }, [dockToSidebar]);
 
-  const handleClose = useCallback(() => {
+  const handleClose = useCallback(async () => {
+    await panel.saveTabsToStorage();
     panelModeManager.setMode('sidebar');
-  }, []);
+  }, [panel]);
 
-  const handleSwitchToFullScreen = useCallback(() => {
+  const handleSwitchToFullScreen = useCallback(async () => {
     // Editor: no guide URL — set a pending editor handoff so the receiving
     // panel switches its active tab to the editor even when fullscreen is
     // already mounted (e.g. journey was in fullscreen and the user wants
@@ -292,8 +286,10 @@ function FloatingPanelInner() {
         content_type: AnalyticsContentType.Editor,
       });
       // Remember where the user was so explicit Exit can land back there.
+      const saveTabs = panel.saveTabsToStorage();
       panelModeManager.capturePriorPath(window.location.pathname + window.location.search);
       panelModeManager.setPendingGuide({ title, type: 'editor' });
+      await saveTabs;
       panelModeManager.setModePersisted('fullscreen');
       locationService.push(`${PLUGIN_BASE_URL}/${ROUTES.FullScreen}`);
       return;
@@ -309,6 +305,7 @@ function FloatingPanelInner() {
     // Preserve the journey type through the handoff so the milestone
     // toolbar renders on the full screen page.
     const tabType = activeTab?.type === 'learning-journey' ? 'learning-journey' : 'docs';
+    const saveTabs = panel.saveTabsToStorage();
     panelModeManager.setPendingGuide({
       url: guideUrl,
       title,
@@ -320,6 +317,7 @@ function FloatingPanelInner() {
     });
     // Remember where the user was so explicit Exit can land back there.
     panelModeManager.capturePriorPath(window.location.pathname + window.location.search);
+    await saveTabs;
     panelModeManager.setModePersisted('fullscreen');
     // Include type in the URL so refresh/share rehydrates as a journey
     // even if findDocPage's URL-based classification can't tell.
@@ -331,7 +329,7 @@ function FloatingPanelInner() {
         guideType: tabType,
       })
     );
-  }, [isEditorTab, guideUrl, title, activeTab?.type, activeTab?.packageInfo]);
+  }, [isEditorTab, guideUrl, title, activeTab?.type, activeTab?.packageInfo, panel]);
 
   // Symmetric counterpart to the sidebar's `pathfinder-request-full-screen`
   // listener — lets surface-aware components (notably the BlockEditor toolbar)
@@ -339,7 +337,7 @@ function FloatingPanelInner() {
   // internals.
   useEffect(() => {
     const handleFullScreenRequest = () => {
-      handleSwitchToFullScreen();
+      void handleSwitchToFullScreen();
     };
     document.addEventListener('pathfinder-request-full-screen', handleFullScreenRequest);
     return () => {

--- a/src/components/floating-panel/FloatingPanelManager.tsx
+++ b/src/components/floating-panel/FloatingPanelManager.tsx
@@ -309,6 +309,9 @@ function FloatingPanelInner() {
     panelModeManager.setPendingGuide({
       url: guideUrl,
       title,
+      // Full screen restores this tab from storage; identify it so the
+      // handoff focuses the restored tab instead of duplicating it.
+      tabId: activeTab?.id,
       type: tabType,
       // Forward synthetic packageInfo (e.g. PR-tester journeys backed by
       // raw GitHub URLs) so the full-screen page rebuilds the milestone
@@ -329,7 +332,7 @@ function FloatingPanelInner() {
         guideType: tabType,
       })
     );
-  }, [isEditorTab, guideUrl, title, activeTab?.type, activeTab?.packageInfo, panel]);
+  }, [isEditorTab, guideUrl, title, activeTab?.id, activeTab?.type, activeTab?.packageInfo, panel]);
 
   // Symmetric counterpart to the sidebar's `pathfinder-request-full-screen`
   // listener — lets surface-aware components (notably the BlockEditor toolbar)

--- a/src/components/floating-panel/floating-panel.pending-guide.test.ts
+++ b/src/components/floating-panel/floating-panel.pending-guide.test.ts
@@ -21,23 +21,13 @@ import * as path from 'path';
 
 const src = fs.readFileSync(path.resolve(__dirname, 'FloatingPanelManager.tsx'), 'utf-8');
 
-describe('FloatingPanelInner consumes the pending guide on mount', () => {
-  it('calls the shared consume step (consume → in-flight → route)', () => {
-    expect(src).toContain('consumePendingGuideOnMount(panel,');
+describe('FloatingPanelInner initializes pending guides on mount', () => {
+  it('calls the shared ordered initialization step (restore → route)', () => {
+    expect(src).toContain('initializePanelTabsOnMount(panel,');
   });
 
-  it('consumes before the tab-restoration effect runs', () => {
-    // Effects run in declaration order; consumption must be declared first
-    // so the restoration gate sees the just-opened tab. Anchor on the call
-    // site `(panel,` — a bare name match would hit the import statement and
-    // pass regardless of effect order.
-    expect(src.indexOf('consumePendingGuideOnMount(panel,')).toBeLessThan(src.indexOf('restoreTabsAsync'));
-  });
-
-  it('gates restoration on LIVE model tabs, not the render snapshot', () => {
-    // The pending-guide open mutates panel.state.tabs synchronously in the
-    // same commit; a closure'd snapshot would restore on top of it.
-    expect(src).toMatch(/const liveTabs = panel\.state\.tabs/);
+  it('reuses one initialization promise across StrictMode effect replay', () => {
+    expect(src).toContain('initializationRef.current ??= initializePanelTabsOnMount');
   });
 });
 

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -6,9 +6,9 @@ import { useStyles2 } from '@grafana/ui';
 import { CombinedLearningJourneyPanel } from '../docs-panel/docs-panel';
 import { useContentReset, useAutoOpenListener } from '../docs-panel/hooks';
 import { useKeyboardShortcuts } from '../docs-panel/keyboard-shortcuts.hook';
-import { consumePendingGuideOnMount } from '../docs-panel/pendingGuideRouter';
+import { consumePendingGuideOnMount, initializePanelTabsOnMount } from '../docs-panel/pendingGuideRouter';
 import { LearningJourneyMilestoneToolbar } from '../docs-panel/components';
-import { hasOnlyNonContentTabs, isNonContentTab } from '../docs-panel/utils';
+import { isNonContentTab } from '../docs-panel/utils';
 import { FloatingPanelContent } from '../floating-panel/FloatingPanelContent';
 import { SkeletonLoader } from '../SkeletonLoader';
 import { useGuideProgressState, useAutoLaunchTutorial, useStepProgressFromEvents } from '../../hooks';
@@ -78,8 +78,10 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
   // Track whether a guide open is in-flight so the empty-state fallback
   // doesn't fire before the handoff or auto-launch has resolved.
   const guideOpenInFlightRef = useRef(false);
+  const initializationRef = useRef<Promise<boolean> | null>(null);
 
-  // Handoff from sidebar/floating: open the pending guide if one was set.
+  // Announce surface ownership. The pending handoff is consumed by the
+  // ordered tab initialization below, not here.
   useEffect(() => {
     const handlePending = () => {
       guideOpenInFlightRef.current = true;
@@ -93,10 +95,6 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     // `getIsSidebarMounted()` and silently fall through (or try to call
     // `openSidebar`, which now no-ops in fullscreen mode).
     sidebarState.setIsSidebarMounted(true);
-
-    consumePendingGuideOnMount(panel, 'fullscreen_handoff', () => {
-      guideOpenInFlightRef.current = true;
-    });
 
     return () => {
       document.removeEventListener('pathfinder-auto-launch-pending', handlePending);
@@ -113,24 +111,17 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     };
   }, [panel]);
 
-  // Tab restoration from storage. Mirror of the floating panel pattern:
-  // restore once on mount, gated on the model still showing only the
-  // default recommendations tab.
+  // Restore the complete strip before applying a pending handoff. Opening the
+  // handoff first leaves this model holding one tab, and the save that follows
+  // persists that one tab over everything else the user had open.
   const { tabs, activeTabId } = panel.useState();
   const [restorationDone, setRestorationDone] = useState(false);
 
   useEffect(() => {
-    // Read live model state instead of closure'd `tabs`. The pending-guide
-    // useEffect above runs BEFORE this one and synchronously calls
-    // `panel.openDocsPage`, which mutates `panel.state.tabs` immediately
-    // but doesn't update the closure'd snapshot from `panel.useState()`
-    // for this render. Using the live state stops us from restoring on
-    // top of a tab the handoff just opened — that would await tabStorage
-    // and overwrite the new tab if storage was empty or stale.
-    // Only restore when no content tabs are open (editor chrome alone is OK).
-    // Mirrors the sidebar gate — avoids skipping restore when only Create Guide is open.
-    const restore = hasOnlyNonContentTabs(panel.state.tabs) ? panel.restoreTabsAsync() : Promise.resolve();
-    restore.then(() => setRestorationDone(true));
+    initializationRef.current ??= initializePanelTabsOnMount(panel, 'fullscreen_handoff', () => {
+      guideOpenInFlightRef.current = true;
+    });
+    initializationRef.current.then(() => setRestorationDone(true));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -244,12 +235,15 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     model: panel,
   });
 
-  const handleExitToSidebar = useCallback(() => {
+  const handleExitToSidebar = useCallback(async () => {
     reportAppInteraction(UserInteraction.FullScreenExit, {
       destination: 'sidebar',
       guide_url: guideUrl || '',
       guide_title: title,
     });
+    // Flush before the mode flip: the sidebar force-restores from tabStorage
+    // when it takes the workspace back, so anything unsaved here is lost.
+    await panel.saveTabsToStorage();
     panelModeManager.setMode('sidebar');
     sidebarState.setPendingOpenSource('fullscreen_handoff', 'open');
     sidebarState.openSidebar('Interactive learning');
@@ -258,7 +252,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     // URLs (no captured prior path).
     const priorPath = panelModeManager.consumePriorPath();
     locationService.push(priorPath ?? PLUGIN_BASE_URL);
-  }, [guideUrl, title]);
+  }, [guideUrl, title, panel]);
 
   /**
    * Hand off to the floating panel — works for both guides and the editor.
@@ -268,14 +262,16 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
    * whatever tabStorage happens to hold (mirrors the inbound direction
    * `FloatingPanelManager.handleSwitchToFullScreen`).
    */
-  const handleSwitchToFloating = useCallback(() => {
+  const handleSwitchToFloating = useCallback(async () => {
     if (isEditorTab) {
       reportAppInteraction(UserInteraction.FullScreenExit, {
         destination: 'floating',
         guide_url: '',
         guide_title: title,
       });
+      const saveTabs = panel.saveTabsToStorage();
       panelModeManager.setPendingGuide({ title, type: 'editor' });
+      await saveTabs;
       panelModeManager.setModePersisted('floating');
       locationService.push(PLUGIN_BASE_URL);
       return;
@@ -292,6 +288,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     // panel reopens it as a learning journey (with milestone navigation)
     // rather than a flat docs tab.
     const tabType = activeTab?.type === 'learning-journey' ? 'learning-journey' : 'docs';
+    const saveTabs = panel.saveTabsToStorage();
     panelModeManager.setPendingGuide({
       url: guideUrl,
       title,
@@ -301,9 +298,10 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
       // direction: raw GitHub URLs aren't recognised package URLs.
       packageInfo: activeTab?.packageInfo,
     });
+    await saveTabs;
     panelModeManager.setModePersisted('floating');
     locationService.push(PLUGIN_BASE_URL);
-  }, [isEditorTab, guideUrl, title, activeTab?.type, activeTab?.packageInfo]);
+  }, [isEditorTab, guideUrl, title, activeTab?.type, activeTab?.packageInfo, panel]);
 
   // Stable ref to the latest exit-to-sidebar callback. Without it, the
   // empty-state fallback effect below would re-subscribe whenever
@@ -324,7 +322,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
   // the ref above so identity changes don't re-fire this effect.
   useEffect(() => {
     if (restorationDone && !hasActiveGuide && !isEditorTab && !guideOpenInFlightRef.current) {
-      handleExitToSidebarRef.current();
+      void handleExitToSidebarRef.current();
     }
   }, [restorationDone, hasActiveGuide, isEditorTab]);
 
@@ -333,7 +331,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
   // fullscreen to hand off without knowing about FullScreenPanel internals.
   useEffect(() => {
     const handleDockRequest = () => {
-      handleExitToSidebar();
+      void handleExitToSidebar();
     };
     document.addEventListener('pathfinder-request-dock', handleDockRequest);
     return () => {

--- a/src/components/full-screen/FullScreenPanel.tsx
+++ b/src/components/full-screen/FullScreenPanel.tsx
@@ -292,6 +292,9 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     panelModeManager.setPendingGuide({
       url: guideUrl,
       title,
+      // The floating panel restores this tab from storage; identify it so the
+      // handoff focuses the restored tab instead of duplicating it.
+      tabId: activeTab?.id,
       type: tabType,
       // Preserve synthetic packageInfo (PR-tester journeys) across the
       // fullscreen → floating handoff for the same reason as the inbound
@@ -301,7 +304,7 @@ function FullScreenPanelRenderer(_props: SceneComponentProps<FullScreenPanel>) {
     await saveTabs;
     panelModeManager.setModePersisted('floating');
     locationService.push(PLUGIN_BASE_URL);
-  }, [isEditorTab, guideUrl, title, activeTab?.type, activeTab?.packageInfo, panel]);
+  }, [isEditorTab, guideUrl, title, activeTab?.id, activeTab?.type, activeTab?.packageInfo, panel]);
 
   // Stable ref to the latest exit-to-sidebar callback. Without it, the
   // empty-state fallback effect below would re-subscribe whenever

--- a/src/components/full-screen/panel-mode-surface-toggles.contract.test.ts
+++ b/src/components/full-screen/panel-mode-surface-toggles.contract.test.ts
@@ -61,8 +61,10 @@ describe('panel-mode surface-toggle persistence classification', () => {
       // scope each assertion to its call site to catch a "right method, wrong
       // call site" swap. The behavioural proof lives in panel-mode.test.ts.
       const floating = read('components/floating-panel/FloatingPanelManager.tsx');
-      expect(floating).toMatch(/handleSwitchToSidebar = useCallback\(\(\) => \{\s*dockToSidebar\(true\);\s*\}/);
-      expect(floating).toMatch(/handleDockRequest = \(\) => \{\s*dockToSidebar\(false\);\s*\}/);
+      expect(floating).toMatch(
+        /handleSwitchToSidebar = useCallback\(async \(\) => \{\s*await dockToSidebar\(true\);\s*\}/
+      );
+      expect(floating).toMatch(/handleDockRequest = \(\) => \{\s*void dockToSidebar\(false\);\s*\}/);
     });
   });
 

--- a/src/global-state/panel-mode.ts
+++ b/src/global-state/panel-mode.ts
@@ -28,6 +28,12 @@ export interface PendingGuide {
    */
   type?: 'learning-journey' | 'docs' | 'interactive' | 'editor';
   /**
+   * Identity of an existing tab moving between surfaces. The receiving surface
+   * restores the whole strip before applying the handoff, so the guide is
+   * already present — focus it by id instead of opening a second copy.
+   */
+  tabId?: string;
+  /**
    * Carry the manifest + pre-resolved milestones across surface handoffs.
    *
    * Required for synthetic packages whose URL is not a recognised package


### PR DESCRIPTION
## Summary

A prior deficient behavior: popping out the panel or switching to fullscreen could overwrite shared tab storage with the single active tab, clearing every other open tab. This change keeps the full tab workspace intact across surface handoffs so sibling tabs survive and come back when ownership returns.

Stacked on #1510 (`ui/editor-tab-chrome-lifecycle`).

## What to look at

- **Restore-before-open** (`pendingGuideRouter.ts` → `initializePanelTabsOnMount`) — consume pending synchronously for in-flight gating, restore the full strip, then apply the handoff. Opening first used to skip restore and let the next save erase siblings.
- **`tabId` on handoffs** — after restore the target tab already exists; focus it instead of appending a duplicate. Skip `setActiveTab` when already active so the restore-time load is not double-fetched.
- **Outbound flush** — await `saveTabsToStorage()` before sidebar/floating/fullscreen mode changes (including close/dock).
- **Sidebar reclaim** (`useTabRestoration.ts`) — `{ force: true }` when returning from floating/fullscreen; empty-strip-only hydrate on initial sidebar mount.
- **Taxonomy** — restore gating moves from `hasOnlyNonContentTabs` to `getGuideStripTabs` (empty strip).

## Alternatives considered

Not really. Without a larger refactor of how surfaces own tab state, the receiving view should align with the passed workspace. This change reinforces that: when state is handed back, or when the active surface mutates tabs, saves include the sibling context other views still need.

## Gotchas

Restore/hydrate gating migrates from `hasOnlyNonContentTabs` to “fetch/use guide strip tabs” (`getGuideStripTabs`). The original non-content flag is still useful for “no URL to fetch” rendering (e.g. remote URL load paths), but it was being conflated with legacy “permanent / chrome-only tabs.” Editor and Dev Tools are strip members now, so they are live strip state — not a reason to treat the strip as empty for restore.

## How to verify

1. Sidebar: open two guides (+ optional editor). Enter fullscreen on guide A — both guides remain in storage/strip context; A is focused once (no duplicate A tab).
2. In fullscreen, open or close a sibling (or rename) — Exit to sidebar — strip matches what fullscreen had (force restore), not the pre-fullscreen snapshot.
3. Fullscreen → floating and floating → fullscreen — same strip; no duplicate of the active guide.
4. Floating dock / close — sidebar reclaim shows floating’s tabs, not the pre-pop-out snapshot.
5. Pop out from sidebar with multiple tabs open — floating shows the active guide; dock back — siblings still present.
6. Home / auto-launch into floating (no `tabId`) — still opens a new tab after restore (genuine launch path unchanged).
7. Editor-only handoff into fullscreen — editor focuses via singleton path; siblings from storage still restored underneath.

## Breaking changes

None.

## Out of scope

- Multi-editor `createEditorTab({ tabId })` from `ui/add-multiple-guide`.
- Making `saveTabsToStorage` fail the mode flip on write errors (still best-effort / logged).