### PR TITLE
claude/interactive learning banner tour

### DIFF
--- a/docs/developer/EXPERIMENT_TESTING.md
+++ b/docs/developer/EXPERIMENT_TESTING.md
@@ -192,7 +192,9 @@ Variant reassignment is the **only** condition where the event auto-refires acro
 
 ## `pathfinder.interactive-learning-banner-experiment`
 
-Tests whether explaining interactive learning up front increases guide engagement. `treatment` renders a dismissible explanatory banner at the top of the context page; `control` and `excluded` render nothing.
+Tests whether explaining interactive learning up front increases guide engagement. `treatment` renders a dismissible banner whose CTA starts a bubble tour; `control` and `excluded` render nothing.
+
+The tour runs on `src/components/BubbleTour/` - the same `NavigationManager` bubble guided mode uses, so it inherits auto-placement, the step counter, progress dots, and scroll-into-view. Steps 1-6 anchor to the context panel and tab bar, step 7's primary button reads **open the guide** and opens the platform-appropriate welcome guide (`bundled:welcome-to-grafana` locally, `bundled:welcome-to-grafana-cloud` on a Cloud stack), steps 8-9 point at that guide's real "Show me" and "Do it" buttons, and step 9's button reads **take me back**, returning to the recommendations tab so step 10 lands on the context panel the tour began on.
 
 ### Treatment
 
@@ -201,7 +203,15 @@ __pathfinderExperiment.setOverride('pathfinder.interactive-learning-banner-exper
 location.reload();
 ```
 
-Open the sidebar. The banner sits above the profile bar, and its only control is the dismiss affordance.
+Open the sidebar. The banner sits above the profile bar, and its CTA starts the tour. Arrow keys navigate, Esc exits.
+
+Three things look like bugs but are not:
+
+- **The "guides from your organization" step is missing locally.** It is `optional`, and `CustomGuidesSection` needs the `aggregation.pathfinderbackend-ext-grafana-app.enabled` toggle that `docker-compose.yaml` does not set. The step is dropped at mount, so the counter reads "of 9" rather than "of 10". Private learning paths are still covered - the My learning step points at them, and that anchor is always present.
+- **Back is disabled on the first in-guide step, and on the last one.** Each of those crosses a tab switch, so the previous step's target no longer exists. Both crossings are deliberately one-way.
+- **The highlight outline fades after a few seconds while the bubble stays.** Pre-existing engine behaviour - the CSS animation completes, and only the auto-remove timer is suppressed for tours.
+
+Worth walking in **floating mode** (pop out) as well as docked: in-panel highlights carry `data-pathfinder-internal`, which is what stops `useHighlightDodge` making the floating panel flee its own highlight.
 
 ### Control
 

--- a/docs/developer/FEATURE_FLAGS.md
+++ b/docs/developer/FEATURE_FLAGS.md
@@ -200,7 +200,7 @@ interface InteractiveLearningBannerConfig {
 | ----------- | ------ | ---------------------------------------------------------------- |
 | `excluded`  | No     | Not in the experiment. Identical to pre-experiment behavior.     |
 | `control`   | No     | In the experiment, no banner. Identical rendering to `excluded`. |
-| `treatment` | Yes    | Dismissible explanatory banner at the top of the context page.   |
+| `treatment` | Yes    | Dismissible banner whose CTA starts a bubble tour of the panel.  |
 
 A rejected payload (not an object, missing `variant`, or an unknown arm) falls back to `excluded`, so a fat-fingered MTFF value enrolls nobody. Rejection sources behave the same way as the highlighted-guide flag (see the table above).
 
@@ -208,9 +208,18 @@ A rejected payload (not an object, missing `variant`, or an unknown arm) falls b
 
 **Dismissal**: persisted per browser under `grafana-pathfinder-interactive-learning-banner-dismissed-{hostname}`. Dismissing hides the banner permanently but does **not** un-enroll the user — they stay in the treatment arm for analysis.
 
-**Behavior events** (in addition to the exposure): `pathfinder_interactive_learning_banner_shown` (once per page load) and `..._banner_dismissed`, both carrying `interaction_location: interactive_learning_banner`.
+**Behavior events** (in addition to the exposure): `pathfinder_interactive_learning_banner_shown` (once per page load) and `..._banner_dismissed` for the banner itself, then `pathfinder_interactive_learning_tour_started` on the CTA and `..._tour_completed` / `..._tour_dismissed` when the tour ends, both carrying `step_index` and `step_total` so per-bubble drop-off is measurable. The tour's hand-off step also reports the ordinary `pathfinder_open_resource_click` with `interaction_location: interactive_learning_banner`, so the guide open sits in the same funnel as every recommendation card.
 
-**Code**: everything except the registry entry lives in [`src/utils/experiments/interactive-learning-banner.ts`](../../src/utils/experiments/interactive-learning-banner.ts) and [`src/components/InteractiveLearningBanner/`](../../src/components/InteractiveLearningBanner/), so retiring the experiment is a directory delete plus the registry entry.
+**The CTA starts a bubble tour, then hands off to a real guide.** Steps 1-6 anchor next/previous bubbles to the context panel and tab bar via [`src/components/BubbleTour/`](../../src/components/BubbleTour/) - the same `NavigationManager.highlightWithComment` bubble guided mode uses. Step 7's primary button opens the platform-appropriate welcome guide (`bundled:welcome-to-grafana` on OSS, `bundled:welcome-to-grafana-cloud` on Cloud), steps 8-9 point at that guide's real "Show me" and "Do it" buttons, and step 9 returns to the recommendations tab so the tour closes where it began.
+
+Four things in that flow are load-bearing:
+
+- **The tour is hosted from the docs-panel root, not from the banner.** The hand-off opens a guide tab, which flips `isRecommendationsTab` false and unmounts the context panel at [`DocsPanelContentArea.tsx:145`](../../src/components/docs-panel/components/DocsPanelContentArea.tsx) - taking the banner, and any tour it owned, down mid-flight. `tour-store.ts` is the seam: the banner's CTA sets a module-level flag and `<InteractiveLearningTour>` on the panel root subscribes via `useSyncExternalStore`.
+- **The guide is platform-branched.** The Cloud guide's nav reftargets do not exist in OSS, and one of them is neither `skippable` nor guarded by `exists-reftarget`, so it hard-blocks a local stack.
+- **The in-guide steps anchor on `.interactive-step-show-btn` / `.interactive-step-do-btn`, not step testids.** Step ids are content hashes (`deriveStepId`), so they shift whenever a guide's blocks are edited or reordered. The class selectors also self-adapt: a step whose requirements have not passed renders neither button, so the first match is always an enabled step.
+- **Private content is covered twice, deliberately.** The context-tab `CustomGuidesSection` step is `optional` - that section is absent whenever the backend aggregation toggle is off or the org has no custom guides, so the step is dropped at mount and the numbering stays truthful. Because that makes it invisible on most stacks, a second non-optional step anchors on the **My learning** icon button (`TabBarActions.tsx:145`, always rendered) and names private learning paths there.
+
+**Code**: [`src/utils/experiments/interactive-learning-banner.ts`](../../src/utils/experiments/interactive-learning-banner.ts) and [`src/components/InteractiveLearningBanner/`](../../src/components/InteractiveLearningBanner/). Retiring the experiment is a directory delete, the registry entry, and the `<InteractiveLearningTour>` line in `docs-panel.tsx`. `src/components/BubbleTour/` outlives it - the block editor's tour uses it too.
 
 **Tracking key**: `interactive_learning_banner_experiment`
 

--- a/src/components/BubbleTour/BubbleTour.test.tsx
+++ b/src/components/BubbleTour/BubbleTour.test.tsx
@@ -86,31 +86,81 @@ describe('BubbleTour', () => {
     await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('First'));
   });
 
-  it('clears highlights then closes from the last step', async () => {
+  it('clears highlights and reports completion from the last step', async () => {
     const { onClose } = await renderTour({ steps: [STEPS[0]!] });
 
     await act(async () => lastHighlight()[ARG.onNext]());
 
     expect(mockClearAllHighlights).toHaveBeenCalled();
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledWith({ reason: 'completed', stepIndex: 0, stepTotal: 1 });
   });
 
-  it('closes when the bubble is cancelled', async () => {
+  it('reports a dismissal with the step it ended on', async () => {
     const { onClose } = await renderTour();
+    await act(async () => lastHighlight()[ARG.onNext]());
+    await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('Second'));
 
     await act(async () => lastHighlight()[ARG.onCancel]());
 
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledWith({ reason: 'dismissed', stepIndex: 1, stepTotal: 3 });
   });
 
-  it('applies finalStepLabel only to the last step', async () => {
-    await renderTour({ steps: [STEPS[0]!, STEPS[1]!], finalStepLabel: 'Start creating' });
+  describe('next label', () => {
+    it('applies finalStepLabel only to the last step', async () => {
+      await renderTour({ steps: [STEPS[0]!, STEPS[1]!], finalStepLabel: 'Start creating' });
 
-    expect(lastHighlight()[ARG.options].nextLabel).toBeUndefined();
+      expect(lastHighlight()[ARG.options].nextLabel).toBeUndefined();
 
-    await act(async () => lastHighlight()[ARG.onNext]());
+      await act(async () => lastHighlight()[ARG.onNext]());
 
-    await waitFor(() => expect(lastHighlight()[ARG.options].nextLabel).toBe('Start creating'));
+      await waitFor(() => expect(lastHighlight()[ARG.options].nextLabel).toBe('Start creating'));
+    });
+
+    it("prefers a step's own label", async () => {
+      await renderTour({ steps: [{ ...STEPS[0]!, nextLabel: 'Open the guide' }] });
+
+      expect(lastHighlight()[ARG.options].nextLabel).toBe('Open the guide');
+    });
+  });
+
+  describe('step behaviour flags', () => {
+    it('runs onAdvance when the step is advanced', async () => {
+      const onAdvance = jest.fn();
+      await renderTour({ steps: [{ ...STEPS[0]!, onAdvance }, STEPS[1]!] });
+
+      await act(async () => lastHighlight()[ARG.onNext]());
+
+      expect(onAdvance).toHaveBeenCalledTimes(1);
+    });
+
+    it('withholds the previous callback on a disableBack step', async () => {
+      await renderTour({ steps: [STEPS[0]!, { ...STEPS[1]!, disableBack: true }] });
+
+      await act(async () => lastHighlight()[ARG.onNext]());
+
+      await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('Second'));
+      expect(lastHighlight()[ARG.onPrevious]).toBeUndefined();
+    });
+
+    it('drops an optional step whose target is absent and adjusts the total', async () => {
+      await renderTour({ steps: [STEPS[0]!, { target: '#absent', title: 'Gone', content: 'Gone', optional: true }] });
+
+      expect(lastHighlight()[ARG.stepInfo]).toEqual({ current: 0, total: 1, completedSteps: [] });
+    });
+
+    it('keeps an optional step whose target is present', async () => {
+      const present = document.createElement('div');
+      present.id = 'present';
+      document.body.appendChild(present);
+
+      await renderTour({
+        steps: [STEPS[0]!, { target: '#present', title: 'Here', content: 'Here', optional: true }],
+      });
+
+      expect(lastHighlight()[ARG.stepInfo]).toEqual({ current: 0, total: 2, completedSteps: [] });
+
+      present.remove();
+    });
   });
 
   describe('unresolvable targets', () => {
@@ -158,14 +208,14 @@ describe('BubbleTour', () => {
       await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('First'));
     });
 
-    it('closes on Escape', async () => {
+    it('dismisses on Escape', async () => {
       const { onClose } = await renderTour();
 
       await act(async () => {
         fireEvent.keyDown(document, { key: 'Escape' });
       });
 
-      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledWith({ reason: 'dismissed', stepIndex: 0, stepTotal: 3 });
     });
 
     it('ignores Enter so it cannot double as next', async () => {

--- a/src/components/BubbleTour/BubbleTour.test.tsx
+++ b/src/components/BubbleTour/BubbleTour.test.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react';
+
+import { BubbleTour, type BubbleTourStep } from './BubbleTour';
+
+const mockHighlightWithComment = jest.fn().mockResolvedValue(undefined);
+const mockShowCenteredComment = jest.fn();
+const mockClearAllHighlights = jest.fn();
+
+jest.mock('../../interactive-engine', () => ({
+  NavigationManager: jest.fn().mockImplementation(() => ({
+    highlightWithComment: mockHighlightWithComment,
+    showCenteredComment: mockShowCenteredComment,
+    clearAllHighlights: mockClearAllHighlights,
+  })),
+}));
+
+const mockResolveWithRetry = jest.fn();
+jest.mock('../../lib/dom', () => ({
+  resolveWithRetry: (...args: unknown[]) => mockResolveWithRetry(...args),
+}));
+
+const STEPS: BubbleTourStep[] = [
+  { target: '#one', title: 'One', content: 'First' },
+  { target: '#two', title: 'Two', content: 'Second' },
+  { target: '#three', title: 'Three', content: 'Third' },
+];
+
+/** Positional contract of `highlightWithComment`. */
+const ARG = {
+  element: 0,
+  comment: 1,
+  stepInfo: 3,
+  onCancel: 5,
+  onNext: 6,
+  onPrevious: 7,
+  options: 8,
+} as const;
+
+function lastHighlight() {
+  return mockHighlightWithComment.mock.calls.at(-1)!;
+}
+
+async function renderTour(props: Partial<React.ComponentProps<typeof BubbleTour>> = {}) {
+  const onClose = props.onClose ?? jest.fn();
+  const result = render(<BubbleTour steps={props.steps ?? STEPS} {...props} onClose={onClose} />);
+  await waitFor(() => expect(mockHighlightWithComment).toHaveBeenCalled());
+  return { ...result, onClose };
+}
+
+describe('BubbleTour', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHighlightWithComment.mockResolvedValue(undefined);
+    mockResolveWithRetry.mockImplementation((target: string) =>
+      Promise.resolve({ element: document.createElement('div'), resolvedSelector: target })
+    );
+  });
+
+  it('resolves the first step target and offers no previous callback', async () => {
+    await renderTour();
+
+    expect(mockResolveWithRetry).toHaveBeenCalledWith('#one', 'highlight');
+    expect(lastHighlight()[ARG.comment]).toBe('First');
+    expect(lastHighlight()[ARG.stepInfo]).toEqual({ current: 0, total: 3, completedSteps: [] });
+    expect(lastHighlight()[ARG.onPrevious]).toBeUndefined();
+  });
+
+  it('advances on next, offering a previous callback from the second step on', async () => {
+    await renderTour();
+
+    await act(async () => lastHighlight()[ARG.onNext]());
+
+    await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('Second'));
+    expect(lastHighlight()[ARG.stepInfo]).toEqual({ current: 1, total: 3, completedSteps: [0] });
+    expect(typeof lastHighlight()[ARG.onPrevious]).toBe('function');
+  });
+
+  it('goes back on previous', async () => {
+    await renderTour();
+    await act(async () => lastHighlight()[ARG.onNext]());
+    await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('Second'));
+
+    await act(async () => lastHighlight()[ARG.onPrevious]());
+
+    await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('First'));
+  });
+
+  it('clears highlights then closes from the last step', async () => {
+    const { onClose } = await renderTour({ steps: [STEPS[0]!] });
+
+    await act(async () => lastHighlight()[ARG.onNext]());
+
+    expect(mockClearAllHighlights).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when the bubble is cancelled', async () => {
+    const { onClose } = await renderTour();
+
+    await act(async () => lastHighlight()[ARG.onCancel]());
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies finalStepLabel only to the last step', async () => {
+    await renderTour({ steps: [STEPS[0]!, STEPS[1]!], finalStepLabel: 'Start creating' });
+
+    expect(lastHighlight()[ARG.options].nextLabel).toBeUndefined();
+
+    await act(async () => lastHighlight()[ARG.onNext]());
+
+    await waitFor(() => expect(lastHighlight()[ARG.options].nextLabel).toBe('Start creating'));
+  });
+
+  describe('unresolvable targets', () => {
+    it('falls back to a centered comment that keeps its callbacks', async () => {
+      mockResolveWithRetry.mockResolvedValue(null);
+      render(<BubbleTour steps={STEPS} onClose={jest.fn()} />);
+
+      await waitFor(() => expect(mockShowCenteredComment).toHaveBeenCalled());
+      const [comment, stepInfo, , onNext] = mockShowCenteredComment.mock.calls.at(-1)!;
+      expect(comment).toContain('First');
+      expect(comment).toContain("isn't on screen right now");
+      expect(stepInfo).toEqual({ current: 0, total: 3, completedSteps: [] });
+      expect(typeof onNext).toBe('function');
+      expect(mockHighlightWithComment).not.toHaveBeenCalled();
+    });
+
+    it('does not highlight when the target resolves after unmount', async () => {
+      let resolveTarget: (value: unknown) => void = () => {};
+      mockResolveWithRetry.mockReturnValue(new Promise((resolve) => (resolveTarget = resolve)));
+
+      const { unmount } = render(<BubbleTour steps={STEPS} onClose={jest.fn()} />);
+      unmount();
+
+      await act(async () => {
+        resolveTarget({ element: document.createElement('div') });
+      });
+
+      expect(mockHighlightWithComment).not.toHaveBeenCalled();
+      expect(mockShowCenteredComment).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('keyboard', () => {
+    it('advances on ArrowRight and goes back on ArrowLeft', async () => {
+      await renderTour();
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: 'ArrowRight' });
+      });
+      await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('Second'));
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: 'ArrowLeft' });
+      });
+      await waitFor(() => expect(lastHighlight()[ARG.comment]).toBe('First'));
+    });
+
+    it('closes on Escape', async () => {
+      const { onClose } = await renderTour();
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: 'Escape' });
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores Enter so it cannot double as next', async () => {
+      await renderTour();
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: 'Enter' });
+      });
+
+      expect(lastHighlight()[ARG.comment]).toBe('First');
+    });
+
+    it.each(['input', 'textarea'])('ignores keys typed inside a %s', async (tagName) => {
+      await renderTour();
+      const field = document.createElement(tagName);
+      document.body.appendChild(field);
+
+      await act(async () => {
+        fireEvent.keyDown(field, { key: 'ArrowRight' });
+      });
+
+      expect(lastHighlight()[ARG.comment]).toBe('First');
+      field.remove();
+    });
+
+    it('ignores keys typed inside a contenteditable', async () => {
+      await renderTour();
+      const editable = document.createElement('div');
+      editable.contentEditable = 'true';
+      Object.defineProperty(editable, 'isContentEditable', { value: true });
+      document.body.appendChild(editable);
+
+      await act(async () => {
+        fireEvent.keyDown(editable, { key: 'ArrowRight' });
+      });
+
+      expect(lastHighlight()[ARG.comment]).toBe('First');
+      editable.remove();
+    });
+
+    it('prevents default so the floating panel cannot also act on the key', async () => {
+      await renderTour();
+
+      const event = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true, bubbles: true });
+      await act(async () => {
+        document.dispatchEvent(event);
+      });
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+  });
+
+  it('clears highlights on unmount', async () => {
+    const { unmount } = await renderTour();
+    mockClearAllHighlights.mockClear();
+
+    unmount();
+
+    expect(mockClearAllHighlights).toHaveBeenCalled();
+  });
+});

--- a/src/components/BubbleTour/BubbleTour.tsx
+++ b/src/components/BubbleTour/BubbleTour.tsx
@@ -10,11 +10,21 @@ export interface BubbleTourStep {
   target: string;
   title: string;
   content: string;
+  nextLabel?: string;
+  onAdvance?: () => void;
+  optional?: boolean;
+  disableBack?: boolean;
+}
+
+export interface BubbleTourOutcome {
+  reason: 'completed' | 'dismissed';
+  stepIndex: number;
+  stepTotal: number;
 }
 
 export interface BubbleTourProps {
   steps: BubbleTourStep[];
-  onClose: () => void;
+  onClose: (outcome: BubbleTourOutcome) => void;
   finalStepLabel?: string;
 }
 
@@ -31,15 +41,27 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
 
   const navigationManager = useMemo(() => new NavigationManager(), []);
 
-  const totalSteps = steps.length;
-  const step = steps[currentStep];
+  // Optional steps whose target is absent are dropped once, so step numbering stays truthful.
+  const effectiveSteps = useMemo(
+    () => steps.filter((step) => !step.optional || document.querySelector(step.target)),
+    [steps]
+  );
 
-  const close = useCallback(() => {
-    navigationManager.clearAllHighlights();
-    onClose();
-  }, [navigationManager, onClose]);
+  const totalSteps = effectiveSteps.length;
+  const step = effectiveSteps[currentStep];
+
+  const finish = useCallback(
+    (reason: BubbleTourOutcome['reason']) => {
+      navigationManager.clearAllHighlights();
+      onClose({ reason, stepIndex: currentStep, stepTotal: totalSteps });
+    },
+    [navigationManager, onClose, currentStep, totalSteps]
+  );
+
+  const dismiss = useCallback(() => finish('dismissed'), [finish]);
 
   const goToNext = useCallback(() => {
+    step?.onAdvance?.();
     setStepsReached((prev) => Math.max(prev, currentStep + 1));
 
     if (currentStep < totalSteps - 1) {
@@ -47,8 +69,8 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
       return;
     }
 
-    close();
-  }, [currentStep, totalSteps, close]);
+    finish('completed');
+  }, [step, currentStep, totalSteps, finish]);
 
   const goToPrevious = useCallback(() => setCurrentStep((prev) => Math.max(0, prev - 1)), []);
 
@@ -64,13 +86,13 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
       total: totalSteps,
       completedSteps: Array.from({ length: stepsReached }, (_, i) => i),
     };
-    const onPrevious = currentStep > 0 ? goToPrevious : undefined;
+    const onPrevious = currentStep > 0 && !step.disableBack ? goToPrevious : undefined;
     const isLastStep = currentStep === totalSteps - 1;
     const options = {
       showKeyboardHint: true,
       skipAnimations: currentStep > 0,
       stepTitle: step.title,
-      nextLabel: isLastStep ? finalStepLabel : undefined,
+      nextLabel: step.nextLabel ?? (isLastStep ? finalStepLabel : undefined),
     };
 
     resolveWithRetry(step.target, 'highlight').then((resolved) => {
@@ -85,7 +107,7 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
           false,
           stepInfo,
           undefined,
-          close,
+          dismiss,
           goToNext,
           onPrevious,
           options
@@ -96,7 +118,7 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
       navigationManager.showCenteredComment(
         `${step.content}<br><br><em>${MISSING_TARGET_NOTE}</em>`,
         stepInfo,
-        close,
+        dismiss,
         goToNext,
         onPrevious,
         options
@@ -106,7 +128,7 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
     return () => {
       cancelled = true;
     };
-  }, [step, currentStep, totalSteps, stepsReached, finalStepLabel, navigationManager, close, goToNext, goToPrevious]);
+  }, [step, currentStep, totalSteps, stepsReached, finalStepLabel, navigationManager, dismiss, goToNext, goToPrevious]);
 
   useEffect(() => () => navigationManager.clearAllHighlights(), [navigationManager]);
 
@@ -119,7 +141,7 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
       if (e.key === 'Escape') {
         // FloatingPanel also minimizes on Escape unless the event is already defaultPrevented.
         safeEventHandler(e, { preventDefault: true });
-        close();
+        dismiss();
       } else if (e.key === 'ArrowRight') {
         safeEventHandler(e, { preventDefault: true });
         goToNext();
@@ -131,7 +153,7 @@ export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) 
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [currentStep, close, goToNext, goToPrevious]);
+  }, [currentStep, dismiss, goToNext, goToPrevious]);
 
   return null;
 }

--- a/src/components/BubbleTour/BubbleTour.tsx
+++ b/src/components/BubbleTour/BubbleTour.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { NavigationManager } from '../../interactive-engine';
+import { resolveWithRetry } from '../../lib/dom';
+import { safeEventHandler } from '../../utils/safe-event-handler.util';
+
+const MISSING_TARGET_NOTE = "This part of the interface isn't on screen right now.";
+
+export interface BubbleTourStep {
+  target: string;
+  title: string;
+  content: string;
+}
+
+export interface BubbleTourProps {
+  steps: BubbleTourStep[];
+  onClose: () => void;
+  finalStepLabel?: string;
+}
+
+function isTextEditable(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null;
+  return Boolean(
+    element && (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA' || element.isContentEditable)
+  );
+}
+
+export function BubbleTour({ steps, onClose, finalStepLabel }: BubbleTourProps) {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [stepsReached, setStepsReached] = useState(0);
+
+  const navigationManager = useMemo(() => new NavigationManager(), []);
+
+  const totalSteps = steps.length;
+  const step = steps[currentStep];
+
+  const close = useCallback(() => {
+    navigationManager.clearAllHighlights();
+    onClose();
+  }, [navigationManager, onClose]);
+
+  const goToNext = useCallback(() => {
+    setStepsReached((prev) => Math.max(prev, currentStep + 1));
+
+    if (currentStep < totalSteps - 1) {
+      setCurrentStep((prev) => prev + 1);
+      return;
+    }
+
+    close();
+  }, [currentStep, totalSteps, close]);
+
+  const goToPrevious = useCallback(() => setCurrentStep((prev) => Math.max(0, prev - 1)), []);
+
+  useEffect(() => {
+    if (!step) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const stepInfo = {
+      current: currentStep,
+      total: totalSteps,
+      completedSteps: Array.from({ length: stepsReached }, (_, i) => i),
+    };
+    const onPrevious = currentStep > 0 ? goToPrevious : undefined;
+    const isLastStep = currentStep === totalSteps - 1;
+    const options = {
+      showKeyboardHint: true,
+      skipAnimations: currentStep > 0,
+      stepTitle: step.title,
+      nextLabel: isLastStep ? finalStepLabel : undefined,
+    };
+
+    resolveWithRetry(step.target, 'highlight').then((resolved) => {
+      if (cancelled) {
+        return;
+      }
+
+      if (resolved) {
+        void navigationManager.highlightWithComment(
+          resolved.element,
+          step.content,
+          false,
+          stepInfo,
+          undefined,
+          close,
+          goToNext,
+          onPrevious,
+          options
+        );
+        return;
+      }
+
+      navigationManager.showCenteredComment(
+        `${step.content}<br><br><em>${MISSING_TARGET_NOTE}</em>`,
+        stepInfo,
+        close,
+        goToNext,
+        onPrevious,
+        options
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [step, currentStep, totalSteps, stepsReached, finalStepLabel, navigationManager, close, goToNext, goToPrevious]);
+
+  useEffect(() => () => navigationManager.clearAllHighlights(), [navigationManager]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isTextEditable(e.target)) {
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        // FloatingPanel also minimizes on Escape unless the event is already defaultPrevented.
+        safeEventHandler(e, { preventDefault: true });
+        close();
+      } else if (e.key === 'ArrowRight') {
+        safeEventHandler(e, { preventDefault: true });
+        goToNext();
+      } else if (e.key === 'ArrowLeft' && currentStep > 0) {
+        safeEventHandler(e, { preventDefault: true });
+        goToPrevious();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [currentStep, close, goToNext, goToPrevious]);
+
+  return null;
+}

--- a/src/components/BubbleTour/index.ts
+++ b/src/components/BubbleTour/index.ts
@@ -1,2 +1,2 @@
 export { BubbleTour } from './BubbleTour';
-export type { BubbleTourStep, BubbleTourProps } from './BubbleTour';
+export type { BubbleTourStep, BubbleTourProps, BubbleTourOutcome } from './BubbleTour';

--- a/src/components/BubbleTour/index.ts
+++ b/src/components/BubbleTour/index.ts
@@ -1,0 +1,2 @@
+export { BubbleTour } from './BubbleTour';
+export type { BubbleTourStep, BubbleTourProps } from './BubbleTour';

--- a/src/components/InteractiveLearningBanner/InteractiveLearningBanner.test.tsx
+++ b/src/components/InteractiveLearningBanner/InteractiveLearningBanner.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import { InteractiveLearningBanner, clearBannerImpressionCache } from './InteractiveLearningBanner';
+import { isInteractiveLearningTourOpen, stopInteractiveLearningTour } from './tour-store';
 import { testIds } from '../../constants/testIds';
 import { StorageKeys } from '../../lib/storage-keys';
 import { UserInteraction } from '../../lib/analytics';
@@ -24,6 +25,7 @@ describe('InteractiveLearningBanner', () => {
     localStorage.clear();
     jest.clearAllMocks();
     clearBannerImpressionCache();
+    stopInteractiveLearningTour();
     mockEnroll.mockReturnValue({ variant: 'treatment' });
   });
 
@@ -39,6 +41,7 @@ describe('InteractiveLearningBanner', () => {
     render(<InteractiveLearningBanner />);
 
     expect(screen.getByTestId(testIds.contextPanel.interactiveLearningBanner)).toBeInTheDocument();
+    expect(screen.getByTestId(testIds.contextPanel.interactiveLearningBannerCta)).toBeInTheDocument();
     expect(mockReportAppInteraction).toHaveBeenCalledWith(UserInteraction.InteractiveLearningBannerShown, {
       interaction_location: 'interactive_learning_banner',
     });
@@ -71,6 +74,19 @@ describe('InteractiveLearningBanner', () => {
     expect(mockReportAppInteraction).toHaveBeenCalledWith(UserInteraction.InteractiveLearningBannerDismissed, {
       interaction_location: 'interactive_learning_banner',
     });
+  });
+
+  it('starts the tour through the store, so it survives the banner unmounting', () => {
+    const view = render(<InteractiveLearningBanner />);
+    fireEvent.click(screen.getByTestId(testIds.contextPanel.interactiveLearningBannerCta));
+
+    expect(isInteractiveLearningTourOpen()).toBe(true);
+    expect(mockReportAppInteraction).toHaveBeenCalledWith(UserInteraction.InteractiveLearningTourStarted, {
+      interaction_location: 'interactive_learning_banner',
+    });
+
+    view.unmount();
+    expect(isInteractiveLearningTourOpen()).toBe(true);
   });
 
   it('degrades to a visible banner when localStorage is unavailable', () => {

--- a/src/components/InteractiveLearningBanner/InteractiveLearningBanner.tsx
+++ b/src/components/InteractiveLearningBanner/InteractiveLearningBanner.tsx
@@ -2,13 +2,13 @@
  * Interactive-learning banner — treatment arm of
  * `pathfinder.interactive-learning-banner-experiment`.
  *
- * Explains what interactive learning is at the top of the context page. Renders
- * nothing for the control and excluded arms, so control is byte-identical to
- * pre-experiment behaviour.
+ * Explains what interactive learning is at the top of the context page, with a CTA
+ * that starts a bubble tour of the panel. Renders nothing for the control and
+ * excluded arms, so control is byte-identical to pre-experiment behaviour.
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, useStyles2 } from '@grafana/ui';
+import { Alert, Button, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import { t } from '@grafana/i18n';
@@ -17,6 +17,7 @@ import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
 import { enrollInteractiveLearningBannerExperiment } from '../../utils/experiments/interactive-learning-banner';
 import { StorageKeys } from '../../lib/storage-keys';
 import { testIds } from '../../constants/testIds';
+import { startInteractiveLearningTour } from './tour-store';
 
 const INTERACTION_LOCATION = 'interactive_learning_banner';
 
@@ -68,6 +69,13 @@ export function InteractiveLearningBanner() {
     });
   }, []);
 
+  const handleStartTour = useCallback(() => {
+    reportAppInteraction(UserInteraction.InteractiveLearningTourStarted, {
+      interaction_location: INTERACTION_LOCATION,
+    });
+    startInteractiveLearningTour();
+  }, []);
+
   const isVisible = isTreatment && !dismissed;
 
   useEffect(() => {
@@ -98,6 +106,15 @@ export function InteractiveLearningBanner() {
             'Interactive guides walk you through Grafana one step at a time. "Show me" highlights the control to use, and "Do it" performs the step for you.'
           )}
         </p>
+        <Button
+          variant="secondary"
+          size="sm"
+          icon="play"
+          onClick={handleStartTour}
+          data-testid={testIds.contextPanel.interactiveLearningBannerCta}
+        >
+          {t('interactiveLearningBanner.cta', 'Show me around')}
+        </Button>
       </Alert>
     </div>
   );
@@ -111,7 +128,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginBottom: 0,
   }),
   body: css({
-    margin: 0,
+    margin: `0 0 ${theme.spacing(1.5)} 0`,
     fontSize: theme.typography.bodySmall.fontSize,
     lineHeight: theme.typography.bodySmall.lineHeight,
   }),

--- a/src/components/InteractiveLearningBanner/InteractiveLearningTour.test.tsx
+++ b/src/components/InteractiveLearningBanner/InteractiveLearningTour.test.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+
+import { InteractiveLearningTour } from './InteractiveLearningTour';
+import { isInteractiveLearningTourOpen, startInteractiveLearningTour, stopInteractiveLearningTour } from './tour-store';
+import { testIds } from '../../constants/testIds';
+import { AnalyticsContentType, UserInteraction } from '../../lib/analytics';
+import type { BubbleTourProps, BubbleTourStep } from '../BubbleTour';
+
+const mockBubbleTour = jest.fn();
+jest.mock('../BubbleTour', () => ({
+  BubbleTour: (props: BubbleTourProps) => {
+    mockBubbleTour(props);
+    return null;
+  },
+}));
+
+const mockReportAppInteraction = jest.fn();
+jest.mock('../../lib/analytics', () => ({
+  ...jest.requireActual('../../lib/analytics'),
+  reportAppInteraction: (...args: unknown[]) => mockReportAppInteraction(...args),
+}));
+
+const mockIsGrafanaCloud = jest.fn();
+jest.mock('../../utils/grafana-platform', () => ({
+  isGrafanaCloud: () => mockIsGrafanaCloud(),
+}));
+
+const OSS_GUIDE_URL = 'bundled:welcome-to-grafana';
+const CLOUD_GUIDE_URL = 'bundled:welcome-to-grafana-cloud';
+
+function lastTourProps(): BubbleTourProps {
+  return mockBubbleTour.mock.calls.at(-1)![0];
+}
+
+function steps(): BubbleTourStep[] {
+  return lastTourProps().steps;
+}
+
+function handoffStep(): BubbleTourStep {
+  return steps().find((step) => step.nextLabel === 'Open the guide')!;
+}
+
+function renderOpen(onOpenGuide = jest.fn(), onReturnToContext = jest.fn()) {
+  const view = render(<InteractiveLearningTour onOpenGuide={onOpenGuide} onReturnToContext={onReturnToContext} />);
+  act(() => startInteractiveLearningTour());
+  return { ...view, onOpenGuide, onReturnToContext };
+}
+
+describe('InteractiveLearningTour', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stopInteractiveLearningTour();
+    mockIsGrafanaCloud.mockReturnValue(false);
+  });
+
+  it('renders nothing until the tour is started', () => {
+    render(<InteractiveLearningTour onOpenGuide={jest.fn()} onReturnToContext={jest.fn()} />);
+
+    expect(mockBubbleTour).not.toHaveBeenCalled();
+  });
+
+  it('returns to the context tab on the second-to-last step, ending where it began', () => {
+    const { onReturnToContext } = renderOpen();
+
+    const all = steps();
+    const last = all[all.length - 1]!;
+    const beforeLast = all[all.length - 2]!;
+
+    beforeLast.onAdvance!();
+    expect(onReturnToContext).toHaveBeenCalledTimes(1);
+
+    expect(last.target).toContain(testIds.contextPanel.container);
+    expect(last.disableBack).toBe(true);
+  });
+
+  it('renders the tour once the store opens it', () => {
+    renderOpen();
+
+    expect(mockBubbleTour).toHaveBeenCalled();
+    expect(steps()).toHaveLength(10);
+  });
+
+  it('points at My learning, the one surface that always shows private paths', () => {
+    renderOpen();
+
+    const myLearning = steps().find((step) => step.target.includes(testIds.docsPanel.myLearningTab));
+    expect(myLearning).toBeDefined();
+    // Not optional: unlike the context-tab section, this anchor is always rendered,
+    // so it is what guarantees the tour covers private content on every stack.
+    expect(myLearning!.optional).toBeUndefined();
+    expect(myLearning!.content).toMatch(/privately/i);
+  });
+
+  describe('hand-off', () => {
+    it('opens the OSS guide on a non-Cloud stack', () => {
+      const { onOpenGuide } = renderOpen();
+
+      handoffStep().onAdvance!();
+
+      expect(onOpenGuide).toHaveBeenCalledWith(OSS_GUIDE_URL, 'Welcome to Grafana');
+    });
+
+    it('opens the Cloud guide on a Cloud stack', () => {
+      mockIsGrafanaCloud.mockReturnValue(true);
+      const { onOpenGuide } = renderOpen();
+
+      handoffStep().onAdvance!();
+
+      expect(onOpenGuide).toHaveBeenCalledWith(CLOUD_GUIDE_URL, 'Welcome to Grafana');
+    });
+
+    it('reports the open as a normal guide open so it lands in the existing funnel', () => {
+      renderOpen();
+
+      handoffStep().onAdvance!();
+
+      expect(mockReportAppInteraction).toHaveBeenCalledWith(UserInteraction.OpenResourceClick, {
+        content_title: 'Welcome to Grafana',
+        content_url: OSS_GUIDE_URL,
+        content_type: AnalyticsContentType.InteractiveGuide,
+        interaction_location: 'interactive_learning_banner',
+      });
+    });
+
+    it('is one-way, so Back cannot land on the unmounted context tab', () => {
+      renderOpen();
+
+      const all = steps();
+      const handoffIndex = all.indexOf(handoffStep());
+      expect(all[handoffIndex + 1]!.disableBack).toBe(true);
+    });
+  });
+
+  it('marks the organization-guides step optional, since that section is often absent', () => {
+    renderOpen();
+
+    const optional = steps().filter((step) => step.optional);
+    expect(optional).toHaveLength(1);
+    expect(optional[0]!.target).toContain(testIds.contextPanel.customGuidesSection);
+  });
+
+  it('anchors the in-guide steps on button classes rather than hashed step ids', () => {
+    renderOpen();
+
+    const targets = steps().map((step) => step.target);
+    expect(targets).toContain('[data-testid="interactive-section-section-grafana-tour"] .interactive-step-show-btn');
+    expect(targets).toContain('[data-testid="interactive-section-section-grafana-tour"] .interactive-step-do-btn');
+    expect(targets.some((target) => /interactive-show-me-/.test(target))).toBe(false);
+  });
+
+  describe('close', () => {
+    it.each([
+      ['completed', UserInteraction.InteractiveLearningTourCompleted],
+      ['dismissed', UserInteraction.InteractiveLearningTourDismissed],
+    ] as const)('closes the store and reports a %s tour', (reason, expectedEvent) => {
+      renderOpen();
+
+      act(() => lastTourProps().onClose({ reason, stepIndex: 3, stepTotal: 8 }));
+
+      expect(isInteractiveLearningTourOpen()).toBe(false);
+      expect(mockReportAppInteraction).toHaveBeenCalledWith(expectedEvent, {
+        interaction_location: 'interactive_learning_banner',
+        step_index: 3,
+        step_total: 8,
+      });
+    });
+  });
+});

--- a/src/components/InteractiveLearningBanner/InteractiveLearningTour.tsx
+++ b/src/components/InteractiveLearningBanner/InteractiveLearningTour.tsx
@@ -1,0 +1,173 @@
+/**
+ * Host for the interactive-learning tour, rendered from the docs-panel root.
+ *
+ * It lives here rather than beside the banner because the tour outlives the context
+ * panel: its hand-off step opens a guide tab, which unmounts the banner.
+ */
+
+import React, { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { t } from '@grafana/i18n';
+
+import { AnalyticsContentType, reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import { isGrafanaCloud } from '../../utils/grafana-platform';
+import { testIds } from '../../constants/testIds';
+import { BubbleTour, type BubbleTourOutcome, type BubbleTourStep } from '../BubbleTour';
+import {
+  isInteractiveLearningTourOpen,
+  stopInteractiveLearningTour,
+  subscribeInteractiveLearningTour,
+} from './tour-store';
+
+const INTERACTION_LOCATION = 'interactive_learning_banner';
+
+// Both guides share the `grafana-tour` section id and seven highlight steps, so the
+// in-guide steps work against either. The Cloud guide's nav targets don't exist in
+// OSS, and one of them is neither skippable nor guarded by `exists-reftarget`.
+const OSS_GUIDE_URL = 'bundled:welcome-to-grafana';
+const CLOUD_GUIDE_URL = 'bundled:welcome-to-grafana-cloud';
+
+// Step ids are content hashes that shift when a guide's blocks are edited or
+// reordered, so anchor on the stable button classes instead.
+const GUIDE_SECTION = '[data-testid="interactive-section-section-grafana-tour"]';
+
+export interface InteractiveLearningTourProps {
+  onOpenGuide: (url: string, title: string) => void;
+  onReturnToContext: () => void;
+}
+
+export function InteractiveLearningTour({ onOpenGuide, onReturnToContext }: InteractiveLearningTourProps) {
+  const isOpen = useSyncExternalStore(
+    subscribeInteractiveLearningTour,
+    isInteractiveLearningTourOpen,
+    isInteractiveLearningTourOpen
+  );
+
+  const guideTitle = t('interactiveLearningBanner.guideTitle', 'Welcome to Grafana');
+
+  const openWelcomeGuide = useCallback(() => {
+    const guideUrl = isGrafanaCloud() ? CLOUD_GUIDE_URL : OSS_GUIDE_URL;
+
+    // The same event every recommendation card fires, so banner-driven opens sit in
+    // the existing funnel; `interaction_location` is what separates them.
+    reportAppInteraction(UserInteraction.OpenResourceClick, {
+      content_title: guideTitle,
+      content_url: guideUrl,
+      content_type: AnalyticsContentType.InteractiveGuide,
+      interaction_location: INTERACTION_LOCATION,
+    });
+    onOpenGuide(guideUrl, guideTitle);
+  }, [guideTitle, onOpenGuide]);
+
+  const steps = useMemo<BubbleTourStep[]>(
+    () => [
+      {
+        target: `[data-testid="${testIds.contextPanel.container}"]`,
+        title: t('interactiveLearningBanner.tour.panelTitle', 'Learning that follows you around'),
+        content: t(
+          'interactiveLearningBanner.tour.panelBody',
+          'This panel stays open beside Grafana while you work, so you practise in the real interface with your own data.'
+        ),
+      },
+      {
+        target: `[data-testid="${testIds.contextPanel.recommendationsContainer}"]`,
+        title: t('interactiveLearningBanner.tour.recommendationsTitle', 'Suggestions for where you are'),
+        content: t(
+          'interactiveLearningBanner.tour.recommendationsBody',
+          'These guides are picked for the page you are on, so the list changes as you move around Grafana.'
+        ),
+      },
+      {
+        target: `[data-testid="${testIds.contextPanel.recommendationCard(0)}"]`,
+        title: t('interactiveLearningBanner.tour.cardTitle', 'Every card is a guide'),
+        content: t(
+          'interactiveLearningBanner.tour.cardBody',
+          'Open one and it runs right here, a step at a time. Your progress is saved if you close the panel partway through.'
+        ),
+      },
+      {
+        target: `[data-testid="${testIds.contextPanel.customGuidesSection}"]`,
+        optional: true,
+        title: t('interactiveLearningBanner.tour.privateTitle', 'Guides from your organization'),
+        content: t(
+          'interactiveLearningBanner.tour.privateBody',
+          'Guides your organization has published privately appear here, in among the public ones.'
+        ),
+      },
+      {
+        target: `[data-testid="${testIds.docsPanel.myLearningTab}"]`,
+        title: t('interactiveLearningBanner.tour.myLearningTitle', 'Where the rest of it lives'),
+        content: t(
+          'interactiveLearningBanner.tour.myLearningBody',
+          'My learning holds every guide you have finished, the badges you have earned, and any learning paths published privately for your organization — including ones not suggested for this page.'
+        ),
+      },
+      {
+        target: `[data-testid="${testIds.contextPanel.userProfileBar}"]`,
+        title: t('interactiveLearningBanner.tour.progressTitle', 'Your progress at a glance'),
+        content: t(
+          'interactiveLearningBanner.tour.progressBody',
+          'Your badges and streak sit up here, so you can see how far you have got without leaving the page.'
+        ),
+      },
+      {
+        target: `[data-testid="${testIds.contextPanel.container}"]`,
+        nextLabel: t('interactiveLearningBanner.tour.openLabel', 'Open the guide'),
+        onAdvance: openWelcomeGuide,
+        title: t('interactiveLearningBanner.tour.handoffTitle', 'Best seen in a real guide'),
+        content: t(
+          'interactiveLearningBanner.tour.handoffBody',
+          'Two buttons do all the work, and they are easier to show than to describe. Open a short guide and we will point them out.'
+        ),
+      },
+      {
+        target: `${GUIDE_SECTION} .interactive-step-show-btn`,
+        disableBack: true,
+        title: t('interactiveLearningBanner.tour.showMeTitle', '"Show me" is always safe'),
+        content: t(
+          'interactiveLearningBanner.tour.showMeBody',
+          'It outlines the exact control the step is talking about and scrolls it into view. Nothing in Grafana changes, so you can look before you act.'
+        ),
+      },
+      {
+        target: `${GUIDE_SECTION} .interactive-step-do-btn`,
+        nextLabel: t('interactiveLearningBanner.tour.backLabel', 'Take me back'),
+        onAdvance: onReturnToContext,
+        title: t('interactiveLearningBanner.tour.doItTitle', '"Do it" performs the step'),
+        content: t(
+          'interactiveLearningBanner.tour.doItBody',
+          'Clicks, navigation, and filling in forms all work this way, so you can watch what happens rather than hunt for it.'
+        ),
+      },
+      {
+        target: `[data-testid="${testIds.contextPanel.container}"]`,
+        disableBack: true,
+        title: t('interactiveLearningBanner.tour.finishTitle', 'Back where you started'),
+        content: t(
+          'interactiveLearningBanner.tour.finishBody',
+          'Steps can be repeated, and most can be skipped if they do not apply to you, so go at your own pace. Pick a guide whenever you are ready — the one you just opened is still in its own tab.'
+        ),
+      },
+    ],
+    [openWelcomeGuide, onReturnToContext]
+  );
+
+  const handleClose = useCallback(({ reason, stepIndex, stepTotal }: BubbleTourOutcome) => {
+    stopInteractiveLearningTour();
+    reportAppInteraction(
+      reason === 'completed'
+        ? UserInteraction.InteractiveLearningTourCompleted
+        : UserInteraction.InteractiveLearningTourDismissed,
+      {
+        interaction_location: INTERACTION_LOCATION,
+        step_index: stepIndex,
+        step_total: stepTotal,
+      }
+    );
+  }, []);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return <BubbleTour steps={steps} onClose={handleClose} />;
+}

--- a/src/components/InteractiveLearningBanner/index.ts
+++ b/src/components/InteractiveLearningBanner/index.ts
@@ -1,1 +1,3 @@
 export { InteractiveLearningBanner } from './InteractiveLearningBanner';
+export { InteractiveLearningTour } from './InteractiveLearningTour';
+export type { InteractiveLearningTourProps } from './InteractiveLearningTour';

--- a/src/components/InteractiveLearningBanner/tour-store.ts
+++ b/src/components/InteractiveLearningBanner/tour-store.ts
@@ -1,0 +1,42 @@
+/**
+ * Open/closed state for the interactive-learning tour.
+ *
+ * Module-level rather than component state because the banner that starts the tour
+ * lives in the context panel, which unmounts the moment the tour's hand-off step
+ * opens a guide tab. The tour is hosted from the docs-panel root instead, and this
+ * is the seam between them.
+ */
+
+let isOpen = false;
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  listeners.forEach((listener) => listener());
+}
+
+export function startInteractiveLearningTour(): void {
+  if (isOpen) {
+    return;
+  }
+  isOpen = true;
+  notify();
+}
+
+export function stopInteractiveLearningTour(): void {
+  if (!isOpen) {
+    return;
+  }
+  isOpen = false;
+  notify();
+}
+
+export function isInteractiveLearningTourOpen(): boolean {
+  return isOpen;
+}
+
+export function subscribeInteractiveLearningTour(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/components/block-editor/BlockEditorTour.test.tsx
+++ b/src/components/block-editor/BlockEditorTour.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { BlockEditorTour } from './BlockEditorTour';
+import { testIds } from '../../constants/testIds';
+import type { BubbleTourProps } from '../BubbleTour';
+
+const mockBubbleTour = jest.fn();
+jest.mock('../BubbleTour', () => ({
+  BubbleTour: (props: BubbleTourProps) => {
+    mockBubbleTour(props);
+    return null;
+  },
+}));
+
+describe('BlockEditorTour', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function tourProps(): BubbleTourProps {
+    render(<BlockEditorTour onClose={jest.fn()} />);
+    return mockBubbleTour.mock.calls.at(-1)![0];
+  }
+
+  it('keeps its own final-step label rather than the generic default', () => {
+    expect(tourProps().finalStepLabel).toBe('Start creating');
+  });
+
+  it('tours the editor surfaces', () => {
+    const targets = tourProps().steps.map((step) => step.target);
+
+    expect(targets[0]).toContain(testIds.blockEditor.container);
+    expect(targets).toContain(`[data-testid="${testIds.blockEditor.palette}"]`);
+    expect(targets).toHaveLength(6);
+  });
+
+  it('forwards close through to the caller', () => {
+    const onClose = jest.fn();
+    render(<BlockEditorTour onClose={onClose} />);
+
+    mockBubbleTour.mock.calls.at(-1)![0].onClose();
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/block-editor/BlockEditorTour.tsx
+++ b/src/components/block-editor/BlockEditorTour.tsx
@@ -1,32 +1,9 @@
-/**
- * Block Editor Tour
- *
- * A tour controller that guides new users through the block editor interface.
- * Uses the unified NavigationManager highlight system for consistent UX with guided mode.
- */
+import React from 'react';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { NavigationManager } from '../../interactive-engine';
+import { BubbleTour, type BubbleTourStep } from '../BubbleTour';
 import { testIds } from '../../constants/testIds';
 
-/**
- * Tour step definition
- */
-interface TourStep {
-  /** CSS selector or data-testid to target */
-  target: string;
-  /** Step title */
-  title: string;
-  /** Explanation text */
-  content: string;
-  /** Optional action to describe what happens when clicking the target */
-  action?: 'highlight' | 'click';
-}
-
-/**
- * Tour steps for the block editor
- */
-const TOUR_STEPS: TourStep[] = [
+const TOUR_STEPS: BubbleTourStep[] = [
   {
     target: `[data-testid="${testIds.blockEditor.container}"]`,
     title: 'Welcome to the guide editor',
@@ -65,129 +42,11 @@ const TOUR_STEPS: TourStep[] = [
 ];
 
 export interface BlockEditorTourProps {
-  /** Called when the tour is closed */
   onClose: () => void;
-  /** Optional custom tour steps */
-  steps?: TourStep[];
 }
 
-/**
- * Tour controller for the block editor.
- * Uses NavigationManager's unified highlight system for visual consistency with guided mode.
- */
-export function BlockEditorTour({ onClose, steps = TOUR_STEPS }: BlockEditorTourProps) {
-  const [currentStep, setCurrentStep] = useState(0);
-  const [completedSteps, setCompletedSteps] = useState<number[]>([]);
-
-  // Navigation manager singleton
-  const navigationManager = useMemo(() => new NavigationManager(), []);
-
-  const totalSteps = steps.length;
-  const step = steps[currentStep];
-
-  // Navigate to next step
-  const goToNext = useCallback(() => {
-    // Mark current step as completed
-    setCompletedSteps((prev) => (prev.includes(currentStep) ? prev : [...prev, currentStep]));
-
-    if (currentStep < totalSteps - 1) {
-      setCurrentStep((prev) => prev + 1);
-    } else {
-      // Tour complete
-      navigationManager.clearAllHighlights();
-      onClose();
-    }
-  }, [currentStep, totalSteps, onClose, navigationManager]);
-
-  // Navigate to previous step
-  const goToPrevious = useCallback(() => {
-    if (currentStep > 0) {
-      setCurrentStep((prev) => prev - 1);
-    }
-  }, [currentStep]);
-
-  // Close the tour
-  const handleClose = useCallback(() => {
-    navigationManager.clearAllHighlights();
-    onClose();
-  }, [navigationManager, onClose]);
-
-  // Highlight the current step's target element using unified system
-  const highlightCurrentStep = useCallback(async () => {
-    if (!step) {
-      return;
-    }
-
-    // Find the target element
-    const element = document.querySelector(step.target) as HTMLElement | null;
-
-    // Build step info for progress display
-    const stepInfo = {
-      current: currentStep,
-      total: totalSteps,
-      completedSteps: [...completedSteps],
-    };
-
-    if (element) {
-      // Use the unified NavigationManager highlight system
-      // Pass navigation callbacks for tour mode, and options for visual enhancements
-      // Skip animations after first step for smooth transitions
-      await navigationManager.highlightWithComment(
-        element,
-        step.content,
-        false, // Disable auto-cleanup for tour mode
-        stepInfo,
-        undefined, // No skip callback for tour
-        handleClose, // Cancel callback
-        goToNext, // Next callback (for tour navigation)
-        currentStep > 0 ? goToPrevious : undefined, // Previous callback (disabled on first step)
-        {
-          showKeyboardHint: true,
-          skipAnimations: currentStep > 0, // Instant transitions after first step
-          stepTitle: step.title,
-        }
-      );
-    } else {
-      // If element not found, show a centered comment
-      navigationManager.showNoopComment(
-        `<strong>${step.title}</strong><br><br>${step.content}<br><br><em style="opacity: 0.7">Target element not visible - it may appear in a different editor state.</em>`
-      );
-    }
-  }, [step, currentStep, totalSteps, completedSteps, navigationManager, handleClose, goToNext, goToPrevious]);
-
-  // Highlight on step change
-  useEffect(() => {
-    highlightCurrentStep();
-  }, [highlightCurrentStep]);
-
-  // Clean up highlights on unmount
-  useEffect(() => {
-    return () => {
-      navigationManager.clearAllHighlights();
-    };
-  }, [navigationManager]);
-
-  // Handle keyboard navigation
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        handleClose();
-      } else if (e.key === 'ArrowRight' || e.key === 'Enter') {
-        goToNext();
-      } else if (e.key === 'ArrowLeft') {
-        if (currentStep > 0) {
-          goToPrevious();
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [currentStep, handleClose, goToNext, goToPrevious]);
-
-  // No JSX needed - the tour renders via NavigationManager's highlight system
-  return null;
+export function BlockEditorTour({ onClose }: BlockEditorTourProps) {
+  return <BubbleTour steps={TOUR_STEPS} onClose={onClose} finalStepLabel="Start creating" />;
 }
 
-// Display name for debugging
 BlockEditorTour.displayName = 'BlockEditorTour';

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -1141,7 +1141,8 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
     <div className={styles.container} data-testid={testIds.contextPanel.container}>
       <div className={styles.content} ref={scrollContainerRef} data-testid={testIds.contextPanel.scrollContainer}>
         <div className={styles.contextSections}>
-          {/* Treatment arm of the interactive-learning banner experiment; renders null otherwise */}
+          {/* Treatment arm of the interactive-learning banner experiment; renders null otherwise.
+              Its tour is hosted from the docs-panel root, which outlives this panel. */}
           <InteractiveLearningBanner />
 
           {/* User profile bar with learning stats and next action */}

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -70,6 +70,7 @@ import { config, getAppEvents, locationService } from '@grafana/runtime';
 import { evaluateAlignment, resolveStartingLocation, type LaunchSource } from '../../recovery';
 import { SessionProvider, useSession, ActionReplaySystem, ActionCaptureSystem } from '../../integrations/workshop';
 import { panelModeManager } from '../../global-state/panel-mode';
+import { InteractiveLearningTour } from '../InteractiveLearningBanner';
 import { shouldOpenAsLearningJourney } from '../../utils/pathfinder-search-params';
 import { testIds } from '../../constants/testIds';
 
@@ -1399,6 +1400,12 @@ function CombinedPanelRendererInner({ model }: SceneComponentProps<CombinedLearn
       <Suspense fallback={null}>
         <AiFixOrchestrator activeTab={activeTab} onPatchApplied={handleAiFixPatchApplied} />
       </Suspense>
+      {/* Hosted here, not beside the banner: the tour opens a guide tab partway
+          through, which unmounts the context panel the banner lives in. */}
+      <InteractiveLearningTour
+        onOpenGuide={(url, title) => model.openDocsPage(url, title, { source: 'recommender' })}
+        onReturnToContext={() => model.setActiveTab(RECOMMENDATIONS_TAB_ID)}
+      />
       {/* Live session controls - only render when there's session content.
           The component returns null when both flags are off, preserving the
           original surface gate. */}

--- a/src/components/floating-panel/useHighlightDodge.test.ts
+++ b/src/components/floating-panel/useHighlightDodge.test.ts
@@ -29,9 +29,12 @@ function addModal(left: number, top: number, width: number, height: number, attr
   return el;
 }
 
-function addHighlight(left: number, top: number, width: number, height: number) {
+function addHighlight(left: number, top: number, width: number, height: number, internal = false) {
   const el = document.createElement('div');
   el.className = 'interactive-highlight-outline';
+  if (internal) {
+    el.setAttribute('data-pathfinder-internal', 'true');
+  }
   document.body.appendChild(el);
   mockRect(el, left, top, width, height);
   return el;
@@ -105,6 +108,14 @@ describe('useHighlightDodge — modal dodging', () => {
     // The chosen corner must clear both modals, including the large one.
     const dodge = cap.events.find((e) => e.type === 'dodge');
     expect(dodge?.detail).toEqual({ x: 32, y: 368 }); // bottom-left
+    cap.cleanup();
+  });
+
+  it('ignores a highlight that targets the panel itself, so it cannot flee its own tour', () => {
+    addHighlight(0, 0, 200, 200, true); // overlaps the panel, but is in-panel chrome
+    const cap = captureEvents();
+    renderHook(() => useHighlightDodge(GEOMETRY, false, true));
+    expect(cap.events).toEqual([]);
     cap.cleanup();
   });
 

--- a/src/components/floating-panel/useHighlightDodge.ts
+++ b/src/components/floating-panel/useHighlightDodge.ts
@@ -8,7 +8,8 @@ import { getVisibleModalRects } from '../../interactive-engine';
 import { FloatingPanelEvents, type FloatingPanelMoveDetail } from '../../lib/event-names';
 
 /** Selectors for interactive overlay elements that the panel should dodge. */
-const HIGHLIGHT_SELECTOR = '.interactive-highlight-outline, .interactive-comment-box';
+const HIGHLIGHT_SELECTOR =
+  '.interactive-highlight-outline:not([data-pathfinder-internal]), .interactive-comment-box:not([data-pathfinder-internal])';
 
 interface Rect {
   left: number;

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -105,6 +105,7 @@ export const testIds = {
     featuredStartButton: (index: number) => `context-panel-featured-start-${index}`,
     featuredSummaryButton: (index: number) => `context-panel-featured-summary-${index}`,
     interactiveLearningBanner: 'context-panel-interactive-learning-banner',
+    interactiveLearningBannerCta: 'context-panel-interactive-learning-banner-cta',
   },
 
   // Dev Tools / Block Editor

--- a/src/interactive-engine/comment-box.tour-chrome.test.ts
+++ b/src/interactive-engine/comment-box.tour-chrome.test.ts
@@ -1,0 +1,258 @@
+import { NavigationManager } from './navigation-manager';
+import * as domUtils from '../lib/dom';
+
+jest.mock('../lib/dom');
+
+class MockResizeObserver {
+  observe = jest.fn();
+  unobserve = jest.fn();
+  disconnect = jest.fn();
+}
+global.ResizeObserver = MockResizeObserver as any;
+
+const mockIsElementVisible = domUtils.isElementVisible as jest.MockedFunction<typeof domUtils.isElementVisible>;
+const mockDescribeElement = domUtils.describeElement as jest.MockedFunction<typeof domUtils.describeElement>;
+const mockGetScrollParent = domUtils.getScrollParent as jest.MockedFunction<typeof domUtils.getScrollParent>;
+const mockGetVisibleHighlightTarget = domUtils.getVisibleHighlightTarget as jest.MockedFunction<
+  typeof domUtils.getVisibleHighlightTarget
+>;
+const mockIsPathfinderContent = domUtils.isPathfinderContent as jest.MockedFunction<
+  typeof domUtils.isPathfinderContent
+>;
+
+const stepInfo = (current: number, total: number, completedSteps: number[] = []) => ({
+  current,
+  total,
+  completedSteps,
+});
+
+function commentBox(): HTMLElement {
+  return document.querySelector('.interactive-comment-box')!;
+}
+
+function navButtons(): HTMLButtonElement[] {
+  return Array.from(commentBox().querySelectorAll('.interactive-comment-nav-btn'));
+}
+
+function buttonLabelled(text: string): HTMLButtonElement | undefined {
+  return navButtons().find((button) => button.textContent === text);
+}
+
+describe('comment box tour chrome', () => {
+  let navigationManager: NavigationManager;
+  let target: HTMLElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDescribeElement.mockReturnValue('div');
+    mockIsElementVisible.mockReturnValue(true);
+    mockGetScrollParent.mockReturnValue(document.documentElement);
+    mockGetVisibleHighlightTarget.mockImplementation((el) => el);
+    mockIsPathfinderContent.mockReturnValue(false);
+
+    navigationManager = new NavigationManager();
+
+    target = document.createElement('div');
+    target.scrollIntoView = jest.fn();
+    target.getBoundingClientRect = jest.fn().mockReturnValue({
+      top: 100,
+      left: 100,
+      bottom: 200,
+      right: 200,
+      width: 100,
+      height: 100,
+    });
+    document.body.appendChild(target);
+  });
+
+  afterEach(() => {
+    navigationManager.clearAllHighlights();
+    target.remove();
+  });
+
+  const highlight = (
+    opts: {
+      current?: number;
+      total?: number;
+      completedSteps?: number[];
+      onNext?: () => void;
+      onPrevious?: () => void;
+      onCancel?: () => void;
+      onSkip?: () => void;
+      nextLabel?: string;
+      showKeyboardHint?: boolean;
+    } = {}
+  ) =>
+    navigationManager.highlightWithComment(
+      target,
+      'step copy',
+      false,
+      stepInfo(opts.current ?? 0, opts.total ?? 3, opts.completedSteps),
+      opts.onSkip,
+      opts.onCancel ?? jest.fn(),
+      'onNext' in opts ? opts.onNext : jest.fn(),
+      opts.onPrevious,
+      { nextLabel: opts.nextLabel, showKeyboardHint: opts.showKeyboardHint }
+    );
+
+  describe('navigation buttons', () => {
+    it('renders Back and Next when both tour callbacks are supplied', async () => {
+      await highlight({ onNext: jest.fn(), onPrevious: jest.fn() });
+
+      expect(buttonLabelled('← Back')).toBeDefined();
+      expect(buttonLabelled('Next →')).toBeDefined();
+    });
+
+    it('disables Back when no previous callback is supplied', async () => {
+      await highlight({ onPrevious: undefined });
+
+      expect(buttonLabelled('← Back')!.disabled).toBe(true);
+    });
+
+    it('enables Back when a previous callback is supplied', async () => {
+      await highlight({ onPrevious: jest.fn() });
+
+      expect(buttonLabelled('← Back')!.disabled).toBe(false);
+    });
+
+    it('invokes the matching callback on click', async () => {
+      const onNext = jest.fn();
+      const onPrevious = jest.fn();
+      await highlight({ onNext, onPrevious });
+
+      buttonLabelled('Next →')!.click();
+      buttonLabelled('← Back')!.click();
+
+      expect(onNext).toHaveBeenCalledTimes(1);
+      expect(onPrevious).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('next label', () => {
+    it('falls back to Done on the last step', async () => {
+      await highlight({ current: 2, total: 3 });
+
+      expect(buttonLabelled('Done')).toBeDefined();
+      expect(buttonLabelled('Done')!.getAttribute('aria-label')).toBe('Done');
+    });
+
+    it('honours an explicit label on the last step', async () => {
+      await highlight({ current: 2, total: 3, nextLabel: 'Start creating' });
+
+      expect(buttonLabelled('Start creating')).toBeDefined();
+      expect(buttonLabelled('Done')).toBeUndefined();
+    });
+
+    it('honours an explicit label mid-tour, keeping the generic aria-label', async () => {
+      await highlight({ current: 1, total: 3, nextLabel: 'Open the guide' });
+
+      const next = buttonLabelled('Open the guide')!;
+      expect(next).toBeDefined();
+      expect(next.getAttribute('aria-label')).toBe('Next step');
+    });
+
+    it('renders Next on a non-final step when no label is supplied', async () => {
+      await highlight({ current: 1, total: 3 });
+
+      expect(buttonLabelled('Next →')).toBeDefined();
+    });
+  });
+
+  describe('progress chrome', () => {
+    it('reads the step badge from stepInfo', async () => {
+      await highlight({ current: 1, total: 5 });
+
+      expect(commentBox().querySelector('.interactive-comment-step-badge')!.textContent).toBe('Step 2 of 5');
+    });
+
+    it('marks the current and completed dots', async () => {
+      await highlight({ current: 2, total: 4, completedSteps: [0, 1] });
+
+      const dots = Array.from(commentBox().querySelectorAll('.interactive-comment-dot'));
+      expect(dots).toHaveLength(4);
+      expect(dots[0]!.classList.contains('interactive-comment-dot--completed')).toBe(true);
+      expect(dots[1]!.classList.contains('interactive-comment-dot--completed')).toBe(true);
+      expect(dots[2]!.classList.contains('interactive-comment-dot--current')).toBe(true);
+      expect(dots[3]!.classList.contains('interactive-comment-dot--current')).toBe(false);
+    });
+
+    it('renders the keyboard hint only when asked', async () => {
+      await highlight({ showKeyboardHint: true });
+      expect(commentBox().querySelector('.interactive-comment-keyboard-hint')).not.toBeNull();
+
+      navigationManager.clearAllHighlights();
+
+      await highlight({ showKeyboardHint: false });
+      expect(commentBox().querySelector('.interactive-comment-keyboard-hint')).toBeNull();
+    });
+  });
+
+  describe('guided mode is unaffected', () => {
+    it('renders Cancel and Skip, and no tour buttons, when only guided callbacks are supplied', async () => {
+      await navigationManager.highlightWithComment(
+        target,
+        'guided copy',
+        false,
+        stepInfo(0, 3),
+        jest.fn(),
+        jest.fn(),
+        undefined,
+        undefined
+      );
+
+      expect(buttonLabelled('Cancel')).toBeDefined();
+      expect(buttonLabelled('Skip →')).toBeDefined();
+      expect(buttonLabelled('← Back')).toBeUndefined();
+      expect(buttonLabelled('Next →')).toBeUndefined();
+    });
+  });
+
+  describe('showCenteredComment', () => {
+    it('keeps the navigation footer and centres without inline coordinates', () => {
+      const onNext = jest.fn();
+      navigationManager.showCenteredComment('missing target copy', stepInfo(1, 4), jest.fn(), onNext, jest.fn());
+
+      const box = commentBox();
+      expect(box.getAttribute('data-position')).toBe('center');
+      expect(box.style.top).toBe('');
+      expect(box.style.left).toBe('');
+      expect(buttonLabelled('Next →')).toBeDefined();
+      expect(buttonLabelled('← Back')).toBeDefined();
+
+      buttonLabelled('Next →')!.click();
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('showNoopComment stays a distinct shape', () => {
+    it('renders no footer and keeps its noop marker', () => {
+      navigationManager.showNoopComment('noop copy');
+
+      const box = commentBox();
+      expect(box.getAttribute('data-noop')).toBe('true');
+      expect(box.getAttribute('data-position')).toBe('center');
+      expect(navButtons()).toHaveLength(0);
+    });
+  });
+
+  describe('in-panel highlights are exempt from the floating-panel dodge', () => {
+    it('marks both the outline and the comment box when the target is inside the panel', async () => {
+      mockIsPathfinderContent.mockReturnValue(true);
+      await highlight();
+
+      expect(document.querySelector('.interactive-highlight-outline')!.hasAttribute('data-pathfinder-internal')).toBe(
+        true
+      );
+      expect(commentBox().hasAttribute('data-pathfinder-internal')).toBe(true);
+    });
+
+    it('leaves ordinary targets unmarked', async () => {
+      await highlight();
+
+      expect(document.querySelector('.interactive-highlight-outline')!.hasAttribute('data-pathfinder-internal')).toBe(
+        false
+      );
+      expect(commentBox().hasAttribute('data-pathfinder-internal')).toBe(false);
+    });
+  });
+});

--- a/src/interactive-engine/index.ts
+++ b/src/interactive-engine/index.ts
@@ -12,7 +12,7 @@ export { updateInteractiveThemeColors } from '../styles/interactive.styles';
 
 // Navigation manager
 export { NavigationManager } from './navigation-manager';
-export type { NavigationOptions } from './navigation-manager';
+export type { NavigationOptions, CommentBoxOptions } from './navigation-manager';
 
 // State management
 export { InteractiveStateManager } from './interactive-state-manager';

--- a/src/interactive-engine/navigation-manager.ts
+++ b/src/interactive-engine/navigation-manager.ts
@@ -21,6 +21,17 @@ export interface NavigationOptions {
   ensureDocked?: boolean;
 }
 
+export interface CommentBoxOptions {
+  showKeyboardHint?: boolean;
+  stepTitle?: string;
+  skipAnimations?: boolean;
+  actionType?: 'hover' | 'button' | 'highlight' | 'formfill';
+  targetValue?: string;
+  /** E2E contract: selector for current target */
+  refTarget?: string;
+  nextLabel?: string;
+}
+
 const NAV_ITEM_SELECTOR = 'a[data-testid="data-testid Nav menu item"]';
 const MEGA_MENU_SELECTOR = '[data-testid="data-testid navigation mega-menu"]';
 
@@ -106,6 +117,37 @@ export class NavigationManager {
 
     // Add to document body (centered via CSS)
     document.body.appendChild(commentBox);
+  }
+
+  /**
+   * Show a viewport-centered comment that keeps its navigation footer.
+   * Used when a tour step's target cannot be resolved, so the user can still move on.
+   */
+  showCenteredComment(
+    comment: string,
+    stepInfo?: { current: number; total: number; completedSteps: number[] },
+    onCancelCallback?: () => void,
+    onNextCallback?: () => void,
+    onPreviousCallback?: () => void,
+    options?: CommentBoxOptions
+  ): HTMLElement {
+    this.clearAllHighlights();
+
+    const commentBox = this.createCommentBox(
+      comment,
+      null,
+      null,
+      stepInfo,
+      undefined,
+      onCancelCallback,
+      onNextCallback,
+      onPreviousCallback,
+      options
+    );
+
+    document.body.appendChild(commentBox);
+
+    return commentBox;
   }
 
   /**
@@ -641,14 +683,7 @@ export class NavigationManager {
     onCancelCallback?: () => void,
     onNextCallback?: () => void,
     onPreviousCallback?: () => void,
-    options?: {
-      showKeyboardHint?: boolean;
-      stepTitle?: string;
-      skipAnimations?: boolean; // For smooth step transitions
-      actionType?: 'hover' | 'button' | 'highlight' | 'formfill';
-      targetValue?: string;
-      refTarget?: string; // E2E contract: selector for current target
-    }
+    options?: CommentBoxOptions
   ): Promise<HTMLElement> {
     // First, ensure navigation is open and element is visible
     // Keep old highlight visible during this async work for smooth transitions
@@ -691,6 +726,12 @@ export class NavigationManager {
 
     // Create highlight element (dot or bounding box)
     const highlightElement = document.createElement('div');
+
+    // The floating panel dodges highlight overlays; exempt in-panel ones so it can't flee its own.
+    const isInternalTarget = isPathfinderContent(highlightTarget);
+    if (isInternalTarget) {
+      highlightElement.setAttribute('data-pathfinder-internal', 'true');
+    }
 
     if (useDotIndicator) {
       highlightElement.className = 'interactive-highlight-dot';
@@ -738,6 +779,10 @@ export class NavigationManager {
         onPreviousCallback,
         options
       );
+
+      if (isInternalTarget) {
+        commentBox.setAttribute('data-pathfinder-internal', 'true');
+      }
 
       // Always append to body (unified positioning)
       document.body.appendChild(commentBox);
@@ -811,21 +856,14 @@ export class NavigationManager {
    */
   private createCommentBox(
     comment: string,
-    targetRect: DOMRect,
-    highlightRect: { top: number; left: number; width: number; height: number },
+    targetRect: DOMRect | null,
+    highlightRect: { top: number; left: number; width: number; height: number } | null,
     stepInfo?: { current: number; total: number; completedSteps: number[] },
     onSkipCallback?: () => void,
     onCancelCallback?: () => void,
     onNextCallback?: () => void,
     onPreviousCallback?: () => void,
-    options?: {
-      showKeyboardHint?: boolean;
-      stepTitle?: string;
-      skipAnimations?: boolean;
-      actionType?: 'hover' | 'button' | 'highlight' | 'formfill';
-      targetValue?: string;
-      refTarget?: string; // E2E contract: selector for current target
-    }
+    options?: CommentBoxOptions
   ): HTMLElement {
     const commentBox = document.createElement('div');
     commentBox.className = 'interactive-comment-box';
@@ -955,7 +993,7 @@ export class NavigationManager {
         // Previous button
         const prevButton = document.createElement('button');
         prevButton.className = 'interactive-comment-nav-btn';
-        prevButton.innerHTML = '← Back'; // eslint-disable-line no-restricted-syntax -- Static HTML literal
+        prevButton.textContent = '← Back';
         prevButton.setAttribute('aria-label', 'Previous step');
         prevButton.disabled = !onPreviousCallback;
 
@@ -976,9 +1014,10 @@ export class NavigationManager {
         // Next button - primary style
         const nextButton = document.createElement('button');
         const isLastStep = stepInfo && stepInfo.current === stepInfo.total - 1;
+        const nextLabel = options?.nextLabel ?? (isLastStep ? 'Done' : 'Next →');
         nextButton.className = 'interactive-comment-nav-btn interactive-comment-nav-btn--primary';
-        nextButton.innerHTML = isLastStep ? 'Start creating' : 'Next →'; // eslint-disable-line no-restricted-syntax -- Static HTML literal
-        nextButton.setAttribute('aria-label', isLastStep ? 'Start creating' : 'Next step');
+        nextButton.textContent = nextLabel;
+        nextButton.setAttribute('aria-label', isLastStep ? nextLabel : 'Next step');
 
         if (onNextCallback) {
           nextButton.addEventListener('click', (e) => {
@@ -1051,6 +1090,12 @@ export class NavigationManager {
     }
 
     commentBox.appendChild(content);
+
+    // Returning before any inline top/left write is what lets the CSS centering rule apply.
+    if (!targetRect || !highlightRect) {
+      commentBox.setAttribute('data-position', 'center');
+      return commentBox;
+    }
 
     // MEASURE ACTUAL HEIGHT: Append off-screen temporarily to measure real dimensions
     commentBox.style.visibility = 'hidden';

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -122,10 +122,14 @@ export enum UserInteraction {
   AiFixApplied = 'ai_fix_applied',
   AiFixFailed = 'ai_fix_failed',
 
-  // Interactive-learning banner experiment (treatment arm only). The CTA reports
-  // OpenResourceClick like every other guide open, so it lands in the same funnel.
+  // Interactive-learning banner experiment (treatment arm only). The tour's hand-off
+  // step reports OpenResourceClick like every other guide open, so the guide open
+  // still lands in the same funnel.
   InteractiveLearningBannerShown = 'interactive_learning_banner_shown',
   InteractiveLearningBannerDismissed = 'interactive_learning_banner_dismissed',
+  InteractiveLearningTourStarted = 'interactive_learning_tour_started',
+  InteractiveLearningTourCompleted = 'interactive_learning_tour_completed',
+  InteractiveLearningTourDismissed = 'interactive_learning_tour_dismissed',
 }
 
 // ============================================================================

--- a/src/locales/cs-CZ/grafana-pathfinder-app.json
+++ b/src/locales/cs-CZ/grafana-pathfinder-app.json
@@ -95,7 +95,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Všechny cesty dokončeny!",

--- a/src/locales/de-DE/grafana-pathfinder-app.json
+++ b/src/locales/de-DE/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Alle Lernpfade abgeschlossen!",

--- a/src/locales/en-US/grafana-pathfinder-app.json
+++ b/src/locales/en-US/grafana-pathfinder-app.json
@@ -58,7 +58,33 @@
   },
   "interactiveLearningBanner": {
     "body": "Interactive guides walk you through Grafana one step at a time. \"Show me\" highlights the control to use, and \"Do it\" performs the step for you.",
-    "title": "Learn by doing"
+    "cta": "Show me around",
+    "guideTitle": "Welcome to Grafana",
+    "title": "Learn by doing",
+    "tour": {
+      "backLabel": "Take me back",
+      "cardBody": "Open one and it runs right here, a step at a time. Your progress is saved if you close the panel partway through.",
+      "cardTitle": "Every card is a guide",
+      "doItBody": "Clicks, navigation, and filling in forms all work this way, so you can watch what happens rather than hunt for it.",
+      "doItTitle": "\"Do it\" performs the step",
+      "finishBody": "Steps can be repeated, and most can be skipped if they do not apply to you, so go at your own pace. Pick a guide whenever you are ready — the one you just opened is still in its own tab.",
+      "finishTitle": "Back where you started",
+      "handoffBody": "Two buttons do all the work, and they are easier to show than to describe. Open a short guide and we will point them out.",
+      "handoffTitle": "Best seen in a real guide",
+      "myLearningBody": "My learning holds every guide you have finished, the badges you have earned, and any learning paths published privately for your organization — including ones not suggested for this page.",
+      "myLearningTitle": "Where the rest of it lives",
+      "openLabel": "Open the guide",
+      "panelBody": "This panel stays open beside Grafana while you work, so you practise in the real interface with your own data.",
+      "panelTitle": "Learning that follows you around",
+      "privateBody": "Guides your organization has published privately appear here, in among the public ones.",
+      "privateTitle": "Guides from your organization",
+      "progressBody": "Your badges and streak sit up here, so you can see how far you have got without leaving the page.",
+      "progressTitle": "Your progress at a glance",
+      "recommendationsBody": "These guides are picked for the page you are on, so the list changes as you move around Grafana.",
+      "recommendationsTitle": "Suggestions for where you are",
+      "showMeBody": "It outlines the exact control the step is talking about and scrolls it into view. Nothing in Grafana changes, so you can look before you act.",
+      "showMeTitle": "\"Show me\" is always safe"
+    }
   },
   "myLearning": {
     "badges": "Badges",

--- a/src/locales/es-ES/grafana-pathfinder-app.json
+++ b/src/locales/es-ES/grafana-pathfinder-app.json
@@ -91,7 +91,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "¡Todas las rutas completadas!",

--- a/src/locales/fr-FR/grafana-pathfinder-app.json
+++ b/src/locales/fr-FR/grafana-pathfinder-app.json
@@ -91,7 +91,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Tous les parcours terminés !",

--- a/src/locales/hu-HU/grafana-pathfinder-app.json
+++ b/src/locales/hu-HU/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Minden útvonal teljesítve!",

--- a/src/locales/id-ID/grafana-pathfinder-app.json
+++ b/src/locales/id-ID/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Semua jalur selesai!",

--- a/src/locales/it-IT/grafana-pathfinder-app.json
+++ b/src/locales/it-IT/grafana-pathfinder-app.json
@@ -91,7 +91,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Tutti i percorsi completati!",

--- a/src/locales/ja-JP/grafana-pathfinder-app.json
+++ b/src/locales/ja-JP/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "すべてのパスが完了しました！",

--- a/src/locales/ko-KR/grafana-pathfinder-app.json
+++ b/src/locales/ko-KR/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "모든 경로 완료!",

--- a/src/locales/nl-NL/grafana-pathfinder-app.json
+++ b/src/locales/nl-NL/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Alle leerpaden voltooid!",

--- a/src/locales/pl-PL/grafana-pathfinder-app.json
+++ b/src/locales/pl-PL/grafana-pathfinder-app.json
@@ -95,7 +95,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Wszystkie ścieżki ukończone!",

--- a/src/locales/pt-BR/grafana-pathfinder-app.json
+++ b/src/locales/pt-BR/grafana-pathfinder-app.json
@@ -91,7 +91,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Todas as jornadas concluídas!",

--- a/src/locales/pt-PT/grafana-pathfinder-app.json
+++ b/src/locales/pt-PT/grafana-pathfinder-app.json
@@ -91,7 +91,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Todos os percursos concluídos!",

--- a/src/locales/ru-RU/grafana-pathfinder-app.json
+++ b/src/locales/ru-RU/grafana-pathfinder-app.json
@@ -95,7 +95,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Все пути пройдены!",

--- a/src/locales/sv-SE/grafana-pathfinder-app.json
+++ b/src/locales/sv-SE/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Alla lärresor slutförda!",

--- a/src/locales/tr-TR/grafana-pathfinder-app.json
+++ b/src/locales/tr-TR/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "Tüm öğrenme yolları tamamlandı!",

--- a/src/locales/zh-CN/grafana-pathfinder-app.json
+++ b/src/locales/zh-CN/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "所有路径已完成！",

--- a/src/locales/zh-Hans/grafana-pathfinder-app.json
+++ b/src/locales/zh-Hans/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "所有路径已完成！",

--- a/src/locales/zh-Hant/grafana-pathfinder-app.json
+++ b/src/locales/zh-Hant/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "所有路徑已完成！",

--- a/src/locales/zh-TW/grafana-pathfinder-app.json
+++ b/src/locales/zh-TW/grafana-pathfinder-app.json
@@ -87,7 +87,33 @@
   },
   "interactiveLearningBanner": {
     "body": "",
-    "title": ""
+    "cta": "",
+    "guideTitle": "",
+    "title": "",
+    "tour": {
+      "backLabel": "",
+      "cardBody": "",
+      "cardTitle": "",
+      "doItBody": "",
+      "doItTitle": "",
+      "finishBody": "",
+      "finishTitle": "",
+      "handoffBody": "",
+      "handoffTitle": "",
+      "myLearningBody": "",
+      "myLearningTitle": "",
+      "openLabel": "",
+      "panelBody": "",
+      "panelTitle": "",
+      "privateBody": "",
+      "privateTitle": "",
+      "progressBody": "",
+      "progressTitle": "",
+      "recommendationsBody": "",
+      "recommendationsTitle": "",
+      "showMeBody": "",
+      "showMeTitle": ""
+    }
   },
   "userProfileBar": {
     "allComplete": "所有路徑已完成！",

--- a/src/utils/grafana-platform.ts
+++ b/src/utils/grafana-platform.ts
@@ -1,0 +1,6 @@
+import { config } from '@grafana/runtime';
+
+/** Whether this Grafana is a Cloud stack. `context.service.ts` still derives this inline. */
+export function isGrafanaCloud(): boolean {
+  return Boolean(config.bootData?.settings?.buildInfo?.versionString?.startsWith('Grafana Cloud'));
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft, parked deliberately.** Stacked on #1628, and its diff also contains #1634's commit because it extends `BubbleTour`. A linear stack can't express a dependency on two branches, so #1634 rides along to keep CI green rather than leaving this draft red and rotting. Once #1628 and #1634 both merge, rebasing this onto `main` drops that commit and the diff shrinks to just the tour.
>
> Review #1628 and #1634 first — this only makes sense on top of both.

## Summary

Gives the interactive-learning banner's CTA something to do. #1628 ships the banner as explanatory text with no action; this adds a ten-step next/previous bubble tour that walks the panel, opens a real guide partway through, and points at the actual "Show me" and "Do it" buttons rather than describing them.

| Steps | Anchored to |
|---|---|
| 1–3 | The panel: what it is, that suggestions follow the page, that each card is a runnable guide |
| 4 | Org-published guides — **optional**, dropped when absent |
| 5 | **My learning**, where private paths and completed guides live |
| 6 | Progress and streak |
| 7 | Hand-off. Button reads **open the guide** |
| 8–9 | The guide's real Show me / Do it. Step 9's button reads **take me back** |
| 10 | Back on the context panel, where the tour began |

## What to look at

**`tour-store.ts` — why the tour isn't rendered by the banner.** This is the non-obvious one and it cost a round of rework. Opening the guide flips `isRecommendationsTab` false, which unmounts the context panel at [`DocsPanelContentArea.tsx:145`](src/components/docs-panel/components/DocsPanelContentArea.tsx) — taking the banner down, and with it any tour the banner owned. The first version killed itself with the very action it triggered. The tour is now hosted from the docs-panel root, which survives tab switches, with a module-level store as the seam: the CTA sets a flag, the host subscribes via `useSyncExternalStore`. **Anything else that must outlive a tab switch needs the same treatment.**

**In-guide steps anchor on `.interactive-step-show-btn` / `.interactive-step-do-btn`, not step testids.** Step ids are DJB2 hashes of `sectionId|index|action|refTarget` (`deriveStepId`), so they shift whenever a guide's blocks are edited or reordered — including inserting a plain markdown block, since `index` counts all children. Hardcoding `interactive-show-me-section-grafana-tour-step-1hojnjs` would be a landmine. The class selectors also self-adapt: `interactive-step` renders **neither** button for a step whose requirements haven't passed, so the first match is always a genuinely enabled step — which matters because step 4 of both welcome guides is gated on `is-admin`.

**The guide is platform-branched.** `welcome-to-grafana-cloud`'s nav reftargets don't exist in OSS, and its `/alerts-and-incidents` step is neither `skippable` nor guarded by `exists-reftarget`, so it hard-blocks a local stack. Bundled recommendations are platform-filtered too, so it never surfaces there anyway. Cloud gets the Cloud guide; everyone else gets `welcome-to-grafana`. Both share the `grafana-tour` section id and seven `highlight` steps, so steps 8–10 work against either.

**Private content is covered twice, on purpose.** The context-tab `CustomGuidesSection` step is `optional` and dropped at mount when its target is missing — which is most stacks: `usePublishedGuides` short-circuits without a namespace, the catalogue needs the `aggregation.pathfinderbackend-ext-grafana-app.enabled` toggle that `docker-compose.yaml` doesn't set, and the section self-hides for any org with zero custom guides. Because that makes it invisible in practice, a second **non-optional** step anchors on the My learning icon button (`TabBarActions.tsx:145`, always rendered) and names private learning paths there — those live on My learning rather than the context tab since #1593. A test asserts that step is not `optional`, so it can't quietly regress to invisible.

**The hand-off is a button, not a link.** `.interactive-comment-box` is `pointer-events: none` so the bubble doesn't block the UI underneath, which means a link in its body copy would be inert. Step 7's primary button does the work instead: one click opens the guide *and* advances.

**Back is withheld on both steps that cross a tab switch** (8 and 10), since the previous step's target doesn't exist on the other side.

**Analytics.** `OpenResourceClick` still fires, now from the hand-off, so a banner-driven guide open stays in the same funnel as every recommendation card. Three tour lifecycle events carry `step_index` / `step_total` for per-bubble drop-off.

## How to verify

```bash
npm run check
```

Passes clean — exit 0, 454 suites, 7194 tests. The 24 lint warnings are pre-existing `getDataSourceSrv` deprecations.

```js
__pathfinderExperiment.setOverride('pathfinder.interactive-learning-banner-experiment', { variant: 'treatment' });
location.reload();
```

Open the sidebar, click the CTA, walk all ten steps with both mouse and arrow keys.

Three things look like bugs but aren't:

- **Step 4 is missing locally** and the counter reads "of 9". That's the `optional` drop described above.
- **Back is disabled on steps 8 and 10.** Deliberate — each crosses a tab switch.
- **The highlight outline fades after a few seconds while the bubble stays.** Pre-existing engine behaviour; only the auto-remove timer is suppressed for tours.

Also walk it in **floating mode** (pop out) and **full screen**.

### Not verified

**I could not run the app** — Docker was unavailable in my environment, so `npm run server` never started. Everything above is test-verified, not eyeball-verified.

Two things deserve a human eye, both timing-dependent and therefore exactly what tests can't settle:

1. Whether bubbles 8–9 actually catch the guide's Show me / Do it buttons after the tab renders. `resolveWithRetry` backs off up to ~2.6s, which should cover it.
2. Whether step 10 anchors cleanly after the tab switch back.

The unmount bug above was this same class of assumption, and tests didn't catch it — a live walkthrough did.

## Breaking changes

None. Gated on the `treatment` arm, which defaults to `excluded`.

## Reversibility

Fully reversible, and remote-controlled: `{ variant: 'excluded' }` in MTFF removes the banner and therefore the tour without a release. Teardown is the `InteractiveLearningBanner/` directory, the registry entry, and the `<InteractiveLearningTour>` line in `docs-panel.tsx`. `src/components/BubbleTour/` outlives the experiment — the block editor's tour uses it too.

## Out of scope

- **Engine-chrome i18n.** `Step X of Y`, `← Back`, `Next →`, `Done` stay English; they're emitted from a non-React class where `t()` can't be called without threading a translator through the engine. Step copy *is* translated. A single translated button beside an untranslated `Next →` would be worse than uniform English.
- **`restoreBanner()` / `startTour()` debug helpers.** Discussed, not added.
- **No "already seen" persistence and no resume** if the user reloads mid-tour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
