### PR TITLE
docs: stop recommending text targets over stable selectors

### DIFF
--- a/docs/developer/interactive-examples/selectors-reference.md
+++ b/docs/developer/interactive-examples/selectors-reference.md
@@ -8,12 +8,22 @@ Follow this priority order when choosing selectors:
 
 1. **`grafana:` selector paths** -- version-aware references to selectors maintained by Grafana core
 2. **`data-testid` attributes** -- stable when no known Grafana selector path exists
-3. **Semantic attributes** -- `href`, `aria-*`, `id`, `role`
-4. **`:contains()` text matching** -- reliable for buttons and labels
-5. **`:has()` structural matching** -- when you need to match by descendants
+3. **Semantic attributes** -- `href`, `id`, `role` (see the localization warning below before using `aria-*`)
+4. **`:has()` structural matching** -- when you need to match by descendants
+5. **`:contains()` / `:text()` text matching** -- last resort; breaks in every locale but the one you authored in
 6. **CSS class selectors** -- least stable; avoid auto-generated class names
 
-> Avoid selecting by auto-generated class names or deep DOM nesting. Use attributes (`data-testid`, `href`, `aria-*`, `id`) instead.
+> Avoid selecting by auto-generated class names or deep DOM nesting. Use attributes (`data-testid`, `href`, `id`) instead.
+
+> **Text-based targets are locale-bound.** Grafana ships translated, and Pathfinder itself ships in
+> 21 locales. `aria-label`, `placeholder`, `title`, `:contains()` and `:text()` all match against
+> translated strings, so a guide targeting `"Save & test"` simply does not match for a user running
+> Grafana in German. The selector engine flags these anchors `i18n-sensitive` and warns that the
+> "Selector uses translatable text — may break in different locales", but it cannot repair them at
+> match time: matching is a plain string comparison against whatever you authored. Only a
+> `grafana:` path or a `data-testid` survives translation. If the target has no stable anchor, the
+> real fix is upstream in the component (`add-e2e-selectors` in grafana/grafana, or `audit-testids`
+> for a plugin repo).
 
 ### Version-aware `grafana:` selectors
 
@@ -170,7 +180,7 @@ Prefer these tested selectors over brittle CSS classes. When you find a new reli
 
 ### Buttons by text
 
-For generic buttons, use the `button` action with the button's visible text as the `reftarget`. The system finds buttons by text reliably.
+For generic buttons with no stable anchor, use the `button` action with the button's visible text as the `reftarget`. The system matches buttons by text dependably **within a single locale** — but the match is a plain string comparison, so these targets break wherever the UI is translated. Reach for this only when no `grafana:` path or `data-testid` is available, and prefer fixing the component upstream over shipping a text-matched step.
 
 ```json
 {

--- a/src/cli/mcp/tools/authoring-start.ts
+++ b/src/cli/mcp/tools/authoring-start.ts
@@ -87,7 +87,7 @@ const AUTHORING_CONTEXT = {
     'Add contextual `requirements` to every interactive step that touches the DOM. At minimum `on-page:/path`; also `navmenu-open` for nav clicks and `is-admin` (or a role) for admin-only features.',
     "Use `verify` on actions that change state (save, create, navigate) so the next step can't run against a half-completed action.",
     'Keep prose punchy and action-oriented — the guide shows in a sidebar. "Click **Save**" beats "The save button can be clicked."',
-    "Prefer `action: button` with the visible button text over a CSS selector when possible — Grafana's button text changes far less often than the DOM tree.",
+    'Prefer a `grafana:` selector path, then a `data-testid`, over any text-based target. Visible text, `aria-label`, `placeholder` and `title` are all translated, so a guide anchored to them breaks for every user not running the locale you authored in — the engine flags these `i18n-sensitive` for exactly this reason. `action: button` with visible text remains the right fallback when you have no verified stable selector (never invent one), but treat it as a fallback, not a preference.',
     'If the target lives in a virtualized list, paginated table, or dashboard row below the fold, use a `guided` block with `lazyRender: true` on the step — a plain `interactive` will fail because `exists-reftarget` waits but cannot scroll.',
   ],
   discovery: [


### PR DESCRIPTION
`authoring-start.ts` told agents to prefer `action: button` with visible text over a CSS selector because "button text changes far less often than the DOM tree". True of English copy, false everywhere else — Grafana ships translated, Pathfinder ships in 21 locales, and our own engine already flags text/`aria-label`/`placeholder`/`title` as `i18n-sensitive` for this exact reason. It can warn but can't repair: matching is a plain string comparison.

Reorders rather than removes. `grafana:` paths and `data-testid` first; text matching stays as the documented fallback when no verified selector exists, since the alternative is an agent inventing one. `selectors-reference.md` gets the same treatment and both spots now route to the upstream fix.

Companion to grafana/deployment_tools#685094.

Note: `yarn typecheck` not run (fresh worktree, no `node_modules`). Changes are string literals only; prettier parsed the TS successfully.