### PR TITLE
chore: add repository-owned community PR gate binding

### DIFF
--- a/.github/community-pr-gate.json
+++ b/.github/community-pr-gate.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "repository": "grafana/grafana-pathfinder-app",
+  "internal_author_policy": "explicit_internal_handles",
+  "ci_config_prefix": ".github/",
+  "cla": {
+    "context": "license/cla",
+    "signed_description": "Contributor License Agreement is signed.",
+    "not_signed_description": "Contributor License Agreement is not signed yet."
+  },
+  "scanner": {
+    "minimum_blocking_severity": "High"
+  },
+  "review_skill": ".cursor/skills/review/SKILL.md",
+  "review_policy": "docs/design/PR_REVIEW.md",
+  "contributor_guide": "https://github.com/grafana/grafana-pathfinder-app/blob/main/CONTRIBUTING.md",
+  "internal_handles": [
+    "Jayclifford345",
+    "tomglenn",
+    "leslie-heinzen",
+    "moxious",
+    "Spidy88",
+    "dgehring-grafana"
+  ],
+  "blocker_priority": ["cla", "signing"]
+}

--- a/.github/community-pr-gate.json
+++ b/.github/community-pr-gate.json
@@ -14,13 +14,6 @@
   "review_skill": ".cursor/skills/review/SKILL.md",
   "review_policy": "docs/design/PR_REVIEW.md",
   "contributor_guide": "https://github.com/grafana/grafana-pathfinder-app/blob/main/CONTRIBUTING.md",
-  "internal_handles": [
-    "Jayclifford345",
-    "tomglenn",
-    "leslie-heinzen",
-    "moxious",
-    "Spidy88",
-    "dgehring-grafana"
-  ],
+  "internal_handles": ["Jayclifford345", "tomglenn", "leslie-heinzen", "moxious", "Spidy88", "dgehring-grafana"],
   "blocker_priority": ["cla", "signing"]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,8 @@ When the review skill's contract-evolution gate fires for an existing capability
 
 Use `/review`. For Go PRs touching `pkg/**/*.go`, also verify `npm run lint:go`, `npm run test:go`, and `go build ./...` pass.
 
+A PR whose author is not listed in `.github/community-pr-gate.json` goes through the community PR gate before review; that binding's handle list decides who bypasses the gate, and it is authoritative even where `.github/CODEOWNERS` differs.
+
 `docs/design/CONCERNS.md` is useful on its own — without a review — for impact analysis, change risk classification, and subsystem-aware debugging.
 
 ## Tech-debt audits


### PR DESCRIPTION
## Summary

Add the repository-owned binding for the community PR gate. The binding makes the explicit six-person internal core-team list authoritative regardless of CODEOWNERS; every other author goes through the zizmor-first community gate.

## What to look at

- [Community PR gate binding](https://github.com/grafana/grafana-pathfinder-app/blob/f19c8ff8e861467ceb02d48a53e556a505a6bd16/.github/community-pr-gate.json) — verify the six canonical GitHub handles, High-severity scanner threshold, CLA and signing priority, and repository review pointers.
- [Agent guidance](https://github.com/grafana/grafana-pathfinder-app/blob/f19c8ff8e861467ceb02d48a53e556a505a6bd16/AGENTS.md) — verify that the binding's explicit handle list, rather than CODEOWNERS, controls the bypass.

## How to verify

1. Run `python3 ~/.claude/skills/community-pr/scripts/community_pr_gate.py validate-binding .github/community-pr-gate.json` and confirm it reports `status: valid`.
2. Confirm each listed handle resolves to the intended core-team account and that an unlisted author remains subject to the community gate.

## Breaking changes

None. This change is additive and fully reversible.

## Out of scope

- Bot authors are not treated as internal. They remain subject to the community gate, and unfamiliar CLA status descriptions continue to fail closed until their issuing integration can be authenticated without relying on spoofable text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
