### PR TITLE
test(docs-retrieval): restore the global backendSrv after the catalogue describe

### DIFF
--- a/src/docs-retrieval/package-content.test.ts
+++ b/src/docs-retrieval/package-content.test.ts
@@ -9,7 +9,7 @@
  * - Manifest metadata passthrough via fetchPackageContent
  * - setPackageResolver injection and resolver-not-configured error
  */
-import { config, setBackendSrv, type BackendSrv } from '@grafana/runtime';
+import { config, getBackendSrv, setBackendSrv, type BackendSrv } from '@grafana/runtime';
 import {
   fetchPackageContent,
   fetchPackageById,
@@ -624,6 +624,9 @@ describe('fetchPackageContent path-type enrichment', () => {
 describe('fetchPackageContent — no public websiteUrl for catalogue-launched private paths', () => {
   const GAP_TOGGLE = 'aggregation.pathfinderbackend-ext-grafana-app.enabled';
   const featureToggles = config.featureToggles as Record<string, boolean>;
+  // setBackendSrv writes a module-level singleton, so the fake below outlives
+  // this block and reaches every later describe unless afterEach puts it back.
+  const originalBackendSrv = getBackendSrv();
 
   async function launchManifestFromCatalogue(manifest: Record<string, unknown>): Promise<Record<string, unknown>> {
     featureToggles[GAP_TOGGLE] = true;
@@ -653,6 +656,7 @@ describe('fetchPackageContent — no public websiteUrl for catalogue-launched pr
   });
 
   afterEach(() => {
+    setBackendSrv(originalBackendSrv);
     delete featureToggles[GAP_TOGGLE];
     invalidateCustomGuideRepositoryCache();
     setPackageResolver(makeResolver({ ok: false, id: 'reset', error: { code: 'not-found', message: 'reset' } }));


### PR DESCRIPTION
## Summary

Follow-up to #1571. That PR added the catalogue-normalization coverage; this restores the global `backendSrv` afterwards so the fake doesn't outlive its own describe.

`setBackendSrv` writes a module-level singleton in `@grafana/runtime` (literally `singletonInstance = instance`). `launchManifestFromCatalogue` installs a fake implementing only `get`, and the `afterEach` put back the feature toggle, the catalogue cache and the package resolver — but not the backendSrv. Four describes follow the affected block, and they ran against that fake.

## What to look at

Three lines in `src/docs-retrieval/package-content.test.ts`: capture `getBackendSrv()` at describe scope, restore it first in the `afterEach`, and one comment naming the invariant so the next editor doesn't re-drop it.

## Why

**Inert today, and the suite is green either way** — nothing downstream in the file reaches `getBackendSrv()`. `ensureNonEmptyCoverContent` is pure, the CDN path goes through `window.fetch`, and the nav-link and milestone describes use the injected package resolver.

It's a latent trap rather than a live failure. The fake implements only `get`, so the next test in this file to exercise `backend-guide.ts:37` (`getBackendSrv().fetch(...)`) fails with `fetch is not a function`, pointing at production code that is fine, from a describe that looks unrelated to the one that caused it.

Blast radius is one file: Jest gives each test file its own module registry, so this could never reach other suites.

Capture-and-restore is safe rather than merely convenient — `getBackendSrv()` returns `undefined` instead of throwing when unset, and `undefined` is the correct pre-test value to put back. Its declared return type is `BackendSrv`, so no cast is needed.

## How to verify

Temporarily append a probe describe after the affected block:

```ts
describe('TEMP probe', () => {
  it('global backendSrv is not the catalogue fake', () => {
    expect(getBackendSrv()).toBeUndefined();
  });
});
```

- with the restore in place it passes — the probe sees `undefined`
- delete the `setBackendSrv(originalBackendSrv)` line and it fails with `Received: {"get": [Function get]}`

Both directions confirmed locally. `package-content.test.ts` is 49/49 before and after (no tests added or removed), typecheck, eslint and prettier clean, and the `test:governance` pre-commit gate passes 164/164.

Note the gate needs Node 24 (`.nvmrc` pins 24.19); on Node 22 `src/validation/import-graph.test.ts` fails on `isNodeBuiltin('node:test')` unrelated to this change, because `node:test` isn't in `builtinModules` before Node 24.

## Breaking changes

None. Test-only, no production file touched.

## Reversibility

Trivially revertible; three lines in one test file.