### PR TITLE
fix(e2e): extend pool lease acquisition timeout

### DIFF
--- a/src/cli/e2e/cloud-stack-pool-manager.test.ts
+++ b/src/cli/e2e/cloud-stack-pool-manager.test.ts
@@ -71,11 +71,60 @@ describe('createCloudStackPoolManagerConfig', () => {
 
   it('exhausts retry budget correctly when the injected clock advances with each wait', async () => {
     let now = 0;
+    const waits: number[] = [];
     const fetchImpl = jest
       .fn()
       .mockResolvedValue(
         jsonResponse({ error: { code: 'no_capacity', message: 'capacity is temporarily exhausted' } }, 503)
       );
+    const manager = new CloudStackPoolManager(
+      { ...CONFIG, maxWaitSeconds: 1 },
+      false,
+      fetchImpl as unknown as typeof fetch,
+      async (ms) => {
+        waits.push(ms);
+        now += ms;
+      },
+      () => 0,
+      () => now
+    );
+
+    await expect(manager.leaseForChain({ chain: [{ id: 'a' }], packageMetaById: new Map() })).rejects.toMatchObject({
+      code: 'no_capacity',
+    });
+    expect(waits).toEqual([125, 250, 500, 125]);
+    expect(now).toBe(1_000);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
+  it('bounds a hanging retry request by the remaining retry budget', async () => {
+    let now = 0;
+    const retryController = new AbortController();
+    const timeoutSpy = jest
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValueOnce(new AbortController().signal)
+      .mockImplementationOnce(() => {
+        queueMicrotask(() => retryController.abort());
+        return retryController.signal;
+      });
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ error: { code: 'no_capacity', message: 'capacity is temporarily exhausted' } }, 503)
+      )
+      .mockImplementationOnce((_url, init: RequestInit | undefined) => {
+        return new Promise<Response>((_resolve, reject) => {
+          if (!init?.signal) {
+            reject(new Error('Missing retry timeout signal'));
+            return;
+          }
+          init.signal.addEventListener(
+            'abort',
+            () => reject(Object.assign(new Error('The operation timed out'), { name: 'TimeoutError' })),
+            { once: true }
+          );
+        });
+      });
     const manager = new CloudStackPoolManager(
       { ...CONFIG, maxWaitSeconds: 1 },
       false,
@@ -87,13 +136,17 @@ describe('createCloudStackPoolManagerConfig', () => {
       () => now
     );
 
-    await expect(manager.leaseForChain({ chain: [{ id: 'a' }], packageMetaById: new Map() })).rejects.toMatchObject({
-      code: 'no_capacity',
-    });
-    // With random=0 and budget=1000ms the delays are 125, 250, 500, 125 (clamped) before
-    // the 5th attempt finds remaining=0 and throws. If the budget were double-counted the
-    // run would stop after only 2 attempts.
-    expect(fetchImpl).toHaveBeenCalledTimes(5);
+    try {
+      await expect(manager.leaseForChain({ chain: [{ id: 'a' }], packageMetaById: new Map() })).rejects.toThrow(
+        'Pool manager request failed: The operation timed out'
+      );
+      expect(timeoutSpy).toHaveBeenNthCalledWith(1, 90_000);
+      expect(timeoutSpy).toHaveBeenNthCalledWith(2, 875);
+      expect((fetchImpl.mock.calls[1]![1] as RequestInit).signal).toBe(retryController.signal);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
   });
 
   it('does not retry non-capacity errors', async () => {
@@ -164,6 +217,51 @@ describe('createCloudStackPoolManagerConfig', () => {
 });
 
 describe('CloudStackPoolManager', () => {
+  it('uses a 90-second acquisition timeout and a 15-second retirement timeout', async () => {
+    const acquisitionSignal = new AbortController().signal;
+    const retirementSignal = new AbortController().signal;
+    const timeoutSpy = jest
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValueOnce(acquisitionSignal)
+      .mockReturnValueOnce(retirementSignal);
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(leaseResponse(), 201, 'Created'))
+      .mockResolvedValueOnce(jsonResponse({ leaseId: 'lease-1', status: 'retired' }));
+    const manager = new CloudStackPoolManager(CONFIG, false, fetchImpl as unknown as typeof fetch);
+
+    try {
+      const lease = await manager.leaseForChain({ chain: [{ id: 'a' }], packageMetaById: new Map() });
+      await lease.teardownChain();
+
+      expect(timeoutSpy).toHaveBeenNthCalledWith(1, 90_000);
+      expect(timeoutSpy).toHaveBeenNthCalledWith(2, 15_000);
+      expect((fetchImpl.mock.calls[0]![1] as RequestInit).signal).toBe(acquisitionSignal);
+      expect((fetchImpl.mock.calls[1]![1] as RequestInit).signal).toBe(retirementSignal);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  it('does not retry ambiguous lease acquisition timeouts', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('The operation timed out'), { name: 'TimeoutError' }));
+    const waitImpl = jest.fn(async () => undefined);
+    const manager = new CloudStackPoolManager(
+      { ...CONFIG, maxWaitSeconds: 5 },
+      false,
+      fetchImpl as unknown as typeof fetch,
+      waitImpl
+    );
+
+    await expect(manager.leaseForChain({ chain: [{ id: 'a' }], packageMetaById: new Map() })).rejects.toThrow(
+      'Pool manager request failed: The operation timed out'
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(waitImpl).not.toHaveBeenCalled();
+  });
+
   it('creates and retires a lease with chain metadata', async () => {
     const fetchImpl = jest
       .fn()

--- a/src/cli/e2e/cloud-stack-pool-manager.ts
+++ b/src/cli/e2e/cloud-stack-pool-manager.ts
@@ -7,7 +7,8 @@ import type {
 } from './cloud-chain-environment';
 import type { PackageMeta } from './e2e-results';
 
-const POOL_MANAGER_FETCH_TIMEOUT_MS = 15_000;
+const POOL_MANAGER_LEASE_TIMEOUT_MS = 90_000;
+const POOL_MANAGER_RETIRE_TIMEOUT_MS = 15_000;
 const FALLBACK_POLICY = 'hot_only';
 const CAPACITY_RETRY_BASE_DELAY_MS = 250;
 const CAPACITY_RETRY_MAX_DELAY_MS = 5_000;
@@ -241,6 +242,7 @@ async function postJson<T>(
   path: string,
   body: unknown,
   errorPrefix: string,
+  timeoutMs: number,
   extraSecrets: string[] = []
 ): Promise<T> {
   const secrets = [config.token, ...extraSecrets];
@@ -255,7 +257,7 @@ async function postJson<T>(
         Accept: 'application/json',
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(POOL_MANAGER_FETCH_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (err) {
     throw new CloudStackPoolManagerError(`Pool manager request failed: ${redact(errorMessage(err), secrets)}`);
@@ -330,6 +332,7 @@ export class CloudStackPoolManager {
     };
     const startedAt = this.nowImpl();
     let capacityRetryAttempt = 0;
+    let requestTimeoutMs = POOL_MANAGER_LEASE_TIMEOUT_MS;
     let response: CreateLeaseResponse;
     while (true) {
       try {
@@ -338,7 +341,8 @@ export class CloudStackPoolManager {
           this.fetchImpl,
           '/v1/leases',
           request,
-          `Pool manager could not lease a stack from pool \"${this.config.poolId}\": `
+          `Pool manager could not lease a stack from pool \"${this.config.poolId}\": `,
+          requestTimeoutMs
         );
         break;
       } catch (error) {
@@ -355,6 +359,11 @@ export class CloudStackPoolManager {
           console.log(`   ⏳ Pool ${this.config.poolId} has no capacity; retrying in ${delayMs}ms`);
         }
         await this.waitImpl(delayMs);
+        const retryBudgetMs = budgetMs - (this.nowImpl() - startedAt);
+        if (retryBudgetMs <= 0) {
+          throw error;
+        }
+        requestTimeoutMs = Math.min(POOL_MANAGER_LEASE_TIMEOUT_MS, retryBudgetMs);
       }
     }
     const lease = {
@@ -425,6 +434,7 @@ export class CloudStackPoolManagerLease implements CloudChainEnvironment {
         `/v1/leases/${this.lease.leaseId}/retire`,
         request,
         '',
+        POOL_MANAGER_RETIRE_TIMEOUT_MS,
         [this.lease.token]
       );
       if (this.verbose) {


### PR DESCRIPTION
## Summary

Managed pool lease acquisition now uses a 90-second timeout. Retirement keeps its 15-second timeout.

After a structured `no_capacity` response, each retry uses only the remaining maximum-wait budget. Transport timeouts remain non-retryable because the request can create a lease with a runner token that the client cannot replay.


## Why

This problem surfaced after the pool manager was retargeted to the Grafana dev environment. That environment applies a much stricter rate limit to non-GET lifecycle requests used for stack leasing, credential management, retirement, and replacement.

The pool manager now paces those requests to stay within the dev API limit. Compliant pacing can make synchronous lease requests wait for quota, but the runner still aborted every pool-manager request after 15 seconds.

During the contained cycle, the runner abandoned 15 lease requests that the pool manager later completed successfully in 15–53 seconds. Each response contained a one-time runner token that the pool manager does not persist. The abandoned requests therefore consumed stacks that the runner could not use.

Lease acquisition now permits 90 seconds, which covers the observed 53-second maximum with operating margin. Acquisition timeouts remain non-retryable because the first request can still issue a lease. Retrying can consume another stack without recovering the first token.

Retirement keeps its separate 15-second deadline because the runner does not need to wait for physical cleanup. Asynchronous retirement is handled in [pathfinder-e2e-platform #194](https://github.com/grafana/pathfinder-e2e-platform/pull/194).

## How to verify

1. Return `no_capacity` from the first lease request, then allow a retry. Confirm that the retry signal uses the remaining wait budget.
2. Let the retry signal expire. Confirm that the client reports the timeout and does not send another lease request.
3. Retire a lease through a delayed endpoint. Confirm that the retirement request uses a 15-second timeout.

## Breaking changes

None. This change is fully reversible.

Co-Authored-By: Warp <agent@warp.dev>
