### PR TITLE
fix(schema): verify and objectives are conditions, described as something else

### DIFF
--- a/docs/design/AGENT-AUTHORING.md
+++ b/docs/design/AGENT-AUTHORING.md
@@ -479,7 +479,9 @@ export const JsonInteractiveBlockSchema = z.object({
   showMe: z.boolean().optional().describe('Enable "Show me" button (highlights target without acting)'),
   doIt: z.boolean().optional().describe('Enable "Do it" button (performs action automatically)'),
   completeEarly: z.boolean().optional().describe('Allow completion before all steps done'),
-  verify: z.string().optional().describe('CSS selector to check for verification after action'),
+  verify: ConditionStringSchema.optional().describe(
+    'Post-action verification condition (e.g., on-page:/connections/datasources/edit)'
+  ),
   lazyRender: z.boolean().optional().describe('Wait for target to appear in DOM (virtual scroll support)'),
   scrollContainer: z.string().optional().describe('CSS selector of scroll container for lazy-rendered targets'),
   openGuide: z.string().optional().describe('Guide ID to open when this block completes'),

--- a/docs/design/AGENT-AUTHORING.md
+++ b/docs/design/AGENT-AUTHORING.md
@@ -471,7 +471,12 @@ export const JsonInteractiveBlockSchema = z.object({
     .array(z.string())
     .optional()
     .describe('Prerequisite conditions (e.g., on-page:/dashboards, is-admin)'),
-  objectives: z.array(z.string()).optional().describe('Learning objectives this block addresses'),
+  objectives: z
+    .array(ObjectiveTokenSchema)
+    .optional()
+    .describe(
+      'Conditions that automatically complete this block, in the same vocabulary as `requirements`, checked before them'
+    ),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),
   hint: z.string().optional().describe('Hint text shown if user is stuck'),
   formHint: z.string().optional().describe('Placeholder text for formfill input fields'),
@@ -667,13 +672,14 @@ Optional:
   --tooltip <string>                Tooltip shown on highlighted element
   --requirements <item> (repeatable)
                                     Prerequisite conditions (e.g., on-page:/dashboards)
-  --objectives <item> (repeatable)  Learning objectives this block addresses
+  --objectives <item> (repeatable)  Conditions that automatically complete this block (checked
+                                    before requirements)
   --skippable                       Allow user to skip this block
   --hint <string>                   Hint text shown if user is stuck
   --show-me                         Enable "Show me" button
   --do-it                           Enable "Do it" button
   --complete-early                  Allow completion before all steps done
-  --verify <string>                 CSS selector for post-action verification
+  --verify <string>                 Post-action verification condition
   --open-guide <string>             Guide ID to open when block completes
 
 Constraints:

--- a/docs/design/AGENT-AUTHORING.md
+++ b/docs/design/AGENT-AUTHORING.md
@@ -456,42 +456,46 @@ Which fields become parameters is a fact about a `CommandSpec`'s own schema, not
 
 Zod v4 supports `.describe()` on any schema field. The bridge reads these descriptions and passes them to Commander as option descriptions. This makes the Zod schema file the single source of truth for both validation and CLI help text.
 
+<!-- Byte-exact copy of the schema. `src/validation/agent-authoring-docs.test.ts` fails if this drifts, so prettier must not reflow it. -->
+<!-- prettier-ignore -->
 ```typescript
-// In json-guide.schema.ts
-export const JsonInteractiveBlockSchema = z.object({
-  type: z.literal('interactive'),
-  action: JsonInteractiveActionSchema.describe('Action to perform on target element'),
-  reftarget: z
-    .string()
-    .optional()
-    .describe('CSS selector or data-testid for the target element (required for non-noop actions)'),
-  content: z.string().min(1).describe('Instructional text shown to user (markdown)'),
-  tooltip: z.string().optional().describe('Tooltip shown on highlighted element'),
-  requirements: z
-    .array(z.string())
-    .optional()
-    .describe('Prerequisite conditions (e.g., on-page:/dashboards, is-admin)'),
-  objectives: z
-    .array(ObjectiveTokenSchema)
-    .optional()
-    .describe(
-      'Conditions that automatically complete this block, in the same vocabulary as `requirements`, checked before them'
+// src/types/json-guide.schema.ts
+export const JsonInteractiveBlockSchema = z
+  .object({
+    type: z.literal('interactive'),
+    id: z.string().optional().describe('Stable identifier for edit-block / remove-block addressing'),
+    action: JsonInteractiveActionSchema.describe('Action to perform on target element'),
+    // ...
+    tooltip: z.string().optional().describe('Tooltip shown on highlighted element'),
+    requirements: z
+      .array(RequirementTokenSchema)
+      .optional()
+      .describe('Prerequisite conditions, one condition per entry (e.g., on-page:/dashboards)'),
+    objectives: z.array(ObjectiveTokenSchema).optional().describe(objectivesDescription('block')),
+    skippable: z.boolean().optional().describe('Allow user to skip this block'),
+    hint: z.string().optional().describe('Hint text shown if user is stuck'),
+    formHint: z.string().optional().describe('Placeholder text for formfill input fields'),
+    validateInput: z.boolean().optional().describe('Strictly validate formfill input against targetvalue'),
+    showMe: z.boolean().optional().describe('Enable "Show me" button (highlights target without acting)'),
+    doIt: z.boolean().optional().describe('Enable "Do it" button (performs action automatically)'),
+    completeEarly: z.boolean().optional().describe('Allow completion before all steps done'),
+    verify: VerifyConditionSchema.optional().describe(
+      'Post-action verification condition, evaluated after the action runs; the step completes only once it is satisfied. Same condition vocabulary as `requirements` (e.g., on-page:/connections/datasources/edit) — not a CSS selector. One string, comma-separated for more than one condition.'
     ),
-  skippable: z.boolean().optional().describe('Allow user to skip this block'),
-  hint: z.string().optional().describe('Hint text shown if user is stuck'),
-  formHint: z.string().optional().describe('Placeholder text for formfill input fields'),
-  validateInput: z.boolean().optional().describe('Strictly validate formfill input against targetvalue'),
-  showMe: z.boolean().optional().describe('Enable "Show me" button (highlights target without acting)'),
-  doIt: z.boolean().optional().describe('Enable "Do it" button (performs action automatically)'),
-  completeEarly: z.boolean().optional().describe('Allow completion before all steps done'),
-  verify: ConditionStringSchema.optional().describe(
-    'Post-action verification condition (e.g., on-page:/connections/datasources/edit)'
-  ),
-  lazyRender: z.boolean().optional().describe('Wait for target to appear in DOM (virtual scroll support)'),
-  scrollContainer: z.string().optional().describe('CSS selector of scroll container for lazy-rendered targets'),
-  openGuide: z.string().optional().describe('Guide ID to open when this block completes'),
-  ...AssistantPropsSchema.shape,
-});
+    lazyRender: z.boolean().optional().describe('Wait for target to appear in DOM (virtual scroll support)'),
+    scrollContainer: z.string().optional().describe('CSS selector of scroll container for lazy-rendered targets'),
+    openGuide: z.string().optional().describe('Guide ID to open when this block completes'),
+    // Assistant customization props
+    ...AssistantPropsSchema.shape,
+    // Editor-only annotation (stripped on export)
+    ...AuthorAnnotatedSchema.shape,
+  })
+```
+
+The excerpt stops at the object literal; the `.refine()` chain that follows supplies the `Constraints:` block in `--help`, not option descriptions. `objectivesDescription` is a generator so the block, section and conditional-branch surfaces cannot drift apart — for a block it resolves to:
+
+```text
+Conditions that automatically complete this block, in the same vocabulary as `requirements`. Checked first, before eligibility and requirements, so a block whose objectives already hold is marked complete without the reader acting (e.g. has-datasource:prometheus for a block that creates one). Prefer this over `skippable` for work the reader may already have done: skippable only lets them past the step, objectives record it as done.
 ```
 
 Fields without `.describe()` fall back to a generic description derived from the field name and type (e.g., `"scrollContainer (string, optional)"`). Descriptions should be added incrementally — start with the most commonly used block types and expand over time.
@@ -653,7 +657,7 @@ Error: --parent "setup" not found in my-guide/
 
 ### Help output
 
-Help output is terse and structured for agent parsing. When an agent runs `--help` on a block type subcommand:
+Help output is terse and structured for agent parsing. The sketch below is abridged in both directions — the real output lists every option, and prints each `.describe()` string in full rather than the one-line summaries shown here. The schema is the authority on wording; this is the authority on shape.
 
 ```
 $ pathfinder-cli add-block interactive my-guide/ --help
@@ -691,7 +695,7 @@ Addressing:
   --id <string>                     ID for this block (required for container types)
 ```
 
-Note what is absent: no verbose paragraphs, no full schema dumps, no JSON examples. An agent gets exactly the flag names, types, descriptions, and constraints. This is the minimum viable context for correct usage.
+Note what is absent: no prose around the flags, no full schema dumps, no JSON examples. An agent gets exactly the flag names, types, descriptions, and constraints. This is the minimum viable context for correct usage.
 
 The help also includes a summary of valid values for common repeatable fields. For `--requirements`:
 

--- a/src/cli/utils/cli-validators.ts
+++ b/src/cli/utils/cli-validators.ts
@@ -244,7 +244,6 @@ export const BLOCK_FIELD_VALIDATORS: Record<string, Record<string, FieldValidato
   },
   interactive: {
     reftarget: [assertCssSelector],
-    verify: [assertCssSelector],
     scrollContainer: [assertCssSelector],
   },
   input: {

--- a/src/types/json-guide-objectives.schema.test.ts
+++ b/src/types/json-guide-objectives.schema.test.ts
@@ -1,10 +1,17 @@
 import { parseJsonGuide } from '../docs-retrieval/json-parser';
 import { validateGuide } from '../validation';
-import { JsonInteractiveBlockSchema, JsonSectionBlockSchema } from './json-guide.schema';
+import { JsonConditionalBlockSchema, JsonInteractiveBlockSchema, JsonSectionBlockSchema } from './json-guide.schema';
 import { isValidRequirement } from './requirements.types';
 
-const objectivesDescription = (schema: { shape: Record<string, { description?: string }> }): string =>
-  schema.shape.objectives?.description ?? '';
+interface DescribedShape {
+  shape: Record<string, { description?: string } | undefined>;
+}
+
+const objectivesDescription = (schema: DescribedShape): string => schema.shape.objectives?.description ?? '';
+
+/** The per-branch section config is not exported; reach it through the conditional block that owns it. */
+const branchSectionConfig = (): DescribedShape =>
+  (JsonConditionalBlockSchema.shape.whenTrueSectionConfig as unknown as { unwrap: () => DescribedShape }).unwrap();
 
 const interactiveGuide = (objectives: string[]) => ({
   id: 'objectives',
@@ -90,6 +97,7 @@ describe('executable objectives', () => {
   describe.each([
     ['interactive block', () => objectivesDescription(JsonInteractiveBlockSchema), 'block'],
     ['section', () => objectivesDescription(JsonSectionBlockSchema), 'section'],
+    ['conditional branch', () => objectivesDescription(branchSectionConfig()), 'branch'],
   ])('%s objectives description', (_label, read, container) => {
     it('describes a condition list rather than learning objectives', () => {
       const description = read();
@@ -108,5 +116,25 @@ describe('executable objectives', () => {
       expect(example).toBeDefined();
       expect(isValidRequirement(example!)).toBe(true);
     });
+  });
+
+  // Only blocks have `skippable`. Telling a section or a conditional branch to
+  // weigh objectives against it points the author at a field their container
+  // does not have — the class of error this suite exists to catch.
+  it.each([
+    ['an interactive block', JsonInteractiveBlockSchema as unknown as DescribedShape],
+    ['a section', JsonSectionBlockSchema as unknown as DescribedShape],
+    ['a conditional branch', branchSectionConfig()],
+  ])('weighs objectives against `skippable` only where %s has one', (_label, schema) => {
+    expect(objectivesDescription(schema).includes('`skippable`')).toBe('skippable' in schema.shape);
+  });
+
+  it.each([
+    ['a section', JsonSectionBlockSchema as unknown as DescribedShape, 'section'],
+    ['a conditional branch', branchSectionConfig(), 'branch'],
+  ])('closes %s with what completing the container does to its steps', (_label, schema, container) => {
+    expect(objectivesDescription(schema)).toContain(
+      `When a ${container}'s objectives hold, every step inside it is marked complete too.`
+    );
   });
 });

--- a/src/types/json-guide-objectives.schema.test.ts
+++ b/src/types/json-guide-objectives.schema.test.ts
@@ -1,6 +1,10 @@
 import { parseJsonGuide } from '../docs-retrieval/json-parser';
 import { validateGuide } from '../validation';
 import { JsonInteractiveBlockSchema, JsonSectionBlockSchema } from './json-guide.schema';
+import { isValidRequirement } from './requirements.types';
+
+const objectivesDescription = (schema: { shape: Record<string, { description?: string }> }): string =>
+  schema.shape.objectives?.description ?? '';
 
 const interactiveGuide = (objectives: string[]) => ({
   id: 'objectives',
@@ -46,11 +50,63 @@ describe('executable objectives', () => {
     ).toBe(true);
   });
 
+  it.each(['has-datasource:prometheus', 'on-page:/explore', 'exists-reftarget'])(
+    'forwards a valid objective to the runtime as a completion condition: %s',
+    (objective) => {
+      const parsed = parseJsonGuide(JSON.stringify(interactiveGuide([objective])));
+      expect(parsed.isValid).toBe(true);
+      expect(parsed.data!.elements.find((element) => element.type === 'interactive-step')?.props.objectives).toEqual([
+        objective,
+      ]);
+    }
+  );
+
+  it('never lets a non-condition objective become completion evidence', () => {
+    const objective = 'Learn how to add a data source';
+    expect(isValidRequirement(objective)).toBe(false);
+
+    const result = validateGuide(interactiveGuide([objective]));
+    expect(result.errors).toEqual([]);
+    expect(JSON.stringify(result.warnings)).toContain('Unknown condition type');
+
+    const parsed = parseJsonGuide(JSON.stringify(interactiveGuide([objective])));
+    expect(
+      parsed.data!.elements.find((element) => element.type === 'interactive-step')?.props.objectives
+    ).toBeUndefined();
+  });
+
   it('forwards only the executable objectives to the runtime', () => {
     const parsed = parseJsonGuide(JSON.stringify(interactiveGuide(['Learn about dashboards', 'has-datasource:loki'])));
     expect(parsed.isValid).toBe(true);
     expect(parsed.data!.elements.find((element) => element.type === 'interactive-step')?.props.objectives).toEqual([
       'has-datasource:loki',
     ]);
+  });
+
+  // `objectives` is a functional auto-complete condition list, not pedagogical
+  // metadata. It was described as "learning objectives" for months, which sent
+  // authors to `skippable` for work a reader had already done. These pin the
+  // corrected meaning on every surface an agent reads.
+  describe.each([
+    ['interactive block', () => objectivesDescription(JsonInteractiveBlockSchema), 'block'],
+    ['section', () => objectivesDescription(JsonSectionBlockSchema), 'section'],
+  ])('%s objectives description', (_label, read, container) => {
+    it('describes a condition list rather than learning objectives', () => {
+      const description = read();
+      expect(description).not.toMatch(/learning objective/i);
+      expect(description).toMatch(new RegExp(`automatically complete this ${container}`, 'i'));
+    });
+
+    it('points at the requirements vocabulary and the ordering that makes it useful', () => {
+      const description = read();
+      expect(description).toMatch(/same vocabulary as `requirements`/i);
+      expect(description).toMatch(/checked first/i);
+    });
+
+    it('carries an example that is itself a valid condition', () => {
+      const example = /has-datasource:[\w-]+/.exec(read())?.[0];
+      expect(example).toBeDefined();
+      expect(isValidRequirement(example!)).toBe(true);
+    });
   });
 });

--- a/src/types/json-guide-verify.schema.test.ts
+++ b/src/types/json-guide-verify.schema.test.ts
@@ -1,4 +1,8 @@
+import { parseJsonGuide } from '../docs-retrieval/json-parser';
+import { validateGuide } from '../validation';
 import { JsonInteractiveBlockSchema } from './json-guide.schema';
+
+const CSS_SELECTOR = "[data-testid='data-testid Data source settings page Save and Test button']";
 
 const parse = (verify: string) =>
   JsonInteractiveBlockSchema.safeParse({
@@ -9,6 +13,19 @@ const parse = (verify: string) =>
     verify,
   });
 
+const verifyGuide = (verify: string) => ({
+  id: 'verify',
+  title: 'Verify',
+  blocks: [
+    { type: 'interactive', action: 'button', reftarget: 'Save & test', content: 'Save the data source', verify },
+  ],
+});
+
+const postVerify = (verify: string): unknown => {
+  const parsed = parseJsonGuide(JSON.stringify(verifyGuide(verify)));
+  return parsed.data!.elements.find((element) => element.type === 'interactive-step')?.props.postVerify;
+};
+
 function verifyDescription(): string {
   const { shape } = JsonInteractiveBlockSchema as unknown as { shape: Record<string, { description?: string }> };
   return shape.verify?.description ?? '';
@@ -16,35 +33,68 @@ function verifyDescription(): string {
 
 describe('interactive verify', () => {
   // The three token shapes that appear across the published packages in
-  // grafana/interactive-tutorials. A refinement that rejects any of them would
-  // break guides that are already live.
-  it.each(['on-page:/connections/datasources/edit', 'dashboard-exists', 'has-datasource:grafanacloud-play-profiles'])(
-    'accepts a condition token that published guides already use: %s',
+  // grafana/interactive-tutorials.
+  it.each([
+    'on-page:/connections/datasources/edit',
+    'dashboard-exists',
+    'has-datasource:grafanacloud-play-profiles',
+    // The comma-separated form `conditionTokens` splits at runtime.
+    'on-page:/explore, exists-reftarget',
+  ])('takes a condition token without complaint: %s', (verify) => {
+    expect(parse(verify).success).toBe(true);
+    expect(validateGuide(verifyGuide(verify)).warnings).toEqual([]);
+  });
+
+  // `verify` was documented as a CSS selector for its whole shipped history,
+  // and `upsert-learning-path.sh` forwards it to the InteractiveGuide CRD
+  // unchecked, so a stack can hold one. `backend-guide.ts` re-validates that
+  // guide at render time: a schema rejection would blank it for the reader.
+  it.each([CSS_SELECTOR, '#save-button', 'on-page:/explore, #save-button'])(
+    'keeps a guide loadable when verify is not a condition: %s',
     (verify) => {
       expect(parse(verify).success).toBe(true);
+
+      const result = validateGuide(verifyGuide(verify));
+      expect(result.isValid).toBe(true);
+      expect(result.guide).not.toBeNull();
     }
   );
 
-  it('accepts the comma-separated form the runtime tokenizes', () => {
-    expect(parse('on-page:/explore, exists-reftarget').success).toBe(true);
+  it('warns about a CSS selector instead of failing the guide', () => {
+    const result = validateGuide(verifyGuide(CSS_SELECTOR));
+    expect(result.errors).toEqual([]);
+    expect(JSON.stringify(result.warnings)).toContain('Unknown condition type');
+    expect(JSON.stringify(result.warnings)).toContain('blocks[0].verify');
   });
 
-  it('rejects a CSS selector', () => {
-    const result = parse("[data-testid='data-testid Data source settings page Save and Test button']");
-    expect(result.success).toBe(false);
-    expect(JSON.stringify(result.error!.issues)).toContain('Unknown requirement');
+  it('warns about one unknown token in an otherwise valid list', () => {
+    const result = validateGuide(verifyGuide('on-page:/explore, #save-button'));
+    expect(result.errors).toEqual([]);
+    expect(JSON.stringify(result.warnings)).toContain("Unknown condition type '#save-button'");
   });
 
-  it('rejects one unknown token in an otherwise valid list', () => {
-    expect(parse('on-page:/explore, #save-button').success).toBe(false);
+  // The authoring gates run `--strict`, which is where a selector should stop.
+  it('fails strict validation, which is what the authoring gates run', () => {
+    const result = validateGuide(verifyGuide(CSS_SELECTOR), { strict: true });
+    expect(result.isValid).toBe(false);
+    expect(JSON.stringify(result.errors)).toContain('Unknown condition type');
   });
 
-  it('describes a condition, and its own example parses', () => {
+  // Unlike an objective, an unrecognised verify is not dropped on the way to
+  // the runtime: `routeUnifiedCheck` returns verdict `invalid` in `post` mode,
+  // so the step refuses to complete rather than completing on no evidence.
+  it('forwards verify to the runtime verbatim, condition or not', () => {
+    expect(postVerify('on-page:/explore')).toBe('on-page:/explore');
+    expect(postVerify(CSS_SELECTOR)).toBe(CSS_SELECTOR);
+  });
+
+  it('describes a condition, and its own example is one', () => {
     const description = verifyDescription();
     expect(description).toMatch(/verification condition/i);
+    expect(description).toMatch(/not a CSS selector/i);
 
     const example = /on-page:[\w/.-]+/.exec(description)?.[0];
     expect(example).toBeDefined();
-    expect(parse(example!).success).toBe(true);
+    expect(validateGuide(verifyGuide(example!)).warnings).toEqual([]);
   });
 });

--- a/src/types/json-guide-verify.schema.test.ts
+++ b/src/types/json-guide-verify.schema.test.ts
@@ -1,0 +1,50 @@
+import { JsonInteractiveBlockSchema } from './json-guide.schema';
+
+const parse = (verify: string) =>
+  JsonInteractiveBlockSchema.safeParse({
+    type: 'interactive',
+    action: 'button',
+    reftarget: 'Save & test',
+    content: 'Save the data source',
+    verify,
+  });
+
+function verifyDescription(): string {
+  const { shape } = JsonInteractiveBlockSchema as unknown as { shape: Record<string, { description?: string }> };
+  return shape.verify?.description ?? '';
+}
+
+describe('interactive verify', () => {
+  // The three token shapes that appear across the published packages in
+  // grafana/interactive-tutorials. A refinement that rejects any of them would
+  // break guides that are already live.
+  it.each(['on-page:/connections/datasources/edit', 'dashboard-exists', 'has-datasource:grafanacloud-play-profiles'])(
+    'accepts a condition token that published guides already use: %s',
+    (verify) => {
+      expect(parse(verify).success).toBe(true);
+    }
+  );
+
+  it('accepts the comma-separated form the runtime tokenizes', () => {
+    expect(parse('on-page:/explore, exists-reftarget').success).toBe(true);
+  });
+
+  it('rejects a CSS selector', () => {
+    const result = parse("[data-testid='data-testid Data source settings page Save and Test button']");
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error!.issues)).toContain('Unknown requirement');
+  });
+
+  it('rejects one unknown token in an otherwise valid list', () => {
+    expect(parse('on-page:/explore, #save-button').success).toBe(false);
+  });
+
+  it('describes a condition, and its own example parses', () => {
+    const description = verifyDescription();
+    expect(description).toMatch(/verification condition/i);
+
+    const example = /on-page:[\w/.-]+/.exec(description)?.[0];
+    expect(example).toBeDefined();
+    expect(parse(example!).success).toBe(true);
+  });
+});

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -74,15 +74,21 @@ const ConditionStringSchema = z.string().superRefine((value, ctx) => {
 
 /**
  * Schema for a single objective token. Deliberately permissive where
- * `RequirementTokenSchema` is strict: `objectives` shipped for months
- * described as free-text "learning objectives", so guides already published to
- * a backend repository or CDN can hold prose. Rejecting them here would blank
- * the whole guide (`validateGuide` returns early on a Zod failure), so the
+ * `RequirementTokenSchema` is strict, and it stays that way even though every
+ * `objectives` value in the in-repo and published corpora is a valid
+ * condition: `upsert-learning-path.sh` forwards `objectives` to the
+ * InteractiveGuide CRD under jq shape checks alone, so customer stacks can
+ * hold guides this repo cannot enumerate — including the prose this field's
+ * own description invited before it was corrected. Rejecting here would blank
+ * such a guide (`validateGuide` returns early on a Zod failure), so the
  * vocabulary is enforced one layer later instead — `condition-validator`
  * warns, `json-parser` drops the unrecognised token, and the runtime refuses
  * to complete a step on any non-`satisfied` verdict.
  */
 const ObjectiveTokenSchema = z.string();
+
+const objectivesDescription = (container: 'block' | 'section' | 'branch'): string =>
+  `Conditions that automatically complete this ${container}, in the same vocabulary as \`requirements\`. Checked first, before eligibility and requirements, so a ${container} whose objectives already hold is marked complete without the reader acting (e.g. has-datasource:prometheus for a ${container} that creates one). Prefer this over \`skippable\` for work the reader may already have done: skippable only lets them past the step, objectives record it as done.`;
 
 /**
  * Desired end state for a toggle target. `true`/`false` auto-detects the
@@ -370,7 +376,7 @@ export const JsonInteractiveBlockSchema = z
       .array(RequirementTokenSchema)
       .optional()
       .describe('Prerequisite conditions, one condition per entry (e.g., on-page:/dashboards)'),
-    objectives: z.array(ObjectiveTokenSchema).optional().describe('Conditions that automatically complete this block'),
+    objectives: z.array(ObjectiveTokenSchema).optional().describe(objectivesDescription('block')),
     skippable: z.boolean().optional().describe('Allow user to skip this block'),
     hint: z.string().optional().describe('Hint text shown if user is stuck'),
     formHint: z.string().optional().describe('Placeholder text for formfill input fields'),
@@ -427,7 +433,7 @@ export const JsonMultistepBlockSchema = z.object({
   content: z.string().min(1, 'Multistep content is required').describe('Block heading/intro text'),
   steps: z.array(JsonStepSchema).min(1, EMPTY_STEPS_MESSAGE).describe('Ordered steps; populated via add-step'),
   requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions'),
-  objectives: z.array(ObjectiveTokenSchema).optional().describe('Conditions that automatically complete this block'),
+  objectives: z.array(ObjectiveTokenSchema).optional().describe(objectivesDescription('block')),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),
   ...AuthorAnnotatedSchema.shape,
 });
@@ -443,7 +449,7 @@ export const JsonGuidedBlockSchema = z.object({
   steps: z.array(JsonStepSchema).min(1, EMPTY_STEPS_MESSAGE).describe('Ordered steps; populated via add-step'),
   stepTimeout: z.number().optional().describe('Per-step timeout in milliseconds'),
   requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions'),
-  objectives: z.array(ObjectiveTokenSchema).optional().describe('Conditions that automatically complete this block'),
+  objectives: z.array(ObjectiveTokenSchema).optional().describe(objectivesDescription('block')),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),
   completeEarly: z
     .boolean()
@@ -644,7 +650,7 @@ export const JsonTerminalBlockSchema = z.object({
   command: z.string().min(1, 'Terminal command is required').describe('Command to execute in the terminal'),
   content: z.string().min(1, 'Terminal content is required').describe('Instructional text shown to the user'),
   requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions'),
-  objectives: z.array(ObjectiveTokenSchema).optional().describe('Conditions that automatically complete this block'),
+  objectives: z.array(ObjectiveTokenSchema).optional().describe(objectivesDescription('block')),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),
   hint: z.string().optional().describe('Hint text shown if user is stuck'),
   ...AuthorAnnotatedSchema.shape,
@@ -718,7 +724,7 @@ export const JsonChallengeBlockSchema = z.object({
   hintLevels: z.array(JsonChallengeHintSchema).optional().describe('Progressive hints revealed on demand'),
   failureMessage: z.string().optional().describe('Message shown when the success check fails'),
   requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions for the challenge'),
-  objectives: z.array(ObjectiveTokenSchema).optional().describe('Conditions that automatically complete this block'),
+  objectives: z.array(ObjectiveTokenSchema).optional().describe(objectivesDescription('block')),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),
 });
 
@@ -741,7 +747,7 @@ export const JsonCodeBlockBlockSchema = z.object({
   code: z.string().min(1, 'Code is required').describe('Code to insert into the editor'),
   content: z.string().optional().describe('Optional instructional text shown above the code'),
   requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions'),
-  objectives: z.array(ObjectiveTokenSchema).optional().describe('Conditions that automatically complete this block'),
+  objectives: z.array(ObjectiveTokenSchema).optional().describe(objectivesDescription('block')),
   skippable: z.boolean().optional().describe('Allow user to skip this block'),
   hint: z.string().optional().describe('Hint text shown if user is stuck'),
   ...AuthorAnnotatedSchema.shape,
@@ -955,7 +961,7 @@ const SectionProps = {
   id: z.string().optional().describe('Stable identifier for the section (required for container blocks via CLI)'),
   title: z.string().optional().describe('Section heading'),
   requirements: z.array(RequirementTokenSchema).optional().describe('Prerequisite conditions'),
-  objectives: z.array(ObjectiveTokenSchema).optional().describe('Conditions that automatically complete this section'),
+  objectives: z.array(ObjectiveTokenSchema).optional().describe(objectivesDescription('section')),
   autoCollapse: z.boolean().optional().describe('Collapse the section after the user completes its contents'),
 };
 
@@ -987,7 +993,7 @@ const AssistantProps = {
 const ConditionalSectionConfigSchema = z.object({
   title: z.string().optional(),
   requirements: z.array(RequirementTokenSchema).optional(),
-  objectives: z.array(ObjectiveTokenSchema).optional(),
+  objectives: z.array(ObjectiveTokenSchema).optional().describe(objectivesDescription('branch')),
 });
 
 const ConditionalProps = {

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -54,41 +54,38 @@ const RequirementTokenSchema = z.string().superRefine((token, ctx) => {
 });
 
 /**
- * Schema for the single-string, comma-separated condition form. Every token is
- * held to the same `isValidRequirement` vocabulary as `RequirementTokenSchema`,
- * and splitting on `,` mirrors `conditionTokens` — how the runtime tokenizes
- * the value before checking it.
+ * Schemas for the two condition-carrying fields that stay permissive where
+ * `RequirementTokenSchema` is strict. Both are deliberate, and both for the
+ * same reason.
  *
- * Used by `verify`, which the JSON model carries as one string rather than an
- * array, so a comma inside a parameter value is not expressible here — the
- * same limitation `validateConditionString` has.
- */
-const ConditionStringSchema = z.string().superRefine((value, ctx) => {
-  for (const part of value.split(',')) {
-    const token = part.trim();
-    if (token && !isValidRequirement(token)) {
-      ctx.addIssue({ code: 'custom', message: unknownRequirementMessage(token) });
-    }
-  }
-});
-
-/**
- * Schema for a single objective token. Deliberately permissive where
- * `RequirementTokenSchema` is strict, and it stays that way even though every
- * `objectives` value in the in-repo and published corpora is a valid
- * condition: `upsert-learning-path.sh` forwards `objectives` to the
- * InteractiveGuide CRD under jq shape checks alone, so customer stacks can
- * hold guides this repo cannot enumerate — including the prose this field's
- * own description invited before it was corrected. Rejecting here would blank
- * such a guide (`validateGuide` returns early on a Zod failure), so the
- * vocabulary is enforced one layer later instead — `condition-validator`
- * warns, `json-parser` drops the unrecognised token, and the runtime refuses
- * to complete a step on any non-`satisfied` verdict.
+ * `upsert-learning-path.sh` forwards `objectives` and `verify` to the
+ * InteractiveGuide CRD under jq shape checks alone, and `backend-guide.ts`
+ * re-runs `validateGuide` on CRD-sourced content at render time. A Zod
+ * rejection there returns `{ isValid: false, guide: null }`, so a token check
+ * here would blank an already-published guide for its reader rather than flag
+ * one bad field. Both fields were documented as something other than a
+ * condition for their whole shipped history — `objectives` as learning
+ * metadata, `verify` as a CSS selector — so customer stacks this repo cannot
+ * enumerate may hold exactly the values that documentation invited.
+ *
+ * The vocabulary is enforced one layer later, and not silently:
+ * `condition-validator` walks both fields and warns, `validate --strict`
+ * promotes that warning to an error at the authoring gates, `json-parser`
+ * drops an unexecutable objective, and the runtime refuses to complete a step
+ * on any non-`satisfied` verdict — so an unrecognised `verify` fails that one
+ * step's verification instead of erasing the guide around it.
  */
 const ObjectiveTokenSchema = z.string();
+const VerifyConditionSchema = z.string();
 
-const objectivesDescription = (container: 'block' | 'section' | 'branch'): string =>
-  `Conditions that automatically complete this ${container}, in the same vocabulary as \`requirements\`. Checked first, before eligibility and requirements, so a ${container} whose objectives already hold is marked complete without the reader acting (e.g. has-datasource:prometheus for a ${container} that creates one). Prefer this over \`skippable\` for work the reader may already have done: skippable only lets them past the step, objectives record it as done.`;
+const objectivesDescription = (container: 'block' | 'section' | 'branch'): string => {
+  // Only blocks carry `skippable`; sections and conditional branches have no such field to weigh it against.
+  const closing =
+    container === 'block'
+      ? 'Prefer this over `skippable` for work the reader may already have done: skippable only lets them past the step, objectives record it as done.'
+      : `When a ${container}'s objectives hold, every step inside it is marked complete too.`;
+  return `Conditions that automatically complete this ${container}, in the same vocabulary as \`requirements\`. Checked first, before eligibility and requirements, so a ${container} whose objectives already hold is marked complete without the reader acting (e.g. has-datasource:prometheus for a ${container} that creates one). ${closing}`;
+};
 
 /**
  * Desired end state for a toggle target. `true`/`false` auto-detects the
@@ -384,7 +381,7 @@ export const JsonInteractiveBlockSchema = z
     showMe: z.boolean().optional().describe('Enable "Show me" button (highlights target without acting)'),
     doIt: z.boolean().optional().describe('Enable "Do it" button (performs action automatically)'),
     completeEarly: z.boolean().optional().describe('Allow completion before all steps done'),
-    verify: ConditionStringSchema.optional().describe(
+    verify: VerifyConditionSchema.optional().describe(
       'Post-action verification condition, evaluated after the action runs; the step completes only once it is satisfied. Same condition vocabulary as `requirements` (e.g., on-page:/connections/datasources/edit) — not a CSS selector. One string, comma-separated for more than one condition.'
     ),
     lazyRender: z.boolean().optional().describe('Wait for target to appear in DOM (virtual scroll support)'),

--- a/src/types/json-guide.schema.ts
+++ b/src/types/json-guide.schema.ts
@@ -54,6 +54,25 @@ const RequirementTokenSchema = z.string().superRefine((token, ctx) => {
 });
 
 /**
+ * Schema for the single-string, comma-separated condition form. Every token is
+ * held to the same `isValidRequirement` vocabulary as `RequirementTokenSchema`,
+ * and splitting on `,` mirrors `conditionTokens` — how the runtime tokenizes
+ * the value before checking it.
+ *
+ * Used by `verify`, which the JSON model carries as one string rather than an
+ * array, so a comma inside a parameter value is not expressible here — the
+ * same limitation `validateConditionString` has.
+ */
+const ConditionStringSchema = z.string().superRefine((value, ctx) => {
+  for (const part of value.split(',')) {
+    const token = part.trim();
+    if (token && !isValidRequirement(token)) {
+      ctx.addIssue({ code: 'custom', message: unknownRequirementMessage(token) });
+    }
+  }
+});
+
+/**
  * Schema for a single objective token. Deliberately permissive where
  * `RequirementTokenSchema` is strict: `objectives` shipped for months
  * described as free-text "learning objectives", so guides already published to
@@ -359,7 +378,9 @@ export const JsonInteractiveBlockSchema = z
     showMe: z.boolean().optional().describe('Enable "Show me" button (highlights target without acting)'),
     doIt: z.boolean().optional().describe('Enable "Do it" button (performs action automatically)'),
     completeEarly: z.boolean().optional().describe('Allow completion before all steps done'),
-    verify: z.string().optional().describe('CSS selector to check for verification after action'),
+    verify: ConditionStringSchema.optional().describe(
+      'Post-action verification condition, evaluated after the action runs; the step completes only once it is satisfied. Same condition vocabulary as `requirements` (e.g., on-page:/connections/datasources/edit) — not a CSS selector. One string, comma-separated for more than one condition.'
+    ),
     lazyRender: z.boolean().optional().describe('Wait for target to appear in DOM (virtual scroll support)'),
     scrollContainer: z.string().optional().describe('CSS selector of scroll container for lazy-rendered targets'),
     openGuide: z.string().optional().describe('Guide ID to open when this block completes'),

--- a/src/validation/agent-authoring-docs.test.ts
+++ b/src/validation/agent-authoring-docs.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Fidelity of the schema quotes in the agent-authoring design doc.
+ *
+ * `AGENT-AUTHORING.md` presents an excerpt of `JsonInteractiveBlockSchema`
+ * and the generated `objectives` description as literal quotes, and authoring
+ * agents read them as the spec. A paraphrase there is the same defect the doc
+ * exists to prevent, so every quoted run must still appear verbatim in the
+ * schema it claims to quote.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { JsonInteractiveBlockSchema } from '../types/json-guide.schema';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const DOC_RELATIVE_PATH = 'docs/design/AGENT-AUTHORING.md';
+const SCHEMA_RELATIVE_PATH = 'src/types/json-guide.schema.ts';
+
+/** First line of the quoted excerpt, naming the file it is copied from. */
+const EXCERPT_MARKER = `// ${SCHEMA_RELATIVE_PATH}`;
+/** Marks omitted fields, so the excerpt is a set of contiguous runs rather than one. */
+const ELISION = '// ...';
+
+interface FencedBlock {
+  language: string;
+  body: string;
+}
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+}
+
+function fencedBlocks(markdown: string): FencedBlock[] {
+  const blocks: FencedBlock[] = [];
+  const pattern = /^```(\w*)\n([\s\S]*?)^```$/gm;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(markdown)) !== null) {
+    blocks.push({ language: match[1] ?? '', body: match[2] ?? '' });
+  }
+  return blocks;
+}
+
+function withoutBlankEdges(lines: string[]): string[] {
+  const trimmed = [...lines];
+  while (trimmed.length > 0 && trimmed[0]!.trim() === '') {
+    trimmed.shift();
+  }
+  while (trimmed.length > 0 && trimmed[trimmed.length - 1]!.trim() === '') {
+    trimmed.pop();
+  }
+  return trimmed;
+}
+
+/** The excerpt's contiguous runs, indentation preserved so a substring check verifies alignment too. */
+function excerptRuns(body: string): string[] {
+  const lines = body.split('\n');
+  expect(lines[0]).toBe(EXCERPT_MARKER);
+
+  const runs: string[][] = [[]];
+  for (const line of lines.slice(1)) {
+    if (line.trim() === ELISION) {
+      runs.push([]);
+    } else {
+      runs[runs.length - 1]!.push(line);
+    }
+  }
+  return runs.map((run) => withoutBlankEdges(run).join('\n')).filter((run) => run !== '');
+}
+
+function objectivesDescription(): string {
+  const { shape } = JsonInteractiveBlockSchema as unknown as { shape: Record<string, { description?: string }> };
+  return shape.objectives?.description ?? '';
+}
+
+describe('AGENT-AUTHORING.md schema quotes', () => {
+  const blocks = fencedBlocks(read(DOC_RELATIVE_PATH));
+  const excerptIndex = blocks.findIndex(
+    (block) => block.language === 'typescript' && block.body.startsWith(EXCERPT_MARKER)
+  );
+
+  it('carries a schema excerpt labelled with the file it quotes', () => {
+    expect(excerptIndex).toBeGreaterThanOrEqual(0);
+  });
+
+  it('quotes the interactive block schema verbatim', () => {
+    const schema = read(SCHEMA_RELATIVE_PATH);
+    const runs = excerptRuns(blocks[excerptIndex]!.body);
+
+    expect(runs.length).toBeGreaterThan(1);
+    for (const run of runs) {
+      expect(run.split('\n').length).toBeGreaterThan(1);
+      expect(schema).toContain(run);
+    }
+  });
+
+  it('quotes the generated objectives description verbatim', () => {
+    const quoted = blocks.slice(excerptIndex + 1).find((block) => block.language === 'text');
+
+    expect(quoted).toBeDefined();
+    expect(quoted!.body.trimEnd()).toBe(objectivesDescription());
+  });
+});


### PR DESCRIPTION
## One concern, two fields

Two fields in the guide schema hold **condition tokens** — the same vocabulary `requirements` uses — and both were described to authoring agents as something else. `verify` was called a CSS selector; `objectives` was called learning-objective metadata. In both cases the description sent authors toward a value or a workaround that the runtime cannot honour.

This is a **description fix**. Neither field's Zod schema gets stricter: both stay `z.string()` for the same reason, spelled out under [Why both stay permissive](#why-both-stay-permissive). The vocabulary is enforced one layer later, where a bad token warns instead of blanking the guide.

This is one concern (the schema's agent-facing description of its condition fields) and the two halves share a file and a mechanism. Of the ~370 added lines, 290 are tests. The second commit was added after the same defect was hit a third time, on `objectives`, by an agent authoring a guide against this schema; the third and fourth answer review.

---

## Field 1 — `verify` holds a condition, not a CSS selector

```ts
// src/types/json-guide.schema.ts, before
verify: z.string().optional().describe('CSS selector to check for verification after action'),
```

Two things were wrong at once: the description pointed authors at the wrong kind of value, and the bare `z.string()` meant nothing rejected what they wrote.

The repository already disagreed with itself:

- `src/types/json-guide.types.ts:376` has it right — `/** Post-action verification requirement (e.g., "on-page:/dashboard") */`
- `docs/developer/interactive-examples/json-guide-format.md` has it right — "The step is only marked complete when this condition is met."
- The block editor has it right — `ConditionChipsField` carries a `'verify'` mode whose placeholder is `on-page:/dashboards`
- `src/validation/condition-validator.ts:296` walks `verify` with `validateConditionString`, the condition grammar
- The schema, `docs/design/AGENT-AUTHORING.md`, and `src/cli/utils/cli-validators.ts` had it wrong

The runtime is unambiguous: `json-parser` maps `block.verify` to `postVerify`, and `interactive-step` passes it to `checkPostconditions` as `requirements` — the same engine, and the same vocabulary, that evaluates `requirements`.

### The MCP validator accepted a value the publishing repository rejects

Putting a `data-testid` selector in `verify` produces a package that **`pathfinder_validate` reports as valid**. `grafana/interactive-tutorials` CI then fails the PR:

```
blocks[3].blocks[1].verify: Unknown condition type '[data-testid='...Save and Test button']'
```

Both are this repository's own code. The split is `--strict`: `validateGuide` runs the Zod parse as a hard gate, then adds condition-validator findings to `warnings`, and only `options.strict` promotes them to errors. `pathfinder_validate` passes no `strict`, so the finding stays a warning and the artifact looks publishable; the tutorials repo runs `validate --strict`, so the same finding is an error there.

**And a selector in `verify` can never work at runtime.** `routeUnifiedCheck` returns `pass: false`, verdict `invalid`, for any token outside `isValidRequirement` in `post` mode — so the description was inviting authors to write a value that permanently breaks the step.

### The change

The description is corrected, and the schema is left permissive:

```ts
verify: VerifyConditionSchema.optional().describe(
  'Post-action verification condition, evaluated after the action runs; the step completes only once it is satisfied. Same condition vocabulary as `requirements` (e.g., on-page:/connections/datasources/edit) — not a CSS selector. One string, comma-separated for more than one condition.'
),
```

`VerifyConditionSchema` is `z.string()`, sharing a doc comment with `ObjectiveTokenSchema` because the two fields are permissive for one shared reason. An earlier revision of this PR held every comma-separated token to `isValidRequirement` here; review was right that this exposes `verify` to the hazard `objectives` was deliberately spared. See [Why both stay permissive](#why-both-stay-permissive).

Where the vocabulary **is** enforced for `verify`:

| Layer | Behaviour on a non-condition `verify` |
| --- | --- |
| Zod (`validateGuide` step 1) | accepts — the guide keeps rendering |
| `condition-validator` (step 3) | `blocks[0].verify: Unknown condition type '…'`, as a warning |
| `validate --strict` / `grafana/interactive-tutorials` CI | that warning becomes an error, so it stops at the authoring gate |
| runtime (`routeUnifiedCheck`, `post` mode) | verdict `invalid`, `pass: false` — that one step's verification fails and the step does not complete |

Two follow-on corrections to the same wrong belief: `src/cli/utils/cli-validators.ts` registered `verify: [assertCssSelector]` (removed — the field is not a selector, and the heuristic only ever rejected `<` and the empty string), and `docs/design/AGENT-AUTHORING.md` quoted the defective line.

### Guardrail

Every `verify` value in every published package in `grafana/interactive-tutorials` (`origin/main`) was checked against `isValidRequirement`: **99 occurrences, 49 distinct, 0 rejected.** 97 `on-page:`, one `dashboard-exists`, one `has-datasource:grafanacloud-play-profiles`. Not one CSS selector, and not one comma-separated value. `src/bundled-interactives/` uses `verify` nowhere.

That is the inspectable corpus, and it is **not** the whole one — which is exactly why the schema stays permissive.

---

## Field 2 — `objectives` are auto-complete conditions, not learning goals

`objectives` is evaluated in the **first** check phase, ahead of eligibility and requirements (`src/requirements-manager/check-phases.ts`), and satisfying it completes the block without the reader acting. Agents read:

```
objectives       array        Learning objectives this block addresses
```

So an author who wanted a step to complete itself for a reader who **already had** a TestData data source read that as documentation metadata and reached for `skippable: true` instead. That is strictly worse: `skippable` lets a reader past a step, where `objectives` records that the step is already done. The feature they wanted existed and the description hid it.

### Where the wrong string came from

The live schema descriptions were already corrected in #1791 — `add-block interactive --help` on `main` prints "Conditions that automatically complete this block", because help output is schema-owned (`src/cli/mcp/tools/help.ts`: "Descriptions, types, and requiredness stay schema-owned"). The wrong string survived in **two hand-written transcripts** in `docs/design/AGENT-AUTHORING.md`: a schema excerpt (which also still showed the pre-#1791 bare `z.array(z.string())`) and a sample `--help` transcript. Both are read as the spec.

That sample transcript **also** still described `--verify` as "CSS selector for post-action verification" — the field-1 defect, in the one place this PR's first commit missed. Fixed here.

### What the descriptions now say

The corrected description was true but thin: it never said the two things that make the field usable — that it draws on the **same vocabulary as `requirements`**, and that it is **checked first**. Both are now stated, along with the `skippable` contrast that is the actual authoring decision:

> Conditions that automatically complete this block, in the same vocabulary as `requirements`. Checked first, before eligibility and requirements, so a block whose objectives already hold is marked complete without the reader acting (e.g. has-datasource:prometheus for a block that creates one). Prefer this over `skippable` for work the reader may already have done: skippable only lets them past the step, objectives record it as done.

It came from one generator rather than eight copies, so the surfaces cannot diverge. The nested conditional branch config (`ConditionalSectionConfigSchema`) carried **no** description at all and now carries one — an agent seeing a bare `objectives (array, optional)` beside `requirements` has every reason to guess "learning objectives" from the name.

**The closing sentence is per-container.** An earlier revision appended the `skippable` contrast to all three, but only blocks have that field: neither `SectionProps` / `JsonSectionBlockSchema` nor `ConditionalSectionConfigSchema` declares `skippable` at any level, and the block editor exposes none there — so the generator was pointing section and branch authors at a field their container does not have, which is the class of error this PR exists to remove. Sections and branches now close with what completing the container actually does:

> Conditions that automatically complete this section, in the same vocabulary as `requirements`. Checked first, before eligibility and requirements, so a section whose objectives already hold is marked complete without the reader acting (e.g. has-datasource:prometheus for a section that creates one). When a section's objectives hold, every step inside it is marked complete too.

That last clause is the runtime behaviour, not a slogan: `interactive-section.tsx` calls `markStepsCompleted(allStepIds, sectionId, 'objectives')` when the section's objectives fire, and `interactive-conditional.tsx` hands a branch's objectives to the section it renders.

### Why both stay permissive

`objectives` and `verify` are both `z.string()`, and it is deliberate. The two share one doc comment in the schema because they share one reason.

I checked the published corpus expecting to tighten `objectives`. **Every `objectives` value already is a valid condition** — 29 occurrences, 16 distinct, 0 rejected by `isValidRequirement`:

| Shape | Distinct | Examples |
| --- | --- | --- |
| `on-page:` | 8 | `on-page:/a/grafana-synthetic-monitoring-app/home` ×5, `.../checks/new/api-endpoint` ×4, `on-page:/a/grafana-pyroscope-app/explore` ×3, `on-page:/explore`, `on-page:/playlists`, `on-page:/alerting/alerts` |
| `has-datasource:` | 4 | `has-datasource:grafanacloud-play-prom` ×5, `has-datasource:testdata`, `has-datasource:volkovlabs-rss-datasource`, `has-datasource:yesoreyeram-infinity-datasource` |
| plugin | 2 | `has-plugin:volkovlabs-rss-datasource`, `plugin-enabled:yesoreyeram-infinity-datasource` |
| fixed | 2 | `exists-reftarget`, `form-valid` |

Sources: `grafana/interactive-tutorials` `origin/main` and `src/bundled-interactives/`.

So the inspectable corpus would not have forced a widening — but it is not the whole corpus, and **the same is true of `verify`**. `upsert-learning-path.sh` forwards both fields to the InteractiveGuide CRD under **jq shape checks alone**, and the backend never validates either, so customer stacks can hold guides this repo cannot enumerate, carrying exactly what the old descriptions invited: prose in `objectives`, a CSS selector in `verify`.

The exposure is at **render time**, not just authoring time. `src/docs-retrieval/content-fetcher/backend-guide.ts` calls `validateGuide()` on CRD-sourced guide content as it loads, and `validate-guide.ts` returns `{ isValid: false, guide: null }` on any Zod failure — so a token check would replace the whole guide with a parse-error panel for its reader, not flag one bad step. That is precisely the failure #1791 removed, and re-introducing it for guides we cannot inspect trades a real outage for a cosmetic gate.

The vocabulary is enforced, one layer later, and it is **not silent**: `condition-validator` walks both fields and warns (`blocks[0].objectives[0]: Unknown condition type 'Learn about dashboards'`, surfaced by `pathfinder_validate`), `validate --strict` promotes that warning to an error at the authoring gates, `json-parser` drops an unexecutable objective, and the runtime refuses to complete a step on any verdict other than `satisfied`. A typo cannot auto-complete a step today, and an unrecognised `verify` fails that step's verification rather than erasing the guide around it.

This **follows** the `guide-schema-and-contracts` contract anchor (`#1662 → #1791`), which already records this treatment for `objectives`; the schema comment is updated to give the durable reason (the CRD path) rather than the now-obsolete one (that the field's own description invited prose — it no longer does), and `verify` is brought under the same comment.

If we do want a hard gate on either field, the repo already has the right shape for it: block at the authoring gates and downgrade at the four runtime guide loaders, the way `#1764` handles `duplicate_heading`. That is a contract change with its own blast radius, and it does not belong in a description fix.

---

## The doc quoted the schema without quoting it

`docs/design/AGENT-AUTHORING.md` presents an excerpt of `JsonInteractiveBlockSchema` as a literal quote, and authoring agents read it as the spec. An earlier revision of this PR replaced the stale lines with a shorter paraphrase — a PR about documentation that misdescribes reality, shipping a quote that was not one.

The excerpt is now **copied out of the source file**, as two contiguous runs with a `// ...` elision between them (the `reftarget` and `targetstate` descriptions are paragraph-length and would swamp the section). `<!-- prettier-ignore -->` keeps prettier from reflowing the fence out of byte-exactness — without it, prettier rewrites `z\n  .object({` to `z.object({` and re-indents, because the real formatting is forced by the `.refine()` chain the excerpt stops short of.

Since the block's `objectives` line now reads `describe(objectivesDescription('block'))`, the generated string is quoted directly underneath, so the doc still shows the text an agent receives.

`src/validation/agent-authoring-docs.test.ts` is the tripwire: every quoted run must appear verbatim in `src/types/json-guide.schema.ts`, and the quoted description must equal `JsonInteractiveBlockSchema.shape.objectives.description`. Both halves fail on a one-word change in either direction — verified by mutating each and watching the suite go red.

The `--help` transcript further down is a hand-written sketch of a format the CLI does not literally emit: Commander prints one unwrapped line per option (up to 581 characters) and each `.describe()` string in full. Making it verbatim is a rewrite well outside this PR, so it now states that it is abridged and names the schema as the authority on wording.

---

## Tests

`src/types/json-guide-verify.schema.test.ts`:

- the three token shapes published today, and the comma-separated form the runtime tokenizes, are accepted with **no** condition warning
- a `[data-testid=...]` selector — the case that started this — **keeps the guide loadable** (`isValid`, `guide` non-null) and warns with `blocks[0].verify: Unknown condition type`, rather than being rejected by the schema
- `validate --strict` turns that warning into an error, which is the authoring gate
- one unknown token inside an otherwise valid list warns the same way
- `verify` reaches the runtime verbatim as `postVerify`, condition or not — unlike an objective it is not dropped, because `routeUnifiedCheck` refuses the step on verdict `invalid` instead of completing it on no evidence
- the description is pinned: it must read as a verification condition, must deny being a CSS selector, and the `on-page:` example inside it must itself validate clean

`src/types/json-guide-objectives.schema.test.ts` (extending the suite #1791 added):

- `has-datasource:prometheus`, `on-page:/explore` and `exists-reftarget` are forwarded to the runtime as completion conditions
- a non-condition objective never becomes completion evidence: it warns with `Unknown condition type`, produces no error, and reaches the runtime as `undefined`
- the description is pinned on **all three** surfaces — interactive block, section, and the conditional branch config reached through `JsonConditionalBlockSchema` — must not match `/learning objective/i`, must claim to complete that container, must name the `requirements` vocabulary and the "checked first" ordering, and its `has-datasource:` example must satisfy `isValidRequirement`
- the `skippable` sentence appears **iff** `'skippable' in schema.shape`, so the generator cannot again offer a comparison against a field the container lacks
- section and branch close with the "every step inside it is marked complete too" clause

`src/validation/agent-authoring-docs.test.ts` (new): the doc's schema excerpt and its quoted `objectives` description must match the source byte for byte.

The pins are real tripwires, not tautologies: reverting the description to "Learning objectives this block addresses" fails 3 tests, restoring the unconditional `skippable` sentence fails 4, and changing one word of a quoted schema line fails the doc suite.

## Verification

- `npm run check` — all 9 steps pass (typecheck, lint, prettier, terms sync, `mage lint`, `mage test`, jest with coverage, review contract, script suites). **537 suites, 8613 tests** (8590 passed, 18 skipped, 5 todo); shell suites 22 and 64 passed, 0 failed.
- `add-block interactive --help` and `add-block section --help` rebuilt and read back, to confirm the corrected text is what an agent actually receives.

## Review round two

Addressing the review on this PR:

- **High —** `verify`'s blocking schema could blank a customer guide, the exposure `objectives` was spared. Taken the second option offered: `verify` is now schema-permissive with the condition validator warning, matching `objectives` exactly. Auditing the live backend/CDN corpus is not something this branch can do, and a guess there is the wrong kind of risk.
- **Medium —** `objectivesDescription()` told `section` and `branch` to weigh against a `skippable` they do not have. Parameterised, with the presence of the sentence pinned against the presence of the field.
- **Nit —** the "corrected" doc excerpt was a paraphrase presented as a quote. Copied from source, prettier-guarded, and pinned by a new test.

## Relationship to #1849

Separate defect, separate PR. #1849 fixes the MCP's self-description output (`requiredParams` on rendered interfaces, and publishing the requirement-token catalogue) and touches neither `json-guide.schema.ts` nor these fields. The only shared file is `docs/design/AGENT-AUTHORING.md`, where the hunks are far apart.

They compose: once both land, these descriptions point at the `requirements` vocabulary, and #1849's `x-requirement-tokens` / `requirementTokens` publish what that vocabulary contains. This PR does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

