### PR TITLE
fix: validate pages array elements in HighlightedGuideConfig

### DIFF
--- a/src/utils/openfeature.test.ts
+++ b/src/utils/openfeature.test.ts
@@ -682,26 +682,27 @@ describe('openfeature', () => {
       jest.isolateModules(() => {
         const mockOF = createMockOpenFeature();
         const mockReact = createMockReactSdk();
-        mockOF.mockClient.getObjectValue.mockReturnValue({
-          variant: 'excluded',
-          pages: [],
-          guideId: '',
-        });
+        const remoteConfig = {
+          variant: 'control',
+          pages: ['/connections/datasources*'],
+          guideId: 'bundled:remote-guide',
+        };
+        mockOF.mockClient.getObjectValue.mockReturnValue(remoteConfig);
         jest.doMock('@openfeature/web-sdk', () => mockOF);
         jest.doMock('@openfeature/react-sdk', () => mockReact);
 
-        const {
-          setFlagOverride,
-          getHighlightedGuideConfig,
-          DEFAULT_HIGHLIGHTED_GUIDE_CONFIG,
-        } = require('./openfeature');
+        const { setFlagOverride, getHighlightedGuideConfig } = require('./openfeature');
         setFlagOverride('pathfinder.highlighted-guide-experiment', {
           variant: 'treatment',
           pages: [1, 2],
           guideId: 'bundled:my-guide',
         });
 
-        expect(getHighlightedGuideConfig()).toEqual(DEFAULT_HIGHLIGHTED_GUIDE_CONFIG);
+        expect(getHighlightedGuideConfig()).toEqual({
+          ...remoteConfig,
+          autoOpen: true,
+          resetCache: false,
+        });
         expect(mockReportFeatureFlagExposure).not.toHaveBeenCalled();
         expect(mockOF.mockClient.getObjectValue).toHaveBeenCalled();
       });
@@ -711,26 +712,27 @@ describe('openfeature', () => {
       jest.isolateModules(() => {
         const mockOF = createMockOpenFeature();
         const mockReact = createMockReactSdk();
-        mockOF.mockClient.getObjectValue.mockReturnValue({
-          variant: 'excluded',
-          pages: [],
-          guideId: '',
-        });
+        const remoteConfig = {
+          variant: 'control',
+          pages: ['/connections/datasources*'],
+          guideId: 'bundled:remote-guide',
+        };
+        mockOF.mockClient.getObjectValue.mockReturnValue(remoteConfig);
         jest.doMock('@openfeature/web-sdk', () => mockOF);
         jest.doMock('@openfeature/react-sdk', () => mockReact);
 
-        const {
-          setFlagOverride,
-          getHighlightedGuideConfig,
-          DEFAULT_HIGHLIGHTED_GUIDE_CONFIG,
-        } = require('./openfeature');
+        const { setFlagOverride, getHighlightedGuideConfig } = require('./openfeature');
         setFlagOverride('pathfinder.highlighted-guide-experiment', {
           variant: 'treatment',
           pages: ['/explore', 1],
           guideId: 'bundled:my-guide',
         });
 
-        expect(getHighlightedGuideConfig()).toEqual(DEFAULT_HIGHLIGHTED_GUIDE_CONFIG);
+        expect(getHighlightedGuideConfig()).toEqual({
+          ...remoteConfig,
+          autoOpen: true,
+          resetCache: false,
+        });
         expect(mockReportFeatureFlagExposure).not.toHaveBeenCalled();
         expect(mockOF.mockClient.getObjectValue).toHaveBeenCalled();
       });

--- a/src/utils/openfeature.test.ts
+++ b/src/utils/openfeature.test.ts
@@ -677,6 +677,89 @@ describe('openfeature', () => {
         expect(mockOF.mockClient.getObjectValue).toHaveBeenCalled();
       });
     });
+
+    it('getHighlightedGuideConfig should fall through when pages contain only non-string elements', () => {
+      jest.isolateModules(() => {
+        const mockOF = createMockOpenFeature();
+        const mockReact = createMockReactSdk();
+        mockOF.mockClient.getObjectValue.mockReturnValue({
+          variant: 'excluded',
+          pages: [],
+          guideId: '',
+        });
+        jest.doMock('@openfeature/web-sdk', () => mockOF);
+        jest.doMock('@openfeature/react-sdk', () => mockReact);
+
+        const {
+          setFlagOverride,
+          getHighlightedGuideConfig,
+          DEFAULT_HIGHLIGHTED_GUIDE_CONFIG,
+        } = require('./openfeature');
+        setFlagOverride('pathfinder.highlighted-guide-experiment', {
+          variant: 'treatment',
+          pages: [1, 2],
+          guideId: 'bundled:my-guide',
+        });
+
+        expect(getHighlightedGuideConfig()).toEqual(DEFAULT_HIGHLIGHTED_GUIDE_CONFIG);
+        expect(mockReportFeatureFlagExposure).not.toHaveBeenCalled();
+        expect(mockOF.mockClient.getObjectValue).toHaveBeenCalled();
+      });
+    });
+
+    it('getHighlightedGuideConfig should fall through when pages mix valid and non-string elements', () => {
+      jest.isolateModules(() => {
+        const mockOF = createMockOpenFeature();
+        const mockReact = createMockReactSdk();
+        mockOF.mockClient.getObjectValue.mockReturnValue({
+          variant: 'excluded',
+          pages: [],
+          guideId: '',
+        });
+        jest.doMock('@openfeature/web-sdk', () => mockOF);
+        jest.doMock('@openfeature/react-sdk', () => mockReact);
+
+        const {
+          setFlagOverride,
+          getHighlightedGuideConfig,
+          DEFAULT_HIGHLIGHTED_GUIDE_CONFIG,
+        } = require('./openfeature');
+        setFlagOverride('pathfinder.highlighted-guide-experiment', {
+          variant: 'treatment',
+          pages: ['/explore', 1],
+          guideId: 'bundled:my-guide',
+        });
+
+        expect(getHighlightedGuideConfig()).toEqual(DEFAULT_HIGHLIGHTED_GUIDE_CONFIG);
+        expect(mockReportFeatureFlagExposure).not.toHaveBeenCalled();
+        expect(mockOF.mockClient.getObjectValue).toHaveBeenCalled();
+      });
+    });
+
+    it('getHighlightedGuideConfig should accept pages with all string elements', () => {
+      jest.isolateModules(() => {
+        const mockOF = createMockOpenFeature();
+        const mockReact = createMockReactSdk();
+        jest.doMock('@openfeature/web-sdk', () => mockOF);
+        jest.doMock('@openfeature/react-sdk', () => mockReact);
+
+        const { setFlagOverride, getHighlightedGuideConfig } = require('./openfeature');
+        setFlagOverride('pathfinder.highlighted-guide-experiment', {
+          variant: 'treatment',
+          pages: ['/explore', '/other'],
+          guideId: 'bundled:my-guide',
+        });
+
+        expect(getHighlightedGuideConfig()).toEqual({
+          variant: 'treatment',
+          pages: ['/explore', '/other'],
+          guideId: 'bundled:my-guide',
+          autoOpen: true,
+          resetCache: false,
+        });
+        expect(mockOF.mockClient.getObjectValue).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('matchPathPattern', () => {

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -553,7 +553,12 @@ function validateHighlightedGuideValue(value: unknown): HighlightedGuideConfig |
     return null;
   }
   const record = value as Record<string, unknown>;
-  if (typeof record.variant !== 'string' || !Array.isArray(record.pages) || typeof record.guideId !== 'string') {
+  if (
+    typeof record.variant !== 'string' ||
+    !Array.isArray(record.pages) ||
+    !record.pages.every((p) => typeof p === 'string') ||
+    typeof record.guideId !== 'string'
+  ) {
     return null;
   }
   const VALID_DOC_TYPES: ReadonlySet<HighlightedGuideDocType> = new Set([

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -556,7 +556,7 @@ function validateHighlightedGuideValue(value: unknown): HighlightedGuideConfig |
   if (
     typeof record.variant !== 'string' ||
     !Array.isArray(record.pages) ||
-    !record.pages.every((p) => typeof p === 'string') ||
+    !record.pages.every((p): p is string => typeof p === 'string') ||
     typeof record.guideId !== 'string'
   ) {
     return null;
@@ -573,7 +573,7 @@ function validateHighlightedGuideValue(value: unknown): HighlightedGuideConfig |
 
   return {
     variant: record.variant as HighlightedGuideConfig['variant'],
-    pages: record.pages as string[],
+    pages: record.pages,
     guideId: record.guideId,
     autoOpen: typeof record.autoOpen === 'boolean' ? record.autoOpen : true,
     resetCache: typeof record.resetCache === 'boolean' ? record.resetCache : false,


### PR DESCRIPTION
## What this fixes

Fixes #1534 .

validateHighlightedGuideValue checks that record.pages is an array but not that its contents are strings, before trying to cast it to string[]. So a malformed payload like { pages: [1, 2] } would validate as okay.

Downstream, matchesHighlightedGuidePage calls pattern.trim() on each pattern, which requires it to be a string so an all-non-string pages array throws. so an all-non-string pages array would throw inside the auto-open orchestrator (uncaught), and a mixed array could silently mask the bug if one of the patterns was a string ( .some() short-circuits).

## The fix

Adds .every((p) => typeof p === 'string') to the existing shape guard, so that a malformed pages array would be caught the same way as other shape mismatches would be, by falling back to the default, rather than throwing. Same guard-and-early-return pattern is used elsewhere in this file.

## Scope of the fix

Only the check for the pages element. The variant already has an equivalent check for being a scalar in the same guard, and docType is checked separately and falls back to default, degrading gracefully rather than rejecting the shape (unrelated to this fix). Does not include the extra logging part of #1529 , which is separate and not merged in yet.

## Testing

Tests were added to openfeature.test.ts by example, in the same vein as the existing indirect tests for these functions through getHighlightedGuideConfig :

all pages are non-strings to fall back to default

pages are mixed to fall back to default (the masking case)

pages are all strings to no change

These were verified by removing the fix and checking that the two negative cases now failed for the expected reason, and then putting it back and checking that all 33 tests are still passing.

tsc --noEmit , eslint, and prettier --check all pass.

## Update

Also addressed the two adjacent design questions from the issue:

- **Type-predicate helpers** (`isValidDocType`, `isHighlightedGuideVariant`) remove the redundant `as` casts at the `docType`/`variant` call sites. One cast remains inside `isValidDocType` itself,  `ReadonlySet.has()` doesn't narrow, so the cast is required to call it at all; the predicate removes casts at the *branching* sites, not that one.
- `variant`'s fallback path (`highlightedGuideVariantFromString`) still uses `as` for unrecognized values, preserving `main`'s current passthrough behavior for unknown variants no rejection was added here, since that's `#1529`'s scope, still unmerged. Once #1529 lands and starts rejecting invalid `variant` in the shape guard, that fallback branch becomes unreachable and can be deleted.
- Documented the rejection-policy rule in a comment above the shape guard: enrollment-gating fields reject the whole payload; presentational fields degrade gracefully.