### PR TITLE
Ratchet eslint-disable comments without justifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Never paste a raw control byte into a tracked file — write it as an escape (`\
 
 **Default to no comments.** Add one only when removing it would confuse a reader who can already read the surrounding code. The narrow band that earns one: counterintuitive-but-correct code, hidden invariants the type system can't express, external-bug workarounds (with an upstream link), and security or correctness warnings. If the comment won't fit on one short line, rename or restructure instead.
 
+Every `eslint-disable` directive requires a narrow explanation after `--`. Legacy directives without one are tracked by the shrink-only #1752 baseline and must not grow.
+
 **Trim on touch.** When editing a function, also trim bad-shape comments inside it and on adjacent declarations in the same file. Do not sweep whole files or grep the repo for cleanup — comment removal rides along on code changes, never as a standalone PR.
 
 The keep-list above is the whole of it. The eight bad shapes (QC8), with worked before/after examples, live in the `comment-hygiene` skill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Never paste a raw control byte into a tracked file — write it as an escape (`\
 
 **Default to no comments.** Add one only when removing it would confuse a reader who can already read the surrounding code. The narrow band that earns one: counterintuitive-but-correct code, hidden invariants the type system can't express, external-bug workarounds (with an upstream link), and security or correctness warnings. If the comment won't fit on one short line, rename or restructure instead.
 
-Every `eslint-disable` directive requires a narrow explanation after `--`. Legacy directives without one are tracked by the shrink-only #1752 baseline and must not grow.
+Every `eslint-disable` directive requires a narrow explanation after `--`. `src/validation/eslint-disable-justifications.test.ts` enforces this; legacy directives without one are tracked by `UNDESCRIBED_ESLINT_DISABLE_BASELINE` and must not grow.
 
 **Trim on touch.** When editing a function, also trim bad-shape comments inside it and on adjacent declarations in the same file. Do not sweep whole files or grep the repo for cleanup — comment removal rides along on code changes, never as a standalone PR.
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:coverage": "jest --coverage",
     "test:review-contract": "node --test .cursor/skills/review/scripts/*.test.mjs",
     "test:scripts": "bash scripts/tests/run.sh",
-    "test:governance": "jest src/validation/architecture.test.ts src/validation/import-graph.test.ts src/validation/security-lint-config.test.ts src/validation/control-bytes.test.ts",
+    "test:governance": "jest src/validation/architecture.test.ts src/validation/import-graph.test.ts src/validation/security-lint-config.test.ts src/validation/control-bytes.test.ts src/validation/eslint-disable-justifications.test.ts",
     "test:coverage:watch": "jest --coverage --watch",
     "test:go": "mage -v test",
     "typecheck": "tsc --noEmit",

--- a/src/validation/eslint-disable-justifications.test.ts
+++ b/src/validation/eslint-disable-justifications.test.ts
@@ -8,6 +8,7 @@ const REPO_ROOT = path.resolve(__dirname, '../..');
 const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx']);
 const DIRECTIVE_PATTERN = /(?:\/\/|\/\*)\s*eslint-disable(?:-next-line|-line)?(?:\s|$)/;
 const JUSTIFICATION_SEPARATOR = ' -- ';
+const ESLINT_DISABLE_DIRECTIVE = ['eslint', 'disable'].join('-');
 
 const UNDESCRIBED_ESLINT_DISABLE_BASELINE = new Set([
   'src/learning-paths/learning-paths.hook.ts:137',
@@ -101,7 +102,7 @@ describe('eslint-disable justifications', () => {
   it('detects a newly introduced undescribed suppression', () => {
     const result = scanEslintDisableComments(
       'src/example.ts',
-      '// eslint-disable-next-line react-hooks/exhaustive-deps\nuseEffect(() => {}, []);'
+      `// ${ESLINT_DISABLE_DIRECTIVE}-next-line react-hooks/exhaustive-deps\nuseEffect(() => {}, []);`
     );
 
     expect(result).toEqual({ directiveCount: 1, undescribed: new Set(['src/example.ts:1']) });
@@ -111,7 +112,7 @@ describe('eslint-disable justifications', () => {
     const result = scanEslintDisableComments(
       'src/example.ts',
       [
-        '// eslint-disable-next-line react-hooks/exhaustive-deps -- dependency is intentionally stable',
+        `// ${ESLINT_DISABLE_DIRECTIVE}-next-line react-hooks/exhaustive-deps -- dependency is intentionally stable`,
         '// This prose says eslint-disable but is not a directive.',
       ].join('\n')
     );
@@ -122,11 +123,11 @@ describe('eslint-disable justifications', () => {
   it('excludes the known documentation and prose examples', () => {
     const docExample = scanEslintDisableComments(
       'src/test-utils/interactive-section-harness.tsx',
-      ' *   // eslint-disable-next-line @typescript-eslint/no-require-imports'
+      ` *   // ${ESLINT_DISABLE_DIRECTIVE}-next-line @typescript-eslint/no-require-imports`
     );
     const proseExample = scanEslintDisableComments(
       'src/requirements-manager/step-checker.hook.ts',
-      '// eslint-disable on its dep array). The callback closes over the value.'
+      `// ${ESLINT_DISABLE_DIRECTIVE} on its dep array). The callback closes over the value.`
     );
 
     expect(docExample).toEqual({ directiveCount: 0, undescribed: new Set() });

--- a/src/validation/eslint-disable-justifications.test.ts
+++ b/src/validation/eslint-disable-justifications.test.ts
@@ -6,93 +6,147 @@ import { assertRatchet } from './import-graph';
 
 const REPO_ROOT = path.resolve(__dirname, '../..');
 const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx']);
-const DIRECTIVE_PATTERN = /(?:\/\/|\/\*)\s*eslint-disable(?:-next-line|-line)?(?:\s|$)/;
+const DIRECTIVE_PATTERN =
+  /(?:\/\/\s*(eslint-disable-(?:next-line|line))|\/\*\s*(eslint-disable(?:-(?:next-line|line))?))(?=\s|\*\/|$)/;
 const JUSTIFICATION_SEPARATOR = ' -- ';
 const ESLINT_DISABLE_DIRECTIVE = ['eslint', 'disable'].join('-');
 
+/**
+ * Shrink-only baseline for #1752. Keys are `path::rule#occurrence`, where the
+ * occurrence counts undescribed suppressions for that rule within the file.
+ * Line numbers stay diagnostic-only so unrelated edits cannot invalidate it.
+ */
 const UNDESCRIBED_ESLINT_DISABLE_BASELINE = new Set([
-  'src/learning-paths/learning-paths.hook.ts:137',
-  'src/learning-paths/learning-paths.hook.ts:243',
-  'src/learning-paths/useDiscoverMore.ts:126',
-  'src/components/docs-panel/hooks/useTabRestoration.ts:80',
-  'src/components/docs-panel/hooks/useSessionJoinUrlCheck.ts:42',
-  'src/components/content-renderer/content-renderer.tsx:374',
-  'src/components/content-renderer/content-renderer.tsx:603',
-  'src/package-engine/recommender-resolver.test.ts:387',
-  'src/components/interactive-tutorial/interactive-step.tsx:475',
-  'src/components/interactive-tutorial/interactive-step.tsx:925',
-  'src/components/interactive-tutorial/hooks/use-section-requirements.ts:192',
-  'src/components/interactive-tutorial/hooks/use-section-persistence.ts:141',
-  'src/components/interactive-tutorial/interactive-quiz.tsx:223',
-  'src/components/interactive-tutorial/datasource-check-step.tsx:228',
-  'src/components/App/ContextPanel.tsx:31',
-  'src/components/full-screen/FullScreenPanel.tsx:130',
-  'src/components/block-editor/hooks/useBackendGuides.ts:391',
-  'src/requirements-manager/step-checker.hook.ts:836',
-  'src/requirements-manager/step-checker.hook.ts:959',
-  'src/components/block-editor/hooks/useBlockPersistence.ts:225',
-  'src/components/block-editor/GitHubPRModal.tsx:227',
-  'src/components/block-editor/LintBadge.tsx:68',
-  'src/docs-retrieval/learning-journey-helpers.ts:20',
-  'src/global-state/completion-store.ts:482',
-  'src/components/floating-panel/FloatingPanelManager.tsx:183',
-  'src/integrations/assistant-integration/AssistantCustomizable.tsx:233',
-  'src/integrations/assistant-integration/AssistantSelectionPopover.tsx:88',
-  'src/utils/usePublishedGuides.ts:90',
-  'src/utils/devtools/element-inspector.hook.ts:114',
+  'src/learning-paths/learning-paths.hook.ts::react-hooks/exhaustive-deps#1',
+  'src/learning-paths/learning-paths.hook.ts::react-hooks/exhaustive-deps#2',
+  'src/learning-paths/useDiscoverMore.ts::react-hooks/exhaustive-deps#1',
+  'src/components/docs-panel/hooks/useTabRestoration.ts::react-hooks/exhaustive-deps#1',
+  'src/components/docs-panel/hooks/useSessionJoinUrlCheck.ts::react-hooks/exhaustive-deps#1',
+  'src/components/content-renderer/content-renderer.tsx::react-hooks/exhaustive-deps#1',
+  'src/components/content-renderer/content-renderer.tsx::react-hooks/exhaustive-deps#2',
+  'src/package-engine/recommender-resolver.test.ts::@typescript-eslint/no-namespace#1',
+  'src/components/interactive-tutorial/interactive-step.tsx::react-hooks/exhaustive-deps#1',
+  'src/components/interactive-tutorial/interactive-step.tsx::react-hooks/exhaustive-deps#2',
+  'src/components/interactive-tutorial/hooks/use-section-requirements.ts::react-hooks/set-state-in-effect#1',
+  'src/components/interactive-tutorial/hooks/use-section-persistence.ts::react-hooks/exhaustive-deps#1',
+  'src/components/interactive-tutorial/interactive-quiz.tsx::react-hooks/exhaustive-deps#1',
+  'src/components/interactive-tutorial/datasource-check-step.tsx::react-hooks/exhaustive-deps#1',
+  'src/components/App/ContextPanel.tsx::react-hooks/exhaustive-deps#1',
+  'src/components/full-screen/FullScreenPanel.tsx::react-hooks/exhaustive-deps#1',
+  'src/components/block-editor/hooks/useBackendGuides.ts::react-hooks/exhaustive-deps#1',
+  'src/requirements-manager/step-checker.hook.ts::react-hooks/exhaustive-deps#1',
+  'src/requirements-manager/step-checker.hook.ts::react-hooks/exhaustive-deps#2',
+  'src/components/block-editor/hooks/useBlockPersistence.ts::react-hooks/exhaustive-deps#1',
+  'src/components/block-editor/GitHubPRModal.tsx::react-hooks/exhaustive-deps#1',
+  'src/components/block-editor/LintBadge.tsx::react-hooks/exhaustive-deps#1',
+  'src/docs-retrieval/learning-journey-helpers.ts::no-restricted-imports#1',
+  'src/global-state/completion-store.ts::react-hooks/exhaustive-deps#1',
+  'src/components/floating-panel/FloatingPanelManager.tsx::react-hooks/exhaustive-deps#1',
+  'src/integrations/assistant-integration/AssistantCustomizable.tsx::react-hooks/set-state-in-effect#1',
+  'src/integrations/assistant-integration/AssistantSelectionPopover.tsx::react-hooks/set-state-in-effect#1',
+  'src/utils/usePublishedGuides.ts::react-hooks/exhaustive-deps#1',
+  'src/utils/devtools/element-inspector.hook.ts::react-hooks/exhaustive-deps#1',
 ]);
+
+type DirectiveForm = 'block' | 'block-next-line' | 'line' | 'line-next-line';
 
 interface ScanResult {
   directiveCount: number;
+  directiveForms: Record<DirectiveForm, number>;
   undescribed: Set<string>;
+  undescribedLocations: Map<string, string>;
 }
 
-function isDocumentedExample(relPath: string, line: string): boolean {
-  if (relPath === 'src/test-utils/interactive-section-harness.tsx' && line.trimStart().startsWith('*')) {
-    return true;
-  }
+function emptyDirectiveForms(): Record<DirectiveForm, number> {
+  return { block: 0, 'block-next-line': 0, line: 0, 'line-next-line': 0 };
+}
+
+function directiveForm(lineDirective: string, blockDirective: string | undefined): DirectiveForm {
+  const prefix = blockDirective ? 'block' : 'line';
+  return lineDirective.endsWith('-next-line') || blockDirective?.endsWith('-next-line')
+    ? `${prefix}-next-line`
+    : prefix;
+}
+
+function directiveRule(line: string, match: RegExpMatchArray): string {
+  const remainder = line.slice((match.index ?? 0) + match[0].length);
+  const beforeJustification = remainder.split(JUSTIFICATION_SEPARATOR, 1)[0] ?? '';
   return (
-    relPath === 'src/requirements-manager/step-checker.hook.ts' && line.includes('eslint-disable on its dep array')
+    beforeJustification
+      .replace(/\*\/.*$/, '')
+      .trim()
+      .replace(/\s*,\s*/g, ',') || '<all>'
   );
 }
 
 export function scanEslintDisableComments(relPath: string, content: string): ScanResult {
   let directiveCount = 0;
+  const directiveForms = emptyDirectiveForms();
   const undescribed = new Set<string>();
+  const undescribedLocations = new Map<string, string>();
+  const occurrences = new Map<string, number>();
 
   content.split(/\r?\n/).forEach((line, index) => {
-    if (!DIRECTIVE_PATTERN.test(line)) {
+    const match = line.match(DIRECTIVE_PATTERN);
+    if (!match || line.trimStart().startsWith('*')) {
       return;
     }
 
-    if (isDocumentedExample(relPath, line)) {
-      return;
-    }
-
-    const location = `${relPath}:${index + 1}`;
     directiveCount++;
+    const lineDirective = match[1] ?? '';
+    const blockDirective = match[2];
+    directiveForms[directiveForm(lineDirective, blockDirective)]++;
     if (!line.includes(JUSTIFICATION_SEPARATOR)) {
-      undescribed.add(location);
+      const baseKey = `${relPath}::${directiveRule(line, match)}`;
+      const occurrence = (occurrences.get(baseKey) ?? 0) + 1;
+      occurrences.set(baseKey, occurrence);
+      const key = `${baseKey}#${occurrence}`;
+      undescribed.add(key);
+      undescribedLocations.set(key, `${relPath}:${index + 1}`);
     }
   });
 
-  return { directiveCount, undescribed };
+  return { directiveCount, directiveForms, undescribed, undescribedLocations };
 }
 
 function trackedSourceFiles(): string[] {
-  return execFileSync('git', ['ls-files', '-z', 'src'], { cwd: REPO_ROOT })
-    .toString('utf-8')
-    .split('\0')
-    .filter((relPath) => relPath && SOURCE_EXTENSIONS.has(path.extname(relPath)));
+  try {
+    return execFileSync('git', ['ls-files', '-z', 'src'], { cwd: REPO_ROOT })
+      .toString('utf-8')
+      .split('\0')
+      .filter((relPath) => {
+        if (!relPath || !SOURCE_EXTENSIONS.has(path.extname(relPath))) {
+          return false;
+        }
+        const fullPath = path.join(REPO_ROOT, relPath);
+        return fs.existsSync(fullPath) && fs.statSync(fullPath).isFile();
+      });
+  } catch (error) {
+    throw new Error(
+      `Could not enumerate tracked source files with \`git ls-files\` in ${REPO_ROOT}. ` +
+        `This governance check needs a git checkout with git on PATH.\n${String(error)}`
+    );
+  }
 }
 
 function scanTrackedSources(): ScanResult {
-  const combined: ScanResult = { directiveCount: 0, undescribed: new Set() };
+  const combined: ScanResult = {
+    directiveCount: 0,
+    directiveForms: emptyDirectiveForms(),
+    undescribed: new Set(),
+    undescribedLocations: new Map(),
+  };
 
   for (const relPath of trackedSourceFiles()) {
     const result = scanEslintDisableComments(relPath, fs.readFileSync(path.join(REPO_ROOT, relPath), 'utf-8'));
     combined.directiveCount += result.directiveCount;
-    result.undescribed.forEach((location) => combined.undescribed.add(location));
+    for (const form of Object.keys(result.directiveForms) as DirectiveForm[]) {
+      combined.directiveForms[form] += result.directiveForms[form];
+    }
+    result.undescribed.forEach((key) => {
+      combined.undescribed.add(key);
+      combined.undescribedLocations.set(key, result.undescribedLocations.get(key) ?? key);
+    });
   }
 
   return combined;
@@ -105,7 +159,12 @@ describe('eslint-disable justifications', () => {
       `// ${ESLINT_DISABLE_DIRECTIVE}-next-line react-hooks/exhaustive-deps\nuseEffect(() => {}, []);`
     );
 
-    expect(result).toEqual({ directiveCount: 1, undescribed: new Set(['src/example.ts:1']) });
+    expect(result).toEqual({
+      directiveCount: 1,
+      directiveForms: { block: 0, 'block-next-line': 0, line: 0, 'line-next-line': 1 },
+      undescribed: new Set(['src/example.ts::react-hooks/exhaustive-deps#1']),
+      undescribedLocations: new Map([['src/example.ts::react-hooks/exhaustive-deps#1', 'src/example.ts:1']]),
+    });
   });
 
   it('distinguishes a justified suppression from prose that mentions the directive', () => {
@@ -117,30 +176,71 @@ describe('eslint-disable justifications', () => {
       ].join('\n')
     );
 
-    expect(result).toEqual({ directiveCount: 1, undescribed: new Set() });
+    expect(result).toEqual({
+      directiveCount: 1,
+      directiveForms: { block: 0, 'block-next-line': 0, line: 0, 'line-next-line': 1 },
+      undescribed: new Set(),
+      undescribedLocations: new Map(),
+    });
   });
 
-  it('excludes the known documentation and prose examples', () => {
+  it('keeps baseline keys stable across line shifts and counts repeated rules', () => {
+    const directives = [
+      `// ${ESLINT_DISABLE_DIRECTIVE}-next-line react-hooks/exhaustive-deps`,
+      'first();',
+      `// ${ESLINT_DISABLE_DIRECTIVE}-next-line react-hooks/exhaustive-deps`,
+      'second();',
+    ].join('\n');
+    const shifted = scanEslintDisableComments('src/example.ts', `const unrelated = true;\n${directives}`);
+
+    expect(shifted.undescribed).toEqual(
+      new Set(['src/example.ts::react-hooks/exhaustive-deps#1', 'src/example.ts::react-hooks/exhaustive-deps#2'])
+    );
+    expect(shifted.undescribedLocations).toEqual(
+      new Map([
+        ['src/example.ts::react-hooks/exhaustive-deps#1', 'src/example.ts:2'],
+        ['src/example.ts::react-hooks/exhaustive-deps#2', 'src/example.ts:4'],
+      ])
+    );
+  });
+
+  it('recognizes every directive form without matching line-comment prose', () => {
     const docExample = scanEslintDisableComments(
       'src/test-utils/interactive-section-harness.tsx',
       ` *   // ${ESLINT_DISABLE_DIRECTIVE}-next-line @typescript-eslint/no-require-imports`
     );
-    const proseExample = scanEslintDisableComments(
-      'src/requirements-manager/step-checker.hook.ts',
-      `// ${ESLINT_DISABLE_DIRECTIVE} on its dep array). The callback closes over the value.`
+    const result = scanEslintDisableComments(
+      'src/example.ts',
+      [
+        `// ${ESLINT_DISABLE_DIRECTIVE}-next-line first/rule`,
+        `value(); // ${ESLINT_DISABLE_DIRECTIVE}-line second/rule`,
+        `/*${ESLINT_DISABLE_DIRECTIVE}*/`,
+        `/* ${ESLINT_DISABLE_DIRECTIVE}-next-line*/`,
+        `// ${ESLINT_DISABLE_DIRECTIVE} is prose, not a directive`,
+      ].join('\n')
     );
 
-    expect(docExample).toEqual({ directiveCount: 0, undescribed: new Set() });
-    expect(proseExample).toEqual({ directiveCount: 0, undescribed: new Set() });
+    expect(docExample.directiveCount).toBe(0);
+    expect(result.directiveForms).toEqual({ block: 1, 'block-next-line': 1, line: 1, 'line-next-line': 1 });
+    expect(result.directiveCount).toBe(4);
   });
 
   it('matches the checked-in baseline and proves the scanner found real directives', () => {
     const result = scanTrackedSources();
 
     expect(result.directiveCount).toBeGreaterThan(UNDESCRIBED_ESLINT_DISABLE_BASELINE.size);
+    expect(result.directiveForms).toEqual({ block: 5, 'block-next-line': 2, line: 10, 'line-next-line': 66 });
+    const locatedUndescribed = new Set(
+      [...result.undescribed].map((key) => `${key} (${result.undescribedLocations.get(key) ?? 'unknown location'})`)
+    );
+    const locatedBaseline = new Set(
+      [...UNDESCRIBED_ESLINT_DISABLE_BASELINE].map(
+        (key) => `${key} (${result.undescribedLocations.get(key) ?? 'removed'})`
+      )
+    );
     assertRatchet(
-      result.undescribed,
-      UNDESCRIBED_ESLINT_DISABLE_BASELINE,
+      locatedUndescribed,
+      locatedBaseline,
       'eslint-disable comments without a `--` justification',
       'UNDESCRIBED_ESLINT_DISABLE_BASELINE',
       'Explain the suppression after `--`, or remove it. Do not grow the baseline.'

--- a/src/validation/eslint-disable-justifications.test.ts
+++ b/src/validation/eslint-disable-justifications.test.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import { assertRatchet } from './import-graph';
 
 const REPO_ROOT = path.resolve(__dirname, '../..');
-const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx']);
+const SOURCE_EXTENSIONS = new Set(['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx']);
 const DIRECTIVE_PATTERN =
   /(?:\/\/\s*(eslint-disable-(?:next-line|line))|\/\*\s*(eslint-disable(?:-(?:next-line|line))?))(?=\s|\*\/|$)/;
 const JUSTIFICATION_SEPARATOR = ' -- ';
@@ -15,6 +15,7 @@ const ESLINT_DISABLE_DIRECTIVE = ['eslint', 'disable'].join('-');
  * Shrink-only baseline for #1752. Keys are `path::rule#occurrence`, where the
  * occurrence counts undescribed suppressions for that rule within the file.
  * Line numbers stay diagnostic-only so unrelated edits cannot invalidate it.
+ * A same-file replacement can retain a count key until this baseline reaches zero.
  */
 const UNDESCRIBED_ESLINT_DISABLE_BASELINE = new Set([
   'src/learning-paths/learning-paths.hook.ts::react-hooks/exhaustive-deps#1',
@@ -68,9 +69,8 @@ function directiveForm(lineDirective: string, blockDirective: string | undefined
     : prefix;
 }
 
-function directiveRule(line: string, match: RegExpMatchArray): string {
-  const remainder = line.slice((match.index ?? 0) + match[0].length);
-  const beforeJustification = remainder.split(JUSTIFICATION_SEPARATOR, 1)[0] ?? '';
+function directiveRule(afterDirective: string): string {
+  const beforeJustification = afterDirective.split(JUSTIFICATION_SEPARATOR, 1)[0] ?? '';
   return (
     beforeJustification
       .replace(/\*\/.*$/, '')
@@ -95,9 +95,10 @@ export function scanEslintDisableComments(relPath: string, content: string): Sca
     directiveCount++;
     const lineDirective = match[1] ?? '';
     const blockDirective = match[2];
+    const afterDirective = line.slice((match.index ?? 0) + match[0].length);
     directiveForms[directiveForm(lineDirective, blockDirective)]++;
-    if (!line.includes(JUSTIFICATION_SEPARATOR)) {
-      const baseKey = `${relPath}::${directiveRule(line, match)}`;
+    if (!afterDirective.includes(JUSTIFICATION_SEPARATOR)) {
+      const baseKey = `${relPath}::${directiveRule(afterDirective)}`;
       const occurrence = (occurrences.get(baseKey) ?? 0) + 1;
       occurrences.set(baseKey, occurrence);
       const key = `${baseKey}#${occurrence}`;
@@ -111,7 +112,7 @@ export function scanEslintDisableComments(relPath: string, content: string): Sca
 
 function trackedSourceFiles(): string[] {
   try {
-    return execFileSync('git', ['ls-files', '-z', 'src'], { cwd: REPO_ROOT })
+    return execFileSync('git', ['ls-files', '-z'], { cwd: REPO_ROOT })
       .toString('utf-8')
       .split('\0')
       .filter((relPath) => {
@@ -182,6 +183,15 @@ describe('eslint-disable justifications', () => {
       undescribed: new Set(),
       undescribedLocations: new Map(),
     });
+  });
+
+  it('does not treat a separator before the directive as its justification', () => {
+    const result = scanEslintDisableComments(
+      'scripts/example.ts',
+      `const command = 'git log -- src/'; // ${ESLINT_DISABLE_DIRECTIVE}-line no-restricted-syntax`
+    );
+
+    expect(result.undescribed).toEqual(new Set(['scripts/example.ts::no-restricted-syntax#1']));
   });
 
   it('keeps baseline keys stable across line shifts and counts repeated rules', () => {

--- a/src/validation/eslint-disable-justifications.test.ts
+++ b/src/validation/eslint-disable-justifications.test.ts
@@ -229,7 +229,6 @@ describe('eslint-disable justifications', () => {
     const result = scanTrackedSources();
 
     expect(result.directiveCount).toBeGreaterThan(UNDESCRIBED_ESLINT_DISABLE_BASELINE.size);
-    expect(result.directiveForms).toEqual({ block: 5, 'block-next-line': 2, line: 10, 'line-next-line': 66 });
     const locatedUndescribed = new Set(
       [...result.undescribed].map((key) => `${key} (${result.undescribedLocations.get(key) ?? 'unknown location'})`)
     );

--- a/src/validation/eslint-disable-justifications.test.ts
+++ b/src/validation/eslint-disable-justifications.test.ts
@@ -1,0 +1,148 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { assertRatchet } from './import-graph';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx']);
+const DIRECTIVE_PATTERN = /(?:\/\/|\/\*)\s*eslint-disable(?:-next-line|-line)?(?:\s|$)/;
+const JUSTIFICATION_SEPARATOR = ' -- ';
+
+const UNDESCRIBED_ESLINT_DISABLE_BASELINE = new Set([
+  'src/learning-paths/learning-paths.hook.ts:137',
+  'src/learning-paths/learning-paths.hook.ts:243',
+  'src/learning-paths/useDiscoverMore.ts:126',
+  'src/components/docs-panel/hooks/useTabRestoration.ts:80',
+  'src/components/docs-panel/hooks/useSessionJoinUrlCheck.ts:42',
+  'src/components/content-renderer/content-renderer.tsx:374',
+  'src/components/content-renderer/content-renderer.tsx:603',
+  'src/package-engine/recommender-resolver.test.ts:387',
+  'src/components/interactive-tutorial/interactive-step.tsx:475',
+  'src/components/interactive-tutorial/interactive-step.tsx:925',
+  'src/components/interactive-tutorial/hooks/use-section-requirements.ts:192',
+  'src/components/interactive-tutorial/hooks/use-section-persistence.ts:141',
+  'src/components/interactive-tutorial/interactive-quiz.tsx:223',
+  'src/components/interactive-tutorial/datasource-check-step.tsx:228',
+  'src/components/App/ContextPanel.tsx:31',
+  'src/components/full-screen/FullScreenPanel.tsx:130',
+  'src/components/block-editor/hooks/useBackendGuides.ts:391',
+  'src/requirements-manager/step-checker.hook.ts:836',
+  'src/requirements-manager/step-checker.hook.ts:959',
+  'src/components/block-editor/hooks/useBlockPersistence.ts:225',
+  'src/components/block-editor/GitHubPRModal.tsx:227',
+  'src/components/block-editor/LintBadge.tsx:68',
+  'src/docs-retrieval/learning-journey-helpers.ts:20',
+  'src/global-state/completion-store.ts:482',
+  'src/components/floating-panel/FloatingPanelManager.tsx:183',
+  'src/integrations/assistant-integration/AssistantCustomizable.tsx:233',
+  'src/integrations/assistant-integration/AssistantSelectionPopover.tsx:88',
+  'src/utils/usePublishedGuides.ts:90',
+  'src/utils/devtools/element-inspector.hook.ts:114',
+]);
+
+interface ScanResult {
+  directiveCount: number;
+  undescribed: Set<string>;
+}
+
+function isDocumentedExample(relPath: string, line: string): boolean {
+  if (relPath === 'src/test-utils/interactive-section-harness.tsx' && line.trimStart().startsWith('*')) {
+    return true;
+  }
+  return (
+    relPath === 'src/requirements-manager/step-checker.hook.ts' && line.includes('eslint-disable on its dep array')
+  );
+}
+
+export function scanEslintDisableComments(relPath: string, content: string): ScanResult {
+  let directiveCount = 0;
+  const undescribed = new Set<string>();
+
+  content.split(/\r?\n/).forEach((line, index) => {
+    if (!DIRECTIVE_PATTERN.test(line)) {
+      return;
+    }
+
+    if (isDocumentedExample(relPath, line)) {
+      return;
+    }
+
+    const location = `${relPath}:${index + 1}`;
+    directiveCount++;
+    if (!line.includes(JUSTIFICATION_SEPARATOR)) {
+      undescribed.add(location);
+    }
+  });
+
+  return { directiveCount, undescribed };
+}
+
+function trackedSourceFiles(): string[] {
+  return execFileSync('git', ['ls-files', '-z', 'src'], { cwd: REPO_ROOT })
+    .toString('utf-8')
+    .split('\0')
+    .filter((relPath) => relPath && SOURCE_EXTENSIONS.has(path.extname(relPath)));
+}
+
+function scanTrackedSources(): ScanResult {
+  const combined: ScanResult = { directiveCount: 0, undescribed: new Set() };
+
+  for (const relPath of trackedSourceFiles()) {
+    const result = scanEslintDisableComments(relPath, fs.readFileSync(path.join(REPO_ROOT, relPath), 'utf-8'));
+    combined.directiveCount += result.directiveCount;
+    result.undescribed.forEach((location) => combined.undescribed.add(location));
+  }
+
+  return combined;
+}
+
+describe('eslint-disable justifications', () => {
+  it('detects a newly introduced undescribed suppression', () => {
+    const result = scanEslintDisableComments(
+      'src/example.ts',
+      '// eslint-disable-next-line react-hooks/exhaustive-deps\nuseEffect(() => {}, []);'
+    );
+
+    expect(result).toEqual({ directiveCount: 1, undescribed: new Set(['src/example.ts:1']) });
+  });
+
+  it('distinguishes a justified suppression from prose that mentions the directive', () => {
+    const result = scanEslintDisableComments(
+      'src/example.ts',
+      [
+        '// eslint-disable-next-line react-hooks/exhaustive-deps -- dependency is intentionally stable',
+        '// This prose says eslint-disable but is not a directive.',
+      ].join('\n')
+    );
+
+    expect(result).toEqual({ directiveCount: 1, undescribed: new Set() });
+  });
+
+  it('excludes the known documentation and prose examples', () => {
+    const docExample = scanEslintDisableComments(
+      'src/test-utils/interactive-section-harness.tsx',
+      ' *   // eslint-disable-next-line @typescript-eslint/no-require-imports'
+    );
+    const proseExample = scanEslintDisableComments(
+      'src/requirements-manager/step-checker.hook.ts',
+      '// eslint-disable on its dep array). The callback closes over the value.'
+    );
+
+    expect(docExample).toEqual({ directiveCount: 0, undescribed: new Set() });
+    expect(proseExample).toEqual({ directiveCount: 0, undescribed: new Set() });
+  });
+
+  it('matches the checked-in baseline and proves the scanner found real directives', () => {
+    const result = scanTrackedSources();
+
+    expect(result.directiveCount).toBeGreaterThan(UNDESCRIBED_ESLINT_DISABLE_BASELINE.size);
+    assertRatchet(
+      result.undescribed,
+      UNDESCRIBED_ESLINT_DISABLE_BASELINE,
+      'eslint-disable comments without a `--` justification',
+      'UNDESCRIBED_ESLINT_DISABLE_BASELINE',
+      'Explain the suppression after `--`, or remove it. Do not grow the baseline.'
+    );
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds a governance ratchet for `eslint-disable` comments that have no `--` justification. It scans tracked JavaScript and TypeScript sources, pins the current 29-site baseline exactly, rejects new undescribed suppressions, and requires stale entries to be removed as existing comments are explained or deleted.

The scanner explicitly distinguishes the three known documentation/prose examples from executable ESLint directives, and a credibility assertion prevents an accidentally empty scan from passing.

## Linked issue(s)

Closes #1752

## Verification

- focused governance test: 4 tests, including new-violation, false-positive, and non-empty-scan coverage
- wired the new test into `test:governance`
- full `npm run check`: all 9 stages passed, including 505 Jest suites / more than 8,100 tests and Go lint/tests

## Checklist

- [x] This PR addresses a **single concern** (one bug fix or feature, or a set of closely-related changes). Unrelated changes belong in separate PRs; see [CONTRIBUTING.md](../CONTRIBUTING.md#pull-request-scope).
- [x] All commits are signed (required, or the checks will not pass). See [CONTRIBUTING.md](../CONTRIBUTING.md#signed-commits).
- [x] I've added or updated tests for the change.
- [x] `npm run check` passes locally — the pre-merge gate. `npm run check -- --list` prints what it runs.
- [x] UI text and docs use [sentence case](https://grafana.com/docs/writers-toolkit/write/style-guide/capitalization-punctuation/#capitalization).
