### PR TITLE
fix(e2e): stabilize requirement fix settling

### DIFF
--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -175,6 +175,10 @@ Requirements met? → Execute step
 
 **Skippable steps** (those with a Skip button) allow the test to continue when requirements cannot be met. **Mandatory steps** cause the test to abort on failure, marking remaining steps as `not_reached`.
 
+An unmet read gets a short settle window before the runner treats it as terminal. This applies whether or not a Fix button is visible. See `Requirements settle window` in the timing table below.
+
+The plugin's requirement check can be mid-transition right after the initial check, or right after a Fix button click. The runner polls briefly for the state to settle, instead of failing on one transient read.
+
 Overall success requires zero mandatory failures and either at least one verified pass or zero failed steps. A run where every step is skipped cleanly succeeds; a run with no verified pass and any failed skippable step fails.
 
 ## Artifacts and reporting
@@ -324,14 +328,15 @@ The environment is reset **between dependency chains**, not between every guide.
 
 ## Timing and timeouts
 
-| Constant             | Value            | Purpose                                      |
-| -------------------- | ---------------- | -------------------------------------------- |
-| Base step timeout    | 30s              | Maximum time for a single step               |
-| Multistep bonus      | +5s per action   | Added for each internal action in multisteps |
-| Guided substep bonus | +30s per substep | Added for each substep in guided blocks      |
-| Button enable wait   | 10s              | Wait for sequential dependencies             |
-| Fix button timeout   | 10s              | Per fix operation                            |
-| Max fix attempts     | 3                | Retry limit before giving up                 |
+| Constant                   | Value            | Purpose                                             |
+| -------------------------- | ---------------- | --------------------------------------------------- |
+| Base step timeout          | 30s              | Maximum time for a single step                      |
+| Multistep bonus            | +5s per action   | Added for each internal action in multisteps        |
+| Guided substep bonus       | +30s per substep | Added for each substep in guided blocks             |
+| Button enable wait         | 10s              | Wait for sequential dependencies                    |
+| Fix button timeout         | 10s              | Per fix operation                                   |
+| Max fix attempts           | 3                | Retry limit before giving up                        |
+| Requirements settle window | 1s               | Poll budget before an unmet read counts as terminal |
 
 Examples:
 

--- a/tests/e2e-runner/utils/guide-runner/constants.ts
+++ b/tests/e2e-runner/utils/guide-runner/constants.ts
@@ -159,6 +159,18 @@ export const REQUIREMENTS_CHECK_TIMEOUT_MS = 10000;
  */
 export const REQUIREMENTS_POLL_INTERVAL_MS = 200;
 
+/**
+ * Maximum time to poll for a settled requirements state before treating
+ * an unmet read (with or without a Fix button) as genuinely terminal,
+ * rather than a transient DOM state.
+ *
+ * The plugin's requirement check can be mid-transition right after the
+ * initial check or right after a Fix button click: a step can read as
+ * unmet even though it settles to met (or to showing a Fix button)
+ * moments later.
+ */
+export const REQUIREMENTS_SETTLE_TIMEOUT_MS = 1000;
+
 // ============================================
 // Fix Button Execution Constants (L3-4B)
 // ============================================

--- a/tests/e2e-runner/utils/guide-runner/requirements.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/requirements.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for guide-runner requirements handling.
+ *
+ * Covers the settle-window behavior in attemptToFixRequirements: when a fix
+ * attempt finds no Fix button, the runner polls briefly for the DOM to
+ * settle before it reports a terminal failure.
+ */
+
+jest.mock('@playwright/test', () => ({
+  Page: jest.fn(),
+  Locator: jest.fn(),
+  expect: jest.fn(),
+  test: jest.fn(),
+}));
+
+import type { Page } from '@playwright/test';
+
+import { testIds } from '../../../../src/constants/testIds';
+import { REQUIREMENTS_POLL_INTERVAL_MS } from './constants';
+import { attemptToFixRequirements } from './requirements';
+import type { TestableStep } from './types';
+
+// ============================================
+// Test Fixtures
+// ============================================
+
+const STEP_ID = 'test-step-1';
+
+function createTestableStep(overrides: Partial<TestableStep> = {}): TestableStep {
+  return {
+    stepId: STEP_ID,
+    index: 0,
+    skippable: false,
+    hasDoItButton: true,
+    hasShowMeButton: false,
+    isPreCompleted: false,
+    isMultistep: false,
+    internalActionCount: 0,
+    isGuided: false,
+    locator: {} as unknown as TestableStep['locator'],
+    ...overrides,
+  };
+}
+
+/**
+ * A snapshot of the DOM state that detectRequirements() would observe.
+ * Only the fields relevant to the settle-window behavior are modeled.
+ */
+interface DomState {
+  doItEnabled: boolean;
+  hasExplanation: boolean;
+  explanationText?: string;
+  hasFixButton: boolean;
+  hasRetryButton: boolean;
+  hasSkipButton: boolean;
+}
+
+/**
+ * Build a mock Page whose getByTestId() responses advance through a
+ * sequence of DOM states, one state per detectRequirements() call.
+ * The last state repeats for any calls beyond the sequence length.
+ */
+function createSequencedPage(states: DomState[]): { page: Page; waitForTimeout: jest.Mock } {
+  let callIndex = -1;
+  const currentState = () => states[Math.min(callIndex, states.length - 1)];
+  const countFor = (pick: (state: DomState) => boolean) =>
+    jest.fn().mockImplementation(() => Promise.resolve(pick(currentState()) ? 1 : 0));
+
+  const doItLocator = {
+    count: jest.fn().mockImplementation(() => {
+      callIndex += 1;
+      return Promise.resolve(currentState().doItEnabled ? 1 : 0);
+    }),
+    isEnabled: jest.fn().mockImplementation(() => Promise.resolve(currentState().doItEnabled)),
+  };
+  const showMeLocator = {
+    count: jest.fn().mockResolvedValue(0),
+    isEnabled: jest.fn().mockResolvedValue(false),
+  };
+  const explanationLocator = {
+    count: countFor((state) => state.hasExplanation),
+    locator: jest.fn().mockReturnValue({ count: jest.fn().mockResolvedValue(0) }),
+    textContent: jest.fn().mockImplementation(() => Promise.resolve(currentState().explanationText ?? '')),
+  };
+  const fixLocator = {
+    count: countFor((state) => state.hasFixButton),
+    click: jest.fn().mockResolvedValue(undefined),
+  };
+  const retryLocator = { count: countFor((state) => state.hasRetryButton) };
+  const skipLocator = { count: countFor((state) => state.hasSkipButton) };
+
+  const locatorsByTestId = new Map<string, unknown>([
+    [testIds.interactive.doItButton(STEP_ID), doItLocator],
+    [testIds.interactive.showMeButton(STEP_ID), showMeLocator],
+    [testIds.interactive.requirementCheck(STEP_ID), explanationLocator],
+    [testIds.interactive.requirementFixButton(STEP_ID), fixLocator],
+    [testIds.interactive.requirementRetryButton(STEP_ID), retryLocator],
+    [testIds.interactive.requirementSkipButton(STEP_ID), skipLocator],
+  ]);
+
+  const getByTestId = jest.fn().mockImplementation((testId: string) => {
+    const locator = locatorsByTestId.get(testId);
+    if (!locator) {
+      throw new Error(`Unexpected testId requested: ${testId}`);
+    }
+    return locator;
+  });
+  const waitForTimeout = jest.fn().mockResolvedValue(undefined);
+
+  const page = { getByTestId, waitForTimeout } as unknown as Page;
+
+  return { page, waitForTimeout };
+}
+
+const UNMET_NO_FIX_BUTTON: DomState = {
+  doItEnabled: false,
+  hasExplanation: true,
+  explanationText: 'Checking your setup',
+  hasFixButton: false,
+  hasRetryButton: false,
+  hasSkipButton: false,
+};
+
+const MET: DomState = {
+  doItEnabled: true,
+  hasExplanation: false,
+  hasFixButton: false,
+  hasRetryButton: false,
+  hasSkipButton: false,
+};
+
+describe('attemptToFixRequirements - no Fix button settle window', () => {
+  it('reports success when requirements settle to met during the settle window', async () => {
+    const { page, waitForTimeout } = createSequencedPage([
+      UNMET_NO_FIX_BUTTON, // initial read in the attempt loop
+      UNMET_NO_FIX_BUTTON, // initial read inside the settle poll
+      MET, // settles to met after one poll
+    ]);
+    const step = createTestableStep();
+
+    const result = await attemptToFixRequirements(page, step);
+
+    expect(result.success).toBe(true);
+    expect(result.finalStatus).toBe('met');
+    expect(result.failureReason).toBeUndefined();
+    expect(result.totalAttempts).toBe(1);
+    // It polled once before concluding the state had settled, instead of
+    // failing on the first sampled state.
+    expect(waitForTimeout).toHaveBeenCalledTimes(1);
+    expect(waitForTimeout).toHaveBeenCalledWith(REQUIREMENTS_POLL_INTERVAL_MS);
+  });
+
+  it('reports "No Fix button available" when requirements stay unmet for the whole window', async () => {
+    const dateNowSpy = jest.spyOn(Date, 'now');
+    let simulatedNow = 0;
+    dateNowSpy.mockImplementation(() => {
+      simulatedNow += 300;
+      return simulatedNow;
+    });
+
+    try {
+      const { page, waitForTimeout } = createSequencedPage([UNMET_NO_FIX_BUTTON]);
+      const step = createTestableStep();
+
+      const result = await attemptToFixRequirements(page, step);
+
+      expect(result.success).toBe(false);
+      expect(result.failureReason).toBe('No Fix button available');
+      expect(result.totalAttempts).toBe(1);
+      expect(result.attempts[0].error).toBe('No Fix button available');
+      // It kept polling for the settle window rather than giving up on the
+      // first sampled state.
+      expect(waitForTimeout.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+  });
+});

--- a/tests/e2e-runner/utils/guide-runner/requirements.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/requirements.test.ts
@@ -4,7 +4,9 @@
  * Covers the settle-window behavior in attemptToFixRequirements: an unmet
  * read (with or without a Fix button) gets a short poll to settle before
  * the runner reports a terminal failure, both on the initial read of an
- * attempt and on the read taken right after a Fix button click.
+ * attempt and on the read taken right after a Fix button click. Also
+ * covers the bounded per-read timeout that keeps a detached element from
+ * hanging past the settle window.
  */
 
 jest.mock('@playwright/test', () => ({
@@ -14,11 +16,11 @@ jest.mock('@playwright/test', () => ({
   test: jest.fn(),
 }));
 
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 import { testIds } from '../../../../src/constants/testIds';
-import { REQUIREMENTS_POLL_INTERVAL_MS } from './constants';
-import { attemptToFixRequirements } from './requirements';
+import { REQUIREMENTS_POLL_INTERVAL_MS, REQUIREMENTS_SETTLE_TIMEOUT_MS } from './constants';
+import { attemptToFixRequirements, detectRequirements } from './requirements';
 import type { TestableStep } from './types';
 
 afterEach(() => {
@@ -54,33 +56,34 @@ function createTestableStep(overrides: Partial<TestableStep> = {}): TestableStep
 interface DomState {
   doItEnabled: boolean;
   hasExplanation: boolean;
+  isChecking: boolean;
   explanationText?: string;
   hasFixButton: boolean;
   hasRetryButton: boolean;
   hasSkipButton: boolean;
 }
 
-/**
- * A fake clock that only advances when page.waitForTimeout() is called,
- * so elapsed time in the code under test matches the waits it actually
- * requested instead of drifting with incidental Date.now() calls.
- *
- * Tests that rely on the settle window expiring, or on a known elapsed
- * amount, must also run `jest.spyOn(Date, 'now').mockImplementation(() => clock.now)`.
- */
-function createFakeClock() {
-  return { now: 0 };
+interface SequencedPageHandles {
+  page: Page;
+  waitForTimeout: jest.Mock;
+  waitForLoadState: jest.Mock;
+  fixButtonClick: jest.Mock;
+  explanationTextContent: jest.Mock;
 }
 
 /**
  * Build a mock Page whose getByTestId() responses advance through a
- * sequence of DOM states, one state per detectRequirements() call.
- * The last state repeats for any calls beyond the sequence length.
+ * sequence of DOM states, one state per detectRequirements() call. The
+ * last state repeats for any calls beyond the sequence length.
+ *
+ * Installs a fake clock that only advances when page.waitForTimeout() is
+ * called, and mocks Date.now() to read from it, so tests cannot
+ * accidentally depend on real wall-clock time.
  */
-function createSequencedPage(
-  states: DomState[],
-  clock: { now: number } = createFakeClock()
-): { page: Page; waitForTimeout: jest.Mock; fixButtonClick: jest.Mock } {
+function createSequencedPage(states: DomState[]): SequencedPageHandles {
+  const clock = { now: 0 };
+  jest.spyOn(Date, 'now').mockImplementation(() => clock.now);
+
   let callIndex = -1;
   const currentState = () => states[Math.min(callIndex, states.length - 1)];
   const countFor = (pick: (state: DomState) => boolean) =>
@@ -97,10 +100,15 @@ function createSequencedPage(
     count: jest.fn().mockResolvedValue(0),
     isEnabled: jest.fn().mockResolvedValue(false),
   };
+  const explanationTextContent = jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(currentState().explanationText ?? ''));
   const explanationLocator = {
     count: countFor((state) => state.hasExplanation),
-    locator: jest.fn().mockReturnValue({ count: jest.fn().mockResolvedValue(0) }),
-    textContent: jest.fn().mockImplementation(() => Promise.resolve(currentState().explanationText ?? '')),
+    locator: jest.fn().mockReturnValue({
+      count: jest.fn().mockImplementation(() => Promise.resolve(currentState().isChecking ? 1 : 0)),
+    }),
+    textContent: explanationTextContent,
   };
   const fixLocator = {
     count: countFor((state) => state.hasFixButton),
@@ -129,15 +137,27 @@ function createSequencedPage(
     clock.now += ms;
     return Promise.resolve(undefined);
   });
+  const waitForLoadState = jest.fn().mockResolvedValue(undefined);
 
-  const page = { getByTestId, waitForTimeout } as unknown as Page;
+  const page = { getByTestId, waitForTimeout, waitForLoadState } as unknown as Page;
 
-  return { page, waitForTimeout, fixButtonClick: fixLocator.click };
+  return { page, waitForTimeout, waitForLoadState, fixButtonClick: fixLocator.click, explanationTextContent };
 }
 
 const UNMET_NO_FIX_BUTTON: DomState = {
   doItEnabled: false,
   hasExplanation: true,
+  isChecking: false,
+  explanationText: 'Checking your setup',
+  hasFixButton: false,
+  hasRetryButton: false,
+  hasSkipButton: false,
+};
+
+const CHECKING: DomState = {
+  doItEnabled: false,
+  hasExplanation: true,
+  isChecking: true,
   explanationText: 'Checking your setup',
   hasFixButton: false,
   hasRetryButton: false,
@@ -147,7 +167,18 @@ const UNMET_NO_FIX_BUTTON: DomState = {
 const UNMET_HAS_FIX_BUTTON: DomState = {
   doItEnabled: false,
   hasExplanation: true,
+  isChecking: false,
   explanationText: 'Fix available',
+  hasFixButton: true,
+  hasRetryButton: false,
+  hasSkipButton: false,
+};
+
+const UNMET_HAS_FIX_BUTTON_LOCATION: DomState = {
+  doItEnabled: false,
+  hasExplanation: true,
+  isChecking: false,
+  explanationText: 'Navigate to the settings page to continue.',
   hasFixButton: true,
   hasRetryButton: false,
   hasSkipButton: false,
@@ -156,6 +187,7 @@ const UNMET_HAS_FIX_BUTTON: DomState = {
 const MET: DomState = {
   doItEnabled: true,
   hasExplanation: false,
+  isChecking: false,
   hasFixButton: false,
   hasRetryButton: false,
   hasSkipButton: false,
@@ -163,15 +195,10 @@ const MET: DomState = {
 
 describe('attemptToFixRequirements - settle window', () => {
   it('reports success when requirements settle to met before a Fix button ever appears', async () => {
-    const clock = createFakeClock();
-    jest.spyOn(Date, 'now').mockImplementation(() => clock.now);
-    const { page, waitForTimeout } = createSequencedPage(
-      [
-        UNMET_NO_FIX_BUTTON, // initial read in the attempt loop
-        MET, // settles to met after one poll
-      ],
-      clock
-    );
+    const { page, waitForTimeout } = createSequencedPage([
+      UNMET_NO_FIX_BUTTON, // initial read in the attempt loop
+      MET, // settles to met after one poll
+    ]);
     const step = createTestableStep();
 
     const result = await attemptToFixRequirements(page, step);
@@ -187,9 +214,7 @@ describe('attemptToFixRequirements - settle window', () => {
   });
 
   it('reports "No Fix button available" when requirements stay unmet for the whole window', async () => {
-    const clock = createFakeClock();
-    jest.spyOn(Date, 'now').mockImplementation(() => clock.now);
-    const { page, waitForTimeout } = createSequencedPage([UNMET_NO_FIX_BUTTON], clock);
+    const { page, waitForTimeout, explanationTextContent } = createSequencedPage([UNMET_NO_FIX_BUTTON]);
     const step = createTestableStep();
 
     const result = await attemptToFixRequirements(page, step);
@@ -198,26 +223,28 @@ describe('attemptToFixRequirements - settle window', () => {
     expect(result.failureReason).toBe('No Fix button available');
     expect(result.totalAttempts).toBe(1);
     expect(result.attempts[0].error).toBe('No Fix button available');
-    // It kept polling for the settle window (driven by the fake clock
-    // advancing with each waitForTimeout call) rather than giving up on
-    // the first sampled state.
-    expect(waitForTimeout.mock.calls.length).toBeGreaterThan(1);
+    // The fake clock only advances via waitForTimeout(), so exactly
+    // REQUIREMENTS_SETTLE_TIMEOUT_MS / REQUIREMENTS_POLL_INTERVAL_MS polls
+    // fit in the settle budget.
+    expect(waitForTimeout.mock.calls.length).toBe(REQUIREMENTS_SETTLE_TIMEOUT_MS / REQUIREMENTS_POLL_INTERVAL_MS);
     for (const call of waitForTimeout.mock.calls) {
       expect(call[0]).toBe(REQUIREMENTS_POLL_INTERVAL_MS);
+    }
+    // The very first read (outside the settle poll) is unbounded; every
+    // read taken during the settle poll is bounded by the remaining budget.
+    const readTimeouts = explanationTextContent.mock.calls.map((call) => call[0]);
+    expect(readTimeouts[0]).toBeUndefined();
+    for (const readOptions of readTimeouts.slice(1)) {
+      expect(readOptions).toEqual({ timeout: expect.any(Number) });
     }
   });
 
   it('settles to met after a Fix click even on the final allowed attempt', async () => {
-    const clock = createFakeClock();
-    jest.spyOn(Date, 'now').mockImplementation(() => clock.now);
-    const { page, waitForTimeout, fixButtonClick } = createSequencedPage(
-      [
-        UNMET_HAS_FIX_BUTTON, // initial read: Fix button present
-        UNMET_NO_FIX_BUTTON, // immediate post-click read: still unmet, no Fix button
-        MET, // settles to met after one poll
-      ],
-      clock
-    );
+    const { page, waitForTimeout, fixButtonClick } = createSequencedPage([
+      UNMET_HAS_FIX_BUTTON, // initial read: Fix button present
+      UNMET_NO_FIX_BUTTON, // immediate post-click read: still unmet, no Fix button
+      MET, // settles to met after one poll
+    ]);
     const step = createTestableStep();
 
     const result = await attemptToFixRequirements(page, step, { maxAttempts: 1 });
@@ -229,5 +256,76 @@ describe('attemptToFixRequirements - settle window', () => {
     // to get there.
     expect(fixButtonClick).toHaveBeenCalledTimes(1);
     expect(waitForTimeout.mock.calls.length).toBe(2);
+  });
+
+  it('preserves fixType when a Fix button reappears during the initial settle poll', async () => {
+    const { page, waitForLoadState } = createSequencedPage([
+      UNMET_NO_FIX_BUTTON, // initial read: no Fix button yet
+      UNMET_HAS_FIX_BUTTON_LOCATION, // settles to a Fix button with a "location" fixType
+      MET,
+    ]);
+    const step = createTestableStep();
+
+    const result = await attemptToFixRequirements(page, step, { maxAttempts: 1 });
+
+    expect(result.success).toBe(true);
+    // Only a "location" fixType triggers a networkidle wait; observing it
+    // proves the settled fixType (not a default) reached clickFixButton.
+    expect(waitForLoadState).toHaveBeenCalledWith('networkidle', expect.anything());
+  });
+
+  it('records finalStatus from the settled post-fix state, across a multi-attempt failing flow', async () => {
+    const { page } = createSequencedPage([
+      UNMET_HAS_FIX_BUTTON, // attempt 1 initial read: Fix button present
+      CHECKING, // attempt 1 immediate post-click read: checking, not settled
+      UNMET_NO_FIX_BUTTON, // attempt 1 settle poll: unmet, no Fix button (repeats until window expires)
+    ]);
+    const step = createTestableStep();
+
+    const result = await attemptToFixRequirements(page, step, { maxAttempts: 2 });
+
+    expect(result.success).toBe(false);
+    expect(result.totalAttempts).toBe(2);
+    expect(result.attempts[0].error).toBe('Requirements still not met after fix');
+    expect(result.attempts[1].error).toBe('No Fix button available');
+    expect(result.failureReason).toBe('No Fix button available');
+    // finalStatus reflects the settled read ('unmet'), not the immediate
+    // post-click read ('checking').
+    expect(result.finalStatus).toBe('unmet');
+  });
+});
+
+describe('detectRequirements - bounded reads', () => {
+  it('treats a bounded isEnabled timeout as disabled instead of throwing', async () => {
+    const doItLocator: Pick<Locator, 'count' | 'isEnabled'> = {
+      count: jest.fn().mockResolvedValue(1),
+      isEnabled: jest.fn().mockImplementation((options?: { timeout?: number }) => {
+        if (options?.timeout !== undefined) {
+          return Promise.reject(new Error(`Locator.isEnabled: Timeout ${options.timeout}ms exceeded.`));
+        }
+        return Promise.resolve(true);
+      }),
+    };
+    const zeroCountLocator = { count: jest.fn().mockResolvedValue(0) };
+    const locatorsByTestId = new Map<string, unknown>([
+      [testIds.interactive.doItButton(STEP_ID), doItLocator],
+      [testIds.interactive.showMeButton(STEP_ID), zeroCountLocator],
+      [testIds.interactive.requirementCheck(STEP_ID), zeroCountLocator],
+      [testIds.interactive.requirementFixButton(STEP_ID), zeroCountLocator],
+      [testIds.interactive.requirementRetryButton(STEP_ID), zeroCountLocator],
+      [testIds.interactive.requirementSkipButton(STEP_ID), zeroCountLocator],
+    ]);
+    const page = {
+      getByTestId: jest.fn().mockImplementation((testId: string) => locatorsByTestId.get(testId)),
+    } as unknown as Page;
+    const step = createTestableStep();
+
+    const result = await detectRequirements(page, step, 50);
+
+    // A present-but-unreadable "Do it" button, with no other signal, reads
+    // as an inconclusive unmet state rather than throwing.
+    expect(result.requirementsMet).toBe(false);
+    expect(result.status).toBe('unknown');
+    expect(doItLocator.isEnabled).toHaveBeenCalledWith({ timeout: 50 });
   });
 });

--- a/tests/e2e-runner/utils/guide-runner/requirements.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/requirements.test.ts
@@ -1,9 +1,10 @@
 /**
  * Unit tests for guide-runner requirements handling.
  *
- * Covers the settle-window behavior in attemptToFixRequirements: when a fix
- * attempt finds no Fix button, the runner polls briefly for the DOM to
- * settle before it reports a terminal failure.
+ * Covers the settle-window behavior in attemptToFixRequirements: an unmet
+ * read (with or without a Fix button) gets a short poll to settle before
+ * the runner reports a terminal failure, both on the initial read of an
+ * attempt and on the read taken right after a Fix button click.
  */
 
 jest.mock('@playwright/test', () => ({
@@ -19,6 +20,10 @@ import { testIds } from '../../../../src/constants/testIds';
 import { REQUIREMENTS_POLL_INTERVAL_MS } from './constants';
 import { attemptToFixRequirements } from './requirements';
 import type { TestableStep } from './types';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 // ============================================
 // Test Fixtures
@@ -56,11 +61,26 @@ interface DomState {
 }
 
 /**
+ * A fake clock that only advances when page.waitForTimeout() is called,
+ * so elapsed time in the code under test matches the waits it actually
+ * requested instead of drifting with incidental Date.now() calls.
+ *
+ * Tests that rely on the settle window expiring, or on a known elapsed
+ * amount, must also run `jest.spyOn(Date, 'now').mockImplementation(() => clock.now)`.
+ */
+function createFakeClock() {
+  return { now: 0 };
+}
+
+/**
  * Build a mock Page whose getByTestId() responses advance through a
  * sequence of DOM states, one state per detectRequirements() call.
  * The last state repeats for any calls beyond the sequence length.
  */
-function createSequencedPage(states: DomState[]): { page: Page; waitForTimeout: jest.Mock } {
+function createSequencedPage(
+  states: DomState[],
+  clock: { now: number } = createFakeClock()
+): { page: Page; waitForTimeout: jest.Mock; fixButtonClick: jest.Mock } {
   let callIndex = -1;
   const currentState = () => states[Math.min(callIndex, states.length - 1)];
   const countFor = (pick: (state: DomState) => boolean) =>
@@ -105,11 +125,14 @@ function createSequencedPage(states: DomState[]): { page: Page; waitForTimeout: 
     }
     return locator;
   });
-  const waitForTimeout = jest.fn().mockResolvedValue(undefined);
+  const waitForTimeout = jest.fn().mockImplementation((ms: number) => {
+    clock.now += ms;
+    return Promise.resolve(undefined);
+  });
 
   const page = { getByTestId, waitForTimeout } as unknown as Page;
 
-  return { page, waitForTimeout };
+  return { page, waitForTimeout, fixButtonClick: fixLocator.click };
 }
 
 const UNMET_NO_FIX_BUTTON: DomState = {
@@ -117,6 +140,15 @@ const UNMET_NO_FIX_BUTTON: DomState = {
   hasExplanation: true,
   explanationText: 'Checking your setup',
   hasFixButton: false,
+  hasRetryButton: false,
+  hasSkipButton: false,
+};
+
+const UNMET_HAS_FIX_BUTTON: DomState = {
+  doItEnabled: false,
+  hasExplanation: true,
+  explanationText: 'Fix available',
+  hasFixButton: true,
   hasRetryButton: false,
   hasSkipButton: false,
 };
@@ -129,13 +161,17 @@ const MET: DomState = {
   hasSkipButton: false,
 };
 
-describe('attemptToFixRequirements - no Fix button settle window', () => {
-  it('reports success when requirements settle to met during the settle window', async () => {
-    const { page, waitForTimeout } = createSequencedPage([
-      UNMET_NO_FIX_BUTTON, // initial read in the attempt loop
-      UNMET_NO_FIX_BUTTON, // initial read inside the settle poll
-      MET, // settles to met after one poll
-    ]);
+describe('attemptToFixRequirements - settle window', () => {
+  it('reports success when requirements settle to met before a Fix button ever appears', async () => {
+    const clock = createFakeClock();
+    jest.spyOn(Date, 'now').mockImplementation(() => clock.now);
+    const { page, waitForTimeout } = createSequencedPage(
+      [
+        UNMET_NO_FIX_BUTTON, // initial read in the attempt loop
+        MET, // settles to met after one poll
+      ],
+      clock
+    );
     const step = createTestableStep();
 
     const result = await attemptToFixRequirements(page, step);
@@ -151,28 +187,47 @@ describe('attemptToFixRequirements - no Fix button settle window', () => {
   });
 
   it('reports "No Fix button available" when requirements stay unmet for the whole window', async () => {
-    const dateNowSpy = jest.spyOn(Date, 'now');
-    let simulatedNow = 0;
-    dateNowSpy.mockImplementation(() => {
-      simulatedNow += 300;
-      return simulatedNow;
-    });
+    const clock = createFakeClock();
+    jest.spyOn(Date, 'now').mockImplementation(() => clock.now);
+    const { page, waitForTimeout } = createSequencedPage([UNMET_NO_FIX_BUTTON], clock);
+    const step = createTestableStep();
 
-    try {
-      const { page, waitForTimeout } = createSequencedPage([UNMET_NO_FIX_BUTTON]);
-      const step = createTestableStep();
+    const result = await attemptToFixRequirements(page, step);
 
-      const result = await attemptToFixRequirements(page, step);
-
-      expect(result.success).toBe(false);
-      expect(result.failureReason).toBe('No Fix button available');
-      expect(result.totalAttempts).toBe(1);
-      expect(result.attempts[0].error).toBe('No Fix button available');
-      // It kept polling for the settle window rather than giving up on the
-      // first sampled state.
-      expect(waitForTimeout.mock.calls.length).toBeGreaterThan(1);
-    } finally {
-      dateNowSpy.mockRestore();
+    expect(result.success).toBe(false);
+    expect(result.failureReason).toBe('No Fix button available');
+    expect(result.totalAttempts).toBe(1);
+    expect(result.attempts[0].error).toBe('No Fix button available');
+    // It kept polling for the settle window (driven by the fake clock
+    // advancing with each waitForTimeout call) rather than giving up on
+    // the first sampled state.
+    expect(waitForTimeout.mock.calls.length).toBeGreaterThan(1);
+    for (const call of waitForTimeout.mock.calls) {
+      expect(call[0]).toBe(REQUIREMENTS_POLL_INTERVAL_MS);
     }
+  });
+
+  it('settles to met after a Fix click even on the final allowed attempt', async () => {
+    const clock = createFakeClock();
+    jest.spyOn(Date, 'now').mockImplementation(() => clock.now);
+    const { page, waitForTimeout, fixButtonClick } = createSequencedPage(
+      [
+        UNMET_HAS_FIX_BUTTON, // initial read: Fix button present
+        UNMET_NO_FIX_BUTTON, // immediate post-click read: still unmet, no Fix button
+        MET, // settles to met after one poll
+      ],
+      clock
+    );
+    const step = createTestableStep();
+
+    const result = await attemptToFixRequirements(page, step, { maxAttempts: 1 });
+
+    expect(result.success).toBe(true);
+    expect(result.finalStatus).toBe('met');
+    expect(result.totalAttempts).toBe(1);
+    // The settle poll re-detected requirements; it did not click Fix again
+    // to get there.
+    expect(fixButtonClick).toHaveBeenCalledTimes(1);
+    expect(waitForTimeout.mock.calls.length).toBe(2);
   });
 });

--- a/tests/e2e-runner/utils/guide-runner/requirements.ts
+++ b/tests/e2e-runner/utils/guide-runner/requirements.ts
@@ -7,13 +7,14 @@
  * @see docs/developer/E2E_TESTING.md#requirements-and-skip-behavior
  */
 
-import { Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 import { testIds } from '../../../../src/constants/testIds';
 import { isSessionValid } from '../../auth/grafana-auth';
 import {
   REQUIREMENTS_CHECK_TIMEOUT_MS,
   REQUIREMENTS_POLL_INTERVAL_MS,
+  REQUIREMENTS_SETTLE_TIMEOUT_MS,
   FIX_BUTTON_TIMEOUT_MS,
   MAX_FIX_ATTEMPTS,
   POST_FIX_SETTLE_DELAY_MS,
@@ -76,9 +77,15 @@ export async function validateSession(page: Page): Promise<boolean> {
  *
  * @param page - Playwright Page object
  * @param step - The testable step to check
+ * @param timeoutMs - Optional per-read timeout, used by the settle poll to keep
+ * a detached or slow-to-settle element from hanging past its settle budget
  * @returns RequirementResult with detected requirements information
  */
-export async function detectRequirements(page: Page, step: TestableStep): Promise<RequirementResult> {
+export async function detectRequirements(
+  page: Page,
+  step: TestableStep,
+  timeoutMs?: number
+): Promise<RequirementResult> {
   const { stepId, skippable } = step;
 
   // Check if step is pre-completed - if so, requirements are implicitly met
@@ -94,12 +101,14 @@ export async function detectRequirements(page: Page, step: TestableStep): Promis
     };
   }
 
+  const readOptions = timeoutMs !== undefined ? { timeout: timeoutMs } : undefined;
+
   const doItButton = page.getByTestId(testIds.interactive.doItButton(stepId));
   const doItButtonCount = await doItButton.count();
-  const doItButtonEnabled = doItButtonCount > 0 ? await doItButton.isEnabled() : false;
+  const doItButtonEnabled = doItButtonCount > 0 ? await readEnabledSafely(doItButton, readOptions) : false;
   const showMeButton = page.getByTestId(testIds.interactive.showMeButton(stepId));
   const showMeButtonCount = await showMeButton.count();
-  const showMeButtonEnabled = showMeButtonCount > 0 ? await showMeButton.isEnabled() : false;
+  const showMeButtonEnabled = showMeButtonCount > 0 ? await readEnabledSafely(showMeButton, readOptions) : false;
   const actionButtonCount = doItButtonCount + showMeButtonCount;
   const actionButtonEnabled = doItButtonEnabled || showMeButtonEnabled;
 
@@ -119,7 +128,7 @@ export async function detectRequirements(page: Page, step: TestableStep): Promis
   let explanationText: string | undefined;
   if (hasExplanation && !isChecking) {
     try {
-      explanationText = await explanationElement.textContent().then((t) => t?.trim());
+      explanationText = await explanationElement.textContent(readOptions).then((t) => t?.trim());
       // Remove button text from explanation (Fix this, Retry, Skip)
       explanationText = explanationText
         ?.replace(/Fix this$/, '')
@@ -147,7 +156,7 @@ export async function detectRequirements(page: Page, step: TestableStep): Promis
   // Determine fix type from DOM if fix button exists
   let fixType: RequirementFixType | undefined;
   if (hasFixButton) {
-    fixType = await detectFixType(page, step);
+    fixType = await detectFixType(page, step, timeoutMs);
   }
 
   // Determine requirement status
@@ -187,6 +196,26 @@ export async function detectRequirements(page: Page, step: TestableStep): Promis
 }
 
 /**
+ * Read a locator's enabled state without letting a detached or
+ * slow-to-settle element hang or throw (L3-4A).
+ *
+ * Used by the settle poll, where reads are intentionally bounded by the
+ * remaining settle budget: a timeout here means the element is mid-transition,
+ * not that the caller should propagate an error.
+ *
+ * @param locator - The locator to read
+ * @param options - Optional timeout to bound the read
+ * @returns The enabled state, or false if the read could not complete
+ */
+async function readEnabledSafely(locator: Locator, options?: { timeout: number }): Promise<boolean> {
+  try {
+    return await locator.isEnabled(options);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Detect the fix type available for a step (L3-4A).
  *
  * Fix types are determined by the requirement that failed:
@@ -200,16 +229,22 @@ export async function detectRequirements(page: Page, step: TestableStep): Promis
  *
  * @param page - Playwright Page object
  * @param step - The testable step to check
+ * @param timeoutMs - Optional per-read timeout, forwarded from detectRequirements
  * @returns The detected fix type, or undefined if cannot be determined
  */
-async function detectFixType(page: Page, step: TestableStep): Promise<RequirementFixType | undefined> {
+async function detectFixType(
+  page: Page,
+  step: TestableStep,
+  timeoutMs?: number
+): Promise<RequirementFixType | undefined> {
   const { stepId, targetAction, refTarget } = step;
 
   // Get explanation text for clues about the fix type
   const explanationElement = page.getByTestId(testIds.interactive.requirementCheck(stepId));
+  const readOptions = timeoutMs !== undefined ? { timeout: timeoutMs } : undefined;
   let explanationText = '';
   try {
-    explanationText = (await explanationElement.textContent()) || '';
+    explanationText = (await explanationElement.textContent(readOptions)) || '';
   } catch {
     // Ignore errors
   }
@@ -376,18 +411,6 @@ function logRequirementResult(stepId: string, result: RequirementResult): void {
 // ============================================
 
 /**
- * Maximum time to poll for a settled requirements state before concluding
- * an unmet read is genuinely terminal, rather than a transient DOM state.
- *
- * The plugin's requirement check can be mid-transition right after the
- * initial check or right after a fix button click: a step can read as
- * unmet (with or without a Fix button) even though it settles to met
- * moments later. Polling here avoids reporting that transient read as a
- * terminal failure.
- */
-const REQUIREMENTS_SETTLE_TIMEOUT_MS = 1000;
-
-/**
  * Click the Fix button for a step and wait for the fix action to complete (L3-4B).
  *
  * This function:
@@ -455,13 +478,15 @@ export async function clickFixButton(
 /**
  * Poll briefly for a settled requirements state starting from an unmet read (L3-4B).
  *
- * Repeatedly re-detects requirements until they become met, a Fix button
- * appears, or `settleTimeoutMs` elapses. Returns the last observed result,
- * so callers can tell a genuinely unfixable state from a transient one.
+ * A visible Fix button is itself an actionable settled state, so the loop
+ * only keeps waiting while the state is unmet with no Fix button; it
+ * returns as soon as either becomes true, or `settleTimeoutMs` elapses.
+ * Callers pass in the unmet result they already read, so an already-settled
+ * state returns immediately without an extra detection round-trip.
  *
- * Callers pass in the unmet result they already read, so a settled state
- * (already met, or already showing a Fix button) returns immediately
- * without an extra detection round-trip.
+ * Each re-detection is bounded by the settle budget remaining, so a
+ * detached element mid-transition fails fast instead of hanging past the
+ * settle window.
  *
  * @param page - Playwright Page object
  * @param step - The testable step to check
@@ -478,9 +503,20 @@ async function waitForRequirementsSettle(
   const startTime = Date.now();
   let latest = initial;
 
-  while (!latest.requirementsMet && !latest.hasFixButton && Date.now() - startTime < settleTimeoutMs) {
-    await page.waitForTimeout(REQUIREMENTS_POLL_INTERVAL_MS);
-    latest = await detectRequirements(page, step);
+  while (!latest.requirementsMet && !latest.hasFixButton) {
+    const remainingBeforeWait = settleTimeoutMs - (Date.now() - startTime);
+    if (remainingBeforeWait <= 0) {
+      break;
+    }
+
+    await page.waitForTimeout(Math.min(REQUIREMENTS_POLL_INTERVAL_MS, remainingBeforeWait));
+
+    const remainingForRead = settleTimeoutMs - (Date.now() - startTime);
+    if (remainingForRead <= 0) {
+      break;
+    }
+
+    latest = await detectRequirements(page, step, remainingForRead);
   }
 
   return latest;
@@ -552,9 +588,6 @@ export async function attemptToFixRequirements(
       break;
     }
 
-    // Check if fix button is available. A missing Fix button can be a
-    // transient DOM read right after a check, so poll briefly for it to
-    // settle before treating this as a terminal failure.
     if (!currentRequirements.hasFixButton) {
       const settledRequirements = await waitForRequirementsSettle(page, step, currentRequirements);
 
@@ -588,8 +621,6 @@ export async function attemptToFixRequirements(
         break;
       }
 
-      // A Fix button appeared during the settle window; use the settled
-      // result (including its fixType) for the click below.
       currentRequirements = settledRequirements;
     }
 
@@ -610,9 +641,6 @@ export async function attemptToFixRequirements(
       continue; // Try again
     }
 
-    // Recheck requirements after fix. A click can leave the DOM mid-transition,
-    // so poll briefly for it to settle before recording this attempt as failed -
-    // without clicking Fix again or consuming another attempt to do so.
     const postFixRequirements = await detectRequirements(page, step);
     const settledPostFixRequirements = postFixRequirements.requirementsMet
       ? postFixRequirements
@@ -644,7 +672,6 @@ export async function attemptToFixRequirements(
         requirementsMet: false,
       });
 
-      // Update final status from the settled post-fix check
       finalStatus = settledPostFixRequirements.status;
     }
   }

--- a/tests/e2e-runner/utils/guide-runner/requirements.ts
+++ b/tests/e2e-runner/utils/guide-runner/requirements.ts
@@ -376,6 +376,17 @@ function logRequirementResult(stepId: string, result: RequirementResult): void {
 // ============================================
 
 /**
+ * Maximum time to poll for a settled requirements state after a fix attempt
+ * finds no Fix button, before concluding the step is genuinely unfixable.
+ *
+ * The plugin's requirement check can be mid-transition right after a fix
+ * attempt (or the initial check): the Fix button is briefly absent even
+ * though the step settles to met/idle moments later. Polling here avoids
+ * reporting a transient DOM read as a terminal failure.
+ */
+const NO_FIX_BUTTON_SETTLE_TIMEOUT_MS = 1000;
+
+/**
  * Click the Fix button for a step and wait for the fix action to complete (L3-4B).
  *
  * This function:
@@ -441,6 +452,34 @@ export async function clickFixButton(
 }
 
 /**
+ * Poll briefly for a settled requirements state when no Fix button is present (L3-4B).
+ *
+ * Repeatedly re-detects requirements until they become met, a Fix button
+ * appears, or `settleTimeoutMs` elapses. Returns the last observed result,
+ * so callers can tell a genuinely unfixable state from a transient one.
+ *
+ * @param page - Playwright Page object
+ * @param step - The testable step to check
+ * @param settleTimeoutMs - Maximum time to poll for a settled state
+ * @returns The last observed RequirementResult
+ */
+async function waitForNoFixButtonSettle(
+  page: Page,
+  step: TestableStep,
+  settleTimeoutMs = NO_FIX_BUTTON_SETTLE_TIMEOUT_MS
+): Promise<RequirementResult> {
+  const startTime = Date.now();
+  let latest = await detectRequirements(page, step);
+
+  while (!latest.requirementsMet && !latest.hasFixButton && Date.now() - startTime < settleTimeoutMs) {
+    await page.waitForTimeout(REQUIREMENTS_POLL_INTERVAL_MS);
+    latest = await detectRequirements(page, step);
+  }
+
+  return latest;
+}
+
+/**
  * Attempt to fix requirements for a step with retry logic (L3-4B).
  *
  * This function implements the fix button retry mechanism:
@@ -488,7 +527,7 @@ export async function attemptToFixRequirements(
     }
 
     // First, detect current requirements to get fix type
-    const currentRequirements = await detectRequirements(page, step);
+    let currentRequirements = await detectRequirements(page, step);
 
     // If requirements are already met, we're done
     if (currentRequirements.requirementsMet) {
@@ -506,20 +545,45 @@ export async function attemptToFixRequirements(
       break;
     }
 
-    // Check if fix button is available
+    // Check if fix button is available. A missing Fix button can be a
+    // transient DOM read right after a check, so poll briefly for it to
+    // settle before treating this as a terminal failure.
     if (!currentRequirements.hasFixButton) {
-      if (verbose) {
-        console.log(`   ✗ No Fix button available - cannot fix requirements`);
+      const settledRequirements = await waitForNoFixButtonSettle(page, step);
+
+      if (settledRequirements.requirementsMet) {
+        if (verbose) {
+          console.log(`   ✓ Requirements settled to met`);
+        }
+        success = true;
+        finalStatus = 'met';
+        attempts.push({
+          success: true,
+          attemptNumber,
+          durationMs: Date.now() - attemptStartTime,
+          requirementsMet: true,
+        });
+        break;
       }
-      failureReason = 'No Fix button available';
-      attempts.push({
-        success: false,
-        attemptNumber,
-        durationMs: Date.now() - attemptStartTime,
-        error: 'No Fix button available',
-        requirementsMet: false,
-      });
-      break;
+
+      if (!settledRequirements.hasFixButton) {
+        if (verbose) {
+          console.log(`   ✗ No Fix button available - cannot fix requirements`);
+        }
+        failureReason = 'No Fix button available';
+        attempts.push({
+          success: false,
+          attemptNumber,
+          durationMs: Date.now() - attemptStartTime,
+          error: 'No Fix button available',
+          requirementsMet: false,
+        });
+        break;
+      }
+
+      // A Fix button appeared during the settle window; use the settled
+      // result (including its fixType) for the click below.
+      currentRequirements = settledRequirements;
     }
 
     // Click the fix button

--- a/tests/e2e-runner/utils/guide-runner/requirements.ts
+++ b/tests/e2e-runner/utils/guide-runner/requirements.ts
@@ -376,15 +376,16 @@ function logRequirementResult(stepId: string, result: RequirementResult): void {
 // ============================================
 
 /**
- * Maximum time to poll for a settled requirements state after a fix attempt
- * finds no Fix button, before concluding the step is genuinely unfixable.
+ * Maximum time to poll for a settled requirements state before concluding
+ * an unmet read is genuinely terminal, rather than a transient DOM state.
  *
- * The plugin's requirement check can be mid-transition right after a fix
- * attempt (or the initial check): the Fix button is briefly absent even
- * though the step settles to met/idle moments later. Polling here avoids
- * reporting a transient DOM read as a terminal failure.
+ * The plugin's requirement check can be mid-transition right after the
+ * initial check or right after a fix button click: a step can read as
+ * unmet (with or without a Fix button) even though it settles to met
+ * moments later. Polling here avoids reporting that transient read as a
+ * terminal failure.
  */
-const NO_FIX_BUTTON_SETTLE_TIMEOUT_MS = 1000;
+const REQUIREMENTS_SETTLE_TIMEOUT_MS = 1000;
 
 /**
  * Click the Fix button for a step and wait for the fix action to complete (L3-4B).
@@ -452,24 +453,30 @@ export async function clickFixButton(
 }
 
 /**
- * Poll briefly for a settled requirements state when no Fix button is present (L3-4B).
+ * Poll briefly for a settled requirements state starting from an unmet read (L3-4B).
  *
  * Repeatedly re-detects requirements until they become met, a Fix button
  * appears, or `settleTimeoutMs` elapses. Returns the last observed result,
  * so callers can tell a genuinely unfixable state from a transient one.
  *
+ * Callers pass in the unmet result they already read, so a settled state
+ * (already met, or already showing a Fix button) returns immediately
+ * without an extra detection round-trip.
+ *
  * @param page - Playwright Page object
  * @param step - The testable step to check
+ * @param initial - The unmet RequirementResult observed just before this call
  * @param settleTimeoutMs - Maximum time to poll for a settled state
  * @returns The last observed RequirementResult
  */
-async function waitForNoFixButtonSettle(
+async function waitForRequirementsSettle(
   page: Page,
   step: TestableStep,
-  settleTimeoutMs = NO_FIX_BUTTON_SETTLE_TIMEOUT_MS
+  initial: RequirementResult,
+  settleTimeoutMs = REQUIREMENTS_SETTLE_TIMEOUT_MS
 ): Promise<RequirementResult> {
   const startTime = Date.now();
-  let latest = await detectRequirements(page, step);
+  let latest = initial;
 
   while (!latest.requirementsMet && !latest.hasFixButton && Date.now() - startTime < settleTimeoutMs) {
     await page.waitForTimeout(REQUIREMENTS_POLL_INTERVAL_MS);
@@ -549,7 +556,7 @@ export async function attemptToFixRequirements(
     // transient DOM read right after a check, so poll briefly for it to
     // settle before treating this as a terminal failure.
     if (!currentRequirements.hasFixButton) {
-      const settledRequirements = await waitForNoFixButtonSettle(page, step);
+      const settledRequirements = await waitForRequirementsSettle(page, step, currentRequirements);
 
       if (settledRequirements.requirementsMet) {
         if (verbose) {
@@ -603,10 +610,15 @@ export async function attemptToFixRequirements(
       continue; // Try again
     }
 
-    // Recheck requirements after fix
+    // Recheck requirements after fix. A click can leave the DOM mid-transition,
+    // so poll briefly for it to settle before recording this attempt as failed -
+    // without clicking Fix again or consuming another attempt to do so.
     const postFixRequirements = await detectRequirements(page, step);
+    const settledPostFixRequirements = postFixRequirements.requirementsMet
+      ? postFixRequirements
+      : await waitForRequirementsSettle(page, step, postFixRequirements);
 
-    if (postFixRequirements.requirementsMet) {
+    if (settledPostFixRequirements.requirementsMet) {
       if (verbose) {
         console.log(`   ✓ Fix successful - requirements now met`);
       }
@@ -632,8 +644,8 @@ export async function attemptToFixRequirements(
         requirementsMet: false,
       });
 
-      // Update final status from post-fix check
-      finalStatus = postFixRequirements.status;
+      // Update final status from the settled post-fix check
+      finalStatus = settledPostFixRequirements.status;
     }
   }
 


### PR DESCRIPTION
## Summary

Prevents the E2E runner from reporting “No Fix button available” from a transient requirement state. After a Fix action, the runner now polls briefly for requirements to become met or for the Fix control to return before it declares a terminal failure.

## How to verify

1. Run `adaptive-metrics-rules-exemptions` against a clean cloud stack.
2. Trigger the navigation requirement for the “Add new rule” step.
3. Confirm the runner continues when the requirement becomes met during the settle window.
4. Confirm a genuinely unmet requirement with no Fix control still fails after the bounded wait.

## Breaking changes

None. The change adds a bounded settle period without changing the existing retry count.

