### PR TITLE
test(telemetry): silence TruffleHog on userinfo URL fixtures

### DIFF
--- a/src/lib/telemetry/url.test.ts
+++ b/src/lib/telemetry/url.test.ts
@@ -14,7 +14,8 @@ describe('normalizeTelemetryUrl', () => {
   });
 
   it('strips userinfo', () => {
-    expect(normalizeTelemetryUrl('https://user:password@grafana.com/docs/page/')).toBe('grafana.com/docs/page/');
+    const withUserinfo = 'https://user:password@grafana.com/docs/page/'; // trufflehog:ignore
+    expect(normalizeTelemetryUrl(withUserinfo)).toBe('grafana.com/docs/page/');
   });
 
   it('passes internal content identifiers through unchanged', () => {
@@ -71,9 +72,8 @@ describe('stripUrlSecrets', () => {
   });
 
   it('strips userinfo', () => {
-    expect(stripUrlSecrets('https://user:password@acme.grafana.net/avatar.png')).toBe(
-      'https://acme.grafana.net/avatar.png'
-    );
+    const withUserinfo = 'https://user:password@acme.grafana.net/avatar.png'; // trufflehog:ignore
+    expect(stripUrlSecrets(withUserinfo)).toBe('https://acme.grafana.net/avatar.png');
   });
 
   it('keeps relative URLs relative', () => {


### PR DESCRIPTION
## Summary

Two test fixtures in `src/lib/telemetry/url.test.ts` — the `https://user:password@…` inputs to the tests that assert userinfo is stripped — trip TruffleHog's URI detector, which matches any `user:password@host`. Both are reported as unverified secrets on unrelated PRs. This hoists each fixture to a named const so the documented `trufflehog:ignore` marker sits on the detected line. Test-only; no production code changes.

Low risk PR that just silences false positives.  Trufflehog output was noisy and useless, this should make it better.
