### PR TITLE
docs(external-api): correct the unknown-field contract to prune, not 422

### DIFF
--- a/docs/developer/EXTERNAL_API.md
+++ b/docs/developer/EXTERNAL_API.md
@@ -308,9 +308,25 @@ The wire format is the standard Kubernetes envelope:
 | `spec.blocks`              | yes      | Array of content blocks. The full schema is owned by the CUE definition in [grafana-pathfinder-backend/kinds/interactiveguide.cue](https://github.com/grafana/grafana-pathfinder-backend/blob/main/kinds/interactiveguide.cue) — that file is the source of truth. |
 | `spec.manifest`            | no       | Package metadata: grouping, sequencing, dependencies. Absent for content-only guides. See [Manifest](#manifest).                                                                                                                                                   |
 
-The CRD schema **is the validator**. Submit unknown fields and you'll
-get a `422 Unprocessable Entity` with a K8s `Status` envelope explaining
-which field is wrong.
+The CRD schema **is the validator**, and it treats two kinds of mistake
+very differently:
+
+- A **declared** field with a bad value is rejected with a `422` and a
+  K8s `Status` envelope naming the offending field. A `manifest` without
+  `type`, a `manifest.type` outside `guide`/`path`/`journey`, and a
+  `manifest.depends` entry that is a bare string instead of a clause
+  array all fail this way.
+- An **undeclared** field is **silently pruned**, not rejected. The write
+  returns `200`/`201`, and the key is gone on the next GET. The only
+  signal is a `Warning:` response header, which `getBackendSrv()` does not
+  surface to callers. This holds at the top level of `spec` and inside
+  `spec.manifest` alike, and it is the same pruning described for blocks
+  in [Block fields the CRD doesn't declare](#block-fields-the-crd-doesnt-declare).
+
+So a successful write is not evidence that everything you sent was
+persisted. For manifest keys `#Manifest` doesn't declare,
+`additionalFields` is the only durable home — not a stylistic
+preference, but the difference between keeping the value and losing it.
 
 ### Manifest
 
@@ -532,14 +548,14 @@ The aggregator returns standard Kubernetes `Status` envelopes:
 
 Common cases:
 
-| HTTP | Reason        | When                                                                         |
-| ---- | ------------- | ---------------------------------------------------------------------------- |
-| 401  | -             | Missing or invalid Bearer token.                                             |
-| 403  | -             | Token's role is too low for the operation (need Editor for writes).          |
-| 404  | NotFound      | The named guide doesn't exist (or, on listing, the namespace doesn't exist). |
-| 409  | AlreadyExists | POST against a name that already exists. Use PUT to update.                  |
-| 409  | Conflict      | Stale `resourceVersion` on PUT. Re-GET and retry.                            |
-| 422  | Invalid       | Spec failed CRD validation — message names the offending field.              |
+| HTTP | Reason        | When                                                                                                                                         |
+| ---- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| 401  | -             | Missing or invalid Bearer token.                                                                                                             |
+| 403  | -             | Token's role is too low for the operation (need Editor for writes).                                                                          |
+| 404  | NotFound      | The named guide doesn't exist (or, on listing, the namespace doesn't exist).                                                                 |
+| 409  | AlreadyExists | POST against a name that already exists. Use PUT to update.                                                                                  |
+| 409  | Conflict      | Stale `resourceVersion` on PUT. Re-GET and retry.                                                                                            |
+| 422  | Invalid       | A **declared** field failed CRD validation — message names the offending field. Undeclared fields are pruned instead, on a successful write. |
 
 ## Choosing this vs. the editor
 


### PR DESCRIPTION
Fixes #1676.

## What

`docs/developer/EXTERNAL_API.md` told implementers that the CRD rejects unknown fields with a `422`:

> The CRD schema **is the validator**. Submit unknown fields and you'll get a `422 Unprocessable Entity` with a K8s `Status` envelope explaining which field is wrong.

That is the opposite of what happens. Undeclared fields are **pruned** on a successful `200`/`201`; the only signal is a `Warning:` response header, which `getBackendSrv()` does not surface to callers. `422` is reserved for **declared** fields carrying a bad value.

This is the dangerous shape of doc drift: it promises the platform will catch a mistake that it will not catch, so a tool that writes an undeclared key reports success and loses the data.

## The change

Two edits, both in `EXTERNAL_API.md`:

1. Replaced the 422 paragraph with the declared-vs-undeclared distinction — rejection for a bad value in a declared field (with the three concrete `manifest` cases from the issue), silent pruning for anything undeclared, at the top level of `spec` and inside `spec.manifest` alike. It closes by naming `additionalFields` as the only durable home for an undeclared manifest key, which the doc previously framed at `:331-338` as a stylistic choice rather than a requirement.
2. Sharpened the `422` row in the errors table so the summary table doesn't restate the old claim.

Both point at the pruning behaviour the same document already documents for block fields under "Block fields the CRD doesn't declare" — the two sections previously contradicted each other, and now the new text cross-links to it.

## Consistency with the rest of the repo

The prune contract the new text describes is the one the codebase already encodes:

- `scripts/upsert-learning-path.sh:171-220` warns per resource about pruning and sweeps extension keys into `additionalFields`.
- `src/validation/upsert-script-crd-fields.test.ts` asserts that undeclared block fields disappear after a successful write.

No non-doc file needed to change; the code was right and the doc was wrong.

The sibling drift in `grafana-pathfinder-backend/AGENTS.md` is tracked separately at grafana/grafana-pathfinder-backend#84 and is out of scope here.

## Validation

- `npx prettier --check docs/developer/EXTERNAL_API.md` — passes (the errors-table column widths in the diff are prettier's own reflow after the row text changed).
- `npx jest --coverage=false src/validation/` — 914 passed. One unrelated pre-existing failure in `import-graph.test.ts` (`isNodeBuiltin('node:test')`), which is a Node-version artifact of my local Node 22 vs. the repo's `>=24` floor and fails identically on an unmodified checkout.
- Docs-only change: no runtime code, no types, no behaviour.

## AI disclosure

Drafted with AI assistance (Claude), reviewed and verified by me against the repo sources cited above before opening.
