### PR TITLE
docs(interactives): remove stale multistep reftarget guidance

### DIFF
--- a/docs/developer/interactive-examples/interactive-types.md
+++ b/docs/developer/interactive-examples/interactive-types.md
@@ -227,8 +227,6 @@ Bring the guide back into the sidebar:
 }
 ```
 
-If you specify `"requirements": ["exists-reftarget"]` on a multistep, also set `reftarget` to the first step's target so the requirement check has something to find.
-
 ### guided
 
 - **Purpose**: highlights elements and waits for the user to perform actions manually.


### PR DESCRIPTION
## Summary

Remove authoring guidance that tells guide authors to set a top-level `reftarget` on `multistep` blocks. That field is not part of `JsonMultistepBlock`; the runtime already derives the block-level requirement target and action type from the first internal action.

## What to look at

- [Interactive type guidance](https://github.com/dvd233/grafana-pathfinder-app/blob/76d8d69ad09344ab44ec61532d90c310a61f632e/docs/developer/interactive-examples/interactive-types.md) no longer advertises an unsupported field between the `multistep` example and `guided` section.

## How to verify

1. Compare the `multistep` example with `JsonMultistepBlock`; confirm the docs now name only fields the shipped type accepts.
2. Trace `firstActionRefTarget` and `firstActionTargetAction` in `InteractiveMultiStep`; confirm `exists-reftarget` checks still receive the first internal action's target without a block-level `reftarget`.

## Breaking changes

None. This documentation-only correction aligns the authoring guide with the shipped schema and runtime behavior.

Closes #334

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)
