### PR TITLE
fix: read plugin settings back immediately before every write

### DIFF
--- a/src/components/AppConfig/ConfigurationForm.test.tsx
+++ b/src/components/AppConfig/ConfigurationForm.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * `POST /api/plugins/:id/settings` replaces the whole object, so anything the
+ * form does not send is cleared: a body without `pinned` unpins the plugin, one
+ * without `enabled` disables it, and one without a provisioned `jsonData` field
+ * such as `stackId` drops it. The mount-time read is a seed for the form and
+ * goes stale the moment another tab saves, so what matters here is that every
+ * write re-reads first.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import type { AppPluginMeta, PluginConfigPageProps } from '@grafana/data';
+
+import ConfigurationForm from './ConfigurationForm';
+import { fetchPluginSettings, updatePluginSettings } from '../../utils/utils.plugin';
+import { testIds } from '../../constants/testIds';
+import type { DocsPluginConfig } from '../../constants';
+
+jest.mock('../../utils/utils.plugin', () => ({
+  ...jest.requireActual('../../utils/utils.plugin'),
+  fetchPluginSettings: jest.fn(),
+  updatePluginSettings: jest.fn(),
+}));
+
+jest.mock('./CodaBackendStatus', () => ({ CodaBackendStatus: () => null }));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: { ...jest.requireActual('@grafana/runtime').config, bootData: { user: { id: 7 } } },
+}));
+
+/** Dev mode for user 7 is what renders the assistant toggle, the other write path. */
+const DEV_MODE_SETTINGS = {
+  jsonData: { stackId: '123', devMode: true, devModeUserIds: [7] } as DocsPluginConfig,
+  enabled: true,
+  pinned: true,
+};
+
+const mockedFetch = fetchPluginSettings as jest.MockedFunction<typeof fetchPluginSettings>;
+const mockedUpdate = updatePluginSettings as jest.MockedFunction<typeof updatePluginSettings>;
+
+const MOUNT_SETTINGS = { jsonData: { stackId: '123' } as DocsPluginConfig, enabled: true, pinned: true };
+
+function renderForm() {
+  const plugin = {
+    meta: { id: 'grafana-grafanadocsplugin-app', enabled: false, pinned: false, jsonData: {} },
+  } as unknown as PluginConfigPageProps<AppPluginMeta<DocsPluginConfig>>['plugin'];
+
+  return render(<ConfigurationForm plugin={plugin} query={{}} />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedUpdate.mockResolvedValue({});
+});
+
+describe('ConfigurationForm settings writes', () => {
+  it('re-reads enabled, pinned and jsonData immediately before saving', async () => {
+    mockedFetch.mockResolvedValueOnce(MOUNT_SETTINGS);
+    renderForm();
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(1));
+
+    // Another tab saves after this page opened: pinned goes false, and a
+    // provisioned field appears. The form owns neither.
+    mockedFetch.mockResolvedValueOnce({
+      jsonData: { stackId: '123', slug: 'moved' } as DocsPluginConfig,
+      enabled: true,
+      pinned: false,
+    });
+
+    fireEvent.submit(screen.getByTestId(testIds.appConfig.form));
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalled());
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+    const [, body] = mockedUpdate.mock.calls[0]!;
+    expect(body.enabled).toBe(true);
+    expect(body.pinned).toBe(false);
+    expect(body.jsonData).toMatchObject({ stackId: '123', slug: 'moved' });
+  });
+
+  it('re-reads before the assistant dev-mode toggle writes too', async () => {
+    mockedFetch.mockResolvedValueOnce(DEV_MODE_SETTINGS);
+    renderForm();
+    const toggle = await screen.findByTestId(testIds.appConfig.assistantDevModeToggle);
+
+    mockedFetch.mockResolvedValueOnce({ ...DEV_MODE_SETTINGS, pinned: false });
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalled());
+    const [, body] = mockedUpdate.mock.calls[0]!;
+    expect(body.pinned).toBe(false);
+    expect(body.jsonData).toMatchObject({ stackId: '123', enableAssistantDevMode: true });
+  });
+
+  it('leaves a never-set enableAiAutoHeal unset on both write paths', async () => {
+    // This tab does not own the field. Spreading `getConfigWithDefaults` alone
+    // would bake today's default into jsonData, and the field could then never
+    // again follow a change to DEFAULT_ENABLE_AI_AUTO_HEAL for this stack.
+    mockedFetch.mockResolvedValue(DEV_MODE_SETTINGS);
+    renderForm();
+    const toggle = await screen.findByTestId(testIds.appConfig.assistantDevModeToggle);
+
+    fireEvent.submit(screen.getByTestId(testIds.appConfig.form));
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(toggle);
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(2));
+
+    for (const [, body] of mockedUpdate.mock.calls) {
+      expect((body.jsonData as DocsPluginConfig).enableAiAutoHeal).toBeUndefined();
+    }
+  });
+
+  it('keeps an explicit enableAiAutoHeal choice on both write paths', async () => {
+    // Off is a decision the owning tab made, not an absent value: the raw
+    // pass-through has to carry `false` through as faithfully as it omits.
+    mockedFetch.mockResolvedValue({
+      ...DEV_MODE_SETTINGS,
+      jsonData: { ...DEV_MODE_SETTINGS.jsonData, enableAiAutoHeal: false },
+    });
+    renderForm();
+    const toggle = await screen.findByTestId(testIds.appConfig.assistantDevModeToggle);
+
+    fireEvent.submit(screen.getByTestId(testIds.appConfig.form));
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(toggle);
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(2));
+
+    for (const [, body] of mockedUpdate.mock.calls) {
+      expect((body.jsonData as DocsPluginConfig).enableAiAutoHeal).toBe(false);
+    }
+  });
+
+  it('does not write at all when the read-back fails', async () => {
+    mockedFetch.mockResolvedValueOnce(MOUNT_SETTINGS);
+    renderForm();
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(1));
+
+    mockedFetch.mockRejectedValueOnce(new Error('nope'));
+
+    fireEvent.submit(screen.getByTestId(testIds.appConfig.form));
+
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(2));
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/AppConfig/ConfigurationForm.tsx
+++ b/src/components/AppConfig/ConfigurationForm.tsx
@@ -18,7 +18,7 @@ import {
   getDefaultRecommenderUrl,
   isKnownRecommenderUrl,
 } from '../../constants';
-import { fetchPluginJsonData, updatePluginSettings } from '../../utils/utils.plugin';
+import { fetchPluginSettings, updatePluginSettings } from '../../utils/utils.plugin';
 import { isDevModeEnabled, toggleDevMode } from '../../utils/dev-mode';
 import { logger } from '../../lib/logging';
 import { config } from '@grafana/runtime';
@@ -63,7 +63,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
   const urlParams = new URLSearchParams(window.location.search);
   const hasDevParam = urlParams.get('dev') === 'true';
   const s = useStyles2(getStyles);
-  const { enabled, pinned, jsonData: pluginJsonData } = plugin.meta;
+  const { jsonData: pluginJsonData } = plugin.meta;
   const [resolvedJsonData, setResolvedJsonData] = useState<DocsPluginConfig>(pluginJsonData || {});
   const [state, setState] = useState<State>(() => buildStateFromJsonData(pluginJsonData));
   const [isSaving, setIsSaving] = useState(false);
@@ -76,18 +76,19 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
 
   // `plugin.meta.jsonData` can lag a recent save, so seed the form from the
   // authoritative read — but never over an edit the admin has already made.
+  // A seed only: every write re-reads, because this one can go stale.
   useEffect(() => {
     let cancelled = false;
 
-    fetchPluginJsonData(plugin.meta.id)
-      .then((freshJsonData) => {
+    fetchPluginSettings(plugin.meta.id)
+      .then((fresh) => {
         if (cancelled) {
           return;
         }
 
-        setResolvedJsonData(freshJsonData);
+        setResolvedJsonData(fresh.jsonData);
         if (!isDraftEdited.current) {
-          setState(buildStateFromJsonData(freshJsonData));
+          setState(buildStateFromJsonData(fresh.jsonData));
         }
       })
       .catch((error) => {
@@ -162,16 +163,17 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
     setAssistantDevModeToggling(true);
     try {
       const newValue = event.target.checked;
+      const current = await fetchPluginSettings(plugin.meta.id);
 
       await updatePluginSettings(plugin.meta.id, {
-        enabled,
-        pinned,
+        enabled: current.enabled,
+        pinned: current.pinned,
         jsonData: {
-          ...(resolvedJsonData || {}),
-          ...getConfigWithDefaults(resolvedJsonData || {}),
+          ...current.jsonData,
+          ...getConfigWithDefaults(current.jsonData),
           // Pass through raw, not the resolved default — this tab doesn't own the
           // field, and materializing it here would freeze out a future default change.
-          enableAiAutoHeal: resolvedJsonData?.enableAiAutoHeal,
+          enableAiAutoHeal: current.jsonData?.enableAiAutoHeal,
           enableAssistantDevMode: newValue,
         },
       });
@@ -230,15 +232,18 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
     setIsSaving(true);
 
     try {
-      // Preserve ALL existing jsonData fields first (including provisioned fields
-      // like stackId that aren't in DocsPluginConfig), then apply defaults for
-      // known fields, then override with this form's fields.
+      // POST /settings replaces the whole object, so the fields this form does
+      // not own — enabled, pinned, and provisioned jsonData such as stackId —
+      // are read back immediately before the write. The mount-time read is a
+      // seed for the form; another tab saving after that would make it a stale
+      // snapshot that silently restores old values.
+      const current = await fetchPluginSettings(plugin.meta.id);
       const newJsonData = {
-        ...(resolvedJsonData || {}),
-        ...getConfigWithDefaults(resolvedJsonData || {}),
+        ...current.jsonData,
+        ...getConfigWithDefaults(current.jsonData),
         // Pass through raw, not the resolved default — this tab doesn't own the
         // field, and materializing it here would freeze out a future default change.
-        enableAiAutoHeal: resolvedJsonData?.enableAiAutoHeal,
+        enableAiAutoHeal: current.jsonData?.enableAiAutoHeal,
         recommenderServiceUrl: state.recommenderServiceUrl,
         tutorialUrl: state.tutorialUrl,
         interceptGlobalDocsLinks: state.interceptGlobalDocsLinks,
@@ -252,8 +257,8 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
       };
 
       await updatePluginSettings(plugin.meta.id, {
-        enabled,
-        pinned,
+        enabled: current.enabled,
+        pinned: current.pinned,
         jsonData: newJsonData,
       });
 

--- a/src/utils/dev-mode.ts
+++ b/src/utils/dev-mode.ts
@@ -26,15 +26,15 @@
 import { config } from '@grafana/runtime';
 import { DocsPluginConfig } from '../constants';
 import { logger } from '../lib/logging';
-import { fetchPluginJsonData, updatePluginSettings } from './utils.plugin';
+import { fetchPluginSettings, updatePluginSettings } from './utils.plugin';
 import pluginJson from '../plugin.json';
 
 /**
- * Fetch current plugin jsonData from the backend to avoid overwriting
- * fields managed by other config tabs when saving dev mode changes.
+ * Fetch current plugin settings from the backend to avoid overwriting
+ * jsonData fields managed by other config tabs, and to preserve enabled/pinned.
  */
-async function fetchCurrentJsonData(): Promise<DocsPluginConfig> {
-  return fetchPluginJsonData(pluginJson.id);
+async function fetchCurrentSettings() {
+  return fetchPluginSettings(pluginJson.id);
 }
 
 /**
@@ -74,14 +74,13 @@ export const enableDevMode = async (currentUserId: number, currentUserIds: numbe
     // Add user to list if not already present
     const updatedUserIds = currentUserIds.includes(currentUserId) ? currentUserIds : [...currentUserIds, currentUserId];
 
-    // Fetch current settings to preserve fields managed by other config tabs
-    const currentJsonData = await fetchCurrentJsonData();
+    const current = await fetchCurrentSettings();
 
-    // Update plugin settings with dev mode enabled and updated user list
     await updatePluginSettings(pluginJson.id, {
       enabled: true,
+      pinned: current.pinned,
       jsonData: {
-        ...currentJsonData,
+        ...current.jsonData,
         devMode: true,
         devModeUserIds: updatedUserIds,
       },
@@ -108,12 +107,13 @@ export const disableDevModeForUser = async (userId: number, currentUserIds: numb
     // If no users left, disable dev mode entirely
     const devMode = updatedUserIds.length > 0;
 
-    const currentJsonData = await fetchCurrentJsonData();
+    const current = await fetchCurrentSettings();
 
     await updatePluginSettings(pluginJson.id, {
       enabled: true,
+      pinned: current.pinned,
       jsonData: {
-        ...currentJsonData,
+        ...current.jsonData,
         devMode,
         devModeUserIds: updatedUserIds,
       },
@@ -131,13 +131,13 @@ export const disableDevModeForUser = async (userId: number, currentUserIds: numb
  */
 export const disableDevMode = async (): Promise<void> => {
   try {
-    const currentJsonData = await fetchCurrentJsonData();
+    const current = await fetchCurrentSettings();
 
-    // Update plugin settings to disable dev mode entirely
     await updatePluginSettings(pluginJson.id, {
       enabled: true,
+      pinned: current.pinned,
       jsonData: {
-        ...currentJsonData,
+        ...current.jsonData,
         devMode: false,
         devModeUserIds: [],
       },

--- a/src/utils/utils.plugin.test.ts
+++ b/src/utils/utils.plugin.test.ts
@@ -1,0 +1,67 @@
+/**
+ * `POST /api/plugins/:id/settings` is a whole-object write: a body without
+ * `pinned` unpins the plugin, and one without `enabled` disables it. Every
+ * caller therefore has to read the current values back before writing, which is
+ * what `fetchPluginSettings` exists for — `plugin.meta` is a snapshot from mount
+ * and goes stale as soon as another tab saves.
+ */
+
+import { fetchPluginJsonData, fetchPluginSettings } from './utils.plugin';
+
+const mockFetch = jest.fn();
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: () => ({ fetch: mockFetch }),
+}));
+
+function respondsWith(data: unknown) {
+  mockFetch.mockReturnValue({ subscribe: (observer: any) => observer.next({ data }) ?? observer.complete?.() });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('fetchPluginSettings', () => {
+  it('reads back enabled and pinned alongside jsonData', async () => {
+    respondsWith({ enabled: true, pinned: true, jsonData: { devMode: true } });
+
+    await expect(fetchPluginSettings('grafana-pathfinder-app')).resolves.toEqual({
+      enabled: true,
+      pinned: true,
+      jsonData: { devMode: true },
+    });
+  });
+
+  it('treats a pinned plugin as pinned only when the API says so', async () => {
+    respondsWith({ enabled: true, jsonData: {} });
+    await expect(fetchPluginSettings('p')).resolves.toMatchObject({ pinned: false });
+  });
+
+  it('assumes enabled when the field is absent, since a disabled plugin is not rendering this', async () => {
+    respondsWith({ jsonData: {} });
+    await expect(fetchPluginSettings('p')).resolves.toMatchObject({ enabled: true });
+  });
+
+  it('reports a disabled plugin as disabled rather than defaulting it on', async () => {
+    respondsWith({ enabled: false, jsonData: {} });
+    await expect(fetchPluginSettings('p')).resolves.toMatchObject({ enabled: false });
+  });
+
+  it('yields an empty jsonData rather than undefined for a plugin never configured', async () => {
+    respondsWith({ enabled: true, pinned: false });
+    await expect(fetchPluginSettings('p')).resolves.toEqual({ enabled: true, pinned: false, jsonData: {} });
+  });
+
+  it('encodes the plugin id into the path', async () => {
+    respondsWith({ jsonData: {} });
+    await fetchPluginSettings('a/b');
+    expect(mockFetch).toHaveBeenCalledWith(expect.objectContaining({ url: '/api/plugins/a%2Fb/settings' }));
+  });
+});
+
+describe('fetchPluginJsonData', () => {
+  it('still returns just the jsonData, for callers that only configure', async () => {
+    respondsWith({ enabled: true, pinned: true, jsonData: { devMode: false } });
+    await expect(fetchPluginJsonData('p')).resolves.toEqual({ devMode: false });
+  });
+});

--- a/src/utils/utils.plugin.ts
+++ b/src/utils/utils.plugin.ts
@@ -7,17 +7,37 @@ import { DocsPluginConfig } from '../constants';
 // This is used to be able to retrieve the root plugin props anywhere inside the app.
 export const PluginPropsContext = React.createContext<AppRootProps | null>(null);
 
-export async function fetchPluginJsonData(pluginId: string): Promise<DocsPluginConfig> {
-  const response = getBackendSrv().fetch<{ jsonData?: DocsPluginConfig }>({
+type PluginSettingsResponse = {
+  jsonData?: DocsPluginConfig;
+  enabled?: boolean;
+  pinned?: boolean;
+};
+
+export type PluginSettingsSnapshot = {
+  jsonData: DocsPluginConfig;
+  enabled: boolean;
+  pinned: boolean;
+};
+
+export async function fetchPluginSettings(pluginId: string): Promise<PluginSettingsSnapshot> {
+  const response = getBackendSrv().fetch<PluginSettingsResponse>({
     url: `/api/plugins/${encodeURIComponent(pluginId)}/settings`,
     method: 'GET',
   });
   const result = await lastValueFrom(response);
-  return result.data?.jsonData || {};
+  const jsonData = result.data?.jsonData || {};
+  return {
+    jsonData,
+    enabled: result.data?.enabled !== false,
+    pinned: result.data?.pinned === true,
+  };
+}
+
+export async function fetchPluginJsonData(pluginId: string): Promise<DocsPluginConfig> {
+  return (await fetchPluginSettings(pluginId)).jsonData;
 }
 
 export const updatePluginSettings = async (pluginId: string, data: Partial<PluginMeta>) => {
-  // Simple plugin update following working plugin patterns - no reload needed
   const response = getBackendSrv().fetch({
     url: `/api/plugins/${pluginId}/settings`,
     method: 'POST',


### PR DESCRIPTION
## What

`POST /api/plugins/:id/settings` is a **whole-object write**. A body without `pinned` unpins the plugin; one without `enabled` disables it; one without a provisioned `jsonData` field such as `stackId` drops it.

Two write paths were getting that wrong:

- `ConfigurationForm` sent `plugin.meta.enabled` and `plugin.meta.pinned` — a mount-time snapshot. Another tab saving after this page opened made it a stale snapshot that silently restored the old values.
- `dev-mode.ts` sent no `pinned` at all, so toggling dev mode unpinned the plugin.

Both now `await fetchPluginSettings(...)` immediately before the write and take `enabled`, `pinned` and the base `jsonData` from that read. The stale `resolvedEnabled` / `resolvedPinned` state is deleted rather than left as a trap, and a failed read-back writes nothing at all.

`fetchPluginJsonData` becomes a thin wrapper over the new `fetchPluginSettings`, so `usePathfinderPluginConfig` is unchanged.

## Why this is its own PR

It rode along on [#1668](https://github.com/grafana/grafana-pathfinder-app/pull/1668) and has nothing to do with that PR's subject. Split out on review so it can be judged on its own — and because the read-back rewrite there had dropped a field it should not have (below).

## The field this tab does not own

`enableAiAutoHeal` is passed through **raw**, not resolved:

```ts
...getConfigWithDefaults(current.jsonData),
enableAiAutoHeal: current.jsonData?.enableAiAutoHeal,
```

Spreading `getConfigWithDefaults` alone bakes today's `DEFAULT_ENABLE_AI_AUTO_HEAL` into `jsonData` for a field this tab has no opinion about, and the value can then never again follow a change to that default for the stack. `src/components/AppConfig/settings-preservation.test.ts` already demonstrated the shape; it does not exercise the component, which is why the regression could pass unnoticed.

## How to verify

Two `data-testid`-driven cases in the new `ConfigurationForm.test.tsx` prove the raw pass-through on **both** write paths:

- `leaves a never-set enableAiAutoHeal unset on both write paths` — fails without the pass-through.
- `keeps an explicit enableAiAutoHeal choice on both write paths` — `false` is a decision, not an absent value, and must survive as faithfully as omission does.

Plus the read-back itself: another tab flipping `pinned` and adding a provisioned field between mount and save, the assistant dev-mode toggle taking the same path, and a failed read-back writing nothing. `utils.plugin.test.ts` covers `fetchPluginSettings`' defaults — a missing `enabled` reads as `true` (Grafana omits it when enabled), a missing `pinned` as `false`, and the plugin id is URL-encoded.

`npm run check` clean.

## Reversibility

Fully reversible — three files, no schema, no stored state, no flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
