### PR TITLE
fix(backend): never share a token-mint failure through the negative cache

### DIFF
--- a/.cursor/rules/coda.mdc
+++ b/.cursor/rules/coda.mdc
@@ -89,7 +89,7 @@ Terminal states: `destroyed`, `destroying`, `error`.
 | `pkg/plugin/resources.go` | HTTP handlers: `/coda/register`, `/vms`, `/vms/{id}`, `/sample-apps`, `/alloy-scenarios`, `/completion-records/my`, `/completion-records/capability`, `/health` |
 | `pkg/plugin/completion_records.go` | App Platform read proxy for completion records: per-user collation, 5-min TTL cache with single-flight refresh, stale-serve/503/capability=false error paths (not a Coda feature) |
 | `pkg/plugin/app_platform_identity.go` | Shared identity helpers for App Platform proxies: `validIDToken`, `subjectFromIDToken` (fail-closed structural JWT validation; trust boundary documented in `docs/developer/CODA.md`). Outbound credentials come from `pkg/plugin/auth` (on-behalf-of token exchange), never the ID token |
-| `pkg/plugin/app_platform_client.go` | Shared paginated LIST client for App Platform proxies: `buildAppPlatformURL`, per-kind decode seam, transient/terminal/identity-scoped error classification, first-request credential diagnostics |
+| `pkg/plugin/app_platform_client.go` | Shared paginated LIST client for App Platform proxies: `buildAppPlatformURL`, per-kind decode seam, two-axis error classification (transient/terminal, namespace-global/caller-scoped), first-request credential diagnostics |
 | `pkg/plugin/app.go` | Plugin lifecycle, `CodaClient` creation from settings, `streamSessions` map |
 | `pkg/plugin/settings.go` | Plugin settings: `CodaRegistered`, `CodaAPIURL`, `CodaRelayURL`, secure `RefreshToken`/`EnrollmentKey`, and the SSS-provisioned `StackID`/`OBOToken` the App Platform proxies authenticate with |
 

--- a/.cursor/rules/systemPatterns.mdc
+++ b/.cursor/rules/systemPatterns.mdc
@@ -182,7 +182,7 @@ The Go backend is a **thin bridge** between the React frontend and the **Coda VM
 | `plugin/package_recommendations.go` | CDN package-index cache (6h TTL, single-flight dedup, 8-way parallel manifest fetch, bounded memory).            |
 | `plugin/completion_records.go`      | Completion Records read proxy (`/completion-records/my`, `/completion-records/capability`). Per-user collation of a full-namespace LIST, 5-min TTL cache with single-flight refresh + negative-cache cooldown, stale-serve/503/capability=false error paths. |
 | `plugin/completion_records_client.go` | Per-kind wrapper over the shared App Platform LIST client for `completionrecords`: supplies group/version + resource and decodes each `items[].spec`. |
-| `plugin/app_platform_client.go`     | Shared paginated LIST client for App Platform proxies (backend proxy pattern §1, PR #1401): `buildAppPlatformURL`, per-page byte cap + timeout, transient/terminal/identity-scoped error classification, first-request credential diagnostics. |
+| `plugin/app_platform_client.go`     | Shared paginated LIST client for App Platform proxies (backend proxy pattern §1, PR #1401): `buildAppPlatformURL`, per-page byte cap + timeout, two-axis error classification (transient/terminal, namespace-global/caller-scoped), first-request credential diagnostics. |
 | `plugin/app_platform_identity.go`   | Shared identity helpers (§3): `validIDToken`, `subjectFromIDToken` — fail-closed structural JWT validation (outbound credentials come from `pkg/plugin/auth`); `deriveCompletionUserID` (the epic's canonical identity contract) delegates here. Trust boundary documented in `docs/developer/CODA.md`. |
 
 **HTTP request flow (e.g., `POST /vms`):**

--- a/docs/design/BACKEND_PROXY_PATTERN.md
+++ b/docs/design/BACKEND_PROXY_PATTERN.md
@@ -36,9 +36,15 @@ flat byte fetches). It must:
   deadline, an N-page drain under `context.WithoutCancel` is bounded only by N × per-page-timeout
   — detached must not mean unkillable. Derive the detach as
   `context.WithTimeout(context.WithoutCancel(ctx), aggregateDeadline)`;
-- classify errors once — **transient** (429 / 5xx / network / timeout) vs **terminal** (other
-  4xx) — and flag whether the failure was **identity-scoped** (upstream 401/403 for _this_
-  caller's forwarded identity). Every downstream decision keys off this classification;
+- classify errors once, on two **orthogonal** axes. **Retryability**: transient (429 / 5xx /
+  network / timeout) vs terminal (other 4xx). **Scope**: namespace-global (a property of the
+  namespace, so shareable across callers) vs caller-scoped (upstream 401/403 for _this_ caller's
+  forwarded identity, or a failure to mint _this_ caller's on-behalf-of token). The combinations
+  are all reachable — a mint failure is caller-scoped **and** transient — so neither axis may be
+  derived from the other. Classify scope as an **allow-list**: only positively recognized
+  namespace-global shapes are shareable, so a statusless failure nobody has classified yet costs
+  re-probes rather than replaying one caller's error to another. Every downstream decision keys
+  off this classification;
 - take a per-kind decode callback (`items[].spec` → typed record) so one client serves every kind.
 
 URL construction: `url.PathEscape` every path segment via one shared
@@ -96,6 +102,8 @@ the fixed internal aggregator.
 - **A stack with no provisioned CAP token is structurally unavailable** (`reason:
 "obo-unavailable"`), not a transient failure. A failed exchange, by contrast, is transient: it
   carries no HTTP status, so the shared classifier retries rather than caching a terminal result.
+  It is also **caller-scoped** — auth-api can reject one subject token while serving others — so
+  it needs its own sentinel error and must never reach a shared negative cache (§1 scope axis).
 - **Never forward `Cookie`.** No branch in this repo's history has ever needed it against the
   aggregator; the caller's full session is the broadest possible ambient grant and the classic
   confused-deputy shape.
@@ -212,9 +220,10 @@ One definition each, package-wide:
 - Mocked-client unit tests cover: pagination draining (multi-page continue tokens), TTL expiry
   (deterministic via `timeNow`), single-flight, refresh rate limit, identity fail-closed
   **including `exp == 0` rejection**, cross-user isolation where data is per-user, the failure
-  matrix (cold-transient, cold-terminal, warm-stale, cooldown, identity-scoped-not-shared), and
-  the config-resolution branch (toggle off / no app URL) — don't let a test-only override
-  short-circuit the structural-unavailability path out of existence.
+  matrix (cold-transient, cold-terminal, warm-stale, cooldown, and caller-scoped-not-shared for
+  both 401/403 and a failed token mint), and the config-resolution branch (toggle off / no app
+  URL) — don't let a test-only override short-circuit the structural-unavailability path out of
+  existence.
 - Mocked tests cannot prove the live credential path. Every PR of this shape carries a **runtime
   smoke procedure** in its body (create a resource upstream, hit the route, see it shaped) and
   treats that smoke as a **gate before dependent work binds to the route** — doubly so where the
@@ -232,7 +241,7 @@ One definition each, package-wide:
 - [ ] Outbound: shared identity-forwarding helper; ID-token-derived headers only; never `Cookie`;
       never replay inbound `Authorization`
 - [ ] Per-user data ⇒ identity-partitioned cache; shared blob ⇒ identity-invariance proven &
-      documented; identity-scoped failures never cached shared
+      documented; caller-scoped failures never cached shared
 - [ ] "Auth enforced at cache-fill, shared for TTL" comment present; no-eviction invariant
       commented
 - [ ] Stale-serve on warm failure; 503+`Retry-After` cold-transient; capability envelope
@@ -267,7 +276,7 @@ Delete this section once both PRs conform. Line references are to the PR diffs a
 - Transient/terminal taxonomy + `Retry-After` — the fetcher already distinguishes 401/403 from
   other non-200s internally but discards the distinction into a flat 503 (§5)
 - Separate failure cooldown + stale-serve; stop unconditionally overwriting last-good data with
-  error entries; identity-scoped failures never cached shared (§4, §5)
+  error entries; caller-scoped failures never cached shared (§4, §5)
 - `timeNow` seam + TTL-expiry test (§8, §10)
 - Stable machine error token; add `asOf` (§6)
 - Document the shared-blob identity-invariance claim at the cache (§4)

--- a/docs/design/BACKEND_PROXY_PATTERN.md
+++ b/docs/design/BACKEND_PROXY_PATTERN.md
@@ -131,9 +131,10 @@ the fixed internal aggregator.
   LIST returns the same result for every authorized caller in the namespace; otherwise one
   caller's richer RBAC view leaks to everyone for a TTL window. The invariance claim must be
   written down, not assumed.
-- **Identity-scoped failures never enter the shared cache.** An upstream 401/403 for caller A's
-  token must not become a cached error served to caller B. Terminal identity failures are
-  per-request responses.
+- **Caller-scoped failures never enter the shared cache.** An upstream 401/403 for caller A's
+  token — or a failure to mint caller A's on-behalf-of token — must not become a cached error
+  served to caller B. Only failures positively classified as namespace-global on the §1 scope axis
+  are shareable; every other failure, transient or terminal, is a per-request response.
 - Cache the **shaped/collated result, not raw records**, so steady-state memory is bounded by the
   meaningful entity count; the §1 aggregate budget bounds the transient build footprint.
 - TTL by data volatility (5 min for slowly-changing per-user records; 30 s for an

--- a/pkg/plugin/app_platform_client.go
+++ b/pkg/plugin/app_platform_client.go
@@ -91,8 +91,8 @@ func newAppPlatformListClient(appURL string, minter accessTokenMinter, idToken s
 var credentialDiagOnce sync.Once
 
 // listPage fetches one page of a namespace LIST. The body is bounded by
-// maxBytes; errors carry the upstream status for transient/terminal/
-// identity-scoped classification.
+// maxBytes; upstream HTTP failures carry the status for retryability and scope
+// classification, and a mint failure carries errAccessTokenMintFailed instead.
 func (c *appPlatformListClient) listPage(ctx context.Context, groupVersion, namespace, resource, continueToken string, pageSize int, maxBytes int64) (*appPlatformListPage, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("app platform list: empty namespace")
@@ -111,8 +111,7 @@ func (c *appPlatformListClient) listPage(ctx context.Context, groupVersion, name
 
 	// Mint per request rather than per client: authlib caches by subject for
 	// most of the token's 10-minute life, so this is a cache hit on all but the
-	// first call for a given user, and a mint failure surfaces as an upstream
-	// error the caller already classifies.
+	// first call for a given user.
 	accessToken, err := c.minter.Mint(reqCtx, namespace, c.idToken)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errAccessTokenMintFailed, err)

--- a/pkg/plugin/app_platform_client.go
+++ b/pkg/plugin/app_platform_client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -114,7 +115,7 @@ func (c *appPlatformListClient) listPage(ctx context.Context, groupVersion, name
 	// error the caller already classifies.
 	accessToken, err := c.minter.Mint(reqCtx, namespace, c.idToken)
 	if err != nil {
-		return nil, fmt.Errorf("app platform list: mint access token: %w", err)
+		return nil, fmt.Errorf("%w: %w", errAccessTokenMintFailed, err)
 	}
 
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)
@@ -183,6 +184,11 @@ type appPlatformUpstreamError struct {
 
 func (e *appPlatformUpstreamError) Error() string { return e.msg }
 
+// errAccessTokenMintFailed marks a failure to mint the caller's on-behalf-of
+// access token. It is caller-scoped (auth-api can reject one subject token
+// while serving others) and carries no HTTP status, so it stays transient.
+var errAccessTokenMintFailed = errors.New("app platform list: mint access token")
+
 // isTransientUpstreamStatus reports whether an HTTP status should be treated
 // as transient (retryable): 429 and any 5xx. All other non-2xx are terminal.
 func isTransientUpstreamStatus(status int) bool {
@@ -208,13 +214,25 @@ func isTerminalUpstreamError(err error) bool {
 	return false
 }
 
-// isIdentityScopedUpstreamError reports whether an upstream failure means the
-// aggregator rejected this caller's forwarded identity (401/403). Error-level
-// companion to isIdentityScopedUpstreamStatus, shared by every proxy route.
-func isIdentityScopedUpstreamError(err error) bool {
+// isNamespaceGlobalUpstreamError reports whether an upstream failure is a
+// property of the namespace rather than of one caller's identity, and may
+// therefore be shared across callers through a negative cache (§4, §5).
+//
+// This is an allow-list, not a deny-list on the identity-scoped statuses: any
+// failure shape we cannot positively place — including future statusless ones —
+// stays unshared, which costs re-probes but never replays one caller's error to
+// another. Scope is orthogonal to transient/terminal: a mint failure is
+// caller-scoped AND transient.
+func isNamespaceGlobalUpstreamError(err error) bool {
+	// Ordering matters: the mint hop is itself an HTTP call to auth-api, so its
+	// failures also satisfy the net.Error check below.
+	if errors.Is(err, errAccessTokenMintFailed) {
+		return false
+	}
 	var ue *appPlatformUpstreamError
 	if errors.As(err, &ue) {
-		return isIdentityScopedUpstreamStatus(ue.status)
+		return !isIdentityScopedUpstreamStatus(ue.status)
 	}
-	return false
+	var netErr net.Error
+	return errors.As(err, &netErr) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/pkg/plugin/app_platform_client_test.go
+++ b/pkg/plugin/app_platform_client_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -158,6 +160,44 @@ func TestAppPlatformListClient_UpstreamErrorClassification(t *testing.T) {
 		if got := isIdentityScopedUpstreamStatus(tt.status); got != tt.identityScoped {
 			t.Errorf("isIdentityScopedUpstreamStatus(%d) = %v, want %v", tt.status, got, tt.identityScoped)
 		}
+	}
+}
+
+// Failure scope (may this be shared across callers?) is orthogonal to
+// transient/terminal, and is an allow-list: only positively recognized
+// namespace-global shapes are shareable.
+func TestAppPlatformListClient_FailureScopeClassification(t *testing.T) {
+	mintFailure := fmt.Errorf("%w: %w", errAccessTokenMintFailed, errors.New("exchange refused"))
+
+	cases := []struct {
+		name            string
+		err             error
+		namespaceGlobal bool
+		terminal        bool
+	}{
+		{"503 upstream", &appPlatformUpstreamError{status: http.StatusServiceUnavailable}, true, false},
+		{"404 upstream", &appPlatformUpstreamError{status: http.StatusNotFound}, true, true},
+		{"401 upstream", &appPlatformUpstreamError{status: http.StatusUnauthorized}, false, true},
+		{"403 upstream", &appPlatformUpstreamError{status: http.StatusForbidden}, false, true},
+		{"mint failure", mintFailure, false, false},
+		{"network failure", &url.Error{Op: "Get", Err: errors.New("connection refused")}, true, false},
+		{"aggregate deadline", fmt.Errorf("app platform list: %w", context.DeadlineExceeded), true, false},
+		{"decode failure", errors.New("app platform list: decode: unexpected token"), false, false},
+	}
+	for _, tt := range cases {
+		if got := isNamespaceGlobalUpstreamError(tt.err); got != tt.namespaceGlobal {
+			t.Errorf("%s: isNamespaceGlobalUpstreamError = %v, want %v", tt.name, got, tt.namespaceGlobal)
+		}
+		if got := isTerminalUpstreamError(tt.err); got != tt.terminal {
+			t.Errorf("%s: isTerminalUpstreamError = %v, want %v", tt.name, got, tt.terminal)
+		}
+	}
+
+	// A mint failure caused by an unreachable auth-api is transport-shaped, so
+	// the sentinel must win over the network-error branch.
+	oboNetworkFailure := fmt.Errorf("%w: %w", errAccessTokenMintFailed, &url.Error{Op: "Post", Err: errors.New("connection refused")})
+	if isNamespaceGlobalUpstreamError(oboNetworkFailure) {
+		t.Error("a mint failure wrapping a network error must still be caller-scoped")
 	}
 }
 

--- a/pkg/plugin/completion_records.go
+++ b/pkg/plugin/completion_records.go
@@ -200,10 +200,10 @@ func resetCompletionRecordsCache() {
 // most once per TTL (or immediately when a rate-limit-permitted forced refresh
 // is requested). On refresh failure it serves a warm (stale) index when one
 // exists; a cold failure returns (nil, err). After a namespace-global failure
-// a short cooldown suppresses TTL-driven re-attempts; identity-scoped (401/403)
-// failures are per-request and never enter that shared negative cache — caller
-// A's denied token must not become a cached error served to caller B.
-// Concurrent refreshes single-flight.
+// a short cooldown suppresses TTL-driven re-attempts; only failures positively
+// classified as namespace-global enter that shared negative cache — caller A's
+// denied token or failed token mint must not become a cached error served to
+// caller B. Concurrent refreshes single-flight.
 func getCompletionIndex(ctx context.Context, namespace string, lister completionRecordLister, forced bool, logger log.Logger) (*completionIndex, error) {
 	completionCacheMu.Lock()
 	completionCacheInit()
@@ -283,15 +283,15 @@ func getCompletionIndex(ctx context.Context, namespace string, lister completion
 			"staleServes", stats.staleServes, "refreshFailures", stats.refreshFailures)
 	} else {
 		stats.refreshFailures++
-		identityScoped := isIdentityScopedCompletionError(err)
-		if !identityScoped {
+		namespaceGlobal := isNamespaceGlobalCompletionError(err)
+		if namespaceGlobal {
 			completionLastFailure[namespace] = completionFailure{at: timeNow(), err: err}
 		}
 		// Refresh attempts are throttled by TTL + cooldown, so this logs state
 		// transitions, not every request.
 		logger.Info("completion index refresh failed",
 			"namespace", namespace, "error", err,
-			"identityScoped", identityScoped, "servingStale", entry != nil,
+			"namespaceGlobal", namespaceGlobal, "servingStale", entry != nil,
 			"refreshFailures", stats.refreshFailures)
 		if entry != nil {
 			// Warm cache + upstream failure: serve stale. asOf reflects true age.
@@ -591,9 +591,9 @@ func isTerminalCompletionError(err error) bool {
 	return isTerminalUpstreamError(err)
 }
 
-// isIdentityScopedCompletionError reports whether an upstream failure means
-// the aggregator rejected this caller's forwarded identity (401/403). Thin
-// domain alias over the shared classifier.
-func isIdentityScopedCompletionError(err error) bool {
-	return isIdentityScopedUpstreamError(err)
+// isNamespaceGlobalCompletionError reports whether an upstream failure may be
+// shared across callers through the negative cache. Thin domain alias over the
+// shared classifier.
+func isNamespaceGlobalCompletionError(err error) bool {
+	return isNamespaceGlobalUpstreamError(err)
 }

--- a/pkg/plugin/completion_records.go
+++ b/pkg/plugin/completion_records.go
@@ -36,8 +36,8 @@ const (
 	// separate constant from the success TTL: after an upstream refresh fails,
 	// TTL-expired re-attempts are suppressed for this long so a sustained
 	// outage doesn't re-trigger a full-namespace LIST on every sequential
-	// request. Identity-scoped (401/403) failures never enter this shared
-	// negative cache — see getCompletionIndex.
+	// request. Only failures positively classified as namespace-global enter this
+	// shared negative cache — see getCompletionIndex.
 	completionFailureCooldown = 30 * time.Second
 
 	// completionRetryAfterSeconds is the Retry-After hint on a cold 503.

--- a/pkg/plugin/completion_records_test.go
+++ b/pkg/plugin/completion_records_test.go
@@ -565,6 +565,36 @@ func TestErrors_IdentityScopedFailureNotCachedShared(t *testing.T) {
 	}
 }
 
+// A failed on-behalf-of token mint is caller-scoped too — auth-api can reject
+// one caller's subject token while serving others — so it must not enter the
+// shared negative cache either, even though it carries no HTTP status.
+func TestErrors_MintFailureNotCachedShared(t *testing.T) {
+	advance := withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	l := &fakeLister{respond: func(token string) (*completionRecordPage, error) {
+		return nil, fmt.Errorf("%w: exchange refused", errAccessTokenMintFailed)
+	}}
+	withLister(t, l)
+
+	// A mint failure is transient (no upstream status), so caller A gets a 503
+	// hiccup rather than capability=false.
+	rr, _ := doMyCompletions(t, "/completion-records/my", "user:a")
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("caller A: expected 503 for a transient mint failure, got %d", rr.Code)
+	}
+	if l.callCount() != 1 {
+		t.Fatalf("expected 1 upstream LIST, got %d", l.callCount())
+	}
+
+	advance(time.Second)
+	rr, _ = doMyCompletions(t, "/completion-records/my", "user:b")
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("caller B: expected 503, got %d", rr.Code)
+	}
+	if l.callCount() != 2 {
+		t.Fatalf("mint failure must not be cached shared: expected a fresh probe for caller B, got %d LIST calls", l.callCount())
+	}
+}
+
 func TestErrors_WarmStaleOutageThrottledByCooldown(t *testing.T) {
 	advance := withFrozenTime(t, time.Unix(1_700_000_000, 0))
 	var fail atomic.Bool


### PR DESCRIPTION
## Intent

Fix GitHub issue https://github.com/grafana/grafana-pathfinder-app/issues/1553: on the App Platform completion-records proxy, a token-mint failure was wrapped with plain fmt.Errorf so it carried no HTTP status, could not be matched by isIdentityScopedUpstreamError, and was therefore written into the namespace-global negative cache in completion_records.go and replayed to OTHER callers on the same namespace — violating the per-caller isolation invariant the handler documents. Goal: give the mint failure its own sentinel error and make the negative-cache decision never share it across callers.

Deliberate decisions made during the work, from the issue's triage comment:
1. Do NOT synthesize an appPlatformUpstreamError with status 401 as a shortcut. TestAppPlatformListClient_MintFailureAbortsRequest explicitly pins mint failures as NON-TERMINAL (transient), and flipping the route to capability:false instead of a 503 would be a regression. Previously identity-scoped was a subset of terminal (401/403 are both non-transient); caller-scoped AND transient is a new combination, so the two axes had to become genuinely orthogonal. That is why there is now a statusless sentinel (errAccessTokenMintFailed) rather than a synthetic status.
2. The guard was deliberately INVERTED, per triage suggestion: isNamespaceGlobalUpstreamError is an allow-list of what MAY be negative-cached (a statused non-identity-scoped appPlatformUpstreamError, plus network/timeout errors via net.Error / context.DeadlineExceeded) rather than a deny-list on identity-scoped errors. This fails safe for any future statusless error, not just this one. The accepted cost is that statusless namespace-global shapes (decode failure, page-too-large, build-request failure) lose their negative-cache cooldown and re-probe on cold cache; single-flight still collapses concurrent probes, so the cost is bounded and it is availability-only, never a correctness risk.
3. Ordering inside isNamespaceGlobalUpstreamError is load-bearing and commented: the mint hop is itself an HTTP call to auth-api, so a mint failure can satisfy the net.Error branch; the sentinel check must short-circuit first.
4. Mint failures are never shared even though they are sometimes not caller-scoped (bad CAP token, unreachable auth-api). Triage considered a per-subject cooldown and rejected it because it would break the deliberate no-eviction property of the namespace-keyed maps. Accepted cost: one exchange attempt per TTL-expired request per caller during an auth-api outage.
5. isIdentityScopedUpstreamError and its thin domain alias isIdentityScopedCompletionError became dead once the guard inverted, so they were removed and the alias renamed to isNamespaceGlobalCompletionError; isIdentityScopedUpstreamStatus is retained and still used by the new allow-list and the existing status-classification test. The refresh-failure log field was renamed identityScoped -> namespaceGlobal to match.

DELIBERATELY OUT OF SCOPE (agreed with the issue triage, and stated in the PR body):
- getCompletionIndex's single-flight path returns fl.err verbatim to a concurrent waiter, so a caller-scoped failure can still become another caller's 503 for the duration of one flight. This is a pre-existing shape that the 401/403 path has today too; widening scope here would make the change hard to review. A follow-up comment describing it with file:line is being posted on issue 1553.
- The custom-guide proxy (custom_guide_repository.go) needs no edit: it has no cross-request cache, so the shared classifier change is safe there.

Tests use the existing harnesses rather than new ones, as the triage directed: TestErrors_MintFailureNotCachedShared in completion_records_test.go is cloned from TestErrors_IdentityScopedFailureNotCachedShared (two callers, mint fails, assert the second caller is NOT served the cached error and the upstream LIST count increments to 2); TestAppPlatformListClient_FailureScopeClassification uses a table over both axes plus an explicit guard that a mint failure wrapping a url.Error stays caller-scoped. TestAppPlatformListClient_MintFailureAbortsRequest passes UNCHANGED — verified.

docs/design/BACKEND_PROXY_PATTERN.md was updated because it is the pattern doc that defines this classification taxonomy: the section 1 bullet now describes two orthogonal axes (retryability and scope) and the allow-list rule, the section 3 outbound bullet about a failed exchange now notes it is caller-scoped and needs its own sentinel, and three checklist/testing lines changed the wording identity-scoped -> caller-scoped. Sentence case throughout per AGENTS.md.

Repo conventions honoured: comments default to none (the two added comments are a hidden-invariant one on the sentinel-ordering short-circuit and one on the allow-list rationale), no summary .md files created, and only the five intended files are staged (no unrelated prettier churn). npm run lint:go, npm run test:go, go build ./... and prettier --check on the doc all pass locally.

## What Changed

- `listPage` now wraps an OBO access-token mint failure in a new statusless sentinel, `errAccessTokenMintFailed`, instead of a plain `fmt.Errorf`, so the failure is classifiable without synthesizing a fake 401 that would flip the route from a transient 503 to `capability: false`.
- Inverted the negative-cache guard: `isIdentityScopedUpstreamError` (and its domain alias `isIdentityScopedCompletionError`) are replaced by `isNamespaceGlobalUpstreamError` / `isNamespaceGlobalCompletionError`, an allow-list admitting only statused non-401/403 upstream errors plus `net.Error` / `context.DeadlineExceeded`. The sentinel check short-circuits first because the mint hop is itself an HTTP call and would otherwise match the `net.Error` branch. Retryability and caller-scope are now genuinely orthogonal axes; the refresh-failure log field is renamed `identityScoped` → `namespaceGlobal`.
- Added `TestErrors_MintFailureNotCachedShared` (two callers, mint fails for the first, asserts the second still hits upstream) and `TestAppPlatformListClient_FailureScopeClassification` (table over both axes, including a mint failure wrapping a `url.Error`), and refreshed `docs/design/BACKEND_PROXY_PATTERN.md` plus the coda/systemPatterns rules to describe the two-axis taxonomy and caller-scoped wording. The custom-guide proxy shares the classifier but has no cross-request cache, so it needed no change.

Known and deliberately out of scope: `getCompletionIndex`'s single-flight path still returns `fl.err` verbatim to concurrent waiters, so a caller-scoped failure can surface as another caller's 503 for the duration of one flight. That shape pre-exists for 401/403 today and this change strictly narrows the leak (a mint failure previously persisted for the full 30s cooldown); a follow-up is tracked on issue 1553.

## Risk Assessment

✅ Low: The round-2 commit is comment-only and accurately resolves both prior documentation-drift findings, leaving a tightly scoped, fail-safe classifier change whose invariant I traced end to end with regression tests on both classification axes and no remaining substantiated issues.

## Testing

Ran the targeted Go tests for the changed classifier and cache path (the new `TestErrors_MintFailureNotCachedShared` and `TestAppPlatformListClient_FailureScopeClassification`, the pre-existing identity-scoped and status-classification tests, and the unchanged `TestAppPlatformListClient_MintFailureAbortsRequest`) plus the whole affected `pkg/plugin` package — all green. Because passing unit tests alone would not show the user-visible effect, I wrote a temporary end-to-end harness that drives the real `GET /completion-records/my` handler through the real App Platform list client against an httptest aggregator, with auth-api rejecting only caller A's subject token, and ran the identical scenario against both the base and the fixed code: on base, caller B is served caller A's cached failure (503, zero upstream LIST calls); with the fix, caller A gets a transient 503 with `Retry-After: 30` while caller B gets HTTP 200 with their own completion records and a fresh upstream LIST. I also confirmed the classifier has a single call site (so the custom-guide proxy is genuinely unaffected) and that no stale references to the removed identity-scoped helpers remain in code or docs. No screenshot or rendered-UI artifact applies: the change is backend-only in the Go proxy with no frontend or markup change, so the HTTP status, headers, and JSON envelope captured in the transcript are the actual end-user-facing surface. Per this phase's rules I did not run linters or formatters. The temporary harness was deleted afterwards and the worktree is clean; its source is preserved in the evidence directory for reproduction.

<details>
<summary>Evidence: Before/after transcript: mint-failure caller isolation at the HTTP surface</summary>

<code>=== auth-api rejects caller A&#39;s subject token; caller B&#39;s mint is healthy ===&#10;&#10;--- BEFORE (base bd5dae6b) ---&#10;caller A (user:a, namespace stacks-1)&#10;&gt; GET /completion-records/my&#10;&lt; HTTP 503 Service Unavailable&#10;&lt; Retry-After: 30&#10;{ &#34;error&#34;: &#34;completion-records-unavailable&#34; }&#10;[upstream App Platform LIST calls so far: 0]&#10;&#10;caller B, 1s later, same namespace (user:b, namespace stacks-1)&#10;&gt; GET /completion-records/my&#10;&lt; HTTP 503 Service Unavailable &lt;-- caller A&#39;s private failure, replayed&#10;&lt; Retry-After: 30&#10;{ &#34;error&#34;: &#34;completion-records-unavailable&#34; }&#10;[upstream App Platform LIST calls so far: 0]&#10;FAIL: caller B was served caller A&#39;s cached mint failure&#10;&#10;--- AFTER (fix 5ca49a02) ---&#10;caller A (user:a, namespace stacks-1)&#10;&gt; GET /completion-records/my&#10;&lt; HTTP 503 Service Unavailable &lt;-- still transient, not capability:false&#10;&lt; Retry-After: 30&#10;{ &#34;error&#34;: &#34;completion-records-unavailable&#34; }&#10;[upstream App Platform LIST calls so far: 0]&#10;&#10;caller B, 1s later, same namespace (user:b, namespace stacks-1)&#10;&gt; GET /completion-records/my&#10;&lt; HTTP 200 OK&#10;{&#10;&#34;asOf&#34;: &#34;2023-11-14T22:13:21Z&#34;,&#10;&#34;capability&#34;: { &#34;available&#34;: true },&#10;&#34;completions&#34;: [&#10;{ &#34;count&#34;: 1, &#34;guideId&#34;: &#34;loki-basics&#34;, &#34;guideSource&#34;: &#34;bundled&#34;,&#10;&#34;guideTitle&#34;: &#34;Explore logs with Loki&#34;, &#34;guideCategory&#34;: &#34;interactive&#34;,&#10;&#34;latestCompletedAt&#34;: &#34;2026-08-09T12:00:00Z&#34;, &#34;latestSource&#34;: &#34;objectives&#34;,&#10;&#34;maxCompletionPercent&#34;: 100, &#34;pathId&#34;: &#34;&#34; }&#10;],&#10;&#34;userId&#34;: &#34;user:b&#34;&#10;}&#10;[upstream App Platform LIST calls so far: 1] &lt;-- fresh probe, not a cached error&#10;PASS</code>

```text
# Issue 1553 — a mint failure must never be replayed to another caller

Same scenario both runs: GET /completion-records/my through the real handler,
real appPlatformListClient, real httptest App Platform aggregator. auth-api
rejects caller A's subject token only; caller B's on-behalf-of mint is healthy.
Harness: evidence-harness.go.txt

## BEFORE (base bd5dae6b) — caller B is poisoned by caller A private failure
=== RUN   TestEvidence_MintFailureIsolation

=== auth-api rejects caller A's subject token; caller B's mint is healthy ===

caller A (user:a, namespace stacks-1)
  > GET /completion-records/my
  < HTTP 503 Service Unavailable
  < Retry-After: 30
    {
      "error": "completion-records-unavailable"
    }
  [upstream App Platform LIST calls so far: 0]

caller B, 1s later, same namespace (user:b, namespace stacks-1)
  > GET /completion-records/my
  < HTTP 503 Service Unavailable
  < Retry-After: 30
    {
      "error": "completion-records-unavailable"
    }
  [upstream App Platform LIST calls so far: 0]
    zz_evidence_demo_test.go:99: caller B was served caller A's cached mint failure: upstream LIST calls = 0, want 1
--- FAIL: TestEvidence_MintFailureIsolation (0.00s)
FAIL
FAIL	github.com/grafana/grafana-pathfinder-app/pkg/plugin	0.297s
FAIL


## AFTER (fix 5ca49a02) — caller B gets their own records
=== RUN   TestEvidence_MintFailureIsolation

=== auth-api rejects caller A's subject token; caller B's mint is healthy ===

caller A (user:a, namespace stacks-1)
  > GET /completion-records/my
  < HTTP 503 Service Unavailable
  < Retry-After: 30
    {
      "error": "completion-records-unavailable"
    }
  [upstream App Platform LIST calls so far: 0]

caller B, 1s later, same namespace (user:b, namespace stacks-1)
  > GET /completion-records/my
  < HTTP 200 OK
    {
      "asOf": "2023-11-14T22:13:21Z",
      "capability": {
        "available": true
      },
      "completions": [
        {
          "count": 1,
          "guideCategory": "interactive",
          "guideId": "loki-basics",
          "guideSource": "bundled",
          "guideTitle": "Explore logs with Loki",
          "latestCompletedAt": "2026-08-09T12:00:00Z",
          "latestSource": "objectives",
          "maxCompletionPercent": 100,
          "pathId": ""
        }
      ],
      "userId": "user:b"
    }
  [upstream App Platform LIST calls so far: 1]
--- PASS: TestEvidence_MintFailureIsolation (0.00s)
PASS
ok  	github.com/grafana/grafana-pathfinder-app/pkg/plugin	(cached)
```
</details>
<details>
<summary>Evidence: Evidence harness source (temporary test, removed from the worktree)</summary>

```text
package plugin

import (
	"context"
	"encoding/json"
	"errors"
	"fmt"
	"net/http"
	"net/http/httptest"
	"testing"
	"time"

	"github.com/grafana/grafana-plugin-sdk-go/backend"
	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
	sdkconfig "github.com/grafana/grafana-plugin-sdk-go/config"
)

// TestEvidence_MintFailureIsolation drives the real GET /completion-records/my
// handler, the real appPlatformListClient, and a real httptest App Platform
// aggregator. auth-api rejects caller A's subject token only; caller B's mint
// succeeds. The transcript shows what each Grafana user sees.
type evidenceMinter struct {
	rejectIDToken string
}

func (m *evidenceMinter) Mint(_ context.Context, namespace, idToken string) (string, error) {
	if idToken == m.rejectIDToken {
		return "", errors.New("auth-api: token exchange refused for this subject (403)")
	}
	return "obo-access-token-for-" + namespace, nil
}

// evidenceLister mirrors production, where resolveCompletionBackend builds a
// fresh client carrying THIS request's ID token; idToken is set per request.
type evidenceLister struct {
	appURL  string
	minter  *evidenceMinter
	idToken string
}

func (l *evidenceLister) ListPage(ctx context.Context, namespace, token string) (*completionRecordPage, error) {
	return newCompletionHTTPClient(l.appURL, l.minter, l.idToken, log.DefaultLogger).ListPage(ctx, namespace, token)
}

func TestEvidence_MintFailureIsolation(t *testing.T) {
	advance := withFrozenTime(t, time.Unix(1_700_000_000, 0))

	upstreamHits := 0
	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		upstreamHits++
		_ = json.NewEncoder(w).Encode(map[string]any{
			"metadata": map[string]any{"continue": ""},
			"items": []map[string]any{
				{"spec": map[string]any{
					"userId": "user:b", "guideId": "loki-basics", "guideSource": "bundled",
					"guideTitle": "Explore logs with Loki", "guideCategory": "interactive",
					"source": "objectives", "completedAt": "2026-08-09T12:00:00Z", "completionPercent": 100,
				}},
			},
		})
	}))
	defer srv.Close()

	tokenA := makeIDToken(t, "user:a", timeNow().Add(time.Hour).Unix())
	tokenB := makeIDToken(t, "user:b", timeNow().Add(time.Hour).Unix())

	lister := &evidenceLister{appURL: srv.URL, minter: &evidenceMinter{rejectIDToken: tokenA}}
	withLister(t, lister)

	call := func(label, sub, idToken string) {
		lister.idToken = idToken
		r, _ := http.NewRequest(http.MethodGet, "/completion-records/my", nil)
		r.Header.Set(backend.GrafanaUserSignInTokenHeaderName, idToken)
		ctx := backend.WithPluginContext(r.Context(), backend.PluginContext{Namespace: testNamespace})
		ctx = sdkconfig.WithGrafanaConfig(ctx, sdkconfig.NewGrafanaCfg(testGrafanaConfig()))

		rec := httptest.NewRecorder()
		newTestApp(t).handleMyCompletions(rec, r.WithContext(ctx))

		fmt.Printf("\n%s (%s, namespace %s)\n", label, sub, testNamespace)
		fmt.Printf("  > GET /completion-records/my\n")
		fmt.Printf("  < HTTP %d %s\n", rec.Code, http.StatusText(rec.Code))
		if ra := rec.Header().Get("Retry-After"); ra != "" {
			fmt.Printf("  < Retry-After: %s\n", ra)
		}
		var pretty any
		_ = json.Unmarshal(rec.Body.Bytes(), &pretty)
		out, _ := json.MarshalIndent(pretty, "    ", "  ")
		fmt.Printf("    %s\n", out)
		fmt.Printf("  [upstream App Platform LIST calls so far: %d]\n", upstreamHits)
	}

	fmt.Printf("\n=== auth-api rejects caller A's subject token; caller B's mint is healthy ===\n")
	call("caller A", "user:a", tokenA)
	advance(time.Second)
	call("caller B, 1s later, same namespace", "user:b", tokenB)

	if upstreamHits != 1 {
		t.Fatalf("caller B was served caller A's cached mint failure: upstream LIST calls = %d, want 1", upstreamHits)
	}
}
```
</details>
<details>
<summary>Evidence: Raw base-commit run (reproduces issue 1553)</summary>

```text
=== RUN   TestEvidence_MintFailureIsolation

=== auth-api rejects caller A's subject token; caller B's mint is healthy ===

caller A (user:a, namespace stacks-1)
  > GET /completion-records/my
  < HTTP 503 Service Unavailable
  < Retry-After: 30
    {
      "error": "completion-records-unavailable"
    }
  [upstream App Platform LIST calls so far: 0]

caller B, 1s later, same namespace (user:b, namespace stacks-1)
  > GET /completion-records/my
  < HTTP 503 Service Unavailable
  < Retry-After: 30
    {
      "error": "completion-records-unavailable"
    }
  [upstream App Platform LIST calls so far: 0]
    zz_evidence_demo_test.go:99: caller B was served caller A's cached mint failure: upstream LIST calls = 0, want 1
--- FAIL: TestEvidence_MintFailureIsolation (0.00s)
FAIL
FAIL	github.com/grafana/grafana-pathfinder-app/pkg/plugin	0.297s
FAIL
```
</details>
<details>
<summary>Evidence: Raw fixed-commit run</summary>

```text
=== RUN   TestEvidence_MintFailureIsolation

=== auth-api rejects caller A's subject token; caller B's mint is healthy ===

caller A (user:a, namespace stacks-1)
  > GET /completion-records/my
  < HTTP 503 Service Unavailable
  < Retry-After: 30
    {
      "error": "completion-records-unavailable"
    }
  [upstream App Platform LIST calls so far: 0]

caller B, 1s later, same namespace (user:b, namespace stacks-1)
  > GET /completion-records/my
  < HTTP 200 OK
    {
      "asOf": "2023-11-14T22:13:21Z",
      "capability": {
        "available": true
      },
      "completions": [
        {
          "count": 1,
          "guideCategory": "interactive",
          "guideId": "loki-basics",
          "guideSource": "bundled",
          "guideTitle": "Explore logs with Loki",
          "latestCompletedAt": "2026-08-09T12:00:00Z",
          "latestSource": "objectives",
          "maxCompletionPercent": 100,
          "pathId": ""
        }
      ],
      "userId": "user:b"
    }
  [upstream App Platform LIST calls so far: 1]
--- PASS: TestEvidence_MintFailureIsolation (0.00s)
PASS
ok  	github.com/grafana/grafana-pathfinder-app/pkg/plugin	(cached)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed ✅</summary>

- ⚠️ `pkg/plugin/completion_records.go:39` - The `completionFailureCooldown` doc comment still states the old deny-list rule: &#34;Identity-scoped (401/403) failures never enter this shared negative cache — see getCompletionIndex.&#34; After this change the rule is an allow-list — mint failures and every other statusless shape are also excluded — so this comment now describes a strictly narrower exclusion than the code enforces. It sits directly on the constant that governs the changed behaviour, so it is the comment most likely to mislead someone later reasoning about (or re-widening) what may be shared across callers. The sibling comment on `getCompletionIndex` was updated; this one was missed. Suggest matching it to line 203-206: only failures positively classified as namespace-global enter the negative cache.
- ℹ️ `pkg/plugin/app_platform_client.go:114` - The comment immediately above the changed mint call now misstates behaviour: &#34;a mint failure surfaces as an upstream error the caller already classifies.&#34; As of line 118 it no longer surfaces as an `appPlatformUpstreamError`, and the entire point of the change is that the shared classifier treats it *differently* from an upstream error. The `listPage` doc at line 94-95 (&#34;errors carry the upstream status for transient/terminal/identity-scoped classification&#34;) is stale for the same reason — the mint hop&#39;s error carries no status. Both are in the function being edited, so AGENTS.md &#34;trim on touch&#34; applies.
- ℹ️ `pkg/plugin/app_platform_client.go:237` - `errors.Is(err, context.DeadlineExceeded)` is redundant with the `errors.As(err, &amp;netErr)` on the same line: `context.DeadlineExceeded`&#39;s concrete type (`context.deadlineExceededError`) implements `Error()`, `Timeout()` and `Temporary()`, so it already satisfies `net.Error` and `errors.As` matches it anywhere in the chain. The &#34;aggregate deadline&#34; table case in `app_platform_client_test.go:181` would pass with the `errors.Is` removed. Harmless and arguably self-documenting, so recording rather than recommending a change.
- ℹ️ `pkg/plugin/completion_records.go:287` - Intent item 4 accepts &#34;one exchange attempt per TTL-expired request per caller&#34; during an auth-api outage, reasoning that single-flight bounds the cost. That bound holds when the mint hangs (the 15s `appPlatformUpstreamTimeout` keeps a flight open for concurrent arrivals to join), but not when auth-api fails fast — e.g. connection refused. With a cold cache there is then no entry, no negative-cache cooldown, and no in-flight refresh to join, so every sequential inbound request to `/completion-records/my` and `/completion-records/capability` issues its own exchange attempt, versus roughly one per 30s `completionFailureCooldown` before this change. Availability-only, never a correctness risk, and explicitly authorized in the intent — recording so the amplification factor is on record rather than recommending a change.
- ℹ️ `pkg/plugin/completion_records.go:253` - The single-flight waiter path returns `fl.err` verbatim, so a caller-scoped failure (401/403 or now a mint failure) raised by the caller that owns the flight is still handed to concurrent waiters for the duration of that one flight. The intent declares this pre-existing and out of scope with a follow-up planned on issue 1553, and I agree it should not block: the change strictly narrows the leak rather than widening it, since a mint failure previously also persisted in the namespace-global negative cache for the full 30s cooldown and is now confined to a single in-flight window.

🔧 Fix: correct stale comments on mint-failure cache classification
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test ./pkg/plugin/ -run &#39;TestErrors_MintFailureNotCachedShared|TestErrors_IdentityScopedFailureNotCachedShared|TestAppPlatformListClient_FailureScopeClassification|TestAppPlatformListClient_MintFailureAbortsRequest|TestAppPlatformListClient_UpstreamErrorClassification|TestErrors_&#39; -v` — all pass, including the unchanged mint-abort test that pins mint failures as transient</code>
- <code>`go test ./pkg/plugin/` — the full affected package, including the custom-guide proxy tests that share the changed classifier</code>
- <code>End-to-end evidence harness `TestEvidence_MintFailureIsolation`: real `handleMyCompletions` + real `appPlatformListClient` + `httptest` App Platform aggregator + a minter that rejects only caller A&#39;s ID token; asserts caller B triggers a fresh upstream LIST</code>
- <code>Same harness replayed against base code via `git checkout bd5dae6b -- pkg/plugin`, then restored with `git checkout HEAD -- pkg/plugin` — reproduces the issue-1553 poisoning (caller B gets 503, 0 upstream LIST calls)</code>
- <code>`grep -rn &#39;isIdentityScopedUpstreamError|isIdentityScopedCompletionError&#39; --include=&#39;*.go&#39; --include=&#39;*.md&#39; .` — no stale references to the removed functions</code>
- <code>`grep -rn &#39;isNamespaceGlobal&#39; pkg/` — confirms the classifier has exactly one non-test call site (the negative-cache write), so `custom_guide_repository.go` is unaffected</code>
- <code>Inspected the emitted backend log line for a mint failure: `completion index refresh failed ... namespaceGlobal=false`, the renamed field from the intent</code>
- <code>`git status --porcelain` after cleanup — evidence harness removed, worktree clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `pkg/plugin/coda.go:90` - Pre-existing gofmt drift under pkg/ in files untouched by this change (pkg/plugin/coda.go, coda_exec.go, coda_exec_test.go, stream.go — struct tag alignment and a trailing blank line). golangci-lint does not flag it, so it is invisible to `npm run lint:go`; fixing it here would add unrelated churn to a five-file backend change. Worth a separate mechanical `gofmt -w pkg/` PR, optionally with the gofmt linter enabled in .golangci.yml to stop the drift recurring.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
