### PR TITLE
feat(requirements-manager): add has-escalation-chain(s) requirement check

### DIFF
--- a/docs/developer/interactive-examples/requirements-reference.md
+++ b/docs/developer/interactive-examples/requirements-reference.md
@@ -275,6 +275,38 @@ Ensures a dashboard with a specific title exists (case-insensitive).
 }
 ```
 
+## IRM/OnCall requirements
+
+### `has-escalation-chains`
+
+Ensures at least one IRM/OnCall escalation chain in the org has one or more escalation steps configured.
+A chain with zero escalation steps notifies nobody, so it does not count as "configured."
+
+```json
+{
+  "type": "interactive",
+  "action": "navigate",
+  "reftarget": "/a/grafana-irm-app/escalations",
+  "objectives": ["has-escalation-chains"],
+  "content": "Create your first escalation chain."
+}
+```
+
+### `has-escalation-chain:<name>`
+
+Ensures an escalation chain matching `<name>` (case-insensitive) exists and has one or more escalation
+steps configured.
+
+```json
+{
+  "type": "interactive",
+  "action": "navigate",
+  "reftarget": "/a/grafana-irm-app/escalations",
+  "objectives": ["has-escalation-chain:Production - Default"],
+  "content": "Create the Production - Default escalation chain."
+}
+```
+
 ## System and environment requirements
 
 ### `has-feature:<toggle>`
@@ -519,16 +551,17 @@ The CLI validates condition syntax statically. Invalid conditions produce **warn
 
 ### Fixed requirements (no parameters)
 
-| Requirement        | Purpose                                |
-| ------------------ | -------------------------------------- |
-| `navmenu-open`     | Navigation menu is open and visible    |
-| `exists-reftarget` | Target element exists on the page      |
-| `form-valid`       | Current form passes validation         |
-| `is-logged-in`     | User is authenticated                  |
-| `is-admin`         | User has Grafana admin privileges      |
-| `is-editor`        | User has at least Editor role          |
-| `has-datasources`  | At least one data source is configured |
-| `dashboard-exists` | At least one dashboard exists          |
+| Requirement             | Purpose                                                       |
+| ----------------------- | ------------------------------------------------------------- |
+| `navmenu-open`          | Navigation menu is open and visible                           |
+| `exists-reftarget`      | Target element exists on the page                             |
+| `form-valid`            | Current form passes validation                                |
+| `is-logged-in`          | User is authenticated                                         |
+| `is-admin`              | User has Grafana admin privileges                             |
+| `is-editor`             | User has at least Editor role                                 |
+| `has-datasources`       | At least one data source is configured                        |
+| `dashboard-exists`      | At least one dashboard exists                                 |
+| `has-escalation-chains` | At least one IRM/OnCall escalation chain has steps configured |
 
 ### Parameterized requirements
 
@@ -542,6 +575,7 @@ The CLI validates condition syntax statically. Invalid conditions produce **warn
 | `has-plugin:<pluginId>`              | Specific plugin is installed                           |
 | `plugin-enabled:<pluginId>`          | Specific plugin is installed and enabled               |
 | `has-dashboard-named:<title>`        | Dashboard with specific title exists                   |
+| `has-escalation-chain:<name>`        | Named IRM/OnCall escalation chain has steps configured |
 | `has-feature:<toggle>`               | Feature toggle is enabled                              |
 | `in-environment:<env>`               | Running in a specific environment                      |
 | `min-version:<version>`              | Grafana version meets minimum requirement              |

--- a/src/requirements-manager/checks/oncall-api.ts
+++ b/src/requirements-manager/checks/oncall-api.ts
@@ -1,0 +1,97 @@
+/**
+ * IRM/OnCall API checks: escalation chains.
+ *
+ * Unlike the Grafana-core checks in `grafana-api.ts`, this calls a different
+ * app plugin's resource proxy (`/api/plugins/grafana-irm-app/resources/...`),
+ * which forwards to the OnCall backend and attaches OnCall identity itself —
+ * the caller just needs a normal authenticated `getBackendSrv()` call.
+ */
+
+import { getBackendSrv } from '@grafana/runtime';
+import type { CheckResultError } from '../../types/requirements.types';
+
+const ONCALL_RESOURCE_BASE = '/api/plugins/grafana-irm-app/resources';
+
+interface OnCallEscalationChain {
+  id: string;
+  name: string;
+}
+
+interface OnCallEscalationPolicy {
+  id: string;
+  escalation_chain: string;
+}
+
+/**
+ * Fetches escalation chains and policies from the OnCall backend (via the
+ * grafana-irm-app resource proxy) and groups policy counts by chain id.
+ *
+ * Fetches full lists and filters/groups client-side rather than relying on
+ * server-side query params, since the internal API's filter support hasn't
+ * been confirmed to match the public API's.
+ */
+async function fetchConfiguredChainNames(): Promise<Set<string>> {
+  const [chains, policies] = await Promise.all([
+    getBackendSrv().get<OnCallEscalationChain[]>(`${ONCALL_RESOURCE_BASE}/escalation_chains/`),
+    getBackendSrv().get<OnCallEscalationPolicy[]>(`${ONCALL_RESOURCE_BASE}/escalation_policies/`),
+  ]);
+
+  const chainIdsWithPolicies = new Set(policies.map((policy) => policy.escalation_chain));
+  const configuredChainNames = new Set<string>();
+
+  for (const chain of chains) {
+    if (chainIdsWithPolicies.has(chain.id)) {
+      configuredChainNames.add(chain.name.toLowerCase());
+    }
+  }
+
+  return configuredChainNames;
+}
+
+/**
+ * Escalation chain existence + configuration check.
+ *
+ * - `has-escalation-chains` (bare): at least one escalation chain in the org
+ *   has one or more escalation steps configured.
+ * - `has-escalation-chain:<name>` (parameterized): a chain matching `<name>`
+ *   (case-insensitive) exists and has one or more escalation steps configured.
+ *
+ * A chain with zero escalation policies resolves to nobody, so it does not
+ * count as "configured" for either form.
+ */
+export async function hasEscalationChainCheck(check: string): Promise<CheckResultError> {
+  const chainName = check.startsWith('has-escalation-chain:') ? check.replace('has-escalation-chain:', '') : null;
+
+  try {
+    const configuredChainNames = await fetchConfiguredChainNames();
+
+    if (chainName === null) {
+      const pass = configuredChainNames.size > 0;
+      return {
+        requirement: check,
+        pass,
+        error: pass ? undefined : 'No escalation chain with configured steps was found',
+        context: { configuredChainCount: configuredChainNames.size },
+      };
+    }
+
+    const pass = configuredChainNames.has(chainName.toLowerCase());
+    return {
+      requirement: check,
+      pass,
+      error: pass ? undefined : `Escalation chain '${chainName}' was not found, or has no escalation steps configured`,
+      context: { searched: chainName, configuredChainCount: configuredChainNames.size },
+    };
+  } catch (error) {
+    return {
+      requirement: check,
+      pass: false,
+      error: `Escalation chain check failed: ${error}`,
+      context: {
+        error: String(error),
+        suggestion:
+          'Check that the grafana-irm-app plugin is installed, enabled, and you have permission to view escalation chains.',
+      },
+    };
+  }
+}

--- a/src/requirements-manager/requirements-checker.utils.test.ts
+++ b/src/requirements-manager/requirements-checker.utils.test.ts
@@ -574,6 +574,93 @@ describe('requirements-checker.utils', () => {
     });
   });
 
+  describe('hasEscalationChainCHECK', () => {
+    beforeEach(() => {
+      (getBackendSrv as jest.Mock).mockReturnValue({
+        get: jest.fn(),
+      });
+    });
+
+    function mockOnCallBackend(
+      chains: Array<{ id: string; name: string }>,
+      policies: Array<{ id: string; escalation_chain: string }>
+    ) {
+      const mockBackend = getBackendSrv();
+      (mockBackend.get as jest.Mock).mockImplementation((url: string) => {
+        if (url.endsWith('/escalation_chains/')) {
+          return Promise.resolve(chains);
+        }
+        if (url.endsWith('/escalation_policies/')) {
+          return Promise.resolve(policies);
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+      });
+      return mockBackend;
+    }
+
+    it('should pass (bare form) when at least one chain has escalation steps', async () => {
+      mockOnCallBackend(
+        [{ id: 'chain-1', name: 'Production - Default' }],
+        [{ id: 'policy-1', escalation_chain: 'chain-1' }]
+      );
+
+      const result = await checkRequirements({ requirements: 'has-escalation-chains' });
+      expect(result.pass).toBe(true);
+    });
+
+    it('should fail (bare form) when no chain has escalation steps', async () => {
+      mockOnCallBackend([{ id: 'chain-1', name: 'Production - Default' }], []);
+
+      const result = await checkRequirements({ requirements: 'has-escalation-chains' });
+      expect(result.pass).toBe(false);
+      expect(result.error[0]!.error).toContain('No escalation chain with configured steps was found');
+    });
+
+    it('should fail (bare form) when no chains exist at all', async () => {
+      mockOnCallBackend([], []);
+
+      const result = await checkRequirements({ requirements: 'has-escalation-chains' });
+      expect(result.pass).toBe(false);
+    });
+
+    it('should pass (named form) when the named chain has escalation steps', async () => {
+      mockOnCallBackend(
+        [{ id: 'chain-1', name: 'Production - Default' }],
+        [{ id: 'policy-1', escalation_chain: 'chain-1' }]
+      );
+
+      const result = await checkRequirements({ requirements: 'has-escalation-chain:production - default' });
+      expect(result.pass).toBe(true);
+    });
+
+    it('should fail (named form) when the named chain exists but has no escalation steps', async () => {
+      mockOnCallBackend([{ id: 'chain-1', name: 'Production - Default' }], []);
+
+      const result = await checkRequirements({ requirements: 'has-escalation-chain:Production - Default' });
+      expect(result.pass).toBe(false);
+      expect(result.error[0]!.error).toContain('no escalation steps configured');
+    });
+
+    it('should fail (named form) when no chain with that name exists', async () => {
+      mockOnCallBackend(
+        [{ id: 'chain-1', name: 'Production - Default' }],
+        [{ id: 'policy-1', escalation_chain: 'chain-1' }]
+      );
+
+      const result = await checkRequirements({ requirements: 'has-escalation-chain:Nonexistent Chain' });
+      expect(result.pass).toBe(false);
+    });
+
+    it('should fail gracefully on a network/plugin error', async () => {
+      const mockBackend = getBackendSrv();
+      (mockBackend.get as jest.Mock).mockRejectedValue(new Error('plugin not installed'));
+
+      const result = await checkRequirements({ requirements: 'has-escalation-chains' });
+      expect(result.pass).toBe(false);
+      expect(result.error[0]!.error).toContain('Escalation chain check failed');
+    });
+  });
+
   describe('formValidCHECK', () => {
     beforeEach(() => {
       // Clear DOM before each test
@@ -1062,6 +1149,8 @@ describe('CHECK_HANDLERS routing parity', () => {
     ['plugin-enabled:my-app', 'plugin-enabled:'],
     ['has-dashboard-named:My Dashboard', 'has-dashboard-named:'],
     ['dashboard-exists', 'dashboard-exists'],
+    ['has-escalation-chains', 'has-escalation-chains'],
+    ['has-escalation-chain:Production - Default', 'has-escalation-chain:'],
     ['on-page:/explore', 'on-page:'],
     ['has-feature:my-toggle', 'has-feature:'],
     ['in-environment:cloud', 'in-environment:'],

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -36,6 +36,7 @@ import {
   dashboardExistsCheck,
   datasourceConfiguredCheck,
 } from './checks/grafana-api';
+import { hasEscalationChainCheck } from './checks/oncall-api';
 import { onPageCheck } from './checks/location';
 import { hasFeatureCheck, inEnvironmentCheck, minVersionCheck, rendererCheck } from './checks/env';
 import { guideVariableCheck } from './checks/vars';
@@ -116,6 +117,16 @@ const CHECK_HANDLERS: readonly CheckHandler[] = [
     run: (c) => hasDashboardNamedCheck(c),
   },
   { id: 'dashboard-exists', match: (c) => c === 'dashboard-exists', run: (c) => dashboardExistsCheck(c) },
+  {
+    id: 'has-escalation-chains',
+    match: (c) => c === 'has-escalation-chains',
+    run: (c) => hasEscalationChainCheck(c),
+  },
+  {
+    id: 'has-escalation-chain:',
+    match: (c) => c.startsWith('has-escalation-chain:'),
+    run: (c) => hasEscalationChainCheck(c),
+  },
   { id: 'on-page:', match: (c) => c.startsWith('on-page:'), run: (c) => onPageCheck(c) },
   { id: 'has-feature:', match: (c) => c.startsWith('has-feature:'), run: (c) => hasFeatureCheck(c) },
   { id: 'in-environment:', match: (c) => c.startsWith('in-environment:'), run: (c) => inEnvironmentCheck(c) },

--- a/src/types/requirements.types.ts
+++ b/src/types/requirements.types.ts
@@ -14,6 +14,7 @@ export enum FixedRequirementType {
   DASHBOARD_EXISTS = 'dashboard-exists',
   FORM_VALID = 'form-valid',
   IS_TERMINAL_ACTIVE = 'is-terminal-active',
+  HAS_ESCALATION_CHAINS = 'has-escalation-chains',
 }
 
 // Parameterized requirement prefixes
@@ -25,6 +26,7 @@ export enum ParameterizedRequirementPrefix {
   HAS_PLUGIN = 'has-plugin:',
   PLUGIN_ENABLED = 'plugin-enabled:',
   HAS_DASHBOARD_NAMED = 'has-dashboard-named:',
+  HAS_ESCALATION_CHAIN = 'has-escalation-chain:',
   ON_PAGE = 'on-page:',
   HAS_FEATURE = 'has-feature:',
   IN_ENVIRONMENT = 'in-environment:',
@@ -112,6 +114,7 @@ export const PARAMETERIZED_REQUIREMENT_EXAMPLES: ReadonlyArray<{ prefix: string;
   { prefix: 'datasource-configured:', example: 'datasource-configured:prometheus' },
   { prefix: 'plugin-enabled:', example: 'plugin-enabled:grafana-clock-panel' },
   { prefix: 'has-dashboard-named:', example: 'has-dashboard-named:Node Exporter Full' },
+  { prefix: 'has-escalation-chain:', example: 'has-escalation-chain:Production - Default' },
   { prefix: 'var-', example: 'var-policyAccepted:true' },
   { prefix: 'renderer:', example: 'renderer:pathfinder' },
   { prefix: 'coda-exit-zero:', example: 'coda-exit-zero:test -f /etc/myapp.conf' },
@@ -141,6 +144,7 @@ export const REQUIREMENT_DESCRIPTIONS: Readonly<Record<string, string>> = Object
   'dashboard-exists': 'At least one dashboard must exist',
   'form-valid': 'All required form fields must be filled correctly',
   'is-terminal-active': 'A terminal session must be active',
+  'has-escalation-chains': 'At least one IRM/OnCall escalation chain has one or more escalation steps configured',
   // Parameterized prefixes
   'has-permission:': 'User has a specific Grafana permission (e.g. has-permission:dashboards:write)',
   'has-role:': 'User has a specific org role (e.g. has-role:editor)',
@@ -149,6 +153,8 @@ export const REQUIREMENT_DESCRIPTIONS: Readonly<Record<string, string>> = Object
   'has-plugin:': 'A plugin with the given ID is installed (e.g. has-plugin:grafana-clock-panel)',
   'plugin-enabled:': 'A plugin with the given ID is installed and enabled',
   'has-dashboard-named:': 'A dashboard with the exact title (case-insensitive) exists',
+  'has-escalation-chain:':
+    'An IRM/OnCall escalation chain matching the given name (case-insensitive) has one or more escalation steps configured',
   'on-page:': 'Current URL path matches the given value (e.g. on-page:/explore)',
   'has-feature:': 'A Grafana feature toggle is enabled (e.g. has-feature:publicDashboards)',
   'in-environment:': 'Running in a specific environment (e.g. in-environment:cloud)',

--- a/src/validation/condition-validator.test.ts
+++ b/src/validation/condition-validator.test.ts
@@ -29,6 +29,7 @@ describe('Condition Validator', () => {
         ['has-plugin:grafana-clock-panel', ParameterizedRequirementPrefix.HAS_PLUGIN],
         ['plugin-enabled:volkovlabs-rss-datasource', ParameterizedRequirementPrefix.PLUGIN_ENABLED],
         ['has-dashboard-named:My Dashboard', ParameterizedRequirementPrefix.HAS_DASHBOARD_NAMED],
+        ['has-escalation-chain:Production - Default', ParameterizedRequirementPrefix.HAS_ESCALATION_CHAIN],
         ['on-page:/dashboards', ParameterizedRequirementPrefix.ON_PAGE],
         ['on-page:/d/abc123', ParameterizedRequirementPrefix.ON_PAGE],
         ['has-feature:alerting', ParameterizedRequirementPrefix.HAS_FEATURE],
@@ -399,6 +400,7 @@ describe('Condition Types Coverage', () => {
     FixedRequirementType.DASHBOARD_EXISTS,
     FixedRequirementType.FORM_VALID,
     FixedRequirementType.IS_TERMINAL_ACTIVE,
+    FixedRequirementType.HAS_ESCALATION_CHAINS,
   ]);
 
   // All parameterized prefixes that should be tested
@@ -410,6 +412,7 @@ describe('Condition Types Coverage', () => {
     ParameterizedRequirementPrefix.HAS_PLUGIN,
     ParameterizedRequirementPrefix.PLUGIN_ENABLED,
     ParameterizedRequirementPrefix.HAS_DASHBOARD_NAMED,
+    ParameterizedRequirementPrefix.HAS_ESCALATION_CHAIN,
     ParameterizedRequirementPrefix.ON_PAGE,
     ParameterizedRequirementPrefix.HAS_FEATURE,
     ParameterizedRequirementPrefix.IN_ENVIRONMENT,


### PR DESCRIPTION
## Summary

- Adds `has-escalation-chains` (bare) and `has-escalation-chain:<name>` (parameterized) requirement/objective checks, so interactive guides can gate or auto-skip steps based on whether an IRM/OnCall escalation chain has actually been configured.
- "Configured" means the chain has at least one escalation policy/step — a chain that exists but is empty notifies nobody, so it doesn't satisfy the check. This mirrors the `has-datasources`/`has-datasource:<name>` bare/named split already used for data sources.
- The check calls the OnCall backend through the `grafana-irm-app` resource proxy (`/api/plugins/grafana-irm-app/resources/escalation_chains/` and `/escalation_policies/`), which forwards to OnCall's API and attaches identity automatically from the caller's Grafana session — no separate OnCall token handling needed on the Pathfinder side.

Motivation: guides like the IRM configuration learning path walk users through *creating* an escalation chain, but had no way to detect "the user already has one" and skip that section. This closes that gap by adding the check type end-to-end, following the checklist in `.cursor/rules/interactiveRequirements.mdc`.

## Changes

- `src/types/requirements.types.ts` — new `FixedRequirementType.HAS_ESCALATION_CHAINS` and `ParameterizedRequirementPrefix.HAS_ESCALATION_CHAIN`, plus authoring examples/tooltips.
- `src/requirements-manager/checks/oncall-api.ts` (new) — `hasEscalationChainCheck`, fetching chains + policies and grouping client-side.
- `src/requirements-manager/requirements-checker.utils.ts` — wires the two new tokens into `CHECK_HANDLERS`.
- `src/requirements-manager/requirements-checker.utils.test.ts` — new test coverage + routing-parity table rows.
- `src/validation/condition-validator.test.ts` — coupling-test coverage for the new enum members.
- `docs/developer/interactive-examples/requirements-reference.md` — documented usage + reference table rows.

## Test plan

- [x] `npx jest src/requirements-manager/requirements-checker.utils.test.ts` — 100 passed
- [x] `npx jest src/validation/condition-validator.test.ts` — 70 passed
- [x] `npx jest src/validation/architecture.test.ts` — no new import-boundary violations
- [x] `npm run check` (typecheck, lint, prettier, docs term sync, go lint/tests, coverage, review-contract, scripts) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)