### PR TITLE
fix(settings): preserve provisioned jsonData fields on plugin settings save

### DIFF
--- a/src/components/AppConfig/ConfigurationForm.tsx
+++ b/src/components/AppConfig/ConfigurationForm.tsx
@@ -155,6 +155,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
         enabled,
         pinned,
         jsonData: {
+          ...(jsonData || {}),
           ...getConfigWithDefaults(jsonData || {}),
           enableAssistantDevMode: newValue,
         },
@@ -265,6 +266,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
           enabled,
           pinned,
           jsonData: {
+            ...(jsonData || {}),
             ...getConfigWithDefaults(jsonData || {}),
             codaRegistered: true,
             codaApiUrl: apiUrl,
@@ -362,10 +364,11 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
         shouldMarkRegistered = true;
       }
 
-      // Spread full config with defaults to preserve fields managed by other tabs,
-      // then override with this form's fields. Prevents data loss if jsonData is
-      // incomplete after a plugin version update.
+      // Preserve ALL existing jsonData fields first (including provisioned fields
+      // like stackId that aren't in DocsPluginConfig), then apply defaults for
+      // known fields, then override with this form's fields.
       const newJsonData = {
+        ...(jsonData || {}),
         ...getConfigWithDefaults(jsonData || {}),
         recommenderServiceUrl: state.recommenderServiceUrl,
         tutorialUrl: state.tutorialUrl,

--- a/src/components/AppConfig/InteractiveFeatures.tsx
+++ b/src/components/AppConfig/InteractiveFeatures.tsx
@@ -133,10 +133,11 @@ const InteractiveFeatures = ({ plugin }: InteractiveFeaturesProps) => {
     setIsSaving(true);
 
     try {
-      // Spread full config with defaults to preserve fields managed by other tabs,
-      // then override with this form's fields. Prevents data loss if jsonData is
-      // incomplete after a plugin version update.
+      // Preserve ALL existing jsonData fields first (including provisioned fields
+      // like stackId that aren't in DocsPluginConfig), then apply defaults for
+      // known fields, then override with this form's fields.
       const newJsonData = {
+        ...(jsonData || {}),
         ...getConfigWithDefaults(jsonData || {}),
         enableAutoDetection: state.enableAutoDetection,
         requirementsCheckTimeout: state.requirementsCheckTimeout,

--- a/src/components/AppConfig/TermsAndConditions.tsx
+++ b/src/components/AppConfig/TermsAndConditions.tsx
@@ -36,10 +36,11 @@ const TermsAndConditions = ({ plugin }: TermsAndConditionsProps) => {
     setIsSaving(true);
 
     try {
-      // Spread full config with defaults to preserve fields managed by other tabs,
-      // then override with this form's fields. Prevents data loss if jsonData is
-      // incomplete after a plugin version update.
+      // Preserve ALL existing jsonData fields first (including provisioned fields
+      // like stackId that aren't in DocsPluginConfig), then apply defaults for
+      // known fields, then override with this form's fields.
       const newJsonData = {
+        ...(jsonData || {}),
         ...getConfigWithDefaults(jsonData || {}),
         acceptedTermsAndConditions: isRecommenderEnabled,
         // Persist the current terms version when enabling; leave unchanged when disabling

--- a/src/components/AppConfig/settings-preservation.test.ts
+++ b/src/components/AppConfig/settings-preservation.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression tests for plugin settings preservation.
+ *
+ * Grafana's plugin settings API does a full overwrite of jsonData (not a merge),
+ * so we must explicitly preserve all existing fields when saving settings.
+ * This is critical for provisioned fields like `stackId` from Grafana Cloud.
+ *
+ * @see https://grafana.com/developers/plugin-tools/how-to-guides/app-plugins/add-authentication-for-app-plugins
+ */
+
+import { getConfigWithDefaults, DocsPluginConfig } from '../../constants';
+
+describe('plugin settings preservation', () => {
+  /**
+   * This test verifies the pattern used in ConfigurationForm, TermsAndConditions,
+   * and InteractiveFeatures when constructing newJsonData for saving.
+   *
+   * The pattern is:
+   *   const newJsonData = {
+   *     ...(jsonData || {}),                      // 1. Preserve ALL existing fields
+   *     ...getConfigWithDefaults(jsonData || {}), // 2. Apply defaults for known fields
+   *     // form-specific overrides...             // 3. Override with form values
+   *   };
+   */
+  describe('jsonData spread pattern', () => {
+    it('preserves unknown/provisioned fields like stackId when constructing newJsonData', () => {
+      // Simulate jsonData from Grafana Cloud with provisioned fields
+      const jsonData = {
+        stackId: '123456',
+        someOtherProvisionedField: 'cloud-value',
+        recommenderServiceUrl: 'https://custom.example.com',
+        tutorialUrl: 'https://custom-tutorial.example.com',
+      } as DocsPluginConfig & { stackId: string; someOtherProvisionedField: string };
+
+      // Simulate the pattern used in our config forms
+      const newJsonData = {
+        ...(jsonData || {}),
+        ...getConfigWithDefaults(jsonData || {}),
+        // Form-specific override (simulating user changing tutorial URL)
+        tutorialUrl: 'https://new-tutorial.example.com',
+      };
+
+      // Provisioned fields must be preserved
+      expect(newJsonData.stackId).toBe('123456');
+      expect(newJsonData.someOtherProvisionedField).toBe('cloud-value');
+
+      // Known fields should have correct values
+      expect(newJsonData.recommenderServiceUrl).toBe('https://custom.example.com');
+      expect(newJsonData.tutorialUrl).toBe('https://new-tutorial.example.com');
+    });
+
+    it('preserves stackId even when other known fields use defaults', () => {
+      // Minimal jsonData with only provisioned field
+      const jsonData = {
+        stackId: '789',
+      } as DocsPluginConfig & { stackId: string };
+
+      const newJsonData = {
+        ...(jsonData || {}),
+        ...getConfigWithDefaults(jsonData || {}),
+      };
+
+      // stackId must be preserved
+      expect(newJsonData.stackId).toBe('789');
+
+      // Known fields should have defaults applied
+      expect(newJsonData.acceptedTermsAndConditions).toBeDefined();
+      expect(newJsonData.enableAutoDetection).toBeDefined();
+    });
+
+    it('handles empty jsonData without losing provisioned fields on subsequent saves', () => {
+      // First save: jsonData has provisioned fields
+      const initialJsonData = {
+        stackId: 'abc',
+        accessToken: 'secret', // This would be in secureJsonData, but testing the pattern
+      } as DocsPluginConfig & { stackId: string; accessToken: string };
+
+      const firstSave = {
+        ...(initialJsonData || {}),
+        ...getConfigWithDefaults(initialJsonData || {}),
+        acceptedTermsAndConditions: true,
+      };
+
+      expect(firstSave.stackId).toBe('abc');
+      expect(firstSave.accessToken).toBe('secret');
+
+      // Second save: using the result of first save (simulating round-trip)
+      const secondSave = {
+        ...(firstSave || {}),
+        ...getConfigWithDefaults(firstSave || {}),
+        tutorialUrl: 'https://changed.example.com',
+      };
+
+      // Provisioned fields still preserved after multiple saves
+      expect(secondSave.stackId).toBe('abc');
+      expect(secondSave.accessToken).toBe('secret');
+      expect(secondSave.acceptedTermsAndConditions).toBe(true);
+      expect(secondSave.tutorialUrl).toBe('https://changed.example.com');
+    });
+  });
+
+  describe('getConfigWithDefaults behavior', () => {
+    it('does not include unknown fields in its output', () => {
+      const jsonData = {
+        stackId: '123',
+        recommenderServiceUrl: 'https://custom.example.com',
+      } as DocsPluginConfig & { stackId: string };
+
+      const defaults = getConfigWithDefaults(jsonData);
+
+      // getConfigWithDefaults only returns known DocsPluginConfig fields
+      expect('stackId' in defaults).toBe(false);
+
+      // This is why we need the first spread: ...(jsonData || {})
+      // Without it, stackId would be lost
+    });
+
+    it('preserves existing values for known fields', () => {
+      const jsonData: DocsPluginConfig = {
+        recommenderServiceUrl: 'https://custom.example.com',
+        tutorialUrl: 'https://custom-tutorial.example.com',
+        enableAutoDetection: false,
+      };
+
+      const defaults = getConfigWithDefaults(jsonData);
+
+      expect(defaults.recommenderServiceUrl).toBe('https://custom.example.com');
+      expect(defaults.tutorialUrl).toBe('https://custom-tutorial.example.com');
+      expect(defaults.enableAutoDetection).toBe(false);
+    });
+  });
+
+  describe('regression: without first spread, provisioned fields are lost', () => {
+    it('demonstrates the bug when only using getConfigWithDefaults', () => {
+      const jsonData = {
+        stackId: '123',
+        recommenderServiceUrl: 'https://custom.example.com',
+      } as DocsPluginConfig & { stackId: string };
+
+      // BUG: This pattern loses stackId
+      const buggyNewJsonData = {
+        ...getConfigWithDefaults(jsonData || {}),
+        tutorialUrl: 'https://new.example.com',
+      };
+
+      // stackId is lost!
+      expect('stackId' in buggyNewJsonData).toBe(false);
+
+      // FIX: Include the original jsonData spread first
+      const fixedNewJsonData = {
+        ...(jsonData || {}),
+        ...getConfigWithDefaults(jsonData || {}),
+        tutorialUrl: 'https://new.example.com',
+      };
+
+      // stackId is preserved
+      expect(fixedNewJsonData.stackId).toBe('123');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes a bug where saving plugin settings would clear provisioned fields like `stackId` from Grafana Cloud
- Ensures all existing `jsonData` fields are preserved when saving settings from any configuration tab

## Problem

When saving plugin settings, the frontend was losing provisioned fields (like `stackId`) that are set by Grafana Cloud. This happened because:

1. `getConfigWithDefaults()` only returns fields defined in `DocsPluginConfig`
2. Grafana's plugin settings API (`POST /api/plugins/{pluginId}/settings`) does a **full overwrite** of `jsonData`, not a merge
3. Any field not explicitly included in the save payload gets deleted from the server

### Impact

Without `stackId`, the backend plugin's OBO (On-Behalf-Of) token exchanger fails to initialize, causing:
- Private guides to become unavailable (`obo-unavailable` error)
- Users needing to wait for settings to be re-provisioned or manually intervene

## Solution

Spread the original `jsonData` first to preserve ALL existing fields before applying defaults and form-specific overrides:

```typescript
const newJsonData = {
  ...(jsonData || {}),                        // 1. Preserve ALL existing fields (incl. provisioned)
  ...getConfigWithDefaults(jsonData || {}),   // 2. Apply defaults for known fields  
  // 3. Override with form-specific values...
};
```

This pattern was applied to all 5 locations where settings are saved:
- `ConfigurationForm.tsx` (3 locations)
- `TermsAndConditions.tsx` (1 location)
- `InteractiveFeatures.tsx` (1 location)

## References

- [Grafana Plugin Tools: Add authentication for app plugins](https://grafana.com/developers/plugin-tools/how-to-guides/app-plugins/add-authentication-for-app-plugins)
- [Grafana source: pkg/api/plugins.go](https://github.com/grafana/grafana/blob/main/pkg/api/plugins.go)