### PR TITLE
fix(block-editor): default challenge brief on conversion

### DIFF
--- a/src/components/block-editor/utils/block-conversion.test.ts
+++ b/src/components/block-editor/utils/block-conversion.test.ts
@@ -501,16 +501,14 @@ describe('convertBlockType', () => {
      * Sources with no `CONTENT_FIELDS` entry — `image`, `video`, `collapsible`,
      * `assistant` and `snippet-ref` — carry no text into a target whose required
      * text field has no `REQUIRED_DEFAULTS` fallback, so the conversion throws.
-     * Pinned here rather than fixed, so a fix has to move this list deliberately;
-     * the `image`/`video` symptom is tracked as
-     * https://github.com/grafana/grafana-pathfinder-app/issues/1575.
+     * Pinned here so adding a fallback moves this list deliberately.
      */
     const CONTENTLESS_SOURCE_FAILURES: Partial<Record<BlockType, readonly BlockType[]>> = {
-      image: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
-      video: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
-      collapsible: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
-      assistant: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
-      'snippet-ref': ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'challenge'],
+      image: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal'],
+      video: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal'],
+      collapsible: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal'],
+      assistant: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal'],
+      'snippet-ref': ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal'],
     };
 
     it('samples every convertible source type', () => {
@@ -532,6 +530,17 @@ describe('convertBlockType', () => {
           expect(convertBlockType(source, target).type).toBe(target);
         }
       }
+    });
+
+    it.each([
+      ['image', { type: 'image', src: 'https://example.com/img.png', alt: 'alt text' }],
+      ['video', { type: 'video', src: 'https://example.com/vid.mp4' }],
+      ['empty markdown', { type: 'markdown', content: '' }],
+    ] satisfies Array<[string, JsonBlock]>)('should convert %s to challenge with a default brief', (_label, source) => {
+      const result = convertBlockType(source, 'challenge');
+
+      expect(result.type).toBe('challenge');
+      expect((result as { brief: string }).brief).toBe('Complete this challenge');
     });
 
     it('should convert image to terminal-connect without throwing (regression #619)', () => {

--- a/src/components/block-editor/utils/block-conversion.ts
+++ b/src/components/block-editor/utils/block-conversion.ts
@@ -147,6 +147,7 @@ const REQUIRED_DEFAULTS: Record<BlockType, Record<string, unknown> | null> = {
   'terminal-connect': { content: 'Connect to terminal' },
   challenge: {
     title: 'Untitled challenge',
+    brief: 'Complete this challenge',
     successCriteria: 'coda-exit-zero:true',
   },
   'code-block': { reftarget: "div[data-testid='data-testid Code editor container']", code: '// Your code here' },


### PR DESCRIPTION
## Summary

Converting an image, video, or empty markdown block to a challenge now succeeds instead of failing schema validation. The conversion supplies a non-empty placeholder brief only when the source has no usable text; content-bearing sources continue mapping their content into the challenge brief.

## How to verify

1. In the block editor, switch an image block to a challenge and confirm the conversion succeeds with `Complete this challenge` in the brief field.
2. Repeat with a video block and an empty markdown block.
3. Switch a non-empty markdown block to a challenge and confirm its original content is used as the brief instead of the placeholder.

## Breaking changes

None. This change is additive and fully reversible.

## Out of scope

- Challenge `mode` selection remains unchanged; it is a separate product decision per the issue scope.

Fixes #1575

Generated with [OpenAI Codex](https://openai.com/codex/).
