### PR TITLE
fix(storage): evict stale completion entries, not the ones in use

### DIFF
--- a/docs/design/COMPLETION-MODEL.md
+++ b/docs/design/COMPLETION-MODEL.md
@@ -388,19 +388,27 @@ candidate set it appears in and inflate the path's number.
 treats a formable-but-absent key as never-opened and scores it zero, which is
 the honest answer for a reader who has not started that guide. It is _not_
 honest for a reader whose record was evicted: `interactiveCompletionStorage`
-caps at `MAX_INTERACTIVE_COMPLETIONS` (100, `src/lib/user-storage.ts`) and
-`writeWithCap` keeps `entries.slice(-limit)` — insertion order, so the earliest
-keys are dropped and updating an existing key does not move it forward. A reader
-past 100 distinct guides therefore loses real progress on their oldest ones, and
-it arrives at the join as a genuine zero. Reading two candidate shapes per
-bundled member raises the pressure slightly, because a guide opened from both
-surfaces occupies two of the 100 slots.
+caps at `MAX_INTERACTIVE_COMPLETIONS` (250, `src/lib/user-storage.ts`), and past
+that cap `writeWithCap` drops zero-progress entries first and then the least
+recently written of the rest. Reading two candidate shapes per bundled member
+raises the pressure, because a guide opened from both surfaces occupies two
+slots.
 
 The information needed to tell eviction from never-opened is gone by the time
-the join runs, so this is not fixable in `path-member-join.ts`. **Known
-follow-on work, storage-side:** raise the cap, evict least-recently-updated
-rather than earliest-inserted, or persist an opened-guides set the join can
-consult. Until one of those lands, a path mean can understate a heavy reader.
+the join runs, so this is not fixable in `path-member-join.ts`. Eviction now
+falls on the entries a reader has stopped touching rather than the ones they
+opened first, which is what closes the case where a heavy reader lost progress
+on a guide they were actively using.
+
+**Recency and furthest-wins disagree on a split pair.** Storage sees two launch
+shapes of one guide as two unrelated keys, so it cannot prefer the pair's higher
+record — it keeps whichever was written more recently. The join prefers the
+higher. A reader who reaches 80% under `bundled:<id>/content.json` and later
+does one step under bare `bundled:<id>` has a fresh 10% and a stale 80%; the
+join reports 80% until the 80% entry ages out, and 10% after. The zero-first
+pass covers the common case, where the twin holds no progress at all and is
+dropped losslessly. Closing the rest needs the pair to be known where the keys
+are paired, which is here and not in storage.
 
 **The key spaces `resetPath` clears are not one space.**
 `interactiveCompletionStorage` and `interactiveStepStorage` are keyed by the

--- a/src/lib/storage/bounded-record-storage.test.ts
+++ b/src/lib/storage/bounded-record-storage.test.ts
@@ -85,6 +85,59 @@ describe('createBoundedRecordStorage', () => {
     expect(await store.getAll()).toEqual({ b: 2, c: 3, d: 4 });
   });
 
+  describe('eviction order', () => {
+    it('keeps an entry the reader is still updating and evicts an untouched one instead', async () => {
+      const store = makeStore({ storageKey: TEST_KEY, limit: 3, label: 'test' });
+      await store.set('early', 10);
+      await store.set('b', 20);
+      await store.set('c', 30);
+
+      // The reader comes back to `early` and earns more progress on it.
+      await store.set('early', 60);
+
+      // A fourth guide pushes the record over budget.
+      await store.set('d', 40);
+
+      expect(await store.get('early')).toBe(60);
+      expect(await store.getAll()).toEqual({ c: 30, early: 60, d: 40 });
+    });
+
+    it('evicts entries with no recorded progress before entries that hold progress', async () => {
+      const store = makeStore({ storageKey: TEST_KEY, limit: 3, label: 'test' });
+      await store.set('has-progress', 20);
+      await store.set('c', 30);
+      await store.set('opened-only', 0);
+      await store.set('d', 40);
+
+      // Dropping a 0 is lossless: `get()` already returns 0 for a missing key.
+      expect(await store.getAll()).toEqual({ 'has-progress': 20, c: 30, d: 40 });
+    });
+
+    it('reads a record written before the change and keeps updated entries from it', async () => {
+      // Shape written by the previous implementation: a plain key -> percentage
+      // record with no recency metadata, already over the new budget.
+      localStorage.setItem(TEST_KEY, JSON.stringify({ old1: 10, old2: 20, old3: 30, old4: 40 }));
+      const store = makeStore({ storageKey: TEST_KEY, limit: 3, label: 'test' });
+
+      expect(await store.get('old1')).toBe(10);
+
+      await store.set('old1', 55);
+
+      expect(await store.get('old1')).toBe(55);
+      expect(await store.getAll()).toEqual({ old3: 30, old4: 40, old1: 55 });
+    });
+
+    it('changes nothing for a record below the limit', async () => {
+      const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
+      await store.set('a', 0);
+      await store.set('b', 20);
+      await store.set('a', 30);
+
+      expect(await store.getAll()).toEqual({ a: 30, b: 20 });
+      expect(JSON.parse(localStorage.getItem(TEST_KEY)!)).toEqual({ a: 30, b: 20 });
+    });
+  });
+
   it('clearAll() removes the underlying storage key entirely', async () => {
     const store = makeStore({ storageKey: TEST_KEY, limit: 100, label: 'test' });
     await store.set('a', 10);

--- a/src/lib/storage/bounded-record-storage.test.ts
+++ b/src/lib/storage/bounded-record-storage.test.ts
@@ -86,6 +86,10 @@ describe('createBoundedRecordStorage', () => {
   });
 
   describe('eviction order', () => {
+    // Key order in the persisted record IS the recency mechanism, and object
+    // equality ignores it, so these assert the order itself.
+    const storedKeys = () => Object.keys(JSON.parse(localStorage.getItem(TEST_KEY) || '{}'));
+
     it('keeps an entry the reader is still updating and evicts an untouched one instead', async () => {
       const store = makeStore({ storageKey: TEST_KEY, limit: 3, label: 'test' });
       await store.set('early', 10);
@@ -94,12 +98,14 @@ describe('createBoundedRecordStorage', () => {
 
       // The reader comes back to `early` and earns more progress on it.
       await store.set('early', 60);
+      expect(storedKeys()).toEqual(['b', 'c', 'early']);
 
       // A fourth guide pushes the record over budget.
       await store.set('d', 40);
 
       expect(await store.get('early')).toBe(60);
       expect(await store.getAll()).toEqual({ c: 30, early: 60, d: 40 });
+      expect(storedKeys()).toEqual(['c', 'early', 'd']);
     });
 
     it('evicts entries with no recorded progress before entries that hold progress', async () => {
@@ -111,6 +117,37 @@ describe('createBoundedRecordStorage', () => {
 
       // Dropping a 0 is lossless: `get()` already returns 0 for a missing key.
       expect(await store.getAll()).toEqual({ 'has-progress': 20, c: 30, d: 40 });
+      expect(storedKeys()).toEqual(['has-progress', 'c', 'd']);
+    });
+
+    it('leaves the record untouched when a zero is written at the cap', async () => {
+      const store = makeStore({ storageKey: TEST_KEY, limit: 3, label: 'test' });
+      await store.set('a', 10);
+      await store.set('b', 20);
+      await store.set('c', 30);
+
+      // A freshly opened guide writes 0. It is evictable like any other zero,
+      // and it is the surplus entry, so nothing real is displaced for it.
+      await store.set('fresh', 0);
+
+      expect(await store.getAll()).toEqual({ a: 10, b: 20, c: 30 });
+      expect(storedKeys()).toEqual(['a', 'b', 'c']);
+      // Indistinguishable from a stored 0, which is why dropping it is sound.
+      expect(await store.get('fresh')).toBe(0);
+    });
+
+    it('stores that same guide once it earns progress, evicting the stalest entry', async () => {
+      const store = makeStore({ storageKey: TEST_KEY, limit: 3, label: 'test' });
+      await store.set('a', 10);
+      await store.set('b', 20);
+      await store.set('c', 30);
+      await store.set('fresh', 0);
+
+      await store.set('fresh', 25);
+
+      expect(await store.get('fresh')).toBe(25);
+      expect(await store.getAll()).toEqual({ b: 20, c: 30, fresh: 25 });
+      expect(storedKeys()).toEqual(['b', 'c', 'fresh']);
     });
 
     it('reads a record written before the change and keeps updated entries from it', async () => {
@@ -125,6 +162,7 @@ describe('createBoundedRecordStorage', () => {
 
       expect(await store.get('old1')).toBe(55);
       expect(await store.getAll()).toEqual({ old3: 30, old4: 40, old1: 55 });
+      expect(storedKeys()).toEqual(['old3', 'old4', 'old1']);
     });
 
     it('changes nothing for a record below the limit', async () => {

--- a/src/lib/storage/bounded-record-storage.ts
+++ b/src/lib/storage/bounded-record-storage.ts
@@ -3,13 +3,25 @@ import type { UserStorage } from '../../types/storage.types';
 
 export interface BoundedRecordStorage {
   get(key: string): Promise<number>;
-  /** Clamps `percentage` to `[0, 100]`, trims down to `limit` entries on overflow, and retries once after `cleanup()` on quota errors. */
+  /**
+   * Clamps `percentage` to `[0, 100]` and retries once after `cleanup()` on quota errors.
+   *
+   * On overflow the record is trimmed to `limit` entries: zero-progress
+   * entries go first (a missing key reads back as 0, so dropping one loses
+   * nothing), then the least recently written of the rest. Writing a key
+   * counts as touching it, so a guide the reader keeps returning to outlives
+   * one they opened earlier and abandoned.
+   */
   set(key: string, percentage: number): Promise<void>;
   clear(key: string): Promise<void>;
   /** Deletes every key in one read-modify-write. Concurrent `clear` calls share one record, so each write restores the keys its siblings deleted. */
   clearMany(keys: string[]): Promise<void>;
   getAll(): Promise<Record<string, number>>;
-  /** Trims the record down to the last `limit` entries in insertion order, not by recency of update. No-op when already within budget. */
+  /**
+   * Trims the record down to `limit` entries, evicting zero-progress entries
+   * first and then the least recently written of the rest. No-op when already
+   * within budget.
+   */
   cleanup(): Promise<void>;
   clearAll(): Promise<void>;
 }
@@ -34,17 +46,37 @@ export interface BoundedRecordStorageConfig {
 export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): BoundedRecordStorage {
   const { storageKey, limit, label, createStorage, onQuotaExceeded } = config;
 
+  const trimToLimit = (data: Record<string, number>): Record<string, number> => {
+    const entries = Object.entries(data);
+    const surplus = entries.length - limit;
+    if (surplus <= 0) {
+      return data;
+    }
+    const evicted = new Set<string>();
+    for (const [key, value] of entries) {
+      if (evicted.size >= surplus) {
+        break;
+      }
+      if (value <= 0) {
+        evicted.add(key);
+      }
+    }
+    const survivors = entries.filter(([key]) => !evicted.has(key));
+    return Object.fromEntries(survivors.slice(-limit));
+  };
+
   const writeWithCap = async (data: Record<string, number>): Promise<void> => {
     const storage = createStorage();
-    const entries = Object.entries(data);
-    const payload = entries.length > limit ? Object.fromEntries(entries.slice(-limit)) : data;
-    await storage.setItem(storageKey, payload);
+    await storage.setItem(storageKey, trimToLimit(data));
   };
 
   const setInternal = async (key: string, percentage: number, hasRetried: boolean): Promise<void> => {
     try {
       const storage = createStorage();
       const data = (await storage.getItem<Record<string, number>>(storageKey)) || {};
+      // Delete before re-adding so the key moves to the end of the record's
+      // key order, which is what `trimToLimit` reads as write recency.
+      delete data[key];
       data[key] = Math.max(0, Math.min(100, percentage));
       await writeWithCap(data);
     } catch (error) {

--- a/src/lib/storage/bounded-record-storage.ts
+++ b/src/lib/storage/bounded-record-storage.ts
@@ -62,6 +62,9 @@ export function createBoundedRecordStorage(config: BoundedRecordStorageConfig): 
       }
     }
     const survivors = entries.filter(([key]) => !evicted.has(key));
+    // A just-written 0 is evictable like any other, so writing one at the cap
+    // leaves the record untouched. Intended: a stored 0 and an absent key read
+    // back identically, so displacing a real record for one is a pure loss.
     return Object.fromEntries(survivors.slice(-limit));
   };
 

--- a/src/lib/user-storage.test.ts
+++ b/src/lib/user-storage.test.ts
@@ -319,6 +319,38 @@ describe('interactiveCompletionStorage.clearAll', () => {
 });
 
 // ============================================================================
+// interactiveCompletionStorage CAP TESTS
+// ============================================================================
+
+describe('interactiveCompletionStorage at its cap', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  const storedCount = () =>
+    Object.keys(JSON.parse(localStorage.getItem(StorageKeys.INTERACTIVE_COMPLETION) || '{}')).length;
+
+  it('keeps progress on a guide the reader is still using once the cap is exceeded', async () => {
+    // Fill the record right up to the cap, oldest first.
+    const seeded: Record<string, number> = {};
+    for (let i = 0; i < 250; i++) {
+      seeded[`guide-${i}`] = 10;
+    }
+    localStorage.setItem(StorageKeys.INTERACTIVE_COMPLETION, JSON.stringify(seeded));
+
+    // The reader returns to the guide they opened first and earns more progress.
+    await interactiveCompletionStorage.set('guide-0', 80);
+
+    // Then they open a guide they have never seen, pushing the record over budget.
+    await interactiveCompletionStorage.set('brand-new-guide', 5);
+
+    expect(await interactiveCompletionStorage.get('guide-0')).toBe(80);
+    expect(await interactiveCompletionStorage.get('brand-new-guide')).toBe(5);
+    expect(storedCount()).toBe(250);
+  });
+});
+
+// ============================================================================
 // sectionAcknowledgementStorage TESTS (issue #842 gate)
 // ============================================================================
 

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -161,7 +161,9 @@ export function unwrapEnvelope(raw: string | null | undefined): StorageEnvelope 
 
 const LIMITS = {
   MAX_JOURNEY_COMPLETIONS: 100, // Prevent quota exhaustion
-  MAX_INTERACTIVE_COMPLETIONS: 100, // Prevent quota exhaustion
+  // Higher than the journey cap because this record is keyed per guide *and*
+  // per milestone, so one multi-milestone path consumes a slot per milestone.
+  MAX_INTERACTIVE_COMPLETIONS: 250, // Prevent quota exhaustion
   MAX_PERSISTED_TABS: 50, // Prevent quota exhaustion
 } as const;
 


### PR DESCRIPTION
## What changed

Completion percentages live in one bounded record keyed by content key, trimmed to a cap when it overflows. The trim ran on **key insertion order**, and updating an existing key did not move it. So the first guide you ever opened was always the first one evicted — including when you had just earned progress on it, and even when the entry being kept was one you opened once and abandoned. Exactly backwards.

Because a missing key reads back as `0`, the loss was invisible. An evicted guide is indistinguishable from one you never opened, on every surface. And a path's percentage is the mean of its milestones' percentages, so a single evicted milestone quietly drags the whole path number down.

Two changes in `src/lib/storage/bounded-record-storage.ts`:

- `set` deletes the key before re-adding it, so the record's key order *is* write recency and the existing `slice(-limit)` trim becomes least-recently-written-first. Earning progress on a guide now protects it.
- Before falling back to recency, the trim drops zero-progress entries. Dropping a `0` is free: `get()` already returns `0` for a missing key, so nothing is lost.

The interactive completion cap goes from 100 to 250 (`src/lib/user-storage.ts`). Journey completions stay at 100.

## Why this shape

Three fixes were on the table: raise the cap, evict by last update instead of first insert, or persist a separate set of opened guides so eviction could at least be told apart from never-opened.

The third was rejected outright — it makes the loss legible but still loses the progress.

**A cap raise alone would not have been enough**: it moves the same bug to a bigger number. Whatever the limit, the guide you use most is still the first one thrown away. That is why the raise rides on top of the ordering fix rather than instead of it, and why it is modest. What justifies raising it at all is that 100 slots is nowhere near 100 guides: this record is keyed per guide **and per milestone**, so one ten-milestone path consumes ten slots, and a bundled guide opened from two surfaces occupies two. A reader with a legitimately small library can reach the cap. At 250, worst case is 250 keys against the existing 200-character key limit, about 52KB, and realistically nearer 20KB — well inside localStorage, with the existing `QuotaExceededError` retry as the backstop.

The persisted shape is unchanged — still `{ contentKey: percentage }` — so existing records are read as-is and there is nothing to migrate.

## What to look at

- `trimToLimit` in `bounded-record-storage.ts` — the eviction order.
- The `delete data[key]` before the re-add in `setInternal`. It looks redundant and is not: it is what makes key order mean write recency.
- The record is shared with journey completion, which gets the same ordering fix through the same building block.
- The `cleanup()` docstring. #1843 landed wording asserting insertion-order eviction, which this change makes false; it is rewritten to describe the new order rather than spliced.

One limitation worth your judgement: a guide at 100% stops being written, so over time it drifts toward the front of the eviction queue. The cap raise softens that but does not cure it.

## How to verify by hand

The record is plain JSON in localStorage, so you can put a reader past the cap without clicking through 250 guides. In devtools, on a Grafana instance with the plugin loaded:

```js
const KEY = 'grafana-pathfinder-app-interactive-completion';
const seeded = {};
for (let i = 0; i < 250; i++) { seeded[`filler-${i}`] = 10; }
localStorage.setItem(KEY, JSON.stringify(seeded));
```

Then reload, open **one guide** in the sidebar and complete a step or two in it, and finally open a **second, different** guide and complete a step there — the second one is what pushes the record over budget.

Re-read the record and look for the first guide you worked in:

```js
JSON.parse(localStorage.getItem(KEY));
```

- **Before this change**: the guide you just earned progress in is gone, and the sidebar shows it at 0% as if you had never opened it.
- **After this change**: both guides you actually used are present with their real percentages, and a `filler-*` entry was dropped instead.

Below the cap nothing changes — a reader with fewer than 250 guides sees identical behaviour, and there is a test pinning that.

## Correction: one guide really can occupy two slots

An earlier version of this description claimed that nothing reads two bundled key shapes for one guide's percentage. **That was wrong**, and it predates this change rather than being introduced by it.

`bundled:<id>` and `bundled:<id>/content.json` are both live launch shapes for the same guide: My Learning opens it bare, the package resolver opens the `/content.json` form. Each is read on its own — `context.service.ts:844` reads `rec.url`, `context.service.ts:894` reads the resolver's `contentUrl` — so the same guide is asked about under either shape with nothing pairing them, and each shape that gets written occupies its own slot. `pathMemberContentKeys` (`src/global-state/path-member-join.ts:206`) does pair them, for the path join. I checked the `bundled:`/`backend-guide:` pairing and `guideMetadata.url`, never the resolver's shape, so I reported a real multiplier as absent.

**It does not change the cap.** 250 still holds, because the doubling is bounded by the bundled catalogue — seven guides — so it adds at most seven slots rather than halving the effective budget. The dominant multiplier is still per-milestone keying, where one ten-milestone path consumes ten slots, and that is what 250 is sized against.

**It does change which entry gets evicted, and that is worth a reviewer's attention.** Storage sees the two shapes as unrelated keys, so it keeps whichever was written more recently. The join prefers the *higher* of the pair. Those disagree: a reader who reaches 80% under `bundled:<id>/content.json` and later does one step under bare `bundled:<id>` has a fresh 10% and a stale 80%, and the join reports 80% until the 80% entry ages out, then 10%.

Two things bound that. The zero-first pass covers the common case, where the twin holds no progress and is dropped for free. And it is not a regression from this change: under insertion order the survivor was whichever happened to be written first, unrelated to either recency or value, so the pair was split arbitrarily. Closing it properly needs the two keys to be known as a pair, which is true in `path-member-join.ts` and not in storage — storage has no notion of pairs to reason about. Written down in `docs/design/COMPLETION-MODEL.md` in this PR rather than fixed here.

## Scope

Storage only. Percentage calculation, the completion recorder, and the progress displays are untouched — a separate consolidated change owns those.

## Reversibility

Straightforward revert. The persisted shape is unchanged, so a revert reads existing records fine; a record grown past 100 entries under the higher cap simply gets trimmed back on its next write.
