### PR TITLE
fix(custom-guides): count catalogue hard failures, not just soft-200s

### DIFF
--- a/src/lib/custom-guide-repository-client.test.ts
+++ b/src/lib/custom-guide-repository-client.test.ts
@@ -121,56 +121,62 @@ describe('fetchCustomGuideRepository', () => {
     expect(result).toEqual([]);
   });
 
-  it('records an http-<status> reason when the request rejects with a status', async () => {
-    mockGet.mockRejectedValue({ status: 503, statusText: 'Service Unavailable', message: 'upstream drain failed' });
-
-    const result = await fetchCustomGuideRepository('stacks-123');
-
-    expect(result).toEqual([]);
-    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenCalledWith('http-503');
-    expect(logger.warn).toHaveBeenCalledWith('[custom-guides] catalogue fetch failed', {
+  // The reason lands on a Faro event attribute and in the bridged log context,
+  // so every rejection shape must collapse to a token from the closed set.
+  it.each([
+    { shape: 'a top-level status', err: { status: 503, statusText: 'Service Unavailable' }, reason: 'http-503' },
+    { shape: 'a top-level statusCode', err: { statusCode: 418 }, reason: 'http-418' },
+    { shape: 'a nested data.statusCode', err: { data: { statusCode: 502 } }, reason: 'http-502' },
+    {
+      shape: 'status ahead of both statusCode shapes',
+      err: { status: 503, statusCode: 404, data: { statusCode: 500 } },
       reason: 'http-503',
-      message: 'upstream drain failed',
-    });
-  });
-
-  it('reads the status off the nested statusCode shapes too', async () => {
-    mockGet.mockRejectedValue({ data: { statusCode: 502 } });
-
-    await fetchCustomGuideRepository('stacks-123');
-
-    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenCalledWith('http-502');
-  });
-
-  it('records transport-error when the rejection carries no status', async () => {
-    mockGet.mockRejectedValue(new Error('network error'));
+    },
+    {
+      shape: 'statusCode ahead of data.statusCode',
+      err: { statusCode: 404, data: { statusCode: 500 } },
+      reason: 'http-404',
+    },
+    { shape: 'one below the low bound', err: { status: 99 }, reason: 'transport-error' },
+    { shape: 'the low bound', err: { status: 100 }, reason: 'http-100' },
+    { shape: 'the high bound', err: { status: 599 }, reason: 'http-599' },
+    { shape: 'one above the high bound', err: { status: 600 }, reason: 'transport-error' },
+    { shape: 'a wildly out-of-range status', err: { status: 99999 }, reason: 'transport-error' },
+    { shape: 'a negative status', err: { status: -503 }, reason: 'transport-error' },
+    { shape: 'a string status', err: { status: '503' }, reason: 'transport-error' },
+    { shape: 'a non-integer status', err: { data: { statusCode: 503.0000001 } }, reason: 'transport-error' },
+    { shape: 'no status at all', err: new Error('network error'), reason: 'transport-error' },
+  ])('records $reason for $shape', async ({ err, reason }) => {
+    mockGet.mockRejectedValue(err);
 
     const result = await fetchCustomGuideRepository('stacks-123');
 
     expect(result).toEqual([]);
-    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenCalledWith('transport-error');
-    expect(logger.warn).toHaveBeenCalledWith('[custom-guides] catalogue fetch failed', {
-      reason: 'transport-error',
-      message: 'network error',
-    });
+    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenCalledWith(reason);
+    expect(logger.warn).toHaveBeenCalledWith('[custom-guides] catalogue fetch failed', { reason });
   });
 
-  // A malformed error shape must not mint an unbounded Faro attribute value.
-  it('keeps the reason bounded when the status is out of range or not an integer', async () => {
-    mockGet.mockRejectedValueOnce({ status: 99999 });
-    await fetchCustomGuideRepository('stacks-123');
-    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenLastCalledWith('transport-error');
+  // logging.ts sanitizes the log context but does not strip it, so anything put
+  // there reaches Faro — an error message would be a user-derived free-text
+  // attribute, which docs/developer/TELEMETRY.md forbids.
+  it('never forwards the error message into the bridged log context', async () => {
+    const sentinel = 'c0ffee-user-derived-detail';
+    mockGet.mockRejectedValue({ status: 503, message: `upstream drain failed for ${sentinel}` });
 
-    mockGet.mockRejectedValueOnce({ data: { statusCode: 503.0000001 } });
     await fetchCustomGuideRepository('stacks-123');
-    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenLastCalledWith('transport-error');
+
+    expect(logger.warn).toHaveBeenCalledWith('[custom-guides] catalogue fetch failed', { reason: 'http-503' });
+    expect(JSON.stringify((logger.warn as jest.Mock).mock.calls)).not.toContain(sentinel);
   });
 
   // Both callers document that this never rejects — a throwing sink must not break that.
-  it('still resolves to an empty array when the observability calls throw', async () => {
+  it.each([
+    { sink: 'the logger', mock: () => logger.warn as jest.Mock },
+    { sink: 'the telemetry facade', mock: () => recordCustomGuideCatalogueUnavailable as jest.Mock },
+  ])('still resolves to an empty array when $sink throws', async ({ mock }) => {
     mockGet.mockRejectedValue(new Error('network error'));
-    (logger.warn as jest.Mock).mockImplementationOnce(() => {
-      throw new Error('logger blew up');
+    mock().mockImplementationOnce(() => {
+      throw new Error('observability blew up');
     });
 
     await expect(fetchCustomGuideRepository('stacks-123')).resolves.toEqual([]);

--- a/src/lib/custom-guide-repository-client.test.ts
+++ b/src/lib/custom-guide-repository-client.test.ts
@@ -155,6 +155,27 @@ describe('fetchCustomGuideRepository', () => {
     });
   });
 
+  // A malformed error shape must not mint an unbounded Faro attribute value.
+  it('keeps the reason bounded when the status is out of range or not an integer', async () => {
+    mockGet.mockRejectedValueOnce({ status: 99999 });
+    await fetchCustomGuideRepository('stacks-123');
+    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenLastCalledWith('transport-error');
+
+    mockGet.mockRejectedValueOnce({ data: { statusCode: 503.0000001 } });
+    await fetchCustomGuideRepository('stacks-123');
+    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenLastCalledWith('transport-error');
+  });
+
+  // Both callers document that this never rejects — a throwing sink must not break that.
+  it('still resolves to an empty array when the observability calls throw', async () => {
+    mockGet.mockRejectedValue(new Error('network error'));
+    (logger.warn as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('logger blew up');
+    });
+
+    await expect(fetchCustomGuideRepository('stacks-123')).resolves.toEqual([]);
+  });
+
   it('caches a successful result within the TTL and de-duplicates concurrent calls', async () => {
     mockGet.mockResolvedValue({ capability: { available: true }, guides: [{ id: 'g1', status: 'published' }] });
 

--- a/src/lib/custom-guide-repository-client.test.ts
+++ b/src/lib/custom-guide-repository-client.test.ts
@@ -11,8 +11,13 @@ jest.mock('./telemetry/facade', () => ({
   recordCustomGuideCatalogueUnavailable: jest.fn(),
 }));
 
+jest.mock('./logging', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
+}));
+
 import { getBackendSrv } from '@grafana/runtime';
 import { fetchCustomGuideRepository, invalidateCustomGuideRepositoryCache } from './custom-guide-repository-client';
+import { logger } from './logging';
 import { recordCustomGuideCatalogueUnavailable } from './telemetry/facade';
 
 const mockGet = jest.fn();
@@ -116,12 +121,38 @@ describe('fetchCustomGuideRepository', () => {
     expect(result).toEqual([]);
   });
 
-  it('returns an empty array and swallows errors on fetch failure', async () => {
+  it('records an http-<status> reason when the request rejects with a status', async () => {
+    mockGet.mockRejectedValue({ status: 503, statusText: 'Service Unavailable', message: 'upstream drain failed' });
+
+    const result = await fetchCustomGuideRepository('stacks-123');
+
+    expect(result).toEqual([]);
+    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenCalledWith('http-503');
+    expect(logger.warn).toHaveBeenCalledWith('[custom-guides] catalogue fetch failed', {
+      reason: 'http-503',
+      message: 'upstream drain failed',
+    });
+  });
+
+  it('reads the status off the nested statusCode shapes too', async () => {
+    mockGet.mockRejectedValue({ data: { statusCode: 502 } });
+
+    await fetchCustomGuideRepository('stacks-123');
+
+    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenCalledWith('http-502');
+  });
+
+  it('records transport-error when the rejection carries no status', async () => {
     mockGet.mockRejectedValue(new Error('network error'));
 
     const result = await fetchCustomGuideRepository('stacks-123');
 
     expect(result).toEqual([]);
+    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenCalledWith('transport-error');
+    expect(logger.warn).toHaveBeenCalledWith('[custom-guides] catalogue fetch failed', {
+      reason: 'transport-error',
+      message: 'network error',
+    });
   });
 
   it('caches a successful result within the TTL and de-duplicates concurrent calls', async () => {
@@ -151,5 +182,7 @@ describe('fetchCustomGuideRepository', () => {
 
     expect(retry.map((g) => g.id)).toEqual(['g1']);
     expect(mockGet).toHaveBeenCalledTimes(2);
+    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenCalledTimes(1);
+    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenCalledWith('transport-error');
   });
 });

--- a/src/lib/custom-guide-repository-client.ts
+++ b/src/lib/custom-guide-repository-client.ts
@@ -81,15 +81,12 @@ function classifyRequestFailure(err: unknown): string {
   return bounded ? `http-${status}` : 'transport-error';
 }
 
-function requestFailureMessage(err: unknown): string {
-  const message = (err as { message?: unknown })?.message;
-  return typeof message === 'string' ? message : 'unknown';
-}
-
 function reportCatalogueFetchFailure(err: unknown): void {
   try {
     const reason = classifyRequestFailure(err);
-    logger.warn('[custom-guides] catalogue fetch failed', { reason, message: requestFailureMessage(err) });
+    // The log context bridges to Faro too (logging.ts sanitizes it, it does not
+    // strip it), so it carries the same bounded token — never `err.message`.
+    logger.warn('[custom-guides] catalogue fetch failed', { reason });
     recordCustomGuideCatalogueUnavailable(reason);
   } catch {
     // Observability must not turn a swallowed listing failure into a rejection.

--- a/src/lib/custom-guide-repository-client.ts
+++ b/src/lib/custom-guide-repository-client.ts
@@ -69,6 +69,21 @@ const CACHE_TTL_MS = 30_000;
 const cache = new Map<string, { entries: CustomGuideRepositoryEntry[]; at: number }>();
 const inflight = new Map<string, Promise<CustomGuideRepositoryEntry[]>>();
 
+// Bounded token, never the error text — it lands on a Faro event attribute,
+// which must stay low-cardinality (docs/developer/TELEMETRY.md).
+function classifyRequestFailure(err: unknown): string {
+  const status =
+    (err as { status?: number })?.status ??
+    (err as { statusCode?: number })?.statusCode ??
+    (err as { data?: { statusCode?: number } })?.data?.statusCode;
+  return typeof status === 'number' && status >= 100 && status <= 599 ? `http-${status}` : 'transport-error';
+}
+
+function requestFailureMessage(err: unknown): string {
+  const message = (err as { message?: unknown })?.message;
+  return typeof message === 'string' ? message : 'unknown';
+}
+
 async function requestCatalogue(): Promise<CustomGuideRepositoryEntry[]> {
   const response = await getBackendSrv().get<CustomGuideRepositoryResponse>(
     CUSTOM_GUIDE_REPOSITORY_URL,
@@ -128,9 +143,15 @@ export async function fetchCustomGuideRepository(namespace: string): Promise<Cus
       cache.set(namespace, { entries, at: Date.now() });
       return entries;
     })
-    // Best-effort: never surface a listing failure, and don't cache it so a
-    // transient error doesn't stick for the whole TTL.
-    .catch(() => [] as CustomGuideRepositoryEntry[])
+    // Best-effort: never surface a listing failure to callers, and don't cache
+    // it so a transient error doesn't stick for the whole TTL. Still counted —
+    // `showErrorAlert: false` makes this otherwise invisible from the browser.
+    .catch((err: unknown) => {
+      const reason = classifyRequestFailure(err);
+      logger.warn('[custom-guides] catalogue fetch failed', { reason, message: requestFailureMessage(err) });
+      recordCustomGuideCatalogueUnavailable(reason);
+      return [] as CustomGuideRepositoryEntry[];
+    })
     .finally(() => {
       inflight.delete(namespace);
     });

--- a/src/lib/custom-guide-repository-client.ts
+++ b/src/lib/custom-guide-repository-client.ts
@@ -70,18 +70,30 @@ const cache = new Map<string, { entries: CustomGuideRepositoryEntry[]; at: numbe
 const inflight = new Map<string, Promise<CustomGuideRepositoryEntry[]>>();
 
 // Bounded token, never the error text — it lands on a Faro event attribute,
-// which must stay low-cardinality (docs/developer/TELEMETRY.md).
+// which must stay low-cardinality (docs/developer/TELEMETRY.md). `data.statusCode`
+// is body-derived, so the integer bound is what keeps the vocabulary finite.
 function classifyRequestFailure(err: unknown): string {
   const status =
     (err as { status?: number })?.status ??
     (err as { statusCode?: number })?.statusCode ??
     (err as { data?: { statusCode?: number } })?.data?.statusCode;
-  return typeof status === 'number' && status >= 100 && status <= 599 ? `http-${status}` : 'transport-error';
+  const bounded = typeof status === 'number' && Number.isInteger(status) && status >= 100 && status <= 599;
+  return bounded ? `http-${status}` : 'transport-error';
 }
 
 function requestFailureMessage(err: unknown): string {
   const message = (err as { message?: unknown })?.message;
   return typeof message === 'string' ? message : 'unknown';
+}
+
+function reportCatalogueFetchFailure(err: unknown): void {
+  try {
+    const reason = classifyRequestFailure(err);
+    logger.warn('[custom-guides] catalogue fetch failed', { reason, message: requestFailureMessage(err) });
+    recordCustomGuideCatalogueUnavailable(reason);
+  } catch {
+    // Observability must not turn a swallowed listing failure into a rejection.
+  }
 }
 
 async function requestCatalogue(): Promise<CustomGuideRepositoryEntry[]> {
@@ -147,9 +159,7 @@ export async function fetchCustomGuideRepository(namespace: string): Promise<Cus
     // it so a transient error doesn't stick for the whole TTL. Still counted —
     // `showErrorAlert: false` makes this otherwise invisible from the browser.
     .catch((err: unknown) => {
-      const reason = classifyRequestFailure(err);
-      logger.warn('[custom-guides] catalogue fetch failed', { reason, message: requestFailureMessage(err) });
-      recordCustomGuideCatalogueUnavailable(reason);
+      reportCatalogueFetchFailure(err);
       return [] as CustomGuideRepositoryEntry[];
     })
     .finally(() => {

--- a/src/lib/telemetry/facade.ts
+++ b/src/lib/telemetry/facade.ts
@@ -99,8 +99,9 @@ export function recordPanelReady(durationMs: number, surface: string): void {
   pushFaroMeasurement(TELEMETRY_MEASUREMENTS.panel, { panel_lcp_ms: durationMs }, { surface });
 }
 
-// The custom-guide catalogue reported itself unavailable (a soft-200 with a
-// machine `reason`), so the surface renders empty. This is the countable,
+// The custom-guide catalogue could not be listed — a soft-200 reporting itself
+// unavailable with a machine `reason`, or a rejected request (`http-<status>` /
+// `transport-error`) — so the surface renders empty. This is the countable,
 // alertable signal the capability-degradation ladder needs — a log alone can't
 // distinguish "no guides authored" from "OBO unavailable on this stack", which
 // is exactly how a recent incident stayed invisible. `reason` is Faro-only


### PR DESCRIPTION
## Summary

The custom-guide catalogue fetch has two failure paths and only one was observable. The soft-200 path (backend returns HTTP 200 with `capability.available: false`) logs and emits `pathfinder_custom_guide_catalogue_unavailable`. The hard path — the request itself rejecting on a 503, a network drop, or a timeout — ended in a bare `.catch(() => [])` that discarded the error: no log, no telemetry.

This makes the hard path emit the same pair of signals, split by cause:

- the rejection carries an HTTP status → `http-<status>` (e.g. `http-503`)
- no status at all (network failure, DNS, abort, timeout) → `transport-error`

Status extraction follows the existing in-repo pattern at `src/utils/fetchBackendGuides.ts:47-51` (`status` / `statusCode` / `data.statusCode`), bounded to the 100-599 range so the token stays low-cardinality.

Fixes #1562

## What to look at

- `src/lib/custom-guide-repository-client.ts` — `classifyRequestFailure`, and the `.catch` in `fetchCustomGuideRepository` that now logs and records before returning `[]`.
- `src/lib/custom-guide-repository-client.test.ts` — the two tests that pinned the silent behaviour are replaced/extended; new coverage for a status-bearing rejection, the nested `data.statusCode` shape, and a status-less rejection.
- `src/lib/telemetry/facade.ts` — comment only. The op's rationale said "a soft-200 with a machine `reason`"; it now covers both causes. No signature or `TELEMETRY_EVENTS` change.

Telemetry policy (`docs/developer/TELEMETRY.md`): the Faro event attribute gets only the bounded token — never `err.message`, never the response body. The raw detail goes to `logger.warn` (not `logger.error`, which escalates to a Faro exception, and which would be the wrong severity for a best-effort listing). `recordCustomGuideCatalogueUnavailable` is `pushFaroEvent`-backed and Faro-only; there is no `reportInteraction` path anywhere in `src/lib/telemetry/`, so nothing here can reach RudderStack.

## Why

The backend genuinely returns hard 503s — a wrong CAP token or an unreachable auth-api 503s the route indefinitely (`pkg/plugin/custom_guide_repository.go`, transient branch). The request passes `showErrorAlert: false`, so Grafana's own toast is suppressed, and the Faro adapter has no fetch instrumentation to compensate. Under that mode the Custom Guides surface renders empty forever, a dashboard on `pathfinder_custom_guide_catalogue_unavailable` reads zero, and the only trace is a backend log. Neither caller can compensate, because `fetchCustomGuideRepository` never rejects.

Splitting by cause is the operational point: it separates "our backend is down" (a page-worthy `http-5xx` cluster) from "their connection died" (`transport-error`, expected background noise).

## How to verify

```bash
eval "$(fnm env --shell bash)" && fnm use 24.18.0
npx jest src/lib/custom-guide-repository-client.test.ts src/lib/telemetry --coverage=false
npm run typecheck
```

The four new/updated assertions fail on `main` (verified by stashing the source change: 4 failed, 8 passed) and pass with it (12/12). Focused run over the client plus the whole telemetry directory: 172 passed. `typecheck`, `eslint`, and `prettier --check` are clean on all three changed files.

Manually: on a stack where the catalogue route 503s, open the Custom Guides surface and confirm a `[custom-guides] catalogue fetch failed` warning in the console with `reason: http-503`, plus one `pathfinder_custom_guide_catalogue_unavailable` event with the same reason.

## Breaking changes

None. `fetchCustomGuideRepository` still resolves to `[]` on every failure and still never rejects — two places document a dependency on that (the function's own docblock and `useCustomGuideCatalogueOnOpen.ts:26-28`). Failures are still not cached, so a transient error does not stick for the TTL. The only new outputs are one log line and one Faro event per failed fetch.

## Reversibility

Runtime-reversible; telemetry history remains. Revert the commit and the runtime behaviour returns to exactly what it was — no schema, storage, or API surface is touched, and `TELEMETRY_EVENTS` is unchanged, so no dashboard or alert breaks on a revert (the event simply stops carrying `http-*` / `transport-error` reasons). What a revert cannot undo is the Faro events and logs already ingested: those survive until retention expires.

## Out of scope

A 200 response with `capability.available: true` but a missing or non-array `guides` field also returns empty silently (`custom-guide-repository-client.ts:89`, pinned by the "returns an empty array when the response is malformed" test). Same symptom — empty surface, no signal — but a different cause: a malformed success envelope rather than a transport or capability failure, so it wants a different reason token and arguably a different severity. Deliberately left alone here; filed as #1591.

