### PR TITLE
fix: small correctness/hardening follow-ups from #1408 (items 1, 2, 5)

### DIFF
--- a/src/learning-paths/app-platform-paths.test.ts
+++ b/src/learning-paths/app-platform-paths.test.ts
@@ -97,6 +97,45 @@ describe('fetchAppPlatformLearningPaths', () => {
     expect(result.guideMetadata['draft-guide']).toBeUndefined();
   });
 
+  // Milestone ids are CR-authored. An inherited built-in name must not pass the
+  // published-member gate: it would render untitled and, because it can never
+  // complete, pin the path's progress denominator below 100%.
+  it.each(['constructor', 'toString', 'hasOwnProperty', '__proto__', 'valueOf'])(
+    'drops the milestone id %s, which has no published guide behind it',
+    async (hostileId) => {
+      mockFetchCustomGuideRepository.mockResolvedValue([
+        {
+          id: 'fe-alerting-path',
+          title: 'Alerting enablement',
+          status: 'published',
+          manifest: { type: 'path', milestones: [hostileId, 'fe-alerting-01'] },
+        },
+        { id: 'fe-alerting-01', title: 'Alerting module 1', status: 'published' },
+      ]);
+
+      const result = await fetchAppPlatformLearningPaths('stacks-123');
+
+      expect(result.paths[0]!.guides).toEqual(['fe-alerting-01']);
+      expect(result.guideMetadata[hostileId]).toBeUndefined();
+    }
+  );
+
+  it('records an entry id of __proto__ as an own metadata key instead of swapping the prototype', async () => {
+    mockFetchCustomGuideRepository.mockResolvedValue([
+      { id: '__proto__', title: 'Hostile', status: 'published' },
+      { id: 'fe-alerting-01', title: 'Alerting module 1', status: 'published' },
+    ]);
+
+    const result = await fetchAppPlatformLearningPaths('stacks-123');
+
+    expect(Object.hasOwn(result.guideMetadata, '__proto__')).toBe(true);
+    expect(result.guideMetadata['fe-alerting-01']).toEqual({
+      title: 'Alerting module 1',
+      estimatedMinutes: 5,
+      url: 'backend-guide:fe-alerting-01',
+    });
+  });
+
   it('falls back to id when a path manifest has no description', async () => {
     mockFetchCustomGuideRepository.mockResolvedValue([
       {

--- a/src/learning-paths/app-platform-paths.ts
+++ b/src/learning-paths/app-platform-paths.ts
@@ -27,7 +27,7 @@ export interface AppPlatformPathsResult {
   guideMetadata: Record<string, GuideMetadataEntry>;
 }
 
-const EMPTY_RESULT: AppPlatformPathsResult = { paths: [], guideMetadata: {} };
+const EMPTY_RESULT: AppPlatformPathsResult = { paths: [], guideMetadata: Object.create(null) };
 
 /**
  * Fetches the namespace's custom-guide catalogue and splits it into
@@ -47,7 +47,9 @@ export async function fetchAppPlatformLearningPaths(namespace: string): Promise<
     return EMPTY_RESULT;
   }
 
-  const guideMetadata: Record<string, GuideMetadataEntry> = {};
+  // Null-prototype: ids are CR-authored, so `constructor`/`toString`/`__proto__`
+  // must not resolve through Object.prototype in the membership gate below.
+  const guideMetadata: Record<string, GuideMetadataEntry> = Object.create(null);
   for (const entry of published) {
     guideMetadata[entry.id] = {
       title: entry.title || entry.id,
@@ -69,7 +71,7 @@ export async function fetchAppPlatformLearningPaths(namespace: string): Promise<
       // in a published path's manifest must not leak into My Learning (it has no
       // guideMetadata entry, so it would render titled by its raw id and inflate
       // the denominator). Matches the resolver's published-only gate.
-      guides: (entry.manifest?.milestones ?? []).filter((id) => id in guideMetadata),
+      guides: (entry.manifest?.milestones ?? []).filter((id) => Object.hasOwn(guideMetadata, id)),
       badgeId: '',
       // Carried so the My Learning launch can render members with milestone
       // chrome (packageInfo) rather than as standalone guides.

--- a/src/learning-paths/fetch-path-guides.test.ts
+++ b/src/learning-paths/fetch-path-guides.test.ts
@@ -134,6 +134,22 @@ describe('fetchPathGuides', () => {
     );
   });
 
+  // resolveGuideMetadata looks this map up by arbitrary guide id, so an id that
+  // happens to name an Object.prototype member must miss, not hand back a function.
+  it.each(['constructor', 'toString', 'hasOwnProperty'])(
+    'resolves no metadata for the inherited name %s',
+    async (inheritedName) => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => SAMPLE_INDEX_JSON,
+      });
+
+      const result = await fetchPathGuides('https://grafana.com/docs/learning-paths/linux-server-integration/');
+
+      expect(result!.guideMetadata[inheritedName]).toBeUndefined();
+    }
+  );
+
   it('returns null on fetch failure', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,

--- a/src/learning-paths/fetch-path-guides.ts
+++ b/src/learning-paths/fetch-path-guides.ts
@@ -72,7 +72,10 @@ export async function fetchPathGuides(pathUrl: string, signal?: AbortSignal): Pr
     const validItems = data.filter((item) => !item.params?.grafana?.skip);
 
     const guides: string[] = [];
-    const guideMetadata: Record<string, GuideMetadataEntry> = {};
+    // Null-prototype: slugs are remote-authored, and consumers look this up by
+    // arbitrary guide id, so `constructor`/`toString` must miss rather than
+    // resolve through Object.prototype.
+    const guideMetadata: Record<string, GuideMetadataEntry> = Object.create(null);
 
     for (const item of validItems) {
       const relpermalink: string = item.relpermalink || '';

--- a/src/learning-paths/learning-paths.hook.test.ts
+++ b/src/learning-paths/learning-paths.hook.test.ts
@@ -114,6 +114,26 @@ describe('useLearningPaths — App Platform path ingestion', () => {
     );
   });
 
+  // The bundled paths.json metadata keeps Object.prototype, and the App Platform
+  // tier is null-prototype, so a member id naming a built-in must fall through to
+  // the id-titled default rather than resolving to Object.prototype.toString.
+  it('titles a member named after an Object.prototype member by its id', async () => {
+    mockFetchAppPlatformLearningPaths.mockResolvedValue({
+      paths: [
+        { id: 'fe-alerting-path', title: 'Alerting enablement', description: '', guides: ['toString'], badgeId: '' },
+      ],
+      guideMetadata: Object.create(null),
+    });
+
+    const { result } = renderHook(() => useLearningPaths());
+
+    await waitFor(() => expect(result.current.paths.map((p) => p.id)).toContain('fe-alerting-path'));
+
+    const [member] = result.current.getPathGuides('fe-alerting-path');
+    expect(member!.title).toBe('toString');
+    expect(member!.url).toBeUndefined();
+  });
+
   it('does not fetch when no namespace is available', async () => {
     mockNamespace = undefined;
 

--- a/src/learning-paths/learning-paths.hook.ts
+++ b/src/learning-paths/learning-paths.hook.ts
@@ -35,7 +35,7 @@ import { fetchPathGuides, type FetchedPathGuides } from './fetch-path-guides';
 import { fetchAppPlatformLearningPaths, type AppPlatformPathsResult } from './app-platform-paths';
 import { markGuideCompleted as coordinatorMarkGuideCompleted } from './badge-coordinator';
 
-const EMPTY_APP_PLATFORM_RESULT: AppPlatformPathsResult = { paths: [], guideMetadata: {} };
+const EMPTY_APP_PLATFORM_RESULT: AppPlatformPathsResult = { paths: [], guideMetadata: Object.create(null) };
 
 // ============================================================================
 // CONSTANTS
@@ -204,7 +204,10 @@ export function useLearningPaths(): UseLearningPathsReturn {
         return appPlatformData.guideMetadata[guideId];
       }
       const { guideMetadata } = getPathsData();
-      return guideMetadata[guideId] || { title: guideId, estimatedMinutes: 5 };
+      // Bundled JSON keeps Object.prototype, so gate on own keys — otherwise a
+      // guide id of `toString` resolves to a function and renders untitled.
+      const staticEntry = Object.hasOwn(guideMetadata, guideId) ? guideMetadata[guideId] : undefined;
+      return staticEntry || { title: guideId, estimatedMinutes: 5 };
     },
     [dynamicGuideData, appPlatformData]
   );

--- a/src/lib/custom-guide-repository-client.test.ts
+++ b/src/lib/custom-guide-repository-client.test.ts
@@ -72,6 +72,35 @@ describe('fetchCustomGuideRepository', () => {
     expect(result[1]!.manifest?.repository).toBe('app-platform');
   });
 
+  // The proxy serializes the stored type verbatim with no validation and no
+  // omitempty, so the wire can carry "" or anything else. Drop it at the
+  // boundary rather than let CustomGuideManifest.type overclaim.
+  it.each(['', 'PATH', 'milestone', 'journey ', 'path\x00'])(
+    'drops the unrecognized manifest type %p',
+    async (wireType) => {
+      mockGet.mockResolvedValue({
+        capability: { available: true },
+        guides: [{ id: 'fe-guide', status: 'published', manifest: { type: wireType, description: 'kept' } }],
+      });
+
+      const result = await fetchCustomGuideRepository('stacks-123');
+
+      expect(result[0]!.manifest?.type).toBeUndefined();
+      expect(result[0]!.manifest?.description).toBe('kept');
+    }
+  );
+
+  it.each(['guide', 'path', 'journey'])('keeps the recognized manifest type %p', async (wireType) => {
+    mockGet.mockResolvedValue({
+      capability: { available: true },
+      guides: [{ id: 'fe-guide', status: 'published', manifest: { type: wireType } }],
+    });
+
+    const result = await fetchCustomGuideRepository('stacks-123');
+
+    expect(result[0]!.manifest?.type).toBe(wireType);
+  });
+
   it('normalizes before caching, so a cached read is stamped too', async () => {
     mockGet.mockResolvedValue({
       capability: { available: true },

--- a/src/lib/custom-guide-repository-client.ts
+++ b/src/lib/custom-guide-repository-client.ts
@@ -16,16 +16,21 @@ import { PLUGIN_BACKEND_URL } from '../constants';
 import { isBackendApiAvailable } from '../utils/fetchBackendGuides';
 import { logger } from './logging';
 import { recordCustomGuideCatalogueUnavailable } from './telemetry/facade';
-import type { Author, DependencyList, PackageType } from '../types/package.types';
+import { PackageTypeSchema } from '../types/package.schema';
+import type { Author, PackageType } from '../types/package.types';
 
+/**
+ * `type` is optional because the Go proxy forwards the stored string verbatim
+ * with no validation and no omitempty — `requestCatalogue` drops anything that
+ * isn't a PackageType rather than let the declaration overclaim the wire.
+ */
 export interface CustomGuideManifest {
-  type: PackageType;
+  type?: PackageType;
   repository?: string;
   description?: string;
   milestones?: string[];
   category?: string;
   author?: Author;
-  depends?: DependencyList;
 }
 
 export interface CustomGuideRepositoryEntry {
@@ -49,9 +54,12 @@ interface CustomGuideCapability {
   reason?: string;
 }
 
+type WireManifest = Omit<CustomGuideManifest, 'type'> & { type?: string };
+type WireEntry = Omit<CustomGuideRepositoryEntry, 'manifest'> & { manifest?: WireManifest };
+
 interface CustomGuideRepositoryResponse {
   capability: CustomGuideCapability;
-  guides: CustomGuideRepositoryEntry[];
+  guides: WireEntry[];
   asOf?: string;
 }
 
@@ -93,6 +101,31 @@ function reportCatalogueFetchFailure(err: unknown): void {
   }
 }
 
+function narrowPackageType(type: string | undefined): PackageType | undefined {
+  const parsed = PackageTypeSchema.safeParse(type);
+  return parsed.success ? parsed.data : undefined;
+}
+
+// Every entry from this proxy is an App Platform package, but the CR manifest
+// leaves `repository` omitempty (and authoring tooling may stamp the CDN
+// default). Force it here — the launch surfaces thread this manifest into
+// packageInfo, and a missing/wrong value fails the `app-platform` gate in
+// package-content.ts (fabricated public websiteUrl) and mislabels the durable
+// completion source (completion-identity.ts guideSource). `type` is narrowed in
+// the same pass: the proxy forwards it unvalidated, so anything that isn't a
+// PackageType becomes undefined, which the `'path'`/`'journey'` comparisons
+// downstream already treat as "not a path".
+function shapeEntry(entry: WireEntry): CustomGuideRepositoryEntry {
+  const { manifest, ...rest } = entry;
+  if (!manifest) {
+    return rest;
+  }
+  return {
+    ...rest,
+    manifest: { ...manifest, type: narrowPackageType(manifest.type), repository: APP_PLATFORM_REPOSITORY },
+  };
+}
+
 async function requestCatalogue(): Promise<CustomGuideRepositoryEntry[]> {
   const response = await getBackendSrv().get<CustomGuideRepositoryResponse>(
     CUSTOM_GUIDE_REPOSITORY_URL,
@@ -111,15 +144,7 @@ async function requestCatalogue(): Promise<CustomGuideRepositoryEntry[]> {
     return [];
   }
   const guides = Array.isArray(response.guides) ? response.guides : [];
-  // Every entry from this proxy is an App Platform package, but the CR manifest
-  // leaves `repository` omitempty (and authoring tooling may stamp the CDN
-  // default). Force it here — the launch surfaces thread this manifest into
-  // packageInfo, and a missing/wrong value fails the `app-platform` gate in
-  // package-content.ts (fabricated public websiteUrl) and mislabels the durable
-  // completion source (completion-identity.ts guideSource).
-  return guides.map((entry) =>
-    entry.manifest ? { ...entry, manifest: { ...entry.manifest, repository: APP_PLATFORM_REPOSITORY } } : entry
-  );
+  return guides.map(shapeEntry);
 }
 
 /**

--- a/src/package-engine/composite-resolver.test.ts
+++ b/src/package-engine/composite-resolver.test.ts
@@ -273,6 +273,22 @@ describe('CompositePackageResolver degradation', () => {
     await expect(composite.resolve('test-guide')).rejects.toThrow('Unexpected resolver crash');
   });
 
+  // Eviction has to land on the first-hop reaction, not on a derived promise:
+  // a caller retrying inside its own rejection handler would otherwise be
+  // handed the still-cached rejected promise and never reach the resolver.
+  it('evicts a rejected resolution before the caller can retry synchronously', async () => {
+    (mockBundledResolver.resolve as jest.Mock)
+      .mockRejectedValueOnce(new Error('Unexpected resolver crash'))
+      .mockResolvedValueOnce(SUCCESS_BUNDLED);
+
+    const composite = new CompositePackageResolver([mockBundledResolver]);
+
+    const retried = await composite.resolve('test-guide').catch(() => composite.resolve('test-guide'));
+
+    expect(retried).toEqual(SUCCESS_BUNDLED);
+    expect(mockBundledResolver.resolve).toHaveBeenCalledTimes(2);
+  });
+
   it('should return network-error code when both resolvers fail with network-error', async () => {
     const bundledNetworkError: PackageResolution = {
       ok: false,

--- a/src/package-engine/composite-resolver.ts
+++ b/src/package-engine/composite-resolver.ts
@@ -51,18 +51,20 @@ export class CompositePackageResolver implements PackageResolver {
     // `repository`; static-tier failures don't, so their negative caching is
     // preserved). Evict right after it settles: truly concurrent callers still
     // share this in-flight promise (dedup preserved), but the next call
-    // re-fetches fresh. The `.catch()` only silences this derived promise — a
-    // thrown/rejected `promise` still propagates normally to whoever awaits the
-    // `resolve()` call itself.
-    promise
-      .then((result) => {
+    // re-fetches fresh. Both handlers go to one `.then`, so each eviction
+    // registers on this promise's own first-hop reaction rather than on a
+    // derived promise a microtask later, and cannot be outrun by a caller
+    // reacting to the same rejection. Handling the rejection here only silences
+    // the derived promise; a rejected `promise` still propagates to whoever
+    // awaits the `resolve()` call itself.
+    promise.then(
+      (result) => {
         if (result.repository && UNCACHEABLE_REPOSITORIES.has(result.repository)) {
           this.cache.delete(cacheKey);
         }
-      })
-      // A rejected resolve() must not linger as a permanently-cached rejected
-      // promise — evict so the next call retries instead of replaying it.
-      .catch(() => this.cache.delete(cacheKey));
+      },
+      () => this.cache.delete(cacheKey)
+    );
 
     return promise;
   }

--- a/src/types/backend-api.schema.ts
+++ b/src/types/backend-api.schema.ts
@@ -84,8 +84,11 @@ export const CustomGuideAuthorWireSchema = z.strictObject({
  * - `type` is `string`, not `PackageType`. Go declares
  *   `Type string \`json:"type"\`` with no `omitempty`, so a manifest with no
  *   type emits `"type": ""` — not a member of `'guide' | 'path' | 'journey'`.
- * - `depends` is an array of arbitrary JSON, not `DependencyList`. Go declares
- *   `Depends []json.RawMessage`, which forwards whatever the CR holds.
+ *   The client narrows it at the boundary, mapping anything else to `undefined`.
+ * - `depends` is an array of arbitrary JSON. Go declares
+ *   `Depends []json.RawMessage`, which forwards whatever the CR holds; the
+ *   client declares no `depends` field, so nothing reads it as a typed
+ *   `DependencyList`.
  *
  * @coupling Go struct: customGuideManifest
  */

--- a/src/validation/backend-api-contract.test.ts
+++ b/src/validation/backend-api-contract.test.ts
@@ -326,9 +326,10 @@ describe('backend API contract: struct tags match the schemas', () => {
 });
 
 // The third hand-mirror (#1408): pkg/plugin/custom_guide_repository_client.go
-// -> src/lib/custom-guide-repository-client.ts. Field names line up, but two
-// Go types are wider than the TypeScript ones they were mirrored as, and Go
-// cannot express the difference. These assertions are the record of that.
+// -> src/lib/custom-guide-repository-client.ts. Field names line up, but two Go
+// types are wider than anything the TypeScript client admits, and Go cannot
+// express the difference. These assertions are the record of that; the client
+// closes the gap at its own boundary, not by narrowing the wire.
 describe('backend API contract: custom-guide manifest is wider than its mirror', () => {
   const golden = VALUE_GOLDENS.find((g) => g.file === 'custom-guide-repository.wire-widened-manifest.json');
 
@@ -346,13 +347,15 @@ describe('backend API contract: custom-guide manifest is wider than its mirror',
   }
 
   // Go: `Type string \`json:"type"\`` with no omitempty, so an untyped manifest
-  // emits "" — which CustomGuideManifest.type: PackageType does not admit.
+  // emits "" — which CustomGuideManifest.type does not admit, so the client
+  // maps it to undefined instead.
   it('emits type "" where PackageType admits only guide | path | journey', () => {
     expect(wireManifest().type).toBe('');
     expect(PackageTypeSchema.safeParse('').success).toBe(false);
   });
 
-  // Go: `Depends []json.RawMessage`, mirrored as the fully-typed DependencyList.
+  // Go: `Depends []json.RawMessage`, forwarding clauses the fully-typed
+  // DependencyList rejects. The client declares no `depends` field at all.
   it('emits depends clauses DependencyList rejects', () => {
     const depends = wireManifest().depends;
     expect(Array.isArray(depends)).toBe(true);


### PR DESCRIPTION
## Summary

Items **1, 2 and 5** of #1565 — three independent low-severity follow-ups from the #1408 second-round review, one commit each.

1. **Prototype-chain leak in the published-member filter.** Guide-metadata lookups are now built with `Object.create(null)` and gated with `Object.hasOwn`, so a milestone id like `constructor` / `toString` / `__proto__` can no longer test as a published member with no guide behind it.
2. **Cache eviction now registers on the resolution's first-hop reaction.** `CompositePackageResolver.resolve` passes both handlers to a single `.then` instead of hanging rejection-eviction off a trailing `.catch` on the derived promise.
3. **`CustomGuideManifest.type` no longer overclaims the wire.** `requestCatalogue()` narrows the unvalidated wire string to a `PackageType` or `undefined` in its existing shaping pass; `depends` (zero readers) is deleted from the interface.

Items **3 and 4 are out of scope here** and are *not* fixed by this PR, despite the `Fixes` line closing the umbrella issue: item 3 (append-only completion numerator) is tracked as **#1586** and needs an API-shape decision; item 4 (journey-progress store vs the completion gate) is tracked as **#1567**.

## What to look at

- `src/learning-paths/app-platform-paths.ts` — the `Object.hasOwn` membership gate and the null-prototype `guideMetadata`. Also converted: `EMPTY_RESULT`, `EMPTY_APP_PLATFORM_RESULT` (`learning-paths.hook.ts`), and the map built in `fetch-path-guides.ts`.
- `src/learning-paths/learning-paths.hook.ts` — the App Platform consumer needed no change (its truthy check is already correct against a null-prototype map, verified by test). One site beyond the issue's list is hardened: the final fallback tier reads bundled `paths.json` metadata, which keeps `Object.prototype`, so a guide id of `toString` resolved to a function and rendered untitled. It is the last hop of the same lookup chain, so it is fixed and tested here rather than left behind.
- `src/package-engine/composite-resolver.ts` — the two-argument `.then`. **Read the commit message**: the accompanying test pins the observable contract (a rejected resolution is evicted, so a retry reaches the resolver again) but does **not** discriminate the two forms. `resolve()` is an `async` method, so its wrapper already interposes a microtask hop and the old derived-promise eviction still landed before any caller's rejection handler. The change is robustness and clarity — it would matter the moment `resolve()` stops being `async` — not a live bug fix, and the misleading "the next call re-fetches fresh" framing in the adjacent comment is corrected.
- `src/lib/custom-guide-repository-client.ts` — `narrowPackageType` plus `shapeEntry`, which now carries the `repository` forcing and the `type` narrowing in one place. The response is typed with `WireManifest` / `WireEntry` so the decode site no longer claims a narrowed `type` it hasn't validated.
- `src/types/backend-api.schema.ts` and `src/validation/backend-api-contract.test.ts` — **comment and doc wording only**. The Go side is deliberately untouched: the #1580 golden fixtures assert the wire is wider than this mirror, so adding validation or `omitempty` in Go would regenerate a golden and break a test that landed on purpose. Assertions, titles, and the committed fixture are unchanged; only prose that would have gone stale (the mirror's `type` is now narrowed at the boundary, and it declares no `depends` field at all) was refreshed.

## Why

Item 1's impact is not merely cosmetic. A phantom member reaches `LearningPath.guides`, which is the progress denominator — `calculatePathProgress` divides by `path.guides.length` — so the member can never complete and the path can never reach 100%. It also renders untitled, since there is no metadata behind the id. An entry id of `__proto__` swapped the local object's prototype (contained; no `Object.prototype` pollution).

Item 2 removes a latent ordering dependency and a comment that promised behaviour the code did not deliver for the retry-in-rejection-handler case.

Item 5 removes a type that lied: the Go proxy serializes the stored manifest type verbatim with no validation and no `omitempty`, so the wire can carry `""` or anything else, while the TS interface declared a required narrowed union. Current readers compare against `'path'` / `'journey'` literals, so behaviour was already safe — this makes the declaration true at the boundary instead of relying on every downstream reader being careful.

## How to verify

```bash
npm run check      # full gate: exits 0
npm run test:ci    # 419 suites, 6684 passed / 18 skipped / 5 todo
go test ./pkg/...  # unchanged, passes
```

Every new test was discrimination-checked by breaking the behaviour it covers and confirming failure:

| Test | Behaviour broken | Result |
| --- | --- | --- |
| 5 hostile milestone ids + `__proto__` entry id (`app-platform-paths.test.ts`) | restore `{}` and `in` | all 6 fail |
| 3 inherited names (`fetch-path-guides.test.ts`) | restore `{}` | all 3 fail |
| id-titled member (`learning-paths.hook.test.ts`) | restore the unguarded fallback read | fails (`title` is `undefined`) |
| reject-once-then-retry (`composite-resolver.test.ts`) | drop rejection eviction entirely | fails |
| reject-once-then-retry | restore the derived-promise `.catch` form | **still passes** — see above; reported as a contract guard, not as coverage of the timing change |
| 5 unrecognized `type` values (`custom-guide-repository-client.test.ts`) | pass the wire string through | all 5 fail |
| 3 recognized `type` values | drop every type | all 3 fail |

## Breaking changes

None at runtime. One type-declaration change: `CustomGuideManifest.type` is now `PackageType | undefined` rather than a required `PackageType`, and `depends` is gone. Both are internal to `src/`; the only reader of `type` compares it against `'path'` / `'journey'`, and `depends` had no readers. The wire contract and the Go structs are unchanged.

## Reversibility

Fully reversible. Three independent commits, revertable individually with no shared state, no migrations, and no persisted-format change.

Fixes #1565
