### PR TITLE
skill:maintain-docs refresh release and learning paths docs

### DIFF
--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -12,6 +12,8 @@ Persistent tracker for the maintain-docs skill's persistent state across runs.
 
 <!-- Docs checked against source and found accurate. Format: date, doc path. Update date on re-validation. -->
 
+- **2026-08-12**: `docs/developer/RELEASE_PROCESS.md` — Corrected dev deployment, CLI publish triggers, runtime dependencies, MCP smoke testing, Node base-image guidance, and plugin-tarball isolation. Validated against current release/publish workflows, `Dockerfile.cli`, `scripts/cli-build-utils.js`, and package scripts.
+- **2026-08-12**: `docs/developer/learning-paths/README.md` — Added App Platform paths and the badge coordinator; corrected completion, reset, metadata lookup, storage ownership, and current test/export coverage. Validated against current learning-path logic, storage integrations, custom-guide catalogue adapter, and My Learning reset flow.
 - **2026-08-07**: `docs/developer/CROSS_TAB_CONTROLLER.md` — Corrected the wire protocol for `runId`, `targetState`, pairing, sidebar handoff, sender-scoped replies, and single-live-tab command execution. Validated against current cross-tab types, controller channel, live-tab executor, and interactive step emitters.
 - **2026-08-07**: `.cursor/rules/schema-coupling.mdc` — Corrected the JSON-guide coupling guarantees, Zod unknown-field behavior, validation layout, test commands, and package-schema distinctions. Validated against current guide/package schemas, types, and coupling tests.
 - **2026-08-07**: `docs/developer/interactive-examples/json-guide-format.md` — Corrected video, code-block, terminal, challenge, snippet-reference, and Grot Guide contracts plus the exported type/guard list. Validated against `json-guide.schema.ts` and `json-guide.types.ts`.
@@ -60,6 +62,7 @@ Persistent tracker for the maintain-docs skill's persistent state across runs.
 
 <!-- Files confirmed as not needing an AGENTS.md entry. Format: path, reason. -->
 
+- `docs/_maintenance-backlog.md` — Workflow-owned state for the maintain-docs skill; the skill reads it directly, so it does not need agent-context indexing.
 - `docs/developer/provisioning/README.md` — 4-line stub with only external links to Grafana provisioning docs. No agent-relevant content.
 - `.cursor/skills/maintain-docs/SKILL.md` — Discovered automatically by IDE via `.cursor/skills/` glob pattern. No AGENTS.md entry needed.
 - `.cursor/skills/design-review/SKILL.md` — Same as above.

--- a/docs/developer/RELEASE_PROCESS.md
+++ b/docs/developer/RELEASE_PROCESS.md
@@ -32,7 +32,7 @@ The project uses several GitHub Actions workflows for different release scenario
   - `push` to `main` (CLI-relevant paths): same, plus push the resulting Docker image to GHCR as `:latest` and `:main-<short-sha>`, cosign-sign the digest, and smoke-test the pushed image.
 - **Process**:
   - Builds the CLI via `npm run build:cli`.
-  - Generates a minimal runtime `package.json` (commander + zod only) via `scripts/cli-build-utils.js runtime-package <out>` so the image doesn't pull the plugin's full dependency tree.
+  - Generates a minimal runtime `package.json` (Commander, Zod, and the Model Context Protocol SDK only) via `scripts/cli-build-utils.js runtime-package <out>` so the image doesn't pull the plugin's full dependency tree.
   - Builds `Dockerfile.cli` and pushes to `ghcr.io/grafana/pathfinder-cli:latest` plus `ghcr.io/grafana/pathfinder-cli:main-<short-sha>`.
   - Authenticates to GHCR with the always-present `GITHUB_TOKEN` — no repo secrets are required to operate this workflow.
 - **No npm publish, no Docker Hub, no tag-driven release.** The image is the only consumable artifact. Pin to `:main-<sha>` for reproducibility; track `:latest` for "tip of trunk."
@@ -74,7 +74,7 @@ npm run sign           # Sign plugin for distribution
 
 ### Environment Progression
 
-1. **Development** (`dev`) - Automatic on push to main
+1. **Development** (`dev`) - Manual via publish workflow; can deploy a PR branch
 2. **Operations** (`ops`) - Manual via publish workflow
 3. **Production** (`prod`) - Manual via publish workflow
 
@@ -105,8 +105,8 @@ npm run sign           # Sign plugin for distribution
 
 ### For Development Deployments
 
-1. Push changes to `main` branch
-2. Automatic deployment to `dev` environment
+1. Run the manual publish workflow
+2. Select the `dev` environment and the branch to deploy
 3. Monitor via Slack channel `#pathfinder-app-release`
 
 ### For Production Deployments
@@ -132,13 +132,13 @@ Plugin signing is available but currently disabled. To enable:
 
 ## CLI and MCP continuous publish
 
-The `pathfinder-cli` Docker image at `ghcr.io/grafana/pathfinder-cli` is rebuilt and pushed on every merge to `main`. There is no tag-driven release flow, no npm publish, and no Docker Hub push — the GHCR image is the single consumable artifact and the only registry. Authentication uses the always-present `GITHUB_TOKEN`; no repo secrets are required to operate the pipeline.
+The `pathfinder-cli` Docker image at `ghcr.io/grafana/pathfinder-cli` is rebuilt and pushed when a merge to `main` changes a CLI-relevant path listed in `.github/workflows/cli-publish.yml`. There is no tag-driven release flow, no npm publish, and no Docker Hub push — the GHCR image is the single consumable artifact and the only registry. Authentication uses the always-present `GITHUB_TOKEN`; no repo secrets are required to operate the pipeline.
 
-### Tags published on every main merge
+### Tags published on each relevant main merge
 
 | Tag                                               | Stability                                                         |
 | ------------------------------------------------- | ----------------------------------------------------------------- |
-| `ghcr.io/grafana/pathfinder-cli:latest`           | Tip of `main`. Moves on every merge. Use for "follow trunk."      |
+| `ghcr.io/grafana/pathfinder-cli:latest`           | Tip of relevant changes on `main`. Use for "follow trunk."        |
 | `ghcr.io/grafana/pathfinder-cli:main-<short-sha>` | Immutable per-commit pointer. Use for reproducible deploys / pin. |
 
 ### Versioning
@@ -153,7 +153,7 @@ To bump what `pathfinder-cli --version` returns, bump `CURRENT_SCHEMA_VERSION` i
 npm run build:cli                                             # compile dist/cli/
 docker build -f Dockerfile.cli -t pathfinder-cli:local .      # produce the image
 docker run --rm pathfinder-cli:local --version                # CLI smoke
-docker run --rm pathfinder-cli:local mcp                      # routes to placeholder, exits 1
+docker run --rm pathfinder-cli:local mcp --version            # MCP subcommand smoke
 ```
 
 ### Consuming the image
@@ -188,18 +188,18 @@ This relies on the `id-token: write` permission granted to the `publish-ghcr-mai
 
 ### Refreshing the Docker base-image digest
 
-`Dockerfile.cli` pins `node:22-alpine` by digest (same digest in both stages) so two builds of the same git commit produce identical images. Refresh the digest periodically by running:
+`Dockerfile.cli` pins `node:24-alpine` by digest (same digest in both stages) so two builds of the same git commit produce identical images. Keep the image at Node 24.14.1 or newer so its bundled npm supports the repository's supply-chain settings. Refresh the digest periodically by running:
 
 ```bash
-docker pull node:22-alpine
-docker inspect --format='{{index .RepoDigests 0}}' node:22-alpine
+docker pull node:24-alpine
+docker inspect --format='{{index .RepoDigests 0}}' node:24-alpine
 ```
 
 Replace both `FROM` lines in `Dockerfile.cli` with the new digest. The two stages must use the same digest.
 
 ### Plugin tarball is unaffected
 
-The CLI is not bundled into the plugin tarball. Webpack only enters from `src/module.tsx` and never traverses `src/cli/`, so the plugin's `dist/` output is identical with or without the CLI changes. Verify by running `npm run build` on this branch and on `main` and diffing the file lists; they should match exactly.
+The CLI is not bundled into the plugin tarball. Webpack only enters from `src/module.tsx` and never traverses `src/cli/`, so changes confined to `src/cli/` do not add the CLI to the plugin's `dist/` output. Verify by running `npm run build` on this branch and on `main` and diffing the file lists; they should match exactly.
 
 ## Troubleshooting
 

--- a/docs/developer/learning-paths/README.md
+++ b/docs/developer/learning-paths/README.md
@@ -4,26 +4,33 @@ The `src/learning-paths/` module provides the business logic layer for the gamif
 
 ## File listing
 
-| File                            | Purpose                                                                                                 |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `index.ts`                      | Public API barrel export                                                                                |
-| `paths-data.ts`                 | Runtime platform selection (OSS vs Grafana Cloud)                                                       |
-| `paths.json`                    | OSS path definitions (static, bundled guide IDs)                                                        |
-| `paths-cloud.json`              | Grafana Cloud path definitions (superset of OSS; includes URL-based paths)                              |
-| `badges.ts`                     | 12 badge definitions, trigger types, and earning logic                                                  |
-| `learning-paths.hook.ts`        | Main `useLearningPaths()` hook — unified state management                                               |
-| `streak-tracker.ts`             | Streak calculation, milestones, and display helpers                                                     |
-| `fetch-path-guides.ts`          | Fetches guide lists from remote `index.json` for URL-based paths                                        |
-| `useNextLearningAction.ts`      | `useNextLearningAction()` hook and pure `computeNextAction()` for the UserProfileBar                    |
-| `useDiscoverMore.ts`            | `useDiscoverMore()` hook — surfaces external learning paths for the My Learning "Discover more" section |
-| `learning-paths.test.ts`        | Tests for the main hook                                                                                 |
-| `fetch-path-guides.test.ts`     | Tests for remote guide fetching                                                                         |
-| `useNextLearningAction.test.ts` | Tests for next-action computation                                                                       |
-| `useDiscoverMore.test.ts`       | Tests for the Discover more hook                                                                        |
+| File                                           | Purpose                                                                                                 |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `index.ts`                                     | Public API barrel export                                                                                |
+| `paths-data.ts`                                | Runtime platform selection (OSS vs Grafana Cloud)                                                       |
+| `paths.json`                                   | OSS path definitions (static, bundled guide IDs)                                                        |
+| `paths-cloud.json`                             | Grafana Cloud path definitions (superset of OSS; includes URL-based paths)                              |
+| `app-platform-paths.ts`                        | Adapts published App Platform path and journey packages into learning paths                             |
+| `badge-coordinator.ts`                         | Orchestrates guide completion, badge awarding, streak updates, analytics, and progress events           |
+| `badges.ts`                                    | 12 badge definitions, trigger types, and earning logic                                                  |
+| `learning-paths.hook.ts`                       | Main `useLearningPaths()` hook — unified state management                                               |
+| `streak-tracker.ts`                            | Streak calculation, milestones, and display helpers                                                     |
+| `fetch-path-guides.ts`                         | Fetches guide lists from remote `index.json` for URL-based paths                                        |
+| `useNextLearningAction.ts`                     | `useNextLearningAction()` hook and pure `computeNextAction()` for the UserProfileBar                    |
+| `useDiscoverMore.ts`                           | `useDiscoverMore()` hook — surfaces external learning paths for the My Learning "Discover more" section |
+| `learning-paths.test.ts`                       | Data-integrity tests for path, badge, and guide metadata definitions                                    |
+| `fetch-path-guides.test.ts`                    | Tests for remote guide fetching                                                                         |
+| `app-platform-paths.test.ts`                   | Tests for App Platform catalogue adaptation                                                             |
+| `badge-coordinator.test.ts`                    | Tests for guide-completion orchestration                                                                |
+| `learning-paths.hook.test.ts`                  | Tests for hook fetching, metadata resolution, and App Platform merging                                  |
+| `learning-paths.completion-round-trip.test.ts` | Integration tests for guide completion flowing back into hook state                                     |
+| `reset-path-completion.test.ts`                | Integration tests for path reset behavior                                                               |
+| `useNextLearningAction.test.ts`                | Tests for next-action computation                                                                       |
+| `useDiscoverMore.test.ts`                      | Tests for the Discover more hook                                                                        |
 
 ## Path types
 
-Learning paths come in two variants based on how their guides are sourced.
+Learning paths come from three sources.
 
 ### Static paths
 
@@ -57,6 +64,12 @@ URL-based paths point to a remote docs site and declare `guides: []` in their st
 At runtime, `fetchPathGuides()` fetches `{url}index.json` and parses the response (a Hugo/Jekyll page listing) into an ordered list of guide slugs and metadata. Items with `params.grafana.skip` set are filtered out. The slug is derived from the last segment of each item's `relpermalink`.
 
 The `useLearningPaths()` hook merges these dynamically fetched guides into the path objects, so consumers see a unified `LearningPath` with a populated `guides` array regardless of the path type.
+
+### App Platform paths
+
+`fetchAppPlatformLearningPaths()` reads the stack's private custom-guide catalogue through `fetchCustomGuideRepository()`. It includes only published packages whose manifest type is `path` or `journey`, and includes only published milestone members in each synthesized path. The adapter also builds metadata for every published catalogue entry, using `backend-guide:{id}` URLs so path members launch through the App Platform content resolver.
+
+These paths are fetched when `config.namespace` is available and appended after the bundled and URL-based paths. Their package manifest is carried on the `LearningPath` so the My Learning launch flow can preserve milestone context.
 
 ## Platform selection
 
@@ -123,7 +136,7 @@ For `path-completed` triggers, `isPathCompleted()` returns `false` when `path.gu
 | Last activity was yesterday                        | `currentStreak + 1`                 |
 | Gap of more than one day                           | Reset to `1`                        |
 
-Dates are compared as `YYYY-MM-DD` strings derived from the user's local timezone.
+Dates are compared as UTC `YYYY-MM-DD` strings derived with `toISOString()`.
 
 ### Display info
 
@@ -151,11 +164,11 @@ If more than one day has elapsed since the last activity, the streak is reported
 
 ### State loading and synchronization
 
-`useLearningPaths()` loads the user's `LearningProgress` from `learningProgressStorage` on mount. It listens for `CustomEvent('learning-progress-updated')` dispatched by the storage layer to sync state when progress changes elsewhere in the app (for example, when a guide is completed from the docs panel). If the event includes a `detail.progress` payload, it is used directly; otherwise, progress is re-read from storage.
+`useLearningPaths()` loads the user's `LearningProgress` from `learningProgressStorage` on mount. It listens for `CustomEvent('learning-progress-updated')` dispatched by the completion coordinator and storage helpers to sync state when progress changes elsewhere in the app (for example, when a guide is completed from the docs panel). If the event includes a `detail.progress` payload, it is used directly; otherwise, progress is re-read from storage.
 
 ### Marking guides completed
 
-`markGuideCompleted(guideId)` delegates to `learningProgressStorage.markGuideCompleted()`, which handles streak updates, badge awarding, and event dispatch. The hook does not perform badge checks itself — it relies on the storage layer and event-driven synchronization.
+`markGuideCompleted(guideId)` delegates to the Tier 2 coordinator in `badge-coordinator.ts`. The coordinator loads and persists progress through `learningProgressStorage`, updates the streak, evaluates and records new badges, reports badge analytics, and dispatches the progress event. The storage layer only persists learning progress and exposes focused mutation helpers. The coordinator function is also exported directly from the module's `index.ts` barrel for completion flows that do not need the hook.
 
 ### Dismissing celebrations
 
@@ -165,9 +178,13 @@ If more than one day has elapsed since the last activity, the streak is reported
 
 `resetPath(pathId)` clears progress for a path. The behavior differs by path type:
 
-**Static paths**: For each guide ID in the path, clears the interactive step storage (`bundled:{guideId}`), interactive completion storage, and journey completion storage. Then removes the guide IDs from `completedGuides`.
+**Static and App Platform paths**: Clears interactive steps, interactive completion, and journey completion for both the path's own keys and each member guide under both `bundled:` and `backend-guide:` schemes. It also clears milestone completion for the path keys, evicts the corresponding in-memory completion cache entries, and removes the member guide IDs from `completedGuides`. Clearing both schemes lets the same reset path handle bundled and App Platform entries without inferring the source from bare guide IDs.
 
-**URL-based paths**: Clears milestone tracking (`milestoneCompletionStorage`), journey completion, and `completedGuides` for the fetched guide slugs. Also clears interactive steps and completions for any content key that starts with the path's normalized URL. After clearing, dispatches `CustomEvent('interactive-progress-cleared')` so UI components can refresh.
+**URL-based paths**: Clears milestone tracking for the path URL and removes the fetched guide slugs from `completedGuides`. It discovers interactive and journey completion keys by normalized URL prefix, clears them in batches (including the path URL's own journey-completion key), clears matching interactive steps, and evicts matching in-memory completion cache entries.
+
+After either reset path, the hook dispatches `CustomEvent('interactive-progress-cleared')` and reloads learning progress so UI components refresh.
+
+The My Learning **Reset all progress** action is broader: it clears all learning progress, journey completion, milestone checklists, interactive steps, interactive completion, and in-memory completion caches before dispatching the same refresh event. Clearing milestone storage prevents an old checklist from immediately re-crossing the whole-path completion threshold after the reset.
 
 ## Key hooks and exports
 
@@ -175,21 +192,22 @@ If more than one day has elapsed since the last activity, the streak is reported
 
 The primary hook exported from the module. Returns `UseLearningPathsReturn`:
 
-| Property                      | Type                        | Description                                                |
-| ----------------------------- | --------------------------- | ---------------------------------------------------------- |
-| `paths`                       | `LearningPath[]`            | Paths for the current platform with dynamic guides merged  |
-| `allBadges`                   | `Badge[]`                   | All defined badges                                         |
-| `badgesWithStatus`            | `EarnedBadge[]`             | Badges with earned state and legacy badges appended        |
-| `progress`                    | `LearningProgress`          | Current progress (guides, badges, streak, celebrations)    |
-| `getPathGuides(pathId)`       | `(string) => PathGuide[]`   | Guides for a path with completion and current-guide status |
-| `getPathProgress(pathId)`     | `(string) => number`        | Completion percentage (0–100)                              |
-| `isPathCompleted(pathId)`     | `(string) => boolean`       | Whether progress is 100%                                   |
-| `markGuideCompleted(guideId)` | `(string) => Promise<void>` | Delegates to storage layer                                 |
-| `resetPath(pathId)`           | `(string) => Promise<void>` | Clears progress for a path                                 |
-| `dismissCelebration(badgeId)` | `(string) => Promise<void>` | Removes a pending celebration                              |
-| `streakInfo`                  | `StreakInfo`                | Current streak display info                                |
-| `isLoading`                   | `boolean`                   | Initial progress loading state                             |
-| `isDynamicLoading`            | `boolean`                   | Whether URL-based guide data is still being fetched        |
+| Property                              | Type                                      | Description                                                |
+| ------------------------------------- | ----------------------------------------- | ---------------------------------------------------------- |
+| `paths`                               | `LearningPath[]`                          | Bundled, URL-based, and App Platform paths                 |
+| `allBadges`                           | `Badge[]`                                 | All defined badges                                         |
+| `badgesWithStatus`                    | `EarnedBadge[]`                           | Badges with earned state and legacy badges appended        |
+| `progress`                            | `LearningProgress`                        | Current progress (guides, badges, streak, celebrations)    |
+| `getPathGuides(pathId)`               | `(string) => PathGuide[]`                 | Guides for a path with completion and current-guide status |
+| `getPathProgress(pathId)`             | `(string) => number`                      | Completion percentage (0–100)                              |
+| `isPathCompleted(pathId)`             | `(string) => boolean`                     | Whether progress is 100%                                   |
+| `getGuideUrlForPath(guideId, pathId)` | `(string, string) => string \| undefined` | Resolves a guide URL within its parent path                |
+| `markGuideCompleted(guideId)`         | `(string) => Promise<void>`               | Delegates to the completion coordinator                    |
+| `resetPath(pathId)`                   | `(string) => Promise<void>`               | Clears progress for a path                                 |
+| `dismissCelebration(badgeId)`         | `(string) => Promise<void>`               | Removes a pending celebration                              |
+| `streakInfo`                          | `StreakInfo`                              | Current streak display info                                |
+| `isLoading`                           | `boolean`                                 | Initial progress loading state                             |
+| `isDynamicLoading`                    | `boolean`                                 | Whether URL-based guide data is still being fetched        |
 
 ### `useGuideCompletion()`
 
@@ -217,7 +235,7 @@ A pure function (no hooks) that computes the next learning action. It sorts path
 2. Not-started paths
 3. Completed paths are skipped
 
-From the highest-priority path, it selects the first guide with `isCurrent: true`. For URL-based paths, the returned `guideUrl` points to the path URL; for static paths, it uses the guide's metadata URL or falls back to `bundled:{guideId}`.
+From the highest-priority path, it selects the first guide with `isCurrent: true`. It prefers the path-scoped URL already resolved on that guide, which opens the actual next module for URL-based paths and uses `backend-guide:` URLs for App Platform members. It then falls back to the path URL, static metadata, or `bundled:{guideId}` in that order.
 
 ### `useDiscoverMore()`
 
@@ -229,13 +247,13 @@ Surfaces novel external learning paths for the My Learning "Discover more" secti
 
 The module depends on several storage instances:
 
-- `learningProgressStorage` — persists `LearningProgress`, handles `markGuideCompleted`, badge awarding, and streak updates
+- `learningProgressStorage` — persists `LearningProgress` and provides focused badge, streak, guide-removal, and reset operations
 - `interactiveStepStorage` — per-guide interactive step progress (used by `resetPath`)
 - `interactiveCompletionStorage` — interactive guide completion flags (used by `resetPath`)
 - `journeyCompletionStorage` — journey-level completion (used by `resetPath`)
-- `milestoneCompletionStorage` — milestone completion for URL-based paths (used by `resetPath`)
+- `milestoneCompletionStorage` — milestone completion for URL-based and package-backed paths (used by resets)
 
-Badge awarding for static paths is handled by `learningProgressStorage`. Badge awarding for URL-based paths is handled by `markMilestoneDone` in `docs-retrieval/learning-journey-helpers.ts`, which also emits the completion fact (and the whole-journey `journey_completed` trigger) through the `completion-records` recorder.
+Static guide completion flows through `markGuideCompleted()` in `badge-coordinator.ts`, which evaluates badges against the bundled path definitions. URL-based and App Platform journey milestones flow through `markMilestoneDone` in `docs-retrieval/learning-journey-helpers.ts`; it updates local completion state and emits completion facts (including the whole-journey `journey_completed` trigger) through the `completion-records` recorder.
 
 ### UI components (`src/components/LearningPaths/`)
 
@@ -243,17 +261,21 @@ The components consume the hooks exported from this module to render learning pa
 
 ### Content system (`src/docs-retrieval/`)
 
-`fetchPathGuides()` fetches guide data from remote `index.json` files, using the same pattern as the content fetcher's learning journey metadata parser. Guide metadata resolution in the hook checks dynamically fetched metadata first, then falls back to the static `guideMetadata` from the JSON data files.
+`fetchPathGuides()` fetches guide data from remote `index.json` files, using the same pattern as the content fetcher's learning journey metadata parser. Guide metadata resolution is scoped to a path for dynamically fetched guides, then falls back to App Platform catalogue metadata and finally the static `guideMetadata` from the JSON data files. Remote- and catalogue-derived metadata maps use null prototypes, while static lookup is gated with `Object.hasOwn()` so authored IDs cannot resolve inherited object properties.
+
+### App Platform package system
+
+`app-platform-paths.ts` consumes the private catalogue exposed by `src/lib/custom-guide-repository-client.ts`. That client calls the backend `/custom-guide-repository` proxy, applies a short per-namespace cache with in-flight request deduplication, and fails soft to an empty catalogue when the capability or request is unavailable. My Learning launches `backend-guide:` member URLs through the package-content resolver while carrying the parent manifest as package context.
 
 ### Events
 
-| Event                          | Dispatched by                  | Listened by                   |
-| ------------------------------ | ------------------------------ | ----------------------------- |
-| `learning-progress-updated`    | Storage layer (`user-storage`) | `useLearningPaths()` hook     |
-| `interactive-progress-cleared` | `resetPath()`                  | UI components needing refresh |
+| Event                          | Dispatched by                              | Listened by                   |
+| ------------------------------ | ------------------------------------------ | ----------------------------- |
+| `learning-progress-updated`    | Completion coordinator and storage helpers | `useLearningPaths()` hook     |
+| `interactive-progress-cleared` | Path reset and Reset all progress          | UI components needing refresh |
 
 ## See also
 
 - [Learning Paths components](../components/LearningPaths/README.md) — UI component documentation
 - `src/types/learning-paths.types.ts` — TypeScript type definitions
-- `src/lib/user-storage/` — Storage layer that handles persistence and badge awarding
+- `src/lib/user-storage.ts` — Storage layer for learning progress and completion state


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-08-12.

### Changes made

- Corrected the release reference for manual dev deployments, path-filtered CLI publishing, current runtime dependencies and MCP smoke testing, Node 24 base-image guidance, and plugin-tarball isolation.
- Refreshed the learning-path reference for App Platform paths, completion coordination, reset behavior, metadata lookup safety, current exports, and test coverage.
- Recorded both validations and excluded the workflow-owned maintenance backlog from general agent-context indexing.

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| High | Release documentation drifted from current deployment, CLI publishing, runtime dependency, and container contracts | Fixed in this PR |
| High | Learning-path documentation predated App Platform paths and current completion/reset ownership | Fixed in this PR |
| Low | The workflow-owned maintenance backlog appeared orphaned in the general discovery graph | Excluded in this PR |
| Low | No other missing references or unhandled operational-document orphans were found | No action needed |

### Recommendations for separate work

- Human design review is still required to decide whether `src/snippet-engine/` needs its own concern in `docs/design/CONCERNS.md`; maintain-docs cannot edit design documents.

### Validation checklist

- [x] All changed files are `.md` or `.mdc` (verified via `git diff --name-only`)
- [x] Phase 2.5 verification passed (delegated output and factual claims reviewed)
- [x] `npm run prettier` equivalent passed using the repository's installed Prettier binary
- [x] Focused architecture and skill-reference tests passed (2 suites, 231 tests)
- [x] No source code files were modified
