### PR TITLE
fix(validation): validate snippet references against catalog

### DIFF
--- a/docs/developer/CLI_TOOLS.md
+++ b/docs/developer/CLI_TOOLS.md
@@ -79,6 +79,7 @@ node dist/cli/cli/index.js validate [options] [files...]
 - `--format <format>`: Output format. Options are `text` (default) or `json`.
 - `--package <dir>`: Validate a single package directory (expects `content.json` and optionally `manifest.json`).
 - `--packages <dir>`: Validate a tree of package directories recursively.
+- `--snippets-catalog <file>`: Optional generated snippet `index.json` to check every `snippet-ref` ID against. The catalog must satisfy the snippet catalog schema; a missing or invalid catalog fails validation. This option applies to file, stdin, bundled, package, and package-tree validation. Omit it when no local catalog is available.
 - File arguments accept explicit paths to JSON guide files.
 
 ### Examples
@@ -115,6 +116,13 @@ npm run validate:strict
 # Equivalent to: node dist/cli/cli/index.js validate --bundled --strict
 ```
 
+**Validate guide references against a generated snippets catalog:**
+
+```bash
+node dist/cli/cli/index.js build-snippets shared/snippets -o /tmp/snippets-index.json
+node dist/cli/cli/index.js validate --strict --snippets-catalog /tmp/snippets-index.json guides/my-guide/content.json
+```
+
 **Get JSON output for CI integration:**
 
 ```bash
@@ -144,6 +152,7 @@ The validator performs these checks in order:
 2. **Schema compliance** - Types, nesting depth, field names
 3. **Unknown fields** - Warns on unrecognized fields (forward compatibility)
 4. **Condition syntax** - Validates requirements/objectives mini-grammar
+5. **Snippet references** - When `--snippets-catalog` is supplied, every `snippet-ref` ID must be a key in that catalog
 
 Example output with condition warnings:
 

--- a/src/cli/__tests__/validate-snippet-catalog.test.ts
+++ b/src/cli/__tests__/validate-snippet-catalog.test.ts
@@ -1,0 +1,114 @@
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const CLI_ENTRY = path.resolve(__dirname, '../index.ts');
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, JSON.stringify(value), 'utf-8');
+}
+
+function runCli(args: string[]) {
+  return spawnSync(process.execPath, ['-r', 'ts-node/register/transpile-only', CLI_ENTRY, ...args], {
+    cwd: path.resolve(__dirname, '../../..'),
+    encoding: 'utf-8',
+  });
+}
+
+describe('validate --snippets-catalog', () => {
+  let tmpDir: string;
+  let catalogPath: string;
+  let guidePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pathfinder-validate-snippets-'));
+    catalogPath = path.join(tmpDir, 'index.json');
+    guidePath = path.join(tmpDir, 'content.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('accepts a referenced catalog key', () => {
+    writeJson(catalogPath, {
+      known: { id: 'known', title: 'Known', description: 'A known snippet' },
+    });
+
+    writeJson(guidePath, {
+      id: 'guide',
+      title: 'Guide',
+      blocks: [{ type: 'snippet-ref', snippetId: 'known' }],
+    });
+
+    const result = runCli(['validate', '--strict', '--snippets-catalog', catalogPath, guidePath]);
+
+    expect(result.status).toBe(0);
+  });
+
+  it('rejects a missing nested snippet ID', () => {
+    writeJson(catalogPath, {});
+
+    writeJson(guidePath, {
+      id: 'guide',
+      title: 'Guide',
+      blocks: [
+        {
+          type: 'conditional',
+          conditions: ['is-admin'],
+          whenTrue: [{ type: 'snippet-ref', snippetId: 'missing' }],
+          whenFalse: [],
+        },
+      ],
+    });
+
+    const result = runCli(['validate', '--strict', '--snippets-catalog', catalogPath, guidePath]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('blocks[0].whenTrue[0].snippetId');
+    expect(result.stdout).toContain('missing');
+  });
+
+  it('preserves snippet-blind validation when the optional flag is absent', () => {
+    writeJson(guidePath, {
+      id: 'guide',
+      title: 'Guide',
+      blocks: [{ type: 'snippet-ref', snippetId: 'not-checked-without-the-flag' }],
+    });
+
+    const result = runCli(['validate', '--strict', guidePath]);
+
+    expect(result.status).toBe(0);
+  });
+
+  it('fails clearly when the supplied catalog is invalid', () => {
+    writeJson(catalogPath, { broken: true });
+
+    writeJson(guidePath, {
+      id: 'guide',
+      title: 'Guide',
+      blocks: [{ type: 'markdown', content: 'Hello' }],
+    });
+
+    const result = runCli(['validate', '--snippets-catalog', catalogPath, guidePath]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Cannot use snippets catalog');
+  });
+
+  it('checks a package directory with the same catalog', () => {
+    writeJson(catalogPath, {});
+
+    writeJson(path.join(tmpDir, 'content.json'), {
+      id: 'package-guide',
+      title: 'Package guide',
+      blocks: [{ type: 'snippet-ref', snippetId: 'missing-package-snippet' }],
+    });
+
+    const result = runCli(['validate', '--package', tmpDir, '--snippets-catalog', catalogPath]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('missing-package-snippet');
+  });
+});

--- a/src/cli/cli-commands.ts
+++ b/src/cli/cli-commands.ts
@@ -87,7 +87,13 @@ const PRESENTATIONS: Record<string, CommanderPresentation> = {
   },
   validate: {
     positionals: ['files'],
-    placeholders: { files: 'files...', format: 'format', package: 'dir', packages: 'dir' },
+    placeholders: {
+      files: 'files...',
+      format: 'format',
+      package: 'dir',
+      packages: 'dir',
+      snippetsCatalog: 'file',
+    },
     inherits: ['format'],
   },
   e2e: {

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -8,15 +8,17 @@ import { z } from 'zod';
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { SnippetCatalogSchema } from '../../types/json-snippet.schema';
 import type { ContentJson, ManifestJson } from '../../types/package.types';
 import { validateGuideFromString, toLegacyResult } from '../../validation';
+import { readJsonFile } from '../../validation/package-io';
 import { validatePackage, validatePackageTree, type PackageValidationResult } from '../../validation/validate-package';
 import { defineCommand } from '../contracts';
 import { loadGuideFiles, loadBundledGuides, resolveCliPath, type LoadedGuide } from '../utils/file-loader';
 import { validatePackageState } from '../utils/package-io';
 import { manyIssuesOutcome, type CommandOutcome } from '../utils/output';
 
-type ValidateOptions = ValidateCliInput;
+type ValidateOptions = ValidateCliInput & { snippetCatalogIds?: ReadonlySet<string> };
 
 /**
  * Stable message code (defined in `validate-package.ts`) for the six
@@ -35,6 +37,22 @@ interface ValidationSummary {
   warnings: Array<{ file: string; warnings: string[] }>;
 }
 
+function loadSnippetCatalogIds(catalogPath: string): ReadonlySet<string> {
+  const absolutePath = resolveCliPath(catalogPath);
+  const read = readJsonFile(absolutePath, SnippetCatalogSchema);
+
+  if (!read.ok) {
+    const detail =
+      read.code === 'schema_validation'
+        ? read.issues?.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('; ')
+        : read.message;
+
+    throw new Error(`Cannot use snippets catalog "${absolutePath}": ${detail ?? 'unknown error'}`);
+  }
+
+  return new Set(Object.keys(read.data));
+}
+
 function validateGuides(guides: LoadedGuide[], options: ValidateOptions): ValidationSummary {
   const summary: ValidationSummary = {
     totalFiles: guides.length,
@@ -46,7 +64,11 @@ function validateGuides(guides: LoadedGuide[], options: ValidateOptions): Valida
   };
 
   for (const guide of guides) {
-    const result = validateGuideFromString(guide.content, { strict: options.strict });
+    const result = validateGuideFromString(guide.content, {
+      strict: options.strict,
+      snippetCatalogIds: options.snippetCatalogIds,
+    });
+
     const legacy = toLegacyResult(result);
 
     if (result.isValid) {
@@ -163,7 +185,10 @@ function formatPackageResult(dirName: string, result: PackageValidationResult, s
 
 function runPackageValidation(packageDir: string, options: ValidateOptions): CommandOutcome {
   const absoluteDir = resolveCliPath(packageDir);
-  const result = validatePackage(absoluteDir, { strict: options.strict });
+  const result = validatePackage(absoluteDir, {
+    strict: options.strict,
+    snippetCatalogIds: options.snippetCatalogIds,
+  });
 
   if (options.format === 'json') {
     console.log(JSON.stringify(result, null, 2));
@@ -178,7 +203,10 @@ function runPackageValidation(packageDir: string, options: ValidateOptions): Com
 
 function runPackagesValidation(rootDir: string, options: ValidateOptions): CommandOutcome {
   const absoluteRoot = resolveCliPath(rootDir);
-  const results = validatePackageTree(absoluteRoot, { strict: options.strict });
+  const results = validatePackageTree(absoluteRoot, {
+    strict: options.strict,
+    snippetCatalogIds: options.snippetCatalogIds,
+  });
 
   if (results.size === 0) {
     const message = `No package directories found under ${absoluteRoot}`;
@@ -249,7 +277,10 @@ function runFileValidation(guides: LoadedGuide[], options: ValidateOptions): Com
 }
 
 function runStdinValidation(input: string, options: ValidateOptions): CommandOutcome {
-  const result = validateGuideFromString(input, { strict: options.strict });
+  const result = validateGuideFromString(input, {
+    strict: options.strict,
+    snippetCatalogIds: options.snippetCatalogIds,
+  });
   const legacy = toLegacyResult(result);
 
   if (options.format === 'json') {
@@ -426,6 +457,11 @@ export const ValidateCliCommand = z.object({
     .describe('Validate a single package directory (expects content.json)')
     .meta({ role: 'io' }),
   packages: z.string().optional().describe('Validate a tree of package directories').meta({ role: 'io' }),
+  snippetsCatalog: z
+    .string()
+    .optional()
+    .describe('Validate snippet-ref IDs against this generated snippets catalog')
+    .meta({ role: 'io' }),
   verbose: z
     .boolean()
     .default(false)
@@ -443,28 +479,41 @@ export async function runValidateCli(args: ValidateCliInput): Promise<CommandOut
   const failed = (code: string, message: string): CommandOutcome => ({ status: 'error', code, message });
   try {
     const mode = resolveMode(args, args.files);
+
+    if (mode.kind === 'error') {
+      console.error(mode.message);
+      return failed('INVALID_OPTIONS', mode.message);
+    }
+
+    const options = args.snippetsCatalog
+      ? { ...args, snippetCatalogIds: loadSnippetCatalogIds(args.snippetsCatalog) }
+      : args;
+
     switch (mode.kind) {
-      case 'error':
-        console.error(mode.message);
-        return failed('INVALID_OPTIONS', mode.message);
       case 'stdin':
-        return runStdinValidation(await readStdin(), args);
+        return runStdinValidation(await readStdin(), options);
+
       case 'package':
-        return runPackageValidation(mode.path, args);
+        return runPackageValidation(mode.path, options);
+
       case 'packages':
-        return runPackagesValidation(mode.path, args);
+        return runPackagesValidation(mode.path, options);
+
       case 'bundled':
       case 'files': {
         const guides = mode.kind === 'bundled' ? loadBundledGuides() : loadGuideFiles(mode.paths);
+
         if (guides.length === 0) {
           const message =
             mode.kind === 'bundled'
               ? 'No bundled guides found in src/bundled-interactives/'
               : 'No valid JSON guide files found in the specified paths';
+
           console.error(message);
           return failed('NO_GUIDES', message);
         }
-        return runFileValidation(guides, args);
+
+        return runFileValidation(guides, options);
       }
     }
   } catch (error) {

--- a/src/validation/snippet-references.test.ts
+++ b/src/validation/snippet-references.test.ts
@@ -1,0 +1,70 @@
+import type { JsonGuide } from '../types/json-guide.types';
+import { validateSnippetReferences } from './snippet-references';
+
+const guideWith = (blocks: JsonGuide['blocks']): JsonGuide => ({
+  id: 'guide',
+  title: 'Guide',
+  blocks,
+});
+
+describe('validateSnippetReferences', () => {
+  const catalogIds = new Set(['top-level', 'section', 'assistant', 'when-true', 'when-false']);
+
+  it('accepts references present in the catalog at every legal nesting level', () => {
+    const errors = validateSnippetReferences(
+      guideWith([
+        { type: 'snippet-ref', snippetId: 'top-level' },
+        { type: 'section', blocks: [{ type: 'snippet-ref', snippetId: 'section' }] },
+        { type: 'assistant', blocks: [{ type: 'snippet-ref', snippetId: 'assistant' }] },
+        {
+          type: 'conditional',
+          conditions: ['is-admin'],
+          whenTrue: [{ type: 'snippet-ref', snippetId: 'when-true' }],
+          whenFalse: [{ type: 'snippet-ref', snippetId: 'when-false' }],
+        },
+      ]),
+      catalogIds
+    );
+
+    expect(errors).toEqual([]);
+  });
+
+  it('reports every missing reference with its exact path', () => {
+    const errors = validateSnippetReferences(
+      guideWith([
+        { type: 'section', blocks: [{ type: 'snippet-ref', snippetId: 'missing-section' }] },
+        {
+          type: 'conditional',
+          conditions: ['is-admin'],
+          whenTrue: [{ type: 'snippet-ref', snippetId: 'missing-true' }],
+          whenFalse: [{ type: 'snippet-ref', snippetId: 'missing-false' }],
+        },
+      ]),
+      new Set<string>()
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        code: 'unknown_snippet_ref',
+        message: 'blocks[0].blocks[0].snippetId: snippet "missing-section" is not present in the snippets catalog',
+      }),
+      expect.objectContaining({
+        code: 'unknown_snippet_ref',
+        message: 'blocks[1].whenTrue[0].snippetId: snippet "missing-true" is not present in the snippets catalog',
+      }),
+      expect.objectContaining({
+        code: 'unknown_snippet_ref',
+        message: 'blocks[1].whenFalse[0].snippetId: snippet "missing-false" is not present in the snippets catalog',
+      }),
+    ]);
+  });
+
+  it('does nothing when no catalog was supplied', () => {
+    const errors = validateSnippetReferences(
+      guideWith([{ type: 'snippet-ref', snippetId: 'not-checked-without-the-flag' }]),
+      undefined
+    );
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/src/validation/snippet-references.ts
+++ b/src/validation/snippet-references.ts
@@ -1,0 +1,54 @@
+import type { JsonBlock, JsonGuide, JsonSnippetRefBlock } from '../types/json-guide.types';
+import { formatPath, type ValidationError } from './errors';
+
+interface SnippetReference {
+  id: string;
+  path: Array<string | number>;
+}
+
+export function validateSnippetReferences(
+  guide: JsonGuide,
+  catalogIds: ReadonlySet<string> | undefined
+): ValidationError[] {
+  if (!catalogIds) {
+    return [];
+  }
+
+  return collectSnippetReferences(guide.blocks).flatMap((reference) =>
+    catalogIds.has(reference.id)
+      ? []
+      : [
+          {
+            message: `${formatPath(reference.path)}: snippet "${reference.id}" is not present in the snippets catalog`,
+            path: reference.path,
+            code: 'unknown_snippet_ref',
+          },
+        ]
+  );
+}
+
+function collectSnippetReferences(
+  blocks: JsonBlock[],
+  parentPath: Array<string | number> = ['blocks']
+): SnippetReference[] {
+  const references: SnippetReference[] = [];
+
+  for (const [index, block] of blocks.entries()) {
+    const path = [...parentPath, index];
+
+    if (isSnippetRef(block)) {
+      references.push({ id: block.snippetId, path: [...path, 'snippetId'] });
+    } else if (block.type === 'section' || block.type === 'assistant') {
+      references.push(...collectSnippetReferences(block.blocks, [...path, 'blocks']));
+    } else if (block.type === 'conditional') {
+      references.push(...collectSnippetReferences(block.whenTrue, [...path, 'whenTrue']));
+      references.push(...collectSnippetReferences(block.whenFalse, [...path, 'whenFalse']));
+    }
+  }
+
+  return references;
+}
+
+function isSnippetRef(block: JsonBlock): block is JsonSnippetRefBlock {
+  return block.type === 'snippet-ref';
+}

--- a/src/validation/validate-guide.ts
+++ b/src/validation/validate-guide.ts
@@ -15,6 +15,7 @@ import { detectUnknownFields } from './unknown-fields';
 import { validateBlockConditions, type ConditionIssue } from './condition-validator';
 import { customErrorMap } from './error-map';
 import { normalizeJsonGuideAliases } from './normalize-guide-aliases';
+import { validateSnippetReferences } from './snippet-references';
 
 export interface ValidationResult {
   isValid: boolean;
@@ -33,8 +34,8 @@ export interface LegacyValidationResult {
 export interface ValidationOptions {
   strict?: boolean;
   skipUnknownFieldCheck?: boolean;
+  snippetCatalogIds?: ReadonlySet<string>;
 }
-
 /**
  * Convert a condition issue to a validation warning.
  */
@@ -107,6 +108,16 @@ export function validateGuide(data: unknown, options: ValidationOptions = {}): V
         type: 'suggestion',
       });
     }
+  }
+
+  const snippetReferenceErrors = validateSnippetReferences(result.data as JsonGuide, options.snippetCatalogIds);
+  if (snippetReferenceErrors.length > 0) {
+    return {
+      isValid: false,
+      errors: snippetReferenceErrors,
+      warnings: [...warnings, ...advisories],
+      guide: null,
+    };
   }
 
   // 5. Strict mode - promote all warnings to errors

--- a/src/validation/validate-package.ts
+++ b/src/validation/validate-package.ts
@@ -61,6 +61,7 @@ export interface PackageValidationResult {
 
 export interface PackageValidationOptions {
   strict?: boolean;
+  snippetCatalogIds?: ReadonlySet<string>;
 }
 
 /**
@@ -112,6 +113,7 @@ export function validatePackage(packageDir: string, options: PackageValidationOp
   contentResult = validateGuide(contentRead.parsed, {
     strict: options.strict,
     skipUnknownFieldCheck: false,
+    snippetCatalogIds: options.snippetCatalogIds,
   });
 
   if (!contentResult.isValid) {


### PR DESCRIPTION
## What does this PR do?

Adds optional snippet-reference validation to `pathfinder-cli validate` through:

`--snippets-catalog <index.json>`

When the option is supplied, the CLI validates the generated snippets catalog and checks every `snippet-ref` in a guide against its catalog keys. References are checked at the top level and when nested inside sections, assistants, and both conditional branches.

Unknown snippet IDs are reported as normal validation errors with their exact guide path, for example:

`blocks[0].whenTrue[0].snippetId`

The catalog is loaded once per `validate` invocation and the option is forwarded through file, stdin, bundled, package, and package-tree validation.

Without `--snippets-catalog`, validation behaves exactly as before, so existing callers remain snippet-blind unless they explicitly provide a catalog.

This only adds authoring-time validation. Runtime snippet resolution and its existing fail-safe behavior are unchanged.

The corresponding `interactive-tutorials` workflow change is being made separately because it lives in another repository. It will reuse the catalog already generated by `build-snippets` and pass it to strict guide validation when available.

## Linked issue(s)

Addresses #1456

## Verification

- `npm run test:ci -- --coverage=false src/validation/snippet-references.test.ts src/cli/__tests__/validate-snippet-catalog.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run prettier-test`
- `npm run build:cli`
- `npm run check`
- `git diff --check`
- manually verified that a known catalog reference passes
- manually verified that a missing nested reference fails with its exact `snippetId` path
- manually verified that the same guide passes when `--snippets-catalog` is omitted

## Checklist

- [x] This PR addresses a **single concern**: validating authored `snippet-ref` IDs against a supplied snippets catalog.
- [x] All commits are signed.
- [x] I've added or updated tests for the change.
- [x] `npm run check` passes locally.
- [x] UI text and docs use sentence case.