### PR TITLE
fix(telemetry): pin the replay pause contract and correct its runbook

### DIFF
--- a/docs/developer/TELEMETRY.md
+++ b/docs/developer/TELEMETRY.md
@@ -73,7 +73,7 @@ Privacy protection is split between enforced normalization and caller discipline
 
 ## Gating and environments
 
-Faro initializes only when `resolveFaroEnvironment()` resolves: Grafana Cloud with analytics enabled, on `.grafana.com` / `.grafana.net` / `.grafana-ops.net` / `.grafana-dev.net` hosts, and only when the default-on `pathfinder.frontend-telemetry` flag is set. Local development sends nothing unless `localStorage['pathfinder.faro.local'] = 'true'` in a dev build. The activity gate drops everything except errors until Pathfinder is opened, so collector sessions mean "used Pathfinder or Pathfinder errored", not "loaded a Grafana page".
+Faro initializes only when `resolveFaroEnvironment()` resolves: Grafana Cloud with analytics enabled, on `.grafana.com` / `.grafana.net` / `.grafana-ops.net` / `.grafana-dev.net` hosts, and only when the default-on `pathfinder.frontend-telemetry` flag is set. Local development sends nothing unless `localStorage['pathfinder.faro.local'] = 'true'` in a dev build. The activity gate drops everything except errors until a Pathfinder surface reports itself on mount — a persisted panel mode alone no longer opens it — so collector sessions mean "used Pathfinder or Pathfinder errored", not "loaded a Grafana page".
 
 Session replay adds a second remote switch (`pathfinder.session-replay`, also default-on) plus a volume dial (`pathfinder.session-replay-sampling-rate`, default `1`, range-checked at the point of use), but no new environment gate: it is registered from inside `initFaro`, after the `resolveFaroEnvironment()` early return, so a self-hosted or OSS Grafana never reaches it — such an instance does not construct a Faro instance in the first place, and the rrweb chunk is never fetched. The first Pathfinder surface open latches the activity gate and starts recording; closing the panel pauses recording after five seconds, while reopening resumes it immediately.
 
@@ -81,10 +81,12 @@ Two consequences of it being default-on. Recordings are only viewable on a stack
 
 ### Stopping a recording
 
-**Both replay flags are read once, during plugin bootstrap.** OFREP visibility refresh is off, and the recorder has no removal path, so flipping either flag — or reverting the plugin — reaches a tab only on its next page load. A tab that was already recording keeps recording until it is closed or reloaded. Deliberate: re-evaluating the flag mid-session would mean either polling it or tearing the recorder down live, and a torn-down rrweb leaves a mutation stream with no snapshot to apply it to.
+**Both replay flags are read once, during plugin bootstrap.** OFREP visibility refresh is off, and the recorder is never removed from the Faro instance, so flipping either flag — or reverting the plugin — reaches a tab only on its next page load. Deliberate: re-evaluating a flag mid-session would mean polling it, and neither flag is worth a poll.
+
+The recorder does stop and start within a session, but on the surface lifecycle rather than on the flags. Closing the last Pathfinder surface pauses recording five seconds later, and reopening resumes it immediately. A pause stops rrweb outright and the resume emits a fresh full-DOM snapshot, so each open yields a playable clip rather than orphaned mutations. `inactivityThresholdMs` is deliberately `0`, which turns the SDK's own idle auto-pause off: its paired auto-resume rebinds document-wide interaction listeners and would restart recording on the first mouse move while Pathfinder was closed. Surface state is the sole pause authority — which also means an open panel on an idle tab keeps recording where the SDK default would have paused it after 60 seconds.
 
 What that means operationally:
 
-- **The kill switch is "no new recordings"**, not "recording stops now". Budget for the tail of long-lived tabs — a dashboard left open overnight is the worst case.
+- **The kill switch is "no new recordings"**, not "recording stops now". Budget for the tail of long-lived tabs, now bounded by Pathfinder use rather than tab lifetime: a tab with no surface open stops five seconds after the last close, so the worst case is a docked sidebar left open on an auto-refreshing dashboard overnight.
 - **Recordings already ingested are not undone by the flip.** Removing them is a collector-side deletion request against the Frontend Observability app, not something a flag or a release can do.
 - If a recording must stop immediately on a known stack, the only in-band lever is a plugin release plus a forced reload; otherwise the flag flip plus natural page turnover is the mechanism.

--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -1579,14 +1579,16 @@ describe('session replay activation', () => {
     expect(mockInstrumentationsAdd).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps recording after Pathfinder is closed again', async () => {
+  it('does not re-register the recorder when Pathfinder closes', async () => {
     const { faro, surface } = freshFaroWithSurface();
     await faro.initFaro({ sessionReplay: true });
 
     surface.reportPathfinderSurface('sidebar');
     await settleReplayImport();
+    jest.useFakeTimers();
     surface.reportPathfinderSurface('closed');
-    await settleReplayImport();
+    jest.advanceTimersByTime(5_000);
+    jest.useRealTimers();
 
     expect(mockInstrumentationsAdd).toHaveBeenCalledTimes(1);
   });
@@ -1608,7 +1610,9 @@ describe('session replay activation', () => {
 
     mockReplayResume.mockClear();
     surface.reportPathfinderSurface('closed');
-    jest.advanceTimersByTime(5_000);
+    jest.advanceTimersByTime(4_999);
+    expect(mockReplayPause).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
     expect(mockReplayPause).toHaveBeenCalledTimes(1);
 
     surface.reportPathfinderSurface('sidebar');
@@ -1848,6 +1852,40 @@ describe('session replay activation failures', () => {
     await Promise.resolve();
     await Promise.resolve();
 
+    expect(controller.pause).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('pauses after the remaining delay when activation resolves inside the close window', async () => {
+    let resolveActivation!: (value: {
+      samplingRate: number;
+      controller: { pause: jest.Mock; resume: jest.Mock };
+    }) => void;
+    const controller = { pause: jest.fn(), resume: jest.fn() };
+    activateSessionReplay.mockReset();
+    activateSessionReplay.mockReturnValue(
+      new Promise((resolve) => {
+        resolveActivation = resolve;
+      })
+    );
+    const { faro, surface } = freshFaroWithFailingReplay();
+    await faro.initFaro({ sessionReplay: true });
+
+    jest.useFakeTimers();
+    surface.reportPathfinderSurface('sidebar');
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+    surface.reportPathfinderSurface('closed');
+    jest.advanceTimersByTime(2_000);
+    resolveActivation({ samplingRate: 1, controller });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(controller.pause).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(2_999);
+    expect(controller.pause).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
     expect(controller.pause).toHaveBeenCalledTimes(1);
     jest.useRealTimers();
   });

--- a/src/lib/telemetry/faro-adapter.ts
+++ b/src/lib/telemetry/faro-adapter.ts
@@ -159,10 +159,7 @@ const REPLAY_CLOSE_PAUSE_DELAY_MS = 5_000;
 
 function callReplayController(controller: SessionReplayController | null, method: 'pause' | 'resume'): void {
   guardTelemetry(() => {
-    const action = controller?.[method];
-    if (typeof action === 'function') {
-      action();
-    }
+    controller?.[method]?.();
   });
 }
 

--- a/src/lib/telemetry/replay-lifecycle.test.ts
+++ b/src/lib/telemetry/replay-lifecycle.test.ts
@@ -5,7 +5,7 @@ import {
   type Faro,
   type TransportItem,
 } from '@grafana/faro-web-sdk';
-import { activateSessionReplay, resolveSamplingRate } from './replay';
+import { activateSessionReplay, resolveSamplingRate, type SessionReplayController } from './replay';
 
 class CaptureTransport extends BaseTransport {
   readonly name = '@pathfinder/replay-lifecycle-transport';
@@ -24,6 +24,7 @@ class CaptureTransport extends BaseTransport {
 describe('session replay lifecycle across session-attribute stamps', () => {
   const transport = new CaptureTransport();
   let faro: Faro;
+  let controller: SessionReplayController;
 
   const recordingEvents = () =>
     transport.items
@@ -47,7 +48,7 @@ describe('session replay lifecycle across session-attribute stamps', () => {
       batching: { enabled: false },
       dedupe: false,
     });
-    await activateSessionReplay(faro);
+    ({ controller } = await activateSessionReplay(faro));
   });
 
   it('starts recording exactly once', () => {
@@ -87,5 +88,21 @@ describe('session replay lifecycle across session-attribute stamps', () => {
     stampSurface('fullscreen');
     expect(faro.api.getSession()?.id).toBe(id);
     expect(faro.api.getSession()?.attributes?.['surface']).toBe('fullscreen');
+  });
+
+  // pauseRecording/resumeRecording are `private` in the SDK and reached through
+  // a cast, so the compiler checks nothing and the unit mock defines the names
+  // it asserts against. This drives the real recorder: rename either upstream
+  // and this goes red instead of the pause silently never firing in production.
+  it('pauses and resumes the real recorder through the surface controller', () => {
+    controller.pause();
+    expect(recordingEvents()).toEqual(['faro.session_recording.started', 'faro.session_recording.paused']);
+
+    controller.resume();
+    expect(recordingEvents()).toEqual([
+      'faro.session_recording.started',
+      'faro.session_recording.paused',
+      'faro.session_recording.resumed',
+    ]);
   });
 });

--- a/src/lib/telemetry/replay.ts
+++ b/src/lib/telemetry/replay.ts
@@ -111,8 +111,8 @@ class ContinuousReplayInstrumentation extends ReplayInstrumentation {
   }
 
   public pauseRecordingForSurface(): void {
-    // The replay SDK keeps these controls private; this adapter is the narrow
-    // boundary that lets Pathfinder follow its surface lifecycle.
+    // Private in the SDK, so unchecked by the compiler; names verified at 2.11.0
+    // and asserted against the real recorder in replay-lifecycle.test.ts.
     (this as unknown as { pauseRecording: () => void }).pauseRecording();
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #1770. Two review findings that survived adversarial verification, plus the cheap remnants. No behaviour change to the replay lifecycle itself — this pins the contract #1770 established and corrects the runbook that still described the old one.

## What to look at

- **`src/lib/telemetry/replay-lifecycle.test.ts`** — the load-bearing change. The surface pause drives two methods that `@grafana/faro-instrumentation-replay` declares `private`, reached through an `as unknown as` cast. Nothing caught a rename: the unit mock in `faro.test.ts` defines the very names it asserts against, this file was the only test touching the real SDK and it discarded the returned controller, the cast defeats `tsc`, and the resulting `TypeError` is swallowed by `guardTelemetry`'s empty catch. A rename would have shipped green with the pause silently never firing. This file already drives the real recorder and captures `faro.session_recording.*`, so it now asserts the `started → paused → resumed` sequence through the controller. Appended last on purpose: every test above it asserts an exact event list.
- **`docs/developer/TELEMETRY.md`** — the "Stopping a recording" runbook still told an operator the recorder never stops mid-session. The section's scope clause saves the flag-flip claims and "no removal path" (nothing in product code calls `instrumentations.remove`), but not "a tab that was already recording keeps recording until it is closed or reloaded", which #1770 made false, nor the rationale that a torn-down rrweb leaves mutations with no snapshot — which #1770's own resume path falsifies by emitting a fresh one. The kill-switch tail bullet is corrected with it.
- **`src/lib/telemetry/faro-adapter.ts`** — `callReplayController` extracted the method and called it bare, losing the receiver. Correct today only because the controller happens to be arrow closures; a class instance satisfying `SessionReplayController` would have thrown into that same empty catch.
- **`src/lib/faro.test.ts`** — two pause-window branches could not discriminate. The reopen test advanced a single 5s block, so a stale `pauseDeadline` firing at 3s would have passed identically; and no case covered activation resolving *inside* the close window (the remaining-delay branch). Also renames the test named for keeping recording after a close, which actually asserts a registration count, and stops it leaving a live 5s timer behind.

## Why

#1770 fixed a real privacy gap — before it, a persisted `fullscreen` panel mode meant rrweb recorded every Grafana page load with no Pathfinder surface on screen. This PR does not revisit that. It closes the two gaps that would have let the new contract rot silently: an SDK rename going undetected, and a runbook that now misdescribes the kill-switch tail an on-call has to reason about.

`inactivityThresholdMs: 0` is **not** a defect and is left as-is. Adversarial review confirmed it is a hard precondition: the SDK's paired auto-resume rebinds document-wide interaction listeners, so at the `6e4` default the first mouse move would restart recording while Pathfinder was closed — strictly worse than either base or head. The docs now record that reasoning, and its one real consequence: an open panel on an idle tab no longer auto-pauses where the SDK default would have stopped it after 60 seconds.

## How to verify

Both new assertions were verified to fail against the bug they pin, not just to pass:

1. `npx jest --coverage=false src/lib/telemetry/replay-lifecycle.test.ts` — green.
2. Simulate the upstream rename: change `pauseRecording` to any other name in `replay.ts`'s cast. `npx tsc --noEmit` stays green (the cast erases the check, which is the point), and the new test goes **red**.
3. `npx jest --coverage=false src/lib/faro.test.ts` — green, 165 tests.
4. Inject the stale-deadline bug: delete `pauseDeadline = undefined;` from the reopen branch of `handleSurfaceChange`. The strengthened pause-window tests go **red**.

Full local gate: `tsc` clean, eslint clean, prettier clean, 1,899 tests passing across `src/lib` and `src/validation`.

## Breaking changes

None. No storage key, telemetry event name, payload shape, schema field, or public DOM contract is touched. The only production-code change is `callReplayController` preserving its receiver, which is behaviour-preserving for the current controller shape.

## Reversibility

Fully reversible by revert. Two test files, one doc file, and a three-line simplification in the adapter.

## Out of scope

- **Moving the `reportPathfinderSurface` calls** into effects whose comments describe them. In `FullScreenPanel.tsx` the call sits above an 18-line comment about `setModeTransient` versus persistence, and there is already an "Announce surface ownership" effect next to it that is the natural home; `FloatingPanelManager.tsx` has the same shape. It is a fair readability point, but it reorders a telemetry path that just took two blockers, and the win is cosmetic — not worth the risk inside a fix-up PR.
- **Re-asserting the pause after an SDK-driven restart.** The close pause is a one-shot rather than a maintained invariant; it holds today only because `pauseRecording` leaves `isRecording` true, the subclass filters session-less metas, and Pathfinder sets no session sample rate. Verified unreachable at the pinned 2.11.0, so left alone rather than guarded speculatively.
- **The `faro.session_recording.paused` / `.resumed` trigger change.** Same event names as before, but they now mean "Pathfinder closed/reopened" rather than "user idle 60s", and they reach the collector unfiltered. No code change needed — flagging it in case any dashboard keys on them.

Refs #1770
