### PR TITLE
fix(e2e): dismiss badge celebrations before actions

### DIFF
--- a/docs/developer/E2E_TESTING_CONTRACT.md
+++ b/docs/developer/E2E_TESTING_CONTRACT.md
@@ -68,6 +68,23 @@ A My learning layout or selector refactor must preserve these values or update t
 
 ---
 
+## Badge celebration runner contract
+
+After a guide completes, Pathfinder can show a full-screen badge celebration before the runner starts the next action.
+
+The runner and plugin share these stable test IDs:
+
+- **`learning-paths-badge-toast`** (`testIds.learningPaths.badgeToast`): identifies the visible badge dialog.
+- **`learning-paths-badge-toast-dismiss`** (`testIds.learningPaths.badgeToastDismiss`): identifies the dismiss action inside the current dialog.
+
+The runner uses only these selectors. It does not close generic Grafana modals.
+
+If a refactor changes these values, update `BadgeUnlockedToast.tsx`, the guide runner, the contract test, and this document in the same change.
+
+The source-level tripwire lives in `src/components/LearningPaths/BadgeUnlockedToast.contract.test.ts`.
+
+---
+
 ## Design Principles
 
 ### 1. Semantic Over Syntactic
@@ -420,6 +437,7 @@ Contract tests enforce the stability of E2E attributes at build time, preventing
 - `src/components/interactive-tutorial/data-attributes.contract.test.tsx` - React component attributes
 - `src/interactive-engine/comment-box.contract.test.ts` - DOM-created element attributes
 - `src/components/docs-panel/docs-panel.contract.test.tsx` - Docs panel test IDs (constant values, source reference mapping, auto-derived exhaustiveness, window globals, scroll-restoration)
+- `src/components/LearningPaths/BadgeUnlockedToast.contract.test.ts` - Badge celebration test IDs and source references
 
 ### Pattern: Dual Assertion
 

--- a/src/components/LearningPaths/BadgeUnlockedToast.contract.test.ts
+++ b/src/components/LearningPaths/BadgeUnlockedToast.contract.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { testIds } from '../../constants/testIds';
+
+const source = readFileSync(join(__dirname, 'BadgeUnlockedToast.tsx'), 'utf-8');
+
+describe('Badge unlocked toast E2E contract', () => {
+  it('keeps the guide-runner test IDs stable', () => {
+    expect(testIds.learningPaths.badgeToast).toBe('learning-paths-badge-toast');
+    expect(testIds.learningPaths.badgeToastDismiss).toBe('learning-paths-badge-toast-dismiss');
+  });
+
+  it('uses both guide-runner test IDs in the component source', () => {
+    expect(source).toContain('data-testid={testIds.learningPaths.badgeToast}');
+    expect(source).toContain('data-testid={testIds.learningPaths.badgeToastDismiss}');
+  });
+});

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
@@ -18,6 +18,11 @@ interface BadgeHarnessOptions {
   remainsVisible?: boolean;
   initialDelayMs?: number;
   interToastDelayMs?: number;
+  textReadFailure?: {
+    call: number;
+    mode: 'disappear' | 'visible';
+    error: Error;
+  };
 }
 
 function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {}) {
@@ -26,6 +31,7 @@ function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {})
   let nextIndex = currentIndex === 0 ? 1 : 0;
   let nextVisibleAt =
     currentIndex === -1 && titles.length > 0 ? (options.initialDelayMs ?? 0) : Number.POSITIVE_INFINITY;
+  let textReadCount = 0;
   const events: string[] = [];
   const toast = {} as Locator;
   const dismissButton = {} as Locator;
@@ -44,9 +50,19 @@ function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {})
   toast.first = jest.fn(() => toast);
   toast.count = jest.fn(async () => (currentIndex >= 0 ? 1 : 0));
   toast.isVisible = jest.fn(async () => currentIndex >= 0);
-  toast.textContent = jest.fn(async () => {
+  toast.textContent = jest.fn(async (textOptions?: { timeout?: number }) => {
     if (currentIndex < 0) {
       return null;
+    }
+    textReadCount++;
+    if (options.textReadFailure?.call === textReadCount) {
+      elapsedMs += textOptions?.timeout ?? 0;
+      if (options.textReadFailure.mode === 'disappear') {
+        currentIndex = -1;
+        nextVisibleAt =
+          nextIndex < titles.length ? elapsedMs + (options.interToastDelayMs ?? 0) : Number.POSITIVE_INFINITY;
+      }
+      throw options.textReadFailure.error;
     }
     const queueCount = titles.length - nextIndex;
     const queueText = queueCount > 0 ? ` (+${queueCount} more)` : '';
@@ -82,9 +98,18 @@ function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {})
     page,
     events,
     dismissClick: dismissButton.click as jest.Mock,
+    textContent: toast.textContent as jest.Mock,
     waitForTimeout,
     getElapsedMs: () => elapsedMs,
   };
+}
+
+function expectBoundedTextReads(textContent: jest.Mock): void {
+  expect(textContent).toHaveBeenCalled();
+  for (const [options] of textContent.mock.calls) {
+    expect(options.timeout).toBeGreaterThan(0);
+    expect(options.timeout).toBeLessThanOrEqual(1000);
+  }
 }
 
 describe('dismissBadgeCelebrations', () => {
@@ -153,6 +178,63 @@ describe('dismissBadgeCelebrations', () => {
     await expect(dismissBadgeCelebrations(page)).rejects.toThrow(
       'Badge celebration dismissal failed on attempt 1 of 3: Dismiss button was detached'
     );
+  });
+
+  it('does not click a stale dismiss control when the initial toast disappears during its text read', async () => {
+    const { page, dismissClick, textContent, getElapsedMs } = createBadgeHarness(['First badge'], {
+      textReadFailure: {
+        call: 1,
+        mode: 'disappear',
+        error: new Error('Text read timed out'),
+      },
+    });
+    const dateNow = jest.spyOn(Date, 'now').mockImplementation(getElapsedMs);
+
+    try {
+      await expect(dismissBadgeCelebrations(page)).resolves.toBeUndefined();
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(dismissClick).not.toHaveBeenCalled();
+    expectBoundedTextReads(textContent);
+  });
+
+  it('accepts a queued toast that disappears during its bounded transition text read', async () => {
+    const { page, dismissClick, textContent, getElapsedMs } = createBadgeHarness(['First badge', 'Second badge'], {
+      textReadFailure: {
+        call: 2,
+        mode: 'disappear',
+        error: new Error('Transition text read timed out'),
+      },
+    });
+    const dateNow = jest.spyOn(Date, 'now').mockImplementation(getElapsedMs);
+
+    try {
+      await expect(dismissBadgeCelebrations(page)).resolves.toBeUndefined();
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(dismissClick).toHaveBeenCalledTimes(1);
+    expectBoundedTextReads(textContent);
+  });
+
+  it('reports a bounded text-read error when the toast remains visible', async () => {
+    const { page, dismissClick, textContent } = createBadgeHarness(['First badge'], {
+      textReadFailure: {
+        call: 1,
+        mode: 'visible',
+        error: new Error('Text read timed out'),
+      },
+    });
+
+    await expect(dismissBadgeCelebrations(page)).rejects.toThrow(
+      'Badge celebration text read before attempt 1 of 3 failed within 1000ms while the toast remained visible: Text read timed out'
+    );
+
+    expect(dismissClick).not.toHaveBeenCalled();
+    expectBoundedTextReads(textContent);
   });
 
   it('dismisses the toast before a requirement Fix click', async () => {

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
@@ -80,6 +80,7 @@ function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {})
         nextIndex < titles.length ? elapsedMs + (options.interToastDelayMs ?? 0) : Number.POSITIVE_INFINITY;
     }
   });
+  dismissButton.first = jest.fn(() => dismissButton);
 
   const page = {
     getByTestId: jest.fn((testId: string) => {

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
@@ -9,30 +9,46 @@ jest.mock('@playwright/test', () => ({
 
 import { testIds } from '../../../../src/constants/testIds';
 import { dismissBadgeCelebrations } from './badge-celebrations';
-import { runGuidedSubstepLoop } from './execution';
+import { runGuidedSubstepLoop, waitForFormfillSettle } from './execution';
 import { clickFixButton } from './requirements';
 import type { TestableStep } from './types';
 
 interface BadgeHarnessOptions {
   clickError?: Error;
   remainsVisible?: boolean;
+  initialDelayMs?: number;
+  interToastDelayMs?: number;
 }
 
 function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {}) {
-  let currentIndex = 0;
+  let elapsedMs = 0;
+  let currentIndex = titles.length > 0 && (options.initialDelayMs ?? 0) === 0 ? 0 : -1;
+  let nextIndex = currentIndex === 0 ? 1 : 0;
+  let nextVisibleAt =
+    currentIndex === -1 && titles.length > 0 ? (options.initialDelayMs ?? 0) : Number.POSITIVE_INFINITY;
   const events: string[] = [];
   const toast = {} as Locator;
   const dismissButton = {} as Locator;
-  const waitForTimeout = jest.fn().mockResolvedValue(undefined);
+  const revealDueToast = () => {
+    if (currentIndex === -1 && nextIndex < titles.length && elapsedMs >= nextVisibleAt) {
+      currentIndex = nextIndex;
+      nextIndex++;
+      nextVisibleAt = Number.POSITIVE_INFINITY;
+    }
+  };
+  const waitForTimeout = jest.fn(async (timeoutMs: number) => {
+    elapsedMs += timeoutMs;
+    revealDueToast();
+  });
 
   toast.first = jest.fn(() => toast);
-  toast.count = jest.fn(async () => (currentIndex < titles.length ? 1 : 0));
-  toast.isVisible = jest.fn(async () => currentIndex < titles.length);
+  toast.count = jest.fn(async () => (currentIndex >= 0 ? 1 : 0));
+  toast.isVisible = jest.fn(async () => currentIndex >= 0);
   toast.textContent = jest.fn(async () => {
-    if (currentIndex >= titles.length) {
+    if (currentIndex < 0) {
       return null;
     }
-    const queueCount = titles.length - currentIndex - 1;
+    const queueCount = titles.length - nextIndex;
     const queueText = queueCount > 0 ? ` (+${queueCount} more)` : '';
     return `Badge unlocked!${queueText} ${titles[currentIndex]} Nice!`;
   });
@@ -43,7 +59,9 @@ function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {})
       throw options.clickError;
     }
     if (!options.remainsVisible) {
-      currentIndex++;
+      currentIndex = -1;
+      nextVisibleAt =
+        nextIndex < titles.length ? elapsedMs + (options.interToastDelayMs ?? 0) : Number.POSITIVE_INFINITY;
     }
   });
 
@@ -65,17 +83,28 @@ function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {})
     events,
     dismissClick: dismissButton.click as jest.Mock,
     waitForTimeout,
+    getElapsedMs: () => elapsedMs,
   };
 }
 
 describe('dismissBadgeCelebrations', () => {
-  it('returns without waiting when no toast is present', async () => {
+  it('returns after a bounded idle check when no toast is present', async () => {
     const { page, dismissClick, waitForTimeout } = createBadgeHarness([]);
 
     await dismissBadgeCelebrations(page);
 
     expect(dismissClick).not.toHaveBeenCalled();
-    expect(waitForTimeout).not.toHaveBeenCalled();
+    expect(waitForTimeout).toHaveBeenCalledTimes(4);
+  });
+
+  it('waits for a delayed first toast', async () => {
+    const { page, dismissClick } = createBadgeHarness(['First badge'], {
+      initialDelayMs: 50,
+    });
+
+    await dismissBadgeCelebrations(page);
+
+    expect(dismissClick).toHaveBeenCalledTimes(1);
   });
 
   it('dismisses one toast', async () => {
@@ -94,6 +123,16 @@ describe('dismissBadgeCelebrations', () => {
     expect(dismissClick).toHaveBeenCalledTimes(3);
   });
 
+  it('waits for the next queued toast across an inter-toast gap', async () => {
+    const { page, dismissClick } = createBadgeHarness(['First badge', 'Second badge'], {
+      interToastDelayMs: 75,
+    });
+
+    await dismissBadgeCelebrations(page);
+
+    expect(dismissClick).toHaveBeenCalledTimes(2);
+  });
+
   it('throws a bounded error when the toast remains visible', async () => {
     const { page, dismissClick, waitForTimeout } = createBadgeHarness(['First badge'], {
       remainsVisible: true,
@@ -103,7 +142,7 @@ describe('dismissBadgeCelebrations', () => {
       'Badge celebration remained visible after attempt 1 of 3 (1000ms timeout)'
     );
     expect(dismissClick).toHaveBeenCalledTimes(1);
-    expect(waitForTimeout).toHaveBeenCalledTimes(20);
+    expect(waitForTimeout).toHaveBeenCalledTimes(40);
   });
 
   it('includes the dismiss control error in the diagnostic', async () => {
@@ -149,7 +188,7 @@ describe('dismissBadgeCelebrations', () => {
     expect(events).toEqual(['dismiss', 'fix']);
   });
 
-  it('dismisses the toast before a guided hover', async () => {
+  it('dismisses the toast before a hidden target reveal hover', async () => {
     const { page: badgePage, events } = createBadgeHarness(['First badge']);
     const stepLocator = {
       count: jest.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(0),
@@ -178,12 +217,24 @@ describe('dismissBadgeCelebrations', () => {
     const commentBoxLocator = {
       first: jest.fn(() => commentBox),
     } as unknown as Locator;
-    const target = {
-      first: jest.fn(),
-      isVisible: jest.fn().mockResolvedValue(true),
+    let targetVisible = false;
+    const panel = {
+      count: jest.fn().mockResolvedValue(1),
       scrollIntoViewIfNeeded: jest.fn().mockResolvedValue(undefined),
       hover: jest.fn(async () => {
-        events.push('hover');
+        events.push('panel-hover');
+        targetVisible = true;
+      }),
+      locator: jest.fn(),
+    } as unknown as Locator;
+    const target = {
+      first: jest.fn(),
+      count: jest.fn().mockResolvedValue(1),
+      isVisible: jest.fn(async () => targetVisible),
+      locator: jest.fn(() => panel),
+      scrollIntoViewIfNeeded: jest.fn().mockResolvedValue(undefined),
+      hover: jest.fn(async () => {
+        events.push('target-hover');
       }),
     } as unknown as Locator;
     target.first = jest.fn(() => target);
@@ -212,6 +263,32 @@ describe('dismissBadgeCelebrations', () => {
       })
     ).resolves.toEqual({ completed: true });
 
-    expect(events).toEqual(['dismiss', 'hover']);
+    expect(events).toEqual(['dismiss', 'panel-hover', 'target-hover']);
+  });
+
+  it('dismisses a delayed toast before a form-fill retry', async () => {
+    const { page, events, getElapsedMs } = createBadgeHarness(['First badge'], {
+      initialDelayMs: 3000,
+    });
+    let retried = false;
+    const stepLocator = {
+      count: jest.fn().mockResolvedValue(1),
+      getAttribute: jest.fn(async () => (retried ? 'valid' : 'invalid')),
+    } as unknown as Locator;
+    const target = {
+      fill: jest.fn(async () => {
+        events.push('retry-fill');
+        retried = true;
+      }),
+    } as unknown as Locator;
+    const dateNow = jest.spyOn(Date, 'now').mockImplementation(getElapsedMs);
+
+    try {
+      await waitForFormfillSettle(page, stepLocator, target, 'value');
+    } finally {
+      dateNow.mockRestore();
+    }
+
+    expect(events).toEqual(['dismiss', 'retry-fill']);
   });
 });

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
@@ -1,0 +1,143 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { testIds } from '../../../../src/constants/testIds';
+import { dismissBadgeCelebrations } from './badge-celebrations';
+import { clickFixButton } from './requirements';
+import type { TestableStep } from './types';
+
+interface BadgeHarnessOptions {
+  clickError?: Error;
+  remainsVisible?: boolean;
+}
+
+function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {}) {
+  let currentIndex = 0;
+  const events: string[] = [];
+  const toast = {} as Locator;
+  const dismissButton = {} as Locator;
+  const waitForTimeout = jest.fn().mockResolvedValue(undefined);
+
+  toast.first = jest.fn(() => toast);
+  toast.count = jest.fn(async () => (currentIndex < titles.length ? 1 : 0));
+  toast.isVisible = jest.fn(async () => currentIndex < titles.length);
+  toast.textContent = jest.fn(async () => {
+    if (currentIndex >= titles.length) {
+      return null;
+    }
+    const queueCount = titles.length - currentIndex - 1;
+    const queueText = queueCount > 0 ? ` (+${queueCount} more)` : '';
+    return `Badge unlocked!${queueText} ${titles[currentIndex]} Nice!`;
+  });
+
+  dismissButton.click = jest.fn(async () => {
+    events.push('dismiss');
+    if (options.clickError) {
+      throw options.clickError;
+    }
+    if (!options.remainsVisible) {
+      currentIndex++;
+    }
+  });
+
+  const page = {
+    getByTestId: jest.fn((testId: string) => {
+      if (testId === testIds.learningPaths.badgeToast) {
+        return toast;
+      }
+      if (testId === testIds.learningPaths.badgeToastDismiss) {
+        return dismissButton;
+      }
+      throw new Error(`Unexpected test ID: ${testId}`);
+    }),
+    waitForTimeout,
+  } as unknown as Page;
+
+  return {
+    page,
+    events,
+    dismissClick: dismissButton.click as jest.Mock,
+    waitForTimeout,
+  };
+}
+
+describe('dismissBadgeCelebrations', () => {
+  it('returns without waiting when no toast is present', async () => {
+    const { page, dismissClick, waitForTimeout } = createBadgeHarness([]);
+
+    await dismissBadgeCelebrations(page);
+
+    expect(dismissClick).not.toHaveBeenCalled();
+    expect(waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it('dismisses one toast', async () => {
+    const { page, dismissClick } = createBadgeHarness(['First badge']);
+
+    await dismissBadgeCelebrations(page);
+
+    expect(dismissClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses queued toasts in sequence', async () => {
+    const { page, dismissClick } = createBadgeHarness(['First badge', 'Second badge', 'Third badge']);
+
+    await dismissBadgeCelebrations(page);
+
+    expect(dismissClick).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws a bounded error when the toast remains visible', async () => {
+    const { page, dismissClick, waitForTimeout } = createBadgeHarness(['First badge'], {
+      remainsVisible: true,
+    });
+
+    await expect(dismissBadgeCelebrations(page)).rejects.toThrow(
+      'Badge celebration remained visible after attempt 1 of 3 (1000ms timeout)'
+    );
+    expect(dismissClick).toHaveBeenCalledTimes(1);
+    expect(waitForTimeout).toHaveBeenCalledTimes(20);
+  });
+
+  it('includes the dismiss control error in the diagnostic', async () => {
+    const { page } = createBadgeHarness(['First badge'], {
+      clickError: new Error('Dismiss button was detached'),
+    });
+
+    await expect(dismissBadgeCelebrations(page)).rejects.toThrow(
+      'Badge celebration dismissal failed on attempt 1 of 3: Dismiss button was detached'
+    );
+  });
+
+  it('dismisses the toast before a requirement Fix click', async () => {
+    const { page: badgePage, events } = createBadgeHarness(['First badge']);
+    const fixButton = {
+      count: jest.fn().mockResolvedValue(1),
+      click: jest.fn(async () => {
+        events.push('fix');
+      }),
+    } as unknown as Locator;
+    const requirementCheck = {
+      count: jest.fn().mockResolvedValue(0),
+    } as unknown as Locator;
+    const getBadgeLocator = badgePage.getByTestId.bind(badgePage);
+    const page = {
+      getByTestId: jest.fn((testId: string) => {
+        if (testId === testIds.interactive.requirementFixButton('test-step')) {
+          return fixButton;
+        }
+        if (testId === testIds.interactive.requirementCheck('test-step')) {
+          return requirementCheck;
+        }
+        return getBadgeLocator(testId);
+      }),
+      waitForTimeout: badgePage.waitForTimeout.bind(badgePage),
+    } as unknown as Page;
+    const step = {
+      stepId: 'test-step',
+    } as TestableStep;
+
+    await clickFixButton(page, step, 'navigation');
+
+    expect(events).toEqual(['dismiss', 'fix']);
+  });
+});

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
@@ -1,7 +1,15 @@
 import type { Locator, Page } from '@playwright/test';
 
+jest.mock('@playwright/test', () => ({
+  Page: jest.fn(),
+  Locator: jest.fn(),
+  expect: jest.fn(),
+  test: jest.fn(),
+}));
+
 import { testIds } from '../../../../src/constants/testIds';
 import { dismissBadgeCelebrations } from './badge-celebrations';
+import { runGuidedSubstepLoop } from './execution';
 import { clickFixButton } from './requirements';
 import type { TestableStep } from './types';
 
@@ -139,5 +147,71 @@ describe('dismissBadgeCelebrations', () => {
     await clickFixButton(page, step, 'navigation');
 
     expect(events).toEqual(['dismiss', 'fix']);
+  });
+
+  it('dismisses the toast before a guided hover', async () => {
+    const { page: badgePage, events } = createBadgeHarness(['First badge']);
+    const stepLocator = {
+      count: jest.fn().mockResolvedValueOnce(1).mockResolvedValueOnce(0),
+      getAttribute: jest.fn(async (name: string) => {
+        if (name === 'data-test-step-state') {
+          return 'executing';
+        }
+        if (name === 'data-test-substep-index') {
+          return '0';
+        }
+        return null;
+      }),
+    } as unknown as Locator;
+    const commentBox = {
+      waitFor: jest.fn().mockResolvedValue(undefined),
+      getAttribute: jest.fn(async (name: string) => {
+        if (name === 'data-test-action') {
+          return 'hover';
+        }
+        if (name === 'data-test-reftarget') {
+          return '#guided-target';
+        }
+        return null;
+      }),
+    } as unknown as Locator;
+    const commentBoxLocator = {
+      first: jest.fn(() => commentBox),
+    } as unknown as Locator;
+    const target = {
+      first: jest.fn(),
+      isVisible: jest.fn().mockResolvedValue(true),
+      scrollIntoViewIfNeeded: jest.fn().mockResolvedValue(undefined),
+      hover: jest.fn(async () => {
+        events.push('hover');
+      }),
+    } as unknown as Locator;
+    target.first = jest.fn(() => target);
+    const getBadgeLocator = badgePage.getByTestId.bind(badgePage);
+    const page = {
+      getByTestId: jest.fn((testId: string) => {
+        if (testId === testIds.interactive.step('guided-step')) {
+          return stepLocator;
+        }
+        return getBadgeLocator(testId);
+      }),
+      locator: jest.fn((selector: string) => {
+        return selector === '.interactive-comment-box' ? commentBoxLocator : target;
+      }),
+      waitForTimeout: badgePage.waitForTimeout.bind(badgePage),
+    } as unknown as Page;
+    const step = {
+      stepId: 'guided-step',
+      guidedStepCount: 1,
+    } as TestableStep;
+
+    await expect(
+      runGuidedSubstepLoop(page, step, {
+        stepLocator,
+        perSubstepTimeoutMs: 100,
+      })
+    ).resolves.toEqual({ completed: true });
+
+    expect(events).toEqual(['dismiss', 'hover']);
   });
 });

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.ts
@@ -15,6 +15,39 @@ function hasQueuedCelebration(text: string): boolean {
   return /\(\+\d+ more\)/.test(text);
 }
 
+type ToastTextResult = { state: 'read'; text: string } | { state: 'gone' };
+
+function errorReason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function readToastText(toast: Locator, timeout: number, context: string): Promise<ToastTextResult> {
+  const boundedTimeout = Math.max(1, Math.min(timeout, BADGE_TRANSITION_TIMEOUT_MS));
+
+  try {
+    return {
+      state: 'read',
+      text: (await toast.textContent({ timeout: boundedTimeout })) ?? '',
+    };
+  } catch (readError) {
+    const readReason = errorReason(readError);
+
+    try {
+      if (!(await isVisible(toast))) {
+        return { state: 'gone' };
+      }
+    } catch (visibilityError) {
+      throw new Error(
+        `Badge celebration ${context} failed within ${boundedTimeout}ms: ${readReason}. Visibility recheck failed: ${errorReason(visibilityError)}`
+      );
+    }
+
+    throw new Error(
+      `Badge celebration ${context} failed within ${boundedTimeout}ms while the toast remained visible: ${readReason}`
+    );
+  }
+}
+
 async function waitForVisibleToast(page: Page, toast: Locator): Promise<boolean> {
   for (let elapsed = 0; elapsed < BADGE_IDLE_TIMEOUT_MS; elapsed += BADGE_TRANSITION_POLL_MS) {
     if (await isVisible(toast)) {
@@ -28,17 +61,28 @@ async function waitForVisibleToast(page: Page, toast: Locator): Promise<boolean>
 
 async function waitForToastTransition(page: Page, previousText: string, expectNextToast: boolean): Promise<boolean> {
   const toast = page.getByTestId(testIds.learningPaths.badgeToast).first();
+  let elapsed = 0;
 
-  for (let elapsed = 0; elapsed < BADGE_TRANSITION_TIMEOUT_MS; elapsed += BADGE_TRANSITION_POLL_MS) {
+  while (elapsed < BADGE_TRANSITION_TIMEOUT_MS) {
     if (!(await isVisible(toast))) {
       if (!expectNextToast) {
         return true;
       }
-    } else if ((await toast.textContent()) !== previousText) {
-      return true;
+    } else {
+      const readStartedAt = Date.now();
+      const textResult = await readToastText(toast, BADGE_TRANSITION_TIMEOUT_MS - elapsed, 'transition text read');
+      elapsed = Math.min(BADGE_TRANSITION_TIMEOUT_MS, elapsed + Math.max(0, Date.now() - readStartedAt));
+      if (textResult.state === 'gone' || textResult.text !== previousText) {
+        return true;
+      }
     }
 
-    await page.waitForTimeout(BADGE_TRANSITION_POLL_MS);
+    const pollDelay = Math.min(BADGE_TRANSITION_POLL_MS, BADGE_TRANSITION_TIMEOUT_MS - elapsed);
+    if (pollDelay <= 0) {
+      break;
+    }
+    await page.waitForTimeout(pollDelay);
+    elapsed += pollDelay;
   }
 
   return !(await isVisible(toast));
@@ -52,7 +96,15 @@ export async function dismissBadgeCelebrations(page: Page): Promise<void> {
       return;
     }
 
-    const previousText = (await toast.textContent()) ?? '';
+    const textResult = await readToastText(
+      toast,
+      BADGE_TRANSITION_TIMEOUT_MS,
+      `text read before attempt ${attempt} of ${MAX_BADGE_CELEBRATIONS}`
+    );
+    if (textResult.state === 'gone') {
+      continue;
+    }
+    const previousText = textResult.text;
     const dismissButton = page.getByTestId(testIds.learningPaths.badgeToastDismiss);
 
     try {

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.ts
@@ -4,7 +4,8 @@ import { testIds } from '../../../../src/constants/testIds';
 
 const MAX_BADGE_CELEBRATIONS = 3;
 const BADGE_TRANSITION_TIMEOUT_MS = 1000;
-const BADGE_TRANSITION_POLL_MS = 50;
+const BADGE_IDLE_TIMEOUT_MS = 100;
+const BADGE_TRANSITION_POLL_MS = 25;
 
 async function isVisible(locator: Locator): Promise<boolean> {
   return (await locator.count()) > 0 && (await locator.isVisible());
@@ -12,6 +13,17 @@ async function isVisible(locator: Locator): Promise<boolean> {
 
 function hasQueuedCelebration(text: string): boolean {
   return /\(\+\d+ more\)/.test(text);
+}
+
+async function waitForVisibleToast(page: Page, toast: Locator): Promise<boolean> {
+  for (let elapsed = 0; elapsed < BADGE_IDLE_TIMEOUT_MS; elapsed += BADGE_TRANSITION_POLL_MS) {
+    if (await isVisible(toast)) {
+      return true;
+    }
+    await page.waitForTimeout(BADGE_TRANSITION_POLL_MS);
+  }
+
+  return isVisible(toast);
 }
 
 async function waitForToastTransition(page: Page, previousText: string, expectNextToast: boolean): Promise<boolean> {
@@ -36,7 +48,7 @@ export async function dismissBadgeCelebrations(page: Page): Promise<void> {
   const toast = page.getByTestId(testIds.learningPaths.badgeToast).first();
 
   for (let attempt = 1; attempt <= MAX_BADGE_CELEBRATIONS; attempt++) {
-    if (!(await isVisible(toast))) {
+    if (!(await waitForVisibleToast(page, toast))) {
       return;
     }
 
@@ -59,7 +71,7 @@ export async function dismissBadgeCelebrations(page: Page): Promise<void> {
     }
   }
 
-  if (await isVisible(toast)) {
+  if (await waitForVisibleToast(page, toast)) {
     throw new Error(`Badge celebration remained visible after ${MAX_BADGE_CELEBRATIONS} dismissal attempts`);
   }
 }

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.ts
@@ -1,0 +1,65 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { testIds } from '../../../../src/constants/testIds';
+
+const MAX_BADGE_CELEBRATIONS = 3;
+const BADGE_TRANSITION_TIMEOUT_MS = 1000;
+const BADGE_TRANSITION_POLL_MS = 50;
+
+async function isVisible(locator: Locator): Promise<boolean> {
+  return (await locator.count()) > 0 && (await locator.isVisible());
+}
+
+function hasQueuedCelebration(text: string): boolean {
+  return /\(\+\d+ more\)/.test(text);
+}
+
+async function waitForToastTransition(page: Page, previousText: string, expectNextToast: boolean): Promise<boolean> {
+  const toast = page.getByTestId(testIds.learningPaths.badgeToast).first();
+
+  for (let elapsed = 0; elapsed < BADGE_TRANSITION_TIMEOUT_MS; elapsed += BADGE_TRANSITION_POLL_MS) {
+    if (!(await isVisible(toast))) {
+      if (!expectNextToast) {
+        return true;
+      }
+    } else if ((await toast.textContent()) !== previousText) {
+      return true;
+    }
+
+    await page.waitForTimeout(BADGE_TRANSITION_POLL_MS);
+  }
+
+  return !(await isVisible(toast));
+}
+
+export async function dismissBadgeCelebrations(page: Page): Promise<void> {
+  const toast = page.getByTestId(testIds.learningPaths.badgeToast).first();
+
+  for (let attempt = 1; attempt <= MAX_BADGE_CELEBRATIONS; attempt++) {
+    if (!(await isVisible(toast))) {
+      return;
+    }
+
+    const previousText = (await toast.textContent()) ?? '';
+    const dismissButton = page.getByTestId(testIds.learningPaths.badgeToastDismiss);
+
+    try {
+      await dismissButton.click({ timeout: BADGE_TRANSITION_TIMEOUT_MS });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Badge celebration dismissal failed on attempt ${attempt} of ${MAX_BADGE_CELEBRATIONS}: ${reason}`
+      );
+    }
+
+    if (!(await waitForToastTransition(page, previousText, hasQueuedCelebration(previousText)))) {
+      throw new Error(
+        `Badge celebration remained visible after attempt ${attempt} of ${MAX_BADGE_CELEBRATIONS} (${BADGE_TRANSITION_TIMEOUT_MS}ms timeout)`
+      );
+    }
+  }
+
+  if (await isVisible(toast)) {
+    throw new Error(`Badge celebration remained visible after ${MAX_BADGE_CELEBRATIONS} dismissal attempts`);
+  }
+}

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.ts
@@ -2,6 +2,7 @@ import type { Locator, Page } from '@playwright/test';
 
 import { testIds } from '../../../../src/constants/testIds';
 
+// The runner opens one guide per browser context, and each guide-completed event awards at most three new badges.
 const MAX_BADGE_CELEBRATIONS = 3;
 const BADGE_TRANSITION_TIMEOUT_MS = 1000;
 const BADGE_IDLE_TIMEOUT_MS = 100;
@@ -105,12 +106,12 @@ export async function dismissBadgeCelebrations(page: Page): Promise<void> {
       continue;
     }
     const previousText = textResult.text;
-    const dismissButton = page.getByTestId(testIds.learningPaths.badgeToastDismiss);
+    const dismissButton = page.getByTestId(testIds.learningPaths.badgeToastDismiss).first();
 
     try {
       await dismissButton.click({ timeout: BADGE_TRANSITION_TIMEOUT_MS });
     } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error);
+      const reason = errorReason(error);
       throw new Error(
         `Badge celebration dismissal failed on attempt ${attempt} of ${MAX_BADGE_CELEBRATIONS}: ${reason}`
       );

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -42,6 +42,7 @@ import {
   captureFinalScreenshot,
 } from './artifacts';
 import { validateSession, handleRequirementsWithFix } from './requirements';
+import { dismissBadgeCelebrations } from './badge-celebrations';
 import type {
   TestableStep,
   SkipReason,
@@ -428,6 +429,7 @@ async function waitForSubstepAdvance(
       const skipBtn = commentBox.getByRole('button', { name: /^Skip$/ });
       const count = await skipBtn.count();
       if (count > 0) {
+        await dismissBadgeCelebrations(page);
         await skipBtn.click().catch(() => {});
       }
     }
@@ -575,6 +577,7 @@ async function runGuidedSubstepLoop(
     try {
       if (action === 'noop') {
         const continueBtn = commentBox.getByRole('button', { name: /Continue/ });
+        await dismissBadgeCelebrations(page);
         await continueBtn.click();
       } else if (action === 'button' || action === 'highlight') {
         if (!reftarget) {
@@ -583,6 +586,7 @@ async function runGuidedSubstepLoop(
         const urlBefore = page.url();
         const target = await resolveGuidedTarget(page, reftarget, action);
         await target.scrollIntoViewIfNeeded();
+        await dismissBadgeCelebrations(page);
         await target.click();
         await page.waitForTimeout(100);
         if (urlBefore !== page.url()) {
@@ -854,6 +858,7 @@ export async function executeStep(
       );
     }
     await waitForStepActionEnabled(page, step.stepId, action);
+    await dismissBadgeCelebrations(page);
     await stepActionButton(page, step.stepId, action).click();
 
     if (verbose) {

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -505,7 +505,7 @@ async function waitForFormfillSettle(
  * Run the guided substep loop: read comment box contract, perform action, wait for advance.
  * Phase 4: formfill validation, hover dwell, skippable substeps, navigation re-query, error diagnostics.
  */
-async function runGuidedSubstepLoop(
+export async function runGuidedSubstepLoop(
   page: Page,
   step: TestableStep,
   options: {
@@ -598,6 +598,7 @@ async function runGuidedSubstepLoop(
         }
         const target = await resolveGuidedTarget(page, reftarget, 'hover');
         await target.scrollIntoViewIfNeeded();
+        await dismissBadgeCelebrations(page);
         await target.hover();
         await page.waitForTimeout(GUIDED_HOVER_DWELL_MS);
       } else if (action === 'formfill') {
@@ -606,6 +607,7 @@ async function runGuidedSubstepLoop(
         }
         const target = await resolveGuidedTarget(page, reftarget, 'formfill');
         await target.scrollIntoViewIfNeeded();
+        await dismissBadgeCelebrations(page);
         await target.fill(targetValue ?? '');
         await waitForFormfillSettle(page, stepLocator, target, targetValue ?? '');
       } else {

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -324,7 +324,7 @@ function guidedSelectorLocator(page: Page, selector: string): Locator {
   return parsed.trailingSelector ? matched.locator(parsed.trailingSelector).first() : matched;
 }
 
-async function revealGuidedTarget(target: Locator, timeout: number): Promise<Locator> {
+async function revealGuidedTarget(page: Page, target: Locator, timeout: number): Promise<Locator> {
   if (await target.isVisible()) {
     return target;
   }
@@ -332,6 +332,7 @@ async function revealGuidedTarget(target: Locator, timeout: number): Promise<Loc
     const panel = target.locator('xpath=ancestor::section[1]');
     if ((await panel.count()) > 0) {
       await panel.scrollIntoViewIfNeeded().catch(() => {});
+      await dismissBadgeCelebrations(page);
       await panel.hover({ timeout }).catch(() => {});
       if (await target.isVisible()) {
         return target;
@@ -352,6 +353,7 @@ async function revealGuidedTarget(target: Locator, timeout: number): Promise<Loc
  * Handles grafana: prefix through the Node-safe E2E resolver.
  */
 async function resolveGuidedTarget(page: Page, reftarget: string, actionType: string): Promise<Locator> {
+  await dismissBadgeCelebrations(page);
   const timeout = GUIDED_TARGET_RESOLUTION_TIMEOUT_MS;
   const selector = reftarget.startsWith('grafana:') ? resolveSelector(reftarget) : reftarget;
 
@@ -359,18 +361,18 @@ async function resolveGuidedTarget(page: Page, reftarget: string, actionType: st
     const byRole = page.getByRole('button', { name: reftarget });
     const n = await byRole.count();
     if (n > 0) {
-      return revealGuidedTarget(byRole.first(), timeout);
+      return revealGuidedTarget(page, byRole.first(), timeout);
     }
     const bySelector = guidedSelectorLocator(page, selector);
     const hasButton = bySelector.filter({ has: page.getByRole('button') });
     const hasCount = await hasButton.count();
     if (hasCount > 0) {
-      return revealGuidedTarget(hasButton.first(), timeout);
+      return revealGuidedTarget(page, hasButton.first(), timeout);
     }
-    return revealGuidedTarget(bySelector.first(), timeout);
+    return revealGuidedTarget(page, bySelector.first(), timeout);
   }
 
-  return revealGuidedTarget(guidedSelectorLocator(page, selector), timeout);
+  return revealGuidedTarget(page, guidedSelectorLocator(page, selector), timeout);
 }
 
 /**
@@ -445,7 +447,7 @@ async function waitForSubstepAdvance(
 /**
  * After formfill: debounce, optionally wait for data-test-form-state="valid", or retry once on persistent invalid (Phase 4.1).
  */
-async function waitForFormfillSettle(
+export async function waitForFormfillSettle(
   page: Page,
   stepLocator: Locator,
   target: Locator,
@@ -480,6 +482,7 @@ async function waitForFormfillSettle(
         invalidSince = Date.now();
       }
       if (Date.now() - invalidSince >= GUIDED_FORMFILL_INVALID_PERSIST_MS) {
+        await dismissBadgeCelebrations(page);
         await target.fill(targetValue);
         await page.waitForTimeout(GUIDED_FORMFILL_DEBOUNCE_MS);
         const afterRetry = await readFormState();

--- a/tests/e2e-runner/utils/guide-runner/index.ts
+++ b/tests/e2e-runner/utils/guide-runner/index.ts
@@ -60,6 +60,7 @@ export {
 // ============================================
 export { discoverStepsFromDOM, logDiscoveryResults, resolveEffectiveSkippable } from './discovery';
 export { ensureDocsPanelOpen } from './bootstrap';
+export { dismissBadgeCelebrations } from './badge-celebrations';
 
 // ============================================
 // Requirements

--- a/tests/e2e-runner/utils/guide-runner/requirements.ts
+++ b/tests/e2e-runner/utils/guide-runner/requirements.ts
@@ -19,6 +19,7 @@ import {
   POST_FIX_SETTLE_DELAY_MS,
   NAVIGATION_FIX_SETTLE_DELAY_MS,
 } from './constants';
+import { dismissBadgeCelebrations } from './badge-celebrations';
 import type {
   TestableStep,
   RequirementStatus,
@@ -410,6 +411,7 @@ export async function clickFixButton(
   if (buttonCount === 0) {
     return false;
   }
+  await dismissBadgeCelebrations(page);
 
   try {
     // Click the fix button with timeout


### PR DESCRIPTION
## Summary

Prevents Pathfinder badge celebrations from blocking E2E runner interactions. The runner now waits through short queue-render gaps, dismisses up to three known badge toasts, and fails with a bounded diagnostic if the overlay remains.

## What to look at

- The helper targets only Pathfinder’s stable badge-toast test IDs. It does not close arbitrary Grafana modals.
- Dismissal runs before target resolution, runner-controlled clicks, hidden-target reveal, guided hover and form-fill retries, guided Skip, and requirement Fix.
- Queue handling is bounded to the plugin’s current three-celebration maximum.

## How to verify

1. Use a fresh user or stack that earns a badge when a guide completes.
2. Complete a guide that queues one or more badge celebrations.
3. Continue into the next runner-controlled action.
4. Confirm each badge toast is dismissed before the underlying action runs.
5. Force the toast to remain visible and confirm the runner reports a bounded badge-dismissal error.

## Breaking changes

None. This adds narrow E2E handling for an existing Pathfinder overlay.
