### PR TITLE
fix(e2e): harden runner lifecycle handling

### DIFF
--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -175,9 +175,12 @@ Requirements met? → Execute step
 
 **Skippable steps** (those with a Skip button) allow the test to continue when requirements cannot be met. **Mandatory steps** cause the test to abort on failure, marking remaining steps as `not_reached`.
 
-An unmet read gets a short settle window before the runner treats it as terminal. This applies whether or not a Fix button is visible. See `Requirements settle window` in the timing table below.
+An unmet read without a Fix button gets a short settle window before the runner treats it as terminal. A visible Fix button is already an actionable settled state. See `Requirements settle window` in the timing table below.
 
 The plugin's requirement check can be mid-transition right after the initial check, or right after a Fix button click. The runner polls briefly for the state to settle, instead of failing on one transient read.
+Skipping a step is a two-part handshake, not just a runner-side decision. The runner clicks the plugin's Skip control (the step's always-available Skip button, or the narrower Skip button inside the requirements-explanation banner, whichever the plugin rendered) and waits for the step to reach a terminal state: `completed`, or a successful detach. Only then does the runner record the step as `SKIPPED`. If the plugin never reaches that terminal state, for example no Skip control is found, the click fails, or it stays `requirements-unmet`, the runner records `FAILED` instead of a false `SKIPPED`. A false skip would leave the plugin gated on "Complete previous step" for every step that follows.
+
+A no-op or objective-based step can complete, or its element can detach, between discovery and this point in execution, before the runner even scrolls to it. The runner rechecks for this right before scrolling and records `PASSED`, the same outcome it records when it observes a step completing via objectives right before clicking "Do it". This keeps one DOM state, attached and `completed`, mapped to one outcome, no matter which check in the runner happens to observe it first.
 
 Overall success requires zero mandatory failures and either at least one verified pass or zero failed steps. A run where every step is skipped cleanly succeeds; a run with no verified pass and any failed skippable step fails.
 
@@ -328,15 +331,19 @@ The environment is reset **between dependency chains**, not between every guide.
 
 ## Timing and timeouts
 
-| Constant                   | Value            | Purpose                                             |
-| -------------------------- | ---------------- | --------------------------------------------------- |
-| Base step timeout          | 30s              | Maximum time for a single step                      |
-| Multistep bonus            | +5s per action   | Added for each internal action in multisteps        |
-| Guided substep bonus       | +30s per substep | Added for each substep in guided blocks             |
-| Button enable wait         | 10s              | Wait for sequential dependencies                    |
-| Fix button timeout         | 10s              | Per fix operation                                   |
-| Max fix attempts           | 3                | Retry limit before giving up                        |
-| Requirements settle window | 1s               | Poll budget before an unmet read counts as terminal |
+| Constant                   | Value            | Purpose                                                                                     |
+| -------------------------- | ---------------- | ------------------------------------------------------------------------------------------- |
+| Base step timeout          | 30s              | Maximum time for a single step                                                              |
+| Multistep bonus            | +5s per action   | Added for each internal action in multisteps                                                |
+| Guided substep bonus       | +30s per substep | Added for each substep in guided blocks                                                     |
+| Button enable wait         | 10s              | Wait for sequential dependencies                                                            |
+| Fix button timeout         | 10s              | Per fix operation                                                                           |
+| Max fix attempts           | 3                | Retry limit before giving up                                                                |
+| Requirements settle window | 1s               | Poll budget before an unmet read with no Fix button counts as terminal                      |
+| Scroll into view           | 5s               | Bounds scrolling a step into view, so a step completing or detaching there can't hang       |
+| Late completion check      | 2s               | Bounds the pre-scroll recheck for a step that completed or detached since discovery         |
+| Skip sync                  | 5s               | Bounds waiting for the plugin to reach a terminal state after the runner clicks Skip        |
+| Guided reload wait         | 15s              | Bounds waiting for `domcontentloaded` after a detected reload or navigation mid-guided-step |
 
 Examples:
 

--- a/docs/developer/E2E_TESTING_CONTRACT.md
+++ b/docs/developer/E2E_TESTING_CONTRACT.md
@@ -564,6 +564,30 @@ if (requirementsState === 'unmet') {
 
 ---
 
+### Skip controls and runner synchronization
+
+The plugin renders two Skip controls that both call the same underlying `markSkipped()` action:
+
+- **`interactive-skip-${stepId}`** (`testIds.interactive.skipButton`): the step's always-available Skip button. It renders whenever the step is skippable, is not a noop action, and is not already completed, regardless of requirements state. Step discovery uses this control to determine `step.skippable`.
+- **`interactive-requirement-skip-${stepId}`** (`testIds.interactive.requirementSkipButton`): a narrower Skip button rendered only inside the requirements-explanation banner when requirements have failed. `detectRequirements()` reports this control's presence as `hasSkipButton`.
+
+A test or runner that needs to skip a step should prefer the step-level control and fall back to the requirement-scoped one only when the step-level control is not rendered, so it supports whichever shape the plugin actually renders instead of assuming one fixed control.
+
+Clicking either control does not skip the step immediately from the runner's point of view. The runner must wait for `data-test-step-state` to reach a terminal value, `completed`, or for the step element to detach, before treating the step as skipped. A transient value such as `checking` is not a terminal state; a runner that stops polling on the first non-`requirements-unmet` value can record a false skip while the plugin is still mid-transition.
+
+```typescript
+// Prefer the step-level Skip control; fall back to the requirement-scoped one.
+const stepSkip = page.getByTestId(testIds.interactive.skipButton(stepId));
+const requirementSkip = page.getByTestId(testIds.interactive.requirementSkipButton(stepId));
+const skipButton = (await stepSkip.count()) > 0 ? stepSkip : requirementSkip;
+await skipButton.click();
+
+// Wait for a terminal state before treating the step as skipped.
+await page.waitForSelector('[data-step-id="my-step"][data-test-step-state="completed"]');
+```
+
+---
+
 ## Versioning and Stability
 
 ### Current Version

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
@@ -274,7 +274,7 @@ describe('dismissBadgeCelebrations', () => {
   it('dismisses the toast before a hidden target reveal hover', async () => {
     const { page: badgePage, events } = createBadgeHarness(['First badge']);
     const stepLocator = {
-      count: jest.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(0),
+      count: jest.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(1).mockResolvedValue(0),
       getAttribute: jest.fn(async (name: string) => {
         if (name === 'data-test-step-state') {
           return 'executing';
@@ -286,7 +286,8 @@ describe('dismissBadgeCelebrations', () => {
       }),
     } as unknown as Locator;
     const commentBox = {
-      waitFor: jest.fn().mockResolvedValue(undefined),
+      count: jest.fn().mockResolvedValue(1),
+      isVisible: jest.fn().mockResolvedValue(true),
       getAttribute: jest.fn(async (name: string) => {
         if (name === 'data-test-action') {
           return 'hover';

--- a/tests/e2e-runner/utils/guide-runner/constants.ts
+++ b/tests/e2e-runner/utils/guide-runner/constants.ts
@@ -137,6 +137,13 @@ export const POST_CLICK_SETTLE_DELAY_MS = 500;
 export const SCROLL_INTO_VIEW_TIMEOUT_MS = 5000;
 
 /**
+ * Timeout for the late-completion/detachment attribute read performed
+ * immediately before scrolling a step into view. Kept short so a step that
+ * detaches mid-read can't stall on an otherwise-unbounded locator read.
+ */
+export const LATE_COMPLETION_CHECK_TIMEOUT_MS = 2000;
+
+/**
  * Polling interval for checking completion during wait.
  * Used for detecting objective-based auto-completion.
  */

--- a/tests/e2e-runner/utils/guide-runner/constants.ts
+++ b/tests/e2e-runner/utils/guide-runner/constants.ts
@@ -98,6 +98,13 @@ export const GUIDED_HOVER_DWELL_MS = 500;
 export const GUIDED_SKIP_AFTER_TIMEOUT_FRACTION = 0.8;
 
 /**
+ * Timeout for a guided action's page-load wait after a detected reload/navigation
+ * (URL change or a `framenavigated` event). Bounded so a stuck reload fails fast
+ * instead of hanging the whole step.
+ */
+export const GUIDED_RELOAD_LOAD_TIMEOUT_MS = 15000;
+
+/**
  * Timeout for waiting for "Do it" button to become enabled.
  * Sequential dependencies (isEligibleForChecking) may disable buttons.
  */
@@ -121,6 +128,13 @@ export const SCROLL_SETTLE_DELAY_MS = 300;
  * Allows the reactive system to settle (debounced rechecks: 500ms context, 1200ms DOM).
  */
 export const POST_CLICK_SETTLE_DELAY_MS = 500;
+
+/**
+ * Timeout for scrolling a step into view.
+ * Kept short: a step that is completing or detaching around this point in
+ * execution should not block the whole run on an unbounded scroll wait.
+ */
+export const SCROLL_INTO_VIEW_TIMEOUT_MS = 5000;
 
 /**
  * Polling interval for checking completion during wait.
@@ -186,6 +200,12 @@ export const FIX_BUTTON_TIMEOUT_MS = 10000;
  * Per design doc: 3 attempts (reduced from original 10 for faster failure).
  */
 export const MAX_FIX_ATTEMPTS = 3;
+
+/**
+ * Timeout for a skippable step's Skip control to take effect after a click:
+ * bounds the wait for the step to leave the `requirements-unmet` state.
+ */
+export const SKIP_SYNC_TIMEOUT_MS = 5000;
 
 /**
  * Delay after fix button click to allow the fix action to complete.

--- a/tests/e2e-runner/utils/guide-runner/execution.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.test.ts
@@ -189,15 +189,20 @@ describe('waitForGuidedCommentBoxReady', () => {
     await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 1000)).resolves.toBe('completed');
   });
 
-  it("resolves 'detached' when the step's element is confirmed gone while waiting", async () => {
+  it("resolves 'detached' when the step's element is confirmed gone while waiting, without reading its attributes", async () => {
+    // In real Playwright, getAttribute() on a missing element auto-waits up to
+    // its own timeout instead of resolving instantly, so detachment must be
+    // decided by count() alone, before any attribute read is attempted.
+    const getAttribute = jest.fn().mockRejectedValue(new Error('must not be called: step is already detached'));
     const stepLocator = createLocator({
-      getAttribute: jest.fn().mockResolvedValue(null),
+      getAttribute,
       count: jest.fn().mockResolvedValue(0),
     });
     const commentBox = createLocator({ count: jest.fn().mockResolvedValue(0) });
     const page = { waitForTimeout: jest.fn().mockResolvedValue(undefined) } as unknown as Page;
 
     await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 1000)).resolves.toBe('detached');
+    expect(getAttribute).not.toHaveBeenCalled();
   });
 
   it('fails fast on an error state instead of waiting out the full timeout', async () => {

--- a/tests/e2e-runner/utils/guide-runner/execution.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.test.ts
@@ -50,6 +50,9 @@ jest.mock('@playwright/test', () => {
 jest.mock('./requirements', () => ({
   handleRequirementsWithFix: jest.fn(),
 }));
+jest.mock('./badge-celebrations', () => ({
+  dismissBadgeCelebrations: jest.fn().mockResolvedValue(undefined),
+}));
 
 import type { Locator, Page } from '@playwright/test';
 
@@ -62,6 +65,7 @@ import {
   summarizeResults,
 } from './execution';
 import { handleRequirementsWithFix } from './requirements';
+import { dismissBadgeCelebrations } from './badge-celebrations';
 import {
   SCROLL_INTO_VIEW_TIMEOUT_MS,
   GUIDED_RELOAD_LOAD_TIMEOUT_MS,
@@ -157,6 +161,10 @@ describe('scrollStepIntoView', () => {
 });
 
 describe('clickSkipButtonAndSync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (dismissBadgeCelebrations as jest.Mock).mockResolvedValue(undefined);
+  });
   it('throws when neither Skip control is rendered', async () => {
     const page = createSkipRoutedPage({});
 
@@ -170,8 +178,12 @@ describe('clickSkipButtonAndSync', () => {
     const page = createSkipRoutedPage({ stepSkipButton, requirementSkipButton, stepLocator });
 
     await expect(clickSkipButtonAndSync(page, 'step-1', 200)).resolves.toBeUndefined();
+    expect(dismissBadgeCelebrations).toHaveBeenCalledWith(page);
 
     expect(stepSkipButton.click).toHaveBeenCalledWith({ timeout: 200 });
+    expect((dismissBadgeCelebrations as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (stepSkipButton.click as jest.Mock).mock.invocationCallOrder[0]
+    );
     expect(requirementSkipButton.click).not.toHaveBeenCalled();
   });
 

--- a/tests/e2e-runner/utils/guide-runner/execution.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.test.ts
@@ -61,7 +61,11 @@ import {
   executeStep,
 } from './execution';
 import { handleRequirementsWithFix } from './requirements';
-import { SCROLL_INTO_VIEW_TIMEOUT_MS, GUIDED_RELOAD_LOAD_TIMEOUT_MS } from './constants';
+import {
+  SCROLL_INTO_VIEW_TIMEOUT_MS,
+  GUIDED_RELOAD_LOAD_TIMEOUT_MS,
+  LATE_COMPLETION_CHECK_TIMEOUT_MS,
+} from './constants';
 import type { TestableStep } from './types';
 
 function createTestableStep(overrides: Partial<TestableStep> = {}): TestableStep {
@@ -505,5 +509,76 @@ describe('executeStep - skip sync sequential-flow regression', () => {
     expect(result.status).toBe('failed');
     expect(result.skippable).toBe(true);
     expect(result.error).toMatch(/skip sync/i);
+  });
+});
+
+describe('executeStep - late completion/detachment precheck', () => {
+  it('propagates a genuine query failure instead of treating it as pre-completion', async () => {
+    const stepLocator = createLocator({ count: jest.fn().mockRejectedValue(new Error('Target closed')) });
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepLocator),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      off: jest.fn(),
+      url: jest.fn().mockReturnValue('http://localhost:3000/'),
+    } as unknown as Page;
+    const step = createTestableStep({ isGuided: false, guidedStepCount: undefined });
+
+    const result = await executeStep(page, step, {});
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('Target closed');
+  });
+
+  it('bounds the completion read and treats a successful re-count of zero as late detachment', async () => {
+    // getAttribute never resolves in time (simulating a mid-read detach); the
+    // precheck must re-count rather than trust a stale "attached" result.
+    let countCalls = 0;
+    const getAttribute = jest.fn().mockRejectedValue(new Error('Element not attached'));
+    const count = jest.fn().mockImplementation(() => {
+      countCalls += 1;
+      return Promise.resolve(countCalls === 1 ? 1 : 0); // attached, then gone mid-read
+    });
+    const stepLocator = createLocator({ count, getAttribute });
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepLocator),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      off: jest.fn(),
+      url: jest.fn().mockReturnValue('http://localhost:3000/'),
+    } as unknown as Page;
+    const step = createTestableStep({ isGuided: false, guidedStepCount: undefined });
+
+    const result = await executeStep(page, step, {});
+
+    expect(result.status).toBe('skipped');
+    expect(result.skipReason).toBe('pre_completed');
+    expect(getAttribute).toHaveBeenCalledWith('data-test-step-state', { timeout: LATE_COMPLETION_CHECK_TIMEOUT_MS });
+    expect(countCalls).toBe(2);
+  });
+
+  it('propagates the original read error when the element is still attached after a failed bounded read', async () => {
+    const readError = new Error('Some other read failure');
+    let countCalls = 0;
+    const getAttribute = jest.fn().mockRejectedValue(readError);
+    const count = jest.fn().mockImplementation(() => {
+      countCalls += 1;
+      return Promise.resolve(1); // always attached
+    });
+    const stepLocator = createLocator({ count, getAttribute });
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepLocator),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      off: jest.fn(),
+      url: jest.fn().mockReturnValue('http://localhost:3000/'),
+    } as unknown as Page;
+    const step = createTestableStep({ isGuided: false, guidedStepCount: undefined });
+
+    const result = await executeStep(page, step, {});
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe(readError.message);
+    expect(countCalls).toBe(2);
   });
 });

--- a/tests/e2e-runner/utils/guide-runner/execution.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Unit tests for the runner lifecycle fixes in execution.ts:
+ * 1. Skip sync (clickSkipButtonAndSync)
+ * 2. Guided readiness (waitForGuidedCommentBoxReady)
+ * 3. Reload/detached-step handling (runGuidedSubstepLoop)
+ * 4. Late no-op completion / bounded scroll (scrollStepIntoView)
+ *
+ * @see tests/e2e-runner/utils/guide-runner/execution.ts
+ */
+
+jest.mock('@playwright/test', () => {
+  const readState = async (locator: { getAttribute: (name: string) => Promise<string | null> }) =>
+    locator.getAttribute('data-test-step-state');
+
+  return {
+    Page: jest.fn(),
+    Locator: jest.fn(),
+    test: jest.fn(),
+    expect: (locator: { getAttribute: (name: string) => Promise<string | null> }) => {
+      const poll = async (matches: (value: string | null) => boolean, opts?: { timeout?: number }) => {
+        const timeout = opts?.timeout ?? 5000;
+        const deadline = Date.now() + timeout;
+        for (;;) {
+          const value = await readState(locator);
+          if (matches(value)) {
+            return;
+          }
+          if (Date.now() >= deadline) {
+            throw new Error('Timed out waiting for attribute');
+          }
+          await new Promise((resolve) => setTimeout(resolve, 1));
+        }
+      };
+      return {
+        toHaveAttribute: (_attr: string, value: string, opts?: { timeout?: number }) =>
+          poll((current) => current === value, opts),
+        not: {
+          toHaveAttribute: (_attr: string, value: string, opts?: { timeout?: number }) =>
+            poll((current) => current !== value, opts),
+        },
+      };
+    },
+  };
+});
+
+import type { Locator, Page } from '@playwright/test';
+
+import {
+  scrollStepIntoView,
+  clickSkipButtonAndSync,
+  waitForGuidedCommentBoxReady,
+  runGuidedSubstepLoop,
+} from './execution';
+import { SCROLL_INTO_VIEW_TIMEOUT_MS, GUIDED_RELOAD_LOAD_TIMEOUT_MS } from './constants';
+import type { TestableStep } from './types';
+
+function createTestableStep(overrides: Partial<TestableStep> = {}): TestableStep {
+  return {
+    stepId: 'test-step-1',
+    index: 0,
+    skippable: false,
+    hasDoItButton: true,
+    hasShowMeButton: false,
+    isPreCompleted: false,
+    isMultistep: false,
+    internalActionCount: 0,
+    isGuided: true,
+    guidedStepCount: 1,
+    locator: {} as unknown as TestableStep['locator'],
+    ...overrides,
+  };
+}
+
+function createLocator(overrides: Partial<Record<string, jest.Mock>> = {}): Locator {
+  return {
+    count: jest.fn().mockResolvedValue(1),
+    isVisible: jest.fn().mockResolvedValue(true),
+    getAttribute: jest.fn().mockResolvedValue(null),
+    click: jest.fn().mockResolvedValue(undefined),
+    scrollIntoViewIfNeeded: jest.fn().mockResolvedValue(undefined),
+    hover: jest.fn().mockResolvedValue(undefined),
+    fill: jest.fn().mockResolvedValue(undefined),
+    first: jest.fn(),
+    filter: jest.fn(),
+    locator: jest.fn(),
+    getByRole: jest.fn(),
+    waitFor: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as Locator;
+}
+
+describe('scrollStepIntoView', () => {
+  it('bounds scrollIntoViewIfNeeded with the scroll timeout', async () => {
+    const stepElement = createLocator();
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepElement),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Page;
+
+    await scrollStepIntoView(page, 'step-1', 0);
+
+    expect(stepElement.scrollIntoViewIfNeeded).toHaveBeenCalledWith({ timeout: SCROLL_INTO_VIEW_TIMEOUT_MS });
+  });
+
+  it('accepts an explicit scroll timeout override', async () => {
+    const stepElement = createLocator();
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepElement),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Page;
+
+    await scrollStepIntoView(page, 'step-1', 0, 1234);
+
+    expect(stepElement.scrollIntoViewIfNeeded).toHaveBeenCalledWith({ timeout: 1234 });
+  });
+});
+
+describe('clickSkipButtonAndSync', () => {
+  it('does nothing when no Skip control is present', async () => {
+    const skipButton = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(skipButton),
+    } as unknown as Page;
+
+    await clickSkipButtonAndSync(page, 'step-1', 100);
+
+    expect(skipButton.click).not.toHaveBeenCalled();
+  });
+
+  it('clicks the Skip control and resolves once the step leaves requirements-unmet', async () => {
+    const stepLocator = createLocator({
+      getAttribute: jest.fn().mockResolvedValueOnce('requirements-unmet').mockResolvedValue('completed'),
+    });
+    const skipButton = createLocator();
+    const page = {
+      getByTestId: jest.fn().mockImplementation((testId: string) =>
+        testId.startsWith('interactive-skip-') ? skipButton : stepLocator
+      ),
+    } as unknown as Page;
+
+    await clickSkipButtonAndSync(page, 'step-1', 200);
+
+    expect(skipButton.click).toHaveBeenCalledWith({ timeout: 200 });
+  });
+
+  it('does not throw when the step never leaves requirements-unmet', async () => {
+    const stepLocator = createLocator({
+      getAttribute: jest.fn().mockResolvedValue('requirements-unmet'),
+    });
+    const skipButton = createLocator();
+    const page = {
+      getByTestId: jest.fn().mockImplementation((testId: string) =>
+        testId.startsWith('interactive-skip-') ? skipButton : stepLocator
+      ),
+    } as unknown as Page;
+
+    await expect(clickSkipButtonAndSync(page, 'step-1', 20)).resolves.toBeUndefined();
+  });
+});
+
+describe('waitForGuidedCommentBoxReady', () => {
+  it('resolves immediately when the comment box is already visible', async () => {
+    const stepLocator = createLocator();
+    const commentBox = createLocator();
+    const page = { waitForTimeout: jest.fn().mockResolvedValue(undefined) } as unknown as Page;
+
+    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 1000)).resolves.toBeUndefined();
+  });
+
+  it('fails fast on an error state instead of waiting out the full timeout', async () => {
+    const stepLocator = createLocator({ getAttribute: jest.fn().mockResolvedValue('error') });
+    const commentBox = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const page = { waitForTimeout: jest.fn().mockResolvedValue(undefined) } as unknown as Page;
+
+    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 30000)).rejects.toThrow(
+      'error state'
+    );
+    // Only one poll iteration should have happened before the fast failure.
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it('fails fast on a cancelled state', async () => {
+    const stepLocator = createLocator({ getAttribute: jest.fn().mockResolvedValue('cancelled') });
+    const commentBox = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const page = { waitForTimeout: jest.fn().mockResolvedValue(undefined) } as unknown as Page;
+
+    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 30000)).rejects.toThrow('cancelled');
+  });
+
+  it('times out with a clear error when the comment box never appears', async () => {
+    const stepLocator = createLocator({ getAttribute: jest.fn().mockResolvedValue('executing') });
+    const commentBox = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const page = { waitForTimeout: jest.fn().mockResolvedValue(undefined) } as unknown as Page;
+
+    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 1)).rejects.toThrow(
+      'comment box not visible'
+    );
+  });
+});
+
+describe('runGuidedSubstepLoop', () => {
+  it('treats a detached step as completion (e.g. after a completeEarly navigation)', async () => {
+    const stepLocator = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepLocator),
+    } as unknown as Page;
+    const step = createTestableStep();
+
+    const result = await runGuidedSubstepLoop(page, step, {
+      stepLocator,
+      perSubstepTimeoutMs: 1000,
+    });
+
+    expect(result).toEqual({ completed: true });
+  });
+
+  it('treats a query failure against a mid-navigation document as detachment rather than throwing', async () => {
+    const stepLocator = createLocator({
+      count: jest.fn().mockRejectedValue(new Error('Execution context was destroyed')),
+    });
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepLocator),
+    } as unknown as Page;
+    const step = createTestableStep();
+
+    await expect(
+      runGuidedSubstepLoop(page, step, {
+        stepLocator,
+        perSubstepTimeoutMs: 1000,
+      })
+    ).resolves.toEqual({ completed: true });
+  });
+
+  it('re-resolves the step locator after a button action triggers a same-URL reload', async () => {
+    // First pass: step is present and executing with a button substep; the click
+    // triggers a `framenavigated` event without changing the URL. After the
+    // reload settles, the step locator is re-queried and found detached
+    // (section gone / navigated away), which is treated as completion.
+    const freshStepLocator = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    let getByTestIdCalls = 0;
+    const listeners = new Map<string, Array<() => void>>();
+
+    const initialStepLocator = createLocator({
+      count: jest.fn().mockResolvedValue(1),
+      getAttribute: jest
+        .fn()
+        .mockResolvedValueOnce('executing') // state check
+        .mockResolvedValueOnce('0'), // substep index
+    });
+
+    const commentBox = createLocator({
+      count: jest.fn().mockResolvedValue(1),
+      isVisible: jest.fn().mockResolvedValue(true),
+      getAttribute: jest
+        .fn()
+        .mockImplementation((name: string) =>
+          Promise.resolve(
+            name === 'data-test-action' ? 'button' : name === 'data-test-reftarget' ? 'Install' : null
+          )
+        ),
+    });
+
+    const buttonTarget = createLocator();
+    const roleLocator = createLocator({
+      count: jest.fn().mockResolvedValue(1),
+      first: jest.fn().mockReturnValue(buttonTarget),
+    });
+
+    const page = {
+      getByTestId: jest.fn().mockImplementation(() => {
+        getByTestIdCalls += 1;
+        // First call resolves the initial step locator; every subsequent
+        // call (post-navigation re-resolution) returns the fresh, detached one.
+        return getByTestIdCalls === 1 ? initialStepLocator : freshStepLocator;
+      }),
+      locator: jest.fn().mockReturnValue({ first: jest.fn().mockReturnValue(commentBox) }),
+      getByRole: jest.fn().mockReturnValue(roleLocator),
+      url: jest.fn().mockReturnValue('http://localhost:3000/'),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+      waitForLoadState: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn().mockImplementation((event: string, handler: () => void) => {
+        const handlers = listeners.get(event) ?? [];
+        handlers.push(handler);
+        listeners.set(event, handlers);
+      }),
+      off: jest.fn(),
+    } as unknown as Page;
+
+    // Simulate the plugin firing a `framenavigated` event as soon as the
+    // target is clicked, standing in for a same-URL page reload.
+    (buttonTarget.click as jest.Mock).mockImplementation(async () => {
+      for (const handler of listeners.get('framenavigated') ?? []) {
+        handler();
+      }
+    });
+
+    const step = createTestableStep();
+
+    const result = await runGuidedSubstepLoop(page, step, {
+      stepLocator: initialStepLocator,
+      perSubstepTimeoutMs: 1000,
+    });
+
+    expect(result).toEqual({ completed: true });
+    expect(page.waitForLoadState).toHaveBeenCalledWith('domcontentloaded', {
+      timeout: GUIDED_RELOAD_LOAD_TIMEOUT_MS,
+    });
+    // getByTestId was called again after the reload to fetch a fresh locator.
+    expect(getByTestIdCalls).toBeGreaterThan(1);
+  });
+});

--- a/tests/e2e-runner/utils/guide-runner/execution.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.test.ts
@@ -1,9 +1,13 @@
 /**
  * Unit tests for the runner lifecycle fixes in execution.ts:
- * 1. Skip sync (clickSkipButtonAndSync)
- * 2. Guided readiness (waitForGuidedCommentBoxReady)
- * 3. Reload/detached-step handling (runGuidedSubstepLoop)
- * 4. Late no-op completion / bounded scroll (scrollStepIntoView)
+ * 1. Skip sync (clickSkipButtonAndSync) — only records a skip after the
+ *    plugin confirms it left requirements-unmet; fails loudly otherwise.
+ * 2. Guided readiness (waitForGuidedCommentBoxReady) — bounds every read by
+ *    the remaining deadline and distinguishes ready/completed/detached.
+ * 3. Reload/detached-step handling (runGuidedSubstepLoop) — re-resolves the
+ *    step locator after a detected reload, but propagates genuine query and
+ *    navigation-sync failures instead of reporting false completion.
+ * 4. Late no-op completion / bounded scroll (scrollStepIntoView).
  *
  * @see tests/e2e-runner/utils/guide-runner/execution.ts
  */
@@ -43,6 +47,10 @@ jest.mock('@playwright/test', () => {
   };
 });
 
+jest.mock('./requirements', () => ({
+  handleRequirementsWithFix: jest.fn(),
+}));
+
 import type { Locator, Page } from '@playwright/test';
 
 import {
@@ -50,7 +58,9 @@ import {
   clickSkipButtonAndSync,
   waitForGuidedCommentBoxReady,
   runGuidedSubstepLoop,
+  executeStep,
 } from './execution';
+import { handleRequirementsWithFix } from './requirements';
 import { SCROLL_INTO_VIEW_TIMEOUT_MS, GUIDED_RELOAD_LOAD_TIMEOUT_MS } from './constants';
 import type { TestableStep } from './types';
 
@@ -116,18 +126,23 @@ describe('scrollStepIntoView', () => {
 });
 
 describe('clickSkipButtonAndSync', () => {
-  it('does nothing when no Skip control is present', async () => {
+  it('throws when no Skip control is available (cannot sync, cannot claim success)', async () => {
     const skipButton = createLocator({ count: jest.fn().mockResolvedValue(0) });
-    const page = {
-      getByTestId: jest.fn().mockReturnValue(skipButton),
-    } as unknown as Page;
+    const page = { getByTestId: jest.fn().mockReturnValue(skipButton) } as unknown as Page;
 
-    await clickSkipButtonAndSync(page, 'step-1', 100);
-
+    await expect(clickSkipButtonAndSync(page, 'step-1', 100)).rejects.toThrow('no Skip control available');
     expect(skipButton.click).not.toHaveBeenCalled();
   });
 
-  it('clicks the Skip control and resolves once the step leaves requirements-unmet', async () => {
+  it('throws when the Skip button click itself fails', async () => {
+    const clickError = new Error('Element is not clickable');
+    const skipButton = createLocator({ click: jest.fn().mockRejectedValue(clickError) });
+    const page = { getByTestId: jest.fn().mockReturnValue(skipButton) } as unknown as Page;
+
+    await expect(clickSkipButtonAndSync(page, 'step-1', 100)).rejects.toBe(clickError);
+  });
+
+  it('resolves only once the step confirms it left requirements-unmet', async () => {
     const stepLocator = createLocator({
       getAttribute: jest.fn().mockResolvedValueOnce('requirements-unmet').mockResolvedValue('completed'),
     });
@@ -138,12 +153,11 @@ describe('clickSkipButtonAndSync', () => {
         .mockImplementation((testId: string) => (testId.startsWith('interactive-skip-') ? skipButton : stepLocator)),
     } as unknown as Page;
 
-    await clickSkipButtonAndSync(page, 'step-1', 200);
-
+    await expect(clickSkipButtonAndSync(page, 'step-1', 200)).resolves.toBeUndefined();
     expect(skipButton.click).toHaveBeenCalledWith({ timeout: 200 });
   });
 
-  it('does not throw when the step never leaves requirements-unmet', async () => {
+  it('throws instead of silently recording a skip when the step never leaves requirements-unmet', async () => {
     const stepLocator = createLocator({
       getAttribute: jest.fn().mockResolvedValue('requirements-unmet'),
     });
@@ -154,17 +168,36 @@ describe('clickSkipButtonAndSync', () => {
         .mockImplementation((testId: string) => (testId.startsWith('interactive-skip-') ? skipButton : stepLocator)),
     } as unknown as Page;
 
-    await expect(clickSkipButtonAndSync(page, 'step-1', 20)).resolves.toBeUndefined();
+    await expect(clickSkipButtonAndSync(page, 'step-1', 20)).rejects.toThrow('Timed out waiting for attribute');
   });
 });
 
 describe('waitForGuidedCommentBoxReady', () => {
-  it('resolves immediately when the comment box is already visible', async () => {
+  it("resolves 'ready' immediately when the comment box is already visible", async () => {
     const stepLocator = createLocator();
     const commentBox = createLocator();
     const page = { waitForTimeout: jest.fn().mockResolvedValue(undefined) } as unknown as Page;
 
-    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 1000)).resolves.toBeUndefined();
+    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 1000)).resolves.toBe('ready');
+  });
+
+  it("resolves 'completed' when the step reaches completed while waiting", async () => {
+    const stepLocator = createLocator({ getAttribute: jest.fn().mockResolvedValue('completed') });
+    const commentBox = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const page = { waitForTimeout: jest.fn().mockResolvedValue(undefined) } as unknown as Page;
+
+    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 1000)).resolves.toBe('completed');
+  });
+
+  it("resolves 'detached' when the step's element is confirmed gone while waiting", async () => {
+    const stepLocator = createLocator({
+      getAttribute: jest.fn().mockResolvedValue(null),
+      count: jest.fn().mockResolvedValue(0),
+    });
+    const commentBox = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const page = { waitForTimeout: jest.fn().mockResolvedValue(undefined) } as unknown as Page;
+
+    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 1000)).resolves.toBe('detached');
   });
 
   it('fails fast on an error state instead of waiting out the full timeout', async () => {
@@ -194,10 +227,36 @@ describe('waitForGuidedCommentBoxReady', () => {
       'comment box not visible'
     );
   });
+
+  it('bounds every state read by the remaining budget, so a stuck locator cannot exceed the overall wait', async () => {
+    const commentBox = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    // A faithful stand-in for Playwright: honors the passed `timeout` by
+    // rejecting once it elapses, instead of resolving instantly.
+    const getAttribute = jest.fn().mockImplementation((_name: string, opts?: { timeout?: number }) => {
+      const boundedTimeout = opts?.timeout ?? 30000;
+      return new Promise((_resolve, reject) => {
+        setTimeout(() => reject(new Error(`Timeout ${boundedTimeout}ms exceeded`)), boundedTimeout);
+      });
+    });
+    const stepLocator = createLocator({ getAttribute, count: jest.fn().mockResolvedValue(1) });
+    const page = { waitForTimeout: jest.fn().mockResolvedValue(undefined) } as unknown as Page;
+
+    const start = Date.now();
+    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 40)).rejects.toThrow(
+      'comment box not visible'
+    );
+    // Bounded to roughly the requested 40ms budget, not Playwright's much
+    // larger default operation timeout (which the unbounded call used).
+    expect(Date.now() - start).toBeLessThan(500);
+    for (const call of getAttribute.mock.calls) {
+      expect(call[1]?.timeout).toBeGreaterThan(0);
+      expect(call[1]?.timeout).toBeLessThanOrEqual(40);
+    }
+  });
 });
 
 describe('runGuidedSubstepLoop', () => {
-  it('treats a detached step as completion (e.g. after a completeEarly navigation)', async () => {
+  it('treats a successfully-confirmed detached step as completion (e.g. after a completeEarly navigation)', async () => {
     const stepLocator = createLocator({ count: jest.fn().mockResolvedValue(0) });
     const page = {
       getByTestId: jest.fn().mockReturnValue(stepLocator),
@@ -212,9 +271,9 @@ describe('runGuidedSubstepLoop', () => {
     expect(result).toEqual({ completed: true });
   });
 
-  it('treats a query failure against a mid-navigation document as detachment rather than throwing', async () => {
+  it('propagates a genuine query failure instead of reporting false completion', async () => {
     const stepLocator = createLocator({
-      count: jest.fn().mockRejectedValue(new Error('Execution context was destroyed')),
+      count: jest.fn().mockRejectedValue(new Error('Target closed')),
     });
     const page = {
       getByTestId: jest.fn().mockReturnValue(stepLocator),
@@ -226,16 +285,10 @@ describe('runGuidedSubstepLoop', () => {
         stepLocator,
         perSubstepTimeoutMs: 1000,
       })
-    ).resolves.toEqual({ completed: true });
+    ).rejects.toThrow('Target closed');
   });
 
-  it('re-resolves the step locator after a button action triggers a same-URL reload', async () => {
-    // First pass: step is present and executing with a button substep; the click
-    // triggers a `framenavigated` event without changing the URL. After the
-    // reload settles, the step locator is re-queried and found detached
-    // (section gone / navigated away), which is treated as completion.
-    const freshStepLocator = createLocator({ count: jest.fn().mockResolvedValue(0) });
-    let getByTestIdCalls = 0;
+  function createButtonSubstepHarness() {
     const listeners = new Map<string, Array<() => void>>();
 
     const initialStepLocator = createLocator({
@@ -257,10 +310,28 @@ describe('runGuidedSubstepLoop', () => {
     });
 
     const buttonTarget = createLocator();
+    (buttonTarget.click as jest.Mock).mockImplementation(async () => {
+      for (const handler of listeners.get('framenavigated') ?? []) {
+        handler();
+      }
+    });
     const roleLocator = createLocator({
       count: jest.fn().mockResolvedValue(1),
       first: jest.fn().mockReturnValue(buttonTarget),
     });
+
+    return { listeners, initialStepLocator, commentBox, buttonTarget, roleLocator };
+  }
+
+  it('re-resolves the step locator after a button action triggers a same-URL reload', async () => {
+    // The step is present and executing with a button substep; the click
+    // triggers a `framenavigated` event without changing the URL. After the
+    // reload settles successfully, the step locator is re-queried and found
+    // detached (section gone / navigated away), which is a legitimate
+    // completion signal because the fresh query itself succeeded.
+    const { listeners, initialStepLocator, commentBox, roleLocator } = createButtonSubstepHarness();
+    const freshStepLocator = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    let getByTestIdCalls = 0;
 
     const page = {
       getByTestId: jest.fn().mockImplementation(() => {
@@ -282,14 +353,6 @@ describe('runGuidedSubstepLoop', () => {
       off: jest.fn(),
     } as unknown as Page;
 
-    // Simulate the plugin firing a `framenavigated` event as soon as the
-    // target is clicked, standing in for a same-URL page reload.
-    (buttonTarget.click as jest.Mock).mockImplementation(async () => {
-      for (const handler of listeners.get('framenavigated') ?? []) {
-        handler();
-      }
-    });
-
     const step = createTestableStep();
 
     const result = await runGuidedSubstepLoop(page, step, {
@@ -303,5 +366,139 @@ describe('runGuidedSubstepLoop', () => {
     });
     // getByTestId was called again after the reload to fetch a fresh locator.
     expect(getByTestIdCalls).toBeGreaterThan(1);
+  });
+
+  it('propagates a failed reload sync instead of treating it as completion', async () => {
+    const { listeners, initialStepLocator, commentBox, roleLocator } = createButtonSubstepHarness();
+    const reloadError = new Error('Navigation timeout of 15000ms exceeded');
+
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(initialStepLocator),
+      locator: jest.fn().mockReturnValue({ first: jest.fn().mockReturnValue(commentBox) }),
+      getByRole: jest.fn().mockReturnValue(roleLocator),
+      url: jest.fn().mockReturnValue('http://localhost:3000/'),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+      waitForLoadState: jest.fn().mockRejectedValue(reloadError),
+      on: jest.fn().mockImplementation((event: string, handler: () => void) => {
+        const handlers = listeners.get(event) ?? [];
+        handlers.push(handler);
+        listeners.set(event, handlers);
+      }),
+      off: jest.fn(),
+    } as unknown as Page;
+
+    const step = createTestableStep();
+
+    await expect(
+      runGuidedSubstepLoop(page, step, {
+        stepLocator: initialStepLocator,
+        perSubstepTimeoutMs: 1000,
+      })
+    ).rejects.toBe(reloadError);
+  });
+
+  it('completes without reading the substep contract when the step finishes while waiting for the comment box', async () => {
+    // The step transitions straight to `completed` before the comment box for
+    // the next substep ever renders (e.g. the final substep auto-completed).
+    const stepLocator = createLocator({
+      count: jest.fn().mockResolvedValue(1),
+      getAttribute: jest
+        .fn()
+        .mockResolvedValueOnce('executing') // top-of-loop state check
+        .mockResolvedValueOnce('0') // substep index
+        .mockResolvedValue('completed'), // comment-box wait's own state polls
+    });
+    const commentBox = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepLocator),
+      locator: jest.fn().mockReturnValue({ first: jest.fn().mockReturnValue(commentBox) }),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Page;
+    const step = createTestableStep();
+
+    const result = await runGuidedSubstepLoop(page, step, {
+      stepLocator,
+      perSubstepTimeoutMs: 1000,
+    });
+
+    expect(result).toEqual({ completed: true });
+    expect(commentBox.getAttribute).not.toHaveBeenCalled();
+  });
+});
+
+describe('executeStep - skip sync sequential-flow regression', () => {
+  beforeEach(() => {
+    (handleRequirementsWithFix as jest.Mock).mockReset();
+  });
+
+  it('only reports skipped once the plugin confirms it left requirements-unmet, unblocking the next step', async () => {
+    (handleRequirementsWithFix as jest.Mock).mockResolvedValue({
+      requirements: {
+        requirementsMet: false,
+        status: 'unmet',
+        skippable: true,
+        hasFixButton: false,
+        isChecking: false,
+        hasSkipButton: true,
+        hasRetryButton: false,
+      },
+    });
+    const stepLocator = createLocator({
+      getAttribute: jest
+        .fn()
+        .mockResolvedValueOnce(null) // pre-scroll late-completion check
+        .mockResolvedValueOnce('requirements-unmet') // skip-sync poll #1
+        .mockResolvedValue('completed'), // skip-sync poll #2 — left requirements-unmet
+    });
+    const skipButton = createLocator();
+    const page = {
+      getByTestId: jest
+        .fn()
+        .mockImplementation((testId: string) => (testId.startsWith('interactive-skip-') ? skipButton : stepLocator)),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      off: jest.fn(),
+      url: jest.fn().mockReturnValue('http://localhost:3000/'),
+    } as unknown as Page;
+    const step = createTestableStep({ skippable: true, isGuided: false, guidedStepCount: undefined });
+
+    const result = await executeStep(page, step, {});
+
+    expect(result.status).toBe('skipped');
+    expect(skipButton.click).toHaveBeenCalled();
+  });
+
+  it('returns a failed result — never a false skip — when Skip sync cannot confirm the transition', async () => {
+    (handleRequirementsWithFix as jest.Mock).mockResolvedValue({
+      requirements: {
+        requirementsMet: false,
+        status: 'unmet',
+        skippable: true,
+        hasFixButton: false,
+        isChecking: false,
+        hasSkipButton: false,
+        hasRetryButton: false,
+      },
+    });
+    const stepLocator = createLocator({ getAttribute: jest.fn().mockResolvedValue(null) });
+    const missingSkipButton = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const page = {
+      getByTestId: jest
+        .fn()
+        .mockImplementation((testId: string) =>
+          testId.startsWith('interactive-skip-') ? missingSkipButton : stepLocator
+        ),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      off: jest.fn(),
+      url: jest.fn().mockReturnValue('http://localhost:3000/'),
+    } as unknown as Page;
+    const step = createTestableStep({ skippable: true, isGuided: false, guidedStepCount: undefined });
+
+    const result = await executeStep(page, step, {});
+
+    expect(result.status).toBe('failed');
+    expect(result.skippable).toBe(true);
+    expect(result.error).toMatch(/skip sync/i);
   });
 });

--- a/tests/e2e-runner/utils/guide-runner/execution.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.test.ts
@@ -1,31 +1,31 @@
 /**
  * Unit tests for the runner lifecycle fixes in execution.ts:
  * 1. Skip sync (clickSkipButtonAndSync) — only records a skip after the
- *    plugin confirms it left requirements-unmet; fails loudly otherwise.
+ *    plugin reaches an explicit terminal state (completed or a successful
+ *    detach), supporting either Skip control the plugin renders.
  * 2. Guided readiness (waitForGuidedCommentBoxReady) — bounds every read by
  *    the remaining deadline and distinguishes ready/completed/detached.
  * 3. Reload/detached-step handling (runGuidedSubstepLoop) — re-resolves the
  *    step locator after a detected reload, but propagates genuine query and
  *    navigation-sync failures instead of reporting false completion.
- * 4. Late no-op completion / bounded scroll (scrollStepIntoView).
+ * 4. Late completion/detachment precheck (executeStep) — bounded, error
+ *    propagating, and classified as 'passed' consistently with the
+ *    pre-click objective check (never a differently-labeled 'skipped').
  *
  * @see tests/e2e-runner/utils/guide-runner/execution.ts
  */
 
 jest.mock('@playwright/test', () => {
-  const readState = async (locator: { getAttribute: (name: string) => Promise<string | null> }) =>
-    locator.getAttribute('data-test-step-state');
-
   return {
     Page: jest.fn(),
     Locator: jest.fn(),
     test: jest.fn(),
-    expect: (locator: { getAttribute: (name: string) => Promise<string | null> }) => {
-      const poll = async (matches: (value: string | null) => boolean, opts?: { timeout?: number }) => {
+    expect: (locator: { getAttribute: (name: string, opts?: { timeout?: number }) => Promise<string | null> }) => {
+      const poll = async (attr: string, matches: (value: string | null) => boolean, opts?: { timeout?: number }) => {
         const timeout = opts?.timeout ?? 5000;
         const deadline = Date.now() + timeout;
         for (;;) {
-          const value = await readState(locator);
+          const value = await locator.getAttribute(attr);
           if (matches(value)) {
             return;
           }
@@ -36,11 +36,11 @@ jest.mock('@playwright/test', () => {
         }
       };
       return {
-        toHaveAttribute: (_attr: string, value: string, opts?: { timeout?: number }) =>
-          poll((current) => current === value, opts),
+        toHaveAttribute: (attr: string, value: string, opts?: { timeout?: number }) =>
+          poll(attr, (current) => current === value, opts),
         not: {
-          toHaveAttribute: (_attr: string, value: string, opts?: { timeout?: number }) =>
-            poll((current) => current !== value, opts),
+          toHaveAttribute: (attr: string, value: string, opts?: { timeout?: number }) =>
+            poll(attr, (current) => current !== value, opts),
         },
       };
     },
@@ -59,6 +59,7 @@ import {
   waitForGuidedCommentBoxReady,
   runGuidedSubstepLoop,
   executeStep,
+  summarizeResults,
 } from './execution';
 import { handleRequirementsWithFix } from './requirements';
 import {
@@ -66,7 +67,7 @@ import {
   GUIDED_RELOAD_LOAD_TIMEOUT_MS,
   LATE_COMPLETION_CHECK_TIMEOUT_MS,
 } from './constants';
-import type { TestableStep } from './types';
+import type { StepTestResult, TestableStep } from './types';
 
 function createTestableStep(overrides: Partial<TestableStep> = {}): TestableStep {
   return {
@@ -103,6 +104,32 @@ function createLocator(overrides: Partial<Record<string, jest.Mock>> = {}): Loca
   } as unknown as Locator;
 }
 
+/** Routes getByTestId to distinct locators for the two Skip control shapes and the step itself. */
+function createSkipRoutedPage(routes: {
+  stepSkipButton?: Locator;
+  requirementSkipButton?: Locator;
+  stepLocator?: Locator;
+  extra?: Record<string, unknown>;
+}): Page {
+  const stepSkipButton = routes.stepSkipButton ?? createLocator({ count: jest.fn().mockResolvedValue(0) });
+  const requirementSkipButton =
+    routes.requirementSkipButton ?? createLocator({ count: jest.fn().mockResolvedValue(0) });
+  const stepLocator = routes.stepLocator ?? createLocator();
+  return {
+    getByTestId: jest.fn().mockImplementation((testId: string) => {
+      if (testId.startsWith('interactive-requirement-skip-')) {
+        return requirementSkipButton;
+      }
+      if (testId.startsWith('interactive-skip-')) {
+        return stepSkipButton;
+      }
+      return stepLocator;
+    }),
+    waitForTimeout: jest.fn().mockResolvedValue(undefined),
+    ...routes.extra,
+  } as unknown as Page;
+}
+
 describe('scrollStepIntoView', () => {
   it('bounds scrollIntoViewIfNeeded with the scroll timeout', async () => {
     const stepElement = createLocator();
@@ -130,49 +157,77 @@ describe('scrollStepIntoView', () => {
 });
 
 describe('clickSkipButtonAndSync', () => {
-  it('throws when no Skip control is available (cannot sync, cannot claim success)', async () => {
-    const skipButton = createLocator({ count: jest.fn().mockResolvedValue(0) });
-    const page = { getByTestId: jest.fn().mockReturnValue(skipButton) } as unknown as Page;
+  it('throws when neither Skip control is rendered', async () => {
+    const page = createSkipRoutedPage({});
 
     await expect(clickSkipButtonAndSync(page, 'step-1', 100)).rejects.toThrow('no Skip control available');
-    expect(skipButton.click).not.toHaveBeenCalled();
+  });
+
+  it('prefers the step-level Skip control when both are rendered', async () => {
+    const stepSkipButton = createLocator();
+    const requirementSkipButton = createLocator();
+    const stepLocator = createLocator({ count: jest.fn().mockResolvedValue(0) }); // detach = terminal
+    const page = createSkipRoutedPage({ stepSkipButton, requirementSkipButton, stepLocator });
+
+    await expect(clickSkipButtonAndSync(page, 'step-1', 200)).resolves.toBeUndefined();
+
+    expect(stepSkipButton.click).toHaveBeenCalledWith({ timeout: 200 });
+    expect(requirementSkipButton.click).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the requirement-scoped Skip control when the step-level one is not rendered', async () => {
+    // detectRequirements().hasSkipButton reflects this narrower control
+    // (interactive-requirement-skip-*); support it too instead of assuming
+    // the always-available step-level control is the only shape.
+    const requirementSkipButton = createLocator();
+    const stepLocator = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const page = createSkipRoutedPage({ requirementSkipButton, stepLocator });
+
+    await expect(clickSkipButtonAndSync(page, 'step-1', 200)).resolves.toBeUndefined();
+
+    expect(requirementSkipButton.click).toHaveBeenCalledWith({ timeout: 200 });
   });
 
   it('throws when the Skip button click itself fails', async () => {
     const clickError = new Error('Element is not clickable');
-    const skipButton = createLocator({ click: jest.fn().mockRejectedValue(clickError) });
-    const page = { getByTestId: jest.fn().mockReturnValue(skipButton) } as unknown as Page;
+    const stepSkipButton = createLocator({ click: jest.fn().mockRejectedValue(clickError) });
+    const page = createSkipRoutedPage({ stepSkipButton });
 
     await expect(clickSkipButtonAndSync(page, 'step-1', 100)).rejects.toBe(clickError);
   });
 
-  it('resolves only once the step confirms it left requirements-unmet', async () => {
+  it('resolves once the step reaches the completed terminal state', async () => {
+    const stepSkipButton = createLocator();
     const stepLocator = createLocator({
-      getAttribute: jest.fn().mockResolvedValueOnce('requirements-unmet').mockResolvedValue('completed'),
-    });
-    const skipButton = createLocator();
-    const page = {
-      getByTestId: jest
+      getAttribute: jest
         .fn()
-        .mockImplementation((testId: string) => (testId.startsWith('interactive-skip-') ? skipButton : stepLocator)),
-    } as unknown as Page;
+        .mockResolvedValueOnce('checking')
+        .mockResolvedValueOnce('requirements-unmet')
+        .mockResolvedValue('completed'),
+    });
+    const page = createSkipRoutedPage({ stepSkipButton, stepLocator });
 
-    await expect(clickSkipButtonAndSync(page, 'step-1', 200)).resolves.toBeUndefined();
-    expect(skipButton.click).toHaveBeenCalledWith({ timeout: 200 });
+    await expect(clickSkipButtonAndSync(page, 'step-1', 500)).resolves.toBeUndefined();
   });
 
-  it('throws instead of silently recording a skip when the step never leaves requirements-unmet', async () => {
+  it('resolves once the step is successfully detached, not merely absent from requirements-unmet', async () => {
+    let calls = 0;
+    const stepSkipButton = createLocator();
     const stepLocator = createLocator({
+      count: jest.fn().mockImplementation(() => Promise.resolve(calls++ === 0 ? 1 : 0)),
       getAttribute: jest.fn().mockResolvedValue('requirements-unmet'),
     });
-    const skipButton = createLocator();
-    const page = {
-      getByTestId: jest
-        .fn()
-        .mockImplementation((testId: string) => (testId.startsWith('interactive-skip-') ? skipButton : stepLocator)),
-    } as unknown as Page;
+    const page = createSkipRoutedPage({ stepSkipButton, stepLocator });
 
-    await expect(clickSkipButtonAndSync(page, 'step-1', 20)).rejects.toThrow('Timed out waiting for attribute');
+    await expect(clickSkipButtonAndSync(page, 'step-1', 500)).resolves.toBeUndefined();
+  });
+
+  it('does not mistake a transient checking state for synchronized completion, and times out with a clear error', async () => {
+    const stepSkipButton = createLocator();
+    const stepLocator = createLocator({ getAttribute: jest.fn().mockResolvedValue('checking') });
+    const page = createSkipRoutedPage({ stepSkipButton, stepLocator });
+
+    await expect(clickSkipButtonAndSync(page, 'step-1', 20)).rejects.toThrow('did not reach a terminal state');
   });
 });
 
@@ -440,7 +495,7 @@ describe('executeStep - skip sync sequential-flow regression', () => {
     (handleRequirementsWithFix as jest.Mock).mockReset();
   });
 
-  it('only reports skipped once the plugin confirms it left requirements-unmet, unblocking the next step', async () => {
+  it('only reports skipped once the plugin confirms a terminal state, unblocking the next step', async () => {
     (handleRequirementsWithFix as jest.Mock).mockResolvedValue({
       requirements: {
         requirementsMet: false,
@@ -452,29 +507,25 @@ describe('executeStep - skip sync sequential-flow regression', () => {
         hasRetryButton: false,
       },
     });
+    const stepSkipButton = createLocator();
     const stepLocator = createLocator({
       getAttribute: jest
         .fn()
         .mockResolvedValueOnce(null) // pre-scroll late-completion check
         .mockResolvedValueOnce('requirements-unmet') // skip-sync poll #1
-        .mockResolvedValue('completed'), // skip-sync poll #2 — left requirements-unmet
+        .mockResolvedValue('completed'), // skip-sync poll #2 — reached the terminal state
     });
-    const skipButton = createLocator();
-    const page = {
-      getByTestId: jest
-        .fn()
-        .mockImplementation((testId: string) => (testId.startsWith('interactive-skip-') ? skipButton : stepLocator)),
-      waitForTimeout: jest.fn().mockResolvedValue(undefined),
-      on: jest.fn(),
-      off: jest.fn(),
-      url: jest.fn().mockReturnValue('http://localhost:3000/'),
-    } as unknown as Page;
+    const page = createSkipRoutedPage({
+      stepSkipButton,
+      stepLocator,
+      extra: { on: jest.fn(), off: jest.fn(), url: jest.fn().mockReturnValue('http://localhost:3000/') },
+    });
     const step = createTestableStep({ skippable: true, isGuided: false, guidedStepCount: undefined });
 
     const result = await executeStep(page, step, {});
 
     expect(result.status).toBe('skipped');
-    expect(skipButton.click).toHaveBeenCalled();
+    expect(stepSkipButton.click).toHaveBeenCalled();
   });
 
   it('returns a failed result — never a false skip — when Skip sync cannot confirm the transition', async () => {
@@ -490,18 +541,10 @@ describe('executeStep - skip sync sequential-flow regression', () => {
       },
     });
     const stepLocator = createLocator({ getAttribute: jest.fn().mockResolvedValue(null) });
-    const missingSkipButton = createLocator({ count: jest.fn().mockResolvedValue(0) });
-    const page = {
-      getByTestId: jest
-        .fn()
-        .mockImplementation((testId: string) =>
-          testId.startsWith('interactive-skip-') ? missingSkipButton : stepLocator
-        ),
-      waitForTimeout: jest.fn().mockResolvedValue(undefined),
-      on: jest.fn(),
-      off: jest.fn(),
-      url: jest.fn().mockReturnValue('http://localhost:3000/'),
-    } as unknown as Page;
+    const page = createSkipRoutedPage({
+      stepLocator,
+      extra: { on: jest.fn(), off: jest.fn(), url: jest.fn().mockReturnValue('http://localhost:3000/') },
+    });
     const step = createTestableStep({ skippable: true, isGuided: false, guidedStepCount: undefined });
 
     const result = await executeStep(page, step, {});
@@ -530,6 +573,71 @@ describe('executeStep - late completion/detachment precheck', () => {
     expect(result.error).toBe('Target closed');
   });
 
+  it("returns 'passed' (not 'skipped') when the step is already completed while still attached", async () => {
+    // Same DOM state the pre-click objective check reports as 'passed'; the
+    // late precheck must classify it the same way, not as a differently
+    // labeled 'skipped'/pre_completed result.
+    const stepLocator = createLocator({ getAttribute: jest.fn().mockResolvedValue('completed') });
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepLocator),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      off: jest.fn(),
+      url: jest.fn().mockReturnValue('http://localhost:3000/'),
+    } as unknown as Page;
+    const step = createTestableStep({ isGuided: false, guidedStepCount: undefined });
+
+    const result = await executeStep(page, step, {});
+
+    expect(result.status).toBe('passed');
+    expect(result.skipReason).toBeUndefined();
+  });
+
+  it("returns 'passed' (not 'skipped') when the step's element is already detached", async () => {
+    const stepLocator = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepLocator),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      off: jest.fn(),
+      url: jest.fn().mockReturnValue('http://localhost:3000/'),
+    } as unknown as Page;
+    const step = createTestableStep({ isGuided: false, guidedStepCount: undefined });
+
+    const result = await executeStep(page, step, {});
+
+    expect(result.status).toBe('passed');
+  });
+
+  it('demonstrates the summary impact: a late-completed step now counts as a verified pass', async () => {
+    const stepLocator = createLocator({ getAttribute: jest.fn().mockResolvedValue('completed') });
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepLocator),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      off: jest.fn(),
+      url: jest.fn().mockReturnValue('http://localhost:3000/'),
+    } as unknown as Page;
+    const step = createTestableStep({ isGuided: false, guidedStepCount: undefined });
+
+    const lateResult = await executeStep(page, step, {});
+    const otherSkippableFailure: StepTestResult = {
+      stepId: 'other-step',
+      status: 'failed',
+      durationMs: 10,
+      currentUrl: 'http://localhost:3000/',
+      consoleErrors: [],
+      skippable: true,
+    };
+
+    const summary = summarizeResults([lateResult, otherSkippableFailure]);
+
+    // Before this fix, the late-completed step was reported as 'skipped', so
+    // a run with zero verified passes and a skippable failure was reported
+    // as a failure. It's now a verified 'passed', so the run succeeds.
+    expect(summary.success).toBe(true);
+  });
+
   it('bounds the completion read and treats a successful re-count of zero as late detachment', async () => {
     // getAttribute never resolves in time (simulating a mid-read detach); the
     // precheck must re-count rather than trust a stale "attached" result.
@@ -551,8 +659,7 @@ describe('executeStep - late completion/detachment precheck', () => {
 
     const result = await executeStep(page, step, {});
 
-    expect(result.status).toBe('skipped');
-    expect(result.skipReason).toBe('pre_completed');
+    expect(result.status).toBe('passed');
     expect(getAttribute).toHaveBeenCalledWith('data-test-step-state', { timeout: LATE_COMPLETION_CHECK_TIMEOUT_MS });
     expect(countCalls).toBe(2);
   });

--- a/tests/e2e-runner/utils/guide-runner/execution.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.test.ts
@@ -133,9 +133,9 @@ describe('clickSkipButtonAndSync', () => {
     });
     const skipButton = createLocator();
     const page = {
-      getByTestId: jest.fn().mockImplementation((testId: string) =>
-        testId.startsWith('interactive-skip-') ? skipButton : stepLocator
-      ),
+      getByTestId: jest
+        .fn()
+        .mockImplementation((testId: string) => (testId.startsWith('interactive-skip-') ? skipButton : stepLocator)),
     } as unknown as Page;
 
     await clickSkipButtonAndSync(page, 'step-1', 200);
@@ -149,9 +149,9 @@ describe('clickSkipButtonAndSync', () => {
     });
     const skipButton = createLocator();
     const page = {
-      getByTestId: jest.fn().mockImplementation((testId: string) =>
-        testId.startsWith('interactive-skip-') ? skipButton : stepLocator
-      ),
+      getByTestId: jest
+        .fn()
+        .mockImplementation((testId: string) => (testId.startsWith('interactive-skip-') ? skipButton : stepLocator)),
     } as unknown as Page;
 
     await expect(clickSkipButtonAndSync(page, 'step-1', 20)).resolves.toBeUndefined();
@@ -172,9 +172,7 @@ describe('waitForGuidedCommentBoxReady', () => {
     const commentBox = createLocator({ count: jest.fn().mockResolvedValue(0) });
     const page = { waitForTimeout: jest.fn().mockResolvedValue(undefined) } as unknown as Page;
 
-    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 30000)).rejects.toThrow(
-      'error state'
-    );
+    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 30000)).rejects.toThrow('error state');
     // Only one poll iteration should have happened before the fast failure.
     expect(page.waitForTimeout).not.toHaveBeenCalled();
   });
@@ -254,9 +252,7 @@ describe('runGuidedSubstepLoop', () => {
       getAttribute: jest
         .fn()
         .mockImplementation((name: string) =>
-          Promise.resolve(
-            name === 'data-test-action' ? 'button' : name === 'data-test-reftarget' ? 'Install' : null
-          )
+          Promise.resolve(name === 'data-test-action' ? 'button' : name === 'data-test-reftarget' ? 'Install' : null)
         ),
     });
 

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -21,6 +21,7 @@ import {
   BUTTON_APPEAR_TIMEOUT_MS,
   SCROLL_SETTLE_DELAY_MS,
   SCROLL_INTO_VIEW_TIMEOUT_MS,
+  LATE_COMPLETION_CHECK_TIMEOUT_MS,
   POST_CLICK_SETTLE_DELAY_MS,
   COMPLETION_POLL_INTERVAL_MS,
   DEFAULT_SESSION_CHECK_INTERVAL,
@@ -203,6 +204,48 @@ export async function waitForStepCompletion(
 export async function checkObjectiveCompletion(page: Page, stepId: string): Promise<boolean> {
   const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
   const state = await stepLocator.getAttribute('data-test-step-state');
+  return state === 'completed';
+}
+
+/**
+ * Recheck completion/detachment immediately before the scroll call in
+ * executeStep. Bounded so a step that's mid-detach can't hang the run on an
+ * otherwise-unbounded attribute read (Playwright auto-waits on a missing
+ * element up to its own timeout by default).
+ *
+ * A successful `count()` of zero (before or after the bounded read) means
+ * the step is already gone and this returns true, matching how detachment is
+ * treated as completion elsewhere in this file. A `count()` error, or an
+ * attached element whose read failed for an unrelated reason, is a genuine
+ * fault and propagates instead of being reported as "already done".
+ *
+ * @param page - Playwright Page object
+ * @param stepId - The step identifier
+ * @param timeout - Bound for the attribute read (ms)
+ * @returns true if the step is already completed or detached
+ */
+async function checkLateCompletionOrDetachment(
+  page: Page,
+  stepId: string,
+  timeout = LATE_COMPLETION_CHECK_TIMEOUT_MS
+): Promise<boolean> {
+  const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
+  if ((await stepLocator.count()) === 0) {
+    return true;
+  }
+
+  let state: string | null;
+  try {
+    state = await stepLocator.getAttribute('data-test-step-state', { timeout });
+  } catch (err) {
+    // The bounded read didn't complete (e.g. the element detached mid-read).
+    // Re-count: a successful zero confirms late detachment; an attached
+    // element (or a failing re-count) is a genuine fault and must propagate.
+    if ((await stepLocator.count()) === 0) {
+      return true;
+    }
+    throw err;
+  }
   return state === 'completed';
 }
 
@@ -873,10 +916,10 @@ export async function executeStep(
 
     // Some no-op/objective-based steps complete (or their element detaches)
     // between discovery and execution; recheck immediately before scrolling so
-    // a step that's already done doesn't block on the scroll below.
-    const stepLocatorForPrecheck = page.getByTestId(testIds.interactive.step(step.stepId));
-    const detachedBeforeScroll = (await stepLocatorForPrecheck.count().catch(() => 0)) === 0;
-    if (detachedBeforeScroll || (await checkObjectiveCompletion(page, step.stepId))) {
+    // a step that's already done doesn't block on the scroll below. Bounded
+    // and error-propagating: a query/navigation fault fails the step instead
+    // of being mistaken for "already done".
+    if (await checkLateCompletionOrDetachment(page, step.stepId)) {
       if (verbose) {
         console.log(`   ⊘ Step ${step.stepId} completed or detached before scroll (late completion)`);
       }

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -20,6 +20,7 @@ import {
   BUTTON_ENABLE_TIMEOUT_MS,
   BUTTON_APPEAR_TIMEOUT_MS,
   SCROLL_SETTLE_DELAY_MS,
+  SCROLL_INTO_VIEW_TIMEOUT_MS,
   POST_CLICK_SETTLE_DELAY_MS,
   COMPLETION_POLL_INTERVAL_MS,
   DEFAULT_SESSION_CHECK_INTERVAL,
@@ -33,6 +34,8 @@ import {
   GUIDED_FORMFILL_INVALID_PERSIST_MS,
   GUIDED_HOVER_DWELL_MS,
   GUIDED_SKIP_AFTER_TIMEOUT_FRACTION,
+  GUIDED_RELOAD_LOAD_TIMEOUT_MS,
+  SKIP_SYNC_TIMEOUT_MS,
 } from './constants';
 import { classifyError } from './classification';
 import {
@@ -72,12 +75,14 @@ import type { Locator } from '@playwright/test';
 export async function scrollStepIntoView(
   page: Page,
   stepId: string,
-  scrollDelay = SCROLL_SETTLE_DELAY_MS
+  scrollDelay = SCROLL_SETTLE_DELAY_MS,
+  scrollTimeout = SCROLL_INTO_VIEW_TIMEOUT_MS
 ): Promise<void> {
   const stepElement = page.getByTestId(testIds.interactive.step(stepId));
 
-  // Scroll within the docs panel container
-  await stepElement.scrollIntoViewIfNeeded();
+  // Scroll within the docs panel container. Bounded: a step that is completing
+  // or detaching around this point should not block on an unbounded wait.
+  await stepElement.scrollIntoViewIfNeeded({ timeout: scrollTimeout });
 
   // Wait for scroll animation to complete
   if (scrollDelay > 0) {
@@ -505,6 +510,35 @@ export async function waitForFormfillSettle(
 }
 
 /**
+ * Wait for the guided comment box to become visible, bounded by the step's own
+ * timeout budget rather than a fixed short constant. Polls step state alongside
+ * the comment box so a step that has already entered `error`/`cancelled` fails
+ * fast instead of waiting out the full timeout.
+ */
+export async function waitForGuidedCommentBoxReady(
+  page: Page,
+  stepLocator: Locator,
+  commentBox: Locator,
+  timeoutMs = GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if ((await commentBox.count()) > 0 && (await commentBox.isVisible())) {
+      return;
+    }
+    const state = await stepLocator.getAttribute('data-test-step-state').catch(() => null);
+    if (state === 'error') {
+      throw new Error('Guided step entered error state while waiting for comment box');
+    }
+    if (state === 'cancelled') {
+      throw new Error('Guided step was cancelled while waiting for comment box');
+    }
+    await page.waitForTimeout(GUIDED_SUBSTEP_ADVANCE_POLL_MS);
+  }
+  throw new Error('Guided step: comment box not visible');
+}
+
+/**
  * Run the guided substep loop: read comment box contract, perform action, wait for advance.
  * Phase 4: formfill validation, hover dwell, skippable substeps, navigation re-query, error diagnostics.
  */
@@ -514,6 +548,8 @@ export async function runGuidedSubstepLoop(
   options: {
     stepLocator: Locator;
     perSubstepTimeoutMs: number;
+    /** Bounds the comment-box visibility wait; defaults to GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS. */
+    commentBoxTimeoutMs?: number;
     verbose?: boolean;
     artifactsDir?: string;
   }
@@ -528,10 +564,16 @@ export async function runGuidedSubstepLoop(
     }
   };
 
-  // Step unmount mid-loop is a completion signal
+  // Step unmount mid-loop is a completion signal. Re-resolving the locator
+  // handles reload/navigation (e.g. a completeEarly action reloading the page);
+  // a query error against a mid-navigation document is treated the same way.
   const stepDetached = async (): Promise<boolean> => {
     stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
-    return (await stepLocator.count()) === 0;
+    try {
+      return (await stepLocator.count()) === 0;
+    } catch {
+      return true;
+    }
   };
 
   while (true) {
@@ -564,10 +606,12 @@ export async function runGuidedSubstepLoop(
     }
 
     const commentBox = page.locator('.interactive-comment-box').first();
-    await commentBox.waitFor({ state: 'visible', timeout: GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS }).catch(async () => {
+    try {
+      await waitForGuidedCommentBoxReady(page, stepLocator, commentBox, options.commentBoxTimeoutMs);
+    } catch (err) {
       await captureLoopArtifacts('comment-box-not-visible');
-      throw new Error('Guided step: comment box not visible');
-    });
+      throw err;
+    }
 
     const action = await commentBox.getAttribute('data-test-action');
     const reftarget = await commentBox.getAttribute('data-test-reftarget');
@@ -587,13 +631,23 @@ export async function runGuidedSubstepLoop(
           throw new Error('Guided step: button/highlight substep missing data-test-reftarget');
         }
         const urlBefore = page.url();
-        const target = await resolveGuidedTarget(page, reftarget, action);
-        await target.scrollIntoViewIfNeeded();
-        await dismissBadgeCelebrations(page);
-        await target.click();
-        await page.waitForTimeout(100);
-        if (urlBefore !== page.url()) {
-          await page.waitForLoadState('domcontentloaded');
+        let navigated = false;
+        const onFrameNavigated = () => {
+          navigated = true;
+        };
+        page.on('framenavigated', onFrameNavigated);
+        try {
+          const target = await resolveGuidedTarget(page, reftarget, action);
+          await target.scrollIntoViewIfNeeded();
+          await dismissBadgeCelebrations(page);
+          await target.click();
+          await page.waitForTimeout(100);
+        } finally {
+          page.off('framenavigated', onFrameNavigated);
+        }
+        if (navigated || urlBefore !== page.url()) {
+          await page.waitForLoadState('domcontentloaded', { timeout: GUIDED_RELOAD_LOAD_TIMEOUT_MS });
+          stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
         }
       } else if (action === 'hover') {
         if (!reftarget) {
@@ -660,6 +714,32 @@ function createSkippedResult(
     skipReason,
     skippable: step.skippable,
   };
+}
+
+/**
+ * Click a skippable step's Skip control and wait for the plugin to leave the
+ * `requirements-unmet` state, so the next step in a sequential section isn't
+ * gated on "Complete previous step". Best-effort: swallows failures so a step
+ * that can't sync still returns the skipped result instead of throwing.
+ *
+ * @param page - Playwright Page object
+ * @param stepId - The step identifier
+ * @param timeout - Maximum time to wait for the state change (ms)
+ */
+export async function clickSkipButtonAndSync(
+  page: Page,
+  stepId: string,
+  timeout = SKIP_SYNC_TIMEOUT_MS
+): Promise<void> {
+  const skipButton = page.getByTestId(testIds.interactive.skipButton(stepId));
+  if ((await skipButton.count().catch(() => 0)) === 0) {
+    return;
+  }
+  await skipButton.click({ timeout }).catch(() => {});
+  const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
+  await expect(stepLocator)
+    .not.toHaveAttribute('data-test-step-state', 'requirements-unmet', { timeout })
+    .catch(() => {});
 }
 
 /**
@@ -731,7 +811,20 @@ export async function executeStep(
       return createSkippedResult(step, page, startTime, consoleErrors, 'pre_completed');
     }
 
-    // Scroll step into view before interaction
+    // Some no-op/objective-based steps complete (or their element detaches)
+    // between discovery and execution; recheck immediately before scrolling so
+    // a step that's already done doesn't block on the scroll below.
+    const stepLocatorForPrecheck = page.getByTestId(testIds.interactive.step(step.stepId));
+    const detachedBeforeScroll = (await stepLocatorForPrecheck.count().catch(() => 0)) === 0;
+    if (detachedBeforeScroll || (await checkObjectiveCompletion(page, step.stepId))) {
+      if (verbose) {
+        console.log(`   ⊘ Step ${step.stepId} completed or detached before scroll (late completion)`);
+      }
+      return createSkippedResult(step, page, startTime, consoleErrors, 'pre_completed');
+    }
+
+    // Scroll step into view before interaction. Bounded so a step that's
+    // completing/detaching right around this point doesn't hang the run.
     await scrollStepIntoView(page, step.stepId, SCROLL_SETTLE_DELAY_MS);
 
     // Capture PRE screenshot if alwaysScreenshot is enabled
@@ -759,6 +852,9 @@ export async function executeStep(
         if (verbose) {
           console.log(`   ⊘ Step ${step.stepId} skipped due to unmet requirements (skippable)`);
         }
+        // Click the Skip control and wait for the plugin to leave requirements-unmet
+        // so the next sequential step isn't gated on "Complete previous step".
+        await clickSkipButtonAndSync(page, step.stepId);
         return createSkippedResult(step, page, startTime, consoleErrors, 'requirements_unmet');
       }
       const errorMsg = fixResult
@@ -880,6 +976,9 @@ export async function executeStep(
       const { completed } = await runGuidedSubstepLoop(page, step, {
         stepLocator,
         perSubstepTimeoutMs: TIMEOUT_PER_GUIDED_SUBSTEP_MS,
+        // Bound the comment-box readiness wait by the step's own timeout budget
+        // (which already accounts for guidedStepCount) instead of a fixed 5s.
+        commentBoxTimeoutMs: timeout,
         verbose,
         artifactsDir,
       });

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -546,7 +546,16 @@ export async function waitForGuidedCommentBoxReady(
       return 'ready';
     }
 
-    // Bound this read by the remaining budget so a stuck/missing locator
+    // Check detachment via an immediate, successful count() BEFORE any bounded
+    // attribute read. In real Playwright, getAttribute() on a missing element
+    // auto-waits up to its own timeout, so an already-detached step must be
+    // caught here first or it would burn the full remaining budget for
+    // nothing. A count() error is not caught: it propagates as designed.
+    if ((await stepLocator.count()) === 0) {
+      return 'detached';
+    }
+
+    // Bound this read by the remaining budget so a stuck-but-attached locator
     // can't exceed this wait's own deadline.
     let state: string | null;
     try {
@@ -563,9 +572,6 @@ export async function waitForGuidedCommentBoxReady(
     }
     if (state === 'cancelled') {
       throw new Error('Guided step was cancelled while waiting for comment box');
-    }
-    if (state === null && (await stepLocator.count()) === 0) {
-      return 'detached';
     }
 
     await page.waitForTimeout(Math.min(GUIDED_SUBSTEP_ADVANCE_POLL_MS, Math.max(1, deadline - Date.now())));

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -909,6 +909,7 @@ export async function clickSkipButtonAndSync(
   if ((await skipButton.count()) === 0) {
     throw new Error(`Step ${stepId}: no Skip control available to sync the requirements-unmet state`);
   }
+  await dismissBadgeCelebrations(page);
   await skipButton.click({ timeout });
 
   const stepLocator = page.getByTestId(testIds.interactive.step(stepId));

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -208,30 +208,38 @@ export async function checkObjectiveCompletion(page: Page, stepId: string): Prom
 }
 
 /**
+ * Outcome of the late completion/detachment precheck:
+ * - `completed`: the step's element is attached and already `completed`.
+ * - `detached`: the step's element is confirmed gone (a successful query
+ *   returned zero matches), which this file treats as a completion signal
+ *   the same way `waitForCompletionWithObjectivePolling` and the guided
+ *   substep loop do.
+ * - `not-complete`: proceed with normal execution.
+ */
+type LateCompletionOutcome = 'completed' | 'detached' | 'not-complete';
+
+/**
  * Recheck completion/detachment immediately before the scroll call in
  * executeStep. Bounded so a step that's mid-detach can't hang the run on an
  * otherwise-unbounded attribute read (Playwright auto-waits on a missing
  * element up to its own timeout by default).
  *
- * A successful `count()` of zero (before or after the bounded read) means
- * the step is already gone and this returns true, matching how detachment is
- * treated as completion elsewhere in this file. A `count()` error, or an
- * attached element whose read failed for an unrelated reason, is a genuine
- * fault and propagates instead of being reported as "already done".
+ * A `count()` error, or an attached element whose read failed for an
+ * unrelated reason, is a genuine fault and propagates instead of being
+ * reported as "already done".
  *
  * @param page - Playwright Page object
  * @param stepId - The step identifier
  * @param timeout - Bound for the attribute read (ms)
- * @returns true if the step is already completed or detached
  */
 async function checkLateCompletionOrDetachment(
   page: Page,
   stepId: string,
   timeout = LATE_COMPLETION_CHECK_TIMEOUT_MS
-): Promise<boolean> {
+): Promise<LateCompletionOutcome> {
   const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
   if ((await stepLocator.count()) === 0) {
-    return true;
+    return 'detached';
   }
 
   let state: string | null;
@@ -242,11 +250,11 @@ async function checkLateCompletionOrDetachment(
     // Re-count: a successful zero confirms late detachment; an attached
     // element (or a failing re-count) is a genuine fault and must propagate.
     if ((await stepLocator.count()) === 0) {
-      return true;
+      return 'detached';
     }
     throw err;
   }
-  return state === 'completed';
+  return state === 'completed' ? 'completed' : 'not-complete';
 }
 
 async function readStepError(page: Page, stepId: string): Promise<string | undefined> {
@@ -818,31 +826,112 @@ function createSkippedResult(
 }
 
 /**
- * Click a skippable step's Skip control and wait for the plugin to leave the
- * `requirements-unmet` state, so the next step in a sequential section isn't
- * gated on "Complete previous step".
+ * Build the success-path artifact bundle for a step, merging in a
+ * previously-captured PRE screenshot if there is one. Returns undefined when
+ * artifact capture isn't enabled, matching every success-return call site.
+ */
+async function buildSuccessArtifacts(
+  page: Page,
+  stepId: string,
+  artifactsDir: string | undefined,
+  alwaysScreenshot: boolean,
+  preScreenshotPath: string | undefined
+): Promise<ArtifactPaths | undefined> {
+  if (!artifactsDir || !alwaysScreenshot) {
+    return undefined;
+  }
+  const artifacts = await captureSuccessArtifacts(page, stepId, artifactsDir);
+  if (artifacts && preScreenshotPath) {
+    artifacts.screenshotPre = preScreenshotPath;
+    return artifacts;
+  }
+  return artifacts ?? (preScreenshotPath ? { screenshotPre: preScreenshotPath } : undefined);
+}
+
+/**
+ * Build the failure-path artifact bundle for a step, merging in a
+ * previously-captured PRE screenshot if there is one. Returns undefined when
+ * no artifacts directory was configured, matching every failure-return call site.
+ */
+async function buildFailureArtifacts(
+  page: Page,
+  stepId: string,
+  consoleErrors: string[],
+  artifactsDir: string | undefined,
+  preScreenshotPath: string | undefined
+): Promise<ArtifactPaths | undefined> {
+  if (!artifactsDir) {
+    return undefined;
+  }
+  const artifacts = await captureFailureArtifacts(page, stepId, consoleErrors, artifactsDir);
+  if (artifacts && preScreenshotPath) {
+    artifacts.screenshotPre = preScreenshotPath;
+    return artifacts;
+  }
+  return artifacts ?? (preScreenshotPath ? { screenshotPre: preScreenshotPath } : undefined);
+}
+
+/**
+ * Click a skippable step's Skip control and wait for the plugin to reach an
+ * explicit terminal state — `completed`, or a successful detach — so the
+ * next step in a sequential section isn't gated on "Complete previous step".
+ * A transient, non-terminal state such as `checking` is not treated as sync;
+ * only `completed`/detachment count, so we never mistake mid-flight state
+ * for a synchronized skip.
  *
- * Throws on any failure (missing Skip control, click error, or a transition
- * timeout) instead of swallowing it: recording a skip while the plugin can
- * still be `requirements-unmet` reproduces the exact bug this fixes, so the
- * caller must surface a clear runner failure rather than a false skip.
+ * Two Skip controls exist in the plugin and both call the same underlying
+ * `markSkipped()` action: the step's always-available Skip button (the one
+ * `discoverStepsFromDOM` uses to determine `step.skippable`), and the
+ * narrower Skip button rendered inside the requirements-explanation banner
+ * (surfaced via `detectRequirements().hasSkipButton`). We prefer the general
+ * one and fall back to the requirement-scoped one, so we support whichever
+ * control the plugin actually rendered instead of assuming a single fixed
+ * shape.
+ *
+ * Throws on any failure (no Skip control found, click error, or a timeout
+ * before reaching a terminal state) instead of swallowing it: recording a
+ * skip while the plugin never reached `completed`/detached reproduces the
+ * exact bug this fixes, so the caller must surface a clear runner failure
+ * rather than a false skip.
  *
  * @param page - Playwright Page object
  * @param stepId - The step identifier
- * @param timeout - Maximum time to wait for the state change (ms)
+ * @param timeout - Maximum time to wait for the terminal state (ms)
  */
 export async function clickSkipButtonAndSync(
   page: Page,
   stepId: string,
   timeout = SKIP_SYNC_TIMEOUT_MS
 ): Promise<void> {
-  const skipButton = page.getByTestId(testIds.interactive.skipButton(stepId));
+  const stepSkipButton = page.getByTestId(testIds.interactive.skipButton(stepId));
+  const requirementSkipButton = page.getByTestId(testIds.interactive.requirementSkipButton(stepId));
+  const skipButton = (await stepSkipButton.count()) > 0 ? stepSkipButton : requirementSkipButton;
   if ((await skipButton.count()) === 0) {
     throw new Error(`Step ${stepId}: no Skip control available to sync the requirements-unmet state`);
   }
   await skipButton.click({ timeout });
+
   const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
-  await expect(stepLocator).not.toHaveAttribute('data-test-step-state', 'requirements-unmet', { timeout });
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error(`Step ${stepId}: Skip did not reach a terminal state within ${timeout}ms`);
+    }
+    if ((await stepLocator.count()) === 0) {
+      return;
+    }
+    let state: string | null;
+    try {
+      state = await stepLocator.getAttribute('data-test-step-state', { timeout: remaining });
+    } catch {
+      state = null;
+    }
+    if (state === 'completed') {
+      return;
+    }
+    await page.waitForTimeout(Math.min(GUIDED_SUBSTEP_ADVANCE_POLL_MS, Math.max(1, deadline - Date.now())));
+  }
 }
 
 /**
@@ -918,12 +1007,37 @@ export async function executeStep(
     // between discovery and execution; recheck immediately before scrolling so
     // a step that's already done doesn't block on the scroll below. Bounded
     // and error-propagating: a query/navigation fault fails the step instead
-    // of being mistaken for "already done".
-    if (await checkLateCompletionOrDetachment(page, step.stepId)) {
+    // of being mistaken for "already done". Reported as 'passed', matching
+    // the pre-click objective check below so the same DOM state (attached +
+    // completed) is never classified differently depending on which check
+    // happened to observe it first; detachment is treated the same way
+    // detachment is treated as completion elsewhere in this file.
+    const lateOutcome = await checkLateCompletionOrDetachment(page, step.stepId);
+    if (lateOutcome !== 'not-complete') {
+      const lateArtifacts = await buildSuccessArtifacts(
+        page,
+        step.stepId,
+        artifactsDir,
+        alwaysScreenshot,
+        preScreenshotPath
+      );
       if (verbose) {
-        console.log(`   ⊘ Step ${step.stepId} completed or detached before scroll (late completion)`);
+        console.log(
+          `   ✓ Step ${step.stepId} ${lateOutcome === 'detached' ? 'detached' : 'completed via objectives'} before scroll`
+        );
+        if (lateArtifacts) {
+          console.log(`   📸 Success screenshot captured`);
+        }
       }
-      return createSkippedResult(step, page, startTime, consoleErrors, 'pre_completed');
+      return {
+        stepId: step.stepId,
+        status: 'passed',
+        durationMs: Date.now() - startTime,
+        currentUrl: page.url(),
+        consoleErrors,
+        skippable: step.skippable,
+        artifacts: lateArtifacts,
+      };
     }
 
     // Scroll step into view before interaction. Bounded so a step that's
@@ -963,15 +1077,6 @@ export async function executeStep(
           if (verbose) {
             console.log(`   ✗ Step ${step.stepId} failed: skip sync did not complete (${syncErrorMsg})`);
           }
-          let artifacts: ArtifactPaths | undefined;
-          if (artifactsDir) {
-            artifacts = await captureFailureArtifacts(page, step.stepId, consoleErrors, artifactsDir);
-            if (artifacts && preScreenshotPath) {
-              artifacts.screenshotPre = preScreenshotPath;
-            } else if (preScreenshotPath) {
-              artifacts = { screenshotPre: preScreenshotPath };
-            }
-          }
           return {
             stepId: step.stepId,
             status: 'failed',
@@ -981,7 +1086,7 @@ export async function executeStep(
             error: `Step is skippable but Skip sync failed: ${syncErrorMsg}`,
             skippable: step.skippable,
             classification: classifyError(syncErrorMsg),
-            artifacts,
+            artifacts: await buildFailureArtifacts(page, step.stepId, consoleErrors, artifactsDir, preScreenshotPath),
           };
         }
         if (verbose) {
@@ -995,15 +1100,6 @@ export async function executeStep(
       if (verbose) {
         console.log(`   ✗ Step ${step.stepId} failed: ${errorMsg}`);
       }
-      let artifacts: ArtifactPaths | undefined;
-      if (artifactsDir) {
-        artifacts = await captureFailureArtifacts(page, step.stepId, consoleErrors, artifactsDir);
-        if (artifacts && preScreenshotPath) {
-          artifacts.screenshotPre = preScreenshotPath;
-        } else if (preScreenshotPath) {
-          artifacts = { screenshotPre: preScreenshotPath };
-        }
-      }
       return {
         stepId: step.stepId,
         status: 'failed',
@@ -1013,7 +1109,7 @@ export async function executeStep(
         error: errorMsg,
         skippable: false,
         classification: classifyError(errorMsg),
-        artifacts,
+        artifacts: await buildFailureArtifacts(page, step.stepId, consoleErrors, artifactsDir, preScreenshotPath),
       };
     }
 
@@ -1025,19 +1121,15 @@ export async function executeStep(
         console.log(`   ✓ Step ${step.stepId} auto-completed via objectives before clicking`);
       }
 
-      // Capture success screenshot if alwaysScreenshot is enabled
-      let artifacts: ArtifactPaths | undefined;
-      if (artifactsDir && alwaysScreenshot) {
-        artifacts = await captureSuccessArtifacts(page, step.stepId, artifactsDir);
-        // Include PRE screenshot if captured
-        if (artifacts && preScreenshotPath) {
-          artifacts.screenshotPre = preScreenshotPath;
-        } else if (preScreenshotPath) {
-          artifacts = { screenshotPre: preScreenshotPath };
-        }
-        if (verbose && artifacts) {
-          console.log(`   📸 Success screenshot captured`);
-        }
+      const artifacts = await buildSuccessArtifacts(
+        page,
+        step.stepId,
+        artifactsDir,
+        alwaysScreenshot,
+        preScreenshotPath
+      );
+      if (verbose && artifacts) {
+        console.log(`   📸 Success screenshot captured`);
       }
 
       return {
@@ -1061,15 +1153,6 @@ export async function executeStep(
     }
     if (!action) {
       if (await checkObjectiveCompletion(page, step.stepId)) {
-        let artifacts: ArtifactPaths | undefined;
-        if (artifactsDir && alwaysScreenshot) {
-          artifacts = await captureSuccessArtifacts(page, step.stepId, artifactsDir);
-          if (artifacts && preScreenshotPath) {
-            artifacts.screenshotPre = preScreenshotPath;
-          } else if (preScreenshotPath) {
-            artifacts = { screenshotPre: preScreenshotPath };
-          }
-        }
         return {
           stepId: step.stepId,
           status: 'passed',
@@ -1077,7 +1160,7 @@ export async function executeStep(
           currentUrl: page.url(),
           consoleErrors,
           skippable: step.skippable,
-          artifacts,
+          artifacts: await buildSuccessArtifacts(page, step.stepId, artifactsDir, alwaysScreenshot, preScreenshotPath),
         };
       }
       if (step.skippable) {
@@ -1119,17 +1202,15 @@ export async function executeStep(
         await waitForCompletionWithObjectivePolling(page, step.stepId, timeout);
       }
 
-      let guidedArtifacts: ArtifactPaths | undefined;
-      if (artifactsDir && alwaysScreenshot) {
-        guidedArtifacts = await captureSuccessArtifacts(page, step.stepId, artifactsDir);
-        if (guidedArtifacts && preScreenshotPath) {
-          guidedArtifacts.screenshotPre = preScreenshotPath;
-        } else if (preScreenshotPath) {
-          guidedArtifacts = { screenshotPre: preScreenshotPath };
-        }
-        if (verbose && guidedArtifacts) {
-          console.log(`   📸 Success screenshot captured`);
-        }
+      const guidedArtifacts = await buildSuccessArtifacts(
+        page,
+        step.stepId,
+        artifactsDir,
+        alwaysScreenshot,
+        preScreenshotPath
+      );
+      if (verbose && guidedArtifacts) {
+        console.log(`   📸 Success screenshot captured`);
       }
 
       return {
@@ -1152,19 +1233,15 @@ export async function executeStep(
       console.log(`   ℹ Step ${step.stepId} completed quickly (possibly via objectives)`);
     }
 
-    // Capture success screenshot if alwaysScreenshot is enabled
-    let successArtifacts: ArtifactPaths | undefined;
-    if (artifactsDir && alwaysScreenshot) {
-      successArtifacts = await captureSuccessArtifacts(page, step.stepId, artifactsDir);
-      // Include PRE screenshot if captured
-      if (successArtifacts && preScreenshotPath) {
-        successArtifacts.screenshotPre = preScreenshotPath;
-      } else if (preScreenshotPath) {
-        successArtifacts = { screenshotPre: preScreenshotPath };
-      }
-      if (verbose && successArtifacts) {
-        console.log(`   📸 Success screenshot captured`);
-      }
+    const successArtifacts = await buildSuccessArtifacts(
+      page,
+      step.stepId,
+      artifactsDir,
+      alwaysScreenshot,
+      preScreenshotPath
+    );
+    if (verbose && successArtifacts) {
+      console.log(`   📸 Success screenshot captured`);
     }
 
     // Return success result with diagnostics
@@ -1182,18 +1259,9 @@ export async function executeStep(
     const errorMsg = error instanceof Error ? error.message : String(error);
 
     // L3-5D: Capture artifacts on failure
-    let artifacts: ArtifactPaths | undefined;
-    if (artifactsDir) {
-      artifacts = await captureFailureArtifacts(page, step.stepId, consoleErrors, artifactsDir);
-      // Include PRE screenshot if captured
-      if (artifacts && preScreenshotPath) {
-        artifacts.screenshotPre = preScreenshotPath;
-      } else if (preScreenshotPath) {
-        artifacts = { screenshotPre: preScreenshotPath };
-      }
-      if (verbose && artifacts) {
-        console.log(`   📸 Artifacts captured to ${artifactsDir}`);
-      }
+    const artifacts = await buildFailureArtifacts(page, step.stepId, consoleErrors, artifactsDir, preScreenshotPath);
+    if (verbose && artifacts) {
+      console.log(`   📸 Artifacts captured to ${artifactsDir}`);
     }
 
     return {

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -510,32 +510,66 @@ export async function waitForFormfillSettle(
 }
 
 /**
- * Wait for the guided comment box to become visible, bounded by the step's own
- * timeout budget rather than a fixed short constant. Polls step state alongside
- * the comment box so a step that has already entered `error`/`cancelled` fails
- * fast instead of waiting out the full timeout.
+ * Outcome of waiting for the guided comment box:
+ * - `ready`: the comment box is visible and its contract can be read.
+ * - `completed`: the step reached `completed` while we were waiting.
+ * - `detached`: the step element was confirmed gone (a successful query
+ *   returned zero matches) while we were waiting.
+ */
+export type GuidedCommentBoxWaitOutcome = 'ready' | 'completed' | 'detached';
+
+/**
+ * Wait for the guided comment box to become visible, bounded by an absolute
+ * deadline rather than a fixed short constant. Every locator read inside the
+ * loop is itself bounded by the remaining time so a missing/slow locator
+ * can't silently consume more than this wait's own budget (e.g. the outer
+ * test timeout). Polls step state alongside the comment box so a step that
+ * has already entered `error`/`cancelled` fails fast, and returns a distinct
+ * outcome for `completed`/detached so the caller can treat those as legitimate
+ * step completion rather than "comment box never appeared".
  */
 export async function waitForGuidedCommentBoxReady(
   page: Page,
   stepLocator: Locator,
   commentBox: Locator,
   timeoutMs = GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS
-): Promise<void> {
+): Promise<GuidedCommentBoxWaitOutcome> {
   const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if ((await commentBox.count()) > 0 && (await commentBox.isVisible())) {
-      return;
+
+  for (;;) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error('Guided step: comment box not visible');
     }
-    const state = await stepLocator.getAttribute('data-test-step-state').catch(() => null);
+
+    if ((await commentBox.count()) > 0 && (await commentBox.isVisible())) {
+      return 'ready';
+    }
+
+    // Bound this read by the remaining budget so a stuck/missing locator
+    // can't exceed this wait's own deadline.
+    let state: string | null;
+    try {
+      state = await stepLocator.getAttribute('data-test-step-state', { timeout: remainingMs });
+    } catch {
+      state = null;
+    }
+
+    if (state === 'completed') {
+      return 'completed';
+    }
     if (state === 'error') {
       throw new Error('Guided step entered error state while waiting for comment box');
     }
     if (state === 'cancelled') {
       throw new Error('Guided step was cancelled while waiting for comment box');
     }
-    await page.waitForTimeout(GUIDED_SUBSTEP_ADVANCE_POLL_MS);
+    if (state === null && (await stepLocator.count()) === 0) {
+      return 'detached';
+    }
+
+    await page.waitForTimeout(Math.min(GUIDED_SUBSTEP_ADVANCE_POLL_MS, Math.max(1, deadline - Date.now())));
   }
-  throw new Error('Guided step: comment box not visible');
 }
 
 /**
@@ -548,14 +582,19 @@ export async function runGuidedSubstepLoop(
   options: {
     stepLocator: Locator;
     perSubstepTimeoutMs: number;
-    /** Bounds the comment-box visibility wait; defaults to GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS. */
-    commentBoxTimeoutMs?: number;
+    /**
+     * Absolute deadline (Date.now()-based epoch ms) bounding the cumulative
+     * comment-box visibility wait across every substep in this loop. Defaults
+     * to `Date.now() + GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS` when omitted.
+     */
+    commentBoxDeadlineMs?: number;
     verbose?: boolean;
     artifactsDir?: string;
   }
 ): Promise<{ completed: boolean }> {
   let stepLocator = options.stepLocator;
   const { perSubstepTimeoutMs, verbose = false, artifactsDir } = options;
+  const commentBoxDeadlineMs = options.commentBoxDeadlineMs ?? Date.now() + GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS;
   const guidedStepCount = step.guidedStepCount ?? 1;
 
   const captureLoopArtifacts = async (context: string) => {
@@ -564,16 +603,15 @@ export async function runGuidedSubstepLoop(
     }
   };
 
-  // Step unmount mid-loop is a completion signal. Re-resolving the locator
-  // handles reload/navigation (e.g. a completeEarly action reloading the page);
-  // a query error against a mid-navigation document is treated the same way.
+  // Step unmount mid-loop is a completion signal (section auto-collapse, or
+  // navigation unmounted it). Re-resolving the locator handles reload (e.g. a
+  // completeEarly action). A query error is NOT treated as detachment here:
+  // callers already synchronize on navigation before calling this, so a fault
+  // at this point (closed page, destroyed context, unrelated query error)
+  // is a genuine failure and must propagate rather than be reported as success.
   const stepDetached = async (): Promise<boolean> => {
     stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
-    try {
-      return (await stepLocator.count()) === 0;
-    } catch {
-      return true;
-    }
+    return (await stepLocator.count()) === 0;
   };
 
   while (true) {
@@ -606,11 +644,20 @@ export async function runGuidedSubstepLoop(
     }
 
     const commentBox = page.locator('.interactive-comment-box').first();
+    let commentBoxOutcome: GuidedCommentBoxWaitOutcome;
     try {
-      await waitForGuidedCommentBoxReady(page, stepLocator, commentBox, options.commentBoxTimeoutMs);
+      commentBoxOutcome = await waitForGuidedCommentBoxReady(
+        page,
+        stepLocator,
+        commentBox,
+        Math.max(1, commentBoxDeadlineMs - Date.now())
+      );
     } catch (err) {
       await captureLoopArtifacts('comment-box-not-visible');
       throw err;
+    }
+    if (commentBoxOutcome === 'completed' || commentBoxOutcome === 'detached') {
+      return { completed: true };
     }
 
     const action = await commentBox.getAttribute('data-test-action');
@@ -646,6 +693,11 @@ export async function runGuidedSubstepLoop(
           page.off('framenavigated', onFrameNavigated);
         }
         if (navigated || urlBefore !== page.url()) {
+          // The action reloaded/navigated the page (e.g. a completeEarly install).
+          // The pre-navigation locator is stale, so wait for the new document to
+          // settle before re-resolving the step locator against it. A failed/timed
+          // out load is a genuine failure (broken reload) and must propagate, not
+          // be swallowed into a false "completed" result.
           await page.waitForLoadState('domcontentloaded', { timeout: GUIDED_RELOAD_LOAD_TIMEOUT_MS });
           stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
         }
@@ -719,8 +771,12 @@ function createSkippedResult(
 /**
  * Click a skippable step's Skip control and wait for the plugin to leave the
  * `requirements-unmet` state, so the next step in a sequential section isn't
- * gated on "Complete previous step". Best-effort: swallows failures so a step
- * that can't sync still returns the skipped result instead of throwing.
+ * gated on "Complete previous step".
+ *
+ * Throws on any failure (missing Skip control, click error, or a transition
+ * timeout) instead of swallowing it: recording a skip while the plugin can
+ * still be `requirements-unmet` reproduces the exact bug this fixes, so the
+ * caller must surface a clear runner failure rather than a false skip.
  *
  * @param page - Playwright Page object
  * @param stepId - The step identifier
@@ -732,14 +788,12 @@ export async function clickSkipButtonAndSync(
   timeout = SKIP_SYNC_TIMEOUT_MS
 ): Promise<void> {
   const skipButton = page.getByTestId(testIds.interactive.skipButton(stepId));
-  if ((await skipButton.count().catch(() => 0)) === 0) {
-    return;
+  if ((await skipButton.count()) === 0) {
+    throw new Error(`Step ${stepId}: no Skip control available to sync the requirements-unmet state`);
   }
-  await skipButton.click({ timeout }).catch(() => {});
+  await skipButton.click({ timeout });
   const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
-  await expect(stepLocator)
-    .not.toHaveAttribute('data-test-step-state', 'requirements-unmet', { timeout })
-    .catch(() => {});
+  await expect(stepLocator).not.toHaveAttribute('data-test-step-state', 'requirements-unmet', { timeout });
 }
 
 /**
@@ -849,12 +903,41 @@ export async function executeStep(
     // If requirements are not met after fix attempts
     if (!requirements.requirementsMet && requirements.status === 'unmet') {
       if (determineUnmetRequirementOutcome(step.skippable) === 'skip') {
+        // Click the Skip control and wait for the plugin to leave requirements-unmet
+        // so the next sequential step isn't gated on "Complete previous step". Only
+        // record the skip once that's confirmed; a sync failure is a clear runner
+        // failure rather than a false skip that reproduces the original bug.
+        try {
+          await clickSkipButtonAndSync(page, step.stepId);
+        } catch (syncError) {
+          const syncErrorMsg = syncError instanceof Error ? syncError.message : String(syncError);
+          if (verbose) {
+            console.log(`   ✗ Step ${step.stepId} failed: skip sync did not complete (${syncErrorMsg})`);
+          }
+          let artifacts: ArtifactPaths | undefined;
+          if (artifactsDir) {
+            artifacts = await captureFailureArtifacts(page, step.stepId, consoleErrors, artifactsDir);
+            if (artifacts && preScreenshotPath) {
+              artifacts.screenshotPre = preScreenshotPath;
+            } else if (preScreenshotPath) {
+              artifacts = { screenshotPre: preScreenshotPath };
+            }
+          }
+          return {
+            stepId: step.stepId,
+            status: 'failed',
+            durationMs: Date.now() - startTime,
+            currentUrl: page.url(),
+            consoleErrors,
+            error: `Step is skippable but Skip sync failed: ${syncErrorMsg}`,
+            skippable: step.skippable,
+            classification: classifyError(syncErrorMsg),
+            artifacts,
+          };
+        }
         if (verbose) {
           console.log(`   ⊘ Step ${step.stepId} skipped due to unmet requirements (skippable)`);
         }
-        // Click the Skip control and wait for the plugin to leave requirements-unmet
-        // so the next sequential step isn't gated on "Complete previous step".
-        await clickSkipButtonAndSync(page, step.stepId);
         return createSkippedResult(step, page, startTime, consoleErrors, 'requirements_unmet');
       }
       const errorMsg = fixResult
@@ -976,9 +1059,10 @@ export async function executeStep(
       const { completed } = await runGuidedSubstepLoop(page, step, {
         stepLocator,
         perSubstepTimeoutMs: TIMEOUT_PER_GUIDED_SUBSTEP_MS,
-        // Bound the comment-box readiness wait by the step's own timeout budget
-        // (which already accounts for guidedStepCount) instead of a fixed 5s.
-        commentBoxTimeoutMs: timeout,
+        // Bound the *cumulative* comment-box readiness wait, across every
+        // substep, by the step's own timeout budget (which already accounts
+        // for guidedStepCount) instead of a fixed 5s re-granted per substep.
+        commentBoxDeadlineMs: Date.now() + timeout,
         verbose,
         artifactsDir,
       });

--- a/tests/e2e-runner/utils/guide-runner/index.ts
+++ b/tests/e2e-runner/utils/guide-runner/index.ts
@@ -38,6 +38,10 @@ export {
   STEP_OVERHEAD_TIMEOUT_MS,
   TIMEOUT_PER_MULTISTEP_ACTION_MS,
   TIMEOUT_PER_GUIDED_SUBSTEP_MS,
+  SCROLL_INTO_VIEW_TIMEOUT_MS,
+  LATE_COMPLETION_CHECK_TIMEOUT_MS,
+  GUIDED_RELOAD_LOAD_TIMEOUT_MS,
+  SKIP_SYNC_TIMEOUT_MS,
 } from './constants';
 
 // ============================================
@@ -78,6 +82,7 @@ export {
 // ============================================
 // Execution
 // ============================================
+export type { GuidedCommentBoxWaitOutcome } from './execution';
 export {
   scrollStepIntoView,
   calculateGuideTimeout,
@@ -88,6 +93,9 @@ export {
   waitForStepCompletion,
   checkObjectiveCompletion,
   waitForCompletionWithObjectivePolling,
+  waitForGuidedCommentBoxReady,
+  runGuidedSubstepLoop,
+  clickSkipButtonAndSync,
   executeStep,
   executeAllSteps,
   logStepResult,


### PR DESCRIPTION
## Summary

Fixes four E2E runner lifecycle gaps that produced false guide failures: skipped steps did not advance plugin state, guided readiness used a fixed five-second deadline, navigation left stale locators, and late no-op completion could hang during scroll.

## What to look at

- The step executor now synchronizes plugin state before it records a requirement-based skip.
- Guided execution uses the step timeout budget, detects terminal states while waiting for overlays, and re-resolves locators after navigation.
- Scroll and late-completion checks now use bounded waits so detached steps cannot consume the full guide timeout.

## How to verify

1. Run `reduce-metrics-cardinality` against a clean cloud stack. Confirm the first skippable step advances plugin state and the next step no longer reports “Complete previous step.”
2. Run `get-started-grafana-assistant-first-prompt`. Confirm the late no-op step exits as pre-completed instead of hanging during scroll.
3. Run a guided step whose first target takes more than five seconds to appear. Confirm the runner waits within the step’s configured budget.
4. Run a guided action that navigates or reloads the page. Confirm the runner does not continue polling the pre-navigation locator.

## Breaking changes

None. The changes are defensive runner behavior and are reversible.

## Out of scope

- Pathfinder badge-celebration overlays are handled in a separate PR.
- The plugin-side `completeEarly` guided-step lifecycle is handled in a separate PR.
