### PR TITLE
refactor(block-editor): make block-conversion eligibility registries total over BlockType

### DIFF
--- a/src/components/block-editor/forms/GrotGuideBlockForm.tsx
+++ b/src/components/block-editor/forms/GrotGuideBlockForm.tsx
@@ -10,7 +10,6 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import { loadAll } from 'js-yaml';
 import { getBlockFormStyles } from '../block-editor.styles';
-import { TypeSwitchDropdown } from './TypeSwitchDropdown';
 import type { BlockFormProps } from '../types';
 import { isGrotGuideBlock, type JsonGrotGuideBlock } from '../../../types/json-guide.types';
 
@@ -116,13 +115,7 @@ const DEFAULT_BLOCK: JsonGrotGuideBlock = {
   ],
 };
 
-export function GrotGuideBlockForm({
-  initialData,
-  onSubmit,
-  onCancel,
-  isEditing = false,
-  onSwitchBlockType,
-}: BlockFormProps) {
+export function GrotGuideBlockForm({ initialData, onSubmit, onCancel, isEditing = false }: BlockFormProps) {
   const styles = useStyles2(getBlockFormStyles);
   const formStyles = useStyles2(getFormStyles);
 
@@ -272,11 +265,6 @@ export function GrotGuideBlockForm({
       )}
 
       <div className={styles.footer}>
-        {isEditing && onSwitchBlockType && (
-          <div className={styles.footerLeft}>
-            <TypeSwitchDropdown currentType="grot-guide" onSwitch={onSwitchBlockType} blockData={initialData} />
-          </div>
-        )}
         <Button variant="secondary" onClick={onCancel} type="button">
           Cancel
         </Button>

--- a/src/components/block-editor/utils/block-conversion.test.ts
+++ b/src/components/block-editor/utils/block-conversion.test.ts
@@ -274,6 +274,23 @@ describe('convertBlockType', () => {
     it.each([...TARGET_EXCLUDED_BLOCK_TYPES])('should throw when converting to %s, naming the reason', (targetType) => {
       expect(() => convertBlockType(markdown, targetType)).toThrow(new RegExp(`Cannot convert to a ${targetType}`));
     });
+
+    /**
+     * The only conversions this registry rejects that the pre-#1577 guard allowed:
+     * that guard rejected container targets only, so both directions used to
+     * succeed by copying `blocks`. Direct-API-only — `getAvailableConversions`
+     * never offered `collapsible` or `assistant` as a target, and no form exposes
+     * the switch for those sources.
+     */
+    const directApiOnlyPairs: Array<[BlockType, BlockType, JsonBlock]> = [
+      ['assistant', 'collapsible', { type: 'assistant', blocks: [] }],
+      ['collapsible', 'assistant', { type: 'collapsible', title: 'T', blocks: [] }],
+    ];
+
+    it.each(directApiOnlyPairs)('should throw on the %s to %s direct-API conversion', (_source, targetType, source) => {
+      expect(getAvailableConversions(source.type as BlockType)).not.toContain(targetType);
+      expect(() => convertBlockType(source, targetType)).toThrow(new RegExp(`Cannot convert to a ${targetType}`));
+    });
   });
 
   describe('content field mapping', () => {
@@ -481,10 +498,12 @@ describe('convertBlockType', () => {
     const sampleEntries = Object.entries(SAMPLE_BLOCKS) as Array<[BlockType, JsonBlock]>;
 
     /**
-     * `image` and `video` have no content field, so a target whose required text
-     * field has no default gets nothing to satisfy it and the conversion throws.
-     * That is https://github.com/grafana/grafana-pathfinder-app/issues/1575, pinned
-     * here rather than fixed, so the fix has to move this list deliberately.
+     * Sources with no `CONTENT_FIELDS` entry — `image`, `video`, `collapsible`,
+     * `assistant` and `snippet-ref` — carry no text into a target whose required
+     * text field has no `REQUIRED_DEFAULTS` fallback, so the conversion throws.
+     * Pinned here rather than fixed, so a fix has to move this list deliberately;
+     * the `image`/`video` symptom is tracked as
+     * https://github.com/grafana/grafana-pathfinder-app/issues/1575.
      */
     const CONTENTLESS_SOURCE_FAILURES: Partial<Record<BlockType, readonly BlockType[]>> = {
       image: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],

--- a/src/components/block-editor/utils/block-conversion.test.ts
+++ b/src/components/block-editor/utils/block-conversion.test.ts
@@ -98,6 +98,24 @@ describe('getAvailableConversions', () => {
       expect(result).toContain('input');
     });
 
+    // This order is user-visible in the switch-type menu and emerges from TARGET_EXCLUSION_REASONS key order.
+    it('should offer targets in the switch-type menu order', () => {
+      expect(getAvailableConversions('markdown')).toEqual([
+        'html',
+        'image',
+        'video',
+        'interactive',
+        'multistep',
+        'guided',
+        'quiz',
+        'input',
+        'terminal',
+        'terminal-connect',
+        'challenge',
+        'code-block',
+      ]);
+    });
+
     it('should offer every non-excluded target except the source, for every eligible source', () => {
       const eligibleSources = ALL_BLOCK_TYPES.filter((type) => !SOURCE_EXCLUDED_BLOCK_TYPES.includes(type));
 

--- a/src/components/block-editor/utils/block-conversion.test.ts
+++ b/src/components/block-editor/utils/block-conversion.test.ts
@@ -4,8 +4,62 @@
  * Tests focus on generic behavior rather than every conversion pair.
  */
 
-import { getAvailableConversions, getConversionWarning, convertBlockType } from './block-conversion';
+import {
+  getAvailableConversions,
+  getConversionWarning,
+  convertBlockType,
+  SOURCE_EXCLUDED_BLOCK_TYPES,
+  TARGET_EXCLUDED_BLOCK_TYPES,
+} from './block-conversion';
+import { VALID_BLOCK_TYPES } from '../../../types/json-guide.schema';
+import type { BlockType } from '../types';
 import type { JsonBlock } from '../../../types/json-guide.types';
+
+const ALL_BLOCK_TYPES = [...VALID_BLOCK_TYPES] as BlockType[];
+const BOTH_WAYS_EXCLUDED: readonly BlockType[] = ['collapsible', 'assistant', 'snippet-ref'];
+
+/**
+ * The compile-time checks in `block-conversion.ts` prove that every block type
+ * has a source and a target verdict; these assertions add the properties types
+ * can't express and give a readable failure. Anchored on `VALID_BLOCK_TYPES` so
+ * they track the block union rather than a restated count.
+ */
+describe('conversion eligibility registries', () => {
+  it('excludes only real block types', () => {
+    const unknown = [...SOURCE_EXCLUDED_BLOCK_TYPES, ...TARGET_EXCLUDED_BLOCK_TYPES].filter(
+      (type) => !VALID_BLOCK_TYPES.has(type)
+    );
+    expect(unknown).toEqual([]);
+  });
+
+  it('offers no conversion at all from a source-excluded type', () => {
+    const offered = SOURCE_EXCLUDED_BLOCK_TYPES.filter((type) => getAvailableConversions(type).length > 0);
+    expect(offered).toEqual([]);
+  });
+
+  it('offers conversions from every type that is not source-excluded', () => {
+    const silent = ALL_BLOCK_TYPES.filter(
+      (type) => !SOURCE_EXCLUDED_BLOCK_TYPES.includes(type) && getAvailableConversions(type).length === 0
+    );
+    expect(silent).toEqual([]);
+  });
+
+  it('never offers a target-excluded type as a target', () => {
+    const offered = ALL_BLOCK_TYPES.flatMap((source) =>
+      getAvailableConversions(source).filter((target) => TARGET_EXCLUDED_BLOCK_TYPES.includes(target))
+    );
+    expect(offered).toEqual([]);
+  });
+
+  it('excludes collapsible, assistant and snippet-ref in both directions', () => {
+    expect(BOTH_WAYS_EXCLUDED.filter((type) => !SOURCE_EXCLUDED_BLOCK_TYPES.includes(type))).toEqual([]);
+    expect(BOTH_WAYS_EXCLUDED.filter((type) => !TARGET_EXCLUDED_BLOCK_TYPES.includes(type))).toEqual([]);
+  });
+
+  it('keeps html a valid target even though the palette excludes it', () => {
+    expect(TARGET_EXCLUDED_BLOCK_TYPES).not.toContain('html');
+  });
+});
 
 describe('getAvailableConversions', () => {
   describe('container types', () => {
@@ -15,6 +69,10 @@ describe('getAvailableConversions', () => {
 
     it('should return empty array for conditional type', () => {
       expect(getAvailableConversions('conditional')).toEqual([]);
+    });
+
+    it('should return empty array for grot-guide type', () => {
+      expect(getAvailableConversions('grot-guide')).toEqual([]);
     });
   });
 
@@ -40,12 +98,15 @@ describe('getAvailableConversions', () => {
       expect(result).toContain('input');
     });
 
-    it('should return 12 options for any non-container type', () => {
-      // 13 non-container types minus 1 (the source type) = 12
-      expect(getAvailableConversions('markdown')).toHaveLength(12);
-      expect(getAvailableConversions('html')).toHaveLength(12);
-      expect(getAvailableConversions('quiz')).toHaveLength(12);
-      expect(getAvailableConversions('interactive')).toHaveLength(12);
+    it('should offer every non-excluded target except the source, for every eligible source', () => {
+      const eligibleSources = ALL_BLOCK_TYPES.filter((type) => !SOURCE_EXCLUDED_BLOCK_TYPES.includes(type));
+
+      for (const source of eligibleSources) {
+        const expected = ALL_BLOCK_TYPES.filter(
+          (target) => target !== source && !TARGET_EXCLUDED_BLOCK_TYPES.includes(target)
+        );
+        expect([...getAvailableConversions(source)].sort()).toEqual([...expected].sort());
+      }
     });
   });
 });
@@ -167,25 +228,36 @@ describe('convertBlockType', () => {
     });
   });
 
-  describe('container block restrictions', () => {
-    it('should throw when trying to convert from section', () => {
-      const source: JsonBlock = { type: 'section', blocks: [] };
-      expect(() => convertBlockType(source, 'markdown')).toThrow(/container blocks/i);
+  describe('excluded type restrictions', () => {
+    const markdown: JsonBlock = { type: 'markdown', content: 'hello' };
+
+    const excludedSources: Array<[BlockType, JsonBlock]> = [
+      ['section', { type: 'section', blocks: [] }],
+      ['conditional', { type: 'conditional', conditions: ['test'], whenTrue: [], whenFalse: [] }],
+      [
+        'grot-guide',
+        {
+          type: 'grot-guide',
+          welcome: { title: 'W', body: 'B', ctas: [{ text: 'Start', screenId: 'r' }] },
+          screens: [{ type: 'result', id: 'r', title: 'T', body: 'B' }],
+        },
+      ],
+      ['collapsible', { type: 'collapsible', title: 'T', blocks: [] }],
+      ['assistant', { type: 'assistant', blocks: [] }],
+      ['snippet-ref', { type: 'snippet-ref', snippetId: 'some-snippet' }],
+    ];
+
+    it.each(excludedSources)('should throw when converting from %s, naming the reason', (sourceType, source) => {
+      expect(() => convertBlockType(source, 'markdown')).toThrow(new RegExp(`Cannot convert from a ${sourceType}`));
     });
 
-    it('should throw when trying to convert from conditional', () => {
-      const source: JsonBlock = { type: 'conditional', conditions: ['test'], whenTrue: [], whenFalse: [] };
-      expect(() => convertBlockType(source, 'markdown')).toThrow(/container blocks/i);
+    it('covers every source-excluded type', () => {
+      const covered = excludedSources.map(([type]) => type);
+      expect([...SOURCE_EXCLUDED_BLOCK_TYPES].sort()).toEqual([...covered].sort());
     });
 
-    it('should throw when trying to convert to section', () => {
-      const source: JsonBlock = { type: 'markdown', content: 'hello' };
-      expect(() => convertBlockType(source, 'section')).toThrow(/container blocks/i);
-    });
-
-    it('should throw when trying to convert to conditional', () => {
-      const source: JsonBlock = { type: 'markdown', content: 'hello' };
-      expect(() => convertBlockType(source, 'conditional')).toThrow(/container blocks/i);
+    it.each([...TARGET_EXCLUDED_BLOCK_TYPES])('should throw when converting to %s, naming the reason', (targetType) => {
+      expect(() => convertBlockType(markdown, targetType)).toThrow(new RegExp(`Cannot convert to a ${targetType}`));
     });
   });
 
@@ -362,21 +434,64 @@ describe('convertBlockType', () => {
   });
 
   describe('schema validation', () => {
-    it('should produce valid blocks that pass schema validation for all types', () => {
-      const source: JsonBlock = { type: 'markdown', content: 'Test content' };
+    let consoleErrorSpy: jest.SpyInstance;
 
-      // All conversions should produce valid blocks (image/video use placeholder URLs)
-      expect(() => convertBlockType(source, 'html')).not.toThrow();
-      expect(() => convertBlockType(source, 'interactive')).not.toThrow();
-      expect(() => convertBlockType(source, 'multistep')).not.toThrow();
-      expect(() => convertBlockType(source, 'guided')).not.toThrow();
-      expect(() => convertBlockType(source, 'quiz')).not.toThrow();
-      expect(() => convertBlockType(source, 'input')).not.toThrow();
-      expect(() => convertBlockType(source, 'image')).not.toThrow();
-      expect(() => convertBlockType(source, 'video')).not.toThrow();
-      expect(() => convertBlockType(source, 'terminal')).not.toThrow();
-      expect(() => convertBlockType(source, 'terminal-connect')).not.toThrow();
-      expect(() => convertBlockType(source, 'code-block')).not.toThrow();
+    beforeEach(() => {
+      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    const SAMPLE_BLOCKS = {
+      markdown: { type: 'markdown', content: 'Sample content' },
+      html: { type: 'html', content: '<p>Sample content</p>' },
+      image: { type: 'image', src: 'https://example.com/i.png', alt: 'a' },
+      video: { type: 'video', src: 'https://example.com/v.mp4' },
+      interactive: { type: 'interactive', action: 'noop', content: 'Sample content' },
+      multistep: { type: 'multistep', content: 'Sample content', steps: [{ action: 'noop' }] },
+      guided: { type: 'guided', content: 'Sample content', steps: [{ action: 'noop' }] },
+      quiz: { type: 'quiz', question: 'Sample content', choices: [{ id: 'a', text: 'A', correct: true }] },
+      input: { type: 'input', prompt: 'Sample content', inputType: 'text', variableName: 'v' },
+      terminal: { type: 'terminal', content: 'Sample content', command: 'echo hi' },
+      'terminal-connect': { type: 'terminal-connect', content: 'Sample content' },
+      challenge: { type: 'challenge', title: 'T', brief: 'Sample content', successCriteria: 'coda-exit-zero:true' },
+      'code-block': { type: 'code-block', reftarget: "div[data-testid='x']", code: 'x', content: 'Sample content' },
+    } satisfies Partial<Record<BlockType, JsonBlock>>;
+
+    const sampleEntries = Object.entries(SAMPLE_BLOCKS) as Array<[BlockType, JsonBlock]>;
+
+    /**
+     * `image` and `video` have no content field, so a target whose required text
+     * field has no default gets nothing to satisfy it and the conversion throws.
+     * That is https://github.com/grafana/grafana-pathfinder-app/issues/1575, pinned
+     * here rather than fixed, so the fix has to move this list deliberately.
+     */
+    const CONTENTLESS_SOURCE_FAILURES: Partial<Record<BlockType, readonly BlockType[]>> = {
+      image: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
+      video: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
+    };
+
+    it('samples every convertible source type', () => {
+      const missing = ALL_BLOCK_TYPES.filter(
+        (type) => !SOURCE_EXCLUDED_BLOCK_TYPES.includes(type) && !sampleEntries.some(([sampled]) => sampled === type)
+      );
+      expect(missing).toEqual([]);
+    });
+
+    it.each(sampleEntries)('should convert %s to every available target', (sourceType, source) => {
+      const expectedFailures = CONTENTLESS_SOURCE_FAILURES[sourceType] ?? [];
+      const targets = getAvailableConversions(sourceType);
+      expect(targets.length).toBeGreaterThan(0);
+
+      for (const target of targets) {
+        if (expectedFailures.includes(target)) {
+          expect(() => convertBlockType(source, target)).toThrow(/failed validation/);
+        } else {
+          expect(convertBlockType(source, target).type).toBe(target);
+        }
+      }
     });
 
     it('should convert image to terminal-connect without throwing (regression #619)', () => {

--- a/src/components/block-editor/utils/block-conversion.test.ts
+++ b/src/components/block-editor/utils/block-conversion.test.ts
@@ -16,7 +16,7 @@ import type { BlockType } from '../types';
 import type { JsonBlock } from '../../../types/json-guide.types';
 
 const ALL_BLOCK_TYPES = [...VALID_BLOCK_TYPES] as BlockType[];
-const BOTH_WAYS_EXCLUDED: readonly BlockType[] = ['collapsible', 'assistant', 'snippet-ref'];
+const SOURCE_ONLY_BLOCK_TYPES: readonly BlockType[] = ['collapsible', 'assistant', 'snippet-ref'];
 
 /**
  * The compile-time checks in `block-conversion.ts` prove that every block type
@@ -51,9 +51,9 @@ describe('conversion eligibility registries', () => {
     expect(offered).toEqual([]);
   });
 
-  it('excludes collapsible, assistant and snippet-ref in both directions', () => {
-    expect(BOTH_WAYS_EXCLUDED.filter((type) => !SOURCE_EXCLUDED_BLOCK_TYPES.includes(type))).toEqual([]);
-    expect(BOTH_WAYS_EXCLUDED.filter((type) => !TARGET_EXCLUDED_BLOCK_TYPES.includes(type))).toEqual([]);
+  it('keeps legacy source-only block types eligible without offering them as targets', () => {
+    expect(SOURCE_ONLY_BLOCK_TYPES.filter((type) => SOURCE_EXCLUDED_BLOCK_TYPES.includes(type))).toEqual([]);
+    expect(SOURCE_ONLY_BLOCK_TYPES.filter((type) => !TARGET_EXCLUDED_BLOCK_TYPES.includes(type))).toEqual([]);
   });
 
   it('keeps html a valid target even though the palette excludes it', () => {
@@ -260,9 +260,6 @@ describe('convertBlockType', () => {
           screens: [{ type: 'result', id: 'r', title: 'T', body: 'B' }],
         },
       ],
-      ['collapsible', { type: 'collapsible', title: 'T', blocks: [] }],
-      ['assistant', { type: 'assistant', blocks: [] }],
-      ['snippet-ref', { type: 'snippet-ref', snippetId: 'some-snippet' }],
     ];
 
     it.each(excludedSources)('should throw when converting from %s, naming the reason', (sourceType, source) => {
@@ -476,6 +473,9 @@ describe('convertBlockType', () => {
       'terminal-connect': { type: 'terminal-connect', content: 'Sample content' },
       challenge: { type: 'challenge', title: 'T', brief: 'Sample content', successCriteria: 'coda-exit-zero:true' },
       'code-block': { type: 'code-block', reftarget: "div[data-testid='x']", code: 'x', content: 'Sample content' },
+      collapsible: { type: 'collapsible', title: 'T', blocks: [] },
+      assistant: { type: 'assistant', blocks: [] },
+      'snippet-ref': { type: 'snippet-ref', snippetId: 'some-snippet' },
     } satisfies Partial<Record<BlockType, JsonBlock>>;
 
     const sampleEntries = Object.entries(SAMPLE_BLOCKS) as Array<[BlockType, JsonBlock]>;
@@ -489,6 +489,9 @@ describe('convertBlockType', () => {
     const CONTENTLESS_SOURCE_FAILURES: Partial<Record<BlockType, readonly BlockType[]>> = {
       image: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
       video: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
+      collapsible: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
+      assistant: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
+      'snippet-ref': ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
     };
 
     it('samples every convertible source type', () => {

--- a/src/components/block-editor/utils/block-conversion.ts
+++ b/src/components/block-editor/utils/block-conversion.ts
@@ -48,6 +48,12 @@ const SOURCE_EXCLUSION_REASONS = {
  *
  * The insertion order of the eligible (`null`) keys is the user-visible order
  * of the switch-type menu, so reordering them here reorders that menu.
+ *
+ * Excluding `collapsible` and `assistant` narrows the direct API: the previous
+ * guard rejected only the three container targets, so `assistant` -> `collapsible`
+ * and `collapsible` -> `assistant` used to succeed by copying `blocks`. Neither
+ * pair is reachable — `getAvailableConversions` never offered either as a target
+ * and no form exposes the switch for those sources.
  */
 const TARGET_EXCLUSION_REASONS = {
   markdown: null,

--- a/src/components/block-editor/utils/block-conversion.ts
+++ b/src/components/block-editor/utils/block-conversion.ts
@@ -2,7 +2,7 @@
  * Block Type Conversion Utility
  *
  * Generic, schema-driven block conversion that:
- * - Allows any non-container block to convert to any other non-container block
+ * - Allows any convertible block to convert to any other convertible block
  * - Auto-computes data loss warnings using KNOWN_FIELDS from the schema
  * - Copies common fields automatically
  * - Maps content-like fields between types
@@ -13,31 +13,79 @@ import type { BlockType } from '../types';
 import type { JsonBlock } from '../../../types/json-guide.types';
 import { logger } from '../../../lib/logging';
 
+// ============ Conversion eligibility ============
+
+/**
+ * Why a block type cannot be a conversion *source*; `null` means it can be one.
+ *
+ * Source and target eligibility are separate registries because the policies
+ * genuinely differ — `html` is excluded from the palette yet is a valid target —
+ * so a single symmetric set would bury the asymmetry behind a misleading name.
+ */
+const SOURCE_EXCLUSION_REASONS = {
+  markdown: null,
+  html: null,
+  image: null,
+  video: null,
+  interactive: null,
+  multistep: null,
+  guided: null,
+  quiz: null,
+  input: null,
+  terminal: null,
+  'terminal-connect': null,
+  challenge: null,
+  'code-block': null,
+  section: 'its nested blocks would be silently dropped',
+  conditional: 'its branch blocks would be silently dropped',
+  'grot-guide': 'its screens would be silently dropped',
+  collapsible: 'its nested blocks would be silently dropped',
+  assistant: 'its nested blocks would be silently dropped',
+  'snippet-ref': 'its snippetId would be silently dropped',
+} satisfies Record<BlockType, string | null>;
+
+/**
+ * Why a block type cannot be a conversion *target*; `null` means it can be one.
+ */
+const TARGET_EXCLUSION_REASONS = {
+  markdown: null,
+  html: null,
+  image: null,
+  video: null,
+  interactive: null,
+  multistep: null,
+  guided: null,
+  quiz: null,
+  input: null,
+  terminal: null,
+  'terminal-connect': null,
+  challenge: null,
+  'code-block': null,
+  section: 'conversion cannot invent the nested blocks a container needs',
+  conditional: 'conversion cannot invent the branch blocks a container needs',
+  'grot-guide': 'conversion cannot invent the screens it needs',
+  collapsible: 'its children are restricted to presentational blocks',
+  assistant: 'it has no form of its own, so the editor would render nothing after the switch',
+  'snippet-ref': 'snippetId has no sensible placeholder',
+} satisfies Record<BlockType, string | null>;
+
+const excludedTypes = (reasons: Record<BlockType, string | null>): readonly BlockType[] =>
+  (Object.keys(reasons) as BlockType[]).filter((type) => reasons[type] !== null);
+
+const eligibleTypes = (reasons: Record<BlockType, string | null>): readonly BlockType[] =>
+  (Object.keys(reasons) as BlockType[]).filter((type) => reasons[type] === null);
+
+export const SOURCE_EXCLUDED_BLOCK_TYPES = excludedTypes(SOURCE_EXCLUSION_REASONS);
+
+export const TARGET_EXCLUDED_BLOCK_TYPES = excludedTypes(TARGET_EXCLUSION_REASONS);
+
+/**
+ * All block types that support conversion, in the order the switch-type menu
+ * offers them.
+ */
+const CONVERTIBLE_TYPES = eligibleTypes(TARGET_EXCLUSION_REASONS);
+
 // ============ Configuration Maps ============
-
-/**
- * Container types excluded from conversion (they have nested blocks).
- */
-const CONTAINER_TYPES: ReadonlySet<BlockType> = new Set(['section', 'conditional', 'grot-guide']);
-
-/**
- * All non-container block types that support conversion.
- */
-const CONVERTIBLE_TYPES: readonly BlockType[] = [
-  'markdown',
-  'html',
-  'image',
-  'video',
-  'interactive',
-  'multistep',
-  'guided',
-  'quiz',
-  'input',
-  'terminal',
-  'terminal-connect',
-  'challenge',
-  'code-block',
-];
 
 /**
  * Fields shared across many block types - always copy if present.
@@ -45,10 +93,10 @@ const CONVERTIBLE_TYPES: readonly BlockType[] = [
 const COMMON_FIELDS = ['requirements', 'objectives', 'skippable'] as const;
 
 /**
- * Primary content field for each block type.
- * Used to map content between different block types.
+ * Primary content field for each block type, or `null` for the types that have
+ * no single body of text to carry across a conversion.
  */
-const CONTENT_FIELDS: Partial<Record<BlockType, string>> = {
+const CONTENT_FIELDS: Record<BlockType, string | null> = {
   markdown: 'content',
   html: 'content',
   interactive: 'content',
@@ -60,6 +108,14 @@ const CONTENT_FIELDS: Partial<Record<BlockType, string>> = {
   'terminal-connect': 'content',
   challenge: 'brief',
   'code-block': 'content',
+  image: null,
+  video: null,
+  section: null,
+  conditional: null,
+  collapsible: null,
+  assistant: null,
+  'grot-guide': null,
+  'snippet-ref': null,
 };
 
 /**
@@ -70,10 +126,11 @@ const CONTENT_FIELDS: Partial<Record<BlockType, string>> = {
 export const PLACEHOLDER_URL = 'https://placeholder.invalid/replace-me';
 
 /**
- * Required defaults when converting TO these types.
- * Provides sensible defaults for required fields that don't have a source mapping.
+ * Required defaults when converting TO these types, or `null` for the types that
+ * need no invented field. Total over `BlockType` so a new type cannot silently
+ * become a target with unsatisfied required fields.
  */
-const REQUIRED_DEFAULTS: Partial<Record<BlockType, Record<string, unknown>>> = {
+const REQUIRED_DEFAULTS: Record<BlockType, Record<string, unknown> | null> = {
   quiz: { choices: [{ id: 'a', text: 'Option A', correct: true }] },
   input: { inputType: 'text', variableName: 'userInput' },
   image: { src: PLACEHOLDER_URL, alt: '' },
@@ -88,6 +145,14 @@ const REQUIRED_DEFAULTS: Partial<Record<BlockType, Record<string, unknown>>> = {
     successCriteria: 'coda-exit-zero:true',
   },
   'code-block': { reftarget: "div[data-testid='data-testid Code editor container']", code: '// Your code here' },
+  markdown: null,
+  html: null,
+  section: null,
+  conditional: null,
+  collapsible: null,
+  assistant: null,
+  'grot-guide': null,
+  'snippet-ref': null,
 };
 
 // ============ Public API ============
@@ -104,15 +169,13 @@ export interface ConversionWarning {
 
 /**
  * Get available target types for a given source type.
- * Returns all non-container types except the source type itself.
+ * Returns every convertible target type except the source type itself.
  */
 export function getAvailableConversions(sourceType: BlockType): BlockType[] {
-  // Container types cannot be converted
-  if (CONTAINER_TYPES.has(sourceType)) {
+  if (SOURCE_EXCLUSION_REASONS[sourceType] !== null) {
     return [];
   }
 
-  // Return all non-container types except the source type
   return CONVERTIBLE_TYPES.filter((t) => t !== sourceType);
 }
 
@@ -164,7 +227,7 @@ export function getConversionWarning(source: JsonBlock, targetType: BlockType): 
  * Convert a block from one type to another.
  * Preserves compatible fields and provides sensible defaults for required fields.
  *
- * @throws Error if conversion involves container blocks or fails schema validation
+ * @throws Error if either type is excluded from conversion, or if the result fails schema validation
  */
 export function convertBlockType(source: JsonBlock, targetType: BlockType): JsonBlock {
   // Same type - no-op
@@ -174,9 +237,14 @@ export function convertBlockType(source: JsonBlock, targetType: BlockType): Json
 
   const sourceType = source.type as BlockType;
 
-  // Validate not converting container blocks
-  if (CONTAINER_TYPES.has(sourceType) || CONTAINER_TYPES.has(targetType)) {
-    throw new Error(`Cannot convert container blocks (section, conditional)`);
+  const sourceExclusion = SOURCE_EXCLUSION_REASONS[sourceType];
+  if (sourceExclusion !== null) {
+    throw new Error(`Cannot convert from a ${sourceType} block: ${sourceExclusion}`);
+  }
+
+  const targetExclusion = TARGET_EXCLUSION_REASONS[targetType];
+  if (targetExclusion !== null) {
+    throw new Error(`Cannot convert to a ${targetType} block: ${targetExclusion}`);
   }
 
   const converted: Record<string, unknown> = { type: targetType };

--- a/src/components/block-editor/utils/block-conversion.ts
+++ b/src/components/block-editor/utils/block-conversion.ts
@@ -18,12 +18,8 @@ import { logger } from '../../../lib/logging';
 /**
  * Why a block type cannot be a conversion *source*; `null` means it can be one.
  *
- * Source and target eligibility stay separate registries even though they
- * happen to exclude the same six types today: they answer different questions,
- * and block-editor eligibility already diverges elsewhere — `html` is excluded
- * from the palette yet is a valid conversion target, and `snippet-ref` is
- * palette-visible yet is not a target. One symmetric set would make a future
- * divergence unrepresentable, turning a UI refactor into silent data loss.
+ * Source and target eligibility stay separate because legacy source-only types
+ * remain callable even though current forms do not expose those conversions.
  */
 const SOURCE_EXCLUSION_REASONS = {
   markdown: null,
@@ -42,9 +38,9 @@ const SOURCE_EXCLUSION_REASONS = {
   section: 'its nested blocks would be silently dropped',
   conditional: 'its branch blocks would be silently dropped',
   'grot-guide': 'its screens would be silently dropped',
-  collapsible: 'its nested blocks would be silently dropped',
-  assistant: 'its nested blocks would be silently dropped',
-  'snippet-ref': 'its snippetId would be silently dropped',
+  collapsible: null,
+  assistant: null,
+  'snippet-ref': null,
 } satisfies Record<BlockType, string | null>;
 
 /**

--- a/src/components/block-editor/utils/block-conversion.ts
+++ b/src/components/block-editor/utils/block-conversion.ts
@@ -18,9 +18,12 @@ import { logger } from '../../../lib/logging';
 /**
  * Why a block type cannot be a conversion *source*; `null` means it can be one.
  *
- * Source and target eligibility are separate registries because the policies
- * genuinely differ — `html` is excluded from the palette yet is a valid target —
- * so a single symmetric set would bury the asymmetry behind a misleading name.
+ * Source and target eligibility stay separate registries even though they
+ * happen to exclude the same six types today: they answer different questions,
+ * and block-editor eligibility already diverges elsewhere — `html` is excluded
+ * from the palette yet is a valid conversion target, and `snippet-ref` is
+ * palette-visible yet is not a target. One symmetric set would make a future
+ * divergence unrepresentable, turning a UI refactor into silent data loss.
  */
 const SOURCE_EXCLUSION_REASONS = {
   markdown: null,
@@ -46,6 +49,9 @@ const SOURCE_EXCLUSION_REASONS = {
 
 /**
  * Why a block type cannot be a conversion *target*; `null` means it can be one.
+ *
+ * The insertion order of the eligible (`null`) keys is the user-visible order
+ * of the switch-type menu, so reordering them here reorders that menu.
  */
 const TARGET_EXCLUSION_REASONS = {
   markdown: null,
@@ -79,10 +85,7 @@ export const SOURCE_EXCLUDED_BLOCK_TYPES = excludedTypes(SOURCE_EXCLUSION_REASON
 
 export const TARGET_EXCLUDED_BLOCK_TYPES = excludedTypes(TARGET_EXCLUSION_REASONS);
 
-/**
- * All block types that support conversion, in the order the switch-type menu
- * offers them.
- */
+/** All block types that support conversion, in `TARGET_EXCLUSION_REASONS` key order. */
 const CONVERTIBLE_TYPES = eligibleTypes(TARGET_EXCLUSION_REASONS);
 
 // ============ Configuration Maps ============


### PR DESCRIPTION
## Intent

Preserve every source conversion that succeeded before PR #1577 while retaining the exhaustive BlockType conversion registries and all target restrictions. Keep collapsible, assistant, and snippet-ref eligible as conversion sources because this PR must remain strictly zero-functional-change; update regression coverage so exhaustive eligibility and all base-successful source-to-target conversions are verified without enshrining the accidental source-exclusion throws. Commit only this focused compatibility fix and non-force push it to the existing PR #1577 branch.

## What Changed

- Replaced the `CONTAINER_TYPES` / `CONVERTIBLE_TYPES` pair in `src/components/block-editor/utils/block-conversion.ts` with two registries — `SOURCE_EXCLUSION_REASONS` and `TARGET_EXCLUSION_REASONS`, each `satisfies Record<BlockType, string | null>` — and made `CONTENT_FIELDS` and `REQUIRED_DEFAULTS` total over `BlockType` as well, so a new block type fails to compile until it has an explicit verdict. Thrown errors now name the offending type and its reason instead of the generic "container blocks" message.
- Kept `collapsible`, `assistant`, and `snippet-ref` eligible as conversion *sources*, so the switch-type menu, its target order, and every UI-reachable conversion behave exactly as before. The only registry-level deltas are the direct-API-only `collapsible -> assistant` and `assistant -> collapsible` pairs, which the retained target restrictions now reject; both are documented in the source and pinned by tests.
- Removed the dead `TypeSwitchDropdown` wiring from `GrotGuideBlockForm` (it rendered nothing, since `grot-guide` has no available conversions), and reworked `block-conversion.test.ts` to assert eligibility exhaustively against `VALID_BLOCK_TYPES` and exercise every source-to-target pair, pinning the contentless-source validation failures (`image`, `video`, `collapsible`, `assistant`, `snippet-ref`) against issue #1575 rather than silently tolerating them.

## Risk Assessment

✅ Low: Both round-1 findings are resolved exactly as the user directed — target restrictions retained, the two unreachable direct-API pairs now documented at block-conversion.ts:52-56 and pinned by a regression test, the CONTENTLESS_SOURCE_FAILURES comment corrected — and I re-verified that source eligibility, switch-menu order, and every UI-reachable conversion are byte-for-byte unchanged from base, leaving a well-bounded registry refactor with no remaining substantiable risk.

## Testing

<code>Ran the block-editor conversion test suites (17 suites / 295 tests, all green), then went beyond unit tests to prove the zero-functional-change claim directly: a differential harness executed all 342 source-to-target pairs against both the pre-#1577 implementation and this branch, showing 160 of the 162 base-successful conversions preserved byte-identically, zero menu changes, and zero payload differences. The only two lost pairs are the direct-API-only `collapsible &lt;-&gt; assistant` conversions the author documented and pinned. I captured reviewer-visible visual evidence by bundling the real `TypeSwitchDropdown` and `GrotGuideBlockForm` from this branch and driving them in Chrome, screenshotting the switch-type availability per block type, an open 13-target menu on a `collapsible` source, and two live conversions performed through the actual Grafana menu. A mutation check confirmed the new coverage genuinely catches the regression rather than just describing current behaviour. All temporary harness files were removed and the worktree is clean.</code>

- Evidence: Switch-type control availability per block type (real Grafana UI) — collapsible / assistant / snippet-ref keep their Switch type button; the three container types render none (local file: <code>/var/folders/hg/34vhzxxj0xd92_m7gnjz5zrw0000gn/T/no-mistakes-evidence/01KZPZEHD1KX2H6PBNY10N1Q4K/01-switch-type-availability.png</code>)
- Evidence: Real switch-type menu opened on a collapsible block, showing all 13 targets in the pinned menu order (local file: <code>/var/folders/hg/34vhzxxj0xd92_m7gnjz5zrw0000gn/T/no-mistakes-evidence/01KZPZEHD1KX2H6PBNY10N1Q4K/02-collapsible-switch-menu-open.png</code>)
- Evidence: Live before/after conversions driven through the real menu (collapsible -&gt; code-block, snippet-ref -&gt; video) plus the grot-guide form footer touched by this fix (local file: <code>/var/folders/hg/34vhzxxj0xd92_m7gnjz5zrw0000gn/T/no-mistakes-evidence/01KZPZEHD1KX2H6PBNY10N1Q4K/03-live-conversions-and-grot-guide-form.png</code>)
<details>
<summary>Evidence: Base-vs-change conversion compatibility report (342 pairs, per-type switch-type menus, source eligibility)</summary>

<code>BLOCK CONVERSION COMPATIBILITY — pre-#1577 (bb668cd5) vs this change (a8ea7fcb)&#10;=&#10;&#10;Block types exercised : 19&#10;Ordered pairs tried : 342&#10;Succeeded on base : 162&#10;Still succeed now : 160&#10;Byte-identical output : 160&#10;&#10;LOST conversions : 2&#10;collapsible -&gt; assistant now: Cannot convert to a assistant block: it has no form of its own, so the editor would render nothing after the switch&#10;assistant -&gt; collapsible now: Cannot convert to a collapsible block: its children are restricted to presentational blocks&#10;Newly allowed : 0&#10;Different payload : 0&#10;&#10;Menus that changed : 0&#10;&#10;SOURCE ELIGIBILITY (can the user start a switch from this block type?)&#10;------------------------------------------------------------------------------&#10;collapsible base-source=true head-source=true head rejects as source=false&#10;assistant base-source=true head-source=true head rejects as source=false&#10;snippet-ref base-source=true head-source=true head rejects as source=false&#10;section base-source=false head-source=false head rejects as source=true&#10;conditional base-source=false head-source=false head rejects as source=true&#10;grot-guide base-source=false head-source=false head rejects as source=true</code>

```text
BLOCK CONVERSION COMPATIBILITY — pre-#1577 (bb668cd5) vs this change (a8ea7fcb)
==============================================================================

Block types exercised : 19
Ordered pairs tried   : 342
Succeeded on base     : 162
Still succeed now     : 160
Byte-identical output : 160

LOST conversions      : 2
   collapsible -> assistant   now: Cannot convert to a assistant block: it has no form of its own, so the editor would render nothing after the switch
   assistant -> collapsible   now: Cannot convert to a collapsible block: its children are restricted to presentational blocks
Newly allowed         : 0
Different payload     : 0

SWITCH-TYPE MENU (targets offered in the block editor UI, in menu order)
------------------------------------------------------------------------------
unchanged  markdown          html, image, video, interactive, multistep, guided, quiz, input, terminal, terminal-connect, challenge, code-block
unchanged  html              markdown, image, video, interactive, multistep, guided, quiz, input, terminal, terminal-connect, challenge, code-block
unchanged  image             markdown, html, video, interactive, multistep, guided, quiz, input, terminal, terminal-connect, challenge, code-block
unchanged  video             markdown, html, image, interactive, multistep, guided, quiz, input, terminal, terminal-connect, challenge, code-block
unchanged  interactive       markdown, html, image, video, multistep, guided, quiz, input, terminal, terminal-connect, challenge, code-block
unchanged  multistep         markdown, html, image, video, interactive, guided, quiz, input, terminal, terminal-connect, challenge, code-block
unchanged  guided            markdown, html, image, video, interactive, multistep, quiz, input, terminal, terminal-connect, challenge, code-block
unchanged  section           (no switch-type button rendered)
unchanged  collapsible       markdown, html, image, video, interactive, multistep, guided, quiz, input, terminal, terminal-connect, challenge, code-block
unchanged  conditional       (no switch-type button rendered)
unchanged  quiz              markdown, html, image, video, interactive, multistep, guided, input, terminal, terminal-connect, challenge, code-block
unchanged  input             markdown, html, image, video, interactive, multistep, guided, quiz, terminal, terminal-connect, challenge, code-block
unchanged  assistant         markdown, html, image, video, interactive, multistep, guided, quiz, input, terminal, terminal-connect, challenge, code-block
unchanged  terminal          markdown, html, image, video, interactive, multistep, guided, quiz, input, terminal-connect, challenge, code-block
unchanged  terminal-connect  markdown, html, image, video, interactive, multistep, guided, quiz, input, terminal, challenge, code-block
unchanged  code-block        markdown, html, image, video, interactive, multistep, guided, quiz, input, terminal, terminal-connect, challenge
unchanged  challenge         markdown, html, image, video, interactive, multistep, guided, quiz, input, terminal, terminal-connect, code-block
unchanged  grot-guide        (no switch-type button rendered)
unchanged  snippet-ref       markdown, html, image, video, interactive, multistep, guided, quiz, input, terminal, terminal-connect, challenge, code-block

Menus that changed    : 0

SOURCE ELIGIBILITY (can the user start a switch from this block type?)
------------------------------------------------------------------------------
markdown          base-source=true  head-source=true  head rejects as source=false
html              base-source=true  head-source=true  head rejects as source=false
image             base-source=true  head-source=true  head rejects as source=false
video             base-source=true  head-source=true  head rejects as source=false
interactive       base-source=true  head-source=true  head rejects as source=false
multistep         base-source=true  head-source=true  head rejects as source=false
guided            base-source=true  head-source=true  head rejects as source=false
section           base-source=false head-source=false head rejects as source=true
collapsible       base-source=true  head-source=true  head rejects as source=false
conditional       base-source=false head-source=false head rejects as source=true
quiz              base-source=true  head-source=true  head rejects as source=false
input             base-source=true  head-source=true  head rejects as source=false
assistant         base-source=true  head-source=true  head rejects as source=false
terminal          base-source=true  head-source=true  head rejects as source=false
terminal-connect  base-source=true  head-source=true  head rejects as source=false
code-block        base-source=true  head-source=true  head rejects as source=false
challenge         base-source=true  head-source=true  head rejects as source=false
grot-guide        base-source=false head-source=false head rejects as source=true
snippet-ref       base-source=true  head-source=true  head rejects as source=false
```
</details>
<details>
<summary>Evidence: Mutation check — reintroducing the PR #1577 source-exclusion regression fails the new coverage</summary>

<code>Mutation check: reintroduce the PR #1577 regression (collapsible/assistant/snippet-ref excluded as conversion SOURCES)&#10;Result — the new regression coverage fails loudly:&#10;&#10;● conversion eligibility registries › keeps legacy source-only block types eligible without offering them as targets&#10;● convertBlockType › excluded type restrictions › covers every source-excluded type&#10;● convertBlockType › excluded type restrictions › should throw on the assistant to collapsible direct-API conversion&#10;● convertBlockType › excluded type restrictions › should throw on the collapsible to assistant direct-API conversion&#10;● convertBlockType › schema validation › should convert collapsible to every available target&#10;● convertBlockType › schema validation › should convert assistant to every available target&#10;● convertBlockType › schema validation › should convert snippet-ref to every available target&#10;Test Suites: 1 failed, 1 total&#10;Tests: 7 failed, 62 passed, 69 total</code>

```text
Mutation check: reintroduce the PR #1577 regression (collapsible/assistant/snippet-ref excluded as conversion SOURCES)
Result — the new regression coverage fails loudly:

  ● conversion eligibility registries › keeps legacy source-only block types eligible without offering them as targets
  ● convertBlockType › excluded type restrictions › covers every source-excluded type
  ● convertBlockType › excluded type restrictions › should throw on the assistant to collapsible direct-API conversion
  ● convertBlockType › excluded type restrictions › should throw on the collapsible to assistant direct-API conversion
  ● convertBlockType › schema validation › should convert collapsible to every available target
  ● convertBlockType › schema validation › should convert assistant to every available target
  ● convertBlockType › schema validation › should convert snippet-ref to every available target
Test Suites: 1 failed, 1 total
Tests:       7 failed, 62 passed, 69 total
```
</details>
<details>
<summary>Evidence: Per-pair base-vs-change status for all 342 conversions plus every switch-type menu</summary>

```text
{
 "pairs": [
  {
   "pair": "markdown -> html",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> image",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> video",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> interactive",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> multistep",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> guided",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> section",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "markdown -> collapsible",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "markdown -> conditional",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "markdown -> quiz",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> input",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> assistant",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "markdown -> terminal",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> terminal-connect",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> code-block",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> challenge",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "markdown -> grot-guide",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "markdown -> snippet-ref",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "html -> markdown",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> image",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> video",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> interactive",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> multistep",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> guided",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> section",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "html -> collapsible",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "html -> conditional",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "html -> quiz",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> input",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> assistant",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "html -> terminal",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> terminal-connect",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> code-block",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> challenge",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "html -> grot-guide",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "html -> snippet-ref",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> markdown",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> html",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> video",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "image -> interactive",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> multistep",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "image -> guided",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "image -> section",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> collapsible",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> conditional",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> quiz",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> input",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> assistant",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> terminal",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> terminal-connect",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "image -> code-block",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "image -> challenge",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> grot-guide",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "image -> snippet-ref",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> markdown",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> html",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> image",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "video -> interactive",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> multistep",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "video -> guided",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "video -> section",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> collapsible",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> conditional",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> quiz",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> input",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> assistant",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> terminal",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> terminal-connect",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "video -> code-block",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "video -> challenge",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> grot-guide",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "video -> snippet-ref",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "interactive -> markdown",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "interactive -> html",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "interactive -> image",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "interactive -> video",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "interactive -> multistep",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "interactive -> guided",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "interactive -> section",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "interactive -> collapsible",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "interactive -> conditional",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "interactive -> qu

... [26258 bytes truncated] ...

throws",
   "status": "same"
  },
  {
   "pair": "snippet-ref -> input",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "snippet-ref -> assistant",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "snippet-ref -> terminal",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "snippet-ref -> terminal-connect",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "snippet-ref -> code-block",
   "base": "ok",
   "head": "ok",
   "status": "same"
  },
  {
   "pair": "snippet-ref -> challenge",
   "base": "throws",
   "head": "throws",
   "status": "same"
  },
  {
   "pair": "snippet-ref -> grot-guide",
   "base": "throws",
   "head": "throws",
   "status": "same"
  }
 ],
 "menus": [
  {
   "type": "markdown",
   "base": [
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "html",
   "base": [
    "markdown",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "image",
   "base": [
    "markdown",
    "html",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "video",
   "base": [
    "markdown",
    "html",
    "image",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "interactive",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "multistep",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "guided",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "section",
   "base": [],
   "head": []
  },
  {
   "type": "collapsible",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "conditional",
   "base": [],
   "head": []
  },
  {
   "type": "quiz",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "input",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "assistant",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "terminal",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "terminal-connect",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "challenge",
    "code-block"
   ]
  },
  {
   "type": "code-block",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge"
   ]
  },
  {
   "type": "challenge",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "code-block"
   ]
  },
  {
   "type": "grot-guide",
   "base": [],
   "head": []
  },
  {
   "type": "snippet-ref",
   "base": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ],
   "head": [
    "markdown",
    "html",
    "image",
    "video",
    "interactive",
    "multistep",
    "guided",
    "quiz",
    "input",
    "terminal",
    "terminal-connect",
    "challenge",
    "code-block"
   ]
  }
 ]
}
```
</details>
- Outcome: ⚠️ 1 info across 1 run (8m15s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `src/components/block-editor/utils/block-conversion.ts:69` - Two conversions that succeeded at base bb668cd5 now throw, so the branch is not strictly zero-functional-change. At base, convertBlockType({type:&#39;assistant&#39;, blocks:[]}, &#39;collapsible&#39;) succeeded: the target guard only rejected section/conditional/grot-guide, step 3 copied `blocks` because KNOWN_FIELDS.collapsible contains &#39;blocks&#39; (json-guide.schema.ts:1133), and {type:&#39;collapsible&#39;, blocks:[]} parses against the collapsible arm of JsonBlockSchema (json-guide.schema.ts:984-988). The mirror pair convertBlockType({type:&#39;collapsible&#39;, title:&#39;T&#39;, blocks:[]}, &#39;assistant&#39;) succeeded the same way via KNOWN_FIELDS.assistant (json-guide.schema.ts:1178). Both now hit the new target guard at block-conversion.ts:244-247 and throw. The intent requires &#34;Preserve every source conversion that succeeded before PR #1577&#34; and &#34;this PR must remain strictly zero-functional-change&#34;, and asks that &#34;all base-successful source-to-target conversions are verified&#34; - but it also requires &#34;retaining ... all target restrictions&#34;, which is exactly what forbids these two pairs, so the two criteria conflict and only you can resolve it. The delta is not user-reachable (no form renders TypeSwitchDropdown for collapsible or assistant, and getAvailableConversions never offered them as targets at base either), and the new exhaustive test iterates getAvailableConversions(source), so it structurally cannot cover these pairs. Decide either (a) keep the target restrictions and drop the absolute &#34;every conversion that succeeded still succeeds&#34; wording from the commit message, recording these two pairs as the known, unreachable exception, or (b) mark collapsible and assistant eligible targets so the pairs survive.
- ℹ️ `src/components/block-editor/utils/block-conversion.test.ts:484` - The doc comment above CONTENTLESS_SOURCE_FAILURES names only `image` and `video` and attributes the whole map to issue #1575, but the map now pins five sources - collapsible, assistant and snippet-ref were added at lines 491-493. Those three fail for the same underlying reason (no field maps into the target&#39;s required text field, and REQUIRED_DEFAULTS supplies no default for markdown/html/interactive/quiz/input/terminal/challenge), yet #1575 only reports the image/video/empty-markdown -&gt; challenge symptom, so a future fixer reading this comment will not know the other three entries are in scope. Restate the rule as &#34;sources with no CONTENT_FIELDS entry&#34; and list all five, keeping the #1575 link as the tracking issue for the image/video case.

🔧 Fix: document and pin collapsible/assistant direct-API conversion exception
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `src/components/block-editor/utils/block-conversion.ts:60` - The change is zero-functional-change for every UI-reachable conversion, but two direct-API-only pairs that succeeded before PR #1577 now throw: `collapsible -&gt; assistant` and `assistant -&gt; collapsible`. The base guard rejected only container targets, so both used to succeed by copying `blocks`. Neither is reachable from the product — `getAvailableConversions` never offered `collapsible` or `assistant` as a target, and no form exposes the switch for those sources. The author documented this exception in commit a8ea7fcb and pinned both directions with explicit tests, and the intent asks to retain all target restrictions, so this is a deliberate and sanctioned deviation rather than a defect. Noting it only so a reviewer consciously accepts it against the literal &#34;strictly zero-functional-change&#34; wording.
- <code>`npx jest --coverage=false src/components/block-editor/utils src/components/block-editor/forms src/components/block-editor/BlockFormModal.test.tsx src/components/block-editor/BlockPalette.test.tsx src/components/block-editor/constants.test.ts` — 17 suites, 295 tests, all passing</code>
- <code>`npx jest --coverage=false src/components/block-editor/utils/block-conversion.test.ts` — 69 tests covering the new exhaustive eligibility registries and per-pair conversion coverage</code>
- <code>Differential harness: extracted the pre-#1577 `block-conversion.ts` from base commit `bb668cd5` and ran all 342 ordered source-to-target pairs across all 19 block types through both implementations, comparing success/failure, serialized output block, and `getAvailableConversions` menu contents</code>
- <code>Mutation check: re-added `collapsible`/`assistant`/`snippet-ref` to `SOURCE_EXCLUSION_REASONS` to reintroduce the PR #1577 regression, confirmed 7 tests fail (including `covers every source-excluded type` and `keeps legacy source-only block types eligible without offering them as targets`), then reverted via `git checkout --`</code>
- <code>Browser verification: bundled the real `TypeSwitchDropdown` and `GrotGuideBlockForm` from this branch with esbuild and drove them in Chrome via `chrome-devtools-axi` — confirmed the `Switch type` button renders for `collapsible`/`assistant`/`snippet-ref` and is absent for `section`/`conditional`/`grot-guide`</code>
- <code>Manual end-to-end conversions through the real Grafana dropdown menu: `collapsible -&gt; code-block` and `snippet-ref -&gt; video`, each producing a valid target block</code>
- <code>Verified the grot-guide block form footer renders Cancel / Update block with no switch-type control, matching base behaviour where `TypeSwitchDropdown` returned null for grot-guide</code>
- <code>`git status --porcelain` — confirmed clean worktree after removing all temporary harness files</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
