### PR TITLE
fix: preserve pending request fallbacks on disconnect

### DIFF
--- a/src/global-state/controller-channel.test.tsx
+++ b/src/global-state/controller-channel.test.tsx
@@ -350,6 +350,45 @@ describe('ControllerChannelProvider', () => {
     await waitFor(() => expect(screen.getByTestId('fix')).toHaveTextContent('ok:true'));
   });
 
+  it('resolves an in-flight requestFix with the fix fallback when the provider unmounts', async () => {
+    let resolveOutcome: ((value: string) => void) | undefined;
+    const outcome = new Promise<string>((resolve) => {
+      resolveOutcome = resolve;
+    });
+
+    function PendingFixProbe() {
+      const channel = useControllerChannel();
+
+      return (
+        <button
+          onClick={() =>
+            channel
+              ?.requestFix('s1', { requirements: 'navmenu-open', fixType: 'navigation' })
+              .then((result) => resolveOutcome?.(`ok:${result.ok}`))
+          }
+        >
+          fix
+        </button>
+      );
+    }
+
+    const transport = new FakeCrossTabTransport();
+    const { unmount } = render(
+      <ControllerChannelProvider transport={transport} pairing={TEST_PAIRING}>
+        <PendingFixProbe />
+      </ControllerChannelProvider>
+    );
+
+    await pairWithLive(transport);
+
+    fireEvent.click(screen.getByText('fix'));
+    await waitForPostedOfKind(transport, 'fix-requirement');
+
+    unmount();
+
+    await expect(outcome).resolves.toBe('ok:false');
+  });
+
   it('falls back to null when no live tab answers within the timeout', async () => {
     jest.useFakeTimers();
     try {

--- a/src/global-state/controller-channel.tsx
+++ b/src/global-state/controller-channel.tsx
@@ -57,6 +57,7 @@ interface ControllerChannel {
 
 interface PendingRequest {
   resolve: (value: RemoteRequirementResult | FixOutcome | null) => void;
+  fallback: RemoteRequirementResult | FixOutcome | null;
   timer: ReturnType<typeof setTimeout>;
 }
 
@@ -197,7 +198,7 @@ export function ControllerChannelProvider({
     const failAllPending = () => {
       pending.forEach((entry) => {
         clearTimeout(entry.timer);
-        entry.resolve(null);
+        entry.resolve(entry.fallback);
       });
       pending.clear();
       stepDone.forEach((resolve) => resolve(false));
@@ -318,7 +319,11 @@ export function ControllerChannelProvider({
           pendingRef.current.delete(requestId);
           resolve(fallback);
         }, REQUEST_TIMEOUT_MS);
-        pendingRef.current.set(requestId, { resolve: resolve as PendingRequest['resolve'], timer });
+        pendingRef.current.set(requestId, {
+          resolve: resolve as PendingRequest['resolve'],
+          fallback,
+          timer,
+        });
         post({ ...payload, requestId });
       });
     },


### PR DESCRIPTION
## Summary

Fixes #1828

Pending cross-tab requests were always resolved with `null` when the controller channel was torn down. This caused `requestFix()` callers to receive an unexpected result and could lead to a runtime error when accessing `result.ok`.

This change stores the fallback associated with each pending request and uses it when resolving requests during channel cleanup, including stale-heartbeat handling.

## Changes

- Store the request-specific fallback in each pending request entry.
- Resolve pending requests with their stored fallback in `failAllPending()`.
- Add a regression test covering an in-flight `requestFix()` when the provider unmounts.

## Testing

- `npm test -- --runInBand`
- 55 test suites passed
- 816 tests passed