### PR TITLE
fix(docs-retrieval): resolve packageInfo for backend-guide: deep links

### DIFF
--- a/src/docs-retrieval/package-content.test.ts
+++ b/src/docs-retrieval/package-content.test.ts
@@ -953,19 +953,21 @@ describe('fetchPackageContent path-type enrichment', () => {
     }
   });
 
-  it('degrades baseUrl gracefully when the manifest id no longer resolves (e.g. a renamed guide)', async () => {
-    // manifest.id feeds the baseUrl-hydration resolve() call below. If it no
-    // longer matches any resolvable resource — the exact shape a resource-name
-    // vs. spec.id divergence produces after app-platform-resolver.ts's
-    // buildManifest fix — that resolve() call fails (`ok: false`), and
-    // learningJourney.baseUrl must fall back to the milestone's own contentUrl
-    // rather than throwing or leaving baseUrl undefined.
+  it('hydrates baseUrl by resolving manifest.id in URL-only mode, which never verifies (matches AppPlatformPackageResolver)', async () => {
+    // AppPlatformPackageResolver's URL-only mode (no verifyPublished) never
+    // probes the upstream resource — it just string-templates the id it's
+    // given into a contentUrl and returns ok: true unconditionally (see
+    // fetchPackageById's "its id is already known-good" comment). This mock
+    // matches that contract: it always succeeds, so correctness here depends
+    // entirely on manifest.id already being the resource-addressable one —
+    // which app-platform-resolver.ts's buildManifest guarantees for
+    // path/journey manifests regardless of a drifted spec.id (pinned in
+    // app-platform-resolver.test.ts). A resolver mock that returns `ok: false`
+    // for a "wrong" id would misrepresent that contract (Cursor Bugbot flagged
+    // exactly this on an earlier version of this test).
     const resolver: PackageResolver = {
-      resolve: jest.fn().mockImplementation((id: string) => {
-        if (id === 'renamed-path-id') {
-          return Promise.resolve({ ok: false, id, error: { code: 'not-found', message: 'renamed' } });
-        }
-        return Promise.resolve({
+      resolve: jest.fn().mockImplementation((id: string) =>
+        Promise.resolve({
           ok: true,
           id,
           contentUrl: `bundled:${id}/content.json`,
@@ -973,13 +975,13 @@ describe('fetchPackageContent path-type enrichment', () => {
           repository: 'bundled',
           content: { id, title: `Milestone: ${id}`, blocks: [] },
           manifest: { id, type: 'guide' },
-        });
-      }),
+        })
+      ),
     };
     setPackageResolver(resolver);
 
     const manifest = {
-      id: 'renamed-path-id',
+      id: 'the-real-resource-name',
       type: 'path',
       milestones: ['first-dashboard'],
     };
@@ -987,7 +989,8 @@ describe('fetchPackageContent path-type enrichment', () => {
     const result = await fetchPackageContent('bundled:first-dashboard/content.json', manifest);
 
     expect(result.content).toBeTruthy();
-    expect(result.content?.metadata.learningJourney?.baseUrl).toBe('bundled:first-dashboard/content.json');
+    expect(result.content?.metadata.learningJourney?.baseUrl).toBe('bundled:the-real-resource-name/content.json');
+    expect(resolver.resolve).toHaveBeenCalledWith('the-real-resource-name', { loadContent: false });
   });
 });
 

--- a/src/docs-retrieval/package-content.test.ts
+++ b/src/docs-retrieval/package-content.test.ts
@@ -952,6 +952,43 @@ describe('fetchPackageContent path-type enrichment', () => {
       expect(result.content.metadata.learningJourney).toBeDefined();
     }
   });
+
+  it('degrades baseUrl gracefully when the manifest id no longer resolves (e.g. a renamed guide)', async () => {
+    // manifest.id feeds the baseUrl-hydration resolve() call below. If it no
+    // longer matches any resolvable resource — the exact shape a resource-name
+    // vs. spec.id divergence produces after app-platform-resolver.ts's
+    // buildManifest fix — that resolve() call fails (`ok: false`), and
+    // learningJourney.baseUrl must fall back to the milestone's own contentUrl
+    // rather than throwing or leaving baseUrl undefined.
+    const resolver: PackageResolver = {
+      resolve: jest.fn().mockImplementation((id: string) => {
+        if (id === 'renamed-path-id') {
+          return Promise.resolve({ ok: false, id, error: { code: 'not-found', message: 'renamed' } });
+        }
+        return Promise.resolve({
+          ok: true,
+          id,
+          contentUrl: `bundled:${id}/content.json`,
+          manifestUrl: `bundled:${id}/manifest.json`,
+          repository: 'bundled',
+          content: { id, title: `Milestone: ${id}`, blocks: [] },
+          manifest: { id, type: 'guide' },
+        });
+      }),
+    };
+    setPackageResolver(resolver);
+
+    const manifest = {
+      id: 'renamed-path-id',
+      type: 'path',
+      milestones: ['first-dashboard'],
+    };
+
+    const result = await fetchPackageContent('bundled:first-dashboard/content.json', manifest);
+
+    expect(result.content).toBeTruthy();
+    expect(result.content?.metadata.learningJourney?.baseUrl).toBe('bundled:first-dashboard/content.json');
+  });
 });
 
 // The realistically-broken catalogue inputs: the CR manifest leaves

--- a/src/docs-retrieval/package-info-from-url.test.ts
+++ b/src/docs-retrieval/package-info-from-url.test.ts
@@ -1,0 +1,93 @@
+import { getPackageResolver } from './content-fetcher/package-resolver-registry';
+import type { PackageResolver, PackageResolution } from '../types';
+
+jest.mock('./content-fetcher/package-resolver-registry', () => ({
+  getPackageResolver: jest.fn(),
+}));
+
+// Imported after the mock so the module under test picks up the mocked registry.
+import { fetchPackageInfoFromUrl, isPackageContentUrl } from './package-info-from-url';
+
+const mockedGetPackageResolver = getPackageResolver as jest.MockedFunction<typeof getPackageResolver>;
+
+function makeResolver(resolution: PackageResolution): PackageResolver {
+  return {
+    resolve: jest.fn().mockResolvedValue(resolution),
+  };
+}
+
+beforeEach(() => {
+  mockedGetPackageResolver.mockReset();
+});
+
+describe('isPackageContentUrl', () => {
+  it('matches interactive-learning package content URLs', () => {
+    expect(isPackageContentUrl('https://interactive-learning.grafana.net/packages/foo/content.json')).toBe(true);
+  });
+
+  it('matches backend-guide: URLs with a non-empty id', () => {
+    expect(isPackageContentUrl('backend-guide:grafana-foundations-lp')).toBe(true);
+  });
+
+  it('rejects a bare backend-guide: prefix with no id', () => {
+    expect(isPackageContentUrl('backend-guide:')).toBe(false);
+    expect(isPackageContentUrl('backend-guide:   ')).toBe(false);
+  });
+
+  it('rejects unrelated URLs', () => {
+    expect(isPackageContentUrl('https://example.com/docs/foo')).toBe(false);
+    expect(isPackageContentUrl('api:some-id')).toBe(false);
+  });
+});
+
+describe('fetchPackageInfoFromUrl — backend-guide: scheme', () => {
+  it('resolves packageInfo via the shared PackageResolver, metadata-only', async () => {
+    const resolution: PackageResolution = {
+      ok: true,
+      id: 'grafana-foundations-lp',
+      contentUrl: 'backend-guide:grafana-foundations-lp',
+      manifestUrl: 'app-platform:default/grafana-foundations-lp',
+      repository: 'app-platform',
+      manifest: { id: 'grafana-foundations-lp', type: 'path', repository: 'app-platform' } as any,
+    };
+    const resolver = makeResolver(resolution);
+    mockedGetPackageResolver.mockResolvedValue(resolver);
+
+    const info = await fetchPackageInfoFromUrl('backend-guide:grafana-foundations-lp');
+
+    expect(resolver.resolve).toHaveBeenCalledWith('grafana-foundations-lp', { loadContent: 'metadata-only' });
+    expect(info).toEqual({
+      packageId: 'grafana-foundations-lp',
+      packageManifest: { id: 'grafana-foundations-lp', type: 'path', repository: 'app-platform' },
+      repository: 'app-platform',
+    });
+  });
+
+  it('returns undefined when the resolver declines (not found / not published)', async () => {
+    mockedGetPackageResolver.mockResolvedValue(
+      makeResolver({ ok: false, id: 'missing', error: { code: 'not-found', message: 'nope' } })
+    );
+
+    const info = await fetchPackageInfoFromUrl('backend-guide:missing');
+
+    expect(info).toBeUndefined();
+  });
+
+  it('returns undefined when no resolver is configured', async () => {
+    mockedGetPackageResolver.mockResolvedValue(undefined);
+
+    const info = await fetchPackageInfoFromUrl('backend-guide:whatever');
+
+    expect(info).toBeUndefined();
+  });
+
+  it('returns undefined for a bare backend-guide: URL with no id, without calling the resolver', async () => {
+    const resolver = makeResolver({ ok: false, id: '', error: { code: 'not-found', message: '' } });
+    mockedGetPackageResolver.mockResolvedValue(resolver);
+
+    const info = await fetchPackageInfoFromUrl('backend-guide:');
+
+    expect(info).toBeUndefined();
+    expect(resolver.resolve).not.toHaveBeenCalled();
+  });
+});

--- a/src/docs-retrieval/package-info-from-url.ts
+++ b/src/docs-retrieval/package-info-from-url.ts
@@ -8,24 +8,68 @@
  * milestone toolbar — see context-panel.tsx ("All packages route through
  * openDocsPage because it handles packageInfo").
  *
- * Pattern matched: `https://interactive-learning.grafana.{net,-dev.net}/packages/<id>/content.json`.
- * The sibling `manifest.json` is fetched and parsed with the loose
- * `ManifestJsonObjectSchema` (no cross-field refinement) so partially-spec
- * manifests still yield enough metadata for routing.
+ * Two URL shapes are recognized:
+ * - `https://interactive-learning.grafana.{net,-dev.net}/packages/<id>/content.json`
+ *   — the sibling `manifest.json` is fetched directly and parsed with the loose
+ *   `ManifestJsonObjectSchema` (no cross-field refinement) so partially-spec
+ *   manifests still yield enough metadata for routing.
+ * - `backend-guide:<id>` — App Platform custom guides. There is no sibling
+ *   manifest URL to fetch; the manifest is resolved metadata-only through the
+ *   shared PackageResolver (same call `resolvePackageMilestones` uses), which
+ *   ultimately reaches `AppPlatformPackageResolver`.
  */
 import { isInteractiveLearningUrl } from '../security';
 import type { PackageOpenInfo } from '../types/content-panel.types';
 import { ManifestJsonObjectSchema } from '../types/package.schema';
 import { DEFAULT_CONTENT_FETCH_TIMEOUT } from '../constants';
+import { getPackageResolver } from './content-fetcher/package-resolver-registry';
 
 const PACKAGE_CONTENT_URL_PATTERN = /\/packages\/([^/]+)\/content\.json(?:[?#].*)?$/;
+const BACKEND_GUIDE_URL_PREFIX = 'backend-guide:';
 
 /** True if the URL is shaped like an interactive-learning package content URL. */
-export function isPackageContentUrl(url: string): boolean {
-  if (!isInteractiveLearningUrl(url)) {
-    return false;
+function isInteractiveLearningPackageUrl(url: string): boolean {
+  return isInteractiveLearningUrl(url) && PACKAGE_CONTENT_URL_PATTERN.test(url);
+}
+
+/** Extracts the bare package id from a `backend-guide:<id>` URL, or undefined if not that scheme. */
+function extractBackendGuideId(url: string): string | undefined {
+  if (!url.startsWith(BACKEND_GUIDE_URL_PREFIX)) {
+    return undefined;
   }
-  return PACKAGE_CONTENT_URL_PATTERN.test(url);
+  const id = url.slice(BACKEND_GUIDE_URL_PREFIX.length).trim();
+  return id.length > 0 ? id : undefined;
+}
+
+/** True if the URL is a package-content URL this module can resolve packageInfo for. */
+export function isPackageContentUrl(url: string): boolean {
+  return isInteractiveLearningPackageUrl(url) || extractBackendGuideId(url) !== undefined;
+}
+
+/**
+ * Resolve packageInfo for a `backend-guide:<id>` URL via the shared
+ * PackageResolver, metadata-only (no content fetch). Mirrors the
+ * resolution → field mapping `resolvePackageMilestones`/`resolvePackageNavLinks`
+ * already use in package-content.ts, just shaped as PackageOpenInfo.
+ */
+async function fetchAppPlatformPackageInfo(packageId: string): Promise<PackageOpenInfo | undefined> {
+  const resolver = await getPackageResolver();
+  if (!resolver) {
+    return undefined;
+  }
+  try {
+    const resolution = await resolver.resolve(packageId, { loadContent: 'metadata-only' });
+    if (!resolution.ok) {
+      return undefined;
+    }
+    return {
+      packageId: resolution.id,
+      packageManifest: resolution.manifest as unknown as Record<string, unknown> | undefined,
+      repository: resolution.repository,
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 function deriveManifestUrl(contentUrl: string): string | undefined {
@@ -41,7 +85,12 @@ function deriveManifestUrl(contentUrl: string): string | undefined {
  * — callers fall back to the legacy plain-fetch path in those cases.
  */
 export async function fetchPackageInfoFromUrl(url: string): Promise<PackageOpenInfo | undefined> {
-  if (!isPackageContentUrl(url)) {
+  const backendGuideId = extractBackendGuideId(url);
+  if (backendGuideId) {
+    return fetchAppPlatformPackageInfo(backendGuideId);
+  }
+
+  if (!isInteractiveLearningPackageUrl(url)) {
     return undefined;
   }
   const manifestUrl = deriveManifestUrl(url);

--- a/src/package-engine/app-platform-resolver.test.ts
+++ b/src/package-engine/app-platform-resolver.test.ts
@@ -237,6 +237,19 @@ describe('AppPlatformPackageResolver — metadata-only', () => {
     });
   });
 
+  it('prefers spec.id over the resolve() input in the inferred (no spec.manifest) branch too', async () => {
+    mockFetch.mockReturnValue(of(okResource({ id: 'renamed-guide-id' })));
+
+    const resolver = new AppPlatformPackageResolver();
+    const result = await resolver.resolve('legacy-resource-name', { loadContent: 'metadata-only' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.manifest?.id).toBe('renamed-guide-id');
+  });
+
   // The loader in docs-retrieval synthesizes a manifest for the same resource shape. If only one of
   // the two filled in a description, a reader would see a different shape depending on which entry
   // point opened the guide.
@@ -405,8 +418,42 @@ describe('AppPlatformPackageResolver — full content', () => {
     expect(result.error.code).toBe('not-found');
   });
 
-  it('does not let a persisted spec.manifest.id override the resolved packageId', async () => {
+  it('does not let a persisted spec.manifest.id override the resource\'s own declared identity', async () => {
     mockFetch.mockReturnValue(of(okResource({ manifest: { type: 'guide', id: 'some-other-id' } })));
+    const resolver = new AppPlatformPackageResolver();
+
+    const result = await resolver.resolve('fe-alerting-01', { loadContent: 'metadata-only' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.manifest?.id).toBe('fe-alerting-01');
+  });
+
+  it('prefers spec.id over the resolve() input when a guide was renamed after its resource name was set', async () => {
+    // packageId ('legacy-resource-name') is the immutable k8s resource name a
+    // guide was created under; spec.id ('renamed-guide-id') is the author's
+    // current, editable guide id. buildLoaderManifest (docs-retrieval's
+    // backend-guide.ts) has always preferred spec.id for this same resource
+    // shape — this pins the two builders agreeing, so completion identity
+    // doesn't drift depending on which one happened to run.
+    mockFetch.mockReturnValue(
+      of(okResource({ id: 'renamed-guide-id', manifest: { type: 'guide' } }))
+    );
+    const resolver = new AppPlatformPackageResolver();
+
+    const result = await resolver.resolve('legacy-resource-name', { loadContent: 'metadata-only' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.manifest?.id).toBe('renamed-guide-id');
+  });
+
+  it('falls back to the resolve() input when the resource carries no spec.id of its own', async () => {
+    mockFetch.mockReturnValue(of(okResource({ id: undefined, manifest: { type: 'guide' } })));
     const resolver = new AppPlatformPackageResolver();
 
     const result = await resolver.resolve('fe-alerting-01', { loadContent: 'metadata-only' });

--- a/src/package-engine/app-platform-resolver.test.ts
+++ b/src/package-engine/app-platform-resolver.test.ts
@@ -418,7 +418,7 @@ describe('AppPlatformPackageResolver — full content', () => {
     expect(result.error.code).toBe('not-found');
   });
 
-  it('does not let a persisted spec.manifest.id override the resource\'s own declared identity', async () => {
+  it("does not let a persisted spec.manifest.id override the resource's own declared identity", async () => {
     mockFetch.mockReturnValue(of(okResource({ manifest: { type: 'guide', id: 'some-other-id' } })));
     const resolver = new AppPlatformPackageResolver();
 
@@ -438,9 +438,7 @@ describe('AppPlatformPackageResolver — full content', () => {
     // backend-guide.ts) has always preferred spec.id for this same resource
     // shape — this pins the two builders agreeing, so completion identity
     // doesn't drift depending on which one happened to run.
-    mockFetch.mockReturnValue(
-      of(okResource({ id: 'renamed-guide-id', manifest: { type: 'guide' } }))
-    );
+    mockFetch.mockReturnValue(of(okResource({ id: 'renamed-guide-id', manifest: { type: 'guide' } })));
     const resolver = new AppPlatformPackageResolver();
 
     const result = await resolver.resolve('legacy-resource-name', { loadContent: 'metadata-only' });

--- a/src/package-engine/app-platform-resolver.test.ts
+++ b/src/package-engine/app-platform-resolver.test.ts
@@ -463,6 +463,41 @@ describe('AppPlatformPackageResolver — full content', () => {
     expect(result.manifest?.id).toBe('fe-alerting-01');
   });
 
+  it('keeps the resolve() input as id for a path/journey manifest, even when spec.id has drifted', async () => {
+    // A path/journey's id must stay resource-name-equal: fetchPackageContent's
+    // baseUrl-hydration re-resolves it in URL-only mode, which never verifies
+    // — it only string-templates `backend-guide:<id>` — on the documented
+    // assumption that the id is "already known-good" (fetchPackageById's own
+    // comment). A drifted spec.id would silently produce an unfetchable URL.
+    // This is the one case where a plain guide's spec.id preference does not
+    // apply (Cursor Bugbot flagged this on the guide-preference commit).
+    mockFetch.mockReturnValue(
+      of(okResource({ id: 'renamed-path-id', manifest: { type: 'path', milestones: ['m1'] } }))
+    );
+    const resolver = new AppPlatformPackageResolver();
+
+    const result = await resolver.resolve('legacy-resource-name', { loadContent: 'metadata-only' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.manifest?.id).toBe('legacy-resource-name');
+  });
+
+  it('keeps the resolve() input as id for a journey manifest too', async () => {
+    mockFetch.mockReturnValue(of(okResource({ id: 'renamed-journey-id', manifest: { type: 'journey' } })));
+    const resolver = new AppPlatformPackageResolver();
+
+    const result = await resolver.resolve('legacy-resource-name', { loadContent: 'metadata-only' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.manifest?.id).toBe('legacy-resource-name');
+  });
+
   it('overwrites a persisted spec.manifest.repository pointing at the public CDN', async () => {
     mockFetch.mockReturnValue(of(okResource({ manifest: { type: 'guide', repository: 'interactive-tutorials' } })));
     const resolver = new AppPlatformPackageResolver();

--- a/src/package-engine/app-platform-resolver.ts
+++ b/src/package-engine/app-platform-resolver.ts
@@ -148,6 +148,17 @@ async function probePublishedGuide(namespace: string, packageId: string): Promis
  * present, otherwise an inferred `{ id, type: 'guide', repository: 'app-platform' }`
  * so legacy content-only guides stay loadable with no migration event (RFC §6.5).
  *
+ * `id` prefers `spec.id` over `packageId` (the resource name used to address
+ * this fetch) so this builder agrees with `buildLoaderManifest` in
+ * docs-retrieval's `backend-guide.ts` — the other manifest-builder for the
+ * same resource shape, which has always preferred `spec.id`. `spec.id` tracks
+ * an author's live guide id and can drift from the immutable resource name
+ * after a rename; before either builder's output reached a completion record
+ * for this scheme, the two disagreeing was dormant. `packageId` remains the
+ * fallback for legacy resources with no `spec.id` of their own, and a stray
+ * `spec.manifest.id` still never wins — it's overwritten by `id` below either
+ * way.
+ *
  * spec.title is mapped into the inferred manifest's `description` — milestone
  * resolution runs metadata-only (no `content`), so the label chain
  * (`content?.title ?? manifest?.description ?? id`) would otherwise fall back
@@ -164,17 +175,20 @@ async function probePublishedGuide(namespace: string, packageId: string): Promis
  * masquerade as authored data.
  */
 function buildManifest(packageId: string, spec: InteractiveGuideResource['spec']): ManifestJson {
+  const resolvedId = spec?.id || packageId;
+
   if (spec?.manifest) {
     // Spread the persisted manifest first, then force BOTH id and repository
-    // last. id: a stray spec.manifest.id must not override the package being
-    // resolved. repository: the CR shape leaves it optional and the schema
-    // defaults it to the public CDN ('interactive-tutorials'); an App Platform
-    // guide is always app-platform-sourced, and `repository` is the sole input
-    // to the durable completion key (guideSource, completion-identity.ts), so a
-    // missing value would mislabel a private guide's provenance.
+    // last. id: a stray spec.manifest.id must not override the resource's own
+    // declared identity (resolvedId). repository: the CR shape leaves it
+    // optional and the schema defaults it to the public CDN
+    // ('interactive-tutorials'); an App Platform guide is always
+    // app-platform-sourced, and `repository` is the sole input to the durable
+    // completion key (guideSource, completion-identity.ts), so a missing value
+    // would mislabel a private guide's provenance.
     const parsed = ManifestJsonObjectSchema.loose().safeParse({
       ...spec.manifest,
-      id: packageId,
+      id: resolvedId,
       repository: APP_PLATFORM_REPOSITORY,
     });
     if (parsed.success) {
@@ -196,7 +210,7 @@ function buildManifest(packageId: string, spec: InteractiveGuideResource['spec']
   }
 
   return {
-    id: packageId,
+    id: resolvedId,
     type: 'guide',
     repository: APP_PLATFORM_REPOSITORY,
     description: spec?.title,

--- a/src/package-engine/app-platform-resolver.ts
+++ b/src/package-engine/app-platform-resolver.ts
@@ -154,10 +154,21 @@ async function probePublishedGuide(namespace: string, packageId: string): Promis
  * same resource shape, which has always preferred `spec.id`. `spec.id` tracks
  * an author's live guide id and can drift from the immutable resource name
  * after a rename; before either builder's output reached a completion record
- * for this scheme, the two disagreeing was dormant. `packageId` remains the
- * fallback for legacy resources with no `spec.id` of their own, and a stray
- * `spec.manifest.id` still never wins — it's overwritten by `id` below either
- * way.
+ * for this scheme, the two disagreeing was dormant.
+ *
+ * A path/journey is the one exception: `packageId` wins there regardless of
+ * `spec.id`, because `fetchPackageContent`'s baseUrl-hydration re-resolves
+ * `manifest.id` in URL-only mode on every milestone fetch on the documented
+ * assumption that it's "already known-good" (`fetchPackageById`'s own
+ * comment) — that mode never verifies, it only string-templates
+ * `backend-guide:<id>`, so a drifted `spec.id` would silently reconstruct a
+ * `backend-guide:` URL the loader can't actually fetch (it addresses
+ * resources by name, not by this author-editable id). A plain guide has no
+ * such consumer.
+ *
+ * `packageId` remains the fallback for legacy resources with no `spec.id` of
+ * their own, and a stray `spec.manifest.id` still never wins — it's
+ * overwritten by `id` below either way.
  *
  * spec.title is mapped into the inferred manifest's `description` — milestone
  * resolution runs metadata-only (no `content`), so the label chain
@@ -175,17 +186,18 @@ async function probePublishedGuide(namespace: string, packageId: string): Promis
  * masquerade as authored data.
  */
 function buildManifest(packageId: string, spec: InteractiveGuideResource['spec']): ManifestJson {
-  const resolvedId = spec?.id || packageId;
-
   if (spec?.manifest) {
+    const isPathOrJourney = spec.manifest.type === 'path' || spec.manifest.type === 'journey';
+    const resolvedId = isPathOrJourney ? packageId : spec.id || packageId;
+
     // Spread the persisted manifest first, then force BOTH id and repository
-    // last. id: a stray spec.manifest.id must not override the resource's own
-    // declared identity (resolvedId). repository: the CR shape leaves it
-    // optional and the schema defaults it to the public CDN
-    // ('interactive-tutorials'); an App Platform guide is always
-    // app-platform-sourced, and `repository` is the sole input to the durable
-    // completion key (guideSource, completion-identity.ts), so a missing value
-    // would mislabel a private guide's provenance.
+    // last. id: a stray spec.manifest.id must not override the resolved
+    // identity above. repository: the CR shape leaves it optional and the
+    // schema defaults it to the public CDN ('interactive-tutorials'); an App
+    // Platform guide is always app-platform-sourced, and `repository` is the
+    // sole input to the durable completion key (guideSource,
+    // completion-identity.ts), so a missing value would mislabel a private
+    // guide's provenance.
     const parsed = ManifestJsonObjectSchema.loose().safeParse({
       ...spec.manifest,
       id: resolvedId,
@@ -209,8 +221,10 @@ function buildManifest(packageId: string, spec: InteractiveGuideResource['spec']
     });
   }
 
+  // Always type 'guide' here (never path/journey), so preferring spec.id is
+  // always safe — no baseUrl-hydration consumer ever sees this shape.
   return {
-    id: resolvedId,
+    id: spec?.id || packageId,
     type: 'guide',
     repository: APP_PLATFORM_REPOSITORY,
     description: spec?.title,


### PR DESCRIPTION
## Summary

A cold `?doc=backend-guide:<id>` deep link (e.g. a shared course link opened in a fresh browser) never rendered the new course cover page, even though the in-app "start" click worked fine — the deep-link path never resolved the guide's manifest. This extends the shared URL→packageInfo helper other entry points already route through to recognize the `backend-guide:` scheme. Fixing that surfaced a second, dormant bug: the manifest-builder now reachable for this scheme disagreed with the one used everywhere else about a guide's identity after a rename, which would have silently changed completion-record keying with no migration — corrected so both builders agree.

## What to look at

- [`src/docs-retrieval/package-info-from-url.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/b0037d9a0deee90c603a67f7331b66e0a81aad72/src/docs-retrieval/package-info-from-url.ts) — `fetchAppPlatformPackageInfo` resolves metadata-only via the shared `PackageResolver`, mirroring the exact call shape `resolvePackageMilestones`/`resolvePackageNavLinks` already use in `package-content.ts`. Worth confirming the pre-existing interactive-learning URL branch's behavior is unchanged (it's a pure extraction, not a rewrite).
- [`src/package-engine/app-platform-resolver.ts`](https://github.com/grafana/grafana-pathfinder-app/blob/b0037d9a0deee90c603a67f7331b66e0a81aad72/src/package-engine/app-platform-resolver.ts) — `buildManifest`'s `id` field now prefers `spec.id` over the resolve() input, matching `backend-guide.ts`'s `buildLoaderManifest`. **Note:** this also changes behavior for the pre-existing "open a standalone custom guide" flow (`CustomGuidesSection`), not just the new deep-link path — that's intentional and verified (both flows share the same auto-derive fallback in `docs-panel.tsx`), not a side effect to flag.

## Why

Considered a narrower fix scoped only to `FullScreenPanel`'s `?doc=` handler (resolve `packageInfo` just for that one entry point). Went with generalizing the shared `isPackageContentUrl`/`fetchPackageInfoFromUrl` helper instead, since it's the established single owner other entry points already route through — the narrower fix would have left the fullscreen-handoff and floating-to-fullscreen entry points still broken.

## How to verify

1. In a fresh/incognito browser session (no existing Pathfinder tab state), navigate directly to a fullscreen `?doc=backend-guide%3A<published-path-id>&type=docs` URL for a published App Platform path. Confirm the course cover page renders (milestone list, cover chrome) rather than falling back to a bare interactive/guide view.
2. Rename a custom guide's id after publishing it (block editor → Guide Settings → change the Guide ID → save), then open it via a `backend-guide:<old-id>` reference (a stale link, or the Custom Guides list) and via its current id. Confirm both resolve to the same, current guide id for any subsequently recorded completion — not the old, immutable resource name.
3. Open a path via "Start" from My Learning as before; confirm the cover page still renders identically to pre-PR behavior (regression check on the already-working path).

## Breaking changes

None. Additive/corrective — no storage format, schema, or public contract shape changes.

## Reversibility

Fully reversible: nothing here touches persisted data shape, only which manifest a `backend-guide:` open resolves at render time and which id backs a subsequently recorded completion. The code path this PR adds (`packageInfo` resolution for `backend-guide:` URLs) has never shipped before, so there's no existing production data keyed under the incorrect, pre-fix identity to reconcile — reverting this PR would simply restore the original bug (deep links losing the cover page).

## Out of scope

- End-to-end test coverage for `docs-panel.tsx`'s auto-derive fallback landing on `type: 'learning-journey'` through the real (unmocked) helpers — the new tests cover the leaf helper and its output shape in isolation, but nothing exercises the full chain end-to-end. Flagged in review; tracked as a follow-up rather than blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
