### PR TITLE
fix(block-editor): compile-check branch block builders

### DIFF
--- a/src/components/block-editor/forms/BranchBlocksEditor.test.ts
+++ b/src/components/block-editor/forms/BranchBlocksEditor.test.ts
@@ -1,8 +1,4 @@
-import {
-  ALLOWED_BRANCH_BLOCK_TYPES,
-  createDefaultBlock,
-  type BranchBlocksEditorProps,
-} from './BranchBlocksEditor';
+import { ALLOWED_BRANCH_BLOCK_TYPES, createDefaultBlock, type BranchBlocksEditorProps } from './BranchBlocksEditor';
 
 const validProps: BranchBlocksEditorProps = {
   label: 'Branch',
@@ -20,22 +16,28 @@ const invalidProps: BranchBlocksEditorProps = {
 
 void invalidProps;
 
+if (false) {
+  // @ts-expect-error collapsible has no default builder
+  createDefaultBlock('collapsible');
+}
+
 describe('BranchBlocksEditor createDefaultBlock', () => {
-  it('does not offer challenge in the inline add picker', () => {
-    expect(ALLOWED_BRANCH_BLOCK_TYPES).not.toContain('challenge');
+  it('offers exactly the block types the inline picker can build', () => {
+    expect(ALLOWED_BRANCH_BLOCK_TYPES).toEqual([
+      'markdown',
+      'interactive',
+      'image',
+      'video',
+      'input',
+      'quiz',
+      'multistep',
+      'guided',
+    ]);
   });
 
-  it('builds a challenge block instead of empty markdown if challenged', () => {
-    expect(createDefaultBlock('challenge')).toEqual({
-      type: 'challenge',
-      title: '',
-      brief: '',
-      successCriteria: '',
-    });
-  });
-
-  it('still defaults unknown types to empty markdown', () => {
-    // html is legacy / palette-excluded and not in the creatable list
-    expect(createDefaultBlock('html' as any)).toEqual({ type: 'markdown', content: '' });
+  it('constructs every offered block without changing its type', () => {
+    for (const type of ALLOWED_BRANCH_BLOCK_TYPES) {
+      expect(createDefaultBlock(type).type).toBe(type);
+    }
   });
 });

--- a/src/components/block-editor/forms/BranchBlocksEditor.test.ts
+++ b/src/components/block-editor/forms/BranchBlocksEditor.test.ts
@@ -1,4 +1,24 @@
-import { ALLOWED_BRANCH_BLOCK_TYPES, createDefaultBlock } from './BranchBlocksEditor';
+import {
+  ALLOWED_BRANCH_BLOCK_TYPES,
+  createDefaultBlock,
+  type BranchBlocksEditorProps,
+} from './BranchBlocksEditor';
+
+const validProps: BranchBlocksEditorProps = {
+  label: 'Branch',
+  variant: 'success',
+  blocks: [],
+  onChange: () => undefined,
+  addableBlockTypes: ['markdown', 'guided'],
+};
+
+const invalidProps: BranchBlocksEditorProps = {
+  ...validProps,
+  // @ts-expect-error challenge has a dedicated editor and cannot be built by the branch add picker
+  addableBlockTypes: ['challenge'],
+};
+
+void invalidProps;
 
 describe('BranchBlocksEditor createDefaultBlock', () => {
   it('does not offer challenge in the inline add picker', () => {

--- a/src/components/block-editor/forms/BranchBlocksEditor.tsx
+++ b/src/components/block-editor/forms/BranchBlocksEditor.tsx
@@ -264,43 +264,31 @@ const getStyles = (theme: GrafanaTheme2) => ({
 /**
  * Create a default block of a given type
  */
-export function createDefaultBlock(type: BlockType): JsonBlock {
-  switch (type) {
-    case 'markdown':
-      return { type: 'markdown', content: '' };
-    case 'interactive':
-      return { type: 'interactive', action: 'highlight', reftarget: '', content: '' };
-    case 'image':
-      return { type: 'image', src: '' };
-    case 'video':
-      return { type: 'video', src: '' };
-    case 'quiz':
-      return {
-        type: 'quiz',
-        question: '',
-        choices: [
-          { id: 'a', text: '', correct: true },
-          { id: 'b', text: '' },
-        ],
-      };
-    case 'input':
-      return { type: 'input', prompt: '', inputType: 'text', variableName: '' };
-    case 'multistep':
-      return { type: 'multistep', content: '', steps: [] };
-    case 'guided':
-      return { type: 'guided', content: '', steps: [] };
-    case 'challenge':
-      return { type: 'challenge', title: '', brief: '', successCriteria: '' };
-    default:
-      return { type: 'markdown', content: '' };
-  }
+const BLOCK_DEFAULT_BUILDERS = {
+  markdown: (): JsonBlock => ({ type: 'markdown', content: '' }),
+  interactive: (): JsonBlock => ({ type: 'interactive', action: 'highlight', reftarget: '', content: '' }),
+  image: (): JsonBlock => ({ type: 'image', src: '' }),
+  video: (): JsonBlock => ({ type: 'video', src: '' }),
+  quiz: (): JsonBlock => ({
+    type: 'quiz',
+    question: '',
+    choices: [
+      { id: 'a', text: '', correct: true },
+      { id: 'b', text: '' },
+    ],
+  }),
+  input: (): JsonBlock => ({ type: 'input', prompt: '', inputType: 'text', variableName: '' }),
+  multistep: (): JsonBlock => ({ type: 'multistep', content: '', steps: [] }),
+  guided: (): JsonBlock => ({ type: 'guided', content: '', steps: [] }),
+} as const satisfies Partial<Record<BlockType, () => JsonBlock>>;
+
+export type DefaultableBlockType = keyof typeof BLOCK_DEFAULT_BUILDERS;
+
+export function createDefaultBlock(type: DefaultableBlockType): JsonBlock {
+  return BLOCK_DEFAULT_BUILDERS[type]();
 }
 
-// Block types the inline branch editor can construct without falling through to an
-// empty markdown stub. Nested containers are excluded; types that need dedicated
-// forms (challenge, quiz, terminal, …) are also excluded so the combobox cannot
-// silently create the wrong block shape (see #1542).
-const BRANCH_INLINE_CREATABLE_TYPES: BlockType[] = [
+export const ALLOWED_BRANCH_BLOCK_TYPES: readonly DefaultableBlockType[] = [
   'markdown',
   'interactive',
   'image',
@@ -311,11 +299,17 @@ const BRANCH_INLINE_CREATABLE_TYPES: BlockType[] = [
   'guided',
 ];
 
-export const ALLOWED_BRANCH_BLOCK_TYPES: BlockType[] = BRANCH_INLINE_CREATABLE_TYPES;
-
 // Block types that support inline form editing in BranchBlocksEditor
 // quiz, multistep, and guided require the dedicated editors and cannot be edited inline
-const INLINE_EDITABLE_TYPES: BlockType[] = ['markdown', 'interactive', 'image', 'video', 'input'];
+const INLINE_EDITABLE_TYPES: readonly DefaultableBlockType[] = ['markdown', 'interactive', 'image', 'video', 'input'];
+
+function isDefaultableBlockType(type: BlockType): type is DefaultableBlockType {
+  return type in BLOCK_DEFAULT_BUILDERS;
+}
+
+function isInlineEditableType(type: BlockType): type is DefaultableBlockType {
+  return isDefaultableBlockType(type) && INLINE_EDITABLE_TYPES.includes(type);
+}
 
 const ACTION_OPTIONS: Array<ComboboxOption<JsonInteractiveAction>> = INTERACTIVE_ACTIONS.map((a) => ({
   value: a.value as JsonInteractiveAction,
@@ -373,7 +367,7 @@ export interface BranchBlocksEditorProps {
   /** Called when blocks change */
   onChange: (blocks: JsonBlock[]) => void;
   /** Block types offered in the add menu. Defaults to ALLOWED_BRANCH_BLOCK_TYPES. */
-  addableBlockTypes?: BlockType[];
+  addableBlockTypes?: readonly DefaultableBlockType[];
   /** Called to start/stop the element picker */
   onPickerModeChange?: BlockFormProps['onPickerModeChange'];
 }
@@ -393,7 +387,7 @@ export function BranchBlocksEditor({
 
   // Add block form state
   const [showAddForm, setShowAddForm] = useState(false);
-  const [newBlockType, setNewBlockType] = useState<BlockType>('markdown');
+  const [newBlockType, setNewBlockType] = useState<DefaultableBlockType>('markdown');
 
   // Edit block state
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
@@ -461,7 +455,7 @@ export function BranchBlocksEditor({
 
   // Build block from form fields
   const buildBlockFromForm = useCallback(
-    (type: BlockType, existing?: JsonBlock): JsonBlock => {
+    (type: DefaultableBlockType, existing?: JsonBlock): JsonBlock => {
       switch (type) {
         case 'markdown':
           return { type: 'markdown', content: formContent };
@@ -552,7 +546,9 @@ export function BranchBlocksEditor({
         return;
       }
       setEditingIndex(index);
-      setNewBlockType(block.type as BlockType);
+      if (isDefaultableBlockType(block.type)) {
+        setNewBlockType(block.type);
+      }
       populateFormFromBlock(block);
     },
     [blocks, populateFormFromBlock]
@@ -567,11 +563,11 @@ export function BranchBlocksEditor({
     if (!editingBlock) {
       return;
     }
-    const blockType = editingBlock.type as BlockType;
+    const blockType = editingBlock.type;
 
     // Safety check: prevent data loss for types without inline editing support
     // These types should use handleCancelEdit instead (UI shows Close button, not Save)
-    if (!INLINE_EDITABLE_TYPES.includes(blockType)) {
+    if (!isInlineEditableType(blockType)) {
       setEditingIndex(null);
       resetFormFields();
       return;
@@ -860,7 +856,7 @@ export function BranchBlocksEditor({
                                   tooltip="Delete block"
                                 />
                               </>
-                            ) : INLINE_EDITABLE_TYPES.includes(block.type as BlockType) ? (
+                            ) : isInlineEditableType(block.type) ? (
                               <>
                                 <Button size="sm" variant="primary" onClick={handleSaveEdit}>
                                   Save

--- a/src/components/block-editor/forms/CollapsibleBlockForm.tsx
+++ b/src/components/block-editor/forms/CollapsibleBlockForm.tsx
@@ -9,15 +9,15 @@
 import React, { useState, useCallback } from 'react';
 import { Button, Field, Input, Switch, useStyles2 } from '@grafana/ui';
 import { getBlockFormStyles } from '../block-editor.styles';
-import { BranchBlocksEditor } from './BranchBlocksEditor';
+import { BranchBlocksEditor, type DefaultableBlockType } from './BranchBlocksEditor';
 import { testIds } from '../../../constants/testIds';
-import type { BlockFormProps, BlockType, JsonBlock } from '../types';
+import type { BlockFormProps, JsonBlock } from '../types';
 import type { JsonCollapsibleBlock, PresentationalBlock } from '../../../types/json-guide.types';
 
 // Content-only block types offered in a collapsible's add menu. Mirrors
 // PresentationalBlock in json-guide.types.ts (html is authored via markdown,
 // not the palette).
-const PRESENTATIONAL_ADDABLE_TYPES: BlockType[] = ['markdown', 'image', 'video'];
+const PRESENTATIONAL_ADDABLE_TYPES: readonly DefaultableBlockType[] = ['markdown', 'image', 'video'];
 
 function isCollapsibleBlock(block: JsonBlock): block is JsonCollapsibleBlock {
   return block.type === 'collapsible';


### PR DESCRIPTION
## Summary

- derive the branch editor's constructible block type from its default-builder registry
- constrain both add-picker lists and the public `addableBlockTypes` prop to constructible types
- remove the permissive unknown-type fallback that silently produced empty markdown
- add compile-time contracts and a runtime whole-picker regression test

Fixes #1655

## Root cause

The picker lists, public prop, and `createDefaultBlock` all accepted the broad `BlockType` union independently. TypeScript therefore could not detect when a picker exposed a type without an intentional builder, allowing the silent empty-markdown behavior from #1542 to return.

## Verification

- `npm run typecheck`
- `npx jest src/components/block-editor/forms/BranchBlocksEditor.test.ts --coverage=false --runInBand`
- `git diff --check origin/main...HEAD`

The focused suite passes both regression tests. A broader local `npm run test:ci` run passed 7,325 tests across 457 suites; the only unrelated failure was the `node:test` builtin assertion under local Node 22, while this repository requires Node 24+. The full `npm run check` also reached the Go lint stage but could not run it because `mage` is not installed locally.

## Risk

Low. The change is limited to the branch block editor's type contract and preserves the existing picker entries and generated block shapes.
