### PR TITLE
fix(husky): make the pre-commit hook run, and give it the right work

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,9 @@
 *.sh text eol=lf
 *.bash text eol=lf
 *.zsh text eol=lf
+# Git hooks have no extension, so no rule above covers them. Checked out
+# with CRLF they fail to execute.
+.husky/* text eol=lf
 
 # Ensure consistent line endings for other text files
 *.ts text eol=lf

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
+# Fast, per-file checks only. Measured on this repo: eslint over one changed
+# file is ~4s warm, prettier ~2s. `npm run typecheck` (25s) and
+# `npm run test:governance` (27s) are whole-project; a 52s commit gets bypassed
+# with --no-verify, which is no better than the hook git was silently skipping.
 npx lint-staged
-npm run typecheck
-npm run test:governance

--- a/docs/developer/GETTING_STARTED.md
+++ b/docs/developer/GETTING_STARTED.md
@@ -37,7 +37,8 @@ node -v && npm -v && go version && docker --version && mage --version
 ### Build and run
 
 ```bash
-npm install            # installs frontend deps and triggers husky hook setup
+npm install            # frontend deps only; .npmrc sets ignore-scripts=true
+npm run prepare        # install the husky git hooks (once, after a fresh clone)
 npm run build:all      # frontend + Linux/ARM64 backend (what docker-compose mounts)
 npm run server         # build:all + docker compose up --build
 ```
@@ -96,7 +97,9 @@ The project ships with `.eslintrc`, `.prettierrc.js`, and `tsconfig.json` config
 - **Prettier — Code formatter** (`esbenp.prettier-vscode`) — set as default formatter, format on save.
 - **Go** (`golang.go`) — for backend work.
 
-A husky pre-commit hook runs `lint-staged`, which applies Prettier to staged `.ts`/`.tsx`/`.js`/`.json`/`.yaml`/`.md` files automatically.
+A husky pre-commit hook runs `lint-staged`, which applies `eslint --fix` then Prettier to
+staged `.ts`/`.tsx`/`.js`/`.mjs` files, and Prettier alone to staged
+`.json`/`.yaml`/`.md` files.
 
 ## First-week reading list
 
@@ -135,7 +138,7 @@ go install github.com/magefile/mage@latest
 export PATH="$PATH:$(go env GOPATH)/bin"
 ```
 
-### Husky pre-commit hook fails
+### Husky pre-commit hook fails or blocks the commit
 
 `npm run check` reproduces the failure locally. Fix the root cause; do not bypass with `--no-verify`.
 

--- a/docs/developer/LOCAL_DEV.md
+++ b/docs/developer/LOCAL_DEV.md
@@ -143,7 +143,8 @@ npm run prettier-test    # check formatting only
 npm run lint:go          # golangci-lint via mage
 ```
 
-Husky runs `lint-staged` on commit (Prettier on staged `.ts`/`.tsx`/`.js`/`.json`/`.yaml`/`.md`).
+Husky runs `lint-staged` on commit: `eslint --fix` then Prettier on staged
+`.ts`/`.tsx`/`.js`/`.mjs`, and Prettier alone on staged `.json`/`.yaml`/`.md`.
 
 ## IDE setup
 
@@ -188,7 +189,7 @@ go install github.com/magefile/mage@latest
 export PATH="$PATH:$(go env GOPATH)/bin"
 ```
 
-### Husky pre-commit hook fails
+### Husky pre-commit hook fails or blocks the commit
 
 `npm run check` reproduces the failure locally. Fix the underlying issue; do not bypass with `--no-verify`.
 

--- a/package.json
+++ b/package.json
@@ -175,7 +175,11 @@
     }
   },
   "lint-staged": {
-    "*.{ts,tsx,js,mjs,json,yaml,md}": "prettier --config .prettierrc.js --write"
+    "*.{ts,tsx,js,mjs}": [
+      "eslint --cache --fix",
+      "prettier --config .prettierrc.js --write"
+    ],
+    "*.{json,yaml,md}": "prettier --config .prettierrc.js --write"
   },
   "packageManager": "npm@12.0.2"
 }


### PR DESCRIPTION
Closes #1817. Refs #603.

Round 2: this is option 2 from the previous round — the mode fix and the lint-staged split, without the `pre-push` hook. All three blockers were properties of that hook and leave with it.

## 1. The hook never ran

`git ls-files -s .husky/pre-commit` was `100644`, so git skipped it and only printed a hint. It is now committed `100755`.

`.gitattributes` had `eol=lf` for `*.sh`, `*.bash`, `*.zsh` and the source extensions, but a git hook has no extension, so nothing covered `.husky/*`. A hook checked out with CRLF fails to execute — the same silent skip, one layer down. Added `.husky/* text eol=lf`.

## 2. `lint-staged` ran only prettier

The lint ratchets in this repo (#1742, #1744, #1752, #1524, #1751, plus the import-boundary rules) apply to `src/`, and fired only on `npm run lint` or in CI. `eslint --cache --fix` now runs on `*.{ts,tsx,js,mjs}` ahead of prettier; `*.{json,yaml,md}` keeps prettier alone. So the coverage this buys is on `src/`, which is where the ratchets live — it is not repo-wide.

## 3. Where each step belongs — measured first

The issue asks to measure before enabling, so I did, on this checkout with a warm eslint cache:

| step | time |
| --- | --- |
| `eslint`, one changed file | 4s |
| `eslint`, five changed files | 14s |
| `prettier`, one file | 2s |
| `npm run typecheck` (whole project) | 25s |
| `npm run test:governance` | 27s |

The hook as written was a **52s commit before eslint was even added** — squarely in "gets bypassed with `--no-verify`" territory, which the issue rightly calls no better than a hook git ignores.

So `pre-commit` runs `lint-staged` only. A real commit on this branch takes ~3s.

`typecheck` and `test:governance` are **not** relocated to a `pre-push` hook here. Round 1 did that, and the review found the reason not to: `npm run test:governance` includes `src/validation/import-graph.test.ts`, which has 4 separator-dependent assertions and fails on Windows. Gating `git push` on a suite that cannot pass off posix is how `--no-verify` becomes a habit. Those two stay on `npm run check` and CI until the separator problem is fixed on its own.

## Proof it now gates

Staged a `.ts` file and ran lint-staged for real:

```
export const probe   =  {a:1,   b:2};      # staged
→ eslint --cache --fix, then prettier
export const probe = { a: 1, b: 2 };       # committed
```

And against a ratchet rule:

```
import moment from 'moment';

✖ eslint --cache --fix
  1:1  error  'moment' import is restricted from being used  no-restricted-imports
✖ 1 problem (1 error, 0 warnings)
✖ Failed to run tasks for staged files!
⋯ Reverting to original state because of errors…
```

The commit does not land. Before this change it did.

## Docs

`LOCAL_DEV.md:146` and `GETTING_STARTED.md:99` both described lint-staged as prettier-only; both now name `eslint --fix` then prettier on `*.{ts,tsx,js,mjs}` and prettier alone on `*.{json,yaml,md}`. Both troubleshooting headings are widened to "Husky pre-commit hook fails or blocks the commit", since the failure people will now hit is a lint error stopping a commit that used to go through.

`GETTING_STARTED.md:40` said `npm install` triggers husky hook setup. `.npmrc` sets `ignore-scripts=true`, so it does not, and `LOCAL_DEV.md:24` already said so. It now shows `npm run prepare`.

## Not done, deliberately

The `--no-warn-ignored` follow-up. The flag *suppresses* the ignored-file notice, so adding it is what would make an uncovered staged file pass silently. On this repo's eslint 9.39.1:

```
$ eslint --cache package.json
  0:0  warning  File ignored because no matching configuration was supplied     exit 0

$ eslint --cache --no-warn-ignored package.json
                                                                                exit 0   # silent
```

Left off, so the notice surfaces. Say the word if the intent was to quiet it instead.
