### PR TITLE
feat(e2e): add step driver registry

### DIFF
--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -135,8 +135,10 @@ The main Playwright suite and dedicated guide runner use a fixed 1920×1080 Chro
    - Plugin loads guide via `bundled:e2e-test` pattern
 
 3. **Step discovery**
-   - Runner scans DOM for interactive step elements
-   - Collects metadata: step IDs, skip buttons, Do it buttons, multistep status
+   - The runner scans for `[data-test-step-kind][data-test-step-id]` roots.
+   - If current roots are absent, the runner uses the documented legacy selector.
+   - The driver registry collects metadata and identifies supported steps.
+   - Unsupported roots remain in coverage, but the runner does not operate their controls.
 
 4. **Sequential execution**
    - For each step:
@@ -224,7 +226,25 @@ Use `--output report.json` to generate a structured report:
     "mandatoryFailed": 1,
     "skippableFailed": 0
   },
-  "steps": [...]
+  "steps": [
+    {
+      "stepId": "section-1-step-1",
+      "stepKind": "plain",
+      "index": 0,
+      "status": "passed",
+      "duration": 1000,
+      "currentUrl": "http://localhost:3000/",
+      "consoleErrors": []
+    }
+  ],
+  "coverage": {
+    "contractSource": "current",
+    "rendered": 2,
+    "supported": 1,
+    "executed": 1,
+    "unsupported": 1,
+    "unsupportedSteps": [{ "stepKind": "quiz", "stepId": "section-1-quiz-1" }]
+  }
 }
 ```
 
@@ -237,6 +257,17 @@ Key contract fields:
 - `guide.contentDigest`: SHA-256 digest of the exact guide content executed
 - `guide.sourceUrl`: remote package source URL when available
 - `selection`: for an explicitly selected path or journey, the multi-guide report records the root package `id` and `type` separately from its executable leaf-guide reports
+- `steps[].stepKind`: optional registered driver kind for a reported step
+- `coverage.contractSource`: `current` for tracked roots, or `legacy` for the compatibility selector
+- `coverage.rendered`: number of tracked roots in the rendered DOM
+- `coverage.supported`: number of rendered roots with supported drivers
+- `coverage.executed`: number of supported roots that reached a terminal runner result
+- `coverage.unsupported`: number of rendered roots without supported drivers
+- `coverage.unsupportedSteps`: unsupported kind and step ID pairs
+
+Coverage fields are optional and additive. Unsupported coverage does not change outcomes, exit codes, skip behavior, or runner action semantics.
+
+Multi-guide reports keep coverage inside each individual guide report. The aggregate outcome and step summary use the existing rules.
 
 ### Report validation
 

--- a/docs/developer/E2E_TESTING_CONTRACT.md
+++ b/docs/developer/E2E_TESTING_CONTRACT.md
@@ -49,10 +49,23 @@ The registered kind values are:
 
 The registry owns the set of kind values. Each component owns its stable root and stable test step ID.
 
-PR 0 only publishes this additive product DOM contract. A later runner change will consume the contract.
 The plain, multistep, and guided roots keep the existing `data-step-id` runtime attribute. The other tracked roots do not add this runtime attribute.
 
-The new attributes do not change existing test IDs or state values. They do not change runner discovery, runner execution, or report outcomes.
+The guide runner discovers current roots with `[data-test-step-kind][data-test-step-id]`. It records `current` as the contract source.
+
+If current roots are absent, the runner uses the legacy `interactive-step-*` test IDs. It records `legacy` as the contract source.
+
+The legacy selector excludes `interactive-step-completed-*` badges. These badges share the old step test ID prefix.
+
+One `StepDriver` registry owns metadata inspection, product controls, execution, skip behavior, and completion rules. The registry uses `data-test-step-kind` keys.
+
+The runner supports `plain`, `multistep`, and `guided`. It reports the other registered kinds as unsupported coverage and does not operate their controls.
+
+Unsupported coverage does not change guide outcomes in this release. The runner reports each unsupported kind and step ID.
+
+Browser actions use only rendered DOM state. Raw guide JSON can identify authored interactive content, but it cannot control browser actions.
+
+These runner changes do not change root ownership, existing test IDs, state values, or product completion behavior.
 
 ---
 

--- a/src/cli/__tests__/schema-e2e-report.test.ts
+++ b/src/cli/__tests__/schema-e2e-report.test.ts
@@ -21,6 +21,8 @@ describe('schema command — e2e-report registration', () => {
     expect(schema).not.toBeNull();
     expect(String(schema?.$id)).toContain('e2e-test-report-1.0.0');
     expect(schema?.['x-schema-version']).toBe('1.0.0');
+    expect(JSON.stringify(schema)).toContain('"coverage"');
+    expect(JSON.stringify(schema)).toContain('"stepKind"');
   });
 
   it('exports the multi-guide report schema without throwing', () => {

--- a/src/cli/e2e/e2e-reporter.test.ts
+++ b/src/cli/e2e/e2e-reporter.test.ts
@@ -113,6 +113,43 @@ describe('generateMultiGuideReport — dependency-skipped guides', () => {
 });
 
 describe('versioned report contract', () => {
+  it('includes additive step-kind and non-gating unsupported coverage', () => {
+    const data = ranGuide('mixed-guide');
+    data.results[0]!.stepKind = 'plain';
+    data.coverage = {
+      contractSource: 'current',
+      rendered: 2,
+      supported: 1,
+      executed: 1,
+      unsupported: 1,
+      unsupportedSteps: [{ stepKind: 'quiz', stepId: 'quiz-1' }],
+    };
+
+    const report = generateReport(data);
+
+    expect(report.outcome).toBe('passed');
+    expect(report.steps[0]!.stepKind).toBe('plain');
+    expect(report.coverage).toEqual(data.coverage);
+    expect(() => E2ETestReportSchema.parse(report)).not.toThrow();
+  });
+
+  it('keeps per-guide coverage in multi-guide reports without changing guide outcomes', () => {
+    const covered = ranGuide('covered');
+    covered.coverage = {
+      contractSource: 'legacy',
+      rendered: 1,
+      supported: 1,
+      executed: 1,
+      unsupported: 0,
+      unsupportedSteps: [],
+    };
+
+    const report = generateMultiGuideReport([covered, ranGuide('other')]);
+
+    expect(report.summary.passedGuides).toBe(2);
+    expect(report.reports[0]!.coverage).toEqual(covered.coverage);
+    expect(() => MultiGuideReportSchema.parse(report)).not.toThrow();
+  });
   it('includes normalized outcome, provenance, target, timestamps, and content digest', () => {
     const report = generateReport({
       ...ranGuide('always-passes'),

--- a/src/cli/e2e/e2e-reporter.ts
+++ b/src/cli/e2e/e2e-reporter.ts
@@ -22,6 +22,7 @@ import {
   type RunnerProvenance,
   type ReportSummary,
   type ArtifactPaths,
+  type StepCoverage,
   type ReportStepResult,
   type GuideMetadata,
   type ReportConfig,
@@ -42,6 +43,7 @@ import {
  */
 export interface TestStepResult {
   stepId: string;
+  stepKind?: ReportStepResult['stepKind'];
   status: 'passed' | 'failed' | 'skipped' | 'not_reached';
   durationMs: number;
   currentUrl: string;
@@ -72,6 +74,8 @@ export interface TestResultsData {
   runner?: Partial<RunnerProvenance>;
   /** Individual step results */
   results: TestStepResult[];
+  /** Rendered tracked-root coverage from DOM discovery. */
+  coverage?: StepCoverage;
   /** Whether execution was aborted */
   aborted: boolean;
   /** Reason for abort if aborted */
@@ -131,6 +135,9 @@ export function convertStepResults(results: TestStepResult[]): ReportStepResult[
       currentUrl: result.currentUrl,
       consoleErrors: result.consoleErrors,
     };
+    if (result.stepKind) {
+      reportStep.stepKind = result.stepKind;
+    }
 
     // Add optional fields only if present
     if (result.skipReason) {
@@ -213,6 +220,7 @@ export function generateReport(data: TestResultsData, grafanaVersion?: string): 
     },
     summary,
     steps,
+    ...(data.coverage ? { coverage: data.coverage } : {}),
   };
 
   // Add optional config fields

--- a/src/cli/e2e/schemas/e2e-report.schema.ts
+++ b/src/cli/e2e/schemas/e2e-report.schema.ts
@@ -91,8 +91,23 @@ export const ArtifactPathsSchema = z.object({
   console: z.string().optional(),
 });
 
+export const StepCoverageSchema = z.object({
+  contractSource: z.enum(['current', 'legacy']),
+  rendered: z.number().int().nonnegative(),
+  supported: z.number().int().nonnegative(),
+  executed: z.number().int().nonnegative(),
+  unsupported: z.number().int().nonnegative(),
+  unsupportedSteps: z.array(
+    z.object({
+      stepKind: z.string(),
+      stepId: z.string(),
+    })
+  ),
+});
+
 export const ReportStepResultSchema = z.object({
   stepId: z.string(),
+  stepKind: z.string().optional(),
   index: z.number().int().nonnegative(),
   status: z.enum(['passed', 'failed', 'skipped', 'not_reached']),
   duration: z.number().nonnegative(),
@@ -161,6 +176,7 @@ export const E2ETestReportSchema = z
     config: ReportConfigSchema,
     summary: ReportSummarySchema,
     steps: z.array(ReportStepResultSchema),
+    coverage: StepCoverageSchema.optional(),
     aborted: z.boolean().optional(),
     abortReason: AbortReasonSchema.optional(),
     abortMessage: z.string().optional(),
@@ -231,6 +247,7 @@ export type RunnerProvenance = z.infer<typeof RunnerProvenanceSchema>;
 export type ReportTarget = z.infer<typeof ReportTargetSchema>;
 export type ReportSummary = z.infer<typeof ReportSummarySchema>;
 export type ArtifactPaths = z.infer<typeof ArtifactPathsSchema>;
+export type StepCoverage = z.infer<typeof StepCoverageSchema>;
 export type ReportStepResult = z.infer<typeof ReportStepResultSchema>;
 export type GuideMetadata = z.infer<typeof GuideMetadataSchema>;
 export type ReportConfig = z.infer<typeof ReportConfigSchema>;

--- a/tests/e2e-runner/guide-runner.spec.ts
+++ b/tests/e2e-runner/guide-runner.spec.ts
@@ -36,6 +36,10 @@ import {
   AllStepsResult,
   AbortReason,
   StepTestResult,
+  StepCoverage,
+  withExecutedCoverage,
+  CURRENT_STEP_SELECTOR,
+  LEGACY_STEP_SELECTOR,
 } from './utils/guide-runner';
 import {
   printHeader,
@@ -85,7 +89,8 @@ function writeResultsFile(
   timestamp: string,
   allStepsResult: AllStepsResult,
   guideContent: string,
-  outcome: TestResultsData['outcome']
+  outcome: TestResultsData['outcome'],
+  coverage?: StepCoverage
 ): void {
   const resultsFilePath = process.env[E2E_ENV.RESULTS_FILE_PATH];
   if (!resultsFilePath) {
@@ -102,6 +107,7 @@ function writeResultsFile(
     errorMessage: allStepsResult.abortMessage,
     results: results.map((r) => ({
       stepId: r.stepId,
+      stepKind: r.stepKind,
       status: r.status,
       durationMs: r.durationMs,
       currentUrl: r.currentUrl,
@@ -117,6 +123,7 @@ function writeResultsFile(
     aborted: allStepsResult.aborted,
     abortReason: allStepsResult.abortReason,
     abortMessage: allStepsResult.abortMessage,
+    coverage,
   };
 
   writeFileSync(resultsFilePath, JSON.stringify(data), 'utf-8');
@@ -268,7 +275,7 @@ test.describe('Guide Runner', () => {
 
     // Verify guide content loaded (first step visible indicates interactive content rendered)
     // Use a more general selector since step IDs vary by guide
-    const firstStep = page.locator('[data-testid^="interactive-step-"]').first();
+    const firstStep = page.locator(`${CURRENT_STEP_SELECTOR}, ${LEGACY_STEP_SELECTOR}`).first();
     await expect(firstStep).toBeVisible({ timeout: 15000 });
 
     // ============================================
@@ -277,8 +284,7 @@ test.describe('Guide Runner', () => {
     const discoveryResult = await discoverStepsFromDOM(page);
     test.setTimeout(calculateGuideTimeout(discoveryResult.steps));
 
-    // Verify step discovery found steps
-    expect(discoveryResult.totalSteps).toBeGreaterThan(0);
+    expect(discoveryResult.coverage.rendered).toBeGreaterThan(0);
 
     // Steps should be in document order (indices should match)
     for (let i = 0; i < discoveryResult.steps.length; i++) {
@@ -293,7 +299,8 @@ test.describe('Guide Runner', () => {
       discoveryResult.totalSteps,
       discoveryResult.preCompletedCount,
       discoveryResult.noDoItButtonCount,
-      discoveryResult.durationMs
+      discoveryResult.durationMs,
+      discoveryResult.coverage.contractSource
     );
 
     // ============================================
@@ -332,7 +339,8 @@ test.describe('Guide Runner', () => {
         ? 'aborted'
         : executionResult.abortReason === 'MANDATORY_FAILURE' || !summary.success
           ? 'failed'
-          : 'passed'
+          : 'passed',
+      withExecutedCoverage(discoveryResult.coverage, executionResult.results)
     );
 
     // L3-3D: Handle session expiry with specific exit code

--- a/tests/e2e-runner/utils/console-reporter.ts
+++ b/tests/e2e-runner/utils/console-reporter.ts
@@ -8,6 +8,7 @@
  */
 
 import { StepTestResult, AllStepsResult, summarizeResults, skippableFailuresAffectSuccess } from './guide-runner';
+import type { StepContractSource } from './guide-runner';
 
 // ============================================
 // Constants
@@ -394,11 +395,15 @@ export function printDiscoveryResults(
   totalSteps: number,
   preCompletedCount: number,
   noDoItButtonCount: number,
-  durationMs: number
+  durationMs: number,
+  contractSource?: StepContractSource
 ): void {
   const duration = formatDuration(durationMs);
   console.log();
   console.log(`📋 Discovered ${totalSteps} steps ${duration}`);
+  if (contractSource) {
+    console.log(`   Contract: ${contractSource}`);
+  }
   if (preCompletedCount > 0 || noDoItButtonCount > 0) {
     console.log(`   (${preCompletedCount} pre-completed, ${noDoItButtonCount} without "Do it" button)`);
   }

--- a/tests/e2e-runner/utils/guide-runner/constants.ts
+++ b/tests/e2e-runner/utils/guide-runner/constants.ts
@@ -11,11 +11,14 @@
 // DOM Selectors
 // ============================================
 
+export const CURRENT_STEP_SELECTOR = '[data-test-step-kind][data-test-step-id]';
+
 /**
- * Selector pattern for interactive step elements.
- * Steps are identified by data-testid starting with "interactive-step-".
+ * Older deployed plugins do not expose the tracked-root contract.
+ * The completed badge shares the step test ID prefix, so this fallback excludes it.
  */
-export const STEP_SELECTOR = '[data-testid^="interactive-step-"]';
+export const LEGACY_STEP_SELECTOR =
+  '[data-testid^="interactive-step-"]:not([data-testid^="interactive-step-completed-"])';
 
 /**
  * Prefix to strip from data-testid to get the step ID.

--- a/tests/e2e-runner/utils/guide-runner/discovery.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/discovery.test.ts
@@ -1,10 +1,3 @@
-/**
- * Unit tests for guide-runner discovery (Phase 5).
- *
- * Covers guided step detection: when the DOM has data-targetaction="guided"
- * and data-test-substep-total, discovered metadata has isGuided and guidedStepCount.
- */
-
 jest.mock('@playwright/test', () => ({
   Page: jest.fn(),
   Locator: jest.fn(),
@@ -12,91 +5,151 @@ jest.mock('@playwright/test', () => ({
   test: jest.fn(),
 }));
 
-import type { Locator } from '@playwright/test';
-import { extractGuidedInfo } from './discovery';
+import type { Locator, Page } from '@playwright/test';
 
-function createMockLocator(attributes: Record<string, string | null>): Locator {
+import { CURRENT_STEP_SELECTOR, LEGACY_STEP_SELECTOR } from './constants';
+import { discoverStepsFromDOM, withExecutedCoverage } from './discovery';
+
+function root(attributes: Record<string, string | null>): Locator {
   return {
-    getAttribute: jest.fn().mockImplementation((name: string) => Promise.resolve(attributes[name] ?? null)),
+    getAttribute: jest.fn((name: string) => Promise.resolve(attributes[name] ?? null)),
+    scrollIntoViewIfNeeded: jest.fn().mockResolvedValue(undefined),
+    evaluate: jest.fn().mockResolvedValue(undefined),
   } as unknown as Locator;
 }
 
-describe('extractGuidedInfo', () => {
-  it('returns isGuided: true and guidedStepCount from data-test-substep-total when targetAction is guided', async () => {
-    const stepElement = createMockLocator({
-      'data-test-substep-total': '3',
+function pageWithRoots(current: Locator[], legacy: Locator[] = []): Page {
+  const control = (count: number) => ({
+    count: jest.fn().mockResolvedValue(count),
+    isVisible: jest.fn().mockResolvedValue(false),
+    getAttribute: jest.fn().mockResolvedValue('idle'),
+  });
+  return {
+    locator: jest.fn((selector: string) => ({
+      all: jest.fn().mockResolvedValue(selector === CURRENT_STEP_SELECTOR ? current : legacy),
+    })),
+    getByTestId: jest.fn((testId: string) => {
+      if (testId.startsWith('interactive-step-completed-')) {
+        return control(1);
+      }
+      if (testId.startsWith('interactive-do-it-')) {
+        return control(1);
+      }
+      return control(0);
+    }),
+  } as unknown as Page;
+}
+
+describe('discoverStepsFromDOM', () => {
+  it('uses the current tracked-root contract and reports unsupported roots', async () => {
+    const page = pageWithRoots([
+      root({
+        'data-test-step-kind': 'plain',
+        'data-test-step-id': 'plain-1',
+        'data-targetaction': 'button',
+      }),
+      root({
+        'data-test-step-kind': 'quiz',
+        'data-test-step-id': 'quiz-1',
+      }),
+    ]);
+
+    const result = await discoverStepsFromDOM(page);
+
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0]).toMatchObject({ stepKind: 'plain', stepId: 'plain-1', index: 0 });
+    expect(result.coverage).toEqual({
+      contractSource: 'current',
+      rendered: 2,
+      supported: 1,
+      executed: 0,
+      unsupported: 1,
+      unsupportedSteps: [{ stepKind: 'quiz', stepId: 'quiz-1' }],
     });
-
-    const result = await extractGuidedInfo(stepElement, 'guided');
-
-    expect(result).toEqual({ isGuided: true, guidedStepCount: 3 });
   });
 
-  it('returns isGuided: false and guidedStepCount 1 when targetAction is not guided', async () => {
-    const stepElement = createMockLocator({
-      'data-test-substep-total': '5',
-    });
+  it('uses the legacy fallback when current roots are absent', async () => {
+    const page = pageWithRoots(
+      [],
+      [
+        root({ 'data-testid': 'interactive-step-plain-1', 'data-targetaction': 'button' }),
+        root({
+          'data-testid': 'interactive-step-multi-1',
+          'data-targetaction': 'multistep',
+          'data-internal-actions': '[{},{}]',
+        }),
+        root({
+          'data-testid': 'interactive-step-guided-1',
+          'data-test-substep-total': '3',
+        }),
+      ]
+    );
 
-    const result = await extractGuidedInfo(stepElement, 'button');
+    const result = await discoverStepsFromDOM(page);
 
-    expect(result).toEqual({ isGuided: false, guidedStepCount: 1 });
+    expect(result.coverage.contractSource).toBe('legacy');
+    expect(result.steps.map(({ stepKind, stepId }) => ({ stepKind, stepId }))).toEqual([
+      { stepKind: 'plain', stepId: 'plain-1' },
+      { stepKind: 'multistep', stepId: 'multi-1' },
+      { stepKind: 'guided', stepId: 'guided-1' },
+    ]);
   });
 
-  it('returns isGuided: false for multistep targetAction', async () => {
-    const stepElement = createMockLocator({
-      'data-test-substep-total': '2',
-    });
+  it('uses the current contract when both contract generations are present', async () => {
+    const page = pageWithRoots(
+      [root({ 'data-test-step-kind': 'plain', 'data-test-step-id': 'current-1' })],
+      [root({ 'data-testid': 'interactive-step-legacy-1' })]
+    );
 
-    const result = await extractGuidedInfo(stepElement, 'multistep');
+    const result = await discoverStepsFromDOM(page);
 
-    expect(result).toEqual({ isGuided: false, guidedStepCount: 1 });
+    expect(result.coverage.contractSource).toBe('current');
+    expect(result.steps.map((step) => step.stepId)).toEqual(['current-1']);
   });
 
-  it('returns isGuided: true when targetAction is undefined but data-test-substep-total present (InteractiveGuided)', async () => {
-    const stepElement = createMockLocator({
-      'data-test-substep-total': '2',
-    });
+  it('uses a legacy selector that excludes completed badges', async () => {
+    const page = pageWithRoots([]);
 
-    const result = await extractGuidedInfo(stepElement, undefined);
+    await discoverStepsFromDOM(page);
 
-    expect(result).toEqual({ isGuided: true, guidedStepCount: 2 });
+    expect(LEGACY_STEP_SELECTOR).toContain(':not([data-testid^="interactive-step-completed-"])');
+    expect(page.locator).toHaveBeenCalledWith(LEGACY_STEP_SELECTOR);
   });
+});
 
-  it('falls back to guidedStepCount 1 when data-test-substep-total is missing for guided', async () => {
-    const stepElement = createMockLocator({});
+describe('withExecutedCoverage', () => {
+  it('counts reached supported steps without changing unsupported coverage', () => {
+    const coverage = withExecutedCoverage(
+      {
+        contractSource: 'current',
+        rendered: 3,
+        supported: 2,
+        executed: 0,
+        unsupported: 1,
+        unsupportedSteps: [{ stepKind: 'quiz', stepId: 'quiz-1' }],
+      },
+      [
+        {
+          stepId: 'plain-1',
+          stepKind: 'plain',
+          status: 'passed',
+          durationMs: 1,
+          currentUrl: '/',
+          consoleErrors: [],
+          skippable: false,
+        },
+        {
+          stepId: 'guided-1',
+          stepKind: 'guided',
+          status: 'not_reached',
+          durationMs: 0,
+          currentUrl: '/',
+          consoleErrors: [],
+          skippable: false,
+        },
+      ]
+    );
 
-    const result = await extractGuidedInfo(stepElement, 'guided');
-
-    expect(result).toEqual({ isGuided: true, guidedStepCount: 1 });
-  });
-
-  it('falls back to guidedStepCount 1 when data-test-substep-total is invalid for guided', async () => {
-    const stepElement = createMockLocator({
-      'data-test-substep-total': 'not-a-number',
-    });
-
-    const result = await extractGuidedInfo(stepElement, 'guided');
-
-    expect(result).toEqual({ isGuided: true, guidedStepCount: 1 });
-  });
-
-  it('falls back to guidedStepCount 1 when data-test-substep-total is zero for guided', async () => {
-    const stepElement = createMockLocator({
-      'data-test-substep-total': '0',
-    });
-
-    const result = await extractGuidedInfo(stepElement, 'guided');
-
-    expect(result).toEqual({ isGuided: true, guidedStepCount: 1 });
-  });
-
-  it('parses data-test-substep-total as integer for guided', async () => {
-    const stepElement = createMockLocator({
-      'data-test-substep-total': '7',
-    });
-
-    const result = await extractGuidedInfo(stepElement, 'guided');
-
-    expect(result).toEqual({ isGuided: true, guidedStepCount: 7 });
+    expect(coverage).toMatchObject({ rendered: 3, supported: 2, executed: 1, unsupported: 1 });
   });
 });

--- a/tests/e2e-runner/utils/guide-runner/discovery.ts
+++ b/tests/e2e-runner/utils/guide-runner/discovery.ts
@@ -1,348 +1,132 @@
-/**
- * Guide Test Runner Discovery
- *
- * Functions for discovering testable steps from the rendered DOM.
- * Implements DOM-based step discovery per the E2E Test Runner design.
- *
- * @see docs/developer/E2E_TESTING.md#how-it-works
- */
+import type { Locator, Page } from '@playwright/test';
 
-import { Page, Locator } from '@playwright/test';
-
-import { testIds } from '../../../../src/constants/testIds';
-import { STEP_SELECTOR, STEP_TESTID_PREFIX } from './constants';
+import { CURRENT_STEP_SELECTOR, LEGACY_STEP_SELECTOR, STEP_TESTID_PREFIX } from './constants';
+import { getStepDriver, isStepTypeKind, resolveLegacyStepKind } from './drivers';
 import { calculateStepTimeout } from './execution';
-import type { TestableStep, StepDiscoveryResult } from './types';
+import type { StepContractSource, StepCoverage, StepDiscoveryResult, StepTestResult, TestableStep } from './types';
 
-// ============================================
-// Discovery Functions
-// ============================================
+interface DiscoveryRoots {
+  contractSource: StepContractSource;
+  roots: Locator[];
+}
 
-/**
- * Discover all testable steps from the rendered DOM.
- *
- * This function implements DOM-based step discovery per the design document.
- * It queries the page for interactive step elements and extracts metadata
- * needed for test execution.
- *
- * Key behaviors:
- * - Steps are returned in document order (top to bottom)
- * - Pre-completed steps are detected (completion indicator visible)
- * - Steps without "Do it" buttons are flagged (doIt: false or noop actions)
- * - Skippable flag is determined by presence of skip button
- *
- * @param page - Playwright Page object
- * @returns StepDiscoveryResult with all discovered steps and statistics
- *
- * @example
- * ```typescript
- * const result = await discoverStepsFromDOM(page);
- * console.log(`Found ${result.totalSteps} steps`);
- * for (const step of result.steps) {
- *   if (step.isPreCompleted) {
- *     console.log(`Step ${step.stepId} already completed`);
- *   }
- * }
- * ```
- */
+async function selectDiscoveryRoots(page: Page): Promise<DiscoveryRoots> {
+  const currentRoots = await page.locator(CURRENT_STEP_SELECTOR).all();
+  if (currentRoots.length > 0) {
+    return { contractSource: 'current', roots: currentRoots };
+  }
+  return {
+    contractSource: 'legacy',
+    roots: await page.locator(LEGACY_STEP_SELECTOR).all(),
+  };
+}
+
+async function readRootIdentity(
+  root: Locator,
+  contractSource: StepContractSource,
+  index: number
+): Promise<{ stepKind: string; stepId: string }> {
+  if (contractSource === 'current') {
+    return {
+      stepKind: (await root.getAttribute('data-test-step-kind')) ?? 'unknown',
+      stepId: (await root.getAttribute('data-test-step-id')) ?? `unknown-${index}`,
+    };
+  }
+
+  const dataTestId = await root.getAttribute('data-testid');
+  return {
+    stepKind: await resolveLegacyStepKind(root),
+    stepId: dataTestId?.replace(STEP_TESTID_PREFIX, '') ?? `unknown-${index}`,
+  };
+}
+
+async function findParentSectionId(root: Locator): Promise<string | undefined> {
+  const sectionId = await root.evaluate((element) => {
+    const section = element.closest('[data-testid^="interactive-section-"]');
+    return section?.getAttribute('data-testid')?.replace('interactive-section-', '') ?? null;
+  });
+  return sectionId ?? undefined;
+}
+
 export async function discoverStepsFromDOM(page: Page): Promise<StepDiscoveryResult> {
-  const startTime = Date.now();
+  const startedAt = Date.now();
+  const { contractSource, roots } = await selectDiscoveryRoots(page);
   const steps: TestableStep[] = [];
+  const unsupportedSteps: StepCoverage['unsupportedSteps'] = [];
 
-  // Query all rendered step elements in DOM order
-  const stepElements = await page.locator(STEP_SELECTOR).all();
-
-  for (let index = 0; index < stepElements.length; index++) {
-    const element = stepElements[index];
-
-    // Extract step ID from data-testid attribute
-    const dataTestId = await element.getAttribute('data-testid');
-    if (!dataTestId) {
-      console.warn(`Step at index ${index} missing data-testid attribute, skipping`);
+  for (let rootIndex = 0; rootIndex < roots.length; rootIndex++) {
+    const root = roots[rootIndex];
+    const { stepKind, stepId } = await readRootIdentity(root, contractSource, rootIndex);
+    if (!isStepTypeKind(stepKind)) {
+      unsupportedSteps.push({ stepKind, stepId });
       continue;
     }
 
-    const stepId = dataTestId.replace(STEP_TESTID_PREFIX, '');
+    const driver = getStepDriver(stepKind);
+    if (!driver.supported) {
+      unsupportedSteps.push({ stepKind, stepId });
+      continue;
+    }
 
-    // Scroll step into view so below-the-fold or lazy-rendered content (e.g. Skip button) is in DOM
-    await element.scrollIntoViewIfNeeded().catch(() => {});
-
-    // Extract target action type from data-targetaction attribute
-    const targetAction = (await element.getAttribute('data-targetaction')) ?? undefined;
-
-    // L3-4A: Extract refTarget for requirements detection
-    const refTarget = (await element.getAttribute('data-reftarget')) ?? undefined;
-
-    // Check if "Do it" button exists (U1: not all steps have buttons)
-    const hasDoItButton = await checkDoItButtonExists(page, stepId);
-    const hasShowMeButton = (await page.getByTestId(testIds.interactive.showMeButton(stepId)).count()) > 0;
-
-    // Check if already completed (U2: objectives-based or noop completion)
-    const isPreCompleted = await checkStepCompleted(page, stepId);
-
-    // Check if step is skippable (presence of skip button indicates skippable)
-    // Note: Skip button only renders when step is skippable AND not completed
-    const skippable = await checkStepSkippable(page, stepId, isPreCompleted, targetAction);
-
-    // Try to find parent section ID
-    const sectionId = await findParentSectionId(element);
-
-    // L3-3C: Detect multisteps and extract internal action count for timeout calculation
-    const { isMultistep, internalActionCount } = await extractMultistepInfo(element, targetAction);
-
-    // E2E contract: detect guided steps and substep count from DOM only
-    const { isGuided, guidedStepCount } = await extractGuidedInfo(element, targetAction);
-
-    const effectiveSkippable = resolveEffectiveSkippable(skippable, isGuided);
-
+    await root.scrollIntoViewIfNeeded().catch(() => undefined);
+    const inspected = await driver.inspect(page, root, stepId);
     steps.push({
+      stepKind,
       stepId,
-      index,
-      sectionId,
-      skippable: effectiveSkippable,
-      hasDoItButton,
-      hasShowMeButton,
-      isPreCompleted,
-      targetAction,
-      isMultistep,
-      internalActionCount,
-      isGuided,
-      guidedStepCount: isGuided ? guidedStepCount : undefined,
-      refTarget,
-      locator: element,
+      index: steps.length,
+      sectionId: await findParentSectionId(root),
+      ...inspected,
+      locator: root,
     });
   }
 
-  const durationMs = Date.now() - startTime;
+  const coverage: StepCoverage = {
+    contractSource,
+    rendered: roots.length,
+    supported: steps.length,
+    executed: 0,
+    unsupported: unsupportedSteps.length,
+    unsupportedSteps,
+  };
 
   return {
     steps,
     totalSteps: steps.length,
-    preCompletedCount: steps.filter((s) => s.isPreCompleted).length,
-    noDoItButtonCount: steps.filter((s) => !s.hasDoItButton).length,
-    durationMs,
+    preCompletedCount: steps.filter((step) => step.isPreCompleted).length,
+    noDoItButtonCount: steps.filter((step) => !step.hasDoItButton).length,
+    durationMs: Date.now() - startedAt,
+    coverage,
   };
 }
 
-export function resolveEffectiveSkippable(skippable: boolean, _isGuided: boolean): boolean {
-  return skippable;
+export function withExecutedCoverage(coverage: StepCoverage, results: StepTestResult[]): StepCoverage {
+  const executedStepIds = new Set(
+    results.filter((result) => result.status !== 'not_reached').map((result) => result.stepId)
+  );
+  return {
+    ...coverage,
+    executed: executedStepIds.size,
+  };
 }
 
-/**
- * Check if a "Do it" button exists for the given step.
- *
- * Per U1 findings: Not all steps have "Do it" buttons.
- * - Steps with `doIt: false` don't render the button
- * - Steps with `targetAction: 'noop'` are informational-only
- *
- * @param page - Playwright Page object
- * @param stepId - The step identifier
- * @returns true if the "Do it" button exists
- */
-async function checkDoItButtonExists(page: Page, stepId: string): Promise<boolean> {
-  const doItButton = page.getByTestId(testIds.interactive.doItButton(stepId));
-  const count = await doItButton.count();
-  return count > 0;
-}
-
-/**
- * Check if a step is already completed.
- *
- * Per U2 findings: Steps can complete via:
- * - Objectives satisfaction before user clicks "Do it"
- * - Noop actions that auto-complete when eligible
- * - `completeEarly: true` flag
- *
- * @param page - Playwright Page object
- * @param stepId - The step identifier
- * @returns true if the completion indicator is visible
- */
-async function checkStepCompleted(page: Page, stepId: string): Promise<boolean> {
-  const completedIndicator = page.getByTestId(testIds.interactive.stepCompleted(stepId));
-  return completedIndicator.isVisible();
-}
-
-/**
- * Determine if a step is skippable.
- *
- * Detection strategy:
- * 1. If step is already completed, we can't detect skip button - assume not skippable
- * 2. If step has noop action, it's not skippable (auto-completes)
- * 3. Otherwise, check for skip button presence
- *
- * Note: The skip button only renders when:
- * - `skippable` prop is true
- * - Not a noop action
- * - Not already completed
- *
- * @param page - Playwright Page object
- * @param stepId - The step identifier
- * @param isPreCompleted - Whether step is already completed
- * @param targetAction - The action type (if known)
- * @returns true if the step is skippable
- */
-async function checkStepSkippable(
-  page: Page,
-  stepId: string,
-  isPreCompleted: boolean,
-  targetAction?: string
-): Promise<boolean> {
-  // Noop actions are informational-only, not skippable
-  if (targetAction === 'noop') {
-    return false;
-  }
-
-  // If already completed, skip button won't be visible
-  // Default to false for completed steps (conservative assumption)
-  if (isPreCompleted) {
-    return false;
-  }
-
-  // Check for skip button presence
-  const skipButton = page.getByTestId(testIds.interactive.skipButton(stepId));
-  const count = await skipButton.count();
-  return count > 0;
-}
-
-/**
- * Find the parent section ID for a step element.
- *
- * Walks up the DOM tree looking for an interactive section container.
- *
- * @param stepElement - Locator for the step element
- * @returns Section ID if found, undefined otherwise
- */
-async function findParentSectionId(stepElement: Locator): Promise<string | undefined> {
-  // Get the closest ancestor with section test ID pattern
-  // We use evaluate to walk up the DOM tree since Playwright doesn't have a direct "closest" method
-  const sectionId = await stepElement.evaluate((el) => {
-    const section = el.closest('[data-testid^="interactive-section-"]');
-    if (!section) return null;
-
-    const testId = section.getAttribute('data-testid');
-    if (!testId) return null;
-
-    return testId.replace('interactive-section-', '');
-  });
-
-  return sectionId ?? undefined;
-}
-
-/**
- * Extract multistep information from a step element (L3-3C).
- *
- * Multisteps have data-targetaction="multistep" and data-internal-actions
- * containing a JSON array of internal action definitions.
- *
- * @param stepElement - Locator for the step element
- * @param targetAction - Already-extracted target action type
- * @returns Object with isMultistep flag and internal action count
- */
-async function extractMultistepInfo(
-  stepElement: Locator,
-  targetAction?: string
-): Promise<{ isMultistep: boolean; internalActionCount: number }> {
-  // Quick check: if targetAction isn't "multistep", skip the expensive DOM read
-  if (targetAction !== 'multistep') {
-    return { isMultistep: false, internalActionCount: 0 };
-  }
-
-  // Extract internal actions count from data-internal-actions attribute
-  const internalActionsJson = await stepElement.getAttribute('data-internal-actions');
-
-  if (!internalActionsJson) {
-    // Fallback: it's a multistep but we couldn't get the count, assume 3 actions
-    return { isMultistep: true, internalActionCount: 3 };
-  }
-
-  try {
-    const internalActions = JSON.parse(internalActionsJson);
-    const count = Array.isArray(internalActions) ? internalActions.length : 0;
-    return { isMultistep: true, internalActionCount: count };
-  } catch {
-    // JSON parse failed, assume 3 actions as fallback
-    return { isMultistep: true, internalActionCount: 3 };
-  }
-}
-
-/**
- * Extract guided step information from a step element (E2E contract).
- *
- * Guided steps have data-targetaction="guided" and data-test-substep-total
- * (always present on multi-step and guided components per contract).
- *
- * Exported for unit testing (Phase 5).
- *
- * @param stepElement - Locator for the step element
- * @param targetAction - Already-extracted target action type
- * @returns Object with isGuided flag and guidedStepCount (substep total)
- */
-export async function extractGuidedInfo(
-  stepElement: Locator,
-  targetAction?: string
-): Promise<{ isGuided: boolean; guidedStepCount: number }> {
-  // Guided steps may have data-targetaction="guided" or only data-test-substep-total (InteractiveGuided does not set targetaction).
-  // Multistep also has data-test-substep-total, so exclude targetAction === 'multistep'.
-  // Only infer guided from hasSubstepTotal when targetAction is unset (undefined); explicit 'button' etc. are not guided.
-  const raw = await stepElement.getAttribute('data-test-substep-total');
-  const parsed = raw !== null && raw !== '' ? parseInt(raw, 10) : NaN;
-  const hasSubstepTotal = Number.isFinite(parsed) && parsed >= 1;
-  const targetActionUnset = targetAction === undefined || targetAction === null || targetAction === '';
-  const isGuided = targetAction === 'guided' || (hasSubstepTotal && targetAction !== 'multistep' && targetActionUnset);
-  if (!isGuided) {
-    return { isGuided: false, guidedStepCount: 1 };
-  }
-  const guidedStepCount = hasSubstepTotal ? parsed : 1;
-  return { isGuided: true, guidedStepCount };
-}
-
-// ============================================
-// Logging Functions
-// ============================================
-
-/**
- * Log step discovery results in a human-readable format.
- *
- * @param result - The step discovery result
- * @param verbose - Whether to log detailed per-step information
- */
 export function logDiscoveryResults(result: StepDiscoveryResult, verbose = false): void {
-  const multistepCount = result.steps.filter((s) => s.isMultistep).length;
-  const guidedCount = result.steps.filter((s) => s.isGuided).length;
-
-  console.log(`\n📋 Step Discovery Results`);
-  console.log(`   Total steps: ${result.totalSteps}`);
+  console.log(`\n📋 Step discovery results`);
+  console.log(`   Contract: ${result.coverage.contractSource}`);
+  console.log(`   Rendered roots: ${result.coverage.rendered}`);
+  console.log(`   Supported steps: ${result.coverage.supported}`);
+  console.log(`   Unsupported steps: ${result.coverage.unsupported}`);
   console.log(`   Pre-completed: ${result.preCompletedCount}`);
   console.log(`   Without "Do it": ${result.noDoItButtonCount}`);
-  if (multistepCount > 0) {
-    console.log(`   Multisteps: ${multistepCount}`);
-  }
-  if (guidedCount > 0) {
-    console.log(`   Guided: ${guidedCount}`);
-  }
   console.log(`   Discovery time: ${result.durationMs}ms`);
 
-  if (verbose && result.steps.length > 0) {
-    console.log(`\n   Steps:`);
+  if (verbose) {
     for (const step of result.steps) {
-      const flags = [
-        step.isPreCompleted ? 'pre-completed' : null,
-        !step.hasDoItButton ? 'no-button' : null,
-        step.skippable ? 'skippable' : null,
-        step.isMultistep ? `multistep:${step.internalActionCount}` : null,
-        step.isGuided && step.guidedStepCount != null ? `guided:${step.guidedStepCount}` : null,
-        step.refTarget ? `target:${step.refTarget.substring(0, 30)}${step.refTarget.length > 30 ? '...' : ''}` : null,
-      ]
-        .filter(Boolean)
-        .join(', ');
-
-      const flagsStr = flags ? ` (${flags})` : '';
-      const actionStr = step.targetAction ? ` [${step.targetAction}]` : '';
-      const sectionStr = step.sectionId ? ` in section:${step.sectionId}` : '';
-
-      const timeoutStr = step.isMultistep ? ` timeout:${Math.round(calculateStepTimeout(step) / 1000)}s` : '';
-
-      console.log(`   ${step.index + 1}. ${step.stepId}${actionStr}${sectionStr}${flagsStr}${timeoutStr}`);
+      console.log(
+        `   ${step.index + 1}. ${step.stepId} [${step.stepKind}] timeout:${Math.round(calculateStepTimeout(step) / 1000)}s`
+      );
+    }
+    for (const unsupported of result.coverage.unsupportedSteps) {
+      console.log(`   Unsupported: ${unsupported.stepId} [${unsupported.stepKind}]`);
     }
   }
 }

--- a/tests/e2e-runner/utils/guide-runner/drivers/guided.ts
+++ b/tests/e2e-runner/utils/guide-runner/drivers/guided.ts
@@ -1,0 +1,473 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { testIds } from '../../../../../src/constants/testIds';
+import { resolveSelector } from '../../selector-resolver';
+import { captureFailureArtifacts } from '../artifacts';
+import { dismissBadgeCelebrations } from '../badge-celebrations';
+import {
+  COMPLETION_POLL_INTERVAL_MS,
+  GUIDED_BETWEEN_SUBSTEP_DELAY_MS,
+  GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS,
+  GUIDED_FORMFILL_DEBOUNCE_MS,
+  GUIDED_FORMFILL_INVALID_PERSIST_MS,
+  GUIDED_FORMFILL_VALID_TIMEOUT_MS,
+  GUIDED_HOVER_DWELL_MS,
+  GUIDED_RELOAD_LOAD_TIMEOUT_MS,
+  GUIDED_SKIP_AFTER_TIMEOUT_FRACTION,
+  GUIDED_SUBSTEP_ADVANCE_POLL_MS,
+  GUIDED_TARGET_RESOLUTION_TIMEOUT_MS,
+  TIMEOUT_PER_GUIDED_SUBSTEP_MS,
+} from '../constants';
+import type { TestableStep } from '../types';
+import { startStepAction, waitForCompletion } from './shared';
+import type { StepDriverExecutionContext, StepDriverExecutionResult } from './types';
+
+// ============================================
+// Guided Step Execution (Phase 3)
+// ============================================
+
+const GUIDED_WAIT_EXECUTING_MS = 5000;
+
+export async function waitForGuidedExecutionStart(
+  page: Page,
+  stepLocator: Locator,
+  timeout = GUIDED_WAIT_EXECUTING_MS
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const state = await stepLocator.getAttribute('data-test-step-state');
+    if (state === 'executing' || state === 'completed') {
+      return;
+    }
+    if (state === 'error' || state === 'cancelled') {
+      throw new Error(`Guided step entered ${state} state before execution`);
+    }
+    await page.waitForTimeout(COMPLETION_POLL_INTERVAL_MS);
+  }
+  throw new Error('Guided step did not enter executing state');
+}
+
+interface ParsedNthMatchSelector {
+  baseSelector: string;
+  index: number;
+  trailingSelector: string;
+}
+
+export function parseNthMatchSelector(selector: string): ParsedNthMatchSelector | undefined {
+  const match = selector.match(/^(.+?):nth-match\((\d+)\)(.*)$/);
+  if (!match) {
+    return undefined;
+  }
+  const oneBasedIndex = Number.parseInt(match[2]!, 10);
+  if (oneBasedIndex < 1) {
+    return undefined;
+  }
+  return {
+    baseSelector: match[1]!,
+    index: oneBasedIndex - 1,
+    trailingSelector: match[3]!.trim(),
+  };
+}
+
+function guidedSelectorLocator(page: Page, selector: string): Locator {
+  const parsed = parseNthMatchSelector(selector);
+  if (!parsed) {
+    return page.locator(selector).first();
+  }
+  const matched = page.locator(parsed.baseSelector).nth(parsed.index);
+  return parsed.trailingSelector ? matched.locator(parsed.trailingSelector).first() : matched;
+}
+
+async function revealGuidedTarget(page: Page, target: Locator, timeout: number): Promise<Locator> {
+  if (await target.isVisible()) {
+    return target;
+  }
+  if ((await target.count()) > 0) {
+    const panel = target.locator('xpath=ancestor::section[1]');
+    if ((await panel.count()) > 0) {
+      await panel.scrollIntoViewIfNeeded().catch(() => {});
+      await dismissBadgeCelebrations(page);
+      await panel.hover({ timeout }).catch(() => {});
+      if (await target.isVisible()) {
+        return target;
+      }
+      const menuButton = panel.locator('button[data-testid^="data-testid Panel menu "]').first();
+      if ((await menuButton.count()) > 0 && (await menuButton.isVisible())) {
+        return menuButton;
+      }
+    }
+  }
+  await target.waitFor({ state: 'visible', timeout });
+  return target;
+}
+
+async function resolveGuidedTarget(page: Page, reftarget: string, actionType: string): Promise<Locator> {
+  await dismissBadgeCelebrations(page);
+  const timeout = GUIDED_TARGET_RESOLUTION_TIMEOUT_MS;
+  const selector = reftarget.startsWith('grafana:') ? resolveSelector(reftarget) : reftarget;
+
+  if (actionType === 'button') {
+    const byRole = page.getByRole('button', { name: reftarget });
+    const n = await byRole.count();
+    if (n > 0) {
+      return revealGuidedTarget(page, byRole.first(), timeout);
+    }
+    const bySelector = guidedSelectorLocator(page, selector);
+    const hasButton = bySelector.filter({ has: page.getByRole('button') });
+    const hasCount = await hasButton.count();
+    if (hasCount > 0) {
+      return revealGuidedTarget(page, hasButton.first(), timeout);
+    }
+    return revealGuidedTarget(page, bySelector.first(), timeout);
+  }
+
+  return revealGuidedTarget(page, guidedSelectorLocator(page, selector), timeout);
+}
+
+async function waitForSubstepAdvance(
+  page: Page,
+  stepLocator: Locator,
+  previousSubstepIndex: number,
+  timeoutMs: number,
+  options: { commentBox?: Locator } = {}
+): Promise<void> {
+  const { commentBox } = options;
+  const deadline = Date.now() + timeoutMs;
+  const skipAfterMs = Math.floor(timeoutMs * GUIDED_SKIP_AFTER_TIMEOUT_FRACTION);
+  let lastState: string | null = null;
+  let lastIndex: string | null = null;
+
+  while (Date.now() < deadline) {
+    // Unmount mid-wait is a completion signal (section auto-collapse on final substep);
+    // a bare getAttribute on a detached locator blocks until the global test timeout.
+    if ((await stepLocator.count()) === 0) {
+      return;
+    }
+
+    try {
+      lastState = await stepLocator.getAttribute('data-test-step-state', { timeout: 2000 });
+      lastIndex = await stepLocator.getAttribute('data-test-substep-index', { timeout: 2000 });
+    } catch {
+      if ((await stepLocator.count()) === 0) {
+        return;
+      }
+      lastState = null;
+      lastIndex = null;
+    }
+
+    if (lastState === 'error') {
+      throw new Error('Guided step entered error state');
+    }
+    if (lastState === 'cancelled') {
+      throw new Error('Guided step was cancelled');
+    }
+    const index = lastIndex != null ? parseInt(lastIndex, 10) : 0;
+    if (!Number.isNaN(index) && index > previousSubstepIndex) {
+      return;
+    }
+    if (lastState === 'completed' && lastIndex === null) {
+      return;
+    }
+
+    const elapsed = Date.now() - (deadline - timeoutMs);
+    if (commentBox && elapsed >= skipAfterMs) {
+      const skipBtn = commentBox.getByRole('button', { name: /^Skip$/ });
+      const count = await skipBtn.count();
+      if (count > 0) {
+        await dismissBadgeCelebrations(page);
+        await skipBtn.click().catch(() => {});
+      }
+    }
+
+    await page.waitForTimeout(GUIDED_SUBSTEP_ADVANCE_POLL_MS);
+  }
+
+  throw new Error(
+    `Guided substep did not advance within ${timeoutMs}ms (previous index: ${previousSubstepIndex}, last state: ${lastState ?? 'unknown'}, last substep-index: ${lastIndex ?? 'unknown'})`
+  );
+}
+
+export async function waitForFormfillSettle(
+  page: Page,
+  stepLocator: Locator,
+  target: Locator,
+  targetValue: string
+): Promise<void> {
+  await page.waitForTimeout(GUIDED_FORMFILL_DEBOUNCE_MS);
+
+  const validDeadline = Date.now() + GUIDED_FORMFILL_VALID_TIMEOUT_MS;
+  let invalidSince: number | null = null;
+
+  const readFormState = async (): Promise<string | null> => {
+    if ((await stepLocator.count()) === 0) {
+      return null;
+    }
+    try {
+      return await stepLocator.getAttribute('data-test-form-state', { timeout: 2000 });
+    } catch {
+      return null;
+    }
+  };
+
+  while (Date.now() < validDeadline) {
+    if ((await stepLocator.count()) === 0) {
+      return;
+    }
+    const formState = await readFormState();
+    if (formState === 'valid') {
+      return;
+    }
+    if (formState === 'invalid') {
+      if (invalidSince == null) {
+        invalidSince = Date.now();
+      }
+      if (Date.now() - invalidSince >= GUIDED_FORMFILL_INVALID_PERSIST_MS) {
+        await dismissBadgeCelebrations(page);
+        await target.fill(targetValue);
+        await page.waitForTimeout(GUIDED_FORMFILL_DEBOUNCE_MS);
+        const afterRetry = await readFormState();
+        if (afterRetry === 'invalid') {
+          throw new Error(
+            `Guided step: formfill validation failed (data-test-form-state="invalid" persisted after retry with value "${targetValue}")`
+          );
+        }
+        if (afterRetry === 'valid') {
+          return;
+        }
+        invalidSince = null;
+      }
+    } else {
+      invalidSince = null;
+    }
+    await page.waitForTimeout(GUIDED_SUBSTEP_ADVANCE_POLL_MS);
+  }
+  // No valid state on step element (e.g. guided step may not set form-state); proceed to waitForSubstepAdvance
+}
+
+export type GuidedCommentBoxWaitOutcome = 'ready' | 'completed' | 'detached';
+
+export async function waitForGuidedCommentBoxReady(
+  page: Page,
+  stepLocator: Locator,
+  commentBox: Locator,
+  timeoutMs = GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS
+): Promise<GuidedCommentBoxWaitOutcome> {
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error('Guided step: comment box not visible');
+    }
+
+    if ((await commentBox.count()) > 0 && (await commentBox.isVisible())) {
+      return 'ready';
+    }
+
+    // Check detachment via an immediate, successful count() BEFORE any bounded
+    // attribute read. In real Playwright, getAttribute() on a missing element
+    // auto-waits up to its own timeout, so an already-detached step must be
+    // caught here first or it would burn the full remaining budget for
+    // nothing. A count() error is not caught: it propagates as designed.
+    if ((await stepLocator.count()) === 0) {
+      return 'detached';
+    }
+
+    // Bound this read by the remaining budget so a stuck-but-attached locator
+    // can't exceed this wait's own deadline.
+    let state: string | null;
+    try {
+      state = await stepLocator.getAttribute('data-test-step-state', { timeout: remainingMs });
+    } catch {
+      state = null;
+    }
+
+    if (state === 'completed') {
+      return 'completed';
+    }
+    if (state === 'error') {
+      throw new Error('Guided step entered error state while waiting for comment box');
+    }
+    if (state === 'cancelled') {
+      throw new Error('Guided step was cancelled while waiting for comment box');
+    }
+
+    await page.waitForTimeout(Math.min(GUIDED_SUBSTEP_ADVANCE_POLL_MS, Math.max(1, deadline - Date.now())));
+  }
+}
+
+export async function runGuidedSubstepLoop(
+  page: Page,
+  step: TestableStep,
+  options: {
+    stepLocator: Locator;
+    perSubstepTimeoutMs: number;
+    commentBoxDeadlineMs?: number;
+    verbose?: boolean;
+    artifactsDir?: string;
+  }
+): Promise<{ completed: boolean }> {
+  let stepLocator = options.stepLocator;
+  const { perSubstepTimeoutMs, verbose = false, artifactsDir } = options;
+  const commentBoxDeadlineMs = options.commentBoxDeadlineMs ?? Date.now() + GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS;
+  const guidedStepCount = step.guidedStepCount ?? 1;
+
+  const captureLoopArtifacts = async (context: string) => {
+    if (artifactsDir) {
+      await captureFailureArtifacts(page, step.stepId, [], artifactsDir).catch(() => {});
+    }
+  };
+
+  // Step unmount mid-loop is a completion signal (section auto-collapse, or
+  // navigation unmounted it). Re-resolving the locator handles reload (e.g. a
+  // completeEarly action). A query error is NOT treated as detachment here:
+  // callers already synchronize on navigation before calling this, so a fault
+  // at this point (closed page, destroyed context, unrelated query error)
+  // is a genuine failure and must propagate rather than be reported as success.
+  const stepDetached = async (): Promise<boolean> => {
+    stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
+    return (await stepLocator.count()) === 0;
+  };
+
+  while (true) {
+    if (await stepDetached()) {
+      return { completed: true };
+    }
+
+    const state = await stepLocator.getAttribute('data-test-step-state');
+    if (state === 'completed') {
+      return { completed: true };
+    }
+    if (state === 'error') {
+      await captureLoopArtifacts('error-state');
+      throw new Error('Guided step entered error state');
+    }
+    if (state === 'cancelled') {
+      await captureLoopArtifacts('cancelled-state');
+      throw new Error('Guided step was cancelled');
+    }
+    if (state !== 'executing') {
+      await captureLoopArtifacts(`unexpected-state-${state}`);
+      throw new Error(`Unexpected guided step state: ${state}`);
+    }
+    const indexStr = await stepLocator.getAttribute('data-test-substep-index');
+
+    const currentIndex = indexStr != null ? parseInt(indexStr, 10) : 0;
+    const safeIndex = Number.isNaN(currentIndex) ? 0 : currentIndex;
+    if (safeIndex >= guidedStepCount) {
+      return { completed: false };
+    }
+
+    const commentBox = page.locator('.interactive-comment-box').first();
+    let commentBoxOutcome: GuidedCommentBoxWaitOutcome;
+    try {
+      commentBoxOutcome = await waitForGuidedCommentBoxReady(
+        page,
+        stepLocator,
+        commentBox,
+        Math.max(1, commentBoxDeadlineMs - Date.now())
+      );
+    } catch (err) {
+      await captureLoopArtifacts('comment-box-not-visible');
+      throw err;
+    }
+    if (commentBoxOutcome === 'completed' || commentBoxOutcome === 'detached') {
+      return { completed: true };
+    }
+
+    const action = await commentBox.getAttribute('data-test-action');
+    const reftarget = await commentBox.getAttribute('data-test-reftarget');
+    const targetValue = await commentBox.getAttribute('data-test-target-value');
+
+    if (verbose) {
+      console.log(`   📍 Guided substep ${safeIndex + 1}/${guidedStepCount} action=${action}`);
+    }
+
+    try {
+      if (action === 'noop') {
+        const continueBtn = commentBox.getByRole('button', { name: /Continue/ });
+        await dismissBadgeCelebrations(page);
+        await continueBtn.click();
+      } else if (action === 'button' || action === 'highlight') {
+        if (!reftarget) {
+          throw new Error('Guided step: button/highlight substep missing data-test-reftarget');
+        }
+        const urlBefore = page.url();
+        let navigated = false;
+        const onFrameNavigated = () => {
+          navigated = true;
+        };
+        page.on('framenavigated', onFrameNavigated);
+        try {
+          const target = await resolveGuidedTarget(page, reftarget, action);
+          await target.scrollIntoViewIfNeeded();
+          await dismissBadgeCelebrations(page);
+          await target.click();
+          await page.waitForTimeout(100);
+        } finally {
+          page.off('framenavigated', onFrameNavigated);
+        }
+        if (navigated || urlBefore !== page.url()) {
+          // The action reloaded/navigated the page (e.g. a completeEarly install).
+          // The pre-navigation locator is stale, so wait for the new document to
+          // settle before re-resolving the step locator against it. A failed/timed
+          // out load is a genuine failure (broken reload) and must propagate, not
+          // be swallowed into a false "completed" result.
+          await page.waitForLoadState('domcontentloaded', { timeout: GUIDED_RELOAD_LOAD_TIMEOUT_MS });
+          stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
+        }
+      } else if (action === 'hover') {
+        if (!reftarget) {
+          throw new Error('Guided step: hover substep missing data-test-reftarget');
+        }
+        const target = await resolveGuidedTarget(page, reftarget, 'hover');
+        await target.scrollIntoViewIfNeeded();
+        await dismissBadgeCelebrations(page);
+        await target.hover();
+        await page.waitForTimeout(GUIDED_HOVER_DWELL_MS);
+      } else if (action === 'formfill') {
+        if (!reftarget) {
+          throw new Error('Guided step: formfill substep missing data-test-reftarget');
+        }
+        const target = await resolveGuidedTarget(page, reftarget, 'formfill');
+        await target.scrollIntoViewIfNeeded();
+        await dismissBadgeCelebrations(page);
+        await target.fill(targetValue ?? '');
+        await waitForFormfillSettle(page, stepLocator, target, targetValue ?? '');
+      } else {
+        throw new Error(`Guided step: unknown data-test-action "${action}"`);
+      }
+    } catch (err) {
+      await captureLoopArtifacts(`substep-${safeIndex}-${action}`);
+      throw err;
+    }
+
+    if (await stepDetached()) {
+      return { completed: true };
+    }
+
+    await waitForSubstepAdvance(page, stepLocator, safeIndex, perSubstepTimeoutMs, { commentBox });
+    await page.waitForTimeout(GUIDED_BETWEEN_SUBSTEP_DELAY_MS);
+  }
+}
+
+export async function executeGuidedStep(context: StepDriverExecutionContext): Promise<StepDriverExecutionResult> {
+  const action = await startStepAction(context);
+  if (action.outcome !== 'started') {
+    return { outcome: action.outcome };
+  }
+
+  const stepLocator = context.page.getByTestId(testIds.interactive.step(context.step.stepId));
+  await waitForGuidedExecutionStart(context.page, stepLocator);
+  const { completed } = await runGuidedSubstepLoop(context.page, context.step, {
+    stepLocator,
+    perSubstepTimeoutMs: TIMEOUT_PER_GUIDED_SUBSTEP_MS,
+    commentBoxDeadlineMs: Date.now() + context.timeout,
+    verbose: context.verbose,
+    artifactsDir: context.artifactsDir,
+  });
+  if (!completed) {
+    await waitForCompletion(context.page, context.step.stepId, context.timeout);
+  }
+  return { outcome: 'completed' };
+}

--- a/tests/e2e-runner/utils/guide-runner/drivers/index.ts
+++ b/tests/e2e-runner/utils/guide-runner/drivers/index.ts
@@ -1,0 +1,3 @@
+export { STEP_DRIVERS, getStepDriver, isStepTypeKind, resolveLegacyStepKind, stepTimeout } from './registry';
+export { clickSkipButtonAndSync, selectStepAction, waitForCompletion } from './shared';
+export type { StepDriver, StepDriverExecutionContext, StepDriverExecutionResult, StepDriverInspection } from './types';

--- a/tests/e2e-runner/utils/guide-runner/drivers/registry.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/drivers/registry.test.ts
@@ -1,0 +1,20 @@
+jest.mock('@playwright/test', () => ({
+  expect: jest.fn(),
+}));
+
+import { STEP_TYPE_KIND_KEYS } from '../../../../../src/components/interactive-tutorial/step-type-registry';
+import { STEP_DRIVERS } from './registry';
+
+describe('STEP_DRIVERS', () => {
+  it('registers every tracked step kind', () => {
+    expect([...STEP_DRIVERS.keys()]).toEqual(STEP_TYPE_KIND_KEYS);
+  });
+
+  it('supports only the existing plain, multistep, and guided behavior', () => {
+    const supported = [...STEP_DRIVERS.values()].filter((driver) => driver.supported).map((driver) => driver.kind);
+    const unsupported = [...STEP_DRIVERS.values()].filter((driver) => !driver.supported).map((driver) => driver.kind);
+
+    expect(supported).toEqual(['plain', 'multistep', 'guided']);
+    expect(unsupported).toEqual(['quiz', 'terminal', 'terminal-connect', 'codeblock', 'challenge', 'datasource-check']);
+  });
+});

--- a/tests/e2e-runner/utils/guide-runner/drivers/registry.ts
+++ b/tests/e2e-runner/utils/guide-runner/drivers/registry.ts
@@ -1,0 +1,144 @@
+import type { Locator, Page } from '@playwright/test';
+
+import {
+  STEP_TYPE_KIND_KEYS,
+  type StepTypeKind,
+} from '../../../../../src/components/interactive-tutorial/step-type-registry';
+import { DEFAULT_STEP_TIMEOUT_MS, TIMEOUT_PER_GUIDED_SUBSTEP_MS, TIMEOUT_PER_MULTISTEP_ACTION_MS } from '../constants';
+import type { TestableStep } from '../types';
+import { clickSkipButtonAndSync, executeStandardStep, inspectCommonStep, isStepComplete } from './shared';
+import { executeGuidedStep } from './guided';
+import type { StepDriver, StepDriverInspection } from './types';
+
+async function inspectPlain(page: Page, root: Locator, stepId: string): Promise<StepDriverInspection> {
+  return {
+    ...(await inspectCommonStep(page, root, stepId)),
+    isMultistep: false,
+    internalActionCount: 0,
+    isGuided: false,
+  };
+}
+
+async function inspectMultistep(page: Page, root: Locator, stepId: string): Promise<StepDriverInspection> {
+  const common = await inspectCommonStep(page, root, stepId);
+  const rawActions = await root.getAttribute('data-internal-actions');
+  let internalActionCount = 3;
+  if (rawActions) {
+    try {
+      const actions = JSON.parse(rawActions);
+      internalActionCount = Array.isArray(actions) ? actions.length : 0;
+    } catch {
+      internalActionCount = 3;
+    }
+  }
+  return {
+    ...common,
+    isMultistep: true,
+    internalActionCount,
+    isGuided: false,
+  };
+}
+
+async function inspectGuided(page: Page, root: Locator, stepId: string): Promise<StepDriverInspection> {
+  const common = await inspectCommonStep(page, root, stepId);
+  const rawTotal = await root.getAttribute('data-test-substep-total');
+  const parsedTotal = rawTotal ? Number.parseInt(rawTotal, 10) : Number.NaN;
+  return {
+    ...common,
+    isMultistep: false,
+    internalActionCount: 0,
+    isGuided: true,
+    guidedStepCount: Number.isFinite(parsedTotal) && parsedTotal >= 1 ? parsedTotal : 1,
+  };
+}
+
+function supportedDriver(
+  kind: 'plain' | 'multistep' | 'guided',
+  inspect: StepDriver['inspect'],
+  timeout: StepDriver['timeout'],
+  execute: StepDriver['execute']
+): StepDriver {
+  return {
+    kind,
+    supported: true,
+    inspect,
+    timeout,
+    completionState: isStepComplete,
+    skip: clickSkipButtonAndSync,
+    execute,
+  };
+}
+
+function unsupportedDriver(kind: Exclude<StepTypeKind, 'plain' | 'multistep' | 'guided'>): StepDriver {
+  const unsupported = (): never => {
+    throw new Error(`Step kind "${kind}" does not have an E2E driver`);
+  };
+  return {
+    kind,
+    supported: false,
+    inspect: unsupported,
+    timeout: () => DEFAULT_STEP_TIMEOUT_MS,
+    completionState: unsupported,
+    skip: unsupported,
+    execute: unsupported,
+  };
+}
+
+const drivers = [
+  supportedDriver('plain', inspectPlain, () => DEFAULT_STEP_TIMEOUT_MS, executeStandardStep),
+  supportedDriver(
+    'multistep',
+    inspectMultistep,
+    (step) =>
+      DEFAULT_STEP_TIMEOUT_MS +
+      (step.internalActionCount > 0 ? step.internalActionCount * TIMEOUT_PER_MULTISTEP_ACTION_MS : 0),
+    executeStandardStep
+  ),
+  supportedDriver(
+    'guided',
+    inspectGuided,
+    (step) =>
+      DEFAULT_STEP_TIMEOUT_MS +
+      (step.guidedStepCount && step.guidedStepCount > 0 ? step.guidedStepCount * TIMEOUT_PER_GUIDED_SUBSTEP_MS : 0),
+    executeGuidedStep
+  ),
+  unsupportedDriver('quiz'),
+  unsupportedDriver('terminal'),
+  unsupportedDriver('terminal-connect'),
+  unsupportedDriver('codeblock'),
+  unsupportedDriver('challenge'),
+  unsupportedDriver('datasource-check'),
+] as const satisfies readonly StepDriver[];
+
+export const STEP_DRIVERS: ReadonlyMap<StepTypeKind, StepDriver> = new Map(
+  drivers.map((driver) => [driver.kind, driver])
+);
+
+export function isStepTypeKind(value: string): value is StepTypeKind {
+  return (STEP_TYPE_KIND_KEYS as readonly string[]).includes(value);
+}
+
+export function getStepDriver(kind: StepTypeKind): StepDriver {
+  const driver = STEP_DRIVERS.get(kind);
+  if (!driver) {
+    throw new Error(`No E2E driver is registered for step kind "${kind}"`);
+  }
+  return driver;
+}
+
+export async function resolveLegacyStepKind(root: Locator): Promise<StepTypeKind> {
+  const targetAction = (await root.getAttribute('data-targetaction')) ?? undefined;
+  if (targetAction === 'multistep') {
+    return 'multistep';
+  }
+  const rawTotal = await root.getAttribute('data-test-substep-total');
+  const hasSubsteps = rawTotal !== null && rawTotal !== '' && Number.parseInt(rawTotal, 10) >= 1;
+  if (targetAction === 'guided' || (hasSubsteps && !targetAction)) {
+    return 'guided';
+  }
+  return 'plain';
+}
+
+export function stepTimeout(step: TestableStep): number {
+  return getStepDriver(step.stepKind).timeout(step);
+}

--- a/tests/e2e-runner/utils/guide-runner/drivers/shared.ts
+++ b/tests/e2e-runner/utils/guide-runner/drivers/shared.ts
@@ -1,0 +1,211 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import { testIds } from '../../../../../src/constants/testIds';
+import { dismissBadgeCelebrations } from '../badge-celebrations';
+import {
+  BUTTON_APPEAR_TIMEOUT_MS,
+  BUTTON_ENABLE_TIMEOUT_MS,
+  COMPLETION_POLL_INTERVAL_MS,
+  DEFAULT_STEP_TIMEOUT_MS,
+  GUIDED_SUBSTEP_ADVANCE_POLL_MS,
+  POST_CLICK_SETTLE_DELAY_MS,
+  SKIP_SYNC_TIMEOUT_MS,
+} from '../constants';
+import type { StepDriverExecutionContext, StepDriverExecutionResult, StepDriverInspection } from './types';
+
+export type StepAction = 'do-it' | 'show-me';
+
+export function selectStepAction(input: { hasDoItButton: boolean; hasShowMeButton: boolean }): StepAction | undefined {
+  if (input.hasDoItButton) {
+    return 'do-it';
+  }
+  if (input.hasShowMeButton) {
+    return 'show-me';
+  }
+  return undefined;
+}
+
+function stepActionButton(page: Page, stepId: string, action: StepAction): Locator {
+  const testId = action === 'do-it' ? testIds.interactive.doItButton(stepId) : testIds.interactive.showMeButton(stepId);
+  return page.getByTestId(testId);
+}
+
+async function currentStepAction(page: Page, stepId: string): Promise<StepAction | undefined> {
+  return selectStepAction({
+    hasDoItButton: (await stepActionButton(page, stepId, 'do-it').count()) > 0,
+    hasShowMeButton: (await stepActionButton(page, stepId, 'show-me').count()) > 0,
+  });
+}
+
+async function waitForStepActionToAppear(
+  page: Page,
+  stepId: string,
+  timeout = BUTTON_APPEAR_TIMEOUT_MS
+): Promise<StepAction | undefined> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const action = await currentStepAction(page, stepId);
+    if (action) {
+      return action;
+    }
+    await page.waitForTimeout(COMPLETION_POLL_INTERVAL_MS);
+  }
+  return undefined;
+}
+
+export async function inspectCommonStep(
+  page: Page,
+  root: Locator,
+  stepId: string
+): Promise<Omit<StepDriverInspection, 'isMultistep' | 'internalActionCount' | 'isGuided' | 'guidedStepCount'>> {
+  const targetAction = (await root.getAttribute('data-targetaction')) ?? undefined;
+  const refTarget = (await root.getAttribute('data-reftarget')) ?? undefined;
+  const hasDoItButton = (await page.getByTestId(testIds.interactive.doItButton(stepId)).count()) > 0;
+  const hasShowMeButton = (await page.getByTestId(testIds.interactive.showMeButton(stepId)).count()) > 0;
+  const isPreCompleted = await page.getByTestId(testIds.interactive.stepCompleted(stepId)).isVisible();
+  const skippable =
+    targetAction !== 'noop' &&
+    !isPreCompleted &&
+    (await page.getByTestId(testIds.interactive.skipButton(stepId)).count()) > 0;
+
+  return {
+    skippable,
+    hasDoItButton,
+    hasShowMeButton,
+    isPreCompleted,
+    targetAction,
+    refTarget,
+  };
+}
+
+export async function isStepComplete(page: Page, stepId: string): Promise<boolean> {
+  return (
+    (await page.getByTestId(testIds.interactive.step(stepId)).getAttribute('data-test-step-state')) === 'completed'
+  );
+}
+
+async function readStepError(page: Page, stepId: string): Promise<string | undefined> {
+  const errorElement = page.getByTestId(testIds.interactive.errorMessage(stepId));
+  if ((await errorElement.count()) > 0) {
+    return (await errorElement.first().textContent())?.trim() || undefined;
+  }
+  const deployedError = page
+    .getByTestId(testIds.interactive.step(stepId))
+    .locator('.interactive-lazy-error-text, .interactive-step-execution-error')
+    .first();
+  return (await deployedError.count()) > 0 ? (await deployedError.textContent())?.trim() || undefined : undefined;
+}
+
+export async function waitForCompletion(
+  page: Page,
+  stepId: string,
+  timeout: number
+): Promise<{ completedViaObjectives: boolean }> {
+  const startTime = Date.now();
+  const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
+
+  while (Date.now() - startTime < timeout) {
+    if ((await stepLocator.count()) === 0) {
+      return { completedViaObjectives: false };
+    }
+    let state: string | null = null;
+    try {
+      state = await stepLocator.getAttribute('data-test-step-state', { timeout: 2000 });
+    } catch {
+      if ((await stepLocator.count()) === 0) {
+        return { completedViaObjectives: false };
+      }
+    }
+    const errorMessage = await readStepError(page, stepId);
+    if (errorMessage) {
+      throw new Error(errorMessage);
+    }
+    if (state === 'completed') {
+      return { completedViaObjectives: Date.now() - startTime < COMPLETION_POLL_INTERVAL_MS * 2 };
+    }
+    if (state === 'error') {
+      throw new Error((await readStepError(page, stepId)) ?? `Step ${stepId} entered error state`);
+    }
+    if (state === 'cancelled' || state === 'requirements-unmet') {
+      throw new Error(`Step ${stepId} entered ${state} state`);
+    }
+    await page.waitForTimeout(COMPLETION_POLL_INTERVAL_MS);
+  }
+
+  await expect(stepLocator).toHaveAttribute('data-test-step-state', 'completed', { timeout: 1000 });
+  return { completedViaObjectives: false };
+}
+
+export async function startStepAction(
+  context: StepDriverExecutionContext
+): Promise<{ outcome: 'started'; action: StepAction } | { outcome: 'completed' | 'no-control' }> {
+  const { page, step, verbose } = context;
+  const discoveredAction = selectStepAction(step);
+  let action = await currentStepAction(page, step.stepId);
+  if (!action) {
+    action = await waitForStepActionToAppear(page, step.stepId, discoveredAction ? 1000 : BUTTON_APPEAR_TIMEOUT_MS);
+  }
+  if (!action) {
+    if (await isStepComplete(page, step.stepId)) {
+      return { outcome: 'completed' };
+    }
+    return { outcome: 'no-control' };
+  }
+
+  await expect(stepActionButton(page, step.stepId, action)).toBeEnabled({ timeout: BUTTON_ENABLE_TIMEOUT_MS });
+  await dismissBadgeCelebrations(page);
+  await stepActionButton(page, step.stepId, action).click();
+  if (verbose) {
+    console.log(`   → Clicked "${action === 'do-it' ? 'Do it' : 'Show me'}" for step ${step.stepId}`);
+  }
+  await page.waitForTimeout(POST_CLICK_SETTLE_DELAY_MS);
+  return { outcome: 'started', action };
+}
+
+export async function executeStandardStep(context: StepDriverExecutionContext): Promise<StepDriverExecutionResult> {
+  const action = await startStepAction(context);
+  if (action.outcome !== 'started') {
+    return { outcome: action.outcome };
+  }
+  const completion = await waitForCompletion(context.page, context.step.stepId, context.timeout);
+  return { outcome: 'completed', completedViaObjectives: completion.completedViaObjectives };
+}
+
+export async function clickSkipButtonAndSync(
+  page: Page,
+  stepId: string,
+  timeout = SKIP_SYNC_TIMEOUT_MS
+): Promise<void> {
+  const stepSkipButton = page.getByTestId(testIds.interactive.skipButton(stepId));
+  const requirementSkipButton = page.getByTestId(testIds.interactive.requirementSkipButton(stepId));
+  const skipButton = (await stepSkipButton.count()) > 0 ? stepSkipButton : requirementSkipButton;
+  if ((await skipButton.count()) === 0) {
+    throw new Error(`Step ${stepId}: no Skip control available to sync the requirements-unmet state`);
+  }
+  await dismissBadgeCelebrations(page);
+  await skipButton.click({ timeout });
+
+  const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error(`Step ${stepId}: Skip did not reach a terminal state within ${timeout}ms`);
+    }
+    if ((await stepLocator.count()) === 0) {
+      return;
+    }
+    let state: string | null;
+    try {
+      state = await stepLocator.getAttribute('data-test-step-state', { timeout: remaining });
+    } catch {
+      state = null;
+    }
+    if (state === 'completed') {
+      return;
+    }
+    await page.waitForTimeout(Math.min(GUIDED_SUBSTEP_ADVANCE_POLL_MS, Math.max(1, deadline - Date.now())));
+  }
+}
+
+export const defaultTimeout = (): number => DEFAULT_STEP_TIMEOUT_MS;

--- a/tests/e2e-runner/utils/guide-runner/drivers/types.ts
+++ b/tests/e2e-runner/utils/guide-runner/drivers/types.ts
@@ -1,0 +1,40 @@
+import type { Locator, Page } from '@playwright/test';
+
+import type { StepTypeKind } from '../../../../../src/components/interactive-tutorial/step-type-registry';
+import type { TestableStep } from '../types';
+
+export interface StepDriverInspection {
+  skippable: boolean;
+  hasDoItButton: boolean;
+  hasShowMeButton: boolean;
+  isPreCompleted: boolean;
+  targetAction?: string;
+  isMultistep: boolean;
+  internalActionCount: number;
+  isGuided: boolean;
+  guidedStepCount?: number;
+  refTarget?: string;
+}
+
+export interface StepDriverExecutionContext {
+  page: Page;
+  step: TestableStep;
+  timeout: number;
+  verbose: boolean;
+  artifactsDir?: string;
+}
+
+export interface StepDriverExecutionResult {
+  outcome: 'completed' | 'no-control';
+  completedViaObjectives?: boolean;
+}
+
+export interface StepDriver {
+  kind: StepTypeKind;
+  supported: boolean;
+  inspect(page: Page, root: Locator, stepId: string): Promise<StepDriverInspection>;
+  timeout(step: TestableStep): number;
+  completionState(page: Page, stepId: string): Promise<boolean>;
+  skip(page: Page, stepId: string, timeout?: number): Promise<void>;
+  execute(context: StepDriverExecutionContext): Promise<StepDriverExecutionResult>;
+}

--- a/tests/e2e-runner/utils/guide-runner/execution.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.test.ts
@@ -58,12 +58,12 @@ import type { Locator, Page } from '@playwright/test';
 
 import {
   scrollStepIntoView,
-  clickSkipButtonAndSync,
   waitForGuidedCommentBoxReady,
   runGuidedSubstepLoop,
   executeStep,
   summarizeResults,
 } from './execution';
+import { clickSkipButtonAndSync } from './drivers';
 import { handleRequirementsWithFix } from './requirements';
 import { dismissBadgeCelebrations } from './badge-celebrations';
 import {
@@ -75,6 +75,7 @@ import type { StepTestResult, TestableStep } from './types';
 
 function createTestableStep(overrides: Partial<TestableStep> = {}): TestableStep {
   return {
+    stepKind: overrides.stepKind ?? (overrides.isGuided === false ? 'plain' : 'guided'),
     stepId: 'test-step-1',
     index: 0,
     skippable: false,

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -8,35 +8,17 @@
  * @see docs/developer/E2E_TESTING.md#how-it-works
  */
 
-import { Page, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 import { testIds } from '../../../../src/constants/testIds';
 import {
-  DEFAULT_STEP_TIMEOUT_MS,
   GUIDE_INITIAL_TIMEOUT_MS,
   STEP_OVERHEAD_TIMEOUT_MS,
-  TIMEOUT_PER_MULTISTEP_ACTION_MS,
-  TIMEOUT_PER_GUIDED_SUBSTEP_MS,
-  BUTTON_ENABLE_TIMEOUT_MS,
-  BUTTON_APPEAR_TIMEOUT_MS,
   SCROLL_SETTLE_DELAY_MS,
   SCROLL_INTO_VIEW_TIMEOUT_MS,
   LATE_COMPLETION_CHECK_TIMEOUT_MS,
-  POST_CLICK_SETTLE_DELAY_MS,
-  COMPLETION_POLL_INTERVAL_MS,
   DEFAULT_SESSION_CHECK_INTERVAL,
   MAX_FIX_ATTEMPTS,
-  GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS,
-  GUIDED_TARGET_RESOLUTION_TIMEOUT_MS,
-  GUIDED_SUBSTEP_ADVANCE_POLL_MS,
-  GUIDED_BETWEEN_SUBSTEP_DELAY_MS,
-  GUIDED_FORMFILL_DEBOUNCE_MS,
-  GUIDED_FORMFILL_VALID_TIMEOUT_MS,
-  GUIDED_FORMFILL_INVALID_PERSIST_MS,
-  GUIDED_HOVER_DWELL_MS,
-  GUIDED_SKIP_AFTER_TIMEOUT_FRACTION,
-  GUIDED_RELOAD_LOAD_TIMEOUT_MS,
-  SKIP_SYNC_TIMEOUT_MS,
 } from './constants';
 import { classifyError } from './classification';
 import {
@@ -46,7 +28,7 @@ import {
   captureFinalScreenshot,
 } from './artifacts';
 import { validateSession, handleRequirementsWithFix } from './requirements';
-import { dismissBadgeCelebrations } from './badge-celebrations';
+import { getStepDriver, selectStepAction as selectDriverAction, stepTimeout } from './drivers';
 import type {
   TestableStep,
   SkipReason,
@@ -56,8 +38,6 @@ import type {
   AllStepsResult,
   OnStepCompleteCallback,
 } from './types';
-import { resolveSelector } from '../selector-resolver';
-import type { Locator } from '@playwright/test';
 
 // ============================================
 // Utility Functions
@@ -101,14 +81,7 @@ export async function scrollStepIntoView(
  * @returns Timeout in milliseconds
  */
 export function calculateStepTimeout(step: TestableStep): number {
-  if (step.isGuided && step.guidedStepCount != null && step.guidedStepCount > 0) {
-    return DEFAULT_STEP_TIMEOUT_MS + step.guidedStepCount * TIMEOUT_PER_GUIDED_SUBSTEP_MS;
-  }
-  if (step.isMultistep && step.internalActionCount > 0) {
-    // Multistep: base timeout + time per internal action
-    return DEFAULT_STEP_TIMEOUT_MS + step.internalActionCount * TIMEOUT_PER_MULTISTEP_ACTION_MS;
-  }
-  return DEFAULT_STEP_TIMEOUT_MS;
+  return stepTimeout(step);
 }
 
 export function calculateGuideTimeout(steps: TestableStep[]): number {
@@ -123,88 +96,11 @@ export type StepAction = 'do-it' | 'show-me';
 export function selectStepAction(
   step: Pick<TestableStep, 'hasDoItButton' | 'hasShowMeButton'>
 ): StepAction | undefined {
-  if (step.hasDoItButton) {
-    return 'do-it';
-  }
-  if (step.hasShowMeButton) {
-    return 'show-me';
-  }
-  return undefined;
+  return selectDriverAction(step);
 }
 
 export function determineUnmetRequirementOutcome(skippable: boolean): 'skip' | 'fail' {
   return skippable ? 'skip' : 'fail';
-}
-
-function stepActionButton(page: Page, stepId: string, action: StepAction): Locator {
-  const testId = action === 'do-it' ? testIds.interactive.doItButton(stepId) : testIds.interactive.showMeButton(stepId);
-  return page.getByTestId(testId);
-}
-
-async function currentStepAction(page: Page, stepId: string): Promise<StepAction | undefined> {
-  return selectStepAction({
-    hasDoItButton: (await stepActionButton(page, stepId, 'do-it').count()) > 0,
-    hasShowMeButton: (await stepActionButton(page, stepId, 'show-me').count()) > 0,
-  });
-}
-
-async function waitForStepActionToAppear(
-  page: Page,
-  stepId: string,
-  timeout = BUTTON_APPEAR_TIMEOUT_MS
-): Promise<StepAction | undefined> {
-  const deadline = Date.now() + timeout;
-  while (Date.now() < deadline) {
-    const action = await currentStepAction(page, stepId);
-    if (action) {
-      return action;
-    }
-    await page.waitForTimeout(COMPLETION_POLL_INTERVAL_MS);
-  }
-  return undefined;
-}
-
-async function waitForStepActionEnabled(
-  page: Page,
-  stepId: string,
-  action: StepAction,
-  timeout = BUTTON_ENABLE_TIMEOUT_MS
-): Promise<void> {
-  await expect(stepActionButton(page, stepId, action)).toBeEnabled({ timeout });
-}
-
-/**
- * Wait for a step to reach completed state (E2E contract).
- *
- * Uses data-test-step-state="completed" on the step element so that all step types
- * (single, multistep, guided) are considered complete when the contract says so.
- *
- * @param page - Playwright Page object
- * @param stepId - The step identifier
- * @param timeout - Maximum time to wait (ms), default 30s per design
- */
-export async function waitForStepCompletion(
-  page: Page,
-  stepId: string,
-  timeout = DEFAULT_STEP_TIMEOUT_MS
-): Promise<void> {
-  const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
-  await expect(stepLocator).toHaveAttribute('data-test-step-state', 'completed', { timeout });
-}
-
-/**
- * Check if a step has completed via objectives while waiting (L3-3C).
- *
- * Reads data-test-step-state from the step element; returns true when value is 'completed'.
- *
- * @param page - Playwright Page object
- * @param stepId - The step identifier
- * @returns true if the step completed via objectives (or any completion)
- */
-export async function checkObjectiveCompletion(page: Page, stepId: string): Promise<boolean> {
-  const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
-  const state = await stepLocator.getAttribute('data-test-step-state');
-  return state === 'completed';
 }
 
 /**
@@ -257,541 +153,14 @@ async function checkLateCompletionOrDetachment(
   return state === 'completed' ? 'completed' : 'not-complete';
 }
 
-async function readStepError(page: Page, stepId: string): Promise<string | undefined> {
-  const errorElement = page.getByTestId(testIds.interactive.errorMessage(stepId));
-  if ((await errorElement.count()) > 0) {
-    return (await errorElement.first().textContent())?.trim() || undefined;
-  }
-  const deployedError = page
-    .getByTestId(testIds.interactive.step(stepId))
-    .locator('.interactive-lazy-error-text, .interactive-step-execution-error')
-    .first();
-  return (await deployedError.count()) > 0 ? (await deployedError.textContent())?.trim() || undefined : undefined;
-}
-
-/**
- * Wait for a step to complete after it has been interacted with.
- *
- * Callers reach this only after the step was alive and acted on (its "Do it"
- * button was clicked, or the guided loop was running). A detached step element
- * therefore means the step completed and its section auto-collapsed — or
- * navigation unmounted it. Either way, detachment is a completion signal.
- *
- * Otherwise it polls data-test-step-state until 'completed', then asserts
- * completion so a genuinely stuck step fails with a clear error.
- *
- * @param page - Playwright Page object
- * @param stepId - The step identifier
- * @param timeout - Maximum time to wait (ms)
- * @returns Object indicating if completion was likely via objectives
- */
-export async function waitForCompletionWithObjectivePolling(
-  page: Page,
-  stepId: string,
-  timeout: number
-): Promise<{ completedViaObjectives: boolean }> {
-  const startTime = Date.now();
-  const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
-
-  while (Date.now() - startTime < timeout) {
-    if ((await stepLocator.count()) === 0) {
-      return { completedViaObjectives: false };
-    }
-
-    let state: string | null = null;
-    try {
-      state = await stepLocator.getAttribute('data-test-step-state', { timeout: 2000 });
-    } catch {
-      if ((await stepLocator.count()) === 0) {
-        return { completedViaObjectives: false };
-      }
-    }
-    const errorMessage = await readStepError(page, stepId);
-    if (errorMessage) {
-      throw new Error(errorMessage);
-    }
-    if (state === 'completed') {
-      const elapsed = Date.now() - startTime;
-      const likelyObjectiveCompletion = elapsed < COMPLETION_POLL_INTERVAL_MS * 2;
-      return { completedViaObjectives: likelyObjectiveCompletion };
-    }
-    if (state === 'error') {
-      throw new Error((await readStepError(page, stepId)) ?? `Step ${stepId} entered error state`);
-    }
-    if (state === 'cancelled' || state === 'requirements-unmet') {
-      throw new Error(`Step ${stepId} entered ${state} state`);
-    }
-    await page.waitForTimeout(COMPLETION_POLL_INTERVAL_MS);
-  }
-
-  await expect(stepLocator).toHaveAttribute('data-test-step-state', 'completed', { timeout: 1000 });
-  return { completedViaObjectives: false };
-}
-
-// ============================================
-// Guided Step Execution (Phase 3)
-// ============================================
-
-const GUIDED_WAIT_EXECUTING_MS = 5000;
-
-async function waitForGuidedExecutionStart(page: Page, stepLocator: Locator, timeout: number): Promise<void> {
-  const deadline = Date.now() + timeout;
-  while (Date.now() < deadline) {
-    const state = await stepLocator.getAttribute('data-test-step-state');
-    if (state === 'executing' || state === 'completed') {
-      return;
-    }
-    if (state === 'error' || state === 'cancelled') {
-      throw new Error(`Guided step entered ${state} state before execution`);
-    }
-    await page.waitForTimeout(COMPLETION_POLL_INTERVAL_MS);
-  }
-  throw new Error('Guided step did not enter executing state');
-}
-
-interface ParsedNthMatchSelector {
-  baseSelector: string;
-  index: number;
-  trailingSelector: string;
-}
-
-export function parseNthMatchSelector(selector: string): ParsedNthMatchSelector | undefined {
-  const match = selector.match(/^(.+?):nth-match\((\d+)\)(.*)$/);
-  if (!match) {
-    return undefined;
-  }
-  const oneBasedIndex = Number.parseInt(match[2]!, 10);
-  if (oneBasedIndex < 1) {
-    return undefined;
-  }
-  return {
-    baseSelector: match[1]!,
-    index: oneBasedIndex - 1,
-    trailingSelector: match[3]!.trim(),
-  };
-}
-
-function guidedSelectorLocator(page: Page, selector: string): Locator {
-  const parsed = parseNthMatchSelector(selector);
-  if (!parsed) {
-    return page.locator(selector).first();
-  }
-  const matched = page.locator(parsed.baseSelector).nth(parsed.index);
-  return parsed.trailingSelector ? matched.locator(parsed.trailingSelector).first() : matched;
-}
-
-async function revealGuidedTarget(page: Page, target: Locator, timeout: number): Promise<Locator> {
-  if (await target.isVisible()) {
-    return target;
-  }
-  if ((await target.count()) > 0) {
-    const panel = target.locator('xpath=ancestor::section[1]');
-    if ((await panel.count()) > 0) {
-      await panel.scrollIntoViewIfNeeded().catch(() => {});
-      await dismissBadgeCelebrations(page);
-      await panel.hover({ timeout }).catch(() => {});
-      if (await target.isVisible()) {
-        return target;
-      }
-      const menuButton = panel.locator('button[data-testid^="data-testid Panel menu "]').first();
-      if ((await menuButton.count()) > 0 && (await menuButton.isVisible())) {
-        return menuButton;
-      }
-    }
-  }
-  await target.waitFor({ state: 'visible', timeout });
-  return target;
-}
-
-/**
- * Resolve data-test-reftarget to a Playwright locator for the current substep.
- * Button: try getByRole('button', { name }) then locator(selector); others use locator(selector).
- * Handles grafana: prefix through the Node-safe E2E resolver.
- */
-async function resolveGuidedTarget(page: Page, reftarget: string, actionType: string): Promise<Locator> {
-  await dismissBadgeCelebrations(page);
-  const timeout = GUIDED_TARGET_RESOLUTION_TIMEOUT_MS;
-  const selector = reftarget.startsWith('grafana:') ? resolveSelector(reftarget) : reftarget;
-
-  if (actionType === 'button') {
-    const byRole = page.getByRole('button', { name: reftarget });
-    const n = await byRole.count();
-    if (n > 0) {
-      return revealGuidedTarget(page, byRole.first(), timeout);
-    }
-    const bySelector = guidedSelectorLocator(page, selector);
-    const hasButton = bySelector.filter({ has: page.getByRole('button') });
-    const hasCount = await hasButton.count();
-    if (hasCount > 0) {
-      return revealGuidedTarget(page, hasButton.first(), timeout);
-    }
-    return revealGuidedTarget(page, bySelector.first(), timeout);
-  }
-
-  return revealGuidedTarget(page, guidedSelectorLocator(page, selector), timeout);
-}
-
-/**
- * Wait until the step's substep index increases or the step completes.
- * Fails if step state becomes 'error' or 'cancelled'.
- * Phase 4.3: If commentBox is provided, after 80% of timeout tries to click Skip button if present.
- * Phase 4.6: Timeout error includes last seen state for diagnostics.
- */
-async function waitForSubstepAdvance(
-  page: Page,
-  stepLocator: Locator,
-  previousSubstepIndex: number,
-  timeoutMs: number,
-  options: { commentBox?: Locator } = {}
-): Promise<void> {
-  const { commentBox } = options;
-  const deadline = Date.now() + timeoutMs;
-  const skipAfterMs = Math.floor(timeoutMs * GUIDED_SKIP_AFTER_TIMEOUT_FRACTION);
-  let lastState: string | null = null;
-  let lastIndex: string | null = null;
-
-  while (Date.now() < deadline) {
-    // Unmount mid-wait is a completion signal (section auto-collapse on final substep);
-    // a bare getAttribute on a detached locator blocks until the global test timeout.
-    if ((await stepLocator.count()) === 0) {
-      return;
-    }
-
-    try {
-      lastState = await stepLocator.getAttribute('data-test-step-state', { timeout: 2000 });
-      lastIndex = await stepLocator.getAttribute('data-test-substep-index', { timeout: 2000 });
-    } catch {
-      if ((await stepLocator.count()) === 0) {
-        return;
-      }
-      lastState = null;
-      lastIndex = null;
-    }
-
-    if (lastState === 'error') {
-      throw new Error('Guided step entered error state');
-    }
-    if (lastState === 'cancelled') {
-      throw new Error('Guided step was cancelled');
-    }
-    const index = lastIndex != null ? parseInt(lastIndex, 10) : 0;
-    if (!Number.isNaN(index) && index > previousSubstepIndex) {
-      return;
-    }
-    if (lastState === 'completed' && lastIndex === null) {
-      return;
-    }
-
-    const elapsed = Date.now() - (deadline - timeoutMs);
-    if (commentBox && elapsed >= skipAfterMs) {
-      const skipBtn = commentBox.getByRole('button', { name: /^Skip$/ });
-      const count = await skipBtn.count();
-      if (count > 0) {
-        await dismissBadgeCelebrations(page);
-        await skipBtn.click().catch(() => {});
-      }
-    }
-
-    await page.waitForTimeout(GUIDED_SUBSTEP_ADVANCE_POLL_MS);
-  }
-
-  throw new Error(
-    `Guided substep did not advance within ${timeoutMs}ms (previous index: ${previousSubstepIndex}, last state: ${lastState ?? 'unknown'}, last substep-index: ${lastIndex ?? 'unknown'})`
-  );
-}
-
-/**
- * After formfill: debounce, optionally wait for data-test-form-state="valid", or retry once on persistent invalid (Phase 4.1).
- */
-export async function waitForFormfillSettle(
-  page: Page,
-  stepLocator: Locator,
-  target: Locator,
-  targetValue: string
-): Promise<void> {
-  await page.waitForTimeout(GUIDED_FORMFILL_DEBOUNCE_MS);
-
-  const validDeadline = Date.now() + GUIDED_FORMFILL_VALID_TIMEOUT_MS;
-  let invalidSince: number | null = null;
-
-  const readFormState = async (): Promise<string | null> => {
-    if ((await stepLocator.count()) === 0) {
-      return null;
-    }
-    try {
-      return await stepLocator.getAttribute('data-test-form-state', { timeout: 2000 });
-    } catch {
-      return null;
-    }
-  };
-
-  while (Date.now() < validDeadline) {
-    if ((await stepLocator.count()) === 0) {
-      return;
-    }
-    const formState = await readFormState();
-    if (formState === 'valid') {
-      return;
-    }
-    if (formState === 'invalid') {
-      if (invalidSince == null) {
-        invalidSince = Date.now();
-      }
-      if (Date.now() - invalidSince >= GUIDED_FORMFILL_INVALID_PERSIST_MS) {
-        await dismissBadgeCelebrations(page);
-        await target.fill(targetValue);
-        await page.waitForTimeout(GUIDED_FORMFILL_DEBOUNCE_MS);
-        const afterRetry = await readFormState();
-        if (afterRetry === 'invalid') {
-          throw new Error(
-            `Guided step: formfill validation failed (data-test-form-state="invalid" persisted after retry with value "${targetValue}")`
-          );
-        }
-        if (afterRetry === 'valid') {
-          return;
-        }
-        invalidSince = null;
-      }
-    } else {
-      invalidSince = null;
-    }
-    await page.waitForTimeout(GUIDED_SUBSTEP_ADVANCE_POLL_MS);
-  }
-  // No valid state on step element (e.g. guided step may not set form-state); proceed to waitForSubstepAdvance
-}
-
-/**
- * Outcome of waiting for the guided comment box:
- * - `ready`: the comment box is visible and its contract can be read.
- * - `completed`: the step reached `completed` while we were waiting.
- * - `detached`: the step element was confirmed gone (a successful query
- *   returned zero matches) while we were waiting.
- */
-export type GuidedCommentBoxWaitOutcome = 'ready' | 'completed' | 'detached';
-
-/**
- * Wait for the guided comment box to become visible, bounded by an absolute
- * deadline rather than a fixed short constant. Every locator read inside the
- * loop is itself bounded by the remaining time so a missing/slow locator
- * can't silently consume more than this wait's own budget (e.g. the outer
- * test timeout). Polls step state alongside the comment box so a step that
- * has already entered `error`/`cancelled` fails fast, and returns a distinct
- * outcome for `completed`/detached so the caller can treat those as legitimate
- * step completion rather than "comment box never appeared".
- */
-export async function waitForGuidedCommentBoxReady(
-  page: Page,
-  stepLocator: Locator,
-  commentBox: Locator,
-  timeoutMs = GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS
-): Promise<GuidedCommentBoxWaitOutcome> {
-  const deadline = Date.now() + timeoutMs;
-
-  for (;;) {
-    const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) {
-      throw new Error('Guided step: comment box not visible');
-    }
-
-    if ((await commentBox.count()) > 0 && (await commentBox.isVisible())) {
-      return 'ready';
-    }
-
-    // Check detachment via an immediate, successful count() BEFORE any bounded
-    // attribute read. In real Playwright, getAttribute() on a missing element
-    // auto-waits up to its own timeout, so an already-detached step must be
-    // caught here first or it would burn the full remaining budget for
-    // nothing. A count() error is not caught: it propagates as designed.
-    if ((await stepLocator.count()) === 0) {
-      return 'detached';
-    }
-
-    // Bound this read by the remaining budget so a stuck-but-attached locator
-    // can't exceed this wait's own deadline.
-    let state: string | null;
-    try {
-      state = await stepLocator.getAttribute('data-test-step-state', { timeout: remainingMs });
-    } catch {
-      state = null;
-    }
-
-    if (state === 'completed') {
-      return 'completed';
-    }
-    if (state === 'error') {
-      throw new Error('Guided step entered error state while waiting for comment box');
-    }
-    if (state === 'cancelled') {
-      throw new Error('Guided step was cancelled while waiting for comment box');
-    }
-
-    await page.waitForTimeout(Math.min(GUIDED_SUBSTEP_ADVANCE_POLL_MS, Math.max(1, deadline - Date.now())));
-  }
-}
-
-/**
- * Run the guided substep loop: read comment box contract, perform action, wait for advance.
- * Phase 4: formfill validation, hover dwell, skippable substeps, navigation re-query, error diagnostics.
- */
-export async function runGuidedSubstepLoop(
-  page: Page,
-  step: TestableStep,
-  options: {
-    stepLocator: Locator;
-    perSubstepTimeoutMs: number;
-    /**
-     * Absolute deadline (Date.now()-based epoch ms) bounding the cumulative
-     * comment-box visibility wait across every substep in this loop. Defaults
-     * to `Date.now() + GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS` when omitted.
-     */
-    commentBoxDeadlineMs?: number;
-    verbose?: boolean;
-    artifactsDir?: string;
-  }
-): Promise<{ completed: boolean }> {
-  let stepLocator = options.stepLocator;
-  const { perSubstepTimeoutMs, verbose = false, artifactsDir } = options;
-  const commentBoxDeadlineMs = options.commentBoxDeadlineMs ?? Date.now() + GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS;
-  const guidedStepCount = step.guidedStepCount ?? 1;
-
-  const captureLoopArtifacts = async (context: string) => {
-    if (artifactsDir) {
-      await captureFailureArtifacts(page, step.stepId, [], artifactsDir).catch(() => {});
-    }
-  };
-
-  // Step unmount mid-loop is a completion signal (section auto-collapse, or
-  // navigation unmounted it). Re-resolving the locator handles reload (e.g. a
-  // completeEarly action). A query error is NOT treated as detachment here:
-  // callers already synchronize on navigation before calling this, so a fault
-  // at this point (closed page, destroyed context, unrelated query error)
-  // is a genuine failure and must propagate rather than be reported as success.
-  const stepDetached = async (): Promise<boolean> => {
-    stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
-    return (await stepLocator.count()) === 0;
-  };
-
-  while (true) {
-    if (await stepDetached()) {
-      return { completed: true };
-    }
-
-    const state = await stepLocator.getAttribute('data-test-step-state');
-    if (state === 'completed') {
-      return { completed: true };
-    }
-    if (state === 'error') {
-      await captureLoopArtifacts('error-state');
-      throw new Error('Guided step entered error state');
-    }
-    if (state === 'cancelled') {
-      await captureLoopArtifacts('cancelled-state');
-      throw new Error('Guided step was cancelled');
-    }
-    if (state !== 'executing') {
-      await captureLoopArtifacts(`unexpected-state-${state}`);
-      throw new Error(`Unexpected guided step state: ${state}`);
-    }
-    const indexStr = await stepLocator.getAttribute('data-test-substep-index');
-
-    const currentIndex = indexStr != null ? parseInt(indexStr, 10) : 0;
-    const safeIndex = Number.isNaN(currentIndex) ? 0 : currentIndex;
-    if (safeIndex >= guidedStepCount) {
-      return { completed: false };
-    }
-
-    const commentBox = page.locator('.interactive-comment-box').first();
-    let commentBoxOutcome: GuidedCommentBoxWaitOutcome;
-    try {
-      commentBoxOutcome = await waitForGuidedCommentBoxReady(
-        page,
-        stepLocator,
-        commentBox,
-        Math.max(1, commentBoxDeadlineMs - Date.now())
-      );
-    } catch (err) {
-      await captureLoopArtifacts('comment-box-not-visible');
-      throw err;
-    }
-    if (commentBoxOutcome === 'completed' || commentBoxOutcome === 'detached') {
-      return { completed: true };
-    }
-
-    const action = await commentBox.getAttribute('data-test-action');
-    const reftarget = await commentBox.getAttribute('data-test-reftarget');
-    const targetValue = await commentBox.getAttribute('data-test-target-value');
-
-    if (verbose) {
-      console.log(`   📍 Guided substep ${safeIndex + 1}/${guidedStepCount} action=${action}`);
-    }
-
-    try {
-      if (action === 'noop') {
-        const continueBtn = commentBox.getByRole('button', { name: /Continue/ });
-        await dismissBadgeCelebrations(page);
-        await continueBtn.click();
-      } else if (action === 'button' || action === 'highlight') {
-        if (!reftarget) {
-          throw new Error('Guided step: button/highlight substep missing data-test-reftarget');
-        }
-        const urlBefore = page.url();
-        let navigated = false;
-        const onFrameNavigated = () => {
-          navigated = true;
-        };
-        page.on('framenavigated', onFrameNavigated);
-        try {
-          const target = await resolveGuidedTarget(page, reftarget, action);
-          await target.scrollIntoViewIfNeeded();
-          await dismissBadgeCelebrations(page);
-          await target.click();
-          await page.waitForTimeout(100);
-        } finally {
-          page.off('framenavigated', onFrameNavigated);
-        }
-        if (navigated || urlBefore !== page.url()) {
-          // The action reloaded/navigated the page (e.g. a completeEarly install).
-          // The pre-navigation locator is stale, so wait for the new document to
-          // settle before re-resolving the step locator against it. A failed/timed
-          // out load is a genuine failure (broken reload) and must propagate, not
-          // be swallowed into a false "completed" result.
-          await page.waitForLoadState('domcontentloaded', { timeout: GUIDED_RELOAD_LOAD_TIMEOUT_MS });
-          stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
-        }
-      } else if (action === 'hover') {
-        if (!reftarget) {
-          throw new Error('Guided step: hover substep missing data-test-reftarget');
-        }
-        const target = await resolveGuidedTarget(page, reftarget, 'hover');
-        await target.scrollIntoViewIfNeeded();
-        await dismissBadgeCelebrations(page);
-        await target.hover();
-        await page.waitForTimeout(GUIDED_HOVER_DWELL_MS);
-      } else if (action === 'formfill') {
-        if (!reftarget) {
-          throw new Error('Guided step: formfill substep missing data-test-reftarget');
-        }
-        const target = await resolveGuidedTarget(page, reftarget, 'formfill');
-        await target.scrollIntoViewIfNeeded();
-        await dismissBadgeCelebrations(page);
-        await target.fill(targetValue ?? '');
-        await waitForFormfillSettle(page, stepLocator, target, targetValue ?? '');
-      } else {
-        throw new Error(`Guided step: unknown data-test-action "${action}"`);
-      }
-    } catch (err) {
-      await captureLoopArtifacts(`substep-${safeIndex}-${action}`);
-      throw err;
-    }
-
-    if (await stepDetached()) {
-      return { completed: true };
-    }
-
-    await waitForSubstepAdvance(page, stepLocator, safeIndex, perSubstepTimeoutMs, { commentBox });
-    await page.waitForTimeout(GUIDED_BETWEEN_SUBSTEP_DELAY_MS);
-  }
-}
+export type { GuidedCommentBoxWaitOutcome } from './drivers/guided';
+export {
+  parseNthMatchSelector,
+  runGuidedSubstepLoop,
+  waitForFormfillSettle,
+  waitForGuidedCommentBoxReady,
+  waitForGuidedExecutionStart,
+} from './drivers/guided';
 
 // ============================================
 // Step Execution Functions (L3-3C Enhanced)
@@ -872,70 +241,6 @@ async function buildFailureArtifacts(
 }
 
 /**
- * Click a skippable step's Skip control and wait for the plugin to reach an
- * explicit terminal state — `completed`, or a successful detach — so the
- * next step in a sequential section isn't gated on "Complete previous step".
- * A transient, non-terminal state such as `checking` is not treated as sync;
- * only `completed`/detachment count, so we never mistake mid-flight state
- * for a synchronized skip.
- *
- * Two Skip controls exist in the plugin and both call the same underlying
- * `markSkipped()` action: the step's always-available Skip button (the one
- * `discoverStepsFromDOM` uses to determine `step.skippable`), and the
- * narrower Skip button rendered inside the requirements-explanation banner
- * (surfaced via `detectRequirements().hasSkipButton`). We prefer the general
- * one and fall back to the requirement-scoped one, so we support whichever
- * control the plugin actually rendered instead of assuming a single fixed
- * shape.
- *
- * Throws on any failure (no Skip control found, click error, or a timeout
- * before reaching a terminal state) instead of swallowing it: recording a
- * skip while the plugin never reached `completed`/detached reproduces the
- * exact bug this fixes, so the caller must surface a clear runner failure
- * rather than a false skip.
- *
- * @param page - Playwright Page object
- * @param stepId - The step identifier
- * @param timeout - Maximum time to wait for the terminal state (ms)
- */
-export async function clickSkipButtonAndSync(
-  page: Page,
-  stepId: string,
-  timeout = SKIP_SYNC_TIMEOUT_MS
-): Promise<void> {
-  const stepSkipButton = page.getByTestId(testIds.interactive.skipButton(stepId));
-  const requirementSkipButton = page.getByTestId(testIds.interactive.requirementSkipButton(stepId));
-  const skipButton = (await stepSkipButton.count()) > 0 ? stepSkipButton : requirementSkipButton;
-  if ((await skipButton.count()) === 0) {
-    throw new Error(`Step ${stepId}: no Skip control available to sync the requirements-unmet state`);
-  }
-  await dismissBadgeCelebrations(page);
-  await skipButton.click({ timeout });
-
-  const stepLocator = page.getByTestId(testIds.interactive.step(stepId));
-  const deadline = Date.now() + timeout;
-  for (;;) {
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) {
-      throw new Error(`Step ${stepId}: Skip did not reach a terminal state within ${timeout}ms`);
-    }
-    if ((await stepLocator.count()) === 0) {
-      return;
-    }
-    let state: string | null;
-    try {
-      state = await stepLocator.getAttribute('data-test-step-state', { timeout: remaining });
-    } catch {
-      state = null;
-    }
-    if (state === 'completed') {
-      return;
-    }
-    await page.waitForTimeout(Math.min(GUIDED_SUBSTEP_ADVANCE_POLL_MS, Math.max(1, deadline - Date.now())));
-  }
-}
-
-/**
  * Execute a single step in the guide (L3-3C enhanced).
  *
  * This function implements step execution with proper timing:
@@ -965,7 +270,7 @@ export async function clickSkipButtonAndSync(
  * @param options - Execution options
  * @returns StepTestResult with execution outcome and diagnostics
  */
-export async function executeStep(
+async function executeStepCore(
   page: Page,
   step: TestableStep,
   options: {
@@ -981,6 +286,7 @@ export async function executeStep(
   const calculatedTimeout = calculateStepTimeout(step);
   const { timeout = calculatedTimeout, verbose = false, artifactsDir, alwaysScreenshot = false } = options;
   const startTime = Date.now();
+  const driver = getStepDriver(step.stepKind);
   const consoleErrors: string[] = [];
 
   // Set up console error capture for this step execution
@@ -1072,7 +378,7 @@ export async function executeStep(
         // record the skip once that's confirmed; a sync failure is a clear runner
         // failure rather than a false skip that reproduces the original bug.
         try {
-          await clickSkipButtonAndSync(page, step.stepId);
+          await driver.skip(page, step.stepId);
         } catch (syncError) {
           const syncErrorMsg = syncError instanceof Error ? syncError.message : String(syncError);
           if (verbose) {
@@ -1116,7 +422,7 @@ export async function executeStep(
 
     // L3-3C: Check for objective-based auto-completion BEFORE clicking
     // Objectives may be satisfied by prior actions (e.g., navigation completed the step)
-    const preClickCompleted = await checkObjectiveCompletion(page, step.stepId);
+    const preClickCompleted = await driver.completionState(page, step.stepId);
     if (preClickCompleted) {
       if (verbose) {
         console.log(`   ✓ Step ${step.stepId} auto-completed via objectives before clicking`);
@@ -1144,93 +450,15 @@ export async function executeStep(
       };
     }
 
-    const discoveredAction = selectStepAction(step);
-    let action = await currentStepAction(page, step.stepId);
-    if (!action) {
-      if (verbose) {
-        console.log(`   ⏳ Waiting for a step action to appear...`);
-      }
-      action = await waitForStepActionToAppear(page, step.stepId, discoveredAction ? 1000 : BUTTON_APPEAR_TIMEOUT_MS);
-    }
-    if (!action) {
-      if (await checkObjectiveCompletion(page, step.stepId)) {
-        return {
-          stepId: step.stepId,
-          status: 'passed',
-          durationMs: Date.now() - startTime,
-          currentUrl: page.url(),
-          consoleErrors,
-          skippable: step.skippable,
-          artifacts: await buildSuccessArtifacts(page, step.stepId, artifactsDir, alwaysScreenshot, preScreenshotPath),
-        };
-      }
+    const execution = await driver.execute({ page, step, timeout, verbose, artifactsDir });
+    if (execution.outcome === 'no-control') {
       if (step.skippable) {
         return createSkippedResult(step, page, startTime, consoleErrors, 'no_do_it_button');
       }
       throw new Error(`No executable Do it or Show me control appeared for mandatory step ${step.stepId}`);
     }
-    if (verbose && step.isMultistep) {
-      console.log(
-        `   ⏱ Multistep detected (${step.internalActionCount} actions), timeout: ${Math.round(timeout / 1000)}s`
-      );
-    }
-    await waitForStepActionEnabled(page, step.stepId, action);
-    await dismissBadgeCelebrations(page);
-    await stepActionButton(page, step.stepId, action).click();
 
-    if (verbose) {
-      console.log(`   → Clicked "${action === 'do-it' ? 'Do it' : 'Show me'}" for step ${step.stepId}`);
-    }
-
-    // Allow the reactive system to settle after click (debounced rechecks).
-    await page.waitForTimeout(POST_CLICK_SETTLE_DELAY_MS);
-
-    // Phase 3: Guided step — wait for executing, run substep loop, then wait for completion
-    if (step.isGuided && step.guidedStepCount != null && step.guidedStepCount > 0) {
-      const stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
-      await waitForGuidedExecutionStart(page, stepLocator, GUIDED_WAIT_EXECUTING_MS);
-      const { completed } = await runGuidedSubstepLoop(page, step, {
-        stepLocator,
-        perSubstepTimeoutMs: TIMEOUT_PER_GUIDED_SUBSTEP_MS,
-        // Bound the *cumulative* comment-box readiness wait, across every
-        // substep, by the step's own timeout budget (which already accounts
-        // for guidedStepCount) instead of a fixed 5s re-granted per substep.
-        commentBoxDeadlineMs: Date.now() + timeout,
-        verbose,
-        artifactsDir,
-      });
-      if (!completed) {
-        await waitForCompletionWithObjectivePolling(page, step.stepId, timeout);
-      }
-
-      const guidedArtifacts = await buildSuccessArtifacts(
-        page,
-        step.stepId,
-        artifactsDir,
-        alwaysScreenshot,
-        preScreenshotPath
-      );
-      if (verbose && guidedArtifacts) {
-        console.log(`   📸 Success screenshot captured`);
-      }
-
-      return {
-        stepId: step.stepId,
-        status: 'passed',
-        durationMs: Date.now() - startTime,
-        currentUrl: page.url(),
-        consoleErrors,
-        skippable: step.skippable,
-        artifacts: guidedArtifacts,
-      };
-    }
-
-    // Wait for step completion. A detached element here means the step
-    // completed (section auto-collapsed) or navigation unmounted it; otherwise
-    // poll data-test-step-state. Detects manual and objective-based completion.
-    const { completedViaObjectives } = await waitForCompletionWithObjectivePolling(page, step.stepId, timeout);
-
-    if (verbose && completedViaObjectives) {
+    if (verbose && execution.completedViaObjectives) {
       console.log(`   ℹ Step ${step.stepId} completed quickly (possibly via objectives)`);
     }
 
@@ -1284,6 +512,21 @@ export async function executeStep(
   }
 }
 
+export async function executeStep(
+  page: Page,
+  step: TestableStep,
+  options: {
+    timeout?: number;
+    verbose?: boolean;
+    artifactsDir?: string;
+    alwaysScreenshot?: boolean;
+  } = {}
+): Promise<StepTestResult> {
+  return {
+    ...(await executeStepCore(page, step, options)),
+    stepKind: step.stepKind,
+  };
+}
 /**
  * Execute all discovered steps in sequence (L3-3D enhanced).
  *
@@ -1353,6 +596,7 @@ export async function executeAllSteps(
     if (aborted) {
       results.push({
         stepId: step.stepId,
+        stepKind: step.stepKind,
         status: 'not_reached',
         durationMs: 0,
         currentUrl: page.url(),
@@ -1384,6 +628,7 @@ export async function executeAllSteps(
         for (let j = i; j < steps.length; j++) {
           results.push({
             stepId: steps[j].stepId,
+            stepKind: steps[j].stepKind,
             status: 'not_reached',
             durationMs: 0,
             currentUrl: page.url(),

--- a/tests/e2e-runner/utils/guide-runner/index.ts
+++ b/tests/e2e-runner/utils/guide-runner/index.ts
@@ -13,6 +13,9 @@
 export type {
   TestableStep,
   StepDiscoveryResult,
+  StepContractSource,
+  UnsupportedStepCoverage,
+  StepCoverage,
   StepStatus,
   SkipReason,
   RequirementStatus,
@@ -42,6 +45,8 @@ export {
   LATE_COMPLETION_CHECK_TIMEOUT_MS,
   GUIDED_RELOAD_LOAD_TIMEOUT_MS,
   SKIP_SYNC_TIMEOUT_MS,
+  CURRENT_STEP_SELECTOR,
+  LEGACY_STEP_SELECTOR,
 } from './constants';
 
 // ============================================
@@ -62,7 +67,7 @@ export {
 // ============================================
 // Discovery
 // ============================================
-export { discoverStepsFromDOM, logDiscoveryResults, resolveEffectiveSkippable } from './discovery';
+export { discoverStepsFromDOM, logDiscoveryResults, withExecutedCoverage } from './discovery';
 export { ensureDocsPanelOpen } from './bootstrap';
 export { dismissBadgeCelebrations } from './badge-celebrations';
 
@@ -90,12 +95,8 @@ export {
   determineUnmetRequirementOutcome,
   parseNthMatchSelector,
   selectStepAction,
-  waitForStepCompletion,
-  checkObjectiveCompletion,
-  waitForCompletionWithObjectivePolling,
   waitForGuidedCommentBoxReady,
   runGuidedSubstepLoop,
-  clickSkipButtonAndSync,
   executeStep,
   executeAllSteps,
   logStepResult,
@@ -103,3 +104,4 @@ export {
   skippableFailuresAffectSuccess,
   logExecutionSummary,
 } from './execution';
+export { clickSkipButtonAndSync } from './drivers';

--- a/tests/e2e-runner/utils/guide-runner/requirements.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/requirements.test.ts
@@ -42,6 +42,7 @@ function requirementWaits(waitForTimeout: jest.Mock): number[] {
 
 function createTestableStep(overrides: Partial<TestableStep> = {}): TestableStep {
   return {
+    stepKind: 'plain',
     stepId: STEP_ID,
     index: 0,
     skippable: false,

--- a/tests/e2e-runner/utils/guide-runner/types.ts
+++ b/tests/e2e-runner/utils/guide-runner/types.ts
@@ -9,6 +9,7 @@
  */
 
 import { Locator } from '@playwright/test';
+import type { StepTypeKind } from '../../../../src/components/interactive-tutorial/step-type-registry';
 
 // ============================================
 // Step Types
@@ -24,6 +25,8 @@ import { Locator } from '@playwright/test';
  * - U3: Steps may not be clickable when discovered (sequential dependencies)
  */
 export interface TestableStep {
+  /** Registered driver kind for this step. */
+  stepKind: StepTypeKind;
   /** Unique identifier for the step (extracted from data-testid) */
   stepId: string;
 
@@ -81,11 +84,27 @@ export interface TestableStep {
   locator: Locator;
 }
 
+export type StepContractSource = 'current' | 'legacy';
+
+export interface UnsupportedStepCoverage {
+  stepKind: string;
+  stepId: string;
+}
+
+export interface StepCoverage {
+  contractSource: StepContractSource;
+  rendered: number;
+  supported: number;
+  executed: number;
+  unsupported: number;
+  unsupportedSteps: UnsupportedStepCoverage[];
+}
+
 /**
  * Result of step discovery operation.
  */
 export interface StepDiscoveryResult {
-  /** All discovered steps in DOM order */
+  /** Supported steps in DOM order. */
   steps: TestableStep[];
 
   /** Total count of steps found */
@@ -99,6 +118,9 @@ export interface StepDiscoveryResult {
 
   /** Duration of discovery in milliseconds */
   durationMs: number;
+
+  /** Coverage for every rendered tracked root. */
+  coverage: StepCoverage;
 }
 
 /**
@@ -297,6 +319,9 @@ export type ErrorClassification =
 export interface StepTestResult {
   /** The step identifier */
   stepId: string;
+
+  /** Registered driver kind for this step. */
+  stepKind?: StepTypeKind;
 
   /** Execution outcome */
   status: StepStatus;

--- a/tests/e2e-runner/utils/guide-test-runner.test.ts
+++ b/tests/e2e-runner/utils/guide-test-runner.test.ts
@@ -23,7 +23,6 @@ import {
   logStepResult,
   logExecutionSummary,
   parseNthMatchSelector,
-  resolveEffectiveSkippable,
   selectStepAction,
   DEFAULT_STEP_TIMEOUT_MS,
   GUIDE_INITIAL_TIMEOUT_MS,
@@ -43,6 +42,7 @@ import type { AllStepsResult, StepTestResult, TestableStep } from './guide-runne
  */
 function createTestableStep(overrides: Partial<TestableStep> = {}): TestableStep {
   return {
+    stepKind: overrides.stepKind ?? (overrides.isGuided ? 'guided' : overrides.isMultistep ? 'multistep' : 'plain'),
     stepId: 'test-step-1',
     index: 0,
     skippable: false,
@@ -233,16 +233,6 @@ describe('determineUnmetRequirementOutcome', () => {
 
   it('fails mandatory steps', () => {
     expect(determineUnmetRequirementOutcome(false)).toBe('fail');
-  });
-});
-
-describe('resolveEffectiveSkippable', () => {
-  it('does not make guided steps skippable unless the UI exposes Skip', () => {
-    expect(resolveEffectiveSkippable(false, true)).toBe(false);
-  });
-
-  it('preserves explicit skippability for guided steps', () => {
-    expect(resolveEffectiveSkippable(true, true)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Routes tracked-step discovery and execution through one kind-keyed driver registry. The runner now consumes the https://github.com/grafana/grafana-pathfinder-app/pull/1640 root contract, keeps a badge-safe legacy fallback, and reports optional non-gating coverage for unsupported kinds.

Existing plain, multistep, and guided outcomes, exit codes, skip rules, timeouts, artifacts, and report schema version remain unchanged. Depends on #1640.

## What to look at

- [The driver registry](https://github.com/grafana/grafana-pathfinder-app/blob/ba22ceb6251b9316e929e14470df1c283ac1ca6b/tests/e2e-runner/utils/guide-runner/drivers/registry.ts) is the only owner of tracked-kind branching. Product-specific inspection, controls, execution, skip, completion, and timeout behavior stay behind driver modules.
- [Discovery](https://github.com/grafana/grafana-pathfinder-app/blob/ba22ceb6251b9316e929e14470df1c283ac1ca6b/tests/e2e-runner/utils/guide-runner/discovery.ts) prefers `[data-test-step-kind][data-test-step-id]`, falls back only when current roots are absent, and excludes completed badges from the legacy selector.
- [The report schema](https://github.com/grafana/grafana-pathfinder-app/blob/ba22ceb6251b9316e929e14470df1c283ac1ca6b/src/cli/e2e/schemas/e2e-report.schema.ts) adds optional `stepKind` and per-guide coverage fields without changing schema version or outcome rules.

## Why

https://github.com/grafana/grafana-pathfinder-app/pull/1640 publishes stable kind and test-step identifiers, but the runner still depends on generic test ID prefixes and spreads step-family knowledge across discovery and execution.

Adding more type checks to those phases would increase contract leakage. This registry concentrates that knowledge behind one interface before specialized drivers arrive. Unsupported kinds remain non-gating so the platform can observe coverage during the staged rollout without turning current guide health red.

## How to verify

1. Run a guide that contains plain, multistep, and guided steps. Inspect the report and confirm each step includes its kind.
2. Inspect the coverage object and confirm rendered, supported, executed, and unsupported counts match the visible roots.
3. Run against a plugin build without the https://github.com/grafana/grafana-pathfinder-app/pull/1640 root attributes. Confirm the report records `legacy` and does not discover completed badges as steps.
4. Render a supported step beside an unsupported tracked kind. Confirm the unsupported root appears in coverage without changing the guide outcome.
5. Complete a guided flow and confirm its substep behavior, timeout, navigation handling, and artifacts match the current runner.

## Breaking changes

None. The new report fields are optional and additive. Existing report schema version and outcomes remain unchanged.

## Reversibility

Reverting this PR restores prefix-based discovery and the prior execution layout. No storage, guide content, or external data migration is required.

## Out of scope

- Drivers for quiz, terminal, terminal-connect, codeblock, challenge, and datasource-check are separate PRs.
- Unsupported coverage remains non-gating until the final enforcement PR.
- Guided timeout and authored substep semantics are handled by the next sequential PR.

Co-Authored-By: Warp <agent@warp.dev>
