### PR TITLE
fix(e2e): teach the requirements stub about the badge toast

### DIFF
--- a/tests/e2e-runner/utils/guide-runner/requirements.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/requirements.test.ts
@@ -19,7 +19,7 @@ jest.mock('@playwright/test', () => ({
 import type { Locator, Page } from '@playwright/test';
 
 import { testIds } from '../../../../src/constants/testIds';
-import { REQUIREMENTS_POLL_INTERVAL_MS, REQUIREMENTS_SETTLE_TIMEOUT_MS } from './constants';
+import { POST_FIX_SETTLE_DELAY_MS, REQUIREMENTS_POLL_INTERVAL_MS, REQUIREMENTS_SETTLE_TIMEOUT_MS } from './constants';
 import { attemptToFixRequirements, detectRequirements } from './requirements';
 import type { TestableStep } from './types';
 
@@ -32,6 +32,13 @@ afterEach(() => {
 // ============================================
 
 const STEP_ID = 'test-step-1';
+
+/** Badge dismissal polls at 25ms; every requirement wait is longer. */
+const BADGE_POLL_MS = 25;
+
+function requirementWaits(waitForTimeout: jest.Mock): number[] {
+  return waitForTimeout.mock.calls.map(([ms]) => ms as number).filter((ms) => ms !== BADGE_POLL_MS);
+}
 
 function createTestableStep(overrides: Partial<TestableStep> = {}): TestableStep {
   return {
@@ -117,6 +124,16 @@ function createSequencedPage(states: DomState[]): SequencedPageHandles {
   const retryLocator = { count: countFor((state) => state.hasRetryButton) };
   const skipLocator = { count: countFor((state) => state.hasSkipButton) };
 
+  // `clickFixButton` dismisses badge celebrations first (#1617). These tests are
+  // about the settle window, so the toast is always absent — but the locator has
+  // to exist, or the fix click throws before it ever reaches the code under test.
+  const badgeToastLocator: Record<string, unknown> = {
+    count: jest.fn().mockResolvedValue(0),
+    isVisible: jest.fn().mockResolvedValue(false),
+    textContent: jest.fn().mockResolvedValue(''),
+  };
+  badgeToastLocator.first = jest.fn().mockReturnValue(badgeToastLocator);
+
   const locatorsByTestId = new Map<string, unknown>([
     [testIds.interactive.doItButton(STEP_ID), doItLocator],
     [testIds.interactive.showMeButton(STEP_ID), showMeLocator],
@@ -124,6 +141,7 @@ function createSequencedPage(states: DomState[]): SequencedPageHandles {
     [testIds.interactive.requirementFixButton(STEP_ID), fixLocator],
     [testIds.interactive.requirementRetryButton(STEP_ID), retryLocator],
     [testIds.interactive.requirementSkipButton(STEP_ID), skipLocator],
+    [testIds.learningPaths.badgeToast, badgeToastLocator],
   ]);
 
   const getByTestId = jest.fn().mockImplementation((testId: string) => {
@@ -255,7 +273,10 @@ describe('attemptToFixRequirements - settle window', () => {
     // The settle poll re-detected requirements; it did not click Fix again
     // to get there.
     expect(fixButtonClick).toHaveBeenCalledTimes(1);
-    expect(waitForTimeout.mock.calls.length).toBe(2);
+    // Counting the requirement waits only. Badge dismissal polls on its own
+    // cadence before every fix click, and this assertion is about the settle
+    // window, not about how long looking for an absent toast takes.
+    expect(requirementWaits(waitForTimeout)).toEqual([POST_FIX_SETTLE_DELAY_MS, REQUIREMENTS_POLL_INTERVAL_MS]);
   });
 
   it('preserves fixType when a Fix button reappears during the initial settle poll', async () => {


### PR DESCRIPTION
## Summary

`main` has been red since [#1617](https://github.com/grafana/grafana-pathfinder-app/pull/1617). Three tests in `tests/e2e-runner/utils/guide-runner/requirements.test.ts` fail with `Unexpected testId requested: learning-paths-badge-toast`, and every PR branched from or merged with `main` inherits it — which is how I found it, on [#1612](https://github.com/grafana/grafana-pathfinder-app/pull/1612).

No production code changes.

## Why

#1617 made `clickFixButton` call `dismissBadgeCelebrations(page)` before clicking, which does `page.getByTestId(testIds.learningPaths.badgeToast).first()`.

`requirements.test.ts` builds its `Page` stub from an explicit `locatorsByTestId` map and **throws** on any testId it does not know:

```ts
const locator = locatorsByTestId.get(testId);
if (!locator) {
  throw new Error(`Unexpected testId requested: ${testId}`);
}
```

That throw is deliberate and worth keeping — it is what catches an unstubbed lookup instead of silently returning `undefined`. It just was not updated when #1617 added a new one, so all three `attemptToFixRequirements` settle-window tests now throw before reaching the code they exist to test.

## What to look at

**The stub gains a badge-toast locator** standing for "no celebration on screen", which is the state these tests mean — they are about the requirement settle window, not about celebrations. `count` resolves 0, and `first()` returns the locator itself, since `dismissBadgeCelebrations` calls it.

**One assertion had to become badge-agnostic.** With no toast present, `waitForVisibleToast` polls its full 100ms idle window (four 25ms waits) before every fix click. `settles to met after a Fix click even on the final allowed attempt` asserted `waitForTimeout.mock.calls.length === 2`, which would now be 6. Rather than hard-code 6, it asserts on the requirement waits alone:

```ts
expect(requirementWaits(waitForTimeout)).toEqual([POST_FIX_SETTLE_DELAY_MS, REQUIREMENTS_POLL_INTERVAL_MS]);
```

That is what the test is actually about — one settle delay, then one poll — and it now says so, rather than encoding a total that changes whenever anything else in the click path waits.

## Worth knowing, not fixed here

`dismissBadgeCelebrations` costs a fixed ~100ms whenever no toast is present, which is the common case, and it runs before every fix click, hidden-target hover, and form-fill retry. That is #1617's deliberate design — the toast may not have appeared yet — but it is a real per-action cost in the runner and someone may want to revisit the idle window separately.

## How to verify

```bash
npx jest tests/e2e-runner/utils/guide-runner/requirements.test.ts --coverage=false
```

3 failed / 3 passed on `main`; 6 passed here. Full suite is green: 429 suites, 6856 tests.

The dismissal behaviour this uncovers is not left untested — `badge-celebrations.test.ts:241` already covers "dismisses the toast before a requirement Fix click".

## Breaking changes

None.

## Reversibility

Fully reversible; the diff is one test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
