### PR TITLE
Publish internal docs to EngHub with the shared TechDocs workflow

### DIFF
--- a/.github/workflows/publish-techdocs.yml
+++ b/.github/workflows/publish-techdocs.yml
@@ -1,0 +1,40 @@
+name: Publish TechDocs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'catalog-info.yaml'
+      - '.github/workflows/publish-techdocs.yml'
+  workflow_dispatch:
+    inputs:
+      instance:
+        description: EngHub instance to publish to
+        required: true
+        type: choice
+        default: 'ops'
+        options:
+          - 'dev'
+          - 'ops'
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  publish-docs:
+    uses: grafana/shared-workflows/.github/workflows/publish-techdocs.yaml@main
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      namespace: default
+      kind: component
+      name: grafana-pathfinder-app
+      rewrite-relative-links: true
+      instance: ${{ github.event.inputs.instance || 'ops' }}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana-pathfinder-app
+  title: grafana-pathfinder-app
+  description: |
+    Grafana Pathfinder brings contextual documentation and interactive tutorials directly into Grafana.
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    github.com/project-slug: grafana/grafana-pathfinder-app
+spec:
+  type: library
+  owner: group:default/pathfinder
+  lifecycle: production

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# Grafana Pathfinder engineering docs
+
+Internal engineering documentation for [grafana-pathfinder-app](https://github.com/grafana/grafana-pathfinder-app).
+
+Start with the [context index](developer/CONTEXT_INDEX.md), which routes to the rest of the tree:
+
+- `developer/` — developer references: getting started, commands, testing, subsystems
+- `design/` — design documents, review concerns, and contract anchors
+- `history/` — implementation records
+
+Product documentation lives under `docs/sources` and is published separately to grafana.com, so it is not part of this site.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,21 @@
+# To run locally
+# npx @techdocs/cli serve -v -c ./mkdocs.yml
+#
+site_name: 'Grafana Pathfinder internal documentation'
+repo_url: https://github.com/grafana/grafana-pathfinder-app
+edit_uri: edit/main/docs
+
+# Explicit so the techdocs-rewrite-relative-links action knows the docs root
+docs_dir: docs
+
+# docs/sources is the product documentation, already published to grafana.com
+exclude_docs: |
+  sources/
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
Closes #445

Wires up the shared [publish-techdocs workflow](https://github.com/grafana/shared-workflows/blob/main/.github/workflows/publish-techdocs.yaml) so the internal engineering docs (`docs/developer`, `docs/design`, `docs/history`) get published to EngHub.

- `.github/workflows/publish-techdocs.yml` — runs on pushes to main that touch docs, plus a manual dispatch with an instance picker so it can be tried against dev before ops
- `catalog-info.yaml` — registers the component with `techdocs-ref: dir:.`
- `mkdocs.yml` — techdocs-core config. `docs_dir` is set explicitly because the rewrite-relative-links action reads that key to find the docs root (without it the rewrite silently does nothing). `docs/sources` is excluded since the product docs are already published to grafana.com
- `docs/index.md` — small landing page so the site root resolves

`rewrite-relative-links: true` handles the ~10 docs with links that escape the docs tree (`AGENTS.md`, `.cursor/rules/*`, `src/...`) by rewriting them to GitHub URLs at build time.

Verified locally with mkdocs + techdocs-core 1.3.5 (the versions the shared workflow pins): builds clean, `sources/` excluded, only the expected out-of-tree link warnings that the rewrite step covers.

Two things I couldn't check from outside the org: the owner group in `catalog-info.yaml` (guessed `pathfinder` — please correct) and whether the repo is already registered with EngHub.
