### PR TITLE
spike(coda): consume @grafana/coda-client instead of the hand copy

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,10 +3,16 @@
 process.env.TZ = 'UTC';
 
 const baseConfig = require('./.config/jest.config');
+const { grafanaESModules, nodeModulesToTransform } = require('./.config/jest/utils');
 
 module.exports = {
   // Jest configuration provided by Grafana scaffolding
   ...baseConfig,
+
+  // @grafana/coda-client ships ESM-only (no CJS build), so it needs the same
+  // treatment as the packages the scaffolding already knows about.
+  // .config/README.md#esm-errors-with-jest
+  transformIgnorePatterns: [nodeModulesToTransform([...grafanaESModules, '@grafana/coda-client'])],
 
   // Polyfill jsdom-only globals before the scaffolded setup runs so test
   // files can opt into `@jest-environment node` without breaking the

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@emotion/css": "^11.13.5",
         "@grafana/assistant": "^0.1.25",
+        "@grafana/coda-client": "npm:@grafana-coda/sandbox-client@^1.1.1",
         "@grafana/data": "13.1.3",
         "@grafana/e2e-selectors": "13.1.3",
         "@grafana/faro-instrumentation-replay": "~2.9.0",
@@ -2088,6 +2089,18 @@
         "@grafana/ui": ">=12.1.0",
         "react": ">=18.0.0",
         "rxjs": ">=7.0.0"
+      }
+    },
+    "node_modules/@grafana/coda-client": {
+      "name": "@grafana-coda/sandbox-client",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@grafana-coda/sandbox-client/-/sandbox-client-1.1.1.tgz",
+      "integrity": "sha512-eUEQKQwt7I62o6veeMjJtNtDTZmPUctwxXsKGqqAStx4Oej3WJO5U7WtrWua9DQRGtY7XUEa4D0HOOZvAZRT8w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@grafana/data": ">=11.1.0",
+        "@grafana/runtime": ">=11.1.0",
+        "rxjs": "^7.0.0"
       }
     },
     "node_modules/@grafana/data": {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@emotion/css": "^11.13.5",
     "@grafana/assistant": "^0.1.25",
+    "@grafana/coda-client": "npm:@grafana-coda/sandbox-client@^1.1.1",
     "@grafana/data": "13.1.3",
     "@grafana/e2e-selectors": "13.1.3",
     "@grafana/faro-instrumentation-replay": "~2.9.0",

--- a/src/integrations/coda/coda-api.test.ts
+++ b/src/integrations/coda/coda-api.test.ts
@@ -1,16 +1,17 @@
-import { of, throwError } from 'rxjs';
-import { getBackendSrv } from '@grafana/runtime';
+/**
+ * This adapter is now a thin wrapper around `@grafana/coda-client`'s
+ * `CodaClient` — request classification, `isCodaUsable`, `codaSessionEligibility`
+ * and friends are plain re-exports and covered by the package's own test suite.
+ * These tests cover only what's Pathfinder-local: the `execInSession` request
+ * re-join, `isRoleForbidden`, and the two URL builders the package has no
+ * equivalent for.
+ */
 
-import {
-  codaSessionEligibility,
-  createSession,
-  execInSession,
-  getCapabilities,
-  isCodaUsable,
-  toCodaError,
-  sessionChannelAddress,
-  type CodaCapabilities,
-} from './coda-api';
+import { of } from 'rxjs';
+import { getBackendSrv } from '@grafana/runtime';
+import { CodaError } from '@grafana/coda-client';
+
+import { alloyScenariosUrl, execInSession, isRoleForbidden, sampleAppsUrl } from './coda-api';
 
 jest.mock('@grafana/runtime', () => ({
   getBackendSrv: jest.fn(),
@@ -28,90 +29,32 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('coda-api request options', () => {
-  // Issue #1539: the plugin answers 401 `coda_auth_failed` when *its* Coda
-  // credential expires, but Grafana's global handler reads any first-attempt
-  // 401 on a relative URL as the caller's Grafana session expiring — it pings
-  // /api/login/ping and replays the request. `retry: 1` opts out.
-  it.each([
-    ['createSession', () => createSession()],
-    ['execInSession', () => execInSession('s_1', { command: 'true' })],
-    ['getCapabilities', () => getCapabilities()],
-  ])('%s opts out of Grafana global 401 handling', async (_name, call) => {
+describe('execInSession', () => {
+  it('re-joins the command with the rest of the options for CodaClient.exec', async () => {
     const fetch = mockFetch();
-    await call();
-    expect(fetch.mock.calls[0]![0]).toMatchObject({ retry: 1, showErrorAlert: false });
-  });
+    await execInSession('s_1', { command: 'true', readyFile: '/tmp/ready', timeoutMs: 5000 });
 
-  it('still classifies a 401 by the backend code rather than the status', async () => {
-    const fetch = jest.fn(() =>
-      throwError(() => ({ status: 401, data: { code: 'coda_auth_failed', error: 'token expired' } }))
-    );
-    mockedGetBackendSrv.mockReturnValue({ fetch } as unknown as ReturnType<typeof getBackendSrv>);
-
-    await expect(getCapabilities()).rejects.toMatchObject({ code: 'coda_auth_failed', status: 401 });
-  });
-});
-
-describe('toCodaError', () => {
-  it('reads a bare 404 as the plugin being absent, since the backend always sends a code', () => {
-    expect(toCodaError({ status: 404 })).toMatchObject({ code: 'plugin_not_installed' });
-  });
-});
-
-function capabilities(overrides: Partial<CodaCapabilities> = {}): CodaCapabilities {
-  return {
-    registered: true,
-    templates: [],
-    sampleApps: [],
-    alloyScenarios: [],
-    limits: { maxVMsPerUser: 3, maxExecTimeoutMs: 120_000, maxOutputBytes: 32_768 },
-    ...overrides,
-  };
-}
-
-describe('isCodaUsable', () => {
-  it('refuses a registered backend whose credential has expired', () => {
-    expect(isCodaUsable(capabilities({ credential: { state: 'expired' } }))).toBe(false);
-  });
-
-  it('refuses a registered backend that reports configuration errors', () => {
-    expect(isCodaUsable(capabilities({ configErrors: ['apiUrl is not set'] }))).toBe(false);
-  });
-
-  it('accepts absent evidence: unknown and unreachable are not a dead credential', () => {
-    expect(isCodaUsable(capabilities({ credential: { state: 'unknown' } }))).toBe(true);
-    expect(isCodaUsable(capabilities({ credential: { state: 'unreachable' } }))).toBe(true);
-  });
-
-  // Never stricter than reading `registered` was, or upgrading Pathfinder would
-  // break a stack running a 1.1.x Coda plugin that cannot answer.
-  it('is no stricter than registered on a backend that omits both fields', () => {
-    expect(isCodaUsable(capabilities())).toBe(true);
-    expect(isCodaUsable(capabilities({ registered: false }))).toBe(false);
-  });
-});
-
-describe('codaSessionEligibility', () => {
-  it('reads an absent caller as unknown rather than guessing either answer', () => {
-    expect(codaSessionEligibility(capabilities())).toBe('unknown');
-  });
-
-  it('answers before a session request is spent finding out', () => {
-    expect(
-      codaSessionEligibility(capabilities({ caller: { canCreateSessions: true, minimumSessionRole: 'Editor' } }))
-    ).toBe('eligible');
-    expect(
-      codaSessionEligibility(capabilities({ caller: { canCreateSessions: false, minimumSessionRole: 'Editor' } }))
-    ).toBe('role_forbidden');
-  });
-});
-
-describe('sessionChannelAddress', () => {
-  it('keeps slashes in the opaque path so a scenario id survives', () => {
-    expect(sessionChannelAddress('plugin/grafana-coda-app/v1/session/s_1')).toMatchObject({
-      stream: 'grafana-coda-app',
-      path: 'v1/session/s_1',
+    const [request] = fetch.mock.calls[0]!;
+    expect(request).toMatchObject({
+      url: expect.stringContaining('/sessions/s_1/exec'),
+      data: { command: 'true', readyFile: '/tmp/ready', timeoutMs: 5000 },
     });
+  });
+});
+
+describe('isRoleForbidden', () => {
+  it('reads the role_forbidden code', () => {
+    expect(isRoleForbidden(new CodaError('nope', 'role_forbidden', 403))).toBe(true);
+  });
+
+  it('is false for any other code', () => {
+    expect(isRoleForbidden(new CodaError('nope', 'internal', 500))).toBe(false);
+  });
+});
+
+describe('URL builders', () => {
+  it('builds sampleAppsUrl and alloyScenariosUrl off the v1 resource base', () => {
+    expect(sampleAppsUrl()).toBe('/api/plugins/grafana-coda-app/resources/v1/sample-apps');
+    expect(alloyScenariosUrl()).toBe('/api/plugins/grafana-coda-app/resources/v1/alloy-scenarios');
   });
 });

--- a/src/integrations/coda/coda-api.ts
+++ b/src/integrations/coda/coda-api.ts
@@ -1,175 +1,53 @@
 /**
- * TEMPORARY local client for the `grafana-coda-app` v1 API.
+ * Thin adapter over the published `@grafana/coda-client` SDK.
  *
- * ---------------------------------------------------------------------------
- * TODO (on or after 2026-08-15): delete this file and depend on the published
- * package instead.
+ * Consumers in this repo keep importing from here rather than from the
+ * package directly, so the free-function call shapes this codebase already
+ * uses (`getCapabilities()`, `createSession(vmOpts)`, `execInSession(id, req)`,
+ * ...) stay unchanged even though the package itself is a `CodaClient` class
+ * with instance methods. `client` below is the one shared instance.
  *
- * It is published as **`@grafana-coda/sandbox-client@1.1.1`** — an interim
- * scope, so it is consumed through an npm alias that keeps the import
- * specifier this file will be replaced by:
- *
- *   "@grafana/coda-client": "npm:@grafana-coda/sandbox-client@^1.1.1"
- *
- * The one thing blocking that line today is our own `.npmrc`:
- * `min-release-age=3` refuses any version published less than three days ago,
- * and 1.1.1 went out at **2026-08-12T15:26:59Z**, so `npm ci` rejects it until
- * **2026-08-15T15:26:59Z**. Adding the dependency before then makes the repo
- * uninstallable, which is why the hand copy is still here.
- *
- * The package is a superset of this file: it also owns the Grafana Live
- * protocol — frame unwrapping, the mandatory `{ useSocket: true }` publish, and
- * a one-shot session object that cannot be left subscribed after an error.
- *
- * The swap is:
- *   - replace this file with re-exports from `@grafana/coda-client`;
- *   - move `useTerminalLive.hook.ts` onto its `CodaSession` class, which
- *     deletes the frame parsing, channel splitting, `publishOverSocket` cast
- *     and handshake timer that still live there;
- *   - note that `CodaSession` in the package is that class, not this response
- *     interface — the package calls this shape `SessionResponse`.
- *
- * Names below deliberately match the package so that diff stays small.
- * ---------------------------------------------------------------------------
+ * `createSession()` below resolves to the package's own `CodaSession` — the
+ * *live terminal session* class (`subscribe`/`write`/`resize`/`exec`/`close`),
+ * not a plain response object. `useTerminalLive.hook.ts` imports that type
+ * directly from `@grafana/coda-client` rather than through this adapter.
  */
 
-import { getBackendSrv } from '@grafana/runtime';
-import { LiveChannelScope, type LiveChannelAddress } from '@grafana/data';
-import { lastValueFrom } from 'rxjs';
+import {
+  CodaClient,
+  CodaError,
+  toCodaError,
+  isNotReady,
+  isUnavailable,
+  CODA_PLUGIN_ID,
+  CODA_RESOURCE_BASE,
+  V1_DEFAULTS,
+  isCodaUsable,
+  codaSessionEligibility,
+  type CodaErrorCode,
+  type CodaCapabilities,
+  type CodaSessionRole,
+  type CreateSessionOptions,
+  type ExecOptions,
+  type ExecResult,
+} from '@grafana/coda-client';
 
-export const CODA_PLUGIN_ID = 'grafana-coda-app';
+export {
+  CodaError,
+  toCodaError,
+  isNotReady,
+  isUnavailable,
+  CODA_PLUGIN_ID,
+  CODA_RESOURCE_BASE,
+  V1_DEFAULTS,
+  isCodaUsable,
+  codaSessionEligibility,
+};
+export type { CodaErrorCode, CodaCapabilities, CodaSessionRole };
 
-const CODA_BACKEND_URL = `/api/plugins/${CODA_PLUGIN_ID}/resources/v1`;
-
-export interface TerminalVMOptions {
-  template?: string;
-  app?: string;
-  scenario?: string;
-}
-
-export interface CodaSession {
-  sessionId: string;
-  channel: string;
-  state: string;
-  vmId?: string;
-  template: string;
-}
-
-export interface CodaCatalogueItem {
-  id: string;
-  name: string;
-  description: string;
-}
-
-/**
- * Facts about the backend that would otherwise be hardcoded here. Optional
- * because an older Coda plugin does not send them — fall back to
- * {@link V1_DEFAULTS} rather than requiring anything it has not advertised.
- */
-export interface CodaTimings {
-  heartbeatIntervalMs: number;
-  estimatedProvisionMs: number;
-  maxProvisionMs: number;
-}
-
-/**
- * Whether the credential the *backend* holds still works.
- *
- * `registered` cannot answer this: it means a credential was obtained and
- * stored, which stays true of a refresh token that expired 90 days ago while
- * every call 401s. `unknown` means nothing has exercised it yet and
- * `unreachable` is a statement about Coda rather than the token — both are
- * absent evidence, not evidence of a dead credential.
- */
-export type CodaCredentialState = 'unknown' | 'ok' | 'expired' | 'unreachable' | (string & {});
-
-export interface CodaCredentialHealth {
-  state: CodaCredentialState;
-  /** RFC 3339. Absent while `unknown`. */
-  checkedAt?: string;
-}
-
-/** A Grafana basic role. Open because the vocabulary is Grafana's, not ours. */
-export type CodaSessionRole = 'Viewer' | 'Editor' | 'Admin' | (string & {});
-
-/** A behaviour-changing *input* the backend advertises honouring. */
-export type CodaFeature = 'exec.readyFile' | (string & {});
-
-export interface CodaCallerCapabilities {
-  /**
-   * Whether this caller's Grafana basic role meets the floor for spending VM
-   * quota — the same check `POST /v1/sessions` and exec enforce, so `false`
-   * means those calls would answer `403 role_forbidden`.
-   */
-  canCreateSessions: boolean;
-  /**
-   * The effective floor, for writing the message ("needs Editor or above").
-   * Not for deciding: the backend sees only the basic role and RBAC cannot
-   * grant past it, so ranking roles here would reimplement the one thing
-   * {@link canCreateSessions} exists to settle.
-   */
-  minimumSessionRole: CodaSessionRole;
-}
-
-export interface CodaCapabilities {
-  registered: boolean;
-  templates: CodaCatalogueItem[];
-  sampleApps: CodaCatalogueItem[];
-  alloyScenarios: CodaCatalogueItem[];
-  limits: {
-    maxVMsPerUser: number;
-    maxExecTimeoutMs: number;
-    maxOutputBytes: number;
-  };
-  apiVersions?: string[];
-  pluginVersion?: string;
-  timings?: CodaTimings;
-  readyGate?: { defaultPath: string };
-  /** Absent on a backend older than the release that added the list. */
-  features?: CodaFeature[];
-  /**
-   * The only per-caller part of this response: never share it between users.
-   * Absent on an older backend — read it through {@link codaSessionEligibility}.
-   */
-  caller?: CodaCallerCapabilities;
-  credential?: CodaCredentialHealth;
-  /** Problems with the backend's own configuration that stop registration. */
-  configErrors?: string[];
-}
-
-/**
- * Whether Coda can actually be used, as opposed to merely being registered.
- *
- * Read this rather than `registered` alone: reading `registered` is how a green
- * "Coda is ready" came to be rendered on a stack that 401s on every session.
- *
- * Absent fields mean an older backend, so they count as "no evidence of a
- * problem" — that is the additive rule this API works by, and it keeps this no
- * stricter than `registered` was against a backend that cannot answer.
- */
-export function isCodaUsable(capabilities: CodaCapabilities): boolean {
-  return (
-    capabilities.registered &&
-    capabilities.credential?.state !== 'expired' &&
-    (capabilities.configErrors?.length ?? 0) === 0
-  );
-}
-
-/**
- * Whether the caller may start a session, as a three-state answer.
- *
- * `unknown` means the backend predates the field. Attempt the call and handle
- * the `403` — do not assume either answer, which would hide the sandbox from
- * someone entitled to it or offer it to someone who cannot have it.
- */
-export type CodaSessionEligibility = 'eligible' | 'role_forbidden' | 'unknown' | (string & {});
-
-export function codaSessionEligibility(capabilities: CodaCapabilities): CodaSessionEligibility {
-  if (!capabilities.caller) {
-    return 'unknown';
-  }
-  return capabilities.caller.canCreateSessions ? 'eligible' : 'role_forbidden';
-}
+export type TerminalVMOptions = CreateSessionOptions;
+export type ExecRequest = ExecOptions & { command: string };
+export type ExecResponse = ExecResult;
 
 /**
  * The ready gate Pathfinder's challenge blocks use.
@@ -180,206 +58,50 @@ export function codaSessionEligibility(capabilities: CodaCapabilities): CodaSess
  * write the file by hand keep working, but it is no longer *their* constant —
  * the coupling that used to exist between this literal and a Go `const` is
  * gone. Both the setup write and the `coda-exit-zero` check read it from here.
+ * Not part of the SDK: it's a Pathfinder convention, not an API contract.
  */
 export const PATHFINDER_READY_FILE = '/tmp/pathfinder-ready';
-
-/** How a v1 backend behaved before it advertised the fields above. */
-export const V1_DEFAULTS = {
-  heartbeatIntervalMs: 3000,
-  estimatedProvisionMs: 55_000,
-  maxProvisionMs: 180_000,
-  readyGateDefaultPath: '/tmp/pathfinder-ready',
-} as const;
-
-export interface ExecRequest {
-  command: string;
-  /**
-   * Absolute path. When set, the command runs only once that file exists on
-   * the VM, so a "check my work" click cannot evaluate a criterion before
-   * setup has finished. A UI-race guard, not a security boundary — the learner
-   * has a root shell on the same VM and can create it themselves.
-   */
-  readyFile?: string;
-  timeoutMs?: number;
-}
-
-export interface ExecResponse {
-  stdout: string;
-  stderr: string;
-  /** -1 means the shell closed without reporting status. Never read as a pass. */
-  exitCode: number;
-  durationMs: number;
-  truncated?: boolean;
-}
-
-// ─── Errors ──────────────────────────────────────────────────────────────────
-
-/**
- * Codes from the backend's closed set. Open-ended on purpose: new ones can
- * appear within v1, and an unrecognised code must fall back to the status
- * rather than being treated as fatal.
- */
-export type CodaErrorCode =
-  | 'invalid_request'
-  | 'invalid_ready_file'
-  | 'conflicting_gate'
-  | 'no_user'
-  | 'coda_auth_failed'
-  | 'admin_required'
-  | 'role_forbidden'
-  | 'session_not_found'
-  | 'vm_not_found'
-  | 'terminal_not_connected'
-  | 'terminal_disconnected'
-  | 'rate_limited'
-  | 'vm_quota_exceeded'
-  | 'coda_not_registered'
-  | 'coda_unavailable'
-  | 'upstream_failed'
-  | 'exec_failed'
-  | 'internal'
-  /** Synthesised here when the plugin itself is absent or disabled. */
-  | 'plugin_not_installed'
-  | (string & {});
-
-export class CodaError extends Error {
-  readonly code: CodaErrorCode;
-  readonly status: number;
-
-  constructor(message: string, code: CodaErrorCode, status: number) {
-    super(message);
-    this.name = 'CodaError';
-    this.code = code;
-    this.status = status;
-  }
-}
-
-/**
- * Normalises a `getBackendSrv` rejection into a CodaError.
- *
- * A 404 is the one genuinely ambiguous status: the backend always sends a
- * code, so a 404 without one did not come from the backend at all — the plugin
- * is absent.
- */
-export function toCodaError(err: unknown): CodaError {
-  if (err instanceof CodaError) {
-    return err;
-  }
-  const e = (err ?? {}) as { status?: number; data?: { error?: string; code?: string }; message?: string };
-  const status = typeof e.status === 'number' ? e.status : 0;
-
-  let code: CodaErrorCode;
-  if (e.data?.code) {
-    code = e.data.code;
-  } else if (status === 404) {
-    code = 'plugin_not_installed';
-  } else if (status === 503) {
-    code = 'coda_not_registered';
-  } else {
-    code = 'internal';
-  }
-
-  const message =
-    e.data?.error ??
-    (code === 'plugin_not_installed'
-      ? 'The Coda app plugin is not installed or not enabled in this Grafana instance.'
-      : (e.message ?? 'Could not reach the Coda plugin'));
-
-  return new CodaError(message, code, status);
-}
-
-/**
- * The sandbox is not usable yet, or is no longer, but the request was fine.
- * `terminal_not_connected` resolves by waiting; the other two need a new
- * session.
- */
-export function isNotReady(err: unknown): boolean {
-  const { code } = toCodaError(err);
-  return code === 'terminal_not_connected' || code === 'terminal_disconnected' || code === 'session_not_found';
-}
-
-/** Coda cannot serve anyone right now: hide the feature rather than retrying. */
-export function isUnavailable(err: unknown): boolean {
-  const { code } = toCodaError(err);
-  return code === 'plugin_not_installed' || code === 'coda_not_registered';
-}
 
 /**
  * The user's Grafana role is too low to spend VM quota. Distinct from
  * unavailable: Coda is working, this person may not use it. An operator can
  * lower the floor with `minimumSessionRole` on the Coda plugin.
+ *
+ * Not exported by the package — kept here rather than upstreamed for a
+ * single-caller predicate.
  */
 export function isRoleForbidden(err: unknown): boolean {
   return toCodaError(err).code === 'role_forbidden';
 }
 
-// ─── Requests ────────────────────────────────────────────────────────────────
+const client = new CodaClient();
 
-async function request<T>(method: string, path: string, data?: unknown): Promise<T> {
-  try {
-    const response = getBackendSrv().fetch<T>({
-      url: `${CODA_BACKEND_URL}${path}`,
-      method,
-      data,
-      // Callers surface failures in place; a global toast on top of an
-      // in-context message is noise.
-      showErrorAlert: false,
-      // The plugin answers 401 `coda_auth_failed` when its own Coda credential
-      // has expired. Grafana's global handler reads any first-attempt 401 on a
-      // relative URL as the *caller's* session expiring, so it pings
-      // /api/login/ping and replays the request. `retry: 1` opts out.
-      retry: 1,
-    });
-    return (await lastValueFrom(response)).data;
-  } catch (err) {
-    throw toCodaError(err);
-  }
+export function getCapabilities() {
+  return client.getCapabilities();
 }
 
 /**
- * Reserves a session and returns the Live channel to subscribe to. VM
- * provisioning happens after subscribe, so this resolves immediately.
+ * Reserves a session and returns it unsubscribed. Subscribing (in
+ * `useTerminalLive.hook.ts`) is what starts VM provisioning.
  */
-export function createSession(vmOpts?: TerminalVMOptions): Promise<CodaSession> {
-  return request<CodaSession>('POST', '/sessions', {
-    template: vmOpts?.template || undefined,
-    app: vmOpts?.app || undefined,
-    scenario: vmOpts?.scenario || undefined,
-  });
+export function createSession(vmOpts?: TerminalVMOptions) {
+  return client.createSession(vmOpts);
 }
 
-export function deleteSession(sessionId: string): Promise<void> {
-  return request<void>('DELETE', `/sessions/${encodeURIComponent(sessionId)}`);
+export function deleteSession(sessionId: string) {
+  return client.deleteSession(sessionId);
 }
 
-export function execInSession(sessionId: string, req: ExecRequest): Promise<ExecResponse> {
-  return request<ExecResponse>('POST', `/sessions/${encodeURIComponent(sessionId)}/exec`, req);
-}
-
-export function getCapabilities(): Promise<CodaCapabilities> {
-  return request<CodaCapabilities>('GET', '/capabilities');
+/** Re-joins `req.command` with the rest of the options for `CodaClient.exec`. */
+export function execInSession(sessionId: string, req: ExecRequest) {
+  const { command, ...options } = req;
+  return client.exec(sessionId, command, options);
 }
 
 export function sampleAppsUrl(): string {
-  return `${CODA_BACKEND_URL}/sample-apps`;
+  return `${CODA_RESOURCE_BASE}/sample-apps`;
 }
 
 export function alloyScenariosUrl(): string {
-  return `${CODA_BACKEND_URL}/alloy-scenarios`;
-}
-
-/**
- * Splits the backend's `plugin/{id}/{path}` channel string into a Live address.
- * The path is opaque to the client — only the backend defines its shape.
- */
-export function sessionChannelAddress(channel: string): LiveChannelAddress {
-  const [scope, stream, ...pathParts] = channel.split('/');
-  if (scope !== 'plugin' || !stream || pathParts.length === 0) {
-    throw new Error(`Unexpected Coda channel address: ${channel}`);
-  }
-  return {
-    scope: LiveChannelScope.Plugin,
-    stream,
-    path: pathParts.join('/'),
-  };
+  return `${CODA_RESOURCE_BASE}/alloy-scenarios`;
 }

--- a/src/integrations/coda/useTerminalLive.hook.test.ts
+++ b/src/integrations/coda/useTerminalLive.hook.test.ts
@@ -3,21 +3,21 @@
  * /v1/sessions/{id}/exec` reuses the stream's SSH client and refuses a session
  * whose terminal is gone. Knowing when a session has died is therefore the
  * consumer's job, and a retained id can only buy a doomed request. These tests
- * pin that every stream-terminating path drops the id.
+ * pin that every session-terminating path drops the id.
+ *
+ * `CodaSession` (from `@grafana/coda-client`) owns the Live channel, frame
+ * validation and its own idle timer now — this hook only reacts to its
+ * handlers, so tests drive those handlers directly rather than a raw Live
+ * channel. Channel-level plumbing and the idle timer are the package's own
+ * test suite's job, not this hook's.
  */
 
 import { act, renderHook } from '@testing-library/react';
-import { Subject } from 'rxjs';
-import { LiveChannelConnectionState, type LiveChannelEvent } from '@grafana/data';
-import { getGrafanaLiveSrv } from '@grafana/runtime';
 import type { Terminal } from '@xterm/xterm';
+import { CodaError, type CodaSession, type SessionHandlers } from '@grafana/coda-client';
 
 import { useTerminalLive } from './useTerminalLive.hook';
 import { createSession } from './coda-api';
-
-jest.mock('@grafana/runtime', () => ({
-  getGrafanaLiveSrv: jest.fn(),
-}));
 
 jest.mock('./coda-api', () => ({
   ...jest.requireActual('./coda-api'),
@@ -28,7 +28,6 @@ jest.mock('../../lib/logging', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(), exception: jest.fn() },
 }));
 
-const mockedGetGrafanaLiveSrv = getGrafanaLiveSrv as jest.MockedFunction<typeof getGrafanaLiveSrv>;
 const mockedCreateSession = createSession as jest.MockedFunction<typeof createSession>;
 
 const SESSION_ID = 's_0123456789abcdef0123456789abcdef';
@@ -44,30 +43,45 @@ function fakeTerminal(): Terminal {
   } as unknown as Terminal;
 }
 
-/** One frame in the shape RunStream sends: a single JSON-encoded string field. */
-function frame(event: Record<string, unknown>) {
-  return {
-    type: 'message',
-    message: { data: { values: [[JSON.stringify(event)]] } },
-  } as unknown as LiveChannelEvent<unknown>;
+interface FakeSession {
+  session: CodaSession;
+  /** Populated once the hook calls `subscribe()`. */
+  handlers: { current: SessionHandlers };
+  close: jest.Mock;
 }
 
-function statusEvent(state: LiveChannelConnectionState) {
-  return { type: 'status', state } as unknown as LiveChannelEvent<unknown>;
-}
-
-async function connectedHook() {
-  const stream = new Subject<LiveChannelEvent<unknown>>();
-  mockedGetGrafanaLiveSrv.mockReturnValue({
-    getStream: jest.fn(() => stream),
-    publish: jest.fn(),
-  } as unknown as ReturnType<typeof getGrafanaLiveSrv>);
-  mockedCreateSession.mockResolvedValue({
-    sessionId: SESSION_ID,
-    channel: 'plugin/grafana-coda-app/v1/session/abc',
-    state: 'pending',
-    template: 'vm-aws',
+/**
+ * A test double for `CodaSession`. `subscribe()` captures the handlers into
+ * `handlers.current` so a test can invoke them directly to simulate backend
+ * behaviour, and `close()` mirrors the real class by firing `onClosed`
+ * synchronously (as `CodaSession.finish()` does) before "resolving" the
+ * destroy call. `handlers` is returned separately, not as a property on the
+ * session object — `CodaSession` itself has a private field of that name,
+ * and a same-named public property on a type intersected with it collapses
+ * to `never`.
+ */
+function fakeSession(sessionId = SESSION_ID): FakeSession {
+  const handlers: { current: SessionHandlers } = { current: {} };
+  const close = jest.fn(async () => {
+    handlers.current.onClosed?.();
   });
+  const session = {
+    sessionId,
+    vmID: undefined,
+    subscribe: jest.fn((h: SessionHandlers) => {
+      handlers.current = h;
+    }),
+    write: jest.fn(),
+    resize: jest.fn(),
+    exec: jest.fn(),
+    close,
+  } as unknown as CodaSession;
+
+  return { session, handlers, close };
+}
+
+async function connectedHook(fake: FakeSession = fakeSession()) {
+  mockedCreateSession.mockResolvedValue(fake.session);
 
   const terminalRef = { current: fakeTerminal() };
   const hook = renderHook(() => useTerminalLive({ terminalRef }));
@@ -75,104 +89,55 @@ async function connectedHook() {
   await act(async () => {
     hook.result.current.connect();
   });
-  expect(hook.result.current.sessionId).toBe(SESSION_ID);
+  expect(hook.result.current.sessionId).toBe(fake.session.sessionId);
 
-  return { hook, stream };
+  return { hook, ...fake };
 }
 
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
-afterEach(() => {
-  jest.useRealTimers();
-});
-
 describe('useTerminalLive session lifetime', () => {
-  it('holds the session id while the stream is live', async () => {
-    const { hook, stream } = await connectedHook();
+  it('holds the session id once connected', async () => {
+    const { hook, handlers } = await connectedHook();
 
     act(() => {
-      stream.next(frame({ type: 'connected', vmId: 'vm-1' }));
+      handlers.current.onConnected?.('vm-1');
     });
 
     expect(hook.result.current.status).toBe('connected');
     expect(hook.result.current.sessionId).toBe(SESSION_ID);
   });
 
-  it('drops the session id on a backend error frame', async () => {
-    const { hook, stream } = await connectedHook();
+  it('drops the session id on a backend error', async () => {
+    const { hook, handlers } = await connectedHook();
 
     act(() => {
-      stream.next(frame({ type: 'error', error: 'vm gone' }));
+      handlers.current.onError?.(new CodaError('vm gone', 'internal', 0));
     });
 
     expect(hook.result.current.status).toBe('error');
     expect(hook.result.current.sessionId).toBeNull();
   });
 
-  it('drops the session id on a backend disconnected frame', async () => {
-    const { hook, stream } = await connectedHook();
+  it('drops the session id when the session closes without an error', async () => {
+    const { hook, handlers } = await connectedHook();
 
     act(() => {
-      stream.next(frame({ type: 'connected' }));
-      stream.next(frame({ type: 'disconnected' }));
+      handlers.current.onConnected?.();
+      handlers.current.onClosed?.();
     });
 
     expect(hook.result.current.status).toBe('disconnected');
     expect(hook.result.current.sessionId).toBeNull();
   });
 
-  it('drops the session id when the Live channel drops', async () => {
-    const { hook, stream } = await connectedHook();
+  it('names an exhausted quota from the error code instead of the generic message', async () => {
+    const { hook, handlers } = await connectedHook();
 
     act(() => {
-      stream.next(frame({ type: 'connected' }));
-      stream.next(statusEvent(LiveChannelConnectionState.Disconnected));
-    });
-
-    expect(hook.result.current.sessionId).toBeNull();
-  });
-
-  it('drops the session id when the subscription errors', async () => {
-    const { hook, stream } = await connectedHook();
-
-    act(() => {
-      stream.error(new Error('socket closed'));
-    });
-
-    expect(hook.result.current.status).toBe('error');
-    expect(hook.result.current.sessionId).toBeNull();
-  });
-
-  it('drops the session id when the stream completes', async () => {
-    const { hook, stream } = await connectedHook();
-
-    act(() => {
-      stream.next(frame({ type: 'connected' }));
-      stream.complete();
-    });
-
-    expect(hook.result.current.sessionId).toBeNull();
-  });
-
-  it('drops the session id when the handshake safety net fires', async () => {
-    jest.useFakeTimers();
-    const { hook } = await connectedHook();
-
-    act(() => {
-      jest.advanceTimersByTime(36_000);
-    });
-
-    expect(hook.result.current.status).toBe('error');
-    expect(hook.result.current.sessionId).toBeNull();
-  });
-
-  it('names an exhausted quota from the frame code instead of the generic message', async () => {
-    const { hook, stream } = await connectedHook();
-
-    act(() => {
-      stream.next(frame({ type: 'error', error: 'Failed to create VM, please try again', code: 'vm_quota_exceeded' }));
+      handlers.current.onError?.(new CodaError('Failed to create VM, please try again', 'vm_quota_exceeded', 0));
     });
 
     expect(hook.result.current.error).toMatch(/maximum number of sandbox VMs/i);
@@ -181,13 +146,13 @@ describe('useTerminalLive session lifetime', () => {
   // New codes are an additive change within v1, and a backend older than the
   // field sends none at all: both must fall back to the sentence, not be fatal.
   it.each([
-    ['an unrecognised code', { type: 'error', error: 'something new went wrong', code: 'quantum_flux' }],
-    ['no code at all', { type: 'error', error: 'something new went wrong' }],
-  ])('falls back to the backend sentence for %s', async (_name, event) => {
-    const { hook, stream } = await connectedHook();
+    ['an unrecognised code', 'quantum_flux'],
+    ['no code at all (CodaSession defaults to "internal")', 'internal'],
+  ])('falls back to the backend sentence for %s', async (_name, code) => {
+    const { hook, handlers } = await connectedHook();
 
     act(() => {
-      stream.next(frame(event));
+      handlers.current.onError?.(new CodaError('something new went wrong', code, 0));
     });
 
     expect(hook.result.current.status).toBe('error');
@@ -195,15 +160,16 @@ describe('useTerminalLive session lifetime', () => {
   });
 
   it('drops the session id on an explicit disconnect', async () => {
-    const { hook, stream } = await connectedHook();
+    const { hook, handlers, close } = await connectedHook();
 
     act(() => {
-      stream.next(frame({ type: 'connected' }));
+      handlers.current.onConnected?.();
     });
     act(() => {
       hook.result.current.disconnect();
     });
 
     expect(hook.result.current.sessionId).toBeNull();
+    expect(close).toHaveBeenCalled();
   });
 });

--- a/src/integrations/coda/useTerminalLive.hook.ts
+++ b/src/integrations/coda/useTerminalLive.hook.ts
@@ -1,31 +1,28 @@
 /**
  * Grafana Live terminal connection hook
  *
- * Bidirectional terminal I/O over a single Grafana Live WebSocket:
- * - Output (SSH → frontend): RunStream sends frames via sender.SendFrame
- * - Input (frontend → SSH): Frontend publishes via liveSrv.publish → PublishStream
+ * Bidirectional terminal I/O over a single Grafana Live WebSocket, driven by
+ * `@grafana/coda-client`'s `CodaSession`: it owns the channel address, frame
+ * validation, the mandatory `{ useSocket: true }` publish and its own idle
+ * timer. This hook keeps only what's Pathfinder-specific — the progress bar,
+ * banner text and xterm wiring — hung off `CodaSession`'s handlers.
+ *
+ * Two things the hand-rolled version had that the class doesn't expose:
+ * - the transient "Waiting for SSH handshake..." line, printed on the raw
+ *   Live channel's own connect event before any backend frame arrives;
+ * - immediate detection of the underlying WebSocket dropping. `CodaSession`
+ *   only reports a dead connection via its own idle timer (silence beyond
+ *   ~12 heartbeats, floored at 35s), not the instant a socket-level
+ *   disconnect event fires.
+ * Both are covered, with a delay, by the connecting banner and the idle
+ * timer's `terminal_disconnected` respectively.
  */
 
 import { useCallback, useEffect, useRef, useState, RefObject } from 'react';
-import { getGrafanaLiveSrv, type GrafanaLiveSrv } from '@grafana/runtime';
-import {
-  LiveChannelAddress,
-  LiveChannelEvent,
-  isLiveChannelMessageEvent,
-  isLiveChannelStatusEvent,
-  LiveChannelConnectionState,
-} from '@grafana/data';
-import { Subscription } from 'rxjs';
 import type { Terminal } from '@xterm/xterm';
+import type { CodaSession } from '@grafana/coda-client';
 import { logger } from '../../lib/logging';
-import {
-  createSession,
-  sessionChannelAddress,
-  toCodaError,
-  type CodaErrorCode,
-  type CodaSession,
-  type TerminalVMOptions,
-} from './coda-api';
+import { createSession, toCodaError, type CodaErrorCode, type TerminalVMOptions } from './coda-api';
 
 interface ConnectionLog {
   error: (message: string, error?: unknown, data?: Record<string, unknown>) => void;
@@ -117,22 +114,6 @@ interface UseTerminalLiveReturn {
   sessionId: string | null;
 }
 
-/** Server → client event, carried in the frame's single "event" field. */
-interface SessionEvent {
-  type: 'output' | 'error' | 'connected' | 'disconnected' | 'status' | 'heartbeat';
-  data?: string;
-  error?: string;
-  /**
-   * Classification of an `error` event, from the same closed set as the REST
-   * `code`. Added after v1.0, so absent on an older backend — branch on it,
-   * fall back to `error` for display.
-   */
-  code?: CodaErrorCode;
-  state?: string;
-  message?: string;
-  vmId?: string;
-}
-
 // ─── Provision progress bar ──────────────────────────────────────────────────
 // Rendered inline in xterm via \r to overwrite the current line every 500ms.
 // Uses an asymptotic ease-out curve so the bar never freezes: it reaches ~38%
@@ -174,16 +155,13 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
 
   const connectionLogRef = useRef<ConnectionLog>(createConnectionLog());
 
-  // REACT: refs for subscriptions and cleanup (R1)
-  const subscriptionRef = useRef<Subscription | null>(null);
+  // The one live session object; owns the channel, frame validation and the
+  // idle timer. Replaces the subscription/address/liveSrv refs the hand-rolled
+  // version needed.
+  const sessionRef = useRef<CodaSession | null>(null);
   // currentVmIdRef tracks the VM ID for the current session (used in logging)
   const currentVmIdRef = useRef<string | null>(null);
   const inputDisposerRef = useRef<{ dispose: () => void } | null>(null);
-  const handshakeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Grafana Live publish refs: populated in connectLiveStream, read by sendInput/sendResize
-  const liveSrvRef = useRef<GrafanaLiveSrv | undefined>(undefined);
-  const addressRef = useRef<LiveChannelAddress | null>(null);
 
   // Provision progress bar state (animated bar during pending/provisioning)
   const provisionProgressRef = useRef<{
@@ -193,31 +171,35 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
   } | null>(null);
   // Dedup guard for non-progress-bar status lines
   const lastStatusLineRef = useRef('');
+  // Set right before onClosed would otherwise print its own "session ended"
+  // banner — user-initiated disconnect prints its own message instead.
+  const suppressClosedBannerRef = useRef(false);
+  // onClosed always fires after onError (CodaSession.finish() calls both), so
+  // this stops it from printing a second, contradictory banner.
+  const hadErrorRef = useRef(false);
 
-  // Tearing the stream down invalidates the session: exec is session-scoped, so
-  // a retained id would be spent on a session the backend has forgotten. Every
+  // Tearing the session down invalidates its id: exec is session-scoped, so a
+  // retained id would be spent on a session the backend has forgotten. Every
   // terminating path must either call this or clear the id itself.
   const cleanup = useCallback(() => {
     setSessionId(null);
-    if (subscriptionRef.current) {
-      subscriptionRef.current.unsubscribe();
-      subscriptionRef.current = null;
+    const session = sessionRef.current;
+    sessionRef.current = null;
+    if (session) {
+      // finish()'s side effects (unsubscribe, onError/onClosed) run
+      // synchronously; the DELETE it issues is fire-and-forget and never
+      // rejects (close() swallows the destroy failure itself).
+      void session.close();
     }
     if (inputDisposerRef.current) {
       inputDisposerRef.current.dispose();
       inputDisposerRef.current = null;
-    }
-    if (handshakeTimeoutRef.current) {
-      clearTimeout(handshakeTimeoutRef.current);
-      handshakeTimeoutRef.current = null;
     }
     if (provisionProgressRef.current) {
       clearInterval(provisionProgressRef.current.intervalId);
       provisionProgressRef.current = null;
     }
     lastStatusLineRef.current = '';
-    liveSrvRef.current = undefined;
-    addressRef.current = null;
   }, []);
 
   // REACT: cleanup on unmount (R1)
@@ -226,338 +208,163 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
   }, [cleanup]);
 
   /**
-   * Publish over the WebSocket rather than HTTP POST.
-   *
-   * GrafanaLiveService.publish() accepts an undeclared third `options` arg.
-   * Passing `{ useSocket: true }` routes the message through the existing
-   * Centrifuge WebSocket instead of `POST /api/live/publish`. This is
-   * critical in multi-node deployments (e.g. Grafana Cloud) where HTTP
-   * requests are load-balanced and may hit a node that isn't running the
-   * stream, causing a 404.
-   */
-  const publishOverSocket = useCallback(
-    (address: LiveChannelAddress, data: unknown) =>
-      (liveSrvRef.current as any)?.publish(address, data, { useSocket: true }),
-    []
-  );
-
-  /**
-   * Send input to the terminal via Grafana Live publish.
-   * Publishes a plain object to the same channel used by RunStream/SubscribeStream.
-   */
-  const sendInput = useCallback(
-    async (inputData: string) => {
-      const address = addressRef.current;
-      if (!liveSrvRef.current || !address) {
-        return;
-      }
-
-      try {
-        await publishOverSocket(address, { type: 'input', data: inputData });
-      } catch {
-        // Input publish failures are transient; ignore silently
-      }
-    },
-    [publishOverSocket]
-  );
-
-  /**
-   * Send resize event to the terminal via Grafana Live publish.
-   */
-  const sendResize = useCallback(
-    async (rows: number, cols: number) => {
-      const address = addressRef.current;
-      if (!liveSrvRef.current || !address) {
-        return;
-      }
-
-      try {
-        await publishOverSocket(address, { type: 'resize', rows, cols });
-      } catch {
-        // Resize publish failures are transient; ignore silently
-      }
-    },
-    [publishOverSocket]
-  );
-
-  /**
-   * Unwraps a coda.session.v1 frame: one string field holding a JSON SessionEvent.
-   */
-  const parseTerminalOutput = useCallback((message: unknown): SessionEvent | null => {
-    try {
-      const frame = message as { data?: { values?: unknown[][] } } | undefined;
-      const raw = frame?.data?.values?.[0]?.[0];
-      if (typeof raw === 'string') {
-        return JSON.parse(raw) as SessionEvent;
-      }
-    } catch {
-      // Parse failures are non-fatal; the stream will deliver subsequent messages
-    }
-    return null;
-  }, []);
-
-  /**
-   * Connect to Grafana Live stream for terminal I/O
+   * Subscribe a fresh session to its Live channel, wiring Pathfinder's
+   * terminal UI onto CodaSession's handlers.
    */
   const connectLiveStream = useCallback(
     (session: CodaSession, terminal: Terminal) => {
-      const liveSrv = getGrafanaLiveSrv();
-      if (!liveSrv) {
-        setError('Grafana Live service not available');
-        setStatus('error');
-        return;
-      }
+      currentVmIdRef.current = session.vmID ?? null;
 
-      // The session id is fresh per connect, so the channel is always new and
-      // Grafana always starts a fresh RunStream.
-      const address = sessionChannelAddress(session.channel);
+      session.subscribe({
+        onOutput: (data) => {
+          terminal.write(data);
+        },
 
-      currentVmIdRef.current = session.vmId ?? null;
-
-      // Store refs so sendInput/sendResize can publish to this channel
-      liveSrvRef.current = liveSrv;
-      addressRef.current = address;
-
-      // Safety-net timeout: if the backend stops sending messages, surface an
-      // error instead of hanging forever. Reset on every backend status message
-      // so that VM provisioning (which can take 1-3 min) doesn't trip the timer.
-      const SSH_HANDSHAKE_TIMEOUT_MS = 35_000;
-      const startHandshakeTimeout = () => {
-        if (handshakeTimeoutRef.current) {
-          clearTimeout(handshakeTimeoutRef.current);
-        }
-        handshakeTimeoutRef.current = setTimeout(() => {
-          handshakeTimeoutRef.current = null;
-          cleanup();
-          setError('SSH handshake timed out');
-          setStatus('error');
-          terminal.writeln('\r\n\x1b[31m✖ SSH handshake timed out — the VM may be unreachable.\x1b[0m');
-          terminal.writeln('\x1b[90m  Press "Connect" to try again.\x1b[0m');
-        }, SSH_HANDSHAKE_TIMEOUT_MS);
-      };
-      startHandshakeTimeout();
-
-      const stream = liveSrv.getStream<unknown>(address);
-      subscriptionRef.current = stream.subscribe({
-        next: (event: LiveChannelEvent<unknown>) => {
-          if (isLiveChannelMessageEvent(event)) {
-            const msg = parseTerminalOutput(event.message);
-            if (msg) {
-              switch (msg.type) {
-                case 'status':
-                  // Backend is alive and making progress -- reset the safety-net
-                  // timeout so VM provisioning (1-3 min) doesn't trip the timer.
-                  startHandshakeTimeout();
-
-                  if (msg.vmId && msg.vmId !== currentVmIdRef.current) {
-                    currentVmIdRef.current = msg.vmId;
-                  }
-
-                  if (msg.state === 'pending' || msg.state === 'provisioning') {
-                    const label = msg.state === 'pending' ? 'Waiting in queue' : 'Booting VM';
-                    if (!provisionProgressRef.current) {
-                      const startTime = Date.now();
-                      terminal.write(renderProvisionProgress(label, 0));
-                      const intervalId = setInterval(() => {
-                        const cur = provisionProgressRef.current;
-                        if (!cur) {
-                          return;
-                        }
-                        const elapsed = Date.now() - cur.startTime;
-                        terminal.write('\r' + renderProvisionProgress(cur.stateLabel, elapsed));
-                      }, PROGRESS_UPDATE_INTERVAL_MS);
-                      provisionProgressRef.current = { intervalId, startTime, stateLabel: label };
-                    } else {
-                      provisionProgressRef.current.stateLabel = label;
-                    }
-                  } else {
-                    // Finish progress bar when leaving pending/provisioning
-                    const hadProgressBar = provisionProgressRef.current !== null;
-                    if (provisionProgressRef.current) {
-                      const elapsed = Date.now() - provisionProgressRef.current.startTime;
-                      clearInterval(provisionProgressRef.current.intervalId);
-                      if (msg.state === 'active') {
-                        terminal.write('\r' + renderProvisionProgress('VM is ready', elapsed, true));
-                      }
-                      terminal.writeln('');
-                      provisionProgressRef.current = null;
-                    }
-
-                    if (msg.state === 'active') {
-                      if (!hadProgressBar) {
-                        const line = `\x1b[90m   │  ✓ ${msg.message || 'VM is ready'}\x1b[0m`;
-                        if (line !== lastStatusLineRef.current) {
-                          lastStatusLineRef.current = line;
-                          terminal.writeln(line);
-                        }
-                      }
-                    } else if (msg.state === 'retrying') {
-                      terminal.writeln(`\x1b[33m   │  ⚠ ${msg.message || 'Retrying...'}\x1b[0m`);
-                    } else {
-                      const line = `\x1b[90m   │  ${msg.message || `Status: ${msg.state}`}\x1b[0m`;
-                      if (line !== lastStatusLineRef.current) {
-                        lastStatusLineRef.current = line;
-                        terminal.writeln(line);
-                      }
-                    }
-                  }
-                  break;
-
-                case 'output':
-                  if (msg.data) {
-                    terminal.write(msg.data);
-                  }
-                  break;
-
-                case 'error': {
-                  connectionLogRef.current.error('Backend error received', null, {
-                    sessionId: session.sessionId,
-                    backendError: msg.error,
-                    backendErrorCode: msg.code,
-                    category: 'backend_error',
-                  });
-
-                  // Tear down the subscription immediately so Grafana Live
-                  // doesn't auto-reconnect and create a retry loop.
-                  cleanup();
-
-                  const message = codaErrorCodeMessage(msg.code, msg.error || 'Unknown error');
-
-                  terminal.writeln('\r\n');
-                  terminal.writeln(`\x1b[31m✖ Error: ${message}\x1b[0m`);
-
-                  setError(message);
-                  setStatus('error');
-                  break;
-                }
-
-                case 'connected':
-                  if (handshakeTimeoutRef.current) {
-                    clearTimeout(handshakeTimeoutRef.current);
-                    handshakeTimeoutRef.current = null;
-                  }
-
-                  // Update current VM ID ref from backend
-                  if (msg.vmId) {
-                    currentVmIdRef.current = msg.vmId;
-                  }
-
-                  setStatus('connected');
-                  terminal.writeln('');
-                  terminal.writeln('\x1b[32m✓ SSH connection established\x1b[0m');
-                  terminal.writeln('');
-                  terminal.writeln('\x1b[36m┌──────────────────────────────────────────────────────────────┐\x1b[0m');
-                  terminal.writeln(
-                    '\x1b[36m│\x1b[0m  \x1b[1;33mGrafana Pathfinder Sandbox\x1b[0m                                 \x1b[36m│\x1b[0m'
-                  );
-                  terminal.writeln(
-                    '\x1b[36m│\x1b[0m                                                              \x1b[36m│\x1b[0m'
-                  );
-                  terminal.writeln(
-                    '\x1b[36m│\x1b[0m  \x1b[90mThis is a temporary sandbox VM for learning Grafana.\x1b[0m       \x1b[36m│\x1b[0m'
-                  );
-                  terminal.writeln(
-                    '\x1b[36m│\x1b[0m  \x1b[90mVM will auto-terminate after inactivity.\x1b[0m                   \x1b[36m│\x1b[0m'
-                  );
-                  terminal.writeln('\x1b[36m└──────────────────────────────────────────────────────────────┘\x1b[0m');
-                  terminal.writeln('');
-
-                  if (inputDisposerRef.current) {
-                    inputDisposerRef.current.dispose();
-                  }
-                  inputDisposerRef.current = terminal.onData((inputData) => {
-                    sendInput(inputData);
-                  });
-
-                  sendResize(terminal.rows, terminal.cols);
-
-                  // Send a blank newline after a short delay to force the shell
-                  // to print a fresh prompt. Without this, broadcast messages
-                  // (e.g. shutdown warnings) or SSH reconnections can leave the
-                  // terminal on a blank line with no visible prompt.
-                  setTimeout(() => sendInput('\n'), 300);
-                  break;
-
-                case 'disconnected':
-                  cleanup();
-                  setStatus('disconnected');
-                  terminal.writeln('\r\n');
-                  terminal.writeln('\x1b[33m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m');
-                  terminal.writeln('\x1b[33m  Session ended - VM disconnected\x1b[0m');
-                  terminal.writeln('\x1b[33m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m');
-                  break;
-
-                case 'heartbeat':
-                  // Silently ignore - backend sends these every 3s to keep stream alive
-                  break;
-              }
-            }
+        onStatus: ({ state, message, vmId }) => {
+          if (vmId && vmId !== currentVmIdRef.current) {
+            currentVmIdRef.current = vmId;
           }
 
-          if (isLiveChannelStatusEvent(event)) {
-            if (event.state === LiveChannelConnectionState.Connected) {
-              terminal.writeln('\x1b[90m       Waiting for SSH handshake...\x1b[0m');
-            } else if (event.state === LiveChannelConnectionState.Disconnected) {
-              connectionLogRef.current.warn('LiveStream disconnected', {
-                sessionId: session.sessionId,
-                category: 'live_channel_disconnected',
-              });
-              if (inputDisposerRef.current) {
-                inputDisposerRef.current.dispose();
-                inputDisposerRef.current = null;
-              }
-              // The channel is gone, so the backend's terminal is detached from
-              // this session whatever the visible status says.
-              setSessionId(null);
-              setStatus((prev) => {
-                if (prev === 'connected') {
-                  terminal.writeln('\r\n\x1b[33m⚠ Connection lost\x1b[0m');
-                  return 'disconnected';
+          if (state === 'pending' || state === 'provisioning') {
+            const label = state === 'pending' ? 'Waiting in queue' : 'Booting VM';
+            if (!provisionProgressRef.current) {
+              const startTime = Date.now();
+              terminal.write(renderProvisionProgress(label, 0));
+              const intervalId = setInterval(() => {
+                const cur = provisionProgressRef.current;
+                if (!cur) {
+                  return;
                 }
-                return prev;
-              });
+                const elapsed = Date.now() - cur.startTime;
+                terminal.write('\r' + renderProvisionProgress(cur.stateLabel, elapsed));
+              }, PROGRESS_UPDATE_INTERVAL_MS);
+              provisionProgressRef.current = { intervalId, startTime, stateLabel: label };
+            } else {
+              provisionProgressRef.current.stateLabel = label;
+            }
+            return;
+          }
+
+          // Finish progress bar when leaving pending/provisioning
+          const hadProgressBar = provisionProgressRef.current !== null;
+          if (provisionProgressRef.current) {
+            const elapsed = Date.now() - provisionProgressRef.current.startTime;
+            clearInterval(provisionProgressRef.current.intervalId);
+            if (state === 'active') {
+              terminal.write('\r' + renderProvisionProgress('VM is ready', elapsed, true));
+            }
+            terminal.writeln('');
+            provisionProgressRef.current = null;
+          }
+
+          if (state === 'active') {
+            if (!hadProgressBar) {
+              const line = `\x1b[90m   │  ✓ ${message || 'VM is ready'}\x1b[0m`;
+              if (line !== lastStatusLineRef.current) {
+                lastStatusLineRef.current = line;
+                terminal.writeln(line);
+              }
+            }
+          } else if (state === 'retrying') {
+            terminal.writeln(`\x1b[33m   │  ⚠ ${message || 'Retrying...'}\x1b[0m`);
+          } else {
+            const line = `\x1b[90m   │  ${message || `Status: ${state}`}\x1b[0m`;
+            if (line !== lastStatusLineRef.current) {
+              lastStatusLineRef.current = line;
+              terminal.writeln(line);
             }
           }
         },
-        error: (err) => {
-          if (handshakeTimeoutRef.current) {
-            clearTimeout(handshakeTimeoutRef.current);
-            handshakeTimeoutRef.current = null;
+
+        onConnected: (vmId) => {
+          if (vmId) {
+            currentVmIdRef.current = vmId;
           }
+
+          setStatus('connected');
+          terminal.writeln('');
+          terminal.writeln('\x1b[32m✓ SSH connection established\x1b[0m');
+          terminal.writeln('');
+          terminal.writeln('\x1b[36m┌──────────────────────────────────────────────────────────────┐\x1b[0m');
+          terminal.writeln(
+            '\x1b[36m│\x1b[0m  \x1b[1;33mGrafana Pathfinder Sandbox\x1b[0m                                 \x1b[36m│\x1b[0m'
+          );
+          terminal.writeln(
+            '\x1b[36m│\x1b[0m                                                              \x1b[36m│\x1b[0m'
+          );
+          terminal.writeln(
+            '\x1b[36m│\x1b[0m  \x1b[90mThis is a temporary sandbox VM for learning Grafana.\x1b[0m       \x1b[36m│\x1b[0m'
+          );
+          terminal.writeln(
+            '\x1b[36m│\x1b[0m  \x1b[90mVM will auto-terminate after inactivity.\x1b[0m                   \x1b[36m│\x1b[0m'
+          );
+          terminal.writeln('\x1b[36m└──────────────────────────────────────────────────────────────┘\x1b[0m');
+          terminal.writeln('');
+
           if (inputDisposerRef.current) {
             inputDisposerRef.current.dispose();
-            inputDisposerRef.current = null;
           }
-          connectionLogRef.current.error('LiveStream subscription error', err, {
-            sessionId: session.sessionId,
-            category: 'live_stream_error',
+          inputDisposerRef.current = terminal.onData((inputData) => {
+            sessionRef.current?.write(inputData);
           });
-          setSessionId(null);
-          setError('Stream connection failed');
-          setStatus('error');
-          terminal.writeln(`\r\n\x1b[31mStream error: ${err?.message || 'Unknown error'}\x1b[0m`);
+
+          session.resize(terminal.rows, terminal.cols);
+
+          // Send a blank newline after a short delay to force the shell
+          // to print a fresh prompt. Without this, broadcast messages
+          // (e.g. shutdown warnings) or SSH reconnections can leave the
+          // terminal on a blank line with no visible prompt.
+          setTimeout(() => sessionRef.current?.write('\n'), 300);
         },
-        complete: () => {
-          if (handshakeTimeoutRef.current) {
-            clearTimeout(handshakeTimeoutRef.current);
-            handshakeTimeoutRef.current = null;
+
+        onError: (err) => {
+          hadErrorRef.current = true;
+          const codaErr = toCodaError(err);
+          connectionLogRef.current.error('Backend error received', err, {
+            sessionId: session.sessionId,
+            backendErrorCode: codaErr.code,
+            category: 'backend_error',
+          });
+
+          cleanup();
+
+          const message = codaSessionErrorMessage(err);
+          terminal.writeln('\r\n');
+          terminal.writeln(`\x1b[31m✖ Error: ${message}\x1b[0m`);
+
+          setError(message);
+          setStatus('error');
+        },
+
+        onClosed: () => {
+          if (hadErrorRef.current) {
+            hadErrorRef.current = false;
+            return;
           }
-          if (inputDisposerRef.current) {
-            inputDisposerRef.current.dispose();
-            inputDisposerRef.current = null;
+          if (suppressClosedBannerRef.current) {
+            suppressClosedBannerRef.current = false;
+            return;
           }
-          setSessionId(null);
-          setStatus((prev) => {
-            if (prev === 'connected') {
-              terminal.writeln('\r\n\x1b[33mStream ended\x1b[0m');
-              return 'disconnected';
-            }
-            return prev;
+
+          cleanup();
+          setStatus('disconnected');
+          terminal.writeln('\r\n');
+          terminal.writeln('\x1b[33m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m');
+          terminal.writeln('\x1b[33m  Session ended - VM disconnected\x1b[0m');
+          terminal.writeln('\x1b[33m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m');
+        },
+
+        onProtocolError: ({ detail, sessionId: sid, vmId }) => {
+          connectionLogRef.current.warn('Coda protocol mismatch', {
+            detail,
+            sessionId: sid,
+            vmId,
+            category: 'protocol_error',
           });
         },
       });
     },
-    [cleanup, parseTerminalOutput, sendInput, sendResize]
+    [cleanup]
   );
 
   /**
@@ -615,6 +422,7 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
         return;
       }
 
+      sessionRef.current = session;
       setSessionId(session.sessionId);
       connectLiveStream(session, terminal);
     },
@@ -626,6 +434,7 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
    * Note: We keep vmId so we can reconnect to the same VM if it's still active
    */
   const disconnect = useCallback(() => {
+    suppressClosedBannerRef.current = true;
     cleanup();
     currentVmIdRef.current = null;
     setStatus('disconnected');
@@ -643,26 +452,20 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
   /**
    * Send resize event to backend via Grafana Live publish
    */
-  const resize = useCallback(
-    (rows: number, cols: number) => {
-      sendResize(rows, cols);
-    },
-    [sendResize]
-  );
+  const resize = useCallback((rows: number, cols: number) => {
+    sessionRef.current?.resize(rows, cols);
+  }, []);
 
   /**
    * Send a command to the terminal (appends newline to execute)
    */
-  const sendCommand = useCallback(
-    async (command: string) => {
-      if (!addressRef.current) {
-        connectionLogRef.current.warn('Cannot send command: not connected');
-        return;
-      }
-      await sendInput(command + '\n');
-    },
-    [sendInput]
-  );
+  const sendCommand = useCallback(async (command: string) => {
+    if (!sessionRef.current) {
+      connectionLogRef.current.warn('Cannot send command: not connected');
+      return;
+    }
+    sessionRef.current.write(command + '\n');
+  }, []);
 
   return {
     status,


### PR DESCRIPTION
## What

Replaces the 293-line hand-copied client at `src/integrations/coda/coda-api.ts`
(added in #1468, with a TODO to delete it "on or after 2026-08-15") with a thin
adapter over the real, published SDK — [`@grafana/coda-client`](https://github.com/grafana/grafana-coda-app/tree/main/packages/coda-client),
consumed via the documented interim alias:

```json
"@grafana/coda-client": "npm:@grafana-coda/sandbox-client@^1.1.1"
```

`useTerminalLive.hook.ts` now runs on the SDK's `CodaSession` class instead of
hand-rolling channel address parsing, frame validation, the `{ useSocket: true }`
publish cast, and its own handshake timer — `CodaSession` owns all of that,
including its own idle timer.

## ⚠️ CI will fail here until 2026-08-15T15:26:59Z — expected, not a bug

Our own `.npmrc` sets `min-release-age=3`: it refuses to install any npm version
published less than three days ago. `1.1.1` of the interim package went out at
`2026-08-12T15:26:59Z`, so `npm ci` 404s/refuses it until `2026-08-15T15:26:59Z`.
That's the policy working as intended, not something this PR should work around —
see the hand copy's own header comment and `packages/coda-client/RELEASING.md` in
`grafana-coda-app` for why. This is a **draft**, opened early on top of #1468
specifically to get the real swap reviewed and locally verified before the window
opens, not to merge before then.

Locally, installing before the window needs a one-off override that isn't
committed anywhere: `npm_config_min_release_age=0 npm install` (or
`--min-release-age=0`), via the `packageManager`-pinned `npm@12.0.2` (ambient npm
on most machines is older and doesn't even recognize the setting). The committed
lockfile just records the resolved tarball, which is fine for CI once the window
passes.

## Known behavior differences, called out rather than papered over

- **`isUnavailable`** now also treats `coda_auth_failed` as unavailable; the hand
  copy's version did not. That's the SDK's classification to own — this PR
  consumes it, not patches it.
- **Session cleanup now proactively frees the slot.** The hand copy never issued
  an explicit `DELETE /sessions/{id}`; it just let the backend's own sweep clean
  up an abandoned session. `CodaSession.close()` (called from every cleanup path
  in the hook) does issue that DELETE, idempotently. This seems like a strict
  improvement — it's what the class is for — flagging in case it isn't.
- **Two cosmetic signals from the raw Live channel are gone**, since `CodaSession`
  doesn't surface them: the transient "Waiting for SSH handshake..." line (printed
  on the channel's own connect event, before any backend frame arrives), and
  immediate client-side detection of the underlying WebSocket dropping — that's
  now covered only by `CodaSession`'s own idle timer (~35s of silence), not an
  instant socket-disconnect event.

## Also

- `jest.config.js` gained `@grafana/coda-client` in the ESM `transformIgnorePatterns`
  list (the package ships ESM-only, same treatment already given to
  `@grafana/schema`, `rxjs`, etc.) — via the documented extension point in
  `.config/README.md#esm-errors-with-jest`, not by editing `.config/`.
- `coda-api.ts` keeps every other consumer's import path and call signature
  unchanged (`getCapabilities`, `createSession`, `execInSession`,
  `deleteSession`, `isRoleForbidden`, `sampleAppsUrl`, `alloyScenariosUrl`,
  `PATHFINDER_READY_FILE`), so only it and `useTerminalLive.hook.ts` (plus their
  tests) actually change.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- Full `npx jest` — 429 suites, 6788 passed (18 skipped, 5 todo, pre-existing)
- Not yet run: the live end-to-end path against a real `grafana-coda-app` +
  Pathfinder dev stack (needs the `docker-compose.coda.yaml` overlay from #1468).

🤖 Generated with [Claude Code](https://claude.com/claude-code)