### PR TITLE
test(validation): guard PresentationalBlock type drift

### DIFF
--- a/src/validation/type-coupling.test.ts
+++ b/src/validation/type-coupling.test.ts
@@ -1,4 +1,4 @@
-import type { JsonGuide, JsonBlock } from '../types/json-guide.types';
+import type { JsonGuide, JsonBlock, PresentationalBlock } from '../types/json-guide.types';
 import {
   JsonGuideSchema,
   JsonMarkdownBlockSchema,
@@ -22,7 +22,13 @@ import {
   KNOWN_FIELDS,
   type InferredJsonGuide,
 } from '../types/json-guide.schema';
-import { z } from 'zod';
+import type { z } from 'zod';
+
+type InferredPresentational = z.infer<typeof PresentationalBlockSchema>;
+
+// Each direction catches an addition the other side did not get.
+export const _schemaMatchesType: PresentationalBlock = {} as InferredPresentational;
+export const _typeMatchesSchema: InferredPresentational = {} as PresentationalBlock;
 
 describe('Type Coupling: TypeScript <-> Zod', () => {
   it('JsonGuide types should be assignable', () => {
@@ -159,9 +165,6 @@ describe('KNOWN_FIELDS sync', () => {
     verifyFields(JsonDividerBlockSchema, 'divider');
   });
 
-  // Drift guard: PresentationalBlockSchema (collapsible children) and the
-  // PresentationalBlock type must list the same block types. If the union
-  // gains/loses a member on one side only, one of these assertions fails.
   describe('PresentationalBlockSchema membership', () => {
     it('accepts the content block types', () => {
       const accepted: unknown[] = [


### PR DESCRIPTION
Fixes #1705

## What changed

- Added bidirectional type-level assertions between the Zod-inferred presentational block type and `PresentationalBlock`.
- Kept the existing runtime `safeParse` membership tests separate.

## Why

The existing runtime tests did not compare the Zod-inferred union with the handwritten TypeScript union, so the two definitions could drift without failing.

## Testing

- `npm run typecheck`
- `npm run test:ci -- src/validation/type-coupling.test.ts --coverage=false`
- `npm run lint`
- Prettier check
- Confirmed that temporarily adding `JsonInputBlock` to only one side fails with `TS2322`