### PR TITLE
fix(guides): make the welcome tour's Home step work on Grafana 13.2

### DIFF
--- a/src/bundled-interactives/welcome-to-grafana-cloud/content.json
+++ b/src/bundled-interactives/welcome-to-grafana-cloud/content.json
@@ -19,7 +19,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "div[data-testid='data-testid navigation mega-menu'] a[data-testid='data-testid Home breadcrumb']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/'], {grafana:components.NavMenu.Menu} {grafana:components.Breadcrumbs.breadcrumb:Home}",
           "content": "First, let's visit the **Home** page - your starting point in Grafana.",
           "tooltip": "The **Home** page in Grafana Cloud is your central hub. It shows your cloud instance overview, recent activity, and quick access to getting started guides. Perfect *starting point* for your observability journey!",
           "requirements": ["navmenu-open", "exists-reftarget"]
@@ -27,14 +27,14 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/dashboards']",
           "content": "Next, **Dashboards** - where you'll create and manage your visualizations.",
           "tooltip": "In Grafana Cloud, **Dashboards** can display data from multiple cloud services simultaneously. Create `time series` from Prometheus, `logs panels` from Loki, and `traces` from Tempo - all in one view!"
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/explore']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/explore']",
           "content": "Then **Explore** - perfect for ad-hoc queries and data exploration.",
           "tooltip": "**Explore** is your data playground! Query logs with `LogQL`, run `PromQL` queries against metrics, and investigate traces with `TraceQL`. Perfect for troubleshooting and *data discovery*.",
           "skippable": true
@@ -42,14 +42,14 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerts-and-incidents']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/alerts-and-incidents']",
           "content": "**Alerting** - where you'll set up notifications when things go wrong.",
           "tooltip": "Grafana Cloud's **Alerting** system can monitor your metrics, logs, and traces simultaneously. Set up `Slack`, `PagerDuty`, or `email` notifications. Get alerted before your users notice issues!"
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/connections']",
           "content": "You need the Admin role to connect data sources. You can skip this step if you don't have permissions.",
           "tooltip": "Grafana Cloud comes with **pre-configured data sources**! Your `Prometheus`, `Loki`, and `Tempo` instances are already connected. You can also add external sources like `AWS`, `GCP`, or your own infrastructure.",
           "requirements": ["is-admin"],
@@ -59,14 +59,14 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/admin']",
           "content": "Finally, **Administration** - for managing users, plugins, and system settings.",
           "tooltip": "Cloud **Administration** gives you control over team management, `API keys`, usage analytics, and billing. Manage your entire cloud stack from here - *powerful stuff*!"
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/plugins']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/admin/plugins']",
           "content": "Plugins extend Grafana by adding capabilities that are not available by default. For example, you can install plugins that add the ability to import data from diverse sources, that bundle data sources and panels, or that provide new visualization types for use in dashboards.",
           "tooltip": "Plugins and data allows you to extend Grafana's functionality. You can install custom plugins from here.",
           "requirements": ["exists-reftarget"],

--- a/src/bundled-interactives/welcome-to-grafana/content.json
+++ b/src/bundled-interactives/welcome-to-grafana/content.json
@@ -19,22 +19,22 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/']",
-          "requirements": ["navmenu-open"],
+          "reftarget": "{grafana:components.NavMenu.item}[href='/'], {grafana:components.NavMenu.Menu} {grafana:components.Breadcrumbs.breadcrumb:Home}",
+          "requirements": ["navmenu-open", "exists-reftarget"],
           "content": "First, let's visit the **Home** page - your starting point in Grafana.",
           "tooltip": "The **Home** page is your Grafana dashboard. It shows recent dashboards, starred dashboards, and quick access to common tasks. Think of it as your *mission control center*!"
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/dashboards']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/dashboards']",
           "content": "Next, **Dashboards** - where you'll create and manage your visualizations.",
           "tooltip": "**Dashboards** are collections of panels that display your data visualizations. You can create `time series charts`, `bar graphs`, `tables`, and more. Each dashboard can pull data from multiple data sources!"
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/explore']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/explore']",
           "skippable": true,
           "content": "Then **Explore** - perfect for ad-hoc queries and data exploration.",
           "tooltip": "**Explore** is your data investigation tool! Write `PromQL` queries, search logs with `LogQL`, and analyze traces. Perfect for troubleshooting incidents and *exploring your data* without creating dashboards."
@@ -42,14 +42,14 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/alerting']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/alerting']",
           "content": "**Alerting** - where you'll set up notifications when things go wrong.",
           "tooltip": "Set up smart **Alerting** rules that monitor your metrics and logs continuously. Get notified via `email`, `Slack`, `PagerDuty`, or webhooks when thresholds are breached. *Be proactive, not reactive!*"
         },
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/connections']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/connections']",
           "requirements": ["is-admin"],
           "skippable": true,
           "hint": "Connections requires data source permissions to access",
@@ -59,7 +59,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/admin']",
           "skippable": true,
           "content": "Finally, **Administration** - for managing users, plugins, and system settings.",
           "tooltip": "The **Administration** section is your control center. Manage user accounts, install `plugins`, configure `authentication`, monitor system health, and adjust global settings. *Admin power at your fingertips!*"
@@ -67,7 +67,7 @@
         {
           "type": "interactive",
           "action": "highlight",
-          "reftarget": "a[data-testid='data-testid Nav menu item'][href='/admin/plugins']",
+          "reftarget": "{grafana:components.NavMenu.item}[href='/admin/plugins']",
           "requirements": ["exists-reftarget"],
           "skippable": true,
           "content": "Plugins extend Grafana by adding capabilities that are not available by default. For example, you can install plugins that add the ability to import data from diverse sources, that bundle data sources and panels, or that provide new visualization types for use in dashboards.",


### PR DESCRIPTION
## Summary

Grafana 13.2 removed **Home** from the mega-menu. The welcome tour's first step targeted `a[data-testid='data-testid Nav menu item'][href='/']`, which now resolves to **zero elements**, so "Do it" never completed and `welcome-journey.spec.ts` failed on the `13.2.0` e2e leg.

This is a pre-existing break on `main`, not a regression from any open PR — `main` fails the identical test on the identical leg (run `32120756741`, job `95661558561`), all three retries, on both branches. `13.2.0` simply entered the matrix when the release landed.

## The awkward part

The two versions disagree about *what Home is*, so **neither selector alone spans the supported range**. Measured against real containers:

| | Home as nav menu item | Home breadcrumb inside mega-menu |
|:--|:--:|:--:|
| 12.3.10 | ✅ 1 match | ❌ 0 (breadcrumb is in the page header, outside the menu) |
| 13.2.0 | ❌ 0 matches | ✅ 1 match |

`welcome-to-grafana` used the first form; `welcome-to-grafana-cloud` already used the second — so the two guides had mirror-image versions of the same bug.

The step now accepts **either**, via a selector list:

```
{grafana:components.NavMenu.item}[href='/'], {grafana:components.NavMenu.Menu} {grafana:components.Breadcrumbs.breadcrumb:Home}
```

plus `exists-reftarget` alongside `navmenu-open`, so a future removal degrades instead of stalling on a dead target.

## Why tokens

Every nav selector in both guides moves from a hardcoded `data-testid` string to a `{grafana:...}` e2e-selector token. These resolve through `@grafana/e2e-selectors` **against the running Grafana's own selector set**, so a rename in core is picked up rather than silently resolving to zero elements — which is exactly how this bug reached us. `components.Breadcrumbs.breadcrumb('Home')` and `components.NavMenu.item` both resolve identically on 12.3.10, 13.1.3, and 13.2.0, so the tokens are safe across the whole `grafanaDependency` range.

Worth noting for anyone reading the 13.2 selector set: `NavMenu.sectionToggleButton` and `NavToolbar.quickAddButton` are new in 13.2. `#mega-menu-toggle` **does** still exist — it only renders while the menu is undocked, which is unchanged behaviour and not part of this bug.

## How to verify

Local containers, plugin volume-mounted:

```bash
GRAFANA_IMAGE=grafana-enterprise GRAFANA_VERSION=13.2.0 docker compose up -d --build grafana
npx playwright test tests/welcome-journey.spec.ts
```

Results with this change:

| Version | `welcome-journey.spec.ts` |
|:--|:--|
| 12.3.10 | ✅ 2 passed |
| 13.1.3 | ✅ 2 passed |
| 13.2.0 | ✅ 2 passed |

Full Playwright suite on 13.2.0: **18 passed, 5 skipped, 0 failed** (CI's red run was 17 passed, 5 skipped, 1 failed).

`npm run check` passes (exit 0, no new lint warnings). `npm run repository:check` is clean — `repository.json` carries package metadata only, so no regeneration was needed.

I checked the reverse direction too: the breadcrumb-only selector (the cloud guide's existing shape) **fails** on 12.3.10 with `"Do it" button not found`, which is why this landed as a selector list rather than adopting the cloud form wholesale.

## Breaking changes

None. Guide content only — no schema, storage, or API change.

## Reversibility

Fully reversible; two JSON files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
