### PR TITLE
fix(review): read concern routing from head

### DIFF
--- a/.cursor/skills/review/scripts/contract-evolution-gate.mjs
+++ b/.cursor/skills/review/scripts/contract-evolution-gate.mjs
@@ -151,7 +151,7 @@ export function computeGate({ base, head, concern, windowDays = DEFAULT_WINDOW_D
   const inStackOutput = git(['rev-list', head, `^${base}`], cwd);
   const inStackShas = inStackOutput ? inStackOutput.split('\n').filter(Boolean) : [];
 
-  const concerns = git(['show', `${base}:docs/design/CONCERNS.md`], cwd);
+  const concerns = git(['show', `${head}:docs/design/CONCERNS.md`], cwd);
   const paths = extractConcernPaths(concerns, concern);
   const baseTimestamp = Number(git(['show', '-s', '--format=%ct', base], cwd));
   const cutoffTimestamp = baseTimestamp - windowDays * 24 * 60 * 60;

--- a/.cursor/skills/review/scripts/contract-evolution.test.mjs
+++ b/.cursor/skills/review/scripts/contract-evolution.test.mjs
@@ -105,6 +105,29 @@ test('gate counts distinct prior PRs and excludes current branch commits', () =>
   assert.equal(result.triggered, true);
 });
 
+test('gate reads newly added concern routing from head while keeping history at base', () => {
+  const repo = createRepo();
+  const base = git(repo, ['rev-parse', 'HEAD']);
+  const concernPath = 'src/lib/new-concern.ts';
+  const concernsFile = join(repo, 'docs/design/CONCERNS.md');
+
+  write(repo, concernPath, 'current change\n');
+  write(
+    repo,
+    'docs/design/CONCERNS.md',
+    `${readFileSync(concernsFile, 'utf8')}| \`new-concern\` | sub | N | strong | 1 | 8 | \`${concernPath}\` | \`new-concern\` |\n`
+  );
+  git(repo, ['add', '.']);
+  git(repo, ['commit', '-m', 'feat(new-concern): add routed concern (#12)']);
+  const head = git(repo, ['rev-parse', 'HEAD']);
+
+  const result = computeGate({ base, head, concern: 'new-concern', cwd: repo });
+
+  assert.deepEqual(result.paths, [concernPath]);
+  assert.equal(result.prior_semantic_pr_count, 0);
+  assert.deepEqual(result.in_stack_shas, [head]);
+});
+
 test('in_stack_shas is empty when base equals head', () => {
   const repo = createRepo();
   const base = commit(repo, 'feat(telemetry): add facade (#10)', 'feature\n');


### PR DESCRIPTION
## What does this PR do?

The contract-evolution gate was reading `docs/design/CONCERNS.md` from the base commit, even though concern routing is based on the PR head.

This changes the routing lookup to read from `head`, while keeping the history query anchored at `base`.

I also added a regression test for a concern routing row introduced by the PR. The test makes sure the new routing is picked up without counting the current PR commit as prior history.

## Linked issue(s)

Closes #1667

## Checklist

- [x] This PR addresses a **single concern**.
- [x] All commits are signed.
- [x] I’ve added tests for the change.
- [x] `npm run check` passes locally.
- [x] No user-facing text or docs were changed.