### PR TITLE
feat: add divider guide blocks

### DIFF
--- a/docs/design/APP-PLATFORM-PUBLISH-HANDOFF.md
+++ b/docs/design/APP-PLATFORM-PUBLISH-HANDOFF.md
@@ -48,6 +48,8 @@ The current Pathfinder custom-guide storage target is an App Platform resource:
 
 `metadata.name` is the App Platform resource name and the key used by Pathfinder deep links. It must be stable after first publication. The auto-generated ID format `<kebab-of-title>-<random-suffix>` (see [Agent authoring CLI — `create`](./AGENT-AUTHORING.md#create)) makes resource names statistically unique within a namespace without requiring a pre-publish lookup.
 
+The handoff encodes native divider blocks as markdown containing `<!-- pathfinder:block=divider;v=1 -->` and `---`. Current Pathfinder releases decode that reserved representation back to a divider. A rollback to a release whose closed block union predates `divider` therefore still validates the resource and renders an equivalent horizontal rule.
+
 ## Handoff tool
 
 The MCP service exposes a finalization tool named `pathfinder_finalize_for_app_platform`.

--- a/docs/developer/CUSTOM_GUIDES.md
+++ b/docs/developer/CUSTOM_GUIDES.md
@@ -153,6 +153,7 @@ When the backend is unavailable the badge area instead shows a **Saved** / **Sav
 
 - Guide IDs are auto-generated as `<title-slug>-<4-char-random>` when a new title is first committed. Later title edits do not change the ID or backend resource name.
 - The backend stores guides as `InteractiveGuide` custom resources in the `pathfinderbackend.ext.grafana.app/v1alpha1` API group.
+- Divider blocks are persisted as reserved markdown (`<!-- pathfinder:block=divider;v=1 -->` followed by `---`) and decoded when Pathfinder loads them. This is the rollback contract: releases from before native divider support still accept the closed block union and render the same horizontal rule. App Platform writers must use this representation rather than persisting `{"type":"divider"}` directly.
 - `resourceVersion` is used for optimistic concurrency control — the editor always fetches the latest version after a save before allowing a subsequent write.
 - Backend tracking state (`resourceName` and the last backend-synced guide JSON) is persisted to localStorage. Draft or published status is derived from the refreshed backend guide list, so the correct button state survives a page refresh.
 

--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -66,6 +66,16 @@ The primary block type for formatted text content.
 }
 ```
 
+#### Divider Block
+
+Adds a semantic horizontal separator with standard guide spacing. Divider blocks have no content fields.
+
+```json
+{
+  "type": "divider"
+}
+```
+
 #### HTML Block
 
 For raw HTML content. Use sparingly—prefer markdown for new content.
@@ -1200,6 +1210,7 @@ If a ref cannot be resolved — unknown ID, catalog fetch failure — it is repl
 | Block Type         | Category    | Description                                                                     |
 | ------------------ | ----------- | ------------------------------------------------------------------------------- |
 | `markdown`         | Content     | Formatted text with headings, lists, code, tables                               |
+| `divider`          | Content     | Horizontal separator between adjacent guide sections                            |
 | `html`             | Content     | Raw HTML for migration/custom content                                           |
 | `image`            | Content     | Embedded images with optional dimensions                                        |
 | `video`            | Content     | YouTube, Vimeo, or native HTML5 video embeds                                    |

--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -448,7 +448,7 @@ Hides its nested blocks behind a toggle. Use it to gate solutions or example out
 | `collapsed` | boolean             | ❌       | Whether it starts collapsed (defaults to `true`)    |
 | `blocks`    | content block array | ✅       | Content hidden behind the toggle                    |
 
-> A collapsible is presentational: it accepts content blocks only — `markdown` (including fenced code), `html`, `image`, and `video`. Interactive steps and containers (`section`, `collapsible`, `conditional`) are rejected, so a collapsible never carries completion state. To gate interactive steps, use a `section`.
+> A collapsible is presentational: it accepts content blocks only — `markdown` (including fenced code), `html`, `image`, `video`, `callout`, and `divider`. Interactive steps and containers (`section`, `collapsible`, `conditional`) are rejected, so a collapsible never carries completion state. To gate interactive steps, use a `section`.
 
 #### Conditional Block
 

--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -66,7 +66,7 @@ The primary block type for formatted text content.
 }
 ```
 
-#### Divider Block
+#### Divider block
 
 Adds a semantic horizontal separator with standard guide spacing. Divider blocks have no content fields.
 

--- a/src/cli/e2e/side-effects.test.ts
+++ b/src/cli/e2e/side-effects.test.ts
@@ -19,6 +19,10 @@ describe('classifyGuideSideEffects', () => {
     expect(result).toEqual({ level: 'readonly', reasons: [] });
   });
 
+  it('classifies dividers as readonly', () => {
+    expect(classifyGuideSideEffects(guide([{ type: 'divider' }]))).toEqual({ level: 'readonly', reasons: [] });
+  });
+
   it('classifies destructive and save-like buttons as mutating', () => {
     const result = classifyGuideSideEffects(
       guide([{ type: 'interactive', action: 'button', reftarget: 'Save dashboard', content: 'Save your work' }])

--- a/src/cli/e2e/side-effects.ts
+++ b/src/cli/e2e/side-effects.ts
@@ -3,6 +3,7 @@ import {
   isChallengeBlock,
   isCodeBlockBlock,
   isConditionalBlock,
+  isDividerBlock,
   isGrotGuideBlock,
   isGuidedBlock,
   isHtmlBlock,
@@ -158,6 +159,7 @@ function classifyBlocks(blocks: JsonBlock[] | undefined, path: string): SideEffe
 function classifyBlock(block: JsonBlock, path: string): SideEffectClassification {
   if (
     isMarkdownBlock(block) ||
+    isDividerBlock(block) ||
     isHtmlBlock(block) ||
     isImageBlock(block) ||
     isVideoBlock(block) ||

--- a/src/cli/mcp/__tests__/finalize.test.ts
+++ b/src/cli/mcp/__tests__/finalize.test.ts
@@ -11,6 +11,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 
 import { CURRENT_SCHEMA_VERSION } from '../../../types/json-guide.schema';
+import { PERSISTED_DIVIDER_MARKDOWN } from '../../../types/app-platform-guide-compat';
 import { InMemorySessionStore, SESSION_GENERATION_ABSENT } from '../lib/session-store';
 import { generateSessionToken } from '../lib/session-token';
 import { buildServer } from '../server';
@@ -21,7 +22,7 @@ interface ToolPayload {
   [key: string]: unknown;
 }
 
-async function callFinalize(): Promise<ToolPayload> {
+async function callFinalize(contentOverrides: Record<string, unknown> = {}): Promise<ToolPayload> {
   const server = buildServer();
   const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
   await server.connect(serverTransport);
@@ -36,6 +37,7 @@ async function callFinalize(): Promise<ToolPayload> {
         title: 'Snapshot Fixture',
         type: 'guide',
         blocks: [{ type: 'markdown', id: 'm-1', content: 'hello' }],
+        ...contentOverrides,
       },
       manifest: {
         id: 'snapshot-fixture',
@@ -268,6 +270,17 @@ describe('pathfinder_finalize_for_app_platform contract', () => {
         },
       }
     `);
+  });
+
+  it('encodes dividers in the App Platform resource without changing the export artifact', async () => {
+    const payload = await callFinalize({ blocks: [{ type: 'divider', id: 'divider-1' }] });
+
+    expect((payload.resource as { spec: { blocks: unknown[] } }).spec.blocks).toEqual([
+      { type: 'markdown', id: 'divider-1', content: PERSISTED_DIVIDER_MARKDOWN },
+    ]);
+    expect((payload.artifact as { content: { blocks: unknown[] } }).content.blocks).toEqual([
+      { type: 'divider', id: 'divider-1' },
+    ]);
   });
 
   it('carries the manifest onto spec so a path does not publish as a flat guide', async () => {

--- a/src/cli/mcp/tools/finalize.ts
+++ b/src/cli/mcp/tools/finalize.ts
@@ -33,6 +33,8 @@ import { renderMachineJson } from '../../utils/output';
 import { projectManifestForCrd } from '../lib/crd-manifest';
 import { PLUGIN_VIEWER_BASE } from '../lib/constants';
 import { tokenLogPrefix } from '../lib/session-token';
+import { encodeAppPlatformGuideBlocks } from '../../../types/app-platform-guide-compat';
+import type { JsonBlock } from '../../../types/json-guide.types';
 import type { AuthoringSessionStore } from '../lib/session-store';
 import { readOnly } from './annotations';
 import { resolveReadOnlyInput } from './read-input';
@@ -135,6 +137,10 @@ async function finalizeImpl(args: {
   // `type` is not declared on `ContentJson`, but clients send it alongside the
   // typed fields, so it has to be stripped through a widened view.
   const { type: _packageType, ...specContent } = content as unknown as Record<string, unknown>;
+  const persistedSpecContent = {
+    ...specContent,
+    blocks: encodeAppPlatformGuideBlocks(specContent.blocks as JsonBlock[]),
+  };
   const crdManifest = projectManifestForCrd(manifest);
 
   const handoff = {
@@ -166,7 +172,7 @@ async function finalizeImpl(args: {
       // declares no `spec.type`, so leaving it in earns a pruning warning on
       // every write. `manifest` carries it, projected onto the CRD's shape.
       spec: {
-        ...specContent,
+        ...persistedSpecContent,
         status,
         ...(crdManifest ? { manifest: crdManifest } : {}),
       },

--- a/src/cli/utils/block-registry.ts
+++ b/src/cli/utils/block-registry.ts
@@ -18,6 +18,7 @@ import {
   JsonCalloutBlockSchema,
   JsonCodeBlockBlockSchema,
   JsonConditionalBlockSchema,
+  JsonDividerBlockSchema,
   JsonGuidedBlockSchema,
   JsonHtmlBlockSchema,
   JsonImageBlockSchema,
@@ -47,6 +48,7 @@ import {
  */
 export const BLOCK_SCHEMA_MAP = {
   markdown: JsonMarkdownBlockSchema,
+  divider: JsonDividerBlockSchema,
   html: JsonHtmlBlockSchema,
   image: JsonImageBlockSchema,
   video: JsonVideoBlockSchema,

--- a/src/components/block-editor/BlockFormModal.tsx
+++ b/src/components/block-editor/BlockFormModal.tsx
@@ -34,6 +34,7 @@ const BLOCK_EDITOR_MODAL_ATTR = 'data-block-editor-modal';
 
 // Import form components
 import { MarkdownBlockForm } from './forms/MarkdownBlockForm';
+import { DividerBlockForm } from './forms/DividerBlockForm';
 import { HtmlBlockForm } from './forms/HtmlBlockForm';
 import { ImageBlockForm } from './forms/ImageBlockForm';
 import { VideoBlockForm } from './forms/VideoBlockForm';
@@ -114,6 +115,7 @@ export interface BlockFormModalProps {
 // suppresses the whole modal rather than rendering an empty one.
 const FORM_COMPONENTS: Record<BlockType, React.ComponentType<BlockFormProps> | null> = {
   markdown: MarkdownBlockForm,
+  divider: DividerBlockForm,
   html: HtmlBlockForm,
   image: ImageBlockForm,
   video: VideoBlockForm,

--- a/src/components/block-editor/GuideLibraryModal.tsx
+++ b/src/components/block-editor/GuideLibraryModal.tsx
@@ -10,6 +10,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import type { JsonGuide } from './types';
 import { ConfirmModal, AlertModal } from './NotificationModals';
+import { decodeAppPlatformGuideBlocks } from '../../types/app-platform-guide-compat';
 
 interface BackendGuide {
   metadata: {
@@ -152,7 +153,7 @@ export function GuideLibraryModal({
       id: backendGuide.spec.id,
       title: backendGuide.spec.title,
       schemaVersion: backendGuide.spec.schemaVersion || '1.0',
-      blocks: backendGuide.spec.blocks,
+      blocks: decodeAppPlatformGuideBlocks(backendGuide.spec.blocks),
     };
     onLoadGuide(guide, backendGuide.metadata.name);
     onClose();

--- a/src/components/block-editor/constants.ts
+++ b/src/components/block-editor/constants.ts
@@ -21,6 +21,13 @@ export const BLOCK_TYPE_METADATA: Record<BlockType, BlockTypeMetadata> = {
     name: 'Markdown',
     description: 'Formatted text with headings, lists, and code',
   },
+  divider: {
+    type: 'divider',
+    icon: '➖',
+    grafanaIcon: 'minus',
+    name: 'Divider',
+    description: 'Horizontal separator between guide sections',
+  },
   html: {
     type: 'html',
     icon: '🔧',
@@ -168,7 +175,7 @@ export const BLOCK_TYPE_GROUPS = [
   {
     id: 'content',
     label: 'Content',
-    types: ['markdown', 'image', 'video', 'code-block', 'callout'],
+    types: ['markdown', 'divider', 'image', 'video', 'code-block', 'callout'],
   },
   {
     id: 'interactive',

--- a/src/components/block-editor/forms/BranchBlocksEditor.test.ts
+++ b/src/components/block-editor/forms/BranchBlocksEditor.test.ts
@@ -23,6 +23,11 @@ describe('BranchBlocksEditor createDefaultBlock', () => {
     expect(ALLOWED_BRANCH_BLOCK_TYPES).toContain('callout');
   });
 
+  it('offers and builds a divider in the inline add picker', () => {
+    expect(ALLOWED_BRANCH_BLOCK_TYPES).toContain('divider');
+    expect(createDefaultBlock('divider')).toEqual({ type: 'divider' });
+  });
+
   it('builds an empty callout block, not empty markdown', () => {
     expect(createDefaultBlock('callout')).toEqual({
       type: 'callout',

--- a/src/components/block-editor/forms/BranchBlocksEditor.tsx
+++ b/src/components/block-editor/forms/BranchBlocksEditor.tsx
@@ -269,6 +269,8 @@ export function createDefaultBlock(type: BlockType): JsonBlock {
   switch (type) {
     case 'markdown':
       return { type: 'markdown', content: '' };
+    case 'divider':
+      return { type: 'divider' };
     case 'interactive':
       return { type: 'interactive', action: 'highlight', reftarget: '', content: '' };
     case 'image':
@@ -305,6 +307,7 @@ export function createDefaultBlock(type: BlockType): JsonBlock {
 // silently create the wrong block shape (see #1542).
 const BRANCH_INLINE_CREATABLE_TYPES: BlockType[] = [
   'markdown',
+  'divider',
   'interactive',
   'image',
   'video',

--- a/src/components/block-editor/forms/CollapsibleBlockForm.test.tsx
+++ b/src/components/block-editor/forms/CollapsibleBlockForm.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { CollapsibleBlockForm } from './CollapsibleBlockForm';
+
+jest.mock('@grafana/ui', () => {
+  const actual = jest.requireActual('@grafana/ui');
+  const React = jest.requireActual('react');
+  type Option = { value: string; label: string };
+
+  return {
+    ...actual,
+    Combobox: ({
+      options,
+      value,
+      onChange,
+    }: {
+      options: Option[];
+      value: string;
+      onChange: (option: Option) => void;
+    }) =>
+      React.createElement(
+        'select',
+        {
+          'aria-label': 'Block type',
+          value,
+          onChange: (event: import('react').ChangeEvent<HTMLSelectElement>) => {
+            const option = options.find((candidate) => candidate.value === event.currentTarget.value);
+            if (option) {
+              onChange(option);
+            }
+          },
+        },
+        options.map((option) => React.createElement('option', { key: option.value, value: option.value }, option.label))
+      ),
+  };
+});
+
+describe('CollapsibleBlockForm', () => {
+  it('adds a divider to the collapsible content', () => {
+    const onSubmit = jest.fn();
+    render(<CollapsibleBlockForm onSubmit={onSubmit} onCancel={jest.fn()} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add block' })[0]!);
+    fireEvent.change(screen.getByRole('combobox', { name: 'Block type' }), { target: { value: 'divider' } });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add block' })[0]!);
+    fireEvent.click(screen.getByTestId('block-editor-submit-button'));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      type: 'collapsible',
+      blocks: [{ type: 'divider' }],
+    });
+  });
+});

--- a/src/components/block-editor/forms/CollapsibleBlockForm.tsx
+++ b/src/components/block-editor/forms/CollapsibleBlockForm.tsx
@@ -17,7 +17,7 @@ import type { JsonCollapsibleBlock, PresentationalBlock } from '../../../types/j
 // Content-only block types offered in a collapsible's add menu. Mirrors
 // PresentationalBlock in json-guide.types.ts (html is authored via markdown,
 // not the palette).
-const PRESENTATIONAL_ADDABLE_TYPES: BlockType[] = ['markdown', 'image', 'video', 'callout'];
+const PRESENTATIONAL_ADDABLE_TYPES: BlockType[] = ['markdown', 'divider', 'image', 'video', 'callout'];
 
 function isCollapsibleBlock(block: JsonBlock): block is JsonCollapsibleBlock {
   return block.type === 'collapsible';

--- a/src/components/block-editor/forms/DividerBlockForm.test.tsx
+++ b/src/components/block-editor/forms/DividerBlockForm.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { DividerBlockForm } from './DividerBlockForm';
+import type { BlockType } from '../types';
+
+jest.mock('./TypeSwitchDropdown', () => ({
+  TypeSwitchDropdown: ({ onSwitch }: { onSwitch: (type: BlockType) => void }) => (
+    <button type="button" onClick={() => onSwitch('markdown')}>
+      Switch type
+    </button>
+  ),
+}));
+
+describe('DividerBlockForm', () => {
+  it('offers type switching while editing', () => {
+    const onSwitchBlockType = jest.fn();
+
+    render(
+      <DividerBlockForm
+        initialData={{ type: 'divider', id: 'divider-1' }}
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+        onSwitchBlockType={onSwitchBlockType}
+        isEditing
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch type' }));
+
+    expect(onSwitchBlockType).toHaveBeenCalledWith('markdown');
+  });
+
+  it('does not offer type switching while creating a divider', () => {
+    render(<DividerBlockForm onSubmit={jest.fn()} onCancel={jest.fn()} onSwitchBlockType={jest.fn()} />);
+
+    expect(screen.queryByRole('button', { name: 'Switch type' })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/block-editor/forms/DividerBlockForm.tsx
+++ b/src/components/block-editor/forms/DividerBlockForm.tsx
@@ -7,8 +7,15 @@ import type { JsonDividerBlock } from '../../../types/json-guide.types';
 import { testIds } from '../../../constants/testIds';
 import { getBlockFormStyles } from '../block-editor.styles';
 import type { BlockFormProps } from '../types';
+import { TypeSwitchDropdown } from './TypeSwitchDropdown';
 
-export function DividerBlockForm({ initialData, onSubmit, onCancel, isEditing = false }: BlockFormProps) {
+export function DividerBlockForm({
+  initialData,
+  onSubmit,
+  onCancel,
+  isEditing = false,
+  onSwitchBlockType,
+}: BlockFormProps) {
   const styles = useStyles2(getBlockFormStyles);
 
   const handleSubmit = useCallback(
@@ -29,6 +36,11 @@ export function DividerBlockForm({ initialData, onSubmit, onCancel, isEditing = 
     <form onSubmit={handleSubmit} className={styles.form}>
       <p>A divider has no editable content. It renders a horizontal separator with standard guide spacing.</p>
       <div className={styles.footer}>
+        {isEditing && onSwitchBlockType && (
+          <div className={styles.footerLeft}>
+            <TypeSwitchDropdown currentType="divider" onSwitch={onSwitchBlockType} blockData={initialData} />
+          </div>
+        )}
         <Button variant="secondary" onClick={onCancel} type="button" data-testid={testIds.blockEditor.formCancelButton}>
           Cancel
         </Button>

--- a/src/components/block-editor/forms/DividerBlockForm.tsx
+++ b/src/components/block-editor/forms/DividerBlockForm.tsx
@@ -1,5 +1,3 @@
-/** Form for a content-free divider block. */
-
 import React, { useCallback } from 'react';
 import { Button, useStyles2 } from '@grafana/ui';
 

--- a/src/components/block-editor/forms/DividerBlockForm.tsx
+++ b/src/components/block-editor/forms/DividerBlockForm.tsx
@@ -1,0 +1,43 @@
+/** Form for a content-free divider block. */
+
+import React, { useCallback } from 'react';
+import { Button, useStyles2 } from '@grafana/ui';
+
+import type { JsonDividerBlock } from '../../../types/json-guide.types';
+import { testIds } from '../../../constants/testIds';
+import { getBlockFormStyles } from '../block-editor.styles';
+import type { BlockFormProps } from '../types';
+
+export function DividerBlockForm({ initialData, onSubmit, onCancel, isEditing = false }: BlockFormProps) {
+  const styles = useStyles2(getBlockFormStyles);
+
+  const handleSubmit = useCallback(
+    (event: React.SubmitEvent) => {
+      event.preventDefault();
+      const existing = initialData?.type === 'divider' ? initialData : undefined;
+      const block: JsonDividerBlock = {
+        type: 'divider',
+        ...(existing?.id && { id: existing.id }),
+        ...(existing?.authorNote && { authorNote: existing.authorNote }),
+      };
+      onSubmit(block);
+    },
+    [initialData, onSubmit]
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.form}>
+      <p>A divider has no editable content. It renders a horizontal separator with standard guide spacing.</p>
+      <div className={styles.footer}>
+        <Button variant="secondary" onClick={onCancel} type="button" data-testid={testIds.blockEditor.formCancelButton}>
+          Cancel
+        </Button>
+        <Button variant="primary" type="submit" data-testid={testIds.blockEditor.submitButton}>
+          {isEditing ? 'Update block' : 'Add block'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+DividerBlockForm.displayName = 'DividerBlockForm';

--- a/src/components/block-editor/forms/index.ts
+++ b/src/components/block-editor/forms/index.ts
@@ -5,6 +5,7 @@
  */
 
 export { MarkdownBlockForm } from './MarkdownBlockForm';
+export { DividerBlockForm } from './DividerBlockForm';
 export { HtmlBlockForm } from './HtmlBlockForm';
 export { ImageBlockForm } from './ImageBlockForm';
 export { VideoBlockForm } from './VideoBlockForm';

--- a/src/components/block-editor/hooks/useBackendGuides.test.ts
+++ b/src/components/block-editor/hooks/useBackendGuides.test.ts
@@ -24,6 +24,7 @@ import { of } from 'rxjs';
 
 import { fetchBackendGuides } from '../../../utils/fetchBackendGuides';
 import { CURRENT_SCHEMA_VERSION } from '../../../types/json-guide.schema';
+import { PERSISTED_DIVIDER_MARKDOWN } from '../../../types/app-platform-guide-compat';
 import type { JsonGuide } from '../types';
 import { hasManageableBackendGuides, useBackendGuides } from './useBackendGuides';
 
@@ -297,6 +298,23 @@ describe('saveGuide — round-trip of fields the editor does not own', () => {
 
     expect(lastRequest().data.spec.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(lastRequest().data.spec.schemaVersion).not.toBe('1.0');
+  });
+
+  it('persists dividers in the rollback-compatible markdown representation', async () => {
+    const result = await renderLoaded([]);
+    const guide = {
+      id: 'divider-guide',
+      title: 'Divider guide',
+      blocks: [{ id: 'divider-1', type: 'divider' }],
+    } as JsonGuide;
+
+    await act(async () => {
+      await result.current.saveGuide(guide);
+    });
+
+    expect(lastRequest().data.spec.blocks).toEqual([
+      { id: 'divider-1', type: 'markdown', content: PERSISTED_DIVIDER_MARKDOWN },
+    ]);
   });
 
   it('does not borrow a manifest from an unrelated resource in the loaded list', async () => {

--- a/src/components/block-editor/hooks/useBackendGuides.ts
+++ b/src/components/block-editor/hooks/useBackendGuides.ts
@@ -12,6 +12,7 @@ import { stripAuthorNotes } from '../utils/block-export';
 import { deriveManifest } from '../utils/derive-manifest';
 import { CURRENT_SCHEMA_VERSION } from '../../../types/json-guide.schema';
 import { logger } from '../../../lib/logging';
+import { encodeAppPlatformGuideBlocks } from '../../../types/app-platform-guide-compat';
 
 export type BackendGuideMetadata = {
   name: string;
@@ -89,7 +90,7 @@ export function preservedSpec(
     title: guide.title,
     // Normalised deliberately: the editor writes the schema version it emits, not the stored one.
     schemaVersion: guide.schemaVersion || CURRENT_SCHEMA_VERSION,
-    blocks: guide.blocks,
+    blocks: encodeAppPlatformGuideBlocks(guide.blocks),
     status,
     manifest: deriveManifest(guide, existingSpec?.manifest, existingSpec?.blocks),
   };

--- a/src/components/block-editor/utils/block-conversion.test.ts
+++ b/src/components/block-editor/utils/block-conversion.test.ts
@@ -479,6 +479,7 @@ describe('convertBlockType', () => {
 
     const SAMPLE_BLOCKS = {
       markdown: { type: 'markdown', content: 'Sample content' },
+      divider: { type: 'divider' },
       html: { type: 'html', content: '<p>Sample content</p>' },
       image: { type: 'image', src: 'https://example.com/i.png', alt: 'a' },
       video: { type: 'video', src: 'https://example.com/v.mp4' },
@@ -508,6 +509,7 @@ describe('convertBlockType', () => {
     const CONTENTLESS_SOURCE_FAILURES: Partial<Record<BlockType, readonly BlockType[]>> = {
       image: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],
       video: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],
+      divider: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],
       collapsible: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],
       assistant: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],
       'snippet-ref': ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],

--- a/src/components/block-editor/utils/block-conversion.test.ts
+++ b/src/components/block-editor/utils/block-conversion.test.ts
@@ -117,15 +117,16 @@ describe('getAvailableConversions', () => {
       ]);
     });
 
-    it('should offer every non-excluded target except the source, for every eligible source', () => {
-      const eligibleSources = ALL_BLOCK_TYPES.filter((type) => !SOURCE_EXCLUDED_BLOCK_TYPES.includes(type));
-
-      for (const source of eligibleSources) {
-        const expected = ALL_BLOCK_TYPES.filter(
-          (target) => target !== source && !TARGET_EXCLUDED_BLOCK_TYPES.includes(target)
-        );
-        expect([...getAvailableConversions(source)].sort()).toEqual([...expected].sort());
-      }
+    it('should hide targets whose required content cannot be supplied by a divider', () => {
+      expect(getAvailableConversions('divider')).toEqual([
+        'image',
+        'video',
+        'multistep',
+        'guided',
+        'terminal-connect',
+        'challenge',
+        'code-block',
+      ]);
     });
   });
 });
@@ -500,21 +501,6 @@ describe('convertBlockType', () => {
 
     const sampleEntries = Object.entries(SAMPLE_BLOCKS) as Array<[BlockType, JsonBlock]>;
 
-    /**
-     * Sources with no `CONTENT_FIELDS` entry — `image`, `video`, `collapsible`,
-     * `assistant` and `snippet-ref` — carry no text into a target whose required
-     * text field has no `REQUIRED_DEFAULTS` fallback, so the conversion throws.
-     * Pinned here so adding a fallback moves this list deliberately.
-     */
-    const CONTENTLESS_SOURCE_FAILURES: Partial<Record<BlockType, readonly BlockType[]>> = {
-      image: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],
-      video: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],
-      divider: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],
-      collapsible: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],
-      assistant: ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],
-      'snippet-ref': ['markdown', 'html', 'interactive', 'quiz', 'input', 'terminal', 'callout'],
-    };
-
     it('samples every convertible source type', () => {
       const missing = ALL_BLOCK_TYPES.filter(
         (type) => !SOURCE_EXCLUDED_BLOCK_TYPES.includes(type) && !sampleEntries.some(([sampled]) => sampled === type)
@@ -523,16 +509,11 @@ describe('convertBlockType', () => {
     });
 
     it.each(sampleEntries)('should convert %s to every available target', (sourceType, source) => {
-      const expectedFailures = CONTENTLESS_SOURCE_FAILURES[sourceType] ?? [];
       const targets = getAvailableConversions(sourceType);
       expect(targets.length).toBeGreaterThan(0);
 
       for (const target of targets) {
-        if (expectedFailures.includes(target)) {
-          expect(() => convertBlockType(source, target)).toThrow(/failed validation/);
-        } else {
-          expect(convertBlockType(source, target).type).toBe(target);
-        }
+        expect(convertBlockType(source, target).type).toBe(target);
       }
     });
 

--- a/src/components/block-editor/utils/block-conversion.ts
+++ b/src/components/block-editor/utils/block-conversion.ts
@@ -23,6 +23,7 @@ import { logger } from '../../../lib/logging';
  */
 const SOURCE_EXCLUSION_REASONS = {
   markdown: null,
+  divider: null,
   html: null,
   image: null,
   video: null,
@@ -58,6 +59,7 @@ const SOURCE_EXCLUSION_REASONS = {
  */
 const TARGET_EXCLUSION_REASONS = {
   markdown: null,
+  divider: 'a divider has no editable fields to receive converted content',
   html: null,
   image: null,
   video: null,
@@ -105,6 +107,7 @@ const COMMON_FIELDS = ['requirements', 'objectives', 'skippable'] as const;
  */
 const CONTENT_FIELDS: Record<BlockType, string | null> = {
   markdown: 'content',
+  divider: null,
   html: 'content',
   interactive: 'content',
   multistep: 'content',
@@ -156,6 +159,7 @@ const REQUIRED_DEFAULTS: Record<BlockType, Record<string, unknown> | null> = {
   },
   'code-block': { reftarget: "div[data-testid='data-testid Code editor container']", code: '// Your code here' },
   markdown: null,
+  divider: null,
   html: null,
   section: null,
   conditional: null,

--- a/src/components/block-editor/utils/block-conversion.ts
+++ b/src/components/block-editor/utils/block-conversion.ts
@@ -169,6 +169,29 @@ const REQUIRED_DEFAULTS: Record<BlockType, Record<string, unknown> | null> = {
   'snippet-ref': null,
 };
 
+const CONTENT_REQUIRED_TARGETS = new Set<BlockType>([
+  'markdown',
+  'html',
+  'callout',
+  'interactive',
+  'quiz',
+  'input',
+  'terminal',
+]);
+
+function canProvideTargetContent(sourceType: BlockType, targetType: BlockType): boolean {
+  if (!CONTENT_REQUIRED_TARGETS.has(targetType) || CONTENT_FIELDS[sourceType]) {
+    return true;
+  }
+
+  const targetContentField = CONTENT_FIELDS[targetType];
+  if (!targetContentField) {
+    return true;
+  }
+
+  return REQUIRED_DEFAULTS[targetType]?.[targetContentField] !== undefined;
+}
+
 // ============ Public API ============
 
 /**
@@ -190,7 +213,9 @@ export function getAvailableConversions(sourceType: BlockType): BlockType[] {
     return [];
   }
 
-  return CONVERTIBLE_TYPES.filter((t) => t !== sourceType);
+  return CONVERTIBLE_TYPES.filter(
+    (targetType) => targetType !== sourceType && canProvideTargetContent(sourceType, targetType)
+  );
 }
 
 /**

--- a/src/components/block-editor/utils/block-preview.ts
+++ b/src/components/block-editor/utils/block-preview.ts
@@ -62,6 +62,10 @@ export function getBlockPreview(block: JsonBlock, options: BlockPreviewOptions =
     return truncate(firstLine, maxLength);
   }
 
+  if (block.type === 'divider') {
+    return 'Horizontal separator';
+  }
+
   if (isHtmlBlock(block)) {
     // Strip HTML tags and show text
     const text = block.content.replace(/<[^>]+>/g, ' ').trim();

--- a/src/components/docs-panel/utils/requires-grafana-ui.ts
+++ b/src/components/docs-panel/utils/requires-grafana-ui.ts
@@ -79,6 +79,7 @@ function blockRequiresGrafanaUi(block: JsonBlock): boolean {
     case 'snippet-ref':
       return true;
     case 'markdown':
+    case 'divider':
     case 'html':
     case 'image':
     case 'video':

--- a/src/components/interactive-tutorial/section-child-classifier.test.tsx
+++ b/src/components/interactive-tutorial/section-child-classifier.test.tsx
@@ -36,6 +36,10 @@ describe('classifySectionChild', () => {
     ])('classifies %s as ignore', (_name, value) => {
       expect(classifySectionChild(value as React.ReactNode)).toBe('ignore');
     });
+
+    it('classifies a divider as ignore', () => {
+      expect(classifySectionChild(<hr className="guide-divider" />)).toBe('ignore');
+    });
   });
 
   describe('passive children', () => {

--- a/src/components/interactive-tutorial/section-child-classifier.ts
+++ b/src/components/interactive-tutorial/section-child-classifier.ts
@@ -60,8 +60,8 @@ export const INTERACTIVE_STEP_COMPONENT_TYPES: ReadonlySet<unknown> = new Set<un
  *   markdown HTML, images, videos, plain text, html blocks, divs and any
  *   non-tracked renderable child.
  * - 'ignore': structurally invisible content (whitespace text nodes,
- *   booleans, null, undefined, empty fragments) — does not count for
- *   acknowledgement either way.
+ *   booleans, null, undefined, empty fragments, dividers) — does not count
+ *   for acknowledgement either way.
  */
 export function classifySectionChild(child: React.ReactNode): ChildKind {
   if (child === null || child === undefined || typeof child === 'boolean') {
@@ -77,6 +77,9 @@ export function classifySectionChild(child: React.ReactNode): ChildKind {
     return 'ignore';
   }
   const childType = (child as React.ReactElement).type;
+  if (childType === 'hr') {
+    return 'ignore';
+  }
   if (childType === InteractiveStep) {
     // All InteractiveStep variants — including noop — count as interactive
     // per issue #842. The `nonNoopSteps` filter inside InteractiveSection

--- a/src/docs-retrieval/content-fetcher/backend-guide.test.ts
+++ b/src/docs-retrieval/content-fetcher/backend-guide.test.ts
@@ -1,5 +1,6 @@
 import { of, throwError } from 'rxjs';
 import { fetchBackendInteractive } from './backend-guide';
+import { PERSISTED_DIVIDER_MARKDOWN } from '../../types/app-platform-guide-compat';
 
 let mockNamespace: string | undefined = 'stacks-123';
 const mockFetch = jest.fn();
@@ -127,6 +128,27 @@ describe('fetchBackendInteractive — happy path', () => {
     const result = await fetchBackendInteractive('backend-guide:my-guide');
 
     expect(JSON.parse(result.content!.content).schemaVersion).toBe('1.0');
+  });
+
+  it('decodes rollback-compatible divider markdown before validation', async () => {
+    mockFetch.mockReturnValue(
+      of(
+        okResource({
+          spec: {
+            id: 'guide-id',
+            title: 'My Guide',
+            blocks: [{ type: 'markdown', id: 'divider-1', content: PERSISTED_DIVIDER_MARKDOWN }],
+          },
+        })
+      )
+    );
+
+    const result = await fetchBackendInteractive('backend-guide:my-guide');
+
+    expect(mockValidateGuide).toHaveBeenCalledWith(
+      expect.objectContaining({ blocks: [{ type: 'divider', id: 'divider-1' }] })
+    );
+    expect(JSON.parse(result.content!.content).blocks).toEqual([{ type: 'divider', id: 'divider-1' }]);
   });
 });
 

--- a/src/docs-retrieval/content-fetcher/backend-guide.ts
+++ b/src/docs-retrieval/content-fetcher/backend-guide.ts
@@ -6,6 +6,8 @@ import { config, getBackendSrv } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
 import { itemUrl } from '../../utils/interactive-guides-api';
 import { validateGuide } from '../../validation';
+import { decodeAppPlatformGuideBlocks } from '../../types/app-platform-guide-compat';
+import type { JsonBlock } from '../../types/json-guide.types';
 
 export interface BackendGuideResource {
   metadata?: {
@@ -74,7 +76,7 @@ export function buildBackendGuideContent(
     id: guideResource.spec.id || guideResource.metadata?.name || resourceName,
     title: guideResource.spec.title,
     schemaVersion: guideResource.spec.schemaVersion || '1.0',
-    blocks: guideResource.spec.blocks,
+    blocks: decodeAppPlatformGuideBlocks(guideResource.spec.blocks as JsonBlock[]),
   };
 
   const validationResult = validateGuide(guide);

--- a/src/docs-retrieval/json-parser-divider.test.ts
+++ b/src/docs-retrieval/json-parser-divider.test.ts
@@ -1,0 +1,29 @@
+import { parseJsonGuide } from './json-parser';
+
+jest.mock('@grafana/runtime', () => ({
+  config: { bootData: { user: null }, buildInfo: { version: '10.0.0' } },
+}));
+
+jest.mock('@grafana/data', () => ({
+  renderMarkdown: (markdown: string) => `<p>${markdown}</p>`,
+}));
+
+describe('json-parser divider block', () => {
+  it('converts a divider into a semantic horizontal rule', () => {
+    const result = parseJsonGuide({
+      id: 'divider-guide',
+      title: 'Divider guide',
+      blocks: [{ type: 'divider' }],
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.data?.elements).toEqual([
+      {
+        type: 'hr',
+        props: { className: 'guide-divider' },
+        children: [],
+      },
+    ]);
+    expect(result.data?.hasInteractiveElements).toBe(false);
+  });
+});

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -278,6 +278,14 @@ function convertBlockByType(
   switch (block.type) {
     case 'markdown':
       return convertMarkdownBlock(block, path, baseUrl);
+    case 'divider':
+      return {
+        element: {
+          type: 'hr',
+          props: { className: 'guide-divider' },
+          children: [],
+        },
+      };
     case 'html':
       return convertHtmlBlock(block, path, baseUrl);
     case 'section':

--- a/src/lib/guide-stats/block-index.test.ts
+++ b/src/lib/guide-stats/block-index.test.ts
@@ -187,6 +187,7 @@ describe('block-type classification', () => {
   /** Types that hold no children at all, so counting one is the only option. */
   const PLAIN_BLOCK_TYPES = [
     'markdown',
+    'divider',
     'html',
     'image',
     'video',

--- a/src/styles/content-html.styles.ts
+++ b/src/styles/content-html.styles.ts
@@ -65,6 +65,12 @@ const getBaseContentStyles = (theme: GrafanaTheme2) => ({
     overflowWrap: 'break-word',
   },
 
+  '& .guide-divider': {
+    border: 0,
+    borderTop: `1px solid ${theme.colors.border.medium}`,
+    margin: `${theme.spacing(4)} 0`,
+  },
+
   '& ul, & ol': {
     marginBottom: theme.spacing(2),
     paddingLeft: theme.spacing(3),

--- a/src/types/app-platform-guide-compat.test.ts
+++ b/src/types/app-platform-guide-compat.test.ts
@@ -1,0 +1,54 @@
+import type { JsonBlock } from './json-guide.types';
+import {
+  decodeAppPlatformGuideBlocks,
+  encodeAppPlatformGuideBlocks,
+  PERSISTED_DIVIDER_MARKDOWN,
+} from './app-platform-guide-compat';
+
+describe('App Platform guide compatibility', () => {
+  it('stores dividers as markdown that pre-divider readers can validate', () => {
+    const blocks: JsonBlock[] = [
+      { type: 'divider', id: 'top-level' },
+      {
+        type: 'section',
+        id: 'section',
+        blocks: [{ type: 'divider', id: 'nested' }],
+      },
+    ];
+
+    expect(encodeAppPlatformGuideBlocks(blocks)).toEqual([
+      { type: 'markdown', id: 'top-level', content: PERSISTED_DIVIDER_MARKDOWN },
+      {
+        type: 'section',
+        id: 'section',
+        blocks: [{ type: 'markdown', id: 'nested', content: PERSISTED_DIVIDER_MARKDOWN }],
+      },
+    ]);
+  });
+
+  it('restores persisted divider markdown for current readers', () => {
+    const persisted = encodeAppPlatformGuideBlocks([
+      {
+        type: 'conditional',
+        conditions: ['always'],
+        whenTrue: [{ type: 'divider', id: 'true-divider' }],
+        whenFalse: [{ type: 'divider', id: 'false-divider' }],
+      },
+    ]);
+
+    expect(decodeAppPlatformGuideBlocks(persisted)).toEqual([
+      {
+        type: 'conditional',
+        conditions: ['always'],
+        whenTrue: [{ type: 'divider', id: 'true-divider' }],
+        whenFalse: [{ type: 'divider', id: 'false-divider' }],
+      },
+    ]);
+  });
+
+  it('does not reinterpret ordinary markdown', () => {
+    const markdown: JsonBlock[] = [{ type: 'markdown', id: 'rule', content: '---' }];
+
+    expect(decodeAppPlatformGuideBlocks(markdown)).toEqual(markdown);
+  });
+});

--- a/src/types/app-platform-guide-compat.ts
+++ b/src/types/app-platform-guide-compat.ts
@@ -1,0 +1,53 @@
+import type { JsonBlock } from './json-guide.types';
+
+/**
+ * App Platform resources outlive an individual Pathfinder deployment. Store
+ * dividers as markdown so releases from before the divider block was added can
+ * still validate and render a saved guide after a rollback.
+ */
+export const PERSISTED_DIVIDER_MARKDOWN = '<!-- pathfinder:block=divider;v=1 -->\n---';
+
+const NESTED_BLOCK_FIELDS = ['blocks', 'whenTrue', 'whenFalse'] as const;
+
+function mapNestedBlocks(block: JsonBlock, mapBlock: (block: JsonBlock) => JsonBlock): JsonBlock {
+  const mapped = { ...block } as unknown as Record<string, unknown>;
+
+  for (const field of NESTED_BLOCK_FIELDS) {
+    if (Array.isArray(mapped[field])) {
+      mapped[field] = (mapped[field] as JsonBlock[]).map(mapBlock);
+    }
+  }
+
+  return mapped as unknown as JsonBlock;
+}
+
+export function encodeAppPlatformGuideBlocks(blocks: JsonBlock[]): JsonBlock[] {
+  const encodeBlock = (block: JsonBlock): JsonBlock => {
+    if (block.type === 'divider') {
+      return {
+        type: 'markdown',
+        ...(block.id ? { id: block.id } : {}),
+        content: PERSISTED_DIVIDER_MARKDOWN,
+      };
+    }
+
+    return mapNestedBlocks(block, encodeBlock);
+  };
+
+  return blocks.map(encodeBlock);
+}
+
+export function decodeAppPlatformGuideBlocks(blocks: JsonBlock[]): JsonBlock[] {
+  const decodeBlock = (block: JsonBlock): JsonBlock => {
+    if (block.type === 'markdown' && block.content === PERSISTED_DIVIDER_MARKDOWN) {
+      return {
+        type: 'divider',
+        ...(block.id ? { id: block.id } : {}),
+      };
+    }
+
+    return mapNestedBlocks(block, decodeBlock);
+  };
+
+  return blocks.map(decodeBlock);
+}

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -238,6 +238,17 @@ export const JsonMarkdownBlockSchema = z.object({
 });
 
 /**
+ * Schema for a content divider. It intentionally has no reader-visible
+ * fields: the block renders a semantic horizontal rule.
+ * @coupling Type: JsonDividerBlock
+ */
+export const JsonDividerBlockSchema = z.object({
+  type: z.literal('divider'),
+  id: z.string().optional().describe('Stable identifier for edit-block / remove-block addressing'),
+  ...AuthorAnnotatedSchema.shape,
+});
+
+/**
  * Schema for HTML block.
  * @coupling Type: JsonHtmlBlock
  */
@@ -845,6 +856,7 @@ export const JsonSnippetRefBlockSchema = z.object({
  */
 const NonRecursiveBlockSchema = z.union([
   JsonMarkdownBlockSchema,
+  JsonDividerBlockSchema,
   JsonHtmlBlockSchema,
   JsonImageBlockSchema,
   JsonVideoBlockSchema,
@@ -869,6 +881,7 @@ const NonRecursiveBlockSchema = z.union([
  */
 const NonRecursiveBlockSchemaNoRef = z.union([
   JsonMarkdownBlockSchema,
+  JsonDividerBlockSchema,
   JsonHtmlBlockSchema,
   JsonImageBlockSchema,
   JsonVideoBlockSchema,
@@ -893,6 +906,7 @@ const NonRecursiveBlockSchemaNoRef = z.union([
  */
 export const PresentationalBlockSchema = z.union([
   JsonMarkdownBlockSchema,
+  JsonDividerBlockSchema,
   JsonHtmlBlockSchema,
   JsonImageBlockSchema,
   JsonVideoBlockSchema,
@@ -1186,6 +1200,7 @@ export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
   // `AuthorAnnotatedSchema` into every block type. It's stripped on
   // export, but stays in the schema so authoring tools can persist it.
   markdown: new Set(['type', 'id', 'content', 'assistantEnabled', 'assistantId', 'assistantType', 'authorNote']),
+  divider: new Set(['type', 'id', 'authorNote']),
   html: new Set(['type', 'id', 'content', 'authorNote']),
   image: new Set(['type', 'id', 'src', 'alt', 'width', 'height', 'authorNote']),
   video: new Set(['type', 'id', 'src', 'provider', 'title', 'start', 'end', 'authorNote']),

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -907,7 +907,6 @@ export function isMarkdownBlock(block: JsonBlock): block is JsonMarkdownBlock {
   return block.type === 'markdown';
 }
 
-/** Type guard for JsonDividerBlock. */
 export function isDividerBlock(block: JsonBlock): block is JsonDividerBlock {
   return block.type === 'divider';
 }

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -30,6 +30,7 @@ export interface JsonGuide {
  */
 export type JsonBlock =
   | JsonMarkdownBlock
+  | JsonDividerBlock
   | JsonHtmlBlock
   | JsonSectionBlock
   | JsonCollapsibleBlock
@@ -96,6 +97,15 @@ export interface JsonMarkdownBlock extends AssistantProps, AuthorAnnotated {
   id?: string;
   /** Markdown-formatted content */
   content: string;
+}
+
+/**
+ * Visual separator between adjacent guide blocks.
+ */
+export interface JsonDividerBlock extends AuthorAnnotated {
+  type: 'divider';
+  /** Stable identifier for edit-block / remove-block addressing (auto-assigned by the CLI when omitted) */
+  id?: string;
 }
 
 /**
@@ -211,7 +221,7 @@ export interface JsonCollapsibleBlock extends AuthorAnnotated {
  * Mirrors `PresentationalBlockSchema` in json-guide.schema.ts.
  */
 export type PresentationalBlock =
-  JsonMarkdownBlock | JsonHtmlBlock | JsonImageBlock | JsonVideoBlock | JsonCalloutBlock;
+  JsonMarkdownBlock | JsonDividerBlock | JsonHtmlBlock | JsonImageBlock | JsonVideoBlock | JsonCalloutBlock;
 
 // ============ CALLOUT BLOCK ============
 
@@ -895,6 +905,11 @@ export interface JsonSnippetRefBlock extends AuthorAnnotated {
  */
 export function isMarkdownBlock(block: JsonBlock): block is JsonMarkdownBlock {
   return block.type === 'markdown';
+}
+
+/** Type guard for JsonDividerBlock. */
+export function isDividerBlock(block: JsonBlock): block is JsonDividerBlock {
+  return block.type === 'divider';
 }
 
 /**

--- a/src/validation/json-guide-format-docs.test.ts
+++ b/src/validation/json-guide-format-docs.test.ts
@@ -18,7 +18,7 @@ const DOC_PATH = path.resolve(__dirname, '../..', DOC_RELATIVE_PATH);
 const SUMMARY_HEADING = '### Block Types Summary';
 
 /** Bump deliberately: a short count means the union shrank or Zod's internals moved. */
-const EXPECTED_BLOCK_TYPE_COUNT = 20;
+const EXPECTED_BLOCK_TYPE_COUNT = 21;
 
 function unwrap(schema: any): any {
   const inner = schema?._zod?.def?.innerType;

--- a/src/validation/type-coupling.test.ts
+++ b/src/validation/type-coupling.test.ts
@@ -11,6 +11,7 @@ import {
   JsonSectionBlockSchema,
   JsonCollapsibleBlockSchema,
   JsonCalloutBlockSchema,
+  JsonDividerBlockSchema,
   PresentationalBlockSchema,
   JsonQuizBlockSchema,
   JsonAssistantBlockSchema,
@@ -154,6 +155,10 @@ describe('KNOWN_FIELDS sync', () => {
     verifyFields(JsonCalloutBlockSchema, 'callout');
   });
 
+  it('should match divider schema fields', () => {
+    verifyFields(JsonDividerBlockSchema, 'divider');
+  });
+
   // Drift guard: PresentationalBlockSchema (collapsible children) and the
   // PresentationalBlock type must list the same block types. If the union
   // gains/loses a member on one side only, one of these assertions fails.
@@ -165,6 +170,7 @@ describe('KNOWN_FIELDS sync', () => {
         { type: 'image', src: 'https://example.com/x.png' },
         { type: 'video', src: 'https://example.com/x.mp4', provider: 'native' },
         { type: 'callout', title: 'Objective', content: 'x' },
+        { type: 'divider' },
       ];
       for (const block of accepted) {
         expect(PresentationalBlockSchema.safeParse(block).success).toBe(true);

--- a/src/validation/validate-guide.test.ts
+++ b/src/validation/validate-guide.test.ts
@@ -40,6 +40,7 @@ describe('JsonGuideSchema', () => {
           { type: 'html', content: '<p>HTML</p>' },
           { type: 'image', src: 'https://example.com/img.png' },
           { type: 'video', src: 'https://youtube.com/watch?v=abc' },
+          { type: 'divider' },
           {
             type: 'interactive',
             action: 'highlight',


### PR DESCRIPTION
## What this changes

- add a divider guide-block type across the schema, parser, editor, conversion, and statistics paths
- render dividers consistently in guide output and document the new block
- add regression coverage for editing, parsing, conversion, and schema drift

## Testing

- full Jest suite: 477 suites, 7,730 passed, 18 skipped, 5 todo
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

All project commands were run in Docker.

Fixes #825