### PR TITLE
fix(e2e): extend Pathfinder bootstrap retry budget

### DIFF
--- a/tests/e2e-runner/utils/guide-runner/bootstrap.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/bootstrap.test.ts
@@ -281,24 +281,55 @@ describe('ensureDocsPanelOpen', () => {
     expect((window as Window & { __pathfinderE2ESidebarMounted?: boolean }).__pathfinderE2ESidebarMounted).toBe(false);
   });
 
-  it('runs one setup-only recovery callback after an initial bootstrap failure', async () => {
-    const beforeRetry = jest.fn().mockResolvedValue(undefined);
-    const { page, helpButton, panelWaitFor } = createHarness({
+  it('uses a fresh 20-second bound for each of at most two bootstrap attempts', async () => {
+    let now = 1_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const beforeRetry = jest.fn().mockImplementation(async () => {
+      now += 5_000;
+    });
+    const { page, panel, helpButton, panelWaitFor, waitForFunction } = createHarness({
+      panelWaitResults: [new Error('first bootstrap failed'), 'resolve'],
+      openConfirmationResults: ['resolve', 'resolve'],
+    });
+    await expect(ensureDocsPanelOpen(page, { beforeRetry })).resolves.toBe(panel);
+
+    expect(beforeRetry).toHaveBeenCalledTimes(1);
+    expect(helpButton.click).toHaveBeenCalledTimes(2);
+    expect(helpButton.click).toHaveBeenNthCalledWith(1, { timeout: 20_000 });
+    expect(helpButton.click).toHaveBeenNthCalledWith(2, { timeout: 20_000 });
+    expect(panelWaitFor).toHaveBeenCalledTimes(2);
+    expect(panelWaitFor).toHaveBeenNthCalledWith(1, { state: 'visible', timeout: 20_000 });
+    expect(panelWaitFor).toHaveBeenNthCalledWith(2, { state: 'visible', timeout: 20_000 });
+    expect(waitForFunction.mock.calls.map((call) => call[2]?.timeout)).toEqual([20_000, 2_000, 20_000, 2_000]);
+  });
+
+  it('uses the explicit timeout independently for both bootstrap attempts', async () => {
+    let now = 1_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const beforeRetry = jest.fn().mockImplementation(async () => {
+      now += 100;
+    });
+    const { page, panel, helpButton, panelWaitFor, waitForFunction } = createHarness({
       panelWaitResults: [new Error('first bootstrap failed'), 'resolve'],
       openConfirmationResults: ['resolve', 'resolve'],
     });
 
-    await ensureDocsPanelOpen(page, { beforeRetry });
+    await expect(ensureDocsPanelOpen(page, { beforeRetry, timeoutMs: 250 })).resolves.toBe(panel);
 
     expect(beforeRetry).toHaveBeenCalledTimes(1);
     expect(helpButton.click).toHaveBeenCalledTimes(2);
+    expect(helpButton.click).toHaveBeenNthCalledWith(1, { timeout: 250 });
+    expect(helpButton.click).toHaveBeenNthCalledWith(2, { timeout: 250 });
     expect(panelWaitFor).toHaveBeenCalledTimes(2);
+    expect(panelWaitFor).toHaveBeenNthCalledWith(1, { state: 'visible', timeout: 250 });
+    expect(panelWaitFor).toHaveBeenNthCalledWith(2, { state: 'visible', timeout: 250 });
+    expect(waitForFunction.mock.calls.map((call) => call[2]?.timeout)).toEqual([250, 250, 250, 250]);
   });
 
-  it('propagates the second bootstrap failure without another retry', async () => {
+  it('stops after the second bounded bootstrap attempt fails', async () => {
     const beforeRetry = jest.fn().mockResolvedValue(undefined);
     const secondFailure = new Error('second bootstrap failed');
-    const { page, helpButton } = createHarness({
+    const { page, helpButton, panelWaitFor } = createHarness({
       panelWaitResults: [new Error('first bootstrap failed'), secondFailure],
       openConfirmationResults: ['resolve', 'resolve'],
     });
@@ -307,6 +338,22 @@ describe('ensureDocsPanelOpen', () => {
 
     expect(beforeRetry).toHaveBeenCalledTimes(1);
     expect(helpButton.click).toHaveBeenCalledTimes(2);
+    expect(panelWaitFor).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops before the second bootstrap attempt when the retry callback fails', async () => {
+    const callbackFailure = new Error('retry callback failed');
+    const beforeRetry = jest.fn().mockRejectedValue(callbackFailure);
+    const { page, helpButton, panelWaitFor } = createHarness({
+      panelWaitResults: [new Error('first bootstrap failed')],
+      openConfirmationResults: ['resolve'],
+    });
+
+    await expect(ensureDocsPanelOpen(page, { beforeRetry })).rejects.toBe(callbackFailure);
+
+    expect(beforeRetry).toHaveBeenCalledTimes(1);
+    expect(helpButton.click).toHaveBeenCalledTimes(1);
+    expect(panelWaitFor).toHaveBeenCalledTimes(1);
   });
 
   it('propagates a custom timeout to every wait in one bootstrap attempt', async () => {
@@ -335,12 +382,14 @@ describe('ensureDocsPanelOpen', () => {
     expect(panelWaitFor).toHaveBeenCalledWith({ state: 'visible', timeout: 1 });
   });
 
-  it('surfaces a timeout failure when no setup retry is configured', async () => {
+  it('stops after one bounded bootstrap attempt when no retry callback exists', async () => {
     const timeoutError = new Error('Panel wait timed out');
-    const { page } = createHarness({
+    const { page, helpButton, panelWaitFor } = createHarness({
       panelWaitResults: [timeoutError],
     });
+    await expect(ensureDocsPanelOpen(page)).rejects.toBe(timeoutError);
 
-    await expect(ensureDocsPanelOpen(page, { timeoutMs: 100 })).rejects.toBe(timeoutError);
+    expect(helpButton.click).toHaveBeenCalledTimes(1);
+    expect(panelWaitFor).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/e2e-runner/utils/guide-runner/bootstrap.ts
+++ b/tests/e2e-runner/utils/guide-runner/bootstrap.ts
@@ -5,7 +5,7 @@ import { EXTENSION_SIDEBAR_DOCKED_KEY } from '../../../../src/lib/storage/extens
 import pluginJson from '../../../../src/plugin.json';
 
 const PATHFINDER_COMPONENT_TITLE = 'Interactive learning';
-const DEFAULT_PANEL_OPEN_TIMEOUT_MS = 10_000;
+const DEFAULT_PANEL_OPEN_TIMEOUT_MS = 20_000;
 const OPEN_CONFIRMATION_TIMEOUT_MS = 2_000;
 const MAX_DOCKED_VALUE_PARSE_DEPTH = 2;
 const MAX_HELP_OPEN_ATTEMPTS = 2;

--- a/tests/e2e-runner/utils/guide-runner/constants.ts
+++ b/tests/e2e-runner/utils/guide-runner/constants.ts
@@ -37,7 +37,7 @@ export const SECTION_SELECTOR = '[data-testid^="interactive-section-"]';
  */
 export const DEFAULT_STEP_TIMEOUT_MS = 30000;
 export const GUIDE_SETUP_TIMEOUT_MS = 60000;
-export const GUIDE_INITIAL_TIMEOUT_MS = GUIDE_SETUP_TIMEOUT_MS * 2;
+export const GUIDE_INITIAL_TIMEOUT_MS = 140000;
 export const STEP_OVERHEAD_TIMEOUT_MS = 20000;
 
 /**

--- a/tests/e2e-runner/utils/guide-test-runner.test.ts
+++ b/tests/e2e-runner/utils/guide-test-runner.test.ts
@@ -28,6 +28,7 @@ import {
   selectStepAction,
   DEFAULT_STEP_TIMEOUT_MS,
   GUIDE_INITIAL_TIMEOUT_MS,
+  GUIDE_SETUP_TIMEOUT_MS,
   TIMEOUT_PER_MULTISTEP_ACTION_MS,
   TIMEOUT_PER_GUIDED_SUBSTEP_MS,
   STEP_DEADLINE_CLEANUP_GRACE_MS,
@@ -267,9 +268,20 @@ describe('parseNthMatchSelector', () => {
 });
 
 describe('calculateGuideTimeout', () => {
+  it('keeps the initial timeout above the complete bounded setup path', () => {
+    const panelAttemptsTimeout = 2 * 20_000;
+    const retryCallbackTimeout = 2 * 10_000;
+    const guideRenderTimeout = 1_000 + 15_000;
+
+    expect(GUIDE_INITIAL_TIMEOUT_MS).toBeGreaterThanOrEqual(
+      GUIDE_SETUP_TIMEOUT_MS + panelAttemptsTimeout + retryCallbackTimeout + guideRenderTimeout
+    );
+  });
+
   it('preserves the full initial setup allowance after discovery', () => {
     expect(calculateGuideTimeout([])).toBe(GUIDE_INITIAL_TIMEOUT_MS);
   });
+
   it('allows the aggregate budget for multiple simple steps to exceed two minutes', () => {
     const steps = Array.from({ length: 5 }, (_, index) => createTestableStep({ stepId: `step-${index}`, index }));
 


### PR DESCRIPTION
## Summary

Give each Pathfinder panel-open attempt 20 seconds instead of 10 seconds. Preserve the existing single reload retry, with at most two independently bounded attempts.

Increase the outer guide setup deadline from 120 to 140 seconds. This lets the complete retry path finish without Playwright truncating attempt two.

## What to look at

- [Panel bootstrap](https://github.com/grafana/grafana-pathfinder-app/blob/b5c4d250e185fdb549d1cd4401bf525915817837/tests/e2e-runner/utils/guide-runner/bootstrap.ts): each attempt gets a fresh 20-second deadline, while `beforeRetry` remains optional and runs once at most.
- [Guide setup budget](https://github.com/grafana/grafana-pathfinder-app/blob/b5c4d250e185fdb549d1cd4401bf525915817837/tests/e2e-runner/utils/guide-runner/constants.ts): the 140-second outer limit covers the 136-second bounded setup path.

## Why

The cycle of guide runs in the e2e platform is recording intermittent plugin bootstrap failures (~15 per run of 161 guide chains). Every failure stopped while waiting for `window.__pathfinderPluginConfig` after 9.89–10.00 seconds.

The affected stacks had already been health-ready and available for 26–58 minutes. This points to a per-page frontend initialization race rather than stack maturity. 

This wasn't something that happened as often when testing against a production org, so I'm hypothesizing that this is related to weaker resources in the dev env, and hoping that a longer timeout will help in conjunction with the existing page refresh/retry.

## How to verify

1. Publish a runner image from this branch and execute one develop cycle.
2. Compare `bootstrap.ts:125` timeout counts with the prior cycle.
3. Inspect a retrying task and confirm that it performs no more than one reload and two panel-open attempts.
4. Confirm that a second attempt can continue beyond the former 120-second outer setup deadline.

## Breaking changes

None. This change is additive and fully reversible.
