### PR TITLE
Use request-scoped logging for custom guide truncation

### DIFF
--- a/pkg/plugin/custom_guide_repository.go
+++ b/pkg/plugin/custom_guide_repository.go
@@ -149,11 +149,11 @@ func (a *App) handleCustomGuideRepository(w http.ResponseWriter, r *http.Request
 	// Detach the drain from the caller's cancellation, bounded by the aggregate
 	// deadline. Per-request (no cross-caller sharing): this fetch rides this
 	// caller's identity and is never handed to another caller.
+	logger := a.ctxLogger(r.Context())
 	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), customGuideAggregateDeadline)
-	entries, pages, err := drainCustomGuides(fetchCtx, namespace, lister)
+	entries, pages, err := drainCustomGuides(fetchCtx, namespace, lister, logger)
 	cancel()
 
-	logger := a.ctxLogger(r.Context())
 	if err != nil {
 		if isTerminalUpstreamError(err) {
 			// Structurally can't serve for this caller ("never works here") —
@@ -201,7 +201,7 @@ func (a *App) writeCustomGuideUnavailable(w http.ResponseWriter) {
 
 // drainCustomGuides drains the namespace LIST across pages — up to the
 // aggregate entry budget — and returns the shaped catalogue entries.
-func drainCustomGuides(ctx context.Context, namespace string, lister customGuideLister) ([]customGuideRepositoryEntry, int, error) {
+func drainCustomGuides(ctx context.Context, namespace string, lister customGuideLister, logger log.Logger) ([]customGuideRepositoryEntry, int, error) {
 	if finalizer, ok := lister.(customGuideDrainFinalizer); ok {
 		defer finalizer.finalizeDrain(namespace)
 	}
@@ -226,7 +226,7 @@ func drainCustomGuides(ctx context.Context, namespace string, lister customGuide
 				entries = entries[:customGuideListMaxTotalEntries]
 			}
 			if truncated {
-				log.DefaultLogger.Warn("custom guide catalogue LIST truncated at aggregate budget",
+				logger.Warn("custom guide catalogue LIST truncated at aggregate budget",
 					"namespace", namespace, "maxTotalEntries", customGuideListMaxTotalEntries, "pages", pages)
 			}
 			break

--- a/pkg/plugin/custom_guide_repository_test.go
+++ b/pkg/plugin/custom_guide_repository_test.go
@@ -917,7 +917,7 @@ func TestCustomGuideHTTPClient_DecodeWarnSummaryOnAggregateBudget(t *testing.T) 
 		t.Fatalf("drainCustomGuides: %v", err)
 	}
 	if !logger.warnedWith("custom guide catalogue LIST truncated at aggregate budget") {
-		t.Fatal("aggregate-budget truncation warning did not use the drain's request-scoped logger")
+		t.Error("aggregate-budget truncation warning did not use the drain's request-scoped logger")
 	}
 
 	details, summaries := 0, 0

--- a/pkg/plugin/custom_guide_repository_test.go
+++ b/pkg/plugin/custom_guide_repository_test.go
@@ -869,7 +869,7 @@ func TestCustomGuideHTTPClient_DecodeWarnBudgetSpansPages(t *testing.T) {
 
 	logger := newCapturingLogger()
 	c := newCustomGuideHTTPClient(srv.URL, &stubMinter{token: "at-xyz"}, "id-token-abc", logger)
-	if _, _, err := drainCustomGuides(context.Background(), testNamespace, c); err != nil {
+	if _, _, err := drainCustomGuides(context.Background(), testNamespace, c, logger); err != nil {
 		t.Fatalf("drainCustomGuides: %v", err)
 	}
 
@@ -913,8 +913,11 @@ func TestCustomGuideHTTPClient_DecodeWarnSummaryOnAggregateBudget(t *testing.T) 
 
 	logger := newCapturingLogger()
 	c := newCustomGuideHTTPClient(srv.URL, &stubMinter{token: "at-xyz"}, "id-token-abc", logger)
-	if _, _, err := drainCustomGuides(context.Background(), testNamespace, c); err != nil {
+	if _, _, err := drainCustomGuides(context.Background(), testNamespace, c, logger); err != nil {
 		t.Fatalf("drainCustomGuides: %v", err)
+	}
+	if !logger.warnedWith("custom guide catalogue LIST truncated at aggregate budget") {
+		t.Fatal("aggregate-budget truncation warning did not use the drain's request-scoped logger")
 	}
 
 	details, summaries := 0, 0
@@ -957,7 +960,7 @@ func TestCustomGuideHTTPClient_DecodeWarnSummaryOnPageError(t *testing.T) {
 
 	logger := newCapturingLogger()
 	c := newCustomGuideHTTPClient(srv.URL, &stubMinter{token: "at-xyz"}, "id-token-abc", logger)
-	if _, _, err := drainCustomGuides(context.Background(), testNamespace, c); err == nil {
+	if _, _, err := drainCustomGuides(context.Background(), testNamespace, c, logger); err == nil {
 		t.Fatal("drainCustomGuides returned nil error")
 	}
 


### PR DESCRIPTION
## What does this PR do?

Routes custom-guide aggregate-budget truncation warnings through the request-scoped logger already used by the handler instead of `log.DefaultLogger`. The logger is captured before the detached, deadline-bounded drain and passed explicitly, matching the completion-index sibling pattern.

Pagination, aggregate caps, `context.WithoutCancel`, per-item decode skipping, and response behavior are unchanged. The aggregate-budget test now proves the warning reaches the drain's capturing logger.

## Linked issue(s)

Closes #1403

## Verification

- focused custom-guide drain tests with real `httptest` listeners
- `go build ./...`
- full `npm run check`: all 9 stages passed, including Go lint/tests and 505 Jest suites / more than 8,100 tests
- no runtime smoke required: this changes only logger routing and does not alter the proxy route, credential path, or wire contract

## Checklist

- [x] This PR addresses a **single concern** (one bug fix or feature, or a set of closely-related changes). Unrelated changes belong in separate PRs; see [CONTRIBUTING.md](../CONTRIBUTING.md#pull-request-scope).
- [x] All commits are signed (required, or the checks will not pass). See [CONTRIBUTING.md](../CONTRIBUTING.md#signed-commits).
- [x] I've added or updated tests for the change.
- [x] `npm run check` passes locally — the pre-merge gate. `npm run check -- --list` prints what it runs.
- [x] UI text and docs use [sentence case](https://grafana.com/docs/writers-toolkit/write/style-guide/capitalization-punctuation/#capitalization).
