### PR TITLE
fix(custom-guides): finalize decode warning budget

### DIFF
--- a/pkg/plugin/custom_guide_repository.go
+++ b/pkg/plugin/custom_guide_repository.go
@@ -202,6 +202,10 @@ func (a *App) writeCustomGuideUnavailable(w http.ResponseWriter) {
 // drainCustomGuides drains the namespace LIST across pages — up to the
 // aggregate entry budget — and returns the shaped catalogue entries.
 func drainCustomGuides(ctx context.Context, namespace string, lister customGuideLister) ([]customGuideRepositoryEntry, int, error) {
+	if finalizer, ok := lister.(customGuideDrainFinalizer); ok {
+		defer finalizer.finalizeDrain(namespace)
+	}
+
 	entries := []customGuideRepositoryEntry{}
 	continueToken := ""
 	pages := 0

--- a/pkg/plugin/custom_guide_repository_client.go
+++ b/pkg/plugin/custom_guide_repository_client.go
@@ -33,7 +33,7 @@ const (
 	// catalogue drain may emit. A schema drift affects every stored guide at
 	// once, and the aggregate drain budget is customGuideListMaxTotalEntries, so
 	// an uncapped warning is a log flood rather than a diagnostic; the remainder
-	// is summarised in a single line when the drain reaches its last page.
+	// is summarised in a single line when the drain finishes.
 	customGuideDecodeWarnPerDrain = 10
 )
 
@@ -226,6 +226,10 @@ type customGuideLister interface {
 	ListPage(ctx context.Context, namespace, continueToken string) (*customGuidePage, error)
 }
 
+type customGuideDrainFinalizer interface {
+	finalizeDrain(namespace string)
+}
+
 // customGuideHTTPClient is the per-kind wrapper over the shared App Platform
 // LIST client: it supplies the interactiveguides coordinates and shapes each
 // `items[].spec` into a slim, block-stripped customGuideRepositoryEntry.
@@ -247,6 +251,14 @@ type customGuideHTTPClient struct {
 // surfaced as an identity-scoped terminal error.
 func newCustomGuideHTTPClient(appURL string, minter accessTokenMinter, idToken string, logger log.Logger) *customGuideHTTPClient {
 	return &customGuideHTTPClient{inner: newAppPlatformListClient(appURL, minter, idToken, logger)}
+}
+
+func (c *customGuideHTTPClient) finalizeDrain(namespace string) {
+	if c.decodeWarns <= customGuideDecodeWarnPerDrain {
+		return
+	}
+	c.inner.logger.Warn("custom guide repository: further decode warnings suppressed",
+		"namespace", namespace, "warnings", c.decodeWarns, "logged", customGuideDecodeWarnPerDrain)
 }
 
 // ListPage fetches one page of InteractiveGuides for the namespace and shapes
@@ -293,12 +305,6 @@ func (c *customGuideHTTPClient) ListPage(ctx context.Context, namespace, continu
 			continue
 		}
 		entries = append(entries, entry)
-	}
-	// The last page ends the drain this client was built for, so the suppression
-	// summary lands exactly once and counts every page.
-	if page.Continue == "" && c.decodeWarns > customGuideDecodeWarnPerDrain {
-		c.inner.logger.Warn("custom guide repository: further decode warnings suppressed",
-			"namespace", namespace, "warnings", c.decodeWarns, "logged", customGuideDecodeWarnPerDrain)
 	}
 	return &customGuidePage{Entries: entries, Continue: page.Continue}, nil
 }

--- a/pkg/plugin/custom_guide_repository_test.go
+++ b/pkg/plugin/custom_guide_repository_test.go
@@ -846,12 +846,8 @@ func TestCustomGuideHTTPClient_DecodeWarnBudgetSpansPages(t *testing.T) {
 
 	logger := newCapturingLogger()
 	c := newCustomGuideHTTPClient(srv.URL, &stubMinter{token: "at-xyz"}, "id-token-abc", logger)
-	first, err := c.ListPage(context.Background(), testNamespace, "")
-	if err != nil {
-		t.Fatalf("ListPage page 1: %v", err)
-	}
-	if _, err := c.ListPage(context.Background(), testNamespace, first.Continue); err != nil {
-		t.Fatalf("ListPage page 2: %v", err)
+	if _, _, err := drainCustomGuides(context.Background(), testNamespace, c); err != nil {
+		t.Fatalf("drainCustomGuides: %v", err)
 	}
 
 	details, summaries := 0, 0
@@ -868,5 +864,87 @@ func TestCustomGuideHTTPClient_DecodeWarnBudgetSpansPages(t *testing.T) {
 	}
 	if summaries != 1 {
 		t.Errorf("got %d suppression summaries, want exactly 1 for the drain", summaries)
+	}
+}
+
+func TestCustomGuideHTTPClient_DecodeWarnSummaryOnAggregateBudget(t *testing.T) {
+	prev := customGuideListMaxTotalEntries
+	customGuideListMaxTotalEntries = 1
+	t.Cleanup(func() { customGuideListMaxTotalEntries = prev })
+
+	items := make([]map[string]any, 0, customGuideDecodeWarnPerDrain+1)
+	for i := 0; i < customGuideDecodeWarnPerDrain+1; i++ {
+		items = append(items, map[string]any{"spec": map[string]any{
+			"id":       fmt.Sprintf("fe-drifted-%d", i),
+			"manifest": map[string]any{"type": "guide", "stats": map[string]any{"version": 1}},
+		}})
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"metadata": map[string]any{"continue": "page-2"},
+			"items":    items,
+		})
+	}))
+	defer srv.Close()
+
+	logger := newCapturingLogger()
+	c := newCustomGuideHTTPClient(srv.URL, &stubMinter{token: "at-xyz"}, "id-token-abc", logger)
+	if _, _, err := drainCustomGuides(context.Background(), testNamespace, c); err != nil {
+		t.Fatalf("drainCustomGuides: %v", err)
+	}
+
+	details, summaries := 0, 0
+	for _, line := range *logger.lines {
+		switch {
+		case strings.Contains(line.msg, "incomplete manifest stats dropped"):
+			details++
+		case strings.Contains(line.msg, "further decode warnings suppressed"):
+			summaries++
+		}
+	}
+	if details != customGuideDecodeWarnPerDrain {
+		t.Errorf("logged %d detail warnings, want %d", details, customGuideDecodeWarnPerDrain)
+	}
+	if summaries != 1 {
+		t.Errorf("got %d suppression summaries, want exactly 1 after aggregate-budget stop", summaries)
+	}
+}
+
+func TestCustomGuideHTTPClient_DecodeWarnSummaryOnPageError(t *testing.T) {
+	items := make([]map[string]any, 0, customGuideDecodeWarnPerDrain+1)
+	for i := 0; i < customGuideDecodeWarnPerDrain+1; i++ {
+		items = append(items, map[string]any{"spec": map[string]any{
+			"id":       fmt.Sprintf("fe-drifted-%d", i),
+			"manifest": map[string]any{"type": "guide", "stats": map[string]any{"version": 1}},
+		}})
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("continue") != "" {
+			http.Error(w, "upstream failed", http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"metadata": map[string]any{"continue": "page-2"},
+			"items":    items,
+		})
+	}))
+	defer srv.Close()
+
+	logger := newCapturingLogger()
+	c := newCustomGuideHTTPClient(srv.URL, &stubMinter{token: "at-xyz"}, "id-token-abc", logger)
+	if _, _, err := drainCustomGuides(context.Background(), testNamespace, c); err == nil {
+		t.Fatal("drainCustomGuides returned nil error")
+	}
+
+	summaries := 0
+	for _, line := range *logger.lines {
+		if strings.Contains(line.msg, "further decode warnings suppressed") {
+			summaries++
+		}
+	}
+	if summaries != 1 {
+		t.Errorf("got %d suppression summaries, want exactly 1 after page error", summaries)
 	}
 }


### PR DESCRIPTION
## Summary

The decode-warning suppression summary was previously emitted from `ListPage`, which meant it only appeared when pagination reached the final page.

A catalogue drain can also stop early when it reaches the aggregate entry budget, or return because a later page fails. In those cases the drain had already accumulated suppressed decode warnings, but the summary was never emitted.

Move that finalization to `drainCustomGuides` so the summary runs once whenever the drain finishes, regardless of which terminal path is taken.

Add regression coverage for normal pagination, aggregate-budget truncation, and page errors using the real `customGuideHTTPClient`.

## How to verify

- `env GOTOOLCHAIN=go1.26.5 go test ./pkg/plugin -count=1`
- `env GOTOOLCHAIN=go1.26.5 npm run lint:go`
- `env GOTOOLCHAIN=go1.26.5 npm run test:go`
- `LC_ALL=C env GOTOOLCHAIN=go1.26.5 npm run check`

## Breaking changes

None.

Fixes #1725
