### PR TITLE
fix(e2e): preserve structured early failures

### DIFF
--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -233,7 +233,12 @@ The report contract's single source of truth is the Zod schema in `src/cli/e2e/s
 Key contract fields:
 
 - `outcome`: one of `passed`, `failed`, `aborted`, `skipped`, `infrastructure_error`, or `configuration_error`. Multi-guide reports surface `aborted` when any guide's session expired.
-- `errorCode`: structured failure code present on non-passing reports. Notable values: `TIER_MISMATCH` (guide requires a different environment tier), `SKIPPED_PREREQ` (a prerequisite guide failed), `REPORT_MISSING` (Playwright exited but wrote no results file), `AUTH_EXPIRED`, `NO_CAPACITY`, `PLAYWRIGHT_SPAWN_FAILED`.
+- `errorCode`: structured failure code present on non-passing reports. Notable values:
+  - `TIER_MISMATCH`: The guide requires a different environment tier.
+  - `SKIPPED_PREREQ`: A prerequisite guide failed.
+  - `UNKNOWN`: Playwright failed before final guide-result persistence.
+  - `REPORT_MISSING`: The child output was missing or unreadable.
+  - `AUTH_EXPIRED`, `NO_CAPACITY`, and `PLAYWRIGHT_SPAWN_FAILED`.
 - `guide.contentDigest`: SHA-256 digest of the exact guide content executed
 - `guide.sourceUrl`: remote package source URL when available
 - `selection`: for an explicitly selected path or journey, the multi-guide report records the root package `id` and `type` separately from its executable leaf-guide reports
@@ -242,7 +247,7 @@ Key contract fields:
 
 The runner always attempts to write a report, even when self-validation fails, so a diagnostic artifact is not lost. A failed validation logs the schema error, writes the original object, and exits with code 2. Consumers must validate the report against the schema matching the producing runner before processing it.
 
-Catchable setup, preflight, provisioning, and Playwright spawn failures still write zero-step reports that validate against the schema. Observable browser termination during step execution produces a runner report. A container OOM or SIGKILL that prevents report creation remains the worker's responsibility.
+Catchable setup, preflight, provisioning, and Playwright spawn failures still write zero-step reports that validate against the schema. The Playwright reporter writes a structured fallback before browser setup. This fallback has a fixed message and does not contain Playwright error details. Final guide results overwrite the fallback. Abort metadata replaces only the fallback. Observable browser termination during step execution produces a runner report. A container OOM or SIGKILL that prevents report creation remains the worker's responsibility.
 
 Consumers that need a language-agnostic contract can extract the JSON Schema from the CLI, so the artifact always matches the binary that produced the report:
 

--- a/src/cli/e2e/playwright-runner.test.ts
+++ b/src/cli/e2e/playwright-runner.test.ts
@@ -5,15 +5,26 @@ import { EventEmitter } from 'events';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
+import { createMinimalResultsData } from './e2e-reporter';
 
 import { ExitCode } from './exit-codes';
 import { findRunnerRoot, processPlaywrightResults, resolveStartingUrl, runPlaywrightTests } from './playwright-runner';
+import { PLAYWRIGHT_EARLY_FAILURE_MESSAGE } from './structured-failure-reporter';
 
 jest.mock('child_process', () => ({
   spawn: jest.fn(),
 }));
 
 const spawnMock = spawn as jest.MockedFunction<typeof spawn>;
+
+function structuredFailureFallback() {
+  return createMinimalResultsData({
+    guide: { id: 'guide', title: 'Guide', path: 'guide.json' },
+    outcome: 'infrastructure_error',
+    errorCode: 'UNKNOWN',
+    errorMessage: PLAYWRIGHT_EARLY_FAILURE_MESSAGE,
+  });
+}
 
 describe('findRunnerRoot', () => {
   let tempRoot: string;
@@ -122,6 +133,60 @@ describe('processPlaywrightResults', () => {
       exitCode: ExitCode.TEST_FAILURE,
       errorCode: 'REPORT_MISSING',
     });
+  });
+
+  it('keeps REPORT_MISSING for unreadable child output', () => {
+    const paths = filePaths();
+    writeFileSync(paths.resultsFilePath, '{not-json');
+
+    expect(processPlaywrightResults(1, { trace: false }, paths)).toMatchObject({
+      success: false,
+      exitCode: ExitCode.TEST_FAILURE,
+      errorCode: 'REPORT_MISSING',
+    });
+  });
+
+  it('uses a structured early-runner failure instead of REPORT_MISSING', () => {
+    const paths = filePaths();
+    writeFileSync(paths.resultsFilePath, JSON.stringify(structuredFailureFallback()));
+
+    expect(processPlaywrightResults(1, { trace: false }, paths)).toMatchObject({
+      success: false,
+      exitCode: ExitCode.TEST_FAILURE,
+      resultsData: {
+        outcome: 'infrastructure_error',
+        errorCode: 'UNKNOWN',
+        errorMessage: PLAYWRIGHT_EARLY_FAILURE_MESSAGE,
+      },
+    });
+  });
+
+  it('does not replace real final guide results with abort metadata', () => {
+    const paths = filePaths();
+    const finalResults = createMinimalResultsData({
+      guide: { id: 'guide', title: 'Guide', path: 'guide.json' },
+      outcome: 'failed',
+      errorCode: 'MANDATORY_FAILURE',
+      errorMessage: 'Final mandatory result',
+      abortReason: 'MANDATORY_FAILURE',
+    });
+    finalResults.results = [
+      {
+        stepId: 'step-1',
+        status: 'failed',
+        durationMs: 1,
+        currentUrl: 'http://localhost:3000',
+        consoleErrors: [],
+        skippable: false,
+      },
+    ];
+    writeFileSync(paths.resultsFilePath, JSON.stringify(finalResults));
+    writeFileSync(
+      paths.abortFilePath,
+      JSON.stringify({ abortReason: 'MANDATORY_FAILURE', message: 'Later abort metadata' })
+    );
+
+    expect(processPlaywrightResults(1, { trace: false }, paths).resultsData).toEqual(finalResults);
   });
   it('ignores structurally invalid abort metadata', () => {
     const paths = filePaths();
@@ -346,10 +411,11 @@ describe('runPlaywrightTests', () => {
   it.each([
     ['AUTH_EXPIRED', 'aborted'],
     ['MANDATORY_FAILURE', 'failed'],
-  ] as const)('preserves %s when only an abort file is produced', async (abortReason, outcome) => {
+  ] as const)('normalizes a reporter fallback to %s abort metadata', async (abortReason, outcome) => {
     const child = new EventEmitter();
     spawnMock.mockImplementation((_command, _args, spawnOptions) => {
       const env = (spawnOptions as { env?: NodeJS.ProcessEnv }).env;
+      writeFileSync(env?.RESULTS_FILE_PATH as string, JSON.stringify(structuredFailureFallback()));
       writeFileSync(env?.ABORT_FILE_PATH as string, JSON.stringify({ abortReason, message: `${abortReason} message` }));
       queueMicrotask(() => child.emit('close', 1));
       return child as never;

--- a/src/cli/e2e/playwright-runner.ts
+++ b/src/cli/e2e/playwright-runner.ts
@@ -14,6 +14,7 @@ import type { LoadedGuide } from '../utils/file-loader';
 import type { E2EErrorCode } from './schemas/e2e-report.schema';
 import { contentDigest, createMinimalResultsData, type TestResultsData } from './e2e-reporter';
 import { resolveStartingPath } from './starting-location';
+import { isStructuredFailureFallback } from './structured-failure-reporter';
 
 export { resolveStartingUrl } from './starting-location';
 
@@ -173,6 +174,17 @@ export function processPlaywrightResults(
   const abortContent = isAbortFileContent(abortValue) ? abortValue : undefined;
   if (abortContent) {
     const abortExitCode = abortContent.abortReason === 'AUTH_EXPIRED' ? ExitCode.AUTH_FAILURE : ExitCode.TEST_FAILURE;
+    const normalizedResultsData = isStructuredFailureFallback(resultsData)
+      ? {
+          ...resultsData,
+          outcome: abortContent.abortReason === 'AUTH_EXPIRED' ? ('aborted' as const) : ('failed' as const),
+          errorCode: abortContent.abortReason,
+          errorMessage: abortContent.message,
+          aborted: true,
+          abortReason: abortContent.abortReason,
+          abortMessage: abortContent.message,
+        }
+      : resultsData;
 
     return {
       success: false,
@@ -181,7 +193,7 @@ export function processPlaywrightResults(
       abortReason: abortContent.abortReason,
       abortMessage: abortContent.message,
       errorCode: abortContent.abortReason,
-      resultsData,
+      resultsData: normalizedResultsData,
     };
   }
 

--- a/src/cli/e2e/structured-failure-reporter.test.ts
+++ b/src/cli/e2e/structured-failure-reporter.test.ts
@@ -1,0 +1,223 @@
+/** @jest-environment node */
+
+import type { TestError, TestResult } from '@playwright/test/reporter';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { generateReport, type TestResultsData } from './e2e-reporter';
+import { E2ETestReportSchema } from './schemas/e2e-report.schema';
+import { PLAYWRIGHT_EARLY_FAILURE_MESSAGE, StructuredFailureReporter } from './structured-failure-reporter';
+
+function failedResult(error: TestError): TestResult {
+  return {
+    status: 'failed',
+    errors: [error],
+  } as TestResult;
+}
+
+describe('StructuredFailureReporter', () => {
+  let tempDir: string;
+  let guidePath: string;
+  let resultsFilePath: string;
+  let originalGuidePath: string | undefined;
+  let originalResultsFilePath: string | undefined;
+  let originalGrafanaUrl: string | undefined;
+  let originalStartingLocation: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pathfinder-structured-failure-'));
+    guidePath = join(tempDir, 'guide.json');
+    resultsFilePath = join(tempDir, 'results.json');
+    writeFileSync(guidePath, JSON.stringify({ id: 'test-guide', title: 'Test guide' }), 'utf-8');
+
+    originalGuidePath = process.env.GUIDE_JSON_PATH;
+    originalResultsFilePath = process.env.RESULTS_FILE_PATH;
+    originalGrafanaUrl = process.env.GRAFANA_URL;
+    originalStartingLocation = process.env.STARTING_LOCATION;
+    process.env.GUIDE_JSON_PATH = guidePath;
+    process.env.RESULTS_FILE_PATH = resultsFilePath;
+    process.env.GRAFANA_URL = 'http://localhost:3000';
+    process.env.STARTING_LOCATION = '/explore';
+  });
+
+  afterEach(() => {
+    restoreEnv('GUIDE_JSON_PATH', originalGuidePath);
+    restoreEnv('RESULTS_FILE_PATH', originalResultsFilePath);
+    restoreEnv('GRAFANA_URL', originalGrafanaUrl);
+    restoreEnv('STARTING_LOCATION', originalStartingLocation);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes a schema-valid result for a preflight failure', () => {
+    const reporter = new StructuredFailureReporter();
+    reporter.onBegin();
+    reporter.onTestEnd(undefined, failedResult({ message: 'Pre-flight plugin check failed: plugin is not installed' }));
+
+    const data = readResults(resultsFilePath);
+    expect(data).toMatchObject({
+      outcome: 'infrastructure_error',
+      errorCode: 'UNKNOWN',
+      errorMessage: PLAYWRIGHT_EARLY_FAILURE_MESSAGE,
+      guide: {
+        id: 'test-guide',
+        title: 'Test guide',
+        targetUrl: 'http://localhost:3000',
+        startingLocation: '/explore',
+      },
+    });
+    expect(E2ETestReportSchema.parse(generateReport(data))).toMatchObject({
+      schemaVersion: '1.0.0',
+      outcome: 'infrastructure_error',
+      errorCode: 'UNKNOWN',
+    });
+  });
+
+  it('records a known Playwright assertion before step-result persistence', () => {
+    const reporter = new StructuredFailureReporter();
+    reporter.onBegin();
+    reporter.onTestEnd(undefined, failedResult({ message: 'expect(locator).toBeVisible() failed' }));
+
+    expect(readResults(resultsFilePath)).toMatchObject({
+      errorCode: 'UNKNOWN',
+      errorMessage: PLAYWRIGHT_EARLY_FAILURE_MESSAGE,
+    });
+  });
+
+  it('does not persist secrets from Playwright error fields', () => {
+    const reporter = new StructuredFailureReporter();
+    const secrets = ['message-secret', 'stack-secret', 'value-secret', 'basic-secret'];
+    reporter.onBegin();
+    reporter.onError({
+      message: 'Authorization: Bearer message-secret',
+      stack: 'Cookie: grafana_session=stack-secret',
+      value: 'E2E_GRAFANA_TOKEN=value-secret Authorization: Basic basic-secret',
+    });
+
+    const serialized = readFileSync(resultsFilePath, 'utf-8');
+    expect(serialized).toContain(PLAYWRIGHT_EARLY_FAILURE_MESSAGE);
+    for (const secret of secrets) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('preserves an AUTH_EXPIRED result', () => {
+    const reporter = new StructuredFailureReporter();
+    reporter.onBegin();
+    writeResults(resultsFilePath, {
+      ...baseResults(),
+      outcome: 'aborted',
+      errorCode: 'AUTH_EXPIRED',
+      errorMessage: 'Session expired mid-test',
+      aborted: true,
+      abortReason: 'AUTH_EXPIRED',
+      abortMessage: 'Session expired mid-test',
+    });
+
+    reporter.onTestEnd(undefined, failedResult({ message: 'AUTH_EXPIRED: Session expired mid-test' }));
+
+    expect(readResults(resultsFilePath)).toMatchObject({
+      outcome: 'aborted',
+      errorCode: 'AUTH_EXPIRED',
+      abortReason: 'AUTH_EXPIRED',
+    });
+  });
+
+  it('preserves an ordinary mandatory guide-step failure', () => {
+    const reporter = new StructuredFailureReporter();
+    reporter.onBegin();
+    writeResults(resultsFilePath, {
+      ...baseResults(),
+      outcome: 'failed',
+      errorCode: 'MANDATORY_FAILURE',
+      errorMessage: 'Mandatory step query-editor failed',
+      aborted: true,
+      abortReason: 'MANDATORY_FAILURE',
+      abortMessage: 'Mandatory step query-editor failed',
+      results: [
+        {
+          stepId: 'query-editor',
+          status: 'failed',
+          durationMs: 25,
+          currentUrl: 'http://localhost:3000/explore',
+          consoleErrors: [],
+          error: 'Expected the query editor to be visible',
+          skippable: false,
+          classification: 'unknown',
+        },
+      ],
+    });
+
+    reporter.onTestEnd(undefined, failedResult({ message: 'expect(received).toBe(true)' }));
+
+    expect(readResults(resultsFilePath)).toMatchObject({
+      outcome: 'failed',
+      errorCode: 'MANDATORY_FAILURE',
+      abortReason: 'MANDATORY_FAILURE',
+      results: [{ status: 'failed', classification: 'unknown' }],
+    });
+  });
+
+  it('keeps final successful results after they overwrite the initial fallback', () => {
+    const reporter = new StructuredFailureReporter();
+    reporter.onBegin();
+    expect(readResults(resultsFilePath)).toMatchObject({
+      errorCode: 'UNKNOWN',
+      errorMessage: PLAYWRIGHT_EARLY_FAILURE_MESSAGE,
+    });
+
+    writeResults(resultsFilePath, baseResults());
+    reporter.onTestEnd(undefined, { status: 'passed', errors: [] } as unknown as TestResult);
+
+    const data = readResults(resultsFilePath);
+    expect(data).toMatchObject({
+      outcome: 'passed',
+      aborted: false,
+      results: [{ stepId: 'step-1', status: 'passed' }],
+    });
+    expect(data.errorCode).toBeUndefined();
+  });
+});
+
+function baseResults(): TestResultsData {
+  return {
+    guide: {
+      id: 'test-guide',
+      title: 'Test guide',
+      path: 'guide.json',
+      targetUrl: 'http://localhost:3000',
+      startingLocation: '/explore',
+    },
+    timestamp: '2026-08-21T04:25:05.000Z',
+    startedAt: '2026-08-21T04:25:05.000Z',
+    endedAt: '2026-08-21T04:25:06.000Z',
+    outcome: 'passed',
+    results: [
+      {
+        stepId: 'step-1',
+        status: 'passed',
+        durationMs: 1000,
+        currentUrl: 'http://localhost:3000/explore',
+        consoleErrors: [],
+        skippable: false,
+      },
+    ],
+    aborted: false,
+  };
+}
+
+function readResults(path: string): TestResultsData {
+  return JSON.parse(readFileSync(path, 'utf-8')) as TestResultsData;
+}
+
+function writeResults(path: string, data: TestResultsData): void {
+  writeFileSync(path, JSON.stringify(data), 'utf-8');
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/src/cli/e2e/structured-failure-reporter.ts
+++ b/src/cli/e2e/structured-failure-reporter.ts
@@ -1,0 +1,116 @@
+import type { Reporter, TestError, TestResult } from '@playwright/test/reporter';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { basename } from 'path';
+
+import { E2E_ENV } from './e2e-runner-contract';
+import { contentDigest, createMinimalResultsData, type TestResultsData } from './e2e-reporter';
+
+export const PLAYWRIGHT_EARLY_FAILURE_MESSAGE = 'Playwright failed before it wrote final guide results.';
+
+function readCurrentResults(resultsFilePath: string): unknown {
+  if (!existsSync(resultsFilePath)) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(readFileSync(resultsFilePath, 'utf-8')) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isStructuredFailureFallback(results: unknown): results is TestResultsData {
+  if (typeof results !== 'object' || results === null) {
+    return false;
+  }
+
+  const candidate = results as Partial<TestResultsData>;
+  return (
+    typeof candidate.guide?.id === 'string' &&
+    typeof candidate.guide.title === 'string' &&
+    typeof candidate.guide.path === 'string' &&
+    typeof candidate.timestamp === 'string' &&
+    candidate.outcome === 'infrastructure_error' &&
+    candidate.errorCode === 'UNKNOWN' &&
+    candidate.errorMessage === PLAYWRIGHT_EARLY_FAILURE_MESSAGE &&
+    candidate.abortMessage === PLAYWRIGHT_EARLY_FAILURE_MESSAGE &&
+    candidate.aborted === true &&
+    candidate.abortReason === undefined &&
+    Array.isArray(candidate.results) &&
+    candidate.results.length === 0
+  );
+}
+
+function canWriteStructuredFailure(resultsFilePath: string): boolean {
+  if (!existsSync(resultsFilePath)) {
+    return true;
+  }
+  return isStructuredFailureFallback(readCurrentResults(resultsFilePath));
+}
+
+function guideMetadata(): TestResultsData['guide'] {
+  const guidePath = process.env[E2E_ENV.GUIDE_JSON_PATH] ?? 'unknown';
+  const pathId = basename(guidePath).replace(/\.json$/, '') || 'unknown';
+  let id = pathId;
+  let title = pathId;
+  let guideContent: string | undefined;
+
+  try {
+    guideContent = readFileSync(guidePath, 'utf-8');
+    const guide = JSON.parse(guideContent) as { id?: unknown; title?: unknown };
+    if (typeof guide.id === 'string' && guide.id) {
+      id = guide.id;
+    }
+    if (typeof guide.title === 'string' && guide.title) {
+      title = guide.title;
+    }
+  } catch {
+    guideContent = undefined;
+  }
+
+  return {
+    id,
+    title,
+    path: guidePath,
+    targetUrl: process.env[E2E_ENV.GRAFANA_URL] ?? 'http://localhost:3000',
+    startingLocation: process.env[E2E_ENV.STARTING_LOCATION] ?? '/',
+    ...(guideContent ? { contentDigest: contentDigest(guideContent) } : {}),
+  };
+}
+export class StructuredFailureReporter implements Reporter {
+  onBegin(): void {
+    this.writeStructuredFailure();
+  }
+
+  onTestEnd(_test: unknown, result: TestResult): void {
+    if (result.status === 'failed' || result.status === 'timedOut' || result.status === 'interrupted') {
+      this.writeStructuredFailure();
+    }
+  }
+
+  onError(_error: TestError): void {
+    this.writeStructuredFailure();
+  }
+
+  private writeStructuredFailure(): void {
+    const resultsFilePath = process.env[E2E_ENV.RESULTS_FILE_PATH];
+    if (!resultsFilePath || !canWriteStructuredFailure(resultsFilePath)) {
+      return;
+    }
+
+    const results = createMinimalResultsData({
+      guide: guideMetadata(),
+      outcome: 'infrastructure_error',
+      errorCode: 'UNKNOWN',
+      errorMessage: PLAYWRIGHT_EARLY_FAILURE_MESSAGE,
+    });
+
+    try {
+      writeFileSync(resultsFilePath, JSON.stringify(results), 'utf-8');
+    } catch {
+      return;
+    }
+  }
+}
+
+export default StructuredFailureReporter;

--- a/tests/e2e-runner/playwright.config.ts
+++ b/tests/e2e-runner/playwright.config.ts
@@ -35,7 +35,10 @@ export default defineConfig<PluginOptions>({
   fullyParallel: false, // Sequential execution for guide tests
   forbidOnly: !!process.env.CI,
   retries: 0, // No retries - failures should be investigated
-  reporter: isEnvFlagEnabled(process.env[E2E_ENV.VERBOSE]) ? 'list' : 'line',
+  reporter: [
+    [isEnvFlagEnabled(process.env[E2E_ENV.VERBOSE]) ? 'list' : 'line'],
+    [join(projectRoot, 'src', 'cli', 'e2e', 'structured-failure-reporter.ts')],
+  ],
   use: {
     channel: 'chromium',
     baseURL: process.env[E2E_ENV.GRAFANA_URL] || 'http://localhost:3000',


### PR DESCRIPTION
## Summary

Playwright can fail before the guide runner writes its final result file. These failures now produce a safe, schema-valid infrastructure result instead of a misleading `REPORT_MISSING` result.

The fallback uses the existing `UNKNOWN` code and a fixed message. Final guide results and abort metadata remain authoritative.

## What to look at

- The Playwright reporter writes the fallback before browser setup. It does not persist raw Playwright error fields.
- The CLI recognizes the complete fallback shape before it applies `AUTH_EXPIRED` or `MANDATORY_FAILURE` metadata. It does not replace real guide results.

## Why

The CLI previously lost known setup, preflight, navigation, and early assertion failures when Playwright exited before final result persistence. The missing file hid the real failure stage behind `REPORT_MISSING`.

## How to verify

1. Run a guide against a Grafana instance without the Pathfinder plugin. Inspect the JSON result for `infrastructure_error`, `UNKNOWN`, and the fixed early-failure message.
2. Trigger an authentication abort. Confirm that the result uses `AUTH_EXPIRED` instead of the fallback outcome.
3. Run a passing guide and a guide with a mandatory step failure. Confirm that each final result replaces the fallback and keeps its step data.

## Breaking changes

None. This change uses the existing 1.0.0 report schema and is fully reversible.

Co-Authored-By: Warp <agent@warp.dev>
