### PR TITLE
docs: update window-global guidance

### DIFF
--- a/.cursor/skills/create-experiment/SKILL.md
+++ b/.cursor/skills/create-experiment/SKILL.md
@@ -50,7 +50,7 @@ Add to `pathfinderFeatureFlags` in `src/utils/openfeature.ts`. This is the one p
 
 Three arms, always: `excluded` (not in the experiment), `control` (in it, current behaviour), `treatment` (in it, new behaviour). `excluded` and `control` must render identically; the difference is only whether the user is counted.
 
-`EXPERIMENT_VARIANTS` in `src/utils/openfeature.ts` is the runtime vocabulary and derives the TypeScript union. Adding an arm also requires an explicit policy in both total projections: `EXPERIMENT_VARIANT_EMITS_EXPOSURE` in `src/utils/openfeature-tracking.ts` and `EXPERIMENT_VARIANT_PRECEDENCE` in `src/lib/analytics.ts`. The compiler should fail until both decisions are made.
+`EXPERIMENT_VARIANTS`, defined in `src/types/openfeature.types.ts` and re-exported from `src/utils/openfeature.ts`, is the runtime vocabulary and derives the TypeScript union. Adding an arm also requires an explicit policy in both total projections: `EXPERIMENT_VARIANT_EMITS_EXPOSURE` in `src/utils/openfeature-tracking.ts` and `EXPERIMENT_VARIANT_PRECEDENCE` in `src/lib/analytics.ts`. The compiler should fail until both decisions are made.
 
 The compiler does not cover the runtime arm gates in `src/utils/experiments/highlighted-guide-orchestrator.ts` and `src/context-engine/context.service.ts`; review both explicitly when adding an arm.
 

--- a/docs/developer/E2E_TESTING_CONTRACT.md
+++ b/docs/developer/E2E_TESTING_CONTRACT.md
@@ -37,6 +37,8 @@ The guide runner must establish a ready Pathfinder panel before it can load guid
 
 The Grafana-owned Help button and `grafana.navigation.extensionSidebarDocked` storage entry are recovery hints, not Pathfinder-owned contracts. A docs-panel or sidebar refactor must preserve the four Pathfinder signals above, or update the guide runner, contract tests, and this document in the same change.
 
+Pathfinder-owned window globals are declared in `src/types/window-globals.ts`; add new globals there and access them through `window` directly.
+
 The runner waits for Help only after Pathfinder readiness signals do not prove that the panel is ready. Bootstrap owns this fallback.
 
 The default bootstrap budget is 20 seconds. Post-navigation guide loading uses 30 seconds for each attempt.
@@ -550,7 +552,7 @@ Contract tests enforce the stability of E2E attributes at build time, preventing
 
 - `src/components/interactive-tutorial/data-attributes.contract.test.tsx` - React component attributes
 - `src/interactive-engine/comment-box.contract.test.ts` - DOM-created element attributes
-- `src/components/docs-panel/docs-panel.contract.test.tsx` - Docs panel test IDs (constant values, source reference mapping, auto-derived exhaustiveness, window globals, scroll-restoration)
+- `src/components/docs-panel/docs-panel.contract.test.tsx` - Docs panel test IDs (constant values, source reference mapping, auto-derived exhaustiveness, bootstrap signals, scroll-restoration)
 - `src/components/LearningPaths/BadgeUnlockedToast.contract.test.ts` - Badge celebration test IDs and source references
 - `src/integrations/coda/GcxSetupPanel.contract.test.tsx` - gcx credential test IDs, source references, and the form's visibility states
 


### PR DESCRIPTION
## What does this PR do?

Updates stale agent-facing guidance after the window-global and OpenFeature type refactor.

- Points `EXPERIMENT_VARIANTS` to its source of truth in `src/types/openfeature.types.ts`, while noting the existing re-export.
- Updates the docs-panel contract coverage from window globals to bootstrap signals.
- Documents `src/types/window-globals.ts` as the home for Pathfinder-owned window globals.

## Linked issue(s)

Closes #1777

## Checklist

- [x] This PR addresses a single concern.
- [x] All commits are signed.
- [x] I've added or updated tests for the change.
- [x] `npm run check` passes locally.
- [x] UI text and docs use sentence case.