### PR TITLE
fix(e2e): add Pathfinder tutorial data-testids for #1515

### DIFF
--- a/src/components/AppConfig/ConfigurationForm.tsx
+++ b/src/components/AppConfig/ConfigurationForm.tsx
@@ -311,7 +311,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
               description="⚠️ WARNING: Disables security protections. Only enable in isolated development environments. Requires admin permissions to change. Only visible to the user who enabled it."
               className={s.marginTop}
             >
-              <div className={s.devModeField}>
+              <div className={s.devModeField} data-testid={testIds.appConfig.pathfinderDevMode}>
                 <Input
                   type="checkbox"
                   id="dev-mode"

--- a/src/constants/testIds.ts
+++ b/src/constants/testIds.ts
@@ -208,6 +208,8 @@ export const testIds = {
     apiKey: 'config-api-key',
     apiUrl: 'config-api-url',
     devModeToggle: 'config-dev-mode-toggle',
+    /** Pathfinder tutorial anchor for #dev-mode (do not rename without Pathfinder squad). */
+    pathfinderDevMode: 'pathfinder-dev-mode',
     assistantDevModeToggle: 'config-assistant-dev-mode-toggle',
     globalLinkInterception: 'config-global-link-interception',
     openPanelOnLaunch: 'config-open-panel-on-launch',
@@ -370,6 +372,8 @@ export const testIds = {
     panel: 'coda-terminal-panel',
     collapsedBar: 'coda-terminal-collapsed-bar',
     expandButton: 'coda-terminal-expand',
+    /** Pathfinder tutorial anchor for Expand terminal (do not rename without Pathfinder squad). */
+    pathfinderExpand: 'pathfinder-expand-terminal',
     collapseButton: 'coda-terminal-collapse',
     closeButton: 'coda-terminal-close',
     resizeHandle: 'coda-terminal-resize-handle',

--- a/src/integrations/coda/TerminalPanel.tsx
+++ b/src/integrations/coda/TerminalPanel.tsx
@@ -442,13 +442,15 @@ export function TerminalPanel({ onClose }: TerminalPanelProps) {
                 )}
                 <span>{getStatusText(status)}</span>
               </div>
-              <IconButton
-                name="angle-up"
-                size="sm"
-                aria-label="Expand"
-                tooltip="Expand terminal"
-                data-testid={testIds.codaTerminal.expandButton}
-              />
+              <span data-testid={testIds.codaTerminal.pathfinderExpand}>
+                <IconButton
+                  name="angle-up"
+                  size="sm"
+                  aria-label="Expand terminal"
+                  tooltip="Expand terminal"
+                  data-testid={testIds.codaTerminal.expandButton}
+                />
+              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Adds stable `pathfinder-dev-mode` and `pathfinder-expand-terminal` data-testids for Pathfinder tutorials that currently target `#dev-mode` and Expand terminal.
- Keeps existing `config-dev-mode-toggle` / `coda-terminal-expand` ids (no renames).
- Aligns the expand IconButton `aria-label` to `Expand terminal`.

Note: `#dev-mode` lives in `ConfigurationForm.tsx` (the issue's AssistantCustomizable.tsx paths were stale).

Fixes #1515

## Test plan
- [ ] Confirm `#dev-mode` checkbox wrapper exposes `data-testid="pathfinder-dev-mode"`
- [ ] Confirm expand control exposes `data-testid="pathfinder-expand-terminal"` and `aria-label="Expand terminal"`
- [ ] Existing e2e selectors using `config-dev-mode-toggle` / `coda-terminal-expand` still resolve