### PR TITLE
feat(interactive-tutorial): restyle the knowledge-check quiz block

### DIFF
--- a/src/components/interactive-tutorial/interactive-quiz.test.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.test.tsx
@@ -219,10 +219,10 @@ describe('InteractiveQuiz: shuffle behavior', () => {
       );
 
       // Find the rendered "Bravo" button (correct=true) — its visual position
-      // is whatever the shuffle produced; we look up by text. Single-select
-      // checks instantly on click — there is no separate Check Answer step.
+      // is whatever the shuffle produced; we look up by text.
       const correctButton = screen.getByRole('button', { name: 'Bravo' });
       fireEvent.click(correctButton);
+      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
 
       expect(screen.getByText(/Correct! Well done\./i)).toBeInTheDocument();
     } finally {
@@ -248,6 +248,7 @@ describe('InteractiveQuiz: shuffle behavior', () => {
         </InteractiveQuiz>
       );
       fireEvent.click(screen.getByRole('button', { name: 'Charlie' }));
+      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
       expect(screen.getByText('Charlie hint')).toBeInTheDocument();
     } finally {
       spy.mockRestore();
@@ -316,8 +317,9 @@ describe('InteractiveQuiz: render-order stability', () => {
       );
       const orderBefore = readChoiceOrder();
 
-      // Answer correctly — single-select checks instantly on click.
+      // Answer correctly.
       fireEvent.click(screen.getByRole('button', { name: 'Bravo' }));
+      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
       expect(screen.getByText(/Correct! Well done\./i)).toBeInTheDocument();
 
       // Force a parent re-render with an unrelated prop change (and a fresh choices reference).
@@ -358,8 +360,9 @@ describe('InteractiveQuiz: render-order stability', () => {
         .map((b) => b.textContent)
         .filter((t): t is string => !!t && /^(Alpha|Bravo|Charlie)$/.test(t));
 
-      // Pick a wrong answer so the hint surfaces — instant on click.
+      // Pick a wrong answer so the hint surfaces.
       fireEvent.click(screen.getByRole('button', { name: 'Charlie' }));
+      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
       expect(screen.getByText('Charlie hint')).toBeInTheDocument();
 
       // Force a re-render with a new choices reference.
@@ -465,6 +468,7 @@ describe('InteractiveQuiz: skip reason', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Bravo' }));
+    fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
 
     const store = require('../../global-state/completion-store') as {
       __getStoredReason: (stepId: string) => string | null;
@@ -494,7 +498,7 @@ describe('InteractiveQuiz: header label and attempts placement', () => {
     expect(screen.getByText('Knowledge check')).toBeInTheDocument();
   });
 
-  it('shows attempts remaining (max-attempts mode) alongside the label, with no Check Answer button for single-select', () => {
+  it('shows attempts remaining (max-attempts mode) alongside the label; Check Answer appears only once a choice is selected', () => {
     const choices: QuizChoice[] = [
       { id: 'a', text: 'True', correct: false },
       { id: 'b', text: 'False', correct: true },
@@ -506,6 +510,9 @@ describe('InteractiveQuiz: header label and attempts placement', () => {
     );
     expect(screen.getByText('2 attempts remaining')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Check Answer/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'True' }));
+    expect(screen.getByRole('button', { name: /Check Answer/i })).toBeInTheDocument();
   });
 
   it('does not show an attempts indicator in correct-only mode (the default)', () => {
@@ -579,7 +586,7 @@ describe('InteractiveQuiz: compact pill layout vs. stacked layout', () => {
   });
 });
 
-describe('InteractiveQuiz: multi-select keeps the explicit Check Answer button', () => {
+describe('InteractiveQuiz: multi-select requires an explicit Check Answer click', () => {
   beforeEach(() => {
     resetQuizCounter();
     (require('../../global-state/completion-store') as { __resetMockStore: () => void }).__resetMockStore();
@@ -610,6 +617,40 @@ describe('InteractiveQuiz: multi-select keeps the explicit Check Answer button',
     );
     fireEvent.click(screen.getByRole('button', { name: 'Alpha' }));
     fireEvent.click(screen.getByRole('button', { name: 'Bravo' }));
+    fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
+    expect(screen.getByText(/Correct! Well done\./i)).toBeInTheDocument();
+  });
+});
+
+describe('InteractiveQuiz: single-select also requires an explicit Check Answer click', () => {
+  beforeEach(() => {
+    resetQuizCounter();
+    (require('../../global-state/completion-store') as { __resetMockStore: () => void }).__resetMockStore();
+  });
+
+  const choices: QuizChoice[] = [
+    { id: 'a', text: 'True', correct: false },
+    { id: 'b', text: 'False', correct: true },
+  ];
+
+  it("does not complete on the choice click alone — matches multi-select, challenge, and data-check's explicit-submit pattern", () => {
+    render(
+      <InteractiveQuiz question="Q" choices={choices} shuffle={false}>
+        Q
+      </InteractiveQuiz>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'False' }));
+    expect(screen.queryByText(/Correct! Well done\./i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Check Answer/i })).toBeInTheDocument();
+  });
+
+  it('completes only after Check Answer is clicked', () => {
+    render(
+      <InteractiveQuiz question="Q" choices={choices} shuffle={false}>
+        Q
+      </InteractiveQuiz>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'False' }));
     fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
     expect(screen.getByText(/Correct! Well done\./i)).toBeInTheDocument();
   });

--- a/src/components/interactive-tutorial/interactive-quiz.test.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.test.tsx
@@ -569,13 +569,12 @@ describe('InteractiveQuiz: compact pill layout vs. stacked layout', () => {
     expect(hasLeadingIndicator(screen.getByRole('button', { name: /This is a much longer answer choice/ }))).toBe(true);
   });
 
-  it('falls back to the stacked layout (leading indicator present) when there are more than 4 short choices', () => {
+  it('falls back to the stacked layout (leading indicator present) when there are more than 3 short choices', () => {
     const choices: QuizChoice[] = [
       { id: 'a', text: 'One', correct: false },
       { id: 'b', text: 'Two', correct: true },
       { id: 'c', text: 'Three', correct: false },
       { id: 'd', text: 'Four', correct: false },
-      { id: 'e', text: 'Five', correct: false },
     ];
     render(
       <InteractiveQuiz question="Q" choices={choices} shuffle={false}>

--- a/src/components/interactive-tutorial/interactive-quiz.test.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.test.tsx
@@ -569,12 +569,13 @@ describe('InteractiveQuiz: compact pill layout vs. stacked layout', () => {
     expect(hasLeadingIndicator(screen.getByRole('button', { name: /This is a much longer answer choice/ }))).toBe(true);
   });
 
-  it('falls back to the stacked layout (leading indicator present) when there are more than 3 short choices', () => {
+  it('falls back to the stacked layout (leading indicator present) when there are more than 4 short choices', () => {
     const choices: QuizChoice[] = [
       { id: 'a', text: 'One', correct: false },
       { id: 'b', text: 'Two', correct: true },
       { id: 'c', text: 'Three', correct: false },
       { id: 'd', text: 'Four', correct: false },
+      { id: 'e', text: 'Five', correct: false },
     ];
     render(
       <InteractiveQuiz question="Q" choices={choices} shuffle={false}>

--- a/src/components/interactive-tutorial/interactive-quiz.test.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.test.tsx
@@ -219,10 +219,10 @@ describe('InteractiveQuiz: shuffle behavior', () => {
       );
 
       // Find the rendered "Bravo" button (correct=true) — its visual position
-      // is whatever the shuffle produced; we look up by text.
+      // is whatever the shuffle produced; we look up by text. Single-select
+      // checks instantly on click — there is no separate Check Answer step.
       const correctButton = screen.getByRole('button', { name: 'Bravo' });
       fireEvent.click(correctButton);
-      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
 
       expect(screen.getByText(/Correct! Well done\./i)).toBeInTheDocument();
     } finally {
@@ -248,7 +248,6 @@ describe('InteractiveQuiz: shuffle behavior', () => {
         </InteractiveQuiz>
       );
       fireEvent.click(screen.getByRole('button', { name: 'Charlie' }));
-      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
       expect(screen.getByText('Charlie hint')).toBeInTheDocument();
     } finally {
       spy.mockRestore();
@@ -317,9 +316,8 @@ describe('InteractiveQuiz: render-order stability', () => {
       );
       const orderBefore = readChoiceOrder();
 
-      // Answer correctly.
+      // Answer correctly — single-select checks instantly on click.
       fireEvent.click(screen.getByRole('button', { name: 'Bravo' }));
-      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
       expect(screen.getByText(/Correct! Well done\./i)).toBeInTheDocument();
 
       // Force a parent re-render with an unrelated prop change (and a fresh choices reference).
@@ -360,9 +358,8 @@ describe('InteractiveQuiz: render-order stability', () => {
         .map((b) => b.textContent)
         .filter((t): t is string => !!t && /^(Alpha|Bravo|Charlie)$/.test(t));
 
-      // Pick a wrong answer so the hint surfaces.
+      // Pick a wrong answer so the hint surfaces — instant on click.
       fireEvent.click(screen.getByRole('button', { name: 'Charlie' }));
-      fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
       expect(screen.getByText('Charlie hint')).toBeInTheDocument();
 
       // Force a re-render with a new choices reference.
@@ -468,12 +465,153 @@ describe('InteractiveQuiz: skip reason', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Bravo' }));
-    fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
 
     const store = require('../../global-state/completion-store') as {
       __getStoredReason: (stepId: string) => string | null;
     };
     expect(store.__getStoredReason('quiz-correct-test')).toBe('manual');
+  });
+});
+
+// ─── Restyle: header label, pill vs. stacked layout, multi-select button ────
+
+describe('InteractiveQuiz: header label and attempts placement', () => {
+  beforeEach(() => {
+    resetQuizCounter();
+    (require('../../global-state/completion-store') as { __resetMockStore: () => void }).__resetMockStore();
+  });
+
+  it('renders the "Knowledge check" label', () => {
+    const choices: QuizChoice[] = [
+      { id: 'a', text: 'True', correct: false },
+      { id: 'b', text: 'False', correct: true },
+    ];
+    render(
+      <InteractiveQuiz question="Q" choices={choices} shuffle={false}>
+        Q
+      </InteractiveQuiz>
+    );
+    expect(screen.getByText('Knowledge check')).toBeInTheDocument();
+  });
+
+  it('shows attempts remaining (max-attempts mode) alongside the label, with no Check Answer button for single-select', () => {
+    const choices: QuizChoice[] = [
+      { id: 'a', text: 'True', correct: false },
+      { id: 'b', text: 'False', correct: true },
+    ];
+    render(
+      <InteractiveQuiz question="Q" choices={choices} shuffle={false} completionMode="max-attempts" maxAttempts={2}>
+        Q
+      </InteractiveQuiz>
+    );
+    expect(screen.getByText('2 attempts remaining')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Check Answer/i })).not.toBeInTheDocument();
+  });
+
+  it('does not show an attempts indicator in correct-only mode (the default)', () => {
+    const choices: QuizChoice[] = [
+      { id: 'a', text: 'True', correct: false },
+      { id: 'b', text: 'False', correct: true },
+    ];
+    render(
+      <InteractiveQuiz question="Q" choices={choices} shuffle={false}>
+        Q
+      </InteractiveQuiz>
+    );
+    expect(screen.queryByText(/attempts? remaining/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('InteractiveQuiz: compact pill layout vs. stacked layout', () => {
+  beforeEach(() => {
+    resetQuizCounter();
+    (require('../../global-state/completion-store') as { __resetMockStore: () => void }).__resetMockStore();
+  });
+
+  // The leading radio/checkbox indicator renders as a `span` nested inside
+  // another `span` (see `choiceIndicator` in the component). Pill layout
+  // omits that wrapper entirely, so counting nested spans is a reliable,
+  // markup-based way to assert presence/absence without depending on
+  // emotion's hashed class names.
+  const hasLeadingIndicator = (button: HTMLElement) => button.querySelectorAll('span span').length > 0;
+
+  it('uses the compact pill layout (no leading indicator) for a short True/False question', () => {
+    const choices: QuizChoice[] = [
+      { id: 'a', text: 'True', correct: false },
+      { id: 'b', text: 'False', correct: true },
+    ];
+    render(
+      <InteractiveQuiz question="Q" choices={choices} shuffle={false}>
+        Q
+      </InteractiveQuiz>
+    );
+    expect(hasLeadingIndicator(screen.getByRole('button', { name: 'True' }))).toBe(false);
+    expect(hasLeadingIndicator(screen.getByRole('button', { name: 'False' }))).toBe(false);
+  });
+
+  it('falls back to the stacked layout (leading indicator present) when choice text is long', () => {
+    const choices: QuizChoice[] = [
+      { id: 'a', text: 'This is a much longer answer choice than a short label', correct: true },
+      { id: 'b', text: 'Also a fairly long second choice for this question', correct: false },
+    ];
+    render(
+      <InteractiveQuiz question="Q" choices={choices} shuffle={false}>
+        Q
+      </InteractiveQuiz>
+    );
+    expect(hasLeadingIndicator(screen.getByRole('button', { name: /This is a much longer answer choice/ }))).toBe(true);
+  });
+
+  it('falls back to the stacked layout (leading indicator present) when there are more than 4 short choices', () => {
+    const choices: QuizChoice[] = [
+      { id: 'a', text: 'One', correct: false },
+      { id: 'b', text: 'Two', correct: true },
+      { id: 'c', text: 'Three', correct: false },
+      { id: 'd', text: 'Four', correct: false },
+      { id: 'e', text: 'Five', correct: false },
+    ];
+    render(
+      <InteractiveQuiz question="Q" choices={choices} shuffle={false}>
+        Q
+      </InteractiveQuiz>
+    );
+    expect(hasLeadingIndicator(screen.getByRole('button', { name: 'One' }))).toBe(true);
+  });
+});
+
+describe('InteractiveQuiz: multi-select keeps the explicit Check Answer button', () => {
+  beforeEach(() => {
+    resetQuizCounter();
+    (require('../../global-state/completion-store') as { __resetMockStore: () => void }).__resetMockStore();
+  });
+
+  const choices: QuizChoice[] = [
+    { id: 'a', text: 'Alpha', correct: true },
+    { id: 'b', text: 'Bravo', correct: true },
+    { id: 'c', text: 'Charlie', correct: false },
+  ];
+
+  it('does not complete on the first choice click — requires an explicit Check Answer click', () => {
+    render(
+      <InteractiveQuiz question="Q" choices={choices} multiSelect shuffle={false}>
+        Q
+      </InteractiveQuiz>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha' }));
+    expect(screen.queryByText(/Correct! Well done\./i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Check Answer/i })).toBeInTheDocument();
+  });
+
+  it('completes once all correct choices are selected and Check Answer is clicked', () => {
+    render(
+      <InteractiveQuiz question="Q" choices={choices} multiSelect shuffle={false}>
+        Q
+      </InteractiveQuiz>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Bravo' }));
+    fireEvent.click(screen.getByRole('button', { name: /Check Answer/i }));
+    expect(screen.getByText(/Correct! Well done\./i)).toBeInTheDocument();
   });
 });
 

--- a/src/components/interactive-tutorial/interactive-quiz.test.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.test.tsx
@@ -584,6 +584,20 @@ describe('InteractiveQuiz: compact pill layout vs. stacked layout', () => {
     );
     expect(hasLeadingIndicator(screen.getByRole('button', { name: 'One' }))).toBe(true);
   });
+
+  it('falls back to the stacked layout (leading checkbox present) for multi-select, even with few short choices', () => {
+    const choices: QuizChoice[] = [
+      { id: 'a', text: 'One', correct: true },
+      { id: 'b', text: 'Two', correct: true },
+    ];
+    render(
+      <InteractiveQuiz question="Q" choices={choices} multiSelect shuffle={false}>
+        Q
+      </InteractiveQuiz>
+    );
+    expect(hasLeadingIndicator(screen.getByRole('button', { name: 'One' }))).toBe(true);
+    expect(hasLeadingIndicator(screen.getByRole('button', { name: 'Two' }))).toBe(true);
+  });
 });
 
 describe('InteractiveQuiz: multi-select requires an explicit Check Answer click', () => {

--- a/src/components/interactive-tutorial/interactive-quiz.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.tsx
@@ -62,7 +62,7 @@ export interface InteractiveQuizProps {
 // Thresholds for the compact side-by-side pill layout — short questions
 // (True/False, single-word choices) read better as pills; anything longer
 // or more numerous falls back to the stacked full-width rows.
-const PILL_LAYOUT_MAX_CHOICES = 3;
+const PILL_LAYOUT_MAX_CHOICES = 4;
 const PILL_LAYOUT_MAX_CHOICE_LENGTH = 20;
 
 // Counter for generating unique quiz IDs

--- a/src/components/interactive-tutorial/interactive-quiz.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.tsx
@@ -62,7 +62,7 @@ export interface InteractiveQuizProps {
 // Thresholds for the compact side-by-side pill layout — short questions
 // (True/False, single-word choices) read better as pills; anything longer
 // or more numerous falls back to the stacked full-width rows.
-const PILL_LAYOUT_MAX_CHOICES = 4;
+const PILL_LAYOUT_MAX_CHOICES = 3;
 const PILL_LAYOUT_MAX_CHOICE_LENGTH = 20;
 
 // Counter for generating unique quiz IDs
@@ -704,8 +704,10 @@ const getQuizStyles = (theme: GrafanaTheme2) => {
 
     choiceCompact: css`
       width: auto;
-      flex: 0 1 auto;
+      flex: 1 1 0;
+      min-width: 0;
       justify-content: center;
+      text-align: center;
     `,
 
     choiceDefault: css``,

--- a/src/components/interactive-tutorial/interactive-quiz.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.tsx
@@ -443,10 +443,14 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
   const showCheckButton = !isCompleted && !isRevealed && displayedSelection.size > 0;
   const attemptsRemaining = completionMode === 'max-attempts' ? maxAttempts - attempts : null;
   const showAttemptsRemaining = attemptsRemaining !== null && !isCompleted && !isRevealed;
-  // Compact pill layout only for short questions — a handful of short
-  // choices (True/False, single words) reads better side-by-side; longer or
-  // more numerous choices keep the stacked full-width rows.
+  // Compact pill layout only for short single-select questions — a handful
+  // of short choices (True/False, single words) reads better side-by-side;
+  // longer or more numerous choices keep the stacked full-width rows.
+  // Multi-select always keeps the stacked layout too: pills drop the leading
+  // indicator, and without the checkbox there's no visual cue that more than
+  // one choice can be selected.
   const useCompactChoiceLayout =
+    !multiSelect &&
     displayChoices.length <= PILL_LAYOUT_MAX_CHOICES &&
     displayChoices.every((c) => c.text.length <= PILL_LAYOUT_MAX_CHOICE_LENGTH);
 

--- a/src/components/interactive-tutorial/interactive-quiz.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.tsx
@@ -262,15 +262,12 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
     }
   }, [selectedIds, correctIds, multiSelect]);
 
-  // Build analytics properties for quiz interactions. `selectedIdsForAnalytics`
-  // is passed explicitly rather than read from `selectedIds` state — for the
-  // single-select instant-check path (see `handleChoiceClick`), the check runs
-  // in the same tick as the click, before React has flushed the state update.
+  // Build analytics properties for quiz interactions
   const buildQuizAnalyticsProps = useCallback(
-    (isCorrect: boolean, attemptCount: number, selectedIdsForAnalytics: Set<string>, revealed = false) => {
+    (isCorrect: boolean, attemptCount: number, revealed = false) => {
       // Get selected answer texts (truncate if too long)
       const selectedAnswers = choices
-        .filter((c) => selectedIdsForAnalytics.has(c.id))
+        .filter((c) => selectedIds.has(c.id))
         .map((c) => c.text)
         .join(', ');
       const truncatedSelected = selectedAnswers.length > 200 ? selectedAnswers.slice(0, 200) + '...' : selectedAnswers;
@@ -308,15 +305,13 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
         sectionTitle,
       });
     },
-    [choices, question, stepId, multiSelect, stepIndex, totalSteps, sectionId, sectionTitle]
+    [choices, selectedIds, question, stepId, multiSelect, stepIndex, totalSteps, sectionId, sectionTitle]
   );
 
-  // Shared "was this correct" outcome handling for both interaction paths:
-  // multi-select's explicit Check Answer button, and single-select's
-  // instant-on-click check. Keeping this in one place means the two paths
-  // can't drift on attempts/hint/reveal/analytics behavior.
+  // Shared "was this correct" outcome handling, used by the single explicit
+  // Check Answer step both quiz modes share (see `handleCheckAnswer`).
   const evaluateAndApply = useCallback(
-    (isCorrect: boolean, wrongChoice: QuizChoice | undefined, selectedIdsForAnalytics: Set<string>) => {
+    (isCorrect: boolean, wrongChoice: QuizChoice | undefined) => {
       const newAttempts = attempts + 1;
       setAttempts(newAttempts);
 
@@ -325,10 +320,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
         persistCompletion();
         setShowHint(null);
 
-        reportAppInteraction(
-          UserInteraction.StepAutoCompleted,
-          buildQuizAnalyticsProps(true, newAttempts, selectedIdsForAnalytics)
-        );
+        reportAppInteraction(UserInteraction.StepAutoCompleted, buildQuizAnalyticsProps(true, newAttempts));
 
         if (onStepComplete && stepId) {
           onStepComplete(stepId);
@@ -343,10 +335,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
           setIsRevealed(true);
           persistCompletion();
 
-          reportAppInteraction(
-            UserInteraction.StepAutoCompleted,
-            buildQuizAnalyticsProps(false, newAttempts, selectedIdsForAnalytics, true)
-          );
+          reportAppInteraction(UserInteraction.StepAutoCompleted, buildQuizAnalyticsProps(false, newAttempts, true));
 
           if (onStepComplete && stepId) {
             onStepComplete(stepId);
@@ -357,43 +346,38 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
     [attempts, persistCompletion, buildQuizAnalyticsProps, onStepComplete, stepId, completionMode, maxAttempts]
   );
 
-  // Handle choice selection. Multi-select only ever toggles — the answer
-  // isn't complete until the user has picked everything they mean to and
-  // clicks "Check Answer" (see `handleCheckAnswer`). Single-select has no
-  // such ambiguity: the clicked choice IS the whole answer, so the click
-  // both selects and checks it in one step, with no separate submit.
+  // Handle choice selection — both quiz modes only ever select/toggle here.
+  // The answer isn't checked until the user clicks "Check Answer"
+  // (`handleCheckAnswer`), matching every other verification-style
+  // interactive block in the product (`challenge`'s "Check my work",
+  // `input`'s "Run check").
   const handleChoiceClick = useCallback(
     (choiceId: string) => {
       if (isCompleted || isRevealed || !isEnabled) {
         return;
       }
 
-      if (multiSelect) {
-        setSelectedIds((prev) => {
-          const newSet = new Set(prev);
+      setSelectedIds((prev) => {
+        const newSet = new Set(prev);
+        if (multiSelect) {
           if (newSet.has(choiceId)) {
             newSet.delete(choiceId);
           } else {
             newSet.add(choiceId);
           }
-          return newSet;
-        });
-        setLastResult('none');
-        setShowHint(null);
-        return;
-      }
-
-      const newSelection = new Set([choiceId]);
-      setSelectedIds(newSelection);
-      const clickedChoice = choices.find((c) => c.id === choiceId);
-      const isCorrect = Boolean(clickedChoice?.correct);
-      evaluateAndApply(isCorrect, isCorrect ? undefined : clickedChoice, newSelection);
+        } else {
+          newSet.clear();
+          newSet.add(choiceId);
+        }
+        return newSet;
+      });
+      setLastResult('none');
+      setShowHint(null);
     },
-    [isCompleted, isRevealed, isEnabled, multiSelect, choices, evaluateAndApply]
+    [isCompleted, isRevealed, isEnabled, multiSelect]
   );
 
-  // Handle check answer (multi-select only — see `handleChoiceClick` for the
-  // single-select instant-check path).
+  // Handle check answer
   const handleCheckAnswer = useCallback(() => {
     if (selectedIds.size === 0) {
       return;
@@ -401,7 +385,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
 
     const isCorrect = checkAnswer();
     const wrongChoice = choices.find((c) => selectedIds.has(c.id) && !c.correct);
-    evaluateAndApply(isCorrect, wrongChoice, selectedIds);
+    evaluateAndApply(isCorrect, wrongChoice);
   }, [selectedIds, checkAnswer, choices, evaluateAndApply]);
 
   // Handle skip
@@ -456,9 +440,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
 
   // Determine if we should show the blocked state
   const isBlocked = !isEnabled && !isCompleted;
-  // Multi-select only — single-select checks instantly on click (see
-  // `handleChoiceClick`), so it never needs an explicit submit button.
-  const showCheckButton = multiSelect && !isCompleted && !isRevealed && displayedSelection.size > 0;
+  const showCheckButton = !isCompleted && !isRevealed && displayedSelection.size > 0;
   const attemptsRemaining = completionMode === 'max-attempts' ? maxAttempts - attempts : null;
   const showAttemptsRemaining = attemptsRemaining !== null && !isCompleted && !isRevealed;
   // Compact pill layout only for short questions — a handful of short
@@ -869,6 +851,7 @@ const getQuizStyles = (theme: GrafanaTheme2) => {
     actions: css`
       display: flex;
       align-items: center;
+      justify-content: flex-end;
       gap: ${theme.spacing(1.5)};
     `,
 

--- a/src/components/interactive-tutorial/interactive-quiz.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.tsx
@@ -59,6 +59,12 @@ export interface InteractiveQuizProps {
 
 // ============ Component ============
 
+// Thresholds for the compact side-by-side pill layout — short questions
+// (True/False, single-word choices) read better as pills; anything longer
+// or more numerous falls back to the stacked full-width rows.
+const PILL_LAYOUT_MAX_CHOICES = 4;
+const PILL_LAYOUT_MAX_CHOICE_LENGTH = 20;
+
 // Counter for generating unique quiz IDs
 let quizCounter = 0;
 
@@ -256,43 +262,15 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
     }
   }, [selectedIds, correctIds, multiSelect]);
 
-  // Handle choice selection
-  const handleChoiceClick = useCallback(
-    (choiceId: string) => {
-      if (isCompleted || isRevealed || !isEnabled) {
-        return;
-      }
-
-      setSelectedIds((prev) => {
-        const newSet = new Set(prev);
-        if (multiSelect) {
-          // Toggle for multi-select
-          if (newSet.has(choiceId)) {
-            newSet.delete(choiceId);
-          } else {
-            newSet.add(choiceId);
-          }
-        } else {
-          // Replace for single-select
-          newSet.clear();
-          newSet.add(choiceId);
-        }
-        return newSet;
-      });
-
-      // Clear previous result/hint when selection changes
-      setLastResult('none');
-      setShowHint(null);
-    },
-    [isCompleted, isRevealed, isEnabled, multiSelect]
-  );
-
-  // Build analytics properties for quiz interactions
+  // Build analytics properties for quiz interactions. `selectedIdsForAnalytics`
+  // is passed explicitly rather than read from `selectedIds` state — for the
+  // single-select instant-check path (see `handleChoiceClick`), the check runs
+  // in the same tick as the click, before React has flushed the state update.
   const buildQuizAnalyticsProps = useCallback(
-    (isCorrect: boolean, attemptCount: number, revealed = false) => {
+    (isCorrect: boolean, attemptCount: number, selectedIdsForAnalytics: Set<string>, revealed = false) => {
       // Get selected answer texts (truncate if too long)
       const selectedAnswers = choices
-        .filter((c) => selectedIds.has(c.id))
+        .filter((c) => selectedIdsForAnalytics.has(c.id))
         .map((c) => c.text)
         .join(', ');
       const truncatedSelected = selectedAnswers.length > 200 ? selectedAnswers.slice(0, 200) + '...' : selectedAnswers;
@@ -330,70 +308,101 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
         sectionTitle,
       });
     },
-    [choices, selectedIds, question, stepId, multiSelect, stepIndex, totalSteps, sectionId, sectionTitle]
+    [choices, question, stepId, multiSelect, stepIndex, totalSteps, sectionId, sectionTitle]
   );
 
-  // Handle check answer
+  // Shared "was this correct" outcome handling for both interaction paths:
+  // multi-select's explicit Check Answer button, and single-select's
+  // instant-on-click check. Keeping this in one place means the two paths
+  // can't drift on attempts/hint/reveal/analytics behavior.
+  const evaluateAndApply = useCallback(
+    (isCorrect: boolean, wrongChoice: QuizChoice | undefined, selectedIdsForAnalytics: Set<string>) => {
+      const newAttempts = attempts + 1;
+      setAttempts(newAttempts);
+
+      if (isCorrect) {
+        setLastResult('correct');
+        persistCompletion();
+        setShowHint(null);
+
+        reportAppInteraction(
+          UserInteraction.StepAutoCompleted,
+          buildQuizAnalyticsProps(true, newAttempts, selectedIdsForAnalytics)
+        );
+
+        if (onStepComplete && stepId) {
+          onStepComplete(stepId);
+        }
+      } else {
+        setLastResult('incorrect');
+        setShakeKey((k) => k + 1);
+        setShowHint(wrongChoice?.hint ?? "That's not quite right. Try again!");
+
+        // Check if max attempts reached (for max-attempts mode)
+        if (completionMode === 'max-attempts' && newAttempts >= maxAttempts) {
+          setIsRevealed(true);
+          persistCompletion();
+
+          reportAppInteraction(
+            UserInteraction.StepAutoCompleted,
+            buildQuizAnalyticsProps(false, newAttempts, selectedIdsForAnalytics, true)
+          );
+
+          if (onStepComplete && stepId) {
+            onStepComplete(stepId);
+          }
+        }
+      }
+    },
+    [attempts, persistCompletion, buildQuizAnalyticsProps, onStepComplete, stepId, completionMode, maxAttempts]
+  );
+
+  // Handle choice selection. Multi-select only ever toggles — the answer
+  // isn't complete until the user has picked everything they mean to and
+  // clicks "Check Answer" (see `handleCheckAnswer`). Single-select has no
+  // such ambiguity: the clicked choice IS the whole answer, so the click
+  // both selects and checks it in one step, with no separate submit.
+  const handleChoiceClick = useCallback(
+    (choiceId: string) => {
+      if (isCompleted || isRevealed || !isEnabled) {
+        return;
+      }
+
+      if (multiSelect) {
+        setSelectedIds((prev) => {
+          const newSet = new Set(prev);
+          if (newSet.has(choiceId)) {
+            newSet.delete(choiceId);
+          } else {
+            newSet.add(choiceId);
+          }
+          return newSet;
+        });
+        setLastResult('none');
+        setShowHint(null);
+        return;
+      }
+
+      const newSelection = new Set([choiceId]);
+      setSelectedIds(newSelection);
+      const clickedChoice = choices.find((c) => c.id === choiceId);
+      const isCorrect = Boolean(clickedChoice?.correct);
+      evaluateAndApply(isCorrect, isCorrect ? undefined : clickedChoice, newSelection);
+    },
+    [isCompleted, isRevealed, isEnabled, multiSelect, choices, evaluateAndApply]
+  );
+
+  // Handle check answer (multi-select only — see `handleChoiceClick` for the
+  // single-select instant-check path).
   const handleCheckAnswer = useCallback(() => {
     if (selectedIds.size === 0) {
       return;
     }
 
-    const newAttempts = attempts + 1;
-    setAttempts(newAttempts);
-
     const isCorrect = checkAnswer();
-
-    if (isCorrect) {
-      setLastResult('correct');
-      persistCompletion();
-      setShowHint(null);
-
-      // Report analytics with detailed quiz data
-      reportAppInteraction(UserInteraction.StepAutoCompleted, buildQuizAnalyticsProps(true, newAttempts));
-
-      // Notify parent
-      if (onStepComplete && stepId) {
-        onStepComplete(stepId);
-      }
-    } else {
-      setLastResult('incorrect');
-      setShakeKey((k) => k + 1);
-
-      // Find hint for selected wrong answer
-      const selectedWrong = choices.find((c) => selectedIds.has(c.id) && !c.correct);
-      if (selectedWrong?.hint) {
-        setShowHint(selectedWrong.hint);
-      } else {
-        setShowHint("That's not quite right. Try again!");
-      }
-
-      // Check if max attempts reached (for max-attempts mode)
-      if (completionMode === 'max-attempts' && newAttempts >= maxAttempts) {
-        setIsRevealed(true);
-        persistCompletion();
-
-        // Report analytics with detailed quiz data (revealed = true)
-        reportAppInteraction(UserInteraction.StepAutoCompleted, buildQuizAnalyticsProps(false, newAttempts, true));
-
-        // Notify parent
-        if (onStepComplete && stepId) {
-          onStepComplete(stepId);
-        }
-      }
-    }
-  }, [
-    selectedIds,
-    attempts,
-    checkAnswer,
-    stepId,
-    onStepComplete,
-    completionMode,
-    maxAttempts,
-    choices,
-    buildQuizAnalyticsProps,
-    persistCompletion,
-  ]);
+    const wrongChoice = choices.find((c) => selectedIds.has(c.id) && !c.correct);
+    evaluateAndApply(isCorrect, wrongChoice, selectedIds);
+  }, [selectedIds, checkAnswer, choices, evaluateAndApply]);
 
   // Handle skip
   const handleSkip = useCallback(() => {
@@ -447,22 +456,40 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
 
   // Determine if we should show the blocked state
   const isBlocked = !isEnabled && !isCompleted;
-  const showCheckButton = !isCompleted && !isRevealed && displayedSelection.size > 0;
+  // Multi-select only — single-select checks instantly on click (see
+  // `handleChoiceClick`), so it never needs an explicit submit button.
+  const showCheckButton = multiSelect && !isCompleted && !isRevealed && displayedSelection.size > 0;
   const attemptsRemaining = completionMode === 'max-attempts' ? maxAttempts - attempts : null;
+  const showAttemptsRemaining = attemptsRemaining !== null && !isCompleted && !isRevealed;
+  // Compact pill layout only for short questions — a handful of short
+  // choices (True/False, single words) reads better side-by-side; longer or
+  // more numerous choices keep the stacked full-width rows.
+  const useCompactChoiceLayout =
+    displayChoices.length <= PILL_LAYOUT_MAX_CHOICES &&
+    displayChoices.every((c) => c.text.length <= PILL_LAYOUT_MAX_CHOICE_LENGTH);
 
   return (
     <div
       className={cx(styles.container, {
-        [styles.completed]: isCompleted,
         [styles.blocked]: isBlocked,
       })}
       data-testid={testIds.interactive.quiz(stepId)}
     >
-      {/* Question */}
-      <div className={styles.question}>
-        <Icon name="question-circle" className={styles.questionIcon} />
-        <div className={styles.questionContent}>{children}</div>
+      {/* Label header */}
+      <div className={styles.header}>
+        <div className={styles.headerLabel}>
+          <Icon name="pen" size="sm" className={styles.headerIcon} />
+          <span>Knowledge check</span>
+        </div>
+        {showAttemptsRemaining && (
+          <span className={styles.attempts}>
+            {attemptsRemaining} attempt{attemptsRemaining !== 1 ? 's' : ''} remaining
+          </span>
+        )}
       </div>
+
+      {/* Question */}
+      <div className={styles.questionContent}>{children}</div>
 
       {/* Blocked message */}
       {isBlocked && (
@@ -475,6 +502,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
       {/* Choices */}
       <div
         className={cx(styles.choices, {
+          [styles.choicesCompact]: useCompactChoiceLayout,
           [styles.shake]: displayedResult === 'incorrect',
         })}
         key={shakeKey}
@@ -487,21 +515,25 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
             <button
               key={choice.id}
               type="button"
-              className={cx(styles.choice, getChoiceClassName(state))}
+              className={cx(styles.choice, getChoiceClassName(state), {
+                [styles.choiceCompact]: useCompactChoiceLayout,
+              })}
               onClick={() => handleChoiceClick(choice.id)}
               disabled={isCompleted || isRevealed || isBlocked}
               aria-pressed={isSelected}
               data-testid={testIds.interactive.quizChoice(stepId, choice.id)}
             >
-              <span className={styles.choiceIndicator}>
-                {multiSelect ? (
-                  <span className={cx(styles.checkbox, { [styles.checked]: isSelected })}>
-                    {isSelected && <Icon name="check" size="xs" />}
-                  </span>
-                ) : (
-                  <span className={cx(styles.radio, { [styles.radioSelected]: isSelected })} />
-                )}
-              </span>
+              {!useCompactChoiceLayout && (
+                <span className={styles.choiceIndicator}>
+                  {multiSelect ? (
+                    <span className={cx(styles.checkbox, { [styles.checked]: isSelected })}>
+                      {isSelected && <Icon name="check" size="xs" />}
+                    </span>
+                  ) : (
+                    <span className={cx(styles.radio, { [styles.radioSelected]: isSelected })} />
+                  )}
+                </span>
+              )}
               <span className={styles.choiceText}>{choice.text}</span>
               {state === 'correct' && <Icon name="check-circle" className={styles.correctIcon} />}
               {state === 'revealed' && <Icon name="check-circle" className={styles.revealedIcon} />}
@@ -536,31 +568,27 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
       )}
 
       {/* Actions */}
-      <div className={styles.actions}>
-        {showCheckButton && (
-          <Button onClick={handleCheckAnswer} disabled={disabled || isBlocked}>
-            Check Answer
-          </Button>
-        )}
+      {(showCheckButton || (canSkip && !isCompleted)) && (
+        <div className={styles.actions}>
+          {showCheckButton && (
+            <Button onClick={handleCheckAnswer} disabled={disabled || isBlocked}>
+              Check Answer
+            </Button>
+          )}
 
-        {attemptsRemaining !== null && !isCompleted && !isRevealed && (
-          <span className={styles.attempts}>
-            {attemptsRemaining} attempt{attemptsRemaining !== 1 ? 's' : ''} remaining
-          </span>
-        )}
-
-        {canSkip && !isCompleted && (
-          <Button
-            variant="secondary"
-            fill="text"
-            onClick={handleSkip}
-            disabled={disabled}
-            data-testid={testIds.interactive.quizSkipButton(stepId)}
-          >
-            Skip
-          </Button>
-        )}
-      </div>
+          {canSkip && !isCompleted && (
+            <Button
+              variant="secondary"
+              fill="text"
+              onClick={handleSkip}
+              disabled={disabled}
+              data-testid={testIds.interactive.quizSkipButton(stepId)}
+            >
+              Skip
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 };
@@ -579,249 +607,277 @@ const pulse = keyframes`
   100% { transform: scale(1); }
 `;
 
-const getQuizStyles = (theme: GrafanaTheme2) => ({
-  container: css`
-    background: ${theme.colors.background.secondary};
-    border: 1px solid ${theme.colors.border.weak};
-    border-radius: ${theme.shape.radius.default};
-    padding: ${theme.spacing(2)};
-    margin: ${theme.spacing(1.5)} 0;
-    transition: all 0.2s ease;
-  `,
+const getQuizStyles = (theme: GrafanaTheme2) => {
+  // Purple label to match Callout's "colored label" treatment (see
+  // content-html.styles.ts) with a different accent so the two read as
+  // distinct at a glance — but scoped to the label text only. The container
+  // itself stays neutral regardless of answer state: a left-border accent or
+  // a success-tinted background here would compete with the per-choice
+  // correct/incorrect highlighting and the success message box, all in the
+  // same small area.
+  const accent = theme.visualization.getColorByName('purple');
 
-  completed: css`
-    border-color: ${theme.colors.success.border};
-    background: ${theme.colors.success.transparent};
-  `,
+  return {
+    container: css`
+      background: ${theme.colors.background.secondary};
+      border: 1px solid ${theme.colors.border.weak};
+      border-radius: ${theme.shape.radius.default};
+      padding: ${theme.spacing(2)};
+      margin: ${theme.spacing(1.5)} 0;
+      transition: all 0.2s ease;
+    `,
 
-  blocked: css`
-    opacity: 0.7;
-    pointer-events: none;
-  `,
+    blocked: css`
+      opacity: 0.7;
+      pointer-events: none;
+    `,
 
-  question: css`
-    display: flex;
-    gap: ${theme.spacing(1)};
-    margin-bottom: ${theme.spacing(2)};
-  `,
+    header: css`
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: ${theme.spacing(1)};
+      margin-bottom: ${theme.spacing(1)};
+    `,
 
-  questionIcon: css`
-    color: ${theme.colors.primary.text};
-    flex-shrink: 0;
-    margin-top: 2px;
-  `,
+    headerLabel: css`
+      display: flex;
+      align-items: center;
+      gap: ${theme.spacing(0.5)};
+      color: ${accent};
+      font-weight: ${theme.typography.fontWeightBold};
+      font-size: ${theme.typography.bodySmall.fontSize};
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    `,
 
-  questionContent: css`
-    flex: 1;
-    font-weight: ${theme.typography.fontWeightMedium};
-
-    p {
-      margin: 0;
-    }
-  `,
-
-  blockedMessage: css`
-    display: flex;
-    align-items: center;
-    gap: ${theme.spacing(1)};
-    padding: ${theme.spacing(1)} ${theme.spacing(1.5)};
-    background: ${theme.colors.warning.transparent};
-    border-radius: ${theme.shape.radius.default};
-    color: ${theme.colors.warning.text};
-    font-size: ${theme.typography.bodySmall.fontSize};
-    margin-bottom: ${theme.spacing(1.5)};
-  `,
-
-  choices: css`
-    display: flex;
-    flex-direction: column;
-    gap: ${theme.spacing(1)};
-    margin-bottom: ${theme.spacing(2)};
-  `,
-
-  shake: css`
-    animation: ${shake} 0.5s ease;
-  `,
-
-  choice: css`
-    display: flex;
-    align-items: center;
-    gap: ${theme.spacing(1.5)};
-    padding: ${theme.spacing(1.5)} ${theme.spacing(2)};
-    background: ${theme.colors.background.primary};
-    border: 1px solid ${theme.colors.border.weak};
-    border-radius: ${theme.shape.radius.default};
-    cursor: pointer;
-    transition: all 0.15s ease;
-    text-align: left;
-    width: 100%;
-
-    &:hover:not(:disabled) {
-      border-color: ${theme.colors.border.medium};
-      background: ${theme.colors.action.hover};
-    }
-
-    &:focus-visible {
-      outline: 2px solid ${theme.colors.primary.main};
-      outline-offset: 2px;
-    }
-
-    &:disabled {
-      cursor: default;
-    }
-  `,
-
-  choiceDefault: css``,
-
-  choiceSelected: css`
-    border-color: ${theme.colors.primary.border};
-    background: ${theme.colors.primary.transparent};
-  `,
-
-  choiceCorrect: css`
-    border-color: ${theme.colors.success.border};
-    background: ${theme.colors.success.transparent};
-    animation: ${pulse} 0.3s ease;
-  `,
-
-  choiceIncorrect: css`
-    border-color: ${theme.colors.error.border};
-    background: ${theme.colors.error.transparent};
-  `,
-
-  choiceRevealed: css`
-    border-color: ${theme.colors.success.border};
-    background: ${theme.colors.success.transparent};
-  `,
-
-  choiceIndicator: css`
-    flex-shrink: 0;
-  `,
-
-  checkbox: css`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 18px;
-    height: 18px;
-    border: 2px solid ${theme.colors.border.strong};
-    border-radius: 3px;
-    background: ${theme.colors.background.primary};
-    transition: all 0.15s ease;
-  `,
-
-  checked: css`
-    background: ${theme.colors.primary.main};
-    border-color: ${theme.colors.primary.main};
-    color: ${theme.colors.primary.contrastText};
-  `,
-
-  radio: css`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 18px;
-    height: 18px;
-    border: 2px solid ${theme.colors.border.strong};
-    border-radius: 50%;
-    background: ${theme.colors.background.primary};
-    transition: all 0.15s ease;
-    box-sizing: border-box;
-
-    &::after {
-      content: '';
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      background: ${theme.colors.primary.main};
-      transform: scale(0);
-      transition: transform 0.15s ease;
-    }
-  `,
-
-  radioSelected: css`
-    border-color: ${theme.colors.primary.main};
-
-    &::after {
-      transform: scale(1);
-    }
-  `,
-
-  choiceText: css`
-    flex: 1;
-  `,
-
-  correctIcon: css`
-    color: ${theme.colors.success.text};
-    flex-shrink: 0;
-  `,
-
-  incorrectIcon: css`
-    color: ${theme.colors.error.text};
-    flex-shrink: 0;
-  `,
-
-  revealedIcon: css`
-    color: ${theme.colors.success.text};
-    flex-shrink: 0;
-  `,
-
-  hint: css`
-    display: flex;
-    align-items: flex-start;
-    gap: ${theme.spacing(1)};
-    padding: ${theme.spacing(1.5)};
-    background: ${theme.colors.warning.transparent};
-    border: 1px solid ${theme.colors.warning.border};
-    border-radius: ${theme.shape.radius.default};
-    color: ${theme.colors.warning.text};
-    font-size: ${theme.typography.bodySmall.fontSize};
-    margin-bottom: ${theme.spacing(2)};
-
-    svg {
+    headerIcon: css`
       flex-shrink: 0;
-      margin-top: 2px;
-    }
-  `,
+    `,
 
-  success: css`
-    display: flex;
-    align-items: center;
-    gap: ${theme.spacing(1)};
-    padding: ${theme.spacing(1.5)};
-    background: ${theme.colors.success.transparent};
-    border: 1px solid ${theme.colors.success.border};
-    border-radius: ${theme.shape.radius.default};
-    color: ${theme.colors.success.text};
-    font-weight: ${theme.typography.fontWeightMedium};
-    margin-bottom: ${theme.spacing(2)};
-    animation: ${pulse} 0.3s ease;
-  `,
+    questionContent: css`
+      font-weight: ${theme.typography.fontWeightMedium};
+      margin-bottom: ${theme.spacing(2)};
 
-  revealed: css`
-    display: flex;
-    align-items: center;
-    gap: ${theme.spacing(1)};
-    padding: ${theme.spacing(1.5)};
-    background: ${theme.colors.info.transparent};
-    border: 1px solid ${theme.colors.info.border};
-    border-radius: ${theme.shape.radius.default};
-    color: ${theme.colors.text.secondary};
-    font-size: ${theme.typography.bodySmall.fontSize};
-    margin-bottom: ${theme.spacing(2)};
-  `,
+      p {
+        margin: 0;
+      }
+    `,
 
-  actions: css`
-    display: flex;
-    align-items: center;
-    gap: ${theme.spacing(1.5)};
-  `,
+    blockedMessage: css`
+      display: flex;
+      align-items: center;
+      gap: ${theme.spacing(1)};
+      padding: ${theme.spacing(1)} ${theme.spacing(1.5)};
+      background: ${theme.colors.warning.transparent};
+      border-radius: ${theme.shape.radius.default};
+      color: ${theme.colors.warning.text};
+      font-size: ${theme.typography.bodySmall.fontSize};
+      margin-bottom: ${theme.spacing(1.5)};
+    `,
 
-  attempts: css`
-    color: ${theme.colors.text.secondary};
-    font-size: ${theme.typography.bodySmall.fontSize};
-    margin-left: auto;
-  `,
-});
+    choices: css`
+      display: flex;
+      flex-direction: column;
+      gap: ${theme.spacing(1)};
+      margin-bottom: ${theme.spacing(2)};
+    `,
+
+    choicesCompact: css`
+      flex-direction: row;
+      flex-wrap: wrap;
+    `,
+
+    shake: css`
+      animation: ${shake} 0.5s ease;
+    `,
+
+    choice: css`
+      display: flex;
+      align-items: center;
+      gap: ${theme.spacing(1.5)};
+      padding: ${theme.spacing(1.5)} ${theme.spacing(2)};
+      background: ${theme.colors.background.primary};
+      border: 1px solid ${theme.colors.border.weak};
+      border-radius: ${theme.shape.radius.default};
+      cursor: pointer;
+      transition: all 0.15s ease;
+      text-align: left;
+      width: 100%;
+
+      &:hover:not(:disabled) {
+        border-color: ${theme.colors.border.medium};
+        background: ${theme.colors.action.hover};
+      }
+
+      &:focus-visible {
+        outline: 2px solid ${theme.colors.primary.main};
+        outline-offset: 2px;
+      }
+
+      &:disabled {
+        cursor: default;
+      }
+    `,
+
+    choiceCompact: css`
+      width: auto;
+      flex: 0 1 auto;
+      justify-content: center;
+    `,
+
+    choiceDefault: css``,
+
+    choiceSelected: css`
+      border-color: ${theme.colors.primary.border};
+      background: ${theme.colors.primary.transparent};
+    `,
+
+    choiceCorrect: css`
+      border-color: ${theme.colors.success.border};
+      background: ${theme.colors.success.transparent};
+      animation: ${pulse} 0.3s ease;
+    `,
+
+    choiceIncorrect: css`
+      border-color: ${theme.colors.error.border};
+      background: ${theme.colors.error.transparent};
+    `,
+
+    choiceRevealed: css`
+      border-color: ${theme.colors.success.border};
+      background: ${theme.colors.success.transparent};
+    `,
+
+    choiceIndicator: css`
+      flex-shrink: 0;
+    `,
+
+    checkbox: css`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 18px;
+      height: 18px;
+      border: 2px solid ${theme.colors.border.strong};
+      border-radius: 3px;
+      background: ${theme.colors.background.primary};
+      transition: all 0.15s ease;
+    `,
+
+    checked: css`
+      background: ${theme.colors.primary.main};
+      border-color: ${theme.colors.primary.main};
+      color: ${theme.colors.primary.contrastText};
+    `,
+
+    radio: css`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 18px;
+      height: 18px;
+      border: 2px solid ${theme.colors.border.strong};
+      border-radius: 50%;
+      background: ${theme.colors.background.primary};
+      transition: all 0.15s ease;
+      box-sizing: border-box;
+
+      &::after {
+        content: '';
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: ${theme.colors.primary.main};
+        transform: scale(0);
+        transition: transform 0.15s ease;
+      }
+    `,
+
+    radioSelected: css`
+      border-color: ${theme.colors.primary.main};
+
+      &::after {
+        transform: scale(1);
+      }
+    `,
+
+    choiceText: css`
+      flex: 1;
+    `,
+
+    correctIcon: css`
+      color: ${theme.colors.success.text};
+      flex-shrink: 0;
+    `,
+
+    incorrectIcon: css`
+      color: ${theme.colors.error.text};
+      flex-shrink: 0;
+    `,
+
+    revealedIcon: css`
+      color: ${theme.colors.success.text};
+      flex-shrink: 0;
+    `,
+
+    hint: css`
+      display: flex;
+      align-items: flex-start;
+      gap: ${theme.spacing(1)};
+      padding: ${theme.spacing(1.5)};
+      background: ${theme.colors.warning.transparent};
+      border: 1px solid ${theme.colors.warning.border};
+      border-radius: ${theme.shape.radius.default};
+      color: ${theme.colors.warning.text};
+      font-size: ${theme.typography.bodySmall.fontSize};
+      margin-bottom: ${theme.spacing(2)};
+
+      svg {
+        flex-shrink: 0;
+        margin-top: 2px;
+      }
+    `,
+
+    success: css`
+      display: flex;
+      align-items: center;
+      gap: ${theme.spacing(1)};
+      padding: ${theme.spacing(1.5)};
+      background: ${theme.colors.success.transparent};
+      border: 1px solid ${theme.colors.success.border};
+      border-radius: ${theme.shape.radius.default};
+      color: ${theme.colors.success.text};
+      font-weight: ${theme.typography.fontWeightMedium};
+      margin-bottom: ${theme.spacing(2)};
+      animation: ${pulse} 0.3s ease;
+    `,
+
+    revealed: css`
+      display: flex;
+      align-items: center;
+      gap: ${theme.spacing(1)};
+      padding: ${theme.spacing(1.5)};
+      background: ${theme.colors.info.transparent};
+      border: 1px solid ${theme.colors.info.border};
+      border-radius: ${theme.shape.radius.default};
+      color: ${theme.colors.text.secondary};
+      font-size: ${theme.typography.bodySmall.fontSize};
+      margin-bottom: ${theme.spacing(2)};
+    `,
+
+    actions: css`
+      display: flex;
+      align-items: center;
+      gap: ${theme.spacing(1.5)};
+    `,
+
+    attempts: css`
+      color: ${theme.colors.text.secondary};
+      font-size: ${theme.typography.bodySmall.fontSize};
+      white-space: nowrap;
+    `,
+  };
+};
 
 export default InteractiveQuiz;


### PR DESCRIPTION
## Summary

Adds a "Knowledge check" label (purple text, echoing the color choice from the Callout block's label — no shared border or background treatment) above quiz questions, plus a compact side-by-side pill layout for short questions like True/False. The answer-checking flow itself is unchanged — every quiz still requires an explicit "Check Answer" click after selecting, matching the product's other verification-style blocks ([`challenge`](https://github.com/grafana/grafana-pathfinder-app/blob/d8fcbd87d00cd2f4133c18071623baa81861db6c/src/components/interactive-tutorial/challenge-block.tsx), [`input`/data-check](https://github.com/grafana/grafana-pathfinder-app/blob/d8fcbd87d00cd2f4133c18071623baa81861db6c/src/components/interactive-tutorial/datasource-check-step.tsx)) and avoiding a one-off instant-check pattern that was tried and deliberately reverted during development (see commit history). This is the third and final item of the guide-visual redesign series — the [Callout block](https://github.com/grafana/grafana-pathfinder-app/pull/1684) and the [consolidated milestone toolbar](https://github.com/grafana/grafana-pathfinder-app/pull/1685) shipped first.

## Screenshots

<img width="1552" height="784" alt="before-short-2choice-default" src="https://github.com/user-attachments/assets/6b12b0af-6398-4ef5-95df-76ec89259fc3" />

Before: stacked layout, no label. Check Answer only appears once a choice is selected (unchanged by this PR) — not shown here since nothing's selected yet.

<img width="1552" height="607" alt="after-truefalse-default" src="https://github.com/user-attachments/assets/d45cfec7-e5ad-409e-bc58-97741a28f846" />

After: "Knowledge check" label, compact side-by-side pills for a short question.

<img width="1552" height="607" alt="after-checkanswer-right-aligned" src="https://github.com/user-attachments/assets/99bae6fe-012e-46ef-9cfa-0f80b0ac3190" />

Check Answer still appears once a choice is selected, right-aligned with Skip.

<img width="1552" height="607" alt="after-correct-via-checkanswer" src="https://github.com/user-attachments/assets/1608eb7f-65eb-4caa-aa0a-ef5be89b4e0a" />

Correct state: the pill and success message turn green, but the container stays neutral.

<img width="1552" height="784" alt="after-multiselect-longtext-default" src="https://github.com/user-attachments/assets/7b284244-ea17-4d5d-8704-08d6322365e4" />

Longer/multi-select quizzes keep the original stacked layout with the leading indicator.

## What to look at

- [`interactive-quiz.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/d8fcbd87d00cd2f4133c18071623baa81861db6c/src/components/interactive-tutorial/interactive-quiz.tsx) — the new header row (label + optional attempts-remaining, right side) replaces the old inline question-icon + bottom-row attempts text. `useCompactChoiceLayout` (≤4 choices, each ≤20 chars) switches between a pill row with no leading radio/checkbox and the original stacked rows for longer/more numerous choices. Pills flex-fill the row evenly (`flex: 1 1 0`) rather than sizing to content, matching the mock's full-width horizontal layout; text wraps instead of truncating, which keeps 4 near-max-length pills readable without overflow (verified live). The container no longer changes background color on correct completion — only the per-choice highlight and the success message carry that color now, deliberately, to avoid three things turning green in the same small area at once.
- `evaluateAndApply` — a small refactor extracting the shared "was this correct" outcome handling (attempts, hint, reveal-on-exhaustion, analytics) that both quiz modes' explicit Check Answer click funnel through. This is a readability-only split of one prior function, not a behavior change — worth confirming directly when reading the diff, since the two-commit history (restyle, then a revert) can make it look like more happened here than did.
- [`interactive-quiz.test.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/d8fcbd87d00cd2f4133c18071623baa81861db6c/src/components/interactive-tutorial/interactive-quiz.test.tsx) — new tests for the header label, attempts placement, and the pill/stacked layout heuristic on both dimensions (choice count and text length). The most load-bearing addition is a pair of tests proving single-select does *not* complete on a bare choice click and still requires the Check Answer click — a direct regression guard against the reverted instant-check behavior recurring.

## Why

The current quiz styling treats every question the same regardless of purpose, and flipping the whole container's background color to green/red on completion competes visually with the per-choice highlight and the success message in the same small area. Design supplied a mock reusing the Objective/Callout block's purple label-text color for the new "Knowledge check" label, plus a tighter side-by-side layout for short True/False-style questions — but no left-border or container-background treatment; an early pass of this PR added a purple left-border and a success-tinted container background to match Callout's box styling more literally, but that was reverted after review because it clashed with the per-choice correct/incorrect highlight and the success message occupying the same small area. The quiz container stays visually neutral regardless of answer state; only the label text borrows Callout's color.

We initially made single-select checks instant on click (no separate submit step) to match the mock's literal appearance. On reflection that would have made single-select the only verification-style block in the product without an explicit submit action — `challenge` has "Check my work", `input`/data-check has "Run check", and multi-select quiz itself already requires clicking Check Answer. We reverted to keep all four consistent: the mock's lack of a visible button turned out to be ambiguous (it only ever depicted already-answered states, never an interim "selected, not yet submitted" one), while the cross-product consistency argument was concrete.

## How to verify

1. Open a guide with a short 2-choice quiz (e.g. True/False). Confirm the purple "Knowledge check" label renders above the question, choices render as side-by-side pills with no leading indicator, and selecting one shows a "Check Answer" button (right-aligned with Skip) rather than completing instantly.
2. Click Check Answer with the correct choice selected — confirm the pill and the success message turn green, but the surrounding container background stays the same as before.
3. Click Check Answer with a wrong choice selected on a `max-attempts` quiz — confirm the wrong pill shakes/turns red, a hint shows, the attempts-remaining count in the header decrements, and exhausting attempts reveals the correct answer.
4. Open a guide with a longer or 5+-choice quiz — confirm it still renders as stacked full-width rows with the leading checkbox/radio, and still requires selecting then clicking Check Answer (unchanged from before this PR).

## Breaking changes

None. Additive/visual only — no schema, storage, or analytics payload changes. Verified across two independent review passes that the analytics event name, payload keys, and emission cadence are byte-identical to the pre-PR baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
