### PR TITLE
Make experiment variant projections total

### DIFF
--- a/.cursor/skills/create-experiment/SKILL.md
+++ b/.cursor/skills/create-experiment/SKILL.md
@@ -37,7 +37,7 @@ Add to `pathfinderFeatureFlags` in `src/utils/openfeature.ts`. This is the one p
 ```typescript
 'pathfinder.<experiment-name>-experiment': {
   valueType: 'object',
-  values: [{ variant: 'excluded' }, { variant: 'control' }, { variant: 'treatment' }],
+  values: EXPERIMENT_VARIANTS.map((variant) => ({ variant })),
   defaultValue: { variant: 'excluded' },
   trackingKey: '<experiment_name>_experiment',
 },
@@ -49,6 +49,8 @@ Add to `pathfinderFeatureFlags` in `src/utils/openfeature.ts`. This is the one p
 - Keep `defaultValue` an inline literal so the registry does not import your experiment module — that import direction causes a cycle (see step 3).
 
 Three arms, always: `excluded` (not in the experiment), `control` (in it, current behaviour), `treatment` (in it, new behaviour). `excluded` and `control` must render identically; the difference is only whether the user is counted.
+
+`EXPERIMENT_VARIANTS` in `src/utils/openfeature.ts` is the runtime vocabulary and derives the TypeScript union. Adding an arm also requires an explicit policy in both total projections: `EXPERIMENT_VARIANT_EMITS_EXPOSURE` in `src/utils/openfeature-tracking.ts` and `EXPERIMENT_VARIANT_PRECEDENCE` in `src/lib/analytics.ts`. The compiler should fail until both decisions are made.
 
 ### 2. Create the experiment module
 

--- a/.cursor/skills/create-experiment/SKILL.md
+++ b/.cursor/skills/create-experiment/SKILL.md
@@ -52,6 +52,8 @@ Three arms, always: `excluded` (not in the experiment), `control` (in it, curren
 
 `EXPERIMENT_VARIANTS` in `src/utils/openfeature.ts` is the runtime vocabulary and derives the TypeScript union. Adding an arm also requires an explicit policy in both total projections: `EXPERIMENT_VARIANT_EMITS_EXPOSURE` in `src/utils/openfeature-tracking.ts` and `EXPERIMENT_VARIANT_PRECEDENCE` in `src/lib/analytics.ts`. The compiler should fail until both decisions are made.
 
+The compiler does not cover the runtime arm gates in `src/utils/experiments/highlighted-guide-orchestrator.ts` and `src/context-engine/context.service.ts`; review both explicitly when adding an arm.
+
 ### 2. Create the experiment module
 
 Everything else goes in `src/utils/experiments/<experiment-name>.ts` so retirement is a directory delete.

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -185,6 +185,14 @@ describe('reportAppInteraction experiment enrichment', () => {
     expect(mockReportInteraction.mock.calls[0][1].variant).toBe('control');
   });
 
+  it('rolls variant up to excluded when every experiment is excluded', () => {
+    bindExperimentsProvider(() => [{ flag: HIGHLIGHTED, variant: 'excluded', pages: [], guideId: 'g' }]);
+
+    reportAppInteraction(UserInteraction.SummaryClick, {});
+
+    expect(mockReportInteraction.mock.calls[0][1].variant).toBe('excluded');
+  });
+
   it('omits variant/experiments when the user is enrolled in nothing', () => {
     bindExperimentsProvider(() => []);
 

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -185,6 +185,19 @@ describe('reportAppInteraction experiment enrichment', () => {
     expect(mockReportInteraction.mock.calls[0][1].variant).toBe('control');
   });
 
+  it.each([
+    ['control before treatment', ['control', 'treatment']],
+    ['treatment before control', ['treatment', 'control']],
+  ] as const)('rolls multiple experiments up to treatment with %s', (_order, variants) => {
+    bindExperimentsProvider(() =>
+      variants.map((variant) => ({ flag: HIGHLIGHTED, variant, pages: [], guideId: 'g' }))
+    );
+
+    reportAppInteraction(UserInteraction.SummaryClick, {});
+
+    expect(mockReportInteraction.mock.calls[0][1].variant).toBe('treatment');
+  });
+
   it('rolls variant up to excluded when every experiment is excluded', () => {
     bindExperimentsProvider(() => [{ flag: HIGHLIGHTED, variant: 'excluded', pages: [], guideId: 'g' }]);
 

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -189,9 +189,7 @@ describe('reportAppInteraction experiment enrichment', () => {
     ['control before treatment', ['control', 'treatment']],
     ['treatment before control', ['treatment', 'control']],
   ] as const)('rolls multiple experiments up to treatment with %s', (_order, variants) => {
-    bindExperimentsProvider(() =>
-      variants.map((variant) => ({ flag: HIGHLIGHTED, variant, pages: [], guideId: 'g' }))
-    );
+    bindExperimentsProvider(() => variants.map((variant) => ({ flag: HIGHLIGHTED, variant, pages: [], guideId: 'g' })));
 
     reportAppInteraction(UserInteraction.SummaryClick, {});
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -187,14 +187,18 @@ export function getBoundActiveExperiments(): ExperimentAnalyticsEntry[] {
   return getExperimentsForAnalytics() ?? [];
 }
 
+const EXPERIMENT_VARIANT_PRECEDENCE = {
+  excluded: 0,
+  control: 1,
+  treatment: 2,
+} satisfies Record<ExperimentConfig['variant'], number>;
+
 function rollUpVariant(experiments: ExperimentAnalyticsEntry[]): ExperimentConfig['variant'] {
-  if (experiments.some((experiment) => experiment.variant === 'treatment')) {
-    return 'treatment';
-  }
-  if (experiments.some((experiment) => experiment.variant === 'control')) {
-    return 'control';
-  }
-  return 'excluded';
+  return experiments.reduce<ExperimentConfig['variant']>((highest, experiment) => {
+    return EXPERIMENT_VARIANT_PRECEDENCE[experiment.variant] > EXPERIMENT_VARIANT_PRECEDENCE[highest]
+      ? experiment.variant
+      : highest;
+  }, 'excluded');
 }
 
 /**

--- a/src/utils/openfeature-tracking.test.ts
+++ b/src/utils/openfeature-tracking.test.ts
@@ -221,6 +221,12 @@ describe('reportFeatureFlagExposure', () => {
     expect(localStorage.length).toBe(0);
   });
 
+  it('skips prototype property names masquerading as variants', () => {
+    const report = freshReportFn();
+    report('pathfinder.highlighted-guide-experiment', { variant: 'toString', pages: [] });
+    expect(mockReportAppInteraction).not.toHaveBeenCalled();
+  });
+
   it('skips boolean flags (config, not experiment arms)', () => {
     const report = freshReportFn();
     report('pathfinder.enabled', true);

--- a/src/utils/openfeature-tracking.ts
+++ b/src/utils/openfeature-tracking.ts
@@ -35,20 +35,19 @@ function markReportedExposure(flagKey: string, variant: string): void {
 }
 
 /**
- * Variants for which we emit a FeatureFlagEvaluated exposure event.
+ * Experiment-arm membership and exposure policy at the analytics boundary.
  *
- * We intentionally skip 'excluded' (user isn't in the experiment) so the
- * event stream only contains real experiment exposures (control + treatment),
- * which is what downstream A/B analysis needs.
+ * Every valid arm is an own key; `false` keeps `excluded` out of the event
+ * stream while control and treatment emit the exposures used by A/B analysis.
  */
-const TRACKED_EXPERIMENT_VARIANTS = {
+const EXPERIMENT_VARIANT_EMITS_EXPOSURE = {
   excluded: false,
   control: true,
   treatment: true,
 } satisfies Record<ExperimentConfig['variant'], boolean>;
 
 function isExperimentVariant(variant: string): variant is ExperimentConfig['variant'] {
-  return Object.hasOwn(TRACKED_EXPERIMENT_VARIANTS, variant);
+  return Object.hasOwn(EXPERIMENT_VARIANT_EMITS_EXPOSURE, variant);
 }
 
 function extractExperimentVariant(value: JsonValue): ExperimentConfig['variant'] | null {
@@ -123,7 +122,7 @@ export function reportFeatureFlagExposure(flagKey: string, value: JsonValue): vo
   }
 
   const variant = extractExperimentVariant(value);
-  if (!variant || !TRACKED_EXPERIMENT_VARIANTS[variant]) {
+  if (!variant || !EXPERIMENT_VARIANT_EMITS_EXPOSURE[variant]) {
     return;
   }
 

--- a/src/utils/openfeature-tracking.ts
+++ b/src/utils/openfeature-tracking.ts
@@ -2,7 +2,7 @@ import type { Hook, HookContext, EvaluationDetails, JsonValue } from '@openfeatu
 
 import { reportAppInteraction, UserInteraction } from '../lib/analytics';
 import { StorageKeys } from '../lib/storage-keys';
-import { pathfinderFeatureFlags, type FeatureFlagName } from './openfeature';
+import { pathfinderFeatureFlags, type ExperimentConfig, type FeatureFlagName } from './openfeature';
 
 /**
  * In-memory fast path so the same flag never fires twice within one page load
@@ -41,18 +41,27 @@ function markReportedExposure(flagKey: string, variant: string): void {
  * event stream only contains real experiment exposures (control + treatment),
  * which is what downstream A/B analysis needs.
  */
-const TRACKED_EXPERIMENT_VARIANTS = new Set(['control', 'treatment']);
+const TRACKED_EXPERIMENT_VARIANTS = {
+  excluded: false,
+  control: true,
+  treatment: true,
+} satisfies Record<ExperimentConfig['variant'], boolean>;
 
-/**
- * Safely extract a string `variant` field from a JSON flag value.
- * Returns null if the value isn't an object or has no string variant.
- */
-function extractVariant(value: JsonValue): string | null {
-  if (value && typeof value === 'object' && !Array.isArray(value) && 'variant' in value) {
-    const raw = (value as { variant: unknown }).variant;
-    return typeof raw === 'string' ? raw : null;
+function isExperimentVariant(variant: string): variant is ExperimentConfig['variant'] {
+  return Object.hasOwn(TRACKED_EXPERIMENT_VARIANTS, variant);
+}
+
+function extractExperimentVariant(value: JsonValue): ExperimentConfig['variant'] | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value) || !('variant' in value)) {
+    return null;
   }
-  return null;
+
+  const variant = (value as { variant: unknown }).variant;
+  if (typeof variant !== 'string' || !isExperimentVariant(variant)) {
+    return null;
+  }
+
+  return variant;
 }
 
 /**
@@ -113,8 +122,8 @@ export function reportFeatureFlagExposure(flagKey: string, value: JsonValue): vo
     return;
   }
 
-  const variant = extractVariant(value);
-  if (!variant || !TRACKED_EXPERIMENT_VARIANTS.has(variant)) {
+  const variant = extractExperimentVariant(value);
+  if (!variant || !TRACKED_EXPERIMENT_VARIANTS[variant]) {
     return;
   }
 

--- a/src/utils/openfeature.test.ts
+++ b/src/utils/openfeature.test.ts
@@ -882,28 +882,31 @@ describe('openfeature', () => {
       });
     });
 
-    it.each(['excluded', 'control', 'treatment'])('passes the %p variant through unchanged', (variant) => {
+    it('passes every registered experiment variant through unchanged', () => {
       jest.isolateModules(() => {
         const mockOF = createMockOpenFeature();
         const mockReact = createMockReactSdk();
-        mockOF.mockClient.getObjectValue.mockReturnValue({
-          variant,
-          pages: ['/a/grafana-irm-app*'],
-          guideId: 'bundled:my-guide',
-          autoOpen: true,
-        });
         jest.doMock('@openfeature/web-sdk', () => mockOF);
         jest.doMock('@openfeature/react-sdk', () => mockReact);
 
-        const { getHighlightedGuideConfig } = require('./openfeature');
+        const { EXPERIMENT_VARIANTS, getHighlightedGuideConfig } = require('./openfeature');
 
-        expect(getHighlightedGuideConfig()).toEqual({
-          variant,
-          pages: ['/a/grafana-irm-app*'],
-          guideId: 'bundled:my-guide',
-          autoOpen: true,
-          resetCache: false,
-        });
+        for (const variant of EXPERIMENT_VARIANTS) {
+          mockOF.mockClient.getObjectValue.mockReturnValue({
+            variant,
+            pages: ['/a/grafana-irm-app*'],
+            guideId: 'bundled:my-guide',
+            autoOpen: true,
+          });
+
+          expect(getHighlightedGuideConfig()).toEqual({
+            variant,
+            pages: ['/a/grafana-irm-app*'],
+            guideId: 'bundled:my-guide',
+            autoOpen: true,
+            resetCache: false,
+          });
+        }
       });
     });
   });

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -33,8 +33,10 @@ type FeatureFlag =
  * @param pages - Target pages where sidebar should auto-open (for treatment)
  * @param resetCache - When toggled true, clears session storage to allow sidebar to auto-open again
  */
+export const EXPERIMENT_VARIANTS = ['excluded', 'control', 'treatment'] as const;
+
 export interface ExperimentConfig {
-  variant: 'excluded' | 'control' | 'treatment';
+  variant: (typeof EXPERIMENT_VARIANTS)[number];
   pages: string[];
   resetCache?: boolean;
 }
@@ -186,7 +188,7 @@ const pathfinderFeatureFlags = {
    */
   'pathfinder.interactive-learning-banner-experiment': {
     valueType: 'object',
-    values: [{ variant: 'excluded' }, { variant: 'control' }, { variant: 'treatment' }],
+    values: EXPERIMENT_VARIANTS.map((variant) => ({ variant })),
     defaultValue: { variant: 'excluded' },
     trackingKey: 'interactive_learning_banner_experiment',
   },
@@ -579,7 +581,7 @@ export const getHighlightedGuideConfig = (): HighlightedGuideConfig => {
   }
 };
 
-const VALID_VARIANTS: ReadonlySet<HighlightedGuideConfig['variant']> = new Set(['excluded', 'control', 'treatment']);
+const VALID_VARIANTS: ReadonlySet<string> = new Set(EXPERIMENT_VARIANTS);
 
 const VALID_DOC_TYPES: ReadonlySet<HighlightedGuideDocType> = new Set(['docs-page', 'learning-journey', 'interactive']);
 

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -25,6 +25,8 @@ type FeatureFlag =
   | { valueType: 'number'; values: readonly number[]; defaultValue: number; trackingKey?: string }
   | { valueType: 'string'; values: readonly string[]; defaultValue: string; trackingKey?: string };
 
+export const EXPERIMENT_VARIANTS = ['excluded', 'control', 'treatment'] as const;
+
 /**
  * Experiment configuration returned by GOFF
  * Contains both the variant assignment and target pages for auto-open
@@ -33,8 +35,6 @@ type FeatureFlag =
  * @param pages - Target pages where sidebar should auto-open (for treatment)
  * @param resetCache - When toggled true, clears session storage to allow sidebar to auto-open again
  */
-export const EXPERIMENT_VARIANTS = ['excluded', 'control', 'treatment'] as const;
-
 export interface ExperimentConfig {
   variant: (typeof EXPERIMENT_VARIANTS)[number];
   pages: string[];
@@ -602,7 +602,7 @@ export function parseExperimentVariant(value: unknown): ExperimentConfig['varian
     return null;
   }
   const { variant } = value as Record<string, unknown>;
-  if (typeof variant !== 'string' || !VALID_VARIANTS.has(variant as ExperimentConfig['variant'])) {
+  if (typeof variant !== 'string' || !VALID_VARIANTS.has(variant)) {
     return null;
   }
   return variant as ExperimentConfig['variant'];
@@ -615,7 +615,7 @@ function classifyExperimentRejection(value: unknown): 'unknown_variant' | 'inval
     value && typeof value === 'object' && !Array.isArray(value)
       ? (value as Record<string, unknown>).variant
       : undefined;
-  const isUnknownArm = typeof variant === 'string' && !VALID_VARIANTS.has(variant as ExperimentConfig['variant']);
+  const isUnknownArm = typeof variant === 'string' && !VALID_VARIANTS.has(variant);
   return isUnknownArm ? 'unknown_variant' : 'invalid_shape';
 }
 


### PR DESCRIPTION
## What does this PR do?

Makes the experiment arm vocabulary a single runtime tuple and derives both its TypeScript union and the banner flag registry from it. The two deliberately different projections remain explicit total records: exposure tracking classifies every arm, and analytics roll-up assigns every arm a precedence.

This preserves the current three-arm behavior while making a future arm fail type-checking until its exposure and roll-up policies are decided. The parser and tracking boundary also reject inherited object property names rather than treating them as variants.

## Linked issue(s)

Closes #1548

## Verification

- focused OpenFeature, exposure-tracking, and analytics tests: 83 tests
- regression coverage for the excluded roll-up and prototype-property variant case
- full `npm run check`: all 9 stages passed, including 505 Jest suites / more than 8,100 tests and Go lint/tests

## Checklist

- [x] This PR addresses a **single concern** (one bug fix or feature, or a set of closely-related changes). Unrelated changes belong in separate PRs; see [CONTRIBUTING.md](../CONTRIBUTING.md#pull-request-scope).
- [x] All commits are signed (required, or the checks will not pass). See [CONTRIBUTING.md](../CONTRIBUTING.md#signed-commits).
- [x] I've added or updated tests for the change.
- [x] `npm run check` passes locally — the pre-merge gate. `npm run check -- --list` prints what it runs.
- [x] UI text and docs use [sentence case](https://grafana.com/docs/writers-toolkit/write/style-guide/capitalization-punctuation/#capitalization).
