### PR TITLE
fix(e2e): stabilize shared milestone transitions

### DIFF
--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -187,6 +187,8 @@ The reset acknowledgment proves cache eviction. Direct residue cleanup does not 
 
 After teardown, the runner navigates only when the authored location differs. Then it prepares the panel and opens the next guide.
 
+Panel bootstrap keeps a 50-second readiness budget. This matches the maximum combined Help and panel budget from the previous flow.
+
 This flow is runner-only. It works with an installed Pathfinder plugin that supports only the existing `bundled:e2e-test` URL.
 
 An ordinary guide failure adds that guide to the blocked set. Later milestones still run unless a resolved `depends` edge names a blocked guide.
@@ -421,6 +423,7 @@ The environment is reset **between dependency chains**, not between every guide.
 | Fix button timeout         | 10s              | Per fix operation                                                                           |
 | Max fix attempts           | 3                | Retry limit before giving up                                                                |
 | Requirements settle window | 1s               | Poll budget before an unmet read with no Fix button counts as terminal                      |
+| Panel bootstrap            | 50s              | Bounds plugin readiness, Help fallback, and panel opening                                   |
 | Scroll into view           | 5s               | Bounds scrolling a step into view, so a step completing or detaching there can't hang       |
 | Late completion check      | 2s               | Bounds the pre-scroll recheck for a step that completed or detached since discovery         |
 | Skip sync                  | 5s               | Bounds waiting for the plugin to reach a terminal state after the runner clicks Skip        |

--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -187,7 +187,7 @@ The reset acknowledgment proves cache eviction. Direct residue cleanup does not 
 
 After teardown, the runner navigates only when the authored location differs. Then it prepares the panel and opens the next guide.
 
-Panel bootstrap keeps a 50-second readiness budget. This matches the maximum combined Help and panel budget from the previous flow.
+Panel bootstrap uses 20 seconds by default. Post-navigation guide loading uses 30 seconds for each attempt.
 
 This flow is runner-only. It works with an installed Pathfinder plugin that supports only the existing `bundled:e2e-test` URL.
 
@@ -423,7 +423,7 @@ The environment is reset **between dependency chains**, not between every guide.
 | Fix button timeout         | 10s              | Per fix operation                                                                           |
 | Max fix attempts           | 3                | Retry limit before giving up                                                                |
 | Requirements settle window | 1s               | Poll budget before an unmet read with no Fix button counts as terminal                      |
-| Panel bootstrap            | 50s              | Bounds plugin readiness, Help fallback, and panel opening                                   |
+| Panel bootstrap            | 20s or 30s       | Uses 30s after navigation and 20s for same-page panel opening                               |
 | Scroll into view           | 5s               | Bounds scrolling a step into view, so a step completing or detaching there can't hang       |
 | Late completion check      | 2s               | Bounds the pre-scroll recheck for a step that completed or detached since discovery         |
 | Skip sync                  | 5s               | Bounds waiting for the plugin to reach a terminal state after the runner clicks Skip        |

--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -163,11 +163,27 @@ A later milestone keeps the current page when it has no authored location. This 
 
 If a later milestone has an authored location, the runner compares the complete path, query, and fragment. It navigates only when these values differ.
 
-Before a later milestone, the runner publishes the prior result and dismisses celebrations. It then uses the existing `Reset guide` control.
+Before a later milestone, the runner publishes the prior result. It opens the current panel and activates the recorded E2E tab.
 
-The runner waits for progress reset, then closes the tab. It waits for all pre-reset and current step roots to detach.
+The runner dismisses badge celebrations and inspects stored E2E step completion. It does not use the authored block count for this decision.
 
-The runner replaces `StorageKeys.E2E_TEST_GUIDE` and reopens the exact `bundled:e2e-test` URL. A zero-step guide without `Reset guide` closes directly.
+If no completed step IDs exist, the runner removes namespaced residue and the E2E percentage entry. Then it closes the tab.
+
+This direct cleanup does not evict a mounted completion cache. It is not a general reset for mounted guide progress.
+
+If completed step IDs exist, the runner uses the accessible `Reset guide` control. This path supports installed plugins without a stable reset test ID.
+
+The runner waits for `interactive-progress-cleared`. This acknowledgment proves that the legacy reset cleared storage and evicted the completion cache.
+
+The runner closes the prior tab and waits for all captured step roots to detach. This teardown occurs before navigation.
+
+The product reload can recreate matching storage without completed step IDs. The runner accepts this safe state after tab closure.
+
+The runner requires completed step IDs to remain absent during a bounded check. Then it removes the recreated residue.
+
+The reset acknowledgment proves cache eviction. Direct residue cleanup does not make this claim.
+
+After teardown, the runner navigates only when the authored location differs. Then it prepares the panel and opens the next guide.
 
 This flow is runner-only. It works with an installed Pathfinder plugin that supports only the existing `bundled:e2e-test` URL.
 
@@ -176,6 +192,17 @@ An ordinary guide failure adds that guide to the blocked set. Later milestones s
 If a dependency is blocked, the runner emits the existing `SKIPPED_PREREQ` result. Milestone order does not create a dependency.
 
 Authentication expiry or browser-session loss stops the chain. The runner writes zero-step authentication or infrastructure results for all unrun milestones.
+
+A fatal transition error also stops the chain while the browser remains open. Fatal errors include these conditions:
+
+- Stored completion has no usable legacy reset control.
+- Stored completion remains after acknowledged reset and tab closure.
+- The prior tab does not close.
+- Prior step roots do not detach.
+- A badge celebration remains as an obstruction.
+- A new guide tab becomes active, but its load does not finish.
+
+A load error before new-tab activation remains recoverable after prior teardown. Later soft-ordered milestones can continue.
 
 Only a 401, a 403, or a login redirect means authentication expired. Network errors, server errors, and browser loss are infrastructure outcomes.
 

--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -171,6 +171,8 @@ If no completed step IDs exist, the runner removes namespaced residue and the E2
 
 This direct cleanup does not evict a mounted completion cache. It is not a general reset for mounted guide progress.
 
+If no prior tab opened, the runner applies this cleanup regardless of stored completion. It removes a malformed shared percentage record.
+
 If completed step IDs exist, the runner uses the accessible `Reset guide` control. This path supports installed plugins without a stable reset test ID.
 
 The runner waits for `interactive-progress-cleared`. This acknowledgment proves that the legacy reset cleared storage and evicted the completion cache.
@@ -200,9 +202,11 @@ A fatal transition error also stops the chain while the browser remains open. Fa
 - The prior tab does not close.
 - Prior step roots do not detach.
 - A badge celebration remains as an obstruction.
-- A new guide tab becomes active, but its load does not finish.
+- An active E2E tab does not publish a usable tab ID.
 
-A load error before new-tab activation remains recoverable after prior teardown. Later soft-ordered milestones can continue.
+A load error remains recoverable before tab activation or after the runner records the new tab ID.
+
+Prior teardown has already removed ambiguous state. Later soft-ordered milestones can continue.
 
 Only a 401, a 403, or a login redirect means authentication expired. Network errors, server errors, and browser loss are infrastructure outcomes.
 

--- a/docs/developer/E2E_TESTING_CONTRACT.md
+++ b/docs/developer/E2E_TESTING_CONTRACT.md
@@ -70,9 +70,9 @@ Before each later runnable milestone, the runner uses this replacement sequence:
 
 The runner uses stored completion for the reset decision. It does not use the authored interactive-block count.
 
-Malformed shared completion JSON is ambiguous. The runner preserves the raw record and requires the legacy reset path.
+Malformed shared completion JSON is ambiguous while a prior tab remains active. The runner preserves it and requires the legacy reset path.
 
-If the previous milestone opened no tab, the no-completion cleanup remains safe. Stored completion without a reset control is a fatal transition error.
+If no prior tab opened, the runner clears stored E2E residue before it continues. It removes an unusable shared completion record.
 
 A page reload can clear the active-tab globals. The recorded tab ID lets the runner reactivate a visible or overflowed E2E tab.
 
@@ -82,7 +82,9 @@ The standalone runner and first shared milestone can reload once during panel re
 
 If later panel recovery fails before new-tab activation, the chain can continue. Prior teardown has already removed the ambiguous state.
 
-If a new tab is active when loading fails, the runner stops the chain. The same rule applies after reset, close, or detach errors.
+If the new tab publishes its ID, a content-load failure remains recoverable. The next milestone can close that recorded tab.
+
+If an active E2E tab has no usable ID, the runner stops the chain. The same rule applies after reset, close, or detach errors.
 
 The legacy UI reset clears Pathfinder progress and its in-memory completion cache. It does not reload the Grafana page.
 

--- a/docs/developer/E2E_TESTING_CONTRACT.md
+++ b/docs/developer/E2E_TESTING_CONTRACT.md
@@ -37,6 +37,8 @@ The guide runner must establish a ready Pathfinder panel before it can load guid
 
 The Grafana-owned Help button and `grafana.navigation.extensionSidebarDocked` storage entry are recovery hints, not Pathfinder-owned contracts. A docs-panel or sidebar refactor must preserve the four Pathfinder signals above, or update the guide runner, contract tests, and this document in the same change.
 
+The runner waits for Help only after Pathfinder readiness signals do not prove that the panel is ready. Bootstrap owns this fallback.
+
 The source-level tripwires live in `src/components/docs-panel/docs-panel.contract.test.tsx` and `src/components/docs-panel/docs-panel.auto-open-event.test.tsx`.
 
 ---
@@ -47,26 +49,30 @@ Both runner modes use the exact `bundled:e2e-test` URL. Shared execution does no
 
 The installed plugin reads guide JSON from `StorageKeys.E2E_TEST_GUIDE`. No guide content or bearer token is stored in the URL.
 
-Before each later interactive milestone, the runner uses this replacement sequence:
+Before each later runnable milestone, the runner uses this replacement sequence:
 
 1. It publishes the completed milestone result.
-2. It navigates to the authored starting location when necessary.
-3. It opens the Pathfinder panel and restores the saved tab strip.
-4. It activates the exact E2E tab that the previous milestone opened.
-5. It dismisses Pathfinder badge celebrations.
-6. It clicks the existing `Reset guide` control.
-7. It waits for `interactive-progress-cleared` with content key `bundled:e2e-test`.
-8. It captures any step roots that appeared during reset.
-9. It closes the E2E guide tab.
-10. It waits until all pre-reset and current step roots detach.
-11. It writes the next guide JSON to `StorageKeys.E2E_TEST_GUIDE`.
-12. It dispatches `pathfinder-auto-open-docs` with `bundled:e2e-test`.
-13. It records the new tab ID.
-14. It waits for the replacement content before step discovery.
+2. It opens the Pathfinder panel at the prior location.
+3. It activates the exact E2E tab that the previous milestone opened.
+4. It dismisses Pathfinder badge celebrations through bounded DOM event dispatch.
+5. It inspects stored step completion for `bundled:e2e-test`.
+6. If completion exists, it captures step roots and clicks the existing `Reset guide` control.
+7. It waits for `interactive-progress-cleared`.
+8. If completion does not exist, it clears only namespaced residue and the E2E percentage entry.
+9. It captures current step roots and closes the E2E guide tab.
+10. It waits until all captured step roots detach.
+11. After the acknowledged reset, it requires completed step IDs to remain absent during a bounded post-close check.
+12. It removes matching residue that the legacy product reload recreated.
+13. It navigates to the authored starting location only when necessary.
+14. It writes the next guide JSON to `StorageKeys.E2E_TEST_GUIDE`.
+15. It dispatches `pathfinder-auto-open-docs` and records the new tab ID.
+16. It waits for the replacement content before step discovery.
 
-If a zero-step guide has no `Reset guide` control, the runner closes its tab directly.
+The runner uses stored completion for the reset decision. It does not use the authored interactive-block count.
 
-If the previous milestone opened no guide tab, the runner clears stored `bundled:e2e-test` progress. It then skips reset and close actions.
+Malformed shared completion JSON is ambiguous. The runner preserves the raw record and requires the legacy reset path.
+
+If the previous milestone opened no tab, the no-completion cleanup remains safe. Stored completion without a reset control is a fatal transition error.
 
 A page reload can clear the active-tab globals. The recorded tab ID lets the runner reactivate a visible or overflowed E2E tab.
 
@@ -74,9 +80,17 @@ The tab close control uses `docs-panel-tab-close-${tabId}`. This test ID is part
 
 The standalone runner and first shared milestone can reload once during panel recovery. A later milestone never reloads during recovery.
 
-If later panel recovery fails, the runner reports infrastructure failure. It does not erase unsaved page state with a reload.
+If later panel recovery fails before new-tab activation, the chain can continue. Prior teardown has already removed the ambiguous state.
 
-The reset clears Pathfinder progress and its in-memory completion cache. It does not reload the Grafana page.
+If a new tab is active when loading fails, the runner stops the chain. The same rule applies after reset, close, or detach errors.
+
+The legacy UI reset clears Pathfinder progress and its in-memory completion cache. It does not reload the Grafana page.
+
+The legacy product reload can recreate matching storage without completed step IDs. The runner accepts this state only after tab closure.
+
+The runner then removes the safe residue. Stored completion that remains after the bounded check is a fatal transition error.
+
+Direct no-completion cleanup does not evict the mounted cache. It is not a general mounted-progress reset.
 
 The same page, browser context, cookies, session storage, form values, and application memory remain active.
 
@@ -134,6 +148,10 @@ The runner and plugin share these stable test IDs:
 - **`learning-paths-badge-toast-dismiss`** (`testIds.learningPaths.badgeToastDismiss`): identifies the dismiss action inside the current dialog.
 
 The runner uses only these selectors. It does not close generic Grafana modals.
+
+The runner dispatches the dismiss click through the DOM. It does not require pointer actionability while the toast moves.
+
+The dispatch and toast transition remain bounded. A persistent toast is a fatal shared-session transition error.
 
 If a refactor changes these values, update `BadgeUnlockedToast.tsx`, the guide runner, the contract test, and this document in the same change.
 

--- a/docs/developer/E2E_TESTING_CONTRACT.md
+++ b/docs/developer/E2E_TESTING_CONTRACT.md
@@ -39,7 +39,7 @@ The Grafana-owned Help button and `grafana.navigation.extensionSidebarDocked` st
 
 The runner waits for Help only after Pathfinder readiness signals do not prove that the panel is ready. Bootstrap owns this fallback.
 
-Each bootstrap attempt has a 50-second readiness budget. This matches the maximum combined Help and panel budget from the previous flow.
+The default bootstrap budget is 20 seconds. Post-navigation guide loading uses 30 seconds for each attempt.
 
 The source-level tripwires live in `src/components/docs-panel/docs-panel.contract.test.tsx` and `src/components/docs-panel/docs-panel.auto-open-event.test.tsx`.
 

--- a/docs/developer/E2E_TESTING_CONTRACT.md
+++ b/docs/developer/E2E_TESTING_CONTRACT.md
@@ -39,6 +39,8 @@ The Grafana-owned Help button and `grafana.navigation.extensionSidebarDocked` st
 
 The runner waits for Help only after Pathfinder readiness signals do not prove that the panel is ready. Bootstrap owns this fallback.
 
+Each bootstrap attempt has a 50-second readiness budget. This matches the maximum combined Help and panel budget from the previous flow.
+
 The source-level tripwires live in `src/components/docs-panel/docs-panel.contract.test.tsx` and `src/components/docs-panel/docs-panel.auto-open-event.test.tsx`.
 
 ---
@@ -91,6 +93,8 @@ The legacy UI reset clears Pathfinder progress and its in-memory completion cach
 The legacy product reload can recreate matching storage without completed step IDs. The runner accepts this state only after tab closure.
 
 The runner then removes the safe residue. Stored completion that remains after the bounded check is a fatal transition error.
+
+Hybrid `__timestamp` keys are not completion evidence. Residue cleanup removes them to match the product reset.
 
 Direct no-completion cleanup does not evict the mounted cache. It is not a general mounted-progress reset.
 

--- a/tests/e2e-runner/guide-runner.spec.ts
+++ b/tests/e2e-runner/guide-runner.spec.ts
@@ -54,7 +54,6 @@ test.describe('Guide runner', () => {
       startingLocation,
       navigateToStartingLocation: true,
       replacePreviousGuide: false,
-      previousGuideHadInteractiveSteps: false,
       allowReloadRecovery: true,
       verbose,
       artifactsDir: process.env[E2E_ENV.ARTIFACTS_DIR],

--- a/tests/e2e-runner/runner-image-smoke.spec.ts
+++ b/tests/e2e-runner/runner-image-smoke.spec.ts
@@ -1,6 +1,8 @@
 import { readdirSync, readFileSync } from 'node:fs';
 
 import { expect, test } from '@playwright/test';
+import { testIds } from '../../src/constants/testIds';
+import { dismissBadgeCelebrations } from './utils/guide-runner/badge-celebrations';
 
 function browserProcessCommands(): string[] {
   return readdirSync('/proc', { withFileTypes: true })
@@ -24,4 +26,35 @@ test('launches the bundled full Chromium browser', async ({ page }) => {
 
   await page.setContent('<main>Pathfinder E2E runner</main>');
   await expect(page.getByRole('main')).toHaveText('Pathfinder E2E runner');
+});
+
+test('dismisses a moving badge toast through DOM event dispatch', async ({ page }) => {
+  await page.setContent(`
+    <style>
+      @keyframes badge-slide {
+        from { transform: translateX(0); }
+        to { transform: translateX(200px); }
+      }
+      [data-testid="${testIds.learningPaths.badgeToast}"] {
+        animation: badge-slide 1500ms linear;
+        position: fixed;
+      }
+    </style>
+    <div data-testid="${testIds.learningPaths.badgeToast}">
+      Badge unlocked!
+      <button data-testid="${testIds.learningPaths.badgeToastDismiss}">Dismiss</button>
+    </div>
+    <script>
+      document.querySelector('[data-testid="${testIds.learningPaths.badgeToastDismiss}"]').addEventListener('click', (event) => {
+        event.currentTarget.parentElement.remove();
+      });
+    </script>
+  `);
+  const toast = page.getByTestId(testIds.learningPaths.badgeToast);
+
+  await expect(toast).toBeVisible();
+  await expect(toast).toHaveCSS('animation-duration', '1.5s');
+  await dismissBadgeCelebrations(page);
+
+  await expect(toast).toHaveCount(0);
 });

--- a/tests/e2e-runner/runner-image-smoke.spec.ts
+++ b/tests/e2e-runner/runner-image-smoke.spec.ts
@@ -36,7 +36,7 @@ test('dismisses a moving badge toast through DOM event dispatch', async ({ page 
         to { transform: translateX(200px); }
       }
       [data-testid="${testIds.learningPaths.badgeToast}"] {
-        animation: badge-slide 1500ms linear;
+        animation: badge-slide 10s linear;
         position: fixed;
       }
     </style>
@@ -53,7 +53,7 @@ test('dismisses a moving badge toast through DOM event dispatch', async ({ page 
   const toast = page.getByTestId(testIds.learningPaths.badgeToast);
 
   await expect(toast).toBeVisible();
-  await expect(toast).toHaveCSS('animation-duration', '1.5s');
+  await expect(toast).toHaveCSS('animation-duration', '10s');
   await dismissBadgeCelebrations(page);
 
   await expect(toast).toHaveCount(0);

--- a/tests/e2e-runner/shared-guide-runner.spec.ts
+++ b/tests/e2e-runner/shared-guide-runner.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../../src/cli/e2e/e2e-runner-contract';
 import { installScopedBearerTokenRoute } from './auth/scoped-bearer-token';
 import { createBrowserTerminationMonitor } from './utils/guide-runner';
-import { countInteractiveBlocks, estimateGuideTimeoutFromContent } from './utils/guide-runner/static-analysis';
+import { estimateGuideTimeoutFromContent } from './utils/guide-runner/static-analysis';
 import { parsePageGuide, runGuideOnPage } from './utils/guide-runner/run-guide';
 import { createRunnerSessionValidator, RunnerPreflightError, runRunnerPreflight } from './utils/runner-preflight';
 import { runSharedGuideChain } from './utils/shared-chain';
@@ -91,7 +91,7 @@ test.describe('Shared guide runner', () => {
     }
 
     const terminationMonitor = createBrowserTerminationMonitor(page);
-    let previousGuideTab: { id: string; hadInteractiveSteps: boolean } | undefined;
+    let previousGuideTabId: string | undefined;
     try {
       const outcome = await runSharedGuideChain(chainInput, {
         currentUrl: () => page.url(),
@@ -102,8 +102,7 @@ test.describe('Shared guide runner', () => {
             if (!session.valid) {
               return setupFailureResult(guide, session.failureKind === 'auth_expired', session.error);
             }
-            const previousTab = previousGuideTab;
-            const guideHasInteractiveSteps = countInteractiveBlocks(JSON.parse(guide.content)) > 0;
+            const previousTabId = previousGuideTabId;
             const milestoneArtifactsDir = artifactsDir
               ? join(artifactsDir, `milestone-${String(index + 1).padStart(3, '0')}-${guide.id}`)
               : undefined;
@@ -112,13 +111,12 @@ test.describe('Shared guide runner', () => {
               startingLocation: transition.startingLocation,
               navigateToStartingLocation: transition.navigateToStartingLocation,
               replacePreviousGuide: index > 0,
-              previousGuideHadInteractiveSteps: previousTab?.hadInteractiveSteps ?? false,
-              previousGuideTabId: previousTab?.id,
+              previousGuideTabId: previousTabId,
               onPreviousGuideCleared: () => {
-                previousGuideTab = undefined;
+                previousGuideTabId = undefined;
               },
               onGuideOpened: (tabId) => {
-                previousGuideTab = { id: tabId, hadInteractiveSteps: guideHasInteractiveSteps };
+                previousGuideTabId = tabId;
               },
               allowReloadRecovery: index === 0,
               verbose,

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.test.ts
@@ -11,13 +11,19 @@ import { testIds } from '../../../../src/constants/testIds';
 import { dismissBadgeCelebrations } from './badge-celebrations';
 import { runGuidedSubstepLoop, waitForFormfillSettle } from './execution';
 import { clickFixButton } from './requirements';
+import { FatalTransitionError } from './transition-error';
 import type { TestableStep } from './types';
 
 interface BadgeHarnessOptions {
-  clickError?: Error;
+  dispatchError?: Error;
+  disappearOnDispatchError?: boolean;
   remainsVisible?: boolean;
   initialDelayMs?: number;
   interToastDelayMs?: number;
+  visibilityFailure?: {
+    call: number;
+    error: Error;
+  };
   textReadFailure?: {
     call: number;
     mode: 'disappear' | 'visible';
@@ -32,6 +38,7 @@ function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {})
   let nextVisibleAt =
     currentIndex === -1 && titles.length > 0 ? (options.initialDelayMs ?? 0) : Number.POSITIVE_INFINITY;
   let textReadCount = 0;
+  let visibilityReadCount = 0;
   const events: string[] = [];
   const toast = {} as Locator;
   const dismissButton = {} as Locator;
@@ -49,7 +56,13 @@ function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {})
 
   toast.first = jest.fn(() => toast);
   toast.count = jest.fn(async () => (currentIndex >= 0 ? 1 : 0));
-  toast.isVisible = jest.fn(async () => currentIndex >= 0);
+  toast.isVisible = jest.fn(async () => {
+    visibilityReadCount++;
+    if (options.visibilityFailure?.call === visibilityReadCount) {
+      throw options.visibilityFailure.error;
+    }
+    return currentIndex >= 0;
+  });
   toast.textContent = jest.fn(async (textOptions?: { timeout?: number }) => {
     if (currentIndex < 0) {
       return null;
@@ -69,10 +82,13 @@ function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {})
     return `Badge unlocked!${queueText} ${titles[currentIndex]} Nice!`;
   });
 
-  dismissButton.click = jest.fn(async () => {
+  dismissButton.dispatchEvent = jest.fn(async () => {
     events.push('dismiss');
-    if (options.clickError) {
-      throw options.clickError;
+    if (options.dispatchError) {
+      if (options.disappearOnDispatchError) {
+        currentIndex = -1;
+      }
+      throw options.dispatchError;
     }
     if (!options.remainsVisible) {
       currentIndex = -1;
@@ -98,7 +114,7 @@ function createBadgeHarness(titles: string[], options: BadgeHarnessOptions = {})
   return {
     page,
     events,
-    dismissClick: dismissButton.click as jest.Mock,
+    dismissDispatch: dismissButton.dispatchEvent as jest.Mock,
     textContent: toast.textContent as jest.Mock,
     waitForTimeout,
     getElapsedMs: () => elapsedMs,
@@ -115,65 +131,65 @@ function expectBoundedTextReads(textContent: jest.Mock): void {
 
 describe('dismissBadgeCelebrations', () => {
   it('returns after a bounded idle check when no toast is present', async () => {
-    const { page, dismissClick, waitForTimeout } = createBadgeHarness([]);
+    const { page, dismissDispatch, waitForTimeout } = createBadgeHarness([]);
 
     await dismissBadgeCelebrations(page);
 
-    expect(dismissClick).not.toHaveBeenCalled();
+    expect(dismissDispatch).not.toHaveBeenCalled();
     expect(waitForTimeout).toHaveBeenCalledTimes(4);
   });
 
   it('waits for a delayed first toast', async () => {
-    const { page, dismissClick } = createBadgeHarness(['First badge'], {
+    const { page, dismissDispatch } = createBadgeHarness(['First badge'], {
       initialDelayMs: 50,
     });
 
     await dismissBadgeCelebrations(page);
 
-    expect(dismissClick).toHaveBeenCalledTimes(1);
+    expect(dismissDispatch).toHaveBeenCalledTimes(1);
   });
 
   it('dismisses one toast', async () => {
-    const { page, dismissClick } = createBadgeHarness(['First badge']);
+    const { page, dismissDispatch } = createBadgeHarness(['First badge']);
 
     await dismissBadgeCelebrations(page);
 
-    expect(dismissClick).toHaveBeenCalledTimes(1);
+    expect(dismissDispatch).toHaveBeenCalledWith('click', undefined, { timeout: 1000 });
   });
 
   it('dismisses queued toasts in sequence', async () => {
-    const { page, dismissClick } = createBadgeHarness(['First badge', 'Second badge', 'Third badge']);
+    const { page, dismissDispatch } = createBadgeHarness(['First badge', 'Second badge', 'Third badge']);
 
     await dismissBadgeCelebrations(page);
 
-    expect(dismissClick).toHaveBeenCalledTimes(3);
+    expect(dismissDispatch).toHaveBeenCalledTimes(3);
   });
 
   it('waits for the next queued toast across an inter-toast gap', async () => {
-    const { page, dismissClick } = createBadgeHarness(['First badge', 'Second badge'], {
+    const { page, dismissDispatch } = createBadgeHarness(['First badge', 'Second badge'], {
       interToastDelayMs: 75,
     });
 
     await dismissBadgeCelebrations(page);
 
-    expect(dismissClick).toHaveBeenCalledTimes(2);
+    expect(dismissDispatch).toHaveBeenCalledTimes(2);
   });
 
   it('throws a bounded error when the toast remains visible', async () => {
-    const { page, dismissClick, waitForTimeout } = createBadgeHarness(['First badge'], {
+    const { page, dismissDispatch, waitForTimeout } = createBadgeHarness(['First badge'], {
       remainsVisible: true,
     });
 
-    await expect(dismissBadgeCelebrations(page)).rejects.toThrow(
-      'Badge celebration remained visible after attempt 1 of 3 (1000ms timeout)'
-    );
-    expect(dismissClick).toHaveBeenCalledTimes(1);
+    const dismissal = dismissBadgeCelebrations(page);
+    await expect(dismissal).rejects.toBeInstanceOf(FatalTransitionError);
+    await expect(dismissal).rejects.toThrow('Badge celebration remained visible after attempt 1 of 3 (1000ms timeout)');
+    expect(dismissDispatch).toHaveBeenCalledTimes(1);
     expect(waitForTimeout).toHaveBeenCalledTimes(40);
   });
 
   it('includes the dismiss control error in the diagnostic', async () => {
     const { page } = createBadgeHarness(['First badge'], {
-      clickError: new Error('Dismiss button was detached'),
+      dispatchError: new Error('Dismiss button was detached'),
     });
 
     await expect(dismissBadgeCelebrations(page)).rejects.toThrow(
@@ -181,8 +197,19 @@ describe('dismissBadgeCelebrations', () => {
     );
   });
 
-  it('does not click a stale dismiss control when the initial toast disappears during its text read', async () => {
-    const { page, dismissClick, textContent, getElapsedMs } = createBadgeHarness(['First badge'], {
+  it('accepts a toast that disappears while DOM event dispatch loses its target', async () => {
+    const { page, dismissDispatch } = createBadgeHarness(['First badge'], {
+      dispatchError: new Error('Dismiss button was detached'),
+      disappearOnDispatchError: true,
+    });
+
+    await expect(dismissBadgeCelebrations(page)).resolves.toBeUndefined();
+
+    expect(dismissDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dispatch to a stale dismiss control when the initial toast disappears during its text read', async () => {
+    const { page, dismissDispatch, textContent, getElapsedMs } = createBadgeHarness(['First badge'], {
       textReadFailure: {
         call: 1,
         mode: 'disappear',
@@ -197,12 +224,12 @@ describe('dismissBadgeCelebrations', () => {
       dateNow.mockRestore();
     }
 
-    expect(dismissClick).not.toHaveBeenCalled();
+    expect(dismissDispatch).not.toHaveBeenCalled();
     expectBoundedTextReads(textContent);
   });
 
   it('accepts a queued toast that disappears during its bounded transition text read', async () => {
-    const { page, dismissClick, textContent, getElapsedMs } = createBadgeHarness(['First badge', 'Second badge'], {
+    const { page, dismissDispatch, textContent, getElapsedMs } = createBadgeHarness(['First badge', 'Second badge'], {
       textReadFailure: {
         call: 2,
         mode: 'disappear',
@@ -217,12 +244,12 @@ describe('dismissBadgeCelebrations', () => {
       dateNow.mockRestore();
     }
 
-    expect(dismissClick).toHaveBeenCalledTimes(1);
+    expect(dismissDispatch).toHaveBeenCalledTimes(1);
     expectBoundedTextReads(textContent);
   });
 
   it('reports a bounded text-read error when the toast remains visible', async () => {
-    const { page, dismissClick, textContent } = createBadgeHarness(['First badge'], {
+    const { page, dismissDispatch, textContent } = createBadgeHarness(['First badge'], {
       textReadFailure: {
         call: 1,
         mode: 'visible',
@@ -234,8 +261,27 @@ describe('dismissBadgeCelebrations', () => {
       'Badge celebration text read before attempt 1 of 3 failed within 1000ms while the toast remained visible: Text read timed out'
     );
 
-    expect(dismissClick).not.toHaveBeenCalled();
+    expect(dismissDispatch).not.toHaveBeenCalled();
     expectBoundedTextReads(textContent);
+  });
+
+  it('makes a failed visibility recheck a fatal badge obstruction', async () => {
+    const { page } = createBadgeHarness(['First badge'], {
+      textReadFailure: {
+        call: 1,
+        mode: 'visible',
+        error: new Error('Text read timed out'),
+      },
+      visibilityFailure: {
+        call: 2,
+        error: new Error('Visibility target was detached'),
+      },
+    });
+    const dismissal = dismissBadgeCelebrations(page);
+
+    await expect(dismissal).rejects.toBeInstanceOf(FatalTransitionError);
+    await expect(dismissal).rejects.toMatchObject({ kind: 'badge-obstruction' });
+    await expect(dismissal).rejects.toThrow('Visibility recheck failed: Visibility target was detached');
   });
 
   it('dismisses the toast before a requirement Fix click', async () => {

--- a/tests/e2e-runner/utils/guide-runner/badge-celebrations.ts
+++ b/tests/e2e-runner/utils/guide-runner/badge-celebrations.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page } from '@playwright/test';
 
 import { testIds } from '../../../../src/constants/testIds';
+import { FatalTransitionError } from './transition-error';
 
 // The runner opens one guide per browser context, and each guide-completed event awards at most three new badges.
 const MAX_BADGE_CELEBRATIONS = 3;
@@ -38,12 +39,14 @@ async function readToastText(toast: Locator, timeout: number, context: string): 
         return { state: 'gone' };
       }
     } catch (visibilityError) {
-      throw new Error(
+      throw new FatalTransitionError(
+        'badge-obstruction',
         `Badge celebration ${context} failed within ${boundedTimeout}ms: ${readReason}. Visibility recheck failed: ${errorReason(visibilityError)}`
       );
     }
 
-    throw new Error(
+    throw new FatalTransitionError(
+      'badge-obstruction',
       `Badge celebration ${context} failed within ${boundedTimeout}ms while the toast remained visible: ${readReason}`
     );
   }
@@ -109,22 +112,30 @@ export async function dismissBadgeCelebrations(page: Page): Promise<void> {
     const dismissButton = page.getByTestId(testIds.learningPaths.badgeToastDismiss).first();
 
     try {
-      await dismissButton.click({ timeout: BADGE_TRANSITION_TIMEOUT_MS });
+      await dismissButton.dispatchEvent('click', undefined, { timeout: BADGE_TRANSITION_TIMEOUT_MS });
     } catch (error) {
+      if (!(await isVisible(toast))) {
+        continue;
+      }
       const reason = errorReason(error);
-      throw new Error(
+      throw new FatalTransitionError(
+        'badge-obstruction',
         `Badge celebration dismissal failed on attempt ${attempt} of ${MAX_BADGE_CELEBRATIONS}: ${reason}`
       );
     }
 
     if (!(await waitForToastTransition(page, previousText, hasQueuedCelebration(previousText)))) {
-      throw new Error(
+      throw new FatalTransitionError(
+        'badge-obstruction',
         `Badge celebration remained visible after attempt ${attempt} of ${MAX_BADGE_CELEBRATIONS} (${BADGE_TRANSITION_TIMEOUT_MS}ms timeout)`
       );
     }
   }
 
   if (await waitForVisibleToast(page, toast)) {
-    throw new Error(`Badge celebration remained visible after ${MAX_BADGE_CELEBRATIONS} dismissal attempts`);
+    throw new FatalTransitionError(
+      'badge-obstruction',
+      `Badge celebration remained visible after ${MAX_BADGE_CELEBRATIONS} dismissal attempts`
+    );
   }
 }

--- a/tests/e2e-runner/utils/guide-runner/bootstrap.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/bootstrap.test.ts
@@ -7,6 +7,7 @@ interface HarnessOptions {
   bootstrapStates?: Array<{ rawDockedValue: string | null; sidebarMounted: boolean }>;
   dockedValue?: string | null;
   helpExpanded?: boolean;
+  helpWaitError?: Error;
   helpMenuVisible?: boolean;
   panelWaitResults?: Array<'resolve' | Error>;
   openConfirmationResults?: Array<'resolve' | Error>;
@@ -37,6 +38,9 @@ function createHarness(options: HarnessOptions = {}) {
     waitFor: panelWaitFor,
   } as unknown as Locator;
   const helpButton = {
+    waitFor: options.helpWaitError
+      ? jest.fn().mockRejectedValue(options.helpWaitError)
+      : jest.fn().mockResolvedValue(undefined),
     click: jest.fn().mockImplementation(async () => options.onHelpClick?.()),
     getAttribute: jest.fn().mockResolvedValue(options.helpExpanded ? 'true' : 'false'),
   } as unknown as Locator;
@@ -89,6 +93,7 @@ function createHarness(options: HarnessOptions = {}) {
     page,
     panel,
     helpButton,
+    helpWaitFor: helpButton.waitFor as jest.Mock,
     panelIsVisible,
     panelWaitFor,
     evaluate,
@@ -160,25 +165,35 @@ describe('ensureDocsPanelOpen', () => {
   });
 
   it('does not treat an expanded generic Help menu as an open Pathfinder panel', async () => {
-    const { page, helpButton, panelWaitFor } = createHarness({
+    const { page, helpButton, helpWaitFor, panelWaitFor } = createHarness({
       helpExpanded: true,
       helpMenuVisible: true,
     });
 
     await ensureDocsPanelOpen(page);
+    expect(helpWaitFor).toHaveBeenCalledTimes(1);
+    expect(helpWaitFor.mock.calls[0]?.[0]).toEqual({
+      state: 'visible',
+      timeout: expect.any(Number),
+    });
+    expect(helpWaitFor.mock.calls[0]?.[0].timeout).toBeGreaterThan(0);
+    expect(helpWaitFor.mock.calls[0]?.[0].timeout).toBeLessThanOrEqual(20_000);
 
     expect(helpButton.click).toHaveBeenCalledTimes(1);
     expect(panelWaitFor).toHaveBeenCalledTimes(1);
   });
 
   it('returns when the panel becomes visible while waiting for plugin readiness', async () => {
-    const { page, panel, helpButton, panelWaitFor, waitForFunction } = createHarness({
+    const { page, panel, helpButton, helpWaitFor, panelWaitFor, waitForFunction } = createHarness({
       panelVisible: [false, true],
+      helpWaitError: new Error('Help is not available'),
     });
 
     await expect(ensureDocsPanelOpen(page)).resolves.toBe(panel);
 
     expect(waitForFunction).toHaveBeenCalledTimes(1);
+    expect(page.locator).not.toHaveBeenCalled();
+    expect(helpWaitFor).not.toHaveBeenCalled();
     expect(helpButton.click).not.toHaveBeenCalled();
     expect(panelWaitFor).not.toHaveBeenCalled();
   });
@@ -224,6 +239,7 @@ describe('ensureDocsPanelOpen', () => {
     });
     const { page, helpButton, panelWaitFor } = createHarness({
       bootstrapStates: [
+        { rawDockedValue: null, sidebarMounted: false },
         { rawDockedValue: null, sidebarMounted: false },
         { rawDockedValue: null, sidebarMounted: false },
         { rawDockedValue: pathfinderDocked, sidebarMounted: false },

--- a/tests/e2e-runner/utils/guide-runner/bootstrap.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/bootstrap.test.ts
@@ -177,7 +177,7 @@ describe('ensureDocsPanelOpen', () => {
       timeout: expect.any(Number),
     });
     expect(helpWaitFor.mock.calls[0]?.[0].timeout).toBeGreaterThan(0);
-    expect(helpWaitFor.mock.calls[0]?.[0].timeout).toBeLessThanOrEqual(50_000);
+    expect(helpWaitFor.mock.calls[0]?.[0].timeout).toBeLessThanOrEqual(20_000);
 
     expect(helpButton.click).toHaveBeenCalledTimes(1);
     expect(panelWaitFor).toHaveBeenCalledTimes(1);
@@ -297,7 +297,7 @@ describe('ensureDocsPanelOpen', () => {
     expect((window as Window & { __pathfinderE2ESidebarMounted?: boolean }).__pathfinderE2ESidebarMounted).toBe(false);
   });
 
-  it('uses a fresh 50-second bound for each of at most two bootstrap attempts', async () => {
+  it('uses a fresh 20-second bound for each of at most two bootstrap attempts', async () => {
     let now = 1_000;
     jest.spyOn(Date, 'now').mockImplementation(() => now);
     const beforeRetry = jest.fn().mockImplementation(async () => {
@@ -311,12 +311,12 @@ describe('ensureDocsPanelOpen', () => {
 
     expect(beforeRetry).toHaveBeenCalledTimes(1);
     expect(helpButton.click).toHaveBeenCalledTimes(2);
-    expect(helpButton.click).toHaveBeenNthCalledWith(1, { timeout: 50_000 });
-    expect(helpButton.click).toHaveBeenNthCalledWith(2, { timeout: 50_000 });
+    expect(helpButton.click).toHaveBeenNthCalledWith(1, { timeout: 20_000 });
+    expect(helpButton.click).toHaveBeenNthCalledWith(2, { timeout: 20_000 });
     expect(panelWaitFor).toHaveBeenCalledTimes(2);
-    expect(panelWaitFor).toHaveBeenNthCalledWith(1, { state: 'visible', timeout: 50_000 });
-    expect(panelWaitFor).toHaveBeenNthCalledWith(2, { state: 'visible', timeout: 50_000 });
-    expect(waitForFunction.mock.calls.map((call) => call[2]?.timeout)).toEqual([50_000, 2_000, 50_000, 2_000]);
+    expect(panelWaitFor).toHaveBeenNthCalledWith(1, { state: 'visible', timeout: 20_000 });
+    expect(panelWaitFor).toHaveBeenNthCalledWith(2, { state: 'visible', timeout: 20_000 });
+    expect(waitForFunction.mock.calls.map((call) => call[2]?.timeout)).toEqual([20_000, 2_000, 20_000, 2_000]);
   });
 
   it('uses the explicit timeout independently for both bootstrap attempts', async () => {

--- a/tests/e2e-runner/utils/guide-runner/bootstrap.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/bootstrap.test.ts
@@ -177,7 +177,7 @@ describe('ensureDocsPanelOpen', () => {
       timeout: expect.any(Number),
     });
     expect(helpWaitFor.mock.calls[0]?.[0].timeout).toBeGreaterThan(0);
-    expect(helpWaitFor.mock.calls[0]?.[0].timeout).toBeLessThanOrEqual(20_000);
+    expect(helpWaitFor.mock.calls[0]?.[0].timeout).toBeLessThanOrEqual(50_000);
 
     expect(helpButton.click).toHaveBeenCalledTimes(1);
     expect(panelWaitFor).toHaveBeenCalledTimes(1);
@@ -297,7 +297,7 @@ describe('ensureDocsPanelOpen', () => {
     expect((window as Window & { __pathfinderE2ESidebarMounted?: boolean }).__pathfinderE2ESidebarMounted).toBe(false);
   });
 
-  it('uses a fresh 20-second bound for each of at most two bootstrap attempts', async () => {
+  it('uses a fresh 50-second bound for each of at most two bootstrap attempts', async () => {
     let now = 1_000;
     jest.spyOn(Date, 'now').mockImplementation(() => now);
     const beforeRetry = jest.fn().mockImplementation(async () => {
@@ -311,12 +311,12 @@ describe('ensureDocsPanelOpen', () => {
 
     expect(beforeRetry).toHaveBeenCalledTimes(1);
     expect(helpButton.click).toHaveBeenCalledTimes(2);
-    expect(helpButton.click).toHaveBeenNthCalledWith(1, { timeout: 20_000 });
-    expect(helpButton.click).toHaveBeenNthCalledWith(2, { timeout: 20_000 });
+    expect(helpButton.click).toHaveBeenNthCalledWith(1, { timeout: 50_000 });
+    expect(helpButton.click).toHaveBeenNthCalledWith(2, { timeout: 50_000 });
     expect(panelWaitFor).toHaveBeenCalledTimes(2);
-    expect(panelWaitFor).toHaveBeenNthCalledWith(1, { state: 'visible', timeout: 20_000 });
-    expect(panelWaitFor).toHaveBeenNthCalledWith(2, { state: 'visible', timeout: 20_000 });
-    expect(waitForFunction.mock.calls.map((call) => call[2]?.timeout)).toEqual([20_000, 2_000, 20_000, 2_000]);
+    expect(panelWaitFor).toHaveBeenNthCalledWith(1, { state: 'visible', timeout: 50_000 });
+    expect(panelWaitFor).toHaveBeenNthCalledWith(2, { state: 'visible', timeout: 50_000 });
+    expect(waitForFunction.mock.calls.map((call) => call[2]?.timeout)).toEqual([50_000, 2_000, 50_000, 2_000]);
   });
 
   it('uses the explicit timeout independently for both bootstrap attempts', async () => {

--- a/tests/e2e-runner/utils/guide-runner/bootstrap.ts
+++ b/tests/e2e-runner/utils/guide-runner/bootstrap.ts
@@ -127,8 +127,17 @@ async function openDocsPanelAttempt(page: Page, timeoutMs: number): Promise<Loca
     undefined,
     { timeout: remainingTimeout(deadline) }
   );
+  if (await panel.isVisible()) {
+    return panel;
+  }
+  state = await readBootstrapState(page, false);
+  if (hasOpenSignal(state)) {
+    await panel.waitFor({ state: 'visible', timeout: remainingTimeout(deadline) });
+    return panel;
+  }
 
   const helpButton = page.locator('button[aria-label="Help"]');
+  await helpButton.waitFor({ state: 'visible', timeout: remainingTimeout(deadline) });
   for (let openAttempt = 0; openAttempt < MAX_HELP_OPEN_ATTEMPTS; openAttempt++) {
     if (await panel.isVisible()) {
       return panel;

--- a/tests/e2e-runner/utils/guide-runner/bootstrap.ts
+++ b/tests/e2e-runner/utils/guide-runner/bootstrap.ts
@@ -5,7 +5,7 @@ import { EXTENSION_SIDEBAR_DOCKED_KEY } from '../../../../src/lib/storage/extens
 import pluginJson from '../../../../src/plugin.json';
 
 const PATHFINDER_COMPONENT_TITLE = 'Interactive learning';
-const DEFAULT_PANEL_OPEN_TIMEOUT_MS = 50_000;
+const DEFAULT_PANEL_OPEN_TIMEOUT_MS = 20_000;
 const OPEN_CONFIRMATION_TIMEOUT_MS = 2_000;
 const MAX_DOCKED_VALUE_PARSE_DEPTH = 2;
 const MAX_HELP_OPEN_ATTEMPTS = 2;

--- a/tests/e2e-runner/utils/guide-runner/bootstrap.ts
+++ b/tests/e2e-runner/utils/guide-runner/bootstrap.ts
@@ -5,7 +5,7 @@ import { EXTENSION_SIDEBAR_DOCKED_KEY } from '../../../../src/lib/storage/extens
 import pluginJson from '../../../../src/plugin.json';
 
 const PATHFINDER_COMPONENT_TITLE = 'Interactive learning';
-const DEFAULT_PANEL_OPEN_TIMEOUT_MS = 20_000;
+const DEFAULT_PANEL_OPEN_TIMEOUT_MS = 50_000;
 const OPEN_CONFIRMATION_TIMEOUT_MS = 2_000;
 const MAX_DOCKED_VALUE_PARSE_DEPTH = 2;
 const MAX_HELP_OPEN_ATTEMPTS = 2;

--- a/tests/e2e-runner/utils/guide-runner/index.ts
+++ b/tests/e2e-runner/utils/guide-runner/index.ts
@@ -50,6 +50,8 @@ export {
 export { classifyError } from './classification';
 export { createBrowserTerminationMonitor } from './termination-monitor';
 export type { BrowserTermination, BrowserTerminationMonitor } from './termination-monitor';
+export { FatalTransitionError, isFatalTransitionError } from './transition-error';
+export type { FatalTransitionKind } from './transition-error';
 
 // ============================================
 // Artifact Collection

--- a/tests/e2e-runner/utils/guide-runner/milestone-replacement.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/milestone-replacement.test.ts
@@ -152,13 +152,13 @@ function replacementHarness(options: ReplacementHarnessOptions) {
   return { page, operations, resetButton, closeButton, tabButton };
 }
 
-function waitForOpenedGuide(): Promise<{ url: string; title: string }> {
+function waitForOpenedGuide(tabId = 'opened-tab'): Promise<{ url: string; title: string }> {
   return new Promise((resolve) => {
     document.addEventListener(
       'pathfinder-auto-open-docs',
       (event) => {
         const detail = (event as CustomEvent<{ url: string; title: string }>).detail;
-        (window as Window & { __DocsPluginActiveTabId?: string }).__DocsPluginActiveTabId = 'opened-tab';
+        (window as Window & { __DocsPluginActiveTabId?: string }).__DocsPluginActiveTabId = tabId;
         (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl = detail.url;
         resolve(detail);
       },
@@ -251,11 +251,11 @@ it('accepts and clears safe residue recreated after reset acknowledgment', async
   await replacePreviousE2EGuide(harness.page);
 
   expect(harness.operations).toEqual(['reset', 'close']);
-  expect(harness.page.waitForTimeout).toHaveBeenCalledTimes(19);
+  expect(harness.page.waitForTimeout).toHaveBeenCalledTimes(4);
   expectMatchingStorageEmpty();
 });
 
-it('ignores and preserves a hybrid-storage timestamp companion after legacy reset', async () => {
+it('ignores and removes a hybrid-storage timestamp companion after legacy reset', async () => {
   seedStoredCompletion();
   const timestampKey = `${E2E_STORAGE_KEYS.steps}__timestamp`;
   localStorage.setItem(timestampKey, '1757060000000');
@@ -265,7 +265,7 @@ it('ignores and preserves a hybrid-storage timestamp companion after legacy rese
 
   expect(harness.operations).toEqual(['reset', 'close']);
   expectMatchingStorageEmpty();
-  expect(localStorage.getItem(timestampKey)).toBe('1757060000000');
+  expect(localStorage.getItem(timestampKey)).toBeNull();
 });
 
 it('preserves malformed shared completion data and requires the reset path', async () => {
@@ -370,6 +370,9 @@ it('fails fatally when previous guide steps remain attached', async () => {
   await expect(replacePreviousE2EGuide(harness.page)).rejects.toMatchObject({
     name: 'FatalTransitionError',
     kind: 'step-detach-failed',
+    message: expect.stringContaining(
+      'The previous E2E guide tab did not close cleanly: Prior E2E guide steps did not detach before replacement'
+    ),
   });
 });
 
@@ -398,6 +401,41 @@ it('recovers a known E2E tab identity at the open wait boundary', async () => {
   const opened = waitForOpenedGuide();
 
   await expect(openLegacyE2EGuide(page, 'Milestone')).resolves.toBe('opened-tab');
+
+  await expect(opened).resolves.toEqual({ url: E2E_GUIDE_URL, title: 'Milestone' });
+});
+
+it('fails fatally when an active E2E tab does not publish an ID', async () => {
+  const page = {
+    evaluate: jest.fn().mockImplementation((callback, argument) => Promise.resolve(callback(argument))),
+    waitForFunction: jest.fn().mockResolvedValue(undefined),
+  } as unknown as Page;
+  const opened = waitForOpenedGuide('');
+
+  await expect(openLegacyE2EGuide(page, 'Milestone')).rejects.toMatchObject({
+    name: 'FatalTransitionError',
+    kind: 'guide-load-ambiguous',
+  });
+
+  await expect(opened).resolves.toEqual({ url: E2E_GUIDE_URL, title: 'Milestone' });
+});
+
+it('reports when the active tab changes before E2E identity confirmation', async () => {
+  const page = {
+    evaluate: jest.fn().mockImplementation((callback, argument) => Promise.resolve(callback(argument))),
+    waitForFunction: jest.fn().mockImplementation((callback, argument) => {
+      if (!callback(argument)) {
+        return Promise.reject(new Error('Condition not met'));
+      }
+      (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl = 'bundled:other';
+      return Promise.resolve(undefined);
+    }),
+  } as unknown as Page;
+  const opened = waitForOpenedGuide();
+
+  await expect(openLegacyE2EGuide(page, 'Milestone')).rejects.toThrow(
+    'The active tab changed before the E2E guide identity was confirmed: bundled:other'
+  );
 
   await expect(opened).resolves.toEqual({ url: E2E_GUIDE_URL, title: 'Milestone' });
 });

--- a/tests/e2e-runner/utils/guide-runner/milestone-replacement.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/milestone-replacement.test.ts
@@ -6,6 +6,7 @@ import { StorageKeys } from '../../../../src/lib/storage-keys';
 
 import { dismissBadgeCelebrations } from './badge-celebrations';
 import { E2E_GUIDE_URL, openLegacyE2EGuide, replacePreviousE2EGuide } from './milestone-replacement';
+import { FatalTransitionError } from './transition-error';
 
 jest.mock('./badge-celebrations', () => ({
   dismissBadgeCelebrations: jest.fn().mockResolvedValue(undefined),
@@ -26,11 +27,50 @@ function stepHandle(): FakeStepHandle {
   return handle;
 }
 
+const E2E_STORAGE_KEYS = {
+  steps: `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${E2E_GUIDE_URL}-section-1`,
+  collapse: `${StorageKeys.SECTION_COLLAPSE_PREFIX}${E2E_GUIDE_URL}-section-1`,
+  acknowledged: `${StorageKeys.SECTION_ACKNOWLEDGED_PREFIX}${E2E_GUIDE_URL}-section-1`,
+  done: `${StorageKeys.SECTION_DONE_PREFIX}${E2E_GUIDE_URL}-section-1`,
+};
+
+function clearMatchingE2EStorage(): void {
+  Object.values(E2E_STORAGE_KEYS).forEach((key) => localStorage.removeItem(key));
+  const completion = JSON.parse(localStorage.getItem(StorageKeys.INTERACTIVE_COMPLETION) ?? '{}') as Record<
+    string,
+    number
+  >;
+  delete completion[E2E_GUIDE_URL];
+  localStorage.setItem(StorageKeys.INTERACTIVE_COMPLETION, JSON.stringify(completion));
+}
+
+function seedStoredCompletion(): void {
+  localStorage.setItem(E2E_STORAGE_KEYS.steps, JSON.stringify(['step-1']));
+  localStorage.setItem(StorageKeys.INTERACTIVE_COMPLETION, JSON.stringify({ [E2E_GUIDE_URL]: 100, other: 50 }));
+}
+
+function seedNoCompletionResidue(): void {
+  localStorage.setItem(E2E_STORAGE_KEYS.steps, JSON.stringify([]));
+  localStorage.setItem(E2E_STORAGE_KEYS.collapse, 'true');
+  localStorage.setItem(E2E_STORAGE_KEYS.acknowledged, 'true');
+  localStorage.setItem(E2E_STORAGE_KEYS.done, 'true');
+  localStorage.setItem(StorageKeys.INTERACTIVE_COMPLETION, JSON.stringify({ [E2E_GUIDE_URL]: 0, other: 50 }));
+}
+
+function expectMatchingStorageEmpty(): void {
+  expect(Object.values(E2E_STORAGE_KEYS).every((key) => localStorage.getItem(key) === null)).toBe(true);
+  expect(JSON.parse(localStorage.getItem(StorageKeys.INTERACTIVE_COMPLETION) ?? '{}')).toEqual({ other: 50 });
+}
+
 interface ReplacementHarnessOptions {
   resetControlCount: number;
   resetControlCountBeforeWait?: number;
   resetSteps?: FakeStepHandle[];
   closeSteps?: FakeStepHandle[];
+  resetClearsStorage?: boolean;
+  resetRecreatesResidue?: boolean;
+  closeError?: Error;
+  closeDetachesSteps?: boolean;
 }
 
 function replacementHarness(options: ReplacementHarnessOptions) {
@@ -54,19 +94,30 @@ function replacementHarness(options: ReplacementHarnessOptions) {
       resetSteps.forEach((step) => {
         step.connected = false;
       });
+      if (options.resetClearsStorage !== false) {
+        clearMatchingE2EStorage();
+      }
       window.dispatchEvent(
         new CustomEvent('interactive-progress-cleared', {
           detail: { contentKey: E2E_GUIDE_URL },
         })
       );
+      if (options.resetRecreatesResidue) {
+        seedNoCompletionResidue();
+      }
     }),
   };
   const closeButton = {
     click: jest.fn().mockImplementation(async () => {
+      if (options.closeError) {
+        throw options.closeError;
+      }
       operations.push('close');
-      [...resetSteps, ...closeSteps].forEach((step) => {
-        step.connected = false;
-      });
+      if (options.closeDetachesSteps !== false) {
+        [...resetSteps, ...closeSteps].forEach((step) => {
+          step.connected = false;
+        });
+      }
       (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl = '';
     }),
   };
@@ -118,12 +169,14 @@ function waitForOpenedGuide(): Promise<{ url: string; title: string }> {
 
 afterEach(() => {
   jest.clearAllMocks();
+  jest.restoreAllMocks();
   localStorage.clear();
   delete (window as Window & { __DocsPluginActiveTabId?: string }).__DocsPluginActiveTabId;
   delete (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl;
 });
 
 it('waits for reset synchronization before closing and detaches both step generations', async () => {
+  seedStoredCompletion();
   const resetStep = stepHandle();
   const closeStep = stepHandle();
   const harness = replacementHarness({
@@ -132,9 +185,10 @@ it('waits for reset synchronization before closing and detaches both step genera
     closeSteps: [closeStep],
   });
 
-  await replacePreviousE2EGuide(harness.page, true);
+  await replacePreviousE2EGuide(harness.page);
 
   expect(harness.operations).toEqual(['reset', 'close']);
+  expectMatchingStorageEmpty();
   expect(resetStep.dispose).toHaveBeenCalledTimes(1);
   expect(closeStep.dispose).toHaveBeenCalledTimes(1);
   expect(harness.page.reload).not.toHaveBeenCalled();
@@ -142,65 +196,166 @@ it('waits for reset synchronization before closing and detaches both step genera
 });
 
 it('waits for an interactive restored tab to render its Reset guide control', async () => {
+  seedStoredCompletion();
   const harness = replacementHarness({
     resetControlCount: 1,
     resetControlCountBeforeWait: 0,
   });
 
-  await replacePreviousE2EGuide(harness.page, true, 'tab-1');
+  await replacePreviousE2EGuide(harness.page, 'tab-1');
 
   expect(harness.resetButton.waitFor).toHaveBeenCalledWith({ state: 'visible', timeout: 15_000 });
   expect(harness.operations).toEqual(['reset', 'close']);
 });
 
-it('closes a zero-step guide directly when no Reset guide control exists', async () => {
+it('clears no-completion residue and closes without requiring Reset guide', async () => {
+  seedNoCompletionResidue();
   const harness = replacementHarness({ resetControlCount: 0, closeSteps: [] });
-  await replacePreviousE2EGuide(harness.page, false);
+  await replacePreviousE2EGuide(harness.page);
 
   expect(harness.resetButton.waitFor).not.toHaveBeenCalled();
   expect(harness.resetButton.click).not.toHaveBeenCalled();
   expect(harness.closeButton.click).toHaveBeenCalledTimes(1);
+  expectMatchingStorageEmpty();
 });
 
-it('fails when an interactive guide has no Reset guide control', async () => {
+it('fails fatally when stored completion has no Reset guide control', async () => {
+  seedStoredCompletion();
   const harness = replacementHarness({ resetControlCount: 0 });
-  await expect(replacePreviousE2EGuide(harness.page, true)).rejects.toMatchObject({ name: 'TimeoutError' });
+  const replacement = replacePreviousE2EGuide(harness.page);
 
+  await expect(replacement).rejects.toBeInstanceOf(FatalTransitionError);
+  await expect(replacement).rejects.toMatchObject({ kind: 'reset-ambiguous' });
+
+  expect(harness.closeButton.click).not.toHaveBeenCalled();
+  expect(localStorage.getItem(E2E_STORAGE_KEYS.steps)).not.toBeNull();
+});
+
+it('fails fatally when legacy reset leaves stored completion after tab close', async () => {
+  seedStoredCompletion();
+  const harness = replacementHarness({ resetControlCount: 1, resetClearsStorage: false });
+  const replacement = replacePreviousE2EGuide(harness.page);
+
+  await expect(replacement).rejects.toBeInstanceOf(FatalTransitionError);
+  await expect(replacement).rejects.toMatchObject({ kind: 'reset-ambiguous' });
+
+  expect(harness.operations).toEqual(['reset', 'close']);
+  expect(harness.closeButton.click).toHaveBeenCalledTimes(1);
+  expect(harness.page.waitForTimeout).not.toHaveBeenCalled();
+});
+
+it('accepts and clears safe residue recreated after reset acknowledgment', async () => {
+  seedStoredCompletion();
+  const harness = replacementHarness({ resetControlCount: 1, resetRecreatesResidue: true });
+
+  await replacePreviousE2EGuide(harness.page);
+
+  expect(harness.operations).toEqual(['reset', 'close']);
+  expect(harness.page.waitForTimeout).toHaveBeenCalledTimes(19);
+  expectMatchingStorageEmpty();
+});
+
+it('ignores and preserves a hybrid-storage timestamp companion after legacy reset', async () => {
+  seedStoredCompletion();
+  const timestampKey = `${E2E_STORAGE_KEYS.steps}__timestamp`;
+  localStorage.setItem(timestampKey, '1757060000000');
+  const harness = replacementHarness({ resetControlCount: 1 });
+
+  await replacePreviousE2EGuide(harness.page);
+
+  expect(harness.operations).toEqual(['reset', 'close']);
+  expectMatchingStorageEmpty();
+  expect(localStorage.getItem(timestampKey)).toBe('1757060000000');
+});
+
+it('preserves malformed shared completion data and requires the reset path', async () => {
+  const malformedCompletion = '{"other-guide":50';
+  const unrelatedStepKey = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}bundled:other-guide-section-1`;
+  localStorage.setItem(StorageKeys.INTERACTIVE_COMPLETION, malformedCompletion);
+  localStorage.setItem(unrelatedStepKey, JSON.stringify(['other-step']));
+  const harness = replacementHarness({ resetControlCount: 0 });
+
+  await expect(replacePreviousE2EGuide(harness.page)).rejects.toMatchObject({
+    name: 'FatalTransitionError',
+    kind: 'reset-ambiguous',
+  });
+
+  expect(harness.resetButton.waitFor).toHaveBeenCalledTimes(1);
+  expect(harness.resetButton.click).not.toHaveBeenCalled();
+  expect(localStorage.getItem(StorageKeys.INTERACTIVE_COMPLETION)).toBe(malformedCompletion);
+  expect(localStorage.getItem(unrelatedStepKey)).toBe(JSON.stringify(['other-step']));
   expect(harness.closeButton.click).not.toHaveBeenCalled();
 });
 
 it('opens a later guide when the prior milestone failed before tab activation', async () => {
+  seedNoCompletionResidue();
   const harness = replacementHarness({ resetControlCount: 0 });
   delete (window as Window & { __DocsPluginActiveTabId?: string }).__DocsPluginActiveTabId;
   delete (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl;
-  const progressKeys = [
-    `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${E2E_GUIDE_URL}-section-1`,
-    `${StorageKeys.SECTION_COLLAPSE_PREFIX}${E2E_GUIDE_URL}-section-1`,
-    `${StorageKeys.SECTION_ACKNOWLEDGED_PREFIX}${E2E_GUIDE_URL}-section-1`,
-    `${StorageKeys.SECTION_DONE_PREFIX}${E2E_GUIDE_URL}-section-1`,
-  ];
-  progressKeys.forEach((key) => localStorage.setItem(key, JSON.stringify(['step-1'])));
-  localStorage.setItem(StorageKeys.INTERACTIVE_COMPLETION, JSON.stringify({ [E2E_GUIDE_URL]: 100, other: 50 }));
   const opened = waitForOpenedGuide();
-  await replacePreviousE2EGuide(harness.page, true);
+  await replacePreviousE2EGuide(harness.page);
   await openLegacyE2EGuide(harness.page, 'Later milestone');
 
   await expect(opened).resolves.toEqual({ url: E2E_GUIDE_URL, title: 'Later milestone' });
-  expect(progressKeys.every((key) => localStorage.getItem(key) === null)).toBe(true);
-  expect(JSON.parse(localStorage.getItem(StorageKeys.INTERACTIVE_COMPLETION) ?? '{}')).toEqual({ other: 50 });
+  expectMatchingStorageEmpty();
   expect(harness.operations).toEqual([]);
   expect(dismissBadgeCelebrations).not.toHaveBeenCalled();
 });
 
+it('fails fatally when stored completion remains after pre-tab loading failed', async () => {
+  seedStoredCompletion();
+  const harness = replacementHarness({ resetControlCount: 0 });
+  delete (window as Window & { __DocsPluginActiveTabId?: string }).__DocsPluginActiveTabId;
+  delete (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl;
+
+  await expect(replacePreviousE2EGuide(harness.page)).rejects.toMatchObject({
+    name: 'FatalTransitionError',
+    kind: 'reset-ambiguous',
+  });
+
+  expect(localStorage.getItem(E2E_STORAGE_KEYS.steps)).not.toBeNull();
+});
+
 it('reactivates and resets a prior E2E guide after browser globals reset', async () => {
+  seedStoredCompletion();
   const harness = replacementHarness({ resetControlCount: 1 });
   delete (window as Window & { __DocsPluginActiveTabId?: string }).__DocsPluginActiveTabId;
   delete (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl;
 
-  await replacePreviousE2EGuide(harness.page, true, 'tab-1');
+  await replacePreviousE2EGuide(harness.page, 'tab-1');
 
   expect(harness.operations).toEqual(['activate', 'reset', 'close']);
   expect(harness.tabButton.click).toHaveBeenCalledTimes(1);
+});
+
+it('fails fatally when the previous tab cannot close', async () => {
+  const harness = replacementHarness({
+    resetControlCount: 0,
+    closeError: new Error('Close button was detached'),
+  });
+
+  await expect(replacePreviousE2EGuide(harness.page)).rejects.toMatchObject({
+    name: 'FatalTransitionError',
+    kind: 'tab-close-failed',
+  });
+});
+
+it('fails fatally when previous guide steps remain attached', async () => {
+  let now = 0;
+  jest.spyOn(Date, 'now').mockImplementation(() => {
+    now += 16_000;
+    return now;
+  });
+  const harness = replacementHarness({
+    resetControlCount: 0,
+    closeSteps: [stepHandle()],
+    closeDetachesSteps: false,
+  });
+
+  await expect(replacePreviousE2EGuide(harness.page)).rejects.toMatchObject({
+    name: 'FatalTransitionError',
+    kind: 'step-detach-failed',
+  });
 });
 
 it('opens only the exact legacy E2E URL', async () => {

--- a/tests/e2e-runner/utils/guide-runner/milestone-replacement.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/milestone-replacement.test.ts
@@ -302,18 +302,33 @@ it('opens a later guide when the prior milestone failed before tab activation', 
   expect(dismissBadgeCelebrations).not.toHaveBeenCalled();
 });
 
-it('fails fatally when stored completion remains after pre-tab loading failed', async () => {
+it('clears stored completion when the prior milestone failed before tab activation', async () => {
   seedStoredCompletion();
   const harness = replacementHarness({ resetControlCount: 0 });
   delete (window as Window & { __DocsPluginActiveTabId?: string }).__DocsPluginActiveTabId;
   delete (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl;
+  await replacePreviousE2EGuide(harness.page);
 
-  await expect(replacePreviousE2EGuide(harness.page)).rejects.toMatchObject({
-    name: 'FatalTransitionError',
-    kind: 'reset-ambiguous',
-  });
+  expectMatchingStorageEmpty();
+  expect(harness.operations).toEqual([]);
+  expect(dismissBadgeCelebrations).not.toHaveBeenCalled();
+});
 
-  expect(localStorage.getItem(E2E_STORAGE_KEYS.steps)).not.toBeNull();
+it('repairs malformed shared completion when no prior tab opened', async () => {
+  const malformedCompletion = '{"other-guide":50';
+  const unrelatedStepKey = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}bundled:other-guide-section-1`;
+  localStorage.setItem(StorageKeys.INTERACTIVE_COMPLETION, malformedCompletion);
+  localStorage.setItem(unrelatedStepKey, JSON.stringify(['other-step']));
+  const harness = replacementHarness({ resetControlCount: 0 });
+  delete (window as Window & { __DocsPluginActiveTabId?: string }).__DocsPluginActiveTabId;
+  delete (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl;
+
+  await replacePreviousE2EGuide(harness.page);
+
+  expect(localStorage.getItem(StorageKeys.INTERACTIVE_COMPLETION)).toBeNull();
+  expect(localStorage.getItem(unrelatedStepKey)).toBe(JSON.stringify(['other-step']));
+  expect(harness.operations).toEqual([]);
+  expect(dismissBadgeCelebrations).not.toHaveBeenCalled();
 });
 
 it('reactivates and resets a prior E2E guide after browser globals reset', async () => {
@@ -373,6 +388,18 @@ it('opens only the exact legacy E2E URL', async () => {
   await expect(openLegacyE2EGuide(page, 'Milestone')).resolves.toBe('opened-tab');
 
   await expect(opened).resolves.toEqual({ url: 'bundled:e2e-test', title: 'Milestone' });
+});
+
+it('recovers a known E2E tab identity at the open wait boundary', async () => {
+  const page = {
+    evaluate: jest.fn().mockImplementation((callback, argument) => Promise.resolve(callback(argument))),
+    waitForFunction: jest.fn().mockRejectedValue(new Error('Open wait timed out')),
+  } as unknown as Page;
+  const opened = waitForOpenedGuide();
+
+  await expect(openLegacyE2EGuide(page, 'Milestone')).resolves.toBe('opened-tab');
+
+  await expect(opened).resolves.toEqual({ url: E2E_GUIDE_URL, title: 'Milestone' });
 });
 
 it('has no unique URL helper or docs-retrieval import in the runner', () => {

--- a/tests/e2e-runner/utils/guide-runner/milestone-replacement.ts
+++ b/tests/e2e-runner/utils/guide-runner/milestone-replacement.ts
@@ -4,13 +4,22 @@ import { testIds } from '../../../../src/constants/testIds';
 import { StorageEvents } from '../../../../src/lib/event-names';
 import { StorageKeys } from '../../../../src/lib/storage-keys';
 import { dismissBadgeCelebrations } from './badge-celebrations';
+import { FatalTransitionError } from './transition-error';
 
 export const E2E_GUIDE_URL = 'bundled:e2e-test';
 
 const STEP_SELECTOR = '[data-testid^="interactive-step-"]';
 const REPLACEMENT_TIMEOUT_MS = 15_000;
+const RESET_POSTCONDITION_ATTEMPTS = 20;
+const RESET_POSTCONDITION_POLL_MS = 50;
+const HYBRID_STORAGE_TIMESTAMP_SUFFIX = '__timestamp';
 
 type StepHandle = ElementHandle<HTMLElement | SVGElement>;
+
+interface E2EProgressStorageState {
+  hasStoredCompletion: boolean;
+  hasMatchingStorage: boolean;
+}
 
 async function activeGuideTab(page: Page): Promise<{ id: string; url: string }> {
   return page.evaluate(() => {
@@ -25,16 +34,109 @@ async function activeGuideTab(page: Page): Promise<{ id: string; url: string }> 
   });
 }
 
-async function clearSharedE2EProgress(page: Page): Promise<void> {
+async function inspectE2EProgressStorage(page: Page): Promise<E2EProgressStorageState> {
+  return page.evaluate(
+    ({ contentKey, keys, timestampSuffix }) => {
+      const stepsPrefix = `${keys.stepsPrefix}${contentKey}-`;
+      const matchingPrefixes = [
+        stepsPrefix,
+        `${keys.collapsePrefix}${contentKey}-`,
+        `${keys.acknowledgedPrefix}${contentKey}-`,
+        `${keys.donePrefix}${contentKey}-`,
+      ];
+      let hasStoredCompletion = false;
+      let hasMatchingStorage = false;
+
+      for (let index = 0; index < localStorage.length; index++) {
+        const key = localStorage.key(index);
+        if (!key || key.endsWith(timestampSuffix) || !matchingPrefixes.some((prefix) => key.startsWith(prefix))) {
+          continue;
+        }
+        hasMatchingStorage = true;
+        if (!key.startsWith(stepsPrefix)) {
+          continue;
+        }
+        const value = localStorage.getItem(key);
+        try {
+          const completedIds = value ? JSON.parse(value) : [];
+          if (Array.isArray(completedIds) && completedIds.length === 0) {
+            continue;
+          }
+        } catch {
+          // A malformed step value is ambiguous and requires the mounted reset path.
+        }
+        hasStoredCompletion = true;
+      }
+
+      const completionValue = localStorage.getItem(keys.completion);
+      if (completionValue) {
+        try {
+          const completion = JSON.parse(completionValue);
+          if (
+            completion &&
+            typeof completion === 'object' &&
+            !Array.isArray(completion) &&
+            Object.prototype.hasOwnProperty.call(completion, contentKey)
+          ) {
+            hasMatchingStorage = true;
+          }
+        } catch {
+          hasMatchingStorage = true;
+          hasStoredCompletion = true;
+        }
+      }
+
+      return { hasStoredCompletion, hasMatchingStorage };
+    },
+    {
+      contentKey: E2E_GUIDE_URL,
+      keys: {
+        stepsPrefix: StorageKeys.INTERACTIVE_STEPS_PREFIX,
+        collapsePrefix: StorageKeys.SECTION_COLLAPSE_PREFIX,
+        acknowledgedPrefix: StorageKeys.SECTION_ACKNOWLEDGED_PREFIX,
+        donePrefix: StorageKeys.SECTION_DONE_PREFIX,
+        completion: StorageKeys.INTERACTIVE_COMPLETION,
+      },
+      timestampSuffix: HYBRID_STORAGE_TIMESTAMP_SUFFIX,
+    }
+  );
+}
+
+async function waitForAcknowledgedResetPostcondition(page: Page): Promise<void> {
+  for (let attempt = 1; attempt <= RESET_POSTCONDITION_ATTEMPTS; attempt++) {
+    const storage = await inspectE2EProgressStorage(page);
+    if (storage.hasStoredCompletion) {
+      throw new FatalTransitionError(
+        'reset-ambiguous',
+        'The previous E2E guide still has stored completion after acknowledged reset and tab close'
+      );
+    }
+    if (attempt < RESET_POSTCONDITION_ATTEMPTS) {
+      await page.waitForTimeout(RESET_POSTCONDITION_POLL_MS);
+    }
+  }
+}
+
+async function requireEmptyE2EProgressStorage(page: Page): Promise<void> {
+  const storage = await inspectE2EProgressStorage(page);
+  if (storage.hasMatchingStorage) {
+    throw new FatalTransitionError(
+      'reset-ambiguous',
+      'The previous E2E guide still has matching progress storage after reset'
+    );
+  }
+}
+
+async function clearNoCompletionResidue(page: Page): Promise<void> {
   await page.evaluate(
-    ({ contentKey, eventName, keys }) => {
+    ({ contentKey, keys, timestampSuffix }) => {
       const prefixes = [keys.stepsPrefix, keys.collapsePrefix, keys.acknowledgedPrefix, keys.donePrefix].map(
         (prefix) => `${prefix}${contentKey}-`
       );
       const keysToRemove: string[] = [];
       for (let index = 0; index < localStorage.length; index++) {
         const key = localStorage.key(index);
-        if (key && prefixes.some((prefix) => key.startsWith(prefix))) {
+        if (key && !key.endsWith(timestampSuffix) && prefixes.some((prefix) => key.startsWith(prefix))) {
           keysToRemove.push(key);
         }
       }
@@ -49,14 +151,12 @@ async function clearSharedE2EProgress(page: Page): Promise<void> {
             localStorage.setItem(keys.completion, JSON.stringify(completion));
           }
         } catch {
-          localStorage.removeItem(keys.completion);
+          // The shared record cannot be changed safely without a valid object.
         }
       }
-      window.dispatchEvent(new CustomEvent(eventName, { detail: { contentKey } }));
     },
     {
       contentKey: E2E_GUIDE_URL,
-      eventName: StorageEvents.InteractiveProgressCleared,
       keys: {
         stepsPrefix: StorageKeys.INTERACTIVE_STEPS_PREFIX,
         collapsePrefix: StorageKeys.SECTION_COLLAPSE_PREFIX,
@@ -64,6 +164,7 @@ async function clearSharedE2EProgress(page: Page): Promise<void> {
         donePrefix: StorageKeys.SECTION_DONE_PREFIX,
         completion: StorageKeys.INTERACTIVE_COMPLETION,
       },
+      timestampSuffix: HYBRID_STORAGE_TIMESTAMP_SUFFIX,
     }
   );
 }
@@ -122,6 +223,21 @@ async function activateE2EGuideTab(page: Page, tabId: string): Promise<void> {
 async function currentStepHandles(page: Page): Promise<StepHandle[]> {
   return page.locator(STEP_SELECTOR).elementHandles();
 }
+function transitionFailure(
+  kind: 'guide-load-ambiguous' | 'reset-ambiguous' | 'tab-close-failed',
+  message: string,
+  error: unknown
+): FatalTransitionError {
+  if (error instanceof FatalTransitionError) {
+    return error;
+  }
+  const reason = error instanceof Error ? error.message : String(error);
+  return new FatalTransitionError(kind, `${message}: ${reason}`);
+}
+
+async function disposeStepHandles(handles: StepHandle[]): Promise<void> {
+  await Promise.all(handles.map((step) => step.dispose().catch(() => undefined)));
+}
 
 export async function waitForStepHandlesToDetach(page: Page, handles: StepHandle[]): Promise<void> {
   const deadline = Date.now() + REPLACEMENT_TIMEOUT_MS;
@@ -135,9 +251,9 @@ export async function waitForStepHandlesToDetach(page: Page, handles: StepHandle
       }
       await page.waitForTimeout(50);
     }
-    throw new Error('Prior E2E guide steps did not detach before replacement');
+    throw new FatalTransitionError('step-detach-failed', 'Prior E2E guide steps did not detach before replacement');
   } finally {
-    await Promise.all(handles.map((step) => step.dispose()));
+    await Promise.all(handles.map((step) => step.dispose().catch(() => undefined)));
   }
 }
 
@@ -207,69 +323,134 @@ export async function openLegacyE2EGuide(page: Page, title: string): Promise<str
     },
     { guideTitle: title, url: E2E_GUIDE_URL }
   );
-  await page.waitForFunction(
-    (url) => (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl === url,
-    E2E_GUIDE_URL,
-    { timeout: REPLACEMENT_TIMEOUT_MS }
-  );
+  try {
+    await page.waitForFunction(
+      (url) => (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl === url,
+      E2E_GUIDE_URL,
+      { timeout: REPLACEMENT_TIMEOUT_MS }
+    );
+  } catch (error) {
+    const activeTab = await activeGuideTab(page);
+    if (activeTab.url === E2E_GUIDE_URL) {
+      throw transitionFailure(
+        'guide-load-ambiguous',
+        'The new E2E guide tab became active before guide loading failed',
+        error
+      );
+    }
+    throw error;
+  }
   const activeTab = await activeGuideTab(page);
+  if (!activeTab.id && activeTab.url === E2E_GUIDE_URL) {
+    throw new FatalTransitionError('guide-load-ambiguous', 'The opened E2E guide tab did not publish its identity');
+  }
   if (!activeTab.id || activeTab.url !== E2E_GUIDE_URL) {
     throw new Error('The opened E2E guide tab did not publish its identity');
   }
   return activeTab.id;
 }
-export async function replacePreviousE2EGuide(
-  page: Page,
-  previousGuideHadInteractiveSteps: boolean,
-  previousGuideTabId?: string
-): Promise<void> {
-  let activeTab = await activeGuideTab(page);
+
+export async function replacePreviousE2EGuide(page: Page, previousGuideTabId?: string): Promise<void> {
+  let storage: E2EProgressStorageState;
+  let activeTab: { id: string; url: string };
+  try {
+    storage = await inspectE2EProgressStorage(page);
+    activeTab = await activeGuideTab(page);
+  } catch (error) {
+    throw transitionFailure('reset-ambiguous', 'The runner could not inspect previous E2E guide state', error);
+  }
   const targetTabId = previousGuideTabId ?? (activeTab.url === E2E_GUIDE_URL ? activeTab.id : '');
   if (!targetTabId) {
-    await clearSharedE2EProgress(page);
+    if (storage.hasStoredCompletion) {
+      throw new FatalTransitionError(
+        'reset-ambiguous',
+        'The previous E2E guide has stored completion but no tab with a Reset guide control'
+      );
+    }
+    try {
+      await clearNoCompletionResidue(page);
+      await requireEmptyE2EProgressStorage(page);
+    } catch (error) {
+      throw transitionFailure('reset-ambiguous', 'The runner could not clear previous E2E guide residue', error);
+    }
     return;
   }
   if (activeTab.id !== targetTabId || activeTab.url !== E2E_GUIDE_URL) {
-    await activateE2EGuideTab(page, targetTabId);
-    activeTab = await activeGuideTab(page);
+    try {
+      await activateE2EGuideTab(page, targetTabId);
+      activeTab = await activeGuideTab(page);
+    } catch (error) {
+      throw transitionFailure('reset-ambiguous', 'The previous E2E guide tab could not be activated', error);
+    }
   }
   if (activeTab.id !== targetTabId || activeTab.url !== E2E_GUIDE_URL) {
-    throw new Error('The previous E2E guide tab did not become active');
+    throw new FatalTransitionError('reset-ambiguous', 'The previous E2E guide tab did not become active');
   }
 
   await dismissBadgeCelebrations(page);
-  const resetButton = page.getByRole('button', { name: 'Reset guide', exact: true });
-  if (previousGuideHadInteractiveSteps) {
-    await resetButton.waitFor({ state: 'visible', timeout: REPLACEMENT_TIMEOUT_MS });
-  }
-  const stepsBeforeReset = await currentStepHandles(page);
-  const resetControlCount = await resetButton.count();
-  if (resetControlCount > 0) {
+  let stepsBeforeReset: StepHandle[] = [];
+  if (storage.hasStoredCompletion) {
+    const resetButton = page.getByRole('button', { name: 'Reset guide', exact: true });
     try {
+      await resetButton.waitFor({ state: 'visible', timeout: REPLACEMENT_TIMEOUT_MS });
+      stepsBeforeReset = await currentStepHandles(page);
       await resetInteractiveProgress(page);
     } catch (error) {
-      await Promise.all(stepsBeforeReset.map((step) => step.dispose()));
-      throw error;
+      await disposeStepHandles(stepsBeforeReset);
+      throw transitionFailure(
+        'reset-ambiguous',
+        'The previous E2E guide has stored completion but the legacy Reset guide path failed',
+        error
+      );
     }
-  } else if (previousGuideHadInteractiveSteps) {
-    await Promise.all(stepsBeforeReset.map((step) => step.dispose()));
-    throw new Error('The interactive E2E guide has no Reset guide control');
+  } else {
+    try {
+      await clearNoCompletionResidue(page);
+      await requireEmptyE2EProgressStorage(page);
+    } catch (error) {
+      throw transitionFailure('reset-ambiguous', 'The runner could not clear previous E2E guide residue', error);
+    }
   }
 
-  const stepsBeforeClose = await currentStepHandles(page);
+  let stepsBeforeClose: StepHandle[];
+  try {
+    stepsBeforeClose = await currentStepHandles(page);
+  } catch (error) {
+    await disposeStepHandles(stepsBeforeReset);
+    throw transitionFailure('reset-ambiguous', 'The runner could not inspect previous E2E guide steps', error);
+  }
   const priorSteps = [...stepsBeforeReset, ...stepsBeforeClose];
   try {
     await page.getByTestId(testIds.docsPanel.tabCloseButton(activeTab.id)).click({
       timeout: REPLACEMENT_TIMEOUT_MS,
     });
+    await waitForStepHandlesToDetach(page, priorSteps);
+    await page.waitForFunction(
+      (url) => (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl !== url,
+      E2E_GUIDE_URL,
+      { timeout: REPLACEMENT_TIMEOUT_MS }
+    );
   } catch (error) {
-    await Promise.all(priorSteps.map((step) => step.dispose()));
-    throw error;
+    await disposeStepHandles(priorSteps);
+    throw transitionFailure('tab-close-failed', 'The previous E2E guide tab did not close cleanly', error);
   }
-  await waitForStepHandlesToDetach(page, priorSteps);
-  await page.waitForFunction(
-    (url) => (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl !== url,
-    E2E_GUIDE_URL,
-    { timeout: REPLACEMENT_TIMEOUT_MS }
-  );
+  if (storage.hasStoredCompletion) {
+    try {
+      await waitForAcknowledgedResetPostcondition(page);
+      await clearNoCompletionResidue(page);
+      const postCleanupStorage = await inspectE2EProgressStorage(page);
+      if (postCleanupStorage.hasStoredCompletion) {
+        throw new FatalTransitionError(
+          'reset-ambiguous',
+          'The previous E2E guide recreated stored completion during post-reset cleanup'
+        );
+      }
+    } catch (error) {
+      throw transitionFailure(
+        'reset-ambiguous',
+        'The acknowledged legacy reset did not reach a safe post-close state',
+        error
+      );
+    }
+  }
 }

--- a/tests/e2e-runner/utils/guide-runner/milestone-replacement.ts
+++ b/tests/e2e-runner/utils/guide-runner/milestone-replacement.ts
@@ -151,7 +151,7 @@ async function clearNoCompletionResidue(page: Page): Promise<void> {
             localStorage.setItem(keys.completion, JSON.stringify(completion));
           }
         } catch {
-          // The shared record cannot be changed safely without a valid object.
+          localStorage.removeItem(keys.completion);
         }
       }
     },
@@ -331,12 +331,11 @@ export async function openLegacyE2EGuide(page: Page, title: string): Promise<str
     );
   } catch (error) {
     const activeTab = await activeGuideTab(page);
+    if (activeTab.id && activeTab.url === E2E_GUIDE_URL) {
+      return activeTab.id;
+    }
     if (activeTab.url === E2E_GUIDE_URL) {
-      throw transitionFailure(
-        'guide-load-ambiguous',
-        'The new E2E guide tab became active before guide loading failed',
-        error
-      );
+      throw transitionFailure('guide-load-ambiguous', 'The new E2E guide tab has no usable identity', error);
     }
     throw error;
   }
@@ -361,12 +360,6 @@ export async function replacePreviousE2EGuide(page: Page, previousGuideTabId?: s
   }
   const targetTabId = previousGuideTabId ?? (activeTab.url === E2E_GUIDE_URL ? activeTab.id : '');
   if (!targetTabId) {
-    if (storage.hasStoredCompletion) {
-      throw new FatalTransitionError(
-        'reset-ambiguous',
-        'The previous E2E guide has stored completion but no tab with a Reset guide control'
-      );
-    }
     try {
       await clearNoCompletionResidue(page);
       await requireEmptyE2EProgressStorage(page);

--- a/tests/e2e-runner/utils/guide-runner/milestone-replacement.ts
+++ b/tests/e2e-runner/utils/guide-runner/milestone-replacement.ts
@@ -4,17 +4,18 @@ import { testIds } from '../../../../src/constants/testIds';
 import { StorageEvents } from '../../../../src/lib/event-names';
 import { StorageKeys } from '../../../../src/lib/storage-keys';
 import { dismissBadgeCelebrations } from './badge-celebrations';
-import { FatalTransitionError } from './transition-error';
+import { FatalTransitionError, type FatalTransitionKind } from './transition-error';
 
 export const E2E_GUIDE_URL = 'bundled:e2e-test';
 
 const STEP_SELECTOR = '[data-testid^="interactive-step-"]';
 const REPLACEMENT_TIMEOUT_MS = 15_000;
-const RESET_POSTCONDITION_ATTEMPTS = 20;
-const RESET_POSTCONDITION_POLL_MS = 50;
+const RESET_POSTCONDITION_ATTEMPTS = 5;
+const RESET_POSTCONDITION_POLL_MS = 250;
 const HYBRID_STORAGE_TIMESTAMP_SUFFIX = '__timestamp';
 
 type StepHandle = ElementHandle<HTMLElement | SVGElement>;
+type WrappedTransitionKind = Exclude<FatalTransitionKind, 'badge-obstruction' | 'step-detach-failed'>;
 
 interface E2EProgressStorageState {
   hasStoredCompletion: boolean;
@@ -102,7 +103,7 @@ async function inspectE2EProgressStorage(page: Page): Promise<E2EProgressStorage
   );
 }
 
-async function waitForAcknowledgedResetPostcondition(page: Page): Promise<void> {
+async function requireStoredCompletionStaysAbsent(page: Page): Promise<void> {
   for (let attempt = 1; attempt <= RESET_POSTCONDITION_ATTEMPTS; attempt++) {
     const storage = await inspectE2EProgressStorage(page);
     if (storage.hasStoredCompletion) {
@@ -129,14 +130,14 @@ async function requireEmptyE2EProgressStorage(page: Page): Promise<void> {
 
 async function clearNoCompletionResidue(page: Page): Promise<void> {
   await page.evaluate(
-    ({ contentKey, keys, timestampSuffix }) => {
+    ({ contentKey, keys }) => {
       const prefixes = [keys.stepsPrefix, keys.collapsePrefix, keys.acknowledgedPrefix, keys.donePrefix].map(
         (prefix) => `${prefix}${contentKey}-`
       );
       const keysToRemove: string[] = [];
       for (let index = 0; index < localStorage.length; index++) {
         const key = localStorage.key(index);
-        if (key && !key.endsWith(timestampSuffix) && prefixes.some((prefix) => key.startsWith(prefix))) {
+        if (key && prefixes.some((prefix) => key.startsWith(prefix))) {
           keysToRemove.push(key);
         }
       }
@@ -164,7 +165,6 @@ async function clearNoCompletionResidue(page: Page): Promise<void> {
         donePrefix: StorageKeys.SECTION_DONE_PREFIX,
         completion: StorageKeys.INTERACTIVE_COMPLETION,
       },
-      timestampSuffix: HYBRID_STORAGE_TIMESTAMP_SUFFIX,
     }
   );
 }
@@ -223,13 +223,9 @@ async function activateE2EGuideTab(page: Page, tabId: string): Promise<void> {
 async function currentStepHandles(page: Page): Promise<StepHandle[]> {
   return page.locator(STEP_SELECTOR).elementHandles();
 }
-function transitionFailure(
-  kind: 'guide-load-ambiguous' | 'reset-ambiguous' | 'tab-close-failed',
-  message: string,
-  error: unknown
-): FatalTransitionError {
+function transitionFailure(kind: WrappedTransitionKind, message: string, error: unknown): FatalTransitionError {
   if (error instanceof FatalTransitionError) {
-    return error;
+    return new FatalTransitionError(error.kind, `${message}: ${error.message}`);
   }
   const reason = error instanceof Error ? error.message : String(error);
   return new FatalTransitionError(kind, `${message}: ${reason}`);
@@ -344,7 +340,9 @@ export async function openLegacyE2EGuide(page: Page, title: string): Promise<str
     throw new FatalTransitionError('guide-load-ambiguous', 'The opened E2E guide tab did not publish its identity');
   }
   if (!activeTab.id || activeTab.url !== E2E_GUIDE_URL) {
-    throw new Error('The opened E2E guide tab did not publish its identity');
+    throw new Error(
+      `The active tab changed before the E2E guide identity was confirmed: ${activeTab.url || 'no active URL'}`
+    );
   }
   return activeTab.id;
 }
@@ -429,7 +427,7 @@ export async function replacePreviousE2EGuide(page: Page, previousGuideTabId?: s
   }
   if (storage.hasStoredCompletion) {
     try {
-      await waitForAcknowledgedResetPostcondition(page);
+      await requireStoredCompletionStaysAbsent(page);
       await clearNoCompletionResidue(page);
       const postCleanupStorage = await inspectE2EProgressStorage(page);
       if (postCleanupStorage.hasStoredCompletion) {

--- a/tests/e2e-runner/utils/guide-runner/panel-recovery.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/panel-recovery.test.ts
@@ -44,4 +44,5 @@ it('keeps reload recovery for standalone and first-milestone execution', async (
 
   expect(currentPage.reload).toHaveBeenCalledTimes(1);
   expect(currentPage.evaluate).toHaveBeenCalledTimes(2);
+  expect(currentPage.locator).not.toHaveBeenCalled();
 });

--- a/tests/e2e-runner/utils/guide-runner/panel-recovery.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/panel-recovery.test.ts
@@ -46,3 +46,22 @@ it('keeps reload recovery for standalone and first-milestone execution', async (
   expect(currentPage.evaluate).toHaveBeenCalledTimes(2);
   expect(currentPage.locator).not.toHaveBeenCalled();
 });
+
+it('forwards an explicit timeout through reload recovery', async () => {
+  const currentPage = page();
+  ensureDocsPanelOpenMock.mockImplementation(async (_page, options) => {
+    await options?.beforeRetry?.();
+    return {} as never;
+  });
+
+  await ensureGuidePanelOpen(currentPage, '{"id":"first"}', true, 30_000);
+
+  expect(ensureDocsPanelOpenMock).toHaveBeenCalledWith(
+    currentPage,
+    expect.objectContaining({
+      timeoutMs: 30_000,
+      beforeRetry: expect.any(Function),
+    })
+  );
+  expect(currentPage.reload).toHaveBeenCalledTimes(1);
+});

--- a/tests/e2e-runner/utils/guide-runner/panel-recovery.ts
+++ b/tests/e2e-runner/utils/guide-runner/panel-recovery.ts
@@ -21,7 +21,6 @@ export async function ensureGuidePanelOpen(page: Page, content: string, allowRel
   await ensureDocsPanelOpen(page, {
     beforeRetry: async () => {
       await page.reload({ waitUntil: 'domcontentloaded', timeout: 10_000 });
-      await page.locator('button[aria-label="Help"]').waitFor({ state: 'visible', timeout: 10_000 });
       await injectGuide(page, content);
     },
   });

--- a/tests/e2e-runner/utils/guide-runner/panel-recovery.ts
+++ b/tests/e2e-runner/utils/guide-runner/panel-recovery.ts
@@ -12,13 +12,23 @@ async function injectGuide(page: Page, content: string): Promise<void> {
   );
 }
 
-export async function ensureGuidePanelOpen(page: Page, content: string, allowReloadRecovery: boolean): Promise<void> {
+export async function ensureGuidePanelOpen(
+  page: Page,
+  content: string,
+  allowReloadRecovery: boolean,
+  timeoutMs?: number
+): Promise<void> {
   await injectGuide(page, content);
   if (!allowReloadRecovery) {
-    await ensureDocsPanelOpen(page);
+    if (timeoutMs === undefined) {
+      await ensureDocsPanelOpen(page);
+    } else {
+      await ensureDocsPanelOpen(page, { timeoutMs });
+    }
     return;
   }
   await ensureDocsPanelOpen(page, {
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
     beforeRetry: async () => {
       await page.reload({ waitUntil: 'domcontentloaded', timeout: 10_000 });
       await injectGuide(page, content);

--- a/tests/e2e-runner/utils/guide-runner/run-guide.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/run-guide.test.ts
@@ -4,6 +4,7 @@ import { ensureDocsPanelOpen } from './bootstrap';
 import { openLegacyE2EGuide, replacePreviousE2EGuide } from './milestone-replacement';
 import { ensureGuidePanelOpen } from './panel-recovery';
 import { runGuideOnPage, type RunGuideOnPageOptions } from './run-guide';
+import { FatalTransitionError } from './transition-error';
 jest.mock('../console-reporter', () => ({
   printDetailedSummary: jest.fn(),
   printDiscoveryResults: jest.fn(),
@@ -47,11 +48,6 @@ function page(events: string[]): Page {
     goto: jest.fn().mockImplementation(async () => {
       events.push('navigate');
     }),
-    locator: jest.fn().mockReturnValue({
-      waitFor: jest.fn().mockImplementation(async () => {
-        events.push('help-ready');
-      }),
-    }),
     getByTestId: jest.fn().mockReturnValue({
       waitFor: jest.fn().mockImplementation(async () => {
         events.push('content-ready');
@@ -66,7 +62,6 @@ function options(events: string[]): RunGuideOnPageOptions {
     startingLocation: '/later',
     navigateToStartingLocation: true,
     replacePreviousGuide: true,
-    previousGuideHadInteractiveSteps: true,
     previousGuideTabId: 'old-tab',
     onPreviousGuideCleared: () => {
       events.push('previous-cleared');
@@ -90,7 +85,7 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-it('restores and clears the recorded previous tab before opening a later guide', async () => {
+it('clears the recorded previous tab before navigation and guide loading', async () => {
   const events: string[] = [];
   const currentPage = page(events);
   ensureDocsPanelOpenMock.mockImplementation(async () => {
@@ -119,17 +114,69 @@ it('restores and clears the recorded previous tab before opening a later guide',
     options(events)
   );
 
-  expect(replacePreviousE2EGuideMock).toHaveBeenCalledWith(currentPage, true, 'old-tab');
+  expect(replacePreviousE2EGuideMock).toHaveBeenCalledWith(currentPage, 'old-tab');
   expect(events).toEqual([
-    'navigate',
-    'help-ready',
     'panel-restored',
     'previous-replaced',
     'previous-cleared',
+    'navigate',
     'guide-injected',
     'guide-opened',
     'opened:new-tab',
     'content-ready',
   ]);
   expect(result.outcome).toBe('passed');
+});
+
+it('keeps a pre-tab guide-load failure recoverable after previous state is cleared', async () => {
+  const events: string[] = [];
+  const currentPage = page(events);
+  const loadError = new Error('The guide panel did not open');
+  ensureDocsPanelOpenMock.mockResolvedValue({} as never);
+  replacePreviousE2EGuideMock.mockResolvedValue(undefined);
+  ensureGuidePanelOpenMock.mockRejectedValue(loadError);
+
+  await expect(
+    runGuideOnPage(
+      currentPage,
+      {
+        id: 'later',
+        title: 'Later guide',
+        path: '/later/content.json',
+        content: '{"id":"later","title":"Later guide","blocks":[]}',
+      },
+      options(events)
+    )
+  ).rejects.toBe(loadError);
+
+  expect(openLegacyE2EGuideMock).not.toHaveBeenCalled();
+});
+
+it('makes a load failure fatal after the new guide tab becomes active', async () => {
+  const events: string[] = [];
+  const currentPage = {
+    ...page(events),
+    getByTestId: jest.fn().mockReturnValue({
+      waitFor: jest.fn().mockRejectedValue(new Error('Guide loading timed out')),
+    }),
+  } as unknown as Page;
+  ensureDocsPanelOpenMock.mockResolvedValue({} as never);
+  replacePreviousE2EGuideMock.mockResolvedValue(undefined);
+  ensureGuidePanelOpenMock.mockResolvedValue(undefined);
+  openLegacyE2EGuideMock.mockResolvedValue('new-tab');
+
+  const loading = runGuideOnPage(
+    currentPage,
+    {
+      id: 'later',
+      title: 'Later guide',
+      path: '/later/content.json',
+      content: '{"id":"later","title":"Later guide","blocks":[]}',
+    },
+    options(events)
+  );
+
+  await expect(loading).rejects.toBeInstanceOf(FatalTransitionError);
+  await expect(loading).rejects.toMatchObject({ kind: 'guide-load-ambiguous' });
+  expect(events).toContain('opened:new-tab');
 });

--- a/tests/e2e-runner/utils/guide-runner/run-guide.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/run-guide.test.ts
@@ -114,6 +114,12 @@ it('clears the recorded previous tab before navigation and guide loading', async
   );
 
   expect(replacePreviousE2EGuideMock).toHaveBeenCalledWith(currentPage, 'old-tab');
+  expect(ensureGuidePanelOpenMock).toHaveBeenCalledWith(
+    currentPage,
+    '{"id":"later","title":"Later guide","blocks":[]}',
+    false,
+    30_000
+  );
   expect(events).toEqual([
     'panel-restored',
     'previous-replaced',

--- a/tests/e2e-runner/utils/guide-runner/run-guide.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/run-guide.test.ts
@@ -4,7 +4,6 @@ import { ensureDocsPanelOpen } from './bootstrap';
 import { openLegacyE2EGuide, replacePreviousE2EGuide } from './milestone-replacement';
 import { ensureGuidePanelOpen } from './panel-recovery';
 import { runGuideOnPage, type RunGuideOnPageOptions } from './run-guide';
-import { FatalTransitionError } from './transition-error';
 jest.mock('../console-reporter', () => ({
   printDetailedSummary: jest.fn(),
   printDiscoveryResults: jest.fn(),
@@ -152,12 +151,13 @@ it('keeps a pre-tab guide-load failure recoverable after previous state is clear
   expect(openLegacyE2EGuideMock).not.toHaveBeenCalled();
 });
 
-it('makes a load failure fatal after the new guide tab becomes active', async () => {
+it('keeps a content-load failure recoverable after the new guide tab becomes active', async () => {
   const events: string[] = [];
+  const loadError = new Error('Guide loading timed out');
   const currentPage = {
     ...page(events),
     getByTestId: jest.fn().mockReturnValue({
-      waitFor: jest.fn().mockRejectedValue(new Error('Guide loading timed out')),
+      waitFor: jest.fn().mockRejectedValue(loadError),
     }),
   } as unknown as Page;
   ensureDocsPanelOpenMock.mockResolvedValue({} as never);
@@ -165,18 +165,17 @@ it('makes a load failure fatal after the new guide tab becomes active', async ()
   ensureGuidePanelOpenMock.mockResolvedValue(undefined);
   openLegacyE2EGuideMock.mockResolvedValue('new-tab');
 
-  const loading = runGuideOnPage(
-    currentPage,
-    {
-      id: 'later',
-      title: 'Later guide',
-      path: '/later/content.json',
-      content: '{"id":"later","title":"Later guide","blocks":[]}',
-    },
-    options(events)
-  );
-
-  await expect(loading).rejects.toBeInstanceOf(FatalTransitionError);
-  await expect(loading).rejects.toMatchObject({ kind: 'guide-load-ambiguous' });
+  await expect(
+    runGuideOnPage(
+      currentPage,
+      {
+        id: 'later',
+        title: 'Later guide',
+        path: '/later/content.json',
+        content: '{"id":"later","title":"Later guide","blocks":[]}',
+      },
+      options(events)
+    )
+  ).rejects.toBe(loadError);
   expect(events).toContain('opened:new-tab');
 });

--- a/tests/e2e-runner/utils/guide-runner/run-guide.ts
+++ b/tests/e2e-runner/utils/guide-runner/run-guide.ts
@@ -15,6 +15,7 @@ import { openLegacyE2EGuide, replacePreviousE2EGuide } from './milestone-replace
 
 const GUIDE_LOAD_TIMEOUT_MS = 15_000;
 const NAVIGATION_TIMEOUT_MS = 30_000;
+const POST_NAVIGATION_PANEL_TIMEOUT_MS = 30_000;
 const STEP_SELECTOR = '[data-testid^="interactive-step-"]';
 
 export interface PageGuide {
@@ -65,7 +66,12 @@ async function loadGuide(page: Page, guide: PageGuide, options: RunGuideOnPageOp
   if (options.navigateToStartingLocation) {
     await page.goto(options.startingLocation, { waitUntil: 'domcontentloaded', timeout: NAVIGATION_TIMEOUT_MS });
   }
-  await ensureGuidePanelOpen(page, guide.content, options.allowReloadRecovery);
+  await ensureGuidePanelOpen(
+    page,
+    guide.content,
+    options.allowReloadRecovery,
+    options.navigateToStartingLocation ? POST_NAVIGATION_PANEL_TIMEOUT_MS : undefined
+  );
   const tabId = await openLegacyE2EGuide(page, guide.title);
   options.onGuideOpened?.(tabId);
   await page.getByTestId(testIds.docsPanel.loadingState).waitFor({

--- a/tests/e2e-runner/utils/guide-runner/run-guide.ts
+++ b/tests/e2e-runner/utils/guide-runner/run-guide.ts
@@ -12,7 +12,6 @@ import type { SessionValidationResult } from '../../auth/grafana-auth';
 import { ensureDocsPanelOpen } from './bootstrap';
 import { ensureGuidePanelOpen } from './panel-recovery';
 import { openLegacyE2EGuide, replacePreviousE2EGuide } from './milestone-replacement';
-import { FatalTransitionError } from './transition-error';
 
 const GUIDE_LOAD_TIMEOUT_MS = 15_000;
 const NAVIGATION_TIMEOUT_MS = 30_000;
@@ -69,18 +68,10 @@ async function loadGuide(page: Page, guide: PageGuide, options: RunGuideOnPageOp
   await ensureGuidePanelOpen(page, guide.content, options.allowReloadRecovery);
   const tabId = await openLegacyE2EGuide(page, guide.title);
   options.onGuideOpened?.(tabId);
-  try {
-    await page.getByTestId(testIds.docsPanel.loadingState).waitFor({
-      state: 'hidden',
-      timeout: GUIDE_LOAD_TIMEOUT_MS,
-    });
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
-    throw new FatalTransitionError(
-      'guide-load-ambiguous',
-      `The E2E guide tab became active but its content did not finish loading: ${reason}`
-    );
-  }
+  await page.getByTestId(testIds.docsPanel.loadingState).waitFor({
+    state: 'hidden',
+    timeout: GUIDE_LOAD_TIMEOUT_MS,
+  });
 }
 
 function toResultsData(

--- a/tests/e2e-runner/utils/guide-runner/run-guide.ts
+++ b/tests/e2e-runner/utils/guide-runner/run-guide.ts
@@ -12,9 +12,10 @@ import type { SessionValidationResult } from '../../auth/grafana-auth';
 import { ensureDocsPanelOpen } from './bootstrap';
 import { ensureGuidePanelOpen } from './panel-recovery';
 import { openLegacyE2EGuide, replacePreviousE2EGuide } from './milestone-replacement';
+import { FatalTransitionError } from './transition-error';
 
 const GUIDE_LOAD_TIMEOUT_MS = 15_000;
-const HELP_READY_TIMEOUT_MS = 30_000;
+const NAVIGATION_TIMEOUT_MS = 30_000;
 const STEP_SELECTOR = '[data-testid^="interactive-step-"]';
 
 export interface PageGuide {
@@ -29,7 +30,6 @@ export interface RunGuideOnPageOptions {
   startingLocation: string;
   navigateToStartingLocation: boolean;
   replacePreviousGuide: boolean;
-  previousGuideHadInteractiveSteps: boolean;
   previousGuideTabId?: string;
   onPreviousGuideCleared?: () => void;
   onGuideOpened?: (tabId: string) => void;
@@ -58,19 +58,29 @@ export function parsePageGuide(path: string, content: string, plannedId?: string
 }
 
 async function loadGuide(page: Page, guide: PageGuide, options: RunGuideOnPageOptions): Promise<void> {
-  if (options.navigateToStartingLocation) {
-    await page.goto(options.startingLocation, { waitUntil: 'domcontentloaded', timeout: HELP_READY_TIMEOUT_MS });
-  }
-  await page.locator('button[aria-label="Help"]').waitFor({ state: 'visible', timeout: HELP_READY_TIMEOUT_MS });
   if (options.replacePreviousGuide) {
     await ensureDocsPanelOpen(page);
-    await replacePreviousE2EGuide(page, options.previousGuideHadInteractiveSteps, options.previousGuideTabId);
+    await replacePreviousE2EGuide(page, options.previousGuideTabId);
     options.onPreviousGuideCleared?.();
+  }
+  if (options.navigateToStartingLocation) {
+    await page.goto(options.startingLocation, { waitUntil: 'domcontentloaded', timeout: NAVIGATION_TIMEOUT_MS });
   }
   await ensureGuidePanelOpen(page, guide.content, options.allowReloadRecovery);
   const tabId = await openLegacyE2EGuide(page, guide.title);
   options.onGuideOpened?.(tabId);
-  await page.getByTestId(testIds.docsPanel.loadingState).waitFor({ state: 'hidden', timeout: GUIDE_LOAD_TIMEOUT_MS });
+  try {
+    await page.getByTestId(testIds.docsPanel.loadingState).waitFor({
+      state: 'hidden',
+      timeout: GUIDE_LOAD_TIMEOUT_MS,
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new FatalTransitionError(
+      'guide-load-ambiguous',
+      `The E2E guide tab became active but its content did not finish loading: ${reason}`
+    );
+  }
 }
 
 function toResultsData(

--- a/tests/e2e-runner/utils/guide-runner/transition-error.ts
+++ b/tests/e2e-runner/utils/guide-runner/transition-error.ts
@@ -1,0 +1,16 @@
+export type FatalTransitionKind =
+  'badge-obstruction' | 'guide-load-ambiguous' | 'reset-ambiguous' | 'tab-close-failed' | 'step-detach-failed';
+
+export class FatalTransitionError extends Error {
+  constructor(
+    public readonly kind: FatalTransitionKind,
+    message: string
+  ) {
+    super(message);
+    this.name = 'FatalTransitionError';
+  }
+}
+
+export function isFatalTransitionError(error: unknown): error is FatalTransitionError {
+  return error instanceof FatalTransitionError;
+}

--- a/tests/e2e-runner/utils/shared-chain.test.ts
+++ b/tests/e2e-runner/utils/shared-chain.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../src/cli/e2e/e2e-reporter';
 import type { E2EChainInput } from '../../../src/cli/e2e/e2e-runner-contract';
 import { MultiGuideReportSchema } from '../../../src/cli/e2e/schemas/e2e-report.schema';
+import { FatalTransitionError } from './guide-runner/transition-error';
 import { resolveMilestoneTransition, runSharedGuideChain } from './shared-chain';
 
 function input(): E2EChainInput {
@@ -92,7 +93,7 @@ describe('shared guide chain', () => {
     expect(publish).toHaveBeenCalledTimes(3);
   });
 
-  it('continues after a guide error while the browser session remains available', async () => {
+  it('continues after a pre-tab guide-load error while the browser session remains available', async () => {
     const runGuide = jest
       .fn()
       .mockRejectedValueOnce(new Error('Guide steps did not render'))
@@ -111,6 +112,27 @@ describe('shared guide chain', () => {
       ['second', 'passed', 'UNKNOWN'],
       ['dependent', 'skipped', 'SKIPPED_PREREQ'],
     ]);
+  });
+
+  it('stops after a fatal transition while the browser session remains available', async () => {
+    const runGuide = jest
+      .fn()
+      .mockRejectedValueOnce(new FatalTransitionError('reset-ambiguous', 'The previous tab reset is ambiguous'));
+
+    const outcome = await runSharedGuideChain(input(), {
+      currentUrl: () => 'http://localhost:3000/current',
+      browserSessionEnded: () => false,
+      runGuide,
+      publish: jest.fn(),
+    });
+
+    expect(runGuide).toHaveBeenCalledTimes(1);
+    expect(outcome.results.map((item) => [item.guide.id, item.outcome, item.errorCode])).toEqual([
+      ['first', 'infrastructure_error', 'REPORT_MISSING'],
+      ['second', 'infrastructure_error', 'REPORT_MISSING'],
+      ['dependent', 'infrastructure_error', 'REPORT_MISSING'],
+    ]);
+    expect(outcome.results.slice(1).every((item) => item.errorMessage?.includes('fatal shared-browser'))).toBe(true);
   });
 
   it('stops after a guide error when the browser session ended', async () => {

--- a/tests/e2e-runner/utils/shared-chain.ts
+++ b/tests/e2e-runner/utils/shared-chain.ts
@@ -1,6 +1,7 @@
 import type { TestResultsData } from '../../../src/cli/e2e/e2e-reporter';
 import { contentDigest, createMinimalResultsData } from '../../../src/cli/e2e/e2e-reporter';
 import type { E2EChainGuide, E2EChainInput, E2EChainPackageMetadata } from '../../../src/cli/e2e/e2e-runner-contract';
+import { isFatalTransitionError } from './guide-runner/transition-error';
 
 export interface MilestoneTransition {
   startingLocation: string;
@@ -100,12 +101,15 @@ function skippedPrerequisiteResult(
 export function unrunSharedSessionResult(
   guide: E2EChainGuide,
   targetUrl: string,
-  activeResult: TestResultsData
+  activeResult: TestResultsData,
+  fatalTransition: boolean
 ): TestResultsData {
   const authExpired = activeResult.abortReason === 'AUTH_EXPIRED' || activeResult.errorCode === 'AUTH_EXPIRED';
   const errorMessage = authExpired
     ? 'The shared browser session authentication expired before this milestone started.'
-    : 'The shared browser session ended before this milestone started.';
+    : fatalTransition
+      ? 'A fatal shared-browser transition error stopped this milestone before it started.'
+      : 'The shared browser session ended before this milestone started.';
   return createMinimalResultsData({
     guide: packageGuideMetadata(guide, guide.packageMetadata, targetUrl),
     outcome: authExpired ? 'aborted' : 'infrastructure_error',
@@ -152,10 +156,12 @@ export async function runSharedGuideChain(
     firstRunnable = false;
     let result: TestResultsData;
     let runnerFailed = false;
+    let fatalTransition = false;
     try {
       result = await executor.runGuide(guide, index, transition);
     } catch (error) {
       runnerFailed = true;
+      fatalTransition = isFatalTransitionError(error);
       result = createMinimalResultsData({
         guide: packageGuideMetadata(guide, guide.packageMetadata, input.targetUrl, transition.startingLocation),
         outcome: 'infrastructure_error',
@@ -169,7 +175,7 @@ export async function runSharedGuideChain(
     if (result.outcome !== 'passed') {
       blocked.add(guide.id);
     }
-    if (runnerFailed && !executor.browserSessionEnded()) {
+    if (runnerFailed && !fatalTransition && !executor.browserSessionEnded()) {
       continue;
     }
     if (!endsSharedSession(result)) {
@@ -178,7 +184,7 @@ export async function runSharedGuideChain(
 
     authExpired = result.abortReason === 'AUTH_EXPIRED' || result.errorCode === 'AUTH_EXPIRED';
     for (const unrun of input.guides.slice(index + 1)) {
-      results.push(unrunSharedSessionResult(unrun, input.targetUrl, result));
+      results.push(unrunSharedSessionResult(unrun, input.targetUrl, result, fatalTransition));
       executor.publish(results);
     }
     break;


### PR DESCRIPTION
## Summary

Shared path and journey runs now dismiss moving badge celebrations without pointer actionability.

The runner tears down prior guide state before navigation and stops when transition state becomes ambiguous.

This prevents deterministic `REPORT_MISSING` cascades while preserving recoverable failures when tab cleanup remains possible.

## What to look at

- [Badge cleanup](https://github.com/grafana/grafana-pathfinder-app/blob/a52b99390a029731ff45e2d8118c17dfccf5e06a/tests/e2e-runner/utils/guide-runner/badge-celebrations.ts) dispatches the scoped dismiss event and keeps persistent obstruction fatal.
- [Milestone replacement](https://github.com/grafana/grafana-pathfinder-app/blob/a52b99390a029731ff45e2d8118c17dfccf5e06a/tests/e2e-runner/utils/guide-runner/milestone-replacement.ts) uses stored progress, recognizes hybrid timestamp metadata, and matches product cleanup.
- [Guide loading](https://github.com/grafana/grafana-pathfinder-app/blob/a52b99390a029731ff45e2d8118c17dfccf5e06a/tests/e2e-runner/utils/guide-runner/run-guide.ts) tears down the prior tab before navigation and delegates Help fallback to panel bootstrap.
- [Shared-chain handling](https://github.com/grafana/grafana-pathfinder-app/blob/a52b99390a029731ff45e2d8118c17dfccf5e06a/tests/e2e-runner/utils/shared-chain.ts) stops fatal transitions but continues recoverable failures with a recorded tab ID.

## Why

Two completed fleet cycles added the same 16 badge-transition failures after shared browser sessions shipped.

Playwright found the animated dismiss button but exhausted its one-second actionability wait before the button became stable.

A longer timeout would keep cleanup coupled to animation timing. DOM dispatch calls the existing React handler without pointer coordinates.

Live pool validation advanced through the badge and reset transitions. It later reached an unrelated SLO guide selector failure.

## How to verify

1. Run `create-availability-slo-lj` through the develop pool manager.
2. Confirm that the first two milestones pass without badge, Reset guide, Help, or fatal-transition errors.
3. Start local Grafana and run `tests/e2e-runner/fixtures/shared-session-path/verify.sh`.
4. Confirm that the shared path passes and the isolated state-dependent guide fails.

## Breaking changes

None. The report schema remains `1.0.0`, and dependency skips retain `SKIPPED_PREREQ`.

## Reversibility

A revert restores the previous runner behavior. The change has no plugin release, storage migration, or persistent data transformation.

## Out of scope

- The plugin-owned atomic reset capability belongs to the next PR.
- A machine-readable transition failure code belongs to the next report-contract change.
- The unrelated `input[name="name"]` SLO guide failure remains a guide-content problem.

Co-Authored-By: Warp <agent@warp.dev>
