### PR TITLE
fix(learning-paths): thread packageInfo through Discover More launches

### DIFF
--- a/src/components/LearningPaths/MyLearningTab.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.test.tsx
@@ -498,9 +498,9 @@ describe('MyLearningTab launch flow', () => {
     );
   });
 
-  // Regression for #1637: without packageInfo, the loader falls through to
-  // plain fetchContent and the item renders as a bare document — no
-  // milestone toolbar, progress chrome, or next/prev nav.
+  // Without packageInfo, the loader falls through to plain fetchContent and
+  // the item renders as a bare document — no milestone toolbar, progress
+  // chrome, or next/prev nav.
   it('threads the inlined manifest through as packageInfo so the item resolves its milestone context', async () => {
     mockDiscoverItems = [
       {

--- a/src/components/LearningPaths/MyLearningTab.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.test.tsx
@@ -498,9 +498,6 @@ describe('MyLearningTab launch flow', () => {
     );
   });
 
-  // Without packageInfo, the loader falls through to plain fetchContent and
-  // the item renders as a bare document — no milestone toolbar, progress
-  // chrome, or next/prev nav.
   it('threads the inlined manifest through as packageInfo so the item resolves its milestone context', async () => {
     mockDiscoverItems = [
       {

--- a/src/components/LearningPaths/MyLearningTab.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.test.tsx
@@ -499,9 +499,9 @@ describe('MyLearningTab launch flow', () => {
   });
 
   // Regression for #1637: without packageInfo, the loader falls through to
-  // plain fetchContent and the item renders as a bare document — no cover,
-  // milestone toolbar, or next/prev nav.
-  it('threads the inlined manifest through as packageInfo so the item lands on its cover', async () => {
+  // plain fetchContent and the item renders as a bare document — no
+  // milestone toolbar, progress chrome, or next/prev nav.
+  it('threads the inlined manifest through as packageInfo so the item resolves its milestone context', async () => {
     mockDiscoverItems = [
       {
         id: 'pkg-1',

--- a/src/components/LearningPaths/MyLearningTab.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.test.tsx
@@ -67,6 +67,7 @@ let mockDiscoverItems: Array<{
   contentUrl: string;
   milestoneCount?: number;
   description?: string;
+  manifest?: Record<string, unknown>;
 }> = [];
 let mockDiscoverExcludeTitles: Set<string> | undefined;
 
@@ -493,7 +494,36 @@ describe('MyLearningTab launch flow', () => {
     await waitFor(() => expect(prepareMock).toHaveBeenCalledTimes(1));
     expect(prepareMock).toHaveBeenCalledWith(
       'https://cdn.example/pkg-1/content.json',
-      expect.objectContaining({ title: 'Package one' })
+      expect.objectContaining({ title: 'Package one', packageInfo: undefined })
+    );
+  });
+
+  // Regression for #1637: without packageInfo, the loader falls through to
+  // plain fetchContent and the item renders as a bare document — no cover,
+  // milestone toolbar, or next/prev nav.
+  it('threads the inlined manifest through as packageInfo so the item lands on its cover', async () => {
+    mockDiscoverItems = [
+      {
+        id: 'pkg-1',
+        title: 'Package one',
+        contentUrl: 'https://cdn.example/pkg-1/content.json',
+        manifest: { type: 'path', milestones: ['m1', 'm2'] },
+      },
+    ];
+    prepareMock.mockResolvedValue(okResult);
+
+    render(<MyLearningTab onOpenGuide={jest.fn()} />);
+    fireEvent.click(screen.getByTestId(testIds.learningPaths.discoverMoreStart('pkg-1')));
+
+    await waitFor(() => expect(prepareMock).toHaveBeenCalledTimes(1));
+    expect(prepareMock).toHaveBeenCalledWith(
+      'https://cdn.example/pkg-1/content.json',
+      expect.objectContaining({
+        packageInfo: {
+          packageId: 'pkg-1',
+          packageManifest: { type: 'path', milestones: ['m1', 'm2'], id: 'pkg-1' },
+        },
+      })
     );
   });
 });

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -231,10 +231,8 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
         interaction_location: 'my_learning_discover_more',
       });
 
-      // Without packageInfo, the loader falls through to plain fetchContent
-      // and the item renders as a bare document — no milestone toolbar, no
-      // progress chrome, no next/prev nav. Mirrors the packageInfo threading
-      // already done for My Courses / App Platform guides above.
+      // prepareGuideLaunch backfills packageInfo from the URL when absent, but
+      // the manifest is already inlined here — passing it saves that re-fetch.
       const packageInfo: PackageOpenInfo | undefined = item.manifest
         ? { packageId: item.id, packageManifest: { ...item.manifest, id: item.id } }
         : undefined;

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -232,9 +232,9 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
       });
 
       // Without packageInfo, the loader falls through to plain fetchContent
-      // and the item renders as a bare document — no cover, no milestone
-      // toolbar, no next/prev nav (#1637). Mirrors the packageInfo threading
-      // already done for My Courses / App Platform guides above.
+      // and the item renders as a bare document — no milestone toolbar, no
+      // progress chrome, no next/prev nav (#1637). Mirrors the packageInfo
+      // threading already done for My Courses / App Platform guides above.
       const packageInfo: PackageOpenInfo | undefined = item.manifest
         ? { packageId: item.id, packageManifest: { ...item.manifest, id: item.id } }
         : undefined;

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -230,7 +230,16 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
         content_type: AnalyticsContentType.LearningJourney,
         interaction_location: 'my_learning_discover_more',
       });
-      void launch(item.contentUrl, item.title, item.id);
+
+      // Without packageInfo, the loader falls through to plain fetchContent
+      // and the item renders as a bare document — no cover, no milestone
+      // toolbar, no next/prev nav (#1637). Mirrors the packageInfo threading
+      // already done for My Courses / App Platform guides above.
+      const packageInfo: PackageOpenInfo | undefined = item.manifest
+        ? { packageId: item.id, packageManifest: { ...item.manifest, id: item.id } }
+        : undefined;
+
+      void launch(item.contentUrl, item.title, item.id, packageInfo);
     },
     [launch]
   );

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -233,8 +233,8 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
 
       // Without packageInfo, the loader falls through to plain fetchContent
       // and the item renders as a bare document — no milestone toolbar, no
-      // progress chrome, no next/prev nav (#1637). Mirrors the packageInfo
-      // threading already done for My Courses / App Platform guides above.
+      // progress chrome, no next/prev nav. Mirrors the packageInfo threading
+      // already done for My Courses / App Platform guides above.
       const packageInfo: PackageOpenInfo | undefined = item.manifest
         ? { packageId: item.id, packageManifest: { ...item.manifest, id: item.id } }
         : undefined;

--- a/src/components/docs-panel/docs-panel.alignment.test.ts
+++ b/src/components/docs-panel/docs-panel.alignment.test.ts
@@ -821,3 +821,28 @@ describe('CombinedLearningJourneyPanel — implied-0th-step alignment', () => {
     });
   });
 });
+
+describe('CombinedLearningJourneyPanel — package resolver config source', () => {
+  afterEach(() => {
+    delete (window as any).__pathfinderPluginConfig;
+  });
+
+  it('seeds the resolver from the published global, not the constructor pluginConfig', () => {
+    const globalConfig = { acceptedTermsAndConditions: true } as any;
+    (window as any).__pathfinderPluginConfig = globalConfig;
+    const constructorConfig = { acceptedTermsAndConditions: false } as any;
+
+    new CombinedLearningJourneyPanel(constructorConfig);
+
+    expect(jest.requireMock('../../package-engine').createCompositeResolver).toHaveBeenCalledWith(globalConfig);
+  });
+
+  it('falls back to the constructor pluginConfig when the global is not set', () => {
+    delete (window as any).__pathfinderPluginConfig;
+    const constructorConfig = { acceptedTermsAndConditions: true } as any;
+
+    new CombinedLearningJourneyPanel(constructorConfig);
+
+    expect(jest.requireMock('../../package-engine').createCompositeResolver).toHaveBeenCalledWith(constructorConfig);
+  });
+});

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -234,7 +234,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
 
     // Wire the composite PackageResolver into docs-retrieval so that
     // fetchPackageContent() and fetchPackageById() can resolve bundled and
-    // remote packages. This is the Tier 3/4 injection point described in Phase 4g.
+    // remote packages — the Tier 3/4 injection point.
     //
     // The resolver is one app-wide singleton, not one per surface, so it must
     // always be seeded from the one authoritative config source — the global

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -236,15 +236,7 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     // fetchPackageContent() and fetchPackageById() can resolve bundled and
     // remote packages — the Tier 3/4 injection point.
     //
-    // The resolver is one app-wide singleton, not one per surface, so it must
-    // always be seeded from the one authoritative config source — the global
-    // usePathfinderPluginConfig publishes — rather than whichever pluginConfig
-    // this particular surface happened to be constructed with. Sidebar builds
-    // its pluginConfig from Grafana's usePluginContext() snapshot, which can
-    // lag a settings save independently of the published global; using it here
-    // would silently re-stale the resolver on every sidebar (re)mount, undoing
-    // module.tsx's post-refresh re-wire. Falls back to pluginConfig when the
-    // global isn't set (e.g. unit tests constructing this class directly).
+    // Seed from the published global, not this surface's snapshot — the resolver is one app-wide singleton.
     const resolverConfig = (window as unknown as { __pathfinderPluginConfig?: DocsPluginConfig })
       .__pathfinderPluginConfig;
     setPackageResolver(createCompositeResolver(resolverConfig ?? pluginConfig));

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -235,7 +235,19 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
     // Wire the composite PackageResolver into docs-retrieval so that
     // fetchPackageContent() and fetchPackageById() can resolve bundled and
     // remote packages. This is the Tier 3/4 injection point described in Phase 4g.
-    setPackageResolver(createCompositeResolver(pluginConfig));
+    //
+    // The resolver is one app-wide singleton, not one per surface, so it must
+    // always be seeded from the one authoritative config source — the global
+    // usePathfinderPluginConfig publishes — rather than whichever pluginConfig
+    // this particular surface happened to be constructed with. Sidebar builds
+    // its pluginConfig from Grafana's usePluginContext() snapshot, which can
+    // lag a settings save independently of the published global; using it here
+    // would silently re-stale the resolver on every sidebar (re)mount, undoing
+    // module.tsx's post-refresh re-wire. Falls back to pluginConfig when the
+    // global isn't set (e.g. unit tests constructing this class directly).
+    const resolverConfig = (window as unknown as { __pathfinderPluginConfig?: DocsPluginConfig })
+      .__pathfinderPluginConfig;
+    setPackageResolver(createCompositeResolver(resolverConfig ?? pluginConfig));
 
     // Note: Tab restoration now happens from React component after storage is initialized
     // to avoid race condition with useUserStorage hook

--- a/src/docs-retrieval/content-fetcher/package-content.ts
+++ b/src/docs-retrieval/content-fetcher/package-content.ts
@@ -6,28 +6,15 @@
 // single home; `fetchContent` itself stays in the orchestrator and is imported
 // here (one-directional — the orchestrator never imports back).
 import { ContentFetchResult, LearningJourneyMetadata, Milestone } from '../../types/content.types';
-import type { PackageResolver } from '../../types';
 import type { ResolvedNavLink } from '../../types/context.types';
 import { getPackageRenderType } from '../../types/package.types';
 import { fetchContent } from '../content-fetcher';
 import { buildBackendGuideContent, type BackendGuideResource } from './backend-guide';
 import { injectJourneyExtrasIntoJsonGuide } from './cover-page';
 import { logger } from '../../lib/logging';
+import { getPackageResolver, setPackageResolver, setPackageResolverFactory } from './package-resolver-registry';
 
-/**
- * Module-level PackageResolver injected at Tier 3+ (docs-panel wires the
- * concrete CompositePackageResolver here so docs-retrieval stays decoupled
- * from the package-engine Tier 2 implementation).
- */
-let _packageResolver: PackageResolver | undefined;
-
-/**
- * Inject the PackageResolver implementation into docs-retrieval.
- * Called once at app startup by Tier 3/4 wiring code.
- */
-export function setPackageResolver(resolver: PackageResolver): void {
-  _packageResolver = resolver;
-}
+export { setPackageResolver, setPackageResolverFactory };
 
 /**
  * Derive the grafana.com/docs/learning-paths/ website URL for a milestone.
@@ -73,12 +60,13 @@ export function derivePathSlug(manifestId: string): string {
  * @returns Milestone[] suitable for LearningJourneyMetadata and Recommendation.milestones
  */
 export async function resolvePackageMilestones(milestoneIds: string[], pathSlug?: string): Promise<Milestone[]> {
-  if (!_packageResolver || milestoneIds.length === 0) {
+  const resolver = await getPackageResolver();
+  if (!resolver || milestoneIds.length === 0) {
     return [];
   }
 
   const settled = await Promise.allSettled(
-    milestoneIds.map((id) => _packageResolver!.resolve(id, { loadContent: 'metadata-only' }))
+    milestoneIds.map((id) => resolver.resolve(id, { loadContent: 'metadata-only' }))
   );
 
   const milestones: Milestone[] = [];
@@ -124,12 +112,13 @@ export async function resolvePackageMilestones(milestoneIds: string[], pathSlug?
  * Unresolvable IDs are silently skipped.
  */
 export async function resolvePackageNavLinks(packageIds: string[]): Promise<ResolvedNavLink[]> {
-  if (!_packageResolver || packageIds.length === 0) {
+  const resolver = await getPackageResolver();
+  if (!resolver || packageIds.length === 0) {
     return [];
   }
 
   const settled = await Promise.allSettled(
-    packageIds.map((id) => _packageResolver!.resolve(id, { loadContent: 'metadata-only' }))
+    packageIds.map((id) => resolver.resolve(id, { loadContent: 'metadata-only' }))
   );
 
   const links: ResolvedNavLink[] = [];
@@ -248,14 +237,16 @@ export async function fetchPackageContent(
   const shouldResolveMilestones =
     needsMilestones && (!preResolvedMilestones || preResolvedMilestones.length === 0) && milestoneIds.length > 0;
 
+  const resolver = await getPackageResolver();
+
   // Run content fetch, milestone resolution, and baseUrl resolution in
   // parallel. These are independent: the page body doesn't need milestones
   // and milestones don't need the page body.
   const [result, resolvedMilestones, baseUrlResolution] = await Promise.all([
     preFetchedContent ?? fetchContent(contentUrl),
     shouldResolveMilestones ? resolvePackageMilestones(milestoneIds, pathSlug) : Promise.resolve(undefined),
-    manifestId && _packageResolver
-      ? _packageResolver.resolve(manifestId, { loadContent: false }).catch(() => undefined)
+    manifestId && resolver
+      ? resolver.resolve(manifestId, { loadContent: false }).catch(() => undefined)
       : Promise.resolve(undefined),
   ]);
 
@@ -325,7 +316,8 @@ export async function fetchPackageById(
   packageId: string,
   packageManifest?: Record<string, unknown>
 ): Promise<ContentFetchResult> {
-  if (!_packageResolver) {
+  const resolver = await getPackageResolver();
+  if (!resolver) {
     return {
       content: null,
       error: 'No package resolver configured — call setPackageResolver() first',
@@ -338,7 +330,7 @@ export async function fetchPackageById(
   // tab restore), so a draft opened by bare id is only caught here. The baseUrl
   // hydration resolve() in fetchPackageContent stays unverified — it runs on
   // every milestone fetch and its id is already known-good.
-  const resolution = await _packageResolver.resolve(packageId, { loadContent: false, verifyPublished: true });
+  const resolution = await resolver.resolve(packageId, { loadContent: false, verifyPublished: true });
 
   if (!resolution.ok) {
     return {

--- a/src/docs-retrieval/content-fetcher/package-content.ts
+++ b/src/docs-retrieval/content-fetcher/package-content.ts
@@ -237,16 +237,19 @@ export async function fetchPackageContent(
   const shouldResolveMilestones =
     needsMilestones && (!preResolvedMilestones || preResolvedMilestones.length === 0) && milestoneIds.length > 0;
 
-  const resolver = await getPackageResolver();
-
   // Run content fetch, milestone resolution, and baseUrl resolution in
   // parallel. These are independent: the page body doesn't need milestones
-  // and milestones don't need the page body.
+  // and milestones don't need the page body. The baseUrl branch awaits
+  // getPackageResolver() itself (rather than a resolver fetched ahead of this
+  // array) so a cold resolver's chunk fetch overlaps fetchContent(contentUrl)
+  // instead of serializing in front of it.
   const [result, resolvedMilestones, baseUrlResolution] = await Promise.all([
     preFetchedContent ?? fetchContent(contentUrl),
     shouldResolveMilestones ? resolvePackageMilestones(milestoneIds, pathSlug) : Promise.resolve(undefined),
-    manifestId && resolver
-      ? resolver.resolve(manifestId, { loadContent: false }).catch(() => undefined)
+    manifestId
+      ? getPackageResolver().then((resolver) =>
+          resolver ? resolver.resolve(manifestId, { loadContent: false }).catch(() => undefined) : undefined
+        )
       : Promise.resolve(undefined),
   ]);
 

--- a/src/docs-retrieval/content-fetcher/package-resolver-registry.ts
+++ b/src/docs-retrieval/content-fetcher/package-resolver-registry.ts
@@ -1,0 +1,29 @@
+// Holds the module-level PackageResolver singleton, split out from
+// package-content.ts specifically so module.tsx can register a resolver
+// without statically importing that file's heavy `content-fetcher` chain.
+// Zero runtime imports — safe for the eager entry bundle.
+import type { PackageResolver } from '../../types';
+
+let _resolverPromise: Promise<PackageResolver> | undefined;
+
+/**
+ * Register an already-constructed resolver. Used by callers outside the
+ * eager entry chunk (e.g. CombinedLearningJourneyPanel's constructor), which
+ * have no reason to defer construction.
+ */
+export function setPackageResolver(resolver: PackageResolver): void {
+  _resolverPromise = Promise.resolve(resolver);
+}
+
+/**
+ * Register a factory that lazily constructs the resolver on first read.
+ * Used by plugin.init so constructing the composite resolver (and its
+ * zod/CDN/etc. dependencies) doesn't happen on the eager module.js chunk.
+ */
+export function setPackageResolverFactory(factory: () => Promise<PackageResolver>): void {
+  _resolverPromise = factory();
+}
+
+export function getPackageResolver(): Promise<PackageResolver | undefined> {
+  return _resolverPromise ?? Promise.resolve(undefined);
+}

--- a/src/docs-retrieval/content-fetcher/package-resolver-registry.ts
+++ b/src/docs-retrieval/content-fetcher/package-resolver-registry.ts
@@ -1,10 +1,11 @@
 // Holds the module-level PackageResolver singleton, split out from
 // package-content.ts specifically so module.tsx can register a resolver
 // without statically importing that file's heavy `content-fetcher` chain.
-// Zero runtime imports — safe for the eager entry bundle.
+// Only import is lib/logging, already proven safe for the eager entry bundle.
 import type { PackageResolver } from '../../types';
+import { logger } from '../../lib/logging';
 
-let _resolverPromise: Promise<PackageResolver> | undefined;
+let _resolverPromise: Promise<PackageResolver | undefined> | undefined;
 
 /**
  * Register an already-constructed resolver. Used by callers outside the
@@ -19,9 +20,18 @@ export function setPackageResolver(resolver: PackageResolver): void {
  * Register a factory that lazily constructs the resolver on first read.
  * Used by plugin.init so constructing the composite resolver (and its
  * zod/CDN/etc. dependencies) doesn't happen on the eager module.js chunk.
+ *
+ * The promise is memoized, so a rejection would otherwise be cached and
+ * re-thrown by every later getPackageResolver() call for the rest of the
+ * session — silently breaking every caller's "no resolver configured"
+ * fallback. Caught here instead, mirroring the other fire-and-forget async
+ * init calls in module.tsx (e.g. initFaro's .catch(logger.exception)).
  */
 export function setPackageResolverFactory(factory: () => Promise<PackageResolver>): void {
-  _resolverPromise = factory();
+  _resolverPromise = factory().catch((error) => {
+    logger.exception(error, { source: 'setPackageResolverFactory' });
+    return undefined;
+  });
 }
 
 export function getPackageResolver(): Promise<PackageResolver | undefined> {

--- a/src/docs-retrieval/content-fetcher/package-resolver-registry.ts
+++ b/src/docs-retrieval/content-fetcher/package-resolver-registry.ts
@@ -5,6 +5,7 @@
 import type { PackageResolver } from '../../types';
 import { logger } from '../../lib/logging';
 
+let _resolverFactory: (() => Promise<PackageResolver>) | undefined;
 let _resolverPromise: Promise<PackageResolver | undefined> | undefined;
 
 /**
@@ -13,27 +14,43 @@ let _resolverPromise: Promise<PackageResolver | undefined> | undefined;
  * have no reason to defer construction.
  */
 export function setPackageResolver(resolver: PackageResolver): void {
+  _resolverFactory = undefined;
   _resolverPromise = Promise.resolve(resolver);
 }
 
 /**
- * Register a factory that lazily constructs the resolver on first read.
- * Used by plugin.init so constructing the composite resolver (and its
- * zod/CDN/etc. dependencies) doesn't happen on the eager module.js chunk.
+ * Register a factory that lazily constructs the resolver on first read. Used
+ * by plugin.init so constructing the composite resolver (and its zod/CDN/etc.
+ * dependencies, split into their own chunk) doesn't happen until something
+ * actually calls getPackageResolver() — not at registration. Calling the
+ * factory here instead would fetch that chunk on every page load where
+ * module.js loads, including for users who never open Pathfinder.
  *
- * The promise is memoized, so a rejection would otherwise be cached and
- * re-thrown by every later getPackageResolver() call for the rest of the
- * session — silently breaking every caller's "no resolver configured"
- * fallback. Caught here instead, mirroring the other fire-and-forget async
- * init calls in module.tsx (e.g. initFaro's .catch(logger.exception)).
+ * Only stores the thunk; clears any previously memoized promise so a second
+ * registration (e.g. module.tsx's post-refresh re-wire) actually takes effect
+ * on the next read instead of returning a stale result.
  */
 export function setPackageResolverFactory(factory: () => Promise<PackageResolver>): void {
-  _resolverPromise = factory().catch((error) => {
-    logger.exception(error, { source: 'setPackageResolverFactory' });
-    return undefined;
-  });
+  _resolverFactory = factory;
+  _resolverPromise = undefined;
 }
 
+/**
+ * The promise is memoized once invoked, so a rejection would otherwise be
+ * cached and re-thrown by every later call for the rest of the session —
+ * silently breaking every caller's "no resolver configured" fallback. Caught
+ * here, mirroring the other fire-and-forget async init calls in module.tsx
+ * (e.g. initFaro's .catch(logger.exception)).
+ */
 export function getPackageResolver(): Promise<PackageResolver | undefined> {
-  return _resolverPromise ?? Promise.resolve(undefined);
+  if (!_resolverPromise) {
+    if (!_resolverFactory) {
+      return Promise.resolve(undefined);
+    }
+    _resolverPromise = _resolverFactory().catch((error) => {
+      logger.exception(error, { source: 'getPackageResolver' });
+      return undefined;
+    });
+  }
+  return _resolverPromise;
 }

--- a/src/docs-retrieval/package-content.test.ts
+++ b/src/docs-retrieval/package-content.test.ts
@@ -376,6 +376,19 @@ describe('setPackageResolverFactory', () => {
 
     expect(milestones).not.toEqual([]);
   });
+
+  it('a rejected factory does not poison later reads with a cached rejection', async () => {
+    setPackageResolverFactory(() => Promise.reject(new Error('dynamic import failed')));
+
+    // The rejection is caught internally — callers see "no resolver
+    // configured" (empty result), never a thrown exception, and that holds
+    // on every subsequent read since the promise is memoized.
+    const first = await resolvePackageMilestones(['m1']);
+    const second = await resolvePackageMilestones(['m1']);
+
+    expect(first).toEqual([]);
+    expect(second).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/docs-retrieval/package-content.test.ts
+++ b/src/docs-retrieval/package-content.test.ts
@@ -347,6 +347,14 @@ describe('setPackageResolverFactory', () => {
     setPackageResolver(makeResolver({ ok: false, id: 'reset', error: { code: 'not-found', message: 'reset' } }));
   });
 
+  it('does not invoke the factory until the resolver is actually read', () => {
+    const factory = jest.fn().mockResolvedValue(makeResolver(makeSuccessResolution({ id: 'm1' })));
+
+    setPackageResolverFactory(factory);
+
+    expect(factory).not.toHaveBeenCalled();
+  });
+
   it('resolves milestones once the factory-registered resolver is available', async () => {
     setPackageResolverFactory(() => Promise.resolve(makeResolver(makeSuccessResolution({ id: 'm1' }))));
 

--- a/src/docs-retrieval/package-content.test.ts
+++ b/src/docs-retrieval/package-content.test.ts
@@ -15,6 +15,7 @@ import {
   fetchPackageContent,
   fetchPackageById,
   setPackageResolver,
+  setPackageResolverFactory,
   resolvePackageMilestones,
   resolvePackageNavLinks,
   ensureNonEmptyCoverContent,
@@ -338,6 +339,42 @@ describe('setPackageResolver', () => {
     setPackageResolver(secondResolver);
     await fetchPackageById('any-id');
     expect(secondResolver.resolve).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('setPackageResolverFactory', () => {
+  afterEach(() => {
+    setPackageResolver(makeResolver({ ok: false, id: 'reset', error: { code: 'not-found', message: 'reset' } }));
+  });
+
+  it('resolves milestones once the factory-registered resolver is available', async () => {
+    setPackageResolverFactory(() => Promise.resolve(makeResolver(makeSuccessResolution({ id: 'm1' }))));
+
+    const milestones = await resolvePackageMilestones(['m1']);
+
+    expect(milestones).not.toEqual([]);
+  });
+
+  it('invokes the factory only once across repeated reads', async () => {
+    const resolver = makeResolver(makeSuccessResolution({ id: 'm1' }));
+    const factory = jest.fn().mockResolvedValue(resolver);
+    setPackageResolverFactory(factory);
+
+    await resolvePackageMilestones(['m1']);
+    await resolvePackageMilestones(['m1']);
+
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('a later setPackageResolver call overrides a pending factory registration', async () => {
+    setPackageResolverFactory(() =>
+      Promise.resolve(makeResolver({ ok: false, id: 'x', error: { code: 'not-found', message: 'factory' } }))
+    );
+    setPackageResolver(makeResolver(makeSuccessResolution({ id: 'm1' })));
+
+    const milestones = await resolvePackageMilestones(['m1']);
+
+    expect(milestones).not.toEqual([]);
   });
 });
 

--- a/src/learning-paths/useDiscoverMore.test.ts
+++ b/src/learning-paths/useDiscoverMore.test.ts
@@ -76,7 +76,7 @@ describe('useDiscoverMore', () => {
 
   // Regression for #1637: without the inlined manifest threaded through as
   // packageInfo, Discover More launches fall through to plain fetchContent
-  // and never render a cover, milestone toolbar, or next/prev nav.
+  // and never resolve a milestone toolbar, progress chrome, or next/prev nav.
   it('threads the inlined manifest through so launch can build packageInfo from it', async () => {
     const { result } = renderHook(() => useDiscoverMore());
 

--- a/src/learning-paths/useDiscoverMore.test.ts
+++ b/src/learning-paths/useDiscoverMore.test.ts
@@ -74,9 +74,9 @@ describe('useDiscoverMore', () => {
     ]);
   });
 
-  // Regression for #1637: without the inlined manifest threaded through as
-  // packageInfo, Discover More launches fall through to plain fetchContent
-  // and never resolve a milestone toolbar, progress chrome, or next/prev nav.
+  // Without the inlined manifest threaded through as packageInfo, Discover
+  // More launches fall through to plain fetchContent and never resolve a
+  // milestone toolbar, progress chrome, or next/prev nav.
   it('threads the inlined manifest through so launch can build packageInfo from it', async () => {
     const { result } = renderHook(() => useDiscoverMore());
 

--- a/src/learning-paths/useDiscoverMore.test.ts
+++ b/src/learning-paths/useDiscoverMore.test.ts
@@ -61,6 +61,7 @@ describe('useDiscoverMore', () => {
         description: 'first',
         contentUrl: 'https://cdn.example/base/packages/a/content.json',
         milestoneCount: 2,
+        manifest: { milestones: ['m1', 'm2'] },
       },
       {
         id: 'b',
@@ -68,8 +69,20 @@ describe('useDiscoverMore', () => {
         description: undefined,
         contentUrl: 'https://cdn.example/base/packages/b/content.json',
         milestoneCount: undefined,
+        manifest: undefined,
       },
     ]);
+  });
+
+  // Regression for #1637: without the inlined manifest threaded through as
+  // packageInfo, Discover More launches fall through to plain fetchContent
+  // and never render a cover, milestone toolbar, or next/prev nav.
+  it('threads the inlined manifest through so launch can build packageInfo from it', async () => {
+    const { result } = renderHook(() => useDiscoverMore());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.items.find((i) => i.id === 'a')?.manifest).toEqual({ milestones: ['m1', 'm2'] });
   });
 
   it('excludes items whose title is already shown elsewhere', async () => {

--- a/src/learning-paths/useDiscoverMore.test.ts
+++ b/src/learning-paths/useDiscoverMore.test.ts
@@ -31,7 +31,7 @@ const response: PackageRecommendationsResponse = {
       title: 'A',
       type: 'path',
       description: 'first',
-      manifest: { milestones: ['m1', 'm2'] },
+      manifest: { id: 'a', type: 'path', milestones: ['m1', 'm2'] },
     },
     { id: 'b', path: 'packages/b', title: 'B', type: 'path' },
     // Individual guide, not a whole path → filtered out.
@@ -54,7 +54,10 @@ describe('useDiscoverMore', () => {
 
     // The 'guide'-typed entry is excluded; only whole paths surface.
     expect(result.current.items.map((i) => i.id)).not.toContain('g');
-    expect(result.current.items).toEqual([
+    // toMatchObject, not toEqual: a schema-valid manifest parses with its
+    // .default() fields applied, so the parsed object has more keys than the
+    // raw fixture — only the fields under test need to match.
+    expect(result.current.items).toMatchObject([
       {
         id: 'a',
         title: 'A',
@@ -74,15 +77,12 @@ describe('useDiscoverMore', () => {
     ]);
   });
 
-  // Without the inlined manifest threaded through as packageInfo, Discover
-  // More launches fall through to plain fetchContent and never resolve a
-  // milestone toolbar, progress chrome, or next/prev nav.
   it('threads the inlined manifest through so launch can build packageInfo from it', async () => {
     const { result } = renderHook(() => useDiscoverMore());
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(result.current.items.find((i) => i.id === 'a')?.manifest).toEqual({ milestones: ['m1', 'm2'] });
+    expect(result.current.items.find((i) => i.id === 'a')?.manifest).toMatchObject({ milestones: ['m1', 'm2'] });
   });
 
   it('excludes items whose title is already shown elsewhere', async () => {

--- a/src/learning-paths/useDiscoverMore.ts
+++ b/src/learning-paths/useDiscoverMore.ts
@@ -16,6 +16,8 @@ import {
   buildPackageFileUrl,
   type OnlinePackageEntry,
 } from '../lib/package-recommendations-client';
+import { ManifestJsonObjectSchema } from '../types/package.schema';
+import type { ManifestJson } from '../types/package.types';
 import { logger } from '../lib/logging';
 
 const DEFAULT_DISCOVER_COUNT = 5;
@@ -32,13 +34,8 @@ export interface DiscoverMoreItem {
   contentUrl: string;
   /** Milestone count from the inlined manifest, when available. */
   milestoneCount?: number;
-  /**
-   * The package's inlined manifest, when available. Threaded into launch as
-   * `packageInfo` — without it, the loader falls through to plain
-   * `fetchContent` and the item renders as a bare document with no milestone
-   * toolbar, progress chrome, or next/prev navigation.
-   */
-  manifest?: Record<string, unknown>;
+  /** The package's inlined manifest, when available and schema-valid — threaded into launch as `packageInfo` to save a redundant re-fetch. */
+  manifest?: ManifestJson;
 }
 
 export interface UseDiscoverMoreOptions {
@@ -58,6 +55,15 @@ function milestoneCountOf(entry: OnlinePackageEntry): number | undefined {
   return Array.isArray(milestones) ? milestones.length : undefined;
 }
 
+// Mirrors online-cdn-resolver.ts's handling of the same OnlinePackageEntry.manifest shape.
+function parseManifest(manifest: Record<string, unknown> | undefined): ManifestJson | undefined {
+  if (!manifest) {
+    return undefined;
+  }
+  const parsed = ManifestJsonObjectSchema.loose().safeParse(manifest);
+  return parsed.success ? (parsed.data as ManifestJson) : undefined;
+}
+
 function toDiscoverItem(entry: OnlinePackageEntry, baseUrl: string): DiscoverMoreItem | null {
   const contentUrl = buildPackageFileUrl(baseUrl, entry.path, 'content.json');
   if (!contentUrl) {
@@ -69,7 +75,7 @@ function toDiscoverItem(entry: OnlinePackageEntry, baseUrl: string): DiscoverMor
     description: entry.description,
     contentUrl,
     milestoneCount: milestoneCountOf(entry),
-    manifest: entry.manifest,
+    manifest: parseManifest(entry.manifest),
   };
 }
 

--- a/src/learning-paths/useDiscoverMore.ts
+++ b/src/learning-paths/useDiscoverMore.ts
@@ -32,6 +32,13 @@ export interface DiscoverMoreItem {
   contentUrl: string;
   /** Milestone count from the inlined manifest, when available. */
   milestoneCount?: number;
+  /**
+   * The package's inlined manifest, when available. Threaded into launch as
+   * `packageInfo` — without it, the loader falls through to plain
+   * `fetchContent` and the item renders as a bare document with no cover,
+   * milestone toolbar, or next/prev navigation.
+   */
+  manifest?: Record<string, unknown>;
 }
 
 export interface UseDiscoverMoreOptions {
@@ -62,6 +69,7 @@ function toDiscoverItem(entry: OnlinePackageEntry, baseUrl: string): DiscoverMor
     description: entry.description,
     contentUrl,
     milestoneCount: milestoneCountOf(entry),
+    manifest: entry.manifest,
   };
 }
 

--- a/src/learning-paths/useDiscoverMore.ts
+++ b/src/learning-paths/useDiscoverMore.ts
@@ -35,8 +35,8 @@ export interface DiscoverMoreItem {
   /**
    * The package's inlined manifest, when available. Threaded into launch as
    * `packageInfo` — without it, the loader falls through to plain
-   * `fetchContent` and the item renders as a bare document with no cover,
-   * milestone toolbar, or next/prev navigation.
+   * `fetchContent` and the item renders as a bare document with no milestone
+   * toolbar, progress chrome, or next/prev navigation.
    */
   manifest?: Record<string, unknown>;
 }

--- a/src/lib/telemetry/entry-bundle-boundary.test.ts
+++ b/src/lib/telemetry/entry-bundle-boundary.test.ts
@@ -13,6 +13,14 @@ const BARREL_IMPORT_RE = /(?:from\s+['"]|require\(['"])[^'"]*\/telemetry['"]/;
 // doubled module.js (113 KB -> 224 KB raw) before this was pinned.
 const HOOKS_BARREL_IMPORT_RE = /(?:from\s+['"]|require\(['"])\.{1,2}(?:\/\.\.)*\/hooks['"]/;
 
+// The same rule for the docs-retrieval and package-engine barrels: docs-retrieval
+// statically imports the whole content-fetcher orchestrator (zod, dompurify, the
+// bundled guide index). Importing either from module.tsx grew module.js 6.2x
+// (115 KB -> 696 KB raw) before this was pinned; use package-resolver-registry.ts
+// (a dependency-free leaf module) plus a dynamic import instead, as module.tsx does.
+const DOCS_RETRIEVAL_BARREL_IMPORT_RE = /(?:from\s+['"]|require\(['"])\.{1,2}(?:\/\.\.)*\/docs-retrieval['"]/;
+const PACKAGE_ENGINE_BARREL_IMPORT_RE = /(?:from\s+['"]|require\(['"])\.{1,2}(?:\/\.\.)*\/package-engine['"]/;
+
 describe('telemetry entry-bundle import discipline', () => {
   it.each(ENTRY_EAGER_FILES)('%s does not import the telemetry barrel', (relativePath) => {
     const source = fs.readFileSync(path.join(__dirname, '../../', relativePath), 'utf8');
@@ -24,5 +32,13 @@ describe('hooks entry-bundle import discipline', () => {
   it('module.tsx does not import the hooks barrel', () => {
     const source = fs.readFileSync(path.join(__dirname, '../../module.tsx'), 'utf8');
     expect(source).not.toMatch(HOOKS_BARREL_IMPORT_RE);
+  });
+});
+
+describe('docs-retrieval/package-engine entry-bundle import discipline', () => {
+  it('module.tsx does not import the docs-retrieval or package-engine barrels', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../../module.tsx'), 'utf8');
+    expect(source).not.toMatch(DOCS_RETRIEVAL_BARREL_IMPORT_RE);
+    expect(source).not.toMatch(PACKAGE_ENGINE_BARREL_IMPORT_RE);
   });
 });

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -153,11 +153,12 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   // constructor (docs-panel.tsx): a launch can fetch and classify package
   // content (My Learning, Discover More) before any docs-panel/sidebar/
   // full-screen instance has ever mounted this session. Without an early
-  // resolver, that fetch's milestone resolution silently no-ops — the cover
-  // page renders with no "In this path" list, no lock/play icons, no real
-  // module count, because it never learns the content is a multi-milestone
-  // package at all (#1637). The panel's own call stays as a harmless re-set
-  // for whichever config that specific surface was constructed with.
+  // resolver, that fetch's milestone resolution silently no-ops — the launch
+  // renders as a bare, standalone document with no milestone toolbar, no
+  // progress chrome, no next/prev navigation, because it never learns the
+  // content is a multi-milestone package at all (#1637). The panel's own
+  // call stays as a harmless re-set for whichever config that specific
+  // surface was constructed with.
   setPackageResolver(createCompositeResolver(config));
 
   // `meta.jsonData` can lag a recent save. Re-publish from the authoritative

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -163,9 +163,14 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
 
   // `meta.jsonData` can lag a recent save. Re-publish from the authoritative
   // read when it lands; subscribers pick it up via the config-updated event.
+  // Re-wire the resolver too: if the authoritative config flips the
+  // recommender-enabled flag relative to the possibly-stale snapshot above,
+  // a launch that races ahead of any panel mount would otherwise keep
+  // resolving through the wrong chain until some panel re-sets it itself.
   void refreshPathfinderPluginConfig().then((refreshed) => {
     if (refreshed) {
       linkInterceptionState.setInterceptionEnabled(refreshed.interceptGlobalDocsLinks);
+      setPackageResolver(createCompositeResolver(refreshed));
     }
   });
 

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -152,11 +152,13 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   const config = publishPathfinderPluginConfig(meta?.jsonData || {});
   linkInterceptionState.setInterceptionEnabled(config.interceptGlobalDocsLinks);
 
-  // Deferred: constructing the resolver eagerly would pull its dependencies into the entry bundle.
+  // Deferred: setPackageResolverFactory only stores this thunk, so the dynamic
+  // import — and its zod/CDN/etc. dependencies — isn't fetched until something
+  // actually calls getPackageResolver(), not on every page load. No
+  // webpackPrefetch here: by the time it's read, it's needed promptly (inside
+  // fetchPackageContent's Promise.all), not at idle-time priority.
   setPackageResolverFactory(() =>
-    import(/* webpackPrefetch: true */ './package-engine/composite-resolver').then((m) =>
-      m.createCompositeResolver(config)
-    )
+    import('./package-engine/composite-resolver').then((m) => m.createCompositeResolver(config))
   );
 
   // `meta.jsonData` can lag a recent save. Re-publish from the authoritative
@@ -167,9 +169,7 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
       // Skip re-registering when nothing changed — avoids a redundant resolver rebuild.
       if (refreshed !== config) {
         setPackageResolverFactory(() =>
-          import(/* webpackPrefetch: true */ './package-engine/composite-resolver').then((m) =>
-            m.createCompositeResolver(refreshed)
-          )
+          import('./package-engine/composite-resolver').then((m) => m.createCompositeResolver(refreshed))
         );
       }
     }

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -156,7 +156,7 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   // resolver, that fetch's milestone resolution silently no-ops — the launch
   // renders as a bare, standalone document with no milestone toolbar, no
   // progress chrome, no next/prev navigation, because it never learns the
-  // content is a multi-milestone package at all (#1637). The panel's own
+  // content is a multi-milestone package at all. The panel's own
   // call stays as a harmless re-set for whichever config that specific
   // surface was constructed with.
   setPackageResolver(createCompositeResolver(config));

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -9,6 +9,8 @@ import { DocsPluginConfig } from './constants';
 // Direct file import, not the ./hooks barrel: the barrel would pull every hook
 // (and zod, via user-storage) into module.js.
 import { publishPathfinderPluginConfig, refreshPathfinderPluginConfig } from './hooks/usePathfinderPluginConfig';
+import { setPackageResolver } from './docs-retrieval';
+import { createCompositeResolver } from './package-engine';
 import { PANEL_MODE_CHANGE_EVENT } from './lib/event-names';
 import { linkInterceptionState } from './global-state/link-interception';
 import { sidebarState } from 'global-state/sidebar';
@@ -146,6 +148,17 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   // the deep-link and link-interception listeners needed to exist.
   const config = publishPathfinderPluginConfig(meta?.jsonData || {});
   linkInterceptionState.setInterceptionEnabled(config.interceptGlobalDocsLinks);
+
+  // Wire the package resolver here, not just in CombinedLearningJourneyPanel's
+  // constructor (docs-panel.tsx): a launch can fetch and classify package
+  // content (My Learning, Discover More) before any docs-panel/sidebar/
+  // full-screen instance has ever mounted this session. Without an early
+  // resolver, that fetch's milestone resolution silently no-ops — the cover
+  // page renders with no "In this path" list, no lock/play icons, no real
+  // module count, because it never learns the content is a multi-milestone
+  // package at all (#1637). The panel's own call stays as a harmless re-set
+  // for whichever config that specific surface was constructed with.
+  setPackageResolver(createCompositeResolver(config));
 
   // `meta.jsonData` can lag a recent save. Re-publish from the authoritative
   // read when it lands; subscribers pick it up via the config-updated event.

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -9,8 +9,11 @@ import { DocsPluginConfig } from './constants';
 // Direct file import, not the ./hooks barrel: the barrel would pull every hook
 // (and zod, via user-storage) into module.js.
 import { publishPathfinderPluginConfig, refreshPathfinderPluginConfig } from './hooks/usePathfinderPluginConfig';
-import { setPackageResolver } from './docs-retrieval';
-import { createCompositeResolver } from './package-engine';
+// Direct file import, not the ./docs-retrieval barrel: the barrel statically
+// imports the whole content-fetcher orchestrator (zod, dompurify, the bundled
+// guide index), which would land in module.js. createCompositeResolver is
+// deferred behind a dynamic import below for the same reason.
+import { setPackageResolverFactory } from './docs-retrieval/content-fetcher/package-resolver-registry';
 import { PANEL_MODE_CHANGE_EVENT } from './lib/event-names';
 import { linkInterceptionState } from './global-state/link-interception';
 import { sidebarState } from 'global-state/sidebar';
@@ -149,28 +152,26 @@ plugin.init = function (meta: AppPluginMeta<DocsPluginConfig>) {
   const config = publishPathfinderPluginConfig(meta?.jsonData || {});
   linkInterceptionState.setInterceptionEnabled(config.interceptGlobalDocsLinks);
 
-  // Wire the package resolver here, not just in CombinedLearningJourneyPanel's
-  // constructor (docs-panel.tsx): a launch can fetch and classify package
-  // content (My Learning, Discover More) before any docs-panel/sidebar/
-  // full-screen instance has ever mounted this session. Without an early
-  // resolver, that fetch's milestone resolution silently no-ops — the launch
-  // renders as a bare, standalone document with no milestone toolbar, no
-  // progress chrome, no next/prev navigation, because it never learns the
-  // content is a multi-milestone package at all. The panel's own
-  // call stays as a harmless re-set for whichever config that specific
-  // surface was constructed with.
-  setPackageResolver(createCompositeResolver(config));
+  // Deferred: constructing the resolver eagerly would pull its dependencies into the entry bundle.
+  setPackageResolverFactory(() =>
+    import(/* webpackPrefetch: true */ './package-engine/composite-resolver').then((m) =>
+      m.createCompositeResolver(config)
+    )
+  );
 
   // `meta.jsonData` can lag a recent save. Re-publish from the authoritative
   // read when it lands; subscribers pick it up via the config-updated event.
-  // Re-wire the resolver too: if the authoritative config flips the
-  // recommender-enabled flag relative to the possibly-stale snapshot above,
-  // a launch that races ahead of any panel mount would otherwise keep
-  // resolving through the wrong chain until some panel re-sets it itself.
   void refreshPathfinderPluginConfig().then((refreshed) => {
     if (refreshed) {
       linkInterceptionState.setInterceptionEnabled(refreshed.interceptGlobalDocsLinks);
-      setPackageResolver(createCompositeResolver(refreshed));
+      // Skip re-registering when nothing changed — avoids a redundant resolver rebuild.
+      if (refreshed !== config) {
+        setPackageResolverFactory(() =>
+          import(/* webpackPrefetch: true */ './package-engine/composite-resolver').then((m) =>
+            m.createCompositeResolver(refreshed)
+          )
+        );
+      }
     }
   });
 

--- a/src/validation/architecture.test.ts
+++ b/src/validation/architecture.test.ts
@@ -148,6 +148,14 @@ const ALLOWED_BARREL_VIOLATIONS = new Set<string>([
   // module.tsx is the entry point: the hooks barrel drags every hook — and zod,
   // via lib/user-storage — into module.js, roughly doubling it.
   'module.tsx -> hooks/usePathfinderPluginConfig',
+  // module.tsx is the entry point: the docs-retrieval barrel statically imports
+  // the whole content-fetcher orchestrator (zod, dompurify, the bundled guide
+  // index), and package-engine's composite-resolver pulls in every resolver
+  // implementation. Both grew module.js 6.2x (115 KB -> 696 KB raw) before this
+  // was pinned; package-resolver-registry.ts is a dependency-free leaf module,
+  // and composite-resolver is reached via a dynamic import, not this barrel.
+  'module.tsx -> docs-retrieval/content-fetcher/package-resolver-registry',
+  'module.tsx -> package-engine/composite-resolver',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Fixes #1637 — Discover More launches never resolve the course's package/manifest context (no milestone toolbar, no progress chrome, no next/prev navigation), rendering as a bare, standalone document instead.

**The actual root cause**: `setPackageResolver()` was only ever called inside `CombinedLearningJourneyPanel`'s constructor, so a launch from My Learning — before any docs-panel/sidebar/full-screen instance has mounted this session — races ahead of the resolver ever being configured. `module.tsx`'s `plugin.init` now wires it at plugin load instead.

(An earlier version of this PR also attributed part of the fix to threading `packageInfo` through Discover More's launch call. That turned out not to be a correctness fix — `prepareGuideLaunch` already backfills `packageInfo` from the URL when the caller passes none, and every live Discover More `contentUrl` already matches the pattern that triggers that backfill. The threading is a worthwhile latency optimization — it saves that redundant sibling-manifest re-fetch — but the resolver wiring above is what actually fixes #1637.)

## What changed

- `src/docs-retrieval/content-fetcher/package-resolver-registry.ts` (new) + `src/module.tsx` — the package resolver singleton, split into a dependency-free leaf module so `plugin.init` can register it without statically pulling `docs-retrieval`'s heavy `content-fetcher` chain into the entry bundle (see "Bundle size" below). `module.tsx` registers a factory that dynamically imports `composite-resolver.ts` directly; `package-content.ts`'s four resolver read sites (all already `async`) await it.
- `src/learning-paths/useDiscoverMore.ts` — `DiscoverMoreItem` now carries the package's inlined `manifest` (already fetched for milestone-count display), parsed through `ManifestJsonObjectSchema.loose().safeParse` (matching `online-cdn-resolver.ts`'s handling of the same shape) before being threaded through.
- `src/components/LearningPaths/MyLearningTab.tsx` — `handleDiscoverStart` builds `packageInfo` from that manifest before calling `launch`, mirroring the existing pattern used above it for My Courses / App Platform guides — a latency win, not the fix (see above).
- `src/components/docs-panel/docs-panel.tsx` — `CombinedLearningJourneyPanel`'s constructor now seeds the resolver from the published `window.__pathfinderPluginConfig` global rather than whichever `pluginConfig` that surface happened to be constructed with. The resolver is one app-wide singleton; sidebar previously built its `pluginConfig` from Grafana's `usePluginContext()` snapshot, which can lag a settings save independently of the published global, so every sidebar (re)mount could silently re-stale it.

## Bundle size

Wiring the resolver via `module.tsx` initially imported the `docs-retrieval` and `package-engine` barrels statically, growing `module.js` 6.2x (115 KB → 696 KB raw — CI's bundle-size bot flagged `+518.96%`) since `docs-retrieval` statically imports the whole `content-fetcher` orchestrator (zod, dompurify, the bundled guide index) and `package-engine`'s composite resolver pulls in every resolver implementation. Total bundle size was unchanged, so this was pure reclassification from lazy to eager, not new functionality.

Fixed by deferring construction behind a factory + dynamic import (see "What changed" above); `module.js` is back to ~116 KB. Guarded against recurrence: `entry-bundle-boundary.test.ts` now denies `module.tsx` importing either barrel, mirroring the existing hooks-barrel check; both new intentional bypasses (the registry leaf module and the dynamic `composite-resolver` import) are recorded in `architecture.test.ts`'s `ALLOWED_BARREL_VIOLATIONS`.

## How to verify

- Unit: `useDiscoverMore.test.ts` and `MyLearningTab.test.tsx` cover the manifest threading; `package-content.test.ts` covers `setPackageResolverFactory` (resolves once available, invoked once across repeated reads, a later `setPackageResolver` overrides a pending factory); `docs-panel.alignment.test.ts` covers the resolver's config-source fix (global wins over constructor `pluginConfig`; falls back when the global is unset).
- `npm run build` — confirm `dist/module.js` is ~116 KB raw with no entrypoint-size warning.
- Live, local dev stack: cleared all Pathfinder localStorage state (fresh session, no prior docs-panel mount), clicked "Start" on a Discover More card as the very first action. Confirmed via network trace that all milestone `manifest.json` requests now resolve — previously none did.
- `npm run check`'s non-Go steps pass clean (7123 tests); architecture/tier/entry-bundle tests pass with the two new bypasses recorded, no unrecorded violations.

## Breaking changes

None. Additive only — `DiscoverMoreItem.manifest` is a new optional field (now typed `ManifestJson`, schema-validated), and the resolver registry is a drop-in replacement for the previous module-level variable with the same public API plus one new factory-registration function.

## Note

Package-backed paths don't render a cover page from any launch source on `main` today — that's the separate, in-progress #1621. This PR is scoped to the underlying missing-context bug, which is independent of covers; #1621 will build on top of this fix once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
