### PR TITLE
fix(custom-guides): signal a malformed catalogue instead of caching it empty

### DIFF
--- a/src/lib/custom-guide-repository-client.test.ts
+++ b/src/lib/custom-guide-repository-client.test.ts
@@ -150,6 +150,68 @@ describe('fetchCustomGuideRepository', () => {
     expect(result).toEqual([]);
   });
 
+  // An omitted or null `guides` on an available capability is an ordinary empty
+  // catalogue, not drift — Go's json.Marshal of a nil slice emits `null`, so the
+  // proxy sends exactly this for a stack with no guides. Signalling here would
+  // fire on the most common case there is.
+  it.each([
+    { shape: 'omitted', response: { capability: { available: true } } },
+    { shape: 'null', response: { capability: { available: true }, guides: null } },
+  ])('stays silent when guides is $shape', async ({ response }) => {
+    mockGet.mockResolvedValue(response);
+
+    const result = await fetchCustomGuideRepository('stacks-123');
+
+    expect(result).toEqual([]);
+    expect(recordCustomGuideCatalogueUnavailable).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  // A present-but-non-array `guides` cannot be a catalogue under any encoding,
+  // so it is schema drift and must be countable rather than silently empty.
+  it.each([
+    { shape: 'an object', guides: { 'fe-alerting-path': {} } },
+    { shape: 'a string', guides: 'fe-alerting-path' },
+    { shape: 'a number', guides: 3 },
+    { shape: 'a boolean', guides: true },
+  ])('reports malformed-response when guides is $shape', async ({ guides }) => {
+    mockGet.mockResolvedValue({ capability: { available: true }, guides });
+
+    const result = await fetchCustomGuideRepository('stacks-123');
+
+    expect(result).toEqual([]);
+    expect(recordCustomGuideCatalogueUnavailable).toHaveBeenCalledWith('malformed-response');
+    expect(logger.warn).toHaveBeenCalledWith('[custom-guides] catalogue malformed', {
+      reason: 'malformed-response',
+    });
+  });
+
+  it('does not cache a malformed response for the TTL', async () => {
+    mockGet.mockResolvedValueOnce({ capability: { available: true }, guides: { nope: true } });
+
+    await expect(fetchCustomGuideRepository('stacks-123')).resolves.toEqual([]);
+
+    // The backend recovers on the very next call; a cached empty would hide it.
+    mockGet.mockResolvedValueOnce({
+      capability: { available: true },
+      guides: [{ id: 'fe-alerting-path', title: 'Alerting enablement', status: 'published' }],
+    });
+
+    const recovered = await fetchCustomGuideRepository('stacks-123');
+
+    expect(recovered).toHaveLength(1);
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('still caches a legitimately empty catalogue', async () => {
+    mockGet.mockResolvedValue({ capability: { available: true }, guides: [] });
+
+    await fetchCustomGuideRepository('stacks-123');
+    await fetchCustomGuideRepository('stacks-123');
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
   // The reason lands on a Faro event attribute and in the bridged log context,
   // so every rejection shape must collapse to a token from the closed set.
   it.each([

--- a/src/lib/custom-guide-repository-client.ts
+++ b/src/lib/custom-guide-repository-client.ts
@@ -101,6 +101,20 @@ function reportCatalogueFetchFailure(err: unknown): void {
   }
 }
 
+interface CatalogueResult {
+  entries: CustomGuideRepositoryEntry[];
+  cacheable: boolean;
+}
+
+// Bounded token, same closed vocabulary as the reasons above (TELEMETRY.md).
+const MALFORMED_REASON = 'malformed-response';
+
+// `null` is absent, not malformed: the proxy is Go, and json.Marshal of a nil
+// []guide emits `null`, so an empty catalogue legitimately sends exactly that.
+function isMalformedGuides(guides: unknown): boolean {
+  return guides !== undefined && guides !== null && !Array.isArray(guides);
+}
+
 function narrowPackageType(type: string | undefined): PackageType | undefined {
   const parsed = PackageTypeSchema.safeParse(type);
   return parsed.success ? parsed.data : undefined;
@@ -126,7 +140,7 @@ function shapeEntry(entry: WireEntry): CustomGuideRepositoryEntry {
   };
 }
 
-async function requestCatalogue(): Promise<CustomGuideRepositoryEntry[]> {
+async function requestCatalogue(): Promise<CatalogueResult> {
   const response = await getBackendSrv().get<CustomGuideRepositoryResponse>(
     CUSTOM_GUIDE_REPOSITORY_URL,
     undefined,
@@ -141,10 +155,17 @@ async function requestCatalogue(): Promise<CustomGuideRepositoryEntry[]> {
     const reason = response?.capability?.reason ?? 'unknown';
     logger.warn('[custom-guides] catalogue unavailable', { reason });
     recordCustomGuideCatalogueUnavailable(reason);
-    return [];
+    return { entries: [], cacheable: true };
+  }
+  if (isMalformedGuides(response.guides)) {
+    // Schema drift between the Go proxy and this client would otherwise render
+    // as "no guides authored", with the metric at zero and a silent console.
+    logger.warn('[custom-guides] catalogue malformed', { reason: MALFORMED_REASON });
+    recordCustomGuideCatalogueUnavailable(MALFORMED_REASON);
+    return { entries: [], cacheable: false };
   }
   const guides = Array.isArray(response.guides) ? response.guides : [];
-  return guides.map(shapeEntry);
+  return { entries: guides.map(shapeEntry), cacheable: true };
 }
 
 /**
@@ -155,7 +176,8 @@ async function requestCatalogue(): Promise<CustomGuideRepositoryEntry[]> {
  * reports itself unavailable, or the request fails — a best-effort listing, not
  * a hard dependency (mirrors fetchBackendGuides). Successful results are cached
  * per namespace for CACHE_TTL_MS with in-flight de-duplication so concurrent
- * callers share a single upstream drain; failures are not cached.
+ * callers share a single upstream drain; failures and malformed responses are
+ * not cached.
  */
 export async function fetchCustomGuideRepository(namespace: string): Promise<CustomGuideRepositoryEntry[]> {
   if (!isBackendApiAvailable() || !namespace) {
@@ -173,8 +195,12 @@ export async function fetchCustomGuideRepository(namespace: string): Promise<Cus
   }
 
   const request = requestCatalogue()
-    .then((entries) => {
-      cache.set(namespace, { entries, at: Date.now() });
+    .then(({ entries, cacheable }) => {
+      // Drift may be fixed by the next deploy; caching it would keep the
+      // surface empty for the whole TTL after the backend recovered.
+      if (cacheable) {
+        cache.set(namespace, { entries, at: Date.now() });
+      }
       return entries;
     })
     // Best-effort: never surface a listing failure to callers, and don't cache


### PR DESCRIPTION
Closes #1591. Follows PR #1587, which fixed the hard-failure path and deliberately left this one out of scope.

## What

`requestCatalogue()` guarded `guides` with `Array.isArray` and fell back to `[]`. Fail-safe, but silent — and the empty result was then **cached for the full TTL**, so a schema mismatch was indistinguishable from "this stack has no guides authored": empty surface, catalogue-unavailable metric at zero, nothing in the console.

Now a present-but-non-array `guides` emits the same pair as its two neighbours, with a bounded `malformed-response` reason, and the result is **not cached**.

The no-cache half is the part I'd flag for review: drift may well be fixed by the next backend deploy, and caching would keep the surface empty for the whole TTL *after* it recovered. `requestCatalogue` now returns `{ entries, cacheable }` so the caller decides; the capability-unavailable path keeps its existing caching behaviour, unchanged.

## The absent/malformed distinction

The issue calls this out and it turned out to matter more than it first looks. **`null` is treated as absent, not malformed** — the proxy is Go, and `json.Marshal` of a nil `[]guide` emits `null`, so a stack with no guides at all is expected to send exactly that. Signalling on it would fire the metric on the most ordinary case there is.

So:

| `guides` | treated as | signal |
| --- | --- | --- |
| omitted | empty catalogue | silent |
| `null` | empty catalogue | silent |
| `[]` | empty catalogue | silent, cached |
| object / string / number / boolean | drift | `malformed-response`, not cached |

If you'd rather `null` were also treated as drift, that's a one-word change — but I think the Go nil-slice encoding argues against it.

## Tests

`custom-guide-repository-client.test.ts` extended, not replaced, as the issue asks — the existing "response is malformed" case (which actually exercises the *absent* path) still passes untouched. Added 8:

- `guides` omitted / `null` → asserts **no** warn and **no** metric
- `guides` as object / string / number / boolean → asserts `malformed-response` on both the logger and the metric
- a malformed response is not cached: second call re-fetches and picks up the recovered catalogue
- a legitimately empty `[]` **is** still cached (one `get`, not two)

With `src/lib/custom-guide-repository-client.ts` reverted to `main`, **5 of the new tests fail**; the 3 that pin deliberately-unchanged behaviour pass either way, which is what I'd want them to do.

## Checks run locally

| gate | result |
| --- | --- |
| `jest src/lib/custom-guide-repository-client.test.ts` | 34 passed (26 existing + 8 new) |
| `npm run typecheck` | pass |
| `npm run lint` | 0 errors (24 pre-existing warnings elsewhere) |
| `prettier --check` | clean |
| `jest src/validation` | 818 passed, 4 failed |

Those 4 failures are in `src/validation/import-graph.test.ts` and are **identical on pristine `main`** on my machine — they look like Windows path-separator assumptions, not something this PR touches. I didn't run `npm run check` in full (no Go toolchain here), so `lint:go` / `test:go` / coverage thresholds are CI's.

Comments kept to the AGENTS.md keep-list — the only one carrying real weight is the Go nil-slice note, since that's the bit that isn't obvious from the code.
