### PR TITLE
test(go): stabilize RawMessage contract type on Go 1.27

### DIFF
--- a/pkg/plugin/contract_fixtures_test.go
+++ b/pkg/plugin/contract_fixtures_test.go
@@ -352,6 +352,9 @@ func contractNestedStruct(typ reflect.Type) (reflect.Type, bool) {
 }
 
 func renderContractType(typ reflect.Type) string {
+	if typ == reflect.TypeOf(json.RawMessage{}) {
+		return "json.RawMessage"
+	}
 	if typ.Name() != "" {
 		return typ.String()
 	}
@@ -464,6 +467,25 @@ type contractJSONValue struct{}
 
 func (contractJSONValue) MarshalJSON() ([]byte, error) {
 	return []byte(`"value"`), nil
+}
+
+func TestContractTypeDescriptors(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"raw message", json.RawMessage{}, "json.RawMessage"},
+		{"raw message slice", []json.RawMessage{}, "[]json.RawMessage"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := renderContractType(reflect.TypeOf(c.value)); got != c.want {
+				t.Errorf("contract type = %q, want %q", got, c.want)
+			}
+		})
+	}
 }
 
 func TestContractWireTypeDescriptors(t *testing.T) {


### PR DESCRIPTION
## Summary

Go 1.27 reflects `json.RawMessage` as `jsontext.Value`, which makes the contract golden test fail.

Handle `json.RawMessage` before the generic named-type case. Added cases for `json.RawMessage` and `[]json.RawMessage` to keep the descriptor consistent on Go 1.26.5 and Go 1.27.

## How to verify

1. Run the focused contract tests with Go 1.26.5 and Go 1.27.
2. Confirm the existing struct-tag golden stays unchanged.

## Breaking changes

None.

Fixes #1724