### PR TITLE
docs(external-api): clarify unknown field pruning

### DIFF
--- a/docs/developer/EXTERNAL_API.md
+++ b/docs/developer/EXTERNAL_API.md
@@ -308,9 +308,16 @@ The wire format is the standard Kubernetes envelope:
 | `spec.blocks`              | yes      | Array of content blocks. The full schema is owned by the CUE definition in [grafana-pathfinder-backend/kinds/interactiveguide.cue](https://github.com/grafana/grafana-pathfinder-backend/blob/main/kinds/interactiveguide.cue) — that file is the source of truth. |
 | `spec.manifest`            | no       | Package metadata: grouping, sequencing, dependencies. Absent for content-only guides. See [Manifest](#manifest).                                                                                                                                                   |
 
-The CRD schema **is the validator**. Submit unknown fields and you'll
-get a `422 Unprocessable Entity` with a K8s `Status` envelope explaining
-which field is wrong.
+The CRD validates declared fields. A required declared field that is missing,
+or a declared value with an invalid type or value, returns a
+`422 Unprocessable Entity` with a K8s `Status` envelope.
+
+Unknown fields are **not rejected by default**. Kubernetes prunes them and
+may still return `200 OK` or `201 Created`. The API can emit a `Warning`
+response header, but callers that do not inspect headers receive no signal;
+`getBackendSrv()` does not surface it. For manifest extensions,
+`spec.manifest.additionalFields` is the only durable home for keys the CRD
+does not declare.
 
 ### Manifest
 
@@ -326,7 +333,7 @@ and what makes a path a path.
 | `author`           | no       | `{ name?, team? }`. The CRD declares no other keys; `upsert-learning-path.sh` moves any it finds (`email`, `github`, …) to `additionalFields.author` instead of dropping them. |
 | `category`         | no       | Free-form grouping label.                                                                                                                                                      |
 | `depends`          | no       | CNF (AND of ORs): an **array of arrays**. A single dependency is a singleton clause — `[["a"], ["b"]]` is "a AND b", `[["a","b"]]` is "a OR b". A bare string is not accepted. |
-| `additionalFields` | no       | Free-form escape hatch, `x-kubernetes-preserve-unknown-fields`. Anything not typed above goes here.                                                                            |
+| `additionalFields` | no       | Free-form escape hatch, `x-kubernetes-preserve-unknown-fields`. This is the only durable home for manifest keys not declared above.                                            |
 
 `recommends`, `suggests`, `provides`, `targeting`, `testEnvironment`,
 `startingLocation`, and the generated `stats` stamp have no typed home yet, so
@@ -532,14 +539,14 @@ The aggregator returns standard Kubernetes `Status` envelopes:
 
 Common cases:
 
-| HTTP | Reason        | When                                                                         |
-| ---- | ------------- | ---------------------------------------------------------------------------- |
-| 401  | -             | Missing or invalid Bearer token.                                             |
-| 403  | -             | Token's role is too low for the operation (need Editor for writes).          |
-| 404  | NotFound      | The named guide doesn't exist (or, on listing, the namespace doesn't exist). |
-| 409  | AlreadyExists | POST against a name that already exists. Use PUT to update.                  |
-| 409  | Conflict      | Stale `resourceVersion` on PUT. Re-GET and retry.                            |
-| 422  | Invalid       | Spec failed CRD validation — message names the offending field.              |
+| HTTP | Reason        | When                                                                                             |
+| ---- | ------------- | ------------------------------------------------------------------------------------------------ |
+| 401  | -             | Missing or invalid Bearer token.                                                                 |
+| 403  | -             | Token's role is too low for the operation (need Editor for writes).                              |
+| 404  | NotFound      | The named guide doesn't exist (or, on listing, the namespace doesn't exist).                     |
+| 409  | AlreadyExists | POST against a name that already exists. Use PUT to update.                                      |
+| 409  | Conflict      | Stale `resourceVersion` on PUT. Re-GET and retry.                                                |
+| 422  | Invalid       | A required declared field is missing, or a declared value is invalid; the message identifies it. |
 
 ## Choosing this vs. the editor
 

--- a/docs/developer/EXTERNAL_API.md
+++ b/docs/developer/EXTERNAL_API.md
@@ -131,11 +131,12 @@ upload in that case; rename the package instead.
 
 The CRD's block schema is generated from `_blockFields` / `#Block` /
 `#NestedBlock` / `#Step` in `kinds/interactiveguide.cue`. A field the app
-accepts and that file does not declare is **silently pruned**: there is
-no 422 and no warning from the API, the write returns 200, and the field
-is gone on the next GET. Blocks nested three or more levels deep fall
-under `x-kubernetes-preserve-unknown-fields` and survive; anything
-shallower does not.
+accepts and that file does not declare is **silently pruned**. The API can emit
+a `Warning` response header, but there is no 422 or error body; the write may
+still return 200 or 201, and the field is gone on the next GET.
+`getBackendSrv()` does not surface that header to callers. Blocks nested three
+or more levels deep fall under `x-kubernetes-preserve-unknown-fields` and
+survive; anything shallower does not.
 
 The gap is currently the `input` block: `defaultValue`, which costs the
 input its prefilled value, and the whole `dataCheck*` family

--- a/docs/developer/EXTERNAL_API.md
+++ b/docs/developer/EXTERNAL_API.md
@@ -134,9 +134,11 @@ The CRD's block schema is generated from `_blockFields` / `#Block` /
 accepts and that file does not declare is **silently pruned**. The API can emit
 a `Warning` response header, but there is no 422 or error body; the write may
 still return 200 or 201, and the field is gone on the next GET.
-`getBackendSrv()` does not surface that header to callers. Blocks nested three
-or more levels deep fall under `x-kubernetes-preserve-unknown-fields` and
-survive; anything shallower does not.
+`getBackendSrv().fetch()` exposes it through `FetchResponse.headers`; the
+`get`/`post`/`put`/`delete` shorthand helpers return only the parsed body.
+Blocks nested three or more levels deep fall under
+`x-kubernetes-preserve-unknown-fields` and survive; anything shallower does
+not.
 
 The gap is currently the `input` block: `defaultValue`, which costs the
 input its prefilled value, and the whole `dataCheck*` family
@@ -315,10 +317,9 @@ or a declared value with an invalid type or value, returns a
 
 Unknown fields are **not rejected by default**. Kubernetes prunes them and
 may still return `200 OK` or `201 Created`. The API can emit a `Warning`
-response header, but callers that do not inspect headers receive no signal;
-`getBackendSrv()` does not surface it. For manifest extensions,
-`spec.manifest.additionalFields` is the only durable home for keys the CRD
-does not declare.
+response header, but callers that do not inspect headers receive no signal.
+For manifest extensions, `spec.manifest.additionalFields` is the only durable
+home for keys the CRD does not declare.
 
 ### Manifest
 


### PR DESCRIPTION
## Summary

Correct the external API documentation to distinguish validation of declared fields from Kubernetes's default pruning of undeclared fields. A write containing unknown fields can still succeed and lose data, so the document now points manifest extensions to `spec.manifest.additionalFields` and describes the optional warning header consistently.

## What to look at

- [`docs/developer/EXTERNAL_API.md`](https://github.com/dvd233/grafana-pathfinder-app/blob/07f1a4ca5d3e85ff91dcf8adf5d2bfbeac2ab9e6/docs/developer/EXTERNAL_API.md) — the block-field guidance, field overview, manifest table, and HTTP error table now share one boundary: invalid declared fields return 422, while undeclared fields are pruned unless they are stored in the CRD's escape hatch.

## How to verify

1. Submit an `InteractiveGuide` with an undeclared top-level or `spec.manifest` key, capture the response headers, and confirm the write can return 200 or 201 with a `Warning: unknown field ...` header while a subsequent GET omits the key.
2. Submit an `InteractiveGuide` with a missing required declared field or an invalid declared value and confirm the API returns a 422 Kubernetes `Status` response.
3. Read the block-field guidance, field overview, manifest table, and HTTP error table together and confirm they describe the same declared-versus-undeclared behavior.

## Breaking changes

None. This is a documentation-only correction and changes no runtime, schema, or payload behavior.

Fixes #1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
