### PR TITLE
feat(outcomes): verify first-dashboard resources independently

### DIFF
--- a/docs/developer/FEATURE_FLAGS.md
+++ b/docs/developer/FEATURE_FLAGS.md
@@ -503,3 +503,7 @@ const showExistingFeature = useBooleanFlag('pathfinder.existing-feature', true);
 - [OpenFeature React SDK](https://openfeature.dev/docs/reference/technologies/client/web/)
 - [OFREP Web Provider](https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/ofrep-web)
 - Source: `src/utils/openfeature.ts`
+
+### Verified outcomes pilot
+
+`pathfinder.verified-outcomes` defaults to `false` and enables the first-dashboard guide's separate resource-verification panel. It does not change guide completion arithmetic. For local QA, run `window.__pathfinderExperiment.setOverride('pathfinder.verified-outcomes', true)` and reload. Disable the override to return to the existing experience. A production rollout requires the corresponding MTFF registration; this change only registers the client flag and keeps rollout off.

--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -1569,3 +1569,9 @@ The prescriptive coupling checklist and the limits of the automated drift checks
 - [Selectors reference](./selectors-reference.md) — targeting DOM elements with the enhanced selector engine
 - [Requirements reference](./requirements-reference.md) — pre-condition and post-condition system
 - [Guided interactions](./guided-interactions.md) — user-performed action mode
+
+## Verified outcome pilot
+
+The bundled `first-dashboard-cloud` guide declares optional root-level `outcomes`. Each declaration has a unique `id`, a sentence-case `label`, and a `kind` (`datasource-health` or `dashboard-saved`). Data source outcomes may constrain selection with `datasourceType`. Both single-file and package content schemas validate these declarations. This pilot is supported for JSON content; publishing these fields through App Platform is outside its scope.
+
+`pathfinder.verified-outcomes` is off by default. When enabled, a separate panel lets a signed-in user select resources by UID, check outcomes, cancel checks, and retry unavailable checks. Dashboard selection searches Grafana rather than assuming the first page is exhaustive. These are API checks, independent of guide progress, manual completion, and skipping. Historical evidence is scoped to the user, organisation, source URL, and SHA-256 content revision; it does not assert that a resource remains healthy after it was checked. Failed checks do not erase history. Outcome storage is bounded and best effort; it is not a certification record or an authorisation boundary.

--- a/src/bundled-interactives/first-dashboard-cloud/content.json
+++ b/src/bundled-interactives/first-dashboard-cloud/content.json
@@ -1,6 +1,15 @@
 {
   "id": "first-dashboard-cloud",
   "title": "Create your first dashboard in Grafana Cloud",
+  "outcomes": [
+    {
+      "id": "testdata-health",
+      "label": "TestData responds successfully",
+      "kind": "datasource-health",
+      "datasourceType": "grafana-testdata-datasource"
+    },
+    { "id": "dashboard-saved", "label": "A dashboard is saved", "kind": "dashboard-saved" }
+  ],
   "blocks": [
     {
       "type": "markdown",

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -1,3 +1,4 @@
+import { GuideOutcomePilot } from '../guide-outcomes/GuideOutcomePilot';
 import React, { useRef, useEffect, useLayoutEffect, useMemo, useState, useCallback } from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
@@ -440,6 +441,7 @@ export const ContentRenderer = React.memo(function ContentRenderer({
           beforeContent={beforeContent}
           fullScreenFallbackLocation={fullScreenFallbackLocation}
         />
+        <GuideOutcomePilot content={processedContent} guideId={content.url} />
       </GuideRequirementsProvider>
     </GuideResponseProvider>
   );

--- a/src/components/guide-outcomes/GuideOutcomePilot.test.tsx
+++ b/src/components/guide-outcomes/GuideOutcomePilot.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { config } from '@grafana/runtime';
+import { GuideOutcomePilot } from './GuideOutcomePilot';
+import { getFeatureFlagValue } from '../../utils/openfeature';
+import { listOutcomeResources } from '../../requirements-manager';
+
+jest.mock('../../utils/openfeature', () => ({ getFeatureFlagValue: jest.fn(), useBooleanFlag: jest.fn(() => false) }));
+jest.mock('../../lib/hash.util', () => ({ hashString: jest.fn().mockResolvedValue('revision') }));
+jest.mock('../../lib/user-storage', () => ({
+  createUserStorage: () => ({ getItem: async () => null, setItem: async () => {} }),
+}));
+jest.mock('../../requirements-manager', () => ({
+  listOutcomeResources: jest.fn().mockResolvedValue([]),
+  verifyGrafanaOutcome: jest.fn(),
+}));
+const content = JSON.stringify({
+  id: 'first-dashboard-cloud',
+  outcomes: [{ id: 'saved', label: 'Saved dashboard', kind: 'dashboard-saved' }],
+});
+
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+    measureText: () => ({ width: 0 }),
+    font: '',
+  })) as unknown as HTMLCanvasElement['getContext'];
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.assign(config.bootData.user, { id: 1, orgId: 1 });
+});
+it('does not load resources or show outcome controls when disabled', () => {
+  jest.mocked(getFeatureFlagValue).mockReturnValue(false);
+  render(<GuideOutcomePilot guideId="guide" content={content} />);
+  expect(screen.queryByText('Verified outcomes')).not.toBeInTheDocument();
+  expect(listOutcomeResources).not.toHaveBeenCalled();
+});
+it('shows verification separately from guide progress when enabled', async () => {
+  jest.mocked(getFeatureFlagValue).mockReturnValue(true);
+  render(<GuideOutcomePilot guideId="guide" content={content} />);
+  await waitFor(() => expect(screen.getByText('Verified outcomes')).toBeInTheDocument());
+  expect(screen.getByText('Not checked')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Check outcome' })).toBeDisabled();
+});
+it('removes the pilot when switching to another guide', async () => {
+  jest.mocked(getFeatureFlagValue).mockReturnValue(true);
+  const { rerender } = render(<GuideOutcomePilot guideId="guide" content={content} />);
+  await waitFor(() => expect(screen.getByText('Verified outcomes')).toBeInTheDocument());
+  rerender(<GuideOutcomePilot guideId="other" content='{"id":"other"}' />);
+  expect(screen.queryByText('Verified outcomes')).not.toBeInTheDocument();
+});

--- a/src/components/guide-outcomes/GuideOutcomePilot.tsx
+++ b/src/components/guide-outcomes/GuideOutcomePilot.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { config } from '@grafana/runtime';
+import { Button, Field, Combobox, Stack } from '@grafana/ui';
+import { z } from 'zod';
+import { GuideOutcomesSchema } from '../../types/outcome.schema';
+import type { GuideOutcome, OutcomeScope } from '../../types/outcome.types';
+import { getFeatureFlagValue } from '../../utils/openfeature';
+import { hashString } from '../../lib/hash.util';
+import { createUserStorage } from '../../lib/user-storage';
+import { createOutcomeEvidenceStore, type OutcomeEvidenceStore } from '../../lib/outcomes/outcome-evidence';
+import { useOutcomeCheck } from './use-outcome-check';
+
+export const VERIFIED_OUTCOMES_FLAG = 'pathfinder.verified-outcomes';
+const PilotSchema = z.object({ id: z.literal('first-dashboard-cloud'), outcomes: GuideOutcomesSchema });
+const statusLabels = {
+  satisfied: 'Verified',
+  unsatisfied: 'Not met yet',
+  unavailable: 'Could not check. Try again.',
+  invalid: 'Select a valid resource.',
+};
+
+function OutcomeRow({
+  scope,
+  outcome,
+  store,
+}: {
+  scope: OutcomeScope;
+  outcome: GuideOutcome;
+  store: OutcomeEvidenceStore;
+}) {
+  const state = useOutcomeCheck(scope, outcome, store);
+  return (
+    <section aria-label={outcome.label}>
+      <Field label={outcome.label}>
+        <Combobox
+          aria-label={outcome.label}
+          value={state.resource}
+          options={state.loadOptions}
+          key={state.resourceRefresh}
+          onChange={(option) => state.selectResource(option.value, option.label)}
+          placeholder="Choose a resource"
+        />
+      </Field>
+      <Stack gap={1}>
+        <Button size="sm" disabled={!state.resourceUid || state.checking} onClick={state.check}>
+          Check outcome
+        </Button>
+        {state.checking && (
+          <Button size="sm" variant="secondary" onClick={state.cancel}>
+            Cancel
+          </Button>
+        )}
+        <Button size="sm" variant="secondary" onClick={state.reloadResources}>
+          Refresh resources
+        </Button>
+      </Stack>
+      <p role="status">
+        {state.checking ? 'Checking…' : state.result?.verdict ? statusLabels[state.result.verdict] : 'Not checked'}
+      </p>
+      {state.historical && <p>Last verified: {new Date(state.historical.verifiedAt).toLocaleString()}</p>}
+      {state.storageError && <p role="alert">Verification history could not be saved or loaded.</p>}
+    </section>
+  );
+}
+
+function PilotSession({
+  guideId,
+  content,
+  outcomes,
+  userId,
+  orgId,
+}: {
+  guideId: string;
+  content: string;
+  outcomes: GuideOutcome[];
+  userId: string;
+  orgId: string;
+}) {
+  const [revision, setRevision] = useState<string | null>(null);
+  const [revisionError, setRevisionError] = useState(false);
+  const store = useMemo(() => createOutcomeEvidenceStore(createUserStorage()), []);
+  useEffect(() => {
+    let cancelled = false;
+    hashString(content)
+      .then((value) => {
+        if (!cancelled) {
+          setRevision(value);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRevisionError(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [content]);
+  const scope = useMemo(
+    () => (revision ? { userId, orgId, guideId, guideRevision: revision } : null),
+    [userId, orgId, guideId, revision]
+  );
+  if (revisionError) {
+    return <p role="alert">Outcome verification could not start. Reload to try again.</p>;
+  }
+  if (!scope) {
+    return null;
+  }
+  return (
+    <section aria-label="Verified outcomes">
+      <h2>Verified outcomes</h2>
+      <p>Guide progress tracks the instructions you complete. These checks verify the selected resources in Grafana.</p>
+      {outcomes.map((outcome) => (
+        <OutcomeRow key={outcome.id} scope={scope} outcome={outcome} store={store} />
+      ))}
+    </section>
+  );
+}
+
+export function GuideOutcomePilot({ content, guideId }: { content: string; guideId: string }) {
+  const enabled = getFeatureFlagValue(VERIFIED_OUTCOMES_FLAG, false);
+  const pilot = useMemo(() => {
+    if (!enabled) {
+      return null;
+    }
+    try {
+      const parsed = PilotSchema.safeParse(JSON.parse(content));
+      return parsed.success ? parsed.data : null;
+    } catch {
+      return null;
+    }
+  }, [content, enabled]);
+  const user = config.bootData?.user;
+  if (!pilot || !user?.id || !user.orgId) {
+    return null;
+  }
+  return (
+    <PilotSession
+      key={JSON.stringify([guideId, content, user.id, user.orgId])}
+      guideId={guideId}
+      content={content}
+      outcomes={pilot.outcomes}
+      userId={String(user.id)}
+      orgId={String(user.orgId)}
+    />
+  );
+}

--- a/src/components/guide-outcomes/use-outcome-check.test.ts
+++ b/src/components/guide-outcomes/use-outcome-check.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useOutcomeCheck } from './use-outcome-check';
+import { listOutcomeResources, verifyGrafanaOutcome } from '../../requirements-manager';
+import type { GuideOutcome, OutcomeScope } from '../../types/outcome.types';
+import type { CheckResultError } from '../../types/requirements.types';
+import type { OutcomeEvidenceStore } from '../../lib/outcomes/outcome-evidence';
+
+jest.mock('../../requirements-manager', () => ({
+  listOutcomeResources: jest.fn(),
+  verifyGrafanaOutcome: jest.fn(),
+}));
+const scope: OutcomeScope = { userId: 'u', orgId: 'o', guideId: 'g', guideRevision: 'r' };
+const outcome: GuideOutcome = { id: 'dashboard', label: 'Saved dashboard', kind: 'dashboard-saved' };
+const store: OutcomeEvidenceStore = { read: jest.fn(), record: jest.fn() };
+const satisfied: CheckResultError = { requirement: 'dashboard-saved:uid', pass: true, verdict: 'satisfied' };
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.mocked(listOutcomeResources).mockResolvedValue([{ uid: 'uid', label: 'Dashboard' }]);
+  jest.mocked(store.read).mockResolvedValue([]);
+  jest.mocked(store.record).mockResolvedValue(null);
+});
+
+it('records verified outcomes independently of any progress callback', async () => {
+  jest.mocked(verifyGrafanaOutcome).mockResolvedValue(satisfied);
+  const { result } = renderHook(() => useOutcomeCheck(scope, outcome, store));
+  await waitFor(() => expect(store.read).toHaveBeenCalled());
+  act(() => result.current.selectResource('uid', 'Walking, adventure'));
+  await act(() => result.current.check());
+  expect(store.record).toHaveBeenCalledWith(scope, outcome.id, 'uid', [satisfied]);
+  expect(result.current.result?.verdict).toBe('satisfied');
+  expect(result.current.resource).toEqual({ value: 'uid', label: 'Walking, adventure' });
+});
+
+it.each(['cancel', 'selection', 'unmount'] as const)('rejects late verification after %s', async (change) => {
+  let resolve: (result: CheckResultError) => void = () => {};
+  jest.mocked(verifyGrafanaOutcome).mockImplementation(
+    () =>
+      new Promise((done) => {
+        resolve = done;
+      })
+  );
+  const { result, unmount } = renderHook(() => useOutcomeCheck(scope, outcome, store));
+  await waitFor(() => expect(store.read).toHaveBeenCalled());
+  act(() => result.current.selectResource('uid'));
+  let pending: Promise<void>;
+  act(() => {
+    pending = result.current.check();
+  });
+  act(() => {
+    if (change === 'cancel') {
+      result.current.cancel();
+    } else if (change === 'selection') {
+      result.current.selectResource('other');
+    } else {
+      unmount();
+    }
+  });
+  await act(async () => {
+    resolve(satisfied);
+    await pending;
+  });
+  expect(store.record).not.toHaveBeenCalled();
+});
+
+it('allows retry after an unavailable check without writing evidence', async () => {
+  jest
+    .mocked(verifyGrafanaOutcome)
+    .mockResolvedValueOnce({ ...satisfied, pass: false, verdict: 'unavailable' })
+    .mockResolvedValueOnce(satisfied);
+  const { result } = renderHook(() => useOutcomeCheck(scope, outcome, store));
+  await waitFor(() => expect(store.read).toHaveBeenCalled());
+  act(() => result.current.selectResource('uid'));
+  await act(() => result.current.check());
+  expect(store.record).not.toHaveBeenCalled();
+  expect(result.current.result?.verdict).toBe('unavailable');
+  await act(() => result.current.check());
+  expect(store.record).toHaveBeenCalledTimes(1);
+});

--- a/src/components/guide-outcomes/use-outcome-check.ts
+++ b/src/components/guide-outcomes/use-outcome-check.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { GuideOutcome, OutcomeEvidence, OutcomeScope } from '../../types/outcome.types';
+import type { CheckResultError } from '../../types/requirements.types';
+import type { OutcomeEvidenceStore } from '../../lib/outcomes/outcome-evidence';
+import { listOutcomeResources, verifyGrafanaOutcome } from '../../requirements-manager';
+
+export function useOutcomeCheck(scope: OutcomeScope, outcome: GuideOutcome, store: OutcomeEvidenceStore) {
+  const [resource, setResource] = useState<{ value: string; label: string } | null>(null);
+  const resourceUid = resource?.value ?? '';
+  const [resourceRefresh, setResourceRefresh] = useState(0);
+  const [checking, setChecking] = useState(false);
+  const [result, setResult] = useState<CheckResultError | null>(null);
+  const [history, setHistory] = useState<OutcomeEvidence[]>([]);
+  const [storageError, setStorageError] = useState(false);
+  const request = useRef<AbortController | null>(null);
+
+  const resourceRequest = useRef<AbortController | null>(null);
+  const loadOptions = useCallback(
+    async (query: string) => {
+      resourceRequest.current?.abort();
+      const controller = new AbortController();
+      resourceRequest.current = controller;
+      const items = await listOutcomeResources(outcome, controller.signal, query);
+      return items.map((item) => ({ label: item.label, value: item.uid }));
+    },
+    [outcome]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    store
+      .read(scope)
+      .then((records) => {
+        if (!cancelled) {
+          setHistory((previous) => [
+            ...records.filter(
+              (record) =>
+                !previous.some((item) => item.outcomeId === record.outcomeId && item.resourceUid === record.resourceUid)
+            ),
+            ...previous,
+          ]);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setStorageError(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+      request.current?.abort();
+      resourceRequest.current?.abort();
+    };
+  }, [scope, store]);
+
+  const selectResource = useCallback((uid: string, label = uid) => {
+    request.current?.abort();
+    setResource({ value: uid, label });
+    setResult(null);
+    setChecking(false);
+  }, []);
+
+  const cancel = useCallback(() => {
+    request.current?.abort();
+    setChecking(false);
+  }, []);
+
+  const check = useCallback(async () => {
+    request.current?.abort();
+    const controller = new AbortController();
+    request.current = controller;
+    setChecking(true);
+    setResult(null);
+    try {
+      const checked = await verifyGrafanaOutcome(outcome, resourceUid, controller.signal);
+      if (controller.signal.aborted) {
+        return;
+      }
+      setResult(checked);
+      if (checked.verdict === 'satisfied') {
+        try {
+          const saved = await store.record(scope, outcome.id, resourceUid, [checked]);
+          if (saved && !controller.signal.aborted) {
+            setHistory((previous) => [
+              ...previous.filter((item) => !(item.outcomeId === outcome.id && item.resourceUid === resourceUid)),
+              saved,
+            ]);
+            setStorageError(false);
+          }
+        } catch {
+          if (!controller.signal.aborted) {
+            setStorageError(true);
+          }
+        }
+      }
+    } finally {
+      if (!controller.signal.aborted) {
+        setChecking(false);
+      }
+    }
+  }, [outcome, resourceUid, scope, store]);
+
+  const reloadResources = useCallback(() => {
+    resourceRequest.current?.abort();
+    setResourceRefresh((value) => value + 1);
+  }, []);
+  const historical = history.find((item) => item.outcomeId === outcome.id && item.resourceUid === resourceUid);
+  return {
+    loadOptions,
+    resourceRefresh,
+    resourceUid,
+    resource,
+    selectResource,
+    reloadResources,
+    checking,
+    result,
+    historical,
+    storageError,
+    check,
+    cancel,
+  };
+}

--- a/src/lib/outcomes/outcome-evidence.test.ts
+++ b/src/lib/outcomes/outcome-evidence.test.ts
@@ -1,0 +1,68 @@
+import { createOutcomeEvidence, createOutcomeEvidenceStore } from './outcome-evidence';
+import type { OutcomeScope } from '../../types/outcome.types';
+import type { CheckResultError } from '../../types/requirements.types';
+import type { UserStorage } from '../../types/storage.types';
+
+const scope: OutcomeScope = { userId: 'user', orgId: 'org', guideId: 'guide', guideRevision: 'revision' };
+const satisfied: CheckResultError = { requirement: 'resource', pass: true, verdict: 'satisfied' };
+function memoryStorage(): UserStorage {
+  const values = new Map<string, unknown>();
+  return {
+    async getItem<T>(key: string) {
+      return (values.get(key) as T | undefined) ?? null;
+    },
+    async setItem(key, value) {
+      values.set(key, value);
+    },
+    async removeItem(key) {
+      values.delete(key);
+    },
+    async clear() {
+      values.clear();
+    },
+  };
+}
+
+it.each<CheckResultError[]>([
+  [],
+  [{ requirement: 'manual', pass: true }],
+  [{ requirement: 'skipped', pass: true }],
+  [{ requirement: 'resource', pass: true, verdict: 'invalid' }],
+  [{ requirement: 'resource', pass: false, verdict: 'unavailable' }],
+  [satisfied, { requirement: 'other', pass: false, verdict: 'unsatisfied' }],
+])('requires explicit successful evidence: %j', (...checks) => {
+  expect(createOutcomeEvidence(scope, 'outcome', 'uid', checks, 123)).toBeNull();
+});
+
+it('restores evidence without converting progress and isolates user, org, guide, and revision', async () => {
+  const storage = memoryStorage();
+  await storage.setItem('pathfinder-interactive-completion', { guide: 100 });
+  const store = createOutcomeEvidenceStore(storage, () => 123);
+  expect(await store.read(scope)).toEqual([]);
+  await store.record(scope, 'outcome', 'uid', [satisfied]);
+  const restored = createOutcomeEvidenceStore(storage);
+  expect(await restored.read(scope)).toMatchObject([{ resourceUid: 'uid', verifiedAt: 123 }]);
+  for (const field of ['userId', 'orgId', 'guideId', 'guideRevision'] as const) {
+    expect(await restored.read({ ...scope, [field]: 'other' })).toEqual([]);
+  }
+});
+
+it('serializes concurrent writes and leaves historical evidence after an unsuccessful check', async () => {
+  const store = createOutcomeEvidenceStore(memoryStorage(), () => 123);
+  await Promise.all([store.record(scope, 'one', 'uid1', [satisfied]), store.record(scope, 'two', 'uid2', [satisfied])]);
+  expect(await store.read(scope)).toHaveLength(2);
+  expect(await store.record(scope, 'one', 'uid1', [{ ...satisfied, pass: false, verdict: 'unavailable' }])).toBeNull();
+  expect(await store.read(scope)).toHaveLength(2);
+});
+
+it('bounds history and propagates storage failures without inventing evidence', async () => {
+  const storage = memoryStorage();
+  const store = createOutcomeEvidenceStore(storage, () => 123);
+  for (let i = 0; i < 202; i++) {
+    await store.record(scope, `outcome-${i}`, 'uid', [satisfied]);
+  }
+  expect(await store.read(scope)).toHaveLength(200);
+  jest.spyOn(storage, 'setItem').mockRejectedValueOnce(new Error('Full'));
+  await expect(store.record(scope, 'failed', 'uid', [satisfied])).rejects.toThrow('Full');
+  expect((await store.read(scope)).some((record) => record.outcomeId === 'failed')).toBe(false);
+});

--- a/src/lib/outcomes/outcome-evidence.ts
+++ b/src/lib/outcomes/outcome-evidence.ts
@@ -1,0 +1,80 @@
+import { OutcomeEvidenceSchema, OutcomeScopeSchema } from '../../types/outcome.schema';
+import type { OutcomeEvidence, OutcomeScope } from '../../types/outcome.types';
+import type { CheckResultError } from '../../types/requirements.types';
+import type { UserStorage } from '../../types/storage.types';
+
+const MAX_RECORDS = 200;
+
+export function outcomeScopeKey(scope: OutcomeScope): string {
+  return JSON.stringify([scope.userId, scope.orgId, scope.guideId, scope.guideRevision]);
+}
+
+export function createOutcomeEvidence(
+  scope: OutcomeScope,
+  outcomeId: string,
+  resourceUid: string,
+  checks: readonly CheckResultError[],
+  verifiedAt: number
+): OutcomeEvidence | null {
+  if (checks.length === 0 || checks.some((check) => !check.pass || check.verdict !== 'satisfied')) {
+    return null;
+  }
+  const result = OutcomeEvidenceSchema.safeParse({ schemaVersion: 1, scope, outcomeId, resourceUid, verifiedAt });
+  return result.success ? result.data : null;
+}
+
+export interface OutcomeEvidenceStore {
+  read(scope: OutcomeScope): Promise<OutcomeEvidence[]>;
+  record(
+    scope: OutcomeScope,
+    outcomeId: string,
+    resourceUid: string,
+    checks: readonly CheckResultError[]
+  ): Promise<OutcomeEvidence | null>;
+}
+
+export function createOutcomeEvidenceStore(
+  storage: Pick<UserStorage, 'getItem' | 'setItem'>,
+  now: () => number = Date.now
+): OutcomeEvidenceStore {
+  let pending: Promise<unknown> = Promise.resolve();
+  const key = (scope: OutcomeScope) => `pathfinder-outcome-evidence:${JSON.stringify([scope.userId, scope.orgId])}`;
+  const readAll = async (scope: OutcomeScope): Promise<OutcomeEvidence[]> => {
+    OutcomeScopeSchema.parse(scope);
+    const raw = await storage.getItem<unknown>(key(scope));
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+    return raw.slice(-MAX_RECORDS).flatMap((entry) => {
+      const parsed = OutcomeEvidenceSchema.safeParse(entry);
+      return parsed.success ? [parsed.data] : [];
+    });
+  };
+  return {
+    async read(scope) {
+      return (await readAll(scope)).filter((entry) => outcomeScopeKey(entry.scope) === outcomeScopeKey(scope));
+    },
+    record(scope, outcomeId, resourceUid, checks) {
+      const evidence = createOutcomeEvidence(scope, outcomeId, resourceUid, checks, now());
+      if (!evidence) {
+        return Promise.resolve(null);
+      }
+      const write = async () => {
+        const previous = await readAll(scope);
+        const retained = previous.filter(
+          (entry) =>
+            !(
+              outcomeScopeKey(entry.scope) === outcomeScopeKey(scope) &&
+              entry.outcomeId === outcomeId &&
+              entry.resourceUid === resourceUid
+            )
+        );
+        await storage.setItem(key(scope), [...retained, evidence].slice(-MAX_RECORDS));
+        return evidence;
+      };
+      const result = pending.then(write, write);
+      pending = result;
+      return result;
+    },
+  };
+}

--- a/src/requirements-manager/grafana-outcomes.test.ts
+++ b/src/requirements-manager/grafana-outcomes.test.ts
@@ -1,0 +1,75 @@
+import { getBackendSrv } from '@grafana/runtime';
+import { Observable, of, throwError } from 'rxjs';
+import { listOutcomeResources, verifyGrafanaOutcome } from './grafana-outcomes';
+import type { GuideOutcome } from '../types/outcome.types';
+
+const fetch = jest.fn();
+jest.mock('@grafana/runtime', () => ({ getBackendSrv: jest.fn() }));
+const dashboard: GuideOutcome = { id: 'dashboard', label: 'Saved dashboard', kind: 'dashboard-saved' };
+const datasource: GuideOutcome = {
+  id: 'source',
+  label: 'Healthy TestData',
+  kind: 'datasource-health',
+  datasourceType: 'testdata',
+};
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.mocked(getBackendSrv).mockReturnValue({ fetch } as never);
+});
+
+it('verifies the selected dashboard UID, not a matching title', async () => {
+  fetch.mockReturnValueOnce(of({ data: { dashboard: { uid: 'other' } } }));
+  expect(await verifyGrafanaOutcome(dashboard, 'selected', new AbortController().signal)).toMatchObject({
+    verdict: 'unsatisfied',
+    pass: false,
+  });
+  fetch.mockReturnValueOnce(of({ data: { dashboard: { uid: 'selected' } } }));
+  expect(await verifyGrafanaOutcome(dashboard, 'selected', new AbortController().signal)).toMatchObject({
+    verdict: 'satisfied',
+    pass: true,
+  });
+  expect(fetch).toHaveBeenCalledWith(expect.objectContaining({ url: '/api/dashboards/uid/selected' }));
+});
+
+it('distinguishes failed health checks from unavailable APIs', async () => {
+  for (const [status, verdict] of [
+    [400, 'unsatisfied'],
+    [403, 'unavailable'],
+    [503, 'unavailable'],
+  ] as const) {
+    fetch.mockReturnValueOnce(throwError(() => ({ status })));
+    expect(await verifyGrafanaOutcome(datasource, 'uid', new AbortController().signal)).toMatchObject({
+      verdict,
+      pass: false,
+    });
+  }
+  fetch.mockReturnValueOnce(of({ data: { status: 'OK' } }));
+  expect(await verifyGrafanaOutcome(datasource, 'uid', new AbortController().signal)).toMatchObject({
+    verdict: 'satisfied',
+    pass: true,
+  });
+});
+
+it('unsubscribes a pending request when cancelled', async () => {
+  const unsubscribe = jest.fn();
+  fetch.mockReturnValueOnce(new Observable(() => unsubscribe));
+  const controller = new AbortController();
+  const result = verifyGrafanaOutcome(dashboard, 'uid', controller.signal);
+  controller.abort();
+  expect(await result).toMatchObject({ pass: false, verdict: 'unavailable' });
+  expect(unsubscribe).toHaveBeenCalledTimes(1);
+});
+
+it('lists only the data source type declared by the outcome', async () => {
+  fetch.mockReturnValueOnce(
+    of({
+      data: [
+        { uid: 'test', name: 'TestData', type: 'testdata' },
+        { uid: 'prom', type: 'prometheus' },
+      ],
+    })
+  );
+  expect(await listOutcomeResources(datasource, new AbortController().signal)).toEqual([
+    { uid: 'test', label: 'TestData' },
+  ]);
+});

--- a/src/requirements-manager/grafana-outcomes.ts
+++ b/src/requirements-manager/grafana-outcomes.ts
@@ -1,0 +1,89 @@
+import { logger } from '../lib/logging';
+import { getBackendSrv } from '@grafana/runtime';
+import { firstValueFrom, fromEvent, takeUntil, timeout } from 'rxjs';
+import type { GuideOutcome } from '../types/outcome.types';
+import type { CheckResultError } from '../types/requirements.types';
+
+export interface OutcomeResource {
+  uid: string;
+  label: string;
+}
+
+export async function listOutcomeResources(
+  outcome: GuideOutcome,
+  signal: AbortSignal,
+  query = ''
+): Promise<OutcomeResource[]> {
+  const url = new URL(
+    outcome.kind === 'datasource-health' ? '/api/datasources' : '/api/search',
+    window.location.origin
+  );
+  if (outcome.kind === 'dashboard-saved') {
+    url.searchParams.set('type', 'dash-db');
+    url.searchParams.set('limit', '100');
+    url.searchParams.set('query', query);
+  }
+  if (signal.aborted) {
+    return [];
+  }
+  const response = await firstValueFrom(
+    getBackendSrv()
+      .fetch<Array<{ uid: string; name?: string; title?: string; type?: string }>>({
+        url: `${url.pathname}${url.search}`,
+        method: 'GET',
+        showErrorAlert: false,
+      })
+      .pipe(timeout(10000), takeUntil(fromEvent(signal, 'abort')))
+  );
+  return response.data
+    .filter(
+      (item) =>
+        typeof item.uid === 'string' &&
+        (outcome.kind !== 'datasource-health' || !outcome.datasourceType || item.type === outcome.datasourceType)
+    )
+    .map((item) => ({ uid: item.uid, label: item.name || item.title || item.uid }));
+}
+
+export async function verifyGrafanaOutcome(
+  outcome: GuideOutcome,
+  resourceUid: string,
+  signal: AbortSignal
+): Promise<CheckResultError> {
+  const requirement = `${outcome.kind}:${resourceUid}`;
+  if (!resourceUid || resourceUid.length > 128) {
+    return { requirement, pass: false, verdict: 'invalid' };
+  }
+  if (signal.aborted) {
+    return { requirement, pass: false, verdict: 'unavailable' };
+  }
+  const path =
+    outcome.kind === 'datasource-health'
+      ? `/api/datasources/uid/${encodeURIComponent(resourceUid)}/health`
+      : `/api/dashboards/uid/${encodeURIComponent(resourceUid)}`;
+  try {
+    const response = await firstValueFrom(
+      getBackendSrv()
+        .fetch<{ status?: string; dashboard?: { uid?: string } }>({
+          url: path,
+          method: 'GET',
+          showErrorAlert: false,
+        })
+        .pipe(timeout(10000), takeUntil(fromEvent(signal, 'abort')))
+    );
+    const pass =
+      outcome.kind === 'datasource-health'
+        ? response.data.status === 'OK'
+        : response.data.dashboard?.uid === resourceUid;
+    return { requirement, pass, verdict: pass ? 'satisfied' : 'unsatisfied' };
+  } catch (error) {
+    const status = typeof error === 'object' && error !== null && 'status' in error ? error.status : undefined;
+    const unmet = status === 404 || (outcome.kind === 'datasource-health' && status === 400);
+    if (!unmet) {
+      logger.warn('Outcome verification unavailable', {
+        kind: outcome.kind,
+        status: typeof status === 'number' ? status : undefined,
+      });
+    }
+    return { requirement, pass: false, verdict: unmet ? 'unsatisfied' : 'unavailable' };
+  }
+}

--- a/src/requirements-manager/index.ts
+++ b/src/requirements-manager/index.ts
@@ -61,3 +61,5 @@ export type { FixTypeValue } from './fix-types';
 // Fix dispatch — shared by step-checker and section-level requirements.
 export { dispatchFix } from './fix-registry';
 export type { FixContext, FixResult } from './fix-handlers';
+
+export { listOutcomeResources, verifyGrafanaOutcome } from './grafana-outcomes';

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -1,3 +1,4 @@
+import { GuideOutcomesSchema } from './outcome.schema';
 /**
  * Zod Schemas for JSON Guide Types
  *
@@ -1147,6 +1148,7 @@ export const JsonGuideSchemaStrict = z.object({
   id: z.string().min(1, 'Guide id is required'),
   title: z.string().min(1, 'Guide title is required'),
   blocks: z.array(JsonBlockSchema),
+  outcomes: GuideOutcomesSchema.optional(),
 });
 
 /**
@@ -1185,7 +1187,7 @@ type KnownFieldsMetaKey = '_guide' | '_step' | '_choice' | '_conditionalSectionC
  * `Record<string, …>` so callers can index with an unvalidated `block.type`.
  */
 export const KNOWN_FIELDS: Record<string, ReadonlySet<string>> = {
-  _guide: new Set(['schemaVersion', 'id', 'title', 'blocks']),
+  _guide: new Set(['schemaVersion', 'id', 'title', 'blocks', 'outcomes']),
   _step: new Set([
     'id',
     'action',

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -1,3 +1,4 @@
+import type { GuideOutcome } from './outcome.types';
 /**
  * JSON Guide Type Definitions
  *
@@ -20,6 +21,7 @@ export interface JsonGuide {
   title: string;
   /** Content blocks that make up the guide */
   blocks: JsonBlock[];
+  outcomes?: GuideOutcome[];
 }
 
 // ============ BLOCK UNION ============

--- a/src/types/outcome.schema.ts
+++ b/src/types/outcome.schema.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import type { OutcomeEvidence, GuideOutcome } from './outcome.types';
+
+export const OutcomeScopeSchema = z.object({
+  userId: z.string().min(1).max(128),
+  orgId: z.string().min(1).max(128),
+  guideId: z.string().min(1).max(2048),
+  guideRevision: z.string().min(1).max(128),
+});
+
+export const OutcomeEvidenceSchema = z.object({
+  schemaVersion: z.literal(1),
+  scope: OutcomeScopeSchema,
+  outcomeId: z.string().min(1).max(128),
+  resourceUid: z.string().min(1).max(128),
+  verifiedAt: z.number().positive(),
+}) satisfies z.ZodType<OutcomeEvidence>;
+
+export const GuideOutcomeSchema = z.object({
+  id: z.string().min(1).max(128),
+  label: z.string().min(1).max(160),
+  kind: z.enum(['datasource-health', 'dashboard-saved']),
+  datasourceType: z.string().min(1).max(128).optional(),
+}) satisfies z.ZodType<GuideOutcome>;
+
+export const GuideOutcomesSchema = z
+  .array(GuideOutcomeSchema)
+  .min(1)
+  .max(8)
+  .refine(
+    (outcomes) => new Set(outcomes.map((outcome) => outcome.id)).size === outcomes.length,
+    'Outcome ids must be unique'
+  );

--- a/src/types/outcome.types.ts
+++ b/src/types/outcome.types.ts
@@ -1,0 +1,21 @@
+export interface OutcomeScope {
+  userId: string;
+  orgId: string;
+  guideId: string;
+  guideRevision: string;
+}
+
+export interface OutcomeEvidence {
+  schemaVersion: 1;
+  scope: OutcomeScope;
+  outcomeId: string;
+  resourceUid: string;
+  verifiedAt: number;
+}
+
+export interface GuideOutcome {
+  id: string;
+  label: string;
+  kind: 'datasource-health' | 'dashboard-saved';
+  datasourceType?: string;
+}

--- a/src/types/package.schema.ts
+++ b/src/types/package.schema.ts
@@ -1,3 +1,4 @@
+import { GuideOutcomesSchema } from './outcome.schema';
 /**
  * Zod Schemas for Package Types
  *
@@ -64,6 +65,7 @@ export const ContentJsonSchema = z.object({
   id: packageIdSchema,
   title: z.string().min(1, 'Content title is required'),
   blocks: z.array(JsonBlockSchema),
+  outcomes: GuideOutcomesSchema.optional(),
 });
 
 // ============ DEPENDENCY SCHEMAS ============

--- a/src/types/package.types.ts
+++ b/src/types/package.types.ts
@@ -1,3 +1,4 @@
+import type { GuideOutcome } from './outcome.types';
 /**
  * Package Type Definitions
  *
@@ -23,6 +24,7 @@ export interface ContentJson {
   id: string;
   title: string;
   blocks: JsonBlock[];
+  outcomes?: GuideOutcome[];
 }
 
 // ============ DEPENDENCY TYPES ============

--- a/src/utils/openfeature.ts
+++ b/src/utils/openfeature.ts
@@ -59,6 +59,7 @@ export const DEFAULT_HIGHLIGHTED_GUIDE_CONFIG: HighlightedGuideConfig = {
  * Naming convention: prefix with component name (e.g., pathfinder.feature-name)
  */
 const pathfinderFeatureFlags = {
+  'pathfinder.verified-outcomes': { valueType: 'boolean', values: [true, false], defaultValue: false },
   /**
    * Global kill-switch for the Pathfinder plugin in Grafana Cloud.
    * When true: Pathfinder loads normally (sidebar available)


### PR DESCRIPTION
Consolidated into #1791, which contains the full implementation in one verified commit directly against `main`. This separate PR is superseded; its changes are included in the combined implementation and validation.
