### PR TITLE
fix(block-editor): compile-check branch block builders

### DIFF
--- a/src/components/block-editor/forms/BranchBlocksEditor.test.ts
+++ b/src/components/block-editor/forms/BranchBlocksEditor.test.ts
@@ -1,8 +1,34 @@
-import { ALLOWED_BRANCH_BLOCK_TYPES, createDefaultBlock } from './BranchBlocksEditor';
+import { ALLOWED_BRANCH_BLOCK_TYPES, createDefaultBlock, type BranchBlocksEditorProps } from './BranchBlocksEditor';
+
+type AddableBlockTypes = NonNullable<BranchBlocksEditorProps['addableBlockTypes']>;
+
+const buildablePropTypes: AddableBlockTypes = ['markdown', 'challenge'];
+// @ts-expect-error terminal has no intentional default builder
+const fallbackOnlyPropTypes: AddableBlockTypes = ['terminal'];
+
+void buildablePropTypes;
+void fallbackOnlyPropTypes;
 
 describe('BranchBlocksEditor createDefaultBlock', () => {
-  it('does not offer challenge in the inline add picker', () => {
-    expect(ALLOWED_BRANCH_BLOCK_TYPES).not.toContain('challenge');
+  it('offers exactly the block types the branch add picker can build', () => {
+    expect(ALLOWED_BRANCH_BLOCK_TYPES).toEqual([
+      'markdown',
+      'divider',
+      'interactive',
+      'image',
+      'video',
+      'input',
+      'callout',
+      'quiz',
+      'multistep',
+      'guided',
+    ]);
+  });
+
+  it('constructs every offered block without changing its type', () => {
+    for (const type of ALLOWED_BRANCH_BLOCK_TYPES) {
+      expect(createDefaultBlock(type).type).toBe(type);
+    }
   });
 
   it('builds a challenge block instead of empty markdown if challenged', () => {
@@ -14,17 +40,7 @@ describe('BranchBlocksEditor createDefaultBlock', () => {
     });
   });
 
-  it('still defaults unknown types to empty markdown', () => {
-    // html is legacy / palette-excluded and not in the creatable list
-    expect(createDefaultBlock('html' as any)).toEqual({ type: 'markdown', content: '' });
-  });
-
-  it('offers callout in the inline add picker', () => {
-    expect(ALLOWED_BRANCH_BLOCK_TYPES).toContain('callout');
-  });
-
-  it('offers and builds a divider in the inline add picker', () => {
-    expect(ALLOWED_BRANCH_BLOCK_TYPES).toContain('divider');
+  it('builds an empty divider block', () => {
     expect(createDefaultBlock('divider')).toEqual({ type: 'divider' });
   });
 

--- a/src/components/block-editor/forms/BranchBlocksEditor.test.ts
+++ b/src/components/block-editor/forms/BranchBlocksEditor.test.ts
@@ -2,11 +2,14 @@ import { ALLOWED_BRANCH_BLOCK_TYPES, createDefaultBlock, type BranchBlocksEditor
 
 type AddableBlockTypes = NonNullable<BranchBlocksEditorProps['addableBlockTypes']>;
 
-const buildablePropTypes: AddableBlockTypes = ['markdown', 'challenge'];
+const buildablePropTypes: AddableBlockTypes = ['markdown', 'guided'];
+// @ts-expect-error challenge has a builder but cannot be edited through this picker
+const nonAddableBuilderType: AddableBlockTypes = ['challenge'];
 // @ts-expect-error terminal has no intentional default builder
 const fallbackOnlyPropTypes: AddableBlockTypes = ['terminal'];
 
 void buildablePropTypes;
+void nonAddableBuilderType;
 void fallbackOnlyPropTypes;
 
 describe('BranchBlocksEditor createDefaultBlock', () => {
@@ -31,6 +34,10 @@ describe('BranchBlocksEditor createDefaultBlock', () => {
     }
   });
 
+  it('does not offer challenge without an inline editor', () => {
+    expect(ALLOWED_BRANCH_BLOCK_TYPES).not.toContain('challenge');
+  });
+
   it('builds a challenge block instead of empty markdown if challenged', () => {
     expect(createDefaultBlock('challenge')).toEqual({
       type: 'challenge',
@@ -42,6 +49,10 @@ describe('BranchBlocksEditor createDefaultBlock', () => {
 
   it('builds an empty divider block', () => {
     expect(createDefaultBlock('divider')).toEqual({ type: 'divider' });
+  });
+
+  it('keeps the legacy fallback for non-defaultable block types', () => {
+    expect(createDefaultBlock('terminal')).toEqual({ type: 'markdown', content: '' });
   });
 
   it('builds an empty callout block, not empty markdown', () => {

--- a/src/components/block-editor/forms/BranchBlocksEditor.tsx
+++ b/src/components/block-editor/forms/BranchBlocksEditor.tsx
@@ -263,16 +263,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
 // Helper Functions
 // ============================================================================
 
-/**
- * Create a default block of a given type
- */
 const BLOCK_DEFAULT_BUILDERS = {
-  markdown: (): JsonBlock => ({ type: 'markdown', content: '' }),
-  divider: (): JsonBlock => ({ type: 'divider' }),
-  interactive: (): JsonBlock => ({ type: 'interactive', action: 'highlight', reftarget: '', content: '' }),
-  image: (): JsonBlock => ({ type: 'image', src: '' }),
-  video: (): JsonBlock => ({ type: 'video', src: '' }),
-  quiz: (): JsonBlock => ({
+  markdown: () => ({ type: 'markdown', content: '' }),
+  divider: () => ({ type: 'divider' }),
+  interactive: () => ({ type: 'interactive', action: 'highlight', reftarget: '', content: '' }),
+  image: () => ({ type: 'image', src: '' }),
+  video: () => ({ type: 'video', src: '' }),
+  quiz: () => ({
     type: 'quiz',
     question: '',
     choices: [
@@ -280,18 +277,21 @@ const BLOCK_DEFAULT_BUILDERS = {
       { id: 'b', text: '' },
     ],
   }),
-  input: (): JsonBlock => ({ type: 'input', prompt: '', inputType: 'text', variableName: '' }),
-  multistep: (): JsonBlock => ({ type: 'multistep', content: '', steps: [] }),
-  guided: (): JsonBlock => ({ type: 'guided', content: '', steps: [] }),
-  challenge: (): JsonBlock => ({ type: 'challenge', title: '', brief: '', successCriteria: '' }),
-  callout: (): JsonBlock => ({ type: 'callout', title: '', content: '' }),
-} as const satisfies Partial<Record<BlockType, () => JsonBlock>>;
+  input: () => ({ type: 'input', prompt: '', inputType: 'text', variableName: '' }),
+  multistep: () => ({ type: 'multistep', content: '', steps: [] }),
+  guided: () => ({ type: 'guided', content: '', steps: [] }),
+  challenge: () => ({ type: 'challenge', title: '', brief: '', successCriteria: '' }),
+  callout: () => ({ type: 'callout', title: '', content: '' }),
+} as const satisfies { [K in BlockType]?: () => Extract<JsonBlock, { type: K }> };
 
 /** Block types that have an intentional default builder. */
 export type DefaultableBlockType = keyof typeof BLOCK_DEFAULT_BUILDERS;
 
+/** Builder-backed block types safe to offer in the branch picker (see #1542). */
+export type BranchAddableBlockType = Exclude<DefaultableBlockType, 'challenge'>;
+
 function isDefaultableBlockType(type: BlockType): type is DefaultableBlockType {
-  return type in BLOCK_DEFAULT_BUILDERS;
+  return Object.hasOwn(BLOCK_DEFAULT_BUILDERS, type);
 }
 
 export function createDefaultBlock(type: BlockType): JsonBlock {
@@ -317,7 +317,6 @@ export function createDefaultBlock(type: BlockType): JsonBlock {
   }
 }
 
-// Block types offered by default in the branch add picker.
 export const ALLOWED_BRANCH_BLOCK_TYPES = [
   'markdown',
   'divider',
@@ -329,7 +328,7 @@ export const ALLOWED_BRANCH_BLOCK_TYPES = [
   'quiz',
   'multistep',
   'guided',
-] as const satisfies readonly DefaultableBlockType[];
+] as const satisfies readonly BranchAddableBlockType[];
 
 // Block types that support inline form editing in BranchBlocksEditor
 // quiz, multistep, and guided require the dedicated editors and cannot be edited inline
@@ -391,7 +390,7 @@ export interface BranchBlocksEditorProps {
   /** Called when blocks change */
   onChange: (blocks: JsonBlock[]) => void;
   /** Block types offered in the add menu. Defaults to ALLOWED_BRANCH_BLOCK_TYPES. */
-  addableBlockTypes?: readonly DefaultableBlockType[];
+  addableBlockTypes?: readonly BranchAddableBlockType[];
   /** Called to start/stop the element picker */
   onPickerModeChange?: BlockFormProps['onPickerModeChange'];
 }

--- a/src/components/block-editor/forms/BranchBlocksEditor.tsx
+++ b/src/components/block-editor/forms/BranchBlocksEditor.tsx
@@ -266,37 +266,40 @@ const getStyles = (theme: GrafanaTheme2) => ({
 /**
  * Create a default block of a given type
  */
+const BLOCK_DEFAULT_BUILDERS = {
+  markdown: (): JsonBlock => ({ type: 'markdown', content: '' }),
+  divider: (): JsonBlock => ({ type: 'divider' }),
+  interactive: (): JsonBlock => ({ type: 'interactive', action: 'highlight', reftarget: '', content: '' }),
+  image: (): JsonBlock => ({ type: 'image', src: '' }),
+  video: (): JsonBlock => ({ type: 'video', src: '' }),
+  quiz: (): JsonBlock => ({
+    type: 'quiz',
+    question: '',
+    choices: [
+      { id: 'a', text: '', correct: true },
+      { id: 'b', text: '' },
+    ],
+  }),
+  input: (): JsonBlock => ({ type: 'input', prompt: '', inputType: 'text', variableName: '' }),
+  multistep: (): JsonBlock => ({ type: 'multistep', content: '', steps: [] }),
+  guided: (): JsonBlock => ({ type: 'guided', content: '', steps: [] }),
+  challenge: (): JsonBlock => ({ type: 'challenge', title: '', brief: '', successCriteria: '' }),
+  callout: (): JsonBlock => ({ type: 'callout', title: '', content: '' }),
+} as const satisfies Partial<Record<BlockType, () => JsonBlock>>;
+
+/** Block types that have an intentional default builder. */
+export type DefaultableBlockType = keyof typeof BLOCK_DEFAULT_BUILDERS;
+
+function isDefaultableBlockType(type: BlockType): type is DefaultableBlockType {
+  return type in BLOCK_DEFAULT_BUILDERS;
+}
+
 export function createDefaultBlock(type: BlockType): JsonBlock {
+  if (isDefaultableBlockType(type)) {
+    return BLOCK_DEFAULT_BUILDERS[type]();
+  }
+
   switch (type) {
-    case 'markdown':
-      return { type: 'markdown', content: '' };
-    case 'divider':
-      return { type: 'divider' };
-    case 'interactive':
-      return { type: 'interactive', action: 'highlight', reftarget: '', content: '' };
-    case 'image':
-      return { type: 'image', src: '' };
-    case 'video':
-      return { type: 'video', src: '' };
-    case 'quiz':
-      return {
-        type: 'quiz',
-        question: '',
-        choices: [
-          { id: 'a', text: '', correct: true },
-          { id: 'b', text: '' },
-        ],
-      };
-    case 'input':
-      return { type: 'input', prompt: '', inputType: 'text', variableName: '' };
-    case 'multistep':
-      return { type: 'multistep', content: '', steps: [] };
-    case 'guided':
-      return { type: 'guided', content: '', steps: [] };
-    case 'challenge':
-      return { type: 'challenge', title: '', brief: '', successCriteria: '' };
-    case 'callout':
-      return { type: 'callout', title: '', content: '' };
     case 'section':
     case 'html':
     case 'conditional':
@@ -314,11 +317,8 @@ export function createDefaultBlock(type: BlockType): JsonBlock {
   }
 }
 
-// Block types the inline branch editor can construct without falling through to an
-// empty markdown stub. Nested containers are excluded; types that need dedicated
-// forms (challenge, quiz, terminal, …) are also excluded so the combobox cannot
-// silently create the wrong block shape (see #1542).
-const BRANCH_INLINE_CREATABLE_TYPES: BlockType[] = [
+// Block types offered by default in the branch add picker.
+export const ALLOWED_BRANCH_BLOCK_TYPES = [
   'markdown',
   'divider',
   'interactive',
@@ -329,9 +329,7 @@ const BRANCH_INLINE_CREATABLE_TYPES: BlockType[] = [
   'quiz',
   'multistep',
   'guided',
-];
-
-export const ALLOWED_BRANCH_BLOCK_TYPES: BlockType[] = BRANCH_INLINE_CREATABLE_TYPES;
+] as const satisfies readonly DefaultableBlockType[];
 
 // Block types that support inline form editing in BranchBlocksEditor
 // quiz, multistep, and guided require the dedicated editors and cannot be edited inline
@@ -393,7 +391,7 @@ export interface BranchBlocksEditorProps {
   /** Called when blocks change */
   onChange: (blocks: JsonBlock[]) => void;
   /** Block types offered in the add menu. Defaults to ALLOWED_BRANCH_BLOCK_TYPES. */
-  addableBlockTypes?: BlockType[];
+  addableBlockTypes?: readonly DefaultableBlockType[];
   /** Called to start/stop the element picker */
   onPickerModeChange?: BlockFormProps['onPickerModeChange'];
 }

--- a/src/components/block-editor/forms/CollapsibleBlockForm.tsx
+++ b/src/components/block-editor/forms/CollapsibleBlockForm.tsx
@@ -9,15 +9,21 @@
 import React, { useState, useCallback } from 'react';
 import { Button, Field, Input, Switch, useStyles2 } from '@grafana/ui';
 import { getBlockFormStyles } from '../block-editor.styles';
-import { BranchBlocksEditor } from './BranchBlocksEditor';
+import { BranchBlocksEditor, type DefaultableBlockType } from './BranchBlocksEditor';
 import { testIds } from '../../../constants/testIds';
-import type { BlockFormProps, BlockType, JsonBlock } from '../types';
+import type { BlockFormProps, JsonBlock } from '../types';
 import type { JsonCollapsibleBlock, PresentationalBlock } from '../../../types/json-guide.types';
 
 // Content-only block types offered in a collapsible's add menu. Mirrors
 // PresentationalBlock in json-guide.types.ts (html is authored via markdown,
 // not the palette).
-const PRESENTATIONAL_ADDABLE_TYPES: BlockType[] = ['markdown', 'divider', 'image', 'video', 'callout'];
+const PRESENTATIONAL_ADDABLE_TYPES = [
+  'markdown',
+  'divider',
+  'image',
+  'video',
+  'callout',
+] as const satisfies readonly DefaultableBlockType[];
 
 function isCollapsibleBlock(block: JsonBlock): block is JsonCollapsibleBlock {
   return block.type === 'collapsible';

--- a/src/components/block-editor/forms/CollapsibleBlockForm.tsx
+++ b/src/components/block-editor/forms/CollapsibleBlockForm.tsx
@@ -23,7 +23,7 @@ const PRESENTATIONAL_ADDABLE_TYPES = [
   'image',
   'video',
   'callout',
-] as const satisfies readonly DefaultableBlockType[];
+] as const satisfies ReadonlyArray<DefaultableBlockType & PresentationalBlock['type']>;
 
 function isCollapsibleBlock(block: JsonBlock): block is JsonCollapsibleBlock {
   return block.type === 'collapsible';


### PR DESCRIPTION
## Summary

The branch add picker now accepts only block types backed by an intentional default builder, so removing or forgetting a builder becomes a TypeScript error instead of silently adding an empty markdown block. The same contract is applied to the collapsible picker and the `addableBlockTypes` prop; legacy fallback behavior for non-picker block types remains unchanged.

## What to look at

- [Builder registry and branch picker](https://github.com/dvd233/grafana-pathfinder-app/blob/bccf64e2adcc80ae95f306a1a03059b22b1b3663/src/components/block-editor/forms/BranchBlocksEditor.tsx): `DefaultableBlockType` is derived from `BLOCK_DEFAULT_BUILDERS`; `createDefaultBlock` delegates buildable types while retaining its legacy fallback switch.
- [Collapsible picker](https://github.com/dvd233/grafana-pathfinder-app/blob/bccf64e2adcc80ae95f306a1a03059b22b1b3663/src/components/block-editor/forms/CollapsibleBlockForm.tsx): its presentational list uses the same type, so both nested and branch entry points reject types without builders.

## Why

Issue #1655 identified two independent hand-maintained lists and a broad prop type. Without a shared type, deleting an arm or adding a fallback-only type can compile and produce an empty markdown block at runtime. The registry keeps the existing ten branch and five collapsible choices while making drift fail at compile time.

## How to verify

1. Open the branch block editor and add each default picker option; confirm the created block's type and shape match the selected option.
2. Open a collapsible block, add each presentational option, save, and reopen it; confirm the nested block type and content are preserved.
3. Temporarily remove the `guided` entry from `BLOCK_DEFAULT_BUILDERS` (or add `terminal` to `ALLOWED_BRANCH_BLOCK_TYPES`) and run the TypeScript checker; confirm it reports a type error at the stale list, then restore the entry.
4. Pass a fallback-only block type such as `terminal` to `addableBlockTypes` in a TypeScript call site; confirm it is rejected before runtime.


## Follow-up

The follow-up commit closes the review gaps without widening the runtime surface: builder values are keyed to their JsonBlock discriminants, Object.hasOwn guards the registry, the branch and collapsible pickers use safe builder-backed types (excluding challenge), and the legacy fallback has a regression assertion. The #1542 picker invariant is recorded in a named type and comment. This extends the original compile-check change rather than replacing the existing fallback contract.

## Breaking changes

The TypeScript `addableBlockTypes` prop is intentionally narrower and now rejects non-buildable block types. Existing valid call sites and runtime picker behavior are unchanged.

## Out of scope

- Narrowing `createDefaultBlock`'s own `BlockType` parameter or removing its legacy fallback remains separate, as requested by the issue.

Fixes #1655

🤖 Generated with [Claude Code](https://claude.com/claude-code)
