### PR TITLE
fix(storage): gate guide-response lookups on own keys

### DIFF
--- a/src/lib/user-storage.test.ts
+++ b/src/lib/user-storage.test.ts
@@ -2,6 +2,7 @@ import { getAppEvents } from '@grafana/runtime';
 
 import {
   __resetQuotaWarningForTests,
+  guideResponseStorage,
   interactiveCompletionStorage,
   interactiveStepStorage,
   journeyCompletionStorage,
@@ -560,5 +561,71 @@ describe('warnQuotaExceededOnce — surfaces a single toast across writes', () =
     throwQuotaOnNextWrite = true;
     await tabStorage.setTabs(['tab-2']);
     expect(publishMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ============================================================================
+// GUIDE RESPONSE STORAGE — OWN-KEY LOOKUPS
+// ============================================================================
+
+describe('guideResponseStorage — own-key lookups', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Seeded so getAll() parses a fresh container instead of returning the module default.
+    localStorage.setItem(StorageKeys.GUIDE_RESPONSES, JSON.stringify({}));
+  });
+
+  it('round-trips responses for an ordinary guide id', async () => {
+    await guideResponseStorage.setResponse('docs-grafana-alerting', 'region', 'us-east-1');
+
+    await expect(guideResponseStorage.getForGuide('docs-grafana-alerting')).resolves.toEqual({ region: 'us-east-1' });
+    await expect(guideResponseStorage.getResponse('docs-grafana-alerting', 'region')).resolves.toBe('us-east-1');
+    await expect(guideResponseStorage.hasResponse('docs-grafana-alerting', 'region')).resolves.toBe(true);
+
+    await guideResponseStorage.deleteResponse('docs-grafana-alerting', 'region');
+
+    await expect(guideResponseStorage.getForGuide('docs-grafana-alerting')).resolves.toEqual({});
+    await expect(guideResponseStorage.hasResponse('docs-grafana-alerting', 'region')).resolves.toBe(false);
+  });
+
+  it('misses a guide id naming an inherited member instead of resolving through the prototype chain', async () => {
+    const responses = await guideResponseStorage.getForGuide('__proto__');
+
+    expect(responses).not.toBe(Object.prototype);
+    expect(responses).toEqual({});
+    await expect(guideResponseStorage.getResponse('__proto__', 'toString')).resolves.toBeUndefined();
+    await expect(guideResponseStorage.hasResponse('__proto__', 'toString')).resolves.toBe(false);
+  });
+
+  it('leaves Object.prototype unmodified when writing under a guide id naming an inherited member', async () => {
+    try {
+      await guideResponseStorage.setResponse('__proto__', 'ownKeyProbe', 'written');
+
+      expect(({} as Record<string, unknown>).ownKeyProbe).toBeUndefined();
+      expect(Object.hasOwn(Object.prototype, 'ownKeyProbe')).toBe(false);
+    } finally {
+      delete (Object.prototype as unknown as Record<string, unknown>).ownKeyProbe;
+    }
+  });
+
+  it('leaves Object.prototype unmodified when deleting under a guide id naming an inherited member', async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Object.prototype, 'toLocaleString');
+
+    try {
+      await guideResponseStorage.deleteResponse('__proto__', 'toLocaleString');
+
+      expect(Object.hasOwn(Object.prototype, 'toLocaleString')).toBe(true);
+    } finally {
+      if (descriptor && !Object.hasOwn(Object.prototype, 'toLocaleString')) {
+        Object.defineProperty(Object.prototype, 'toLocaleString', descriptor);
+      }
+    }
+  });
+
+  it('misses a variable name naming an inherited member', async () => {
+    await guideResponseStorage.setResponse('docs-grafana-alerting', 'region', 'us-east-1');
+
+    await expect(guideResponseStorage.getResponse('docs-grafana-alerting', 'toString')).resolves.toBeUndefined();
+    await expect(guideResponseStorage.hasResponse('docs-grafana-alerting', 'toString')).resolves.toBe(false);
   });
 });

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -1704,7 +1704,10 @@ export const guideResponseStorage = {
    */
   async getForGuide(guideId: string): Promise<Record<string, GuideResponseValue>> {
     const all = await guideResponseStorage.getAll();
-    return all[guideId] || {};
+    if (!Object.hasOwn(all, guideId)) {
+      return {};
+    }
+    return all[guideId] ?? {};
   },
 
   /**
@@ -1712,7 +1715,7 @@ export const guideResponseStorage = {
    */
   async getResponse(guideId: string, variableName: string): Promise<GuideResponseValue | undefined> {
     const guideResponses = await guideResponseStorage.getForGuide(guideId);
-    return guideResponses[variableName];
+    return Object.hasOwn(guideResponses, variableName) ? guideResponses[variableName] : undefined;
   },
 
   /**
@@ -1731,11 +1734,9 @@ export const guideResponseStorage = {
       const storage = createUserStorage();
       const all = await guideResponseStorage.getAll();
 
-      // Update the nested structure
-      if (!all[guideId]) {
-        all[guideId] = {};
-      }
-      all[guideId][variableName] = value;
+      const guideRecord = Object.hasOwn(all, guideId) ? (all[guideId] ?? {}) : {};
+      guideRecord[variableName] = value;
+      all[guideId] = guideRecord;
 
       await storage.setItem(StorageKeys.GUIDE_RESPONSES, all);
 
@@ -1758,11 +1759,12 @@ export const guideResponseStorage = {
       const storage = createUserStorage();
       const all = await guideResponseStorage.getAll();
 
-      if (all[guideId]) {
-        delete all[guideId][variableName];
+      const guideRecord = Object.hasOwn(all, guideId) ? all[guideId] : undefined;
+      if (guideRecord) {
+        delete guideRecord[variableName];
 
         // Clean up empty guide entries
-        if (Object.keys(all[guideId]).length === 0) {
+        if (Object.keys(guideRecord).length === 0) {
           delete all[guideId];
         }
 


### PR DESCRIPTION
## Intent

Make the guide-response storage lookups gate on own keys.

Guide-response records in `guideResponseStorage` (`src/lib/user-storage.ts`) are keyed by an author-supplied guide id derived from the content URL, and by author-supplied input-block variable names. Every keyed lookup should therefore gate on `Object.hasOwn`: an id or variable name that happens to name an inherited `Object.prototype` member must miss rather than resolve through the prototype chain.

This follows the own-key convention already used in `src/package-engine/resolver.ts`. PR #1594 (in flight, not depended on here) applies the same idiom to the learning-path guide-metadata maps.

## What changed

- The four keyed lookups in `guideResponseStorage` — `getForGuide`, `getResponse`, `setResponse`, `deleteResponse` — now gate on `Object.hasOwn` before reading the responses container. `setResponse` builds the per-guide record from an own-key hit (or a fresh object) before writing; `deleteResponse` operates on that resolved record.
- Added a `guideResponseStorage — own-key lookups` suite in `src/lib/user-storage.test.ts` covering the ordinary round-trip plus inherited-member cases for both guide ids and variable names.

12 changed lines of production code plus focused tests.

## Deliberately out of scope

These are decisions, not omissions:

- `clearForGuide` is unchanged — `delete all[guideId]` only removes own properties and never walks the prototype chain, so it is already own-key by construction.
- `getAll`, `GuideResponsesSchema` and `DEFAULT_GUIDE_RESPONSES` are unchanged. Own-key gating at the lookup sites is sufficient; changing the container shape or the schema was ruled out as unnecessary scope.
- No shared own-key or null-prototype helper was extracted, and the other storage records in this file were not converted.
- No new methods, no signature changes, no event or telemetry changes, no schema changes.
- Two adjacent gaps are deferred to follow-up issues rather than fixed here: the UI read path for the same data (`GuideResponseContext`, `variable-substitution.ts`, `input-block.tsx`), which never touches storage; and `getAll()` returning the shared module-level `DEFAULT_GUIDE_RESPONSES`, which `setResponse` then mutates. The new tests seed an empty record into storage in `beforeEach` so they stay order-independent without a production change for the latter.

## How to verify

```bash
npx jest src/lib/user-storage.test.ts --coverage=false   # 53 passed
npm run check                                             # full gate
```

Green locally: `tsc --noEmit`, `eslint` on both changed files, the focused suite, and the full `npm run check` gate (419 suites, 6670 tests). Mutation-checked: reverting only the production change fails exactly the four new own-key tests, while the baseline round-trip test passes either way.

No UI surface is involved, so no browser or screenshot verification applies.

## Reversibility

Fully reversible. One commit, one module, no persisted-format change and no migration.
