### PR TITLE
docs: correct exported schema descriptions

### DIFF
--- a/src/cli/__tests__/schema-command.test.ts
+++ b/src/cli/__tests__/schema-command.test.ts
@@ -67,6 +67,16 @@ describe('schema command', () => {
       expect((schema!['x-refinements'] as string[]).length).toBeGreaterThan(0);
     });
 
+    it('exports accurate challenge mode and snippet reference descriptions', () => {
+      const schema = exportSchema('block', false);
+      const serialized = JSON.stringify(schema);
+
+      expect(serialized).toContain('Upstream snippet ID, resolved after validation and before render');
+      expect(serialized).toContain("The schema has no default: JSON that omits mode resolves to 'coda' at runtime");
+      expect(serialized).not.toContain('Upstream snippet ID to resolve at parse time');
+      expect(serialized).not.toContain("'coda' (default)");
+    });
+
     it('omits x-refinements for schemas without refinements', () => {
       const schema = exportSchema('repository', false);
       expect(schema).not.toBeNull();

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -645,7 +645,7 @@ export const JsonChallengeBlockSchema = z.object({
     .enum(['coda', 'standard'])
     .optional()
     .describe(
-      "Execution model. 'standard' runs against the learner's own Grafana — successCriteria is any Pathfinder requirement (e.g. has-dashboard-named:Foo). 'coda' (default) runs in a Coda VM with a terminal — successCriteria is typically coda-exit-zero:<command>."
+      "Execution model. 'standard' runs against the learner's own Grafana — successCriteria is any Pathfinder requirement (e.g. has-dashboard-named:Foo). 'coda' runs in a Coda VM with a terminal — successCriteria is typically coda-exit-zero:<command>. The schema has no default: JSON that omits mode resolves to 'coda' at runtime, while the block editor seeds a new block with 'standard'. Set mode explicitly."
     ),
   title: z.string().min(1, 'Challenge title is required').describe('Short title shown above the brief'),
   brief: z.string().min(1, 'Challenge brief is required').describe('Markdown problem statement'),
@@ -826,14 +826,14 @@ const SnippetIdSchema = z
   .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, 'Snippet ID must be kebab-case (lowercase letters, numbers, hyphens)');
 
 /**
- * Schema for snippet reference block. Resolves at parse time — never
- * reaches the renderer.
+ * Schema for snippet reference block. Resolves after validation and before
+ * render, so it never reaches the renderer.
  * @coupling Type: JsonSnippetRefBlock
  */
 export const JsonSnippetRefBlockSchema = z.object({
   type: z.literal('snippet-ref'),
   id: z.string().optional().describe('Stable identifier for this snippet-ref instance'),
-  snippetId: SnippetIdSchema.describe('Upstream snippet ID to resolve at parse time'),
+  snippetId: SnippetIdSchema.describe('Upstream snippet ID, resolved after validation and before render'),
   ...AuthorAnnotatedSchema.shape,
 });
 


### PR DESCRIPTION
## What this changes

- correct misleading descriptions in the exported Pathfinder schema
- keep the generated and runtime schema documentation aligned
- add regression coverage so the corrected descriptions cannot silently drift

## Testing

- focused CLI and schema suites (30 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

All project commands were run in Docker.

Fixes #1545