### PR TITLE
docs(agents): add the self-governance section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,3 +125,13 @@ Keep this file for knowledge useful to almost every future agent session in this
 Do not repeat what the codebase already shows; point to the authoritative file or command instead.
 Prefer rewriting or pruning existing entries over appending new ones.
 When updating this file, preserve this bar for all agents and keep entries concise.
+
+Two exceptions, both enforced elsewhere:
+
+- The tier list under "Frontend tier model" is a deliberate repetition of `TIER_MAP` in
+  `src/validation/import-graph.ts`. `src/validation/architecture.test.ts` fails when the two
+  disagree, so keep that list in sync rather than replacing it with a pointer.
+- The section headings are addressable. `.cursor/skills/prevent-doc-drift/SKILL.md` decides where to
+  write by heading name — "Essential commands", "Frontend tier model", "Backend (`pkg/`)" and
+  "On-demand context" — so renaming or removing one of those means updating that skill in the same
+  change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,10 @@ Use `/create-experiment`. Experiments are remote-configured through MTFF, alloca
 ## `npx` examples
 
 Namespace every `npx` example under `pathfinder-cli@...` — for a hypothetical `pathfinder-example` package, write `npx pathfinder-cli@... example`. This keeps us from being namesquatted.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.


### PR DESCRIPTION
## What this adds

A "maintaining this file" section to `AGENTS.md`, setting the bar for what belongs in it: knowledge
useful to almost every agent session, pointers rather than restatements of what the code already
shows, and rewriting existing entries in preference to appending new ones.

This was originally committed alongside the auth fix in #1700. It is unrelated to that change — it
is a standing instruction to every future agent session, and an auth reviewer is not the right
person to judge it — so it has been reverted out of that PR and moved here.

## The two exceptions, and why they are in the text

Two of the rules contradict something this repository already enforces. Rather than soften the
rules, each carries its exception where the rule is:

- **"Do not repeat what the codebase already shows."** The tier list under "Frontend tier model" is
  a deliberate repetition of `TIER_MAP` in `src/validation/import-graph.ts`, and
  `src/validation/architecture.test.ts` fails when the two disagree. An agent that followed the rule
  literally and replaced that list with a pointer would break the build.
- **"Prefer rewriting or pruning existing entries over appending new ones."**
  `.cursor/skills/prevent-doc-drift/SKILL.md` decides where to write by heading name. Four of this
  file's headings — "Essential commands", "Frontend tier model", "Backend (`pkg/`)" and "On-demand
  context" — are addressable that way, so renaming or removing one silently breaks that skill.

## What to look at

Whether the bar itself is the one we want, since every future agent session reads it. The exceptions
are mechanical; the four lines above them are the judgement call.

## How to verify

`npx jest src/validation` — the tier-documentation sync test is the one the first exception is about.

## Breaking changes

None. Documentation only.

## Reversibility

Fully reversible; a revert removes the section.
