### PR TITLE
fix(block-editor): stamp saves with the schema version the editor emits

### DIFF
--- a/src/components/block-editor/hooks/useBackendGuides.test.ts
+++ b/src/components/block-editor/hooks/useBackendGuides.test.ts
@@ -286,6 +286,19 @@ describe('saveGuide — round-trip of fields the editor does not own', () => {
     expect(request.data.metadata).toEqual({ name: 'fresh', namespace: 'stacks-1' });
   });
 
+  it('stamps the schema version the editor emits, not a stale literal', async () => {
+    const result = await renderLoaded([]);
+
+    // getGuide() never returns a schemaVersion, so every editor save takes the fallback.
+    const guide = { id: 'fresh', title: 'Fresh guide', blocks: [] };
+    await act(async () => {
+      await result.current.saveGuide(guide as JsonGuide);
+    });
+
+    expect(lastRequest().data.spec.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+    expect(lastRequest().data.spec.schemaVersion).not.toBe('1.0');
+  });
+
   it('does not borrow a manifest from an unrelated resource in the loaded list', async () => {
     const resource = pathCoverPage();
     const result = await renderLoaded([resource]);


### PR DESCRIPTION
## Summary

Every guide the block editor saves to App Platform was stamped `spec.schemaVersion: "1.0"` while the editor actually emits `1.1.0`. `preservedSpec` fell back to a hardcoded `'1.0'`, and since `getGuide()` never returns a `schemaVersion`, that fallback was taken on **every** editor save — so each editor-authored guide misreported which schema produced its blocks, which is the one question `schemaVersion` exists to answer.

The comment on that line already stated the correct intent — "the editor writes the schema version it emits, not the stored one" — it just named the wrong constant. Pointing the fallback at `CURRENT_SCHEMA_VERSION` makes the two impossible to drift apart again.

Guides already stored as `"1.0"` keep that value until re-saved, which is correct: the field describes the schema that produced the blocks on the resource.

## How to verify

1. Open the block editor, create a new guide with a single markdown block, and save it as a draft.
2. Read the resource back — `GET /apis/pathfinderbackend.ext.grafana.app/v1alpha1/namespaces/<ns>/interactiveguides/<id>` — and confirm `spec.schemaVersion` is now `1.1.0` rather than `1.0`.
3. Load an existing guide that was stored with `"1.0"` and save it without editing; confirm it is re-stamped to the current version rather than pinned to the stale literal.

Two regression tests are added alongside: one asserting the saved version tracks `CURRENT_SCHEMA_VERSION` (and explicitly is *not* `'1.0'`, so a re-hardcode fails loudly), and one confirming a caller-supplied `schemaVersion` is still respected rather than overwritten.

## Breaking changes

None. This changes what future saves write; stored resources are untouched until they are next saved. Nothing on the App Platform read path branches on `spec.schemaVersion` today.

Fixes #1678
