### PR TITLE
fix(validation): stop the JSONC stripper eating comments inside strings

### DIFF
--- a/src/validation/import-graph.test.ts
+++ b/src/validation/import-graph.test.ts
@@ -40,6 +40,7 @@ import {
   collectSourceFiles,
   loadTsconfigPaths,
   readJsoncFile,
+  stripJsonComments,
   resolveImportToRelative,
   resolvePathAlias,
   toPosixPath,
@@ -164,6 +165,35 @@ describe('readJsoncFile', () => {
       path.join(REPO_ROOT, '.config', 'tsconfig.json')
     );
     expect(parsed.compilerOptions?.paths).toEqual({ '*': ['../src/*'] });
+  });
+
+  it('keeps recursive globs intact', () => {
+    const parsed = readJsoncFile<{ include: string[] }>(path.join(REPO_ROOT, 'tsconfig.cli.json'));
+    expect(parsed.include).toContain('src/cli/**/*');
+  });
+});
+
+describe('stripJsonComments', () => {
+  it('strips line and block comments', () => {
+    expect(JSON.parse(stripJsonComments('{ // a\n"x": /* b */ 1 }'))).toEqual({ x: 1 });
+  });
+
+  it('leaves comment-like text inside strings alone', () => {
+    // A blind regex sweep turns "src/cli/**/*" into "src/cli*" by treating the
+    // `/**/` as an empty block comment, which silently narrows a tsconfig glob.
+    const cases = ['src/cli/**/*', 'a/**/b', 'https://example.com', '// not a comment', '/* nor this */'];
+    for (const value of cases) {
+      expect(JSON.parse(stripJsonComments(JSON.stringify({ value })))).toEqual({ value });
+    }
+  });
+
+  it('does not treat an escaped quote as the end of a string', () => {
+    const value = 'say \\"/**/\\" once';
+    expect(JSON.parse(stripJsonComments(`{ "value": "${value}" }`))).toEqual({ value: 'say "/**/" once' });
+  });
+
+  it('tolerates an unterminated comment rather than throwing', () => {
+    expect(stripJsonComments('{ "x": 1 } /* trailing')).toBe('{ "x": 1 } ');
   });
 });
 

--- a/src/validation/import-graph.ts
+++ b/src/validation/import-graph.ts
@@ -130,10 +130,55 @@ export interface TsconfigPathsConfig {
   paths: Record<string, string[]>;
 }
 
+/**
+ * Strip JSONC comments without touching comment-like text inside string
+ * values. A blind regex sweep eats the `/**\/` in a glob such as
+ * `"src/cli/**\/*"`, silently turning it into `"src/cli*"`.
+ */
+export function stripJsonComments(text: string): string {
+  let out = '';
+  let inString = false;
+  let index = 0;
+
+  while (index < text.length) {
+    const char = text[index];
+    if (inString) {
+      out += char;
+      if (char === '\\' && index + 1 < text.length) {
+        out += text[index + 1];
+        index += 2;
+        continue;
+      }
+      if (char === '"') {
+        inString = false;
+      }
+      index += 1;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      out += char;
+      index += 1;
+      continue;
+    }
+    if (char === '/' && text[index + 1] === '*') {
+      const end = text.indexOf('*/', index + 2);
+      index = end === -1 ? text.length : end + 2;
+      continue;
+    }
+    if (char === '/' && text[index + 1] === '/') {
+      const end = text.indexOf('\n', index + 2);
+      index = end === -1 ? text.length : end;
+      continue;
+    }
+    out += char;
+    index += 1;
+  }
+  return out;
+}
+
 export function readJsoncFile<T>(filePath: string): T {
-  const text = fs.readFileSync(filePath, 'utf-8');
-  const stripped = text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
-  return JSON.parse(stripped) as T;
+  return JSON.parse(stripJsonComments(fs.readFileSync(filePath, 'utf-8'))) as T;
 }
 
 export function loadTsconfigPaths(tsconfigPath: string): TsconfigPathsConfig {


### PR DESCRIPTION
## Summary

`readJsoncFile` in `src/validation/import-graph.ts` stripped JSONC comments with two blind regexes:

```ts
text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
```

Neither is string-aware, so any string *value* containing comment syntax gets corrupted. The concrete case: a tsconfig `include` of `"src/cli/**/*"` comes back as `"src/cli*"` — the `/**/` is matched as an empty block comment and removed — silently narrowing the glob to a path that matches nothing.

Replaced with a string-aware scan that tracks quoting and backslash escapes and only strips comments outside string literals, extracted as `stripJsonComments` so the string cases are directly testable.

## Why now

Latent today — the existing callers (`loadTsconfigPaths`, `architecture.test.ts`) only read `compilerOptions.paths` and `baseUrl`, which contain no `/**/`. It surfaced while writing a test that reads `tsconfig.cli.json`'s `include`, where the corruption made the expansion silently return nothing rather than fail.

Split out of #1597 to keep that PR scoped to the data-check step type.

## What to look at

- `stripJsonComments` — the escape handling (`\\` inside a string consumes the next char, so `\"` doesn't end the string) and the unterminated-comment path, which truncates rather than throwing.

## How to verify

`npx jest src/validation/import-graph.test.ts` — 130 pass. The `keeps recursive globs intact` case fails against the old implementation, which is the regression this locks in.

Full `npm run test:ci`: 424 suites / 6739 tests pass. `npm run typecheck` and `npm run lint` clean (0 errors).

## Breaking changes

None. Comment stripping is unchanged for every input that doesn't embed comment syntax in a string.

## Reversibility

Fully reversible — one self-contained function, no persisted state or external contract.

## Follow-up not included here

The failure that led here was a `Dockerfile.cli` COPY list that didn't cover the CLI's compile closure — invisible locally, fails minutes into the CLI publish Docker build. Fixed for the immediate case in #1597; a guard test for the general case is still open (#1603) because the version I wrote destabilised the jest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)