### PR TITLE
refactor(tour): extract a reusable BubbleTour from the block-editor tour

### DIFF
--- a/src/components/BubbleTour/BubbleTour.test.tsx
+++ b/src/components/BubbleTour/BubbleTour.test.tsx
@@ -264,6 +264,34 @@ describe('BubbleTour', () => {
 
       expect(event.defaultPrevented).toBe(true);
     });
+
+    it('sees defaultPrevented ahead of a bubble-phase document listener mounted before it', async () => {
+      // Simulates FloatingPanel: a bubble-phase `document` Escape listener registered before
+      // BubbleTour mounts. Dispatching on a descendant (not `document` itself) makes capture
+      // vs. bubble ordering actually matter, the way it does with real focus inside a field.
+      const panelSawPrevented: boolean[] = [];
+      const panelListener = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          panelSawPrevented.push(e.defaultPrevented);
+        }
+      };
+      document.addEventListener('keydown', panelListener);
+
+      const { onClose } = await renderTour();
+      const field = document.createElement('input');
+      document.body.appendChild(field);
+
+      const event = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true, bubbles: true });
+      await act(async () => {
+        field.dispatchEvent(event);
+      });
+
+      expect(panelSawPrevented).toEqual([true]);
+      expect(onClose).toHaveBeenCalledTimes(1);
+
+      document.removeEventListener('keydown', panelListener);
+      field.remove();
+    });
   });
 
   it('clears highlights on unmount', async () => {
@@ -273,5 +301,22 @@ describe('BubbleTour', () => {
     unmount();
 
     expect(mockClearAllHighlights).toHaveBeenCalled();
+  });
+
+  it('clears a highlight that paints after the tour has already unmounted', async () => {
+    let resolvePaint: () => void = () => {};
+    mockHighlightWithComment.mockImplementation(() => new Promise<void>((resolve) => (resolvePaint = resolve)));
+
+    const { unmount } = await renderTour();
+    mockClearAllHighlights.mockClear();
+
+    unmount();
+    expect(mockClearAllHighlights).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolvePaint();
+    });
+
+    expect(mockClearAllHighlights).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/BubbleTour/BubbleTour.test.tsx
+++ b/src/components/BubbleTour/BubbleTour.test.tsx
@@ -86,6 +86,39 @@ describe('BubbleTour', () => {
     await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('First'));
   });
 
+  describe('a bubble that outlives its step', () => {
+    it('ignores next from a bubble whose step has already advanced', async () => {
+      await renderTour();
+      const staleNext = lastHighlight()[ARG.onNext];
+
+      await act(async () => staleNext());
+      await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('Second'));
+
+      await act(async () => staleNext());
+
+      expect(mockHighlightWithComment.mock.calls.map((call) => call[ARG.comment])).not.toContain('Third');
+      expect(lastHighlight()[ARG.stepInfo]).toEqual({ current: 1, total: 3, completedSteps: [0] });
+    });
+
+    it('waits for a slow paint before painting the next step', async () => {
+      let releaseFirst: () => void = () => {};
+      mockHighlightWithComment.mockImplementation((_element: unknown, comment: string) =>
+        comment === 'First' ? new Promise<void>((resolve) => (releaseFirst = resolve)) : Promise.resolve()
+      );
+
+      render(<BubbleTour steps={STEPS} onClose={jest.fn()} />);
+      await waitFor(() => expect(mockHighlightWithComment).toHaveBeenCalledTimes(1));
+
+      await act(async () => lastHighlight()[ARG.onNext]());
+
+      expect(mockHighlightWithComment).toHaveBeenCalledTimes(1);
+
+      await act(async () => releaseFirst());
+
+      await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('Second'));
+    });
+  });
+
   it('clears highlights then closes from the last step', async () => {
     const { onClose } = await renderTour({ steps: [STEPS[0]!] });
 
@@ -188,6 +221,21 @@ describe('BubbleTour', () => {
       });
 
       expect(lastHighlight()[ARG.comment]).toBe('First');
+      field.remove();
+    });
+
+    it('closes on Escape even while a text field has focus', async () => {
+      const { onClose } = await renderTour();
+      const field = document.createElement('input');
+      document.body.appendChild(field);
+
+      const event = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true, bubbles: true });
+      await act(async () => {
+        field.dispatchEvent(event);
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(event.defaultPrevented).toBe(true);
       field.remove();
     });
 

--- a/src/components/BubbleTour/BubbleTour.test.tsx
+++ b/src/components/BubbleTour/BubbleTour.test.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react';
+
+import { BubbleTour, type BubbleTourStep } from './BubbleTour';
+
+const mockHighlightWithComment = jest.fn().mockResolvedValue(undefined);
+const mockShowCenteredComment = jest.fn();
+const mockClearAllHighlights = jest.fn();
+
+jest.mock('../../interactive-engine', () => ({
+  NavigationManager: jest.fn().mockImplementation(() => ({
+    highlightWithComment: mockHighlightWithComment,
+    showCenteredComment: mockShowCenteredComment,
+    clearAllHighlights: mockClearAllHighlights,
+  })),
+}));
+
+const mockResolveWithRetry = jest.fn();
+jest.mock('../../lib/dom', () => ({
+  resolveWithRetry: (...args: unknown[]) => mockResolveWithRetry(...args),
+}));
+
+const STEPS: BubbleTourStep[] = [
+  { target: '#one', title: 'One', content: 'First' },
+  { target: '#two', title: 'Two', content: 'Second' },
+  { target: '#three', title: 'Three', content: 'Third' },
+];
+
+/** Positional contract of `highlightWithComment`. */
+const ARG = {
+  element: 0,
+  comment: 1,
+  stepInfo: 3,
+  onCancel: 5,
+  onNext: 6,
+  onPrevious: 7,
+  options: 8,
+} as const;
+
+function lastHighlight() {
+  return mockHighlightWithComment.mock.calls.at(-1)!;
+}
+
+async function renderTour(props: Partial<React.ComponentProps<typeof BubbleTour>> = {}) {
+  const onClose = props.onClose ?? jest.fn();
+  const result = render(<BubbleTour steps={props.steps ?? STEPS} {...props} onClose={onClose} />);
+  await waitFor(() => expect(mockHighlightWithComment).toHaveBeenCalled());
+  return { ...result, onClose };
+}
+
+describe('BubbleTour', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHighlightWithComment.mockResolvedValue(undefined);
+    mockResolveWithRetry.mockImplementation((target: string) =>
+      Promise.resolve({ element: document.createElement('div'), resolvedSelector: target })
+    );
+  });
+
+  it('resolves the first step target and offers no previous callback', async () => {
+    await renderTour();
+
+    expect(mockResolveWithRetry).toHaveBeenCalledWith('#one', 'highlight');
+    expect(lastHighlight()[ARG.comment]).toBe('First');
+    expect(lastHighlight()[ARG.stepInfo]).toEqual({ current: 0, total: 3, completedSteps: [] });
+    expect(lastHighlight()[ARG.onPrevious]).toBeUndefined();
+  });
+
+  it('advances on next, offering a previous callback from the second step on', async () => {
+    await renderTour();
+
+    await act(async () => lastHighlight()[ARG.onNext]());
+
+    await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('Second'));
+    expect(lastHighlight()[ARG.stepInfo]).toEqual({ current: 1, total: 3, completedSteps: [0] });
+    expect(typeof lastHighlight()[ARG.onPrevious]).toBe('function');
+  });
+
+  it('goes back on previous', async () => {
+    await renderTour();
+    await act(async () => lastHighlight()[ARG.onNext]());
+    await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('Second'));
+
+    await act(async () => lastHighlight()[ARG.onPrevious]());
+
+    await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('First'));
+  });
+
+  it('clears highlights then closes from the last step', async () => {
+    const { onClose } = await renderTour({ steps: [STEPS[0]!] });
+
+    await act(async () => lastHighlight()[ARG.onNext]());
+
+    expect(mockClearAllHighlights).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when the bubble is cancelled', async () => {
+    const { onClose } = await renderTour();
+
+    await act(async () => lastHighlight()[ARG.onCancel]());
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies finalStepLabel only to the last step', async () => {
+    await renderTour({ steps: [STEPS[0]!, STEPS[1]!], finalStepLabel: 'Start creating' });
+
+    expect(lastHighlight()[ARG.options].nextLabel).toBeUndefined();
+
+    await act(async () => lastHighlight()[ARG.onNext]());
+
+    await waitFor(() => expect(lastHighlight()[ARG.options].nextLabel).toBe('Start creating'));
+  });
+
+  describe('unresolvable targets', () => {
+    it('falls back to a centered comment that keeps its callbacks', async () => {
+      mockResolveWithRetry.mockResolvedValue(null);
+      render(<BubbleTour steps={STEPS} onClose={jest.fn()} />);
+
+      await waitFor(() => expect(mockShowCenteredComment).toHaveBeenCalled());
+      const [comment, stepInfo, , onNext] = mockShowCenteredComment.mock.calls.at(-1)!;
+      expect(comment).toContain('First');
+      expect(comment).toContain("isn't on screen right now");
+      expect(stepInfo).toEqual({ current: 0, total: 3, completedSteps: [] });
+      expect(typeof onNext).toBe('function');
+      expect(mockHighlightWithComment).not.toHaveBeenCalled();
+    });
+
+    it('does not highlight when the target resolves after unmount', async () => {
+      let resolveTarget: (value: unknown) => void = () => {};
+      mockResolveWithRetry.mockReturnValue(new Promise((resolve) => (resolveTarget = resolve)));
+
+      const { unmount } = render(<BubbleTour steps={STEPS} onClose={jest.fn()} />);
+      unmount();
+
+      await act(async () => {
+        resolveTarget({ element: document.createElement('div') });
+      });
+
+      expect(mockHighlightWithComment).not.toHaveBeenCalled();
+      expect(mockShowCenteredComment).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('keyboard', () => {
+    it('advances on ArrowRight and goes back on ArrowLeft', async () => {
+      await renderTour();
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: 'ArrowRight' });
+      });
+      await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('Second'));
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: 'ArrowLeft' });
+      });
+      await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('First'));
+    });
+
+    it('closes on Escape', async () => {
+      const { onClose } = await renderTour();
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: 'Escape' });
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores Enter so it cannot double as next', async () => {
+      await renderTour();
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: 'Enter' });
+      });
+
+      expect(lastHighlight()[ARG.comment]).toBe('First');
+    });
+
+    it.each(['input', 'textarea'])('ignores keys typed inside a %s', async (tagName) => {
+      await renderTour();
+      const field = document.createElement(tagName);
+      document.body.appendChild(field);
+
+      await act(async () => {
+        fireEvent.keyDown(field, { key: 'ArrowRight' });
+      });
+
+      expect(lastHighlight()[ARG.comment]).toBe('First');
+      field.remove();
+    });
+
+    it('ignores keys typed inside a contenteditable', async () => {
+      await renderTour();
+      const editable = document.createElement('div');
+      editable.contentEditable = 'true';
+      Object.defineProperty(editable, 'isContentEditable', { value: true });
+      document.body.appendChild(editable);
+
+      await act(async () => {
+        fireEvent.keyDown(editable, { key: 'ArrowRight' });
+      });
+
+      expect(lastHighlight()[ARG.comment]).toBe('First');
+      editable.remove();
+    });
+
+    it('prevents default so the floating panel cannot also act on the key', async () => {
+      await renderTour();
+
+      const event = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true, bubbles: true });
+      await act(async () => {
+        document.dispatchEvent(event);
+      });
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+  });
+
+  it('clears highlights on unmount', async () => {
+    const { unmount } = await renderTour();
+    mockClearAllHighlights.mockClear();
+
+    unmount();
+
+    expect(mockClearAllHighlights).toHaveBeenCalled();
+  });
+});

--- a/src/components/BubbleTour/BubbleTour.tsx
+++ b/src/components/BubbleTour/BubbleTour.tsx
@@ -87,17 +87,26 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
         }
 
         if (resolved) {
-          return navigationManager.highlightWithComment(
-            resolved.element,
-            step.content,
-            false,
-            stepInfo,
-            undefined,
-            close,
-            goToNext,
-            onPrevious,
-            options
-          );
+          // highlightWithComment awaits navigation/scroll before it paints. If the tour is
+          // torn down mid-await, `cancelled` is already true by the time it resolves — clear
+          // what it just painted so it doesn't outlive its own component and key listener.
+          return navigationManager
+            .highlightWithComment(
+              resolved.element,
+              step.content,
+              false,
+              stepInfo,
+              undefined,
+              close,
+              goToNext,
+              onPrevious,
+              options
+            )
+            .then(() => {
+              if (cancelled) {
+                navigationManager.clearAllHighlights();
+              }
+            });
         }
 
         navigationManager.showCenteredComment(
@@ -149,8 +158,11 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    // Capture phase: FloatingPanel's own Escape listener is bubble-phase on document and
+    // registered first, so on bubble order alone it would see defaultPrevented as false and
+    // minimize before this handler runs. Capture always runs first regardless of mount order.
+    document.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => document.removeEventListener('keydown', handleKeyDown, { capture: true });
   }, [currentStep, close, goToNext, goToPrevious]);
 
   return null;

--- a/src/components/BubbleTour/BubbleTour.tsx
+++ b/src/components/BubbleTour/BubbleTour.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { NavigationManager } from '../../interactive-engine';
 import { resolveWithRetry } from '../../lib/dom';
+import { logger } from '../../lib/logging';
 import { safeEventHandler } from '../../utils/safe-event-handler.util';
 
 const MISSING_TARGET_NOTE = "This part of the interface isn't on screen right now.";
@@ -30,6 +31,7 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
   const [stepsReached, setStepsReached] = useState(0);
 
   const navigationManager = useMemo(() => new NavigationManager(), []);
+  const paintQueue = useRef<Promise<unknown>>(Promise.resolve());
 
   const totalSteps = steps.length;
   const step = steps[currentStep];
@@ -43,14 +45,19 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
     setStepsReached((prev) => Math.max(prev, currentStep + 1));
 
     if (currentStep < totalSteps - 1) {
-      setCurrentStep((prev) => prev + 1);
+      // A bubble outlives its step while the next target resolves, so a click on that
+      // stale bubble must not advance past the step already loading.
+      setCurrentStep((prev) => (prev === currentStep ? prev + 1 : prev));
       return;
     }
 
     close();
   }, [currentStep, totalSteps, close]);
 
-  const goToPrevious = useCallback(() => setCurrentStep((prev) => Math.max(0, prev - 1)), []);
+  const goToPrevious = useCallback(
+    () => setCurrentStep((prev) => (prev === currentStep ? Math.max(0, prev - 1) : prev)),
+    [currentStep]
+  );
 
   useEffect(() => {
     if (!step) {
@@ -73,34 +80,42 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
       nextLabel: isLastStep ? finalStepLabel : undefined,
     };
 
-    resolveWithRetry(step.target, 'highlight').then((resolved) => {
-      if (cancelled) {
-        return;
-      }
+    void resolveWithRetry(step.target, 'highlight').then((resolved) => {
+      const paint = () => {
+        if (cancelled) {
+          return;
+        }
 
-      if (resolved) {
-        void navigationManager.highlightWithComment(
-          resolved.element,
-          step.content,
-          false,
+        if (resolved) {
+          return navigationManager.highlightWithComment(
+            resolved.element,
+            step.content,
+            false,
+            stepInfo,
+            undefined,
+            close,
+            goToNext,
+            onPrevious,
+            options
+          );
+        }
+
+        navigationManager.showCenteredComment(
+          `${step.content}<br><br><em>${MISSING_TARGET_NOTE}</em>`,
           stepInfo,
-          undefined,
           close,
           goToNext,
           onPrevious,
           options
         );
         return;
-      }
+      };
 
-      navigationManager.showCenteredComment(
-        `${step.content}<br><br><em>${MISSING_TARGET_NOTE}</em>`,
-        stepInfo,
-        close,
-        goToNext,
-        onPrevious,
-        options
-      );
+      // highlightWithComment awaits a scroll before it paints, so concurrent paints can
+      // finish out of order and leave an earlier step's bubble on top of a later one.
+      paintQueue.current = paintQueue.current.then(paint).catch((error) => {
+        logger.warn('BubbleTour failed to paint a step', { error });
+      });
     });
 
     return () => {
@@ -112,15 +127,20 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Escape is handled ahead of the text-field guard: FloatingPanel minimizes on Escape
+      // unless the event is already defaultPrevented, so bailing out here would minimize
+      // the panel and leave the tour running.
+      if (e.key === 'Escape') {
+        safeEventHandler(e, { preventDefault: true });
+        close();
+        return;
+      }
+
       if (isTextEditable(e.target)) {
         return;
       }
 
-      if (e.key === 'Escape') {
-        // FloatingPanel also minimizes on Escape unless the event is already defaultPrevented.
-        safeEventHandler(e, { preventDefault: true });
-        close();
-      } else if (e.key === 'ArrowRight') {
+      if (e.key === 'ArrowRight') {
         safeEventHandler(e, { preventDefault: true });
         goToNext();
       } else if (e.key === 'ArrowLeft' && currentStep > 0) {

--- a/src/components/BubbleTour/BubbleTour.tsx
+++ b/src/components/BubbleTour/BubbleTour.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { NavigationManager } from '../../interactive-engine';
+import { resolveWithRetry } from '../../lib/dom';
+import { safeEventHandler } from '../../utils/safe-event-handler.util';
+
+const MISSING_TARGET_NOTE = "This part of the interface isn't on screen right now.";
+
+export interface BubbleTourStep {
+  target: string;
+  title: string;
+  content: string;
+}
+
+export interface BubbleTourProps {
+  steps: BubbleTourStep[];
+  onClose: () => void;
+  finalStepLabel?: string;
+}
+
+function isTextEditable(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null;
+  return Boolean(
+    element && (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA' || element.isContentEditable)
+  );
+}
+
+export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [stepsReached, setStepsReached] = useState(0);
+
+  const navigationManager = useMemo(() => new NavigationManager(), []);
+
+  const totalSteps = steps.length;
+  const step = steps[currentStep];
+
+  const close = useCallback(() => {
+    navigationManager.clearAllHighlights();
+    onClose();
+  }, [navigationManager, onClose]);
+
+  const goToNext = useCallback(() => {
+    setStepsReached((prev) => Math.max(prev, currentStep + 1));
+
+    if (currentStep < totalSteps - 1) {
+      setCurrentStep((prev) => prev + 1);
+      return;
+    }
+
+    close();
+  }, [currentStep, totalSteps, close]);
+
+  const goToPrevious = useCallback(() => setCurrentStep((prev) => Math.max(0, prev - 1)), []);
+
+  useEffect(() => {
+    if (!step) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const stepInfo = {
+      current: currentStep,
+      total: totalSteps,
+      completedSteps: Array.from({ length: stepsReached }, (_, i) => i),
+    };
+    const onPrevious = currentStep > 0 ? goToPrevious : undefined;
+    const isLastStep = currentStep === totalSteps - 1;
+    const options = {
+      showKeyboardHint: true,
+      skipAnimations: currentStep > 0,
+      stepTitle: step.title,
+      nextLabel: isLastStep ? finalStepLabel : undefined,
+    };
+
+    resolveWithRetry(step.target, 'highlight').then((resolved) => {
+      if (cancelled) {
+        return;
+      }
+
+      if (resolved) {
+        void navigationManager.highlightWithComment(
+          resolved.element,
+          step.content,
+          false,
+          stepInfo,
+          undefined,
+          close,
+          goToNext,
+          onPrevious,
+          options
+        );
+        return;
+      }
+
+      navigationManager.showCenteredComment(
+        `${step.content}<br><br><em>${MISSING_TARGET_NOTE}</em>`,
+        stepInfo,
+        close,
+        goToNext,
+        onPrevious,
+        options
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [step, currentStep, totalSteps, stepsReached, finalStepLabel, navigationManager, close, goToNext, goToPrevious]);
+
+  useEffect(() => () => navigationManager.clearAllHighlights(), [navigationManager]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isTextEditable(e.target)) {
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        // FloatingPanel also minimizes on Escape unless the event is already defaultPrevented.
+        safeEventHandler(e, { preventDefault: true });
+        close();
+      } else if (e.key === 'ArrowRight') {
+        safeEventHandler(e, { preventDefault: true });
+        goToNext();
+      } else if (e.key === 'ArrowLeft' && currentStep > 0) {
+        safeEventHandler(e, { preventDefault: true });
+        goToPrevious();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [currentStep, close, goToNext, goToPrevious]);
+
+  return null;
+}

--- a/src/components/BubbleTour/index.ts
+++ b/src/components/BubbleTour/index.ts
@@ -1,0 +1,2 @@
+export { BubbleTour } from './BubbleTour';
+export type { BubbleTourStep, BubbleTourProps } from './BubbleTour';

--- a/src/components/block-editor/BlockEditorTour.test.tsx
+++ b/src/components/block-editor/BlockEditorTour.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { BlockEditorTour } from './BlockEditorTour';
+import { testIds } from '../../constants/testIds';
+import type { BubbleTourProps } from '../BubbleTour';
+
+const mockBubbleTour = jest.fn();
+jest.mock('../BubbleTour', () => ({
+  BubbleTour: (props: BubbleTourProps) => {
+    mockBubbleTour(props);
+    return null;
+  },
+}));
+
+describe('BlockEditorTour', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function tourProps(): BubbleTourProps {
+    render(<BlockEditorTour onClose={jest.fn()} />);
+    return mockBubbleTour.mock.calls.at(-1)![0];
+  }
+
+  it('keeps its own final-step label rather than the generic default', () => {
+    expect(tourProps().finalStepLabel).toBe('Start creating');
+  });
+
+  it('tours the editor surfaces', () => {
+    const targets = tourProps().steps.map((step) => step.target);
+
+    expect(targets[0]).toContain(testIds.blockEditor.container);
+    expect(targets).toContain(`[data-testid="${testIds.blockEditor.palette}"]`);
+    expect(targets).toHaveLength(6);
+  });
+
+  it('forwards close through to the caller', () => {
+    const onClose = jest.fn();
+    render(<BlockEditorTour onClose={onClose} />);
+
+    mockBubbleTour.mock.calls.at(-1)![0].onClose();
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/block-editor/BlockEditorTour.tsx
+++ b/src/components/block-editor/BlockEditorTour.tsx
@@ -1,32 +1,9 @@
-/**
- * Block Editor Tour
- *
- * A tour controller that guides new users through the block editor interface.
- * Uses the unified NavigationManager highlight system for consistent UX with guided mode.
- */
+import React from 'react';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { NavigationManager } from '../../interactive-engine';
+import { BubbleTour, type BubbleTourStep } from '../BubbleTour';
 import { testIds } from '../../constants/testIds';
 
-/**
- * Tour step definition
- */
-interface TourStep {
-  /** CSS selector or data-testid to target */
-  target: string;
-  /** Step title */
-  title: string;
-  /** Explanation text */
-  content: string;
-  /** Optional action to describe what happens when clicking the target */
-  action?: 'highlight' | 'click';
-}
-
-/**
- * Tour steps for the block editor
- */
-const TOUR_STEPS: TourStep[] = [
+const TOUR_STEPS: BubbleTourStep[] = [
   {
     target: `[data-testid="${testIds.blockEditor.container}"]`,
     title: 'Welcome to the guide editor',
@@ -65,129 +42,11 @@ const TOUR_STEPS: TourStep[] = [
 ];
 
 export interface BlockEditorTourProps {
-  /** Called when the tour is closed */
   onClose: () => void;
-  /** Optional custom tour steps */
-  steps?: TourStep[];
 }
 
-/**
- * Tour controller for the block editor.
- * Uses NavigationManager's unified highlight system for visual consistency with guided mode.
- */
-export function BlockEditorTour({ onClose, steps = TOUR_STEPS }: BlockEditorTourProps) {
-  const [currentStep, setCurrentStep] = useState(0);
-  const [completedSteps, setCompletedSteps] = useState<number[]>([]);
-
-  // Navigation manager singleton
-  const navigationManager = useMemo(() => new NavigationManager(), []);
-
-  const totalSteps = steps.length;
-  const step = steps[currentStep];
-
-  // Navigate to next step
-  const goToNext = useCallback(() => {
-    // Mark current step as completed
-    setCompletedSteps((prev) => (prev.includes(currentStep) ? prev : [...prev, currentStep]));
-
-    if (currentStep < totalSteps - 1) {
-      setCurrentStep((prev) => prev + 1);
-    } else {
-      // Tour complete
-      navigationManager.clearAllHighlights();
-      onClose();
-    }
-  }, [currentStep, totalSteps, onClose, navigationManager]);
-
-  // Navigate to previous step
-  const goToPrevious = useCallback(() => {
-    if (currentStep > 0) {
-      setCurrentStep((prev) => prev - 1);
-    }
-  }, [currentStep]);
-
-  // Close the tour
-  const handleClose = useCallback(() => {
-    navigationManager.clearAllHighlights();
-    onClose();
-  }, [navigationManager, onClose]);
-
-  // Highlight the current step's target element using unified system
-  const highlightCurrentStep = useCallback(async () => {
-    if (!step) {
-      return;
-    }
-
-    // Find the target element
-    const element = document.querySelector(step.target) as HTMLElement | null;
-
-    // Build step info for progress display
-    const stepInfo = {
-      current: currentStep,
-      total: totalSteps,
-      completedSteps: [...completedSteps],
-    };
-
-    if (element) {
-      // Use the unified NavigationManager highlight system
-      // Pass navigation callbacks for tour mode, and options for visual enhancements
-      // Skip animations after first step for smooth transitions
-      await navigationManager.highlightWithComment(
-        element,
-        step.content,
-        false, // Disable auto-cleanup for tour mode
-        stepInfo,
-        undefined, // No skip callback for tour
-        handleClose, // Cancel callback
-        goToNext, // Next callback (for tour navigation)
-        currentStep > 0 ? goToPrevious : undefined, // Previous callback (disabled on first step)
-        {
-          showKeyboardHint: true,
-          skipAnimations: currentStep > 0, // Instant transitions after first step
-          stepTitle: step.title,
-        }
-      );
-    } else {
-      // If element not found, show a centered comment
-      navigationManager.showNoopComment(
-        `<strong>${step.title}</strong><br><br>${step.content}<br><br><em style="opacity: 0.7">Target element not visible - it may appear in a different editor state.</em>`
-      );
-    }
-  }, [step, currentStep, totalSteps, completedSteps, navigationManager, handleClose, goToNext, goToPrevious]);
-
-  // Highlight on step change
-  useEffect(() => {
-    highlightCurrentStep();
-  }, [highlightCurrentStep]);
-
-  // Clean up highlights on unmount
-  useEffect(() => {
-    return () => {
-      navigationManager.clearAllHighlights();
-    };
-  }, [navigationManager]);
-
-  // Handle keyboard navigation
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        handleClose();
-      } else if (e.key === 'ArrowRight' || e.key === 'Enter') {
-        goToNext();
-      } else if (e.key === 'ArrowLeft') {
-        if (currentStep > 0) {
-          goToPrevious();
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [currentStep, handleClose, goToNext, goToPrevious]);
-
-  // No JSX needed - the tour renders via NavigationManager's highlight system
-  return null;
+export function BlockEditorTour({ onClose }: BlockEditorTourProps) {
+  return <BubbleTour steps={TOUR_STEPS} onClose={onClose} finalStepLabel="Start creating" />;
 }
 
-// Display name for debugging
 BlockEditorTour.displayName = 'BlockEditorTour';

--- a/src/components/floating-panel/useHighlightDodge.test.ts
+++ b/src/components/floating-panel/useHighlightDodge.test.ts
@@ -29,9 +29,12 @@ function addModal(left: number, top: number, width: number, height: number, attr
   return el;
 }
 
-function addHighlight(left: number, top: number, width: number, height: number) {
+function addHighlight(left: number, top: number, width: number, height: number, internal = false) {
   const el = document.createElement('div');
   el.className = 'interactive-highlight-outline';
+  if (internal) {
+    el.setAttribute('data-pathfinder-internal', 'true');
+  }
   document.body.appendChild(el);
   mockRect(el, left, top, width, height);
   return el;
@@ -105,6 +108,14 @@ describe('useHighlightDodge — modal dodging', () => {
     // The chosen corner must clear both modals, including the large one.
     const dodge = cap.events.find((e) => e.type === 'dodge');
     expect(dodge?.detail).toEqual({ x: 32, y: 368 }); // bottom-left
+    cap.cleanup();
+  });
+
+  it('ignores a highlight that targets the panel itself, so it cannot flee its own tour', () => {
+    addHighlight(0, 0, 200, 200, true); // overlaps the panel, but is in-panel chrome
+    const cap = captureEvents();
+    renderHook(() => useHighlightDodge(GEOMETRY, false, true));
+    expect(cap.events).toEqual([]);
     cap.cleanup();
   });
 

--- a/src/components/floating-panel/useHighlightDodge.ts
+++ b/src/components/floating-panel/useHighlightDodge.ts
@@ -8,7 +8,8 @@ import { getVisibleModalRects } from '../../interactive-engine';
 import { FloatingPanelEvents, type FloatingPanelMoveDetail } from '../../lib/event-names';
 
 /** Selectors for interactive overlay elements that the panel should dodge. */
-const HIGHLIGHT_SELECTOR = '.interactive-highlight-outline, .interactive-comment-box';
+const HIGHLIGHT_SELECTOR =
+  '.interactive-highlight-outline:not([data-pathfinder-internal]), .interactive-comment-box:not([data-pathfinder-internal])';
 
 interface Rect {
   left: number;

--- a/src/interactive-engine/comment-box.tour-chrome.test.ts
+++ b/src/interactive-engine/comment-box.tour-chrome.test.ts
@@ -1,0 +1,258 @@
+import { NavigationManager } from './navigation-manager';
+import * as domUtils from '../lib/dom';
+
+jest.mock('../lib/dom');
+
+class MockResizeObserver {
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+}
+global.ResizeObserver = MockResizeObserver as any;
+
+const mockIsElementVisible = domUtils.isElementVisible as jest.MockedFunction<typeof domUtils.isElementVisible>;
+const mockDescribeElement = domUtils.describeElement as jest.MockedFunction<typeof domUtils.describeElement>;
+const mockGetScrollParent = domUtils.getScrollParent as jest.MockedFunction<typeof domUtils.getScrollParent>;
+const mockGetVisibleHighlightTarget = domUtils.getVisibleHighlightTarget as jest.MockedFunction<
+  typeof domUtils.getVisibleHighlightTarget
+>;
+const mockIsPathfinderContent = domUtils.isPathfinderContent as jest.MockedFunction<
+  typeof domUtils.isPathfinderContent
+>;
+
+const stepInfo = (current: number, total: number, completedSteps: number[] = []) => ({
+  current,
+  total,
+  completedSteps,
+});
+
+function commentBox(): HTMLElement {
+  return document.querySelector('.interactive-comment-box')!;
+}
+
+function navButtons(): HTMLButtonElement[] {
+  return Array.from(commentBox().querySelectorAll('.interactive-comment-nav-btn'));
+}
+
+function buttonLabelled(text: string): HTMLButtonElement | undefined {
+  return navButtons().find((button) => button.textContent === text);
+}
+
+describe('comment box tour chrome', () => {
+  let navigationManager: NavigationManager;
+  let target: HTMLElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDescribeElement.mockReturnValue('div');
+    mockIsElementVisible.mockReturnValue(true);
+    mockGetScrollParent.mockReturnValue(document.documentElement);
+    mockGetVisibleHighlightTarget.mockImplementation((el) => el);
+    mockIsPathfinderContent.mockReturnValue(false);
+
+    navigationManager = new NavigationManager();
+
+    target = document.createElement('div');
+    target.scrollIntoView = jest.fn();
+    target.getBoundingClientRect = jest.fn().mockReturnValue({
+      top: 100,
+      left: 100,
+      bottom: 200,
+      right: 200,
+      width: 100,
+      height: 100,
+    });
+    document.body.appendChild(target);
+  });
+
+  afterEach(() => {
+    navigationManager.clearAllHighlights();
+    target.remove();
+  });
+
+  const highlight = (
+    opts: {
+      current?: number;
+      total?: number;
+      completedSteps?: number[];
+      onNext?: () => void;
+      onPrevious?: () => void;
+      onCancel?: () => void;
+      onSkip?: () => void;
+      nextLabel?: string;
+      showKeyboardHint?: boolean;
+    } = {}
+  ) =>
+    navigationManager.highlightWithComment(
+      target,
+      'step copy',
+      false,
+      stepInfo(opts.current ?? 0, opts.total ?? 3, opts.completedSteps),
+      opts.onSkip,
+      opts.onCancel ?? jest.fn(),
+      'onNext' in opts ? opts.onNext : jest.fn(),
+      opts.onPrevious,
+      { nextLabel: opts.nextLabel, showKeyboardHint: opts.showKeyboardHint }
+    );
+
+  describe('navigation buttons', () => {
+    it('renders Back and Next when both tour callbacks are supplied', async () => {
+      await highlight({ onNext: jest.fn(), onPrevious: jest.fn() });
+
+      expect(buttonLabelled('← Back')).toBeDefined();
+      expect(buttonLabelled('Next →')).toBeDefined();
+    });
+
+    it('disables Back when no previous callback is supplied', async () => {
+      await highlight({ onPrevious: undefined });
+
+      expect(buttonLabelled('← Back')!.disabled).toBe(true);
+    });
+
+    it('enables Back when a previous callback is supplied', async () => {
+      await highlight({ onPrevious: jest.fn() });
+
+      expect(buttonLabelled('← Back')!.disabled).toBe(false);
+    });
+
+    it('invokes the matching callback on click', async () => {
+      const onNext = jest.fn();
+      const onPrevious = jest.fn();
+      await highlight({ onNext, onPrevious });
+
+      buttonLabelled('Next →')!.click();
+      buttonLabelled('← Back')!.click();
+
+      expect(onNext).toHaveBeenCalledTimes(1);
+      expect(onPrevious).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('next label', () => {
+    it('falls back to Done on the last step', async () => {
+      await highlight({ current: 2, total: 3 });
+
+      expect(buttonLabelled('Done')).toBeDefined();
+      expect(buttonLabelled('Done')!.getAttribute('aria-label')).toBe('Done');
+    });
+
+    it('honours an explicit label on the last step', async () => {
+      await highlight({ current: 2, total: 3, nextLabel: 'Start creating' });
+
+      expect(buttonLabelled('Start creating')).toBeDefined();
+      expect(buttonLabelled('Done')).toBeUndefined();
+    });
+
+    it('honours an explicit label mid-tour, keeping the generic aria-label', async () => {
+      await highlight({ current: 1, total: 3, nextLabel: 'Open the guide' });
+
+      const next = buttonLabelled('Open the guide')!;
+      expect(next).toBeDefined();
+      expect(next.getAttribute('aria-label')).toBe('Next step');
+    });
+
+    it('renders Next on a non-final step when no label is supplied', async () => {
+      await highlight({ current: 1, total: 3 });
+
+      expect(buttonLabelled('Next →')).toBeDefined();
+    });
+  });
+
+  describe('progress chrome', () => {
+    it('reads the step badge from stepInfo', async () => {
+      await highlight({ current: 1, total: 5 });
+
+      expect(commentBox().querySelector('.interactive-comment-step-badge')!.textContent).toBe('Step 2 of 5');
+    });
+
+    it('marks the current and completed dots', async () => {
+      await highlight({ current: 2, total: 4, completedSteps: [0, 1] });
+
+      const dots = Array.from(commentBox().querySelectorAll('.interactive-comment-dot'));
+      expect(dots).toHaveLength(4);
+      expect(dots[0]!.classList.contains('interactive-comment-dot--completed')).toBe(true);
+      expect(dots[1]!.classList.contains('interactive-comment-dot--completed')).toBe(true);
+      expect(dots[2]!.classList.contains('interactive-comment-dot--current')).toBe(true);
+      expect(dots[3]!.classList.contains('interactive-comment-dot--current')).toBe(false);
+    });
+
+    it('renders the keyboard hint only when asked', async () => {
+      await highlight({ showKeyboardHint: true });
+      expect(commentBox().querySelector('.interactive-comment-keyboard-hint')).not.toBeNull();
+
+      navigationManager.clearAllHighlights();
+
+      await highlight({ showKeyboardHint: false });
+      expect(commentBox().querySelector('.interactive-comment-keyboard-hint')).toBeNull();
+    });
+  });
+
+  describe('guided mode is unaffected', () => {
+    it('renders Cancel and Skip, and no tour buttons, when only guided callbacks are supplied', async () => {
+      await navigationManager.highlightWithComment(
+        target,
+        'guided copy',
+        false,
+        stepInfo(0, 3),
+        jest.fn(),
+        jest.fn(),
+        undefined,
+        undefined
+      );
+
+      expect(buttonLabelled('Cancel')).toBeDefined();
+      expect(buttonLabelled('Skip →')).toBeDefined();
+      expect(buttonLabelled('← Back')).toBeUndefined();
+      expect(buttonLabelled('Next →')).toBeUndefined();
+    });
+  });
+
+  describe('showCenteredComment', () => {
+    it('keeps the navigation footer and centres without inline coordinates', () => {
+      const onNext = jest.fn();
+      navigationManager.showCenteredComment('missing target copy', stepInfo(1, 4), jest.fn(), onNext, jest.fn());
+
+      const box = commentBox();
+      expect(box.getAttribute('data-position')).toBe('center');
+      expect(box.style.top).toBe('');
+      expect(box.style.left).toBe('');
+      expect(buttonLabelled('Next →')).toBeDefined();
+      expect(buttonLabelled('← Back')).toBeDefined();
+
+      buttonLabelled('Next →')!.click();
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('showNoopComment stays a distinct shape', () => {
+    it('renders no footer and keeps its noop marker', () => {
+      navigationManager.showNoopComment('noop copy');
+
+      const box = commentBox();
+      expect(box.getAttribute('data-noop')).toBe('true');
+      expect(box.getAttribute('data-position')).toBe('center');
+      expect(navButtons()).toHaveLength(0);
+    });
+  });
+
+  describe('in-panel highlights are exempt from the floating-panel dodge', () => {
+    it('marks both the outline and the comment box when the target is inside the panel', async () => {
+      mockIsPathfinderContent.mockReturnValue(true);
+      await highlight();
+
+      expect(document.querySelector('.interactive-highlight-outline')!.hasAttribute('data-pathfinder-internal')).toBe(
+        true
+      );
+      expect(commentBox().hasAttribute('data-pathfinder-internal')).toBe(true);
+    });
+
+    it('leaves ordinary targets unmarked', async () => {
+      await highlight();
+
+      expect(document.querySelector('.interactive-highlight-outline')!.hasAttribute('data-pathfinder-internal')).toBe(
+        false
+      );
+      expect(commentBox().hasAttribute('data-pathfinder-internal')).toBe(false);
+    });
+  });
+});

--- a/src/interactive-engine/index.ts
+++ b/src/interactive-engine/index.ts
@@ -12,7 +12,7 @@ export { updateInteractiveThemeColors } from '../styles/interactive.styles';
 
 // Navigation manager
 export { NavigationManager } from './navigation-manager';
-export type { NavigationOptions } from './navigation-manager';
+export type { NavigationOptions, CommentBoxOptions } from './navigation-manager';
 
 // State management
 export { InteractiveStateManager } from './interactive-state-manager';

--- a/src/interactive-engine/navigation-manager.ts
+++ b/src/interactive-engine/navigation-manager.ts
@@ -21,6 +21,17 @@ export interface NavigationOptions {
   ensureDocked?: boolean;
 }
 
+export interface CommentBoxOptions {
+  showKeyboardHint?: boolean;
+  stepTitle?: string;
+  skipAnimations?: boolean;
+  actionType?: 'hover' | 'button' | 'highlight' | 'formfill';
+  targetValue?: string;
+  /** E2E contract: selector for current target */
+  refTarget?: string;
+  nextLabel?: string;
+}
+
 const NAV_ITEM_SELECTOR = 'a[data-testid="data-testid Nav menu item"]';
 const MEGA_MENU_SELECTOR = '[data-testid="data-testid navigation mega-menu"]';
 
@@ -106,6 +117,37 @@ export class NavigationManager {
 
     // Add to document body (centered via CSS)
     document.body.appendChild(commentBox);
+  }
+
+  /**
+   * Show a viewport-centered comment that keeps its navigation footer.
+   * Used when a tour step's target cannot be resolved, so the user can still move on.
+   */
+  showCenteredComment(
+    comment: string,
+    stepInfo?: { current: number; total: number; completedSteps: number[] },
+    onCancelCallback?: () => void,
+    onNextCallback?: () => void,
+    onPreviousCallback?: () => void,
+    options?: CommentBoxOptions
+  ): HTMLElement {
+    this.clearAllHighlights();
+
+    const commentBox = this.createCommentBox(
+      comment,
+      null,
+      null,
+      stepInfo,
+      undefined,
+      onCancelCallback,
+      onNextCallback,
+      onPreviousCallback,
+      options
+    );
+
+    document.body.appendChild(commentBox);
+
+    return commentBox;
   }
 
   /**
@@ -641,14 +683,7 @@ export class NavigationManager {
     onCancelCallback?: () => void,
     onNextCallback?: () => void,
     onPreviousCallback?: () => void,
-    options?: {
-      showKeyboardHint?: boolean;
-      stepTitle?: string;
-      skipAnimations?: boolean; // For smooth step transitions
-      actionType?: 'hover' | 'button' | 'highlight' | 'formfill';
-      targetValue?: string;
-      refTarget?: string; // E2E contract: selector for current target
-    }
+    options?: CommentBoxOptions
   ): Promise<HTMLElement> {
     // First, ensure navigation is open and element is visible
     // Keep old highlight visible during this async work for smooth transitions
@@ -691,6 +726,12 @@ export class NavigationManager {
 
     // Create highlight element (dot or bounding box)
     const highlightElement = document.createElement('div');
+
+    // The floating panel dodges highlight overlays; exempt in-panel ones so it can't flee its own.
+    const isInternalTarget = isPathfinderContent(highlightTarget);
+    if (isInternalTarget) {
+      highlightElement.setAttribute('data-pathfinder-internal', 'true');
+    }
 
     if (useDotIndicator) {
       highlightElement.className = 'interactive-highlight-dot';
@@ -738,6 +779,10 @@ export class NavigationManager {
         onPreviousCallback,
         options
       );
+
+      if (isInternalTarget) {
+        commentBox.setAttribute('data-pathfinder-internal', 'true');
+      }
 
       // Always append to body (unified positioning)
       document.body.appendChild(commentBox);
@@ -811,21 +856,14 @@ export class NavigationManager {
    */
   private createCommentBox(
     comment: string,
-    targetRect: DOMRect,
-    highlightRect: { top: number; left: number; width: number; height: number },
+    targetRect: DOMRect | null,
+    highlightRect: { top: number; left: number; width: number; height: number } | null,
     stepInfo?: { current: number; total: number; completedSteps: number[] },
     onSkipCallback?: () => void,
     onCancelCallback?: () => void,
     onNextCallback?: () => void,
     onPreviousCallback?: () => void,
-    options?: {
-      showKeyboardHint?: boolean;
-      stepTitle?: string;
-      skipAnimations?: boolean;
-      actionType?: 'hover' | 'button' | 'highlight' | 'formfill';
-      targetValue?: string;
-      refTarget?: string; // E2E contract: selector for current target
-    }
+    options?: CommentBoxOptions
   ): HTMLElement {
     const commentBox = document.createElement('div');
     commentBox.className = 'interactive-comment-box';
@@ -955,7 +993,7 @@ export class NavigationManager {
         // Previous button
         const prevButton = document.createElement('button');
         prevButton.className = 'interactive-comment-nav-btn';
-        prevButton.innerHTML = '← Back'; // eslint-disable-line no-restricted-syntax -- Static HTML literal
+        prevButton.textContent = '← Back';
         prevButton.setAttribute('aria-label', 'Previous step');
         prevButton.disabled = !onPreviousCallback;
 
@@ -976,9 +1014,10 @@ export class NavigationManager {
         // Next button - primary style
         const nextButton = document.createElement('button');
         const isLastStep = stepInfo && stepInfo.current === stepInfo.total - 1;
+        const nextLabel = options?.nextLabel ?? (isLastStep ? 'Done' : 'Next →');
         nextButton.className = 'interactive-comment-nav-btn interactive-comment-nav-btn--primary';
-        nextButton.innerHTML = isLastStep ? 'Start creating' : 'Next →'; // eslint-disable-line no-restricted-syntax -- Static HTML literal
-        nextButton.setAttribute('aria-label', isLastStep ? 'Start creating' : 'Next step');
+        nextButton.textContent = nextLabel;
+        nextButton.setAttribute('aria-label', isLastStep ? nextLabel : 'Next step');
 
         if (onNextCallback) {
           nextButton.addEventListener('click', (e) => {
@@ -1051,6 +1090,12 @@ export class NavigationManager {
     }
 
     commentBox.appendChild(content);
+
+    // Returning before any inline top/left write is what lets the CSS centering rule apply.
+    if (!targetRect || !highlightRect) {
+      commentBox.setAttribute('data-position', 'center');
+      return commentBox;
+    }
 
     // MEASURE ACTUAL HEIGHT: Append off-screen temporarily to measure real dimensions
     commentBox.style.visibility = 'hidden';

--- a/src/styles/interactive.overlay.styles.test.ts
+++ b/src/styles/interactive.overlay.styles.test.ts
@@ -1,0 +1,35 @@
+import { addGlobalInteractiveStyles } from './interactive.overlay.styles';
+
+function commentBox(attributes: Record<string, string>, className = 'interactive-comment-box'): HTMLElement {
+  const box = document.createElement('div');
+  box.className = className;
+  Object.entries(attributes).forEach(([name, value]) => box.setAttribute(name, value));
+  document.body.appendChild(box);
+  return box;
+}
+
+describe('interactive comment box visibility', () => {
+  beforeEach(() => {
+    document.getElementById('interactive-global-styles')?.remove();
+    document.body.innerHTML = '';
+    addGlobalInteractiveStyles();
+  });
+
+  it('starts hidden before it is marked ready', () => {
+    const box = commentBox({ 'data-position': 'center' });
+
+    expect(getComputedStyle(box).opacity).toBe('0');
+  });
+
+  it.each(['right', 'left', 'top', 'bottom', 'center'])('reveals a ready %s box', (position) => {
+    const box = commentBox({ 'data-position': position, 'data-ready': 'true' });
+
+    expect(getComputedStyle(box).opacity).toBe('1');
+  });
+
+  it.each(['right', 'left', 'top', 'bottom', 'center'])('reveals an instant %s box', (position) => {
+    const box = commentBox({ 'data-position': position }, 'interactive-comment-box interactive-comment-box--instant');
+
+    expect(getComputedStyle(box).opacity).toBe('1');
+  });
+});

--- a/src/styles/interactive.overlay.styles.ts
+++ b/src/styles/interactive.overlay.styles.ts
@@ -399,6 +399,7 @@ export const addGlobalInteractiveStyles = () => {
     }
 
     .interactive-comment-box[data-ready="true"][data-position="center"] {
+      opacity: 1;
       transform: scale(1) translate(-50%, -50%);
     }
 


### PR DESCRIPTION
## Summary

Lifts the block editor's tour into a reusable `src/components/BubbleTour/`, leaving `BlockEditorTour` as a thin wrapper that supplies its own steps. Along the way it fixes three defects that exist on `main` today.

`BlockEditorTour` was already headless — it `return null`ed and owned only step data, an index, and a keydown listener, while all the bubble UI came from `NavigationManager.highlightWithComment`. This makes that reusability real rather than incidental.

## Why

A second caller wants the same next/previous bubble. Rather than copy the controller, this extracts it — and extracting forced the three bugs below into the open, each of which is reachable on `main` right now.

## What to look at

**`src/interactive-engine/navigation-manager.ts`** is the only shared-engine change, and it has three parts:

1. `'Start creating'` was block-editor copy hardcoded in the engine (`:980`). It becomes `options.nextLabel`, defaulting to `Done`. `BlockEditorTour.test.tsx` pins the editor's own label so its visible copy can't regress.
2. `createCommentBox` now accepts null rects and returns a viewport-centered box **with its footer intact**, exposed as `showCenteredComment`. Previously a missing target fell through to `showNoopComment`, which takes only a string — so the user lost Back/Next and only the keyboard could move them on.
3. In-panel overlays get `data-pathfinder-internal`, derived from `isPathfinderContent(highlightTarget)`.

`showNoopComment` is deliberately **not** touched — its box has different chrome and three contract tests pin its `data-noop` marker.

**The signature stays positional.** `guided-handler.test.ts:145-155` asserts all nine arguments; options are matched with `objectContaining`, so adding a field is safe where an options-object refactor would not be.

**`useHighlightDodge.ts`** — one selector line, and the actual bug fix. See below.

## Bugs fixed

**The floating panel fled its own highlight.** `useHighlightDodge` moves the panel away from `.interactive-highlight-outline` / `.interactive-comment-box`, and the block editor renders inside `FloatingPanel` (`FloatingPanelManager.tsx:376`), whose root carries `data-pathfinder-content="true"`. Pop the editor out, take the tour, and the panel runs from the thing it's pointing at. Both the outline and the bubble are exempted — exempting only the outline lets the panel dodge the bubble, which moves the target, which re-anchors the bubble, which oscillates.

**The keydown listener hijacked typing.** It listened on `document` with no target check and treated `Enter` as "next", so `Enter` or an arrow key inside any editor text field advanced the tour. Now scoped to ignore `input` / `textarea` / `contenteditable`, `Enter` dropped, and `preventDefault` called — that last part matters because `FloatingPanel.tsx:103-110` minimizes on Escape unless the event is already `defaultPrevented`, so one Escape would otherwise both close the tour *and* minimize the panel.

**A missing target stranded the user.** Covered above.

## Test coverage

The tour branch of `createCommentBox` had **no** coverage — no Back/Next, no step badge, no dots, no last-step label. `comment-box.tour-chrome.test.ts` covers it, including a regression guard that guided mode still renders Cancel/Skip and *not* Back/Next, which protects the six other `highlightWithComment` callers (`guided-handler`, `hover-handler`, `button-handler`, `form-fill-handler`, `focus-handler`, `action-replay`).

## How to verify

```bash
npm run check
```

Then in a local Grafana, open the block editor → kebab → **Take tour**:

- Walk it with both mouse and arrow keys. The last button still reads **Start creating**.
- Type in a block's text field mid-tour — `Enter` and arrows no longer advance it.
- Press Escape once — the tour closes and the panel does **not** also minimize.
- Pop the editor out and repeat. The panel must not flee its own highlight.

## Breaking changes

None. `BlockEditorTour`'s props narrow from `{ onClose, steps? }` to `{ onClose }` — the `steps?` override was never passed by any caller, and `BlockEditorModals.tsx:85` is unchanged.

## Reversibility

Fully reversible. The engine change is additive on the options bag; the dodge change is one selector. Reverting restores the previous behaviour including the three bugs.
