### PR TITLE
fix(ci): pin release workflow Go toolchain, cut release-prep over to release branches

### DIFF
--- a/.claude/skills/release-prep/SKILL.md
+++ b/.claude/skills/release-prep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-prep
-description: Orchestrate the pre-release flow for grafana-pathfinder-app — bump the version in package.json, draft a CHANGELOG entry (via the `changelog` skill), run `npm run check` and `npm run build`, then print the exact `git tag` command for the user to execute. Never creates or pushes the tag itself; tagging is a one-way door the user owns.
+description: Orchestrate the pre-release flow for grafana-pathfinder-app — cut a release branch off origin/main to freeze scope, bump the version in package.json, draft a CHANGELOG entry (via the `changelog` skill), run `npm run check` and `npm run build`, then print the exact `git push`/`git tag` commands for the user to execute. Never pushes the branch or the tag itself; both are one-way doors the user owns.
 ---
 
 Read `.cursor/skills/release-prep/SKILL.md` and follow it exactly.

--- a/.cursor/skills/release-prep/SKILL.md
+++ b/.cursor/skills/release-prep/SKILL.md
@@ -1,31 +1,33 @@
 ---
 name: release-prep
-description: Orchestrate the pre-release flow for grafana-pathfinder-app — bump the version in package.json, draft a CHANGELOG entry (via the `changelog` skill), run `npm run check` and `npm run build`, then print the exact `git tag` command for the user to execute. Never creates or pushes the tag itself; tagging is a one-way door the user owns.
+description: Orchestrate the pre-release flow for grafana-pathfinder-app — cut a release branch off origin/main to freeze scope, bump the version in package.json, draft a CHANGELOG entry (via the `changelog` skill), run `npm run check` and `npm run build`, then print the exact `git push`/`git tag` commands for the user to execute. Never pushes the branch or the tag itself; both are one-way doors the user owns.
 ---
 
 # Release prep
 
-Pre-release orchestrator. Handles the safe, reversible parts of cutting a release (version bump, changelog, validation) and stops short of the irreversible step (tag push) so the user reviews everything before the GitHub release workflow fires.
+Pre-release orchestrator. Handles the safe, reversible parts of cutting a release (branch, version bump, changelog, validation) and stops short of the irreversible steps (branch push, tag push) so the user reviews everything before the GitHub release workflow fires.
 
 This skill pairs with `.cursor/skills/changelog/SKILL.md`, which drafts the actual CHANGELOG entry. `release-prep` is the wrapper that runs `changelog` plus the surrounding validation.
+
+## Why a release branch instead of prepping on main
+
+Earlier versions of this skill worked directly on `main` and printed `git push origin main` as the last step. That races: anything merged to `main` between drafting the changelog and actually pushing lands in the release with no changelog entry, and — because `main` is protected — a "push directly" step never actually worked anyway. Cutting a fresh `release/v<version>` branch off `origin/main` the moment prep starts freezes the release's scope immediately: everything merged to `main` afterward simply rolls into the next release instead of racing this one. The GitHub tag itself was always race-free (a tag pins an exact SHA), but a `workflow_dispatch` input like `publish.yml`'s `branch` field re-resolves a branch name live — so pointing that at `main` would silently reintroduce the same race for the Cloud publish step. Point it at the release branch instead.
 
 ## Hard constraints
 
 These constraints are absolute and override any other instructions:
 
 1. **Never create or push the git tag.** Print the exact command for the user to run. The user controls the moment of release.
-2. **Never push commits.** Stay on the local branch.
+2. **Never push the release branch, and never push to `main`.** Commit locally on `release/v<version>` and print the exact `git push` command for the user to run. Pushing (and any Cloud `workflow_dispatch`) requires the user's explicit go-ahead in chat each time — this skill does not carry standing authorization to push, even though the release-branch pattern depends on that branch eventually reaching origin.
 3. **`npm run check` must pass before claiming "ready".** If it fails, abort with the failure log and stop. Do not "fix-up and retry" — a failing check is real signal.
 4. **Only edit `package.json` (version bump), `package-lock.json` (synced version fields), and `CHANGELOG.md`** (via the `changelog` skill). No other files. `src/plugin.json` carries `"%VERSION%"` and is substituted at build time — never edit it.
 5. **If the proposed tag already exists**, abort.
 6. **If the working tree is dirty**, abort with `git status` output. Don't try to be clever about which dirt is safe.
-7. **One commit.** Title: `chore: prep v<version> release`. Contains the version bump (manifest + lockfile) + CHANGELOG draft.
+7. **One commit** for the version bump + CHANGELOG (title: `chore: prep v<version> release`) — unless the changelog was already merged to `main` independently before prep started, in which case the CHANGELOG.md edit is skipped and this becomes a version-bump-only commit. Either way, one commit on the release branch.
 
 ## Workflow
 
-### Phase 0 — Preconditions
-
-Verify the environment is safe to proceed:
+### Phase 0 — Cut the release branch
 
 1. **Clean working tree**:
 
@@ -35,24 +37,30 @@ Verify the environment is safe to proceed:
 
    Must be empty. Abort otherwise.
 
-2. **On main branch** (or a release branch — warn but allow):
+2. **Fetch and read the actual current tip of origin/main** — this is the moment that freezes the release's scope, so do it first, not after drafting anything:
 
    ```
-   git branch --show-current
+   git fetch origin main
+   git log origin/main -1 --format='%H %cI %s'
    ```
 
-   Default expectation: `main`. If on another branch, warn the user — they may be cutting from a release branch intentionally, which is fine, but they should confirm.
-
-3. **In sync with origin**:
+3. **Check the CHANGELOG on origin/main for an existing entry at the target version** before assuming one needs drafting:
 
    ```
-   git fetch origin
-   git log HEAD..origin/main --oneline
+   git show origin/main:CHANGELOG.md | head -5
    ```
 
-   Must be empty (no upstream commits we don't have). Otherwise abort with "Branch is behind origin/main by N commits. Pull first."
+   If a matching `## <version>` section is already there (someone ran `/changelog` and merged it separately, as happened for v2.17.0), Phase 3 skips drafting and this becomes a version-bump-only commit.
 
-4. **Capture the last tag**:
+4. **Create the release branch from that exact commit**:
+
+   ```
+   git checkout -b release/v<version> origin/main
+   ```
+
+   If a same-named local branch already exists from an earlier, abandoned attempt, don't overwrite or delete it blindly — rename it aside (`git branch -m release/v<version> archive/release-v<version>-stale-<date>`) and cut a fresh one. It may be in-progress work from another session.
+
+5. **Capture the last tag**:
 
    ```
    git tag --sort=-v:refname | head -1
@@ -119,7 +127,9 @@ The version lives in **two** files that must stay in lock-step: `package.json` (
 
 ### Phase 3 — Draft CHANGELOG
 
-Invoke the `changelog` skill (or replicate its Phase 1-3 inline if the skill is unavailable). Pass the target version explicitly.
+**Skip this phase entirely if Phase 0 step 3 already found a `## <version>` section on `origin/main`'s CHANGELOG.md** — someone ran `/changelog` and merged it independently before this release branch was cut. Note that in the run output ("CHANGELOG for v<version> already on main; skipping draft") and proceed straight to Phase 4 with a version-bump-only change set.
+
+Otherwise, invoke the `changelog` skill (or replicate its Phase 1-3 inline if the skill is unavailable). Pass the target version explicitly.
 
 When the `changelog` skill is invoked from `release-prep`, override its Phase 3 commit step:
 
@@ -155,41 +165,43 @@ When the `changelog` skill is invoked from `release-prep`, override its Phase 3 
    git diff --name-only
    ```
 
-   Must be exactly:
+   Must be exactly `package-lock.json` + `package.json`, or those two plus `CHANGELOG.md` if Phase 3 actually drafted one. If anything else appears, abort. The skill should never modify other files.
+
+2. **Commit** (do not push — see hard constraint 2):
 
    ```
-   CHANGELOG.md
-   package-lock.json
-   package.json
-   ```
-
-   If anything else appears, abort. The skill should never modify other files.
-
-2. **Commit** (do not push):
-
-   ```
-   git add CHANGELOG.md package.json package-lock.json
+   git add package.json package-lock.json CHANGELOG.md   # omit CHANGELOG.md if Phase 3 was skipped
    git commit -m "chore: prep v<version> release"
    ```
 
-3. **Print the release summary**:
+3. **Print the release summary and hand off every remaining step** — pushing the branch, tagging, and pushing the tag are all one-way doors this skill does not take on its own:
 
    ```
-   Ready to release v<version>.
+   Ready to release v<version> on release/v<version> (frozen at <short-sha>, off origin/main).
 
    Previous: v<last-version>
    Included: <N> PRs (<X> added, <Y> fixed, <Z> chore)
 
    To cut the release, run:
 
-     git push origin main
-     git tag -a v<version> -m "Release v<version>"
+     git push -u origin release/v<version>
+     git tag -a v<version> -m "Release v<version>" release/v<version>
      git push origin v<version>
 
-   The `release.yml` workflow triggers on `v*` tag push and creates the GitHub release.
+   The `release.yml` workflow triggers on `v*` tag push and creates the GitHub release — it builds
+   whatever commit the tag points to, so main can keep moving after this without affecting it.
+
+   If you also publish to Grafana Cloud via `publish.yml` (workflow_dispatch), point its `branch`
+   input at `release/v<version>`, not `main` — that input re-resolves live, so `main` would reintroduce
+   the exact race this branch exists to avoid.
+
+   The next release's `/changelog` scopes from this tag regardless, so nothing is at risk of being
+   missed either way. But if Phase 3 actually drafted a CHANGELOG section here (rather than finding
+   one already on main), open a small PR merging that CHANGELOG.md + version bump back into `main` —
+   otherwise `main`'s own CHANGELOG.md permanently skips this version's entry.
    ```
 
-   Order matters: push the commit first so the tag points at an upstream-known SHA, then tag, then push the tag. Confirm this order with the user if they're unfamiliar.
+   Order matters: push the branch first so the tag points at an upstream-known SHA, then tag, then push the tag.
 
 ## Reuses
 
@@ -211,7 +223,7 @@ The skill must abort cleanly (no partial state, no commits) if any of these are 
 | Condition                                     | Reason                                                                |
 | --------------------------------------------- | --------------------------------------------------------------------- |
 | Working tree dirty                            | Cannot reason about what state is being released                      |
-| Branch behind origin                          | Upstream commits would be missing from the release                    |
+| `git fetch origin main` fails                 | Cannot freeze scope against a tip we can't confirm                    |
 | Tag `v<version>` already exists               | Cannot reuse a tag; double-tagging breaks GitHub releases             |
 | Version is not strictly > last tag            | Regression — semver violation                                         |
 | `npm run check` fails                         | Test suite or lint catches a real problem                             |
@@ -239,7 +251,8 @@ Total context per run: under 30k tokens for a typical release. Pull `npm run che
 
 ## What this skill does NOT do
 
-- Push commits or tags
+- Push the release branch, commits, or tags
+- Merge the release branch back into `main`
 - Sign the plugin (disabled per RELEASE_PROCESS.md)
 - Run E2E tests (`npm run e2e` is not part of `npm run check`; if needed, the user runs it separately)
 - Coordinate cross-repo releases (e.g., `grafana-recommender`) — out of scope
@@ -260,7 +273,9 @@ Reply with the version to proceed.
 > 2.11.0
 
 ✓ Working tree clean
-✓ On main, in sync with origin
+✓ Fetched origin/main (a1b2c3d)
+✓ No v2.11.0 section on main's CHANGELOG.md yet — drafting one
+✓ Cut release/v2.11.0 from origin/main
 ✓ No existing v2.11.0 tag
 ✓ package.json bumped to 2.11.0
 ✓ package-lock.json synced (2 version fields)
@@ -268,15 +283,19 @@ Reply with the version to proceed.
 ✓ CHANGELOG drafted (3 added, 7 fixed, 5 chore)
 ✓ npm run check (132 suites, 2511 tests, all passing)
 ✓ npm run build (bundle produced)
-✓ Committed: chore: prep v2.11.0 release
+✓ Committed on release/v2.11.0: chore: prep v2.11.0 release
 
-Ready to release v2.11.0.
+Ready to release v2.11.0 on release/v2.11.0 (frozen at a1b2c3d, off origin/main).
 
 To cut the release, run:
 
-  git push origin main
-  git tag -a v2.11.0 -m "Release v2.11.0"
+  git push -u origin release/v2.11.0
+  git tag -a v2.11.0 -m "Release v2.11.0" release/v2.11.0
   git push origin v2.11.0
 
-The `release.yml` workflow triggers on `v*` tag push and creates the GitHub release.
+The `release.yml` workflow triggers on `v*` tag push and creates the GitHub release — it builds
+whatever commit the tag points to, so main can keep moving after this without affecting it.
+
+If you also publish to Grafana Cloud via `publish.yml`, point its `branch` input at `release/v2.11.0`,
+not `main`.
 ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      # build-plugin has no Go setup of its own and falls behind go.mod; pin it like ci.yml does.
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
-        with:
-          go-version-file: go.mod
       - uses: grafana/plugin-actions/build-plugin@4698961fa64137fcac207108397ebe8a738a33d1
         with:
           # The action defaults to Node 20; this repo requires >=24 (.nvmrc, engines.node).
           node-version: '24'
+          # The action defaults to Go 1.25 via its own internal setup-go; go.mod requires 1.26.5.
+          go-version: '1.26.5'
           # Uncomment to enable plugin signing
           # (For more info on how to generate the access policy token see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
           # Make sure to save the token in your repository secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      # build-plugin has no Go setup of its own and falls behind go.mod; pin it like ci.yml does.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
       - uses: grafana/plugin-actions/build-plugin@4698961fa64137fcac207108397ebe8a738a33d1
         with:
           # The action defaults to Node 20; this repo requires >=24 (.nvmrc, engines.node).

--- a/docs/developer/RELEASE_PROCESS.md
+++ b/docs/developer/RELEASE_PROCESS.md
@@ -10,7 +10,7 @@ The project uses several GitHub Actions workflows for different release scenario
 
 - **Trigger**: Push of version tags matching pattern `v*` (e.g., `v1.0.0`)
 - **Process**:
-  - Pins the Go toolchain via `actions/setup-go` (`go-version-file: go.mod`) before building, same as `ci.yml`
+  - Pins the Go toolchain via `build-plugin`'s `go-version` input (its own internal setup-go step defaults to 1.25 and would otherwise drift behind `go.mod`)
   - Uses `grafana/plugin-actions/build-plugin` action
   - Builds the plugin for distribution
   - Plugin signing is available but currently commented out
@@ -209,7 +209,7 @@ The CLI is not bundled into the plugin tarball. Webpack only enters from `src/mo
 
 ### Common Issues
 
-- **Build Failures**: Check GitHub Actions logs for specific error messages. `release.yml` pins its Go toolchain via `actions/setup-go` with `go-version-file: go.mod`, matching `ci.yml` — without it, the runner's preinstalled Go can drift behind `go.mod`'s minimum and `mage` fails with `go.mod requires go >= X (running go Y; GOTOOLCHAIN=local)`.
+- **Build Failures**: Check GitHub Actions logs for specific error messages. `release.yml` passes `go-version` to `grafana/plugin-actions/build-plugin` to match `go.mod`'s minimum — a separate top-level `setup-go` step doesn't work here, since `build-plugin` runs its own internal `setup-go` (default Go 1.25) afterward and silently overwrites it. Without the input pinned, `mage` fails with `go.mod requires go >= X (running go Y; GOTOOLCHAIN=local)`.
 - **Deployment Issues**: Verify environment permissions and Argo Workflow status
 - **Version Conflicts**: Ensure `package.json` version matches expected format
 

--- a/docs/developer/RELEASE_PROCESS.md
+++ b/docs/developer/RELEASE_PROCESS.md
@@ -10,6 +10,7 @@ The project uses several GitHub Actions workflows for different release scenario
 
 - **Trigger**: Push of version tags matching pattern `v*` (e.g., `v1.0.0`)
 - **Process**:
+  - Pins the Go toolchain via `actions/setup-go` (`go-version-file: go.mod`) before building, same as `ci.yml`
   - Uses `grafana/plugin-actions/build-plugin` action
   - Builds the plugin for distribution
   - Plugin signing is available but currently commented out
@@ -98,22 +99,25 @@ npm run sign           # Sign plugin for distribution
 
 ### For Official Releases
 
-1. Update version in `package.json`
-2. Create and push version tag (`git tag v1.1.32 && git push origin v1.1.32`)
-3. GitHub Actions automatically builds and creates release
-4. Optionally sign plugin for distribution
+Releases are prepared on a dedicated `release/v<version>` branch, not on `main` directly — see [`/release-prep`](../../.cursor/skills/release-prep/SKILL.md) for the full rationale and workflow. Cutting the branch the moment prep starts freezes the release's scope: anything merged to `main` afterward rolls into the next release instead of racing this one.
+
+1. Fetch `origin/main` and cut `release/v<version>` from its current tip
+2. Update version in `package.json` (and `package-lock.json`), and draft the CHANGELOG entry (skip if one was already merged to `main` independently)
+3. Push the branch, then create and push the version tag against it (`git tag v1.1.32 release/v1.1.32 && git push origin v1.1.32`)
+4. GitHub Actions automatically builds and creates release from the tagged commit
+5. Optionally sign plugin for distribution
 
 ### For Development Deployments
 
 1. Run the manual publish workflow
-2. Select the `dev` environment and the branch to deploy
+2. Select the `dev` environment and the branch to deploy — use the `release/v<version>` branch for an actual release, not `main`, since the `branch` input re-resolves live and `main` may have moved since the release was cut
 3. Monitor via Slack channel `#pathfinder-app-release`
 
 ### For Production Deployments
 
 1. Use manual publish workflow
 2. Select target environment (ops/prod)
-3. Choose branch to deploy from
+3. Choose the `release/v<version>` branch to deploy from — not `main`, for the same reason as above
 4. Monitor deployment via Argo Workflow
 
 ## Monitoring and Notifications
@@ -205,7 +209,7 @@ The CLI is not bundled into the plugin tarball. Webpack only enters from `src/mo
 
 ### Common Issues
 
-- **Build Failures**: Check GitHub Actions logs for specific error messages
+- **Build Failures**: Check GitHub Actions logs for specific error messages. `release.yml` pins its Go toolchain via `actions/setup-go` with `go-version-file: go.mod`, matching `ci.yml` — without it, the runner's preinstalled Go can drift behind `go.mod`'s minimum and `mage` fails with `go.mod requires go >= X (running go Y; GOTOOLCHAIN=local)`.
 - **Deployment Issues**: Verify environment permissions and Argo Workflow status
 - **Version Conflicts**: Ensure `package.json` version matches expected format
 


### PR DESCRIPTION
## Summary

- `release.yml` had no Go setup step, so it relied on whatever Go the `ubuntu-latest` runner image ships with. `go.mod` requires `go 1.26.5`; the runner had `1.25.14`, and `GOTOOLCHAIN=local` (set by the mage-action) blocks it from fetching the right version automatically. Result: `mage` fails with `go.mod requires go >= 1.26.5 (running go 1.25.14; GOTOOLCHAIN=local)`, and the v2.17.0 tag push failed exactly this way — as did an earlier v2.17.0 attempt on 2026-08-24.
- Adds the same `actions/setup-go@v7` step (with `go-version-file: go.mod`) that every job in `ci.yml` already runs, before the `grafana/plugin-actions/build-plugin` step.
- Updates the `release-prep` skill (`.cursor/skills/release-prep/SKILL.md` + its `.claude/` pointer stub) and `docs/developer/RELEASE_PROCESS.md` to cut a `release/v<version>` branch off `origin/main` at the *start* of prep, rather than working on `main` directly. Anything merged to `main` between drafting the changelog and tagging used to land in the release with no changelog entry (and `git push origin main` never actually worked anyway, since `main` is protected). Freezing scope on a dedicated branch the moment prep starts closes that race — everything merged to `main` afterward just rolls into the next release.
- Also documents that `publish.yml`'s `branch` workflow-dispatch input should point at the `release/v<version>` branch, not `main` — that input re-resolves live at dispatch time, so pointing it at `main` would silently reintroduce the same race for the Cloud publish step even though the GitHub tag itself (which pins an exact SHA) was already race-free.

## What to look at

- `.github/workflows/release.yml` — the added `setup-go` step
- `.cursor/skills/release-prep/SKILL.md` — restructured Phase 0 (cut the branch first), updated hard constraints, Phase 5 hand-off commands
- `docs/developer/RELEASE_PROCESS.md` — official release steps + dev/prod deployment steps now reference the release branch

## Why

Discovered live while cutting v2.17.0: the changelog PR (#1694) merged, another PR (#1711) landed on `main` in the gap before the release branch existed, and then the tag push itself failed on the Go-version gap. All three of those were real, so this PR fixes the CI gap and updates the documented process so the next release doesn't hit the same two problems.

## How to verify

```bash
npm run check
npm run build
npx --yes npm@12.0.2 run test:ci -- src/validation/skill-references.test.ts src/validation/control-bytes.test.ts --coverage=false
```

Both pass on this branch. The real proof is the next tag push actually building — this PR doesn't retest `release.yml` itself since it only fires on tag push.

## Breaking changes

None — CI/process only.