### PR TITLE
skill:maintain-docs refresh guide authoring entry point

### DIFF
--- a/docs/_maintenance-backlog.md
+++ b/docs/_maintenance-backlog.md
@@ -12,6 +12,7 @@ Persistent tracker for the maintain-docs skill's persistent state across runs.
 
 <!-- Docs checked against source and found accurate. Format: date, doc path. Update date on re-validation. -->
 
+- **2026-08-26**: `docs/developer/interactive-examples/authoring-interactive-journeys.md` — Corrected the authoring entry points, public-repository scope, action versus block types, and optional-manifest package model. Validated against the current JSON guide schemas and types, package/custom-guide/API references, block-editor workflow, and external contributor README.
 - **2026-08-12**: `docs/developer/RELEASE_PROCESS.md` — Corrected dev deployment, CLI publish triggers, runtime dependencies, MCP smoke testing, Node base-image guidance, and plugin-tarball isolation. Validated against current release/publish workflows, `Dockerfile.cli`, `scripts/cli-build-utils.js`, and package scripts.
 - **2026-08-19**: `docs/developer/learning-paths/README.md` — Revalidated after the private-path split and Discover more launch changes. Documented private-path routing, schema-validated manifest propagation, and the lazy package-resolver registry lifecycle. Supersedes the 2026-08-12 entry.
 - **2026-08-19**: `.cursor/rules/systemPatterns.mdc` — Corrected the composite resolver chain and documented lazy package-resolver registration plus the published-only App Platform bare-ID gate. Validated against the current package engine, resolver registry, and plugin initialization. Supersedes the 2026-06-16 entry.

--- a/docs/developer/interactive-examples/authoring-interactive-journeys.md
+++ b/docs/developer/interactive-examples/authoring-interactive-journeys.md
@@ -1,25 +1,31 @@
 # Authoring interactive guides
 
-This page is the starting point for creating interactive tutorials in Grafana Pathfinder. It links to the external guide repository and to the detailed reference docs in this directory.
+This page is the starting point for creating interactive guides in Grafana Pathfinder. Choose an authoring workflow below, then use the reference docs for the guide and package formats.
+
+## Choose an authoring workflow
+
+- **Publish a guide to a Grafana stack:** Use the Pathfinder block editor, then save the guide as a draft and publish it. See the [block editor authoring guide](../../sources/block-editor/_index.md) for the UI workflow and [Custom guides](../CUSTOM_GUIDES.md) for the storage and lifecycle details.
+- **Contribute a public guide:** Use the block editor to create and preview the content, then follow the contribution workflow in the [`grafana/interactive-tutorials` README](https://github.com/grafana/interactive-tutorials/blob/main/README.md). Use [Package authoring](../package-authoring.md) when adding package metadata or composing a learning path or journey.
+- **Import guides through automation:** See [Custom guides](../CUSTOM_GUIDES.md#external-import-ci--terraform--scripts) for single-guide and learning-path upload scripts, or [External API](../EXTERNAL_API.md) for the API contract.
 
 ## External repository
 
-There is a public GitHub repository at [https://github.com/grafana/interactive-tutorials](https://github.com/grafana/interactive-tutorials) where all interactive guides are maintained. Use existing guides for inspiration and to extrapolate common patterns.
+The public [`grafana/interactive-tutorials`](https://github.com/grafana/interactive-tutorials) repository contains shared interactive learning packages. Use existing guides for examples, but validate formats and supported behavior against the references below.
 
-The [README.md](https://github.com/grafana/interactive-tutorials/blob/main/README.md) in that repo contains best practices and workflow recommendations for authoring your own interactive journeys.
+Its [README](https://github.com/grafana/interactive-tutorials/blob/main/README.md) documents the contributor setup, block editor workflow, preview options, and PR process.
 
 ## Reference docs
 
-The following reference docs cover every aspect of the guide format and interactive system:
+The following docs are the primary authoring references:
 
-| Document                                              | What it covers                                                                                                                                                   |
-| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [JSON guide format](./json-guide-format.md)           | Complete schema reference for JSON guides — blocks, interactive elements, sections, sequences, conditionals, quizzes, and metadata                               |
-| [Interactive types](./interactive-types.md)           | Supported action types (`highlight`, `button`, `formfill`, `navigate`, `hover`, `guided`, `noop`, `sequence`), Show vs Do behavior, and `reftarget` expectations |
-| [Selectors reference](./selectors-reference.md)       | How to target DOM elements — selector priority, `grafana:` prefix resolution, pseudo-selectors, and debugging techniques                                         |
-| [Requirements reference](./requirements-reference.md) | Pre-condition and post-condition system — requirement types, validation flow, `canFix` behavior, and the requirements manager                                    |
-| [Guided interactions](./guided-interactions.md)       | User-performed action mode — when to use guided blocks, completion detection, cancel/skip behavior, and multi-step guided sequences                              |
-| [Package authoring](../package-authoring.md)          | Two-file package model — `content.json` + `manifest.json` field reference, dependency syntax, targeting, templates, and repository index                         |
+| Document                                              | What it covers                                                                                                                                                                        |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [JSON guide format](./json-guide-format.md)           | Complete block schema reference for content, interactive steps, containers, assessments, inputs, and specialized blocks                                                               |
+| [Interactive types](./interactive-types.md)           | Supported action types (`highlight`, `button`, `formfill`, `navigate`, `hover`, `noop`, `popout`), `multistep` and `guided` blocks, Show vs Do behavior, and `reftarget` expectations |
+| [Selectors reference](./selectors-reference.md)       | How to target DOM elements — selector priority, `grafana:` prefix resolution, pseudo-selectors, and debugging techniques                                                              |
+| [Requirements reference](./requirements-reference.md) | Pre-condition and post-condition system — requirement types, validation flow, `canFix` behavior, and the requirements manager                                                         |
+| [Guided interactions](./guided-interactions.md)       | User-performed action mode — when to use guided blocks, completion detection, cancel/skip behavior, and multi-step guided sequences                                                   |
+| [Package authoring](../package-authoring.md)          | Package directory model — required `content.json`, optional `manifest.json` and assets, guide/path/journey metadata, dependencies, targeting, templates, and repository indexes       |
 
 ## Related engine docs
 
@@ -28,4 +34,4 @@ The following reference docs cover every aspect of the guide format and interact
 
 ## Agent rules
 
-For prescriptive constraints when authoring guides, see `.cursor/rules/interactiveRequirements.mdc`.
+For prescriptive constraints when authoring guides, see [interactive requirements](../../../.cursor/rules/interactiveRequirements.mdc).


### PR DESCRIPTION
## Summary

Documentation maintenance run — 2026-08-26.

### Changes made

- Correct the interactive-guide authoring entry point to distinguish stack publishing, public contributions, and API-based imports.
- Replace stale action and package summaries with the current action/block taxonomy and optional-manifest package model.
- Record the completed validation in the maintenance backlog.

### Full audit findings

| Priority | Finding | Status |
| -------- | ------- | ------ |
| HIGH | The interactive-guide authoring entry point incorrectly said all guides live in the public repository and described stale action/package contracts. | Fixed in this PR |
| MEDIUM | Recent release, MCP, block-editor, experiment, backend, schema, and learning-path changes already include matching documentation updates. | No action needed |
| LOW | No broken indexed paths or new operational-document orphans were found. | No action needed |

### Recommendations for separate work

- The existing snippet-engine concern-routing backlog item remains blocked on human review because `docs/design/` is outside this skill's scope.

### Validation checklist

- [x] All changed files are `.md` or `.mdc` (verified via `git diff --name-only`)
- [x] Phase 2.5 verification passed (sub-agent output reviewed)
- [x] `npm run prettier` passed using the repository-pinned Prettier 3.9.6 binary from the primary clone
- [x] No source code files were modified
- [x] `git diff --check` passed
- [x] All added local links and the section anchor resolve
