### PR TITLE
feat(interactive-tutorial): 2x2 grid layout for exactly 4 quiz choices

### DIFF
--- a/src/components/interactive-tutorial/interactive-quiz.test.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.test.tsx
@@ -569,6 +569,21 @@ describe('InteractiveQuiz: compact pill layout vs. stacked layout', () => {
     expect(hasLeadingIndicator(screen.getByRole('button', { name: /This is a much longer answer choice/ }))).toBe(true);
   });
 
+  it('uses the compact 2x2 grid layout (no leading indicator) for exactly 4 short choices', () => {
+    const choices: QuizChoice[] = [
+      { id: 'a', text: 'One', correct: false },
+      { id: 'b', text: 'Two', correct: true },
+      { id: 'c', text: 'Three', correct: false },
+      { id: 'd', text: 'Four', correct: false },
+    ];
+    render(
+      <InteractiveQuiz question="Q" choices={choices} shuffle={false}>
+        Q
+      </InteractiveQuiz>
+    );
+    expect(hasLeadingIndicator(screen.getByRole('button', { name: 'One' }))).toBe(false);
+  });
+
   it('falls back to the stacked layout (leading indicator present) when there are more than 4 short choices', () => {
     const choices: QuizChoice[] = [
       { id: 'a', text: 'One', correct: false },

--- a/src/components/interactive-tutorial/interactive-quiz.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.tsx
@@ -445,7 +445,9 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
   const showAttemptsRemaining = attemptsRemaining !== null && !isCompleted && !isRevealed;
   // Compact pill layout only for short single-select questions — a handful
   // of short choices (True/False, single words) reads better side-by-side;
-  // longer or more numerous choices keep the stacked full-width rows.
+  // longer or more numerous choices keep the stacked full-width rows. Exactly
+  // 4 short choices get a 2x2 grid instead of a single row of 4 — one row
+  // stays readable up to 3 pills, but a 4-wide row starts feeling cramped.
   // Multi-select always keeps the stacked layout too: pills drop the leading
   // indicator, and without the checkbox there's no visual cue that more than
   // one choice can be selected.
@@ -453,6 +455,7 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
     !multiSelect &&
     displayChoices.length <= PILL_LAYOUT_MAX_CHOICES &&
     displayChoices.every((c) => c.text.length <= PILL_LAYOUT_MAX_CHOICE_LENGTH);
+  const useGridChoiceLayout = useCompactChoiceLayout && displayChoices.length === 4;
 
   return (
     <div
@@ -488,7 +491,8 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
       {/* Choices */}
       <div
         className={cx(styles.choices, {
-          [styles.choicesCompact]: useCompactChoiceLayout,
+          [styles.choicesCompact]: useCompactChoiceLayout && !useGridChoiceLayout,
+          [styles.choicesGrid]: useGridChoiceLayout,
           [styles.shake]: displayedResult === 'incorrect',
         })}
         key={shakeKey}
@@ -502,7 +506,8 @@ export const InteractiveQuiz: React.FC<InteractiveQuizProps> = ({
               key={choice.id}
               type="button"
               className={cx(styles.choice, getChoiceClassName(state), {
-                [styles.choiceCompact]: useCompactChoiceLayout,
+                [styles.choiceCompact]: useCompactChoiceLayout && !useGridChoiceLayout,
+                [styles.choiceGridItem]: useGridChoiceLayout,
               })}
               onClick={() => handleChoiceClick(choice.id)}
               disabled={isCompleted || isRevealed || isBlocked}
@@ -674,6 +679,11 @@ const getQuizStyles = (theme: GrafanaTheme2) => {
       flex-wrap: wrap;
     `,
 
+    choicesGrid: css`
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+    `,
+
     shake: css`
       animation: ${shake} 0.5s ease;
     `,
@@ -710,6 +720,12 @@ const getQuizStyles = (theme: GrafanaTheme2) => {
       width: auto;
       flex: 1 1 0;
       min-width: 0;
+      justify-content: center;
+      text-align: center;
+    `,
+
+    choiceGridItem: css`
+      width: 100%;
       justify-content: center;
       text-align: center;
     `,


### PR DESCRIPTION
## Summary

Stacked on top of #1689. That PR's pill layout fills the row evenly for up to 4 short choices — but a single row of 4 evenly-split pills still feels cramped. This PR gives exactly 4 short choices a 2x2 grid instead: 2-3 choices still share one row, 4 choices split into two rows of two, and 5+ still falls back to the original stacked layout, unchanged.

This is a trial balloon, not a settled design decision — opened as a separate, stacked PR specifically so it can be closed outright without touching #1689 if the team prefers the single-row-of-4 look instead.

## Screenshots

<img width="1552" height="784" alt="4choice-2x2-grid-default" src="https://github.com/user-attachments/assets/475dfba2-966e-4f99-8908-d487d980ee91" />

4 short choices split into a 2x2 grid instead of one cramped row of 4.

<img width="1552" height="784" alt="4choice-2x2-grid-selected" src="https://github.com/user-attachments/assets/17dddf9c-3624-403e-8bc5-e96aa66e8b83" />

Selecting a choice still shows Check Answer + Skip right-aligned below the grid, same as the row/stacked layouts.

## What to look at

- [`interactive-quiz.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/80a483dfd7bda67d46d764e96fd6ac8cbb50b66f/src/components/interactive-tutorial/interactive-quiz.tsx) — `useGridChoiceLayout` is `useCompactChoiceLayout && displayChoices.length === 4`, a narrow addition on top of #1689's existing pill-eligibility check. `choicesGrid` (`display: grid; grid-template-columns: repeat(2, 1fr)`) and `choiceGridItem` are the only new styles; nothing about the 2-3 choice row layout or the 5+ stacked fallback changed.
- [`interactive-quiz.test.tsx`](https://github.com/grafana/grafana-pathfinder-app/blob/80a483dfd7bda67d46d764e96fd6ac8cbb50b66f/src/components/interactive-tutorial/interactive-quiz.test.tsx) — one new test confirming exactly 4 short choices still get the no-leading-indicator compact treatment (a boundary check between the row and stacked layouts); the row-vs-grid visual split itself was verified manually since it's a pure CSS difference.

## Why

The 3-vs-4 boundary was originally going to just be a lower pill-count cap (see #1689's commit history — briefly capped at 3, then reverted back to 4 once fill-width sizing proved it fit fine). Revisiting it after seeing 4 fill-width pills in one row live: it's readable, but visually busier than the mock intended. A 2x2 grid keeps all 4 choices equally sized and scannable without needing a 5th "make it wrap" heuristic.

## How to verify

1. Open a guide with exactly 4 short choices (each ≤20 characters). Confirm they render as a 2x2 grid, not a single row.
2. Open a guide with 2-3 short choices — confirm they still render as a single fill-width row (unchanged from #1689).
3. Open a guide with 5+ short choices, or any choice longer than 20 characters — confirm the stacked full-width layout with leading radio/checkbox is unchanged.
4. Select a choice in the 4-choice grid — confirm Check Answer and Skip appear right-aligned below the grid.

## Breaking changes

None. Purely visual, and scoped to the one new 4-choice case — no schema, storage, or analytics changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
