### PR TITLE
fix(cli): classify every guide block side effect

### DIFF
--- a/src/cli/e2e/side-effects.test.ts
+++ b/src/cli/e2e/side-effects.test.ts
@@ -1,5 +1,6 @@
 import { classifyGuideSideEffects, classifyGuideSideEffectsFromString } from './side-effects';
-import type { JsonGuide } from '../../types/json-guide.types';
+import { VALID_BLOCK_TYPES } from '../../types/json-guide.schema';
+import type { JsonBlock, JsonGuide } from '../../types/json-guide.types';
 
 function guide(blocks: JsonGuide['blocks']): JsonGuide {
   return { id: 'g', title: 'Guide', blocks };
@@ -21,6 +22,32 @@ describe('classifyGuideSideEffects', () => {
 
   it('classifies dividers as readonly', () => {
     expect(classifyGuideSideEffects(guide([{ type: 'divider' }]))).toEqual({ level: 'readonly', reasons: [] });
+  });
+
+  it('classifies callouts as readonly', () => {
+    expect(classifyGuideSideEffects(guide([{ type: 'callout', title: 'Note', content: 'Read this' }]))).toEqual({
+      level: 'readonly',
+      reasons: [],
+    });
+  });
+
+  it('walks collapsible children and preserves the runtime fallback', () => {
+    const futureBlock = { type: 'future-presentational' } as unknown as JsonBlock;
+    const collapsible = { type: 'collapsible', title: 'Details', blocks: [futureBlock] } as JsonBlock;
+
+    expect(classifyGuideSideEffects(guide([collapsible]))).toMatchObject({
+      level: 'unknown',
+      reasons: [{ path: 'blocks[0].blocks[0]', message: 'Unknown block type' }],
+    });
+  });
+
+  it('has an explicit classification path for every valid block type', () => {
+    const unclassified = [...VALID_BLOCK_TYPES].filter((type) => {
+      const result = classifyGuideSideEffects(guide([{ type } as JsonBlock]));
+      return result.reasons.some((entry) => entry.message === 'Unknown block type');
+    });
+
+    expect(unclassified).toEqual([]);
   });
 
   it('classifies destructive and save-like buttons as mutating', () => {

--- a/src/cli/e2e/side-effects.ts
+++ b/src/cli/e2e/side-effects.ts
@@ -1,7 +1,9 @@
 import {
   isAssistantBlock,
+  isCalloutBlock,
   isChallengeBlock,
   isCodeBlockBlock,
+  isCollapsibleBlock,
   isConditionalBlock,
   isDividerBlock,
   isGrotGuideBlock,
@@ -159,6 +161,7 @@ function classifyBlocks(blocks: JsonBlock[] | undefined, path: string): SideEffe
 function classifyBlock(block: JsonBlock, path: string): SideEffectClassification {
   if (
     isMarkdownBlock(block) ||
+    isCalloutBlock(block) ||
     isDividerBlock(block) ||
     isHtmlBlock(block) ||
     isImageBlock(block) ||
@@ -181,6 +184,9 @@ function classifyBlock(block: JsonBlock, path: string): SideEffectClassification
     return classifySteps(block.steps, path);
   }
   if (isSectionBlock(block)) {
+    return classifyBlocks(block.blocks, `${path}.blocks`);
+  }
+  if (isCollapsibleBlock(block)) {
     return classifyBlocks(block.blocks, `${path}.blocks`);
   }
   if (isConditionalBlock(block)) {


### PR DESCRIPTION
## Summary

- classify `callout` blocks as readonly
- recurse through `collapsible.blocks` instead of falling through to the unknown classifier
- add a `VALID_BLOCK_TYPES`-driven totality guard while retaining the safe runtime fallback for external JSON

## Why

An unclassified block becomes `unknown`, which marks the guide unsafe. On a shared cloud stack without a stack pool, that can skip the whole E2E chain with a success-coded result. `callout` and `collapsible` were both missing from the classifier even though they are valid guide block types.

The registry-driven test makes future omissions fail with the missing discriminator names. A separate nested fallback assertion verifies that recursive collapsibles preserve the precise child path for malformed or future external input.

## Verification

- `jest src/cli/e2e --coverage=false --runInBand`: 20 suites, 297 tests passed
- mutation check: removing the `callout` arm makes the totality test fail with `callout`
- full Jest suite: 501/501 suites, 8081 passed
- `tsc --noEmit`
- ESLint and Prettier on changed files
- `git diff --check`

Closes #1706
