### PR TITLE
fix(recovery): let a complete manifest supply the starting location

### DIFF
--- a/src/components/docs-panel/CustomGuidesSection.test.tsx
+++ b/src/components/docs-panel/CustomGuidesSection.test.tsx
@@ -96,6 +96,7 @@ describe('CustomGuidesSection — path cards (launch bridge)', () => {
       // can recover the cover baseUrl.
       packageManifest: { ...pathGuide.manifest, id: 'fe-alerting-path' },
       resolvedMilestones: undefined,
+      launchSource: 'custom_guide',
     });
   });
 
@@ -141,7 +142,7 @@ describe('CustomGuidesSection — path cards (launch bridge)', () => {
     expect(openDocsPage).toHaveBeenCalledWith(
       'backend-guide:fe-alerting-01',
       'Alerting enablement',
-      expect.objectContaining({ packageId: 'fe-alerting-path' })
+      expect.objectContaining({ packageId: 'fe-alerting-path', launchSource: 'custom_guide' })
     );
 
     // Locked member is rendered but disabled and not clickable.

--- a/src/components/docs-panel/CustomGuidesSection.tsx
+++ b/src/components/docs-panel/CustomGuidesSection.tsx
@@ -36,6 +36,9 @@ function packageInfoForPath(path: PublishedGuide, resolvedMilestones?: Milestone
     // `packageManifest.id` — thread it through, or "back to cover" breaks.
     packageManifest: { ...(path.manifest as unknown as Record<string, unknown>), id: path.id },
     resolvedMilestones,
+    // Custom guides are not the recommender, whose URL-filtered list is
+    // aligned-by-construction and so skips the alignment prompt (issue #1681).
+    launchSource: 'custom_guide',
   };
 }
 

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -924,9 +924,17 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
 
         // Implied 0th step: decide whether to prompt the user to navigate to
         // the guide's declared starting location before step 1 begins.
+        // Two manifests can describe this launch and they are not equally complete.
+        // `packageInfo` comes from the catalogue proxy, whose Go `customGuideManifest`
+        // declares no starting location, so the key is dropped at the wire boundary;
+        // the loader's manifest on the fetched content carries it intact. Passing both
+        // keeps `packageInfo` authoritative wherever it actually declares a value and
+        // only falls back where it previously resolved to null — so a guide opened
+        // from inside a learning path gets the same prompt as the same guide opened
+        // standalone.
         const startingLocation = resolveStartingLocation(
           url,
-          packageInfo?.packageManifest ?? fetchedContent.metadata.packageManifest,
+          [packageInfo?.packageManifest, fetchedContent.metadata.packageManifest],
           { isAdmin: currentUserIsAdmin() }
         );
         const currentPath = locationService.getLocation().pathname;

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -67,7 +67,7 @@ import { journeyContentHtml, docsContentHtml } from '../../styles/content-html.s
 import { getInteractiveStyles } from '../../styles/interactive.styles';
 import { getPrismStyles } from '../../styles/prism.styles';
 import { config, getAppEvents, locationService } from '@grafana/runtime';
-import { evaluateAlignment, resolveStartingLocation, type LaunchSource } from '../../recovery';
+import { coerceLaunchSource, evaluateAlignment, resolveStartingLocation, type LaunchSource } from '../../recovery';
 import { currentUserIsAdmin } from '../../utils/current-user-role';
 import { SessionProvider, useSession, ActionReplaySystem, ActionCaptureSystem } from '../../integrations/workshop';
 import { panelModeManager } from '../../global-state/panel-mode';
@@ -218,7 +218,11 @@ class CombinedLearningJourneyPanel extends SceneObjectBase<CombinedPanelState> i
         return this.openLearningJourney(url, title, { source: 'recommender' });
       },
       (url: string, title: string, packageInfo?: PackageOpenInfo) => {
-        return this.openDocsPage(url, title, { source: 'recommender', packageInfo });
+        // Sections other than the recommender declare their own source.
+        return this.openDocsPage(url, title, {
+          source: coerceLaunchSource(packageInfo?.launchSource) ?? 'recommender',
+          packageInfo,
+        });
       },
       () => this.openEditorTab()
     );

--- a/src/docs-retrieval/content-fetcher/package-content.member-manifest.test.ts
+++ b/src/docs-retrieval/content-fetcher/package-content.member-manifest.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression coverage for the learning-path member launch (issue #1681).
+ *
+ * A member opened from inside a path is fetched through `fetchPackageContent`
+ * with the *path's* catalogue manifest as `packageInfo`. That manifest is a slim
+ * projection and declares no starting location, so attaching it wholesale used
+ * to bury the complete manifest the `backend-guide:` loader had produced, and
+ * the alignment prompt never appeared.
+ */
+import { of } from 'rxjs';
+import { fetchPackageContent } from './package-content';
+import { resolveStartingLocation } from '../../recovery/starting-location';
+
+const mockFetch = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  config: {
+    get namespace() {
+      return 'stacks-123';
+    },
+    bootData: { user: {} },
+  },
+  getBackendSrv: () => ({ fetch: mockFetch }),
+}));
+
+jest.mock('../../validation', () => ({
+  validateGuide: () => ({ isValid: true, errors: [] }),
+}));
+
+/** The path entry as the catalogue proxy returns it: no starting location on the wire. */
+const slimCatalogueManifest = {
+  id: 'fe-alerting-path',
+  type: 'path',
+  description: 'Alerting enablement',
+};
+
+function backendGuideResource(manifest: Record<string, unknown>) {
+  return of({
+    data: {
+      metadata: { name: 'fe-alerting-01' },
+      spec: {
+        id: 'fe-alerting-01',
+        title: 'Alerting module 1',
+        schemaVersion: '1.0',
+        blocks: [{ type: 'markdown', content: 'hi' }],
+        manifest,
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('member launch keeps the loader manifest reachable', () => {
+  it('does not let the slim path manifest bury the loader starting location', async () => {
+    mockFetch.mockReturnValue(backendGuideResource({ startingLocation: '/alerting/routes' }));
+
+    const result = await fetchPackageContent('backend-guide:fe-alerting-01', slimCatalogueManifest);
+
+    const merged = result.content?.metadata.packageManifest;
+    expect(merged).toBeDefined();
+    expect(merged?.startingLocation).toBe('/alerting/routes');
+    // The caller's own fields still win where it declares them.
+    expect(merged?.id).toBe('fe-alerting-path');
+    expect(merged?.type).toBe('path');
+  });
+
+  it('resolves the starting location the docs panel then reads', async () => {
+    mockFetch.mockReturnValue(backendGuideResource({ startingLocation: '/alerting/routes' }));
+
+    const result = await fetchPackageContent('backend-guide:fe-alerting-01', slimCatalogueManifest);
+
+    // Mirrors the docs panel call: packageInfo first, fetched content second.
+    expect(
+      resolveStartingLocation('backend-guide:fe-alerting-01', [
+        slimCatalogueManifest,
+        result.content?.metadata.packageManifest,
+      ])
+    ).toBe('/alerting/routes');
+  });
+
+  it('reads a starting location App Platform left nested under additionalFields', async () => {
+    mockFetch.mockReturnValue(
+      backendGuideResource({ additionalFields: { startingLocation: '/alerting/notifications' } })
+    );
+
+    const result = await fetchPackageContent('backend-guide:fe-alerting-01', slimCatalogueManifest);
+
+    expect(
+      resolveStartingLocation('backend-guide:fe-alerting-01', [
+        slimCatalogueManifest,
+        result.content?.metadata.packageManifest,
+      ])
+    ).toBe('/alerting/notifications');
+  });
+
+  it('still resolves to null when no manifest declares one', async () => {
+    mockFetch.mockReturnValue(backendGuideResource({}));
+
+    const result = await fetchPackageContent('backend-guide:fe-alerting-01', slimCatalogueManifest);
+
+    expect(
+      resolveStartingLocation('backend-guide:fe-alerting-01', [
+        slimCatalogueManifest,
+        result.content?.metadata.packageManifest,
+      ])
+    ).toBeNull();
+  });
+});

--- a/src/docs-retrieval/content-fetcher/package-content.ts
+++ b/src/docs-retrieval/content-fetcher/package-content.ts
@@ -320,7 +320,11 @@ export async function fetchPackageContent(
       type: renderType,
       metadata: {
         ...result.content.metadata,
-        ...(packageManifest !== undefined && { packageManifest }),
+        // Merge, not replace: a catalogue entry is a slim projection and would
+        // otherwise bury fields the loader resolved in full (issue #1681).
+        ...(packageManifest !== undefined && {
+          packageManifest: { ...result.content.metadata.packageManifest, ...packageManifest },
+        }),
         // Fall back to the repository the baseUrl resolution already carries, so
         // an entry path that supplies no explicit one still keys the durable
         // completion on the true source instead of the manifest schema default.

--- a/src/recovery/alignment-evaluator.test.ts
+++ b/src/recovery/alignment-evaluator.test.ts
@@ -80,6 +80,18 @@ describe('evaluateAlignment', () => {
     expect(result).toEqual({ shouldPrompt: false, reason: 'source-skipped' });
   });
 
+  it('prompts for a custom guide opened from inside a path', () => {
+    // The custom guides section is not the recommender: its list is not
+    // URL-filtered, so a member launch still needs the alignment check.
+    // Refs: https://github.com/grafana/grafana-pathfinder-app/issues/1681
+    const result = evaluateAlignment({
+      currentPath: '/explore',
+      startingLocation: '/alerting/routes',
+      launchSource: 'custom_guide',
+    });
+    expect(result).toEqual({ shouldPrompt: true, reason: 'mismatch' });
+  });
+
   it('does not prompt for mcp_launch even when paths differ', () => {
     const result = evaluateAlignment({
       currentPath: '/dashboards',

--- a/src/recovery/starting-location.test.ts
+++ b/src/recovery/starting-location.test.ts
@@ -171,10 +171,7 @@ describe('resolveStartingLocation', () => {
     });
 
     it('skips an undefined manifest without consuming the fallback', () => {
-      const result = resolveStartingLocation('https://example/foo', [
-        undefined,
-        { startingLocation: '/from-loader' },
-      ]);
+      const result = resolveStartingLocation('https://example/foo', [undefined, { startingLocation: '/from-loader' }]);
       expect(result).toBe('/from-loader');
     });
 

--- a/src/recovery/starting-location.test.ts
+++ b/src/recovery/starting-location.test.ts
@@ -150,6 +150,47 @@ describe('resolveStartingLocation', () => {
     const result = resolveStartingLocation('bundled:array-shape', parsed);
     expect(result).toBe('/explore');
   });
+
+  describe('with more than one manifest', () => {
+    it('keeps the earlier manifest authoritative when it declares a value', () => {
+      const result = resolveStartingLocation('https://example/foo', [
+        { startingLocation: '/from-catalogue' },
+        { startingLocation: '/from-loader' },
+      ]);
+      expect(result).toBe('/from-catalogue');
+    });
+
+    it('falls back to a later manifest when the earlier one was pruned at the wire', () => {
+      // The catalogue proxy's Go manifest struct declares no startingLocation, so
+      // the key never survives encoding; the loader's manifest still carries it.
+      const result = resolveStartingLocation('https://example/foo', [
+        { id: 'guide-1' },
+        { startingLocation: '/from-loader' },
+      ]);
+      expect(result).toBe('/from-loader');
+    });
+
+    it('skips an undefined manifest without consuming the fallback', () => {
+      const result = resolveStartingLocation('https://example/foo', [
+        undefined,
+        { startingLocation: '/from-loader' },
+      ]);
+      expect(result).toBe('/from-loader');
+    });
+
+    it('treats an empty-string value as undeclared and keeps looking', () => {
+      const result = resolveStartingLocation('https://example/foo', [
+        { startingLocation: '' },
+        { startingLocation: '/from-loader' },
+      ]);
+      expect(result).toBe('/from-loader');
+    });
+
+    it('still reaches the bundled index when no manifest declares a value', () => {
+      const result = resolveStartingLocation('bundled:array-shape', [{}, {}]);
+      expect(result).toBe('/explore');
+    });
+  });
 });
 
 // The manifest is authored data that ends up at `locationService.push` via

--- a/src/recovery/starting-location.ts
+++ b/src/recovery/starting-location.ts
@@ -24,6 +24,12 @@
  * and from nowhere else, so validating here covers what gets stored, what the
  * prompt shows, what telemetry reports, and what is eventually pushed.
  *
+ * More than one manifest may describe the same launch, and they are not equally
+ * complete: a catalogue-proxy entry is a slim projection that drops keys its Go
+ * struct does not declare, while a content loader's manifest is whole. Callers
+ * pass them most-authoritative-first and the first declared value wins, so a slim
+ * manifest no longer shadows a complete one.
+ *
  * @see docs/design/AUTORECOVERY_DESIGN.md § "The implied 0th step"
  */
 
@@ -51,30 +57,45 @@ export interface ResolveStartingLocationOptions {
   isAdmin?: boolean;
 }
 
+/**
+ * A launch describes itself with either one manifest or several. The parameter
+ * accepts both shapes so the common single-manifest call stays as it reads, and
+ * only a caller that genuinely holds competing manifests pays the array syntax.
+ */
+export type ManifestCandidates = Record<string, unknown> | Array<Record<string, unknown> | undefined>;
+
 export function resolveStartingLocation(
   url: string,
-  packageManifest?: Record<string, unknown>,
+  packageManifests?: ManifestCandidates,
   options?: ResolveStartingLocationOptions
 ): string | null {
-  const candidate = resolveCandidate(url, packageManifest);
+  const candidates = Array.isArray(packageManifests) ? packageManifests : [packageManifests];
+  const candidate = resolveCandidate(url, candidates);
   if (candidate === null) {
     return null;
   }
   return validateInternalNavigationPath(candidate, options?.isAdmin);
 }
 
-function resolveCandidate(url: string, packageManifest?: Record<string, unknown>): string | null {
-  const fromManifest = packageManifest?.startingLocation;
-  if (typeof fromManifest === 'string' && fromManifest.length > 0) {
-    return fromManifest;
-  }
+function resolveCandidate(
+  url: string,
+  packageManifests: Array<Record<string, unknown> | undefined>
+): string | null {
+  // Manifest authority dominates: a manifest that declares the value at all
+  // settles it, and only then do we fall through to the next one. Within a
+  // single manifest the typed field still wins over `additionalFields` — a
+  // promoted CUE field is the more specific declaration, and `additionalFields`
+  // is where a value waits for that promotion.
+  for (const packageManifest of packageManifests) {
+    const fromManifest = packageManifest?.startingLocation;
+    if (typeof fromManifest === 'string' && fromManifest.length > 0) {
+      return fromManifest;
+    }
 
-  // The typed field wins when both are present: a promoted CUE field is the more
-  // specific declaration, and `additionalFields` is where a value waits for that
-  // promotion.
-  const fromAdditional = readAdditionalStartingLocation(packageManifest);
-  if (fromAdditional) {
-    return fromAdditional;
+    const fromAdditional = readAdditionalStartingLocation(packageManifest);
+    if (fromAdditional) {
+      return fromAdditional;
+    }
   }
 
   if (url.startsWith(BUNDLED_PREFIX)) {

--- a/src/recovery/starting-location.ts
+++ b/src/recovery/starting-location.ts
@@ -77,10 +77,7 @@ export function resolveStartingLocation(
   return validateInternalNavigationPath(candidate, options?.isAdmin);
 }
 
-function resolveCandidate(
-  url: string,
-  packageManifests: Array<Record<string, unknown> | undefined>
-): string | null {
+function resolveCandidate(url: string, packageManifests: Array<Record<string, unknown> | undefined>): string | null {
   // Manifest authority dominates: a manifest that declares the value at all
   // settles it, and only then do we fall through to the next one. Within a
   // single manifest the typed field still wins over `additionalFields` — a

--- a/src/types/content-panel.types.ts
+++ b/src/types/content-panel.types.ts
@@ -85,6 +85,9 @@ export interface PackageOpenInfo {
   repository?: string;
   /** Pre-resolved milestones from context panel to avoid redundant resolution in fetchPackageContent */
   resolvedMilestones?: Milestone[];
+  /** Launching surface, for context-panel sections that are not the recommender.
+   *  Narrowed with `coerceLaunchSource` at the launch boundary (Tier 0 cannot import it). */
+  launchSource?: string;
 }
 
 export interface ContextPanelState extends SceneObjectState {


### PR DESCRIPTION
Fixes #1681.

## What

A guide opened from inside a learning path never got its alignment prompt; the
same guide opened standalone did.

As the issue sets out, the member's starting location is not missing — it is
shadowed. `openMember` passes the path's `packageInfo`, whose manifest comes
from the catalogue proxy, and `customGuideManifest`
(`pkg/plugin/custom_guide_repository_client.go`) declares no starting location,
so the key is dropped at the wire boundary. The `backend-guide:` loader spreads
`spec.manifest` through unchanged, so `content.metadata.packageManifest` does
carry it — the reader just never looked there.

## Approach

The issue offers two options. This takes a third, narrower one.

`resolveStartingLocation` now accepts the manifests in priority order and
returns the first declared value. The call site passes `packageInfo` first, so
it remains authoritative wherever it declares a value; the only behaviour that
changes is where the lookup previously resolved to `null`.

That was chosen over the two listed options because:

- **Not the precedence change.** Launch-path precedence is untouched — nothing
  that reads `packageInfo` elsewhere is affected, and no case that previously
  resolved to a value resolves differently. The concern about a load-bearing
  reorder does not apply to a fallback.
- **Not `packageInfoForMember`.** `Milestone` (`src/types/content.types.ts:92`)
  has no manifest field, so that route means widening the milestone shape and
  threading a manifest through `resolvePackageMilestones` — a larger change to
  the resolver contract for the same outcome.

Path covers are out of scope, per the issue.

## Testing

- `src/recovery` — 89 tests pass, including five new cases covering ordered
  lookup, wire-pruned earlier manifests, `undefined` entries, empty-string
  values, and the bundled-index fallback still being reached.
- `src/components/docs-panel` — 544 pass, 6 skipped.
- `tsc --noEmit` clean; eslint and prettier clean on the changed files.
