### PR TITLE
docs: correct guide schema descriptions

### DIFF
--- a/docs/developer/CLI_TOOLS.md
+++ b/docs/developer/CLI_TOOLS.md
@@ -337,7 +337,7 @@ The output is a D3-compatible JSON object with `nodes`, `edges`, and `metadata`:
 
 ## Build-snippets command
 
-Generates a snippet catalog (`index.json`) from a directory of snippet bodies. Snippet bodies (`<id>.json`) are the source of truth; the catalog is always regenerated, never hand-edited. The catalog is consumed by the snippet engine, which resolves `snippet-ref` blocks by fetching `<id>.json` at parse time.
+Generates a snippet catalog (`index.json`) from a directory of snippet bodies. Snippet bodies (`<id>.json`) are the source of truth; the catalog is always regenerated, never hand-edited. The catalog is consumed by the snippet engine, which resolves `snippet-ref` blocks by fetching `<id>.json` after guide validation and before render.
 
 ### Basic syntax
 

--- a/src/cli/e2e/side-effects.ts
+++ b/src/cli/e2e/side-effects.ts
@@ -197,7 +197,11 @@ function classifyBlock(block: JsonBlock, path: string): SideEffectClassification
     return reason('unknown', path, `${block.type} block can have side effects outside static guide analysis`);
   }
   if (isSnippetRefBlock(block)) {
-    return reason('unknown', path, 'Snippet content is resolved after validation and must be classified after expansion');
+    return reason(
+      'unknown',
+      path,
+      'Snippet content is resolved after validation and must be classified after expansion'
+    );
   }
   return reason('unknown', path, 'Unknown block type');
 }

--- a/src/cli/e2e/side-effects.ts
+++ b/src/cli/e2e/side-effects.ts
@@ -197,7 +197,7 @@ function classifyBlock(block: JsonBlock, path: string): SideEffectClassification
     return reason('unknown', path, `${block.type} block can have side effects outside static guide analysis`);
   }
   if (isSnippetRefBlock(block)) {
-    return reason('unknown', path, 'Snippet content is resolved at parse time and must be classified after expansion');
+    return reason('unknown', path, 'Snippet content is resolved after validation and must be classified after expansion');
   }
   return reason('unknown', path, 'Unknown block type');
 }

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -551,7 +551,7 @@ export const JsonChallengeBlockSchema = z.object({
     .enum(['coda', 'standard'])
     .optional()
     .describe(
-      "Execution model. 'standard' runs against the learner's own Grafana — successCriteria is any Pathfinder requirement (e.g. has-dashboard-named:Foo). 'coda' (default) runs in a Coda VM with a terminal — successCriteria is typically coda-exit-zero:<command>."
+      "Execution model. 'standard' runs against the learner's own Grafana — successCriteria is any Pathfinder requirement (e.g. has-dashboard-named:Foo). 'coda' runs in a Coda VM with a terminal — successCriteria is typically coda-exit-zero:<command>. The schema has no default: JSON that omits mode resolves to 'coda' at runtime, while the block editor seeds a new block with 'standard'. Set mode explicitly."
     ),
   title: z.string().min(1, 'Challenge title is required').describe('Short title shown above the brief'),
   brief: z.string().min(1, 'Challenge brief is required').describe('Markdown problem statement'),
@@ -732,14 +732,14 @@ const SnippetIdSchema = z
   .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, 'Snippet ID must be kebab-case (lowercase letters, numbers, hyphens)');
 
 /**
- * Schema for snippet reference block. Resolves at parse time — never
- * reaches the renderer.
+ * Schema for snippet reference block. Accepted during validation, then
+ * resolved before render — never reaches the renderer.
  * @coupling Type: JsonSnippetRefBlock
  */
 export const JsonSnippetRefBlockSchema = z.object({
   type: z.literal('snippet-ref'),
   id: z.string().optional().describe('Stable identifier for this snippet-ref instance'),
-  snippetId: SnippetIdSchema.describe('Upstream snippet ID to resolve at parse time'),
+  snippetId: SnippetIdSchema.describe('Upstream snippet ID, resolved after validation and before render'),
   ...AuthorAnnotatedSchema.shape,
 });
 

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -825,10 +825,10 @@ export interface JsonGrotGuideBlock extends AuthorAnnotated {
 // ============ SNIPPET REFERENCE BLOCK ============
 
 /**
- * Reference to a reusable snippet. The block resolves at parse time:
- * the parser fetches the snippet by id (CDN-first, bundled fallback),
- * validates its content, and splices the snippet's blocks into this
- * block's position. The renderer never sees a snippet-ref.
+ * Reference to a reusable snippet. The guide is validated with the block
+ * intact; the snippet engine then fetches the snippet by id (CDN-first,
+ * bundled fallback), validates its content, and splices its blocks into
+ * this block's position before render. The renderer never sees a snippet-ref.
  *
  * Snippets are authored upstream in `grafana/interactive-tutorials` and
  * are immutable from the consumer's perspective. To customize an

--- a/src/types/json-snippet.types.ts
+++ b/src/types/json-snippet.types.ts
@@ -4,9 +4,9 @@
  * Snippets are reusable fragments of guide schema, authored upstream in
  * `grafana/interactive-tutorials` under `shared/snippets/` and published
  * to the CDN at `<cdn>/guides/shared/snippets/<id>.json`. A guide
- * references a snippet by id via a `snippet-ref` block; the parser
- * resolves the ref and splices the snippet's blocks into the guide at
- * parse time.
+ * references a snippet by id via a `snippet-ref` block; after guide
+ * validation, the snippet engine resolves the ref and splices the
+ * snippet's blocks into the guide before render.
  *
  * In v1 snippets may contain any block type EXCEPT another snippet-ref
  * — i.e. no nesting. The Zod schema enforces this; see

--- a/src/validation/json-guide-format-docs.test.ts
+++ b/src/validation/json-guide-format-docs.test.ts
@@ -11,11 +11,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import {
-  JsonBlockSchema,
-  JsonChallengeBlockSchema,
-  JsonSnippetRefBlockSchema,
-} from '../types/json-guide.schema';
+import { JsonBlockSchema, JsonChallengeBlockSchema, JsonSnippetRefBlockSchema } from '../types/json-guide.schema';
 
 const DOC_RELATIVE_PATH = 'docs/developer/interactive-examples/json-guide-format.md';
 const DOC_PATH = path.resolve(__dirname, '../..', DOC_RELATIVE_PATH);

--- a/src/validation/json-guide-format-docs.test.ts
+++ b/src/validation/json-guide-format-docs.test.ts
@@ -11,7 +11,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { JsonBlockSchema } from '../types/json-guide.schema';
+import {
+  JsonBlockSchema,
+  JsonChallengeBlockSchema,
+  JsonSnippetRefBlockSchema,
+} from '../types/json-guide.schema';
 
 const DOC_RELATIVE_PATH = 'docs/developer/interactive-examples/json-guide-format.md';
 const DOC_PATH = path.resolve(__dirname, '../..', DOC_RELATIVE_PATH);
@@ -85,6 +89,20 @@ function claimedByLongerType(heading: string, blockType: string): boolean {
 }
 
 describe('JSON guide format reference', () => {
+  it('describes snippet references as resolving after validation and before render', () => {
+    expect(JsonSnippetRefBlockSchema.shape.snippetId.description).toContain(
+      'resolved after validation and before render'
+    );
+  });
+
+  it('describes the challenge mode fallback without claiming a schema default', () => {
+    const description = JsonChallengeBlockSchema.shape.mode.description;
+
+    expect(description).toContain('The schema has no default');
+    expect(description).toContain("JSON that omits mode resolves to 'coda' at runtime");
+    expect(description).not.toContain("'coda' (default)");
+  });
+
   it('reads every block type out of the schema union', () => {
     expect(blockTypes).toContain('markdown');
     expect(blockTypes).toHaveLength(EXPECTED_BLOCK_TYPE_COUNT);


### PR DESCRIPTION
## Summary

Correct the author-facing guide schema descriptions for `challenge.mode` and `snippet-ref` resolution.

Snippet references are now described as resolving after guide validation and before rendering. The challenge mode description now distinguishes between the absence of a schema default, the runtime `coda` fallback, and the block editor's `standard` initial value.

## What to look at

- Align the exported schema descriptions, type comments, CLI documentation, and E2E diagnostic wording with the actual validation and expansion order.
- Add regression coverage for the two author-facing schema descriptions.

## How to verify

1. Export the block schema and confirm the `snippetId` description says references resolve after validation and before rendering.
2. Confirm the `challenge.mode` description distinguishes the absent schema default from the runtime `coda` fallback and the editor's `standard` initial value.
3. Compare the descriptions with the challenge and snippet-reference sections of the JSON guide format documentation.

## Local verification

`git diff --check` passed. The focused Jest test and full project checks were not run locally because dependency installation failed with a registry connection reset. This Draft PR will use CI for the complete test result.

## Breaking changes

None. This changes documentation and schema descriptions only; validation and runtime behavior are unchanged.

Fixes #1545

🤖 Generated with [Codex](https://openai.com/codex/)
