### PR TITLE
fix(docs-retrieval): persist backend guide completion

### DIFF
--- a/src/docs-retrieval/learning-journey-helpers.completion-boundary.test.ts
+++ b/src/docs-retrieval/learning-journey-helpers.completion-boundary.test.ts
@@ -115,6 +115,13 @@ describe('bundled guide reaching 100% (trigger class A)', () => {
     expect(journeySetMock).toHaveBeenCalledTimes(3);
   });
 
+  it('continues to persist ordinal percentages for URL-based journeys', () => {
+    setJourneyCompletionPercentage('https://example.com/learning-path/', 50);
+
+    expect(journeySetMock).toHaveBeenCalledWith('https://example.com/learning-path/', 50);
+    expect(emitted).toHaveLength(0);
+  });
+
   it('emits exactly once across the whole progress→100 sequence', () => {
     setJourneyCompletionPercentage('bundled:foo', 50);
     setJourneyCompletionPercentage('bundled:foo', 100);
@@ -173,6 +180,12 @@ describe('bundled guide reaching 100% (trigger class A)', () => {
     await setJourneyCompletionPercentageAsync('bundled:foo', 100);
     expect(emitted).toHaveLength(1);
     expect(markGuideCompletedMock).toHaveBeenCalledWith('foo');
+  });
+
+  it('async twin also ignores ordinal percentages for backend-guide journeys', async () => {
+    await setJourneyCompletionPercentageAsync('backend-guide:linux-path', 50);
+    expect(journeySetMock).not.toHaveBeenCalled();
+    expect(emitted).toHaveLength(0);
   });
 });
 
@@ -328,6 +341,52 @@ describe('whole-journey completion (trigger class D — the new journey_complete
     await markMilestoneDone('base', 'm2', ['m1', 'm2', 'm3']);
 
     expect(emitted.filter((f) => f.kind === 'journey')).toHaveLength(1);
+  });
+
+  it('persists terminal completion for a backend-guide journey under its base key', async () => {
+    milestoneGetCompletedMock.mockResolvedValue(new Set(['m1', 'm2', 'm3']));
+
+    await markMilestoneDone('backend-guide:linux-path', 'm3', ['m1', 'm2', 'm3'], {
+      packageManifest: { id: 'linux-path', type: 'journey' },
+      repository: 'app-platform',
+    });
+
+    expect(journeySetMock).toHaveBeenCalledTimes(1);
+    expect(journeySetMock).toHaveBeenCalledWith('backend-guide:linux-path', 100);
+    expect(emitted.filter((f) => f.kind === 'guide')).toHaveLength(1);
+    expect(emitted.filter((f) => f.kind === 'journey')).toHaveLength(1);
+  });
+
+  it('does not persist terminal completion before every backend-guide milestone is complete', async () => {
+    milestoneGetCompletedMock.mockResolvedValue(new Set(['m1', 'm2']));
+
+    await markMilestoneDone('backend-guide:linux-path', 'm2', ['m1', 'm2', 'm3'], {
+      packageManifest: { id: 'linux-path', type: 'journey' },
+      repository: 'app-platform',
+    });
+
+    expect(journeySetMock).not.toHaveBeenCalled();
+    expect(emitted.filter((f) => f.kind === 'journey')).toHaveLength(0);
+  });
+
+  it('does not replace terminal backend-guide completion with an ordinal percentage', async () => {
+    milestoneGetCompletedMock.mockResolvedValue(new Set(['m1', 'm2', 'm3']));
+
+    await markMilestoneDone('backend-guide:linux-path', 'm3', ['m1', 'm2', 'm3'], {
+      packageManifest: { id: 'linux-path', type: 'journey' },
+      repository: 'app-platform',
+    });
+    setJourneyCompletionPercentage('backend-guide:linux-path', 33);
+
+    expect(journeySetMock).toHaveBeenCalledTimes(1);
+    expect(journeySetMock).toHaveBeenCalledWith('backend-guide:linux-path', 100);
+  });
+
+  it('does not treat the final backend-guide ordinal as terminal completion', () => {
+    setJourneyCompletionPercentage('backend-guide:linux-path', 100);
+
+    expect(journeySetMock).not.toHaveBeenCalled();
+    expect(emitted).toHaveLength(0);
   });
 });
 

--- a/src/docs-retrieval/learning-journey-helpers.ts
+++ b/src/docs-retrieval/learning-journey-helpers.ts
@@ -429,7 +429,15 @@ export function setMilestoneCompletionPercentage(journeyBaseUrl: string, percent
   persistJourneyCompletionPercentage(journeyBaseUrl, percentage);
 }
 
+function isBackendGuideJourney(journeyBaseUrl: string): boolean {
+  return journeyBaseUrl.startsWith('backend-guide:');
+}
+
 function persistJourneyCompletionPercentage(journeyBaseUrl: string, percentage: number): string | undefined {
+  if (isBackendGuideJourney(journeyBaseUrl)) {
+    return undefined;
+  }
+
   // Fire and forget - storage handles errors internally
   journeyCompletionStorage.set(journeyBaseUrl, percentage);
 
@@ -447,6 +455,10 @@ export async function setJourneyCompletionPercentageAsync(
   percentage: number,
   context?: CompletionContext
 ): Promise<void> {
+  if (isBackendGuideJourney(journeyBaseUrl)) {
+    return;
+  }
+
   await journeyCompletionStorage.set(journeyBaseUrl, percentage);
 
   // Update learning paths progress when a bundled guide reaches 100%
@@ -672,6 +684,10 @@ export async function markMilestoneDone(
   if (expectedMilestoneIds && expectedMilestoneIds.length > 0) {
     const completed = await milestoneCompletionStorage.getCompleted(journeyBaseUrl);
     if (expectedMilestoneIds.every((id) => completed.has(id))) {
+      if (journeyBaseUrl.startsWith('backend-guide:')) {
+        await journeyCompletionStorage.set(journeyBaseUrl, 100);
+      }
+
       const { getPathsData } = await import('../learning-paths');
       const normalizedBase = journeyBaseUrl.replace(/\/+$/, '');
       const path = getPathsData().paths.find((p) => p.url && normalizedBase === p.url.replace(/\/+$/, ''));


### PR DESCRIPTION
## Summary

App Platform learning journeys addressed through `backend-guide:` currently persist the last loaded milestone's ordinal percentage, so a completed journey never stores `100` and revisiting an earlier milestone can move the value backward.

This change ignores ordinal percentage writes for those journey keys and persists `100` under the journey base key only after whole-set milestone membership proves completion. Bundled and URL-based journey behavior stays unchanged, and the existing durable completion-record emission remains on its current boundary.

## What to look at

- [`learning-journey-helpers.ts`](https://github.com/dvd233/grafana-pathfinder-app/blob/b2a0480bb5521f48f24c4c67408d4126b8e84654/src/docs-retrieval/learning-journey-helpers.ts) — ordinal writes are skipped only for `backend-guide:` journeys, while the terminal write happens inside the existing whole-set membership gate. The terminal path intentionally writes storage directly instead of broadening the bundled branch, which would also trigger bundled-only completion side effects.

## How to verify

1. Complete every milestone in an App Platform journey and inspect its `backend-guide:<pathId>` entry; it should store `100`.
2. Reopen an earlier milestone after completion; the stored terminal value should remain `100` instead of falling back to that milestone's ordinal percentage.
3. Exercise a URL-based journey and a bundled guide; their existing ordinal and terminal persistence behavior should remain unchanged.

## Breaking changes

The persisted meaning of `backend-guide:` journey percentages changes from last-loaded ordinal progress to terminal-only completion. No production surface currently reads this value for affected keys, so no user-facing migration is expected.

## Reversibility

Reverting the change restores ordinal writes, but it does not automatically remove `100` values already persisted by this version. A later milestone load or the existing progress reset paths will overwrite or clear those values; with no current production reader, rollback impact is limited.

## Out of scope

- URL-based journeys continue to persist ordinal percentages; this issue is scoped to `backend-guide:` paths.
- Durable completion-record identity and emission are unchanged; this only corrects `journeyCompletionStorage`.

Fixes #1567

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)
