### PR TITLE
test: close the App Platform coverage gaps from the #1408 second-round review

### DIFF
--- a/pkg/plugin/app_platform_client_test.go
+++ b/pkg/plugin/app_platform_client_test.go
@@ -230,4 +230,12 @@ func TestAggregationToggleMatchesGroup(t *testing.T) {
 	if customGuideAggregationToggle == pathfinderBackendAggregationToggle {
 		t.Error("custom-guide and completion-records must gate on distinct aggregation toggles")
 	}
+
+	// The cases above derive the expected toggle FROM the Go group constants, so
+	// editing a group would move both sides together and stay green while the TS
+	// literal (APP_PLATFORM_API_VERSION, src/utils/interactive-guides-api.ts)
+	// kept pinning the old group. Pin the Go side to the same literal.
+	if customGuideGroupVersion != "pathfinderbackend.ext.grafana.app/v1alpha1" {
+		t.Errorf("customGuideGroupVersion = %q, but src/utils/interactive-guides-api.ts pins pathfinderbackend.ext.grafana.app/v1alpha1", customGuideGroupVersion)
+	}
 }

--- a/pkg/plugin/completion_records_test.go
+++ b/pkg/plugin/completion_records_test.go
@@ -712,6 +712,27 @@ func TestMyCompletions_NoAppURLStructurallyUnavailable(t *testing.T) {
 	}
 }
 
+// An unprovisioned stack has no way to authenticate as the caller upstream, so
+// the read route reports itself unavailable rather than attempting a call that
+// can only 401. No lister override here: that override short-circuits ahead of
+// the exchanger gate, so this is the real resolve path.
+func TestMyCompletions_NoOBOCredentialsStructurallyUnavailable(t *testing.T) {
+	withFrozenTime(t, time.Unix(1_700_000_000, 0))
+	resetCompletionRecordsCache()
+	t.Cleanup(resetCompletionRecordsCache)
+
+	rr, body := doMyCompletionsReq(t, completionRequest(t, "/completion-records/my", "user:1"))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if body.Capability.Available || body.Capability.Reason != reasonOBOUnavailable {
+		t.Fatalf("expected capability=false %q without provisioned credentials, got %+v", reasonOBOUnavailable, body.Capability)
+	}
+	if len(body.Completions) != 0 {
+		t.Errorf("expected no completions, got %d", len(body.Completions))
+	}
+}
+
 // --- Capability probe --------------------------------------------------------
 
 func doCapability(t *testing.T, sub string) (*httptest.ResponseRecorder, completionCapability) {

--- a/src/learning-paths/learning-paths.completion-round-trip.test.ts
+++ b/src/learning-paths/learning-paths.completion-round-trip.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Write → read round-trip for App Platform path progress.
+ *
+ * The completion write (`markMilestoneDone`, docs-retrieval) and the progress
+ * read (`getPathProgress` → the module-private `calculatePathProgress`) agree
+ * only if both key on the bare package id. Every other test on either side
+ * mocks the other away, so the two could drift apart — a member recorded under
+ * `backend-guide:fe-alerting-01` would leave My Learning stuck at 0%.
+ *
+ * Storage is real here and backed by localStorage; only `@grafana/runtime` is
+ * mocked, so the catalogue fetch, path synthesis, badge coordinator and
+ * progress storage all run for real.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+
+const mockGet = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  config: {
+    namespace: 'stacks-123',
+    featureToggles: { 'aggregation.pathfinderbackend-ext-grafana-app.enabled': true },
+  },
+  getBackendSrv: () => ({ get: mockGet }),
+  usePluginUserStorage: jest.fn(),
+  getAppEvents: jest.fn(() => ({ publish: jest.fn() })),
+  reportInteraction: jest.fn(),
+}));
+
+import { markMilestoneDone, getMilestoneSlug } from '../docs-retrieval/learning-journey-helpers';
+import { invalidateCustomGuideRepositoryCache } from '../lib/custom-guide-repository-client';
+import { StorageKeys } from '../lib/storage-keys';
+import { useLearningPaths } from './learning-paths.hook';
+
+const EMPTY_PROGRESS = {
+  completedGuides: [],
+  earnedBadges: [],
+  streakDays: 0,
+  lastActivityDate: '',
+  pendingCelebrations: [],
+};
+
+const PATH_ID = 'fe-alerting-path';
+const MEMBERS = ['fe-alerting-01', 'fe-alerting-02'];
+const PATH_LAUNCH_URL = `backend-guide:${PATH_ID}`;
+
+const catalogue = {
+  capability: { available: true },
+  guides: [
+    {
+      id: PATH_ID,
+      title: 'Alerting enablement',
+      status: 'published',
+      manifest: { type: 'path', description: 'Two private guides', milestones: MEMBERS },
+    },
+    { id: MEMBERS[0], title: 'Alerting module 1', status: 'published', manifest: { type: 'guide' } },
+    { id: MEMBERS[1], title: 'Alerting module 2', status: 'published', manifest: { type: 'guide' } },
+  ],
+};
+
+async function renderPaths() {
+  const { result } = renderHook(() => useLearningPaths());
+  await waitFor(() => {
+    expect(result.current.paths.some((p) => p.id === PATH_ID)).toBe(true);
+  });
+  return result;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+  // Seed an explicit empty record: on a storage miss learningProgressStorage.get
+  // hands back a shared module-level default that the badge coordinator mutates
+  // in place, so completions would leak between cases.
+  localStorage.setItem(StorageKeys.LEARNING_PROGRESS, JSON.stringify(EMPTY_PROGRESS));
+  invalidateCustomGuideRepositoryCache();
+  mockGet.mockResolvedValue(catalogue);
+});
+
+describe('App Platform path progress — completion write → getPathProgress read', () => {
+  it('reports 0% before anything is completed', async () => {
+    const result = await renderPaths();
+    expect(result.current.getPathProgress(PATH_ID)).toBe(0);
+  });
+
+  it('reports 100% after both members are completed through the real write path', async () => {
+    for (const member of MEMBERS) {
+      await markMilestoneDone(PATH_LAUNCH_URL, getMilestoneSlug(`backend-guide:${member}`));
+    }
+
+    const result = await renderPaths();
+
+    await waitFor(() => {
+      expect(result.current.getPathProgress(PATH_ID)).toBe(100);
+    });
+    expect(result.current.isPathCompleted(PATH_ID)).toBe(true);
+  });
+
+  it('reports 50% when only one of the two members is completed', async () => {
+    await markMilestoneDone(PATH_LAUNCH_URL, getMilestoneSlug(`backend-guide:${MEMBERS[0]}`));
+
+    const result = await renderPaths();
+
+    await waitFor(() => {
+      expect(result.current.getPathProgress(PATH_ID)).toBe(50);
+    });
+    expect(result.current.isPathCompleted(PATH_ID)).toBe(false);
+  });
+
+  it('marks the completed member — and only that member — through getPathGuides', async () => {
+    await markMilestoneDone(PATH_LAUNCH_URL, getMilestoneSlug(`backend-guide:${MEMBERS[1]}`));
+
+    const result = await renderPaths();
+
+    await waitFor(() => {
+      expect(result.current.getPathGuides(PATH_ID).map((g) => g.completed)).toEqual([false, true]);
+    });
+  });
+});

--- a/src/package-engine/app-platform-resolver.test.ts
+++ b/src/package-engine/app-platform-resolver.test.ts
@@ -59,6 +59,9 @@ describe('AppPlatformPackageResolver — no loadContent', () => {
 
     expect(result.ok).toBe(false);
     expect(mockFetch).not.toHaveBeenCalled();
+    // Untagged: composite-resolver.ts keys cache eviction on `repository`, so a
+    // tag here would repeal negative caching for every tier.
+    expect(result.repository).toBeUndefined();
   });
 
   it('declines (not-found) when the GAP aggregation toggle is off', async () => {
@@ -72,6 +75,7 @@ describe('AppPlatformPackageResolver — no loadContent', () => {
     }
     expect(result.error.code).toBe('not-found');
     expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.repository).toBeUndefined();
   });
 });
 
@@ -202,6 +206,21 @@ describe('AppPlatformPackageResolver — full content', () => {
       return;
     }
     expect(result.manifest?.id).toBe('fe-alerting-01');
+  });
+
+  it('overwrites a persisted spec.manifest.repository pointing at the public CDN', async () => {
+    mockFetch.mockReturnValue(of(okResource({ manifest: { type: 'guide', repository: 'interactive-tutorials' } })));
+    const resolver = new AppPlatformPackageResolver();
+
+    const result = await resolver.resolve('fe-alerting-01', { loadContent: 'metadata-only' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    // `repository` is the sole input to the durable completion key (guideSource),
+    // so a stale CDN value would mislabel a private guide's provenance.
+    expect(result.manifest?.repository).toBe('app-platform');
   });
 
   it('tags failures with the app-platform repository so the composite resolver can skip caching them', async () => {


### PR DESCRIPTION
## Summary

Additive, test-only coverage for the App Platform gaps flagged in the #1408 second-round review (#1566). No production code changes.

- **Completion-records read path.** `resolveCompletionBackend`'s nil-exchanger gate (`pkg/plugin/completion_records.go`) reported `obo-unavailable` with nothing asserting it. New `TestMyCompletions_NoOBOCredentialsStructurallyUnavailable` mirrors the custom-guide twin. Distinct from the write resolver (`resolveCompletionWriteBackend`) covered by the open PR #1433, so expect a trivial rebase.
- **Cheap declines stay untagged.** The two pre-network declines in `app-platform-resolver.ts` now assert `result.repository` is absent. That absence is load-bearing: `composite-resolver.ts` uses `result.repository` as the sole trigger for cache eviction, so tagging a cheap decline would repeal negative caching for every tier.
- **`buildManifest` repository forcing.** Every existing case already passed the correct `'app-platform'`, so deleting the force broke nothing. Added a case feeding `'interactive-tutorials'` (the schema's public-CDN default) and asserting the forced value wins.
- **Go group-version pin.** `TestAggregationToggleMatchesGroup` derives the expected toggle *from* `customGuideGroupVersion`, so editing the Go group would move both sides together and stay green while TypeScript kept pinning its own literal. One literal assertion closes that.
- **Completion write to read round-trip.** New suite exercising the real localStorage-backed storage layer: completing the members of a synthesized App Platform path through `markMilestoneDone` must read back through `getPathProgress`.

## What to look at

- `src/learning-paths/learning-paths.completion-round-trip.test.ts` — the only new file. It mocks `@grafana/runtime` and nothing else, so the catalogue fetch, path synthesis, badge coordinator and progress storage all run for real. The existing `learning-paths.hook.test.ts` is untouched: it documents itself as a deliberately narrow App-Platform-ingestion suite and stubs storage away on purpose.
- The `beforeEach` in that file seeds an explicit empty progress record rather than relying on an empty `localStorage`. On a storage miss `learningProgressStorage.get()` hands back a shared module-level `DEFAULT_PROGRESS` object that `badge-coordinator.markGuideCompleted` mutates in place via `push`, so completions leak between cases. Benign in production (the miss happens once per session) but worth a look — it is a latent shared-mutable-default, and out of scope for a test-only PR.

## Why

Each of these guards an already-correct behaviour whose silent regression would be invisible to the current suite. The round-trip is the highest value: the write side (`getMilestoneSlug` stripping the `backend-guide:` scheme) and the read side (`calculatePathProgress` matching bare ids in `LearningPath.guides`) are only coupled by convention, and every test on either side mocked the other away. If they drift, My Learning silently reports 0% for private paths.

## How to verify

```
go test ./pkg/...
npx jest src/package-engine/app-platform-resolver.test.ts src/learning-paths/learning-paths.completion-round-trip.test.ts --coverage=false
npm run typecheck && npm run lint:go
```

Every new assertion was checked to discriminate — the covered behaviour was removed, the failure observed, and the code restored:

| Test | Break applied | Result |
| --- | --- | --- |
| `TestMyCompletions_NoOBOCredentialsStructurallyUnavailable` | removed the `a.oboExchanger == nil` gate | fails (nil-pointer panic on the doomed upstream call) |
| `TestAggregationToggleMatchesGroup` (new pin) | `customGuideGroupVersion` → `.../v1beta1` | fails on the pin only; the derived-toggle cases stay green, which is exactly the drift the pin exists for |
| both untagged-decline assertions | made `decline()` tag `repository` | 2 failures |
| repository-forcing case | dropped `repository` from the forced overwrite | fails, received `interactive-tutorials` |
| round-trip suite | removed the `backend-guide:` strip in `getMilestoneSlug` | 3 of 4 fail |
| round-trip suite | broke `calculatePathProgress`'s completed count | the 100% case fails |

Full suite: 418 suites / 6638 tests passing.

## Breaking changes

None. Tests only.

## Reversibility

Fully reversible — revert the commit. Nothing outside test files changes.

## Note on the issue

Refs #1566, deliberately not `Fixes`. **Item 4 was rescoped.** The issue asks for two toggle-name tests that already exist: the Go comment naming the TypeScript counterpart (`pkg/plugin/app_platform_client_test.go`, present since #1408) and the TypeScript literal assertion (`src/utils/interactive-guides-api.test.ts`, from #1430). Neither was re-added. The one real gap — the Go side deriving its expectation from its own constant — is closed here. Please review the issue before closing it.
