### PR TITLE
fix(block-editor): preserve step text when switching types

### DIFF
--- a/src/components/block-editor/BlockFormModal.test.tsx
+++ b/src/components/block-editor/BlockFormModal.test.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BlockFormModal } from './BlockFormModal';
 import type { ConversionWarning } from './forms/TypeSwitchDropdown';
-import type { JsonMarkdownBlock } from '../../types/json-guide.types';
+import type { JsonGuidedBlock, JsonMarkdownBlock, JsonMultistepBlock } from '../../types/json-guide.types';
 
 // Mock the form components to simplify testing
 jest.mock('./forms/MarkdownBlockForm', () => ({
@@ -51,8 +51,37 @@ jest.mock('./forms/VideoBlockForm', () => ({ VideoBlockForm: () => null }));
 jest.mock('./forms/SectionBlockForm', () => ({ SectionBlockForm: () => null }));
 jest.mock('./forms/ConditionalBlockForm', () => ({ ConditionalBlockForm: () => null }));
 jest.mock('./forms/InteractiveBlockForm', () => ({ InteractiveBlockForm: () => null }));
-jest.mock('./forms/MultistepBlockForm', () => ({ MultistepBlockForm: () => null }));
-jest.mock('./forms/GuidedBlockForm', () => ({ GuidedBlockForm: () => null }));
+jest.mock('./forms/MultistepBlockForm', () => ({
+  MultistepBlockForm: ({ onSwitchBlockType }: { onSwitchBlockType?: (type: string) => void }) => (
+    <button data-testid="multistep-to-guided" onClick={() => onSwitchBlockType?.('guided')}>
+      Switch to guided
+    </button>
+  ),
+}));
+jest.mock('./forms/GuidedBlockForm', () => ({
+  GuidedBlockForm: ({
+    onSwitchBlockType,
+  }: {
+    onSwitchBlockType?: (type: string, warning?: ConversionWarning) => void;
+  }) => (
+    <>
+      <button data-testid="guided-to-multistep" onClick={() => onSwitchBlockType?.('multistep')}>
+        Switch to multistep
+      </button>
+      <button
+        data-testid="guided-to-multistep-with-warning"
+        onClick={() =>
+          onSwitchBlockType?.('multistep', {
+            message: 'Converting will lose guided settings',
+            lostFields: ['stepTimeout', 'completeEarly'],
+          })
+        }
+      >
+        Switch to multistep with warning
+      </button>
+    </>
+  ),
+}));
 jest.mock('./forms/QuizBlockForm', () => ({ QuizBlockForm: () => null }));
 jest.mock('./forms/InputBlockForm', () => ({ InputBlockForm: () => null }));
 
@@ -118,6 +147,108 @@ describe('BlockFormModal type switch integration', () => {
 
       // Form should still render
       expect(screen.getByTestId('markdown-form')).toBeInTheDocument();
+    });
+
+    it('routes multistep to guided through the field-aware converter', () => {
+      const onConvertType = jest.fn();
+      const onSwitchBlockType = jest.fn();
+      const initialData: JsonMultistepBlock = {
+        type: 'multistep',
+        content: 'Complete these steps',
+        steps: [{ action: 'noop', tooltip: 'Preserve this text' }],
+      };
+
+      render(
+        <BlockFormModal
+          {...defaultProps}
+          blockType="multistep"
+          initialData={initialData}
+          onConvertType={onConvertType}
+          onSwitchBlockType={onSwitchBlockType}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('multistep-to-guided'));
+
+      expect(onConvertType).toHaveBeenCalledWith('guided');
+      expect(onSwitchBlockType).not.toHaveBeenCalled();
+    });
+
+    it('routes guided to multistep through the field-aware converter', () => {
+      const onConvertType = jest.fn();
+      const onSwitchBlockType = jest.fn();
+      const initialData: JsonGuidedBlock = {
+        type: 'guided',
+        content: 'Follow these steps',
+        steps: [{ action: 'noop', description: 'Preserve this text' }],
+      };
+
+      render(
+        <BlockFormModal
+          {...defaultProps}
+          blockType="guided"
+          initialData={initialData}
+          onConvertType={onConvertType}
+          onSwitchBlockType={onSwitchBlockType}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('guided-to-multistep'));
+
+      expect(onConvertType).toHaveBeenCalledWith('multistep');
+      expect(onSwitchBlockType).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the generic switch when no field-aware converter is available', () => {
+      const onSwitchBlockType = jest.fn();
+
+      render(
+        <BlockFormModal
+          {...defaultProps}
+          blockType="multistep"
+          initialData={{ type: 'multistep', content: 'Complete these steps', steps: [] }}
+          onSwitchBlockType={onSwitchBlockType}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('multistep-to-guided'));
+
+      expect(onSwitchBlockType).toHaveBeenCalledWith('guided');
+    });
+
+    it('waits for confirmation before a warning-bearing field-aware conversion', async () => {
+      const onConvertType = jest.fn();
+      const onSwitchBlockType = jest.fn();
+      const initialData: JsonGuidedBlock = {
+        type: 'guided',
+        content: 'Follow these steps',
+        steps: [{ action: 'noop', description: 'Preserve this text' }],
+        stepTimeout: 15_000,
+        completeEarly: true,
+      };
+
+      render(
+        <BlockFormModal
+          {...defaultProps}
+          blockType="guided"
+          initialData={initialData}
+          onConvertType={onConvertType}
+          onSwitchBlockType={onSwitchBlockType}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('guided-to-multistep-with-warning'));
+
+      expect(onConvertType).not.toHaveBeenCalled();
+      expect(onSwitchBlockType).not.toHaveBeenCalled();
+      expect(screen.getByText('Converting will lose guided settings')).toBeInTheDocument();
+      expect(screen.getByText('stepTimeout')).toBeInTheDocument();
+      expect(screen.getByText('completeEarly')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Convert anyway'));
+
+      await waitFor(() => expect(onConvertType).toHaveBeenCalledWith('multistep'));
+      expect(onSwitchBlockType).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/block-editor/BlockFormModal.tsx
+++ b/src/components/block-editor/BlockFormModal.tsx
@@ -15,7 +15,7 @@
  * 3. Keeping ConfirmModal here ensures it survives form component unmounts
  *
  * Flow: FormComponent -> TypeSwitchDropdown -> handleTypeSwitchRequest ->
- *       (if warning) pendingSwitch state -> ConfirmModal -> onSwitchBlockType
+ *       (if warning) pendingSwitch state -> ConfirmModal -> selected conversion handler
  */
 
 import React, { useState, useCallback, useRef, useEffect } from 'react';
@@ -164,6 +164,7 @@ export function BlockFormModal({
   const [pendingSwitch, setPendingSwitch] = useState<{
     type: BlockType;
     warning: ConversionWarning;
+    useFieldAwareConversion: boolean;
   } | null>(null);
 
   // Store a callback to receive the selected element
@@ -428,27 +429,38 @@ export function BlockFormModal({
    */
   const handleTypeSwitchRequest = useCallback(
     (newType: BlockType, warning?: ConversionWarning) => {
+      const useFieldAwareConversion =
+        Boolean(onConvertType) &&
+        ((blockType === 'multistep' && newType === 'guided') || (blockType === 'guided' && newType === 'multistep'));
+
       if (warning) {
         // Show confirmation dialog at modal level - survives form component unmount
-        setPendingSwitch({ type: newType, warning });
+        setPendingSwitch({ type: newType, warning, useFieldAwareConversion });
+      } else if (useFieldAwareConversion && (newType === 'multistep' || newType === 'guided')) {
+        onConvertType?.(newType);
       } else {
         // No data loss - proceed directly
         onSwitchBlockType?.(newType);
       }
     },
-    [onSwitchBlockType]
+    [blockType, onConvertType, onSwitchBlockType]
   );
 
   /**
    * Handle confirmation from the type switch warning dialog.
    */
   const handleTypeSwitchConfirm = useCallback(() => {
-    const type = pendingSwitch?.type;
+    const pending = pendingSwitch;
     setPendingSwitch(null);
-    if (type) {
-      onSwitchBlockType?.(type);
+    if (!pending) {
+      return;
     }
-  }, [pendingSwitch, onSwitchBlockType]);
+    if (pending.useFieldAwareConversion && (pending.type === 'multistep' || pending.type === 'guided')) {
+      onConvertType?.(pending.type);
+    } else {
+      onSwitchBlockType?.(pending.type);
+    }
+  }, [onConvertType, onSwitchBlockType, pendingSwitch]);
 
   /**
    * Handle cancellation of the type switch warning dialog.

--- a/src/components/block-editor/hooks/useBlockConversionHandlers.test.ts
+++ b/src/components/block-editor/hooks/useBlockConversionHandlers.test.ts
@@ -1,0 +1,118 @@
+import { act, renderHook } from '@testing-library/react';
+
+import type { JsonGuidedBlock, JsonMultistepBlock } from '../../../types/json-guide.types';
+import {
+  useBlockConversionHandlers,
+  type ConversionEditorInterface,
+  type ConversionFormStateInterface,
+} from './useBlockConversionHandlers';
+
+describe('useBlockConversionHandlers', () => {
+  it('field-maps a conditional-branch block without losing shared metadata', () => {
+    const source: JsonMultistepBlock = {
+      type: 'multistep',
+      id: 'conditional-step-group',
+      content: 'Complete these steps',
+      steps: [{ action: 'noop', tooltip: 'Preserve this text' }],
+      authorNote: 'Keep this note',
+    };
+    const updateConditionalBranchBlock = jest.fn();
+    const closeBlockForm = jest.fn();
+    const editor: ConversionEditorInterface = {
+      state: { blocks: [] },
+      removeBlock: jest.fn(),
+      addBlock: jest.fn(),
+      addBlockToSection: jest.fn(),
+      deleteNestedBlock: jest.fn(),
+      updateBlock: jest.fn(),
+      updateNestedBlock: jest.fn(),
+      updateConditionalBranchBlock,
+    };
+    const formState: ConversionFormStateInterface = {
+      editingBlock: null,
+      editingNestedBlock: null,
+      editingConditionalBranchBlock: {
+        conditionalId: 'conditional-1',
+        branch: 'whenTrue',
+        nestedIndex: 2,
+        block: source,
+      },
+      closeBlockForm,
+      setEditingBlockType: jest.fn(),
+      setEditingBlock: jest.fn(),
+      setEditingNestedBlock: jest.fn(),
+      setEditingConditionalBranchBlock: jest.fn(),
+    };
+
+    const { result } = renderHook(() => useBlockConversionHandlers({ editor, formState }));
+
+    act(() => result.current.handleConvertType('guided'));
+
+    expect(updateConditionalBranchBlock).toHaveBeenCalledWith(
+      'conditional-1',
+      'whenTrue',
+      2,
+      expect.objectContaining({
+        type: 'guided',
+        id: 'conditional-step-group',
+        authorNote: 'Keep this note',
+        steps: [expect.objectContaining({ description: 'Preserve this text', tooltip: undefined })],
+      })
+    );
+    expect(closeBlockForm).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps guided descriptions back to tooltips in conditional branches', () => {
+    const source: JsonGuidedBlock = {
+      type: 'guided',
+      id: 'conditional-guided-group',
+      content: 'Complete these steps',
+      steps: [{ action: 'noop', description: 'Preserve this description' }],
+      authorNote: 'Keep this note too',
+    };
+    const updateConditionalBranchBlock = jest.fn();
+    const closeBlockForm = jest.fn();
+    const editor: ConversionEditorInterface = {
+      state: { blocks: [] },
+      removeBlock: jest.fn(),
+      addBlock: jest.fn(),
+      addBlockToSection: jest.fn(),
+      deleteNestedBlock: jest.fn(),
+      updateBlock: jest.fn(),
+      updateNestedBlock: jest.fn(),
+      updateConditionalBranchBlock,
+    };
+    const formState: ConversionFormStateInterface = {
+      editingBlock: null,
+      editingNestedBlock: null,
+      editingConditionalBranchBlock: {
+        conditionalId: 'conditional-2',
+        branch: 'whenFalse',
+        nestedIndex: 1,
+        block: source,
+      },
+      closeBlockForm,
+      setEditingBlockType: jest.fn(),
+      setEditingBlock: jest.fn(),
+      setEditingNestedBlock: jest.fn(),
+      setEditingConditionalBranchBlock: jest.fn(),
+    };
+
+    const { result } = renderHook(() => useBlockConversionHandlers({ editor, formState }));
+
+    act(() => result.current.handleConvertType('multistep'));
+
+    expect(updateConditionalBranchBlock).toHaveBeenCalledWith(
+      'conditional-2',
+      'whenFalse',
+      1,
+      expect.objectContaining({
+        type: 'multistep',
+        id: 'conditional-guided-group',
+        authorNote: 'Keep this note too',
+        steps: [expect.objectContaining({ tooltip: 'Preserve this description', description: undefined })],
+      })
+    );
+    expect(closeBlockForm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/block-editor/hooks/useBlockConversionHandlers.test.ts
+++ b/src/components/block-editor/hooks/useBlockConversionHandlers.test.ts
@@ -1,13 +1,125 @@
 import { act, renderHook } from '@testing-library/react';
+import { getAppEvents } from '@grafana/runtime';
 
 import type { JsonGuidedBlock, JsonMultistepBlock } from '../../../types/json-guide.types';
+import { JsonBlockSchema } from '../../../types/json-guide.schema';
 import {
   useBlockConversionHandlers,
   type ConversionEditorInterface,
   type ConversionFormStateInterface,
 } from './useBlockConversionHandlers';
 
+jest.mock('@grafana/runtime', () => ({ getAppEvents: jest.fn() }));
+
+const publish = jest.fn();
+
+function makeEditor(overrides: Partial<ConversionEditorInterface> = {}): ConversionEditorInterface {
+  return {
+    state: { blocks: [] },
+    removeBlock: jest.fn(),
+    addBlock: jest.fn(),
+    addBlockToSection: jest.fn(),
+    deleteNestedBlock: jest.fn(),
+    updateBlock: jest.fn(),
+    updateNestedBlock: jest.fn(),
+    updateConditionalBranchBlock: jest.fn(),
+    ...overrides,
+  };
+}
+
+function makeFormState(overrides: Partial<ConversionFormStateInterface> = {}): ConversionFormStateInterface {
+  return {
+    editingBlock: null,
+    editingNestedBlock: null,
+    editingConditionalBranchBlock: null,
+    closeBlockForm: jest.fn(),
+    setEditingBlockType: jest.fn(),
+    setEditingBlock: jest.fn(),
+    setEditingNestedBlock: jest.fn(),
+    setEditingConditionalBranchBlock: jest.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  publish.mockClear();
+  (getAppEvents as jest.Mock).mockReturnValue({ publish });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('useBlockConversionHandlers', () => {
+  it('field-maps a root block and writes schema-valid guided data', () => {
+    const source: JsonMultistepBlock = {
+      type: 'multistep',
+      id: 'root-step-group',
+      content: 'Complete these steps',
+      steps: [{ action: 'noop', tooltip: 'Preserve this root text' }],
+    };
+    const updateBlock = jest.fn();
+    const closeBlockForm = jest.fn();
+    const editor = makeEditor({ updateBlock });
+    const formState = makeFormState({
+      editingBlock: { id: 'root-step-group', block: source },
+      closeBlockForm,
+    });
+
+    const { result } = renderHook(() => useBlockConversionHandlers({ editor, formState }));
+
+    act(() => result.current.handleConvertType('guided'));
+
+    expect(updateBlock).toHaveBeenCalledWith(
+      'root-step-group',
+      expect.objectContaining({
+        type: 'guided',
+        id: 'root-step-group',
+        steps: [expect.objectContaining({ description: 'Preserve this root text', tooltip: undefined })],
+      })
+    );
+    const convertedBlock = updateBlock.mock.calls[0][1];
+    expect(JsonBlockSchema.safeParse(convertedBlock).success).toBe(true);
+    expect(closeBlockForm).toHaveBeenCalledTimes(1);
+  });
+
+  it('field-maps a section-nested block and writes schema-valid multistep data', () => {
+    const source: JsonGuidedBlock = {
+      type: 'guided',
+      id: 'nested-step-group',
+      content: 'Follow these steps',
+      steps: [{ action: 'noop', description: 'Preserve this nested text' }],
+    };
+    const updateNestedBlock = jest.fn();
+    const closeBlockForm = jest.fn();
+    const editor = makeEditor({ updateNestedBlock });
+    const formState = makeFormState({
+      editingNestedBlock: {
+        sectionId: 'section-1',
+        nestedIndex: 3,
+        block: source,
+      },
+      closeBlockForm,
+    });
+
+    const { result } = renderHook(() => useBlockConversionHandlers({ editor, formState }));
+
+    act(() => result.current.handleConvertType('multistep'));
+
+    expect(updateNestedBlock).toHaveBeenCalledWith(
+      'section-1',
+      3,
+      expect.objectContaining({
+        type: 'multistep',
+        id: 'nested-step-group',
+        steps: [expect.objectContaining({ tooltip: 'Preserve this nested text', description: undefined })],
+      })
+    );
+    const convertedBlock = updateNestedBlock.mock.calls[0][2];
+    expect(JsonBlockSchema.safeParse(convertedBlock).success).toBe(true);
+    expect(closeBlockForm).toHaveBeenCalledTimes(1);
+  });
+
   it('field-maps a conditional-branch block without losing shared metadata', () => {
     const source: JsonMultistepBlock = {
       type: 'multistep',
@@ -18,19 +130,8 @@ describe('useBlockConversionHandlers', () => {
     };
     const updateConditionalBranchBlock = jest.fn();
     const closeBlockForm = jest.fn();
-    const editor: ConversionEditorInterface = {
-      state: { blocks: [] },
-      removeBlock: jest.fn(),
-      addBlock: jest.fn(),
-      addBlockToSection: jest.fn(),
-      deleteNestedBlock: jest.fn(),
-      updateBlock: jest.fn(),
-      updateNestedBlock: jest.fn(),
-      updateConditionalBranchBlock,
-    };
-    const formState: ConversionFormStateInterface = {
-      editingBlock: null,
-      editingNestedBlock: null,
+    const editor = makeEditor({ updateConditionalBranchBlock });
+    const formState = makeFormState({
       editingConditionalBranchBlock: {
         conditionalId: 'conditional-1',
         branch: 'whenTrue',
@@ -38,11 +139,7 @@ describe('useBlockConversionHandlers', () => {
         block: source,
       },
       closeBlockForm,
-      setEditingBlockType: jest.fn(),
-      setEditingBlock: jest.fn(),
-      setEditingNestedBlock: jest.fn(),
-      setEditingConditionalBranchBlock: jest.fn(),
-    };
+    });
 
     const { result } = renderHook(() => useBlockConversionHandlers({ editor, formState }));
 
@@ -72,19 +169,8 @@ describe('useBlockConversionHandlers', () => {
     };
     const updateConditionalBranchBlock = jest.fn();
     const closeBlockForm = jest.fn();
-    const editor: ConversionEditorInterface = {
-      state: { blocks: [] },
-      removeBlock: jest.fn(),
-      addBlock: jest.fn(),
-      addBlockToSection: jest.fn(),
-      deleteNestedBlock: jest.fn(),
-      updateBlock: jest.fn(),
-      updateNestedBlock: jest.fn(),
-      updateConditionalBranchBlock,
-    };
-    const formState: ConversionFormStateInterface = {
-      editingBlock: null,
-      editingNestedBlock: null,
+    const editor = makeEditor({ updateConditionalBranchBlock });
+    const formState = makeFormState({
       editingConditionalBranchBlock: {
         conditionalId: 'conditional-2',
         branch: 'whenFalse',
@@ -92,11 +178,7 @@ describe('useBlockConversionHandlers', () => {
         block: source,
       },
       closeBlockForm,
-      setEditingBlockType: jest.fn(),
-      setEditingBlock: jest.fn(),
-      setEditingNestedBlock: jest.fn(),
-      setEditingConditionalBranchBlock: jest.fn(),
-    };
+    });
 
     const { result } = renderHook(() => useBlockConversionHandlers({ editor, formState }));
 
@@ -114,5 +196,38 @@ describe('useBlockConversionHandlers', () => {
       })
     );
     expect(closeBlockForm).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies the user and keeps editor state unchanged when conversion validation fails', () => {
+    const source: JsonMultistepBlock = {
+      type: 'multistep',
+      content: '',
+      steps: [],
+    };
+    const updateConditionalBranchBlock = jest.fn();
+    const closeBlockForm = jest.fn();
+    const editor = makeEditor({ updateConditionalBranchBlock });
+    const formState = makeFormState({
+      editingConditionalBranchBlock: {
+        conditionalId: 'conditional-invalid',
+        branch: 'whenTrue',
+        nestedIndex: 0,
+        block: source,
+      },
+      closeBlockForm,
+    });
+    jest.spyOn(console, 'error').mockImplementation();
+
+    const { result } = renderHook(() => useBlockConversionHandlers({ editor, formState }));
+
+    expect(() => {
+      act(() => result.current.handleConvertType('guided'));
+    }).not.toThrow();
+    expect(updateConditionalBranchBlock).not.toHaveBeenCalled();
+    expect(closeBlockForm).not.toHaveBeenCalled();
+    expect(publish).toHaveBeenCalledWith({
+      type: 'alert-error',
+      payload: ['Conversion failed', 'Could not convert to the selected block type.'],
+    });
   });
 });

--- a/src/components/block-editor/hooks/useBlockConversionHandlers.ts
+++ b/src/components/block-editor/hooks/useBlockConversionHandlers.ts
@@ -161,35 +161,28 @@ export function useBlockConversionHandlers(
   // Convert between multistep and guided types
   const handleConvertType = useCallback(
     (newType: 'multistep' | 'guided') => {
-      const blockData = editingNestedBlock?.block ?? editingBlock?.block;
+      const blockData = editingConditionalBranchBlock?.block ?? editingNestedBlock?.block ?? editingBlock?.block;
       if (!blockData || (blockData.type !== 'multistep' && blockData.type !== 'guided')) {
         return;
       }
 
       const currentBlock = blockData as JsonMultistepBlock | JsonGuidedBlock;
-      let convertedBlock: JsonMultistepBlock | JsonGuidedBlock;
+      const convertedBlock = {
+        ...convertBlockType(currentBlock, newType),
+        steps:
+          newType === 'guided'
+            ? currentBlock.steps.map(stepMultistepToGuided)
+            : currentBlock.steps.map(stepGuidedToMultistep),
+      } as JsonMultistepBlock | JsonGuidedBlock;
 
-      if (newType === 'guided') {
-        convertedBlock = {
-          type: 'guided',
-          content: currentBlock.content,
-          steps: currentBlock.steps.map(stepMultistepToGuided),
-          ...(currentBlock.requirements && { requirements: currentBlock.requirements }),
-          ...(currentBlock.objectives && { objectives: currentBlock.objectives }),
-          ...(currentBlock.skippable && { skippable: currentBlock.skippable }),
-        };
-      } else {
-        convertedBlock = {
-          type: 'multistep',
-          content: currentBlock.content,
-          steps: currentBlock.steps.map(stepGuidedToMultistep),
-          ...(currentBlock.requirements && { requirements: currentBlock.requirements }),
-          ...(currentBlock.objectives && { objectives: currentBlock.objectives }),
-          ...(currentBlock.skippable && { skippable: currentBlock.skippable }),
-        };
-      }
-
-      if (editingNestedBlock) {
+      if (editingConditionalBranchBlock) {
+        editor.updateConditionalBranchBlock(
+          editingConditionalBranchBlock.conditionalId,
+          editingConditionalBranchBlock.branch,
+          editingConditionalBranchBlock.nestedIndex,
+          convertedBlock
+        );
+      } else if (editingNestedBlock) {
         // Update nested block
         editor.updateNestedBlock(editingNestedBlock.sectionId, editingNestedBlock.nestedIndex, convertedBlock);
       } else if (editingBlock) {
@@ -200,7 +193,7 @@ export function useBlockConversionHandlers(
       // Close the modal
       closeBlockForm();
     },
-    [editingBlock, editingNestedBlock, editor, closeBlockForm]
+    [editingBlock, editingNestedBlock, editingConditionalBranchBlock, editor, closeBlockForm]
   );
 
   // Switch any block to a different type

--- a/src/components/block-editor/hooks/useBlockConversionHandlers.ts
+++ b/src/components/block-editor/hooks/useBlockConversionHandlers.ts
@@ -18,6 +18,14 @@ import { stepGuidedToMultistep, stepMultistepToGuided } from '../utils/stepField
 import type { NestedBlockEditingState, ConditionalBranchEditingState } from './useBlockFormState';
 import { logger } from '../../../lib/logging';
 
+function notifyConversionFailure(error: unknown): void {
+  logger.error('Failed to convert block type', { error });
+  getAppEvents().publish({
+    type: 'alert-error',
+    payload: ['Conversion failed', 'Could not convert to the selected block type.'],
+  });
+}
+
 /**
  * Minimal interface for editor functionality needed by this hook.
  */
@@ -158,7 +166,6 @@ export function useBlockConversionHandlers(
     closeBlockForm();
   }, [editingBlock, editingNestedBlock, editor, closeBlockForm]);
 
-  // Convert between multistep and guided types
   const handleConvertType = useCallback(
     (newType: 'multistep' | 'guided') => {
       const blockData = editingConditionalBranchBlock?.block ?? editingNestedBlock?.block ?? editingBlock?.block;
@@ -166,32 +173,33 @@ export function useBlockConversionHandlers(
         return;
       }
 
-      const currentBlock = blockData as JsonMultistepBlock | JsonGuidedBlock;
-      const convertedBlock = {
-        ...convertBlockType(currentBlock, newType),
-        steps:
-          newType === 'guided'
-            ? currentBlock.steps.map(stepMultistepToGuided)
-            : currentBlock.steps.map(stepGuidedToMultistep),
-      } as JsonMultistepBlock | JsonGuidedBlock;
+      try {
+        const currentBlock = blockData as JsonMultistepBlock | JsonGuidedBlock;
+        const convertedBlock = {
+          ...convertBlockType(currentBlock, newType),
+          steps:
+            newType === 'guided'
+              ? currentBlock.steps.map(stepMultistepToGuided)
+              : currentBlock.steps.map(stepGuidedToMultistep),
+        } as JsonMultistepBlock | JsonGuidedBlock;
 
-      if (editingConditionalBranchBlock) {
-        editor.updateConditionalBranchBlock(
-          editingConditionalBranchBlock.conditionalId,
-          editingConditionalBranchBlock.branch,
-          editingConditionalBranchBlock.nestedIndex,
-          convertedBlock
-        );
-      } else if (editingNestedBlock) {
-        // Update nested block
-        editor.updateNestedBlock(editingNestedBlock.sectionId, editingNestedBlock.nestedIndex, convertedBlock);
-      } else if (editingBlock) {
-        // Update root-level block
-        editor.updateBlock(editingBlock.id, convertedBlock);
+        if (editingConditionalBranchBlock) {
+          editor.updateConditionalBranchBlock(
+            editingConditionalBranchBlock.conditionalId,
+            editingConditionalBranchBlock.branch,
+            editingConditionalBranchBlock.nestedIndex,
+            convertedBlock
+          );
+        } else if (editingNestedBlock) {
+          editor.updateNestedBlock(editingNestedBlock.sectionId, editingNestedBlock.nestedIndex, convertedBlock);
+        } else if (editingBlock) {
+          editor.updateBlock(editingBlock.id, convertedBlock);
+        }
+
+        closeBlockForm();
+      } catch (error) {
+        notifyConversionFailure(error);
       }
-
-      // Close the modal
-      closeBlockForm();
     },
     [editingBlock, editingNestedBlock, editingConditionalBranchBlock, editor, closeBlockForm]
   );
@@ -237,11 +245,7 @@ export function useBlockConversionHandlers(
         // Update block type - triggers form remount via key prop change
         setEditingBlockType(newType);
       } catch (error) {
-        logger.error('Failed to convert block type', { error });
-        getAppEvents().publish({
-          type: 'alert-error',
-          payload: ['Conversion failed', 'Could not convert to the selected block type.'],
-        });
+        notifyConversionFailure(error);
       }
     },
     [


### PR DESCRIPTION
## What does this PR do?

Preserves step text when switching between multistep and guided blocks from the type dropdown.

The dropdown previously used the generic block converter, which copied steps without translating the type-specific text field. As a result, multistep `tooltip` values were not moved to guided `description` values, and the reverse conversion had the same problem.

This change routes that pair through the existing field-aware conversion owner while preserving:

- the existing confirmation dialog for target-incompatible fields;
- shared block metadata such as `id` and `authorNote`;
- root, section-nested, and conditional-branch editing behavior;
- the generic fallback when no field-aware handler is available.

Multistep/guided dropdown conversion closes the modal after writing the converted block, while other target-type switches continue in place. Keeping this field-aware path open would render stale initial form data.

## Linked issue(s)

Fixes #804

## Verification

- Focused block-form and conversion-handler tests: 14 passed
- Applicable frontend suite with coverage: 422 suites, 6,606 tests passed
- TypeScript typecheck
- ESLint (0 errors; existing deprecation warnings only)
- Prettier
- Production webpack build
- Documentation synchronization check
- Negative controls confirmed the regression tests fail against the pre-fix implementation

## Checklist

- [x] This PR addresses a **single concern** (one bug fix or feature, or a set of closely-related changes). Unrelated changes belong in separate PRs; see [CONTRIBUTING.md](../CONTRIBUTING.md#pull-request-scope).
- [x] All commits are signed (required, or the checks will not pass). See [CONTRIBUTING.md](../CONTRIBUTING.md#signed-commits).
- [x] I've added or updated tests for the change.
- [ ] `npm run check` passes locally (typecheck, lint, prettier, Go lint/tests, frontend tests).
- [x] UI text and docs use [sentence case](https://grafana.com/docs/writers-toolkit/write/style-guide/capitalization-punctuation/#capitalization).
