### PR TITLE
fix(e2e): Carry locations across guide chains

### DIFF
--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -321,6 +321,10 @@ Before running, the CLI builds an execution plan from a `repository.json` index 
 - Missing milestones, incompatible targets, and cycles crossing `depends` and `milestones` fail before Grafana provisioning or Playwright execution.
 - The metapackage cover `content.json` is not executed; only leaf guides are sent to Playwright.
 
+After a guide passes, the runner carries its final passed step location to the next guide in that chain. The location includes its path, query, and fragment. It must use the same origin as the Grafana target.
+
+An explicit manifest `startingLocation` always takes precedence. A failed guide, a skipped final step, an unsafe final URL, or a zero-step guide does not replace the carried location. Each new chain starts without a carried location, so omitted metadata falls back to `/`.
+
 This ordering applies to every run. `--clean` additionally isolates each chain in its own environment (see below).
 
 ## Clean-slate runs (`--clean`)
@@ -473,7 +477,7 @@ These variables are consumed by the CLI or passed to the spawned Playwright proc
 | ----------------------- | ------------------------------------------------------------------------------ | ----------------------- |
 | `GUIDE_JSON_PATH`       | Path to JSON guide file                                                        | Required                |
 | `GRAFANA_URL`           | Grafana instance URL                                                           | `http://localhost:3000` |
-| `STARTING_LOCATION`     | Same-origin path where the guide should begin (set from manifest or `/`)       | `/`                     |
+| `STARTING_LOCATION`     | Effective same-origin start path from the manifest, current chain, or `/`      | `/`                     |
 | `AUTH_STATE_FILE`       | Per-guide Playwright storage-state path for form-login auth                    | Temporary CLI path      |
 | `E2E_VERBOSE`           | Enable verbose logging                                                         | `false`                 |
 | `E2E_TRACE`             | Generate Playwright trace file                                                 | `false`                 |

--- a/src/cli/commands/build-repository.ts
+++ b/src/cli/commands/build-repository.ts
@@ -17,6 +17,7 @@ import type { RepositoryEntry, RepositoryJson } from '../../types/package.types'
 // refinement (ManifestJsonSchema) for strict correctness checking.
 import { ContentJsonSchema, ManifestJsonObjectSchema, RepositoryJsonSchema } from '../../types/package.schema';
 import { readJsonFile } from '../../validation/package-io';
+import { preserveAuthoredStartingLocation } from '../e2e/starting-location';
 import { resolveCliPath } from '../utils/file-loader';
 import { formatJsonWithPrettier } from '../utils/output';
 
@@ -128,7 +129,7 @@ function readPackage(root: string, packageDir: string): PackageReadResult {
       return { id, dirName, entry, warnings, errors };
     }
 
-    const manifest = manifestRead.data;
+    const manifest = preserveAuthoredStartingLocation(manifestRead.parsed, manifestRead.data);
 
     if (manifest.id !== id) {
       errors.push(`ID mismatch: content.json has "${id}", manifest.json has "${manifest.id}"`);
@@ -138,7 +139,9 @@ function readPackage(root: string, packageDir: string): PackageReadResult {
     entry.description = manifest.description;
     entry.category = manifest.category;
     entry.author = manifest.author;
-    entry.startingLocation = manifest.startingLocation;
+    if (manifest.startingLocation !== undefined) {
+      entry.startingLocation = manifest.startingLocation;
+    }
     entry.milestones = manifest.milestones;
     entry.depends = manifest.depends?.length ? manifest.depends : undefined;
     entry.recommends = manifest.recommends?.length ? manifest.recommends : undefined;

--- a/src/cli/commands/e2e.ts
+++ b/src/cli/commands/e2e.ts
@@ -75,6 +75,11 @@ import {
   type CloudStackPoolManagerConfig,
 } from '../e2e/cloud-stack-pool-manager';
 import { assertTierHomogeneousChains, preflightTargetUrlsForPlan } from '../e2e/preflight-targets';
+import { createStartingLocationTracker } from '../e2e/starting-location';
+import {
+  applyLocalManifestStartingLocation,
+  applyLocalRepositoryStartingLocations,
+} from '../e2e/local-starting-location';
 
 /**
  * CLI options for the e2e command
@@ -690,6 +695,7 @@ async function runChains(
     }
     let provisionedTargets: Awaited<ReturnType<typeof provisionCloudTargetsForChain>>;
     let chainHadFailure = false;
+    const startingLocations = createStartingLocationTracker();
     try {
       provisionedTargets = await provisionCloudTargetsForChain({
         targetUrls: cloudTargetsInChain(chain, packageMetaById, cloudAuth),
@@ -763,7 +769,7 @@ async function runChains(
         const targetUrl = provisionedTargets.targetUrlForGuide(planned.id, meta?.targetUrl ?? options.grafanaUrl);
         const runGuideOptions: RunGuideOptions = {
           targetUrl,
-          startingLocation: meta?.startingLocation ?? '/',
+          startingLocation: startingLocations.select(meta?.startingLocation),
           verbose: options.verbose,
           trace: options.trace,
           headed: options.headed,
@@ -817,6 +823,7 @@ async function runChains(
         } else {
           console.log(`   ✅ Test passed`);
         }
+        startingLocations.record(result.success, result.resultsData, targetUrl);
 
         if (result.traceFile && options.trace) {
           console.log(`   📊 Trace file: ${result.traceFile}`);
@@ -898,10 +905,20 @@ function resolveLocalRunInputs(files: string[], options: E2ECommandOptions): Run
       throw error;
     }
   }
+  let repoSource: LocalRepositorySource;
+  try {
+    repoSource = loadLocalRepositorySource(options.repository);
+  } catch (error) {
+    throw new E2ECommandError(
+      error instanceof Error ? error.message : 'Failed to load repository index.',
+      ExitCode.CONFIGURATION_ERROR
+    );
+  }
 
   return {
     mode: 'local',
     guides: resolveValidGuides(files, options),
+    repoSource,
     preRunSkipped: [],
     packageMetaById: new Map(),
     localPackageDir: options.package,
@@ -1061,6 +1078,9 @@ export const e2eCommand = new Command('e2e')
       printRunConfiguration(inputs.guides, options, inputs.mode);
 
       const plan = inputs.executionPlan ?? buildExecutionPlan(inputs.guides, options, inputs.repoSource);
+      if (inputs.mode === 'local' && inputs.repoSource) {
+        applyLocalRepositoryStartingLocations(plan, inputs.repoSource, inputs.packageMetaById);
+      }
       assertTierHomogeneousChains(plan, inputs.packageMetaById);
 
       await maybeCleanStart(cleanEnv, options);
@@ -1082,10 +1102,7 @@ export const e2eCommand = new Command('e2e')
         inputs.localPackageDir
       );
       if (localManifest) {
-        inputs.packageMetaById.set(localManifest.id, {
-          packageId: localManifest.id,
-          startingLocation: localManifest.startingLocation ?? '/',
-        });
+        applyLocalManifestStartingLocation(localManifest, inputs.packageMetaById);
       }
 
       const outcome = await runChains(

--- a/src/cli/e2e/e2e-local-package.test.ts
+++ b/src/cli/e2e/e2e-local-package.test.ts
@@ -45,6 +45,28 @@ describe('local metapackage input resolution', () => {
     consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
   });
 
+  it('preserves an explicit milestone starting location', () => {
+    const repository = join(root, 'repository.json');
+    writeJson(repository, {
+      'coverless-path': {
+        path: 'path/',
+        type: 'path',
+        milestones: ['coverless-step'],
+        testEnvironment: { tier: 'local' },
+      },
+      'coverless-step': {
+        path: 'step/',
+        type: 'guide',
+        startingLocation: '/connections',
+        testEnvironment: { tier: 'local' },
+      },
+    });
+
+    const inputs = resolveLocalMetapackage(options(root, repository))!;
+
+    expect(inputs.packageMetaById.get('coverless-step')?.startingLocation).toBe('/connections');
+  });
+
   afterEach(() => {
     consoleSpy.mockRestore();
     rmSync(root, { recursive: true, force: true });
@@ -72,6 +94,7 @@ describe('local metapackage input resolution', () => {
     expect(inputs.guides).toHaveLength(1);
     expect(JSON.parse(inputs.guides[0]!.content).id).toBe('coverless-step');
     expect(inputs.executionPlan?.chains[0]?.map((guide) => guide.id)).toEqual(['coverless-step']);
+    expect(inputs.packageMetaById.get('coverless-step')?.startingLocation).toBeUndefined();
   });
 
   it('makes the root non-runnable when its own target is incompatible with the environment', () => {

--- a/src/cli/e2e/e2e-local-package.ts
+++ b/src/cli/e2e/e2e-local-package.ts
@@ -213,7 +213,7 @@ export function resolveLocalMetapackage(options: LocalMetapackageOptions): Local
         instance: target.instance,
         targetUrl: target.targetUrl!,
         sourceUrl: planned.guide.path,
-        startingLocation: entry?.startingLocation ?? '/',
+        ...(entry?.startingLocation !== undefined ? { startingLocation: entry.startingLocation } : {}),
         sideEffects: classifyGuideSideEffectsFromString(planned.guide.content),
         ...(entry?.testEnvironment?.plugins?.length ? { plugins: entry.testEnvironment.plugins } : {}),
       });

--- a/src/cli/e2e/e2e-package.test.ts
+++ b/src/cli/e2e/e2e-package.test.ts
@@ -97,7 +97,7 @@ describe('resolveRemotePackage (single, recommender)', () => {
         id: 'alerting-101',
         path: 'alerting-101/',
         type: 'guide',
-        startingLocation: '/alerting',
+        startingLocation: '/repository-location',
         testEnvironment: { tier: 'local' },
       },
     ]);
@@ -121,6 +121,35 @@ describe('resolveRemotePackage (single, recommender)', () => {
     expect(result.runnable[0]!.guide.content).toBe(
       '{"id":"alerting-101","title":"Alerting","blocks":[{"type":"markdown","content":"Read this"}]}'
     );
+  });
+
+  it('preserves an omitted starting location for chain handoff', async () => {
+    mockResolve({
+      ok: true,
+      id: 'chain-guide',
+      contentUrl: 'https://cdn.test/chain-guide/content.json',
+      manifestUrl: 'https://cdn.test/chain-guide/manifest.json',
+      repository: 'r',
+      manifest: {
+        id: 'chain-guide',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+    });
+    mockIndex([
+      {
+        id: 'chain-guide',
+        path: 'chain-guide/',
+        type: 'guide',
+        testEnvironment: { tier: 'local' },
+      },
+    ]);
+    mockFetch({ ok: true, text: '{"id":"chain-guide"}' });
+
+    const result = await resolveRemotePackage('chain-guide', OPTIONS);
+
+    expect(result.skipped).toHaveLength(0);
+    expect(result.runnable[0]?.startingLocation).toBeUndefined();
   });
 
   it('maps a recommender failure to resolution_failed', async () => {

--- a/src/cli/e2e/e2e-package.ts
+++ b/src/cli/e2e/e2e-package.ts
@@ -58,7 +58,7 @@ export interface ResolvedRemoteGuide {
   targetUrl: string;
   /** The content.json URL the guide was fetched from. */
   sourceUrl: string;
-  startingLocation: string;
+  startingLocation?: string;
   /** Conservative side-effect classification for the fetched content. */
   sideEffects: SideEffectClassification;
   /** Plugin IDs required by this guide, from testEnvironment.plugins. */
@@ -169,19 +169,21 @@ async function buildGuideOrSkip(
     };
   }
 
-  let resolvedStartingLocation: string;
-  try {
-    resolvedStartingLocation = resolveStartingPath(target.targetUrl!, startingLocation);
-  } catch (error) {
-    return {
-      skipped: {
-        id,
-        reason: 'validation_failed',
-        message: `Invalid startingLocation: ${error instanceof Error ? error.message : 'unknown error'}`,
-        sourceUrl: contentUrl,
-        tier: target.tier,
-      },
-    };
+  let resolvedStartingLocation: string | undefined;
+  if (startingLocation !== undefined) {
+    try {
+      resolvedStartingLocation = resolveStartingPath(target.targetUrl!, startingLocation);
+    } catch (error) {
+      return {
+        skipped: {
+          id,
+          reason: 'validation_failed',
+          message: `Invalid startingLocation: ${error instanceof Error ? error.message : 'unknown error'}`,
+          sourceUrl: contentUrl,
+          tier: target.tier,
+        },
+      };
+    }
   }
 
   const fetched = await fetchText(contentUrl);
@@ -231,7 +233,7 @@ async function buildGuideOrSkip(
       instance: target.instance,
       targetUrl: target.targetUrl!,
       sourceUrl: contentUrl,
-      startingLocation: resolvedStartingLocation,
+      ...(resolvedStartingLocation !== undefined ? { startingLocation: resolvedStartingLocation } : {}),
       sideEffects,
       ...(testEnvironment.plugins?.length ? { plugins: testEnvironment.plugins } : {}),
     },

--- a/src/cli/e2e/e2e-results.test.ts
+++ b/src/cli/e2e/e2e-results.test.ts
@@ -185,6 +185,36 @@ describe('applyPackageMeta', () => {
 
     expect(() => applyPackageMeta(undefined, { packageId: 'a' })).not.toThrow();
   });
+
+  it('preserves the effective report starting location when package metadata omits it', () => {
+    const data = reportData();
+    data.guide.startingLocation = '/connections/datasources/edit/uid?tab=settings#details';
+
+    applyPackageMeta(data, {
+      packageId: 'a',
+      tier: 'local',
+      sourceUrl: 'https://cdn.test/a/content.json',
+    });
+
+    expect(data.guide.startingLocation).toBe('/connections/datasources/edit/uid?tab=settings#details');
+  });
+
+  it.each([
+    ['connections?tab=x#details', '/connections?tab=x#details'],
+    ['http://localhost:3000/connections?tab=x#details', '/connections?tab=x#details'],
+  ])('preserves the normalized runner path for authored location %s', (authored, normalized) => {
+    const data = reportData();
+    data.guide.startingLocation = normalized;
+
+    applyPackageMeta(data, {
+      packageId: 'a',
+      tier: 'local',
+      sourceUrl: 'https://cdn.test/a/content.json',
+      startingLocation: authored,
+    });
+
+    expect(data.guide.startingLocation).toBe(normalized);
+  });
 });
 
 describe('provisioningFailureResults', () => {

--- a/src/cli/e2e/e2e-results.ts
+++ b/src/cli/e2e/e2e-results.ts
@@ -178,13 +178,14 @@ export function applyPackageMeta(data: TestResultsData | undefined, meta: Packag
   if (!data || !meta) {
     return;
   }
+  const startingLocation = data.guide.startingLocation ?? meta.startingLocation;
   data.guide = {
     ...data.guide,
     packageId: meta.packageId,
     tier: meta.tier,
     instance: meta.instance,
     sourceUrl: meta.sourceUrl,
-    startingLocation: meta.startingLocation,
+    ...(startingLocation !== undefined ? { startingLocation } : {}),
     sideEffects: meta.sideEffects,
   };
 }

--- a/src/cli/e2e/local-starting-location.test.ts
+++ b/src/cli/e2e/local-starting-location.test.ts
@@ -1,0 +1,111 @@
+import type { RepositoryJson } from '../../types/package.types';
+import type { LocalRepositorySource } from './e2e-local-package';
+import type { PackageMeta } from './e2e-results';
+import type { ExecutionPlan } from './guide-chains';
+import { applyLocalManifestStartingLocation, applyLocalRepositoryStartingLocations } from './local-starting-location';
+import { createStartingLocationTracker } from './starting-location';
+
+function plan(...guides: Array<{ id: string; path: string }>): ExecutionPlan {
+  return {
+    chains: [
+      guides.map(({ id, path }) => ({
+        id,
+        guide: { path, content: JSON.stringify({ id }) },
+        dependencies: [],
+        autoIncluded: false,
+      })),
+    ],
+    autoIncludedIds: [],
+    errors: [],
+  };
+}
+
+function repoSource(repository: RepositoryJson): LocalRepositorySource {
+  return {
+    repository,
+    loadGuideById(id, entry) {
+      return { path: `/repo/${entry.path}content.json`, content: JSON.stringify({ id }) };
+    },
+  };
+}
+
+function trackerWithCarry() {
+  const tracker = createStartingLocationTracker();
+  tracker.record(
+    true,
+    {
+      guide: { id: 'first', title: 'First', path: '/repo/first/content.json' },
+      timestamp: '2026-01-01T00:00:00.000Z',
+      results: [
+        {
+          stepId: 'final',
+          status: 'passed',
+          durationMs: 1,
+          currentUrl: 'http://localhost:3000/carried?tab=query#editor',
+          consoleErrors: [],
+          skippable: false,
+        },
+      ],
+      aborted: false,
+    },
+    'http://localhost:3000'
+  );
+  return tracker;
+}
+
+describe('applyLocalRepositoryStartingLocations', () => {
+  it('makes bundled explicit starts win while omitted starts inherit', () => {
+    const repository: RepositoryJson = {
+      explicit: { path: 'explicit/', type: 'guide', startingLocation: '/connections' },
+      root: { path: 'root/', type: 'guide', startingLocation: '/' },
+      omitted: { path: 'omitted/', type: 'guide' },
+    };
+    const metadata = new Map<string, PackageMeta>();
+
+    applyLocalRepositoryStartingLocations(
+      plan(
+        { id: 'explicit', path: '/repo/explicit/content.json' },
+        { id: 'root', path: '/repo/root/content.json' },
+        { id: 'omitted', path: '/repo/omitted/content.json' }
+      ),
+      repoSource(repository),
+      metadata
+    );
+    const tracker = trackerWithCarry();
+
+    expect(tracker.select(metadata.get('explicit')?.startingLocation)).toBe('/connections');
+    expect(tracker.select(metadata.get('root')?.startingLocation)).toBe('/');
+    expect(tracker.select(metadata.get('omitted')?.startingLocation)).toBe('/carried?tab=query#editor');
+  });
+
+  it('does not apply bundled metadata to an unrelated local file with the same id', () => {
+    const repository: RepositoryJson = {
+      shared: { path: 'shared/', type: 'guide', startingLocation: '/bundled-start' },
+    };
+    const metadata = new Map<string, PackageMeta>();
+
+    applyLocalRepositoryStartingLocations(
+      plan({ id: 'shared', path: '/workspace/local-guide.json' }),
+      repoSource(repository),
+      metadata
+    );
+
+    expect(metadata.get('shared')).toBeUndefined();
+  });
+});
+
+describe('applyLocalManifestStartingLocation', () => {
+  it.each(['/local-start', '/'] as const)('makes local manifest location %s win over carried state', (explicit) => {
+    const metadata = new Map<string, PackageMeta>();
+    applyLocalManifestStartingLocation({ id: 'local-guide', startingLocation: explicit }, metadata);
+
+    expect(trackerWithCarry().select(metadata.get('local-guide')?.startingLocation)).toBe(explicit);
+  });
+
+  it('lets an omitted local manifest location inherit carried state', () => {
+    const metadata = new Map<string, PackageMeta>();
+    applyLocalManifestStartingLocation({ id: 'local-guide' }, metadata);
+
+    expect(trackerWithCarry().select(metadata.get('local-guide')?.startingLocation)).toBe('/carried?tab=query#editor');
+  });
+});

--- a/src/cli/e2e/local-starting-location.ts
+++ b/src/cli/e2e/local-starting-location.ts
@@ -1,0 +1,44 @@
+import { resolveCliPath } from '../utils/file-loader';
+import type { ManifestJson } from '../../types/package.types';
+import type { LocalRepositorySource } from './e2e-local-package';
+import type { PackageMeta } from './e2e-results';
+import type { ExecutionPlan } from './guide-chains';
+
+function sameGuideFile(left: string, right: string): boolean {
+  return resolveCliPath(left) === resolveCliPath(right);
+}
+
+export function applyLocalRepositoryStartingLocations(
+  plan: ExecutionPlan,
+  repoSource: LocalRepositorySource,
+  packageMetaById: Map<string, PackageMeta>
+): void {
+  for (const planned of plan.chains.flat()) {
+    const entry = repoSource.repository[planned.id];
+    if (entry?.startingLocation === undefined) {
+      continue;
+    }
+    const repositoryGuide = repoSource.loadGuideById(planned.id, entry);
+    if (!repositoryGuide || !sameGuideFile(repositoryGuide.path, planned.guide.path)) {
+      continue;
+    }
+    const current = packageMetaById.get(planned.id);
+    packageMetaById.set(planned.id, {
+      ...current,
+      packageId: current?.packageId ?? planned.id,
+      startingLocation: entry.startingLocation,
+    });
+  }
+}
+
+export function applyLocalManifestStartingLocation(
+  manifest: Pick<ManifestJson, 'id' | 'startingLocation'>,
+  packageMetaById: Map<string, PackageMeta>
+): void {
+  const current = packageMetaById.get(manifest.id);
+  packageMetaById.set(manifest.id, {
+    ...current,
+    packageId: manifest.id,
+    ...(manifest.startingLocation !== undefined ? { startingLocation: manifest.startingLocation } : {}),
+  });
+}

--- a/src/cli/e2e/manifest-preflight.ts
+++ b/src/cli/e2e/manifest-preflight.ts
@@ -14,6 +14,7 @@ import { join } from 'path';
 
 import { ManifestJsonSchema } from '../../types/package.schema';
 import type { ManifestJson, TestEnvironment } from '../../types/package.types';
+import { preserveAuthoredStartingLocation } from './starting-location';
 
 // ============ RESULT TYPES ============
 
@@ -330,7 +331,7 @@ export function loadManifestFromDir(packageDir: string): ManifestJson | null {
   if (!result.success) {
     throw new Error(`Invalid manifest.json in ${packageDir}: ${result.error.issues.map((i) => i.message).join('; ')}`);
   }
-  return result.data as ManifestJson;
+  return preserveAuthoredStartingLocation(parsed, result.data) as ManifestJson;
 }
 
 // ============ ORCHESTRATION ============

--- a/src/cli/e2e/recommender-resolver.test.ts
+++ b/src/cli/e2e/recommender-resolver.test.ts
@@ -59,6 +59,7 @@ describe('resolvePackageById', () => {
     });
     expect(res.ok && res.manifest?.type).toBe('guide');
     expect(res.ok && res.manifest?.testEnvironment?.tier).toBe('local');
+    expect(res.ok && res.manifest?.startingLocation).toBeUndefined();
   });
 
   it('maps a 404 from the resolver to a failure', async () => {

--- a/src/cli/e2e/recommender-resolver.ts
+++ b/src/cli/e2e/recommender-resolver.ts
@@ -14,6 +14,7 @@
 
 import { ManifestJsonObjectSchema } from '../../types/package.schema';
 import type { ManifestJson } from '../../types/package.types';
+import { preserveAuthoredStartingLocation } from './starting-location';
 
 const FETCH_TIMEOUT_MS = 15_000;
 
@@ -102,5 +103,5 @@ async function fetchManifest(manifestUrl: string): Promise<ManifestJson | undefi
     return undefined;
   }
   const parsed = ManifestJsonObjectSchema.loose().safeParse(raw);
-  return parsed.success ? (parsed.data as ManifestJson) : undefined;
+  return parsed.success ? (preserveAuthoredStartingLocation(raw, parsed.data) as ManifestJson) : undefined;
 }

--- a/src/cli/e2e/starting-location.test.ts
+++ b/src/cli/e2e/starting-location.test.ts
@@ -1,0 +1,98 @@
+import type { TestResultsData, TestStepResult } from './e2e-reporter';
+import { createStartingLocationTracker, finalSuccessfulStartingLocation } from './starting-location';
+
+function result(currentUrl: string, status: TestStepResult['status'] = 'passed'): TestResultsData {
+  return {
+    guide: { id: 'guide', title: 'Guide', path: 'guide/content.json', targetUrl: 'http://localhost:3000' },
+    timestamp: '2026-01-01T00:00:00.000Z',
+    results: [
+      {
+        stepId: 'final-step',
+        status,
+        durationMs: 1,
+        currentUrl,
+        consoleErrors: [],
+        skippable: false,
+      },
+    ],
+    aborted: false,
+  };
+}
+
+describe('finalSuccessfulStartingLocation', () => {
+  it('returns the final same-origin path with its query and fragment', () => {
+    expect(
+      finalSuccessfulStartingLocation(
+        result('http://localhost:3000/connections/datasources/edit/uid?tab=settings#details'),
+        'http://localhost:3000'
+      )
+    ).toBe('/connections/datasources/edit/uid?tab=settings#details');
+  });
+
+  it.each(['failed', 'skipped', 'not_reached'] as const)('rejects a final %s step', (status) => {
+    expect(
+      finalSuccessfulStartingLocation(result('http://localhost:3000/ignored', status), 'http://localhost:3000')
+    ).toBeUndefined();
+  });
+
+  it.each(['https://example.com/connections', 'not a URL', 'javascript:alert(1)'])(
+    'rejects an unsafe or malformed final URL: %s',
+    (currentUrl) => {
+      expect(finalSuccessfulStartingLocation(result(currentUrl), 'http://localhost:3000')).toBeUndefined();
+    }
+  );
+
+  it('rejects a report without step results', () => {
+    const data = result('http://localhost:3000/');
+    data.results = [];
+
+    expect(finalSuccessfulStartingLocation(data, 'http://localhost:3000')).toBeUndefined();
+  });
+});
+
+describe('createStartingLocationTracker', () => {
+  it('selects root before a location is carried', () => {
+    expect(createStartingLocationTracker().select(undefined)).toBe('/');
+  });
+
+  it('carries a successful final location with its query and fragment', () => {
+    const tracker = createStartingLocationTracker();
+
+    tracker.record(true, result('http://localhost:3000/carried?tab=query#editor'), 'http://localhost:3000');
+
+    expect(tracker.select(undefined)).toBe('/carried?tab=query#editor');
+  });
+
+  it.each(['/explicit-start', '/'] as const)('gives explicit location %s precedence over carried state', (explicit) => {
+    const tracker = createStartingLocationTracker();
+    tracker.record(true, result('http://localhost:3000/carried'), 'http://localhost:3000');
+
+    expect(tracker.select(explicit)).toBe(explicit);
+  });
+
+  it('does not carry a location from a failed guide', () => {
+    const tracker = createStartingLocationTracker();
+
+    tracker.record(false, result('http://localhost:3000/failed-guide-location'), 'http://localhost:3000');
+
+    expect(tracker.select(undefined)).toBe('/');
+  });
+
+  it('retains the carried location after a successful zero-step guide', () => {
+    const tracker = createStartingLocationTracker();
+    tracker.record(true, result('http://localhost:3000/carried'), 'http://localhost:3000');
+    const emptyResult = result('http://localhost:3000/');
+    emptyResult.results = [];
+
+    tracker.record(true, emptyResult, 'http://localhost:3000');
+
+    expect(tracker.select(undefined)).toBe('/carried');
+  });
+
+  it('resets carried state when a new tracker is created', () => {
+    const firstChain = createStartingLocationTracker();
+    firstChain.record(true, result('http://localhost:3000/first-chain-finish'), 'http://localhost:3000');
+
+    expect(createStartingLocationTracker().select(undefined)).toBe('/');
+  });
+});

--- a/src/cli/e2e/starting-location.ts
+++ b/src/cli/e2e/starting-location.ts
@@ -1,3 +1,14 @@
+import type { TestResultsData } from './e2e-reporter';
+
+export function preserveAuthoredStartingLocation<T extends { startingLocation?: string }>(raw: unknown, parsed: T): T {
+  if (typeof raw === 'object' && raw !== null && Object.prototype.hasOwnProperty.call(raw, 'startingLocation')) {
+    return parsed;
+  }
+
+  const preserved = { ...parsed };
+  delete preserved.startingLocation;
+  return preserved;
+}
 export function resolveStartingUrl(targetUrl: string, startingLocation: string): string {
   const target = new URL(targetUrl);
   const resolved = new URL(startingLocation || '/', target);
@@ -13,4 +24,54 @@ export function resolveStartingUrl(targetUrl: string, startingLocation: string):
 export function resolveStartingPath(targetUrl: string, startingLocation: string | undefined): string {
   const resolved = new URL(resolveStartingUrl(targetUrl, startingLocation ?? '/'));
   return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+}
+
+export function finalSuccessfulStartingLocation(
+  data: TestResultsData | undefined,
+  targetUrl: string
+): string | undefined {
+  const results = data?.results;
+  const finalStep = results?.[results.length - 1];
+  if (!finalStep || finalStep.status !== 'passed') {
+    return undefined;
+  }
+
+  try {
+    const target = new URL(targetUrl);
+    const current = new URL(finalStep.currentUrl);
+    if (
+      (target.protocol !== 'http:' && target.protocol !== 'https:') ||
+      (current.protocol !== 'http:' && current.protocol !== 'https:') ||
+      current.origin !== target.origin
+    ) {
+      return undefined;
+    }
+    return `${current.pathname}${current.search}${current.hash}`;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface StartingLocationTracker {
+  select: (explicitLocation: string | undefined) => string;
+  record: (success: boolean, data: TestResultsData | undefined, targetUrl: string) => void;
+}
+
+export function createStartingLocationTracker(): StartingLocationTracker {
+  let carriedLocation: string | undefined;
+
+  return {
+    select(explicitLocation) {
+      return explicitLocation ?? carriedLocation ?? '/';
+    },
+    record(success, data, targetUrl) {
+      if (!success) {
+        return;
+      }
+      const finalLocation = finalSuccessfulStartingLocation(data, targetUrl);
+      if (finalLocation !== undefined) {
+        carriedLocation = finalLocation;
+      }
+    },
+  };
 }

--- a/src/validation/build-repository.test.ts
+++ b/src/validation/build-repository.test.ts
@@ -125,6 +125,31 @@ describe('buildRepository', () => {
     expect(entry!.replaces).toEqual(['legacy-test']);
   });
 
+  it('preserves omitted and explicit root starting locations', () => {
+    for (const id of ['omitted-location', 'explicit-root']) {
+      writeJson(path.join(tmpDir, id, 'content.json'), {
+        id,
+        title: id,
+        blocks: [],
+      });
+    }
+    writeJson(path.join(tmpDir, 'omitted-location', 'manifest.json'), {
+      id: 'omitted-location',
+      type: 'guide',
+    });
+    writeJson(path.join(tmpDir, 'explicit-root', 'manifest.json'), {
+      id: 'explicit-root',
+      type: 'guide',
+      startingLocation: '/',
+    });
+
+    const { repository, errors } = buildRepository(tmpDir);
+
+    expect(errors).toHaveLength(0);
+    expect(repository['omitted-location']).not.toHaveProperty('startingLocation');
+    expect(repository['explicit-root']?.startingLocation).toBe('/');
+  });
+
   it('should error on ID mismatch between content and manifest', () => {
     writeJson(path.join(tmpDir, 'mismatched', 'content.json'), {
       id: 'content-id',


### PR DESCRIPTION
## Summary

The E2E CLI now carries a guide’s final successful same-origin location to the next guide in its dependency chain. 

For example, in `prometheus-lj`, this lets the URL milestone start on the dynamically created data source settings page instead of restarting at `/`.

## What to look at

- [Chain execution](https://github.com/grafana/grafana-pathfinder-app/blob/8f232752560f5973d4ef1e754fe55583bc21dd96/src/cli/commands/e2e.ts) — trace how one chain-scoped tracker passes successful locations between guides and resets for each new chain.
- [Location tracking](https://github.com/grafana/grafana-pathfinder-app/blob/8f232752560f5973d4ef1e754fe55583bc21dd96/src/cli/e2e/starting-location.ts) — confirm that explicit locations win and only final passed-step URLs from the target origin can become carried state.
- [Local and bundled metadata](https://github.com/grafana/grafana-pathfinder-app/blob/8f232752560f5973d4ef1e754fe55583bc21dd96/src/cli/e2e/local-starting-location.ts) — confirm that authored starts apply only when the planned guide matches the repository guide file.
- [Package metadata](https://github.com/grafana/grafana-pathfinder-app/blob/8f232752560f5973d4ef1e754fe55583bc21dd96/src/cli/commands/build-repository.ts) — confirm that an omitted `startingLocation` remains distinct from an explicitly authored `/`.
- [Report metadata](https://github.com/grafana/grafana-pathfinder-app/blob/8f232752560f5973d4ef1e754fe55583bc21dd96/src/cli/e2e/e2e-results.ts) — confirm that reports preserve the normalized location used by Playwright.

## Why

Learning-path milestones often depend on resources created by earlier milestones. Those resources can have dynamic routes that cannot be declared in a manifest.

Adding fixed `startingLocation` values would not work for generated data source UIDs. Adding repeated navigation steps to every dependent guide would make human learning journeys repetitive.

## How to verify

1. Run a dependency chain where the first guide finishes on a dynamic route and the next guide omits `startingLocation`.
2. Confirm that the second guide starts on the first guide’s final route, including its query and fragment.
3. Give the second guide an explicit `startingLocation` and confirm that the explicit value takes precedence.
4. Run a bundled or local chain with an explicit `/` and confirm that it wins over carried state.
5. Run two independent chains and confirm that the second chain starts without location state from the first.
6. Inspect the report and confirm that `guide.startingLocation` contains the normalized path used by Playwright.

## Breaking changes

None. Explicit manifest locations keep their existing behavior, and carried locations remain scoped to one execution chain. The change is fully reversible.

## Out of scope

- The `e2e-platform` worker remains unchanged because the CLI owns nested guide execution.
- This does not address the Grafana service-account bug in the Kubernetes data source creation API.

Co-Authored-By: Warp <agent@warp.dev>
