### PR TITLE
feat(telemetry): enable Faro request compression

### DIFF
--- a/src/lib/faro.test.ts
+++ b/src/lib/faro.test.ts
@@ -56,6 +56,7 @@ const mockFaroInstance = {
 };
 interface CapturedFaroConfig {
   isolate: boolean;
+  requestCompression: boolean;
   app: { name: string; version: string; environment: string };
   sessionTracking: { samplingRate?: number; persistent: boolean };
   instrumentations: Array<{ constructor: { name: string } }>;
@@ -517,6 +518,13 @@ describe('initFaro', () => {
     await faro.initFaro();
     const calledWith = mockInitializeFaro.mock.calls[0]![0];
     expect(calledWith.sessionTracking.persistent).toBe(false);
+  });
+
+  it('enables Faro request compression', async () => {
+    const faro = freshFaro();
+    await faro.initFaro();
+    const calledWith = mockInitializeFaro.mock.calls[0]![0];
+    expect(calledWith.requestCompression).toBe(true);
   });
 
   it('sets no samplingRate — every engaged session sends (the SDK default of 1 applies)', async () => {

--- a/src/lib/telemetry/faro-adapter.ts
+++ b/src/lib/telemetry/faro-adapter.ts
@@ -68,6 +68,7 @@ export async function initFaro(options?: InitFaroOptions): Promise<void> {
 
   faroInstance = initializeFaro({
     url: COLLECTOR_URL,
+    requestCompression: true,
     globalObjectKey: GLOBAL_OBJECT_KEY,
     // Isolate from Grafana core's own Faro instance and other app plugins' —
     // without this, initializing here would clobber the global object Grafana


### PR DESCRIPTION
## Summary

- enable Faro gzip request compression during SDK initialization
- verify the initialization contract in the Faro adapter tests
- document the telemetry transport configuration

The Faro SDK falls back to uncompressed requests when the browser does not provide CompressionStream.