### PR TITLE
docs(cross-tab): document requirement shape mismatch

### DIFF
--- a/docs/developer/CROSS_TAB_CONTROLLER.md
+++ b/docs/developer/CROSS_TAB_CONTROLLER.md
@@ -155,7 +155,11 @@ Defense in depth on top of authentication:
 - **Same-build / same-origin / one-session assumption.** Controller and live
   tabs are the same plugin build in the same browser profile and session; there
   is no protocol-version negotiation and cross-version compatibility is not a
-  goal.
+  goal. Requirement traffic is a concrete example: `check-requirements` can now
+  carry array-shaped guide `requirements` and `objectives`, and
+  `fix-requirement` also accepts a `ConditionInput` in its `requirements` field.
+  An older validator that accepts only strings drops the command; the controller
+  times out and falls back to its local-only check.
 
 ### Known limitations / future work
 

--- a/docs/developer/CROSS_TAB_CONTROLLER.md
+++ b/docs/developer/CROSS_TAB_CONTROLLER.md
@@ -155,11 +155,12 @@ Defense in depth on top of authentication:
 - **Same-build / same-origin / one-session assumption.** Controller and live
   tabs are the same plugin build in the same browser profile and session; there
   is no protocol-version negotiation and cross-version compatibility is not a
-  goal. Requirement traffic is a concrete example: `check-requirements` can now
-  carry array-shaped guide `requirements` and `objectives`, and
-  `fix-requirement` also accepts a `ConditionInput` in its `requirements` field.
-  An older validator that accepts only strings drops the command; the controller
-  times out and falls back to its local-only check.
+  goal. Requirement traffic is a concrete example: `check-requirements` can
+  carry array-shaped guide `requirements`, and `fix-requirement` carries the
+  same `ConditionInput` shape. Guide `objectives` are evaluated in the
+  controller tab and never cross this wire. An older validator that accepts
+  only strings can drop a command; the timeout behavior differs by message kind
+  as described below.
 
 ### Known limitations / future work
 
@@ -264,10 +265,13 @@ Controller (useStepChecker, controller mode)        Live tab (installLiveTabExec
   `requestRequirementCheck` posts regardless of connection state (the channel
   value omits `connected`), so the check fires the moment a step renders;
   `connected` only drives the presence badge.
-- If no live tab answers within the timeout, the round-tripped half falls back to
-  stripping the tab-local tokens and evaluating the rest locally —
-  session/permission requirements still gate, and a disconnected controller never
-  hangs. The guide-scoped half is unaffected: it never depended on the live tab.
+- If no live tab answers within the 4-second request timeout, a
+  `check-requirements` request falls back to stripping the tab-local tokens and
+  evaluating the rest locally — session/permission requirements still gate, and
+  a disconnected controller never hangs. A `fix-requirement` request instead
+  returns `No live tab responded`, is not retried locally, and leaves the step
+  blocked while logging a warning. The guide-scoped half is unaffected: it
+  never depended on the live tab.
 
 ## Presence
 

--- a/src/types/cross-tab.types.ts
+++ b/src/types/cross-tab.types.ts
@@ -210,7 +210,11 @@ export const SIGNED_MESSAGE_KINDS: ReadonlySet<CrossTabMessage['kind']> = new Se
 // Same-build assumption: the controller and live tabs are the same plugin
 // build in the same browser/origin/session, so there is no protocol-version
 // negotiation. Cross-version compatibility is not a goal; a mismatched build
-// is out of scope. See docs/developer/CROSS_TAB_CONTROLLER.md.
+// is out of scope. Requirement traffic is one concrete case: check-requirements
+// can now carry array-shaped guide requirements/objectives, and fix-requirement
+// also accepts ConditionInput. Older validators accept only strings and drop
+// these commands; the controller then times out and falls back locally. See
+// docs/developer/CROSS_TAB_CONTROLLER.md.
 
 // Recognized interactive action verbs. Kept as a literal set (not derived
 // from InteractiveAction) so the receive gate stays decoupled from the

--- a/src/types/cross-tab.types.ts
+++ b/src/types/cross-tab.types.ts
@@ -211,9 +211,11 @@ export const SIGNED_MESSAGE_KINDS: ReadonlySet<CrossTabMessage['kind']> = new Se
 // build in the same browser/origin/session, so there is no protocol-version
 // negotiation. Cross-version compatibility is not a goal; a mismatched build
 // is out of scope. Requirement traffic is one concrete case: check-requirements
-// can now carry array-shaped guide requirements/objectives, and fix-requirement
-// also accepts ConditionInput. Older validators accept only strings and drop
-// these commands; the controller then times out and falls back locally. See
+// can carry array-shaped guide requirements, and fix-requirement carries the
+// same ConditionInput shape. Guide objectives stay local to the controller and
+// never cross this wire. A dropped check falls back locally after 4s with
+// tab-local tokens stripped; a dropped fix returns "No live tab responded", is
+// not retried locally, and leaves the step blocked. See
 // docs/developer/CROSS_TAB_CONTROLLER.md.
 
 // Recognized interactive action verbs. Kept as a literal set (not derived


### PR DESCRIPTION
## Summary

The two-tab controller's same-build assumption now names array-shaped guide `requirements` as a concrete cross-version failure mode. Older live tabs that accept only strings can drop a `check-requirements` command; it then times out and uses the documented local-only fallback, while a dropped `fix-requirement` returns `No live tab responded` and is not retried locally.

This records the existing cross-version non-goal; it does not change wire types, validation, or runtime behavior. Guide `objectives` are evaluated in the controller tab and never cross this wire.

## What to look at

- [Developer contract](https://github.com/dvd233/grafana-pathfinder-app/blob/d19ca7943672cc3a224dae37efe1167251194d08/docs/developer/CROSS_TAB_CONTROLLER.md) distinguishes the `check-requirements` local fallback from the `fix-requirement` blocked outcome and records that guide objectives stay local.
- [Protocol-side contract](https://github.com/dvd233/grafana-pathfinder-app/blob/d19ca7943672cc3a224dae37efe1167251194d08/src/types/cross-tab.types.ts) keeps both messages on the existing `ConditionInput` shape and explains the same-build boundary.

## How to verify

1. Read both linked paragraphs and confirm they describe array-shaped guide requirements, controller-local objectives, and the distinct timeout behavior for checks versus fixes.
2. Trace `CheckRequirementsMessage` and `FixRequirementMessage`; confirm their `requirements` field remains `ConditionInput`, neither message carries `objectives`, and no validator or signed-message kind changes in this PR.

## Breaking changes

None. This change is documentation-only and fully reversible.

Closes #1808

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)
