### PR TITLE
fix(learning-paths): clear the path's own completion keys on reset

### DIFF
--- a/src/components/LearningPaths/MyLearningTab.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.test.tsx
@@ -16,6 +16,7 @@ import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import { MyLearningTab } from './MyLearningTab';
 import { prepareGuideLaunch, type PrepareGuideLaunchResult } from '../docs-panel/utils/prepare-guide-launch';
 import { testIds } from '../../constants/testIds';
+import { milestoneCompletionStorage } from '../../lib/user-storage';
 
 jest.mock('../docs-panel/utils/prepare-guide-launch', () => ({
   prepareGuideLaunch: jest.fn(),
@@ -92,6 +93,7 @@ jest.mock('../../lib/user-storage', () => ({
   journeyCompletionStorage: { getAll: jest.fn(async () => ({})), clear: jest.fn() },
   interactiveStepStorage: { clearAll: jest.fn() },
   interactiveCompletionStorage: { clearAll: jest.fn() },
+  milestoneCompletionStorage: { clearAll: jest.fn() },
 }));
 jest.mock('../../global-state/completion-store', () => ({ evictAllContentCaches: jest.fn() }));
 
@@ -495,5 +497,28 @@ describe('MyLearningTab — App Platform guide launch', () => {
       source: 'home_page',
       packageInfo: undefined,
     });
+  });
+});
+
+describe('MyLearningTab — reset all learning progress', () => {
+  it('drops milestone checklists so a single later completion cannot re-complete a course', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<MyLearningTab onOpenGuide={jest.fn()} />);
+    fireEvent.click(screen.getByTestId(testIds.learningPaths.resetProgressButton));
+
+    await waitFor(() => expect(milestoneCompletionStorage.clearAll).toHaveBeenCalledTimes(1));
+    confirmSpy.mockRestore();
+  });
+
+  it('leaves milestone checklists alone when the confirmation is declined', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+
+    render(<MyLearningTab onOpenGuide={jest.fn()} />);
+    fireEvent.click(screen.getByTestId(testIds.learningPaths.resetProgressButton));
+
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
+    expect(milestoneCompletionStorage.clearAll).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
   });
 });

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -25,6 +25,7 @@ import {
   journeyCompletionStorage,
   interactiveStepStorage,
   interactiveCompletionStorage,
+  milestoneCompletionStorage,
 } from '../../lib/user-storage';
 import { evictAllContentCaches } from '../../global-state/completion-store';
 import type { EarnedBadge } from '../../types';
@@ -233,6 +234,11 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
       for (const url of Object.keys(completions)) {
         await journeyCompletionStorage.clear(url);
       }
+
+      // Milestone checklists outlive a per-path reset for paths that predate the
+      // path-key fix, so a global reset has to drop them too — otherwise the next
+      // single completion re-crosses the all-milestones threshold.
+      await milestoneCompletionStorage.clearAll();
 
       // Clear all interactive guide step and completion state
       // This prevents guides from instantly re-completing when reopened

--- a/src/learning-paths/learning-paths.hook.ts
+++ b/src/learning-paths/learning-paths.hook.ts
@@ -409,81 +409,57 @@ export function useLearningPaths(): UseLearningPathsReturn {
       }
 
       if (path.url) {
-        // URL-based path: clear milestone tracking and journey completion
         await milestoneCompletionStorage.clear(path.url);
-        await journeyCompletionStorage.clear(path.url);
 
-        // Remove milestone slugs from completedGuides (path.guides contains fetched slugs)
         if (path.guides.length > 0) {
           await learningProgressStorage.removeCompletedGuides(path.guides);
         }
 
-        // Clear interactive steps for milestone URLs (iterate over completed milestones)
-        // Since we don't have the full milestone URLs stored, clear by prefix pattern
-        // The content keys for milestones start with the path URL
         const [completions, journeyCompletions] = await Promise.all([
           interactiveCompletionStorage.getAll(),
           journeyCompletionStorage.getAll(),
         ]);
 
+        // Milestone content keys aren't stored anywhere, so recover them by prefix.
         const normalizedUrl = path.url.replace(/\/+$/, '');
-
-        // Batch clear operations for better performance with many milestones
         const milestoneKeys = Object.keys(completions).filter((key) => key.startsWith(normalizedUrl));
-        await Promise.all([
-          ...milestoneKeys.map((key) =>
-            Promise.all([interactiveCompletionStorage.clear(key), interactiveStepStorage.clearAllForContent(key)])
-          ),
-          ...Object.keys(journeyCompletions)
-            .filter((key) => key.startsWith(normalizedUrl))
-            .map((key) => journeyCompletionStorage.clear(key)),
-        ]);
-        // Drop the completion store's in-memory cache for each milestone
-        // we cleared. Without this, any open guide in the path would
-        // still surface its prior completion snapshot via the store.
+        const journeyKeys = [path.url, ...Object.keys(journeyCompletions).filter((k) => k.startsWith(normalizedUrl))];
+
+        await Promise.all(milestoneKeys.map((key) => interactiveStepStorage.clearAllForContent(key)));
+        await interactiveCompletionStorage.clearMany(milestoneKeys);
+        await journeyCompletionStorage.clearMany(journeyKeys);
+
         milestoneKeys.forEach((key) => evictContentCache(key));
       } else {
         // No base URL: either a static bundled path (`bundled:<id>`) or an App
         // Platform path whose members are `backend-guide:<id>`. We can't tell
         // them apart from `path.guides` alone, so clear both content schemes.
+        const pathKeys = [`bundled:${path.id}`, `backend-guide:${path.id}`];
+        const contentKeys = [
+          ...pathKeys,
+          ...path.guides.flatMap((guideId) => [`bundled:${guideId}`, `backend-guide:${guideId}`]),
+        ];
 
-        // The path's OWN key, not just its members: milestone checklists and the
-        // journey percentage are stored under the cover key. Sequential because
-        // both helpers read-modify-write one shared record.
-        for (const pathKey of [`bundled:${path.id}`, `backend-guide:${path.id}`]) {
+        for (const pathKey of pathKeys) {
           await milestoneCompletionStorage.clear(pathKey);
-          await journeyCompletionStorage.clear(pathKey);
         }
 
-        await Promise.all(
-          path.guides.flatMap((guideId) =>
-            [`bundled:${guideId}`, `backend-guide:${guideId}`].map((contentKey) =>
-              Promise.all([
-                interactiveStepStorage.clearAllForContent(contentKey),
-                interactiveCompletionStorage.clear(contentKey),
-                journeyCompletionStorage.clear(contentKey),
-              ])
-            )
-          )
-        );
-        path.guides.forEach((guideId) => {
-          evictContentCache(`bundled:${guideId}`);
-          evictContentCache(`backend-guide:${guideId}`);
-        });
+        await Promise.all(contentKeys.map((key) => interactiveStepStorage.clearAllForContent(key)));
+        // Batched, not one clear per key: each helper read-modify-writes a single shared record.
+        await interactiveCompletionStorage.clearMany(contentKeys);
+        await journeyCompletionStorage.clearMany(contentKeys);
 
-        // Remove guide IDs from completedGuides (bare ids, matching how App
-        // Platform + bundled completions are keyed).
+        contentKeys.forEach((key) => evictContentCache(key));
+
         await learningProgressStorage.removeCompletedGuides(path.guides);
       }
 
-      // Dispatch event to notify UI components to refresh
       window.dispatchEvent(
         new CustomEvent(StorageEvents.InteractiveProgressCleared, {
           detail: { contentKey: '*', pathId },
         })
       );
 
-      // Reload progress to update UI
       await loadProgress({ current: true });
     },
     [paths, loadProgress]

--- a/src/learning-paths/learning-paths.hook.ts
+++ b/src/learning-paths/learning-paths.hook.ts
@@ -446,6 +446,15 @@ export function useLearningPaths(): UseLearningPathsReturn {
         // No base URL: either a static bundled path (`bundled:<id>`) or an App
         // Platform path whose members are `backend-guide:<id>`. We can't tell
         // them apart from `path.guides` alone, so clear both content schemes.
+
+        // The path's OWN key, not just its members: milestone checklists and the
+        // journey percentage are stored under the cover key. Sequential because
+        // both helpers read-modify-write one shared record.
+        for (const pathKey of [`bundled:${path.id}`, `backend-guide:${path.id}`]) {
+          await milestoneCompletionStorage.clear(pathKey);
+          await journeyCompletionStorage.clear(pathKey);
+        }
+
         await Promise.all(
           path.guides.flatMap((guideId) =>
             [`bundled:${guideId}`, `backend-guide:${guideId}`].map((contentKey) =>

--- a/src/learning-paths/reset-path-completion.test.ts
+++ b/src/learning-paths/reset-path-completion.test.ts
@@ -1,0 +1,127 @@
+/**
+ * `resetPath` against the REAL storage modules (#1560).
+ *
+ * `learning-paths.hook.test.ts` mocks `../lib/user-storage` wholesale, so it
+ * cannot see which storage keys a reset actually touches — and the bug was
+ * exactly that: an App Platform path (no `url`, so it takes the second branch)
+ * had its members cleared but never its own cover key, leaving the
+ * "all milestones done" checklist behind for the next completion to re-cross.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+jest.mock('@grafana/runtime', () => ({
+  config: { namespace: 'stacks-123' },
+  usePluginUserStorage: jest.fn(),
+  getAppEvents: jest.fn(() => ({ publish: jest.fn() })),
+}));
+
+const mockFetchAppPlatformLearningPaths = jest.fn();
+jest.mock('./app-platform-paths', () => ({
+  fetchAppPlatformLearningPaths: (namespace: string) => mockFetchAppPlatformLearningPaths(namespace),
+}));
+
+jest.mock('./fetch-path-guides', () => ({
+  fetchPathGuides: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('./paths-data', () => ({
+  getPathsData: () => ({ paths: [], guideMetadata: {} }),
+}));
+
+jest.mock('../lib/analytics', () => ({
+  reportAppInteraction: jest.fn(),
+  UserInteraction: new Proxy({}, { get: (_t, p) => String(p) }),
+}));
+
+import { __resetRecorderForTests, onCompletionRecorded, type CompletionFact } from '../completion-records';
+import { markMilestoneDone } from '../docs-retrieval';
+import { journeyCompletionStorage, milestoneCompletionStorage } from '../lib/user-storage';
+import { useLearningPaths } from './learning-paths.hook';
+
+const PATH_ID = 'fe-alerting-path';
+const PATH_KEY = `backend-guide:${PATH_ID}`;
+const GUIDES = ['fe-alerting-01', 'fe-alerting-02', 'fe-alerting-03'];
+
+async function seedCompletedCourse(): Promise<void> {
+  for (const guideId of GUIDES) {
+    await milestoneCompletionStorage.markCompleted(PATH_KEY, guideId);
+  }
+  await journeyCompletionStorage.set(PATH_KEY, 100);
+}
+
+async function renderAndResetPath(): Promise<void> {
+  const { result, unmount } = renderHook(() => useLearningPaths());
+  await waitFor(() => expect(result.current.paths.map((p) => p.id)).toContain(PATH_ID));
+  await act(async () => {
+    await result.current.resetPath(PATH_ID);
+  });
+  unmount();
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  __resetRecorderForTests();
+  mockFetchAppPlatformLearningPaths.mockResolvedValue({
+    paths: [
+      {
+        id: PATH_ID,
+        title: 'Alerting enablement',
+        description: '',
+        guides: GUIDES,
+        badgeId: '',
+        manifest: { id: PATH_ID, type: 'path', repository: 'app-platform', milestones: GUIDES },
+      },
+    ],
+    guideMetadata: Object.fromEntries(
+      GUIDES.map((id) => [id, { title: id, estimatedMinutes: 5, url: `backend-guide:${id}` }])
+    ),
+  });
+});
+
+describe('resetPath — App Platform path (no url)', () => {
+  it('clears the milestone checklist stored under the path cover key', async () => {
+    await seedCompletedCourse();
+
+    await renderAndResetPath();
+
+    await expect(milestoneCompletionStorage.getCompleted(PATH_KEY)).resolves.toEqual(new Set());
+  });
+
+  it('clears the journey completion percentage stored under the path cover key', async () => {
+    await seedCompletedCourse();
+
+    await renderAndResetPath();
+
+    await expect(journeyCompletionStorage.get(PATH_KEY)).resolves.toBe(0);
+  });
+
+  it('also clears the bundled cover key, for a bundled path that carries no url', async () => {
+    const bundledKey = `bundled:${PATH_ID}`;
+    await milestoneCompletionStorage.markCompleted(bundledKey, GUIDES[0]!);
+    await journeyCompletionStorage.set(bundledKey, 100);
+
+    await renderAndResetPath();
+
+    await expect(milestoneCompletionStorage.getCompleted(bundledKey)).resolves.toEqual(new Set());
+    await expect(journeyCompletionStorage.get(bundledKey)).resolves.toBe(0);
+  });
+
+  it('leaves one completed guide short of the whole-course threshold after a reset', async () => {
+    await seedCompletedCourse();
+
+    await renderAndResetPath();
+
+    __resetRecorderForTests();
+    const facts: CompletionFact[] = [];
+    const unsubscribe = onCompletionRecorded((fact) => facts.push(fact));
+
+    await markMilestoneDone(PATH_KEY, GUIDES[0]!, GUIDES.length, {
+      packageManifest: { id: PATH_ID, repository: 'app-platform' },
+    });
+    unsubscribe();
+
+    await expect(milestoneCompletionStorage.getCompleted(PATH_KEY)).resolves.toEqual(new Set([GUIDES[0]]));
+    expect(facts.filter((fact) => fact.kind === 'journey')).toEqual([]);
+  });
+});

--- a/src/learning-paths/reset-path-completion.test.ts
+++ b/src/learning-paths/reset-path-completion.test.ts
@@ -1,12 +1,3 @@
-/**
- * `resetPath` against the REAL storage modules (#1560).
- *
- * `learning-paths.hook.test.ts` mocks `../lib/user-storage` wholesale, so it
- * cannot see which storage keys a reset actually touches — and the bug was
- * exactly that: an App Platform path (no `url`, so it takes the second branch)
- * had its members cleared but never its own cover key, leaving the
- * "all milestones done" checklist behind for the next completion to re-cross.
- */
 import { act, renderHook, waitFor } from '@testing-library/react';
 
 jest.mock('@grafana/runtime', () => ({
@@ -24,9 +15,22 @@ jest.mock('./fetch-path-guides', () => ({
   fetchPathGuides: jest.fn().mockResolvedValue(null),
 }));
 
+const mockBundledPaths: { current: unknown[] } = { current: [] };
 jest.mock('./paths-data', () => ({
-  getPathsData: () => ({ paths: [], guideMetadata: {} }),
+  getPathsData: () => ({ paths: mockBundledPaths.current, guideMetadata: {} }),
 }));
+
+const mockEvictContentCache = jest.fn();
+jest.mock('../global-state/completion-store', () => {
+  const actual = jest.requireActual('../global-state/completion-store');
+  return {
+    ...actual,
+    evictContentCache: (contentKey: string) => {
+      mockEvictContentCache(contentKey);
+      return actual.evictContentCache(contentKey);
+    },
+  };
+});
 
 jest.mock('../lib/analytics', () => ({
   reportAppInteraction: jest.fn(),
@@ -35,12 +39,20 @@ jest.mock('../lib/analytics', () => ({
 
 import { __resetRecorderForTests, onCompletionRecorded, type CompletionFact } from '../completion-records';
 import { markMilestoneDone } from '../docs-retrieval';
-import { journeyCompletionStorage, milestoneCompletionStorage } from '../lib/user-storage';
+import {
+  interactiveCompletionStorage,
+  interactiveStepStorage,
+  journeyCompletionStorage,
+  milestoneCompletionStorage,
+} from '../lib/user-storage';
 import { useLearningPaths } from './learning-paths.hook';
 
 const PATH_ID = 'fe-alerting-path';
 const PATH_KEY = `backend-guide:${PATH_ID}`;
+const BUNDLED_PATH_KEY = `bundled:${PATH_ID}`;
 const GUIDES = ['fe-alerting-01', 'fe-alerting-02', 'fe-alerting-03'];
+const MEMBER_KEYS = GUIDES.flatMap((id) => [`bundled:${id}`, `backend-guide:${id}`]);
+const SENTINEL_KEY = 'backend-guide:unrelated-guide';
 
 async function seedCompletedCourse(): Promise<void> {
   for (const guideId of GUIDES) {
@@ -49,11 +61,11 @@ async function seedCompletedCourse(): Promise<void> {
   await journeyCompletionStorage.set(PATH_KEY, 100);
 }
 
-async function renderAndResetPath(): Promise<void> {
+async function renderAndResetPath(pathId: string = PATH_ID): Promise<void> {
   const { result, unmount } = renderHook(() => useLearningPaths());
-  await waitFor(() => expect(result.current.paths.map((p) => p.id)).toContain(PATH_ID));
+  await waitFor(() => expect(result.current.paths.map((p) => p.id)).toContain(pathId));
   await act(async () => {
-    await result.current.resetPath(PATH_ID);
+    await result.current.resetPath(pathId);
   });
   unmount();
 }
@@ -62,6 +74,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   localStorage.clear();
   __resetRecorderForTests();
+  mockBundledPaths.current = [];
   mockFetchAppPlatformLearningPaths.mockResolvedValue({
     paths: [
       {
@@ -123,5 +136,80 @@ describe('resetPath — App Platform path (no url)', () => {
 
     await expect(milestoneCompletionStorage.getCompleted(PATH_KEY)).resolves.toEqual(new Set([GUIDES[0]]));
     expect(facts.filter((fact) => fact.kind === 'journey')).toEqual([]);
+  });
+
+  it('clears every member key in one pass, without restoring siblings, and spares unrelated content', async () => {
+    for (const key of [...MEMBER_KEYS, SENTINEL_KEY]) {
+      await journeyCompletionStorage.set(key, 100);
+      await interactiveCompletionStorage.set(key, 100);
+    }
+
+    await renderAndResetPath();
+
+    const [journeys, interactives] = await Promise.all([
+      journeyCompletionStorage.getAll(),
+      interactiveCompletionStorage.getAll(),
+    ]);
+    expect(MEMBER_KEYS.filter((key) => key in journeys)).toEqual([]);
+    expect(MEMBER_KEYS.filter((key) => key in interactives)).toEqual([]);
+    expect(journeys[SENTINEL_KEY]).toBe(100);
+    expect(interactives[SENTINEL_KEY]).toBe(100);
+  });
+
+  it('clears interactive progress recorded against the path cover itself', async () => {
+    for (const pathKey of [PATH_KEY, BUNDLED_PATH_KEY]) {
+      await interactiveStepStorage.setCompleted(pathKey, 'cover-section', new Set(['step-1', 'step-2']));
+      await interactiveCompletionStorage.set(pathKey, 100);
+      interactiveStepStorage.countAllCompleted(pathKey);
+    }
+
+    await renderAndResetPath();
+
+    for (const pathKey of [PATH_KEY, BUNDLED_PATH_KEY]) {
+      await expect(interactiveStepStorage.getCompleted(pathKey, 'cover-section')).resolves.toEqual(new Set());
+      await expect(interactiveCompletionStorage.get(pathKey)).resolves.toBe(0);
+      expect(interactiveStepStorage.countAllCompleted(pathKey)).toBe(0);
+      expect(mockEvictContentCache).toHaveBeenCalledWith(pathKey);
+    }
+  });
+});
+
+describe('resetPath — URL-based journey path', () => {
+  const URL_PATH_ID = 'alerting-journey';
+  const PATH_URL = 'https://grafana.com/docs/learning-journeys/alerting/';
+  const MILESTONE_SLUGS = ['collect-logs', 'define-rules', 'route-alerts'];
+  const MILESTONE_URLS = MILESTONE_SLUGS.map((slug) => `${PATH_URL}${slug}/`);
+  const OTHER_JOURNEY_KEY = 'https://grafana.com/docs/learning-journeys/dashboards/';
+
+  beforeEach(() => {
+    mockBundledPaths.current = [
+      {
+        id: URL_PATH_ID,
+        title: 'Alerting journey',
+        description: '',
+        guides: MILESTONE_SLUGS,
+        badgeId: '',
+        url: PATH_URL,
+      },
+    ];
+  });
+
+  it('clears every milestone key in one pass, without restoring siblings, and spares other journeys', async () => {
+    for (const url of [...MILESTONE_URLS, OTHER_JOURNEY_KEY]) {
+      await interactiveCompletionStorage.set(url, 100);
+      await journeyCompletionStorage.set(url, 100);
+    }
+    await journeyCompletionStorage.set(PATH_URL, 100);
+
+    await renderAndResetPath(URL_PATH_ID);
+
+    const [journeys, interactives] = await Promise.all([
+      journeyCompletionStorage.getAll(),
+      interactiveCompletionStorage.getAll(),
+    ]);
+    expect([PATH_URL, ...MILESTONE_URLS].filter((url) => url in journeys)).toEqual([]);
+    expect(MILESTONE_URLS.filter((url) => url in interactives)).toEqual([]);
+    expect(journeys[OTHER_JOURNEY_KEY]).toBe(100);
+    expect(interactives[OTHER_JOURNEY_KEY]).toBe(100);
   });
 });

--- a/src/lib/storage/bounded-record-storage.test.ts
+++ b/src/lib/storage/bounded-record-storage.test.ts
@@ -51,6 +51,17 @@ describe('createBoundedRecordStorage', () => {
     expect(await store.get('b')).toBe(75);
   });
 
+  it('clearMany() removes every listed entry in one write, leaving the rest', async () => {
+    const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
+    await store.set('a', 25);
+    await store.set('b', 75);
+    await store.set('keep', 50);
+
+    await store.clearMany(['a', 'b', 'never-stored']);
+
+    expect(await store.getAll()).toEqual({ keep: 50 });
+  });
+
   it('getAll() returns the full record', async () => {
     const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
     await store.set('a', 10);

--- a/src/lib/storage/bounded-record-storage.ts
+++ b/src/lib/storage/bounded-record-storage.ts
@@ -6,6 +6,8 @@ export interface BoundedRecordStorage {
   /** Clamps `percentage` to `[0, 100]`, trims down to `limit` entries on overflow, and retries once after `cleanup()` on quota errors. */
   set(key: string, percentage: number): Promise<void>;
   clear(key: string): Promise<void>;
+  /** Deletes every key in one read-modify-write. Concurrent `clear` calls share one record, so each write restores the keys its siblings deleted. */
+  clearMany(keys: string[]): Promise<void>;
   getAll(): Promise<Record<string, number>>;
   /** Trims the record down to `limit` entries (most recent kept). No-op when already within budget. */
   cleanup(): Promise<void>;
@@ -83,6 +85,19 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
         const storage = createStorage();
         const data = (await storage.getItem<Record<string, number>>(storageKey)) || {};
         delete data[key];
+        await storage.setItem(storageKey, data);
+      } catch (error) {
+        logger.warn(`Failed to clear ${label}`, { error });
+      }
+    },
+
+    async clearMany(keys: string[]): Promise<void> {
+      try {
+        const storage = createStorage();
+        const data = (await storage.getItem<Record<string, number>>(storageKey)) || {};
+        for (const key of keys) {
+          delete data[key];
+        }
         await storage.setItem(storageKey, data);
       } catch (error) {
         logger.warn(`Failed to clear ${label}`, { error });

--- a/src/lib/user-storage.test.ts
+++ b/src/lib/user-storage.test.ts
@@ -174,6 +174,17 @@ describe('milestoneCompletionStorage', () => {
     await expect(milestoneCompletionStorage.getCompleted(journeyUrl)).resolves.toEqual(new Set());
     expect(JSON.parse(localStorage.getItem(StorageKeys.MILESTONE_COMPLETION) ?? '{}')).toEqual({});
   });
+
+  it('clearAll drops every journey', async () => {
+    await milestoneCompletionStorage.markCompleted(journeyUrl, 'install-alloy');
+    await milestoneCompletionStorage.markCompleted('backend-guide:fe-alerting-path', 'fe-alerting-01');
+
+    await milestoneCompletionStorage.clearAll();
+
+    await expect(milestoneCompletionStorage.getCompleted(journeyUrl)).resolves.toEqual(new Set());
+    await expect(milestoneCompletionStorage.getCompleted('backend-guide:fe-alerting-path')).resolves.toEqual(new Set());
+    expect(localStorage.getItem(StorageKeys.MILESTONE_COMPLETION)).toBeNull();
+  });
 });
 
 // ============================================================================

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -832,6 +832,15 @@ export const milestoneCompletionStorage = {
       logger.warn('Failed to clear milestone completion', { error });
     }
   },
+
+  async clearAll(): Promise<void> {
+    try {
+      const storage = createUserStorage();
+      await storage.removeItem(StorageKeys.MILESTONE_COMPLETION);
+    } catch (error) {
+      logger.warn('Failed to clear all milestone completion', { error });
+    }
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary

`resetPath` never cleared the path's own completion keys for paths that carry no `url` — the branch App Platform courses always take. Resetting a completed course cleared the visible state but left the "all milestones done" checklist behind, so the next single guide completion re-crossed the whole-course threshold and the app re-declared the course complete. Nothing in the product could clear that record.

Review then surfaced two more defects in the same reset flow, both reproduced: member completion records were being lost to a read-modify-write race, and a path's own key can hold interactive progress that reset ignored. Both are fixed here.

This clears the path-level milestone checklist, journey percentage and interactive progress; batches every bounded-record delete so none are lost; and adds a backfill so users already in the bad state can get out.

Fixes #1560
Closes #1590

## What to look at

- **`src/lib/storage/bounded-record-storage.ts` — new `clearMany(keys)`.** Every entry in one of these stores lives under a single storage key, so `clear(key)` is a whole-record read-delete-write. Firing N of those concurrently means they all read the same snapshot and the last write restores what its siblings deleted. `clearMany` does one read, N deletes, one write, with the same error handling as `clear`.
- **`src/learning-paths/learning-paths.hook.ts`** — both branches of `resetPath` now route their bounded-record deletes through `clearMany`:
  - the no-`url` branch clears the path's own key under both `backend-guide:<pathId>` and `bundled:<pathId>` — milestone checklist, journey percentage, interactive completion and interactive step state — alongside the member keys it already handled;
  - the `url` branch collects its milestone and journey keys first and issues one batched delete per record, replacing the per-key concurrent clears that had the same race.
- `src/lib/user-storage.ts` — new `milestoneCompletionStorage.clearAll()`, following the existing `clearAll` pattern on the other storage helpers.
- `src/components/LearningPaths/MyLearningTab.tsx` — "Reset all learning progress" now calls it. That surface previously never touched milestone records at all.
- `src/learning-paths/reset-path-completion.test.ts` and `src/lib/storage/bounded-record-storage.test.ts` — new, and deliberately using the **real** storage modules.

Scope note: the two branches are still not unified. Both now share `clearMany`, but their key-discovery differs — the `url` branch recovers milestone keys by prefix scan, the other derives them from `path.guides` — and collapsing that is a refactor this PR isn't.

## Why

App Platform paths are built from the backend catalogue with no `url` (`src/learning-paths/app-platform-paths.ts`), so they always fall into the second branch of `resetPath`. Path-level data is nonetheless written under `backend-guide:<pathId>` — by the resolver's `contentUrl`, by `markMilestoneDone`, and by the journey percentage write in `docs-panel.tsx`. The branch only ever iterated `path.guides`, so it cleared members and left the cover key untouched, and it never called `milestoneCompletionStorage` at all.

Two corrections from review, both worth recording because the original scope cuts were wrong:

- **Interactive state under the path key is not hypothetical.** `CustomGuidesSection` opens a path directly as `backend-guide:<pathId>`, and `AppPlatformPackageResolver` renders that resource's `spec.blocks` under the same content key. Nothing in the schema forbids interactive blocks on a path cover, and an interactive step seeded at 100% under that key survived a reset. If interactive path covers are meant to be impossible, that belongs in schema validation rather than being assumed here.
- **The member-clear race was real and reproducible.** Seeding six member journey keys for a three-guide path and running `resetPath` left five behind, because the surrounding `Promise.all` issued one whole-record rewrite per key. The same shape existed in the `url` branch, tracked as #1590 and fixed here rather than deferred — shipping a reset that clears its cover key but still loses most member deletions would have been worse than either state alone.

`resetPath` had zero direct coverage. The existing `learning-paths.hook.test.ts` mocks the whole storage module — including `milestoneCompletionStorage: { clear: jest.fn() }` — so it structurally cannot observe which keys a reset touches, and a mocked `clear` races with nothing. The new files are modelled on `src/lib/user-storage.test.ts` and assert against real storage.

The backfill exists because the bad record is already on disk for affected users and no product button reached it.

## How to verify

```
npm run test:ci
```

Seven `resetPath` cases plus the `clearMany` unit tests. Each was checked by breaking the behaviour it covers and confirming failure:

- reverting the hook change fails the four cover-key cases;
- restoring the old `Promise.all(map(clear))` in either branch fails the two "in one pass, without restoring siblings" cases — the race reproduces on demand;
- excluding cover keys from the interactive clears fails the cover-progress case in isolation.

Each race test seeds an unrelated sentinel key and asserts it survives, so a fix that over-deletes fails too.

Manually: complete every guide in an App Platform course, reset it from My Learning, then complete one guide. The course should read as 1-of-N, not complete.

## Breaking changes

None. Reset now deletes additional storage keys for the path's own cover — milestone, journey and interactive state — and the global reset deletes milestone records it previously left behind. Both are the intended semantics of "reset". `clearMany` is additive; no existing caller changes behaviour.

## Reversibility

Fully reversible; revert the commit. No schema, no migration, no server-side state. The only irreversible effect is per-user and intended: records deleted by a reset are gone, which is what the button says it does.

## Ordering

This should land before #1433/#1434. Today the surviving record is local only; once those land, the same stale threshold gets written to the server as a durable completion record.

Also for #1434, not handled here: a reset does not currently discard writes already sitting in the durable completion-write queue. `src/completion-records/` is untouched by this PR.