### PR TITLE
feat(outcomes): add evidence storage separate from progress

### DIFF
--- a/docs/developer/engines/requirements-manager.md
+++ b/docs/developer/engines/requirements-manager.md
@@ -479,3 +479,9 @@ Check results are cached during retry cycles to avoid redundant API calls.
 - `docs/developer/interactive-examples/requirements-reference.md` - Requirements reference
 - `docs/developer/engines/interactive-engine.md` - Interactive engine documentation
 - `src/constants/interactive-config.ts` - Configuration options
+
+## Structured check verdicts
+
+Checks report `satisfied`, `unsatisfied`, `unavailable`, or `invalid`. A missing resource is unsatisfied; an API read that cannot complete is unavailable. Verification uses strict context-service reads so network failures are not converted into empty resource lists. Recommendation callers retain their availability-first fallback.
+
+The legacy `pass` field remains available. Unknown prerequisite tokens retain the existing fail-open policy, with an `invalid` verdict; postcondition verification refuses them. Only an explicit `satisfied` verdict is outcome evidence. Condition arrays preserve parameter commas; comma-separated strings remain a legacy input boundary, and result labels are for display only.

--- a/src/components/interactive-tutorial/challenge-block.test.tsx
+++ b/src/components/interactive-tutorial/challenge-block.test.tsx
@@ -478,7 +478,7 @@ describe('ChallengeBlock', () => {
 
       await waitFor(() => {
         expect(mockedCheckPostconditions).toHaveBeenCalledWith(
-          expect.objectContaining({ requirements: 'has-dashboard-named:My Dashboard' })
+          expect.objectContaining({ requirements: ['has-dashboard-named:My Dashboard'] })
         );
       });
     });

--- a/src/components/interactive-tutorial/challenge-block.tsx
+++ b/src/components/interactive-tutorial/challenge-block.tsx
@@ -474,7 +474,7 @@ export const ChallengeBlock: React.FC<ChallengeBlockProps> = ({
     setErrorDetail('');
     try {
       const result = await checkPostconditions({
-        requirements: successCriteria,
+        requirements: [successCriteria],
         stepId,
         maxRetries: 0,
       });

--- a/src/components/interactive-tutorial/code-block-step.tsx
+++ b/src/components/interactive-tutorial/code-block-step.tsx
@@ -1,3 +1,4 @@
+import type { ConditionInput } from '../../types/requirements.types';
 /**
  * CodeBlockStep Component
  *
@@ -25,8 +26,8 @@ export interface CodeBlockStepProps {
   code: string;
   language?: string;
   refTarget: string;
-  requirements?: string;
-  objectives?: string;
+  requirements?: ConditionInput;
+  objectives?: ConditionInput;
   skippable?: boolean;
   hints?: string;
   children?: React.ReactNode;

--- a/src/components/interactive-tutorial/datasource-check-step.tsx
+++ b/src/components/interactive-tutorial/datasource-check-step.tsx
@@ -1,3 +1,4 @@
+import type { ConditionInput } from '../../types/requirements.types';
 /**
  * The datasource picker when its author asked a failing check to block. The
  * advisory form of the same check stays passive inside `InputBlock`; only this
@@ -28,7 +29,7 @@ export interface DatasourceCheckStepProps {
   failureMessage?: string;
   timeFrom?: string;
   timeTo?: string;
-  requirements?: string;
+  requirements?: ConditionInput;
   skippable?: boolean;
   hints?: string;
   children?: React.ReactNode;

--- a/src/components/interactive-tutorial/hooks/use-section-requirements.ts
+++ b/src/components/interactive-tutorial/hooks/use-section-requirements.ts
@@ -1,3 +1,4 @@
+import type { ConditionInput } from '../../../types/requirements.types';
 /**
  * `useSectionRequirements` — owns section-level requirements polling.
  *
@@ -46,7 +47,7 @@ interface SectionRequirementsResult {
 }
 
 interface SectionRequirementsData {
-  requirements: string;
+  requirements: ConditionInput;
   targetAction: string;
   refTarget: string;
   targetValue: string | undefined;
@@ -66,7 +67,7 @@ export interface SectionRequirementsStatus {
 }
 
 export interface UseSectionRequirementsArgs {
-  requirements: string | undefined;
+  requirements: ConditionInput | undefined;
   sectionId: string;
   title: string | undefined;
   hints?: string;

--- a/src/components/interactive-tutorial/input-block.tsx
+++ b/src/components/interactive-tutorial/input-block.tsx
@@ -1,3 +1,4 @@
+import type { ConditionInput } from '../../types/requirements.types';
 /**
  * Input Block Renderer
  *
@@ -39,7 +40,7 @@ export interface InputBlockProps {
   /** Message shown when validation fails */
   validationMessage?: string;
   /** Requirements for this input */
-  requirements?: string;
+  requirements?: ConditionInput;
   /** Whether input can be skipped */
   skippable?: boolean;
   /** Children elements (rendered prompt content) */

--- a/src/components/interactive-tutorial/interactive-conditional.tsx
+++ b/src/components/interactive-tutorial/interactive-conditional.tsx
@@ -41,13 +41,6 @@ export interface InteractiveConditionalProps {
   keyPrefix: string;
 }
 
-/**
- * Parse conditions array into a requirements string for the checker
- */
-function conditionsToRequirementsString(conditions: string[]): string {
-  return conditions.join(',');
-}
-
 /** True when conditions may flip after DOM updates (e.g. viz picker opens). */
 function conditionsKeyNeedsDomWatch(conditionsKey: string): boolean {
   return conditionsKey.includes('exists-reftarget');
@@ -76,7 +69,7 @@ export function InteractiveConditional({
   // on every render (parsed from JSON), so keying effects off the array would
   // tear down and re-attach the MutationObserver on every parent render. The
   // joined string is referentially stable as long as the underlying values are.
-  const conditionsKey = useMemo(() => conditions.join(','), [conditions]);
+  const conditionsKey = useMemo(() => JSON.stringify(conditions), [conditions]);
 
   // Generate a stable ID for this conditional (derived from the stable key).
   const conditionalId = useMemo(
@@ -105,7 +98,7 @@ export function InteractiveConditional({
   const reevalTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   // Convert conditions to requirements string format
-  const requirementsString = conditionsToRequirementsString(conditions);
+  const requirements = useMemo<string[]>(() => JSON.parse(conditionsKey), [conditionsKey]);
 
   // Function to evaluate conditions
   const evaluateConditions = useCallback(
@@ -127,7 +120,7 @@ export function InteractiveConditional({
         // Create requirement data for checking
         // Use provided refTarget for exists-reftarget condition, fallback to placeholder
         const requirementData = {
-          requirements: requirementsString,
+          requirements: requirements,
           targetAction: 'conditional',
           refTarget: refTarget || 'conditional-block',
           targetValue: undefined,
@@ -154,7 +147,7 @@ export function InteractiveConditional({
         setIsChecking(false);
       }
     },
-    [requirementsString, checkRequirementsFromData, description, refTarget]
+    [requirements, checkRequirementsFromData, description, refTarget]
   );
 
   const needsDomWatch = conditionsKeyNeedsDomWatch(conditionsKey);
@@ -299,8 +292,8 @@ export function InteractiveConditional({
   if (display === 'section') {
     // Extract config values, using defaults if not provided
     const sectionTitle = sectionConfig?.title || (conditionsPassed ? 'When conditions pass' : 'When conditions fail');
-    const sectionRequirements = sectionConfig?.requirements?.join(',');
-    const sectionObjectives = sectionConfig?.objectives?.join(',');
+    const sectionRequirements = sectionConfig?.requirements;
+    const sectionObjectives = sectionConfig?.objectives;
 
     return (
       <div

--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -1,3 +1,4 @@
+import type { ConditionInput } from '../../types/requirements.types';
 import React, { useState, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo, useRef } from 'react';
 import { Button } from '@grafana/ui';
 import { usePluginContext } from '@grafana/data';
@@ -102,8 +103,8 @@ interface InteractiveGuidedProps {
   className?: string;
   disabled?: boolean;
   hints?: string;
-  requirements?: string;
-  objectives?: string;
+  requirements?: ConditionInput;
+  objectives?: ConditionInput;
   onComplete?: () => void;
   skippable?: boolean;
   completeEarly?: boolean;

--- a/src/components/interactive-tutorial/interactive-multi-step.tsx
+++ b/src/components/interactive-tutorial/interactive-multi-step.tsx
@@ -1,3 +1,4 @@
+import type { ConditionInput } from '../../types/requirements.types';
 import React, { useState, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo, useRef } from 'react';
 import { Button } from '@grafana/ui';
 import { getAppEvents } from '@grafana/runtime';
@@ -50,8 +51,8 @@ interface InteractiveMultiStepProps {
   className?: string;
   disabled?: boolean;
   hints?: string;
-  requirements?: string; // Overall requirements for the multi-step
-  objectives?: string; // Overall objectives for the multi-step
+  requirements?: ConditionInput; // Overall requirements for the multi-step
+  objectives?: ConditionInput; // Overall objectives for the multi-step
   onComplete?: () => void;
   skippable?: boolean; // Whether this multi-step can be skipped if requirements fail
   completeEarly?: boolean; // Whether to mark complete before action execution (for navigation steps)

--- a/src/components/interactive-tutorial/interactive-quiz.tsx
+++ b/src/components/interactive-tutorial/interactive-quiz.tsx
@@ -1,3 +1,4 @@
+import type { ConditionInput } from '../../types/requirements.types';
 import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { css, cx, keyframes } from '@emotion/css';
 import { Button, Icon, useStyles2 } from '@grafana/ui';
@@ -33,7 +34,7 @@ export interface InteractiveQuizProps {
   /** Max attempts for max-attempts mode */
   maxAttempts?: number;
   /** Requirements for this quiz */
-  requirements?: string;
+  requirements?: ConditionInput;
   /** Whether quiz can be skipped */
   skippable?: boolean;
   /**

--- a/src/components/interactive-tutorial/terminal-step.tsx
+++ b/src/components/interactive-tutorial/terminal-step.tsx
@@ -1,3 +1,4 @@
+import type { ConditionInput } from '../../types/requirements.types';
 /**
  * TerminalStep Component
  *
@@ -28,8 +29,8 @@ const SANDBOX_SUBJECT = 'This step runs its command in a Coda sandbox VM';
 
 export interface TerminalStepProps {
   command: string;
-  requirements?: string;
-  objectives?: string;
+  requirements?: ConditionInput;
+  objectives?: ConditionInput;
   skippable?: boolean;
   hints?: string;
   children?: React.ReactNode;

--- a/src/context-engine/context.service.completion.test.ts
+++ b/src/context-engine/context.service.completion.test.ts
@@ -1,3 +1,4 @@
+import { getBackendSrv } from '@grafana/runtime';
 /**
  * Tests for completion percentage storage selection in ContextService.
  *
@@ -383,4 +384,30 @@ describe('ContextService: Completion Percentage Storage Selection', () => {
       }
     });
   });
+});
+
+describe('strict verification reads', () => {
+  it.each(['datasources', 'plugins', 'dashboards'] as const)(
+    'preserves errors for %s verification only',
+    async (kind) => {
+      const fetch = (throwOnError: boolean) => {
+        switch (kind) {
+          case 'datasources':
+            return ContextService.fetchDataSources({ throwOnError });
+          case 'plugins':
+            return ContextService.fetchPlugins({ throwOnError });
+          case 'dashboards':
+            return ContextService.fetchDashboardsByName('Example', { throwOnError });
+        }
+      };
+      jest
+        .mocked(getBackendSrv)
+        .mockReturnValueOnce({ get: jest.fn().mockRejectedValue(new Error('Offline')) } as never);
+      await expect(fetch(false)).resolves.toEqual([]);
+      jest
+        .mocked(getBackendSrv)
+        .mockReturnValueOnce({ get: jest.fn().mockRejectedValue(new Error('Offline')) } as never);
+      await expect(fetch(true)).rejects.toThrow('Offline');
+    }
+  );
 });

--- a/src/context-engine/context.service.ts
+++ b/src/context-engine/context.service.ts
@@ -1026,11 +1026,14 @@ export class ContextService {
   /**
    * Fetch data sources
    */
-  static async fetchDataSources(): Promise<DataSource[]> {
+  static async fetchDataSources(options: { throwOnError?: boolean } = {}): Promise<DataSource[]> {
     try {
       const dataSources = await getBackendSrv().get('/api/datasources');
       return dataSources || [];
     } catch (error) {
+      if (options.throwOnError) {
+        throw error;
+      }
       logger.warn('Failed to fetch data sources', { error });
       return [];
     }
@@ -1039,11 +1042,14 @@ export class ContextService {
   /**
    * Fetch plugins
    */
-  static async fetchPlugins(): Promise<Plugin[]> {
+  static async fetchPlugins(options: { throwOnError?: boolean } = {}): Promise<Plugin[]> {
     try {
       const plugins = await getBackendSrv().get('/api/plugins');
       return plugins || [];
     } catch (error) {
+      if (options.throwOnError) {
+        throw error;
+      }
       logger.warn('Failed to fetch plugins', { error });
       return [];
     }
@@ -1052,7 +1058,10 @@ export class ContextService {
   /**
    * Fetch dashboards by name using search API
    */
-  static async fetchDashboardsByName(name: string): Promise<DashboardSearchResult[]> {
+  static async fetchDashboardsByName(
+    name: string,
+    options: { throwOnError?: boolean } = {}
+  ): Promise<DashboardSearchResult[]> {
     try {
       const dashboards = await getBackendSrv().get('/api/search', {
         type: 'dash-db',
@@ -1062,6 +1071,9 @@ export class ContextService {
       });
       return dashboards || [];
     } catch (error) {
+      if (options.throwOnError) {
+        throw error;
+      }
       logger.warn('Failed to fetch dashboards', { error });
       return [];
     }

--- a/src/docs-retrieval/json-parser-datasource-check.test.ts
+++ b/src/docs-retrieval/json-parser-datasource-check.test.ts
@@ -97,7 +97,7 @@ describe('input block → parsed element type', () => {
     });
   });
 
-  it('flattens requirements to the comma-separated form the checker takes', () => {
+  it('preserves requirement arrays for the checker', () => {
     const element = firstOf([
       picker({
         dataCheckQuery: 'up',
@@ -105,7 +105,7 @@ describe('input block → parsed element type', () => {
         requirements: ['is-admin', 'has-datasource:prometheus'],
       }),
     ]);
-    expect(element.props.requirements).toBe('is-admin,has-datasource:prometheus');
+    expect(element.props.requirements).toEqual(['is-admin', 'has-datasource:prometheus']);
   });
 
   it('defaults skippable to false, so a blocking check really blocks', () => {

--- a/src/docs-retrieval/json-parser-terminal.test.ts
+++ b/src/docs-retrieval/json-parser-terminal.test.ts
@@ -62,7 +62,7 @@ describe('json-parser terminal block', () => {
 
     const terminalEl = result.data!.elements.find((el) => el.type === 'terminal-step');
     expect(terminalEl).toBeDefined();
-    expect(terminalEl!.props.requirements).toBe('is-terminal-active');
+    expect(terminalEl!.props.requirements).toEqual(['is-terminal-active']);
     expect(terminalEl!.props.skippable).toBe(true);
     expect(terminalEl!.props.hints).toBe('Connect first');
   });
@@ -197,4 +197,26 @@ describe('json-parser terminal-connect gcx field', () => {
     );
     expect(result.isValid).toBe(false);
   });
+});
+
+it('preserves comma-containing objective and prerequisite tokens', () => {
+  const parsed = parseJsonGuide(
+    JSON.stringify({
+      id: 'comma',
+      title: 'Comma',
+      blocks: [
+        {
+          type: 'interactive',
+          action: 'button',
+          reftarget: 'button',
+          content: 'Save',
+          requirements: ['has-dashboard-named:CPU, memory'],
+          objectives: ['has-dashboard-named:CPU, memory'],
+        },
+      ],
+    })
+  );
+  const step = parsed.data!.elements.find((element) => element.type === 'interactive-step');
+  expect(step?.props.requirements).toEqual(['has-dashboard-named:CPU, memory']);
+  expect(step?.props.objectives).toEqual(['has-dashboard-named:CPU, memory']);
 });

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -537,9 +537,8 @@ function convertSectionBlock(block: JsonSectionBlock, path: string, baseUrl?: st
     }
   }
 
-  // Convert requirements array to comma-separated string (as expected by renderer)
-  const requirements = block.requirements?.join(',') || undefined;
-  const objectives = block.objectives?.join(',') || undefined;
+  const requirements = block.requirements?.length ? block.requirements : undefined;
+  const objectives = block.objectives?.length ? block.objectives : undefined;
 
   return {
     element: {
@@ -690,9 +689,8 @@ function convertInteractiveBlock(
     children.unshift(tooltipElement);
   }
 
-  // Convert requirements array to comma-separated string
-  const requirements = block.requirements?.join(',') || undefined;
-  const objectives = block.objectives?.join(',') || undefined;
+  const requirements = block.requirements?.length ? block.requirements : undefined;
+  const objectives = block.objectives?.length ? block.objectives : undefined;
 
   return {
     element: {
@@ -736,16 +734,15 @@ function convertMultistepBlock(block: JsonMultistepBlock, path: string, stepCont
     refTarget: step.reftarget ?? step.refTarget,
     targetValue: step.targetvalue ?? step.targetValue,
     targetState: step.targetstate ?? step.targetState,
-    requirements: step.requirements?.join(','),
+    requirements: step.requirements,
     targetComment: step.tooltip ? markdownToHtml(step.tooltip) : undefined,
   }));
 
   // Parse content as markdown for children
   const children = parseMarkdownToElements(block.content);
 
-  // Convert requirements array to comma-separated string
-  const requirements = block.requirements?.join(',') || undefined;
-  const objectives = block.objectives?.join(',') || undefined;
+  const requirements = block.requirements?.length ? block.requirements : undefined;
+  const objectives = block.objectives?.length ? block.objectives : undefined;
 
   // The multistep's overall identity uses the first internal action as
   // the discriminator — that's the action shown when the block opens.
@@ -781,7 +778,7 @@ function convertGuidedBlock(block: JsonGuidedBlock, path: string, stepContext?: 
     refTarget: step.reftarget ?? step.refTarget,
     targetValue: step.targetvalue ?? step.targetValue,
     targetState: step.targetstate ?? step.targetState,
-    requirements: step.requirements?.join(','),
+    requirements: step.requirements,
     // For guided blocks, prefer description (shown in steps panel), fall back to tooltip for backward compatibility
     targetComment: step.description
       ? markdownToHtml(step.description)
@@ -796,9 +793,8 @@ function convertGuidedBlock(block: JsonGuidedBlock, path: string, stepContext?: 
   // Parse content as markdown for children
   const children = parseMarkdownToElements(block.content);
 
-  // Convert requirements array to comma-separated string
-  const requirements = block.requirements?.join(',') || undefined;
-  const objectives = block.objectives?.join(',') || undefined;
+  const requirements = block.requirements?.length ? block.requirements : undefined;
+  const objectives = block.objectives?.length ? block.objectives : undefined;
 
   const stepId = resolveStepId(
     block.id,
@@ -898,8 +894,7 @@ function convertQuizBlock(block: JsonQuizBlock, path: string, stepContext?: Step
   // Parse question as markdown for the content
   const questionElements = parseMarkdownToElements(block.question);
 
-  // Convert requirements array to comma-separated string
-  const requirements = block.requirements?.join(',') || undefined;
+  const requirements = block.requirements?.length ? block.requirements : undefined;
 
   // Build choices (textElements removed - not used by quiz component)
   const choices = block.choices.map((choice) => ({
@@ -941,8 +936,7 @@ function convertInputBlock(block: JsonInputBlock, path: string, stepContext?: St
   // Parse prompt as markdown for the content
   const promptElements = parseMarkdownToElements(block.prompt);
 
-  // Convert requirements array to comma-separated string
-  const requirements = block.requirements?.join(',') || undefined;
+  const requirements = block.requirements?.length ? block.requirements : undefined;
 
   const hasDataCheck = block.inputType === 'datasource' && Boolean(block.dataCheckQuery?.trim());
 
@@ -999,8 +993,8 @@ function convertInputBlock(block: JsonInputBlock, path: string, stepContext?: St
 
 function convertTerminalBlock(block: JsonTerminalBlock, _path: string, stepContext?: StepContext): ConversionResult {
   const children = parseMarkdownToElements(block.content);
-  const requirements = block.requirements?.join(',') || undefined;
-  const objectives = block.objectives?.join(',') || undefined;
+  const requirements = block.requirements?.length ? block.requirements : undefined;
+  const objectives = block.objectives?.length ? block.objectives : undefined;
   const stepId = resolveStepId(block.id, stepContext, 'terminal', block.command);
 
   return {
@@ -1074,8 +1068,8 @@ function convertChallengeBlock(block: JsonChallengeBlock, _path: string, stepCon
 
 function convertCodeBlockBlock(block: JsonCodeBlockBlock, _path: string, stepContext?: StepContext): ConversionResult {
   const children = block.content ? parseMarkdownToElements(block.content) : [];
-  const requirements = block.requirements?.join(',') || undefined;
-  const objectives = block.objectives?.join(',') || undefined;
+  const requirements = block.requirements?.length ? block.requirements : undefined;
+  const objectives = block.objectives?.length ? block.objectives : undefined;
   const stepId = resolveStepId(block.id, stepContext, 'code-block', block.reftarget);
 
   return {

--- a/src/global-state/controller-channel.tsx
+++ b/src/global-state/controller-channel.tsx
@@ -48,7 +48,7 @@ interface ControllerChannel {
   ) => Promise<RemoteRequirementResult | null>;
   requestFix: (
     stepId: string,
-    opts: { requirements: string; fixType?: string; targetHref?: string; scrollContainer?: string }
+    opts: { requirements: ConditionInput; fixType?: string; targetHref?: string; scrollContainer?: string }
   ) => Promise<FixOutcome>;
   awaitStepComplete: (stepId: string, runId: string) => Promise<boolean>;
   cancelStepComplete: (stepId: string, runId: string) => void;

--- a/src/interactive-engine/sequence-manager.ts
+++ b/src/interactive-engine/sequence-manager.ts
@@ -1,3 +1,4 @@
+import { conditionLabel } from '../lib/condition-input';
 import { InteractiveElementData } from '../types/interactive.types';
 import { InteractiveStateManager } from './interactive-state-manager';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
@@ -93,7 +94,7 @@ export class SequenceManager {
     logger.warn(
       `${context.stepName} ${context.stepIndex + 1} failed after ${this.MAX_RETRIES} retries, stopping sequence`
     );
-    const requirement = (context.data.requirements ?? '').slice(0, MAX_REQUIREMENT_CONTEXT_LENGTH);
+    const requirement = conditionLabel(context.data.requirements).slice(0, MAX_REQUIREMENT_CONTEXT_LENGTH);
     if (lastFailure === 'action') {
       recordSequenceActionError(requirement, this.MAX_RETRIES, classifySequenceError(lastError));
       return 'failed_action';

--- a/src/lib/check-verdict.test.ts
+++ b/src/lib/check-verdict.test.ts
@@ -1,0 +1,10 @@
+import { combineCheckVerdicts } from './check-verdict';
+
+it('does not treat a permissive legacy boolean as verified evidence', () => {
+  expect(combineCheckVerdicts([{ pass: true, verdict: 'invalid' }, { pass: true }])).toBe('invalid');
+});
+it('distinguishes incomplete evaluations from a negative result', () => {
+  expect(combineCheckVerdicts([{ pass: false, verdict: 'unavailable' }, { pass: false }])).toBe('unavailable');
+  expect(combineCheckVerdicts([{ pass: false }])).toBe('unsatisfied');
+  expect(combineCheckVerdicts([{ pass: true }])).toBe('satisfied');
+});

--- a/src/lib/check-verdict.ts
+++ b/src/lib/check-verdict.ts
@@ -1,0 +1,15 @@
+import type { CheckResultError, CheckVerdict } from '../types/requirements.types';
+
+export function checkVerdict(result: Pick<CheckResultError, 'pass' | 'verdict'>): CheckVerdict {
+  return result.verdict ?? (result.pass ? 'satisfied' : 'unsatisfied');
+}
+
+export function combineCheckVerdicts(results: Array<Pick<CheckResultError, 'pass' | 'verdict'>>): CheckVerdict {
+  const verdicts = results.map(checkVerdict);
+  for (const verdict of ['invalid', 'unavailable', 'unsatisfied'] as const) {
+    if (verdicts.includes(verdict)) {
+      return verdict;
+    }
+  }
+  return 'satisfied';
+}

--- a/src/lib/outcomes/outcome-evidence.test.ts
+++ b/src/lib/outcomes/outcome-evidence.test.ts
@@ -1,0 +1,68 @@
+import { createOutcomeEvidence, createOutcomeEvidenceStore } from './outcome-evidence';
+import type { OutcomeScope } from '../../types/outcome.types';
+import type { CheckResultError } from '../../types/requirements.types';
+import type { UserStorage } from '../../types/storage.types';
+
+const scope: OutcomeScope = { userId: 'user', orgId: 'org', guideId: 'guide', guideRevision: 'revision' };
+const satisfied: CheckResultError = { requirement: 'resource', pass: true, verdict: 'satisfied' };
+function memoryStorage(): UserStorage {
+  const values = new Map<string, unknown>();
+  return {
+    async getItem<T>(key: string) {
+      return (values.get(key) as T | undefined) ?? null;
+    },
+    async setItem(key, value) {
+      values.set(key, value);
+    },
+    async removeItem(key) {
+      values.delete(key);
+    },
+    async clear() {
+      values.clear();
+    },
+  };
+}
+
+it.each<CheckResultError[]>([
+  [],
+  [{ requirement: 'manual', pass: true }],
+  [{ requirement: 'skipped', pass: true }],
+  [{ requirement: 'resource', pass: true, verdict: 'invalid' }],
+  [{ requirement: 'resource', pass: false, verdict: 'unavailable' }],
+  [satisfied, { requirement: 'other', pass: false, verdict: 'unsatisfied' }],
+])('requires explicit successful evidence: %j', (...checks) => {
+  expect(createOutcomeEvidence(scope, 'outcome', 'uid', checks, 123)).toBeNull();
+});
+
+it('restores evidence without converting progress and isolates user, org, guide, and revision', async () => {
+  const storage = memoryStorage();
+  await storage.setItem('pathfinder-interactive-completion', { guide: 100 });
+  const store = createOutcomeEvidenceStore(storage, () => 123);
+  expect(await store.read(scope)).toEqual([]);
+  await store.record(scope, 'outcome', 'uid', [satisfied]);
+  const restored = createOutcomeEvidenceStore(storage);
+  expect(await restored.read(scope)).toMatchObject([{ resourceUid: 'uid', verifiedAt: 123 }]);
+  for (const field of ['userId', 'orgId', 'guideId', 'guideRevision'] as const) {
+    expect(await restored.read({ ...scope, [field]: 'other' })).toEqual([]);
+  }
+});
+
+it('serializes concurrent writes and leaves historical evidence after an unsuccessful check', async () => {
+  const store = createOutcomeEvidenceStore(memoryStorage(), () => 123);
+  await Promise.all([store.record(scope, 'one', 'uid1', [satisfied]), store.record(scope, 'two', 'uid2', [satisfied])]);
+  expect(await store.read(scope)).toHaveLength(2);
+  expect(await store.record(scope, 'one', 'uid1', [{ ...satisfied, pass: false, verdict: 'unavailable' }])).toBeNull();
+  expect(await store.read(scope)).toHaveLength(2);
+});
+
+it('bounds history and propagates storage failures without inventing evidence', async () => {
+  const storage = memoryStorage();
+  const store = createOutcomeEvidenceStore(storage, () => 123);
+  for (let i = 0; i < 202; i++) {
+    await store.record(scope, `outcome-${i}`, 'uid', [satisfied]);
+  }
+  expect(await store.read(scope)).toHaveLength(200);
+  jest.spyOn(storage, 'setItem').mockRejectedValueOnce(new Error('Full'));
+  await expect(store.record(scope, 'failed', 'uid', [satisfied])).rejects.toThrow('Full');
+  expect((await store.read(scope)).some((record) => record.outcomeId === 'failed')).toBe(false);
+});

--- a/src/lib/outcomes/outcome-evidence.ts
+++ b/src/lib/outcomes/outcome-evidence.ts
@@ -1,0 +1,80 @@
+import { OutcomeEvidenceSchema, OutcomeScopeSchema } from '../../types/outcome.schema';
+import type { OutcomeEvidence, OutcomeScope } from '../../types/outcome.types';
+import type { CheckResultError } from '../../types/requirements.types';
+import type { UserStorage } from '../../types/storage.types';
+
+const MAX_RECORDS = 200;
+
+export function outcomeScopeKey(scope: OutcomeScope): string {
+  return JSON.stringify([scope.userId, scope.orgId, scope.guideId, scope.guideRevision]);
+}
+
+export function createOutcomeEvidence(
+  scope: OutcomeScope,
+  outcomeId: string,
+  resourceUid: string,
+  checks: readonly CheckResultError[],
+  verifiedAt: number
+): OutcomeEvidence | null {
+  if (checks.length === 0 || checks.some((check) => !check.pass || check.verdict !== 'satisfied')) {
+    return null;
+  }
+  const result = OutcomeEvidenceSchema.safeParse({ schemaVersion: 1, scope, outcomeId, resourceUid, verifiedAt });
+  return result.success ? result.data : null;
+}
+
+export interface OutcomeEvidenceStore {
+  read(scope: OutcomeScope): Promise<OutcomeEvidence[]>;
+  record(
+    scope: OutcomeScope,
+    outcomeId: string,
+    resourceUid: string,
+    checks: readonly CheckResultError[]
+  ): Promise<OutcomeEvidence | null>;
+}
+
+export function createOutcomeEvidenceStore(
+  storage: Pick<UserStorage, 'getItem' | 'setItem'>,
+  now: () => number = Date.now
+): OutcomeEvidenceStore {
+  let pending: Promise<unknown> = Promise.resolve();
+  const key = (scope: OutcomeScope) => `pathfinder-outcome-evidence:${JSON.stringify([scope.userId, scope.orgId])}`;
+  const readAll = async (scope: OutcomeScope): Promise<OutcomeEvidence[]> => {
+    OutcomeScopeSchema.parse(scope);
+    const raw = await storage.getItem<unknown>(key(scope));
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+    return raw.slice(-MAX_RECORDS).flatMap((entry) => {
+      const parsed = OutcomeEvidenceSchema.safeParse(entry);
+      return parsed.success ? [parsed.data] : [];
+    });
+  };
+  return {
+    async read(scope) {
+      return (await readAll(scope)).filter((entry) => outcomeScopeKey(entry.scope) === outcomeScopeKey(scope));
+    },
+    record(scope, outcomeId, resourceUid, checks) {
+      const evidence = createOutcomeEvidence(scope, outcomeId, resourceUid, checks, now());
+      if (!evidence) {
+        return Promise.resolve(null);
+      }
+      const write = async () => {
+        const previous = await readAll(scope);
+        const retained = previous.filter(
+          (entry) =>
+            !(
+              outcomeScopeKey(entry.scope) === outcomeScopeKey(scope) &&
+              entry.outcomeId === outcomeId &&
+              entry.resourceUid === resourceUid
+            )
+        );
+        await storage.setItem(key(scope), [...retained, evidence].slice(-MAX_RECORDS));
+        return evidence;
+      };
+      const result = pending.then(write, write);
+      pending = result;
+      return result;
+    },
+  };
+}

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -1,3 +1,4 @@
+import type { ConditionInput } from '../types/requirements.types';
 /**
  * User storage abstraction for the Grafana Docs Plugin
  *
@@ -1355,7 +1356,7 @@ export interface PersistedBundledStep {
     contextStrategy?: string;
   };
   interactiveComment?: string;
-  requirements?: string;
+  requirements?: ConditionInput;
 }
 
 export interface PersistedSectionInfo {
@@ -1363,7 +1364,7 @@ export interface PersistedSectionInfo {
   sectionTitle?: string;
   description?: string;
   interactiveComment?: string;
-  requirements?: string;
+  requirements?: ConditionInput;
 }
 
 export const fullScreenModeStorage = {

--- a/src/requirements-manager/checks/coda.ts
+++ b/src/requirements-manager/checks/coda.ts
@@ -89,6 +89,7 @@ export async function codaExitZeroCheck(check: string): Promise<CheckResultError
       error = `Could not reach the challenge VM: ${codaErr.message}`;
     }
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error,

--- a/src/requirements-manager/checks/env.ts
+++ b/src/requirements-manager/checks/env.ts
@@ -22,6 +22,7 @@ export async function hasFeatureCheck(check: string): Promise<CheckResultError> 
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Feature check failed: ${error}`,
@@ -47,6 +48,7 @@ export async function inEnvironmentCheck(check: string): Promise<CheckResultErro
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Environment check failed: ${error}`,
@@ -83,6 +85,7 @@ export async function minVersionCheck(check: string): Promise<CheckResultError> 
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Version check failed: ${error}`,
@@ -120,11 +123,13 @@ export async function rendererCheck(check: string): Promise<CheckResultError> {
     return {
       requirement: check,
       pass: false,
+      verdict: 'invalid',
       error: `Unknown renderer value: '${rendererValue}'. Supported values: 'pathfinder', 'website'`,
       context: { renderer: rendererValue, supported: ['pathfinder', 'website'] },
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Renderer check failed: ${error}`,

--- a/src/requirements-manager/checks/grafana-api.ts
+++ b/src/requirements-manager/checks/grafana-api.ts
@@ -26,6 +26,7 @@ export async function hasPermissionCheck(check: string): Promise<CheckResultErro
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Permission check failed: ${error}`,
@@ -83,6 +84,7 @@ export async function hasRoleCheck(check: string): Promise<CheckResultError> {
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Role check failed: ${error}`,
@@ -139,6 +141,7 @@ export async function hasDataSourceCheck(check: string): Promise<CheckResultErro
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Data source check failed: ${error}`,
@@ -154,7 +157,7 @@ export async function hasDataSourceCheck(check: string): Promise<CheckResultErro
 export async function hasPluginCheck(check: string): Promise<CheckResultError> {
   try {
     const pluginId = check.replace('has-plugin:', '');
-    const plugins = await ContextService.fetchPlugins();
+    const plugins = await ContextService.fetchPlugins({ throwOnError: true });
     const pluginExists = plugins.some((plugin) => plugin.id === pluginId);
 
     return {
@@ -172,6 +175,7 @@ export async function hasPluginCheck(check: string): Promise<CheckResultError> {
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Plugin check failed: ${error}`,
@@ -186,7 +190,7 @@ export async function hasPluginCheck(check: string): Promise<CheckResultError> {
 export async function hasDashboardNamedCheck(check: string): Promise<CheckResultError> {
   try {
     const dashboardName = check.replace('has-dashboard-named:', '');
-    const dashboards = await ContextService.fetchDashboardsByName(dashboardName);
+    const dashboards = await ContextService.fetchDashboardsByName(dashboardName, { throwOnError: true });
     const dashboardExists = dashboards.some(
       (dashboard) => dashboard.title.toLowerCase() === dashboardName.toLowerCase()
     );
@@ -206,6 +210,7 @@ export async function hasDashboardNamedCheck(check: string): Promise<CheckResult
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Dashboard check failed: ${error}`,
@@ -249,6 +254,7 @@ export async function isLoggedInCheck(check: string): Promise<CheckResultError> 
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Login check failed: ${error}`,
@@ -287,6 +293,7 @@ export async function isEditorCheck(check: string): Promise<CheckResultError> {
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Editor check failed: ${error}`,
@@ -300,7 +307,7 @@ export async function isEditorCheck(check: string): Promise<CheckResultError> {
  */
 export async function hasDatasourcesCheck(check: string): Promise<CheckResultError> {
   try {
-    const dataSources = await ContextService.fetchDataSources();
+    const dataSources = await ContextService.fetchDataSources({ throwOnError: true });
     return {
       requirement: check,
       pass: dataSources.length > 0,
@@ -309,6 +316,7 @@ export async function hasDatasourcesCheck(check: string): Promise<CheckResultErr
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Failed to check data sources: ${error}`,
@@ -323,7 +331,7 @@ export async function hasDatasourcesCheck(check: string): Promise<CheckResultErr
 export async function pluginEnabledCheck(check: string): Promise<CheckResultError> {
   try {
     const pluginId = check.replace('plugin-enabled:', '');
-    const plugins = await ContextService.fetchPlugins();
+    const plugins = await ContextService.fetchPlugins({ throwOnError: true });
 
     // Find the specific plugin
     const plugin = plugins.find((p) => p.id === pluginId);
@@ -358,6 +366,7 @@ export async function pluginEnabledCheck(check: string): Promise<CheckResultErro
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Plugin enabled check failed: ${error}`,
@@ -389,6 +398,7 @@ export async function dashboardExistsCheck(check: string): Promise<CheckResultEr
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Dashboard existence check failed: ${error}`,
@@ -404,7 +414,7 @@ export async function dashboardExistsCheck(check: string): Promise<CheckResultEr
 export async function datasourceConfiguredCheck(check: string): Promise<CheckResultError> {
   try {
     const dsRequirement = check.replace('datasource-configured:', '').toLowerCase();
-    const dataSources = await ContextService.fetchDataSources();
+    const dataSources = await ContextService.fetchDataSources({ throwOnError: true });
 
     if (dataSources.length === 0) {
       return {
@@ -480,6 +490,7 @@ export async function datasourceConfiguredCheck(check: string): Promise<CheckRes
     } catch (testError) {
       // If test fails, it might still be configured but unreachable
       return {
+        verdict: 'unavailable',
         requirement: check,
         pass: false,
         error: `Data source configuration test failed: ${testError}`,
@@ -497,6 +508,7 @@ export async function datasourceConfiguredCheck(check: string): Promise<CheckRes
     }
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Data source configuration check failed: ${error}`,

--- a/src/requirements-manager/checks/location.ts
+++ b/src/requirements-manager/checks/location.ts
@@ -25,6 +25,7 @@ export async function onPageCheck(check: string): Promise<CheckResultError> {
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Page check failed: ${error}`,

--- a/src/requirements-manager/checks/section-completed-check.ts
+++ b/src/requirements-manager/checks/section-completed-check.ts
@@ -1,3 +1,4 @@
+import type { CheckResultError } from '../../types/requirements.types';
 /**
  * Section completion check — `section-completed:<sectionId>` requirement.
  *
@@ -27,12 +28,7 @@ import { getContentKey } from '../../global-state/content-key';
 import { sectionDoneStorage } from '../../lib/user-storage';
 import { logger } from '../../lib/logging';
 
-export async function sectionCompletedCheck(check: string): Promise<{
-  requirement: string;
-  pass: boolean;
-  error?: string;
-  context?: Record<string, unknown> | null;
-}> {
+export async function sectionCompletedCheck(check: string): Promise<CheckResultError> {
   try {
     const rawId = check.replace('section-completed:', '');
     const sectionId = rawId.startsWith('section-') ? rawId : `section-${rawId}`;
@@ -64,6 +60,7 @@ export async function sectionCompletedCheck(check: string): Promise<{
   } catch (error) {
     logger.error('Section completion check error', { error });
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Section completion check failed: ${error}`,

--- a/src/requirements-manager/checks/terminal.ts
+++ b/src/requirements-manager/checks/terminal.ts
@@ -21,6 +21,7 @@ export async function terminalActiveCheck(check: string): Promise<CheckResultErr
     };
   } catch {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: 'Terminal integration is not available.',

--- a/src/requirements-manager/checks/vars.ts
+++ b/src/requirements-manager/checks/vars.ts
@@ -19,6 +19,7 @@ export async function guideVariableCheck(check: string, explicitGuideId?: string
       return {
         requirement: check,
         pass: false,
+        verdict: 'invalid',
         error: `Invalid variable requirement format: ${check}. Expected: var-{variableName}:{expectedValue}`,
         context: { format: 'var-{variableName}:{expectedValue}' },
       };
@@ -72,6 +73,7 @@ export async function guideVariableCheck(check: string, explicitGuideId?: string
     };
   } catch (error) {
     return {
+      verdict: 'unavailable',
       requirement: check,
       pass: false,
       error: `Variable check failed: ${error}`,

--- a/src/requirements-manager/controller-requirements.test.ts
+++ b/src/requirements-manager/controller-requirements.test.ts
@@ -85,3 +85,9 @@ describe('splitGuideScopedRequirements (#1574)', () => {
     expect(splitGuideScopedRequirements('')).toEqual({ guideScoped: '', remaining: '' });
   });
 });
+
+it('preserves comma-containing tokens while removing tab-local conditions', () => {
+  expect(stripTabLocalRequirements(['on-page:/explore', 'has-dashboard-named:CPU, memory'])).toEqual([
+    'has-dashboard-named:CPU, memory',
+  ]);
+});

--- a/src/requirements-manager/controller-requirements.ts
+++ b/src/requirements-manager/controller-requirements.ts
@@ -1,3 +1,5 @@
+import type { ConditionInput } from '../types/requirements.types';
+import { conditionTokens } from '../lib/condition-input';
 // Requirements that probe THIS tab's live DOM / URL / navigation and therefore
 // cannot be evaluated from a controller tab driving a different Grafana tab.
 // Session / permission requirements (is-admin, has-datasources, dashboard-exists,
@@ -13,16 +15,12 @@ function isTabLocal(token: string): boolean {
   return TAB_LOCAL_REQUIREMENTS.some((id) => token === id || token.startsWith(`${id}:`));
 }
 
-export function stripTabLocalRequirements(requirements: string | undefined): string | undefined {
+export function stripTabLocalRequirements(requirements: ConditionInput | undefined): ConditionInput | undefined {
   if (!requirements) {
     return requirements;
   }
-  return requirements
-    .split(',')
-    .map((token) => token.trim())
-    .filter(Boolean)
-    .filter((token) => !isTabLocal(token))
-    .join(',');
+  const tokens = conditionTokens(requirements).filter((token) => !isTabLocal(token));
+  return typeof requirements === 'string' ? tokens.join(',') : tokens;
 }
 
 // Requirements answered from per-guide state that only the renderer owning the
@@ -38,17 +36,14 @@ function isGuideScoped(token: string): boolean {
   return GUIDE_SCOPED_REQUIREMENT_PREFIXES.some((prefix) => token.startsWith(prefix));
 }
 
-export function splitGuideScopedRequirements(requirements: string | undefined): {
-  guideScoped: string;
-  remaining: string;
+export function splitGuideScopedRequirements(requirements: ConditionInput | undefined): {
+  guideScoped: ConditionInput;
+  remaining: ConditionInput;
 } {
-  const tokens = (requirements ?? '')
-    .split(',')
-    .map((token) => token.trim())
-    .filter(Boolean);
-
-  return {
-    guideScoped: tokens.filter(isGuideScoped).join(','),
-    remaining: tokens.filter((token) => !isGuideScoped(token)).join(','),
-  };
+  const tokens = conditionTokens(requirements);
+  const guideScoped = tokens.filter(isGuideScoped);
+  const remaining = tokens.filter((token) => !isGuideScoped(token));
+  return typeof requirements === 'string' || requirements === undefined
+    ? { guideScoped: guideScoped.join(','), remaining: remaining.join(',') }
+    : { guideScoped, remaining };
 }

--- a/src/requirements-manager/fix-handlers/types.ts
+++ b/src/requirements-manager/fix-handlers/types.ts
@@ -1,3 +1,4 @@
+import type { ConditionInput } from '../../types/requirements.types';
 /**
  * Fix handler interfaces.
  *
@@ -32,7 +33,7 @@ export interface FixContext {
   targetHref?: string;
   scrollContainer?: string;
   /** Raw requirements string from the step; used by the navigation handler's legacy fallback. */
-  requirements?: string;
+  requirements?: ConditionInput;
   stepId: string;
   /** May be null if the lazy `import('../interactive-engine')` has not yet resolved. */
   navigationManager: FixHandlerNavigationManager | null;

--- a/src/requirements-manager/requirements-checker.utils.test.ts
+++ b/src/requirements-manager/requirements-checker.utils.test.ts
@@ -1096,8 +1096,24 @@ describe('condition array execution', () => {
   it('passes an entire dashboard name to the Grafana check', async () => {
     jest.mocked(ContextService.fetchDashboardsByName).mockResolvedValue([{ title: 'CPU, memory' }] as never);
     const result = await checkRequirements({ requirements: ['has-dashboard-named:CPU, memory'], maxRetries: 0 });
-    expect(ContextService.fetchDashboardsByName).toHaveBeenCalledWith('CPU, memory');
+    expect(ContextService.fetchDashboardsByName).toHaveBeenCalledWith('CPU, memory', { throwOnError: true });
     expect(result.error).toHaveLength(1);
     expect(result.pass).toBe(true);
+  });
+});
+
+describe('structured check verdicts', () => {
+  it('distinguishes missing dashboards from unavailable reads', async () => {
+    jest.mocked(ContextService.fetchDashboardsByName).mockResolvedValueOnce([]);
+    const missing = await checkPostconditions({ requirements: ['has-dashboard-named:Example'], maxRetries: 0 });
+    expect(missing).toMatchObject({ pass: false, verdict: 'unsatisfied' });
+    jest.mocked(ContextService.fetchDashboardsByName).mockRejectedValueOnce(new Error('Offline'));
+    const unavailable = await checkPostconditions({ requirements: ['has-dashboard-named:Example'], maxRetries: 0 });
+    expect(unavailable).toMatchObject({ pass: false, verdict: 'unavailable' });
+  });
+  it('refuses invalid verification while retaining the legacy prerequisite fallback', async () => {
+    const options = { requirements: ['has-dashbord-named:Example'], maxRetries: 0 };
+    expect(await checkRequirements(options)).toMatchObject({ pass: true, verdict: 'invalid' });
+    expect(await checkPostconditions(options)).toMatchObject({ pass: false, verdict: 'invalid' });
   });
 });

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -1,3 +1,4 @@
+import { checkVerdict, combineCheckVerdicts } from '../lib/check-verdict';
 import { conditionTokens, conditionLabel } from '../lib/condition-input';
 /**
  * Requirements checking — router and retry harness.
@@ -18,7 +19,12 @@ import { conditionTokens, conditionLabel } from '../lib/condition-input';
 
 import { reftargetExistsCheck, navmenuOpenCheck, formValidCheck } from '../lib/dom';
 import { sectionCompletedCheck } from './checks/section-completed-check';
-import { isValidRequirement, type CheckResultError, type ConditionInput } from '../types/requirements.types';
+import {
+  isValidRequirement,
+  type CheckResultError,
+  type ConditionInput,
+  type CheckVerdict,
+} from '../types/requirements.types';
 import { INTERACTIVE_CONFIG } from '../constants/interactive-config';
 import { logger } from '../lib/logging';
 import { TimeoutManager } from '../utils/timeout-manager';
@@ -44,6 +50,7 @@ import { terminalActiveCheck } from './checks/terminal';
 import { codaExitZeroCheck } from './checks/coda';
 
 export interface RequirementsCheckResult {
+  verdict?: CheckVerdict;
   requirements: string;
   pass: boolean;
   error: CheckResultError[];
@@ -131,24 +138,30 @@ const CHECK_HANDLERS: readonly CheckHandler[] = [
 
 export { CHECK_HANDLERS };
 
-async function routeUnifiedCheck(check: string, ctx: CheckContext): Promise<CheckResultError> {
+async function routeUnifiedCheck(check: string, ctx: CheckContext, mode: CheckMode): Promise<CheckResultError> {
   // Type-safe validation with helpful developer feedback
-  if (!isValidRequirement(check)) {
+  if (!isValidRequirement(check) || check.endsWith(':') || check === 'var-') {
     logger.warn(
       `Unknown requirement type: '${check}'. Check the requirement syntax and ensure it's supported. Allowing step to proceed.`
     );
 
     return {
       requirement: check,
-      pass: true,
-      error: `Warning: Unknown requirement type '${check}' - step allowed to proceed`,
+      pass: mode === 'pre',
+      verdict: 'invalid',
+      error: `Warning: Unknown requirement type '${check}' - ${mode === 'pre' ? 'step allowed to proceed' : 'verification refused'}`,
       context: null,
     };
   }
 
   const handler = CHECK_HANDLERS.find((h) => h.match(check));
   if (handler) {
-    return handler.run(check, ctx);
+    try {
+      const result = await handler.run(check, ctx);
+      return { ...result, verdict: checkVerdict(result) };
+    } catch (error) {
+      return { requirement: check, pass: false, verdict: 'unavailable', error: String(error) };
+    }
   }
 
   // Should never be reached due to the validation above, but keep as a fallback.
@@ -158,8 +171,9 @@ async function routeUnifiedCheck(check: string, ctx: CheckContext): Promise<Chec
 
   return {
     requirement: check,
-    pass: true,
-    error: `Warning: Unexpected requirement type '${check}' - step allowed to proceed`,
+    pass: mode === 'pre',
+    verdict: 'invalid',
+    error: `Warning: Unexpected requirement type '${check}' - ${mode === 'pre' ? 'step allowed to proceed' : 'verification refused'}`,
     context: null,
   };
 }
@@ -171,11 +185,12 @@ async function runUnifiedChecks(
 ): Promise<RequirementsCheckResult> {
   const checks = conditionTokens(checksString);
 
-  const results = await Promise.all(checks.map((check) => routeUnifiedCheck(check, ctx)));
+  const results = await Promise.all(checks.map((check) => routeUnifiedCheck(check, ctx, mode)));
 
   return {
     requirements: conditionLabel(checksString),
     pass: results.every((r) => r.pass),
+    verdict: combineCheckVerdicts(results),
     error: results,
   };
 }
@@ -203,6 +218,7 @@ async function executeChecksWithRetry(
     return {
       requirements: conditionLabel(requirements),
       pass: true,
+      verdict: 'satisfied',
       error: [],
     };
   }
@@ -272,6 +288,7 @@ async function executeChecksWithRetry(
     return {
       requirements: conditionLabel(requirements),
       pass: false,
+      verdict: 'unavailable',
       error: [
         {
           requirement: conditionLabel(requirements),

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -308,7 +308,7 @@ export async function checkPostconditions(options: RequirementsCheckOptions): Pr
  */
 export function validateInteractiveRequirements(
   props: {
-    requirements?: string;
+    requirements?: ConditionInput;
     refTarget?: string;
     stepId?: string;
     originalHTML?: string;
@@ -323,7 +323,7 @@ export function validateInteractiveRequirements(
   }
 
   // Check if requirements include 'exists-reftarget'
-  const requirementList = requirements.split(',').map((r) => r.trim());
+  const requirementList = conditionTokens(requirements);
   const hasExistsReftarget = requirementList.includes('exists-reftarget');
 
   // If 'exists-reftarget' is present but no refTarget, this is an impossible configuration

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -1,3 +1,4 @@
+import { conditionTokens, conditionLabel } from '../lib/condition-input';
 /**
  * Unified hook for checking both tutorial-specific requirements and objectives
  * Combines and replaces useStepRequirements and useStepObjectives
@@ -33,7 +34,12 @@ import { stepReducer, createInitialState, toLegacyState, type StepAction } from 
 import { useInteractiveElements, useSequentialStepState } from '../interactive-engine';
 import { INTERACTIVE_CONFIG, isFirstStep } from '../constants/interactive-config';
 import { TERMINAL_STATUS_CHANGED_EVENT } from '../lib/event-names';
-import { FixedRequirementType, ParameterizedRequirementPrefix, isValidRequirement } from '../types/requirements.types';
+import {
+  FixedRequirementType,
+  ParameterizedRequirementPrefix,
+  isValidRequirement,
+  type ConditionInput,
+} from '../types/requirements.types';
 import { logger } from '../lib/logging';
 import { useTimeoutManager } from '../utils/timeout-manager';
 import { useIsAlignmentPaused } from '../global-state/alignment-pending-context';
@@ -91,12 +97,12 @@ function actionFromBaseStepState(s: LegacyStateShape): StepAction {
 
 /** Conjunction of partial verdicts, reported against the original requirements string. */
 function mergeRequirementResults(
-  requirements: string,
+  requirements: ConditionInput,
   parts: Array<RequirementsCheckResult | undefined>
 ): RequirementsCheckResult {
   const present = parts.filter((part): part is RequirementsCheckResult => part !== undefined);
   return {
-    requirements,
+    requirements: conditionLabel(requirements),
     pass: present.every((part) => part.pass),
     error: present.flatMap((part) => part.error ?? []),
   };
@@ -235,7 +241,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
   const checkRequirementsWithStateUpdates = useCallback(
     async (
       options: {
-        requirements: string;
+        requirements: ConditionInput;
         targetAction?: string;
         refTarget?: string;
         stepId?: string;
@@ -273,13 +279,13 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       const attemptCheck = async (retryCount: number): Promise<RequirementsCheckResult> => {
         // REACT: Check mounted before state updates to prevent updates after unmount (R4)
         if (!isMountedRef.current) {
-          return { requirements: requirements || '', pass: false, error: [] };
+          return { requirements: conditionLabel(requirements), pass: false, error: [] };
         }
 
         // Update state with current retry info
         onStateUpdate(retryCount, maxRetries, retryCount > 0);
 
-        const checkHere = (localRequirements: string) =>
+        const checkHere = (localRequirements: ConditionInput) =>
           checkRequirements({
             requirements: localRequirements,
             targetAction,
@@ -314,8 +320,8 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
             };
 
             const [guideScopedResult, remainingResult] = await Promise.all([
-              guideScoped ? checkHere(guideScoped) : undefined,
-              remaining ? checkOnLiveTab() : undefined,
+              conditionTokens(guideScoped).length ? checkHere(guideScoped) : undefined,
+              conditionTokens(remaining).length ? checkOnLiveTab() : undefined,
             ]);
             result = mergeRequirementResults(requirements, [guideScopedResult, remainingResult]);
           } else {
@@ -347,7 +353,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
         } catch (error) {
           // REACT: Check mounted before retry (R4)
           if (!isMountedRef.current) {
-            return { requirements: requirements || '', pass: false, error: [] };
+            return { requirements: conditionLabel(requirements), pass: false, error: [] };
           }
 
           // On error, retry if we have attempts left
@@ -355,18 +361,18 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
             await new Promise((resolve) => setTimeout(resolve, INTERACTIVE_CONFIG.delays.requirements.retryDelay));
             // Check mounted again after delay
             if (!isMountedRef.current) {
-              return { requirements: requirements || '', pass: false, error: [] };
+              return { requirements: conditionLabel(requirements), pass: false, error: [] };
             }
             return attemptCheck(retryCount + 1);
           }
 
           // No more retries, return error
           return {
-            requirements: requirements || '',
+            requirements: conditionLabel(requirements),
             pass: false,
             error: [
               {
-                requirement: requirements || 'unknown',
+                requirement: conditionLabel(requirements) || 'unknown',
                 pass: false,
                 error: `Requirements check failed after ${maxRetries + 1} attempts: ${error}`,
               },
@@ -511,17 +517,14 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       // Letting an objectives-check rejection propagate to the outer `catch` would
       // strand the step in an error state on slow networks. Treat any objectives
       // failure here as "objectives unmet" and continue.
-      if (objectives && objectives.trim() !== '') {
-        const objectiveTokens = objectives
-          .split(',')
-          .map((token) => token.trim())
-          .filter(Boolean);
+      if (conditionTokens(objectives).length > 0) {
+        const objectiveTokens = conditionTokens(objectives);
         const validObjectives = objectiveTokens.length > 0 && objectiveTokens.every(isValidRequirement);
         let objectivesPassed = false;
         try {
           const objectivesResult = await checkRequirementsWithStateUpdatesRef.current(
             {
-              requirements: objectives,
+              requirements: objectives ?? [],
               targetAction: targetAction || 'button',
               refTarget: refTarget || stepId,
               stepId,
@@ -564,10 +567,10 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       }
 
       // PHASE 3: Check requirements (only if objectives not met and eligible)
-      if (requirements && requirements.trim() !== '') {
+      if (conditionTokens(requirements).length > 0) {
         const requirementsResult = await checkRequirementsWithStateUpdatesRef.current(
           {
-            requirements,
+            requirements: requirements ?? [],
             targetAction: targetAction || 'button',
             refTarget: refTarget || stepId,
             stepId,
@@ -578,7 +581,12 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
           }
         );
 
-        const requirementsState = createRequirementsState(requirementsResult, requirements, hints, skippable);
+        const requirementsState = createRequirementsState(
+          requirementsResult,
+          conditionLabel(requirements),
+          hints,
+          skippable
+        );
 
         // REACT: Check mounted before state update (R4)
         if (!isMountedRef.current) {
@@ -623,7 +631,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       updateManager(enabledState);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Failed to check step conditions';
-      const errorState = createErrorState(errorMessage, requirements || objectives, hints, skippable);
+      const errorState = createErrorState(errorMessage, conditionLabel(requirements || objectives), hints, skippable);
       safeDispatch(actionFromBaseStepState(errorState));
       updateManager(errorState);
     }
@@ -645,12 +653,12 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
   // result into the FSM so a regressed prerequisite re-surfaces, and return
   // whether the action may proceed.
   const revalidate = useCallback(async (): Promise<boolean> => {
-    if (!requirements || requirements.trim() === '') {
+    if (conditionTokens(requirements).length === 0) {
       return true;
     }
     const result = await checkRequirementsWithStateUpdates(
       {
-        requirements,
+        requirements: requirements ?? [],
         targetAction: targetAction || 'button',
         refTarget: refTarget || stepId,
         stepId,
@@ -663,7 +671,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
     if (!isMountedRef.current) {
       return result.pass;
     }
-    const requirementsState = createRequirementsState(result, requirements, hints, skippable);
+    const requirementsState = createRequirementsState(result, conditionLabel(requirements), hints, skippable);
     safeDispatch(actionFromBaseStepState(requirementsState));
     updateManager(requirementsState);
     prevIsEnabledRef.current = result.pass;
@@ -1035,7 +1043,7 @@ export function useStepChecker(props: UseStepCheckerProps): UseStepCheckerReturn
       // Recheck if:
       // 1. Step is blocked (not enabled) - might become enabled after navigation
       // 2. Step is enabled with objectives - objectives might be satisfied after navigation
-      const hasObjectives = currentObjectives && currentObjectives.trim() !== '';
+      const hasObjectives = conditionTokens(currentObjectives).length > 0;
       const shouldRecheck = !isCompleted && !isChecking && (!isEnabled || hasObjectives);
 
       if (shouldRecheck) {

--- a/src/requirements-manager/step-checker.hook.ts
+++ b/src/requirements-manager/step-checker.hook.ts
@@ -1,3 +1,4 @@
+import { combineCheckVerdicts } from '../lib/check-verdict';
 import { conditionTokens, conditionLabel } from '../lib/condition-input';
 /**
  * Unified hook for checking both tutorial-specific requirements and objectives
@@ -104,6 +105,7 @@ function mergeRequirementResults(
   return {
     requirements: conditionLabel(requirements),
     pass: present.every((part) => part.pass),
+    verdict: combineCheckVerdicts(present),
     error: present.flatMap((part) => part.error ?? []),
   };
 }

--- a/src/types/collaboration.types.ts
+++ b/src/types/collaboration.types.ts
@@ -1,3 +1,4 @@
+import type { ConditionInput } from './requirements.types';
 /**
  * Type definitions for Collaborative Live Learning Sessions
  *
@@ -137,7 +138,7 @@ export interface InteractiveAction {
     targetAction: string;
     refTarget?: string;
     targetValue?: string;
-    requirements?: string;
+    requirements?: ConditionInput;
   }>;
 }
 

--- a/src/types/component-props.types.ts
+++ b/src/types/component-props.types.ts
@@ -1,3 +1,4 @@
+import type { ConditionInput } from './requirements.types';
 /**
  * Component prop type definitions
  * Centralized prop interfaces for components used across the application
@@ -13,8 +14,8 @@ import React from 'react';
  * Base props shared by all interactive components
  */
 export interface BaseInteractiveProps {
-  requirements?: string;
-  objectives?: string;
+  requirements?: ConditionInput;
+  objectives?: ConditionInput;
   hints?: string;
   onComplete?: () => void;
   disabled?: boolean;
@@ -90,7 +91,7 @@ export interface StepInfo {
   targetValue?: string;
   targetState?: boolean | string;
   targetComment?: string; // Optional comment to show during execution
-  requirements?: string;
+  requirements?: ConditionInput;
   postVerify?: string;
   skippable?: boolean; // Whether this step can be skipped
   showMe?: boolean; // Whether to show the "Show me" button and phase

--- a/src/types/cross-tab.types.ts
+++ b/src/types/cross-tab.types.ts
@@ -35,6 +35,7 @@ interface CrossTabEnvelope {
 // able to reshape the wire silently. A compile-time guard in
 // cross-tab.types.test.ts forces a conscious update here when they diverge.
 export interface RemoteRequirementError {
+  verdict?: 'satisfied' | 'unsatisfied' | 'unavailable' | 'invalid';
   requirement: string;
   pass: boolean;
   error?: string;
@@ -46,6 +47,7 @@ export interface RemoteRequirementError {
 }
 
 export interface RemoteRequirementResult {
+  verdict?: 'satisfied' | 'unsatisfied' | 'unavailable' | 'invalid';
   requirements: string;
   pass: boolean;
   error: RemoteRequirementError[];
@@ -316,6 +318,13 @@ function isValidFixRequirement(message: Record<string, unknown>): boolean {
 // requirement-result / fix-result are replies the controller feeds into its
 // requirements-state path; validate the reply shape so a malformed result can't
 // resolve a pending request with garbage.
+function isOptionalVerdict(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (typeof value === 'string' && ['satisfied', 'unsatisfied', 'unavailable', 'invalid'].includes(value))
+  );
+}
+
 function isValidRequirementResult(message: Record<string, unknown>): boolean {
   if (typeof message.requestId !== 'string' || typeof message.stepId !== 'string' || !isRecord(message.result)) {
     return false;
@@ -323,12 +332,14 @@ function isValidRequirementResult(message: Record<string, unknown>): boolean {
   const result = message.result;
   return (
     typeof result.requirements === 'string' &&
+    isOptionalVerdict(result.verdict) &&
     typeof result.pass === 'boolean' &&
     Array.isArray(result.error) &&
     result.error.every(
       (e) =>
         isRecord(e) &&
         typeof e.requirement === 'string' &&
+        isOptionalVerdict(e.verdict) &&
         typeof e.pass === 'boolean' &&
         isOptionalString(e.error) &&
         isOptionalString(e.fixType) &&

--- a/src/types/cross-tab.types.ts
+++ b/src/types/cross-tab.types.ts
@@ -122,7 +122,7 @@ export interface FixRequirementMessage extends CrossTabEnvelope, Partial<Control
   kind: 'fix-requirement';
   requestId: string;
   stepId: string;
-  requirements: string;
+  requirements: ConditionInput;
   fixType?: string;
   targetHref?: string;
   scrollContainer?: string;
@@ -305,7 +305,8 @@ function isValidFixRequirement(message: Record<string, unknown>): boolean {
   return (
     typeof message.requestId === 'string' &&
     typeof message.stepId === 'string' &&
-    typeof message.requirements === 'string' &&
+    (typeof message.requirements === 'string' ||
+      (Array.isArray(message.requirements) && message.requirements.every((token) => typeof token === 'string'))) &&
     isOptionalString(message.fixType) &&
     isOptionalString(message.targetHref) &&
     isOptionalString(message.scrollContainer)

--- a/src/types/hooks.types.ts
+++ b/src/types/hooks.types.ts
@@ -1,3 +1,4 @@
+import type { ConditionInput } from './requirements.types';
 /**
  * Hook-related type definitions
  * Centralized interfaces for React hooks across the application
@@ -12,8 +13,8 @@
  * Unified hook for checking tutorial-specific requirements and objectives
  */
 export interface UseStepCheckerProps {
-  requirements?: string;
-  objectives?: string;
+  requirements?: ConditionInput;
+  objectives?: ConditionInput;
   hints?: string;
   stepId: string;
   targetAction?: string; // Pass through to requirements checking

--- a/src/types/interactive-actions.types.ts
+++ b/src/types/interactive-actions.types.ts
@@ -1,3 +1,4 @@
+import type { ConditionInput } from './requirements.types';
 /**
  * Interactive action type definitions
  * Centralized types for internal actions used in multi-step and guided components
@@ -13,7 +14,7 @@ export interface InternalAction {
   targetValue?: string;
   /** Desired end state for a toggle target; see `lib/dom/toggle-state`. */
   targetState?: boolean | string;
-  requirements?: string;
+  requirements?: ConditionInput;
   targetComment?: string; // Optional comment to display during this step
 }
 

--- a/src/types/interactive.types.ts
+++ b/src/types/interactive.types.ts
@@ -1,3 +1,4 @@
+import type { ConditionInput } from './requirements.types';
 export const INTERACTIVE_ACTION_TYPES = [
   'button',
   'highlight',
@@ -21,8 +22,8 @@ export interface InteractiveElementData {
   /** Desired end state for a toggle target; see `lib/dom/toggle-state`. */
   targetState?: boolean | string;
   targetComment?: string;
-  requirements?: string;
-  objectives?: string;
+  requirements?: ConditionInput;
+  objectives?: ConditionInput;
   skippable?: boolean; // Whether this step can be skipped if requirements fail
 
   // Lazy render support for virtualized containers

--- a/src/types/outcome.schema.ts
+++ b/src/types/outcome.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import type { OutcomeEvidence } from './outcome.types';
+
+export const OutcomeScopeSchema = z.object({
+  userId: z.string().min(1).max(128),
+  orgId: z.string().min(1).max(128),
+  guideId: z.string().min(1).max(2048),
+  guideRevision: z.string().min(1).max(128),
+});
+
+export const OutcomeEvidenceSchema = z.object({
+  schemaVersion: z.literal(1),
+  scope: OutcomeScopeSchema,
+  outcomeId: z.string().min(1).max(128),
+  resourceUid: z.string().min(1).max(128),
+  verifiedAt: z.number().positive(),
+}) satisfies z.ZodType<OutcomeEvidence>;

--- a/src/types/outcome.types.ts
+++ b/src/types/outcome.types.ts
@@ -1,0 +1,14 @@
+export interface OutcomeScope {
+  userId: string;
+  orgId: string;
+  guideId: string;
+  guideRevision: string;
+}
+
+export interface OutcomeEvidence {
+  schemaVersion: 1;
+  scope: OutcomeScope;
+  outcomeId: string;
+  resourceUid: string;
+  verifiedAt: number;
+}

--- a/src/types/requirements.types.ts
+++ b/src/types/requirements.types.ts
@@ -79,7 +79,7 @@ export interface CheckResultError {
 
 // Type-safe requirement checker options
 export interface TypeSafeRequirementsCheckOptions {
-  requirements: string; // We keep this as string for backward compatibility, but validate at runtime
+  requirements: ConditionInput;
   targetAction?: string;
   refTarget?: string;
   targetValue?: string;

--- a/src/types/requirements.types.ts
+++ b/src/types/requirements.types.ts
@@ -1,3 +1,5 @@
+export type CheckVerdict = 'satisfied' | 'unsatisfied' | 'unavailable' | 'invalid';
+
 export type ConditionInput = string | readonly string[];
 
 /**
@@ -65,6 +67,7 @@ export const isValidRequirement = (req: string): req is ValidRequirement => {
  * importing each other (#1359).
  */
 export interface CheckResultError {
+  verdict?: CheckVerdict;
   requirement: string;
   pass: boolean;
   error?: string;


### PR DESCRIPTION
Consolidated into #1791, which contains the full implementation in one verified commit directly against `main`. This separate PR is superseded; its changes are included in the combined implementation and validation.
