### PR TITLE
docs: document the challenge and snippet-ref guide block types

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ Editors and admins can author custom interactive guides in two ways:
 
 ### Documentation
 
-- **[JSON Guide Format Reference](docs/developer/interactive-examples/json-guide-format.md)** — Complete reference for the JSON guide structure and all block types (markdown, image, video, section, conditional, interactive, multistep, guided, code-block, terminal, terminal-connect, grot-guide, quiz, input, assistant)
+- **[JSON Guide Format Reference](docs/developer/interactive-examples/json-guide-format.md)** — Complete reference for the JSON guide structure and every block type, with a summary table and a per-type section
 - **[Interactive Types](docs/developer/interactive-examples/interactive-types.md)** — Action types (`highlight`, `button`, `formfill`, `navigate`, `hover`, `noop`, `popout`) and when to use each
 - **[Requirements Reference](docs/developer/interactive-examples/requirements-reference.md)** — Available requirements for controlling when interactive elements are accessible
 - **[Selectors Reference](docs/developer/interactive-examples/selectors-reference.md)** — How to target DOM elements with the enhanced selector engine and the resilience pipeline
 
-See the [JSON Guide Demo](src/bundled-interactives/json-guide-demo.json) for a complete example of all block types.
+See the [JSON Guide Demo](src/bundled-interactives/json-guide-demo/content.json) for a worked example of the most common block types.
 
 ## For developers
 

--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -1013,6 +1013,99 @@ A choose-your-own-adventure decision tree where each screen offers options that 
 
 Each screen has `id`, `title`, `body` (markdown), and an `options[]` array. Each option has a `label` and a `next` screen ID. A screen with no `options` ends the tree. The block editor includes a YAML import flow for converting Grot Guide YAML directly into JSON.
 
+#### Challenge block
+
+A capture-the-flag style task: a title, a markdown brief, optional progressive hints, and a "Check my work" button that evaluates a single requirement token. The `mode` field picks the execution model, and most of the other fields follow from it.
+
+| Mode         | Behavior                                                                                                                                                                                                           |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `"standard"` | Runs against the learner's own Grafana. Nothing is provisioned, and the brief and "Check my work" are available immediately. `successCriteria` is any Pathfinder requirement, such as `has-datasource:prometheus`. |
+| `"coda"`     | Provisions a Coda VM with a terminal, runs the setup script, then reveals "Check my work". `successCriteria` is typically `coda-exit-zero:<command>`.                                                              |
+
+`mode` is optional, and it resolves to a different value depending on how the block reaches you:
+
+- **Omitted in JSON** — the runtime treats the block as `"coda"`. Challenges predate `"standard"`, so an existing guide with no `mode` keeps its original Coda behavior.
+- **Created in the block editor** — the challenge form writes `mode` explicitly and seeds a brand-new block with `"standard"`, the cheaper authoring path. Opening a legacy block that has no `mode` infers `"coda"`, either from the presence of a VM or setup field or as the safe fallback.
+
+Both defaults are intentional. Set `mode` explicitly in hand-written JSON so the block does not depend on which path it came through.
+
+Standard mode:
+
+```json
+{
+  "type": "challenge",
+  "mode": "standard",
+  "title": "Connect your first data source",
+  "brief": "Add a Prometheus data source so the rest of this guide has something to query.",
+  "successCriteria": "has-datasource:prometheus",
+  "failureMessage": "No Prometheus data source yet — check the connections page.",
+  "hintLevels": [
+    { "text": "Start from Connections > Data sources." },
+    { "text": "The Add new data source button is in the top right." }
+  ]
+}
+```
+
+Coda mode:
+
+```json
+{
+  "type": "challenge",
+  "mode": "coda",
+  "title": "Fix the broken scrape config",
+  "brief": "The Prometheus config in `/etc/prometheus` has a bad scrape target. Repair it.",
+  "vmTemplate": "vm-aws",
+  "setupScript": "set -euo pipefail\nsed -i 's/localhost:9999/localhost:9090/' /etc/prometheus/prometheus.yml.broken",
+  "successCriteria": "coda-exit-zero:promtool check config /etc/prometheus/prometheus.yml"
+}
+```
+
+| Field             | Type                     | Required | Default   | Description                                                                       |
+| ----------------- | ------------------------ | -------- | --------- | --------------------------------------------------------------------------------- |
+| `mode`            | `"coda"` \| `"standard"` | ❌       | see above | Execution model                                                                   |
+| `title`           | string                   | ✅       | —         | Short title shown above the brief                                                 |
+| `brief`           | string                   | ✅       | —         | Markdown problem statement                                                        |
+| `successCriteria` | string                   | ✅       | —         | Requirement evaluated when the user clicks "Check my work"                        |
+| `id`              | string                   | ❌       | —         | Block ID                                                                          |
+| `vmTemplate`      | string                   | ❌       | `vm-aws`  | VM template to provision; ignored when `mode` is `"standard"`                     |
+| `vmScenario`      | string                   | ❌       | —         | Scenario for the `alloy-scenario` template; ignored when `mode` is `"standard"`   |
+| `vmApp`           | string                   | ❌       | —         | App for the `sample-app` template; ignored when `mode` is `"standard"`            |
+| `setupScript`     | string                   | ❌       | —         | Bash script run server-side once the VM is ready                                  |
+| `setupCommands`   | string[]                 | ❌       | —         | **Deprecated** — bash commands run sequentially server-side; prefer `setupScript` |
+| `hintLevels`      | `{ text: string }[]`     | ❌       | `[]`      | Progressive hints revealed on demand                                              |
+| `failureMessage`  | string                   | ❌       | —         | Message shown when the success check fails                                        |
+| `requirements`    | string[]                 | ❌       | —         | Prerequisite conditions for the challenge                                         |
+| `objectives`      | string[]                 | ❌       | —         | Objectives marked complete after this block                                       |
+| `skippable`       | boolean                  | ❌       | `false`   | Allow skipping                                                                    |
+
+`hintLevels` is an array of objects, not an array of strings. Each entry is `{ "text": "..." }` with non-empty text, and hints are revealed one at a time in array order.
+
+`setupScript` and `setupCommands` do the same job, and `setupScript` wins when both are present. The whole `setupScript` string is passed to the remote login shell as a single command, so multi-line scripts, heredocs, and control flow all work. `setupCommands` is kept only for back-compat: opening a legacy block in the block editor joins the array with newlines into `setupScript` and drops `setupCommands` on save, so a block migrates the first time an author edits it. Write `setupScript` in new content.
+
+Challenges in `"coda"` mode need the Coda terminal integration enabled by the administrator; `"standard"` mode has no such dependency.
+
+#### Snippet reference block
+
+A pointer to a published snippet. The parser never sees this block — every `snippet-ref` is expanded before rendering, and the referenced snippet's blocks are spliced in at the ref's position. A guide therefore picks up the snippet's latest published content on every load.
+
+```json
+{
+  "type": "snippet-ref",
+  "snippetId": "connect-prometheus-data-source"
+}
+```
+
+| Field       | Type   | Required | Description                                                                                         |
+| ----------- | ------ | -------- | --------------------------------------------------------------------------------------------------- |
+| `snippetId` | string | ✅       | Upstream snippet ID to resolve at parse time. Must be kebab-case: `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` |
+| `id`        | string | ❌       | Stable identifier for this snippet-ref instance                                                     |
+
+A ref may sit at the top level of `blocks`, or nested inside a `section`, a `conditional` (in either `whenTrue` or `whenFalse`), or an `assistant`.
+
+Snippets cannot reference other snippets. The snippet schema rejects `snippet-ref` at every supported nesting depth, so a snippet body may contain any other block type but never a ref.
+
+If a ref cannot be resolved — unknown ID, catalog fetch failure — it is replaced with an inert markdown placeholder that names the snippet ID. The guide still renders, but nothing interactive appears in the ref's place.
+
 ---
 
 ### Block Types Summary
@@ -1033,9 +1126,11 @@ Each screen has `id`, `title`, `body` (markdown), and an `options[]` array. Each
 | `guided`           | Interactive | User-performed sequence with detection                                          |
 | `terminal`         | Interactive | A shell command with copy and execute (requires Coda terminal)                  |
 | `terminal-connect` | Interactive | Button that provisions a sandbox VM and opens a terminal panel                  |
+| `challenge`        | Interactive | Task with hints and a "Check my work" success check                             |
 | `grot-guide`       | Interactive | Choose-your-own-adventure decision tree                                         |
 | `quiz`             | Assessment  | Knowledge check with single/multiple choice                                     |
 | `input`            | Assessment  | Collects user responses as variables                                            |
+| `snippet-ref`      | Reusable    | Expands a published snippet in place at parse time                              |
 
 ---
 

--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -1053,9 +1053,9 @@ Coda mode:
   "type": "challenge",
   "mode": "coda",
   "title": "Fix the broken scrape config",
-  "brief": "The Prometheus config in `/etc/prometheus` has a bad scrape target. Repair it.",
+  "brief": "The Prometheus config in `/etc/prometheus` has an invalid scrape setting. Repair it so `promtool check config` passes.",
   "vmTemplate": "vm-aws",
-  "setupScript": "set -euo pipefail\nsed -i 's/localhost:9999/localhost:9090/' /etc/prometheus/prometheus.yml.broken",
+  "setupScript": "set -euo pipefail\nsed -i 's/scrape_interval:/scrape_intervall:/' /etc/prometheus/prometheus.yml",
   "successCriteria": "coda-exit-zero:promtool check config /etc/prometheus/prometheus.yml"
 }
 ```
@@ -1086,7 +1086,7 @@ Challenges in `"coda"` mode need the Coda terminal integration enabled by the ad
 
 #### Snippet reference block
 
-A pointer to a published snippet. The parser never sees this block — every `snippet-ref` is expanded before rendering, and the referenced snippet's blocks are spliced in at the ref's position. A guide therefore picks up the snippet's latest published content on every load.
+A pointer to a published snippet. The parser never sees this block — every `snippet-ref` is expanded before rendering, and the referenced snippet's blocks are spliced in at the ref's position. A guide therefore picks up the snippet's published content on every load, subject to a short cache: successful resolutions are held for about five minutes, so a republished snippet can take that long to appear. Failed resolutions are not cached.
 
 ```json
 {

--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -1027,7 +1027,7 @@ A capture-the-flag style task: a title, a markdown brief, optional progressive h
 - **Omitted in JSON** — the runtime treats the block as `"coda"`. Challenges predate `"standard"`, so an existing guide with no `mode` keeps its original Coda behavior.
 - **Created in the block editor** — the challenge form writes `mode` explicitly and seeds a brand-new block with `"standard"`, the cheaper authoring path. Opening a legacy block that has no `mode` infers `"coda"`, either from the presence of a VM or setup field or as the safe fallback.
 
-Both defaults are intentional. Set `mode` explicitly in hand-written JSON so the block does not depend on which path it came through.
+**Always write `mode` explicitly in hand-written JSON.** A challenge with no `mode` resolves to `"coda"` and provisions a VM, which is rarely what an author omitting the field intended. Read the availability note at the end of this section before choosing that path.
 
 Standard mode:
 
@@ -1060,33 +1060,39 @@ Coda mode:
 }
 ```
 
-| Field             | Type                     | Required | Default   | Description                                                                       |
-| ----------------- | ------------------------ | -------- | --------- | --------------------------------------------------------------------------------- |
-| `mode`            | `"coda"` \| `"standard"` | ❌       | see above | Execution model                                                                   |
-| `title`           | string                   | ✅       | —         | Short title shown above the brief                                                 |
-| `brief`           | string                   | ✅       | —         | Markdown problem statement                                                        |
-| `successCriteria` | string                   | ✅       | —         | Requirement evaluated when the user clicks "Check my work"                        |
-| `id`              | string                   | ❌       | —         | Block ID                                                                          |
-| `vmTemplate`      | string                   | ❌       | `vm-aws`  | VM template to provision; ignored when `mode` is `"standard"`                     |
-| `vmScenario`      | string                   | ❌       | —         | Scenario for the `alloy-scenario` template; ignored when `mode` is `"standard"`   |
-| `vmApp`           | string                   | ❌       | —         | App for the `sample-app` template; ignored when `mode` is `"standard"`            |
-| `setupScript`     | string                   | ❌       | —         | Bash script run server-side once the VM is ready                                  |
-| `setupCommands`   | string[]                 | ❌       | —         | **Deprecated** — bash commands run sequentially server-side; prefer `setupScript` |
-| `hintLevels`      | `{ text: string }[]`     | ❌       | `[]`      | Progressive hints revealed on demand                                              |
-| `failureMessage`  | string                   | ❌       | —         | Message shown when the success check fails                                        |
-| `requirements`    | string[]                 | ❌       | —         | Prerequisite conditions for the challenge                                         |
-| `objectives`      | string[]                 | ❌       | —         | Objectives marked complete after this block                                       |
-| `skippable`       | boolean                  | ❌       | `false`   | Allow skipping                                                                    |
+| Field             | Type                     | Required | Default   | Description                                                                        |
+| ----------------- | ------------------------ | -------- | --------- | ---------------------------------------------------------------------------------- |
+| `mode`            | `"coda"` \| `"standard"` | ❌       | see above | Execution model                                                                    |
+| `title`           | string                   | ✅       | —         | Short title shown above the brief                                                  |
+| `brief`           | string                   | ✅       | —         | Markdown problem statement                                                         |
+| `successCriteria` | string                   | ✅       | —         | Requirement evaluated when the user clicks "Check my work"                         |
+| `id`              | string                   | ❌       | —         | Block ID                                                                           |
+| `vmTemplate`      | string                   | ❌       | `vm-aws`  | VM template to provision; ignored when `mode` is `"standard"`                      |
+| `vmScenario`      | string                   | ❌       | —         | Scenario for the `alloy-scenario` template; ignored when `mode` is `"standard"`    |
+| `vmApp`           | string                   | ❌       | —         | App for the `sample-app` template; ignored when `mode` is `"standard"`             |
+| `setupScript`     | string                   | ❌       | —         | Bash script run server-side once the VM is ready                                   |
+| `setupCommands`   | string[]                 | ❌       | —         | **Deprecated** — bash commands run sequentially server-side; prefer `setupScript`  |
+| `hintLevels`      | `{ text: string }[]`     | ❌       | `[]`      | Progressive hints revealed on demand                                               |
+| `failureMessage`  | string                   | ❌       | —         | Message shown when the success check fails, replacing the checker's own error text |
+| `requirements`    | string[]                 | ❌       | —         | Prerequisite conditions for the challenge                                          |
+| `objectives`      | string[]                 | ❌       | —         | Objectives marked complete after this block                                        |
+| `skippable`       | boolean                  | ❌       | `false`   | Allow skipping                                                                     |
 
-`hintLevels` is an array of objects, not an array of strings. Each entry is `{ "text": "..." }` with non-empty text, and hints are revealed one at a time in array order.
+`requirements`, `objectives`, and `skippable` are accepted by the schema, but the challenge runtime does not receive them yet — the block always renders, never contributes to objective tracking, and shows no skip control. Do not rely on them to gate a challenge or to credit an objective.
 
-`setupScript` and `setupCommands` do the same job, and `setupScript` wins when both are present. The whole `setupScript` string is passed to the remote login shell as a single command, so multi-line scripts, heredocs, and control flow all work. `setupCommands` is kept only for back-compat: opening a legacy block in the block editor joins the array with newlines into `setupScript` and drops `setupCommands` on save, so a block migrates the first time an author edits it. Write `setupScript` in new content.
+`hintLevels` is an array of objects, not an array of strings. Each entry is `{ "text": "..." }` with non-empty text, and hints are revealed one at a time in array order. Hints appear only once the challenge is ready to attempt or has failed a check, so a learner stuck waiting on VM provisioning cannot reach them.
 
-Challenges in `"coda"` mode need the Coda terminal integration enabled by the administrator; `"standard"` mode has no such dependency.
+`setupScript` and `setupCommands` are not equivalent. The whole `setupScript` string is passed to the remote login shell as a single command with a 120-second budget, so multi-line scripts, heredocs, and control flow all work. Each `setupCommands` entry is a separate remote invocation with its own 30-second budget and no shared shell state, so `cd`, `export`, and heredocs do not carry from one entry to the next; the first non-zero exit abandons the remaining entries.
+
+`setupScript` takes precedence, but only when it is non-empty after trimming — a whitespace-only `setupScript` falls through to `setupCommands`. `setupCommands` is kept only for back-compat: opening a legacy block in the block editor joins the array with newlines into `setupScript` and drops `setupCommands` on save, so a block migrates the first time an author edits it. Write `setupScript` in new content.
+
+Switching a challenge from `"coda"` to `"standard"` in the block editor discards `setupScript` along with the VM fields, and switching back does not restore it. Copy the script out first if you might need it again.
+
+Coda mode is gated on two settings at once: the plugin's Coda-terminal setting, and per-user dev mode for the user viewing the guide. Both must be on, so coda mode is currently a development-only path rather than something an administrator turns on for everyone. When the gate is closed the block neither errors nor hides — it sits on "Provisioning challenge VM…" indefinitely, offering only a Cancel button ([#1541](https://github.com/grafana/grafana-pathfinder-app/issues/1541)). Because a challenge with no `mode` resolves to `"coda"`, an omitted `mode` is the most common way to reach that state. `"standard"` mode has no such dependency and works on every stack.
 
 #### Snippet reference block
 
-A pointer to a published snippet. The parser never sees this block — every `snippet-ref` is expanded before rendering, and the referenced snippet's blocks are spliced in at the ref's position. A guide therefore picks up the snippet's published content on every load, subject to a short cache: successful resolutions are held for about five minutes, so a republished snippet can take that long to appear. Failed resolutions are not cached.
+A pointer to a published snippet. The renderer never sees this block — the guide schema accepts `snippet-ref`, and every ref is expanded after validation and before render, splicing the referenced snippet's blocks in at the ref's position. A guide therefore picks up the snippet's published content on every load, subject to a short cache: successful resolutions are held for five minutes, so a republished snippet can take that long to appear. Failed resolutions are not cached, so a broken ref is retried on every load.
 
 ```json
 {
@@ -1095,16 +1101,16 @@ A pointer to a published snippet. The parser never sees this block — every `sn
 }
 ```
 
-| Field       | Type   | Required | Description                                                                                         |
-| ----------- | ------ | -------- | --------------------------------------------------------------------------------------------------- |
-| `snippetId` | string | ✅       | Upstream snippet ID to resolve at parse time. Must be kebab-case: `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` |
-| `id`        | string | ❌       | Stable identifier for this snippet-ref instance                                                     |
+| Field       | Type   | Required | Description                                                                                                             |
+| ----------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `snippetId` | string | ✅       | Upstream snippet ID, resolved after validation and before render. Must be kebab-case: `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` |
+| `id`        | string | ❌       | Stable identifier for this snippet-ref instance                                                                         |
 
-A ref may sit at the top level of `blocks`, or nested inside a `section`, a `conditional` (in either `whenTrue` or `whenFalse`), or an `assistant`.
+A ref may sit at the top level of `blocks`, or nested inside a `section`, a `conditional` (in either `whenTrue` or `whenFalse`), or an `assistant`. It may not sit inside a `collapsible` — that container holds content blocks only, and the schema rejects a ref there.
 
 Snippets cannot reference other snippets. The snippet schema rejects `snippet-ref` at every supported nesting depth, so a snippet body may contain any other block type but never a ref.
 
-If a ref cannot be resolved — unknown ID, catalog fetch failure — it is replaced with an inert markdown placeholder that names the snippet ID. The guide still renders, but nothing interactive appears in the ref's place.
+If a ref cannot be resolved — unknown ID, catalog fetch failure — it is replaced with an inert markdown placeholder naming the snippet ID and an error code. The guide still renders, but nothing interactive appears in the ref's place. The resolver does not distinguish a missing snippet from a transient failure, so an unknown ID reports `network-error` rather than a not-found code.
 
 ---
 
@@ -1130,7 +1136,7 @@ If a ref cannot be resolved — unknown ID, catalog fetch failure — it is repl
 | `grot-guide`       | Interactive | Choose-your-own-adventure decision tree                                         |
 | `quiz`             | Assessment  | Knowledge check with single/multiple choice                                     |
 | `input`            | Assessment  | Collects user responses as variables                                            |
-| `snippet-ref`      | Reusable    | Expands a published snippet in place at parse time                              |
+| `snippet-ref`      | Reusable    | Expands a published snippet in place before render                              |
 
 ---
 

--- a/src/validation/json-guide-format-docs.test.ts
+++ b/src/validation/json-guide-format-docs.test.ts
@@ -15,6 +15,7 @@ import { JsonBlockSchema } from '../types/json-guide.schema';
 
 const DOC_RELATIVE_PATH = 'docs/developer/interactive-examples/json-guide-format.md';
 const DOC_PATH = path.resolve(__dirname, '../..', DOC_RELATIVE_PATH);
+const SUMMARY_HEADING = '### Block Types Summary';
 
 function unwrap(schema: any): any {
   const inner = schema?._zod?.def?.innerType;
@@ -51,8 +52,21 @@ function normalize(text: string): string {
   return text.toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
+/** The summary table alone — other field tables also carry rows like `| \`section\``. */
+function summaryTableSection(markdown: string): string {
+  const lines = markdown.split('\n');
+  const start = lines.findIndex((line) => line.trim() === SUMMARY_HEADING);
+  if (start === -1) {
+    return '';
+  }
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => line.startsWith('#') || line.trim() === '---');
+  return (end === -1 ? rest : rest.slice(0, end)).join('\n');
+}
+
 const blockTypes = blockTypesFromSchema();
 const doc = fs.readFileSync(DOC_PATH, 'utf-8');
+const summaryTable = summaryTableSection(doc);
 const headings = doc
   .split('\n')
   .filter((line) => line.startsWith('#### '))
@@ -74,9 +88,16 @@ describe('JSON guide format reference', () => {
     expect(blockTypes.length).toBeGreaterThan(15);
   });
 
+  it('locates the block types summary table', () => {
+    expect(
+      summaryTable.includes('| Block Type') ||
+        `No "${SUMMARY_HEADING}" table found in ${DOC_RELATIVE_PATH}; the per-type row checks cannot run.`
+    ).toBe(true);
+  });
+
   describe.each(blockTypes)('%s', (blockType) => {
     it('has a row in the block types summary table', () => {
-      const hasRow = doc.includes(`| \`${blockType}\``);
+      const hasRow = summaryTable.includes(`| \`${blockType}\``);
       expect(
         hasRow ||
           `Block type "${blockType}" has no summary-table row. Add one to the "Block Types Summary" table in ${DOC_RELATIVE_PATH}.`

--- a/src/validation/json-guide-format-docs.test.ts
+++ b/src/validation/json-guide-format-docs.test.ts
@@ -5,7 +5,7 @@
  * "Block Types Summary" table and a per-type section heading in
  * json-guide-format.md. Block types are read out of the schema at runtime, so
  * adding a variant to the union fails this test until the reference documents
- * it. Coverage only — the prose itself stays hand-written.
+ * it.
  */
 
 import * as fs from 'fs';
@@ -16,6 +16,9 @@ import { JsonBlockSchema } from '../types/json-guide.schema';
 const DOC_RELATIVE_PATH = 'docs/developer/interactive-examples/json-guide-format.md';
 const DOC_PATH = path.resolve(__dirname, '../..', DOC_RELATIVE_PATH);
 const SUMMARY_HEADING = '### Block Types Summary';
+
+/** Bump deliberately: a short count means the union shrank or Zod's internals moved. */
+const EXPECTED_BLOCK_TYPE_COUNT = 19;
 
 function unwrap(schema: any): any {
   const inner = schema?._zod?.def?.innerType;
@@ -47,7 +50,6 @@ function blockTypesFromSchema(): string[] {
   return [...types].sort();
 }
 
-/** Compare heading text to type names ignoring case, hyphens, and spacing. */
 function normalize(text: string): string {
   return text.toLowerCase().replace(/[^a-z0-9]/g, '');
 }
@@ -85,7 +87,7 @@ function claimedByLongerType(heading: string, blockType: string): boolean {
 describe('JSON guide format reference', () => {
   it('reads every block type out of the schema union', () => {
     expect(blockTypes).toContain('markdown');
-    expect(blockTypes.length).toBeGreaterThan(15);
+    expect(blockTypes).toHaveLength(EXPECTED_BLOCK_TYPE_COUNT);
   });
 
   it('locates the block types summary table', () => {

--- a/src/validation/json-guide-format-docs.test.ts
+++ b/src/validation/json-guide-format-docs.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Documentation coverage for the JSON guide format reference.
+ *
+ * Every block type in the `JsonBlockSchema` union must have a row in the
+ * "Block Types Summary" table and a per-type section heading in
+ * json-guide-format.md. Block types are read out of the schema at runtime, so
+ * adding a variant to the union fails this test until the reference documents
+ * it. Coverage only — the prose itself stays hand-written.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { JsonBlockSchema } from '../types/json-guide.schema';
+
+const DOC_RELATIVE_PATH = 'docs/developer/interactive-examples/json-guide-format.md';
+const DOC_PATH = path.resolve(__dirname, '../..', DOC_RELATIVE_PATH);
+
+function unwrap(schema: any): any {
+  const inner = schema?._zod?.def?.innerType;
+  return inner ? unwrap(inner) : schema;
+}
+
+function collectBlockTypes(schema: any, out: Set<string>): void {
+  const def = unwrap(schema)?._zod?.def;
+  if (!def) {
+    return;
+  }
+  if (def.type === 'union') {
+    for (const option of def.options) {
+      collectBlockTypes(option, out);
+    }
+    return;
+  }
+  if (def.type === 'object') {
+    const discriminator = unwrap(def.shape?.type)?._zod?.def?.values;
+    if (discriminator) {
+      out.add([...discriminator][0]);
+    }
+  }
+}
+
+function blockTypesFromSchema(): string[] {
+  const types = new Set<string>();
+  collectBlockTypes(JsonBlockSchema, types);
+  return [...types].sort();
+}
+
+/** Compare heading text to type names ignoring case, hyphens, and spacing. */
+function normalize(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+const blockTypes = blockTypesFromSchema();
+const doc = fs.readFileSync(DOC_PATH, 'utf-8');
+const headings = doc
+  .split('\n')
+  .filter((line) => line.startsWith('#### '))
+  .map((line) => normalize(line));
+
+/**
+ * True when a heading is explained by a longer block type — `terminal` must
+ * not be satisfied by the `terminal-connect` heading.
+ */
+function claimedByLongerType(heading: string, blockType: string): boolean {
+  return blockTypes.some(
+    (other) => other !== blockType && other.length > blockType.length && heading.includes(normalize(other))
+  );
+}
+
+describe('JSON guide format reference', () => {
+  it('reads every block type out of the schema union', () => {
+    expect(blockTypes).toContain('markdown');
+    expect(blockTypes.length).toBeGreaterThan(15);
+  });
+
+  describe.each(blockTypes)('%s', (blockType) => {
+    it('has a row in the block types summary table', () => {
+      const hasRow = doc.includes(`| \`${blockType}\``);
+      expect(
+        hasRow ||
+          `Block type "${blockType}" has no summary-table row. Add one to the "Block Types Summary" table in ${DOC_RELATIVE_PATH}.`
+      ).toBe(true);
+    });
+
+    it('has a per-type section heading', () => {
+      const normalized = normalize(blockType);
+      const hasHeading = headings.some(
+        (heading) => heading.includes(normalized) && !claimedByLongerType(heading, blockType)
+      );
+      expect(
+        hasHeading ||
+          `Block type "${blockType}" has no "#### " section. Add one to ${DOC_RELATIVE_PATH} describing its fields.`
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The JSON guide format reference documented 17 of the 19 `JsonBlock` variants — `challenge` and `snippet-ref` had neither a summary-table row nor a per-type section. Both are now documented, and a coverage test reads the block-type list out of the schema union at runtime so the next new block type cannot land undocumented.

**Round-2 note.** The first pass drafted the prose from the schema's `.describe()` strings and claimed it was verified against runtime source. A field-by-field review found four statements that were wrong rather than merely imprecise, and they are corrected in `61b19688`. Treat the earlier "verified against runtime source" claim as overstated — the schema descriptions turned out not to be a trustworthy source, which is now the main argument against generating this reference (see **Why**).

## What to look at

- [`docs/developer/interactive-examples/json-guide-format.md`](https://github.com/grafana/grafana-pathfinder-app/blob/61b196881374d2b5fa37a210e67aed716b2c9f6a/docs/developer/interactive-examples/json-guide-format.md) — two new per-type sections plus two summary rows (`challenge` is Interactive, `snippet-ref` is Reusable, matching the block-palette grouping once #1531 lands). The prose deliberately describes several quirks rather than smoothing them over: `mode` resolves to `coda` when omitted from JSON but to `standard` for a block created in the editor; `hintLevels` is `{ text: string }[]`, not a string array; `setupScript` beats the deprecated `setupCommands` at runtime and the editor migrates the latter on save.

  The four corrections in `61b19688`, each traced to source:

  - **`snippet-ref` "the parser never sees this block" was inverted.** The guide schema accepts `snippet-ref` (`json-guide.schema.ts:761`), validation runs before expansion (`content-fetcher.ts:230`), and `json-parser.ts:315-321` carries a dedicated `case 'snippet-ref':` arm. It is the _renderer_ that never sees it. The table cell and summary row said "at parse time" and are now consistent with the prose.
  - **`setupScript` and `setupCommands` do not "do the same job".** `setupScript` is one remote invocation with a 120s budget; each `setupCommands` entry is a separate invocation with its own 30s budget and no shared shell state, so `cd`, `export` and heredocs do not carry between entries (`challenge-block.tsx:265-297`). An author who trusted "same job" and wrote `["cd /etc/prometheus", "sed -i … prometheus.yml"]` would get the `sed` in the wrong directory with setup reporting success.
  - **The coda-mode gate was understated.** It is `isDevMode && pluginConfig.enableCodaTerminal` (`docs-panel.tsx:1430`) — per-user dev mode as well as the plugin setting, so not a single admin toggle. And when the gate is closed the block neither errors nor hides: it sits on "Provisioning challenge VM…" indefinitely (#1541). Since an omitted `mode` resolves to `coda`, that is the usual way in, so the `mode` note is now a warning rather than a neutral statement.
  - **`requirements`, `objectives` and `skippable` are schema-accepted but runtime-inert.** `convertChallengeBlock` maps 11 props and none of these three (`json-parser.ts:987-999`), while `convertCodeBlockBlock` immediately below it does map them. So a challenge with `"requirements": ["is-admin"]` renders for everyone, `objectives` never credits, and `skippable` shows no skip control — with no validation error anywhere. The rows stay (the schema really does accept them) but are now labelled as not yet honoured. Converter fix tracked in #1544; the editor-side half is #1543.

  Four smaller trap-closers in the same commit: `failureMessage` _replaces_ the requirement checker's own error text rather than adding to it; hints are unreachable outside the `ready` and `failed-check` states, so a learner stuck on provisioning cannot see them; an unresolved ref reports `network-error` even for an unknown ID (#1546); and a ref may not sit inside a `collapsible`.

- [`src/validation/json-guide-format-docs.test.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/61b196881374d2b5fa37a210e67aed716b2c9f6a/src/validation/json-guide-format-docs.test.ts) — the guard walks the `JsonBlockSchema` union at runtime rather than reading a hand-maintained list, because the hand-maintained lists are exactly what drifts (`VALID_BLOCK_TYPES` on `main` is itself missing `challenge`; #1531 fixes that separately). Worth tracing: the summary-row check is scoped to the "Block Types Summary" table only, and the heading check refuses a match that a longer block type already explains, so `terminal` is not satisfied by the `terminal-connect` heading.

  `61b19688` replaces `toBeGreaterThan(15)` with an exact count of 19. The loose bound tolerated silently losing up to three union arms, and on a Zod-internals break it surfaced as `` `.each` called with an empty Array `` rather than naming the cause. The `expect(new Set(blockTypes)).toEqual(VALID_BLOCK_TYPES)` cross-check was considered and left out: it fails today, because that set is still the hand-written 18-entry list missing `challenge`. It becomes worth adding once #1531 merges and derives the set from `KNOWN_FIELDS`.

- [`README.md`](https://github.com/grafana/grafana-pathfinder-app/blob/61b196881374d2b5fa37a210e67aed716b2c9f6a/README.md) — the docs bullet hand-copied a block-type list this change would have made stale; it now points at the reference instead of duplicating it. The adjacent demo link also pointed at a path that no longer exists after the package restructure, and claimed the demo covered "all block types" when it contains 9 of 19.

## Why

Fixes #1530. Both block types have been parseable for a while, but `challenge` became urgent because #1531 makes it insertable from the block-editor palette — authors can now reach a block the reference never describes.

Generating the reference from the CLI schema walker was considered and rejected. The original reasons still hold: `challenge` and `snippet-ref` are both outside the CLI authoring registry, and `schema-options.ts` skips arrays of objects such as `hintLevels`. The stronger reason emerged from the round-2 review — two `.describe()` strings are themselves wrong (`snippetId` says "resolve at parse time"; `mode` says "'coda' (default)" on a field with no `.default()`), so generation would have propagated both defects into the reference instead of catching them. #1545 tracks fixing them at the source, since the CLI and MCP surface that text. The guard therefore checks coverage only and leaves the prose hand-written.

## How to verify

1. Read the two new sections against `src/types/json-guide.schema.ts` for field names, requiredness and types. Do **not** treat the `.describe()` strings as the oracle for behaviour — check `challenge-block.tsx` and `ChallengeBlockForm.tsx` for that, and see #1545.
2. Confirm the guard bites, both modes. Delete the `` | `challenge` `` row from the "Block Types Summary" table and run `npx jest src/validation/json-guide-format-docs.test.ts --coverage=false`; then restore it and rename the `#### Challenge block` heading instead. Each should fail naming the block type and the file to edit:
   - `Block type "challenge" has no summary-table row. Add one to the "Block Types Summary" table in docs/developer/interactive-examples/json-guide-format.md.`
   - `Block type "challenge" has no "#### " section. Add one to docs/developer/interactive-examples/json-guide-format.md describing its fields.`
3. Confirm the exact-count assertion is live: set `EXPECTED_BLOCK_TYPE_COUNT` to 20 and check it fails with `Expected length: 20 / Received length: 19`.
4. Confirm the guard is not satisfied by a row outside the table: delete the real `` | `challenge` `` row and plant a matching one next to the `#### Challenge block` heading. The row check should still fail.
5. Every fenced `json` example in the two new sections parses under `JsonBlockSchema.safeParse` — worth re-checking mechanically rather than by eye, since authors copy them.
6. Copy the standard-mode challenge example into a guide and load it — the brief and "Check my work" should appear immediately with no provisioning step.

## Breaking changes

None. Documentation plus one test; no runtime behaviour changed, and no source file is touched. The quirks described above are intentional and covered by existing tests, and were documented as-is rather than altered.

## Reversibility

Fully reversible — reverting restores the previous prose and drops the guard. The four behavioural defects the review surfaced are filed separately (#1544, #1545, #1546) and are not fixed here, so a revert loses documentation only, not fixes.

## Out of scope

- **All source-code changes.** The four defects this review found in the challenge and snippet-ref runtimes are documented as current behaviour and filed as #1544, #1545 and #1546. #1541 and #1543 were filed independently by the #1531 fix pass.
- `docs/developer/components/block-editor/README.md` and `docs/sources/block-editor/_index.md` are owned by in-flight #1531 and deliberately untouched.
- The two new `####` headings are sentence case per `AGENTS.md`; the existing 17 are title case. Left mismatched rather than expanding this into a repo-wide heading sweep.
- `authorNote` is undocumented for all 19 block types in this file, and the summary table's row order does not match the prose order. Both predate this change.
- The "TypeScript Types" section of the reference hand-lists a subset of the exported types and guards (missing `JsonChallengeBlock`, `JsonSnippetRefBlock`, and others). That drift predates this change and the new guard does not cover it.

Fixes #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)
