### PR TITLE
ci: enforce Go lint in the required CI Gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ concurrency:
 
 env:
   NODE_VERSION: '24'
+  # Pinned so an upstream golangci-lint release cannot redden the repo on its own.
+  # `npm run lint:go` reproduces CI exactly when your local golangci-lint matches this.
+  GOLANGCI_LINT_VERSION: 'v2.13.1'
 
 jobs:
   # Parallel quality check jobs
@@ -167,6 +170,39 @@ jobs:
       - name: Test shell scripts
         run: npm run test:scripts
 
+  # Backend lint runs the same golangci-lint invocation as `npm run lint:go`, at the
+  # version pinned in GOLANGCI_LINT_VERSION above. No node_modules and no secrets:
+  # this job only needs Go, so fork pull requests can satisfy it.
+  lint-backend:
+    name: Lint backend
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Check for backend
+        id: check-for-backend
+        run: |
+          if [ -f "Magefile.go" ]; then
+            echo "has-backend=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Go environment
+        if: steps.check-for-backend.outputs.has-backend == 'true'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+
+      - name: Lint backend
+        if: steps.check-for-backend.outputs.has-backend == 'true'
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+
   # Backend tests run in parallel with the frontend build and quality checks.
   # No dependency on setup: this job only needs Go, not node_modules.
   test-backend:
@@ -292,7 +328,7 @@ jobs:
   # CI gate job for branch protection - aggregates all required checks
   ci-gate:
     name: CI Gate
-    needs: [lint, typecheck, prettier, test, validate-packages, build, test-backend, test-scripts]
+    needs: [lint, typecheck, prettier, test, validate-packages, build, lint-backend, test-backend, test-scripts]
     if: always()
     runs-on: ubuntu-latest
     permissions: {} # No permissions needed - only checks job results
@@ -305,6 +341,7 @@ jobs:
           echo "Test: ${{ needs.test.result }}"
           echo "Validate packages: ${{ needs.validate-packages.result }}"
           echo "Build: ${{ needs.build.result }}"
+          echo "Lint backend: ${{ needs.lint-backend.result }}"
           echo "Test backend: ${{ needs.test-backend.result }}"
           echo "Test scripts: ${{ needs.test-scripts.result }}"
 
@@ -319,10 +356,28 @@ jobs:
             exit 1
           fi
 
+          # lint-backend and test-backend are skipped when no Magefile.go is present;
+          # that is expected, so tolerate "skipped" for both.
+          if [[ "${{ needs.lint-backend.result }}" != "success" ]] && \
+             [[ "${{ needs.lint-backend.result }}" != "skipped" ]]; then
+            echo "Go lint failed. Reproduce it locally with:"
+            echo ""
+            echo "    npm run lint:go"
+            echo ""
+            echo "CI pins golangci-lint ${GOLANGCI_LINT_VERSION}; install that version to get the same"
+            echo "diagnostics (GOLANGCI_LINT_VERSION in .github/workflows/ci.yml is the pin)."
+            echo "Fix each diagnostic, or suppress a wrong one at the line with"
+            echo "//nolint:<linter> // <reason>. Do not widen the linter set in .golangci.yaml."
+            exit 1
+          fi
+
           # test-backend is skipped when no Magefile.go is present; that is expected
           if [[ "${{ needs.test-backend.result }}" != "success" ]] && \
              [[ "${{ needs.test-backend.result }}" != "skipped" ]]; then
-            echo "Backend tests failed"
+            echo "Backend tests failed. Reproduce them locally with:"
+            echo ""
+            echo "    npm run test:go"
+            echo ""
             exit 1
           fi
 
@@ -331,7 +386,7 @@ jobs:
   # Alerts #grafana-pathfinder-alerts on main-branch CI failures only.
   notify-ci-failure:
     name: Notify CI failure
-    needs: [lint, typecheck, prettier, test, validate-packages, build, test-backend, test-scripts]
+    needs: [lint, typecheck, prettier, test, validate-packages, build, lint-backend, test-backend, test-scripts]
     if: >-
       always() &&
       github.event_name == 'push' &&
@@ -342,6 +397,7 @@ jobs:
        needs.test.result == 'failure' ||
        needs.validate-packages.result == 'failure' ||
        needs.build.result == 'failure' ||
+       needs.lint-backend.result == 'failure' ||
        needs.test-backend.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
@@ -359,6 +415,7 @@ jobs:
           TEST_RESULT: ${{ needs.test.result }}
           VALIDATE_RESULT: ${{ needs.validate-packages.result }}
           BUILD_RESULT: ${{ needs.build.result }}
+          LINT_BACKEND_RESULT: ${{ needs.lint-backend.result }}
           TEST_BACKEND_RESULT: ${{ needs.test-backend.result }}
           RUN_ID: ${{ github.run_id }}
           SHA: ${{ github.sha }}
@@ -373,12 +430,13 @@ jobs:
             ["Test"]="$TEST_RESULT"
             ["Validate packages"]="$VALIDATE_RESULT"
             ["Build"]="$BUILD_RESULT"
+            ["Lint backend"]="$LINT_BACKEND_RESULT"
             ["Test backend"]="$TEST_BACKEND_RESULT"
           )
 
           nl=$'\n'
           text="*CI failed on \`main\`*${nl}*Failed jobs:*"
-          for name in "Lint" "Typecheck" "Prettier" "Test" "Validate packages" "Build" "Test backend"; do
+          for name in "Lint" "Typecheck" "Prettier" "Test" "Validate packages" "Build" "Lint backend" "Test backend"; do
             if [[ "${results[$name]}" == "failure" ]]; then
               url=$(echo "$jobs_json" | jq -r --arg n "$name" '.jobs[] | select(.name == $n) | .html_url')
               text="${text}${nl}• <${url}|${name}>"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,11 +47,12 @@ npm run server           # Run Grafana locally with Docker
 npm run test:ci          # Frontend tests, no coverage (agents should use this, not `npm test`)
 npm run test:coverage    # Frontend tests with coverage + thresholds (used by `npm run check`)
 npm run lint:fix         # Lint + autofix
+npm run lint:go          # Go lint (golangci-lint); CI-enforced, so a diagnostic here blocks merge
 npm run check            # Full pre-merge gate: typecheck + lint + prettier + lint:go + test:go + test:coverage + test:scripts
 npm run test:scripts     # Shell scripts: bash -n, shellcheck, stubbed-curl behavioural suite
 ```
 
-Dev server runs at http://localhost:3000 (admin/admin). Focused Jest runs need `--coverage=false`, or global thresholds report a false failure. For the complete command reference (build targets, mage tasks, validation, i18n, peerjs, etc.), see `docs/developer/COMMANDS.md` or read `package.json#scripts` directly.
+Dev server runs at http://localhost:3000 (admin/admin). Focused Jest runs need `--coverage=false`, or global thresholds report a false failure. Go lint is this repository's linting just as much as eslint is: the `Lint backend` CI job runs the same `golangci-lint run ./...` that `npm run lint:go` does, `CI Gate` requires it, and `CI Gate` is required on `main` — so a Go lint diagnostic blocks merge. The linter version is pinned in `GOLANGCI_LINT_VERSION` in `.github/workflows/ci.yml`; match it locally to see the same diagnostics. For the complete command reference (build targets, mage tasks, validation, i18n, peerjs, etc.), see `docs/developer/COMMANDS.md` or read `package.json#scripts` directly.
 
 ## Code organization
 

--- a/docs/developer/COMMANDS.md
+++ b/docs/developer/COMMANDS.md
@@ -53,6 +53,21 @@ npm run prettier-test
 npm run lint:go
 ```
 
+## Go lint
+
+`npm run lint:go` runs `mage -v lint`, which is `golangci-lint run ./...` over the default
+linter set configured by `.golangci.yaml`.
+
+CI runs the identical invocation in the `Lint backend` job of `.github/workflows/ci.yml`, and that job
+is one of the checks `CI Gate` aggregates. `CI Gate` is a required status check on `main`, so a Go lint
+diagnostic blocks merge exactly as an eslint or typecheck error does.
+
+The linter version is pinned in `GOLANGCI_LINT_VERSION` at the top of `.github/workflows/ci.yml`, so an
+upstream release cannot turn the repository red on its own. Install that version locally to reproduce
+CI exactly — `golangci-lint --version` tells you what you have. When a diagnostic is wrong rather than
+a real defect, suppress it at the line with `//nolint:<linter> // <reason>` rather than widening the
+linter set in `.golangci.yaml`.
+
 ## Pre-merge check
 
 `npm run check` runs typecheck + lint + prettier + lint:go + test:go + test:coverage + test:scripts in one command.

--- a/pkg/plugin/completion_records_write_test.go
+++ b/pkg/plugin/completion_records_write_test.go
@@ -69,6 +69,7 @@ func writeRequest(t *testing.T, sub string, body map[string]any, cfg map[string]
 	if sub != "" {
 		r.Header.Set(backend.GrafanaUserSignInTokenHeaderName, makeValidIDToken(t, sub))
 	}
+	//nolint:staticcheck // OrgID is the numeric org the CRD requires; see completion_records_write.go
 	ctx := backend.WithPluginContext(r.Context(), backend.PluginContext{Namespace: testNamespace, OrgID: testOrgID})
 	ctx = sdkconfig.WithGrafanaConfig(ctx, sdkconfig.NewGrafanaCfg(cfg))
 	return r.WithContext(ctx)
@@ -84,7 +85,7 @@ func writeRequestWithUser(t *testing.T, sub string, body map[string]any, cfg map
 	r := writeRequest(t, sub, body, cfg)
 	ctx := backend.WithPluginContext(r.Context(), backend.PluginContext{
 		Namespace: testNamespace,
-		OrgID:     testOrgID,
+		OrgID:     testOrgID, //nolint:staticcheck // see writeRequest
 		User:      &backend.User{Login: login, Name: name},
 	})
 	return r.WithContext(ctx)


### PR DESCRIPTION
## Intent

Put Go linting inside this repository's enforced build chain, clean up the Go lint errors that already exist, and make the instruction sources say so.

Why this exists: a repository ruleset made `CI Gate` a required status check on the default branch, and it is now the only mechanically required check apart from the org's secret and Actions scanners. But `CI Gate` (.github/workflows/ci.yml) aggregates only eight jobs — lint, typecheck, prettier, test, validate-packages, build, test-backend, test-scripts — and its `lint` job is frontend eslint only. `golangci-lint` and `lint:go` appeared in no workflow at all: a grep across .github/workflows/ returned zero hits. So the newly required gate did not cover the Go half of the repo, and Go lint failures could sit on main indefinitely without CI noticing. Two had.

This must be ONE pull request. Because `CI Gate` is required, wiring a new and initially failing Go lint job into `CI Gate.needs` in one PR and cleaning up in a second would block that first PR and every other open PR. The cleanup and the wiring land together, green, or not at all.

DELIVERABLE 1 — a strictly lint-only cleanup sweep. Get `npm run lint:go` to pass with no behaviour change whatsoever. This discipline is the most important part of the work: every edit must be justified by a specific named linter diagnostic, and if the diagnostic a change silences cannot be named, the change must not be made. No refactors, no renames beyond what the diagnostic requires, no "while I'm here" improvements, no test restructuring, no dependency changes. `.golangci.yaml` is minimal (schema version 2, excluding only node_modules) so this runs golangci-lint's default linter set, and that set must NOT be expanded in this PR. A lint sweep that quietly alters behaviour is precisely the class of defect this whole effort exists to prevent — a reviewer finding one behaviour change hidden in a lint PR is a worse outcome than the lint errors staying.

Decision made on the only failures found. `npm run lint:go` failed with exactly two SA1019 diagnostics, both in pkg/plugin/completion_records_write_test.go: "(backend.PluginContext).OrgID is deprecated: Use Namespace instead." The OrgID -> Namespace deprecation was deliberately NOT treated as a rename, and was NOT migrated. In the Grafana plugin SDK these are not interchangeable: `Namespace` is a string-shaped scope identifier while `OrgID` is numeric. pkg/plugin/completion_records_write.go already carries the same `//nolint:staticcheck` on the production read, with the rationale that the CRD requires a numeric orgId, that PluginContext.OrgID is its only source, and that the SDK deprecates OrgID for request *scoping* (where Namespace replaces it, and is separately recorded as stackNamespace) rather than for reading the numeric org. The two test sites construct the very PluginContext that production read consumes, so they take the same suppression, each with a short comment pointing at that established rationale. The resulting Go diff is three comment lines and no statement change at all. A faithful Namespace migration would have changed behaviour, which the lint-only rule forbids; choosing the documented suppression deliberately is the correct outcome here rather than a silent semantic change.

DELIVERABLE 2 — wire it into CI and into the gate.

A new `Lint backend` job in .github/workflows/ci.yml, shaped like the existing `test-backend` job: the same `Check for backend` guard on Magefile.go, the same Go setup from go.mod, minimal `permissions` (contents: read), and `persist-credentials: false` on checkout. It runs the same `golangci-lint run ./...` that `npm run lint:go` runs via `mage -v lint`.

The golangci-lint version is pinned. It was previously unpinned everywhere — not in package.json, not in .golangci.yaml — and an unpinned linter means a future upstream release adds a check and turns the whole repo red without anyone changing a line. A ratchet that can fire on its own is not a ratchet. Deliberate choice of pin location: `GOLANGCI_LINT_VERSION` in the workflow-level `env:` block of ci.yml, directly beside the existing `NODE_VERSION` pin, rather than in a new dedicated file. That matches the file's own established convention for pinned tool versions, keeps the version in exactly one place, and lets the gate's failure message interpolate it. AGENTS.md and docs/developer/COMMANDS.md point at that pin rather than restating the number, since duplicate prose that later drifts is the specific failure this repo's reviewers flag most often.

The job is added to `CI Gate.needs`, to the aggregator's echo block, and to the aggregator's result check. It follows the existing bash block's shape, including tolerating a legitimately `skipped` result for the same reason the `test-backend` check already does — the steps are guarded on Magefile.go existing.

The failure is instructive, not bare. This repo's standard is that a failing check must tell a reader what to do about it, not merely that something is wrong; the in-repo example of the bar is TestContractStructTagGolden's failure text, which names the exact regeneration command. The aggregator previously ended with a bare "One or more required jobs failed". The Go lint path now names the exact local command that reproduces it (`npm run lint:go`), the pinned version and where the pin lives, and how to suppress a genuinely wrong diagnostic (`//nolint:<linter> // <reason>`) rather than widening .golangci.yaml. The backend test path got the same treatment with `npm run test:go`.

Fork safety was a hard requirement: the last four community contributions came from forks and all passed `CI Gate`, so a required job that depends on a secret would block every future fork PR with a check it cannot satisfy. The new job references no `secrets.*` at all and takes no permission it does not need.

Additionally, `lint-backend` was wired into the existing main-branch Slack notifier (needs list, failure condition, env block, results map, and the display-name loop) so that a newly required job cannot fail on main without an alert.

DELIVERABLE 3 — make the instruction sources say it. AGENTS.md already documented `npm run check` as including lint:go and test:go, and already told reviewers to verify `npm run lint:go` for Go PRs, so the knowledge existed; what was missing is that it is now mechanically enforced. AGENTS.md now states that Go lint is part of this repository's linting rather than a separate optional concern, that CI runs the same invocation and `CI Gate` requires it, that `CI Gate` is required on main so a Go lint diagnostic blocks merge, and where the pin lives. The detail — the enforcement chain, matching the pinned version locally, and preferring a line-level //nolint over widening the linter set — lives once in docs/developer/COMMANDS.md, which AGENTS.md already points to as the complete command reference. Following the repo's one-source-of-truth discipline, the pinned version number itself is not restated outside ci.yml, and .cursor/rules/techContext.mdc was deliberately left alone because its existing mention of golangci-lint is still accurate and duplicating the enforcement rule there would drift.

INVESTIGATED AND REPORTED, DELIBERATELY NOT FIXED — the mage target discrepancy. There was an unresolved contradiction worth one bounded look, because it bears on whether the gate being strengthened actually holds: CI's `test-backend` job runs `mage coverage`, `npm run test:go` runs `mage -v test`, and at main's head 45d34e6a a clean local run reported TestContractStructTagGolden failing on a supposedly stale golden (pkg/plugin/testdata/contract/struct-tags.json) while CI's test-backend at that same SHA reported success. Both halves resolve, and the answer is the opposite of a stale golden.

First: `mage coverage` and `mage test` run the identical test set. In grafana-plugin-sdk-go v0.296.2 build/common.go, Test() is `go test ./pkg/...` and Coverage() is `go test ./pkg/... -coverpkg ./... -v -cover -coverprofile=coverage/backend.out`. Same packages, same tests; coverage only adds instrumentation flags, and it propagates the exit code. There is no test-set discrepancy between the two targets.

Second: the golden is NOT stale on the tracked tree. The entire delta is two fields — `Match` and `Depends` — rendering as `json.RawMessage` versus `jsontext.Value`. In Go 1.27, encoding/json.RawMessage became a type *alias* for jsontext.Value (`go doc` confirms `type RawMessage = jsontext.Value`), and TestContractStructTagGolden records reflect.Type.String(). go.mod pins go 1.26.5, which is what CI's setup-go installs via go-version-file. Verified directly: `GOTOOLCHAIN=go1.26.5 go test ./pkg/plugin -run TestContract` passes. So CI was correct at that SHA and the local failure was purely a toolchain artifact. Regenerating that golden would have broken CI — which is a pointed argument for the instruction not to fold it into this PR. The golden was NOT regenerated and NOT fixed here. The genuine follow-up, which belongs in its own separately reviewed change, is that this golden is toolchain-sensitive and must be regenerated in the same change that moves the repo to Go 1.27.

Verification already run locally and green: `npm run lint:go` reports 0 issues; `go build ./...` clean; `go test ./pkg/...` green under go.mod's pinned toolchain; `npm run prettier-test` clean; `npm run docs:sync-terms:check` clean; the src/validation suite passes 854 tests across 20 suites; `golangci-lint config verify` accepts .golangci.yaml unchanged.

Repository constraints that apply to this change: commits must be signed (the existing commit is signed and verified). No AI or agent attribution anywhere — no co-author trailer, no "generated with" footer, no attribution in code, commit messages, or docs. This PR is not to be self-merged; the repository requires a separate reviewer, so the work ends at green and ready for review.

## What Changed

- Adds a `Lint backend` job to `.github/workflows/ci.yml` that runs `golangci-lint run ./...` — the same invocation `npm run lint:go` performs via `mage -v lint` — shaped like the existing `test-backend` job (`Magefile.go` guard, Go toolchain from `go.mod`, `permissions: contents: read`, `persist-credentials: false`, no `secrets.*` so fork PRs can satisfy it). The version is pinned in a new `GOLANGCI_LINT_VERSION` entry in the workflow-level `env:` block beside `NODE_VERSION`.
- Wires `lint-backend` into `CI Gate` (needs list, echo block, result check, tolerating `skipped` as `test-backend` already does) and into the main-branch Slack notifier (needs, failure condition, env, results map, display-name loop). The gate's Go lint and backend test failure paths now name the reproducing local command (`npm run lint:go` / `npm run test:go`), where the pin lives, and `//nolint:<linter> // <reason>` as the suppression route instead of widening `.golangci.yaml`.
- Clears the two pre-existing SA1019 diagnostics in `pkg/plugin/completion_records_write_test.go` by adding `//nolint:staticcheck` comments pointing at the rationale already recorded on the production read in `completion_records_write.go` — three comment lines, no statement change, since `PluginContext.OrgID` and `Namespace` are not interchangeable and a migration would alter behaviour. `AGENTS.md` and `docs/developer/COMMANDS.md` now state that Go lint is mechanically enforced and point at the pin rather than restating the version.

## Risk Assessment

✅ Low: Well-bounded CI plumbing plus three comment-only Go lines: the Go diff contains no statement changes, `golangci-lint run ./...` is verifiably clean at the pinned version, the workflow parses with all `needs` resolving, the new job takes no secrets and only `contents: read` so forks can satisfy it, and every stated intent criterion is met — the two findings are informational tradeoffs the intent already chose.

## Testing

I exercised the change at the surface a developer actually meets: the CI Gate log and the Slack alert. Both shell bodies were extracted verbatim from ci.yml and replayed under bash 5 with substituted job results, so the captured transcripts are the real output — a Go lint failure blocks merge and prints the reproduce command with the pinned version interpolated, a cancelled lint-backend also blocks, a skipped backend job is tolerated as before, and a lint failure on main renders as a linked "Lint backend" bullet in the Slack payload. Structural assertions over the parsed workflow confirm the new job mirrors test-backend's shape, takes only contents:read, references no secrets (so fork PRs can satisfy it), and pins the linter in exactly one place. For the lint-only discipline I proved the Go edit changes nothing by reparsing the file at base and head with comments discarded and diffing the reprinted source — identical — and pkg/... tests are green under go.mod's pinned toolchain. I also reproduced the reported TestContractStructTagGolden toolchain artifact (passes on go1.26.5, fails on go1.27.0 because json.RawMessage became a jsontext.Value alias), confirming the author was right not to regenerate the golden. No screenshot or rendered-UI artifact applies: this change is a CI workflow, three Go comments, and documentation, with no rendered end-user surface — the CLI transcripts are the equivalent artifact. I deliberately did not run `npm run lint:go` itself; linters are out of scope for this phase and owned by the pipeline's lint step, so I instead verified everything around it (the invocation is byte-identical to CI's, and the locally installed golangci-lint 2.13.1 matches the pin, so that run reproduces CI exactly). No findings; the worktree is clean and temp scratch files were removed.

<details>
<summary>Evidence: CI Gate replay — 5 scenarios, verbatim aggregator output including the instructive Go lint failure</summary>

<code>SCENARIO: Go lint diagnostic on the branch -&gt; lint-backend failure&#10;------------------------------------------------------------------&#10;Lint: success&#10;Typecheck: success&#10;Prettier: success&#10;Test: success&#10;Validate packages: success&#10;Build: success&#10;Lint backend: failure&#10;Test backend: success&#10;Test scripts: success&#10;Go lint failed. Reproduce it locally with:&#10;&#10;npm run lint:go&#10;&#10;CI pins golangci-lint v2.13.1; install that version to get the same&#10;diagnostics (GOLANGCI_LINT_VERSION in .github/workflows/ci.yml is the pin).&#10;Fix each diagnostic, or suppress a wrong one at the line with&#10;//nolint:&lt;linter&gt; // &lt;reason&gt;. Do not widen the linter set in .golangci.yaml.&#10;------------------------------------------------------------------&#10;CI Gate exit code: 1 -&gt; FAIL (merge blocked)&#10;&#10;SCENARIO: no Magefile.go -&gt; both backend jobs skipped, tolerated&#10;Lint backend: skipped&#10;Test backend: skipped&#10;All required jobs passed!&#10;CI Gate exit code: 0 -&gt; PASS&#10;&#10;SCENARIO: backend tests fail -&gt; test-backend failure&#10;Backend tests failed. Reproduce them locally with:&#10;&#10;npm run test:go&#10;&#10;CI Gate exit code: 1 -&gt; FAIL (merge blocked)&#10;&#10;EXPECTED EXIT CODES: all matched</code>

```text
==============================================================================
SCENARIO: every job green (this PR at HEAD)
  job results: lint-backend=success, test-backend=success
------------------------------------------------------------------------------
Lint: success
Typecheck: success
Prettier: success
Test: success
Validate packages: success
Build: success
Lint backend: success
Test backend: success
Test scripts: success
All required jobs passed!
------------------------------------------------------------------------------
CI Gate exit code: 0  ->  PASS

==============================================================================
SCENARIO: Go lint diagnostic on the branch -> lint-backend failure
  job results: lint-backend=failure, test-backend=success
------------------------------------------------------------------------------
Lint: success
Typecheck: success
Prettier: success
Test: success
Validate packages: success
Build: success
Lint backend: failure
Test backend: success
Test scripts: success
Go lint failed. Reproduce it locally with:

    npm run lint:go

CI pins golangci-lint v2.13.1; install that version to get the same
diagnostics (GOLANGCI_LINT_VERSION in .github/workflows/ci.yml is the pin).
Fix each diagnostic, or suppress a wrong one at the line with
//nolint:<linter> // <reason>. Do not widen the linter set in .golangci.yaml.
------------------------------------------------------------------------------
CI Gate exit code: 1  ->  FAIL (merge blocked)

==============================================================================
SCENARIO: lint-backend cancelled (non-success, non-skipped)
  job results: lint-backend=cancelled, test-backend=success
------------------------------------------------------------------------------
Lint: success
Typecheck: success
Prettier: success
Test: success
Validate packages: success
Build: success
Lint backend: cancelled
Test backend: success
Test scripts: success
Go lint failed. Reproduce it locally with:

    npm run lint:go

CI pins golangci-lint v2.13.1; install that version to get the same
diagnostics (GOLANGCI_LINT_VERSION in .github/workflows/ci.yml is the pin).
Fix each diagnostic, or suppress a wrong one at the line with
//nolint:<linter> // <reason>. Do not widen the linter set in .golangci.yaml.
------------------------------------------------------------------------------
CI Gate exit code: 1  ->  FAIL (merge blocked)

==============================================================================
SCENARIO: no Magefile.go -> both backend jobs skipped, tolerated
  job results: lint-backend=skipped, test-backend=skipped
------------------------------------------------------------------------------
Lint: success
Typecheck: success
Prettier: success
Test: success
Validate packages: success
Build: success
Lint backend: skipped
Test backend: skipped
Test scripts: success
All required jobs passed!
------------------------------------------------------------------------------
CI Gate exit code: 0  ->  PASS

==============================================================================
SCENARIO: backend tests fail -> test-backend failure
  job results: lint-backend=success, test-backend=failure
------------------------------------------------------------------------------
Lint: success
Typecheck: success
Prettier: success
Test: success
Validate packages: success
Build: success
Lint backend: success
Test backend: failure
Test scripts: success
Backend tests failed. Reproduce them locally with:

    npm run test:go
------------------------------------------------------------------------------
CI Gate exit code: 1  ->  FAIL (merge blocked)

==============================================================================
EXPECTED EXIT CODES: all matched
```
</details>
<details>
<summary>Evidence: Slack alert a Go lint failure on main now produces</summary>

<code>notifier display names present as real job names: all match&#10;notifier `if:` gates on lint-backend failure: True&#10;&#10;SCENARIO: Go lint fails on main -&gt; Slack alert payload&#10;-----------------------------------------------------&#10;Slack message rendered:&#10;&#10;*CI failed on `main`*&#10;*Failed jobs:*&#10;• &lt;https://github.com/grafana/grafana-pathfinder-app/actions/runs/42/job/7|Lint backend&gt;&#10;&lt;https://github.com/grafana/grafana-pathfinder-app/actions/runs/42|Open CI run&gt;&#10;Commit: `d6d37069` · triggered by `flapjack`&#10;-----------------------------------------------------&#10;step exit code: 0</code>

```text
notifier display names present as real job names: all match
notifier `if:` gates on lint-backend failure: True

SCENARIO: Go lint fails on main -> Slack alert payload
------------------------------------------------------------------------------
Slack message rendered:

  *CI failed on `main`*
  *Failed jobs:*
  • <https://github.com/grafana/grafana-pathfinder-app/actions/runs/42/job/7|Lint backend>
  <https://github.com/grafana/grafana-pathfinder-app/actions/runs/42|Open CI run>
  Commit: `d6d37069` · triggered by `flapjack`
------------------------------------------------------------------------------
step exit code: 0
```
</details>
<details>
<summary>Evidence: Enforcement chain + comment-only proof + backend tests green</summary>

<code>== 1. mage lint == golangci-lint run ./... (the claim AGENTS.md and COMMANDS.md make) ==&#10;package.json: &#34;lint:go&#34;: &#34;mage -v lint&#34;&#10;Magefile.go imports grafana-plugin-sdk-go/build; that package&#39;s Lint target is:&#10;417:func Lint() error {&#10;418- return sh.RunV(&#34;golangci-lint&#34;, &#34;run&#34;, &#34;./...&#34;)&#10;CI&#39;s Lint backend job runs golangci-lint at the pinned version:&#10;23: GOLANGCI_LINT_VERSION: &#39;v2.13.1&#39;&#10;204: version: ${{ env.GOLANGCI_LINT_VERSION }}&#10;locally installed golangci-lint: 2.13.1 -&gt; matches the pin&#10;&#10;== 2. The Go cleanup changes no behaviour ==&#10;Whole Go diff, base..head:&#10;+ //nolint:staticcheck // OrgID is the numeric org the CRD requires; see completion_records_write.go&#10;- OrgID: testOrgID,&#10;+ OrgID: testOrgID, //nolint:staticcheck // see writeRequest&#10;&#10;Parsed with go/parser in comment-discarding mode and reprinted, base and head are identical:&#10;IDENTICAL - no statement, expression, or declaration changed.&#10;&#10;== 3. Backend tests still green under the toolchain CI installs from go.mod ==&#10;? github.com/grafana/grafana-pathfinder-app/pkg [no test files]&#10;ok github.com/grafana/grafana-pathfinder-app/pkg/plugin 0.609s&#10;ok github.com/grafana/grafana-pathfinder-app/pkg/plugin/auth 0.490s</code>

```text
Go-lint enforcement: end-to-end evidence
branch fm/go-lint-in-ci  base 45d34e6a  head d6d37069

== 1. mage lint == golangci-lint run ./... (the claim AGENTS.md and COMMANDS.md make) ==
package.json:  "lint:go": "mage -v lint"
Magefile.go imports grafana-plugin-sdk-go/build; that package's Lint target is:
417:func Lint() error {
418-	return sh.RunV("golangci-lint", "run", "./...")
CI's Lint backend job runs golangci-lint at the pinned version:
23:  GOLANGCI_LINT_VERSION: 'v2.13.1'
174:  # version pinned in GOLANGCI_LINT_VERSION above. No node_modules and no secrets:
204:          version: ${{ env.GOLANGCI_LINT_VERSION }}
367:            echo "CI pins golangci-lint ${GOLANGCI_LINT_VERSION}; install that version to get the same"
368:            echo "diagnostics (GOLANGCI_LINT_VERSION in .github/workflows/ci.yml is the pin)."
locally installed golangci-lint: 2.13.1  -> matches the pin

== 2. The Go cleanup changes no behaviour ==
Whole Go diff, base..head:
+	//nolint:staticcheck // OrgID is the numeric org the CRD requires; see completion_records_write.go
-		OrgID:     testOrgID,
+		OrgID:     testOrgID, //nolint:staticcheck // see writeRequest

Parsed with go/parser in comment-discarding mode and reprinted, base and head are identical:
  IDENTICAL - no statement, expression, or declaration changed.

== 3. Backend tests still green under the toolchain CI installs from go.mod ==
?   	github.com/grafana/grafana-pathfinder-app/pkg	[no test files]
ok  	github.com/grafana/grafana-pathfinder-app/pkg/plugin	0.609s
ok  	github.com/grafana/grafana-pathfinder-app/pkg/plugin/auth	0.490s
```
</details>
<details>
<summary>Evidence: Replay harness — CI Gate aggregator (reusable)</summary>

```text
"""Replay the CI Gate aggregator step out of .github/workflows/ci.yml, verbatim.

Substitutes ${{ needs.<job>.result }} with scenario values and runs the real bash
body with the workflow-level env, so the transcript is what a developer sees in
the Actions log.
"""
import re, subprocess, sys, yaml

WF = yaml.safe_load(open('.github/workflows/ci.yml'))
GATE = WF['jobs']['ci-gate']['steps'][0]['run']
ENV = {k: str(v) for k, v in WF['env'].items()}
JOBS = WF['jobs']['ci-gate']['needs']

def replay(results, label):
    script = GATE
    for job in JOBS:
        script = script.replace('${{ needs.%s.result }}' % job, results[job])
    assert '${{' not in script, 'unsubstituted expression left in script'
    p = subprocess.run(['/opt/homebrew/bin/bash', '-e', '-c', script], capture_output=True, text=True, env={'PATH': '/usr/bin:/bin', **ENV})
    print('=' * 78)
    print(f'SCENARIO: {label}')
    print(f'  job results: ' + ', '.join(f'{j}={results[j]}' for j in JOBS if results[j] != 'success'or j.endswith('backend')))
    print('-' * 78)
    print(p.stdout.rstrip())
    if p.stderr.strip():
        print('[stderr] ' + p.stderr.rstrip())
    print('-' * 78)
    print(f'CI Gate exit code: {p.returncode}  ->  ' + ('FAIL (merge blocked)' if p.returncode else 'PASS'))
    print()
    return p.returncode

def base(**over):
    r = {j: 'success' for j in JOBS}
    r.update(over)
    return r

codes = {}
codes['all green'] = replay(base(), 'every job green (this PR at HEAD)')
codes['go lint failed'] = replay(base(**{'lint-backend': 'failure'}), 'Go lint diagnostic on the branch -> lint-backend failure')
codes['go lint cancelled'] = replay(base(**{'lint-backend': 'cancelled'}), 'lint-backend cancelled (non-success, non-skipped)')
codes['no Magefile'] = replay(base(**{'lint-backend': 'skipped', 'test-backend': 'skipped'}), 'no Magefile.go -> both backend jobs skipped, tolerated')
codes['go tests failed'] = replay(base(**{'test-backend': 'failure'}), 'backend tests fail -> test-backend failure')

expect = {'all green': 0, 'go lint failed': 1, 'go lint cancelled': 1, 'no Magefile': 0, 'go tests failed': 1}
bad = {k: (codes[k], expect[k]) for k in expect if codes[k] != expect[k]}
print('=' * 78)
print('EXPECTED EXIT CODES: ' + ('all matched' if not bad else f'MISMATCH {bad}'))
sys.exit(1 if bad else 0)
```
</details>
<details>
<summary>Evidence: Replay harness — Slack notifier payload (reusable)</summary>

```text
"""Replay the main-branch Slack notifier payload step from ci.yml with a stubbed gh."""
import os, subprocess, sys, yaml, json

WF = yaml.safe_load(open('.github/workflows/ci.yml'))
job = WF['jobs']['notify-ci-failure']
step = job['steps'][0]

# the display names the loop iterates over must match real job `name:` values
names = [j.get('name') for j in WF['jobs'].values()]
loop = ["Lint","Typecheck","Prettier","Test","Validate packages","Build","Lint backend","Test backend"]
missing = [n for n in loop if n not in names]
print('notifier display names present as real job names:', 'all match' if not missing else f'MISSING {missing}')
print('notifier `if:` gates on lint-backend failure:', 'needs.lint-backend.result == \'failure\'' in job['if'])
print()

env = dict(os.environ)
env['PATH'] = os.environ['EV'] + '/stub:' + '/usr/bin:/bin:/opt/homebrew/bin'
env.update({
    'GITHUB_REPOSITORY': 'grafana/grafana-pathfinder-app',
    'GITHUB_SERVER_URL': 'https://github.com',
    'RUN_ID': '42', 'SHA': 'd6d37069', 'ACTOR': 'flapjack',
    'LINT_RESULT': 'success', 'TYPECHECK_RESULT': 'success', 'PRETTIER_RESULT': 'success',
    'TEST_RESULT': 'success', 'VALIDATE_RESULT': 'success', 'BUILD_RESULT': 'success',
    'LINT_BACKEND_RESULT': 'failure', 'TEST_BACKEND_RESULT': 'success',
    'GITHUB_OUTPUT': env['EV'] + '/notifier_output.txt',
})
open(env['GITHUB_OUTPUT'], 'w').close()
p = subprocess.run(['/opt/homebrew/bin/bash', '-e', '-c', step['run']], capture_output=True, text=True, env=env)
print('SCENARIO: Go lint fails on main -> Slack alert payload')
print('-' * 78)
if p.stderr.strip():
    print('[stderr]', p.stderr.rstrip())
out = open(env['GITHUB_OUTPUT']).read()
# the step writes payload as a heredoc block; render the Slack text a human reads
import re as _re
m = _re.search(r'payload<<EOF\n(.*?)\nEOF', out, _re.S)
if not m:
    print('NO PAYLOAD EMITTED'); raise SystemExit(1)
blob = json.loads(m.group(1))
print('Slack message rendered:')
print()
def walk(o):
    if isinstance(o, dict):
        if o.get('type') in ('mrkdwn', 'plain_text') and 'text' in o:
            print('  ' + o['text'].replace('\n', '\n  '))
        for v in o.values(): walk(v)
    elif isinstance(o, list):
        for v in o: walk(v)
walk(blob)
print('-' * 78)
print('step exit code:', p.returncode)
sys.exit(p.returncode)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `.github/workflows/ci.yml:359` - The `Check for backend` guard makes the new required check silently vacuous if Magefile.go ever disappears while pkg/ remains: `lint-backend` has no job-level `if:` and no `needs`, so its *steps* skip but the *job* reports `success`, not `skipped`. CI Gate then prints &#34;All required jobs passed!&#34; having linted nothing. Consequently the `!= &#34;skipped&#34;` tolerance at line 361 is unreachable dead code, and the comment at line 359 (&#34;lint-backend and test-backend are skipped when no Magefile.go is present&#34;) describes step-level skipping, not the job result it is guarding. This mirrors the pre-existing test-backend shape and the intent explicitly required &#34;the same `Check for backend` guard on Magefile.go&#34;, so the tradeoff is deliberate — noting it because a silently-passing required check is the exact failure class this PR closes elsewhere.
- ℹ️ `docs/developer/COMMANDS.md:61` - The pin constrains CI only. `npm run lint:go` shells out to `mage -v lint`, which runs whatever `golangci-lint` is on the developer&#39;s PATH — nothing in the repo makes a local run use v2.13.1, so `npm run check` can pass locally on a different linter version than the gate enforces. The docs&#39; mitigation (&#34;Install that version locally&#34;) is manual by design; the intent deliberately rejected a dedicated pin file. Separately, &#34;CI runs the identical invocation&#34; is true today only transitively: CI invokes golangci-lint-action directly rather than mage, so it matches `npm run lint:go` for exactly as long as the SDK&#39;s `Lint()` stays `golangci-lint run ./...` (verified equal at v0.296.2). A future SDK bump that adds flags to that target would drift CI from the local command without any signal.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`python3 run_gate.py` — replays the `CI Gate` aggregator step verbatim from ci.yml under bash 5 across 5 job-result scenarios (all-green, lint-backend=failure, lint-backend=cancelled, both backend jobs skipped, test-backend=failure) and asserts the expected exit codes</code>
- <code>`python3 run_notifier.py` — replays the main-branch Slack notifier payload step with `LINT_BACKEND_RESULT=failure` and a stubbed `gh api`, renders the resulting Slack message, and checks every notifier display name resolves to a real job `name:`</code>
- <code>PyYAML structural assertions on `.github/workflows/ci.yml`: `lint-backend` present in `ci-gate.needs` and `notify-ci-failure.needs`, `permissions: {contents: read}`, `persist-credentials: false`, `Magefile.go` guard byte-identical to `test-backend`&#39;s, `go-version-file: go.mod`, `version: ${{ env.GOLANGCI_LINT_VERSION }}`, and no `secrets.*` anywhere in the job (fork safety)</code>
- <code>`grep -rn &#39;2\.13\.1&#39;` across md/mdc/json/yaml — pin restated nowhere outside ci.yml</code>
- <code>`grep -n -A1 &#39;func Lint() error&#39; $(go env GOMODCACHE)/github.com/grafana/grafana-plugin-sdk-go@v0.296.2/build/common.go` — confirms `mage lint` is `golangci-lint run ./...`, matching the AGENTS.md/COMMANDS.md claim; `golangci-lint --version` reports 2.13.1, matching the pin</code>
- <code>AST equivalence check: reparsed `pkg/plugin/completion_records_write_test.go` at 45d34e6a and d6d37069 with `go/parser` in comment-discarding mode, reprinted both, and diffed — identical (comment-only change proven)</code>
- `GOTOOLCHAIN=go1.26.5 go test ./pkg/plugin -run TestCompletionWrite -count=1`
- `GOTOOLCHAIN=go1.26.5 go test ./pkg/... -count=1`
- <code>`GOTOOLCHAIN=go1.26.5 go test ./pkg/plugin -run TestContractStructTagGolden` vs `GOTOOLCHAIN=go1.27.0 ...` plus `go doc encoding/json.RawMessage` — reproduces the reported toolchain sensitivity</code>

</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `AGENTS.md:51` - Pre-existing (not caused by this change): the composition of `npm run check` is hand-copied into five places and every copy has drifted from package.json. AGENTS.md:51 and docs/developer/COMMANDS.md:73 both omit `docs:sync-terms:check` and `test:review-contract`; .cursor/skills/release-prep/SKILL.md:138 says `test:ci` where the script runs `test:coverage` and also omits `test:review-contract` and `test:scripts`; the code blocks in docs/developer/GETTING_STARTED.md and docs/developer/LOCAL_DEV.md list six commands and omit `docs:sync-terms:check`, `test:coverage`, `test:review-contract`, and `test:scripts`. I deliberately did not fix this: synchronizing five prose copies is the exact anti-pattern the placement policy forbids, and the composition is a schema-backed fact whose authoritative source is package.json#scripts.check. Proposed follow-up in its own change: make docs/developer/COMMANDS.md the single owner (or generate the list from package.json with a drift check, alongside the existing docs:sync-terms:check), and reduce the other four to pointers.
- ℹ️ `pkg/plugin/contract_fixtures_test.go:188` - Judgment call, left unfixed per this change&#39;s own scope decision. The change&#39;s investigation established that pkg/plugin/testdata/contract/struct-tags.json is toolchain-sensitive: TestContractStructTagGolden records reflect.Type.String(), and in Go 1.27 encoding/json.RawMessage became an alias for jsontext.Value, so the `Match` and `Depends` fields render differently under a 1.27 toolchain than under the go 1.26.5 pinned in go.mod. Nothing in the test, the golden, or any doc records this. assertContractGolden&#39;s failure text names the regeneration command but not the toolchain caveat, so the next developer on a 1.27 toolchain sees a plausible &#39;stale golden&#39; failure, regenerates, and reddens CI. I did not add the note here because this change touches no part of that test and the intent explicitly reserves it for the separately reviewed Go 1.27 move; the durable follow-up is a short comment at the golden&#39;s assertion plus regeneration in the same change that bumps the toolchain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
