### PR TITLE
fix(snippets): classify and cache missing snippets

### DIFF
--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -1226,7 +1226,7 @@ A ref may sit at the top level of `blocks`, or nested inside a `section`, a `con
 
 Snippets cannot reference other snippets. The snippet schema rejects `snippet-ref` at every supported nesting depth, so a snippet body may contain any other block type but never a ref.
 
-If a ref cannot be resolved — unknown ID, catalog fetch failure — it is replaced with an inert markdown placeholder naming the snippet ID and an error code. The guide still renders, but nothing interactive appears in the ref's place. The resolver does not distinguish a missing snippet from a transient failure, so an unknown ID reports `network-error` rather than a not-found code.
+If a ref cannot be resolved — unknown ID, catalog fetch failure — it is replaced with an inert markdown placeholder naming the snippet ID and an error code. The guide still renders, but nothing interactive appears in the ref's place.
 
 ---
 

--- a/src/snippet-engine/caching-snippet-resolver.test.ts
+++ b/src/snippet-engine/caching-snippet-resolver.test.ts
@@ -43,7 +43,28 @@ describe('CachingSnippetResolver', () => {
     expect(inner.resolveCalls).toBe(2);
   });
 
-  it('does not cache failures', async () => {
+  it('caches not-found resolutions within the TTL', async () => {
+    const inner = new StubResolver((id) => ({
+      ok: false,
+      id,
+      error: { code: 'not-found', message: 'missing' },
+    }));
+
+    let now = 0;
+    const cache = new CachingSnippetResolver(inner, { ttlMs: 1000, now: () => now });
+
+    await cache.resolve('foo');
+    await cache.resolve('foo');
+
+    expect(inner.resolveCalls).toBe(1);
+
+    now = 1500;
+    await cache.resolve('foo');
+
+    expect(inner.resolveCalls).toBe(2);
+  });
+
+  it('does not cache transient failures', async () => {
     const inner = new StubResolver((id) => ({ ok: false, id, error: { code: 'network-error', message: 'down' } }));
     const cache = new CachingSnippetResolver(inner, { ttlMs: 1000, now: () => 0 });
 

--- a/src/snippet-engine/caching-snippet-resolver.ts
+++ b/src/snippet-engine/caching-snippet-resolver.ts
@@ -1,8 +1,8 @@
 /**
  * Wraps a resolver with a short-lived cache (~5 min TTL) and in-flight
  * dedupe — the parser splice and editor picker can race for the same snippet
- * on first open. Failures aren't cached; they surface as the caller's
- * inert placeholder.
+ * on first open. Successful and not-found resolutions are cached; transient
+ * failures remain uncached.
  */
 
 import type { SnippetCatalog } from '../types/json-snippet.types';
@@ -44,9 +44,7 @@ export class CachingSnippetResolver implements SnippetResolver, SnippetCatalogPr
     const promise = this.inner
       .resolve(snippetId)
       .then((resolution) => {
-        // Only cache successes — a transient failure shouldn't pin a guide
-        // to an error for the session.
-        if (resolution.ok) {
+        if (resolution.ok || resolution.error.code === 'not-found') {
           this.cache.set(snippetId, { resolution, expiresAt: this.now() + this.ttlMs });
         }
         return resolution;

--- a/src/snippet-engine/inline-refs.test.ts
+++ b/src/snippet-engine/inline-refs.test.ts
@@ -116,6 +116,7 @@ describe('inlineSnippetRefsInGuide', () => {
     const placeholder = out.blocks[0]!;
     expect(placeholder.type).toBe('markdown');
     expect((placeholder as { content: string }).content).toMatch(/missing/);
+    expect((placeholder as { content: string }).content).toContain('(not-found)');
   });
 });
 

--- a/src/snippet-engine/online-snippet-resolver.test.ts
+++ b/src/snippet-engine/online-snippet-resolver.test.ts
@@ -72,10 +72,18 @@ describe('OnlineCdnSnippetResolver.resolve', () => {
     expect(global.fetch).toHaveBeenCalledWith(`${SNIPPETS_BASE}/..%2F..%2Fetc%2Fpasswd.json`, expect.anything());
   });
 
-  it('returns a network-error failure on a non-ok HTTP response (no throw)', async () => {
+  it('returns a not-found failure on a 404 response (no throw)', async () => {
     mockFetchResolved({ ok: false, status: 404 });
 
     const result = await createOnlineSnippetResolver().resolve('missing');
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'not-found' } });
+  });
+
+  it('returns a network-error failure on a server error (no throw)', async () => {
+    mockFetchResolved({ ok: false, status: 500 });
+
+    const result = await createOnlineSnippetResolver().resolve('datasource-picker');
 
     expect(result).toMatchObject({ ok: false, error: { code: 'network-error' } });
   });

--- a/src/snippet-engine/online-snippet-resolver.ts
+++ b/src/snippet-engine/online-snippet-resolver.ts
@@ -47,7 +47,10 @@ export class OnlineCdnSnippetResolver implements SnippetResolver, SnippetCatalog
         return {
           ok: false,
           id: snippetId,
-          error: { code: 'network-error', message: `Snippet fetch failed: HTTP ${response.status}` },
+          error: {
+            code: response.status === 404 ? 'not-found' : 'network-error',
+            message: `Snippet fetch failed: HTTP ${response.status}`,
+          },
         };
       }
       const raw = await response.json();


### PR DESCRIPTION
## Summary

- classify HTTP 404 snippet responses as `not-found` instead of `network-error`
- cache `not-found` resolutions for the existing TTL while keeping transient failures uncached
- add regression coverage for the `not-found` placeholder and remove the documentation for the old behavior

## Verification

- focused snippet-engine tests
- all steps from the local pre-merge check passed
- `git diff --check`

Closes #1546