### PR TITLE
fix(docs-panel): validate guide content before launch and keep diagnostics out of telemetry

### DIFF
--- a/src/components/LearningPaths/MyLearningTab.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.test.tsx
@@ -189,11 +189,16 @@ describe('MyLearningTab launch flow', () => {
     const onOpenGuide = jest.fn();
 
     render(<MyLearningTab onOpenGuide={onOpenGuide} />);
-    fireEvent.click(screen.getByTestId(testIds.learningPaths.continueButton('path-1')));
+    const continueButton = screen.getByTestId(testIds.learningPaths.continueButton('path-1'));
+    fireEvent.click(continueButton);
 
     await waitFor(() => expect(publishMock).toHaveBeenCalledTimes(1));
     expect(publishMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'alert-error' }));
     expect(onOpenGuide).not.toHaveBeenCalled();
+    // The alert replaces the pending pill: a dead click that only cleared the
+    // pending state is the failure this path exists to rule out.
+    expect(continueButton).not.toBeDisabled();
+    expect(continueButton).not.toHaveTextContent('Opening…');
   });
 
   it('keeps every not-yet-complete path in My Courses and only 100% in Completed', () => {

--- a/src/components/LearningPaths/MyLearningTab.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.test.tsx
@@ -196,7 +196,7 @@ describe('MyLearningTab launch flow', () => {
   });
 
   it('surfaces a failed prepare as an error alert without opening a guide', async () => {
-    prepareMock.mockResolvedValue({ ok: false, error: 'Failed to load content' });
+    prepareMock.mockResolvedValue({ ok: false, error: 'Failed to load content', errorCode: 'fetch-failed' });
     const onOpenGuide = jest.fn();
 
     render(<MyLearningTab onOpenGuide={onOpenGuide} />);
@@ -212,11 +212,18 @@ describe('MyLearningTab launch flow', () => {
     expect(continueButton).not.toHaveTextContent('Opening…');
   });
 
-  it('keeps launch-URL secrets out of logger and Faro context on a failed prepare', async () => {
+  it('keeps launch-URL secrets and forwarded error text out of logger and Faro context', async () => {
     mockGetGuideUrlForPath.mockReturnValue(
       'https://grafana.com/docs/learning-paths/path-1/guide-1/?token=url-secret#fragment-secret'
     );
-    prepareMock.mockResolvedValue({ ok: false, error: 'Guide content failed schema validation' });
+    // Shaped like the fetch tier's forwarded Zod message (content-fetcher's
+    // `Invalid guide: ${message}`), which interpolates the authored token.
+    prepareMock.mockResolvedValue({
+      ok: false,
+      error:
+        'Invalid guide: Unknown requirement "authored-token-secret". See https://grafana.com/docs/x?leak=free-text-secret',
+      errorCode: 'fetch-failed',
+    });
     const consoleError = jest.spyOn(console, 'error').mockImplementation();
 
     try {
@@ -226,7 +233,7 @@ describe('MyLearningTab launch flow', () => {
       await waitFor(() => expect(publishMock).toHaveBeenCalledTimes(1));
       const expectedContext = {
         content_url: 'grafana.com/docs/learning-paths/path-1/guide-1/',
-        error: 'Guide content failed schema validation',
+        error_code: 'fetch-failed',
       };
       expect(consoleError).toHaveBeenCalledWith('[MyLearning] Guide launch preparation failed', expectedContext);
       expect(pushFaroLogMock).toHaveBeenCalledWith(
@@ -237,6 +244,8 @@ describe('MyLearningTab launch flow', () => {
       const emittedContext = JSON.stringify({ console: consoleError.mock.calls, faro: pushFaroLogMock.mock.calls });
       expect(emittedContext).not.toContain('url-secret');
       expect(emittedContext).not.toContain('fragment-secret');
+      expect(emittedContext).not.toContain('authored-token-secret');
+      expect(emittedContext).not.toContain('free-text-secret');
     } finally {
       consoleError.mockRestore();
     }

--- a/src/components/LearningPaths/MyLearningTab.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.test.tsx
@@ -15,10 +15,20 @@ import React from 'react';
 import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { MyLearningTab } from './MyLearningTab';
 import { prepareGuideLaunch, type PrepareGuideLaunchResult } from '../docs-panel/utils/prepare-guide-launch';
+import { pushFaroLog } from '../../lib/telemetry/bridge';
 import { testIds } from '../../constants/testIds';
 
 jest.mock('../docs-panel/utils/prepare-guide-launch', () => ({
   prepareGuideLaunch: jest.fn(),
+}));
+
+// Not mocking `lib/logging`: the assertion below is about what the real
+// logger-to-Faro bridge emits, so only the bridge sink is replaced.
+jest.mock('../../lib/telemetry/bridge', () => ({
+  pushFaroError: jest.fn(),
+  pushFaroLog: jest.fn(),
+  pushFaroUserAction: jest.fn(),
+  registerTelemetryBridge: jest.fn(),
 }));
 
 const publishMock = jest.fn();
@@ -88,6 +98,7 @@ jest.mock('../../lib/user-storage', () => ({
 jest.mock('../../global-state/completion-store', () => ({ evictAllContentCaches: jest.fn() }));
 
 const prepareMock = prepareGuideLaunch as jest.MockedFunction<typeof prepareGuideLaunch>;
+const pushFaroLogMock = pushFaroLog as jest.Mock;
 
 function deferred() {
   let resolve!: (r: PrepareGuideLaunchResult) => void;
@@ -199,6 +210,36 @@ describe('MyLearningTab launch flow', () => {
     // pending state is the failure this path exists to rule out.
     expect(continueButton).not.toBeDisabled();
     expect(continueButton).not.toHaveTextContent('Opening…');
+  });
+
+  it('keeps launch-URL secrets out of logger and Faro context on a failed prepare', async () => {
+    mockGetGuideUrlForPath.mockReturnValue(
+      'https://grafana.com/docs/learning-paths/path-1/guide-1/?token=url-secret#fragment-secret'
+    );
+    prepareMock.mockResolvedValue({ ok: false, error: 'Guide content failed schema validation' });
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      render(<MyLearningTab onOpenGuide={jest.fn()} />);
+      fireEvent.click(screen.getByTestId(testIds.learningPaths.continueButton('path-1')));
+
+      await waitFor(() => expect(publishMock).toHaveBeenCalledTimes(1));
+      const expectedContext = {
+        content_url: 'grafana.com/docs/learning-paths/path-1/guide-1/',
+        error: 'Guide content failed schema validation',
+      };
+      expect(consoleError).toHaveBeenCalledWith('[MyLearning] Guide launch preparation failed', expectedContext);
+      expect(pushFaroLogMock).toHaveBeenCalledWith(
+        'error',
+        '[MyLearning] Guide launch preparation failed',
+        expectedContext
+      );
+      const emittedContext = JSON.stringify({ console: consoleError.mock.calls, faro: pushFaroLogMock.mock.calls });
+      expect(emittedContext).not.toContain('url-secret');
+      expect(emittedContext).not.toContain('fragment-secret');
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('keeps every not-yet-complete path in My Courses and only 100% in Completed', () => {

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -117,13 +117,14 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
         if (result.ok) {
           onOpenGuide(result.launch);
         } else {
-          // The raw error is internal-shaped — keep it for the logs (Faro
-          // bridge makes launch failures countable) and show a translated
-          // generic message. Log context reaches Faro attributes verbatim, so
-          // the URL is normalized here: query and fragment can carry secrets.
+          // Log context reaches Faro attributes verbatim, so only stable,
+          // low-cardinality values go in: the URL loses its query and fragment,
+          // and the classification code stands in for `result.error`, whose free
+          // text can echo fetched-guide values. The user sees a translated
+          // generic message either way.
           logger.error('[MyLearning] Guide launch preparation failed', {
             content_url: normalizeTelemetryUrl(url),
-            error: result.error,
+            error_code: result.errorCode,
           });
           getAppEvents().publish({
             type: 'alert-error',

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -19,6 +19,7 @@ import { SkeletonLoader } from '../SkeletonLoader';
 import { FeedbackButton } from '../FeedbackButton/FeedbackButton';
 import { reportAppInteraction, UserInteraction, AnalyticsContentType } from '../../lib/analytics';
 import { logger } from '../../lib/logging';
+import { normalizeTelemetryUrl } from '../../lib/telemetry';
 import { StorageEvents } from '../../lib/event-names';
 import {
   learningProgressStorage,
@@ -118,8 +119,12 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
         } else {
           // The raw error is internal-shaped — keep it for the logs (Faro
           // bridge makes launch failures countable) and show a translated
-          // generic message.
-          logger.error('[MyLearning] Guide launch preparation failed', { url, error: result.error });
+          // generic message. Log context reaches Faro attributes verbatim, so
+          // the URL is normalized here: query and fragment can carry secrets.
+          logger.error('[MyLearning] Guide launch preparation failed', {
+            content_url: normalizeTelemetryUrl(url),
+            error: result.error,
+          });
           getAppEvents().publish({
             type: 'alert-error',
             payload: [

--- a/src/components/docs-panel/utils/prepare-guide-launch.test.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.test.ts
@@ -123,6 +123,25 @@ describe('prepareGuideLaunch', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toBe('not found');
+      expect(result.errorCode).toBe('fetch-failed');
+    }
+  });
+
+  it('classifies a forwarded fetch-tier error without echoing its message', async () => {
+    // The fetch tier builds this from the authored token (content-fetcher's
+    // `Invalid guide: ${validationResult.errors[0].message}`), so the message
+    // stays available to the caller but only the code is telemetry-safe.
+    mockLoad.mockResolvedValue({
+      content: null,
+      error: 'Invalid guide: Unknown requirement "authored-token-secret".',
+    });
+
+    const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errorCode).toBe('fetch-failed');
+      expect(result.error).toContain('authored-token-secret');
     }
   });
 
@@ -134,6 +153,9 @@ describe('prepareGuideLaunch', () => {
     const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
 
     expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errorCode).toBe('unparseable');
+    }
   });
 
   describe('schema validation before the walks', () => {
@@ -184,6 +206,9 @@ describe('prepareGuideLaunch', () => {
         const result = await prepareGuideLaunch(contentUrl, { title: 'X', source: 'home_page' });
 
         expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.errorCode).toBe('schema-invalid');
+        }
         expect(consoleError).toHaveBeenCalledWith('[PrepareGuideLaunch] Guide content failed schema validation', {
           content_url: 'grafana.com/docs/x',
           validation_error_count: 1,

--- a/src/components/docs-panel/utils/prepare-guide-launch.test.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.test.ts
@@ -2,6 +2,10 @@ import { prepareGuideLaunch } from './prepare-guide-launch';
 import { loadDocsTabContentResult } from './docs-tab-loader';
 import { fetchPackageInfoFromUrl, isPackageContentUrl } from '../../../docs-retrieval';
 import { inlineSnippetRefsInGuideWithStatus } from '../../../snippet-engine';
+// The real inliner, reached past the barrel mock: it walks nested `blocks`, so
+// structurally malformed guides fail here exactly as they do in production.
+import { inlineSnippetRefsInGuideWithStatus as realInlineSnippetRefs } from '../../../snippet-engine/inline-refs';
+import type { SnippetResolver } from '../../../snippet-engine/types';
 import type { JsonGuide } from '../../../types/json-guide.types';
 import type { RawContent } from '../../../types/content.types';
 
@@ -11,12 +15,11 @@ jest.mock('./docs-tab-loader', () => ({
 
 jest.mock('../../../docs-retrieval', () => ({
   fetchPackageInfoFromUrl: jest.fn(),
-  isPackageContentUrl: jest.fn(() => false),
+  isPackageContentUrl: jest.fn(),
 }));
 
 jest.mock('../../../snippet-engine', () => ({
-  // Default: passthrough with no failed refs. Individual tests override.
-  inlineSnippetRefsInGuideWithStatus: jest.fn(async (guide: JsonGuide) => ({ guide, unresolvedSnippetIds: [] })),
+  inlineSnippetRefsInGuideWithStatus: jest.fn(),
 }));
 
 const mockLoad = loadDocsTabContentResult as jest.Mock;
@@ -24,17 +27,26 @@ const mockIsPackage = isPackageContentUrl as jest.Mock;
 const mockFetchPackageInfo = fetchPackageInfoFromUrl as jest.Mock;
 const mockInline = inlineSnippetRefsInGuideWithStatus as jest.Mock;
 
-function rawContentFor(guide: JsonGuide, url = 'https://grafana.com/docs/x'): RawContent {
+const neverResolvingResolver: SnippetResolver = {
+  resolve: jest.fn(async (id: string) => ({
+    ok: false as const,
+    id,
+    error: { code: 'not-found' as const, message: 'no catalog in tests' },
+  })),
+};
+
+function rawContentFor(guide: unknown, url = 'https://grafana.com/docs/x'): RawContent {
   return {
     content: JSON.stringify(guide),
-    metadata: { title: guide.title },
+    metadata: { title: (guide as JsonGuide | null)?.title ?? 'untitled' },
     type: 'interactive',
     url,
     lastFetched: '2026-07-28T00:00:00.000Z',
   };
 }
 
-function fetchResolves(guide: JsonGuide, url?: string) {
+/** Accepts unknown so malformed and alias-carrying payloads can be fetched as-is. */
+function fetchResolves(guide: unknown, url?: string) {
   mockLoad.mockResolvedValue({ content: rawContentFor(guide, url) });
 }
 
@@ -42,7 +54,7 @@ describe('prepareGuideLaunch', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsPackage.mockReturnValue(false);
-    mockInline.mockImplementation(async (guide: JsonGuide) => ({ guide, unresolvedSnippetIds: [] }));
+    mockInline.mockImplementation((guide: JsonGuide) => realInlineSnippetRefs(guide, neverResolvingResolver));
   });
 
   it('fetches the content exactly once', async () => {
@@ -66,7 +78,11 @@ describe('prepareGuideLaunch', () => {
   });
 
   it('classifies a guide with a Grafana-driving action as requiring the Grafana UI', async () => {
-    fetchResolves({ id: 'g', title: 'g', blocks: [{ type: 'interactive', action: 'button', content: 'go' }] });
+    fetchResolves({
+      id: 'g',
+      title: 'g',
+      blocks: [{ type: 'interactive', action: 'button', reftarget: 'button[data-testid="save"]', content: 'go' }],
+    });
 
     const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
 
@@ -109,6 +125,63 @@ describe('prepareGuideLaunch', () => {
     const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
 
     expect(result.ok).toBe(false);
+  });
+
+  describe('schema validation before the walks', () => {
+    it('returns a failure result when the guide has no blocks at all', async () => {
+      fetchResolves({ id: 'g', title: 'g' });
+
+      const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+
+      expect(result.ok).toBe(false);
+      expect(mockInline).not.toHaveBeenCalled();
+    });
+
+    it('returns a failure result when a nested section is missing its blocks', async () => {
+      fetchResolves({
+        id: 'g',
+        title: 'g',
+        blocks: [{ type: 'section', title: 'Set up' }],
+      });
+
+      const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+
+      expect(result.ok).toBe(false);
+      expect(mockInline).not.toHaveBeenCalled();
+    });
+
+    it('launches an alias-carrying guide, so camelCase authoring still normalizes', async () => {
+      const aliasGuide = {
+        id: 'g',
+        title: 'g',
+        blocks: [{ type: 'interactive', targetAction: 'button', refTarget: 'button[type="submit"]', content: 'go' }],
+      };
+      fetchResolves(aliasGuide);
+
+      const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.launch.requiresGrafanaUi).toBe(true);
+        // The aliases reach the renderer untouched — validation only gates the launch.
+        expect(JSON.parse(result.launch.preparedContent.content)).toEqual(aliasGuide);
+      }
+    });
+
+    it('preserves unknown fields nested inside blocks', async () => {
+      fetchResolves({
+        id: 'g',
+        title: 'g',
+        blocks: [{ type: 'markdown', content: 'hi', futureField: 'keep me' }],
+      });
+
+      const result = await prepareGuideLaunch('https://grafana.com/docs/x', { title: 'X', source: 'home_page' });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(JSON.parse(result.launch.preparedContent.content).blocks[0].futureField).toBe('keep me');
+      }
+    });
   });
 
   it('derives package info for a package URL and fetches only once', async () => {

--- a/src/components/docs-panel/utils/prepare-guide-launch.test.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.test.ts
@@ -158,6 +158,40 @@ describe('prepareGuideLaunch', () => {
     }
   });
 
+  it('keeps URL secrets out of logger and Faro context when the content is not parseable', async () => {
+    const contentUrl = 'https://grafana.com/docs/x?token=url-secret#fragment-secret';
+    mockLoad.mockResolvedValue({
+      content: {
+        content: 'not json',
+        metadata: { title: 'x' },
+        type: 'interactive',
+        url: contentUrl,
+        lastFetched: 't',
+      },
+    });
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      const result = await prepareGuideLaunch(contentUrl, { title: 'X', source: 'home_page' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errorCode).toBe('unparseable');
+      }
+      expect(consoleError).toHaveBeenCalledWith('[PrepareGuideLaunch] Guide content could not be parsed', {
+        content_url: 'grafana.com/docs/x',
+      });
+      expect(mockPushFaroLog).toHaveBeenCalledWith('error', '[PrepareGuideLaunch] Guide content could not be parsed', {
+        content_url: 'grafana.com/docs/x',
+      });
+      const emittedContext = JSON.stringify({ console: consoleError.mock.calls, faro: mockPushFaroLog.mock.calls });
+      expect(emittedContext).not.toContain('url-secret');
+      expect(emittedContext).not.toContain('fragment-secret');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   describe('schema validation before the walks', () => {
     it('returns a failure result when the guide has no blocks at all', async () => {
       fetchResolves({ id: 'g', title: 'g' });

--- a/src/components/docs-panel/utils/prepare-guide-launch.test.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.test.ts
@@ -1,6 +1,7 @@
 import { prepareGuideLaunch } from './prepare-guide-launch';
 import { loadDocsTabContentResult } from './docs-tab-loader';
 import { fetchPackageInfoFromUrl, isPackageContentUrl } from '../../../docs-retrieval';
+import { pushFaroLog } from '../../../lib/telemetry/bridge';
 import { inlineSnippetRefsInGuideWithStatus } from '../../../snippet-engine';
 // The real inliner, reached past the barrel mock: it walks nested `blocks`, so
 // structurally malformed guides fail here exactly as they do in production.
@@ -22,10 +23,18 @@ jest.mock('../../../snippet-engine', () => ({
   inlineSnippetRefsInGuideWithStatus: jest.fn(),
 }));
 
+jest.mock('../../../lib/telemetry/bridge', () => ({
+  pushFaroError: jest.fn(),
+  pushFaroLog: jest.fn(),
+  pushFaroUserAction: jest.fn(),
+  registerTelemetryBridge: jest.fn(),
+}));
+
 const mockLoad = loadDocsTabContentResult as jest.Mock;
 const mockIsPackage = isPackageContentUrl as jest.Mock;
 const mockFetchPackageInfo = fetchPackageInfoFromUrl as jest.Mock;
 const mockInline = inlineSnippetRefsInGuideWithStatus as jest.Mock;
+const mockPushFaroLog = pushFaroLog as jest.Mock;
 
 const neverResolvingResolver: SnippetResolver = {
   resolve: jest.fn(async (id: string) => ({
@@ -148,6 +157,54 @@ describe('prepareGuideLaunch', () => {
 
       expect(result.ok).toBe(false);
       expect(mockInline).not.toHaveBeenCalled();
+    });
+
+    it('keeps URL secrets and guide-authored values out of logger and Faro context', async () => {
+      const contentUrl = 'https://grafana.com/docs/x?token=url-secret#fragment-secret';
+      const invalidRequirement = 'not-a-requirement-authored-secret';
+      fetchResolves(
+        {
+          id: 'g',
+          title: 'g',
+          blocks: [
+            {
+              type: 'interactive',
+              action: 'button',
+              reftarget: 'button[type="submit"]',
+              content: 'go',
+              requirements: [invalidRequirement],
+            },
+          ],
+        },
+        contentUrl
+      );
+      const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+      try {
+        const result = await prepareGuideLaunch(contentUrl, { title: 'X', source: 'home_page' });
+
+        expect(result.ok).toBe(false);
+        expect(consoleError).toHaveBeenCalledWith('[PrepareGuideLaunch] Guide content failed schema validation', {
+          content_url: 'grafana.com/docs/x',
+          validation_error_count: 1,
+          validation_error_codes: ['custom'],
+        });
+        expect(mockPushFaroLog).toHaveBeenCalledWith(
+          'error',
+          '[PrepareGuideLaunch] Guide content failed schema validation',
+          {
+            content_url: 'grafana.com/docs/x',
+            validation_error_count: '1',
+            validation_error_codes: '["custom"]',
+          }
+        );
+        const emittedContext = JSON.stringify({ console: consoleError.mock.calls, faro: mockPushFaroLog.mock.calls });
+        expect(emittedContext).not.toContain('url-secret');
+        expect(emittedContext).not.toContain('fragment-secret');
+        expect(emittedContext).not.toContain(invalidRequirement);
+      } finally {
+        consoleError.mockRestore();
+      }
     });
 
     it('launches an alias-carrying guide, so camelCase authoring still normalizes', async () => {

--- a/src/components/docs-panel/utils/prepare-guide-launch.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.ts
@@ -25,12 +25,13 @@
 
 import { fetchPackageInfoFromUrl, isPackageContentUrl } from '../../../docs-retrieval';
 import { logger } from '../../../lib/logging';
+import { normalizeTelemetryUrl } from '../../../lib/telemetry';
 import { inlineSnippetRefsInGuideWithStatus } from '../../../snippet-engine';
 import type { LaunchSource } from '../../../recovery';
 import type { PackageOpenInfo } from '../../../types/content-panel.types';
 import type { RawContent } from '../../../types/content.types';
 import type { JsonGuide } from '../../../types/json-guide.types';
-import { formatErrorsAsStrings, validateGuide } from '../../../validation';
+import { validateGuide } from '../../../validation';
 
 import { loadDocsTabContentResult } from './docs-tab-loader';
 import { requiresGrafanaUi } from './requires-grafana-ui';
@@ -97,8 +98,9 @@ export async function prepareGuideLaunch(
   const validation = validateGuide(guide);
   if (!validation.isValid) {
     logger.error('[PrepareGuideLaunch] Guide content failed schema validation', {
-      url,
-      errors: formatErrorsAsStrings(validation.errors).join('; '),
+      content_url: normalizeTelemetryUrl(url),
+      validation_error_count: validation.errors.length,
+      validation_error_codes: [...new Set(validation.errors.map((error) => error.code))].sort(),
     });
     return { ok: false, error: 'Guide content failed schema validation' };
   }

--- a/src/components/docs-panel/utils/prepare-guide-launch.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.ts
@@ -100,7 +100,9 @@ export async function prepareGuideLaunch(
   try {
     guide = JSON.parse(rawContent.content) as JsonGuide;
   } catch {
-    logger.error('[PrepareGuideLaunch] Guide content could not be parsed', { url });
+    logger.error('[PrepareGuideLaunch] Guide content could not be parsed', {
+      content_url: normalizeTelemetryUrl(url),
+    });
     return { ok: false, error: 'Guide content could not be parsed', errorCode: 'unparseable' };
   }
 

--- a/src/components/docs-panel/utils/prepare-guide-launch.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.ts
@@ -13,6 +13,14 @@
  * `RawContent`, so the renderer takes its synchronous parse path and issues no
  * post-mount snippet requests. It is one-shot memory state — carried through a
  * launch handoff and consumed once, never persisted to tab storage.
+ *
+ * Fetched content is guide-SHAPED but not guaranteed valid: `wrapContentAsJsonGuide`
+ * admits already-JSON content on a shallow `id && title && Array.isArray(blocks)`
+ * check, so nesting can be malformed. Both the expansion and the classification
+ * walk nested `blocks`/`steps` and throw on a missing one, so the guide is
+ * validated first — through the same `validateGuide` gate `parseJsonGuide`
+ * applies, so nothing that renders today is rejected here. Both failure branches
+ * log because the fetch ladder's telemetry already recorded a success.
  */
 
 import { fetchPackageInfoFromUrl, isPackageContentUrl } from '../../../docs-retrieval';
@@ -22,6 +30,7 @@ import type { LaunchSource } from '../../../recovery';
 import type { PackageOpenInfo } from '../../../types/content-panel.types';
 import type { RawContent } from '../../../types/content.types';
 import type { JsonGuide } from '../../../types/json-guide.types';
+import { formatErrorsAsStrings, validateGuide } from '../../../validation';
 
 import { loadDocsTabContentResult } from './docs-tab-loader';
 import { requiresGrafanaUi } from './requires-grafana-ui';
@@ -81,14 +90,21 @@ export async function prepareGuideLaunch(
   try {
     guide = JSON.parse(rawContent.content) as JsonGuide;
   } catch {
-    // fetchContent validates native JSON guides, so this is not expected;
-    // fail safe rather than commit a surface for uninspectable content. The
-    // log is the only aggregate signal for this branch — the fetch ladder's
-    // own telemetry saw a successful fetch.
     logger.error('[PrepareGuideLaunch] Guide content could not be parsed', { url });
     return { ok: false, error: 'Guide content could not be parsed' };
   }
 
+  const validation = validateGuide(guide);
+  if (!validation.isValid) {
+    logger.error('[PrepareGuideLaunch] Guide content failed schema validation', {
+      url,
+      errors: formatErrorsAsStrings(validation.errors).join('; '),
+    });
+    return { ok: false, error: 'Guide content failed schema validation' };
+  }
+
+  // Expand the parsed guide, never `validation.guide`: only the root schema is
+  // loose, so the validated copy has dropped unknown fields nested in blocks.
   const { guide: expandedGuide, unresolvedSnippetIds } = await inlineSnippetRefsInGuideWithStatus(guide);
   const needsGrafanaUi = requiresGrafanaUi(expandedGuide) || unresolvedSnippetIds.length > 0;
 

--- a/src/components/docs-panel/utils/prepare-guide-launch.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.ts
@@ -63,8 +63,7 @@ export interface PreparedGuideLaunch {
 export type PrepareGuideLaunchErrorCode = 'fetch-failed' | 'unparseable' | 'schema-invalid';
 
 export type PrepareGuideLaunchResult =
-  | { ok: true; launch: PreparedGuideLaunch }
-  | { ok: false; error: string; errorCode: PrepareGuideLaunchErrorCode };
+  { ok: true; launch: PreparedGuideLaunch } | { ok: false; error: string; errorCode: PrepareGuideLaunchErrorCode };
 
 interface PrepareGuideLaunchContext {
   title: string;

--- a/src/components/docs-panel/utils/prepare-guide-launch.ts
+++ b/src/components/docs-panel/utils/prepare-guide-launch.ts
@@ -55,7 +55,16 @@ export interface PreparedGuideLaunch {
   packageInfo?: PackageOpenInfo;
 }
 
-export type PrepareGuideLaunchResult = { ok: true; launch: PreparedGuideLaunch } | { ok: false; error: string };
+/**
+ * Stable, low-cardinality failure classification. `error` is free text that can
+ * carry fetched-guide values (the fetch tier forwards Zod messages), so
+ * telemetry reports this code and never the message.
+ */
+export type PrepareGuideLaunchErrorCode = 'fetch-failed' | 'unparseable' | 'schema-invalid';
+
+export type PrepareGuideLaunchResult =
+  | { ok: true; launch: PreparedGuideLaunch }
+  | { ok: false; error: string; errorCode: PrepareGuideLaunchErrorCode };
 
 interface PrepareGuideLaunchContext {
   title: string;
@@ -82,7 +91,7 @@ export async function prepareGuideLaunch(
 
   const result = await loadDocsTabContentResult(url, { packageInfo });
   if (!result.content) {
-    return { ok: false, error: result.error || 'Failed to load content' };
+    return { ok: false, error: result.error || 'Failed to load content', errorCode: 'fetch-failed' };
   }
 
   const rawContent = result.content;
@@ -92,7 +101,7 @@ export async function prepareGuideLaunch(
     guide = JSON.parse(rawContent.content) as JsonGuide;
   } catch {
     logger.error('[PrepareGuideLaunch] Guide content could not be parsed', { url });
-    return { ok: false, error: 'Guide content could not be parsed' };
+    return { ok: false, error: 'Guide content could not be parsed', errorCode: 'unparseable' };
   }
 
   const validation = validateGuide(guide);
@@ -102,7 +111,7 @@ export async function prepareGuideLaunch(
       validation_error_count: validation.errors.length,
       validation_error_codes: [...new Set(validation.errors.map((error) => error.code))].sort(),
     });
-    return { ok: false, error: 'Guide content failed schema validation' };
+    return { ok: false, error: 'Guide content failed schema validation', errorCode: 'schema-invalid' };
   }
 
   // Expand the parsed guide, never `validation.guide`: only the root schema is

--- a/src/global-state/guide-launch.ts
+++ b/src/global-state/guide-launch.ts
@@ -1,8 +1,9 @@
 /**
  * Module-owned staging area for prepared (one-fetch) launch payloads.
  *
- * `prepareGuideLaunch` produces trusted, already-validated content. The
- * launch handoff sometimes has to cross PUBLIC channels — the
+ * `prepareGuideLaunch` produces content it fetched through the validated fetch
+ * pipeline and then schema-checked itself, so what is staged here is trusted.
+ * The launch handoff sometimes has to cross PUBLIC channels — the
  * `pathfinder-auto-open-docs` CustomEvent and the cold-sidebar link queue —
  * that any same-page script can also write to. The payload itself must never
  * ride those channels: a forged `preparedContent` would bypass the fetch


### PR DESCRIPTION
## Intent

Fix PR #1576's confirmed telemetry privacy issue without changing launch behavior: normalize the validation-failure content URL before logging, replace formatted schema messages that can echo guide-authored values with stable low-cardinality validation counts and error codes, and add focused regression coverage through the real logger-to-Faro bridge proving URL query/fragment secrets and invalid requirement tokens never enter logger or Faro context. Keep the change limited to the existing guide-launch validation path and its tests, commit only that fix, and push the existing PR head branch without force-pushing.

## What Changed

- `prepareGuideLaunch` now runs fetched content through the same `validateGuide` gate `parseJsonGuide` applies, before the snippet-expansion and `requiresGrafanaUi` walks touch nested `blocks`/`steps` — a malformed guide returns a clean failure result instead of throwing into an uncaught rejection mid-launch.
- Launch-failure telemetry carries only stable, low-cardinality values: both failure branches log `content_url` through `normalizeTelemetryUrl` (dropping query and fragment), and schema failures report an error count plus deduped, sorted Zod codes instead of formatted messages that can echo guide-authored strings.
- The failure arm of `PrepareGuideLaunchResult` gained an `errorCode` discriminator (`fetch-failed` | `unparseable` | `schema-invalid`), and `MyLearningTab` logs that code rather than the forwarded free-text `error`, whose fetch-tier messages can interpolate authored requirement tokens. The user-visible translated alert is unchanged.
- Regression coverage in `prepare-guide-launch.test.ts` and `MyLearningTab.test.tsx` drives the real logger-to-Faro bridge and asserts that URL query/fragment secrets and invalid requirement tokens never reach logger or Faro context.

## Risk Assessment

✅ Low: The change is well-bounded and now holds the stated invariant on every launch-failure branch — a three-value discriminator replaces the free-text message at the semantic owner, the caller emits only normalized low-cardinality context, and the coverage genuinely exercises the real logger-to-Faro path with authored-token and URL-secret markers — leaving only the near-unreachable defensive `unparseable` log the author explicitly accepted in round 1.

## Testing

I exercised the committed unit tests for the guide-launch validation path (prepare-guide-launch, MyLearningTab, and the telemetry URL normalizer) — 50 tests, all passing — and then, because unit assertions alone don't show what actually leaves the app, built a throwaway harness that drives prepareGuideLaunch through the real logger → real telemetry bridge → real Faro adapter with only the Faro web SDK faked, so I could record the literal faro.api.pushLog payloads. Against a URL carrying a query token, an api_key, and a fragment, plus a guide-authored requirement string, all four planted secrets reached Faro before the fix and none reach it after, across the unparseable branch, the schema-invalid branch, and the MyLearningTab launch-failure branch; the failure result, the "Could not open the guide" alert, and the re-enabled Continue button are identical before and after, so launch behavior is unchanged. The change has no rendered UI delta of its own (it only alters telemetry context), so the reviewer-visible artifact is a rendered HTML before/after of those payloads with the secrets highlighted, captured as a screenshot, backed by the raw JSON captures. The round-1 residual on the unparseable branch is now closed and no findings remain; the harness file was deleted and the working tree is clean.

- Evidence: Before/after: what actually reaches Faro (screenshot of rendered comparison) (local file: <code>/var/folders/hg/34vhzxxj0xd92_m7gnjz5zrw0000gn/T/no-mistakes-evidence/01KZPRMH25YRZGQF6WD3QQB4ZC/launch-telemetry-before-after.png</code>)
<details>
<summary>Evidence: Before/after telemetry comparison (rendered HTML source)</summary>

```text
<!doctype html>
<html><head><meta charset="utf-8"><title>Guide-launch validation telemetry — before/after</title>
<style>
  :root { color-scheme: dark; }
  body { margin:0; padding:28px 32px; background:#111217; color:#ccccdc;
         font:14px/1.5 Inter,-apple-system,"Segoe UI",Roboto,sans-serif; }
  h1 { font-size:22px; margin:0 0 4px; color:#fff; font-weight:600; }
  .sub { color:#8e8e9e; margin:0 0 24px; font-size:13px; }
  h3 { font-size:15px; margin:26px 0 10px; color:#fff; font-weight:600; }
  h4 { font-size:12px; margin:0 0 8px; color:#8e8e9e; text-transform:none; font-weight:600; letter-spacing:.02em; }
  .row { display:grid; grid-template-columns:minmax(0,1fr) minmax(0,1fr); gap:16px; }
  .pane { min-width:0; background:#181b1f; border:1px solid #2a2d34; border-radius:6px; padding:14px 16px; }
  .pane.before { border-left:3px solid #d10e5c; }
  .pane.after  { border-left:3px solid #1a7f4b; }
  pre { margin:6px 0 0; padding:10px 12px; background:#0b0c0e; border-radius:4px; overflow-x:auto;
        font:12px/1.55 "SF Mono",Menlo,Consolas,monospace; color:#b9bcc5; white-space:pre-wrap; word-break:break-all; }
  mark { background:#d10e5c; color:#fff; border-radius:2px; padding:0 2px; }
  .lbl { font-size:11px; color:#6e7078; margin-top:10px; }
  .good { display:inline-block; font-size:11px; font-weight:600; color:#6ccf8e; background:#0e2a1b;
          border:1px solid #1a7f4b; border-radius:3px; padding:2px 7px; }
  .bad  { display:inline-block; font-size:11px; font-weight:600; color:#ff8ab4; background:#2d0d1c;
          border:1px solid #d10e5c; border-radius:3px; padding:2px 7px; }
  .warn { display:inline-block; font-size:11px; font-weight:600; color:#f5c26b; background:#2e2410;
          border:1px solid #b8891f; border-radius:3px; padding:2px 7px; }
  .card { background:#181b1f; border:1px solid #2a2d34; border-radius:6px; padding:14px 16px; }
  .card.warnborder { border-left:3px solid #b8891f; }
  .toast { display:flex; gap:10px; align-items:flex-start; background:#181b1f; border:1px solid #2a2d34;
           border-left:3px solid #d10e5c; border-radius:4px; padding:12px 14px; max-width:420px; }
  .toast .x { color:#d10e5c; font-weight:700; }
  .toast b { color:#fff; display:block; font-size:13px; }
  .toast span { color:#9a9aa8; font-size:12.5px; }
  .inputs { font-size:12px; color:#8e8e9e; margin:2px 0 10px; }
  .inputs code { color:#d0d0dd; background:#0b0c0e; padding:1px 5px; border-radius:3px; word-break:break-all; }
</style></head><body>
<h1>Guide-launch validation — what actually reaches Faro</h1>
<p class="sub">Captured at the Faro SDK boundary (<code>faro.api.pushLog</code>) by driving the real code through the real
logger → telemetry bridge → Faro adapter. Highlighted values are the planted secrets: a URL query token, a URL
fragment, and a guide-authored requirement string.</p>

<h3>prepareGuideLaunch() — schema-invalid guide</h3>
  <div class="inputs">inputs: <code>https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&amp;api_key=abcd1234#FRAGMENT_SECRET</code> &nbsp;·&nbsp; <code>has-secret-datasource:PROD_SECRET_DATASOURCE_NAME</code></div>
  <div class="row"><div class="pane before">
    <h4>Before — PR #1576 head (0cb2375b)</h4>
    <span class="bad">4 secrets sent to Faro</span>
    <div class="lbl">faro.api.pushLog(…)</div>
    <pre>{
  "message": "[pathfinder] [PrepareGuideLaunch] Guide content failed schema validation",
  "level": "error",
  "context": {
    "url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=<mark>URL_QUERY_SECRET</mark>&amp;api_key=<mark>abcd1234</mark>#<mark>FRAGMENT_SECRET</mark>",
    "errors": "blocks[0].requirements[0]: Unknown requirement \"has-secret-datasource:<mark>PROD_SECRET_DATASOURCE_NAME</mark>\". Run \"pathfinder-cli requirements list\" for valid tokens."
  }
}</pre>
  </div><div class="pane after">
    <h4>After — 594f49b2</h4>
    <span class="good">0 secrets sent to Faro</span>
    <div class="lbl">faro.api.pushLog(…)</div>
    <pre>{
  "message": "[pathfinder] [PrepareGuideLaunch] Guide content failed schema validation",
  "level": "error",
  "context": {
    "content_url": "grafana.com/docs/learning-paths/path-1/guide-1/",
    "validation_error_count": "1",
    "validation_error_codes": "[\"custom\"]"
  }
}</pre>
  </div></div>
<h3>MyLearningTab — “Continue” click, launch fails</h3>
  <div class="inputs">inputs: <code>https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET#FRAGMENT_SECRET</code> &nbsp;·&nbsp; <code>Invalid guide: Unknown condition type 'has-secret-datasource:PROD_SECRET_DATASOURCE_NAME' at blocks.0.requirements.0</code></div>
  <div class="row"><div class="pane before">
    <h4>Before — PR #1576 head (0cb2375b)</h4>
    <span class="bad">3 secrets sent to Faro</span>
    <div class="lbl">faro.api.pushLog(…)</div>
    <pre>{
  "message": "[pathfinder] [MyLearning] Guide launch preparation failed",
  "level": "error",
  "context": {
    "url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=<mark>URL_QUERY_SECRET</mark>#<mark>FRAGMENT_SECRET</mark>",
    "error": "Invalid guide: Unknown condition type 'has-secret-datasource:<mark>PROD_SECRET_DATASOURCE_NAME</mark>' at blocks.0.requirements.0"
  }
}</pre>
  </div><div class="pane after">
    <h4>After — 594f49b2</h4>
    <span class="good">0 secrets sent to Faro</span>
    <div class="lbl">faro.api.pushLog(…)</div>
    <pre>{
  "message": "[pathfinder] [MyLearning] Guide launch preparation failed",
  "level": "error",
  "context": {
    "content_url": "grafana.com/docs/learning-paths/path-1/guide-1/",
    "error_code": "fetch-failed"
  }
}</pre>
  </div></div>

<h3>prepareGuideLaunch() — unparseable content <span class="good">fixed in 594f49b2</span></h3>
  <div class="inputs">inputs: <code>https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&amp;api_key=abcd1234#FRAGMENT_SECRET</code> &nbsp;·&nbsp; body that is not JSON</div>
  <div class="row"><div class="pane before">
    <h4>Before — same-class sibling call site, still raw</h4>
    <span class="bad">3 secrets sent to Faro</span>
    <div class="lbl">faro.api.pushLog(…)</div>
    <pre>{
  "message": "[pathfinder] [PrepareGuideLaunch] Guide content could not be parsed",
  "level": "error",
  "context": {
    "url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=<mark>URL_QUERY_SECRET</mark>&amp;api_key=<mark>abcd1234</mark>#<mark>FRAGMENT_SECRET</mark>"
  }
}</pre>
  </div><div class="pane after">
    <h4>After — 594f49b2</h4>
    <span class="good">0 secrets sent to Faro</span>
    <div class="lbl">faro.api.pushLog(…)</div>
    <pre>{
  "message": "[pathfinder] [PrepareGuideLaunch] Guide content could not be parsed",
  "level": "error",
  "context": {
    "content_url": "grafana.com/docs/learning-paths/path-1/guide-1/"
  }
}</pre>
    <div class="lbl">result still <code>{ ok: false, errorCode: "unparseable" }</code> — launch behaviour unchanged</div>
  </div></div>

<h3>User-visible surface — unchanged by the fix <span class="good">identical before/after</span></h3>
<div class="row">
  <div class="card">
    <h4>alert published to Grafana app events</h4>
    <div class="toast"><span class="x">✕</span><div><b>Could not open the guide</b>
      <span>Something went wrong while loading the guide. Please try again.</span></div></div>
  </div>
  <div class="card">
    <h4>“Continue” button after the failed launch</h4>
    <pre>{
  "text": "Continue",
  "disabled": false
}</pre>
    <div class="lbl">pending pill cleared, control re-enabled — no dead click</div>
  </div>
</div>

</body></html>
```
</details>
<details>
<summary>Evidence: unparseable branch — faro.api.pushLog before vs after the fix</summary>

```text
BEFORE (raw { url }):
context: {
"url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&api_key=abcd1234#FRAGMENT_SECRET"
}
secrets_found_in_telemetry: ["URL_QUERY_SECRET", "abcd1234", "FRAGMENT_SECRET"]

AFTER (594f49b2):
context: {
"content_url": "grafana.com/docs/learning-paths/path-1/guide-1/"
}
secrets_found_in_telemetry: []
user_visible_result: { ok: false, error: "Guide content could not be parsed", errorCode: "unparseable" }
```
</details>
<details>
<summary>Evidence: unparseable branch — raw capture, pre-fix</summary>

```text
{
  "label": "before (unparseable branch, pre-fix)",
  "scenario": "prepareGuideLaunch() on non-JSON content fetched from a URL carrying query + fragment secrets",
  "input": {
    "content_url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&api_key=abcd1234#FRAGMENT_SECRET"
  },
  "user_visible_result": {
    "ok": false,
    "error": "Guide content could not be parsed",
    "errorCode": "unparseable"
  },
  "emitted_console_error": [
    [
      "[PrepareGuideLaunch] Guide content could not be parsed",
      {
        "url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&api_key=abcd1234#FRAGMENT_SECRET"
      }
    ]
  ],
  "emitted_to_faro_sdk": [
    {
      "api": "pushLog",
      "args": [
        [
          "[pathfinder] [PrepareGuideLaunch] Guide content could not be parsed"
        ],
        {
          "level": "error",
          "context": {
            "url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&api_key=abcd1234#FRAGMENT_SECRET"
          }
        }
      ]
    }
  ],
  "secrets_searched_for": [
    "URL_QUERY_SECRET",
    "abcd1234",
    "FRAGMENT_SECRET",
    "PROD_SECRET_DATASOURCE_NAME"
  ],
  "secrets_found_in_telemetry": [
    "URL_QUERY_SECRET",
    "abcd1234",
    "FRAGMENT_SECRET"
  ]
}
```
</details>
<details>
<summary>Evidence: unparseable branch — raw capture, post-fix</summary>

```text
{
  "label": "after (HEAD 594f49b2)",
  "scenario": "prepareGuideLaunch() on non-JSON content fetched from a URL carrying query + fragment secrets",
  "input": {
    "content_url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&api_key=abcd1234#FRAGMENT_SECRET"
  },
  "user_visible_result": {
    "ok": false,
    "error": "Guide content could not be parsed",
    "errorCode": "unparseable"
  },
  "emitted_console_error": [
    [
      "[PrepareGuideLaunch] Guide content could not be parsed",
      {
        "content_url": "grafana.com/docs/learning-paths/path-1/guide-1/"
      }
    ]
  ],
  "emitted_to_faro_sdk": [
    {
      "api": "pushLog",
      "args": [
        [
          "[pathfinder] [PrepareGuideLaunch] Guide content could not be parsed"
        ],
        {
          "level": "error",
          "context": {
            "content_url": "grafana.com/docs/learning-paths/path-1/guide-1/"
          }
        }
      ]
    }
  ],
  "secrets_searched_for": [
    "URL_QUERY_SECRET",
    "abcd1234",
    "FRAGMENT_SECRET",
    "PROD_SECRET_DATASOURCE_NAME"
  ],
  "secrets_found_in_telemetry": []
}
```
</details>
<details>
<summary>Evidence: schema-invalid branch — raw capture, post-fix (counts + codes, no echoed guide values)</summary>

```text
{
  "label": "after (HEAD 594f49b2)",
  "scenario": "prepareGuideLaunch() on a schema-invalid guide (guide-authored requirement token) fetched from a secret-bearing URL",
  "input": {
    "content_url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&api_key=abcd1234#FRAGMENT_SECRET",
    "guide_authored_invalid_requirement": "has-secret-datasource:PROD_SECRET_DATASOURCE_NAME"
  },
  "user_visible_result": {
    "ok": false,
    "error": "Guide content failed schema validation",
    "errorCode": "schema-invalid"
  },
  "emitted_console_error": [
    [
      "[PrepareGuideLaunch] Guide content failed schema validation",
      {
        "content_url": "grafana.com/docs/learning-paths/path-1/guide-1/",
        "validation_error_count": 1,
        "validation_error_codes": [
          "custom"
        ]
      }
    ]
  ],
  "emitted_to_faro_sdk": [
    {
      "api": "pushLog",
      "args": [
        [
          "[pathfinder] [PrepareGuideLaunch] Guide content failed schema validation"
        ],
        {
          "level": "error",
          "context": {
            "content_url": "grafana.com/docs/learning-paths/path-1/guide-1/",
            "validation_error_count": "1",
            "validation_error_codes": "[\"custom\"]"
          }
        }
      ]
    }
  ],
  "secrets_searched_for": [
    "URL_QUERY_SECRET",
    "abcd1234",
    "FRAGMENT_SECRET",
    "PROD_SECRET_DATASOURCE_NAME"
  ],
  "secrets_found_in_telemetry": []
}
```
</details>
<details>
<summary>Evidence: schema-invalid branch — raw capture, pre-fix (leaks all four secrets)</summary>

```text
{
  "label": "before",
  "scenario": "prepareGuideLaunch() on a schema-invalid guide fetched from a URL carrying query + fragment secrets",
  "input": {
    "content_url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&api_key=abcd1234#FRAGMENT_SECRET",
    "guide_authored_invalid_requirement": "has-secret-datasource:PROD_SECRET_DATASOURCE_NAME"
  },
  "user_visible_result": {
    "ok": false,
    "error": "Guide content failed schema validation"
  },
  "emitted_console_error": [
    [
      "[PrepareGuideLaunch] Guide content failed schema validation",
      {
        "url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&api_key=abcd1234#FRAGMENT_SECRET",
        "errors": "blocks[0].requirements[0]: Unknown requirement \"has-secret-datasource:PROD_SECRET_DATASOURCE_NAME\". Run \"pathfinder-cli requirements list\" for valid tokens."
      }
    ]
  ],
  "emitted_to_faro_sdk": [
    {
      "api": "pushLog",
      "args": [
        [
          "[pathfinder] [PrepareGuideLaunch] Guide content failed schema validation"
        ],
        {
          "level": "error",
          "context": {
            "url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&api_key=abcd1234#FRAGMENT_SECRET",
            "errors": "blocks[0].requirements[0]: Unknown requirement \"has-secret-datasource:PROD_SECRET_DATASOURCE_NAME\". Run \"pathfinder-cli requirements list\" for valid tokens."
          }
        }
      ]
    }
  ],
  "secrets_searched_for": [
    "URL_QUERY_SECRET",
    "abcd1234",
    "FRAGMENT_SECRET",
    "PROD_SECRET_DATASOURCE_NAME"
  ],
  "secrets_found_in_telemetry": [
    "URL_QUERY_SECRET",
    "abcd1234",
    "FRAGMENT_SECRET",
    "PROD_SECRET_DATASOURCE_NAME"
  ]
}
```
</details>
<details>
<summary>Evidence: MyLearningTab launch failure — raw captures, pre/post fix</summary>

```text
{
  "label": "after",
  "scenario": "MyLearningTab \"Continue\" click whose prepareGuideLaunch fails, from a secret-bearing guide URL",
  "input": {
    "guide_url": "https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET#FRAGMENT_SECRET",
    "forwarded_fetch_tier_error": "Invalid guide: Unknown condition type 'has-secret-datasource:PROD_SECRET_DATASOURCE_NAME' at blocks.0.requirements.0"
  },
  "user_visible_alert": {
    "type": "alert-error",
    "payload": [
      "Could not open the guide",
      "Something went wrong while loading the guide. Please try again."
    ]
  },
  "continue_button_after_failure": {
    "text": "Continue",
    "disabled": false
  },
  "emitted_console_error": [
    [
      "[MyLearning] Guide launch preparation failed",
      {
        "content_url": "grafana.com/docs/learning-paths/path-1/guide-1/",
        "error_code": "fetch-failed"
      }
    ]
  ],
  "emitted_to_faro_sdk": [
    {
      "api": "pushLog",
      "args": [
        [
          "[pathfinder] [MyLearning] Guide launch preparation failed"
        ],
        {
          "level": "error",
          "context": {
            "content_url": "grafana.com/docs/learning-paths/path-1/guide-1/",
            "error_code": "fetch-failed"
          }
        }
      ]
    }
  ],
  "secrets_searched_for": [
    "URL_QUERY_SECRET",
    "FRAGMENT_SECRET",
    "PROD_SECRET_DATASOURCE_NAME"
  ],
  "secrets_found_in_telemetry": []
}
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (17m27s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/components/LearningPaths/MyLearningTab.tsx:122` - The normalization at prepare-guide-launch.ts:101 is defeated one frame up by its only production caller. `MyLearningTab.launch` logs `{ url, error }` with the un-normalized URL on every `ok: false` result — including the schema-validation failure this commit introduces. `logger.error` → `sanitizeContext` → `pushFaroLog` puts context values into Faro attributes verbatim (only control chars escaped), and `filterPathfinderTelemetry` applies `redactEmbeddedUrls` to `payload.message`/`payload.value` only, never to `payload.context` (src/lib/telemetry/filtering.ts:162-171). So the exact scenario the new regression test asserts is impossible still occurs in production. This is also newly reachable: before commit 0cb2375b a malformed guide threw a TypeError into an uncaught rejection and never reached this log; now it returns `ok: false` and does. Minimal fix: `content_url: normalizeTelemetryUrl(url)` at this call site (matching docs/developer/TELEMETRY.md:60 and every sibling site in fetch-raw.ts/facade.ts). Durable fix at the earliest existing shared boundary: extend `redactEmbeddedUrls` in filtering.ts to log/exception *context* values, which closes the whole class instead of one more call site. Flagging rather than fixing because the intent scopes the commit to &#34;the existing guide-launch validation path and its tests&#34; and MyLearningTab.tsx is outside it.
- ⚠️ `src/components/docs-panel/utils/prepare-guide-launch.ts:94` - The sibling failure branch three lines above the fix still logs the raw `url`, so the same query/fragment secrets reach Faro context unnormalized when it fires. The file header the commit rewrote now says &#34;Both failure branches log&#34;, but only one of the two was normalized. Reachability is low — every fetch tier hands back JSON (`wrapContentAsJsonGuide` wraps non-JSON into an `html` block, and backend guides are already `validateGuide`d in backend-guide.ts:61) — so this is a defensive branch, but it is squarely inside the scope the intent defines and the fix is the same one-call change: `{ content_url: normalizeTelemetryUrl(url) }`.
- ℹ️ `src/components/docs-panel/utils/prepare-guide-launch.ts:103` - Dropping the formatted messages is the right privacy call, but it leaves the aggregate signal at count + Zod code with no locator, so a guide blocked at launch is hard to diagnose from telemetry alone (the guide never reaches the renderer, which is where the full messages would otherwise surface). `validation.errors[*].path` is structural only — schema field names and array indices, never authored values — so emitting the first error&#39;s path alongside the codes would restore actionability without reintroducing the leak. Noting the tradeoff; the intent explicitly specifies counts and codes, so this is the author&#39;s call, not a defect.

🔧 Fix: normalize launch-failure URL in MyLearningTab telemetry context
1 warning still open:
- ⚠️ `src/components/LearningPaths/MyLearningTab.tsx:126` - `content_url` is now normalized, but the sibling `error` field on the same log line still carries un-normalized free text that can echo guide-authored values — the exact class the intent requires excluded (&#34;invalid requirement tokens never enter logger or Faro context&#34;). The round-1 instruction assumed &#34;stable low-cardinality error context&#34;, which holds only for prepareGuideLaunch&#39;s own three fixed strings, not for the fetch-tier errors it forwards at prepare-guide-launch.ts:85. Concrete reachable path: a learning-path guide is a native JSON guide whose `blocks[0].requirements[0]` is an invalid token → `fetchContent` validates it at content-fetcher.ts:230 → returns `error: `Invalid guide: ${validationResult.errors[0].message}`` (content-fetcher.ts:238), and that message is built by `unknownRequirementMessage` (src/types/requirements.types.ts:244), which interpolates the authored token verbatim: `Unknown requirement &#34;&lt;token&gt;&#34;` → `prepareGuideLaunch` forwards it as `result.error` → this line puts it in logger context → `sanitizeContext` only escapes control chars and truncates at 1000 → `pushFaroLog` passes `context` straight to `api.pushLog` (faro-adapter.ts:219) with no redaction (`filterPathfinderTelemetry` applies `redactEmbeddedUrls` to `payload.message`/`payload.value` only), and `passesActivityGate` always admits error-level logs. `backend-guide.ts:66` reaches the same string through `Invalid custom guide: ${errorMessage}`, and free-text fetch errors like `bundled.ts:75` can also re-introduce URL text that context-level redaction does not cover. Earliest shared boundary that makes the invariant hold for all three failure branches at once, and stays inside the guide-launch validation path the intent scopes: give `PrepareGuideLaunchResult`&#39;s failure arm a stable discriminator (e.g. `errorCode: &#39;fetch-failed&#39; | &#39;unparseable&#39; | &#39;schema-invalid&#39;`) — `prepareGuideLaunch` is already the semantic owner of that mapping and already emits low-cardinality codes for its own gate — and log the code instead of the message. Nothing user-visible changes: `result.error` is log-only here (the alert is already a translated generic message) and `prepareGuideLaunch` has no other caller. This is pre-existing on the line rather than introduced by this commit, so it is a follow-up rather than a blocker — but it is the same invariant this commit exists to establish, hence flagging rather than fixing.

🔧 Fix: log stable launch error code instead of forwarded message
1 info still open:
- ℹ️ `src/components/docs-panel/utils/prepare-guide-launch.ts:67` - `error` now has no production reader — `MyLearningTab` was its only consumer and it reads `errorCode` instead, so the field exists solely to carry free text that the type&#39;s own JSDoc says must never be logged. Keeping it is defensible (the classification code is deliberately coarse, and a future surface may want the detail for a developer-facing message), and the JSDoc at prepare-guide-launch.ts:58-62 documents the rule at the definition site, which is the right place for it. Noting the tradeoff only: nothing enforces the rule mechanically anymore, so if a later call site starts reading `.error` for telemetry the leak reopens. No action needed for this change.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/components/docs-panel/utils/prepare-guide-launch.ts:102` - The sibling `unparseable` branch in the same function still ships the raw content URL to Faro: `logger.error(&#39;[PrepareGuideLaunch] Guide content could not be parsed&#39;, { url })` is not normalized, so a URL query token and fragment reach Faro context verbatim (captured in prepare-guide-launch-unparseable-after.json). This is pre-existing at base commit bb668cd5 and outside the intent&#39;s stated scope (&#34;normalize the validation-failure content URL&#34;), so I did not change it — but it sits eight lines above the fixed branch and defeats the &#34;URL query/fragment secrets never enter logger or Faro context&#34; property for that one path. Your call whether to normalize it in this PR or file it separately.
- <code>`npx jest src/components/docs-panel/utils/prepare-guide-launch.test.ts src/components/LearningPaths/MyLearningTab.test.tsx --coverage=false` — the change&#39;s own regression coverage, including the two new secret-leak assertions (25 tests)</code>
- <code>`npx jest src/components/LearningPaths/MyLearningTab.cover-launch.test.tsx src/snippet-engine/online-snippet-resolver.test.ts src/lib/telemetry/url.test.ts src/lib/logging.test.ts src/validation/validate-guide.test.ts --coverage=false` — adjacent consumers of the changed modules (107 tests)</code>
- <code>Evidence harness (temporary, removed after the run): drove the real `prepareGuideLaunch` on a schema-invalid guide fetched from `https://grafana.com/docs/learning-paths/path-1/guide-1/?token=URL_QUERY_SECRET&amp;api_key=abcd1234#FRAGMENT_SECRET` carrying the authored requirement `has-secret-datasource:PROD_SECRET_DATASOURCE_NAME`, through the real logger/bridge/Faro adapter with only the Faro SDK instance faked, and recorded the literal `faro.api.pushLog` arguments</code>
- <code>Same harness driving the real `MyLearningTab`: clicked &#34;Continue&#34;, let `prepareGuideLaunch` reject with a fetch-tier message echoing the authored token, and recorded the Faro payload plus the published alert and the post-failure button state</code>
- <code>Before/after comparison: re-ran both harness scenarios with `src/components/docs-panel/utils/prepare-guide-launch.ts` and `src/components/LearningPaths/MyLearningTab.tsx` temporarily checked out at pre-fix commit `0cb2375b`, then restored with `git checkout HEAD -- &lt;files&gt;` (worktree verified clean afterward)</code>
- <code>Third harness scenario on non-JSON content to probe the sibling `unparseable` branch&#39;s log context</code>

🔧 Fix: normalize unparseable-branch content URL in launch telemetry
✅ Re-checked - no issues remain.
- <code>`npx jest src/components/docs-panel/utils/prepare-guide-launch.test.ts src/components/LearningPaths/MyLearningTab.test.tsx --coverage=false` — 26 tests, all pass, including the new `keeps URL secrets out of logger and Faro context when the content is not parseable` case</code>
- <code>`npx jest src/components/docs-panel/utils/prepare-guide-launch.test.ts src/components/LearningPaths/MyLearningTab.test.tsx src/lib/telemetry/url.test.ts --coverage=false` — 50 tests, all pass (re-run after removing the transient evidence harness, tree clean)</code>
- <code>Transient evidence harness `src/components/docs-panel/utils/launch-telemetry-evidence.test.ts` (written, run, then deleted): drove `prepareGuideLaunch` through the real `logger` → real `lib/telemetry/bridge` → real `faro-adapter`, faking only `@grafana/faro-web-sdk`, and recorded the exact `faro.api.pushLog` arguments for the `unparseable` and `schema-invalid` branches</code>
- <code>Captured the pre-fix `unparseable` payload by temporarily reverting the single changed line in `prepare-guide-launch.ts`, re-running the harness, then restoring the file (`git status` verified clean afterward)</code>
- <code>`grep -rn &#34;logger\.(error|warn|info)&#34; src/components/docs-panel/utils/prepare-guide-launch.ts src/components/LearningPaths/MyLearningTab.tsx src/global-state/guide-launch.ts` — confirmed all three remaining call sites pass normalized context</code>
- <code>Rendered the before/after telemetry comparison to HTML and screenshotted it via `chrome-devtools-axi open` / `screenshot`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
