### PR TITLE
fix(review): read review state through a publisher's closing prose

### DIFF
--- a/.cursor/skills/review/scripts/review-report.mjs
+++ b/.cursor/skills/review/scripts/review-report.mjs
@@ -128,21 +128,23 @@ function trailingStateMarker(output) {
   if (markerIndexes.length !== 1) {
     return null;
   }
-  const recap = lines.slice(-RECAP_LINE_COUNT);
+  const markerIndex = markerIndexes[0];
+  // Anchor the recap to the marker, not to the end of the body: a publisher may
+  // append its own closing prose after the rendered report (the community-pr
+  // gate does). Marker-then-recap adjacency is what defeats a marker quoted
+  // mid-prose, so that still holds - only the end-of-body coupling is dropped.
+  let index = markerIndex + 1;
+  while (index < lines.length && lines[index].trim() === '') {
+    index += 1;
+  }
+  const recap = lines.slice(index, index + RECAP_LINE_COUNT);
   if (
     recap.length !== RECAP_LINE_COUNT ||
-    !RECAP_SHAPES.some((shapes) => shapes.every((shape, index) => shape.test(recap[index])))
+    !RECAP_SHAPES.some((shapes) => shapes.every((shape, offset) => shape.test(recap[offset])))
   ) {
     return null;
   }
-  let index = lines.length - RECAP_LINE_COUNT - 1;
-  while (index >= 0 && lines[index].trim() === '') {
-    index -= 1;
-  }
-  if (index !== markerIndexes[0]) {
-    return null;
-  }
-  const encoded = lines[index].match(STATE_MARKER)?.[1];
+  const encoded = lines[markerIndex].match(STATE_MARKER)?.[1];
   return encoded ? { encoded, recap } : null;
 }
 

--- a/.cursor/skills/review/scripts/review-report.test.mjs
+++ b/.cursor/skills/review/scripts/review-report.test.mjs
@@ -253,6 +253,27 @@ test('marker parsing keeps v1 compatibility and fails closed on malformed, forge
   assert.equal(parseReviewState(nonCompact), null);
 });
 
+test('review state survives closing prose appended after the operator recap', () => {
+  const valid = renderReviewReport(report());
+  const marker = valid.split('\n').find((line) => line.startsWith('<!-- pathfinder-review-state:'));
+  const expected = parseReviewState(valid);
+  assert.ok(expected);
+
+  // The community-pr gate ends a published community review with what happens
+  // next, which lands after the rendered report. That must not erase state.
+  const addendum = 'Next: this PR is from a fork, so its CI workflows are held pending maintainer authorization.';
+  assert.deepEqual(parseReviewState(`${valid}\n\n${addendum}`), expected);
+  assert.deepEqual(parseReviewState(`${valid}\n${addendum}`), expected);
+  assert.deepEqual(parseReviewState(`${valid}\n\n## Notes\n\n- ${addendum}\n`), expected);
+
+  // Adjacency between the marker and the recap is still what authenticates the
+  // marker, so an interposed line remains a hard reject.
+  assert.equal(parseReviewState(valid.replace(`${marker}\n\nPR Review:`, `${marker}\nextra\nPR Review:`)), null);
+
+  // Closing prose cannot smuggle a second marker in.
+  assert.equal(parseReviewState(`${valid}\n\n${addendum}\n${marker}`), null);
+});
+
 test('the renderer rejects marker injection, duplicate IDs, invalid state, and unknown fields', () => {
   const forged = '<!-- pathfinder-review-state:{} -->';
   assert.throws(

--- a/docs/design/PR_REVIEW.md
+++ b/docs/design/PR_REVIEW.md
@@ -251,7 +251,7 @@ Verdict: Request Changes
 Results: 1 blocker, 5 non-blocking findings, 2 follow-ups
 ```
 
-Nothing follows the results line. `Summary` is one line of at most 120 characters. `Verdict` is `Approve`, `Approve with Minor`, `Request Changes`, or `Review Incomplete`. Results count current rendered findings: suggestions plus nits are non-blocking findings, and carried deferred IDs without repeated prose are not follow-ups.
+The marker and the results recap must stay adjacent, in that order, separated only by blank lines - that adjacency is what authenticates the marker, so never interpose a line between them. A publisher may append its own closing prose after the recap; `--parse-state` reads state through it. `Summary` is one line of at most 120 characters. `Verdict` is `Approve`, `Approve with Minor`, `Request Changes`, or `Review Incomplete`. Results count current rendered findings: suggestions plus nits are non-blocking findings, and carried deferred IDs without repeated prose are not follow-ups.
 
 ### Debug trace
 


### PR DESCRIPTION
## Summary

`review-report.mjs --parse-state` returned `null` for any review body that carried prose after the four-line operator recap, even when the state marker and recap were intact and adjacent. The orchestrator reads that `null` as "no prior state" and silently runs a **full** review instead of an incremental one.

`trailingStateMarker` anchored the recap to the end of the body (`lines.slice(-RECAP_LINE_COUNT)`) and then required the marker to be the line immediately before it. So the end-of-body position, not the marker/recap relationship, was doing the load-bearing work.

This bites in practice: the `community-pr` gate ends a published community review with what happens next, which lands after the rendered report. Reviewing six community PRs in one sitting, **three** hit this and each incremental round degraded to a full review.

## What to look at

`trailingStateMarker` now anchors the recap to the **marker** rather than to the end of the body.

- Marker-then-recap adjacency is unchanged - that is what authenticates the marker against one quoted mid-prose, and an interposed line is still a hard reject.
- The single-marker rule is unchanged, so closing prose cannot smuggle a second marker in.
- Only the end-of-body coupling is dropped.

## Why

Silent degradation is the worst failure shape here: nothing errors, the review just costs several times more and re-reports settled findings. It also defeats the round-3+ rule that suppresses new nits, because without prior state every round looks like round 1.

## How to verify

`npm run test:review-contract` - 78 tests, one new.

The new test asserts state survives closing prose in three shapes, and pins both guards that must not regress (interposed line rejects; a second marker in the prose rejects). Reverting the `.mjs` change alone fails it.

Checked against the four real bodies that failed:

| body | before | after |
| --- | --- | --- |
| #1823 round 1 | fails | parses |
| #1824 round 1 | fails | parses |
| #1825 round 1 | fails | parses |
| #1809 round 2 | fails | **still fails, correctly** |

#1809's round-2 body had its recap *replaced* by hand-written prose. With no verdict/results pair there is nothing to cross-check `blocking_findings.length` against, so it stays fail-closed. That case is publisher discipline, not a parser bug, and is called out below.

## Breaking changes

None. Strictly widens what parses. Every previously-parsing body still parses identically, and all three fail-closed guards (single marker, adjacency, shape) are intact.

## Reversibility

Single function, no persisted state, no schema change. Revert restores the prior behaviour exactly.

## Follow-up not in this PR

The `community-pr` skill should self-check that an assembled body round-trips through `--parse-state` before publishing, which is what would have caught the #1809 shape. That skill lives outside this repo.

Generated with [Claude Code](https://claude.com/claude-code)
