### PR TITLE
test: pin app-platform normalization of catalogue manifests

### DIFF
--- a/src/docs-retrieval/learning-journey-helpers.completion-boundary.test.ts
+++ b/src/docs-retrieval/learning-journey-helpers.completion-boundary.test.ts
@@ -33,6 +33,7 @@ jest.mock('../learning-paths', () => ({
   getPathsData: () => getPathsDataMock(),
 }));
 
+import { config, setBackendSrv, type BackendSrv } from '@grafana/runtime';
 import {
   setJourneyCompletionPercentage,
   setJourneyCompletionPercentageAsync,
@@ -40,6 +41,10 @@ import {
   getMilestoneSlug,
 } from './learning-journey-helpers';
 import { onCompletionRecorded, __resetRecorderForTests, type CompletionFact } from '../completion-records';
+import {
+  fetchCustomGuideRepository,
+  invalidateCustomGuideRepositoryCache,
+} from '../lib/custom-guide-repository-client';
 
 let emitted: CompletionFact[];
 let unsubscribe: () => void;
@@ -238,5 +243,50 @@ describe('whole-journey completion (trigger class D — the new journey_complete
     await markMilestoneDone('base', 'm2', 3);
 
     expect(emitted.filter((f) => f.kind === 'journey')).toHaveLength(1);
+  });
+});
+
+// Durable completion identity for the launch surfaces that thread the raw
+// catalogue manifest. Un-normalized, these two shapes split the durable key
+// against resolver-path launches of the same guide: an omitted `repository`
+// lands on fallbackSource 'bundled', and the CLI's stamped default lands on
+// 'interactive-tutorials'.
+describe('catalogue-launched path (App Platform provenance)', () => {
+  const GAP_TOGGLE = 'aggregation.pathfinderbackend-ext-grafana-app.enabled';
+  const featureToggles = config.featureToggles as Record<string, boolean>;
+
+  async function launchManifestFromCatalogue(manifest: Record<string, unknown>): Promise<Record<string, unknown>> {
+    featureToggles[GAP_TOGGLE] = true;
+    invalidateCustomGuideRepositoryCache();
+    setBackendSrv({
+      get: async () => ({ capability: { available: true }, guides: [{ id: 'fe-alerting-path', manifest }] }),
+    } as unknown as BackendSrv);
+
+    const [entry] = await fetchCustomGuideRepository('stacks-123');
+    return { ...entry!.manifest, id: entry!.id };
+  }
+
+  afterEach(() => {
+    delete featureToggles[GAP_TOGGLE];
+    invalidateCustomGuideRepositoryCache();
+  });
+
+  it.each([
+    ['omits repository entirely', undefined],
+    ["carries the CLI's interactive-tutorials default", 'interactive-tutorials'],
+  ])("records journey completion as 'app-platform' when the catalogue manifest %s", async (_label, repository) => {
+    milestoneGetCompletedMock.mockResolvedValue(new Set(['m1', 'm2', 'm3']));
+    const packageManifest = await launchManifestFromCatalogue({
+      type: 'path',
+      milestones: ['m1', 'm2', 'm3'],
+      ...(repository != null && { repository }),
+    });
+
+    await markMilestoneDone('base', 'm3', 3, { packageManifest });
+
+    expect(emitted.find((f) => f.kind === 'journey')).toMatchObject({
+      guideSource: 'app-platform',
+      guideId: 'fe-alerting-path',
+    });
   });
 });

--- a/src/docs-retrieval/package-content.test.ts
+++ b/src/docs-retrieval/package-content.test.ts
@@ -9,6 +9,7 @@
  * - Manifest metadata passthrough via fetchPackageContent
  * - setPackageResolver injection and resolver-not-configured error
  */
+import { config, setBackendSrv, type BackendSrv } from '@grafana/runtime';
 import {
   fetchPackageContent,
   fetchPackageById,
@@ -18,6 +19,10 @@ import {
   ensureNonEmptyCoverContent,
 } from './content-fetcher/package-content';
 import { fetchContent } from './content-fetcher';
+import {
+  fetchCustomGuideRepository,
+  invalidateCustomGuideRepositoryCache,
+} from '../lib/custom-guide-repository-client';
 import type { PackageResolver, PackageResolution } from '../types';
 
 // Mock AbortSignal.timeout for Node environments
@@ -609,6 +614,71 @@ describe('fetchPackageContent path-type enrichment', () => {
       expect(result.content.metadata.packageManifest).toEqual(manifest);
       expect(result.content.metadata.learningJourney).toBeDefined();
     }
+  });
+});
+
+// The realistically-broken catalogue inputs: the CR manifest leaves
+// `repository` omitempty, and the CLI authoring tooling stamps the CDN default
+// `interactive-tutorials`. Both reach the launch surfaces through the catalogue
+// client, so the suppression gate is only sound if that client normalizes them.
+describe('fetchPackageContent — no public websiteUrl for catalogue-launched private paths', () => {
+  const GAP_TOGGLE = 'aggregation.pathfinderbackend-ext-grafana-app.enabled';
+  const featureToggles = config.featureToggles as Record<string, boolean>;
+
+  async function launchManifestFromCatalogue(manifest: Record<string, unknown>): Promise<Record<string, unknown>> {
+    featureToggles[GAP_TOGGLE] = true;
+    invalidateCustomGuideRepositoryCache();
+    setBackendSrv({
+      get: async () => ({ capability: { available: true }, guides: [{ id: 'fe-alerting-path', manifest }] }),
+    } as unknown as BackendSrv);
+
+    const [entry] = await fetchCustomGuideRepository('stacks-123');
+    return { ...entry!.manifest, id: entry!.id };
+  }
+
+  beforeEach(() => {
+    setPackageResolver({
+      resolve: jest.fn().mockImplementation((id: string) =>
+        Promise.resolve({
+          ok: true,
+          id,
+          contentUrl: `bundled:${id}/content.json`,
+          manifestUrl: `bundled:${id}/manifest.json`,
+          repository: 'app-platform',
+          content: { id, title: `Milestone: ${id}`, blocks: [] },
+          manifest: { id, type: 'guide' },
+        })
+      ),
+    });
+  });
+
+  afterEach(() => {
+    delete featureToggles[GAP_TOGGLE];
+    invalidateCustomGuideRepositoryCache();
+    setPackageResolver(makeResolver({ ok: false, id: 'reset', error: { code: 'not-found', message: 'reset' } }));
+  });
+
+  it.each([
+    ['omits repository entirely', undefined],
+    ["carries the CLI's interactive-tutorials default", 'interactive-tutorials'],
+  ])('synthesizes no learning-paths URL when the catalogue manifest %s', async (_label, repository) => {
+    const manifest = await launchManifestFromCatalogue({
+      type: 'path',
+      // Shares the derived path slug's prefix, so an un-suppressed slug WOULD
+      // build both the cover and the per-milestone URL.
+      milestones: ['fe-alerting-path-01'],
+      ...(repository != null && { repository }),
+    });
+    expect(manifest.repository).toBe('app-platform');
+
+    const result = await fetchPackageContent('bundled:first-dashboard/content.json', manifest);
+
+    const learningJourney = result.content!.metadata.learningJourney!;
+    expect(learningJourney.milestones).toHaveLength(1);
+    expect(learningJourney.websiteUrl).toBeUndefined();
+    expect(learningJourney.milestones[0]!.websiteUrl).toBeUndefined();
+    // Catches the injected cover copy too, not just the metadata fields.
+    expect(JSON.stringify(result)).not.toContain('grafana.com/docs/learning-paths');
   });
 });
 

--- a/src/lib/custom-guide-repository-client.test.ts
+++ b/src/lib/custom-guide-repository-client.test.ts
@@ -67,6 +67,19 @@ describe('fetchCustomGuideRepository', () => {
     expect(result[1]!.manifest?.repository).toBe('app-platform');
   });
 
+  it('normalizes before caching, so a cached read is stamped too', async () => {
+    mockGet.mockResolvedValue({
+      capability: { available: true },
+      guides: [{ id: 'fe-alerting-path', status: 'published', manifest: { type: 'path' } }],
+    });
+
+    await fetchCustomGuideRepository('stacks-123');
+    const cached = await fetchCustomGuideRepository('stacks-123');
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(cached[0]!.manifest?.repository).toBe('app-platform');
+  });
+
   it('returns an empty array when the proxy reports itself unavailable', async () => {
     mockGet.mockResolvedValue({
       capability: { available: false, reason: 'backend-unavailable' },


### PR DESCRIPTION
## Summary

**This PR is tests-only, on purpose.** The production fix for https://github.com/grafana/grafana-pathfinder-app/issues/1558 already landed in `main` as part of https://github.com/grafana/grafana-pathfinder-app/pull/1408, commit `2a14664a`: `requestCatalogue` in `src/lib/custom-guide-repository-client.ts` forces `repository: 'app-platform'` on every catalogue entry's manifest, at the single shaping return and pre-cache, so cached entries carry the normalized shape too.

I re-derived that placement from scratch before writing anything, and it is correct and complete. Both real launch surfaces — `CustomGuidesSection.tsx` and `MyLearningTab.tsx` — thread the raw catalogue manifest, and both funnel through `fetchCustomGuideRepository`. I checked for a second ingestion boundary that might bypass the normalization and there isn't one: `usePublishedGuides.ts`, `app-platform-paths.ts`, and `useCustomGuideCatalogueOnOpen.ts` all go through the same client, and `fetchBackendGuides` only feeds the block editor's authoring surface, never `fetchPackageContent`.

What was actually still missing was coverage. The force had exactly one unit assertion — its own — and **nothing pinned either consequence the force exists for**. Deleting it broke no test. This PR closes that.

## What each new test pins

All three drive the real catalogue client, so they exercise the normalization rather than a hand-authored fixture:

1. **`src/docs-retrieval/package-content.test.ts`** — no fabricated public URL. A catalogue path manifest that omits `repository`, and one carrying the CLI's stamped `interactive-tutorials` default, synthesize no `grafana.com/docs/learning-paths` URL anywhere in `fetchPackageContent`'s result: not the journey cover `websiteUrl`, not the per-milestone `websiteUrl`, and not the injected cover copy (swept with a `JSON.stringify` assertion). The milestone id deliberately shares the derived path-slug prefix, so an un-suppressed slug genuinely would build a URL.
2. **`src/docs-retrieval/learning-journey-helpers.completion-boundary.test.ts`** — durable completion identity. A catalogue-launched path records `guideSource: 'app-platform'` on the journey fact.
3. **`src/lib/custom-guide-repository-client.test.ts`** — the normalization happens pre-cache, so a cached read is stamped too. This was genuinely unpinned; the existing case only covered the first, uncached fetch.

## How I verified they discriminate

I removed the production force from `requestCatalogue` and re-ran each new test, then restored it. Every new case fails without the fix:

- websiteUrl suppression: both cases fail, synthesizing the fabricated URL.
- completion identity: the journey fact's `guideSource` degrades to `'bundled'` for the omitted-`repository` case and `'interactive-tutorials'` for the explicit one.

Those two values are worth recording, because they confirm the triage correction on the issue rather than the issue body: absent `repository`, the journey fact falls to `'bundled'` via `fallbackSource` (checked before the schema default), **not** to `'interactive-tutorials'`.

## Deliberately left alone

- **Step 5 of the issue** — centralizing the gate inside `derivePathSlug` / the second synthesis site in `src/context-engine/context.service.ts` — is out of scope. It needs a `derivePathSlug` signature change, and the site is unreachable for App Platform packages today because recommendations are CDN-only. Deferred by design, not overlooked.
- **The resolver-level force** in `src/package-engine/app-platform-resolver.ts` (`buildManifest`) stays in place as defense-in-depth. Not removed.
- **The issue's item 2** (`MyLearningTab.test.tsx` fixture and assertion) was already satisfied in `main` by https://github.com/grafana/grafana-pathfinder-app/pull/1408, so it is correctly absent here. Per that issue's triage comment, the test mocks `../../learning-paths` wholesale, so a client-side fix never executes in it — it can only carry the normalized fixture, which it now does.

## One correction to the issue text

The issue's item 3, read literally — "call `fetchPackageContent` with a manifest that omits `repository`, assert no `websiteUrl`" — is false against the gate in isolation. The gate is `packageManifest?.repository !== 'app-platform'`, so an omitted value **fails open** by design and does synthesize a URL. The assertion only holds once the manifest has been routed through the client normalization, which is what the issue's "after normalization" qualifier means and what these tests do.

## Testing notes

The new tests inject a fake `BackendSrv` through the real `setBackendSrv` and flip `config.featureToggles['aggregation.pathfinderbackend-ext-grafana-app.enabled']`, restoring it in `afterEach`. I chose that over `jest.mock('@grafana/runtime')` deliberately: `package-content.test.ts` is a large existing suite whose subject graph reads real `config` in several modules, and a file-wide module mock risked breaking unrelated cases. No module mocking was needed.

## How to verify

```
npm run check
```

Passes locally: 408 suites, 6451 tests. To reproduce the discrimination check, delete the `guides.map(...)` normalization in `requestCatalogue` and re-run the three test files — five cases should fail.

## Reversibility

Fully reversible. Tests-only, additions only, no production behavior touched.

Closes https://github.com/grafana/grafana-pathfinder-app/issues/1558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
