### PR TITLE
fix(e2e): repair guided substep contract

### DIFF
--- a/docs/developer/CROSS_TAB_CONTROLLER.md
+++ b/docs/developer/CROSS_TAB_CONTROLLER.md
@@ -59,12 +59,14 @@ the `pathfinder-cross-tab` channel. Every message carries an envelope
 (`source: 'pathfinder'`, a per-tab `senderId` used to drop self-echoes, and a
 `timestamp`):
 
-- `step-command` — `{ phase: 'show' | 'do', stepId, runId, action: { targetAction, refTarget, targetValue?, targetState?, targetComment?, internalActions? } }`.
+- `step-command` — `{ phase: 'show' | 'do', stepId, runId, action }`.
   `targetState` carries an authored `targetstate` through to the live tab so
   toggle actions converge on the requested state instead of clicking blindly.
-  Composite steps carry their ordered sub-actions in `internalActions`; the
-  wire shape is derived from `InternalAction` and omits only `requirements`,
-  which the controller gates separately. A
+  Composite steps carry their ordered sub-actions in `internalActions`.
+  Each sub-action can carry `requirements`, `isSkippable`, `formHint`,
+  `validateInput`, `lazyRender`, and `scrollContainer`.
+  A guided command also carries `guideId`, `contentKey`, `stepTimeout`, and
+  `completeEarly`. The validated wire preserves these fields. A
   `multistep` replays with staged pacing (see [Replay pacing](#replay-pacing));
   a `guided` step runs through the live tab's `GuidedHandler` instead — it
   highlights each target and waits for the user.
@@ -223,6 +225,13 @@ For both simple and composite commands, the executor copies `targetState` into
 the interactive-engine request; guided actions can therefore skip an instruction
 that is already satisfied, while automated actions click only when needed.
 
+The live guided handler uses the authored timeout for each substep. It checks
+substep requirements before target resolution. Requirement checks, one lazy
+discovery cycle, target setup, highlighting, and user action share one deadline.
+
+The live tab dispatches the same guided settlement events as local execution.
+Thus, the E2E runner can collect the same evidence in both modes.
+
 ## Requirement evaluation (round-trip)
 
 A controller tab drives a _different_ Grafana tab, so requirements that probe
@@ -245,6 +254,10 @@ Controller (useStepChecker, controller mode)        Live tab (installLiveTabExec
   controller evaluates them itself, in parallel with the round-trip of the
   remaining tokens, and ANDs the two verdicts — see
   [Guide identity for `var-*` checks](engines/requirements-manager.md#guide-identity-for-var-checks).
+- Guided substep requirements are different from the parent entry gate. They
+  cross the wire inside `internalActions` and run in the live tab.
+  The command carries `guideId` and `contentKey`, so `var-*` and
+  `section-completed:*` use the correct guide and content scope.
 - The reply is a plain `RequirementsCheckResult`; it flows through the **same**
   `createRequirementsState` path the in-tab checker uses, so the warning and
   "Fix this" affordance render identically — no controller-specific UI.
@@ -280,7 +293,8 @@ badge.
   including tab-local ones, but excluding the guide-scoped set the controller
   keeps — are evaluated and fixed on the live tab, re-checked at click time so a
   regressed prerequisite gates, and composites complete only once the live tab
-  reports `step-complete`.
+  reports `step-complete`. Guided substep requirements run on the live tab with
+  the controller's guide and content scope.
 - **Replies scoped to one live tab:** a controller trusts requirement/fix/
   completion replies from a single paired tab; see [Tab pairing](#tab-pairing).
   Commands are physically broadcast but authenticated for one `liveTabId`, so
@@ -300,5 +314,4 @@ badge.
 2. If the action shape differs (e.g. `internalActions` for multi-step / guided),
    extend `CrossTabAction` / `CrossTabMessage` and handle the new shape in
    `live-tab-executor.ts`. Build nested wire actions with
-   `toCrossTabInternalAction()`; it preserves fields such as `targetState` while
-   removing the requirements already evaluated by the controller.
+   `toCrossTabInternalAction()`; it preserves the engine and guided fields.

--- a/docs/developer/E2E_TESTING.md
+++ b/docs/developer/E2E_TESTING.md
@@ -150,6 +150,7 @@ The main Playwright suite and dedicated guide runner use a fixed 1920×1080 Chro
      - Handle requirements (Fix buttons with retry)
      - Click "Do it" button
      - Wait for completion indicator
+     - For guided steps, collect each substep settlement when it occurs
    - Session validated before each shared milestone and every 5 steps
 
 5. **Reporting**
@@ -289,7 +290,7 @@ Use `--output report.json` to generate a structured report:
 ```json
 {
   "schemaVersion": "1.1.0",
-  "outcome": "passed",
+  "outcome": "failed",
   "runner": {
     "name": "pathfinder-e2e-runner",
     "version": "commit-<sha>",
@@ -302,12 +303,12 @@ Use `--output report.json` to generate a structured report:
   "guide": { "id": "...", "title": "...", "path": "...", "targetUrl": "..." },
   "config": { "timestamp": "..." },
   "summary": {
-    "total": 10,
-    "passed": 8,
+    "total": 2,
+    "passed": 1,
     "failed": 1,
-    "skipped": 1,
+    "skipped": 0,
     "notReached": 0,
-    "duration": 1000,
+    "duration": 47000,
     "mandatoryFailed": 1,
     "skippableFailed": 0
   },
@@ -320,13 +321,42 @@ Use `--output report.json` to generate a structured report:
       "duration": 1000,
       "currentUrl": "http://localhost:3000/",
       "consoleErrors": []
+    },
+    {
+      "stepId": "section-1-guided-1",
+      "stepKind": "guided",
+      "index": 1,
+      "status": "failed",
+      "duration": 46000,
+      "currentUrl": "http://localhost:3000/",
+      "consoleErrors": [],
+      "guidedSubsteps": [
+        {
+          "index": 0,
+          "total": 2,
+          "action": "button",
+          "outcome": "completed",
+          "durationMs": 1000,
+          "timeoutMs": 45000,
+          "skippable": false
+        },
+        {
+          "index": 1,
+          "total": 2,
+          "action": "formfill",
+          "outcome": "timeout",
+          "durationMs": 45000,
+          "timeoutMs": 45000,
+          "skippable": false
+        }
+      ]
     }
   ],
   "coverage": {
     "contractSource": "current",
-    "rendered": 2,
-    "supported": 1,
-    "executed": 1,
+    "rendered": 3,
+    "supported": 2,
+    "executed": 2,
     "unsupported": 1,
     "unsupportedSteps": [{ "stepKind": "quiz", "stepId": "section-1-quiz-1" }]
   }
@@ -344,6 +374,7 @@ Key contract fields:
 - `guide.sourceUrl`: remote package source URL when available
 - `selection`: for an explicitly selected path or journey, the multi-guide report records the root package `id` and `type` separately from its executable leaf-guide reports
 - `steps[].stepKind`: optional registered driver kind for a reported step
+- `steps[].guidedSubsteps`: optional settlement evidence for each observed guided substep
 - `coverage.contractSource`: `current` for tracked roots, or `legacy` for the compatibility selector
 - `coverage.rendered`: number of tracked roots in the rendered DOM
 - `coverage.supported`: number of rendered roots with supported drivers
@@ -400,6 +431,8 @@ With `--always-screenshot`, the runner also captures pre-step screenshots, succe
 
 Trace capture is disabled for bearer-token cloud runs. Traces can contain authorization headers, cookies, and temporary credentials.
 
+The runner keeps the first failure artifact bundle when later cleanup also captures artifacts. Guided evidence remains in failed and deadline-exceeded step results.
+
 ## Guided-block test guide
 
 To verify guided-block support (substep loop, comment box contract, completion), run the E2E CLI against a guide that includes at least one guided block. The bundled guide **Block editor tutorial** (`block-editor-tutorial`) contains a guided block with two highlight substeps and is skippable:
@@ -414,7 +447,21 @@ Or by path:
 npx pathfinder-cli e2e src/bundled-interactives/block-editor-tutorial/content.json
 ```
 
-Guided steps are discovered via `data-targetaction="guided"` and `data-test-substep-total`; after "Do it", the runner drives substeps using only the comment box (`data-test-action`, `data-test-reftarget`, `data-test-target-value`) and step state (`data-test-step-state`, `data-test-substep-index`). Full coverage (button, highlight, formfill, hover, noop, skippable) may require additional guides such as `prometheus-grafana-101` or `loki-grafana-101`.
+Guided steps use the `guided` step driver. The driver reads `data-test-substep-total` and `data-test-step-timeout-ms` from the tracked root.
+
+After "Do it", the runner drives each substep from the comment box. It reads `data-test-action`, `data-test-reftarget`, and `data-test-target-value`.
+
+The runner reads `data-test-substep-skippable` before it waits for the comment box. It can skip consecutive unavailable substeps without a fixed delay.
+
+The runtime dispatches `pathfinder:guided-substep-settled` for each settled substep. The runner stores these events immediately.
+
+Each `guidedSubsteps` report entry contains `index`, `total`, `action`, `outcome`, `durationMs`, `timeoutMs`, and `skippable`. Evidence remains after parent failure, detachment, or a hard runner deadline.
+
+The local and cross-tab paths preserve all authored substep fields. These fields include requirements, target state, skippability, form validation, hints, and lazy-render options.
+
+The runtime checks substep requirements before target resolution. One timeout deadline covers requirements, one lazy-scroll cycle, target resolution, setup, highlighting, and user action.
+
+Full action coverage can require additional guides such as `prometheus-grafana-101` or `loki-grafana-101`.
 
 ## Framework test guide
 
@@ -464,27 +511,30 @@ The environment is reset **between dependency chains**, not between every guide.
 
 ## Timing and timeouts
 
-| Constant                   | Value            | Purpose                                                                                     |
-| -------------------------- | ---------------- | ------------------------------------------------------------------------------------------- |
-| Base step timeout          | 30s              | Maximum time for a single step                                                              |
-| Multistep bonus            | +5s per action   | Added for each internal action in multisteps                                                |
-| Guided substep bonus       | +30s per substep | Added for each substep in guided blocks                                                     |
-| Runner step backstop       | 2× step + 20s    | Wall-clock limit after normal step operation budgets                                        |
-| Backstop cleanup grace     | 3s per guide     | Page close, inner-work drain, and result publication after a backstop                       |
-| Button enable wait         | 10s              | Wait for sequential dependencies                                                            |
-| Fix button timeout         | 10s              | Per fix operation                                                                           |
-| Max fix attempts           | 3                | Retry limit before giving up                                                                |
-| Requirements settle window | 1s               | Poll budget before an unmet read with no Fix button counts as terminal                      |
-| Panel bootstrap            | 20s or 30s       | Uses 30s after navigation and 20s for same-page panel opening                               |
-| Scroll into view           | 5s               | Bounds scrolling a step into view, so a step completing or detaching there can't hang       |
-| Late completion check      | 2s               | Bounds the pre-scroll recheck for a step that completed or detached since discovery         |
-| Skip sync                  | 5s               | Bounds waiting for the plugin to reach a terminal state after the runner clicks Skip        |
-| Guided reload wait         | 15s              | Bounds waiting for `domcontentloaded` after a detected reload or navigation mid-guided-step |
+| Constant                   | Value                      | Purpose                                                                                |
+| -------------------------- | -------------------------- | -------------------------------------------------------------------------------------- |
+| Base step timeout          | 30s                        | Outer allowance for one step                                                           |
+| Multistep bonus            | +5s per action             | Added for each internal action in multisteps                                           |
+| Guided substep timeout     | Authored value per substep | Defaults to 120s and has a 600s maximum                                                |
+| Guided operation budget    | 30s + substeps × timeout   | Covers the guided driver and all authored substep budgets                              |
+| Runner step backstop       | 2× step + 20s              | Wall-clock limit after normal step operation budgets                                   |
+| Backstop cleanup grace     | 3s per guide               | Page close, inner-work drain, and result publication after a backstop                  |
+| Button enable wait         | 10s                        | Wait for sequential dependencies                                                       |
+| Fix button timeout         | 10s                        | Per fix operation                                                                      |
+| Max fix attempts           | 3                          | Retry limit before giving up                                                           |
+| Requirements settle window | 1s                         | Poll budget before an unmet read with no Fix button counts as terminal                 |
+| Panel bootstrap            | 20s or 30s                 | Uses 30s after navigation and 20s for same-page panel opening                          |
+| Scroll into view           | 5s                         | Bounds scrolling a step into view, so a step completing or detaching there cannot hang |
+| Late completion check      | 2s                         | Bounds the pre-scroll recheck for a step that completed or detached since discovery    |
+| Skip sync                  | 5s                         | Bounds waiting for the plugin to reach a terminal state after the runner clicks Skip   |
+| Guided reload wait         | Up to 15s                  | Uses the remaining substep budget after a detected reload or navigation                |
 
 Examples:
 
 - A multistep with 5 internal actions gets a 55s timeout (30s base + 5×5s).
-- A guided block with 3 substeps gets a 120s timeout (30s base + 3×30s).
+- A guided block with 3 substeps and the default gets a 390s budget (30s base + 3×120s).
+- A guided block with 3 substeps and `stepTimeout: 30000` gets a 120s budget.
+- Authored values such as 45s and 60s apply to each substep.
 
 The calculated step timeout remains the operation budget for normal completion and artifact collection. The runner backstop is twice this budget plus 20 seconds.
 

--- a/docs/developer/E2E_TESTING_CONTRACT.md
+++ b/docs/developer/E2E_TESTING_CONTRACT.md
@@ -20,7 +20,7 @@ See: [`docs/developer/interactive-examples/json-guide-format.md`](./interactive-
 
 Used by E2E tests to observe the current state of the interactive system. These are **declarative** - they describe what state the component is in.
 
-Examples: `data-test-step-kind`, `data-test-step-id`, `data-test-step-state`, `data-test-substep-index`, `data-test-action`
+Examples: `data-test-step-kind`, `data-test-step-id`, `data-test-step-state`, `data-test-substep-index`, `data-test-step-timeout-ms`, `data-test-action`
 
 **This document describes the E2E testing contract attributes.**
 
@@ -366,6 +366,55 @@ console.log(`Progress: ${parseInt(currentIndex) + 1}/${totalSteps}`);
 
 ---
 
+#### `data-test-step-timeout-ms`
+
+**Purpose**: Effective timeout for each guided substep, in milliseconds
+
+**Values**: A positive integer. The default is `120000`, and the maximum is `600000`.
+
+**Presence**: Always present on guided components
+
+The runner uses `120000` when this attribute is absent or invalid. This fallback supports older plugin builds.
+
+---
+
+#### `data-test-substep-skippable`
+
+**Purpose**: States whether the current guided substep can be skipped
+
+**Values**: `true` or `false`
+
+**Presence**: Present only during guided execution
+
+The component updates this value before each substep starts. Thus, the runner can skip a failed substep without waiting for most of its timeout.
+
+---
+
+### Guided settlement events
+
+The guided runtime dispatches these document events in local and cross-tab modes:
+
+- `pathfinder:guided-substep-settled`: Dispatches once when a substep settles.
+- `pathfinder:guided-run-settled`: Dispatches when the parent guided run settles.
+
+The substep event detail contains:
+
+- `stepId`
+- `index`
+- `total`
+- `action`
+- `outcome`
+- `durationMs`
+- `skippable`
+
+The supported outcomes are `completed`, `skipped`, `timeout`, `cancelled`, and `error`.
+
+The run event detail contains `stepId`. The substep event occurs after any `completeEarly` completion callback sets the final outcome.
+
+The runner combines each substep event with `data-test-step-timeout-ms`. It stores the result before the parent step completes, fails, or detaches.
+
+---
+
 #### `data-test-fix-type`
 
 **Purpose**: Classification of requirement fix needed when requirements are unmet
@@ -680,19 +729,23 @@ await page.waitForSelector('[data-test-step-state="completed"]', { timeout: 3000
 Guided steps run a substep loop driven by the comment box. The runner uses only the DOM and contract attributes (no guide JSON):
 
 1. **Wait for execution to start**: After clicking "Do it", wait for the step element to have `data-test-step-state="executing"`.
-2. **Read substep bounds**: From the step element, read `data-test-substep-index` (current substep, 0-based) and `data-test-substep-total` (total substeps).
-3. **Locate the comment box**: Use `.interactive-comment-box` (visible while the guided step is executing).
-4. **Read the comment box contract**: From the comment box, read `data-test-action` (e.g. `button`, `highlight`, `formfill`, `hover`, `noop`), `data-test-reftarget` (selector for the current target; see [Comment Boxes](#comment-boxes) — absent for noop), and `data-test-target-value` (for formfill).
-5. **Perform the substep**: For noop, click the Continue button; for button/highlight, resolve the target from `data-test-reftarget` and click; for hover, resolve and hover; for formfill, resolve and fill with `data-test-target-value`.
-6. **Wait for advance**: Poll the step element until `data-test-substep-index` increases or `data-test-step-state` becomes `"completed"`. If the step becomes `"error"` or `"cancelled"`, fail.
+2. **Read substep bounds**: Read `data-test-substep-index` and `data-test-substep-total` from the step element.
+3. **Read execution rules**: Read `data-test-step-timeout-ms` and `data-test-substep-skippable` from the step element.
+4. **Locate the comment box**: Use `.interactive-comment-box` while the guided step is executing.
+5. **Read the comment box contract**: Read `data-test-action`, `data-test-reftarget`, and `data-test-target-value` from the comment box.
+6. **Perform the substep**: Click, hover, fill, or continue as specified by the comment box attributes.
+7. **Collect evidence**: Record each `pathfinder:guided-substep-settled` event when it occurs.
+8. **Wait for advance**: Wait for the next index, parent completion, parent error, parent cancellation, or detachment.
 
 Completion is standardized on `data-test-step-state="completed"` for all step types (single, multistep, guided).
 
-The calculated step timeout remains the inner operation budget. A separate wall-clock backstop uses twice this budget plus 20 seconds.
+Each guided substep has one runtime deadline. Requirement checks, one lazy-scroll cycle, target resolution, setup, highlighting, and user action share this deadline.
+
+The runner operation budget is 30 seconds plus the effective timeout for each guided substep. A separate wall-clock backstop uses twice this budget plus 20 seconds.
 
 If the backstop expires, the runner closes the page and reports an infrastructure outcome. Normal step failures retain their evidence and skippable behavior.
 
-During active step execution, an unexpected page, context, or browser termination produces an infrastructure outcome. The runner retains results from steps that completed before the termination.
+During active step execution, an unexpected page, context, or browser termination produces an infrastructure outcome. The runner retains prior results and settled guided evidence.
 
 ```typescript
 // Wait for guided execution to start
@@ -702,6 +755,8 @@ await page.waitForSelector('[data-test-step-state="executing"]');
 const stepElement = page.locator('[data-testid="interactive-step-my-step"]');
 const totalStr = await stepElement.getAttribute('data-test-substep-total');
 const total = parseInt(totalStr ?? '1', 10);
+const timeoutStr = await stepElement.getAttribute('data-test-step-timeout-ms');
+const perSubstepTimeout = parseInt(timeoutStr ?? '120000', 10);
 
 // Each substep: read comment box, perform action, wait for advance
 const commentBox = page.locator('.interactive-comment-box').first();

--- a/src/cli/__tests__/schema-e2e-report.test.ts
+++ b/src/cli/__tests__/schema-e2e-report.test.ts
@@ -23,6 +23,7 @@ describe('schema command — e2e-report registration', () => {
     expect(schema?.['x-schema-version']).toBe('1.1.0');
     expect(JSON.stringify(schema)).toContain('"coverage"');
     expect(JSON.stringify(schema)).toContain('"stepKind"');
+    expect(JSON.stringify(schema)).toContain('"guidedSubsteps"');
   });
 
   it('exports the multi-guide report schema without throwing', () => {

--- a/src/cli/e2e/e2e-reporter.test.ts
+++ b/src/cli/e2e/e2e-reporter.test.ts
@@ -239,6 +239,66 @@ describe('versioned report contract', () => {
     expect(fail.errorCode).toBe('MANDATORY_FAILURE');
   });
 
+  it('preserves completed and skipped guided evidence on a passed parent step', () => {
+    const data = ranGuide('guided-pass');
+    data.results[0]!.stepKind = 'guided';
+    data.results[0]!.guidedSubsteps = [
+      {
+        index: 0,
+        total: 2,
+        action: 'button',
+        outcome: 'completed',
+        durationMs: 25,
+        timeoutMs: 45_000,
+        skippable: false,
+      },
+      {
+        index: 1,
+        total: 2,
+        action: 'noop',
+        outcome: 'skipped',
+        durationMs: 5,
+        timeoutMs: 45_000,
+        skippable: true,
+      },
+    ];
+
+    const report = generateReport(data);
+
+    expect(report.steps[0]).toMatchObject({
+      status: 'passed',
+      stepKind: 'guided',
+      guidedSubsteps: data.results[0]!.guidedSubsteps,
+    });
+    expect(() => E2ETestReportSchema.parse(report)).not.toThrow();
+  });
+
+  it('preserves partial guided evidence and deadline metadata on a failed parent step', () => {
+    const data = ranGuide('guided-fail', { failed: true });
+    data.results[0]!.stepKind = 'guided';
+    data.results[0]!.deadlineExceeded = true;
+    data.results[0]!.guidedSubsteps = [
+      {
+        index: 0,
+        total: 2,
+        action: 'formfill',
+        outcome: 'completed',
+        durationMs: 100,
+        timeoutMs: 60_000,
+        skippable: false,
+      },
+    ];
+
+    const report = generateReport(data);
+
+    expect(report.steps[0]).toMatchObject({
+      status: 'failed',
+      deadlineExceeded: true,
+      guidedSubsteps: data.results[0]!.guidedSubsteps,
+    });
+    expect(() => E2ETestReportSchema.parse(report)).not.toThrow();
+  });
+
   it('includes typed fatal transition metadata', () => {
     const report = generateReport({
       ...ranGuide('transition-failed'),

--- a/src/cli/e2e/e2e-reporter.ts
+++ b/src/cli/e2e/e2e-reporter.ts
@@ -24,6 +24,7 @@ import {
   type ReportSummary,
   type ArtifactPaths,
   type StepCoverage,
+  type GuidedSubstepResult,
   type ReportStepResult,
   type GuideMetadata,
   type ReportConfig,
@@ -50,6 +51,8 @@ export interface TestStepResult {
   currentUrl: string;
   consoleErrors: string[];
   error?: string;
+  deadlineExceeded?: boolean;
+  guidedSubsteps?: GuidedSubstepResult[];
   skipReason?: string;
   skippable: boolean;
   /** Error classification for failure triage (L3-5C) */
@@ -148,6 +151,12 @@ export function convertStepResults(results: TestStepResult[]): ReportStepResult[
 
     if (result.error) {
       reportStep.error = result.error;
+    }
+    if (result.deadlineExceeded) {
+      reportStep.deadlineExceeded = true;
+    }
+    if (result.guidedSubsteps?.length) {
+      reportStep.guidedSubsteps = result.guidedSubsteps;
     }
 
     // Include skippable flag for failed steps (useful for understanding why test passed/failed)

--- a/src/cli/e2e/schemas/e2e-report.schema.ts
+++ b/src/cli/e2e/schemas/e2e-report.schema.ts
@@ -113,6 +113,16 @@ export const StepCoverageSchema = z.object({
   ),
 });
 
+export const GuidedSubstepResultSchema = z.object({
+  index: z.number().int().nonnegative(),
+  total: z.number().int().positive(),
+  action: z.string(),
+  outcome: z.enum(['completed', 'skipped', 'timeout', 'cancelled', 'error']),
+  durationMs: z.number().nonnegative(),
+  timeoutMs: z.number().int().positive(),
+  skippable: z.boolean(),
+});
+
 export const ReportStepResultSchema = z.object({
   stepId: z.string(),
   stepKind: z.string().optional(),
@@ -123,6 +133,8 @@ export const ReportStepResultSchema = z.object({
   consoleErrors: z.array(z.string()),
   skipReason: z.string().optional(),
   error: z.string().optional(),
+  deadlineExceeded: z.boolean().optional(),
+  guidedSubsteps: z.array(GuidedSubstepResultSchema).optional(),
   skippable: z.boolean().optional(),
   classification: ErrorClassificationSchema.optional(),
   artifacts: ArtifactPathsSchema.optional(),
@@ -258,6 +270,7 @@ export type ReportTarget = z.infer<typeof ReportTargetSchema>;
 export type ReportSummary = z.infer<typeof ReportSummarySchema>;
 export type ArtifactPaths = z.infer<typeof ArtifactPathsSchema>;
 export type StepCoverage = z.infer<typeof StepCoverageSchema>;
+export type GuidedSubstepResult = z.infer<typeof GuidedSubstepResultSchema>;
 export type ReportStepResult = z.infer<typeof ReportStepResultSchema>;
 export type GuideMetadata = z.infer<typeof GuideMetadataSchema>;
 export type ReportConfig = z.infer<typeof ReportConfigSchema>;

--- a/src/components/content-renderer/content-renderer.tsx
+++ b/src/components/content-renderer/content-renderer.tsx
@@ -425,7 +425,7 @@ export const ContentRenderer = React.memo(function ContentRenderer({
 
   return (
     <GuideResponseProvider guideId={guideId}>
-      <GuideRequirementsProvider guideId={guideId}>
+      <GuideRequirementsProvider guideId={guideId} contentKey={content.url}>
         <ContentWithVariables
           processedContent={processedContent}
           contentType={content.type}

--- a/src/components/interactive-tutorial/interactive-guided.test.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.test.tsx
@@ -14,6 +14,7 @@ import { deriveGuidedUiState, InteractiveGuided } from './interactive-guided';
 import { useStepChecker } from '../../requirements-manager';
 import { useAiFixEnabled } from '../../integrations/assistant-integration/use-ai-fix-enabled';
 import { testIds } from '../../constants/testIds';
+import { GUIDED_RUN_SETTLED_EVENT, GUIDED_SUBSTEP_SETTLED_EVENT } from '../../types/interactive-actions.types';
 
 // ─── Mock @grafana/ui ────────────────────────────────────────────────────────
 jest.mock('@grafana/ui', () => ({
@@ -84,6 +85,25 @@ let mockCompletionReason = 'none';
 const mockMarkSkipped = jest.fn(() => {
   mockStoredCompleted = true;
 });
+const mockCheckGuidedRequirements = jest.fn().mockResolvedValue({
+  requirements: '',
+  pass: true,
+  error: [],
+});
+let mockInteractiveMode = 'local';
+const mockControllerChannel = {
+  post: jest.fn(),
+  onStepProgress: jest.fn(() => jest.fn()),
+  awaitStepComplete: jest.fn().mockResolvedValue(true),
+  cancelStepComplete: jest.fn(),
+};
+
+jest.mock('../../global-state/interactive-mode-context', () => ({
+  useInteractiveMode: () => mockInteractiveMode,
+}));
+jest.mock('../../global-state/controller-channel', () => ({
+  useControllerChannel: () => mockControllerChannel,
+}));
 
 // ─── Mock completion store ────────────────────────────────────────────────
 jest.mock('../../global-state/completion-store', () => ({
@@ -97,6 +117,12 @@ jest.mock('../../global-state/completion-store', () => ({
 
 // ─── Mock requirements manager ───────────────────────────────────────────────
 jest.mock('../../requirements-manager', () => ({
+  useGuideRequirements: jest.fn(() => ({
+    guideId: 'test-guide',
+    contentKey: '/guides/test/content.json',
+    checkRequirements: mockCheckGuidedRequirements,
+    checkPostconditions: jest.fn(),
+  })),
   useStepChecker: jest.fn(() => ({
     isEnabled: true,
     isChecking: false,
@@ -167,6 +193,12 @@ beforeEach(() => {
   mockStoredCompleted = false;
   mockCompletionReason = 'none';
   mockExecuteGuidedStep.mockReset();
+  mockInteractiveMode = 'local';
+  mockControllerChannel.post.mockReset();
+  mockControllerChannel.onStepProgress.mockClear();
+  mockControllerChannel.awaitStepComplete.mockReset();
+  mockControllerChannel.awaitStepComplete.mockResolvedValue(true);
+  mockControllerChannel.cancelStepComplete.mockClear();
   mockMarkSkipped.mockReset();
   mockMarkSkipped.mockImplementation(() => {
     mockStoredCompleted = true;
@@ -255,6 +287,124 @@ describe('InteractiveGuided — double skip button (issue #786)', () => {
     expect(skipButtons).toHaveLength(1);
     expect(skipButtons[0]).toHaveTextContent('Skip');
   });
+
+  it('exposes the effective timeout and active substep skippability', async () => {
+    render(
+      <InteractiveGuided
+        stepId="guided-contract"
+        stepTimeout={45_000}
+        internalActions={[{ targetAction: 'noop', isSkippable: true }]}
+      />
+    );
+    const step = screen.getByTestId(testIds.interactive.step('guided-contract'));
+
+    expect(step).toHaveAttribute('data-test-step-timeout-ms', '45000');
+    expect(step).not.toHaveAttribute('data-test-substep-skippable');
+
+    fireEvent.click(screen.getByRole('button', { name: /start guided interaction/i }));
+
+    await waitFor(() => {
+      expect(step).toHaveAttribute('data-test-step-state', 'executing');
+      expect(step).toHaveAttribute('data-test-substep-skippable', 'true');
+    });
+  });
+});
+
+describe('InteractiveGuided — guided settlement contract', () => {
+  it('forwards the canonical checker and publishes substep and run settlement', async () => {
+    const onSubstepSettled = jest.fn();
+    const onRunSettled = jest.fn();
+    document.addEventListener(GUIDED_SUBSTEP_SETTLED_EVENT, onSubstepSettled);
+    document.addEventListener(GUIDED_RUN_SETTLED_EVENT, onRunSettled);
+    mockExecuteGuidedStep.mockImplementation(async (_action, _index, _total, options) => {
+      options.onSettled({
+        index: 0,
+        total: 1,
+        action: 'noop',
+        outcome: 'skipped',
+        durationMs: 12,
+        skippable: true,
+      });
+      return 'skipped';
+    });
+
+    render(
+      <InteractiveGuided
+        stepId="settlement-contract"
+        stepTimeout={60_000}
+        internalActions={[{ targetAction: 'noop', requirements: ['is-admin'], isSkippable: true }]}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /start guided interaction/i }));
+
+    await waitFor(() => expect(onRunSettled).toHaveBeenCalledTimes(1));
+    expect(mockExecuteGuidedStep).toHaveBeenCalledWith(
+      expect.objectContaining({ requirements: ['is-admin'], isSkippable: true }),
+      0,
+      1,
+      expect.objectContaining({
+        timeout: 60_000,
+        checkRequirements: mockCheckGuidedRequirements,
+        onSettled: expect.any(Function),
+      })
+    );
+    expect((onSubstepSettled.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      stepId: 'settlement-contract',
+      index: 0,
+      total: 1,
+      action: 'noop',
+      outcome: 'skipped',
+      durationMs: 12,
+      skippable: true,
+    });
+    expect((onRunSettled.mock.calls[0][0] as CustomEvent).detail).toEqual({ stepId: 'settlement-contract' });
+
+    document.removeEventListener(GUIDED_SUBSTEP_SETTLED_EVENT, onSubstepSettled);
+    document.removeEventListener(GUIDED_RUN_SETTLED_EVENT, onRunSettled);
+  });
+
+  it('preserves guided fields, scope, timeout, and completeEarly in controller mode', async () => {
+    mockInteractiveMode = 'controller';
+    const internalAction = {
+      targetAction: 'formfill' as const,
+      refTarget: '#name',
+      targetValue: '^Grafana$',
+      targetComment: 'Enter the product name',
+      requirements: ['exists-reftarget'],
+      isSkippable: true,
+      formHint: 'Use the product name',
+      validateInput: true,
+      lazyRender: true,
+      scrollContainer: '.settings-scroll',
+    };
+
+    render(
+      <InteractiveGuided
+        stepId="controller-contract"
+        stepTimeout={30_000}
+        completeEarly={true}
+        internalActions={[internalAction]}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /start guided interaction/i }));
+
+    await waitFor(() => expect(mockControllerChannel.post).toHaveBeenCalled());
+    expect(mockControllerChannel.post).toHaveBeenCalledWith({
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'controller-contract',
+      runId: expect.any(String),
+      action: {
+        targetAction: 'guided',
+        refTarget: '',
+        internalActions: [internalAction],
+        guideId: 'test-guide',
+        contentKey: '/guides/test/content.json',
+        stepTimeout: 30_000,
+        completeEarly: true,
+      },
+    });
+  });
 });
 
 describe('deriveGuidedUiState', () => {
@@ -334,9 +484,9 @@ describe('InteractiveGuided — completeEarly lifecycle', () => {
 
   it('persists a final click signal only after its listener starts', async () => {
     const actionOrder: string[] = [];
-    mockExecuteGuidedStep.mockImplementation(async (_action, _index, _total, _timeout, onActionCompleted) => {
+    mockExecuteGuidedStep.mockImplementation(async (_action, _index, _total, options) => {
       actionOrder.push('listener started');
-      onActionCompleted();
+      options.onActionCompleted();
       return 'completed';
     });
     function AutoCollapseHarness() {
@@ -368,9 +518,9 @@ describe('InteractiveGuided — completeEarly lifecycle', () => {
   it('passes the completion callback only to the final action', async () => {
     const actionOrder: string[] = [];
     const onStepComplete = jest.fn(() => actionOrder.push('completion persisted'));
-    mockExecuteGuidedStep.mockImplementation(async (_action, index, _total, _timeout, onActionCompleted) => {
+    mockExecuteGuidedStep.mockImplementation(async (_action, index, _total, options) => {
       actionOrder.push(`action ${index}`);
-      onActionCompleted?.();
+      options.onActionCompleted?.();
       return 'completed';
     });
 
@@ -393,8 +543,8 @@ describe('InteractiveGuided — completeEarly lifecycle', () => {
       expect(mockExecuteGuidedStep).toHaveBeenCalledTimes(2);
       expect(onStepComplete).toHaveBeenCalledTimes(1);
     });
-    expect(mockExecuteGuidedStep.mock.calls[0][4]).toBeUndefined();
-    expect(mockExecuteGuidedStep.mock.calls[1][4]).toEqual(expect.any(Function));
+    expect(mockExecuteGuidedStep.mock.calls[0][3].onActionCompleted).toBeUndefined();
+    expect(mockExecuteGuidedStep.mock.calls[1][3].onActionCompleted).toEqual(expect.any(Function));
     expect(actionOrder).toEqual(['action 0', 'action 1', 'completion persisted']);
   });
 
@@ -405,11 +555,11 @@ describe('InteractiveGuided — completeEarly lifecycle', () => {
         throw new Error('parent persistence failed');
       })
       .mockImplementation(() => undefined);
-    mockExecuteGuidedStep.mockImplementation(async (_action, _index, _total, _timeout, onActionCompleted) => {
+    mockExecuteGuidedStep.mockImplementation(async (_action, _index, _total, options) => {
       try {
-        onActionCompleted?.();
+        options.onActionCompleted?.();
       } catch {
-        onActionCompleted?.();
+        options.onActionCompleted?.();
       }
       return 'completed';
     });

--- a/src/components/interactive-tutorial/interactive-guided.tsx
+++ b/src/components/interactive-tutorial/interactive-guided.tsx
@@ -14,11 +14,17 @@ import {
 } from '../../interactive-engine';
 import { waitForReactUpdates } from '../../lib/async-utils';
 import { logger } from '../../lib/logging';
-import { useStepChecker, validateInteractiveRequirements } from '../../requirements-manager';
+import { useGuideRequirements, useStepChecker, validateInteractiveRequirements } from '../../requirements-manager';
 import { getInteractiveConfig } from '../../constants/interactive-config';
 import { getConfigWithDefaults } from '../../constants';
 import { findButtonByText, querySelectorAllEnhanced } from '../../lib/dom';
-import { GuidedAction } from '../../types/interactive-actions.types';
+import {
+  GUIDED_RUN_SETTLED_EVENT,
+  GUIDED_SUBSTEP_SETTLED_EVENT,
+  type GuidedAction,
+  type GuidedRunSettledDetail,
+  type GuidedSubstepSettledDetail,
+} from '../../types/interactive-actions.types';
 import { testIds } from '../../constants/testIds';
 // Deep import (not the barrel): the barrel re-exports @grafana/assistant, which crashes under jsdom.
 import { useAiFixEnabled } from '../../integrations/assistant-integration/use-ai-fix-enabled';
@@ -211,6 +217,7 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
     // Local UI state
     const mode = useInteractiveMode();
     const controllerChannel = useControllerChannel();
+    const guideRequirements = useGuideRequirements();
     const [isExecuting, setIsExecuting] = useState(false);
     // Set when the user cancels a controller-mode run, so the awaiting branch
     // distinguishes a deliberate cancel from a disconnect/failure (skips the toast).
@@ -415,13 +422,18 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
 
             const completeBeforeActionEffect =
               completeEarly && i === internalActions.length - 1 ? completeStep : undefined;
-            const result = await guidedHandler.executeGuidedStep(
-              action!,
-              i,
-              internalActions.length,
-              stepTimeout,
-              completeBeforeActionEffect
-            );
+            const result = await guidedHandler.executeGuidedStep(action!, i, internalActions.length, {
+              timeout: stepTimeout,
+              checkRequirements: guideRequirements.checkRequirements,
+              onActionCompleted: completeBeforeActionEffect,
+              onSettled: (detail) => {
+                document.dispatchEvent(
+                  new CustomEvent<GuidedSubstepSettledDetail>(GUIDED_SUBSTEP_SETTLED_EVENT, {
+                    detail: { ...detail, stepId: renderedStepId },
+                  })
+                );
+              },
+            });
 
             if (result === 'completed' || result === 'skipped') {
               if (completeEarly && i === internalActions.length - 1) {
@@ -453,6 +465,11 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
           return false;
         }
       } finally {
+        document.dispatchEvent(
+          new CustomEvent<GuidedRunSettledDetail>(GUIDED_RUN_SETTLED_EVENT, {
+            detail: { stepId: renderedStepId },
+          })
+        );
         isExecutingRef.current = false;
         if (isMountedRef.current) {
           setIsExecuting(false);
@@ -473,6 +490,8 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
       persistCompletion,
       checker.completionReason,
       fullScreenFallbackLocation,
+      guideRequirements.checkRequirements,
+      renderedStepId,
     ]);
 
     // Expose execute method for parent (section execution)
@@ -678,6 +697,10 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
             targetAction: 'guided',
             refTarget: '',
             internalActions: internalActions.map(toCrossTabInternalAction),
+            guideId: guideRequirements.guideId,
+            contentKey: guideRequirements.contentKey,
+            stepTimeout,
+            completeEarly,
           },
         });
         try {
@@ -722,6 +745,10 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
       onStepComplete,
       onComplete,
       stepId,
+      guideRequirements.guideId,
+      guideRequirements.contentKey,
+      stepTimeout,
+      completeEarly,
     ]);
 
     // Handle step reset (redo functionality)
@@ -813,6 +840,8 @@ export const InteractiveGuided = forwardRef<{ executeStep: () => Promise<boolean
         data-test-step-state={uiState}
         data-test-substep-index={isExecuting ? currentStepIndex : undefined}
         data-test-substep-total={internalActions.length}
+        data-test-step-timeout-ms={stepTimeout}
+        data-test-substep-skippable={isExecuting ? String(currentAction?.isSkippable === true) : undefined}
         data-test-requirements-state={
           checker.isChecking ? 'checking' : checker.isEnabled ? 'met' : checker.explanation ? 'unmet' : 'unknown'
         }

--- a/src/docs-retrieval/json-parser-aliases.test.ts
+++ b/src/docs-retrieval/json-parser-aliases.test.ts
@@ -135,6 +135,57 @@ describe('json-parser — field-name alias acceptance', () => {
     expect(actions[1]!.targetState).toBe('data-state:open');
     expect(actions[2]!.targetState).toBeUndefined();
   });
+
+  it('guided block: preserves all substep execution fields and the block timeout', () => {
+    const guide: JsonGuide = {
+      id: 'guided-contract',
+      title: 'Guided contract',
+      blocks: [
+        {
+          type: 'guided',
+          content: 'Complete the form',
+          stepTimeout: 45_000,
+          completeEarly: true,
+          steps: [
+            {
+              action: 'formfill',
+              reftarget: '#name',
+              targetvalue: '^Grafana$',
+              description: 'Enter **Grafana**',
+              requirements: ['exists-reftarget'],
+              skippable: true,
+              formHint: 'Use the product name',
+              validateInput: true,
+              lazyRender: true,
+              scrollContainer: '.settings-scroll',
+            },
+          ],
+        },
+      ],
+    };
+
+    const block = parseJsonGuide(guide).data!.elements.find((element) => element.type === 'interactive-guided');
+    const props = block!.props as {
+      stepTimeout: number;
+      completeEarly: boolean;
+      internalActions: Array<Record<string, unknown>>;
+    };
+
+    expect(props.stepTimeout).toBe(45_000);
+    expect(props.completeEarly).toBe(true);
+    expect(props.internalActions[0]).toMatchObject({
+      targetAction: 'formfill',
+      refTarget: '#name',
+      targetValue: '^Grafana$',
+      targetComment: expect.stringContaining('<strong>Grafana</strong>'),
+      requirements: ['exists-reftarget'],
+      isSkippable: true,
+      formHint: 'Use the product name',
+      validateInput: true,
+      lazyRender: true,
+      scrollContainer: '.settings-scroll',
+    });
+  });
 });
 
 describe('json-parser — stable derived stepIds (closes #8 standalone instability)', () => {

--- a/src/docs-retrieval/json-parser.ts
+++ b/src/docs-retrieval/json-parser.ts
@@ -799,8 +799,10 @@ function convertGuidedBlock(block: JsonGuidedBlock, path: string, stepContext?: 
         ? markdownToHtml(step.tooltip)
         : undefined,
     isSkippable: step.skippable ?? false,
-    formHint: step.formHint, // Pass form hint for formfill validation feedback
-    validateInput: step.validateInput, // Pass validation toggle for formfill
+    formHint: step.formHint,
+    validateInput: step.validateInput,
+    lazyRender: step.lazyRender ?? false,
+    scrollContainer: step.scrollContainer,
   }));
 
   // Parse content as markdown for children

--- a/src/integrations/cross-tab/live-tab-executor.test.ts
+++ b/src/integrations/cross-tab/live-tab-executor.test.ts
@@ -7,6 +7,7 @@ import { sidebarState } from '../../global-state/sidebar';
 import { isExtensionSidebarOwnedByOther } from '../../lib/storage/extension-sidebar';
 import { FakeCrossTabTransport } from '../../test-utils/fake-cross-tab-transport';
 import type { CrossTabMessage } from '../../types/cross-tab.types';
+import { GUIDED_RUN_SETTLED_EVENT, GUIDED_SUBSTEP_SETTLED_EVENT } from '../../types/interactive-actions.types';
 import { withFaroUserAction } from '../../lib/faro';
 import { isInteractiveActionType } from '../../lib/interactive-action';
 
@@ -276,7 +277,10 @@ describe('installLiveTabExecutor', () => {
     expect(executeGuidedStep).toHaveBeenCalledWith(
       expect.objectContaining({ targetState: 'aria-expanded:true' }),
       0,
-      1
+      1,
+      expect.objectContaining({
+        checkRequirements: expect.any(Function),
+      })
     );
     uninstall();
   });
@@ -339,6 +343,201 @@ describe('installLiveTabExecutor', () => {
         expect.objectContaining({ kind: 'step-complete', stepId: 'g1', runId: 'run-g1', ok: true })
       )
     );
+    uninstall();
+  });
+
+  it('passes the complete guided action, timeout, and guide scope to the guided handler', async () => {
+    const transport = new FakeCrossTabTransport('live-self');
+    const uninstall = installLiveTabExecutor(transport, DEFAULT_PACING, openAuthGate);
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'guided-full',
+      runId: 'run-guided-full',
+      action: {
+        targetAction: 'guided',
+        refTarget: '',
+        guideId: 'guide-a',
+        contentKey: '/guides/a/content.json',
+        stepTimeout: 45_000,
+        internalActions: [
+          {
+            targetAction: 'formfill',
+            refTarget: '#name',
+            targetValue: '^Grafana$',
+            targetComment: 'Enter the product name',
+            requirements: ['exists-reftarget'],
+            isSkippable: true,
+            formHint: 'Use the product name',
+            validateInput: true,
+            lazyRender: true,
+            scrollContainer: '.settings-scroll',
+          },
+        ],
+      },
+    });
+
+    const executeGuidedStep = (GuidedHandler as jest.Mock).mock.results[0]?.value.executeGuidedStep as jest.Mock;
+    await waitFor(() => expect(executeGuidedStep).toHaveBeenCalled());
+    expect(executeGuidedStep).toHaveBeenCalledWith(
+      {
+        targetAction: 'formfill',
+        refTarget: '#name',
+        targetValue: '^Grafana$',
+        targetComment: 'Enter the product name',
+        requirements: ['exists-reftarget'],
+        isSkippable: true,
+        formHint: 'Use the product name',
+        validateInput: true,
+        lazyRender: true,
+        scrollContainer: '.settings-scroll',
+      },
+      0,
+      1,
+      expect.objectContaining({ timeout: 45_000 })
+    );
+
+    const options = executeGuidedStep.mock.calls[0]?.[3] as {
+      checkRequirements: (options: {
+        requirements: string[];
+        targetAction: 'formfill';
+        refTarget: string;
+        stepId: string;
+      }) => Promise<unknown>;
+    };
+    await options.checkRequirements({
+      requirements: ['section-completed:setup'],
+      targetAction: 'formfill',
+      refTarget: '#name',
+      stepId: 'guided-full',
+    });
+    expect(checkRequirements).toHaveBeenCalledWith({
+      requirements: ['section-completed:setup'],
+      targetAction: 'formfill',
+      refTarget: '#name',
+      stepId: 'guided-full',
+      guideId: 'guide-a',
+      contentKey: '/guides/a/content.json',
+    });
+    uninstall();
+  });
+
+  it('dispatches guided substep and run settlement events', async () => {
+    const executeGuidedStep = jest.fn(
+      async (_action: unknown, _index: number, _total: number, options: { onSettled?: (detail: unknown) => void }) => {
+        options.onSettled?.({
+          index: 0,
+          total: 1,
+          action: 'button',
+          outcome: 'completed',
+          durationMs: 25,
+          skippable: false,
+        });
+        return 'completed';
+      }
+    );
+    (GuidedHandler as jest.Mock).mockImplementationOnce(() => ({
+      resetProgress: jest.fn(),
+      executeGuidedStep,
+    }));
+    const dispatchEvent = jest.spyOn(document, 'dispatchEvent');
+    const transport = new FakeCrossTabTransport('live-self');
+    const uninstall = installLiveTabExecutor(transport, DEFAULT_PACING, openAuthGate);
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'guided-events',
+      runId: 'run-guided-events',
+      action: {
+        targetAction: 'guided',
+        refTarget: '',
+        stepTimeout: 60_000,
+        internalActions: [{ targetAction: 'button', refTarget: '#save' }],
+      },
+    });
+
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({ kind: 'step-complete', stepId: 'guided-events', ok: true })
+      )
+    );
+    const events = dispatchEvent.mock.calls.map(([event]) => event);
+    const substepEvent = events.find((event) => event.type === GUIDED_SUBSTEP_SETTLED_EVENT) as CustomEvent;
+    const runEvent = events.find((event) => event.type === GUIDED_RUN_SETTLED_EVENT) as CustomEvent;
+    expect(substepEvent.detail).toEqual({
+      index: 0,
+      total: 1,
+      action: 'button',
+      outcome: 'completed',
+      durationMs: 25,
+      skippable: false,
+      stepId: 'guided-events',
+    });
+    expect(runEvent.detail).toEqual({ stepId: 'guided-events' });
+    dispatchEvent.mockRestore();
+    uninstall();
+  });
+
+  it('posts completion once when completeEarly settles the last guided action', async () => {
+    const executeGuidedStep = jest.fn(
+      async (_action: unknown, _index: number, _total: number, options: { onActionCompleted?: () => void }) => {
+        options.onActionCompleted?.();
+        return 'completed';
+      }
+    );
+    (GuidedHandler as jest.Mock).mockImplementationOnce(() => ({
+      resetProgress: jest.fn(),
+      executeGuidedStep,
+    }));
+    const transport = new FakeCrossTabTransport('live-self');
+    const uninstall = installLiveTabExecutor(transport, DEFAULT_PACING, openAuthGate);
+
+    transport.emit({
+      source: 'pathfinder',
+      senderId: 'controller',
+      timestamp: 0,
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'guided-early',
+      runId: 'run-guided-early',
+      action: {
+        targetAction: 'guided',
+        refTarget: '',
+        completeEarly: true,
+        internalActions: [
+          { targetAction: 'highlight', refTarget: '#first' },
+          { targetAction: 'button', refTarget: '#last' },
+        ],
+      },
+    });
+
+    await waitFor(() => expect(executeGuidedStep).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(transport.postedMessages).toContainEqual(
+        expect.objectContaining({ kind: 'step-complete', stepId: 'guided-early', ok: true })
+      )
+    );
+    expect(executeGuidedStep.mock.calls[0]?.[3]).toEqual(expect.objectContaining({ onActionCompleted: undefined }));
+    expect(executeGuidedStep.mock.calls[1]?.[3]).toEqual(
+      expect.objectContaining({ onActionCompleted: expect.any(Function) })
+    );
+    expect(
+      transport.postedMessages.filter((message) => {
+        if (typeof message !== 'object' || message === null) {
+          return false;
+        }
+        const posted = message as { kind?: unknown; stepId?: unknown };
+        return posted.kind === 'step-complete' && posted.stepId === 'guided-early';
+      })
+    ).toHaveLength(1);
     uninstall();
   });
 

--- a/src/integrations/cross-tab/live-tab-executor.ts
+++ b/src/integrations/cross-tab/live-tab-executor.ts
@@ -16,7 +16,13 @@ import {
   NavigateHandler,
   NavigationManager,
 } from '../../interactive-engine';
-import type { GuidedAction } from '../../types/interactive-actions.types';
+import {
+  GUIDED_RUN_SETTLED_EVENT,
+  GUIDED_SUBSTEP_SETTLED_EVENT,
+  type GuidedAction,
+  type GuidedRunSettledDetail,
+  type GuidedSubstepSettledDetail,
+} from '../../types/interactive-actions.types';
 import { CrossTabTransport, createSenderId } from '../../lib/cross-tab-transport';
 import { checkRequirements, dispatchFix, type RequirementsCheckResult } from '../../requirements-manager';
 import {
@@ -242,28 +248,55 @@ export function installLiveTabExecutor(
 
   // Guided is human-driven: highlight each target and wait for the user to perform
   // it on the live tab, rather than the auto replay a multi-step uses.
-  const runGuided = async (actions: ActionList, onProgress: OnProgress): Promise<boolean> => {
+  const runGuided = async (
+    command: StepCommandMessage,
+    actions: ActionList,
+    onProgress: OnProgress,
+    onCompletedEarly: () => void
+  ): Promise<boolean> => {
     guidedHandler.resetProgress();
-    for (let i = 0; i < actions.length; i++) {
-      onProgress(i);
-      const action = actions[i]!;
-      // The receive gate accepts any KNOWN_TARGET_ACTIONS verb, which is wider than
-      // the guided verb set — guard the cast so a non-guided verb (e.g. navigate)
-      // fails loud instead of being mistyped into the guided handler (F-1073-nit-cast).
-      if (!GUIDED_VERBS.has(action.targetAction as GuidedAction['targetAction'])) {
-        logger.warn(`[Pathfinder] cross-tab executor: guided step has non-guided verb "${action.targetAction}"`);
-        return false;
+    try {
+      for (let i = 0; i < actions.length; i++) {
+        onProgress(i);
+        const action = actions[i]!;
+        if (!GUIDED_VERBS.has(action.targetAction as GuidedAction['targetAction'])) {
+          logger.warn(`[Pathfinder] cross-tab executor: guided step has non-guided verb "${action.targetAction}"`);
+          return false;
+        }
+        const result = await guidedHandler.executeGuidedStep(
+          { ...action, targetAction: action.targetAction as GuidedAction['targetAction'] },
+          i,
+          actions.length,
+          {
+            timeout: command.action.stepTimeout,
+            checkRequirements: (options) =>
+              checkRequirements({
+                ...options,
+                guideId: command.action.guideId,
+                contentKey: command.action.contentKey,
+              }),
+            onActionCompleted: command.action.completeEarly && i === actions.length - 1 ? onCompletedEarly : undefined,
+            onSettled: (detail) => {
+              document.dispatchEvent(
+                new CustomEvent<GuidedSubstepSettledDetail>(GUIDED_SUBSTEP_SETTLED_EVENT, {
+                  detail: { ...detail, stepId: command.stepId },
+                })
+              );
+            },
+          }
+        );
+        if (result !== 'completed' && result !== 'skipped') {
+          return false;
+        }
       }
-      const result = await guidedHandler.executeGuidedStep(
-        { ...action, targetAction: action.targetAction as GuidedAction['targetAction'] },
-        i,
-        actions.length
+      return true;
+    } finally {
+      document.dispatchEvent(
+        new CustomEvent<GuidedRunSettledDetail>(GUIDED_RUN_SETTLED_EVENT, {
+          detail: { stepId: command.stepId },
+        })
       );
-      if (result !== 'completed' && result !== 'skipped') {
-        return false;
-      }
     }
-    return true;
   };
 
   const runStepCommand = async (command: StepCommandMessage): Promise<void> => {
@@ -274,6 +307,14 @@ export function installLiveTabExecutor(
     const internalActions = command.action.internalActions;
     const postProgress = (index: number) =>
       transport.post({ kind: 'step-progress', stepId, runId, index, total: internalActions?.length ?? 0 });
+    let completionPosted = false;
+    const postCompletion = (ok: boolean) => {
+      if (completionPosted) {
+        return;
+      }
+      completionPosted = true;
+      transport.post({ kind: 'step-complete', stepId, runId, ok });
+    };
     await withFaroUserAction(
       TELEMETRY_ACTIONS.remoteStep,
       {
@@ -289,7 +330,7 @@ export function installLiveTabExecutor(
         try {
           if (internalActions?.length) {
             if (command.action.targetAction === 'guided') {
-              ok = await runGuided(internalActions, postProgress);
+              ok = await runGuided(command, internalActions, postProgress, () => postCompletion(true));
             } else {
               await runComposite(internalActions, postProgress);
               ok = true;
@@ -307,7 +348,7 @@ export function installLiveTabExecutor(
         // failure instead of completing early. Simple steps stay optimistic by design
         // and report nothing back.
         if (internalActions?.length) {
-          transport.post({ kind: 'step-complete', stepId, runId, ok });
+          postCompletion(ok);
         }
       },
       USER_ACTION_TIMEOUT_LONG_MS

--- a/src/interactive-engine/action-handlers/guided-handler.test.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.test.ts
@@ -3,6 +3,7 @@ import { InteractiveStateManager } from '../interactive-state-manager';
 import { NavigationManager } from '../navigation-manager';
 import { querySelectorAllEnhanced } from '../../lib/dom';
 import { withFaroUserAction } from '../../lib/faro';
+import { scrollUntilElementFound } from '../../lib/dom/dom-utils';
 import type { InteractiveElementData } from '../../types/interactive.types';
 
 jest.mock('../interactive-state-manager');
@@ -21,6 +22,9 @@ jest.mock('../../lib/dom', () => ({
 }));
 jest.mock('../../lib/dom/selector-detector', () => ({
   isCssSelector: jest.fn().mockReturnValue(false),
+}));
+jest.mock('../../lib/dom/dom-utils', () => ({
+  scrollUntilElementFound: jest.fn(),
 }));
 
 describe('GuidedHandler', () => {
@@ -50,6 +54,7 @@ describe('GuidedHandler', () => {
 
   afterEach(() => {
     guidedHandler.cancel();
+    jest.useRealTimers();
   });
 
   describe('execute', () => {
@@ -274,6 +279,7 @@ describe('GuidedHandler', () => {
       (querySelectorAllEnhanced as jest.Mock).mockReturnValue({ elements: [button], usedFallback: false });
       mockNavigationManager.highlightWithComment = jest.fn().mockImplementation(async () => {
         button.click();
+        return button;
       });
       mockNavigationManager.clearAllHighlights = jest.fn(() => {
         throw new Error('cleanup failed');
@@ -343,25 +349,186 @@ describe('GuidedHandler', () => {
       const onActionCompleted = jest.fn(() => {
         throw new Error('persistence failed');
       });
+      const onSettled = jest.fn();
       (querySelectorAllEnhanced as jest.Mock).mockReturnValue({ elements: [button], usedFallback: false });
       mockNavigationManager.highlightWithComment = jest.fn().mockImplementation(async () => {
         button.click();
       });
 
-      const result = await guidedHandler.executeGuidedStep(
-        { targetAction: 'highlight', refTarget: '#install' },
-        0,
-        1,
-        100,
-        onActionCompleted
-      );
+      const result = await guidedHandler.executeGuidedStep({ targetAction: 'highlight', refTarget: '#install' }, 0, 1, {
+        timeout: 100,
+        onActionCompleted,
+        onSettled,
+      });
 
       expect(result).toBe('error');
       expect(onActionCompleted).toHaveBeenCalledTimes(1);
+      expect(onSettled).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'error' }));
       expect(mockNavigationManager.clearAllHighlights).toHaveBeenCalled();
       expect((guidedHandler as any).activeListeners).toHaveLength(0);
       expect((guidedHandler as any).pendingTimeouts).toHaveLength(0);
       expect((guidedHandler as any).pendingIntervals).toHaveLength(0);
+    });
+
+    it('checks authored requirements before target resolution', async () => {
+      const order: string[] = [];
+      const button = document.createElement('button');
+      document.body.appendChild(button);
+      const checkRequirements = jest.fn(async () => {
+        order.push('requirements');
+        return { pass: true, error: [] };
+      });
+      (querySelectorAllEnhanced as jest.Mock).mockImplementation(() => {
+        order.push('target');
+        return { elements: [button], usedFallback: false };
+      });
+      mockNavigationManager.highlightWithComment.mockImplementation(async () => {
+        button.click();
+        return button;
+      });
+      const onSettled = jest.fn();
+
+      const result = await guidedHandler.executeGuidedStep(
+        {
+          targetAction: 'highlight',
+          refTarget: '#name',
+          targetValue: '^Grafana$',
+          requirements: ['exists-reftarget'],
+          formHint: 'Use the product name',
+          validateInput: true,
+          lazyRender: true,
+          scrollContainer: '.settings-scroll',
+        },
+        0,
+        1,
+        { timeout: 1_000, checkRequirements, onSettled }
+      );
+
+      expect(order.slice(0, 2)).toEqual(['requirements', 'target']);
+      expect(checkRequirements).toHaveBeenCalledWith({
+        requirements: ['exists-reftarget'],
+        targetAction: 'highlight',
+        refTarget: '#name',
+        targetValue: '^Grafana$',
+        maxRetries: expect.any(Number),
+        lazyRender: true,
+        scrollContainer: '.settings-scroll',
+      });
+      expect(result).toBe('completed');
+      expect(onSettled).toHaveBeenCalledWith(expect.objectContaining({ outcome: 'completed', skippable: false }));
+    });
+
+    it.each([
+      [false, 'error'],
+      [true, 'skipped'],
+    ] as const)('settles a failed requirement with skippable=%s as %s', async (isSkippable, expected) => {
+      const checkRequirements = jest.fn().mockResolvedValue({
+        pass: false,
+        error: [{ fixType: 'navigation' }],
+      });
+      const onSettled = jest.fn();
+
+      const result = await guidedHandler.executeGuidedStep(
+        {
+          targetAction: 'highlight',
+          refTarget: '#missing',
+          requirements: ['on-page:/dashboards'],
+          isSkippable,
+        },
+        0,
+        1,
+        { timeout: 1_000, checkRequirements, onSettled }
+      );
+
+      expect(result).toBe(expected);
+      expect(querySelectorAllEnhanced).not.toHaveBeenCalled();
+      expect(onSettled).toHaveBeenCalledWith(expect.objectContaining({ outcome: expected, skippable: isSkippable }));
+    });
+
+    it('performs one lazy discovery cycle and rechecks requirements without retries', async () => {
+      const button = document.createElement('button');
+      document.body.appendChild(button);
+      const checkRequirements = jest
+        .fn()
+        .mockResolvedValueOnce({ pass: false, error: [{ fixType: 'lazy-scroll' }] })
+        .mockResolvedValueOnce({ pass: true, error: [] });
+      (scrollUntilElementFound as jest.Mock).mockResolvedValue(button);
+      (querySelectorAllEnhanced as jest.Mock).mockReturnValue({ elements: [button], usedFallback: false });
+      mockNavigationManager.highlightWithComment.mockImplementation(async () => {
+        button.click();
+        return button;
+      });
+
+      const result = await guidedHandler.executeGuidedStep(
+        {
+          targetAction: 'highlight',
+          refTarget: '#lazy',
+          requirements: ['exists-reftarget'],
+          lazyRender: true,
+          scrollContainer: '.dashboard-scroll',
+        },
+        0,
+        1,
+        { timeout: 1_000, checkRequirements }
+      );
+
+      expect(result).toBe('completed');
+      expect(scrollUntilElementFound).toHaveBeenCalledTimes(1);
+      expect(scrollUntilElementFound).toHaveBeenCalledWith(
+        '#lazy',
+        expect.objectContaining({
+          scrollContainerSelector: '.dashboard-scroll',
+          deadline: expect.any(Number),
+          isCancelled: expect.any(Function),
+        })
+      );
+      expect(checkRequirements).toHaveBeenCalledTimes(2);
+      expect(checkRequirements.mock.calls[1][0]).toEqual(expect.objectContaining({ maxRetries: 0 }));
+    });
+
+    it('uses one timeout budget for requirements and the user action', async () => {
+      jest.useFakeTimers();
+      const checkRequirements = jest.fn(
+        () =>
+          new Promise<{ pass: boolean; error: [] }>((resolve) => {
+            setTimeout(() => resolve({ pass: true, error: [] }), 40);
+          })
+      );
+      let settled = false;
+
+      const resultPromise = guidedHandler
+        .executeGuidedStep({ targetAction: 'noop', requirements: ['is-admin'] }, 0, 1, {
+          timeout: 100,
+          checkRequirements,
+        })
+        .then((result) => {
+          settled = true;
+          return result;
+        });
+
+      await jest.advanceTimersByTimeAsync(99);
+      expect(settled).toBe(false);
+      await jest.advanceTimersByTimeAsync(1);
+      await expect(resultPromise).resolves.toBe('timeout');
+    });
+
+    it('uses the same timeout budget for element preparation', async () => {
+      jest.useFakeTimers();
+      const button = document.createElement('button');
+      document.body.appendChild(button);
+      (querySelectorAllEnhanced as jest.Mock).mockReturnValue({ elements: [button], usedFallback: false });
+      mockNavigationManager.ensureNavigationOpen = jest.fn(
+        (_element: HTMLElement) => new Promise<void>(() => undefined)
+      );
+
+      const resultPromise = guidedHandler.executeGuidedStep({ targetAction: 'highlight', refTarget: '#slow' }, 0, 1, {
+        timeout: 100,
+      });
+
+      await jest.advanceTimersByTimeAsync(100);
+
+      await expect(resultPromise).resolves.toBe('timeout');
+      expect(mockNavigationManager.highlightWithComment).not.toHaveBeenCalled();
     });
   });
 

--- a/src/interactive-engine/action-handlers/guided-handler.ts
+++ b/src/interactive-engine/action-handlers/guided-handler.ts
@@ -14,12 +14,18 @@ import { createInteractionName, UserInteraction } from '../../lib/analytics';
 import { type CompletionResult, outcomeFromCompletionResult } from '../outcome-classifier';
 import { isCssSelector } from '../../lib/dom/selector-detector';
 import { parseTargetState, resolveStateSource, satisfiesTargetState } from '../../lib/dom/toggle-state';
-import { GuidedAction } from '../../types/interactive-actions.types';
+import type {
+  GuidedAction,
+  GuidedRequirementsChecker,
+  GuidedStepExecutionOptions,
+  GuidedStepOutcome,
+} from '../../types/interactive-actions.types';
 import { INTERACTIVE_CONFIG } from '../../constants/interactive-config';
 import { sanitizeDocumentationHTML } from '../../security/html-sanitizer';
 import { matchFormValue } from '../auto-completion/action-matcher';
 import { applyE2ECommentBoxAttributes } from '../e2e-attributes';
 import { commentForTargetState } from './toggle-click';
+import { scrollUntilElementFound } from '../../lib/dom/dom-utils';
 
 export type { CompletionResult };
 
@@ -42,6 +48,7 @@ export class GuidedHandler {
   private pendingIntervals: Array<ReturnType<typeof setInterval>> = [];
   private currentAbortController: AbortController | null = null;
   private completedSteps: number[] = [];
+  private currentArbiter: GuidedStepArbiter | null = null;
 
   constructor(
     private stateManager: InteractiveStateManager,
@@ -79,9 +86,16 @@ export class GuidedHandler {
     action: GuidedAction,
     stepIndex: number,
     totalSteps: number,
-    timeout: number = INTERACTIVE_CONFIG.guided.stepTimeout,
-    onActionCompleted?: () => void
+    optionsOrTimeout: GuidedStepExecutionOptions | number = {},
+    legacyOnActionCompleted?: () => void
   ): Promise<CompletionResult> {
+    const options: GuidedStepExecutionOptions =
+      typeof optionsOrTimeout === 'number'
+        ? { timeout: optionsOrTimeout, onActionCompleted: legacyOnActionCompleted }
+        : optionsOrTimeout;
+    const timeout = options.timeout ?? INTERACTIVE_CONFIG.guided.stepTimeout;
+    const startedAt = Date.now();
+    const deadline = startedAt + timeout;
     return withFaroUserAction(
       createInteractionName(UserInteraction.DoItButtonClick),
       {
@@ -90,14 +104,24 @@ export class GuidedHandler {
         step_index: stepIndex,
         total_steps: totalSteps,
       },
-      () => this.runGuidedStep(action, stepIndex, totalSteps, timeout, onActionCompleted),
+      () =>
+        this.runGuidedStep(action, stepIndex, totalSteps, deadline, options, (outcome) => {
+          options.onSettled?.({
+            index: stepIndex,
+            total: totalSteps,
+            action: action.targetAction,
+            outcome,
+            durationMs: Date.now() - startedAt,
+            skippable: action.isSkippable === true,
+          });
+        }),
       // Internal waits are bounded by `timeout`; the margin only catches a hung step.
       timeout + 10_000,
       { critical: true, outcomeFrom: outcomeFromCompletionResult }
     );
   }
 
-  private createGuidedStepArbiter(): GuidedStepArbiter {
+  private createGuidedStepArbiter(onSettled?: (result: CompletionResult) => void): GuidedStepArbiter {
     let result: CompletionResult | null = null;
     let resolvePromise!: (result: CompletionResult) => void;
     const promise = new Promise<CompletionResult>((resolve) => {
@@ -118,6 +142,11 @@ export class GuidedHandler {
           logger.error('Guided completion callback failed', { error });
           result = 'error';
         }
+        try {
+          onSettled?.(result);
+        } catch (error) {
+          logger.error('Guided settlement callback failed', { error });
+        }
         resolvePromise(result);
         return result;
       },
@@ -129,15 +158,29 @@ export class GuidedHandler {
     action: GuidedAction,
     stepIndex: number,
     totalSteps: number,
-    timeout: number,
-    onActionCompleted?: () => void
+    deadline: number,
+    options: GuidedStepExecutionOptions,
+    onSettled: (result: GuidedStepOutcome) => void
   ): Promise<CompletionResult> {
-    const arbiter = this.createGuidedStepArbiter();
+    const arbiter = this.createGuidedStepArbiter(onSettled);
+    this.currentArbiter = arbiter;
 
     try {
       this.cleanupListeners();
+      const deadlineTimeout = setTimeout(() => arbiter.settle('timeout'), Math.max(0, deadline - Date.now()));
+      this.pendingTimeouts.push(deadlineTimeout);
+
+      const requirementFailure = await this.checkActionRequirements(
+        action,
+        deadline,
+        arbiter,
+        options.checkRequirements
+      );
+      if (requirementFailure) {
+        return this.finishGuidedStep(arbiter.settle(requirementFailure), stepIndex);
+      }
       if (action.targetAction === 'noop') {
-        return await this.executeNoopStep(action, stepIndex, totalSteps, timeout);
+        return await this.executeNoopStep(action, stepIndex, totalSteps, Math.max(0, deadline - Date.now()), arbiter);
       }
 
       const refTarget = action.refTarget;
@@ -147,41 +190,49 @@ export class GuidedHandler {
         throw new Error(`Non-noop action ${targetAction} requires a refTarget`);
       }
 
-      await this.expandNavigationParentIfNeeded(refTarget);
+      await this.waitForResultOrSettlement(this.expandNavigationParentIfNeeded(refTarget), arbiter);
+      if (arbiter.getResult() !== null) {
+        return this.finishGuidedStep(arbiter.getResult()!, stepIndex);
+      }
 
       let targetElement: HTMLElement;
       try {
-        targetElement = await this.findTargetElementWithRetry(
-          refTarget,
-          targetAction,
-          timeout,
-          INTERACTIVE_CONFIG.guided.retryInterval,
-          action.isSkippable === true
-        );
+        targetElement = await this.findTargetElementForAction(action, targetAction, deadline, arbiter);
       } catch (elementNotFoundError) {
         if (action.isSkippable) {
-          return this.finishGuidedStep('skipped', stepIndex);
+          return this.finishGuidedStep(arbiter.settle('skipped'), stepIndex);
         }
         throw elementNotFoundError;
       }
 
-      await this.prepareElement(targetElement);
-      // Attach before highlighting so click activation cannot beat the listener.
-      this.createCompletionListener(action, targetElement, timeout, arbiter, onActionCompleted);
+      await this.waitForResultOrSettlement(this.prepareElement(targetElement), arbiter);
+      if (arbiter.getResult() !== null) {
+        return this.finishGuidedStep(arbiter.getResult()!, stepIndex);
+      }
+      this.createCompletionListener(
+        action,
+        targetElement,
+        Math.max(0, deadline - Date.now()),
+        arbiter,
+        options.onActionCompleted
+      );
       if (action.isSkippable) {
         this.createSkipListener(stepIndex, arbiter);
       }
       this.createCancelListener(stepIndex, arbiter);
-      await this.highlightTarget(
-        targetElement,
-        targetAction,
-        stepIndex,
-        totalSteps,
-        commentForTargetState(action.targetComment, targetElement, action.targetState),
-        action.isSkippable,
-        action.formHint,
-        action.targetValue,
-        action.refTarget!
+      await this.waitForResultOrSettlement(
+        this.highlightTarget(
+          targetElement,
+          targetAction,
+          stepIndex,
+          totalSteps,
+          commentForTargetState(action.targetComment, targetElement, action.targetState),
+          action.isSkippable,
+          action.formHint,
+          action.targetValue,
+          action.refTarget!
+        ),
+        arbiter
       );
 
       return this.finishGuidedStep(await arbiter.promise, stepIndex);
@@ -194,6 +245,110 @@ export class GuidedHandler {
       }
       const result = settledResult ?? arbiter.settle('error');
       return this.finishGuidedStep(result, stepIndex);
+    }
+  }
+
+  private async checkActionRequirements(
+    action: GuidedAction,
+    deadline: number,
+    arbiter: GuidedStepArbiter,
+    checkRequirements?: GuidedRequirementsChecker
+  ): Promise<CompletionResult | null> {
+    if (!action.requirements) {
+      return null;
+    }
+    if (!checkRequirements) {
+      logger.error('Guided action requirements cannot be checked');
+      return action.isSkippable ? 'skipped' : 'error';
+    }
+
+    const runCheck = (maxRetries: number) =>
+      checkRequirements({
+        requirements: action.requirements!,
+        targetAction: action.targetAction,
+        refTarget: action.refTarget,
+        targetValue: action.targetValue,
+        maxRetries,
+        lazyRender: action.lazyRender,
+        scrollContainer: action.scrollContainer,
+      });
+    const retryDelay = INTERACTIVE_CONFIG.delays.requirements.retryDelay;
+    const remainingTime = Math.max(0, deadline - Date.now());
+    const maxRetries = Math.min(
+      INTERACTIVE_CONFIG.delays.requirements.maxRetries,
+      Math.max(0, Math.floor(remainingTime / retryDelay) - 1)
+    );
+    let result = await this.waitForResultOrSettlement(runCheck(maxRetries), arbiter);
+    if (!result) {
+      return arbiter.getResult() ?? 'timeout';
+    }
+
+    const needsLazyScroll =
+      action.lazyRender === true &&
+      result.error.length > 0 &&
+      result.error.every((error) => error.fixType === 'lazy-scroll');
+    if (!result.pass && needsLazyScroll && action.refTarget) {
+      const found = await this.discoverLazyTarget(action, deadline, arbiter);
+      if (found) {
+        result = await this.waitForResultOrSettlement(runCheck(0), arbiter);
+        if (!result) {
+          return arbiter.getResult() ?? 'timeout';
+        }
+      }
+    }
+
+    if (result.pass) {
+      return null;
+    }
+    return action.isSkippable ? 'skipped' : 'error';
+  }
+
+  private async waitForResultOrSettlement<T>(promise: Promise<T>, arbiter: GuidedStepArbiter): Promise<T | null> {
+    return Promise.race([promise, arbiter.promise.then(() => null)]);
+  }
+
+  private async findTargetElementForAction(
+    action: GuidedAction,
+    actionType: 'hover' | 'button' | 'highlight' | 'formfill',
+    deadline: number,
+    arbiter: GuidedStepArbiter
+  ): Promise<HTMLElement> {
+    try {
+      return await this.findTargetElement(action.refTarget!, actionType);
+    } catch (error) {
+      if (action.lazyRender && (await this.discoverLazyTarget(action, deadline, arbiter))) {
+        return this.findTargetElement(action.refTarget!, actionType);
+      }
+      if (action.isSkippable || arbiter.getResult() !== null) {
+        throw error;
+      }
+    }
+
+    return this.findTargetElementWithRetry(
+      action.refTarget!,
+      actionType,
+      Math.max(0, deadline - Date.now()),
+      INTERACTIVE_CONFIG.guided.retryInterval,
+      false,
+      () => arbiter.getResult() !== null
+    );
+  }
+
+  private async discoverLazyTarget(
+    action: GuidedAction,
+    deadline: number,
+    arbiter: GuidedStepArbiter
+  ): Promise<boolean> {
+    try {
+      const found = await scrollUntilElementFound(action.refTarget!, {
+        scrollContainerSelector: action.scrollContainer,
+        deadline,
+        isCancelled: () => arbiter.getResult() !== null,
+      });
+      return found !== null;
+    } catch (error) {
+      logger.warn('Lazy target discovery failed', { error });
+      return false;
     }
   }
 
@@ -210,6 +365,7 @@ export class GuidedHandler {
     if ((result === 'completed' || result === 'skipped') && !this.completedSteps.includes(stepIndex)) {
       this.completedSteps.push(stepIndex);
     }
+    this.currentArbiter = null;
     return result;
   }
 
@@ -221,10 +377,9 @@ export class GuidedHandler {
     action: GuidedAction,
     stepIndex: number,
     totalSteps: number,
-    timeout: number
+    timeout: number,
+    arbiter: GuidedStepArbiter
   ): Promise<CompletionResult> {
-    this.cleanupListeners();
-    const arbiter = this.createGuidedStepArbiter();
     this.currentAbortController = new AbortController();
     const signal = this.currentAbortController.signal;
     if (action.isSkippable) {
@@ -243,11 +398,14 @@ export class GuidedHandler {
       handler: handleAbort,
       options: { once: true },
     });
-    await this.showNoopCommentBox(
-      stepIndex,
-      totalSteps,
-      action.targetComment || 'Complete this step to continue',
-      action.isSkippable
+    await this.waitForResultOrSettlement(
+      this.showNoopCommentBox(
+        stepIndex,
+        totalSteps,
+        action.targetComment || 'Complete this step to continue',
+        action.isSkippable
+      ),
+      arbiter
     );
     return this.finishGuidedStep(await arbiter.promise, stepIndex);
   }
@@ -379,12 +537,13 @@ export class GuidedHandler {
     actionType: 'hover' | 'button' | 'highlight' | 'formfill',
     timeout: number,
     retryInterval: number,
-    skipRetryOnFailure = false
+    skipRetryOnFailure = false,
+    isCancelled: () => boolean = () => false
   ): Promise<HTMLElement> {
     const startTime = Date.now();
     let attemptCount = 0;
 
-    while (Date.now() - startTime < timeout) {
+    while (Date.now() - startTime < timeout && !isCancelled()) {
       attemptCount++;
       try {
         const element = await this.findTargetElement(selector, actionType);
@@ -1130,6 +1289,8 @@ export class GuidedHandler {
     }
   }
   cancel(): void {
+    this.currentArbiter?.settle('cancelled');
+    this.currentArbiter = null;
     if (this.currentAbortController) {
       this.currentAbortController.abort();
       this.currentAbortController = null;

--- a/src/lib/dom/dom-utils.ts
+++ b/src/lib/dom/dom-utils.ts
@@ -320,6 +320,8 @@ export interface LazyScrollOptions {
   maxScrollAttempts?: number;
   scrollIncrement?: number;
   waitTime?: number;
+  deadline?: number;
+  isCancelled?: () => boolean;
 }
 
 /**
@@ -339,6 +341,8 @@ export async function scrollUntilElementFound(
     maxScrollAttempts = 15, // More attempts since we scroll smaller increments
     scrollIncrement = 400, // Smaller increments for smoother scrolling
     waitTime = 350, // Longer wait to allow smooth scroll animation to complete
+    deadline,
+    isCancelled,
   } = options;
 
   // Find the scroll container
@@ -359,11 +363,19 @@ export async function scrollUntilElementFound(
   }
 
   for (let attempt = 0; attempt < maxScrollAttempts; attempt++) {
+    if (isCancelled?.() || (deadline !== undefined && Date.now() >= deadline)) {
+      break;
+    }
     // Scroll down with smooth animation for better UX
     scrollContainer.scrollBy({ top: scrollIncrement, behavior: 'smooth' });
 
     // Wait for smooth scroll animation + lazy render to kick in
-    await new Promise((resolve) => setTimeout(resolve, waitTime));
+    const remainingTime = deadline === undefined ? waitTime : Math.max(0, deadline - Date.now());
+    await new Promise((resolve) => setTimeout(resolve, Math.min(waitTime, remainingTime)));
+
+    if (isCancelled?.() || (deadline !== undefined && Date.now() >= deadline)) {
+      break;
+    }
 
     // Check if element now exists using enhanced selector
     const result = querySelectorAllEnhanced(resolvedSelector);

--- a/src/requirements-manager/checks/section-completed-check.ts
+++ b/src/requirements-manager/checks/section-completed-check.ts
@@ -28,12 +28,12 @@ import { getContentKey } from '../../global-state/content-key';
 import { sectionDoneStorage } from '../../lib/user-storage';
 import { logger } from '../../lib/logging';
 
-export async function sectionCompletedCheck(check: string): Promise<CheckResultError> {
+export async function sectionCompletedCheck(check: string, explicitContentKey?: string): Promise<CheckResultError> {
   try {
     const rawId = check.replace('section-completed:', '');
     const sectionId = rawId.startsWith('section-') ? rawId : `section-${rawId}`;
 
-    const contentKey = getContentKey();
+    const contentKey = explicitContentKey ?? getContentKey();
     const persistedDone = await sectionDoneStorage.get(contentKey, sectionId);
     if (persistedDone === true) {
       return {

--- a/src/requirements-manager/guide-identity-mount-order.test.tsx
+++ b/src/requirements-manager/guide-identity-mount-order.test.tsx
@@ -236,6 +236,6 @@ describe('ContentRenderer guide-identity contract', () => {
       'utf8'
     );
     expect(source).toMatch(/useLayoutEffect\(\s*\(\)\s*=>\s*registerCompatibilityGuideId\(/);
-    expect(source).toMatch(/<GuideRequirementsProvider guideId=\{guideId\}>/);
+    expect(source).toMatch(/<GuideRequirementsProvider guideId=\{guideId\} contentKey=\{content\.url\}>/);
   });
 });

--- a/src/requirements-manager/guide-requirements-context.tsx
+++ b/src/requirements-manager/guide-requirements-context.tsx
@@ -7,9 +7,11 @@ import {
   type RequirementsCheckResult,
 } from './requirements-checker.utils';
 
-export type GuideRequirementsCheckOptions = Omit<RequirementsCheckOptions, 'guideId'>;
+export type GuideRequirementsCheckOptions = Omit<RequirementsCheckOptions, 'guideId' | 'contentKey'>;
 
 interface GuideRequirementsContextValue {
+  guideId?: string;
+  contentKey?: string;
   checkRequirements: (options: GuideRequirementsCheckOptions) => Promise<RequirementsCheckResult>;
   checkPostconditions: (options: GuideRequirementsCheckOptions) => Promise<RequirementsCheckResult>;
 }
@@ -21,13 +23,19 @@ const compatibilityFallback: GuideRequirementsContextValue = {
 
 const GuideRequirementsContext = createContext<GuideRequirementsContextValue>(compatibilityFallback);
 
-export function GuideRequirementsProvider({ guideId, children }: PropsWithChildren<{ guideId: string }>) {
+export function GuideRequirementsProvider({
+  guideId,
+  contentKey,
+  children,
+}: PropsWithChildren<{ guideId: string; contentKey?: string }>) {
   const value = useMemo<GuideRequirementsContextValue>(
     () => ({
-      checkRequirements: (options) => checkRequirementsWithOptions({ ...options, guideId }),
-      checkPostconditions: (options) => checkPostconditionsWithOptions({ ...options, guideId }),
+      guideId,
+      contentKey,
+      checkRequirements: (options) => checkRequirementsWithOptions({ ...options, guideId, contentKey }),
+      checkPostconditions: (options) => checkPostconditionsWithOptions({ ...options, guideId, contentKey }),
     }),
-    [guideId]
+    [contentKey, guideId]
   );
 
   return <GuideRequirementsContext.Provider value={value}>{children}</GuideRequirementsContext.Provider>;

--- a/src/requirements-manager/requirements-checker.utils.test.ts
+++ b/src/requirements-manager/requirements-checker.utils.test.ts
@@ -726,6 +726,18 @@ describe('requirements-checker.utils', () => {
         expect(result.pass).toBe(true);
       });
 
+      it('uses an explicit content key instead of the live tab ambient key', async () => {
+        const contentKey = '/guides/controller/content.json';
+        await sectionDoneStorage.set(contentKey, 'section-controller-setup', true);
+
+        const result = await checkRequirements({
+          requirements: 'section-completed:controller-setup',
+          contentKey,
+        });
+
+        expect(result.pass).toBe(true);
+      });
+
       it('clearing the done bit re-blocks the requirement even though the DOM is empty', async () => {
         await sectionDoneStorage.set(getContentKey(), 'section-redo-test', true);
         await sectionDoneStorage.clear(getContentKey(), 'section-redo-test');

--- a/src/requirements-manager/requirements-checker.utils.ts
+++ b/src/requirements-manager/requirements-checker.utils.ts
@@ -60,6 +60,8 @@ export interface RequirementsCheckOptions {
   requirements: ConditionInput;
   /** Guide scope for var-* checks; omit only for compatibility callers outside a renderer tree. */
   guideId?: string;
+  /** Content scope for section-completed:* checks. */
+  contentKey?: string;
   targetAction?: string;
   refTarget?: string;
   targetValue?: string;
@@ -76,6 +78,7 @@ type CheckMode = 'pre' | 'post';
 
 interface CheckContext {
   guideId?: string;
+  contentKey?: string;
   targetAction?: string;
   refTarget?: string;
   /** Enable progressive scroll discovery for virtualized containers */
@@ -128,7 +131,11 @@ const CHECK_HANDLERS: readonly CheckHandler[] = [
   { id: 'has-feature:', match: (c) => c.startsWith('has-feature:'), run: (c) => hasFeatureCheck(c) },
   { id: 'in-environment:', match: (c) => c.startsWith('in-environment:'), run: (c) => inEnvironmentCheck(c) },
   { id: 'min-version:', match: (c) => c.startsWith('min-version:'), run: (c) => minVersionCheck(c) },
-  { id: 'section-completed:', match: (c) => c.startsWith('section-completed:'), run: (c) => sectionCompletedCheck(c) },
+  {
+    id: 'section-completed:',
+    match: (c) => c.startsWith('section-completed:'),
+    run: (c, ctx) => sectionCompletedCheck(c, ctx.contentKey),
+  },
   { id: 'form-valid', match: (c) => c === 'form-valid', run: (c) => formValidCheck(c) },
   { id: 'is-terminal-active', match: (c) => c === 'is-terminal-active', run: (c) => terminalActiveCheck(c) },
   { id: 'coda-exit-zero:', match: (c) => c.startsWith('coda-exit-zero:'), run: (c) => codaExitZeroCheck(c) },
@@ -206,6 +213,7 @@ async function executeChecksWithRetry(
   const {
     requirements,
     guideId,
+    contentKey,
     targetAction = 'button',
     refTarget = '',
     retryCount = 0,
@@ -229,6 +237,7 @@ async function executeChecksWithRetry(
   try {
     const result = await runUnifiedChecks(requirements, mode, {
       guideId,
+      contentKey,
       targetAction,
       refTarget,
       lazyRender,

--- a/src/types/cross-tab.types.test.ts
+++ b/src/types/cross-tab.types.test.ts
@@ -1,4 +1,9 @@
-import { validateCrossTabMessage, type RemoteRequirementError, type WireMirrors } from './cross-tab.types';
+import {
+  toCrossTabInternalAction,
+  validateCrossTabMessage,
+  type RemoteRequirementError,
+  type WireMirrors,
+} from './cross-tab.types';
 import type { CheckResultError } from './requirements.types';
 
 function envelope(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -134,6 +139,77 @@ describe('validateCrossTabMessage', () => {
     ).toBeNull();
   });
 
+  it.each([
+    ['a zero timeout', { stepTimeout: 0 }],
+    ['a fractional timeout', { stepTimeout: 30_000.5 }],
+    ['a timeout above the maximum', { stepTimeout: 600_001 }],
+    ['a non-string guide id', { guideId: 1 }],
+    ['a non-string content key', { contentKey: 1 }],
+  ])('rejects a guided command with %s', (_label, invalidField) => {
+    const message = envelope({
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'guided-1',
+      runId: 'run-1',
+      action: {
+        targetAction: 'guided',
+        refTarget: '',
+        internalActions: [{ targetAction: 'noop' }],
+        ...invalidField,
+      },
+    });
+
+    expect(validateCrossTabMessage(message)).toBeNull();
+  });
+
+  it('rejects an unbounded internal action list', () => {
+    const message = envelope({
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'guided-1',
+      runId: 'run-1',
+      action: {
+        targetAction: 'guided',
+        refTarget: '',
+        internalActions: new Array(257).fill(null).map(() => ({ targetAction: 'noop' })),
+      },
+    });
+
+    expect(validateCrossTabMessage(message)).toBeNull();
+  });
+
+  it('rejects strict form validation without a target value', () => {
+    const message = envelope({
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'guided-1',
+      runId: 'run-1',
+      action: {
+        targetAction: 'guided',
+        refTarget: '',
+        internalActions: [{ targetAction: 'formfill', refTarget: '#name', validateInput: true }],
+      },
+    });
+
+    expect(validateCrossTabMessage(message)).toBeNull();
+  });
+
+  it('rejects oversized guided action strings', () => {
+    const message = envelope({
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'guided-1',
+      runId: 'run-1',
+      action: {
+        targetAction: 'guided',
+        refTarget: '',
+        internalActions: [{ targetAction: 'highlight', refTarget: `#${'a'.repeat(16_384)}` }],
+      },
+    });
+
+    expect(validateCrossTabMessage(message)).toBeNull();
+  });
+
   it('rejects a heartbeat with an invalid role', () => {
     expect(validateCrossTabMessage(envelope({ kind: 'heartbeat', role: 'admin' }))).toBeNull();
   });
@@ -203,6 +279,25 @@ describe('validateCrossTabMessage', () => {
   });
 });
 
+describe('toCrossTabInternalAction', () => {
+  it('preserves every guided-only field', () => {
+    const action = {
+      targetAction: 'formfill' as const,
+      refTarget: '#name',
+      targetValue: '^Grafana$',
+      targetComment: 'Enter the product name',
+      requirements: ['exists-reftarget'],
+      isSkippable: true,
+      formHint: 'Use the product name',
+      validateInput: true,
+      lazyRender: true,
+      scrollContainer: '.settings-scroll',
+    };
+
+    expect(toCrossTabInternalAction(action)).toEqual(action);
+  });
+});
+
 describe('RemoteRequirementError wire mirror', () => {
   // Compile-time guard for the deliberate re-statement in cross-tab.types.ts:
   // if CheckResultError and the wire type diverge by a field, a key, or the
@@ -227,6 +322,40 @@ describe('condition array transport', () => {
       stepId: 's',
       requirements: ['has-dashboard-named:CPU, memory'],
     });
+    expect(validateCrossTabMessage(message)).toBe(message);
+  });
+
+  it('accepts the complete guided command contract', () => {
+    const message = envelope({
+      kind: 'step-command',
+      phase: 'do',
+      stepId: 'guided-1',
+      runId: 'run-1',
+      action: {
+        targetAction: 'guided',
+        refTarget: '',
+        guideId: 'guide-a',
+        contentKey: '/guides/a/content.json',
+        stepTimeout: 60_000,
+        completeEarly: true,
+        internalActions: [
+          {
+            targetAction: 'formfill',
+            refTarget: '#name',
+            targetValue: '^Grafana$',
+            targetComment: 'Enter the product name',
+            requirements: ['exists-reftarget'],
+            isSkippable: true,
+            formHint: 'Use the product name',
+            validateInput: true,
+            lazyRender: true,
+            scrollContainer: '.settings-scroll',
+          },
+          { targetAction: 'noop', requirements: ['section-completed:setup'], isSkippable: true },
+        ],
+      },
+    });
+
     expect(validateCrossTabMessage(message)).toBe(message);
   });
   it('rejects non-string condition entries', () => {

--- a/src/types/cross-tab.types.ts
+++ b/src/types/cross-tab.types.ts
@@ -1,26 +1,26 @@
 import type { ConditionInput } from './requirements.types';
-import type { InternalAction } from './interactive-actions.types';
+import type { GuidedAction, InternalAction } from './interactive-actions.types';
 
 export const CROSS_TAB_CHANNEL = 'pathfinder-cross-tab';
 
 export type CrossTabRole = 'controller' | 'live';
 
-// Derived by exclusion rather than restated: a field the engine reads off an
-// action must reach the live tab, and hand-listing the fields is what dropped
-// targetState on this wire three times over. Only `requirements` stays behind —
-// the controller gates them, the live tab replays. Fields added to
-// InternalAction therefore reach the wire by default rather than by remembering.
-export type CrossTabInternalAction = Omit<InternalAction, 'requirements'>;
+type GuidedOnlyActionFields = Omit<GuidedAction, keyof InternalAction | 'targetAction'>;
+
+export type CrossTabInternalAction = InternalAction & Partial<GuidedOnlyActionFields>;
 
 /** Narrow an engine action to what the wire carries. */
 export function toCrossTabInternalAction(action: InternalAction): CrossTabInternalAction {
-  const { requirements, ...wire } = action;
-  return wire;
+  return { ...action };
 }
 
 export interface CrossTabAction extends CrossTabInternalAction {
   refTarget: string;
   internalActions?: CrossTabInternalAction[];
+  guideId?: string;
+  contentKey?: string;
+  stepTimeout?: number;
+  completeEarly?: boolean;
 }
 
 interface CrossTabEnvelope {
@@ -207,6 +207,10 @@ export const SIGNED_MESSAGE_KINDS: ReadonlySet<CrossTabMessage['kind']> = new Se
   'sidebar-handoff',
 ]);
 
+const MAX_GUIDED_STEP_TIMEOUT_MS = 600_000;
+const MAX_INTERNAL_ACTIONS = 256;
+const MAX_ACTION_STRING_LENGTH = 16_384;
+
 // Same-build assumption: the controller and live tabs are the same plugin
 // build in the same browser/origin/session, so there is no protocol-version
 // negotiation. Cross-version compatibility is not a goal; a mismatched build
@@ -221,6 +225,7 @@ const KNOWN_TARGET_ACTIONS: ReadonlySet<string> = new Set([
   'formfill',
   'navigate',
   'hover',
+  'noop',
   'guided',
   'multistep',
 ]);
@@ -253,10 +258,23 @@ function isValidStepCommand(message: Record<string, unknown>): boolean {
   }
   const action = message.action;
   if (
-    typeof action.refTarget !== 'string' ||
+    !isBoundedString(action.refTarget, MAX_ACTION_STRING_LENGTH) ||
     typeof action.targetAction !== 'string' ||
     !KNOWN_TARGET_ACTIONS.has(action.targetAction) ||
-    !isOptionalTargetState(action.targetState)
+    !isOptionalTargetState(action.targetState) ||
+    (action.requirements !== undefined && !isBoundedConditionInput(action.requirements)) ||
+    !isOptionalBoundedString(action.targetValue, MAX_ACTION_STRING_LENGTH) ||
+    !isOptionalBoundedString(action.targetComment, MAX_ACTION_STRING_LENGTH) ||
+    !isOptionalBoolean(action.isSkippable) ||
+    !isOptionalBoundedString(action.formHint, MAX_ACTION_STRING_LENGTH) ||
+    !isOptionalBoolean(action.validateInput) ||
+    !isOptionalBoolean(action.lazyRender) ||
+    !isOptionalBoundedString(action.scrollContainer, MAX_ACTION_STRING_LENGTH) ||
+    !isOptionalBoundedString(action.guideId, MAX_ACTION_STRING_LENGTH) ||
+    !isOptionalBoundedString(action.contentKey, MAX_ACTION_STRING_LENGTH) ||
+    !isOptionalGuidedStepTimeout(action.stepTimeout) ||
+    !isOptionalBoolean(action.completeEarly) ||
+    !hasValidFormValidation(action)
   ) {
     return false;
   }
@@ -267,15 +285,24 @@ function isValidStepCommand(message: Record<string, unknown>): boolean {
   if (action.internalActions !== undefined) {
     return (
       Array.isArray(action.internalActions) &&
+      action.internalActions.length <= MAX_INTERNAL_ACTIONS &&
       action.internalActions.every(
         (sub) =>
           isRecord(sub) &&
           typeof sub.targetAction === 'string' &&
           KNOWN_TARGET_ACTIONS.has(sub.targetAction) &&
-          isOptionalString(sub.refTarget) &&
-          isOptionalString(sub.targetValue) &&
-          isOptionalString(sub.targetComment) &&
-          isOptionalTargetState(sub.targetState)
+          hasValidActionTarget(sub) &&
+          isOptionalBoundedString(sub.refTarget, MAX_ACTION_STRING_LENGTH) &&
+          isOptionalBoundedString(sub.targetValue, MAX_ACTION_STRING_LENGTH) &&
+          isOptionalBoundedString(sub.targetComment, MAX_ACTION_STRING_LENGTH) &&
+          isOptionalTargetState(sub.targetState) &&
+          (sub.requirements === undefined || isBoundedConditionInput(sub.requirements)) &&
+          isOptionalBoolean(sub.isSkippable) &&
+          isOptionalBoundedString(sub.formHint, MAX_ACTION_STRING_LENGTH) &&
+          isOptionalBoolean(sub.validateInput) &&
+          isOptionalBoolean(sub.lazyRender) &&
+          isOptionalBoundedString(sub.scrollContainer, MAX_ACTION_STRING_LENGTH) &&
+          hasValidFormValidation(sub)
       )
     );
   }
@@ -295,7 +322,22 @@ function isOptionalString(value: unknown): boolean {
 }
 
 function isOptionalTargetState(value: unknown): boolean {
-  return value === undefined || typeof value === 'boolean' || typeof value === 'string';
+  return (
+    value === undefined ||
+    typeof value === 'boolean' ||
+    (typeof value === 'string' && value.length <= MAX_ACTION_STRING_LENGTH)
+  );
+}
+
+function isOptionalBoolean(value: unknown): boolean {
+  return value === undefined || typeof value === 'boolean';
+}
+
+function isOptionalGuidedStepTimeout(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= MAX_GUIDED_STEP_TIMEOUT_MS)
+  );
 }
 
 const MAX_PAIRING_FIELD_LENGTH = 512;
@@ -307,8 +349,31 @@ const MAX_PAIRING_FIELD_LENGTH = 512;
 const MAX_CONDITION_TOKENS = 32;
 const MAX_CONDITION_TOKEN_LENGTH = 512;
 
-function isBoundedString(value: unknown, maxLength: number): boolean {
+function isBoundedString(value: unknown, maxLength: number): value is string {
   return typeof value === 'string' && value.length <= maxLength;
+}
+function isOptionalBoundedString(value: unknown, maxLength: number): boolean {
+  return value === undefined || isBoundedString(value, maxLength);
+}
+
+function hasValidActionTarget(action: Record<string, unknown>): boolean {
+  if (action.targetAction === 'noop') {
+    return true;
+  }
+  const refTarget = action.refTarget;
+  return isBoundedString(refTarget, MAX_ACTION_STRING_LENGTH) && refTarget.length > 0;
+}
+
+function hasValidFormValidation(action: Record<string, unknown>): boolean {
+  if (action.validateInput !== true) {
+    return true;
+  }
+  const targetValue = action.targetValue;
+  return (
+    action.targetAction === 'formfill' &&
+    isBoundedString(targetValue, MAX_ACTION_STRING_LENGTH) &&
+    targetValue.length > 0
+  );
 }
 
 function isBoundedConditionInput(value: unknown): boolean {

--- a/src/types/interactive-actions.types.ts
+++ b/src/types/interactive-actions.types.ts
@@ -4,6 +4,53 @@
  */
 
 import type { ConditionInput } from './requirements.types';
+
+export type GuidedStepOutcome = 'completed' | 'skipped' | 'timeout' | 'cancelled' | 'error';
+
+export interface GuidedSubstepSettledDetail {
+  stepId: string;
+  index: number;
+  total: number;
+  action: GuidedAction['targetAction'];
+  outcome: GuidedStepOutcome;
+  durationMs: number;
+  skippable: boolean;
+}
+
+export interface GuidedRunSettledDetail {
+  stepId: string;
+}
+
+export const GUIDED_SUBSTEP_SETTLED_EVENT = 'pathfinder:guided-substep-settled';
+export const GUIDED_RUN_SETTLED_EVENT = 'pathfinder:guided-run-settled';
+
+export interface GuidedRequirementsCheckOptions {
+  requirements: ConditionInput;
+  targetAction?: string;
+  refTarget?: string;
+  targetValue?: string;
+  maxRetries?: number;
+  lazyRender?: boolean;
+  scrollContainer?: string;
+}
+
+export interface GuidedRequirementsCheckResult {
+  pass: boolean;
+  error: Array<{
+    fixType?: string;
+  }>;
+}
+
+export type GuidedRequirementsChecker = (
+  options: GuidedRequirementsCheckOptions
+) => Promise<GuidedRequirementsCheckResult>;
+
+export interface GuidedStepExecutionOptions {
+  timeout?: number;
+  checkRequirements?: GuidedRequirementsChecker;
+  onActionCompleted?: () => void;
+  onSettled?: (detail: Omit<GuidedSubstepSettledDetail, 'stepId'>) => void;
+}
 /**
  * Base internal action interface (flexible)
  * Used for multi-step sequences where action types may vary
@@ -31,6 +78,8 @@ export interface GuidedAction extends InternalAction {
   isSkippable?: boolean; // Whether this specific step can be skipped
   formHint?: string; // Hint shown when form validation fails (for formfill with regex)
   validateInput?: boolean; // Enable strict validation for formfill (require targetValue match)
+  lazyRender?: boolean;
+  scrollContainer?: string;
 }
 
 /**

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -420,7 +420,13 @@ export const JsonGuidedBlockSchema = z.object({
   id: z.string().optional().describe('Stable identifier for this block (required for container blocks via CLI)'),
   content: z.string().min(1, 'Guided content is required').describe('Block heading/intro text'),
   steps: z.array(JsonStepSchema).min(1, EMPTY_STEPS_MESSAGE).describe('Ordered steps; populated via add-step'),
-  stepTimeout: z.number().optional().describe('Per-step timeout in milliseconds'),
+  stepTimeout: z
+    .number()
+    .int()
+    .positive()
+    .max(600_000)
+    .optional()
+    .describe('Per-step timeout in milliseconds (default: 120000)'),
   requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions'),
   objectives: z.array(ObjectiveTokenSchema).optional().describe('Conditions that automatically complete this block'),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),

--- a/src/types/json-guide.types.ts
+++ b/src/types/json-guide.types.ts
@@ -419,7 +419,7 @@ export interface JsonGuidedBlock extends AuthorAnnotated {
   content: string;
   /** Sequence of steps for user to perform */
   steps: JsonStep[];
-  /** Timeout per step in milliseconds (default: 30000) */
+  /** Timeout per step in milliseconds (default: 120000, maximum: 600000) */
   stepTimeout?: number;
   /** Requirements for the entire guided block */
   requirements?: string[];

--- a/tests/e2e-runner/utils/guide-runner/constants.ts
+++ b/tests/e2e-runner/utils/guide-runner/constants.ts
@@ -52,10 +52,9 @@ export const STEP_DEADLINE_CLEANUP_GRACE_MS = 3000;
 export const TIMEOUT_PER_MULTISTEP_ACTION_MS = 5000;
 
 /**
- * Additional timeout per guided substep (Phase 3).
- * Guided steps run a substep loop; the driver scales this by its action count.
+ * Fallback timeout per guided substep for older plugins without the DOM contract.
  */
-export const TIMEOUT_PER_GUIDED_SUBSTEP_MS = 30000;
+export const TIMEOUT_PER_GUIDED_SUBSTEP_MS = 120000;
 
 /**
  * Timeout for comment box to become visible during guided execution.
@@ -96,11 +95,6 @@ export const GUIDED_FORMFILL_INVALID_PERSIST_MS = 3000;
  * Minimal dwell after hover before waiting for substep advance (Phase 4.2).
  */
 export const GUIDED_HOVER_DWELL_MS = 500;
-
-/**
- * Fraction of per-substep timeout after which we try Skip button if present (Phase 4.3). 0.8 = 80%.
- */
-export const GUIDED_SKIP_AFTER_TIMEOUT_FRACTION = 0.8;
 
 /**
  * Timeout for a guided action's page-load wait after a detected reload/navigation

--- a/tests/e2e-runner/utils/guide-runner/discovery.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/discovery.test.ts
@@ -120,6 +120,43 @@ describe('discoverStepsFromDOM', () => {
     expect(result.steps.map((step) => step.stepId)).toEqual(['current-1']);
   });
 
+  it('discovers authored guided timeouts and the 120-second default', async () => {
+    const page = pageWithRoots([
+      root({
+        'data-test-step-kind': 'guided',
+        'data-test-step-id': 'guided-30',
+        'data-test-substep-total': '1',
+        'data-test-step-timeout-ms': '30000',
+      }),
+      root({
+        'data-test-step-kind': 'guided',
+        'data-test-step-id': 'guided-45',
+        'data-test-substep-total': '1',
+        'data-test-step-timeout-ms': '45000',
+      }),
+      root({
+        'data-test-step-kind': 'guided',
+        'data-test-step-id': 'guided-60',
+        'data-test-substep-total': '1',
+        'data-test-step-timeout-ms': '60000',
+      }),
+      root({
+        'data-test-step-kind': 'guided',
+        'data-test-step-id': 'guided-default',
+        'data-test-substep-total': '1',
+      }),
+    ]);
+
+    const result = await discoverStepsFromDOM(page);
+
+    expect(result.steps.map(({ stepId, guidedStepTimeoutMs }) => ({ stepId, guidedStepTimeoutMs }))).toEqual([
+      { stepId: 'guided-30', guidedStepTimeoutMs: 30_000 },
+      { stepId: 'guided-45', guidedStepTimeoutMs: 45_000 },
+      { stepId: 'guided-60', guidedStepTimeoutMs: 60_000 },
+      { stepId: 'guided-default', guidedStepTimeoutMs: 120_000 },
+    ]);
+  });
+
   it('uses a legacy selector that excludes completed badges', async () => {
     const page = pageWithRoots([]);
 

--- a/tests/e2e-runner/utils/guide-runner/drivers/guided.ts
+++ b/tests/e2e-runner/utils/guide-runner/drivers/guided.ts
@@ -1,6 +1,10 @@
 import type { Locator, Page } from '@playwright/test';
 
 import { testIds } from '../../../../../src/constants/testIds';
+import {
+  GUIDED_SUBSTEP_SETTLED_EVENT,
+  type GuidedSubstepSettledDetail,
+} from '../../../../../src/types/interactive-actions.types';
 import { resolveSelector } from '../../selector-resolver';
 import { captureFailureArtifacts } from '../artifacts';
 import { dismissBadgeCelebrations } from '../badge-celebrations';
@@ -13,16 +17,138 @@ import {
   GUIDED_FORMFILL_VALID_TIMEOUT_MS,
   GUIDED_HOVER_DWELL_MS,
   GUIDED_RELOAD_LOAD_TIMEOUT_MS,
-  GUIDED_SKIP_AFTER_TIMEOUT_FRACTION,
   GUIDED_SUBSTEP_ADVANCE_POLL_MS,
   GUIDED_TARGET_RESOLUTION_TIMEOUT_MS,
   TIMEOUT_PER_GUIDED_SUBSTEP_MS,
 } from '../constants';
-import type { TestableStep } from '../types';
+import type { ArtifactPaths, GuidedSubstepResult, TestableStep } from '../types';
 import { startStepAction, waitForCompletion } from './shared';
 import type { StepDriverExecutionContext, StepDriverExecutionResult } from './types';
 
 const GUIDED_WAIT_EXECUTING_MS = 5000;
+let guidedCollectorId = 0;
+
+function remainingTimeout(deadline: number, maximum = Number.POSITIVE_INFINITY): number {
+  return Math.max(1, Math.min(maximum, deadline - Date.now()));
+}
+
+function isGuidedSubstepDetail(value: unknown, stepId: string): value is GuidedSubstepSettledDetail {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const detail = value as Partial<GuidedSubstepSettledDetail>;
+  return (
+    detail.stepId === stepId &&
+    Number.isInteger(detail.index) &&
+    detail.index! >= 0 &&
+    Number.isInteger(detail.total) &&
+    detail.total! > 0 &&
+    detail.index! < detail.total! &&
+    typeof detail.action === 'string' &&
+    ['completed', 'skipped', 'timeout', 'cancelled', 'error'].includes(detail.outcome ?? '') &&
+    typeof detail.durationMs === 'number' &&
+    Number.isFinite(detail.durationMs) &&
+    detail.durationMs >= 0 &&
+    typeof detail.skippable === 'boolean'
+  );
+}
+
+async function installGuidedSettlementCollector(context: StepDriverExecutionContext): Promise<() => Promise<void>> {
+  if (
+    typeof context.page.exposeFunction !== 'function' ||
+    typeof context.page.evaluate !== 'function' ||
+    !context.onGuidedSubstepSettled
+  ) {
+    return async () => undefined;
+  }
+
+  guidedCollectorId += 1;
+  const bindingName = `__pathfinderGuidedSettlement${guidedCollectorId}`;
+  const listenerName = `${bindingName}Listener`;
+  const storageKey = `pathfinder-e2e-guided-${Date.now()}-${guidedCollectorId}`;
+  const activeKey = `${storageKey}-active`;
+  const seen = new Set<string>();
+  const record = (value: unknown) => {
+    if (!isGuidedSubstepDetail(value, context.step.stepId)) {
+      return;
+    }
+    const key = JSON.stringify(value);
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    const result: GuidedSubstepResult = {
+      index: value.index,
+      total: value.total,
+      action: value.action,
+      outcome: value.outcome,
+      durationMs: value.durationMs,
+      timeoutMs: context.step.guidedStepTimeoutMs ?? TIMEOUT_PER_GUIDED_SUBSTEP_MS,
+      skippable: value.skippable,
+    };
+    context.onGuidedSubstepSettled?.(result);
+  };
+
+  await context.page.exposeFunction(bindingName, record);
+  const collector = {
+    bindingName,
+    listenerName,
+    storageKey,
+    activeKey,
+    stepId: context.step.stepId,
+    eventName: GUIDED_SUBSTEP_SETTLED_EVENT,
+  };
+  await context.page.evaluate(
+    ({ bindingName: name, listenerName, storageKey: evidenceKey, activeKey: enabledKey, stepId, eventName }) => {
+      sessionStorage.setItem(evidenceKey, '[]');
+      sessionStorage.setItem(enabledKey, 'true');
+      const listener = (event: Event) => {
+        if (sessionStorage.getItem(enabledKey) !== 'true') {
+          return;
+        }
+        const detail = (event as CustomEvent<GuidedSubstepSettledDetail>).detail;
+        if (detail?.stepId !== stepId) {
+          return;
+        }
+        const current = JSON.parse(sessionStorage.getItem(evidenceKey) ?? '[]') as unknown[];
+        current.push(detail);
+        sessionStorage.setItem(evidenceKey, JSON.stringify(current));
+        const binding = (window as unknown as Record<string, ((value: unknown) => Promise<void>) | undefined>)[name];
+        void binding?.(detail);
+      };
+      (window as unknown as Record<string, EventListener | undefined>)[listenerName] = listener;
+      document.addEventListener(eventName, listener);
+    },
+    collector
+  );
+
+  return async () => {
+    const stored = await context.page
+      .evaluate(({ listenerName, storageKey: evidenceKey, activeKey: enabledKey, eventName }) => {
+        sessionStorage.setItem(enabledKey, 'false');
+        const listeners = window as unknown as Record<string, EventListener | undefined>;
+        const listener = listeners[listenerName];
+        if (listener) {
+          document.removeEventListener(eventName, listener);
+          delete listeners[listenerName];
+        }
+        const value = sessionStorage.getItem(evidenceKey);
+        sessionStorage.removeItem(evidenceKey);
+        sessionStorage.removeItem(enabledKey);
+        return value;
+      }, collector)
+      .catch(() => null);
+    if (!stored) {
+      return;
+    }
+    try {
+      const values = JSON.parse(stored) as unknown[];
+      values.forEach(record);
+    } catch {
+      return;
+    }
+  };
+}
 
 export async function waitForGuidedExecutionStart(
   page: Page,
@@ -31,7 +157,7 @@ export async function waitForGuidedExecutionStart(
 ): Promise<void> {
   const deadline = Date.now() + timeout;
   while (Date.now() < deadline) {
-    const state = await stepLocator.getAttribute('data-test-step-state');
+    const state = await stepLocator.getAttribute('data-test-step-state', { timeout: remainingTimeout(deadline) });
     if (state === 'executing' || state === 'completed') {
       return;
     }
@@ -97,9 +223,13 @@ async function revealGuidedTarget(page: Page, target: Locator, timeout: number):
   return target;
 }
 
-async function resolveGuidedTarget(page: Page, reftarget: string, actionType: string): Promise<Locator> {
+async function resolveGuidedTarget(
+  page: Page,
+  reftarget: string,
+  actionType: string,
+  timeout = GUIDED_TARGET_RESOLUTION_TIMEOUT_MS
+): Promise<Locator> {
   await dismissBadgeCelebrations(page);
-  const timeout = GUIDED_TARGET_RESOLUTION_TIMEOUT_MS;
   const selector = reftarget.startsWith('grafana:') ? resolveSelector(reftarget) : reftarget;
 
   if (actionType === 'button') {
@@ -124,12 +254,9 @@ async function waitForSubstepAdvance(
   page: Page,
   stepLocator: Locator,
   previousSubstepIndex: number,
-  timeoutMs: number,
-  options: { commentBox?: Locator } = {}
+  timeoutMs: number
 ): Promise<void> {
-  const { commentBox } = options;
   const deadline = Date.now() + timeoutMs;
-  const skipAfterMs = Math.floor(timeoutMs * GUIDED_SKIP_AFTER_TIMEOUT_FRACTION);
   let lastState: string | null = null;
   let lastIndex: string | null = null;
 
@@ -140,8 +267,12 @@ async function waitForSubstepAdvance(
     }
 
     try {
-      lastState = await stepLocator.getAttribute('data-test-step-state', { timeout: 2000 });
-      lastIndex = await stepLocator.getAttribute('data-test-substep-index', { timeout: 2000 });
+      lastState = await stepLocator.getAttribute('data-test-step-state', {
+        timeout: remainingTimeout(deadline, 2000),
+      });
+      lastIndex = await stepLocator.getAttribute('data-test-substep-index', {
+        timeout: remainingTimeout(deadline, 2000),
+      });
     } catch {
       if ((await stepLocator.count()) === 0) {
         return;
@@ -164,17 +295,7 @@ async function waitForSubstepAdvance(
       return;
     }
 
-    const elapsed = Date.now() - (deadline - timeoutMs);
-    if (commentBox && elapsed >= skipAfterMs) {
-      const skipBtn = commentBox.getByRole('button', { name: /^Skip$/ });
-      const count = await skipBtn.count();
-      if (count > 0) {
-        await dismissBadgeCelebrations(page);
-        await skipBtn.click().catch(() => {});
-      }
-    }
-
-    await page.waitForTimeout(GUIDED_SUBSTEP_ADVANCE_POLL_MS);
+    await page.waitForTimeout(Math.min(GUIDED_SUBSTEP_ADVANCE_POLL_MS, Math.max(0, deadline - Date.now())));
   }
 
   throw new Error(
@@ -186,19 +307,25 @@ export async function waitForFormfillSettle(
   page: Page,
   stepLocator: Locator,
   target: Locator,
-  targetValue: string
+  targetValue: string,
+  deadline = Date.now() + GUIDED_FORMFILL_DEBOUNCE_MS + GUIDED_FORMFILL_VALID_TIMEOUT_MS
 ): Promise<void> {
-  await page.waitForTimeout(GUIDED_FORMFILL_DEBOUNCE_MS);
+  await page.waitForTimeout(Math.min(GUIDED_FORMFILL_DEBOUNCE_MS, Math.max(0, deadline - Date.now())));
 
-  const validDeadline = Date.now() + GUIDED_FORMFILL_VALID_TIMEOUT_MS;
+  const validDeadline = Math.min(deadline, Date.now() + GUIDED_FORMFILL_VALID_TIMEOUT_MS);
   let invalidSince: number | null = null;
 
   const readFormState = async (): Promise<string | null> => {
     if ((await stepLocator.count()) === 0) {
       return null;
     }
+    if (Date.now() >= deadline) {
+      return null;
+    }
     try {
-      return await stepLocator.getAttribute('data-test-form-state', { timeout: 2000 });
+      return await stepLocator.getAttribute('data-test-form-state', {
+        timeout: remainingTimeout(deadline, 2000),
+      });
     } catch {
       return null;
     }
@@ -218,8 +345,8 @@ export async function waitForFormfillSettle(
       }
       if (Date.now() - invalidSince >= GUIDED_FORMFILL_INVALID_PERSIST_MS) {
         await dismissBadgeCelebrations(page);
-        await target.fill(targetValue);
-        await page.waitForTimeout(GUIDED_FORMFILL_DEBOUNCE_MS);
+        await target.fill(targetValue, { timeout: remainingTimeout(deadline) });
+        await page.waitForTimeout(Math.min(GUIDED_FORMFILL_DEBOUNCE_MS, Math.max(0, deadline - Date.now())));
         const afterRetry = await readFormState();
         if (afterRetry === 'invalid') {
           throw new Error(
@@ -234,17 +361,18 @@ export async function waitForFormfillSettle(
     } else {
       invalidSince = null;
     }
-    await page.waitForTimeout(GUIDED_SUBSTEP_ADVANCE_POLL_MS);
+    await page.waitForTimeout(Math.min(GUIDED_SUBSTEP_ADVANCE_POLL_MS, Math.max(0, deadline - Date.now())));
   }
 }
 
-export type GuidedCommentBoxWaitOutcome = 'ready' | 'completed' | 'detached';
+export type GuidedCommentBoxWaitOutcome = 'ready' | 'advanced' | 'completed' | 'detached';
 
 export async function waitForGuidedCommentBoxReady(
   page: Page,
   stepLocator: Locator,
   commentBox: Locator,
-  timeoutMs = GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS
+  timeoutMs = GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS,
+  previousSubstepIndex?: number
 ): Promise<GuidedCommentBoxWaitOutcome> {
   const deadline = Date.now() + timeoutMs;
 
@@ -253,11 +381,6 @@ export async function waitForGuidedCommentBoxReady(
     if (remainingMs <= 0) {
       throw new Error('Guided step: comment box not visible');
     }
-
-    if ((await commentBox.count()) > 0 && (await commentBox.isVisible())) {
-      return 'ready';
-    }
-
     // Count first because Playwright waits for attributes on a missing locator.
     if ((await stepLocator.count()) === 0) {
       return 'detached';
@@ -279,6 +402,20 @@ export async function waitForGuidedCommentBoxReady(
     if (state === 'cancelled') {
       throw new Error('Guided step was cancelled while waiting for comment box');
     }
+    if (previousSubstepIndex !== undefined) {
+      const indexReadTimeout = deadline - Date.now();
+      if (indexReadTimeout <= 0) {
+        throw new Error('Guided step: comment box not visible');
+      }
+      const rawIndex = await stepLocator.getAttribute('data-test-substep-index', { timeout: indexReadTimeout });
+      const index = rawIndex === null ? Number.NaN : Number.parseInt(rawIndex, 10);
+      if (Number.isFinite(index) && index > previousSubstepIndex) {
+        return 'advanced';
+      }
+    }
+    if ((await commentBox.count()) > 0 && (await commentBox.isVisible())) {
+      return 'ready';
+    }
 
     await page.waitForTimeout(Math.min(GUIDED_SUBSTEP_ADVANCE_POLL_MS, Math.max(1, deadline - Date.now())));
   }
@@ -297,13 +434,18 @@ export async function runGuidedSubstepLoop(
 ): Promise<{ completed: boolean }> {
   let stepLocator = options.stepLocator;
   const { perSubstepTimeoutMs, verbose = false, artifactsDir } = options;
-  const commentBoxDeadlineMs = options.commentBoxDeadlineMs ?? Date.now() + GUIDED_COMMENT_BOX_VISIBLE_TIMEOUT_MS;
   const actionCount = Math.max(1, step.actionCount);
 
-  const captureLoopArtifacts = async () => {
-    if (artifactsDir) {
-      await captureFailureArtifacts(page, step.stepId, [], artifactsDir).catch(() => {});
+  const captureLoopError = async (error: unknown): Promise<Error> => {
+    const normalized = error instanceof Error ? error : new Error(String(error));
+    if (!artifactsDir) {
+      return normalized;
     }
+    const artifacts = await captureFailureArtifacts(page, step.stepId, [], artifactsDir).catch(() => undefined);
+    if (artifacts) {
+      (normalized as Error & { artifacts?: ArtifactPaths }).artifacts = artifacts;
+    }
+    return normalized;
   };
 
   // Re-resolve after navigation, but propagate locator errors as execution failures.
@@ -317,29 +459,35 @@ export async function runGuidedSubstepLoop(
       return { completed: true };
     }
 
-    const state = await stepLocator.getAttribute('data-test-step-state');
+    const substepDeadline = Date.now() + perSubstepTimeoutMs;
+    const state = await stepLocator.getAttribute('data-test-step-state', {
+      timeout: remainingTimeout(substepDeadline),
+    });
     if (state === 'completed') {
       return { completed: true };
     }
     if (state === 'error') {
-      await captureLoopArtifacts();
-      throw new Error('Guided step entered error state');
+      throw await captureLoopError(new Error('Guided step entered error state'));
     }
     if (state === 'cancelled') {
-      await captureLoopArtifacts();
-      throw new Error('Guided step was cancelled');
+      throw await captureLoopError(new Error('Guided step was cancelled'));
     }
     if (state !== 'executing') {
-      await captureLoopArtifacts();
-      throw new Error(`Unexpected guided step state: ${state}`);
+      throw await captureLoopError(new Error(`Unexpected guided step state: ${state}`));
     }
-    const indexStr = await stepLocator.getAttribute('data-test-substep-index');
+    const indexStr = await stepLocator.getAttribute('data-test-substep-index', {
+      timeout: remainingTimeout(substepDeadline),
+    });
 
     const currentIndex = indexStr != null ? parseInt(indexStr, 10) : 0;
     const safeIndex = Number.isNaN(currentIndex) ? 0 : currentIndex;
     if (safeIndex >= actionCount) {
       return { completed: false };
     }
+    const isSkippable =
+      (await stepLocator.getAttribute('data-test-substep-skippable', {
+        timeout: remainingTimeout(substepDeadline),
+      })) === 'true';
 
     const commentBox = page.locator('.interactive-comment-box').first();
     let commentBoxOutcome: GuidedCommentBoxWaitOutcome;
@@ -348,19 +496,40 @@ export async function runGuidedSubstepLoop(
         page,
         stepLocator,
         commentBox,
-        Math.max(1, commentBoxDeadlineMs - Date.now())
+        Math.max(1, Math.min(options.commentBoxDeadlineMs ?? substepDeadline, substepDeadline) - Date.now()),
+        safeIndex
       );
     } catch (err) {
-      await captureLoopArtifacts();
-      throw err;
+      if (isSkippable) {
+        const skipButton = commentBox.getByRole('button', { name: /^(Skip|Skip this step)$/ });
+        if ((await skipButton.count()) > 0) {
+          await dismissBadgeCelebrations(page);
+          await skipButton.click({ timeout: remainingTimeout(substepDeadline) });
+          await waitForSubstepAdvance(page, stepLocator, safeIndex, remainingTimeout(substepDeadline));
+          continue;
+        } else {
+          throw await captureLoopError(err);
+        }
+      } else {
+        throw await captureLoopError(err);
+      }
     }
     if (commentBoxOutcome === 'completed' || commentBoxOutcome === 'detached') {
       return { completed: true };
     }
+    if (commentBoxOutcome === 'advanced') {
+      continue;
+    }
 
-    const action = await commentBox.getAttribute('data-test-action');
-    const reftarget = await commentBox.getAttribute('data-test-reftarget');
-    const targetValue = await commentBox.getAttribute('data-test-target-value');
+    const action = await commentBox.getAttribute('data-test-action', {
+      timeout: remainingTimeout(substepDeadline),
+    });
+    const reftarget = await commentBox.getAttribute('data-test-reftarget', {
+      timeout: remainingTimeout(substepDeadline),
+    });
+    const targetValue = await commentBox.getAttribute('data-test-target-value', {
+      timeout: remainingTimeout(substepDeadline),
+    });
 
     if (verbose) {
       console.log(`   📍 Guided substep ${safeIndex + 1}/${actionCount} action=${action}`);
@@ -370,7 +539,7 @@ export async function runGuidedSubstepLoop(
       if (action === 'noop') {
         const continueBtn = commentBox.getByRole('button', { name: /Continue/ });
         await dismissBadgeCelebrations(page);
-        await continueBtn.click();
+        await continueBtn.click({ timeout: remainingTimeout(substepDeadline) });
       } else if (action === 'button' || action === 'highlight') {
         if (!reftarget) {
           throw new Error('Guided step: button/highlight substep missing data-test-reftarget');
@@ -382,71 +551,101 @@ export async function runGuidedSubstepLoop(
         };
         page.on('framenavigated', onFrameNavigated);
         try {
-          const target = await resolveGuidedTarget(page, reftarget, action);
-          await target.scrollIntoViewIfNeeded();
+          const target = await resolveGuidedTarget(
+            page,
+            reftarget,
+            action,
+            remainingTimeout(substepDeadline, GUIDED_TARGET_RESOLUTION_TIMEOUT_MS)
+          );
+          await target.scrollIntoViewIfNeeded({ timeout: remainingTimeout(substepDeadline) });
           await dismissBadgeCelebrations(page);
-          await target.click();
-          await page.waitForTimeout(100);
+          await target.click({ timeout: remainingTimeout(substepDeadline) });
+          await page.waitForTimeout(Math.min(100, Math.max(0, substepDeadline - Date.now())));
         } finally {
           page.off('framenavigated', onFrameNavigated);
         }
         if (navigated || urlBefore !== page.url()) {
           // Navigation invalidates the old locator, so wait for the new document.
-          await page.waitForLoadState('domcontentloaded', { timeout: GUIDED_RELOAD_LOAD_TIMEOUT_MS });
+          await page.waitForLoadState('domcontentloaded', {
+            timeout: remainingTimeout(substepDeadline, GUIDED_RELOAD_LOAD_TIMEOUT_MS),
+          });
           stepLocator = page.getByTestId(testIds.interactive.step(step.stepId));
         }
       } else if (action === 'hover') {
         if (!reftarget) {
           throw new Error('Guided step: hover substep missing data-test-reftarget');
         }
-        const target = await resolveGuidedTarget(page, reftarget, 'hover');
-        await target.scrollIntoViewIfNeeded();
+        const target = await resolveGuidedTarget(
+          page,
+          reftarget,
+          'hover',
+          remainingTimeout(substepDeadline, GUIDED_TARGET_RESOLUTION_TIMEOUT_MS)
+        );
+        await target.scrollIntoViewIfNeeded({ timeout: remainingTimeout(substepDeadline) });
         await dismissBadgeCelebrations(page);
-        await target.hover();
-        await page.waitForTimeout(GUIDED_HOVER_DWELL_MS);
+        await target.hover({ timeout: remainingTimeout(substepDeadline) });
+        await page.waitForTimeout(Math.min(GUIDED_HOVER_DWELL_MS, Math.max(0, substepDeadline - Date.now())));
       } else if (action === 'formfill') {
         if (!reftarget) {
           throw new Error('Guided step: formfill substep missing data-test-reftarget');
         }
-        const target = await resolveGuidedTarget(page, reftarget, 'formfill');
-        await target.scrollIntoViewIfNeeded();
+        const target = await resolveGuidedTarget(
+          page,
+          reftarget,
+          'formfill',
+          remainingTimeout(substepDeadline, GUIDED_TARGET_RESOLUTION_TIMEOUT_MS)
+        );
+        await target.scrollIntoViewIfNeeded({ timeout: remainingTimeout(substepDeadline) });
         await dismissBadgeCelebrations(page);
-        await target.fill(targetValue ?? '');
-        await waitForFormfillSettle(page, stepLocator, target, targetValue ?? '');
+        await target.fill(targetValue ?? '', { timeout: remainingTimeout(substepDeadline) });
+        await waitForFormfillSettle(page, stepLocator, target, targetValue ?? '', substepDeadline);
       } else {
         throw new Error(`Guided step: unknown data-test-action "${action}"`);
       }
     } catch (err) {
-      await captureLoopArtifacts();
-      throw err;
+      if (isSkippable) {
+        const skipButton = commentBox.getByRole('button', { name: /^(Skip|Skip this step)$/ });
+        if ((await skipButton.count()) > 0) {
+          await dismissBadgeCelebrations(page);
+          await skipButton.click({ timeout: Math.max(1, substepDeadline - Date.now()) });
+        } else {
+          throw await captureLoopError(err);
+        }
+      } else {
+        throw await captureLoopError(err);
+      }
     }
 
     if (await stepDetached()) {
       return { completed: true };
     }
 
-    await waitForSubstepAdvance(page, stepLocator, safeIndex, perSubstepTimeoutMs, { commentBox });
+    await waitForSubstepAdvance(page, stepLocator, safeIndex, remainingTimeout(substepDeadline));
     await page.waitForTimeout(GUIDED_BETWEEN_SUBSTEP_DELAY_MS);
   }
 }
 
 export async function executeGuidedStep(context: StepDriverExecutionContext): Promise<StepDriverExecutionResult> {
-  const action = await startStepAction(context);
-  if (action.outcome !== 'started') {
-    return { outcome: action.outcome };
-  }
+  const stopCollector = await installGuidedSettlementCollector(context);
+  try {
+    const action = await startStepAction(context);
+    if (action.outcome !== 'started') {
+      return { outcome: action.outcome };
+    }
 
-  const stepLocator = context.page.getByTestId(testIds.interactive.step(context.step.stepId));
-  await waitForGuidedExecutionStart(context.page, stepLocator);
-  const { completed } = await runGuidedSubstepLoop(context.page, context.step, {
-    stepLocator,
-    perSubstepTimeoutMs: TIMEOUT_PER_GUIDED_SUBSTEP_MS,
-    commentBoxDeadlineMs: Date.now() + context.timeout,
-    verbose: context.verbose,
-    artifactsDir: context.artifactsDir,
-  });
-  if (!completed) {
-    await waitForCompletion(context.page, context.step.stepId, context.timeout);
+    const stepLocator = context.page.getByTestId(testIds.interactive.step(context.step.stepId));
+    await waitForGuidedExecutionStart(context.page, stepLocator);
+    const { completed } = await runGuidedSubstepLoop(context.page, context.step, {
+      stepLocator,
+      perSubstepTimeoutMs: context.step.guidedStepTimeoutMs ?? TIMEOUT_PER_GUIDED_SUBSTEP_MS,
+      verbose: context.verbose,
+      artifactsDir: context.artifactsDir,
+    });
+    if (!completed) {
+      await waitForCompletion(context.page, context.step.stepId, context.timeout);
+    }
+    return { outcome: 'completed' };
+  } finally {
+    await stopCollector();
   }
-  return { outcome: 'completed' };
 }

--- a/tests/e2e-runner/utils/guide-runner/drivers/registry.ts
+++ b/tests/e2e-runner/utils/guide-runner/drivers/registry.ts
@@ -39,9 +39,15 @@ async function inspectGuided(page: Page, root: Locator, stepId: string): Promise
   const common = await inspectCommonStep(page, root, stepId);
   const rawTotal = await root.getAttribute('data-test-substep-total');
   const parsedTotal = rawTotal ? Number.parseInt(rawTotal, 10) : Number.NaN;
+  const rawTimeout = await root.getAttribute('data-test-step-timeout-ms');
+  const parsedTimeout = rawTimeout ? Number.parseInt(rawTimeout, 10) : Number.NaN;
   return {
     ...common,
     actionCount: Number.isFinite(parsedTotal) && parsedTotal >= 1 ? parsedTotal : 1,
+    guidedStepTimeoutMs:
+      Number.isFinite(parsedTimeout) && parsedTimeout > 0 && parsedTimeout <= 600_000
+        ? parsedTimeout
+        : TIMEOUT_PER_GUIDED_SUBSTEP_MS,
   };
 }
 
@@ -88,7 +94,9 @@ const drivers = [
   supportedDriver(
     'guided',
     inspectGuided,
-    (step) => DEFAULT_STEP_TIMEOUT_MS + (step.actionCount > 0 ? step.actionCount * TIMEOUT_PER_GUIDED_SUBSTEP_MS : 0),
+    (step) =>
+      DEFAULT_STEP_TIMEOUT_MS +
+      (step.actionCount > 0 ? step.actionCount * (step.guidedStepTimeoutMs ?? TIMEOUT_PER_GUIDED_SUBSTEP_MS) : 0),
     executeGuidedStep
   ),
   unsupportedDriver('quiz'),

--- a/tests/e2e-runner/utils/guide-runner/drivers/types.ts
+++ b/tests/e2e-runner/utils/guide-runner/drivers/types.ts
@@ -1,7 +1,7 @@
 import type { Locator, Page } from '@playwright/test';
 
 import type { StepTypeKind } from '../../../../../src/components/interactive-tutorial/step-type-registry';
-import type { TestableStep } from '../types';
+import type { GuidedSubstepResult, TestableStep } from '../types';
 
 export interface StepDriverInspection {
   skippable: boolean;
@@ -10,6 +10,7 @@ export interface StepDriverInspection {
   isPreCompleted: boolean;
   targetAction?: string;
   actionCount: number;
+  guidedStepTimeoutMs?: number;
   refTarget?: string;
 }
 
@@ -19,6 +20,7 @@ export interface StepDriverExecutionContext {
   timeout: number;
   verbose: boolean;
   artifactsDir?: string;
+  onGuidedSubstepSettled?: (result: GuidedSubstepResult) => void;
 }
 
 export interface StepDriverExecutionResult {

--- a/tests/e2e-runner/utils/guide-runner/execution.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.test.ts
@@ -36,6 +36,7 @@ jest.mock('@playwright/test', () => {
         }
       };
       return {
+        toBeEnabled: jest.fn().mockResolvedValue(undefined),
         toHaveAttribute: (attr: string, value: string, opts?: { timeout?: number }) =>
           poll(attr, (current) => current === value, opts),
         not: {
@@ -53,6 +54,10 @@ jest.mock('./requirements', () => ({
 jest.mock('./badge-celebrations', () => ({
   dismissBadgeCelebrations: jest.fn().mockResolvedValue(undefined),
 }));
+jest.mock('./artifacts', () => {
+  const actual = jest.requireActual('./artifacts');
+  return { ...actual, captureFailureArtifacts: jest.fn() };
+});
 
 import type { Locator, Page } from '@playwright/test';
 
@@ -69,12 +74,9 @@ import {
 import { clickSkipButtonAndSync } from './drivers';
 import { handleRequirementsWithFix } from './requirements';
 import { dismissBadgeCelebrations } from './badge-celebrations';
-import {
-  SCROLL_INTO_VIEW_TIMEOUT_MS,
-  GUIDED_RELOAD_LOAD_TIMEOUT_MS,
-  LATE_COMPLETION_CHECK_TIMEOUT_MS,
-  STEP_OVERHEAD_TIMEOUT_MS,
-} from './constants';
+import { captureFailureArtifacts } from './artifacts';
+import { STEP_DRIVERS } from './drivers/registry';
+import { SCROLL_INTO_VIEW_TIMEOUT_MS, LATE_COMPLETION_CHECK_TIMEOUT_MS, STEP_OVERHEAD_TIMEOUT_MS } from './constants';
 import type { StepTestResult, TestableStep } from './types';
 
 function createTestableStep(overrides: Partial<TestableStep> = {}): TestableStep {
@@ -161,6 +163,18 @@ function createDeadlinePage(closeOverride?: jest.Mock): Page {
   } as unknown as Page;
 }
 
+function createExecutablePage(stepLocator = createLocator(), close = jest.fn().mockResolvedValue(undefined)): Page {
+  return {
+    getByTestId: jest.fn(() => stepLocator),
+    waitForTimeout: jest.fn().mockResolvedValue(undefined),
+    on: jest.fn(),
+    off: jest.fn(),
+    url: jest.fn(() => 'http://localhost:3000/'),
+    close,
+    isClosed: jest.fn(() => false),
+  } as unknown as Page;
+}
+
 describe('scrollStepIntoView', () => {
   it('bounds scrollIntoViewIfNeeded with the scroll timeout', async () => {
     const stepElement = createLocator();
@@ -184,6 +198,197 @@ describe('scrollStepIntoView', () => {
     await scrollStepIntoView(page, 'step-1', 0, 1234);
 
     expect(stepElement.scrollIntoViewIfNeeded).toHaveBeenCalledWith({ timeout: 1234 });
+  });
+});
+
+describe('guided substep evidence', () => {
+  beforeEach(() => {
+    (handleRequirementsWithFix as jest.Mock).mockReset().mockResolvedValue({
+      requirements: { requirementsMet: true, status: 'met' },
+      fixResult: undefined,
+    });
+    (captureFailureArtifacts as jest.Mock).mockReset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('collects completed and skipped evidence before the guided step detaches', async () => {
+    let binding: ((value: unknown) => void) | undefined;
+    let stateReads = 0;
+    let countReads = 0;
+    const stepLocator = createLocator({
+      count: jest.fn(() => Promise.resolve(countReads++ === 0 ? 1 : 0)),
+      getAttribute: jest.fn((name: string) => {
+        if (name !== 'data-test-step-state') {
+          return Promise.resolve(null);
+        }
+        stateReads += 1;
+        return Promise.resolve(stateReads === 3 ? 'executing' : null);
+      }),
+    });
+    const absentControl = createLocator({ count: jest.fn().mockResolvedValue(0) });
+    const doItButton = createLocator({
+      click: jest.fn(async () => {
+        binding?.({
+          stepId: 'test-step-1',
+          index: 0,
+          total: 2,
+          action: 'button',
+          outcome: 'completed',
+          durationMs: 25,
+          timeoutMs: 45_000,
+          skippable: false,
+        });
+        binding?.({
+          stepId: 'test-step-1',
+          index: 1,
+          total: 2,
+          action: 'noop',
+          outcome: 'skipped',
+          durationMs: 5,
+          timeoutMs: 45_000,
+          skippable: true,
+        });
+      }),
+    });
+    const page = {
+      getByTestId: jest.fn((testId: string) => {
+        if (testId.startsWith('interactive-do-it-')) {
+          return doItButton;
+        }
+        if (testId.startsWith('interactive-show-me-')) {
+          return absentControl;
+        }
+        return stepLocator;
+      }),
+      exposeFunction: jest.fn((name: string, callback: (value: unknown) => void) => {
+        expect(name).toMatch(/^__pathfinderGuidedSettlement\d+$/);
+        binding = callback;
+      }),
+      evaluate: jest.fn().mockResolvedValueOnce(undefined).mockResolvedValueOnce(null),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      off: jest.fn(),
+      url: jest.fn(() => 'http://localhost:3000/'),
+      isClosed: jest.fn(() => false),
+    } as unknown as Page;
+
+    const result = await executeStep(page, createTestableStep({ actionCount: 2, guidedStepTimeoutMs: 45_000 }), {});
+
+    expect(result).toMatchObject({
+      status: 'passed',
+      guidedSubsteps: [
+        {
+          index: 0,
+          total: 2,
+          action: 'button',
+          outcome: 'completed',
+          durationMs: 25,
+          timeoutMs: 45_000,
+          skippable: false,
+        },
+        {
+          index: 1,
+          total: 2,
+          action: 'noop',
+          outcome: 'skipped',
+          durationMs: 5,
+          timeoutMs: 45_000,
+          skippable: true,
+        },
+      ],
+    });
+  });
+
+  it('retains partial evidence and reuses captured artifacts after a parent failure', async () => {
+    const firstArtifacts = { screenshot: '/artifacts/first.png', dom: '/artifacts/first.html' };
+    const error = Object.assign(new Error('parent failed after one substep'), { artifacts: firstArtifacts });
+    const guidedDriver = STEP_DRIVERS.get('guided')!;
+    jest.spyOn(guidedDriver, 'execute').mockImplementation(async (context) => {
+      context.onGuidedSubstepSettled?.({
+        index: 0,
+        total: 2,
+        action: 'noop',
+        outcome: 'skipped',
+        durationMs: 5,
+        timeoutMs: 30_000,
+        skippable: true,
+      });
+      throw error;
+    });
+    (captureFailureArtifacts as jest.Mock).mockResolvedValue({
+      screenshot: '/artifacts/second.png',
+      dom: '/artifacts/second.html',
+    });
+
+    const result = await executeStep(createExecutablePage(), createTestableStep({ actionCount: 2 }), {
+      artifactsDir: '/artifacts',
+    });
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      error: 'parent failed after one substep',
+      artifacts: firstArtifacts,
+      guidedSubsteps: [
+        {
+          index: 0,
+          outcome: 'skipped',
+        },
+      ],
+    });
+    expect(captureFailureArtifacts).not.toHaveBeenCalled();
+  });
+
+  it('retains settled evidence when the hard deadline closes the page', async () => {
+    jest.useFakeTimers();
+    let rejectExecution: ((error: Error) => void) | undefined;
+    let markStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const guidedDriver = STEP_DRIVERS.get('guided')!;
+    jest.spyOn(guidedDriver, 'execute').mockImplementation((context) => {
+      context.onGuidedSubstepSettled?.({
+        index: 0,
+        total: 2,
+        action: 'button',
+        outcome: 'completed',
+        durationMs: 40,
+        timeoutMs: 30_000,
+        skippable: false,
+      });
+      markStarted?.();
+      return new Promise((_resolve, reject) => {
+        rejectExecution = reject;
+      });
+    });
+    const close = jest.fn(async () => {
+      rejectExecution?.(new Error('Target page has been closed'));
+    });
+    const page = createExecutablePage(createLocator(), close);
+    const result = executeStep(page, createTestableStep({ actionCount: 2 }), {
+      timeout: 50,
+      deadlineMs: 100,
+    });
+
+    await started;
+    await jest.advanceTimersByTimeAsync(100);
+
+    await expect(result).resolves.toMatchObject({
+      status: 'failed',
+      deadlineExceeded: true,
+      classification: 'infrastructure',
+      guidedSubsteps: [
+        {
+          index: 0,
+          outcome: 'completed',
+        },
+      ],
+    });
+    expect(close).toHaveBeenCalledWith({ runBeforeUnload: false });
   });
 });
 
@@ -481,6 +686,19 @@ describe('waitForGuidedCommentBoxReady', () => {
     await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 1000)).resolves.toBe('ready');
   });
 
+  it('reports advancement before accepting a visible comment box from the prior substep', async () => {
+    const stepLocator = createLocator({
+      getAttribute: jest.fn((name: string) =>
+        Promise.resolve(name === 'data-test-step-state' ? 'executing' : name === 'data-test-substep-index' ? '1' : null)
+      ),
+    });
+    const commentBox = createLocator();
+    const page = { waitForTimeout: jest.fn().mockResolvedValue(undefined) } as unknown as Page;
+
+    await expect(waitForGuidedCommentBoxReady(page, stepLocator, commentBox, 1000, 0)).resolves.toBe('advanced');
+    expect(commentBox.isVisible).not.toHaveBeenCalled();
+  });
+
   it("resolves 'completed' when the step reaches completed while waiting", async () => {
     const stepLocator = createLocator({ getAttribute: jest.fn().mockResolvedValue('completed') });
     const commentBox = createLocator({ count: jest.fn().mockResolvedValue(0) });
@@ -593,6 +811,62 @@ describe('runGuidedSubstepLoop', () => {
     ).rejects.toThrow('Target closed');
   });
 
+  it('attaches the first failure artifacts to a guided loop error', async () => {
+    const artifacts = { screenshot: '/artifacts/first.png', dom: '/artifacts/first.html' };
+    (captureFailureArtifacts as jest.Mock).mockReset().mockResolvedValue(artifacts);
+    const stepLocator = createLocator({
+      getAttribute: jest.fn((name: string) => Promise.resolve(name === 'data-test-step-state' ? 'error' : null)),
+    });
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepLocator),
+    } as unknown as Page;
+
+    await expect(
+      runGuidedSubstepLoop(page, createTestableStep(), {
+        stepLocator,
+        perSubstepTimeoutMs: 1000,
+        artifactsDir: '/artifacts',
+      })
+    ).rejects.toMatchObject({
+      message: 'Guided step entered error state',
+      artifacts,
+    });
+    expect(captureFailureArtifacts).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows consecutive automatic skips without reading stale comment-box actions', async () => {
+    const states = ['executing', 'executing', 'executing', 'executing', 'completed'];
+    const indexes = ['0', '1', '1', '2'];
+    const stepLocator = createLocator({
+      getAttribute: jest.fn((name: string) => {
+        if (name === 'data-test-step-state') {
+          return Promise.resolve(states.shift() ?? 'completed');
+        }
+        if (name === 'data-test-substep-index') {
+          return Promise.resolve(indexes.shift() ?? '2');
+        }
+        if (name === 'data-test-substep-skippable') {
+          return Promise.resolve('true');
+        }
+        return Promise.resolve(null);
+      }),
+    });
+    const commentBox = createLocator();
+    const page = {
+      getByTestId: jest.fn().mockReturnValue(stepLocator),
+      locator: jest.fn().mockReturnValue({ first: jest.fn().mockReturnValue(commentBox) }),
+      waitForTimeout: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Page;
+
+    const result = await runGuidedSubstepLoop(page, createTestableStep({ actionCount: 3 }), {
+      stepLocator,
+      perSubstepTimeoutMs: 1000,
+    });
+
+    expect(result).toEqual({ completed: true });
+    expect(commentBox.getAttribute).not.toHaveBeenCalled();
+  });
+
   function createButtonSubstepHarness() {
     const listeners = new Map<string, Array<() => void>>();
 
@@ -667,7 +941,7 @@ describe('runGuidedSubstepLoop', () => {
 
     expect(result).toEqual({ completed: true });
     expect(page.waitForLoadState).toHaveBeenCalledWith('domcontentloaded', {
-      timeout: GUIDED_RELOAD_LOAD_TIMEOUT_MS,
+      timeout: 1000,
     });
     // getByTestId was called again after the reload to fetch a fresh locator.
     expect(getByTestIdCalls).toBeGreaterThan(1);

--- a/tests/e2e-runner/utils/guide-runner/execution.ts
+++ b/tests/e2e-runner/utils/guide-runner/execution.ts
@@ -35,6 +35,7 @@ import type {
   SkipReason,
   AbortReason,
   ArtifactPaths,
+  GuidedSubstepResult,
   StepTestResult,
   AllStepsResult,
   OnStepCompleteCallback,
@@ -226,6 +227,13 @@ async function buildSuccessArtifacts(
   }
   return artifacts ?? (preScreenshotPath ? { screenshotPre: preScreenshotPath } : undefined);
 }
+function capturedArtifactsFrom(error: unknown): ArtifactPaths | undefined {
+  if (typeof error !== 'object' || error === null || !('artifacts' in error)) {
+    return undefined;
+  }
+  const artifacts = error.artifacts;
+  return typeof artifacts === 'object' && artifacts !== null ? (artifacts as ArtifactPaths) : undefined;
+}
 
 /**
  * Build the failure-path artifact bundle for a step, merging in a
@@ -237,12 +245,13 @@ async function buildFailureArtifacts(
   stepId: string,
   consoleErrors: string[],
   artifactsDir: string | undefined,
-  preScreenshotPath: string | undefined
+  preScreenshotPath: string | undefined,
+  capturedArtifacts?: ArtifactPaths
 ): Promise<ArtifactPaths | undefined> {
   if (!artifactsDir) {
-    return undefined;
+    return capturedArtifacts;
   }
-  const artifacts = await captureFailureArtifacts(page, stepId, consoleErrors, artifactsDir);
+  const artifacts = capturedArtifacts ?? (await captureFailureArtifacts(page, stepId, consoleErrors, artifactsDir));
   if (artifacts && preScreenshotPath) {
     artifacts.screenshotPre = preScreenshotPath;
     return artifacts;
@@ -257,6 +266,7 @@ interface StepExecutionOptions {
   artifactsDir?: string;
   alwaysScreenshot?: boolean;
   onDeadline?(): void;
+  onGuidedSubstepSettled?: (result: GuidedSubstepResult) => void;
 }
 
 interface AllStepsOptions extends StepExecutionOptions {
@@ -299,7 +309,18 @@ async function executeStepCore(
   const timeout = options.timeout ?? calculateStepTimeout(step);
   const deadlineMs = options.deadlineMs ?? calculateStepDeadline(step, timeout);
   const startedAt = Date.now();
-  const work = executeStepWork(page, step, { ...options, timeout });
+  const guidedSubsteps: GuidedSubstepResult[] = [];
+  const work = executeStepWork(page, step, {
+    ...options,
+    timeout,
+    onGuidedSubstepSettled: (result) => {
+      guidedSubsteps.push(result);
+      options.onGuidedSubstepSettled?.(result);
+    },
+  }).then((result) => ({
+    ...result,
+    ...(guidedSubsteps.length > 0 ? { guidedSubsteps: [...guidedSubsteps] } : {}),
+  }));
 
   return new Promise<StepTestResult>((resolve, reject) => {
     let settled = false;
@@ -325,6 +346,7 @@ async function executeStepCore(
           skippable: step.skippable,
           classification: 'infrastructure',
           artifacts: evidence?.artifacts,
+          guidedSubsteps: evidence?.guidedSubsteps ?? (guidedSubsteps.length > 0 ? [...guidedSubsteps] : undefined),
         });
       })();
     }, deadlineMs);
@@ -521,7 +543,14 @@ async function executeStepWork(
       };
     }
 
-    const execution = await driver.execute({ page, step, timeout, verbose, artifactsDir });
+    const execution = await driver.execute({
+      page,
+      step,
+      timeout,
+      verbose,
+      artifactsDir,
+      onGuidedSubstepSettled: options.onGuidedSubstepSettled,
+    });
     if (execution.outcome === 'no-control') {
       if (step.skippable) {
         return createSkippedResult(step, page, startTime, consoleErrors, 'no_do_it_button');
@@ -559,7 +588,14 @@ async function executeStepWork(
     const errorMsg = error instanceof Error ? error.message : String(error);
 
     // L3-5D: Capture artifacts on failure
-    const artifacts = await buildFailureArtifacts(page, step.stepId, consoleErrors, artifactsDir, preScreenshotPath);
+    const artifacts = await buildFailureArtifacts(
+      page,
+      step.stepId,
+      consoleErrors,
+      artifactsDir,
+      preScreenshotPath,
+      capturedArtifactsFrom(error)
+    );
     if (verbose && artifacts) {
       console.log(`   📸 Artifacts captured to ${artifactsDir}`);
     }

--- a/tests/e2e-runner/utils/guide-runner/run-guide.ts
+++ b/tests/e2e-runner/utils/guide-runner/run-guide.ts
@@ -112,6 +112,8 @@ function toResultsData(
       currentUrl: result.currentUrl,
       consoleErrors: result.consoleErrors,
       error: result.error,
+      deadlineExceeded: result.deadlineExceeded,
+      guidedSubsteps: result.guidedSubsteps,
       skipReason: result.skipReason,
       skippable: result.skippable,
       classification: result.classification,

--- a/tests/e2e-runner/utils/guide-runner/static-analysis.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/static-analysis.test.ts
@@ -114,11 +114,23 @@ describe('estimateGuideTimeoutFromContent', () => {
   it('adds the guided and multistep action budgets', () => {
     const content = JSON.stringify({
       blocks: [
-        { type: 'guided', steps: [{}, {}] },
+        { type: 'guided', stepTimeout: 45_000, steps: [{}, {}] },
         { type: 'multistep', steps: [{}, {}, {}] },
       ],
     });
+    expect(estimateGuideTimeoutFromContent(content)).toBe(513_000);
+  });
 
-    expect(estimateGuideTimeoutFromContent(content)).toBe(453_000);
+  it.each([
+    ['30-second', 30_000, 283_000],
+    ['45-second', 45_000, 313_000],
+    ['60-second', 60_000, 343_000],
+    ['default 120-second', undefined, 463_000],
+  ])('uses the %s guided substep timeout', (_label, stepTimeout, expected) => {
+    const content = JSON.stringify({
+      blocks: [{ type: 'guided', ...(stepTimeout === undefined ? {} : { stepTimeout }), steps: [{}] }],
+    });
+
+    expect(estimateGuideTimeoutFromContent(content)).toBe(expected);
   });
 });

--- a/tests/e2e-runner/utils/guide-runner/static-analysis.ts
+++ b/tests/e2e-runner/utils/guide-runner/static-analysis.ts
@@ -8,6 +8,8 @@ import {
   TIMEOUT_PER_MULTISTEP_ACTION_MS,
 } from './constants';
 
+const MAX_GUIDED_STEP_TIMEOUT_MS = 600_000;
+
 export function countInteractiveBlocks(guide: unknown): number {
   let count = 0;
 
@@ -55,9 +57,17 @@ export function estimateGuideTimeoutFromContent(content: string): number {
     if (isInteractiveBlockType(block.type) || block.type === 'snippet-ref') {
       stepCount++;
       const actions = Array.isArray(block.steps) ? block.steps.length : 0;
+      const authoredGuidedTimeout = block.stepTimeout;
+      const guidedTimeout =
+        typeof authoredGuidedTimeout === 'number' &&
+        Number.isInteger(authoredGuidedTimeout) &&
+        authoredGuidedTimeout > 0 &&
+        authoredGuidedTimeout <= MAX_GUIDED_STEP_TIMEOUT_MS
+          ? authoredGuidedTimeout
+          : TIMEOUT_PER_GUIDED_SUBSTEP_MS;
       const timeout =
         block.type === 'guided'
-          ? DEFAULT_STEP_TIMEOUT_MS + actions * TIMEOUT_PER_GUIDED_SUBSTEP_MS
+          ? DEFAULT_STEP_TIMEOUT_MS + actions * guidedTimeout
           : block.type === 'multistep'
             ? DEFAULT_STEP_TIMEOUT_MS + actions * TIMEOUT_PER_MULTISTEP_ACTION_MS
             : DEFAULT_STEP_TIMEOUT_MS;

--- a/tests/e2e-runner/utils/guide-runner/types.ts
+++ b/tests/e2e-runner/utils/guide-runner/types.ts
@@ -10,6 +10,7 @@
 
 import { Locator } from '@playwright/test';
 import type { StepTypeKind } from '../../../../src/components/interactive-tutorial/step-type-registry';
+import type { GuidedStepOutcome } from '../../../../src/types/interactive-actions.types';
 
 // ============================================
 // Step Types
@@ -52,6 +53,8 @@ export interface TestableStep {
 
   /** Number of driver-owned actions for timeout and execution scaling */
   actionCount: number;
+  /** Effective timeout for each guided substep. */
+  guidedStepTimeoutMs?: number;
 
   /**
    * The target element selector (L3-4A).
@@ -106,6 +109,16 @@ export interface StepDiscoveryResult {
  * Status of a step execution.
  */
 export type StepStatus = 'passed' | 'failed' | 'skipped' | 'not_reached';
+
+export interface GuidedSubstepResult {
+  index: number;
+  total: number;
+  action: string;
+  outcome: GuidedStepOutcome;
+  durationMs: number;
+  timeoutMs: number;
+  skippable: boolean;
+}
 
 /**
  * Reason why a step was skipped.
@@ -318,6 +331,8 @@ export interface StepTestResult {
   error?: string;
   /** Whether the runner stopped the step at its hard deadline */
   deadlineExceeded?: boolean;
+  /** Settled guided substeps captured before parent completion or failure. */
+  guidedSubsteps?: GuidedSubstepResult[];
 
   /** Reason if status is 'skipped' */
   skipReason?: SkipReason;


### PR DESCRIPTION
## Summary

- Preserve the full guided action contract through parsing, local execution, and cross-tab execution.
- Apply substep requirements before target lookup and share one authored timeout across setup, discovery, highlighting, and user action.
- Emit substep and run settlement events, record structured substep evidence, and keep the first failure artifacts after skips, failures, detachment, or runner deadlines.
- Add static timeout estimates and document the guided E2E contract. The report schema stays at version 1.1.0 because the new fields are optional.

## Validation

- Focused PR2 tests: 11 suites and 345 tests passed.
- E2E runner and reporter tests: 39 suites and 573 tests passed.
- Governance tests on Node.js 24.20: 6 suites and 188 tests passed.
- CLI build, ESLint, Prettier, terms synchronization, and `git diff --check` passed. ESLint reported 19 existing deprecation warnings and no errors.
- Full Jest run: 533 of 535 suites passed, with 8,590 tests passed. The two failing untouched baseline suites are `src/validation/bundled-guide-selectors.test.ts` (four unavailable Grafana selector tokens) and `src/integrations/coda/coda-api.test.ts` (the installed Coda client lacks `provisionGcxCredential`).
- Full type checking still reports the known baseline of 38 errors in 31 files: existing `React.SubmitEvent` errors, React ref incompatibilities, and missing Coda client exports. No PR-specific type errors remain.

## Live canaries

Live canaries were not run because the selected Grafana Learn and Grafana Play packages require cloud credentials that are not available in this environment.

Co-Authored-By: Warp <agent@warp.dev>
