### PR TITLE
fix(config): give plugin-settings distribution a single owner

### DIFF
--- a/docs/developer/components/App/README.md
+++ b/docs/developer/components/App/README.md
@@ -81,12 +81,9 @@ The root application component that initializes the plugin, handles error bounda
 ```typescript
 function App(props: AppRootProps) {
   const scene = useMemo(() => getSceneApp(), []);
-  const config = useMemo(() => getConfigWithDefaults(props.meta.jsonData || {}), [props.meta.jsonData]);
 
-  // Set global config for module-level utilities
-  useEffect(() => {
-    (window as any).__pathfinderPluginConfig = config;
-  }, [config]);
+  // `window.__pathfinderPluginConfig` is published by `plugin.init` via
+  // `publishPathfinderPluginConfig`, which is its only writer.
 
   // Initialize plugin lifecycle
   useEffect(() => {

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -8,7 +8,6 @@ import { homePage } from '../../pages/homePage';
 import { docsPage } from '../../pages/docsPage';
 import { fullScreenPage } from '../../pages/fullScreenPage';
 import { PluginPropsContext } from '../../utils/utils.plugin';
-import { getConfigWithDefaults } from '../../constants';
 import { onPluginStart } from '../../context-engine';
 import { PathfinderFeatureProvider } from '../OpenFeatureProvider';
 import { pauseFaroBeforeReload, pushFaroError } from '../../lib/faro';
@@ -134,14 +133,6 @@ function getSceneApp() {
 
 function App(props: AppRootProps) {
   const scene = useMemo(() => getSceneApp(), []);
-
-  // Get configuration
-  const config = useMemo(() => getConfigWithDefaults(props.meta.jsonData || {}), [props.meta.jsonData]);
-
-  // Set global config early for module-level utilities
-  useEffect(() => {
-    (window as any).__pathfinderPluginConfig = config;
-  }, [config]);
 
   // SECURITY: Initialize plugin on mount (includes dev mode from server)
   useEffect(() => {

--- a/src/components/AppConfig/ConfigurationForm.tsx
+++ b/src/components/AppConfig/ConfigurationForm.tsx
@@ -19,7 +19,7 @@ import {
   getDefaultRecommenderUrl,
   isKnownRecommenderUrl,
 } from '../../constants';
-import { updatePluginSettings } from '../../utils/utils.plugin';
+import { fetchPluginJsonData, updatePluginSettings } from '../../utils/utils.plugin';
 import { isDevModeEnabled, toggleDevMode } from '../../utils/dev-mode';
 import { logger } from '../../lib/logging';
 import { config, getBackendSrv } from '@grafana/runtime';
@@ -42,17 +42,8 @@ type State = {
   codaRelayUrl: string;
 };
 
-export interface ConfigurationFormProps extends PluginConfigPageProps<AppPluginMeta<JsonData>> {}
-
-const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
-  const urlParams = new URLSearchParams(window.location.search);
-  const hasDevParam = urlParams.get('dev') === 'true';
-  const s = useStyles2(getStyles);
-  const { enabled, pinned, jsonData } = plugin.meta;
-
-  // SINGLE SOURCE OF TRUTH: Initialize draft state ONCE from jsonData
-  // After save, page reload brings fresh jsonData - no sync needed
-  const [state, setState] = useState<State>(() => ({
+function buildStateFromJsonData(jsonData: DocsPluginConfig | undefined): State {
+  return {
     recommenderServiceUrl:
       jsonData?.recommenderServiceUrl && !isKnownRecommenderUrl(jsonData.recommenderServiceUrl)
         ? jsonData.recommenderServiceUrl
@@ -66,14 +57,57 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
     peerjsKey: jsonData?.peerjsKey || DEFAULT_PEERJS_KEY,
     peerjsSecure: jsonData?.peerjsSecure ?? DEFAULT_PEERJS_SECURE,
     enableCodaTerminal: jsonData?.enableCodaTerminal ?? DEFAULT_ENABLE_CODA_TERMINAL,
+    // Never seeded from jsonData: the key is write-only, held in secureJsonData.
     codaEnrollmentKey: '',
     codaApiUrl: jsonData?.codaApiUrl || '',
     codaRelayUrl: jsonData?.codaRelayUrl || '',
-  }));
+  };
+}
+
+export interface ConfigurationFormProps extends PluginConfigPageProps<AppPluginMeta<JsonData>> {}
+
+const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const hasDevParam = urlParams.get('dev') === 'true';
+  const s = useStyles2(getStyles);
+  const { enabled, pinned, jsonData: pluginJsonData } = plugin.meta;
+  const [resolvedJsonData, setResolvedJsonData] = useState<DocsPluginConfig>(pluginJsonData || {});
+  const [state, setState] = useState<State>(() => buildStateFromJsonData(pluginJsonData));
   const [isSaving, setIsSaving] = useState(false);
+  const isDraftEdited = useRef(false);
+
+  const editDraft = (changes: Partial<State>) => {
+    isDraftEdited.current = true;
+    setState((previous) => ({ ...previous, ...changes }));
+  };
+
+  // `plugin.meta.jsonData` can lag a recent save, so seed the form from the
+  // authoritative read — but never over an edit the admin has already made.
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchPluginJsonData(plugin.meta.id)
+      .then((freshJsonData) => {
+        if (cancelled) {
+          return;
+        }
+
+        setResolvedJsonData(freshJsonData);
+        if (!isDraftEdited.current) {
+          setState(buildStateFromJsonData(freshJsonData));
+        }
+      })
+      .catch((error) => {
+        logger.error('Failed to fetch plugin settings for configuration form', { error });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [plugin.meta.id]);
 
   // Coda registration state
-  const codaRegistered = jsonData?.codaRegistered ?? false;
+  const codaRegistered = resolvedJsonData?.codaRegistered ?? false;
   const hasProvisionedKey = plugin.meta.secureJsonFields?.codaEnrollmentKey ?? false;
   const [isRegistering, setIsRegistering] = useState(false);
   const [registrationError, setRegistrationError] = useState<string | null>(null);
@@ -82,14 +116,14 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
   // SECURITY: Dev mode - hybrid approach (jsonData storage, multi-user ID scoping)
   // Get current user ID for scoping
   const currentUserId = config.bootData.user?.id;
-  const devModeUserIds = jsonData?.devModeUserIds ?? [];
+  const devModeUserIds = resolvedJsonData?.devModeUserIds ?? [];
 
   // Check if dev mode is enabled for THIS user (synchronous)
-  const devModeEnabledForUser = isDevModeEnabled(jsonData || {}, currentUserId);
+  const devModeEnabledForUser = isDevModeEnabled(resolvedJsonData || {}, currentUserId);
   const [devModeToggling, setDevModeToggling] = useState<boolean>(false);
 
   // Assistant dev mode state
-  const assistantDevModeEnabled = jsonData?.enableAssistantDevMode ?? false;
+  const assistantDevModeEnabled = resolvedJsonData?.enableAssistantDevMode ?? false;
   const [assistantDevModeToggling, setAssistantDevModeToggling] = useState<boolean>(false);
 
   // Show dev mode input if URL param is set OR if dev mode is already enabled for this user
@@ -106,17 +140,11 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
   const isSubmitDisabled = isRecommenderUrlMissing || isCodaApiUrlMissing || isRelayUrlMissing;
 
   const onChangeRecommenderServiceUrl = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      recommenderServiceUrl: event.target.value.trim(),
-    });
+    editDraft({ recommenderServiceUrl: event.target.value.trim() });
   };
 
   const onChangeTutorialUrl = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      tutorialUrl: event.target.value.trim(),
-    });
+    editDraft({ tutorialUrl: event.target.value.trim() });
   };
 
   const onChangeDevMode = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -155,8 +183,8 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
         enabled,
         pinned,
         jsonData: {
-          ...(jsonData || {}),
-          ...getConfigWithDefaults(jsonData || {}),
+          ...(resolvedJsonData || {}),
+          ...getConfigWithDefaults(resolvedJsonData || {}),
           enableAssistantDevMode: newValue,
         },
       });
@@ -177,53 +205,32 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
   };
 
   const onToggleGlobalLinkInterception = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      interceptGlobalDocsLinks: event.target.checked,
-    });
+    editDraft({ interceptGlobalDocsLinks: event.target.checked });
   };
 
   const onToggleOpenPanelOnLaunch = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      openPanelOnLaunch: event.target.checked,
-    });
+    editDraft({ openPanelOnLaunch: event.target.checked });
   };
 
   const onToggleLiveSessions = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      enableLiveSessions: event.target.checked,
-    });
+    editDraft({ enableLiveSessions: event.target.checked });
   };
 
   const onToggleCodaTerminal = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      enableCodaTerminal: event.target.checked,
-    });
+    editDraft({ enableCodaTerminal: event.target.checked });
   };
 
   const onChangeCodaEnrollmentKey = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      codaEnrollmentKey: event.target.value,
-    });
+    editDraft({ codaEnrollmentKey: event.target.value });
     setRegistrationError(null);
   };
 
   const onChangeCodaApiUrl = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      codaApiUrl: event.target.value.trim(),
-    });
+    editDraft({ codaApiUrl: event.target.value.trim() });
   };
 
   const onChangeCodaRelayUrl = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      codaRelayUrl: event.target.value.trim(),
-    });
+    editDraft({ codaRelayUrl: event.target.value.trim() });
   };
 
   const performCodaRegistration = useCallback(
@@ -266,8 +273,8 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
           enabled,
           pinned,
           jsonData: {
-            ...(jsonData || {}),
-            ...getConfigWithDefaults(jsonData || {}),
+            ...(resolvedJsonData || {}),
+            ...getConfigWithDefaults(resolvedJsonData || {}),
             codaRegistered: true,
             codaApiUrl: apiUrl,
           },
@@ -285,7 +292,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
         setIsRegistering(false);
       }
     },
-    [hasProvisionedKey, enabled, pinned, jsonData, plugin.meta.id, state.codaApiUrl]
+    [hasProvisionedKey, enabled, pinned, resolvedJsonData, plugin.meta.id, state.codaApiUrl]
   );
 
   useEffect(() => {
@@ -310,33 +317,21 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
   ]);
 
   const onChangePeerjsHost = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      peerjsHost: event.target.value.trim(),
-    });
+    editDraft({ peerjsHost: event.target.value.trim() });
   };
 
   const onChangePeerjsPort = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value.trim();
     const port = value === '' ? DEFAULT_PEERJS_PORT : parseInt(value, 10);
-    setState({
-      ...state,
-      peerjsPort: isNaN(port) ? DEFAULT_PEERJS_PORT : port,
-    });
+    editDraft({ peerjsPort: isNaN(port) ? DEFAULT_PEERJS_PORT : port });
   };
 
   const onChangePeerjsKey = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      peerjsKey: event.target.value.trim(),
-    });
+    editDraft({ peerjsKey: event.target.value.trim() });
   };
 
   const onTogglePeerjsSecure = (event: ChangeEvent<HTMLInputElement>) => {
-    setState({
-      ...state,
-      peerjsSecure: event.target.checked,
-    });
+    editDraft({ peerjsSecure: event.target.checked });
   };
 
   const onSubmit = async (event: React.FormEvent) => {
@@ -368,8 +363,8 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
       // like stackId that aren't in DocsPluginConfig), then apply defaults for
       // known fields, then override with this form's fields.
       const newJsonData = {
-        ...(jsonData || {}),
-        ...getConfigWithDefaults(jsonData || {}),
+        ...(resolvedJsonData || {}),
+        ...getConfigWithDefaults(resolvedJsonData || {}),
         recommenderServiceUrl: state.recommenderServiceUrl,
         tutorialUrl: state.tutorialUrl,
         interceptGlobalDocsLinks: state.interceptGlobalDocsLinks,

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -1083,11 +1083,6 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
   const currentUserId = config.bootData.user?.id;
   const devModeEnabled = isDevModeEnabled(configWithDefaults, currentUserId);
 
-  // REACT HOOKS v7: Set global config in useEffect to avoid modifying globals during render
-  useEffect(() => {
-    (window as any).__pathfinderPluginConfig = configWithDefaults;
-  }, [configWithDefaults]);
-
   // Use the simplified context hook
   const {
     contextData,

--- a/src/components/docs-panel/docs-panel.contract.test.tsx
+++ b/src/components/docs-panel/docs-panel.contract.test.tsx
@@ -29,10 +29,21 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { testIds } from '../../constants/testIds';
 const moduleSource = fs.readFileSync(path.join(__dirname, '..', '..', 'module.tsx'), 'utf-8');
+const configHookSource = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'hooks', 'usePathfinderPluginConfig.ts'),
+  'utf-8'
+);
 
 describe('E2E Contract: Docs panel bootstrap signals', () => {
   it('exposes Pathfinder plugin readiness', () => {
-    expect(moduleSource).toContain('__pathfinderPluginConfig');
+    expect(configHookSource).toContain('__pathfinderPluginConfig');
+  });
+
+  // The runner waits for the readiness global before clicking Grafana's Help
+  // control, so `init` must publish it without awaiting anything.
+  it('publishes readiness synchronously from plugin.init', () => {
+    expect(moduleSource).toContain('plugin.init = function');
+    expect(moduleSource).toContain('publishPathfinderPluginConfig(meta?.jsonData || {})');
   });
 
   it('publishes the sidebar-mounted event', () => {
@@ -268,7 +279,7 @@ describe('E2E Contract: Scroll-restoration DOM id', () => {
  * update the owner path here in the same commit that moves the source.
  */
 const WINDOW_GLOBAL_OWNERS: Array<{ global: string; ownerFile: string }> = [
-  { global: '__pathfinderPluginConfig', ownerFile: 'docs-panel.tsx' },
+  { global: '__pathfinderPluginConfig', ownerFile: '../../hooks/usePathfinderPluginConfig.ts' },
   { global: '__DocsPluginActiveTabId', ownerFile: 'hooks/useGlobalActiveTabExposure.ts' },
   { global: '__DocsPluginActiveTabUrl', ownerFile: 'hooks/useGlobalActiveTabExposure.ts' },
 ];

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -21,8 +21,7 @@ const TerminalProviderLazy = lazy(() =>
 );
 // Lazy so @grafana/assistant stays out of the docs-panel init chain (see AiFixOrchestrator).
 const AiFixOrchestrator = lazy(() => import('./AiFixOrchestrator'));
-import { usePluginContext } from '@grafana/data';
-import { DocsPluginConfig, getConfigWithDefaults } from '../../constants';
+import { DocsPluginConfig } from '../../constants';
 
 import { useInteractiveElements, NavigationManager } from '../../interactive-engine';
 import { useKeyboardShortcuts } from './keyboard-shortcuts.hook';
@@ -39,7 +38,12 @@ import { logger } from '../../lib/logging';
 import { withGuideOpenAction, type GuideLoadOutcome } from '../../lib/telemetry';
 import { usePanelReadyMeasurement } from './hooks/usePanelReadyMeasurement';
 import { tabStorage, useUserStorage } from '../../lib/user-storage';
-import { useGuideProgressState, useAutoLaunchTutorial, type AutoLaunchTutorialDetail } from '../../hooks';
+import {
+  useGuideProgressState,
+  useAutoLaunchTutorial,
+  usePathfinderPluginConfig,
+  type AutoLaunchTutorialDetail,
+} from '../../hooks';
 import {
   fetchContent,
   getNextMilestoneUrlFromContent,
@@ -971,14 +975,10 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
 
   useCustomGuideCatalogueOnOpen();
 
-  // Get plugin configuration for dev mode check. `meta` present means the
-  // context resolved; without it `getConfigWithDefaults({})` would read as an
-  // explicit "dev mode off" rather than "not known yet".
-  const pluginContext = usePluginContext();
-  const isPluginConfigResolved = Boolean(pluginContext?.meta);
-  const pluginConfig = React.useMemo(() => {
-    return getConfigWithDefaults(pluginContext?.meta?.jsonData || {});
-  }, [pluginContext?.meta?.jsonData]);
+  // Get plugin configuration for dev mode check. `isResolved` distinguishes a
+  // known config from "not known yet"; without it an all-defaults config would
+  // read as an explicit "dev mode off" and prune authorized tabs.
+  const { config: pluginConfig, isResolved: isPluginConfigResolved } = usePathfinderPluginConfig();
 
   // SECURITY: Dev mode - hybrid approach (synchronous check with user ID scoping)
   const currentUserId = config.bootData.user?.id;
@@ -989,11 +989,6 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
   // SECURITY: Scoped logger that only emits in dev mode to prevent user data leaking to console.
   // Stable callback identity so effects depending on it do not re-run when isDevMode toggles.
   const logSession = useDevModeLogger(isDevMode);
-
-  // Set global config for utility functions that can't access React context
-  React.useEffect(() => {
-    (window as any).__pathfinderPluginConfig = pluginConfig;
-  }, [pluginConfig]);
 
   const { tabs, activeTabId, contextPanel } = model.useState();
   const { recommendationsReady = false } = contextPanel.useState();

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,3 +9,10 @@ export { usePersistedBoolean, usePersistedLocalState, usePersistedString } from 
 export { useDocumentOutline, type OutlineItem } from './useDocumentOutline';
 export { useActiveOutlineItem, type ActiveOutlineItem } from './useActiveOutlineItem';
 export { useVerticalOverflow } from './useVerticalOverflow';
+export {
+  usePathfinderPluginConfig,
+  publishPathfinderPluginConfig,
+  refreshPathfinderPluginConfig,
+  type PathfinderPluginConfigState,
+  type ResolvedPathfinderConfig,
+} from './usePathfinderPluginConfig';

--- a/src/hooks/usePathfinderPluginConfig.test.ts
+++ b/src/hooks/usePathfinderPluginConfig.test.ts
@@ -1,0 +1,235 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { usePluginContext } from '@grafana/data';
+import { getConfigWithDefaults } from '../constants';
+import { PATHFINDER_CONFIG_UPDATED_EVENT } from '../lib/event-names';
+import { fetchPluginJsonData } from '../utils/utils.plugin';
+import {
+  __resetPathfinderPluginConfigForTests,
+  publishPathfinderPluginConfig,
+  refreshPathfinderPluginConfig,
+  usePathfinderPluginConfig,
+} from './usePathfinderPluginConfig';
+
+jest.mock('../utils/utils.plugin', () => ({
+  fetchPluginJsonData: jest.fn(),
+}));
+
+jest.mock('@grafana/data', () => ({
+  ...jest.requireActual('@grafana/data'),
+  usePluginContext: jest.fn(),
+}));
+
+const mockFetch = fetchPluginJsonData as jest.MockedFunction<typeof fetchPluginJsonData>;
+const mockPluginContext = usePluginContext as unknown as jest.Mock;
+
+function readGlobal() {
+  return (window as Window & { __pathfinderPluginConfig?: ReturnType<typeof getConfigWithDefaults> })
+    .__pathfinderPluginConfig;
+}
+
+/** Flush the mount-time refresh so later publishes are not clobbered by it. */
+async function settleRefresh() {
+  await act(async () => {
+    await refreshPathfinderPluginConfig();
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __resetPathfinderPluginConfigForTests();
+  mockFetch.mockResolvedValue({});
+  mockPluginContext.mockReturnValue(null);
+});
+
+describe('publishPathfinderPluginConfig', () => {
+  it('writes the defaulted config to the readiness global', () => {
+    const published = publishPathfinderPluginConfig({ devMode: true, devModeUserIds: [7] });
+
+    expect(readGlobal()).toBe(published);
+    expect(published.devMode).toBe(true);
+    expect(published.devModeUserIds).toEqual([7]);
+    // Defaults are applied, not just the supplied fields.
+    expect(published.tutorialUrl).toBe(getConfigWithDefaults({}).tutorialUrl);
+  });
+
+  it('dispatches a payload-free event so subscribers cannot be fed a forged config', () => {
+    const listener = jest.fn();
+    document.addEventListener(PATHFINDER_CONFIG_UPDATED_EVENT, listener);
+
+    publishPathfinderPluginConfig({ devMode: true, devModeUserIds: [7] });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect((listener.mock.calls[0][0] as CustomEvent).detail).toBeNull();
+
+    document.removeEventListener(PATHFINDER_CONFIG_UPDATED_EVENT, listener);
+  });
+
+  it('keeps the existing identity and skips the event when nothing changed', () => {
+    const first = publishPathfinderPluginConfig({ devMode: true, devModeUserIds: [7] });
+
+    const listener = jest.fn();
+    document.addEventListener(PATHFINDER_CONFIG_UPDATED_EVENT, listener);
+    const second = publishPathfinderPluginConfig({ devMode: true, devModeUserIds: [7] });
+
+    expect(second).toBe(first);
+    expect(listener).not.toHaveBeenCalled();
+
+    document.removeEventListener(PATHFINDER_CONFIG_UPDATED_EVENT, listener);
+  });
+
+  it('republishes when a value actually changes', () => {
+    const first = publishPathfinderPluginConfig({ devModeUserIds: [7] });
+    const second = publishPathfinderPluginConfig({ devModeUserIds: [7, 8] });
+
+    expect(second).not.toBe(first);
+    expect(second.devModeUserIds).toEqual([7, 8]);
+  });
+});
+
+describe('refreshPathfinderPluginConfig', () => {
+  it('coalesces concurrent callers into a single request', async () => {
+    await Promise.all([
+      refreshPathfinderPluginConfig(),
+      refreshPathfinderPluginConfig(),
+      refreshPathfinderPluginConfig(),
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes the fetched settings', async () => {
+    mockFetch.mockResolvedValue({ enableLiveSessions: true });
+
+    const refreshed = await refreshPathfinderPluginConfig();
+
+    expect(refreshed?.enableLiveSessions).toBe(true);
+    expect(readGlobal()?.enableLiveSessions).toBe(true);
+  });
+
+  it('resolves undefined and leaves the published config alone on failure', async () => {
+    publishPathfinderPluginConfig({ enableLiveSessions: true });
+    mockFetch.mockRejectedValue(new Error('403'));
+
+    await expect(refreshPathfinderPluginConfig()).resolves.toBeUndefined();
+    expect(readGlobal()?.enableLiveSessions).toBe(true);
+  });
+});
+
+describe('usePathfinderPluginConfig', () => {
+  it('reports isResolved false with no published config and no plugin context', () => {
+    const { result } = renderHook(() => usePathfinderPluginConfig());
+
+    expect(result.current.isResolved).toBe(false);
+    expect(result.current.config.devMode).toBe(false);
+  });
+
+  it('prefers the published global over the plugin context snapshot', () => {
+    publishPathfinderPluginConfig({ devMode: true, devModeUserIds: [7] });
+    mockPluginContext.mockReturnValue({ meta: { jsonData: { devMode: false } } });
+
+    const { result } = renderHook(() => usePathfinderPluginConfig());
+
+    expect(result.current.isResolved).toBe(true);
+    expect(result.current.config.devMode).toBe(true);
+  });
+
+  it('falls back to the plugin context when nothing is published yet', () => {
+    mockPluginContext.mockReturnValue({ meta: { jsonData: { enableLiveSessions: true } } });
+
+    const { result } = renderHook(() => usePathfinderPluginConfig());
+
+    expect(result.current.isResolved).toBe(true);
+    expect(result.current.config.enableLiveSessions).toBe(true);
+  });
+
+  it('treats an empty jsonData on a present meta as resolved', () => {
+    mockPluginContext.mockReturnValue({ meta: {} });
+
+    const { result } = renderHook(() => usePathfinderPluginConfig());
+
+    expect(result.current.isResolved).toBe(true);
+  });
+
+  it('adopts a later publish via the config-updated event', async () => {
+    mockFetch.mockRejectedValue(new Error('403'));
+    const { result } = renderHook(() => usePathfinderPluginConfig());
+    await settleRefresh();
+    expect(result.current.isResolved).toBe(false);
+
+    act(() => {
+      publishPathfinderPluginConfig({ devMode: true, devModeUserIds: [7] });
+    });
+
+    expect(result.current.isResolved).toBe(true);
+    expect(result.current.config.devMode).toBe(true);
+  });
+
+  it('ignores a forged config carried as event detail', async () => {
+    publishPathfinderPluginConfig({ devMode: false });
+    const { result } = renderHook(() => usePathfinderPluginConfig());
+    await waitFor(() => expect(result.current.isResolved).toBe(true));
+
+    act(() => {
+      document.dispatchEvent(
+        new CustomEvent(PATHFINDER_CONFIG_UPDATED_EVENT, { detail: { devMode: true, devModeUserIds: [7] } })
+      );
+    });
+
+    expect(result.current.config.devMode).toBe(false);
+  });
+
+  it('keeps a stable state identity when a publish changes nothing', async () => {
+    mockFetch.mockResolvedValue({ enableLiveSessions: true });
+    const { result } = renderHook(() => usePathfinderPluginConfig());
+    await settleRefresh();
+    const first = result.current;
+    expect(first.config.enableLiveSessions).toBe(true);
+
+    act(() => {
+      publishPathfinderPluginConfig({ enableLiveSessions: true });
+    });
+
+    expect(result.current).toBe(first);
+  });
+
+  it('stops responding to publishes after unmount', async () => {
+    mockFetch.mockRejectedValue(new Error('403'));
+    const { result, unmount } = renderHook(() => usePathfinderPluginConfig());
+    await settleRefresh();
+    const last = result.current;
+    unmount();
+
+    expect(() => publishPathfinderPluginConfig({ devMode: true, devModeUserIds: [7] })).not.toThrow();
+    expect(result.current).toBe(last);
+  });
+
+  it('shares one request across concurrent mounts', async () => {
+    renderHook(() => usePathfinderPluginConfig());
+    renderHook(() => usePathfinderPluginConfig());
+    renderHook(() => usePathfinderPluginConfig());
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+  });
+
+  it('publishes the fetched config for non-React readers of the global', async () => {
+    mockFetch.mockResolvedValue({ enableLiveSessions: true });
+
+    const { result } = renderHook(() => usePathfinderPluginConfig());
+
+    await waitFor(() => expect(result.current.config.enableLiveSessions).toBe(true));
+    expect(readGlobal()?.enableLiveSessions).toBe(true);
+  });
+});
+
+describe('getConfigWithDefaults idempotence', () => {
+  // The hook feeds an already-defaulted config back through the defaulter, so a
+  // second pass must be a no-op — including the isKnownRecommenderUrl branch.
+  it.each([
+    ['empty', {}],
+    ['custom recommender', { recommenderServiceUrl: 'https://recommender.example.com' }],
+    ['known recommender', { recommenderServiceUrl: getConfigWithDefaults({}).recommenderServiceUrl }],
+  ])('is idempotent for %s', (_label, input) => {
+    const once = getConfigWithDefaults(input);
+    expect(getConfigWithDefaults(once)).toEqual(once);
+  });
+});

--- a/src/hooks/usePathfinderPluginConfig.ts
+++ b/src/hooks/usePathfinderPluginConfig.ts
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState } from 'react';
+import { usePluginContext } from '@grafana/data';
+import { DocsPluginConfig, getConfigWithDefaults } from '../constants';
+import { PATHFINDER_CONFIG_UPDATED_EVENT } from '../lib/event-names';
+import { logger } from '../lib/logging';
+import pluginJson from '../plugin.json';
+import { fetchPluginJsonData } from '../utils/utils.plugin';
+
+export type ResolvedPathfinderConfig = ReturnType<typeof getConfigWithDefaults>;
+
+interface PathfinderConfigWindow extends Window {
+  __pathfinderPluginConfig?: ResolvedPathfinderConfig;
+}
+
+export interface PathfinderPluginConfigState {
+  config: ResolvedPathfinderConfig;
+  /** `false` means "not known yet", which is distinct from an explicit all-defaults config. */
+  isResolved: boolean;
+}
+
+function configWindow(): PathfinderConfigWindow {
+  return window as PathfinderConfigWindow;
+}
+
+let unresolvedState: PathfinderPluginConfigState | undefined;
+
+function unresolved(): PathfinderPluginConfigState {
+  unresolvedState ??= { config: getConfigWithDefaults({}), isResolved: false };
+  return unresolvedState;
+}
+
+function configEquals(a: ResolvedPathfinderConfig, b: ResolvedPathfinderConfig): boolean {
+  return (Object.keys(b) as Array<keyof ResolvedPathfinderConfig>).every((key) => {
+    const left = a[key];
+    const right = b[key];
+    if (Array.isArray(left) && Array.isArray(right)) {
+      return left.length === right.length && left.every((value, index) => value === right[index]);
+    }
+    return left === right;
+  });
+}
+
+/**
+ * The only writer of `window.__pathfinderPluginConfig`, which is the readiness
+ * signal documented in `docs/developer/E2E_TESTING_CONTRACT.md` and the config
+ * source for callers that run outside React (scene construction, dev-mode
+ * helpers, url-validator). Returns the published config so callers can use it
+ * without re-reading the global.
+ */
+export function publishPathfinderPluginConfig(jsonData: DocsPluginConfig): ResolvedPathfinderConfig {
+  const target = configWindow();
+  const next = getConfigWithDefaults(jsonData);
+  const current = target.__pathfinderPluginConfig;
+
+  if (current && configEquals(current, next)) {
+    return current;
+  }
+
+  target.__pathfinderPluginConfig = next;
+  // Deliberately payload-free: any script sharing the document can dispatch
+  // this, so subscribers re-read the global instead of trusting event detail.
+  document.dispatchEvent(new CustomEvent(PATHFINDER_CONFIG_UPDATED_EVENT));
+  return next;
+}
+
+let refreshInFlight: Promise<ResolvedPathfinderConfig | undefined> | null = null;
+
+/**
+ * Single-flight read of the saved settings. Grafana's `meta.jsonData` snapshot
+ * can lag a save, so this is the authoritative value — but nothing waits on it:
+ * failure leaves whatever was already published in place.
+ */
+export function refreshPathfinderPluginConfig(): Promise<ResolvedPathfinderConfig | undefined> {
+  refreshInFlight ??= fetchPluginJsonData(pluginJson.id)
+    .then((jsonData) => publishPathfinderPluginConfig(jsonData))
+    .catch((error) => {
+      logger.warn('Failed to read plugin settings; keeping the plugin meta snapshot', { error });
+      return undefined;
+    });
+
+  return refreshInFlight;
+}
+
+function resolveState(contextState: PathfinderPluginConfigState | undefined): PathfinderPluginConfigState {
+  const published = configWindow().__pathfinderPluginConfig;
+  if (published) {
+    return { config: published, isResolved: true };
+  }
+  return contextState ?? unresolved();
+}
+
+export function usePathfinderPluginConfig(): PathfinderPluginConfigState {
+  const pluginContext = usePluginContext();
+  const pluginMeta = pluginContext?.meta;
+  const contextState = useMemo<PathfinderPluginConfigState | undefined>(
+    () => (pluginMeta ? { config: getConfigWithDefaults(pluginMeta.jsonData || {}), isResolved: true } : undefined),
+    [pluginMeta]
+  );
+
+  const [state, setState] = useState<PathfinderPluginConfigState>(() => resolveState(contextState));
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const sync = () => {
+      if (cancelled) {
+        return;
+      }
+      const next = resolveState(contextState);
+      setState((previous) => (previous.config === next.config ? previous : next));
+    };
+
+    document.addEventListener(PATHFINDER_CONFIG_UPDATED_EVENT, sync);
+    sync();
+    void refreshPathfinderPluginConfig().then(sync);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener(PATHFINDER_CONFIG_UPDATED_EVENT, sync);
+    };
+  }, [contextState]);
+
+  return state;
+}
+
+/**
+ * Test-only reset of the module-level single-flight and the published global.
+ */
+export function __resetPathfinderPluginConfigForTests(): void {
+  refreshInFlight = null;
+  unresolvedState = undefined;
+  delete configWindow().__pathfinderPluginConfig;
+}

--- a/src/lib/event-names.ts
+++ b/src/lib/event-names.ts
@@ -15,6 +15,11 @@ export const PANEL_MODE_CHANGE_EVENT = 'pathfinder-panel-mode-change';
 // already-mounted floating panel must be signalled to consume directly.
 export const REQUEST_FLOATING_GUIDE_EVENT = 'pathfinder-request-floating-guide';
 
+// Signals that window.__pathfinderPluginConfig has a new value; carries no
+// payload, because any script sharing the document can dispatch it. Owned by
+// publishPathfinderPluginConfig in hooks/usePathfinderPluginConfig.ts.
+export const PATHFINDER_CONFIG_UPDATED_EVENT = 'pathfinder-config-updated';
+
 // Ask the docs panel to open a URL in a new tab. Dispatched by the global
 // link interceptor, HomePanel's beside-Grafana launch path, and grot guides;
 // handled by useAutoOpenListener. Detail: { url, title, source?, launchKey? }

--- a/src/lib/telemetry/entry-bundle-boundary.test.ts
+++ b/src/lib/telemetry/entry-bundle-boundary.test.ts
@@ -8,9 +8,21 @@ const ENTRY_EAGER_FILES = ['lib/analytics.ts', 'lib/logging.ts', 'global-state/p
 
 const BARREL_IMPORT_RE = /(?:from\s+['"]|require\(['"])[^'"]*\/telemetry['"]/;
 
+// The same rule for the hooks barrel: it re-exports useGuideProgressState, whose
+// chain reaches lib/user-storage and zod. Importing it from module.tsx roughly
+// doubled module.js (113 KB -> 224 KB raw) before this was pinned.
+const HOOKS_BARREL_IMPORT_RE = /(?:from\s+['"]|require\(['"])\.{1,2}(?:\/\.\.)*\/hooks['"]/;
+
 describe('telemetry entry-bundle import discipline', () => {
   it.each(ENTRY_EAGER_FILES)('%s does not import the telemetry barrel', (relativePath) => {
     const source = fs.readFileSync(path.join(__dirname, '../../', relativePath), 'utf8');
     expect(source).not.toMatch(BARREL_IMPORT_RE);
+  });
+});
+
+describe('hooks entry-bundle import discipline', () => {
+  it('module.tsx does not import the hooks barrel', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../../module.tsx'), 'utf8');
+    expect(source).not.toMatch(HOOKS_BARREL_IMPORT_RE);
   });
 });

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -1,11 +1,14 @@
-import { AppPlugin, AppPluginMeta, type AppRootProps, PluginExtensionPoints, usePluginContext } from '@grafana/data';
-import React, { lazy, Suspense, useEffect, useMemo } from 'react';
+import { AppPlugin, AppPluginMeta, type AppRootProps, PluginExtensionPoints } from '@grafana/data';
+import React, { lazy, Suspense, useEffect } from 'react';
 import { LoadingPlaceholder } from '@grafana/ui';
 import { reportAppInteraction, UserInteraction } from './lib/analytics';
 import { logger } from './lib/logging';
 import { initPluginTranslations } from '@grafana/i18n';
 import pluginJson from './plugin.json';
-import { getConfigWithDefaults, DocsPluginConfig } from './constants';
+import { DocsPluginConfig } from './constants';
+// Direct file import, not the ./hooks barrel: the barrel would pull every hook
+// (and zod, via user-storage) into module.js.
+import { publishPathfinderPluginConfig, refreshPathfinderPluginConfig } from './hooks/usePathfinderPluginConfig';
 import { PANEL_MODE_CHANGE_EVENT } from './lib/event-names';
 import { linkInterceptionState } from './global-state/link-interception';
 import { sidebarState } from 'global-state/sidebar';
@@ -137,12 +140,20 @@ const plugin = new AppPlugin<{}>()
 
 // Override init() to handle auto-open when plugin loads
 plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
-  const jsonData = meta?.jsonData || {};
-  const config = getConfigWithDefaults(jsonData);
+  // Everything here must stay synchronous. `AppPlugin.init` is typed `void` and
+  // Grafana never awaits it, so work behind an await would run after first paint
+  // — after scene construction has already read the published config, and after
+  // the deep-link and link-interception listeners needed to exist.
+  const config = publishPathfinderPluginConfig(meta?.jsonData || {});
   linkInterceptionState.setInterceptionEnabled(config.interceptGlobalDocsLinks);
 
-  // Set global config immediately so other code can use it
-  (window as any).__pathfinderPluginConfig = config;
+  // `meta.jsonData` can lag a recent save. Re-publish from the authoritative
+  // read when it lands; subscribers pick it up via the config-updated event.
+  void refreshPathfinderPluginConfig().then((refreshed) => {
+    if (refreshed) {
+      linkInterceptionState.setInterceptionEnabled(refreshed.interceptGlobalDocsLinks);
+    }
+  });
 
   // Snapshotted before handlePathfinderDeepLink strips it from the URL.
   const { doc: docsParam, controller: controllerParam } = parsePathfinderDeepLink(window.location.search);
@@ -311,20 +322,6 @@ if (pathfinderEnabled) {
     title: 'Interactive learning',
     description: 'Opens Interactive learning',
     component: function ContextSidebar() {
-      // Get plugin configuration
-      const pluginContext = usePluginContext();
-      const config = useMemo(() => {
-        const rawJsonData = pluginContext?.meta?.jsonData || {};
-        const configWithDefaults = getConfigWithDefaults(rawJsonData);
-
-        return configWithDefaults;
-      }, [pluginContext?.meta?.jsonData]);
-
-      // Set global config for utility functions (including auto-open logic)
-      useEffect(() => {
-        (window as any).__pathfinderPluginConfig = config;
-      }, [config]);
-
       // Process queued docs links when sidebar mounts
       useEffect(() => {
         sidebarState.setIsSidebarMounted(true);

--- a/src/utils/dev-mode.ts
+++ b/src/utils/dev-mode.ts
@@ -23,11 +23,10 @@
  * - disableDevMode() - Disable dev mode entirely
  */
 
-import { config, getBackendSrv } from '@grafana/runtime';
-import { lastValueFrom } from 'rxjs';
+import { config } from '@grafana/runtime';
 import { DocsPluginConfig } from '../constants';
 import { logger } from '../lib/logging';
-import { updatePluginSettings } from './utils.plugin';
+import { fetchPluginJsonData, updatePluginSettings } from './utils.plugin';
 import pluginJson from '../plugin.json';
 
 /**
@@ -35,12 +34,7 @@ import pluginJson from '../plugin.json';
  * fields managed by other config tabs when saving dev mode changes.
  */
 async function fetchCurrentJsonData(): Promise<DocsPluginConfig> {
-  const response = getBackendSrv().fetch<{ jsonData?: DocsPluginConfig }>({
-    url: `/api/plugins/${pluginJson.id}/settings`,
-    method: 'GET',
-  });
-  const result = await lastValueFrom(response);
-  return result.data?.jsonData || {};
+  return fetchPluginJsonData(pluginJson.id);
 }
 
 /**

--- a/src/utils/utils.plugin.ts
+++ b/src/utils/utils.plugin.ts
@@ -2,9 +2,19 @@ import React from 'react';
 import { AppRootProps, PluginMeta } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
+import { DocsPluginConfig } from '../constants';
 
 // This is used to be able to retrieve the root plugin props anywhere inside the app.
 export const PluginPropsContext = React.createContext<AppRootProps | null>(null);
+
+export async function fetchPluginJsonData(pluginId: string): Promise<DocsPluginConfig> {
+  const response = getBackendSrv().fetch<{ jsonData?: DocsPluginConfig }>({
+    url: `/api/plugins/${encodeURIComponent(pluginId)}/settings`,
+    method: 'GET',
+  });
+  const result = await lastValueFrom(response);
+  return result.data?.jsonData || {};
+}
 
 export const updatePluginSettings = async (pluginId: string, data: Partial<PluginMeta>) => {
   // Simple plugin update following working plugin patterns - no reload needed

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -140,7 +140,11 @@ const ALLOWED_LATERAL_VIOLATIONS = new Set([
  * Phase 4a cleared all 15 original entries by re-exporting from barrels
  * and updating consumer import paths.
  */
-const ALLOWED_BARREL_VIOLATIONS = new Set<string>([]);
+const ALLOWED_BARREL_VIOLATIONS = new Set<string>([
+  // module.tsx is the entry point: the hooks barrel drags every hook — and zod,
+  // via lib/user-storage — into module.js, roughly doubling it.
+  'module.tsx -> hooks/usePathfinderPluginConfig',
+]);
 
 /**
  * Known circular-dependency clusters (strongly-connected components of the


### PR DESCRIPTION
## Summary

Pathfinder reads its settings from Grafana's `meta.jsonData` snapshot, which can lag a recent save. This switches to the settings API as the authoritative source, and consolidates the four places that wrote `window.__pathfinderPluginConfig` down to one.

The new `hooks/usePathfinderPluginConfig.ts` is the only writer of that global — the readiness signal the e2e runner waits on, and the config source for callers outside React.

## What to look at

**Boot ordering (`src/module.tsx`).** `plugin.init` stays synchronous and publishes from `meta.jsonData` immediately, then kicks off an unawaited refresh. `AppPlugin.init` is typed `void` and Grafana never awaits it, so anything behind an `await` would run after first paint — after scene construction has already read the published config, and after the deep-link and link-interception listeners needed to exist. Worth a look if you disagree that a synchronous first publish is required.

**Entry bundle.** `module.tsx` imports the hook file directly rather than through the `hooks` barrel. The barrel reaches `lib/user-storage` and transitively zod, which took `module.js` from 113 KB to 224 KB raw. Now 114,429 bytes raw / 37,791 gzip with zero zod references. Pinned by a new case in `entry-bundle-boundary.test.ts` plus an `ALLOWED_BARREL_VIOLATIONS` entry so the direct import is a documented decision rather than an oversight.

**Trust boundary on the update event.** `PATHFINDER_CONFIG_UPDATED_EVENT` is dispatched on `document`, so any script sharing the page can fire it. The event therefore carries no payload and subscribers re-read the global; nothing trusts `event.detail`. `event-names.ts` says so now.

**Draft preservation (`ConfigurationForm.tsx`, second commit).** The form seeds its draft from the API read, which unconditionally would discard whatever the admin typed before the response landed — and the draft is what `onSubmit` writes back, so the loss reached durable settings. Now gated on an `isDraftEdited` ref, with all field changes routed through an `editDraft` helper.

## Why

Four components each derived config from context and wrote the global on a last-writer-wins basis, so whichever effect ran last won and stale values could overwrite fetched ones. Each consumer also fetched independently. The refresh is now single-flight (one request per page load), and publishing is value-compared so a redundant publish costs no re-renders.

## How to verify

- `npm run check` passes; 425 suites / 6756 tests green.
- `npm run build` then check `dist/module.js` is ~114 KB raw and contains no `_zod` references.
- Manually: change a setting, save, and confirm the panel picks it up without a full reload. Then start typing in the config form on a slow connection and confirm your edit survives the settings response.

## Reversibility

Fully revertable — no schema, storage, or API-contract change. The two commits are independent and can be reverted separately.

## Open item

This establishes a contract (one owner for `window.__pathfinderPluginConfig`, payload-free invalidation event). Per `AGENTS.md` that wants a contract anchor row in `docs/design/CONCERNS.md`; not added yet — say the word and I'll push it here rather than leaving it for a follow-up.

## Note on provenance

Split out of the `spike/coda-client-real-sdk` branch behind #1607, where it was unrelated to that PR's subject. Rebased onto `main`; the only file both touch is `docs-panel.tsx`, in non-overlapping regions.

Made with [Cursor](https://cursor.com)