### PR TITLE
fix(review): remove unreachable duplicate gate loop

### DIFF
--- a/.cursor/skills/review/scripts/concern-context.mjs
+++ b/.cursor/skills/review/scripts/concern-context.mjs
@@ -252,8 +252,9 @@ function firedContractGates(contract_evolution) {
   }
   const listed = Array.isArray(contract_evolution);
   const gates = listed ? contract_evolution.filter(Boolean) : [contract_evolution];
-  for (const key of duplicateValues(gates.map((gate) => gate.concern_id ?? 'unknown'))) {
-    throw new Error(`fired contract gate ${key} must be unique`);
+  const duplicate = duplicateValues(gates.map((gate) => gate.concern_id ?? 'unknown'))[0];
+  if (duplicate !== undefined) {
+    throw new Error(`fired contract gate ${duplicate} must be unique`);
   }
   for (const gate of listed ? gates : []) {
     validateGateRanking(gate);


### PR DESCRIPTION
## Summary

The review planner used a loop that always threw on its first duplicate gate. PR #1742 enabled `no-unreachable-loop` after PR #1760 ran its checks against an older `main`.

This change replaces the throw-only loop with a direct duplicate lookup. Duplicate gates produce the same error, and the new lint rule passes.

## How to verify

No manual verification is required. The change affects only duplicate validation in the review planner.

## Breaking changes

None. This change preserves the existing validation behavior and is fully reversible.

Co-Authored-By: Warp <agent@warp.dev>
