### PR TITLE
test: add a launch-path parity matrix over the day-one launch families

### DIFF
--- a/docs/developer/COMMANDS.md
+++ b/docs/developer/COMMANDS.md
@@ -32,7 +32,28 @@ npm test
 
 # Run tests with coverage + threshold enforcement (used by `npm run check`)
 npm run test:coverage
+
+# Launch-path parity matrix (red on purpose - see below)
+npm run test:parity
 ```
+
+### Launch-path parity matrix
+
+`npm run test:parity` runs `tests/parity/`, which feeds one manifest through every
+day-one guide launch path and asserts the resulting launch requests are identical to
+each other. It never asserts against an expected value, so it fires only when the
+paths disagree.
+
+**It is red today, and that is the point.** The launch paths genuinely diverge - some
+omit the top-level repository, so the same guide can key its durable completion under
+two different repositories. The failure output names each disagreeing path. Do not
+narrow the table, loosen the assertion, or add an intentional-difference entry to
+quiet it; fix the production divergence or leave it reported.
+
+The default suite and CI deliberately exclude it: `npm run check` and the CI gate must
+stay green, and this matrix is a standing diagnostic of a known contract gap rather
+than a merge gate. That is why it lives under `tests/parity/`, outside the base
+`testMatch`, and is reached only through its own `--testMatch`.
 
 ## Code quality
 

--- a/docs/developer/learning-paths/README.md
+++ b/docs/developer/learning-paths/README.md
@@ -18,6 +18,7 @@ The `src/learning-paths/` module provides the business logic layer for the gamif
 | `fetch-path-guides.ts`                         | Fetches guide lists from remote `index.json` for URL-based paths                                        |
 | `useNextLearningAction.ts`                     | `useNextLearningAction()` hook and pure `computeNextAction()` for the UserProfileBar                    |
 | `useDiscoverMore.ts`                           | `useDiscoverMore()` hook — surfaces external learning paths for the My Learning "Discover more" section |
+| `launch-package-info.ts`                       | Pure `PackageOpenInfo` factories for the two manifest-backed My Learning launches                       |
 | `learning-paths.test.ts`                       | Data-integrity tests for path, badge, and guide metadata definitions                                    |
 | `fetch-path-guides.test.ts`                    | Tests for remote guide fetching                                                                         |
 | `app-platform-paths.test.ts`                   | Tests for App Platform catalogue adaptation                                                             |

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:coverage": "jest --coverage",
     "test:review-contract": "node --test .cursor/skills/review/scripts/contract-evolution.test.mjs",
     "test:scripts": "bash scripts/tests/run.sh",
+    "test:parity": "jest --testMatch '<rootDir>/tests/parity/**/*.test.ts'",
     "test:governance": "jest src/validation/architecture.test.ts src/validation/import-graph.test.ts src/validation/security-lint-config.test.ts src/validation/control-bytes.test.ts",
     "test:coverage:watch": "jest --coverage --watch",
     "test:go": "mage -v test",

--- a/src/components/LearningPaths/MyLearningTab.cover-launch.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.cover-launch.test.tsx
@@ -32,6 +32,9 @@ const moduleUrl = 'https://grafana.com/docs/learning-paths/path-1/guide-1/';
 let pathProgress = 0;
 
 jest.mock('../../learning-paths', () => ({
+  // The launch package-context factories are pure — keep the real ones so
+  // the packageInfo assertions below still prove production behaviour.
+  ...jest.requireActual('../../learning-paths/launch-package-info'),
   BADGES: [],
   getPathsData: () => ({ guideMetadata: {} }),
   useDiscoverMore: () => ({

--- a/src/components/LearningPaths/MyLearningTab.test.tsx
+++ b/src/components/LearningPaths/MyLearningTab.test.tsx
@@ -80,6 +80,9 @@ let mockDiscoverItems: Array<{
 let mockDiscoverExcludeTitles: Set<string> | undefined;
 
 jest.mock('../../learning-paths', () => ({
+  // The launch package-context factories are pure — keep the real ones so
+  // the packageInfo assertions below still prove production behaviour.
+  ...jest.requireActual('../../learning-paths/launch-package-info'),
   BADGES: [],
   getPathsData: () => ({ guideMetadata: mockGuideMetadata }),
   useDiscoverMore: ({ excludeTitles }: { excludeTitles?: Set<string> }) => {

--- a/src/components/LearningPaths/MyLearningTab.tsx
+++ b/src/components/LearningPaths/MyLearningTab.tsx
@@ -13,7 +13,15 @@ import { t } from '@grafana/i18n';
 
 import { prepareGuideLaunch, type PreparedGuideLaunch } from '../docs-panel/utils/prepare-guide-launch';
 import type { PackageOpenInfo } from '../../types/content-panel.types';
-import { useLearningPaths, useDiscoverMore, BADGES, getPathsData, type DiscoverMoreItem } from '../../learning-paths';
+import {
+  useLearningPaths,
+  useDiscoverMore,
+  BADGES,
+  getPathsData,
+  packageInfoForPathMember,
+  packageInfoForDiscoverItem,
+  type DiscoverMoreItem,
+} from '../../learning-paths';
 import { testIds } from '../../constants/testIds';
 import { SkeletonLoader } from '../SkeletonLoader';
 import { FeedbackButton } from '../FeedbackButton/FeedbackButton';
@@ -209,16 +217,7 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
         });
       }
 
-      // App Platform paths carry a manifest but no cover `url`, so the member
-      // launches as `backend-guide:<id>`. Thread the PATH manifest through as
-      // packageInfo (mirroring CustomGuidesSection) — without it the loader
-      // falls through to plain fetchContent and the member renders as a
-      // standalone guide with no milestone toolbar, next/prev, or cover.
-      const packageInfo: PackageOpenInfo | undefined = parentPath?.manifest
-        ? { packageId: parentPath.id, packageManifest: { ...parentPath.manifest, id: parentPath.id } }
-        : undefined;
-
-      void launch(guideUrl, title, pathId, packageInfo);
+      void launch(guideUrl, title, pathId, packageInfoForPathMember(parentPath));
     },
     [launch, paths, getPathProgress, getPathGuides, getGuideUrlForPath]
   );
@@ -232,13 +231,7 @@ export function MyLearningTab({ onOpenGuide }: MyLearningTabProps) {
         interaction_location: 'my_learning_discover_more',
       });
 
-      // prepareGuideLaunch backfills packageInfo from the URL when absent, but
-      // the manifest is already inlined here — passing it saves that re-fetch.
-      const packageInfo: PackageOpenInfo | undefined = item.manifest
-        ? { packageId: item.id, packageManifest: { ...item.manifest, id: item.id } }
-        : undefined;
-
-      void launch(item.contentUrl, item.title, item.id, packageInfo);
+      void launch(item.contentUrl, item.title, item.id, packageInfoForDiscoverItem(item));
     },
     [launch]
   );

--- a/src/components/docs-panel/CustomGuidesSection.tsx
+++ b/src/components/docs-panel/CustomGuidesSection.tsx
@@ -28,7 +28,7 @@ interface CustomGuidesSectionProps {
   openDocsPage: (url: string, title: string, packageInfo?: PackageOpenInfo) => void;
 }
 
-function packageInfoForPath(path: PublishedGuide, resolvedMilestones?: Milestone[]): PackageOpenInfo {
+export function packageInfoForPath(path: PublishedGuide, resolvedMilestones?: Milestone[]): PackageOpenInfo {
   return {
     packageId: path.id,
     // The catalogue manifest is slim and carries no `id` (it lives on the

--- a/src/components/docs-panel/context-panel.test.tsx
+++ b/src/components/docs-panel/context-panel.test.tsx
@@ -560,4 +560,90 @@ describe('RecommendationsSection', () => {
       packageManifest: { id: 'visualization-metrics-lj', type: 'path' },
     });
   });
+  it('emits the same package context from all four nav-link click sites', () => {
+    const openDocsPage = jest.fn();
+    const navLinkRecommendation = {
+      title: 'Grafana Cloud Tour',
+      url: '',
+      contentUrl: 'https://cdn.example.com/packages/cloud-tour/content.json',
+      type: 'package' as const,
+      summary: 'Tour Grafana Cloud.',
+      summaryExpanded: true,
+      manifest: {
+        id: 'grafana-cloud-tour-lj',
+        type: 'path',
+        recommends: ['alerting-notifications'],
+        suggests: ['visualization-metrics-lj'],
+      },
+      resolvedRecommends: [
+        {
+          packageId: 'alerting-notifications',
+          title: 'Alerting notifications',
+          contentUrl: 'bundled:alerting-notifications/content.json',
+          manifest: { id: 'alerting-notifications', type: 'path' },
+          repository: 'online-cdn',
+        },
+      ],
+      resolvedSuggests: [
+        {
+          packageId: 'visualization-metrics-lj',
+          title: 'Visualize metrics',
+          contentUrl: 'bundled:visualization-metrics-lj/content.json',
+          manifest: { id: 'visualization-metrics-lj', type: 'path' },
+          repository: 'online-cdn',
+        },
+      ],
+    };
+
+    const props = {
+      customGuides: [],
+      customGuidePaths: [],
+      customGuideOrphans: [],
+      isLoadingCustomGuides: false,
+      customGuidesExpanded: true,
+      suggestedGuidesExpanded: true,
+      isLoadingRecommendations: false,
+      isLoadingContext: false,
+      recommendationsError: null,
+      otherDocsExpanded: false,
+      showEnableRecommenderBanner: false,
+      openLearningJourney: jest.fn(),
+      openDocsPage,
+      toggleCustomGuidesExpansion: jest.fn(),
+      toggleSuggestedGuidesExpansion: jest.fn(),
+      toggleSummaryExpansion: jest.fn(),
+      toggleOtherDocsExpansion: jest.fn(),
+    };
+
+    // The same card rendered featured and unfeatured gives all four click sites.
+    const featured = render(
+      <RecommendationsSection recommendations={[]} featuredRecommendations={[navLinkRecommendation]} {...props} />
+    );
+    fireEvent.click(screen.getByText('Alerting notifications'));
+    fireEvent.click(screen.getByText('Visualize metrics'));
+    featured.unmount();
+
+    render(
+      <RecommendationsSection recommendations={[navLinkRecommendation]} featuredRecommendations={[]} {...props} />
+    );
+    fireEvent.click(screen.getByText('Alerting notifications'));
+    fireEvent.click(screen.getByText('Visualize metrics'));
+
+    const [featuredRecommends, featuredSuggests, plainRecommends, plainSuggests] = openDocsPage.mock.calls.map(
+      (call) => call[2]
+    );
+
+    expect(featuredRecommends).toEqual({
+      packageId: 'alerting-notifications',
+      packageManifest: { id: 'alerting-notifications', type: 'path' },
+      repository: 'online-cdn',
+    });
+    expect(plainRecommends).toEqual(featuredRecommends);
+    expect(featuredSuggests).toEqual({
+      packageId: 'visualization-metrics-lj',
+      packageManifest: { id: 'visualization-metrics-lj', type: 'path' },
+      repository: 'online-cdn',
+    });
+    expect(plainSuggests).toEqual(featuredSuggests);
+  });
 });

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -193,6 +193,14 @@ function getManifestNavigation(recommendation: Recommendation): {
 const getNavLinkIcon = (link: ResolvedNavLink): IconName =>
   getPackageRenderType(link.manifest) === 'learning-journey' ? 'graph-bar' : 'link';
 
+/** Package context for a resolved recommends/suggests nav link. Shared by every
+ *  nav-link click site so all four produce identical launch context. */
+export const packageInfoForNavLink = (link: ResolvedNavLink): PackageOpenInfo => ({
+  packageId: link.packageId,
+  packageManifest: link.manifest,
+  repository: link.repository,
+});
+
 const getRecommendationPackageInfo = (recommendation: Recommendation): PackageOpenInfo | undefined => {
   if (recommendation.type !== 'package') {
     return undefined;
@@ -634,11 +642,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                                                   content_type: AnalyticsContentType.PackageNavLink,
                                                   interaction_location: 'featured_recommends_section',
                                                 });
-                                                openDocsPage(link.contentUrl, link.title, {
-                                                  packageId: link.packageId,
-                                                  packageManifest: link.manifest,
-                                                  repository: link.repository,
-                                                });
+                                                openDocsPage(link.contentUrl, link.title, packageInfoForNavLink(link));
                                               }}
                                               className={styles.milestoneItem}
                                             >
@@ -669,11 +673,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                                                   content_type: AnalyticsContentType.PackageNavLink,
                                                   interaction_location: 'featured_suggests_section',
                                                 });
-                                                openDocsPage(link.contentUrl, link.title, {
-                                                  packageId: link.packageId,
-                                                  packageManifest: link.manifest,
-                                                  repository: link.repository,
-                                                });
+                                                openDocsPage(link.contentUrl, link.title, packageInfoForNavLink(link));
                                               }}
                                               className={styles.milestoneItem}
                                             >
@@ -934,11 +934,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                                                 content_type: AnalyticsContentType.PackageNavLink,
                                                 interaction_location: 'recommends_section',
                                               });
-                                              openDocsPage(link.contentUrl, link.title, {
-                                                packageId: link.packageId,
-                                                packageManifest: link.manifest,
-                                                repository: link.repository,
-                                              });
+                                              openDocsPage(link.contentUrl, link.title, packageInfoForNavLink(link));
                                             }}
                                             className={styles.milestoneItem}
                                           >
@@ -969,11 +965,7 @@ export const RecommendationsSection = memo(function RecommendationsSection({
                                                 content_type: AnalyticsContentType.PackageNavLink,
                                                 interaction_location: 'suggests_section',
                                               });
-                                              openDocsPage(link.contentUrl, link.title, {
-                                                packageId: link.packageId,
-                                                packageManifest: link.manifest,
-                                                repository: link.repository,
-                                              });
+                                              openDocsPage(link.contentUrl, link.title, packageInfoForNavLink(link));
                                             }}
                                             className={styles.milestoneItem}
                                           >

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -201,7 +201,7 @@ export const packageInfoForNavLink = (link: ResolvedNavLink): PackageOpenInfo =>
   repository: link.repository,
 });
 
-const getRecommendationPackageInfo = (recommendation: Recommendation): PackageOpenInfo | undefined => {
+export const getRecommendationPackageInfo = (recommendation: Recommendation): PackageOpenInfo | undefined => {
   if (recommendation.type !== 'package') {
     return undefined;
   }

--- a/src/learning-paths/index.ts
+++ b/src/learning-paths/index.ts
@@ -16,6 +16,9 @@ export type { LearningProfileSummary, NextLearningAction } from './useNextLearni
 export { useDiscoverMore } from './useDiscoverMore';
 export type { DiscoverMoreItem, UseDiscoverMoreReturn } from './useDiscoverMore';
 
+// Launch package-context factories (My Learning path members and Discover More)
+export { packageInfoForPathMember, packageInfoForDiscoverItem, parseDiscoverMoreManifest } from './launch-package-info';
+
 // Badge utilities
 export {
   BADGES,

--- a/src/learning-paths/launch-package-info.ts
+++ b/src/learning-paths/launch-package-info.ts
@@ -1,0 +1,50 @@
+/**
+ * Package context factories for the two manifest-backed My Learning launches:
+ * App Platform path members, and Discover More cards.
+ *
+ * Both derive `PackageOpenInfo` from a catalogue manifest that carries no `id`
+ * of its own (the id lives on the entry), so both graft the entry id onto the
+ * manifest — `fetchPackageContent` recovers the path cover baseUrl from
+ * `packageManifest.id`, and without it "back to cover" breaks.
+ *
+ * They live here rather than inline in the launch handlers so the launch-path
+ * parity matrix can call the same code the UI calls.
+ */
+
+import { ManifestJsonObjectSchema } from '../types/package.schema';
+import type { PackageOpenInfo } from '../types/content-panel.types';
+import type { DiscoverMoreItem, LearningPath } from '../types/learning-paths.types';
+import type { ManifestJson } from '../types/package.types';
+
+/** Mirrors online-cdn-resolver.ts's handling of the same OnlinePackageEntry.manifest shape. */
+export function parseDiscoverMoreManifest(manifest: Record<string, unknown> | undefined): ManifestJson | undefined {
+  if (!manifest) {
+    return undefined;
+  }
+  const parsed = ManifestJsonObjectSchema.loose().safeParse(manifest);
+  return parsed.success ? (parsed.data as ManifestJson) : undefined;
+}
+
+/**
+ * App Platform paths carry a manifest but no cover `url`, so a member launches
+ * as `backend-guide:<id>`. Without the PATH manifest as packageInfo the loader
+ * falls through to plain fetchContent and the member renders as a standalone
+ * guide with no milestone toolbar, next/prev, or cover.
+ */
+export function packageInfoForPathMember(path: LearningPath | undefined): PackageOpenInfo | undefined {
+  if (!path?.manifest) {
+    return undefined;
+  }
+  return { packageId: path.id, packageManifest: { ...path.manifest, id: path.id } };
+}
+
+/**
+ * `prepareGuideLaunch` backfills packageInfo from the URL when absent, but the
+ * Discover More manifest is already inlined — passing it saves that re-fetch.
+ */
+export function packageInfoForDiscoverItem(item: DiscoverMoreItem): PackageOpenInfo | undefined {
+  if (!item.manifest) {
+    return undefined;
+  }
+  return { packageId: item.id, packageManifest: { ...item.manifest, id: item.id } };
+}

--- a/src/learning-paths/useDiscoverMore.ts
+++ b/src/learning-paths/useDiscoverMore.ts
@@ -16,27 +16,14 @@ import {
   buildPackageFileUrl,
   type OnlinePackageEntry,
 } from '../lib/package-recommendations-client';
-import { ManifestJsonObjectSchema } from '../types/package.schema';
-import type { ManifestJson } from '../types/package.types';
+import type { DiscoverMoreItem } from '../types/learning-paths.types';
 import { logger } from '../lib/logging';
+
+import { parseDiscoverMoreManifest } from './launch-package-info';
 
 const DEFAULT_DISCOVER_COUNT = 5;
 
-/**
- * A path-shaped item ready to render as a Discover More card. `contentUrl`
- * points at the package's `content.json` and is safe to hand to
- * `prepareGuideLaunch`, which derives package context from the URL.
- */
-export interface DiscoverMoreItem {
-  id: string;
-  title: string;
-  description?: string;
-  contentUrl: string;
-  /** Milestone count from the inlined manifest, when available. */
-  milestoneCount?: number;
-  /** The package's inlined manifest, when available and schema-valid — threaded into launch as `packageInfo` to save a redundant re-fetch. */
-  manifest?: ManifestJson;
-}
+export type { DiscoverMoreItem } from '../types/learning-paths.types';
 
 export interface UseDiscoverMoreOptions {
   /** Titles already surfaced elsewhere (My Courses / Completed) to skip. */
@@ -55,15 +42,6 @@ function milestoneCountOf(entry: OnlinePackageEntry): number | undefined {
   return Array.isArray(milestones) ? milestones.length : undefined;
 }
 
-// Mirrors online-cdn-resolver.ts's handling of the same OnlinePackageEntry.manifest shape.
-function parseManifest(manifest: Record<string, unknown> | undefined): ManifestJson | undefined {
-  if (!manifest) {
-    return undefined;
-  }
-  const parsed = ManifestJsonObjectSchema.loose().safeParse(manifest);
-  return parsed.success ? (parsed.data as ManifestJson) : undefined;
-}
-
 function toDiscoverItem(entry: OnlinePackageEntry, baseUrl: string): DiscoverMoreItem | null {
   const contentUrl = buildPackageFileUrl(baseUrl, entry.path, 'content.json');
   if (!contentUrl) {
@@ -75,7 +53,7 @@ function toDiscoverItem(entry: OnlinePackageEntry, baseUrl: string): DiscoverMor
     description: entry.description,
     contentUrl,
     milestoneCount: milestoneCountOf(entry),
-    manifest: parseManifest(entry.manifest),
+    manifest: parseDiscoverMoreManifest(entry.manifest),
   };
 }
 

--- a/src/types/learning-paths.types.ts
+++ b/src/types/learning-paths.types.ts
@@ -5,6 +5,8 @@
  * progress tracking, and badges.
  */
 
+import type { ManifestJson } from './package.types';
+
 // ============================================================================
 // LEARNING PATH TYPES
 // ============================================================================
@@ -40,6 +42,22 @@ export interface LearningPath {
    * of as standalone guides. Omitted for bundled/CDN paths.
    */
   manifest?: Record<string, unknown>;
+}
+
+/**
+ * A path-shaped item ready to render as a Discover More card. `contentUrl`
+ * points at the package's `content.json` and is safe to hand to
+ * `prepareGuideLaunch`, which derives package context from the URL.
+ */
+export interface DiscoverMoreItem {
+  id: string;
+  title: string;
+  description?: string;
+  contentUrl: string;
+  /** Milestone count from the inlined manifest, when available. */
+  milestoneCount?: number;
+  /** The package's inlined manifest, when available and schema-valid — threaded into launch as `packageInfo` to save a redundant re-fetch. */
+  manifest?: ManifestJson;
 }
 
 /**

--- a/src/validation/import-graph.test.ts
+++ b/src/validation/import-graph.test.ts
@@ -832,6 +832,16 @@ describe('isJestManagedTestFile', () => {
     ).toBe(true);
   });
 
+  it('matches tests/parity unit tests, which run under jest via test:parity', () => {
+    expect(isJestManagedTestFile(path.join(REPO_ROOT, 'tests', 'parity', 'launch-path-parity.test.ts'))).toBe(true);
+  });
+
+  it('keeps the tests/parity exemption scoped to that directory and to .test files', () => {
+    expect(isJestManagedTestFile(path.join(REPO_ROOT, 'tests', 'parity', 'symmetry.ts'))).toBe(false);
+    expect(isJestManagedTestFile(path.join(REPO_ROOT, 'tests', 'other', 'thing.test.ts'))).toBe(false);
+    expect(isJestManagedTestFile(path.join(REPO_ROOT, 'tests', 'thing.test.ts'))).toBe(false);
+  });
+
   it('does not match Playwright spec files (Playwright loads them in real Node)', () => {
     expect(isJestManagedTestFile(path.join(REPO_ROOT, 'tests', 'e2e-runner', 'guide-runner.spec.ts'))).toBe(false);
     expect(isJestManagedTestFile(path.join(REPO_ROOT, 'tests', 'open-close.spec.ts'))).toBe(false);

--- a/src/validation/import-graph.ts
+++ b/src/validation/import-graph.ts
@@ -691,13 +691,20 @@ export const NODE_CONTEXT_ROOTS = ['src/cli', 'tests', 'playwright.config.ts'];
  * .config/jest.config.js plus tests/e2e-runner/utils/**\/*.test.*. Playwright
  * loads only *.spec.ts files (see playwright.config.ts testMatch), which jest
  * never matches outside src/.
+ *
+ * tests/parity/ is jest-managed too, but by an explicit --testMatch rather
+ * than the config: it holds the launch-path parity matrix, run on demand by
+ * `npm run test:parity` and deliberately kept out of the default suite. It
+ * still executes under jsdom with jest.mock available, and Playwright cannot
+ * pick it up (only *.spec.ts), so nothing there is evidence of plain-Node
+ * execution either.
  */
 export function isJestManagedTestFile(absPath: string): boolean {
   const rel = toPosixPath(path.relative(REPO_ROOT, absPath));
   if (rel.startsWith('src/')) {
     return /\.(test|spec|jest)\.(ts|tsx)$/.test(rel) || rel.includes('/__tests__/');
   }
-  if (rel.startsWith('tests/e2e-runner/utils/')) {
+  if (rel.startsWith('tests/e2e-runner/utils/') || rel.startsWith('tests/parity/')) {
     return /\.test\.(ts|tsx)$/.test(rel);
   }
   return false;

--- a/tests/parity/launch-path-parity.test.ts
+++ b/tests/parity/launch-path-parity.test.ts
@@ -26,8 +26,14 @@
  * merge gate.
  *
  * ---------------------------------------------------------------------------
- * Ten families are in scope. Three are deliberately absent, because each needs
- * a production change before it can produce a comparable request at all:
+ * Nine families are in scope across thirteen concrete paths. Two of those paths
+ * — a recommendation's start button and its milestone rows — are separate UI
+ * entry points that share one producer (`getRecommendationPackageInfo`), so
+ * they sit in one family and can never disagree with each other; the matrix
+ * covers nine independent producers, not thirteen.
+ *
+ * Three families are deliberately absent, because each needs a production
+ * change before it can produce a comparable request at all:
  *
  *   1. Generic URL-backed journeys and raw guides. The My Learning URL branch
  *      calls `launch` with no package context, and `openLearningJourney`
@@ -73,7 +79,7 @@ import { consumePendingGuideOnMount } from '../../src/components/docs-panel/pend
 import { useAutoOpenListener } from '../../src/components/docs-panel/hooks/useAutoOpenListener';
 import { useFullScreenHandoff } from '../../src/components/docs-panel/hooks/useFullScreenHandoff';
 import { buildPathPackageInfo } from '../../src/components/PrTester/pr-path-package';
-import { fetchPackageInfoFromUrl } from '../../src/docs-retrieval';
+import { fetchPackageInfoFromUrl } from '../../src/docs-retrieval/package-info-from-url';
 import { guideLaunchStore } from '../../src/global-state/guide-launch';
 import { linkInterceptionState } from '../../src/global-state/link-interception';
 import { panelModeManager, type PendingGuide } from '../../src/global-state/panel-mode';
@@ -154,19 +160,21 @@ const PREPARED_CONTENT: RawContent = {
 // ---------------------------------------------------------------------------
 
 /**
- * The comparable core of a launch request: which package, whose manifest, and
- * under which repository the guide's completion will be keyed.
+ * The comparable core of a launch request: which package, whose manifest, under
+ * which repository the guide's completion will be keyed, and which milestones
+ * the launch arrives pre-resolved with.
  *
- * `resolvedMilestones` is deliberately NOT compared. It is a pre-resolution
- * cache that only some callers can populate — four of the adapters below have
- * no milestone input at all — so including it would make the matrix fail on a
- * structural difference that is a legitimate per-caller performance choice, on
- * top of the contract gaps this test exists to surface.
+ * `resolvedMilestones` is compared rather than excluded. Whether a launch
+ * carries pre-resolved milestones decides whether the milestone toolbar renders
+ * populated on first paint, so a path that stops pre-resolving them has changed
+ * the request — calling it a per-caller caching choice would let that change
+ * land unreported.
  */
 interface NormalizedLaunchRequest {
   packageId: string | undefined;
   repository: string | undefined;
   packageManifest: Record<string, unknown> | undefined;
+  resolvedMilestones: Milestone[] | undefined;
 }
 
 function normalize(info: PackageOpenInfo | undefined): NormalizedLaunchRequest {
@@ -174,6 +182,7 @@ function normalize(info: PackageOpenInfo | undefined): NormalizedLaunchRequest {
     packageId: info?.packageId,
     repository: info?.repository,
     packageManifest: info?.packageManifest,
+    resolvedMilestones: info?.resolvedMilestones,
   };
 }
 
@@ -186,7 +195,8 @@ function assertFixtureCompleteness(): void {
   const parsed = ManifestJsonObjectSchema.parse(MANIFEST) as Record<string, unknown>;
   const added = Object.keys(parsed).filter((key) => !(key in MANIFEST) && parsed[key] !== undefined);
   expect(added).toEqual(['repository']);
-  expect(parsed.repository).toBe('interactive-tutorials');
+  const schemaDefault = ManifestJsonObjectSchema.parse({ id: PACKAGE_ID, type: 'guide' }) as Record<string, unknown>;
+  expect(parsed.repository).toBe(schemaDefault.repository);
 }
 
 // ---------------------------------------------------------------------------
@@ -392,10 +402,14 @@ describe('launch-path parity: one guide, every day-one launch path', () => {
         adapter: async () => normalize(await fetchPackageInfoFromUrl(CONTENT_URL)),
       },
 
-      // --- Families: package recommendation ----------------------------------
+      // --- Family: package recommendation ------------------------------------
+      // Two UI entry points, one producer: the milestone rows reuse the same
+      // `packageInfo` const the start button was built from (context-panel.tsx
+      // computes it once per card), so these two cannot disagree with each
+      // other. Both are kept because both are real click sites.
       {
         path: 'package recommendation start',
-        family: 'recommendation-start',
+        family: 'recommendation',
         adapter: () =>
           normalize(
             getRecommendationPackageInfo({
@@ -410,7 +424,7 @@ describe('launch-path parity: one guide, every day-one launch path', () => {
       },
       {
         path: 'package recommendation milestone',
-        family: 'recommendation-milestone',
+        family: 'recommendation',
         adapter: () =>
           normalize(
             getRecommendationPackageInfo({
@@ -506,13 +520,14 @@ describe('launch-path parity: one guide, every day-one launch path', () => {
       },
     ];
 
-    // Ten families, thirteen concrete paths (the relay family has four
-    // destinations). A shrinking table is a regression, not a fix.
-    expect(new Set(paths.map((entry) => entry.family)).size).toBe(10);
+    // Nine families, thirteen concrete paths (the relay family has four
+    // destinations and the recommendation family two). A shrinking table is a
+    // regression, not a fix.
+    expect(new Set(paths.map((entry) => entry.family)).size).toBe(9);
     expect(paths).toHaveLength(13);
 
     await assertSymmetric(paths, {
-      subject: 'the normalized launch request (packageId, repository, packageManifest)',
+      subject: 'the normalized launch request (packageId, repository, packageManifest, resolvedMilestones)',
       intentionalDifferences: INTENTIONAL_PATH_DIFFERENCES,
     });
   });

--- a/tests/parity/launch-path-parity.test.ts
+++ b/tests/parity/launch-path-parity.test.ts
@@ -1,0 +1,519 @@
+/**
+ * Launch-path parity matrix.
+ *
+ * Grafana Pathfinder opens a guide from many places, and each place builds its
+ * own launch request. The common package-context type is `PackageOpenInfo`
+ * (src/types/content-panel.types.ts) — `PreparedGuideLaunch` is the only
+ * request-shaped type and only My Learning uses it, so no production type spans
+ * every launch path. Nothing, therefore, forces those requests to agree, and
+ * they have drifted: the same guide opened from two places can key its durable
+ * completion under two different repositories.
+ *
+ * This matrix feeds ONE parsed manifest through every day-one launch path and
+ * asserts the normalized requests are identical TO EACH OTHER. It never asserts
+ * against an expected value: whoever decides the right answer can change it and
+ * this test stays green as long as every path moves together. It fires only on
+ * disagreement.
+ *
+ * Every path calls production code. Where a path's own entry point is module-
+ * private (`pendingGuideFrom` in HomePanel), the matrix builds that function's
+ * INPUT and runs the real relay from the next exported boundary onward — the
+ * package context it carries still comes from a real producer, never from a
+ * payload assembled here.
+ *
+ * Run with `npm run test:parity`. It is deliberately outside the default suite
+ * and outside CI: it is a standing diagnostic of a known contract gap, not a
+ * merge gate.
+ *
+ * ---------------------------------------------------------------------------
+ * Ten families are in scope. Three are deliberately absent, because each needs
+ * a production change before it can produce a comparable request at all:
+ *
+ *   1. Generic URL-backed journeys and raw guides. The My Learning URL branch
+ *      calls `launch` with no package context, and `openLearningJourney`
+ *      discards `options.packageInfo` for non-package URLs, so the plain loader
+ *      never calls `resolveStartingLocation`. There is no manifest-backed
+ *      request to compare — reading `RawContent.metadata.packageManifest` here
+ *      would only duplicate the normalization production is missing.
+ *
+ *   2. Published orphan custom guides. `openCustomGuide` is called without
+ *      `PackageOpenInfo`, and supplying one moves the guide from the plain
+ *      loader to the package-aware loader — a loader-selection change that
+ *      needs its own rendering regression coverage.
+ *
+ *   3. The controller guide-reader overlay. It calls `fetchUnifiedContent`
+ *      directly and stores only `RawContent`, never constructing
+ *      `PackageOpenInfo`, `PreparedGuideLaunch`, or `PendingGuide`. It bypasses
+ *      the launch pipeline entirely, so there is nothing to normalize until it
+ *      is routed through a shared package-aware adapter.
+ * ---------------------------------------------------------------------------
+ */
+
+jest.mock('@grafana/scenes', () => ({
+  SceneObjectBase: class {},
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  getAppEvents: jest.fn(() => ({ publish: jest.fn() })),
+  locationService: { push: jest.fn() },
+  // The full-screen handoff reports an interaction on its way through.
+  reportInteraction: jest.fn(),
+  config: { bootData: { user: { id: 1 } } },
+}));
+
+jest.mock('@grafana/i18n', () => ({
+  t: jest.fn((_key: string, fallback: string) => fallback),
+}));
+
+import { act, renderHook } from '@testing-library/react';
+
+import { packageInfoForNavLink, getRecommendationPackageInfo } from '../../src/components/docs-panel/context-panel';
+import { packageInfoForPath } from '../../src/components/docs-panel/CustomGuidesSection';
+import { consumePendingGuideOnMount } from '../../src/components/docs-panel/pendingGuideRouter';
+import { useAutoOpenListener } from '../../src/components/docs-panel/hooks/useAutoOpenListener';
+import { useFullScreenHandoff } from '../../src/components/docs-panel/hooks/useFullScreenHandoff';
+import { buildPathPackageInfo } from '../../src/components/PrTester/pr-path-package';
+import { fetchPackageInfoFromUrl } from '../../src/docs-retrieval';
+import { guideLaunchStore } from '../../src/global-state/guide-launch';
+import { linkInterceptionState } from '../../src/global-state/link-interception';
+import { panelModeManager, type PendingGuide } from '../../src/global-state/panel-mode';
+import {
+  packageInfoForPathMember,
+  packageInfoForDiscoverItem,
+  parseDiscoverMoreManifest,
+} from '../../src/learning-paths';
+import { AUTO_OPEN_DOCS_EVENT } from '../../src/lib/event-names';
+import { ManifestJsonObjectSchema } from '../../src/types/package.schema';
+import type { PackageOpenInfo } from '../../src/types/content-panel.types';
+import type { Milestone, RawContent } from '../../src/types/content.types';
+
+import { assertSymmetric, type IntentionalDifference, type SymmetryEntry } from './symmetry';
+
+// ---------------------------------------------------------------------------
+// The one guide every path is handed
+// ---------------------------------------------------------------------------
+
+const PACKAGE_ID = 'grafana-fundamentals';
+const TITLE = 'Grafana fundamentals';
+const CONTENT_URL = `https://interactive-learning.grafana.net/packages/${PACKAGE_ID}/content.json`;
+const MANIFEST_URL = `https://interactive-learning.grafana.net/packages/${PACKAGE_ID}/manifest.json`;
+const CATALOG_BASE_URL = 'https://interactive-learning.grafana.net';
+const MILESTONE_IDS = ['fundamentals-intro', 'fundamentals-dashboards'];
+
+/**
+ * The package's true source, carried OUTSIDE the manifest. This models a real
+ * online-CDN package: `V1Recommendation.repository` is a sibling of `manifest`,
+ * and online-CDN resolution assigns `online-cdn`. Paths that accept a
+ * repository input get this value.
+ */
+const TRUE_REPOSITORY = 'online-cdn';
+
+/**
+ * Complete against `ManifestJsonObjectSchema` except for `repository`, which is
+ * absent on purpose — a V1 manifest does not carry its own provenance, and the
+ * schema defaults the missing field to `interactive-tutorials`. Every other
+ * defaulted field is spelled out so a schema parse is otherwise a no-op and the
+ * matrix cannot fail on incidental default-filling. `assertFixtureCompleteness`
+ * below holds that property.
+ */
+const MANIFEST: Record<string, unknown> = {
+  schemaVersion: '1.0.0',
+  id: PACKAGE_ID,
+  type: 'path',
+  milestones: MILESTONE_IDS,
+  description: 'Learn the fundamentals of Grafana.',
+  language: 'en',
+  startingLocation: '/connections',
+  depends: [],
+  recommends: [],
+  suggests: [],
+  provides: [],
+  conflicts: [],
+  replaces: [],
+  testEnvironment: { tier: 'cloud' },
+};
+
+const MILESTONES: Milestone[] = MILESTONE_IDS.map((id, index) => ({
+  number: index + 1,
+  title: id,
+  duration: '',
+  url: `${CATALOG_BASE_URL}/packages/${id}/content.json`,
+  isActive: false,
+}));
+
+const PREPARED_CONTENT: RawContent = {
+  content: JSON.stringify({ id: PACKAGE_ID, title: TITLE, blocks: [] }),
+  metadata: { title: TITLE },
+  type: 'interactive',
+  url: CONTENT_URL,
+  lastFetched: '2026-08-25T00:00:00.000Z',
+};
+
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * The comparable core of a launch request: which package, whose manifest, and
+ * under which repository the guide's completion will be keyed.
+ *
+ * `resolvedMilestones` is deliberately NOT compared. It is a pre-resolution
+ * cache that only some callers can populate — four of the adapters below have
+ * no milestone input at all — so including it would make the matrix fail on a
+ * structural difference that is a legitimate per-caller performance choice, on
+ * top of the contract gaps this test exists to surface.
+ */
+interface NormalizedLaunchRequest {
+  packageId: string | undefined;
+  repository: string | undefined;
+  packageManifest: Record<string, unknown> | undefined;
+}
+
+function normalize(info: PackageOpenInfo | undefined): NormalizedLaunchRequest {
+  return {
+    packageId: info?.packageId,
+    repository: info?.repository,
+    packageManifest: info?.packageManifest,
+  };
+}
+
+/**
+ * Fixture guard, not a parity assertion. Proves the only field the schema fills
+ * in is `repository`; if the schema gains another default, this fails here with
+ * a clear cause instead of showing up as unexplained noise in the matrix.
+ */
+function assertFixtureCompleteness(): void {
+  const parsed = ManifestJsonObjectSchema.parse(MANIFEST) as Record<string, unknown>;
+  const added = Object.keys(parsed).filter((key) => !(key in MANIFEST) && parsed[key] !== undefined);
+  expect(added).toEqual(['repository']);
+  expect(parsed.repository).toBe('interactive-tutorials');
+}
+
+// ---------------------------------------------------------------------------
+// Test doubles for the relay destinations (inputs only — never payloads)
+// ---------------------------------------------------------------------------
+
+interface CapturingPanel {
+  state: { tabs: unknown[]; activeTabId: string | undefined };
+  openDocsPage: jest.Mock;
+  openLearningJourney: jest.Mock;
+  openEditorTab: jest.Mock;
+  setActiveTab: jest.Mock;
+}
+
+function capturingPanel(): CapturingPanel {
+  return {
+    state: { tabs: [], activeTabId: undefined },
+    openDocsPage: jest.fn(),
+    openLearningJourney: jest.fn(),
+    openEditorTab: jest.fn(),
+    setActiveTab: jest.fn(),
+  };
+}
+
+/** The packageInfo the panel was actually asked to open with. */
+function openedWith(panel: CapturingPanel): PackageOpenInfo | undefined {
+  const call = panel.openDocsPage.mock.calls[0] ?? panel.openLearningJourney.mock.calls[0];
+  if (!call) {
+    throw new Error('relay did not open anything — the launch was dropped');
+  }
+  return (call[2] as { packageInfo?: PackageOpenInfo } | undefined)?.packageInfo;
+}
+
+function drainQueue(): void {
+  while (linkInterceptionState.hasQueuedLinks()) {
+    linkInterceptionState.shiftFromQueue();
+  }
+}
+
+/** Mirrors HomePanel's module-private `pendingGuideFrom`, minus the payload. */
+function pendingFrom(packageInfo: PackageOpenInfo | undefined): PendingGuide {
+  return {
+    url: CONTENT_URL,
+    title: TITLE,
+    type: 'docs',
+    packageInfo,
+    preparedContent: PREPARED_CONTENT,
+    source: 'home_page',
+  } as PendingGuide;
+}
+
+// ---------------------------------------------------------------------------
+// The matrix
+// ---------------------------------------------------------------------------
+
+/**
+ * Divergences that are known, accepted, and tracked. Empty by design: every
+ * disagreement this matrix currently reports is a real contract gap, not an
+ * intentional difference. Adding an entry here to quiet a failure — rather than
+ * because the divergence is genuinely correct — defeats the test.
+ */
+const INTENTIONAL_PATH_DIFFERENCES: readonly IntentionalDifference[] = [];
+
+describe('launch-path parity: one guide, every day-one launch path', () => {
+  let upstreamFromUrl: PackageOpenInfo | undefined;
+
+  beforeAll(async () => {
+    // The URL producer is the upstream for every prepared-launch relay path:
+    // `prepareGuideLaunch` derives package context by calling exactly this.
+    global.fetch = jest.fn(async (input: unknown) => {
+      if (String(input) !== MANIFEST_URL) {
+        throw new Error(`unexpected fetch: ${String(input)}`);
+      }
+      return { ok: true, json: async () => MANIFEST } as Response;
+    }) as unknown as typeof fetch;
+
+    upstreamFromUrl = await fetchPackageInfoFromUrl(CONTENT_URL);
+    expect(upstreamFromUrl).toBeDefined();
+  });
+
+  beforeEach(() => {
+    drainQueue();
+    panelModeManager.setModeTransient('sidebar');
+  });
+
+  it('the fixture manifest is schema-complete except for repository', () => {
+    assertFixtureCompleteness();
+  });
+
+  it('produces an identical normalized request on every path', async () => {
+    const paths: Array<SymmetryEntry<NormalizedLaunchRequest>> = [
+      // --- Family: prepared-launch relay (four destinations) -----------------
+      {
+        path: 'prepared launch → mounted sidebar',
+        family: 'prepared-launch-relay',
+        adapter: async () => {
+          panelModeManager.setModeTransient('sidebar');
+          const panel = capturingPanel();
+          const listener = renderHook(() => useAutoOpenListener(panel as never, 'sidebar'));
+          const launchKey = guideLaunchStore.stage({
+            url: CONTENT_URL,
+            preparedContent: PREPARED_CONTENT,
+            packageInfo: upstreamFromUrl,
+          });
+          await act(async () => {
+            document.dispatchEvent(
+              new CustomEvent(AUTO_OPEN_DOCS_EVENT, {
+                detail: { url: CONTENT_URL, title: TITLE, source: 'home_page', launchKey },
+              })
+            );
+          });
+          const opened = normalize(openedWith(panel));
+          // Consume-once staging is broadcast to every mounted listener, so this
+          // one must go before the next path stages its own key.
+          listener.unmount();
+          return opened;
+        },
+      },
+      {
+        path: 'prepared launch → cold sidebar (queue relay)',
+        family: 'prepared-launch-relay',
+        adapter: async () => {
+          panelModeManager.setModeTransient('sidebar');
+          const launchKey = guideLaunchStore.stage({
+            url: CONTENT_URL,
+            preparedContent: PREPARED_CONTENT,
+            packageInfo: upstreamFromUrl,
+          });
+          linkInterceptionState.addToQueue({ url: CONTENT_URL, title: TITLE, timestamp: Date.now(), launchKey });
+          const panel = capturingPanel();
+          const listener = renderHook(() => useAutoOpenListener(panel as never, 'sidebar'));
+          // The hook defers the queue drain to the end of the tick on purpose.
+          await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 1));
+          });
+          const opened = normalize(openedWith(panel));
+          listener.unmount();
+          return opened;
+        },
+      },
+      {
+        path: 'prepared launch → floating panel',
+        family: 'prepared-launch-relay',
+        adapter: () => {
+          panelModeManager.setModeTransient('floating');
+          panelModeManager.setPendingGuide(pendingFrom(upstreamFromUrl));
+          const panel = capturingPanel();
+          consumePendingGuideOnMount(panel as never, 'home_page', () => undefined);
+          return normalize(openedWith(panel));
+        },
+      },
+      {
+        path: 'prepared launch → full screen',
+        family: 'prepared-launch-relay',
+        adapter: () => {
+          panelModeManager.setModeTransient('fullscreen');
+          panelModeManager.setPendingGuide(pendingFrom(upstreamFromUrl));
+          const panel = capturingPanel();
+          consumePendingGuideOnMount(panel as never, 'home_page', () => undefined);
+          return normalize(openedWith(panel));
+        },
+      },
+
+      // --- Family: existing-tab surface handoff ------------------------------
+      {
+        path: 'existing tab → full screen handoff',
+        family: 'surface-handoff',
+        adapter: async () => {
+          const model = {
+            state: {
+              tabs: [
+                {
+                  id: 'tab-1',
+                  title: TITLE,
+                  baseUrl: CONTENT_URL,
+                  currentUrl: CONTENT_URL,
+                  type: 'learning-journey',
+                  packageInfo: upstreamFromUrl,
+                },
+              ],
+              activeTabId: 'tab-1',
+            },
+            saveTabsToStorage: jest.fn(async () => undefined),
+          };
+          const handoff = renderHook(() => useFullScreenHandoff(model as never, false));
+          await act(async () => {
+            document.dispatchEvent(new CustomEvent('pathfinder-request-full-screen'));
+            await new Promise((resolve) => setTimeout(resolve, 1));
+          });
+          const pending = panelModeManager.consumePendingGuide();
+          handoff.unmount();
+          if (!pending) {
+            throw new Error('handoff produced no pending guide');
+          }
+          return normalize(pending.packageInfo);
+        },
+      },
+
+      // --- Family: recognized package URL -----------------------------------
+      {
+        path: 'recognized package URL auto-open',
+        family: 'url-package-autoopen',
+        adapter: async () => normalize(await fetchPackageInfoFromUrl(CONTENT_URL)),
+      },
+
+      // --- Families: package recommendation ----------------------------------
+      {
+        path: 'package recommendation start',
+        family: 'recommendation-start',
+        adapter: () =>
+          normalize(
+            getRecommendationPackageInfo({
+              title: TITLE,
+              url: CONTENT_URL,
+              type: 'package',
+              manifest: MANIFEST,
+              repository: TRUE_REPOSITORY,
+              milestones: MILESTONES,
+            } as never)
+          ),
+      },
+      {
+        path: 'package recommendation milestone',
+        family: 'recommendation-milestone',
+        adapter: () =>
+          normalize(
+            getRecommendationPackageInfo({
+              title: TITLE,
+              url: MILESTONES[0]!.url,
+              type: 'package',
+              manifest: MANIFEST,
+              repository: TRUE_REPOSITORY,
+              milestones: MILESTONES,
+            } as never)
+          ),
+      },
+
+      // --- Family: resolved recommends / suggests nav link -------------------
+      {
+        path: 'resolved recommends/suggests nav link',
+        family: 'nav-link',
+        adapter: () =>
+          normalize(
+            packageInfoForNavLink({
+              packageId: PACKAGE_ID,
+              title: TITLE,
+              contentUrl: CONTENT_URL,
+              manifest: MANIFEST,
+              repository: TRUE_REPOSITORY,
+            })
+          ),
+      },
+
+      // --- Family: My Learning App Platform member --------------------------
+      {
+        path: 'My Learning App Platform path member',
+        family: 'my-learning-path-member',
+        adapter: () =>
+          normalize(
+            packageInfoForPathMember({
+              id: PACKAGE_ID,
+              title: TITLE,
+              description: 'Learn the fundamentals of Grafana.',
+              guides: [],
+              badgeId: 'fundamentals',
+              manifest: MANIFEST,
+            })
+          ),
+      },
+
+      // --- Family: My Learning Discover More --------------------------------
+      {
+        path: 'My Learning Discover More card',
+        family: 'my-learning-discover-more',
+        adapter: () =>
+          normalize(
+            packageInfoForDiscoverItem({
+              id: PACKAGE_ID,
+              title: TITLE,
+              contentUrl: CONTENT_URL,
+              // Production stores the schema-parsed manifest on the item, so
+              // the real parser supplies it here rather than the raw fixture.
+              manifest: parseDiscoverMoreManifest(MANIFEST),
+            })
+          ),
+      },
+
+      // --- Family: published custom path ------------------------------------
+      {
+        path: 'published custom path start',
+        family: 'custom-path',
+        adapter: () => normalize(packageInfoForPath({ id: PACKAGE_ID, title: TITLE, manifest: MANIFEST } as never)),
+      },
+
+      // --- Family: PR tester path preview -----------------------------------
+      {
+        path: 'PR tester path preview',
+        family: 'pr-tester-path',
+        adapter: () => {
+          const catalogById = new Map(
+            [PACKAGE_ID, ...MILESTONE_IDS].map((id) => [id, { id, path: `packages/${id}`, title: id, type: 'path' }])
+          );
+          const result = buildPathPackageInfo({
+            pathId: PACKAGE_ID,
+            description: TITLE,
+            milestoneIds: MILESTONE_IDS,
+            packageManifest: MANIFEST,
+            prContentById: new Map(),
+            catalogById: catalogById as never,
+            catalogBaseUrl: CATALOG_BASE_URL,
+          });
+          if (!result.ok) {
+            throw new Error(`PR tester path build failed: ${result.reason}`);
+          }
+          return normalize(result.packageInfo);
+        },
+      },
+    ];
+
+    // Ten families, thirteen concrete paths (the relay family has four
+    // destinations). A shrinking table is a regression, not a fix.
+    expect(new Set(paths.map((entry) => entry.family)).size).toBe(10);
+    expect(paths).toHaveLength(13);
+
+    await assertSymmetric(paths, {
+      subject: 'the normalized launch request (packageId, repository, packageManifest)',
+      intentionalDifferences: INTENTIONAL_PATH_DIFFERENCES,
+    });
+  });
+});

--- a/tests/parity/symmetry.test.ts
+++ b/tests/parity/symmetry.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Guard tests for the parity symmetry assertion itself.
+ *
+ * The launch-path matrix is expected to be red, so these prove the helper is
+ * red for the right reason — and, more importantly, that the ways of quietly
+ * making a parity matrix pass are all closed.
+ */
+
+import { assertSymmetric, type SymmetryEntry } from './symmetry';
+
+const options = { subject: 'the test subject', intentionalDifferences: [] };
+
+function entry<T>(path: string, family: string, value: T): SymmetryEntry<T> {
+  return { path, family, adapter: () => value };
+}
+
+describe('assertSymmetric', () => {
+  it('passes when every path agrees', async () => {
+    await expect(
+      assertSymmetric([entry('a', 'f', { id: 1 }), entry('b', 'g', { id: 1 })], options)
+    ).resolves.toBeUndefined();
+  });
+
+  it('ignores property order, which is not disagreement', async () => {
+    await expect(
+      assertSymmetric([entry('a', 'f', { x: 1, y: 2 }), entry('b', 'g', { y: 2, x: 1 })], options)
+    ).resolves.toBeUndefined();
+  });
+
+  it('fails when paths disagree, naming the dissenters', async () => {
+    await expect(
+      assertSymmetric([entry('a', 'f', { id: 1 }), entry('b', 'g', { id: 1 }), entry('c', 'h', { id: 2 })], options)
+    ).rejects.toThrow(/disagree.*[\s\S]*Unexplained dissent:[\s\S]*- c/);
+  });
+
+  it('fails on an empty table, so deleting the cases is not a fix', async () => {
+    await expect(assertSymmetric([], options)).rejects.toThrow(/is empty/);
+  });
+
+  it('fails on a declared path with no adapter', async () => {
+    await expect(
+      assertSymmetric([entry('a', 'f', { id: 1 }), { path: 'b', family: 'g', adapter: undefined }], options)
+    ).rejects.toThrow(/declares paths with no adapter:[\s\S]*- b/);
+  });
+
+  it('fails on duplicate path names, which would hide a case', async () => {
+    await expect(assertSymmetric([entry('a', 'f', { id: 1 }), entry('a', 'g', { id: 1 })], options)).rejects.toThrow(
+      /duplicate path names: a/
+    );
+  });
+
+  it('accepts a divergence covered by an intentional-difference entry', async () => {
+    await expect(
+      assertSymmetric([entry('a', 'f', { id: 1 }), entry('b', 'g', { id: 1 }), entry('c', 'h', { id: 2 })], {
+        subject: 'the test subject',
+        intentionalDifferences: [{ paths: ['c'], reason: 'c is special', tracking: 'owner/repo#1' }],
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('fails a stale entry whose paths now agree', async () => {
+    await expect(
+      assertSymmetric([entry('a', 'f', { id: 1 }), entry('b', 'g', { id: 1 })], {
+        subject: 'the test subject',
+        intentionalDifferences: [{ paths: ['b'], reason: 'b used to differ', tracking: 'owner/repo#1' }],
+      })
+    ).rejects.toThrow(/Stale INTENTIONAL_PATH_DIFFERENCES[\s\S]*- \[b\]/);
+  });
+
+  it('fails a stale entry naming a path that no longer exists', async () => {
+    await expect(
+      assertSymmetric([entry('a', 'f', { id: 1 }), entry('b', 'g', { id: 2 })], {
+        subject: 'the test subject',
+        intentionalDifferences: [
+          { paths: ['b'], reason: 'b differs', tracking: 'owner/repo#1' },
+          { paths: ['gone'], reason: 'retired path', tracking: 'owner/repo#2' },
+        ],
+      })
+    ).rejects.toThrow(/Stale INTENTIONAL_PATH_DIFFERENCES[\s\S]*- \[gone\]/);
+  });
+
+  it('awaits async adapters', async () => {
+    await expect(
+      assertSymmetric(
+        [
+          { path: 'a', family: 'f', adapter: async () => ({ id: 1 }) },
+          { path: 'b', family: 'g', adapter: () => ({ id: 1 }) },
+        ],
+        options
+      )
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/parity/symmetry.test.ts
+++ b/tests/parity/symmetry.test.ts
@@ -79,6 +79,42 @@ describe('assertSymmetric', () => {
     ).rejects.toThrow(/Stale INTENTIONAL_PATH_DIFFERENCES[\s\S]*- \[gone\]/);
   });
 
+  it('fails an intentional-difference entry with no reason', async () => {
+    await expect(
+      assertSymmetric([entry('a', 'f', { id: 1 }), entry('c', 'h', { id: 2 })], {
+        subject: 'the test subject',
+        intentionalDifferences: [{ paths: ['c'], reason: '  ', tracking: 'owner/repo#1' }],
+      })
+    ).rejects.toThrow(/Incomplete INTENTIONAL_PATH_DIFFERENCES[\s\S]*\[c\] missing reason/);
+  });
+
+  it('fails an intentional-difference entry with no tracking issue', async () => {
+    await expect(
+      assertSymmetric([entry('a', 'f', { id: 1 }), entry('c', 'h', { id: 2 })], {
+        subject: 'the test subject',
+        intentionalDifferences: [{ paths: ['c'], reason: 'c is special', tracking: '' }],
+      })
+    ).rejects.toThrow(/Incomplete INTENTIONAL_PATH_DIFFERENCES[\s\S]*\[c\] missing tracking/);
+  });
+
+  it('fails an intentional-difference entry with no paths', async () => {
+    await expect(
+      assertSymmetric([entry('a', 'f', { id: 1 }), entry('c', 'h', { id: 2 })], {
+        subject: 'the test subject',
+        intentionalDifferences: [{ paths: [], reason: 'c is special', tracking: 'owner/repo#1' }],
+      })
+    ).rejects.toThrow(/Incomplete INTENTIONAL_PATH_DIFFERENCES[\s\S]*\(unnamed\) missing paths/);
+  });
+
+  it('fails an intentional-difference entry that omits the fields entirely', async () => {
+    await expect(
+      assertSymmetric([entry('a', 'f', { id: 1 }), entry('c', 'h', { id: 2 })], {
+        subject: 'the test subject',
+        intentionalDifferences: [{ paths: ['c'] } as never],
+      })
+    ).rejects.toThrow(/Incomplete INTENTIONAL_PATH_DIFFERENCES[\s\S]*\[c\] missing reason, tracking/);
+  });
+
   it('awaits async adapters', async () => {
     await expect(
       assertSymmetric(

--- a/tests/parity/symmetry.ts
+++ b/tests/parity/symmetry.ts
@@ -1,0 +1,157 @@
+/**
+ * Reusable symmetry assertion for parity matrices.
+ *
+ * A parity matrix answers "do N independent code paths that are supposed to
+ * agree actually agree?" — without anyone having to decide which one is right.
+ * That distinction is the whole point: `assertSymmetric` never compares a value
+ * against an expectation, only against the other values in the table. A matrix
+ * built this way survives a deliberate change to the right answer (every path
+ * moves together and the test stays green) and fires only on disagreement.
+ *
+ * Guards that make a matrix hard to fake green:
+ *   - an empty table fails, so deleting the cases is not a fix;
+ *   - a declared path with no adapter fails, so a path cannot be silently
+ *     retired by dropping its wiring while its name lingers in the table;
+ *   - an `intentionalDifferences` entry that no longer describes a real
+ *     divergence fails as stale, so the allowlist cannot rot into a
+ *     blanket exemption.
+ */
+
+/** One path's answer. `path` is unique; `family` groups paths that share a producer. */
+export interface SymmetryEntry<T> {
+  path: string;
+  family: string;
+  /** `undefined` means "this path declared no adapter" and is always a failure. */
+  adapter: (() => T | Promise<T>) | undefined;
+}
+
+/**
+ * A divergence that is known, accepted, and tracked. Every field is required:
+ * an entry without a reason and a tracking issue is indistinguishable from a
+ * test someone silenced.
+ */
+export interface IntentionalDifference {
+  /** Paths permitted to sit outside the agreeing majority. */
+  paths: readonly string[];
+  reason: string;
+  /** Issue URL or `owner/repo#123`. */
+  tracking: string;
+}
+
+export interface SymmetryOptions {
+  /** What the paths are being compared on, for the failure message. */
+  subject: string;
+  intentionalDifferences: readonly IntentionalDifference[];
+}
+
+/** Stable key: object keys sorted, so property order never reads as disagreement. */
+function canonical(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      return Object.fromEntries(Object.entries(val as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)));
+    }
+    return val;
+  });
+}
+
+interface ResolvedEntry<T> {
+  path: string;
+  family: string;
+  value: T;
+  key: string;
+}
+
+function fail(lines: string[]): never {
+  throw new Error(lines.join('\n'));
+}
+
+/**
+ * Resolve every adapter, then assert all answers are identical to each other.
+ * Throws with a grouped report naming which paths disagreed and on what.
+ */
+export async function assertSymmetric<T>(
+  entries: readonly SymmetryEntry<T>[],
+  options: SymmetryOptions
+): Promise<void> {
+  if (entries.length === 0) {
+    fail([
+      `Parity matrix for ${options.subject} is empty.`,
+      'A matrix with no paths proves nothing. Declare the launch paths it must cover.',
+    ]);
+  }
+
+  const duplicates = entries.map((e) => e.path).filter((p, i, all) => all.indexOf(p) !== i);
+  if (duplicates.length > 0) {
+    fail([
+      `Parity matrix for ${options.subject} declares duplicate path names: ${[...new Set(duplicates)].join(', ')}`,
+    ]);
+  }
+
+  const unwired = entries.filter((e) => e.adapter === undefined).map((e) => e.path);
+  if (unwired.length > 0) {
+    fail([
+      `Parity matrix for ${options.subject} declares paths with no adapter:`,
+      ...unwired.map((p) => `  - ${p}`),
+      '',
+      'Every declared path must call the production code for that path. Wire it up,',
+      'or remove the declaration and record why the path is out of scope.',
+    ]);
+  }
+
+  const resolved: Array<ResolvedEntry<T>> = [];
+  for (const entry of entries) {
+    const value = await entry.adapter!();
+    resolved.push({ path: entry.path, family: entry.family, value, key: canonical(value) });
+  }
+
+  const groups = new Map<string, ResolvedEntry<T>[]>();
+  for (const entry of resolved) {
+    const bucket = groups.get(entry.key);
+    if (bucket) {
+      bucket.push(entry);
+    } else {
+      groups.set(entry.key, [entry]);
+    }
+  }
+
+  // The largest group is the working consensus. It carries no authority — it is
+  // only the baseline the report measures dissent from.
+  const ordered = [...groups.values()].sort((a, b) => b.length - a.length);
+  const majority = ordered[0]!;
+  const majorityPaths = new Set(majority.map((e) => e.path));
+  const dissenting = resolved.filter((e) => !majorityPaths.has(e.path));
+
+  const knownPaths = new Set(resolved.map((e) => e.path));
+  const staleEntries = options.intentionalDifferences.filter((diff) =>
+    diff.paths.every((p) => !knownPaths.has(p) || majorityPaths.has(p))
+  );
+  if (staleEntries.length > 0) {
+    fail([
+      `Stale INTENTIONAL_PATH_DIFFERENCES entries for ${options.subject}`,
+      '(these paths now agree with the rest, or no longer exist — remove the entry):',
+      ...staleEntries.map((d) => `  - [${d.paths.join(', ')}] ${d.reason} (${d.tracking})`),
+    ]);
+  }
+
+  const excused = new Set(options.intentionalDifferences.flatMap((d) => d.paths));
+  const unexplained = dissenting.filter((e) => !excused.has(e.path));
+  if (unexplained.length === 0) {
+    return;
+  }
+
+  const describe = (entry: ResolvedEntry<T>) => `      ${entry.path}  [${entry.family}]`;
+  fail([
+    `Launch paths disagree on ${options.subject}.`,
+    '',
+    `${groups.size} distinct answers across ${resolved.length} paths:`,
+    ...ordered.flatMap((group) => ['', `  ${JSON.stringify(group[0]!.value)}`, ...group.map(describe)]),
+    '',
+    'Unexplained dissent:',
+    ...unexplained.map((e) => `  - ${e.path}`),
+    '',
+    'These paths are supposed to produce the same request for the same guide.',
+    'Fix the production code so they agree, or — if a divergence is genuinely',
+    'correct — add an INTENTIONAL_PATH_DIFFERENCES entry with a reason and a',
+    'tracking issue. Do not narrow the table.',
+  ]);
+}

--- a/tests/parity/symmetry.ts
+++ b/tests/parity/symmetry.ts
@@ -14,7 +14,16 @@
  *     retired by dropping its wiring while its name lingers in the table;
  *   - an `intentionalDifferences` entry that no longer describes a real
  *     divergence fails as stale, so the allowlist cannot rot into a
- *     blanket exemption.
+ *     blanket exemption;
+ *   - an `intentionalDifferences` entry missing its paths, reason, or tracking
+ *     issue fails, so a divergence cannot be excused without a justification a
+ *     reviewer can read. Nothing typechecks `tests/`, so this is enforced at
+ *     runtime rather than left to the type.
+ *
+ * Adapters are resolved one at a time, never concurrently: a stateful adapter
+ * may drive process-wide singletons or the document event bus, and two of those
+ * running at once would claim each other's consume-once reads and report a
+ * disagreement that does not exist.
  */
 
 /** One path's answer. `path` is unique; `family` groups paths that share a producer. */
@@ -65,6 +74,27 @@ function fail(lines: string[]): never {
   throw new Error(lines.join('\n'));
 }
 
+function isNonEmptyText(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isNonEmptyList(value: unknown): boolean {
+  return Array.isArray(value) && value.length > 0 && value.every(isNonEmptyText);
+}
+
+function describeInvalidDifference(diff: IntentionalDifference | undefined): string {
+  if (!diff) {
+    return 'entry is missing';
+  }
+  const missing = [
+    isNonEmptyList(diff.paths) ? undefined : 'paths',
+    isNonEmptyText(diff.reason) ? undefined : 'reason',
+    isNonEmptyText(diff.tracking) ? undefined : 'tracking',
+  ].filter((field): field is string => field !== undefined);
+  const named = isNonEmptyList(diff.paths) ? `[${diff.paths.join(', ')}]` : '(unnamed)';
+  return `${named} missing ${missing.join(', ')}`;
+}
+
 /**
  * Resolve every adapter, then assert all answers are identical to each other.
  * Throws with a grouped report naming which paths disagreed and on what.
@@ -73,6 +103,19 @@ export async function assertSymmetric<T>(
   entries: readonly SymmetryEntry<T>[],
   options: SymmetryOptions
 ): Promise<void> {
+  const invalidDifferences = options.intentionalDifferences.filter(
+    (diff) => !isNonEmptyList(diff?.paths) || !isNonEmptyText(diff?.reason) || !isNonEmptyText(diff?.tracking)
+  );
+  if (invalidDifferences.length > 0) {
+    fail([
+      `Incomplete INTENTIONAL_PATH_DIFFERENCES entries for ${options.subject}:`,
+      ...invalidDifferences.map((diff, index) => `  - entry ${index + 1}: ${describeInvalidDifference(diff)}`),
+      '',
+      'Every entry needs at least one path, a reason, and a tracking issue. An entry',
+      'without them is indistinguishable from a test someone silenced.',
+    ]);
+  }
+
   if (entries.length === 0) {
     fail([
       `Parity matrix for ${options.subject} is empty.`,


### PR DESCRIPTION
## Summary

Pathfinder opens a guide from many places. Each place builds its own launch request inline, at the click site.

`PackageOpenInfo` is the common package-context type, but it is not a full launch request. `PreparedGuideLaunch` is the only request-shaped type, and only My Learning uses it. No production type spans every launch path, so nothing forces those requests to agree.

They do not agree. This PR makes that measurable. It has two parts:

1. Three behavior-preserving extractions. The inline literals become callable production factories.
2. A launch-path parity matrix. It feeds one parsed manifest through every day-one launch path, then asserts that the normalized requests are identical to each other.

**The parity test is red on purpose. That red is the deliverable.** It runs in neither `npm run check` nor any workflow, so CI stays green.

## Why the assertion has this shape

The matrix never compares a value against an expectation. It compares the paths against each other.

Whoever decides the correct answer can therefore change it. This test stays green while every path moves together. It fires only on disagreement. Nobody needs to settle the question of which repository is authoritative before this lands.

## What it exposes

`npm run test:parity` reports six distinct answers across 13 paths, all for one guide.

| # | Answer | Paths |
|---|---|---|
| 1 | `repository: 'interactive-tutorials'`, the schema default. The manifest carries that default too. No pre-resolved milestones. | the four prepared-launch relay destinations, the existing-tab full-screen handoff, and recognized package URL auto-open (6) |
| 2 | `repository: 'online-cdn'`, the true source. Milestones pre-resolved. | recommendation start, recommendation milestone (2) |
| 3 | Top-level `repository` absent. No pre-resolved milestones. | My Learning App Platform path member, published custom path start (2) |
| 4 | `repository: 'online-cdn'`. No pre-resolved milestones. | resolved recommends and suggests nav link (1) |
| 5 | Top-level `repository` absent, but the manifest carries the schema-defaulted value. | My Learning Discover More card (1) |
| 6 | Top-level `repository` absent. Milestones pre-resolved. | PR tester path preview (1) |

Three contract gaps follow from that table.

**Some paths omit the top-level repository.** Custom paths, PR-tester paths, and both My Learning manifest paths omit it. A guide opened from those surfaces keys its durable completion differently from the same guide opened from a recommendation.

**URL fetching substitutes a schema default for absent provenance.** `ManifestJsonObjectSchema` defaults an absent `repository` to `interactive-tutorials`. `fetchPackageInfoFromUrl` then returns that default as if it were real. The true source lives outside the V1 manifest, as a sibling of it. Five of the six paths in group 1 inherit the wrong value.

**Pre-resolved milestones travel inconsistently.** The presence of `resolvedMilestones` decides whether the milestone toolbar shows populated on first paint. A path that stops pre-resolving them changes the request.

`INTENTIONAL_PATH_DIFFERENCES` is empty. None of these is an accepted divergence.

## Guards, so this cannot go green quietly

The symmetry helper is reusable, and its guards are themselves tested. Fifteen cases pass beside the one red matrix:

- An empty table fails, so removing the cases is not a fix.
- A declared path with no adapter fails, so a path cannot retire by dropping its wiring while its name stays.
- Duplicate path names fail.
- Each `INTENTIONAL_PATH_DIFFERENCES` entry needs a non-empty reason and a tracking issue, confirmed at run time.
- A stale entry fails. Stale means its paths now agree, or it names a path that no longer exists. The allowlist cannot rot into a blanket exemption.

A fixture guard pins that `repository` is the only field the schema fills in. It derives the expected default from the schema instead of restating it. A future change to that default therefore surfaces with a clear cause, not as noise in the matrix.

## Scope: nine families, three deferred

The matrix covers nine independent producers across 13 concrete paths.

Two paths share one producer: the start button of a recommendation and its milestone rows. Both are real click sites, so both rows stay. They sit in one family and can never disagree with each other, and the count does not claim them as two independent contracts. One commit message says "ten day-one families". That count predates this finding. The test file and this description carry the corrected number.

Three families are absent on purpose. The test file names each one with its reason. Each needs a production change before it can produce a comparable request:

- **Generic URL-backed journeys and raw guides.** `openLearningJourney` discards `options.packageInfo` for a non-package URL, so the plain loader never calls `resolveStartingLocation`. No manifest-backed request exists to compare. Reading `RawContent.metadata.packageManifest` in the test only duplicates the normalization that production lacks. This is also where `startingLocation` is lost today.
- **Published orphan custom guides.** Supplying `PackageOpenInfo` moves the guide from the plain loader to the package-aware loader. That is a loader-selection change, and it needs its own rendering regression coverage.
- **The controller guide-reader overlay.** It calls `fetchUnifiedContent` directly and stores only `RawContent`, so it bypasses the launch pipeline.

## One edit outside the feature

`src/validation/import-graph.ts` gains one line. `isJestManagedTestFile` now exempts `tests/parity/` beside the existing `tests/e2e-runner/utils/` entry.

This is maintenance of the Node-reachability scan, not a relaxation of it. The scan treats everything under `tests/` as a plain-Node root, because Playwright discovery runs there without browser globals. `tests/parity/` is different: it runs only under jest and jsdom, through `npm run test:parity`. Playwright matches `**/*.spec.ts`, so it cannot pick up a `.test.ts` file. Six of the seven adapters the matrix calls are browser-coupled, so a Node-safe parity test is not possible.

The exemption keeps the `.test.ts` suffix requirement. A new case in `src/validation/import-graph.test.ts` pins the scope. If a later edit broadens the prefix to `tests/` or removes the suffix requirement, that case fails.

The root cause is that the exemption list is hardcoded rather than derived from the jest config. It therefore goes stale whenever a jest-managed directory appears outside `src/`. That fix has its own task.

## Behavior preservation

Units 1 to 3 are extractions only. Each factory returns what the literal it replaced returned, including the fields it does not set. The repository omissions above are preserved, not corrected. A correction during the refactor makes the matrix prove nothing.

Evidence:

- The existing `MyLearningTab` `packageInfo` assertions pass unmodified. Their barrel mocks call `requireActual` on the real factories, so they still test production code.
- A new test in `context-panel.test.tsx` covers all four nav-link click sites. The two `featured_*` sites had no test before, and nothing asserted that `repository` was threaded. This test reproduces the same results against the pre-refactor version of the file.

The extractions found no bug to leave alone. The divergences above are pre-existing gaps that the matrix exists to surface. They are not new findings.

Two incidental changes that the architecture rules of this repo required:

- `DiscoverMoreItem` moved to `types/learning-paths.types.ts`, and `useDiscoverMore` re-exports it. No consumer import changed. This keeps the new module acyclic.
- The `learning-paths` barrel exports the factories, because barrel-bypass discipline rejects a deep import.

## How to confirm

Run these commands:

```sh
npm run check          # green
npm run test:parity    # RED by design: 1 failed matrix, 15 passed guards
npm run test:governance
npx jest --listTests | grep -c tests/parity   # 0, so it is outside the default suite
```

## Follow-ups, not done here

- The parity guard contract now lives in `docs/developer/COMMANDS.md` and in the test file. `docs/design/CONCERNS.md` owns deliberately established capability contracts and has no launch-context anchor. Adding one is worth its own change.
- The real fixes this matrix exists to drive are the decision on the authoritative repository, and the three deferred families.

Note for local runs: `TestContractStructTagGolden` fails under Go 1.27 on this branch and on unmodified `main`. CI pins an older toolchain and passes. The golden was not regenerated.