### PR TITLE
fix(ci): pin the release workflow to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,12 @@ jobs:
         with:
           persist-credentials: false
       - uses: grafana/plugin-actions/build-plugin@4698961fa64137fcac207108397ebe8a738a33d1
-        # Uncomment to enable plugin signing
-        # (For more info on how to generate the access policy token see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
-        #with:
-        # Make sure to save the token in your repository secrets
-        #policy_token: $
-        # Usage of GRAFANA_API_KEY is deprecated, prefer `policy_token` option above
-        #grafana_token: $
+        with:
+          # The action defaults to Node 20; this repo requires >=24 (.nvmrc, engines.node).
+          node-version: '24'
+          # Uncomment to enable plugin signing
+          # (For more info on how to generate the access policy token see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
+          # Make sure to save the token in your repository secrets
+          #policy_token: $
+          # Usage of GRAFANA_API_KEY is deprecated, prefer `policy_token` option above
+          #grafana_token: $


### PR DESCRIPTION
## Summary

`release.yml` passes no `node-version` to `grafana/plugin-actions/build-plugin`, whose input defaults to `"20"`. This repo requires Node >=24 (`.nvmrc` is `24.19`, `engines.node` is `>=24`), so every tag-triggered release run has failed since December 2025 — v2.15.0 and v2.17.0 included.

## Why it fails on Node 20

`webpack-cli` cannot load `webpack.config.ts` by either route:

- **ESM** — `TypeError: Unknown file extension ".ts"`
- **CJS** (via ts-node) — `TypeError: webidl.util.markAsUncloneable is not a function`, thrown from `undici/lib/web/cache/cachestorage.js` while loading `@grafana/faro-bundlers-shared`

`webidl.util.markAsUncloneable` is a Node 22+ API, so the installed `undici` cannot initialise at all on Node 20. The run dies before the build, and every downstream step — package, attestation, `Create Github release` — is skipped.

Full log: [run 32740470769](https://github.com/grafana/grafana-pathfinder-app/actions/runs/32740470769).

`ci.yml` already pins `NODE_VERSION: '24'`. This just brings `release.yml` in line.

## What to look at

The commented-out signing lines were previously under a commented-out `#with:`. Now that `with:` is real, they are indented one level deeper so uncommenting `#policy_token:` puts it inside the `with:` block rather than alongside it. Their text is otherwise unchanged.

## How to verify

`with` parses as expected:

```
python3 -c "import yaml;print(yaml.safe_load(open('.github/workflows/release.yml'))['jobs']['release']['steps'][1]['with'])"
# {'node-version': '24'}
```

End to end, this can only be confirmed by the next tag push: a tag-triggered run uses the workflow file **at the tag ref**, so re-running an existing tag still uses the old file. It cannot retroactively fix `v2.17.0`.

## Scope note

This does not make `release.yml` the release path. Artifacts and the draft GitHub release come from `publish.yml` (Plugins - CD), which is why the breakage went unnoticed — v2.16.0's draft and its 14 assets were produced by its `Deploy main to dev` run. This PR just stops the tag workflow failing on every release.

## Breaking changes

None. CI-only.

## Reversibility

Fully reversible — revert the commit.