### PR TITLE
fix: isolate progress reset for prefixed content keys

### DIFF
--- a/docs/developer/STEP_MODEL.md
+++ b/docs/developer/STEP_MODEL.md
@@ -26,7 +26,7 @@ The hash inputs are documented at `src/global-state/step-id.ts` (`deriveStepId(.
 
 ## Completion store — canonical persistence
 
-Step completion lives in `src/global-state/completion-store.ts`. The store is the canonical persistence layer — `SectionState` no longer carries a parallel `completed` set, and step components no longer maintain a local `isLocallyCompleted` flag. The store backs the existing `interactiveStepStorage` namespace so localStorage shape is preserved.
+Step completion lives in `src/global-state/completion-store.ts`. The store is the canonical persistence layer — `SectionState` no longer carries a parallel `completed` set, and step components no longer maintain a local `isLocallyCompleted` flag. The store uses `interactiveStepStorage`; untouched content keeps the legacy section-key shape, while a reset switches that content key to collision-safe length-prefixed section keys.
 
 The step-checker FSM (`src/requirements-manager/step-checker.hook.ts`) and the `SequentialRequirementsManager` orchestrator remain as mirrors of the store — they hold the in-memory checking state needed to drive the UI. The FSM writes through to the store on every terminal transition (manual completion, skipped, objectives auto-complete, and reset) via `writeStoreCompletion` / `writeStoreReset`, so the orchestration mirrors and the canonical store cannot disagree on either axis. The `step-checker.store-bridge.test.ts` tripwire pins this contract.
 
@@ -66,7 +66,8 @@ The completion store's caches (`entries`, `hydratedSections`, `hydrationVersion`
 A module-scope `storage` event listener (installed via `installCrossTabSync` at module init) reacts to cross-tab writes:
 
 1. `event.key === null` — another tab called `localStorage.clear()`; drop every in-memory cache via `evictAllContentCaches`.
-2. `event.key.startsWith(StorageKeys.INTERACTIVE_STEPS_PREFIX)` — another tab wrote a `(contentKey, sectionId)` slot; resolve the contentKey against the live set of active keys (`entries` ∪ `hydratedSections`), then `evictSectionCacheForKey` + `notify` so the subscriber re-hydrates from authoritative storage on the next render.
+2. `event.key.startsWith(StorageKeys.CONTENT_PROGRESS_V2_PREFIX)` — another tab switched one content key to versioned progress storage; match the exact marker key against known content keys, invalidate its count cache, and evict that content cache.
+3. `event.key.startsWith(StorageKeys.INTERACTIVE_STEPS_PREFIX)` — another tab wrote either a legacy or versioned `(contentKey, sectionId)` slot; reconstruct both exact key forms from the live set of active sections, then `evictSectionCacheForKey` + `notify` so the subscriber re-hydrates from authoritative storage on the next render.
 
 A per-section monotonic `hydrationVersion` counter closes the in-flight hydration race: every cache-clearing path bumps the version, and `ensureHydrated` snapshots the version at schedule time. When the storage read resolves, a mismatch indicates the cycle was invalidated (by an eviction or a fresh re-hydration kicked off by the listener) and the merge is dropped. This strictly supersedes the `!hydratedSections.has(key)` race guard — the version check also catches the case where a new `ensureHydrated` cycle has already re-added the key before the old `.then` runs.
 

--- a/src/components/docs-panel/hooks/resetGuideProgress.integration.test.tsx
+++ b/src/components/docs-panel/hooks/resetGuideProgress.integration.test.tsx
@@ -92,7 +92,9 @@ describe('resetGuideProgress integration', () => {
     try {
       await resetGuideProgress(E2E_GUIDE_URL);
 
-      e2eKeys.forEach((key) => expect(localStorage.getItem(key)).toBeNull());
+      // Legacy section keys remain physically present after reset; the per-content
+      // v2 marker makes them logically inactive without risking prefix collisions.
+      e2eKeys.forEach((key) => expect(localStorage.getItem(key)).toBe(JSON.stringify([STEP_ID])));
       expect(localStorage.getItem(otherGuideKey)).toBe(JSON.stringify([STEP_ID]));
       expect(JSON.parse(localStorage.getItem(StorageKeys.INTERACTIVE_COMPLETION) ?? '{}')).toEqual({
         [OTHER_GUIDE_URL]: 50,

--- a/src/global-state/completion-store.test.tsx
+++ b/src/global-state/completion-store.test.tsx
@@ -19,7 +19,7 @@ import {
 } from './completion-store';
 import { setActiveTabUrl, resetContentKeyForTests } from './content-key';
 import { subscribeProgressEvent, type ProgressEventDetail } from './progress-events';
-import { StorageKeys } from '../lib/storage-keys';
+import { StorageKeys, buildVersionedContentStorageKey, buildVersionedSectionStorageKey } from '../lib/storage-keys';
 
 // In-memory mocks for the persisted-storage layer so tests are hermetic
 // and synchronous-where-they-can-be.
@@ -550,6 +550,54 @@ describe('completion-store', () => {
       await flushMicrotasks();
       // Subscriber re-reads authoritative storage on the next render
       // and sees the empty set.
+      expect(screen.getByTestId('completed').textContent).toBe('false');
+    });
+
+    it('evicts the in-memory section cache for versioned storage keys', async () => {
+      render(<StepProbe stepId="step-1" sectionId="section-x" />);
+      act(() => markStepCompleted('step-1', 'section-x', 'manual'));
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('completed').textContent).toBe('true');
+
+      storedCompleted.delete(`${CONTENT_KEY}-section-x`);
+
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: buildVersionedSectionStorageKey(StorageKeys.INTERACTIVE_STEPS_PREFIX, CONTENT_KEY, 'section-x'),
+            newValue: null,
+            oldValue: '["step-1"]',
+          })
+        );
+      });
+
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('completed').textContent).toBe('false');
+    });
+
+    it('evicts the content cache when another tab switches the guide to versioned progress storage', async () => {
+      render(<StepProbe stepId="step-1" sectionId="section-x" />);
+      act(() => markStepCompleted('step-1', 'section-x', 'manual'));
+      await flushMicrotasks();
+
+      expect(screen.getByTestId('completed').textContent).toBe('true');
+
+      storedCompleted.delete(`${CONTENT_KEY}-section-x`);
+
+      act(() => {
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key: buildVersionedContentStorageKey(StorageKeys.CONTENT_PROGRESS_V2_PREFIX, CONTENT_KEY),
+            newValue: 'true',
+            oldValue: null,
+          })
+        );
+      });
+
+      await flushMicrotasks();
+
       expect(screen.getByTestId('completed').textContent).toBe('false');
     });
 

--- a/src/global-state/completion-store.ts
+++ b/src/global-state/completion-store.ts
@@ -2,9 +2,10 @@
  * Step completion store.
  *
  * Authoritative in-memory store for per-step completion, backed by
- * the existing `interactiveStepStorage` namespace so localStorage and
- * Grafana-user-storage shapes stay unchanged. Hydration is lazy and
- * scoped to the (contentKey, sectionId) the caller asks about.
+ * `interactiveStepStorage`. Existing guides keep reading their legacy
+ * keys until a reset switches that content key to collision-safe
+ * versioned section keys. Hydration is lazy and scoped to the
+ * (contentKey, sectionId) the caller asks about.
  *
  * Every step component subscribes via `useStepCompletion(stepId, sectionId)`
  * and writes via `markStepCompleted` / `resetStep`. Section-managed steps
@@ -34,7 +35,7 @@ import {
   sectionAcknowledgementStorage,
 } from '../lib/user-storage';
 import { StorageEvents } from '../lib/event-names';
-import { StorageKeys } from '../lib/storage-keys';
+import { StorageKeys, buildVersionedContentStorageKey, buildVersionedSectionStorageKey } from '../lib/storage-keys';
 import { logger } from '../lib/logging';
 
 import { getContentKey } from './content-key';
@@ -851,31 +852,53 @@ function handleStorageEvent(event: StorageEvent): void {
     evictAllContentCaches();
     return;
   }
+
+  if (event.key.startsWith(StorageKeys.CONTENT_PROGRESS_V2_PREFIX)) {
+    const knownContentKeys = new Set(entries.keys());
+
+    for (const hydratedKey of hydratedSections) {
+      const separator = hydratedKey.indexOf('::');
+      if (separator > 0) {
+        knownContentKeys.add(hydratedKey.slice(0, separator));
+      }
+    }
+
+    for (const contentKey of knownContentKeys) {
+      const markerKey = buildVersionedContentStorageKey(StorageKeys.CONTENT_PROGRESS_V2_PREFIX, contentKey);
+
+      if (event.key !== markerKey) {
+        continue;
+      }
+
+      interactiveStepStorage.invalidateCountCache(contentKey);
+      evictContentCache(contentKey);
+      return;
+    }
+
+    return;
+  }
+
   if (!event.key.startsWith(StorageKeys.INTERACTIVE_STEPS_PREFIX)) {
     return;
   }
-  // Key shape: `${INTERACTIVE_STEPS_PREFIX}${contentKey}-${sectionId}`.
-  // `contentKey` may contain hyphens (URLs, bundled paths), so naive
-  // prefix matching against a single `contentKey` would misroute when
-  // one active key is a prefix of another (e.g. `bundled:loki-101` and
-  // `bundled:loki-101-extended` both match an event for the longer
-  // key). Disambiguate by reconstructing each known
-  // `(contentKey, sectionId)` pair from `hydratedSections` and
-  // requiring an exact match. Every section with an in-memory cache
-  // passes through `ensureHydrated`, which adds the pair before the
-  // async read fires and keeps it until eviction, so in-flight
-  // hydration (the exact case the `hydrationVersion` guard exists for)
-  // is still represented here. Content keys we've never seen produce
-  // no match; the next render hydrates fresh.
-  const stripped = event.key.slice(StorageKeys.INTERACTIVE_STEPS_PREFIX.length);
+  // Step progress may use either the legacy `${contentKey}-${sectionId}`
+  // suffix or the collision-safe length-prefixed format. Because legacy
+  // keys are ambiguous when content keys share a prefix, match both forms
+  // against the exact (contentKey, sectionId) pairs already known to this
+  // store instead of trying to parse the key.
   for (const hydratedKey of hydratedSections) {
     const separator = hydratedKey.indexOf('::');
     if (separator <= 0) {
       continue;
     }
+
     const contentKey = hydratedKey.slice(0, separator);
     const sectionId = hydratedKey.slice(separator + 2);
-    if (`${contentKey}-${sectionId}` !== stripped) {
+
+    const legacyKey = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${contentKey}-${sectionId}`;
+    const versionedKey = buildVersionedSectionStorageKey(StorageKeys.INTERACTIVE_STEPS_PREFIX, contentKey, sectionId);
+
+    if (event.key !== legacyKey && event.key !== versionedKey) {
       continue;
     }
     evictSectionCacheForKey(contentKey, sectionId);

--- a/src/lib/storage-keys.test.ts
+++ b/src/lib/storage-keys.test.ts
@@ -10,7 +10,12 @@
  * When ADDING a new key, add it here too. When CHANGING an existing value, stop
  * and consider the migration implications before updating this test.
  */
-import { StorageKeys, buildAssistantStorageKey } from './storage-keys';
+import {
+  StorageKeys,
+  buildAssistantStorageKey,
+  buildVersionedContentStorageKey,
+  buildVersionedSectionStorageKey,
+} from './storage-keys';
 
 describe('StorageKeys — stable string contract', () => {
   it('matches the locked key values exactly', () => {
@@ -21,6 +26,7 @@ describe('StorageKeys — stable string contract', () => {
       TABS: 'grafana-pathfinder-app-tabs',
       ACTIVE_TAB: 'grafana-pathfinder-app-active-tab',
       INTERACTIVE_STEPS_PREFIX: 'grafana-pathfinder-app-interactive-steps-',
+      CONTENT_PROGRESS_V2_PREFIX: 'grafana-pathfinder-app-content-progress-v2:',
       WYSIWYG_PREVIEW: 'grafana-pathfinder-app-wysiwyg-preview',
       WYSIWYG_PREVIEW_JSON: 'grafana-pathfinder-app-wysiwyg-preview-json',
       E2E_TEST_GUIDE: 'grafana-pathfinder-app-e2e-test-guide',
@@ -81,5 +87,10 @@ describe('StorageKeys — stable string contract', () => {
 
   it('builds the assistant customization key from the prefix', () => {
     expect(buildAssistantStorageKey('my-content', 'asst-1')).toBe('pathfinder-assistant-my-content-asst-1');
+  });
+
+  it('builds collision-safe versioned storage keys', () => {
+    expect(buildVersionedContentStorageKey('progress:', 'guide-a')).toBe('progress:7:guide-a');
+    expect(buildVersionedSectionStorageKey('steps:', 'guide-a', 'section-1')).toBe('steps:7:guide-a:section-1');
   });
 });

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -13,7 +13,8 @@ export const StorageKeys = {
   INTERACTIVE_COMPLETION: 'grafana-pathfinder-app-interactive-completion', // Stores completion percentage by contentKey
   TABS: 'grafana-pathfinder-app-tabs',
   ACTIVE_TAB: 'grafana-pathfinder-app-active-tab',
-  INTERACTIVE_STEPS_PREFIX: 'grafana-pathfinder-app-interactive-steps-', // Dynamic: grafana-pathfinder-app-interactive-steps-{contentKey}-{sectionId}
+  INTERACTIVE_STEPS_PREFIX: 'grafana-pathfinder-app-interactive-steps-', // Legacy prefix; reset guides use versioned section keys.
+  CONTENT_PROGRESS_V2_PREFIX: 'grafana-pathfinder-app-content-progress-v2:',
   WYSIWYG_PREVIEW: 'grafana-pathfinder-app-wysiwyg-preview', // HTML content for editor persistence
   WYSIWYG_PREVIEW_JSON: 'grafana-pathfinder-app-wysiwyg-preview-json', // JSON content for test preview
   E2E_TEST_GUIDE: 'grafana-pathfinder-app-e2e-test-guide', // JSON content for E2E test runner
@@ -104,4 +105,12 @@ export type StorageKeyValue = (typeof StorageKeys)[StorageKeyName];
  */
 export function buildAssistantStorageKey(contentKey: string, assistantId: string): string {
   return `${StorageKeys.ASSISTANT_CUSTOMIZATION_PREFIX}${contentKey}-${assistantId}`;
+}
+
+export function buildVersionedSectionStorageKey(prefix: string, contentKey: string, sectionId: string): string {
+  return `${prefix}${contentKey.length}:${contentKey}:${sectionId}`;
+}
+
+export function buildVersionedContentStorageKey(prefix: string, contentKey: string): string {
+  return `${prefix}${contentKey.length}:${contentKey}`;
 }

--- a/src/lib/user-storage.test.ts
+++ b/src/lib/user-storage.test.ts
@@ -8,6 +8,8 @@ import {
   journeyCompletionStorage,
   milestoneCompletionStorage,
   sectionAcknowledgementStorage,
+  sectionCollapseStorage,
+  sectionDoneStorage,
   tabStorage,
   unwrapEnvelope,
   wrapEnvelope,
@@ -397,10 +399,10 @@ describe('sectionAcknowledgementStorage.countAllAcknowledged', () => {
 });
 
 // ============================================================================
-// interactiveStepStorage.clearAllForContent — ack-prefix sweep TESTS
+// interactiveStepStorage.clearAllForContent — content-key isolation tests
 // ============================================================================
 
-describe('interactiveStepStorage.clearAllForContent — ack prefix sweep (#842)', () => {
+describe('interactiveStepStorage.clearAllForContent — content-key isolation (#1846)', () => {
   beforeEach(() => {
     localStorage.clear();
   });
@@ -423,6 +425,59 @@ describe('interactiveStepStorage.clearAllForContent — ack prefix sweep (#842)'
 
     expect(await sectionAcknowledgementStorage.get('guide-a', 'section-1')).toBeNull();
     expect(await sectionAcknowledgementStorage.get('guide-b', 'section-1')).toBe(true);
+  });
+
+  it('does not remove progress when another content key shares its prefix', async () => {
+    const target = 'bundled:welcome-to-grafana';
+    const sibling = 'bundled:welcome-to-grafana-cloud';
+    const sectionId = 'section-1';
+
+    await interactiveStepStorage.setCompleted(target, sectionId, new Set(['step-1']));
+    await sectionCollapseStorage.set(target, sectionId, true);
+    await sectionAcknowledgementStorage.set(target, sectionId, true);
+    await sectionDoneStorage.set(target, sectionId, true);
+
+    await interactiveStepStorage.setCompleted(sibling, sectionId, new Set(['step-1']));
+    await sectionCollapseStorage.set(sibling, sectionId, true);
+    await sectionAcknowledgementStorage.set(sibling, sectionId, true);
+    await sectionDoneStorage.set(sibling, sectionId, true);
+
+    await interactiveStepStorage.clearAllForContent(target);
+
+    expect(await interactiveStepStorage.getCompleted(target, sectionId)).toEqual(new Set());
+    expect(await sectionCollapseStorage.get(target, sectionId)).toBe(false);
+    expect(await sectionAcknowledgementStorage.get(target, sectionId)).toBeNull();
+    expect(await sectionDoneStorage.get(target, sectionId)).toBeNull();
+
+    expect(await interactiveStepStorage.getCompleted(sibling, sectionId)).toEqual(new Set(['step-1']));
+    expect(await sectionCollapseStorage.get(sibling, sectionId)).toBe(true);
+    expect(await sectionAcknowledgementStorage.get(sibling, sectionId)).toBe(true);
+    expect(await sectionDoneStorage.get(sibling, sectionId)).toBe(true);
+  });
+
+  it('clears versioned progress on subsequent resets without affecting a prefix-sharing sibling', async () => {
+    const target = 'bundled:welcome-to-grafana';
+    const sibling = 'bundled:welcome-to-grafana-cloud';
+    const sectionId = 'section-1';
+
+    await interactiveStepStorage.setCompleted(target, sectionId, new Set(['legacy-step']));
+    await interactiveStepStorage.setCompleted(sibling, sectionId, new Set(['sibling-step']));
+
+    await interactiveStepStorage.clearAllForContent(target);
+
+    await interactiveStepStorage.setCompleted(target, sectionId, new Set(['versioned-step']));
+    await sectionCollapseStorage.set(target, sectionId, true);
+    await sectionAcknowledgementStorage.set(target, sectionId, true);
+    await sectionDoneStorage.set(target, sectionId, true);
+
+    await interactiveStepStorage.clearAllForContent(target);
+
+    expect(await interactiveStepStorage.getCompleted(target, sectionId)).toEqual(new Set());
+    expect(await sectionCollapseStorage.get(target, sectionId)).toBe(false);
+    expect(await sectionAcknowledgementStorage.get(target, sectionId)).toBeNull();
+    expect(await sectionDoneStorage.get(target, sectionId)).toBeNull();
+
+    expect(await interactiveStepStorage.getCompleted(sibling, sectionId)).toEqual(new Set(['sibling-step']));
   });
 });
 

--- a/src/lib/user-storage.ts
+++ b/src/lib/user-storage.ts
@@ -46,7 +46,7 @@ import { StorageEvents } from './event-names';
 import { getLearningJourneyBaseUrl } from './learning-journey-url';
 import { logger } from './logging';
 import { createBoundedRecordStorage } from './storage/bounded-record-storage';
-import { StorageKeys } from './storage-keys';
+import { StorageKeys, buildVersionedContentStorageKey, buildVersionedSectionStorageKey } from './storage-keys';
 
 // ============================================================================
 // LEARNING PROGRESS SCHEMA (for defense-in-depth validation)
@@ -109,6 +109,30 @@ const TIMESTAMP_SUFFIX = '__timestamp';
  */
 function getTimestampKey(key: string): string {
   return `${key}${TIMESTAMP_SUFFIX}`;
+}
+
+function getContentProgressV2MarkerKey(contentKey: string): string {
+  return buildVersionedContentStorageKey(StorageKeys.CONTENT_PROGRESS_V2_PREFIX, contentKey);
+}
+
+function usesVersionedProgressStorage(contentKey: string): boolean {
+  try {
+    return localStorage.getItem(getContentProgressV2MarkerKey(contentKey)) !== null;
+  } catch {
+    return false;
+  }
+}
+
+function buildProgressSectionStorageKey(prefix: string, contentKey: string, sectionId: string): string {
+  return usesVersionedProgressStorage(contentKey)
+    ? buildVersionedSectionStorageKey(prefix, contentKey, sectionId)
+    : `${prefix}${contentKey}-${sectionId}`;
+}
+
+function buildProgressContentStoragePrefix(prefix: string, contentKey: string): string {
+  return usesVersionedProgressStorage(contentKey)
+    ? `${buildVersionedContentStorageKey(prefix, contentKey)}:`
+    : `${prefix}${contentKey}-`;
 }
 
 // ============================================================================
@@ -969,7 +993,7 @@ export const interactiveStepStorage = {
   async getCompleted(contentKey: string, sectionId: string): Promise<Set<string>> {
     try {
       const storage = createUserStorage();
-      const key = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.INTERACTIVE_STEPS_PREFIX, contentKey, sectionId);
       const ids = await storage.getItem<string[]>(key);
       return new Set(ids || []);
     } catch {
@@ -985,7 +1009,7 @@ export const interactiveStepStorage = {
       // Invalidate count cache before write so next countAllCompleted() re-scans
       completedCountCache.delete(contentKey);
       const storage = createUserStorage();
-      const key = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.INTERACTIVE_STEPS_PREFIX, contentKey, sectionId);
       await storage.setItem(key, Array.from(completedIds));
     } catch (error) {
       logger.warn('Failed to save completed steps', { error });
@@ -999,7 +1023,7 @@ export const interactiveStepStorage = {
     try {
       completedCountCache.delete(contentKey);
       const storage = createUserStorage();
-      const key = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.INTERACTIVE_STEPS_PREFIX, contentKey, sectionId);
       await storage.removeItem(key);
     } catch (error) {
       logger.warn('Failed to clear completed steps', { error });
@@ -1011,7 +1035,7 @@ export const interactiveStepStorage = {
    */
   async hasProgress(contentKey: string): Promise<boolean> {
     try {
-      const prefix = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${contentKey}-`;
+      const prefix = buildProgressContentStoragePrefix(StorageKeys.INTERACTIVE_STEPS_PREFIX, contentKey);
       // Check localStorage directly for keys matching the prefix
       for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
@@ -1036,23 +1060,29 @@ export const interactiveStepStorage = {
   },
 
   /**
-   * Clear all progress for a content key (all sections)
-   * Also clears section collapse states for the same content
+   * Clears all logical section progress for one content key.
+   *
+   * Legacy section keys are intentionally left in place because their
+   * `${contentKey}-${sectionId}` suffix is ambiguous when content keys
+   * share a prefix. The per-content v2 marker makes subsequent reads ignore
+   * those legacy entries and use collision-safe length-prefixed keys.
    */
   async clearAllForContent(contentKey: string): Promise<void> {
     try {
       completedCountCache.delete(contentKey);
-      const stepsPrefix = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${contentKey}-`;
-      const collapsePrefix = `${StorageKeys.SECTION_COLLAPSE_PREFIX}${contentKey}-`;
-      const ackPrefix = `${StorageKeys.SECTION_ACKNOWLEDGED_PREFIX}${contentKey}-`;
-      const donePrefix = `${StorageKeys.SECTION_DONE_PREFIX}${contentKey}-`;
+      const storage = createUserStorage();
 
-      // Find and remove all matching keys
+      const stepsPrefix = `${buildVersionedContentStorageKey(StorageKeys.INTERACTIVE_STEPS_PREFIX, contentKey)}:`;
+      const collapsePrefix = `${buildVersionedContentStorageKey(StorageKeys.SECTION_COLLAPSE_PREFIX, contentKey)}:`;
+      const ackPrefix = `${buildVersionedContentStorageKey(StorageKeys.SECTION_ACKNOWLEDGED_PREFIX, contentKey)}:`;
+      const donePrefix = `${buildVersionedContentStorageKey(StorageKeys.SECTION_DONE_PREFIX, contentKey)}:`;
+
       const keysToRemove: string[] = [];
       for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
         if (
           key &&
+          !key.endsWith(TIMESTAMP_SUFFIX) &&
           (key.startsWith(stepsPrefix) ||
             key.startsWith(collapsePrefix) ||
             key.startsWith(ackPrefix) ||
@@ -1062,8 +1092,8 @@ export const interactiveStepStorage = {
         }
       }
 
-      // Remove all matching keys
-      keysToRemove.forEach((key) => localStorage.removeItem(key));
+      await Promise.all(keysToRemove.map((key) => storage.removeItem(key)));
+      await storage.setItem(getContentProgressV2MarkerKey(contentKey), true);
     } catch (error) {
       logger.warn('Failed to clear all progress for content', { error });
     }
@@ -1117,7 +1147,7 @@ export const interactiveStepStorage = {
     }
 
     try {
-      const prefix = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${contentKey}-`;
+      const prefix = buildProgressContentStoragePrefix(StorageKeys.INTERACTIVE_STEPS_PREFIX, contentKey);
       let total = 0;
       for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
@@ -1157,7 +1187,7 @@ export const sectionCollapseStorage = {
   async get(contentKey: string, sectionId: string): Promise<boolean> {
     try {
       const storage = createUserStorage();
-      const key = `${StorageKeys.SECTION_COLLAPSE_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.SECTION_COLLAPSE_PREFIX, contentKey, sectionId);
       const isCollapsed = await storage.getItem<boolean>(key);
       return isCollapsed ?? false; // Default to expanded (false)
     } catch {
@@ -1171,7 +1201,7 @@ export const sectionCollapseStorage = {
   async set(contentKey: string, sectionId: string, isCollapsed: boolean): Promise<void> {
     try {
       const storage = createUserStorage();
-      const key = `${StorageKeys.SECTION_COLLAPSE_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.SECTION_COLLAPSE_PREFIX, contentKey, sectionId);
       await storage.setItem(key, isCollapsed);
     } catch (error) {
       logger.warn('Failed to save section collapse state', { error });
@@ -1184,7 +1214,7 @@ export const sectionCollapseStorage = {
   async clear(contentKey: string, sectionId: string): Promise<void> {
     try {
       const storage = createUserStorage();
-      const key = `${StorageKeys.SECTION_COLLAPSE_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.SECTION_COLLAPSE_PREFIX, contentKey, sectionId);
       await storage.removeItem(key);
     } catch (error) {
       logger.warn('Failed to clear section collapse state', { error });
@@ -1220,7 +1250,7 @@ export const sectionAcknowledgementStorage = {
   async get(contentKey: string, sectionId: string): Promise<true | null> {
     try {
       const storage = createUserStorage();
-      const key = `${StorageKeys.SECTION_ACKNOWLEDGED_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.SECTION_ACKNOWLEDGED_PREFIX, contentKey, sectionId);
       const acknowledged = await storage.getItem<boolean>(key);
       return acknowledged === true ? true : null;
     } catch {
@@ -1237,7 +1267,7 @@ export const sectionAcknowledgementStorage = {
   async set(contentKey: string, sectionId: string, isAcknowledged: true): Promise<void> {
     try {
       const storage = createUserStorage();
-      const key = `${StorageKeys.SECTION_ACKNOWLEDGED_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.SECTION_ACKNOWLEDGED_PREFIX, contentKey, sectionId);
       await storage.setItem(key, isAcknowledged);
     } catch (error) {
       logger.warn('Failed to save section acknowledgement state', { error });
@@ -1253,7 +1283,7 @@ export const sectionAcknowledgementStorage = {
   async clear(contentKey: string, sectionId: string): Promise<void> {
     try {
       const storage = createUserStorage();
-      const key = `${StorageKeys.SECTION_ACKNOWLEDGED_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.SECTION_ACKNOWLEDGED_PREFIX, contentKey, sectionId);
       await storage.removeItem(key);
     } catch (error) {
       logger.warn('Failed to clear section acknowledgement state', { error });
@@ -1268,7 +1298,7 @@ export const sectionAcknowledgementStorage = {
    */
   countAllAcknowledged(contentKey: string): number {
     try {
-      const prefix = `${StorageKeys.SECTION_ACKNOWLEDGED_PREFIX}${contentKey}-`;
+      const prefix = buildProgressContentStoragePrefix(StorageKeys.SECTION_ACKNOWLEDGED_PREFIX, contentKey);
       let count = 0;
       for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
@@ -1307,7 +1337,7 @@ export const sectionDoneStorage = {
   async get(contentKey: string, sectionId: string): Promise<true | null> {
     try {
       const storage = createUserStorage();
-      const key = `${StorageKeys.SECTION_DONE_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.SECTION_DONE_PREFIX, contentKey, sectionId);
       const done = await storage.getItem<boolean>(key);
       return done === true ? true : null;
     } catch {
@@ -1318,7 +1348,7 @@ export const sectionDoneStorage = {
   async set(contentKey: string, sectionId: string, isDone: true): Promise<void> {
     try {
       const storage = createUserStorage();
-      const key = `${StorageKeys.SECTION_DONE_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.SECTION_DONE_PREFIX, contentKey, sectionId);
       await storage.setItem(key, isDone);
     } catch (error) {
       logger.warn('Failed to save section done state', { error });
@@ -1328,7 +1358,7 @@ export const sectionDoneStorage = {
   async clear(contentKey: string, sectionId: string): Promise<void> {
     try {
       const storage = createUserStorage();
-      const key = `${StorageKeys.SECTION_DONE_PREFIX}${contentKey}-${sectionId}`;
+      const key = buildProgressSectionStorageKey(StorageKeys.SECTION_DONE_PREFIX, contentKey, sectionId);
       await storage.removeItem(key);
     } catch (error) {
       logger.warn('Failed to clear section done state', { error });

--- a/tests/e2e-runner/utils/guide-runner/milestone-replacement.test.ts
+++ b/tests/e2e-runner/utils/guide-runner/milestone-replacement.test.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import type { ElementHandle, Page } from '@playwright/test';
 
 import { testIds } from '../../../../src/constants/testIds';
-import { StorageKeys } from '../../../../src/lib/storage-keys';
+import { StorageKeys, buildVersionedContentStorageKey } from '../../../../src/lib/storage-keys';
 
 import { dismissBadgeCelebrations } from './badge-celebrations';
 import { STEP_ROOT_SELECTOR } from './constants';
@@ -60,8 +60,16 @@ function seedNoCompletionResidue(): void {
 }
 
 function expectMatchingStorageEmpty(): void {
-  expect(Object.values(E2E_STORAGE_KEYS).every((key) => localStorage.getItem(key) === null)).toBe(true);
-  expect(JSON.parse(localStorage.getItem(StorageKeys.INTERACTIVE_COMPLETION) ?? '{}')).toEqual({ other: 50 });
+  const markerKey = buildVersionedContentStorageKey(StorageKeys.CONTENT_PROGRESS_V2_PREFIX, E2E_GUIDE_URL);
+
+  const legacyStorageIsInactive =
+    localStorage.getItem(markerKey) !== null ||
+    Object.values(E2E_STORAGE_KEYS).every((key) => localStorage.getItem(key) === null);
+
+  expect(legacyStorageIsInactive).toBe(true);
+  expect(JSON.parse(localStorage.getItem(StorageKeys.INTERACTIVE_COMPLETION) ?? '{}')).toEqual({
+    other: 50,
+  });
 }
 
 interface ReplacementHarnessOptions {
@@ -285,6 +293,24 @@ it('uses the plugin reset capability when only no-completion residue exists', as
 
   expect(harness.operations).toEqual(['capability-reset', 'close']);
   expectMatchingStorageEmpty();
+});
+
+it('preserves legacy progress for a sibling guide whose content key shares the E2E guide prefix', async () => {
+  const siblingKey = `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${E2E_GUIDE_URL}-cloud-section-1`;
+  const siblingValue = JSON.stringify(['step-1']);
+
+  localStorage.setItem(siblingKey, siblingValue);
+
+  const harness = replacementHarness({
+    resetControlCount: 0,
+  });
+
+  (window as Window & { __DocsPluginActiveTabId?: string }).__DocsPluginActiveTabId = '';
+  (window as Window & { __DocsPluginActiveTabUrl?: string }).__DocsPluginActiveTabUrl = '';
+
+  await replacePreviousE2EGuide(harness.page);
+
+  expect(localStorage.getItem(siblingKey)).toBe(siblingValue);
 });
 
 it('fails fatally when the plugin reset capability rejects reset', async () => {
@@ -527,7 +553,7 @@ it('accepts and clears safe residue recreated after reset acknowledgment', async
   expectMatchingStorageEmpty();
 });
 
-it('ignores and removes a hybrid-storage timestamp companion after legacy reset', async () => {
+it('ignores a legacy hybrid-storage timestamp companion after reset', async () => {
   seedStoredCompletion();
   const timestampKey = `${E2E_STORAGE_KEYS.steps}__timestamp`;
   localStorage.setItem(timestampKey, '1757060000000');
@@ -537,7 +563,7 @@ it('ignores and removes a hybrid-storage timestamp companion after legacy reset'
 
   expect(harness.operations).toEqual(['reset', 'close']);
   expectMatchingStorageEmpty();
-  expect(localStorage.getItem(timestampKey)).toBeNull();
+  expect(localStorage.getItem(timestampKey)).toBe('1757060000000');
 });
 
 it('preserves malformed shared completion data and requires the reset path', async () => {

--- a/tests/e2e-runner/utils/guide-runner/milestone-replacement.ts
+++ b/tests/e2e-runner/utils/guide-runner/milestone-replacement.ts
@@ -2,7 +2,7 @@ import type { ElementHandle, Page } from '@playwright/test';
 
 import { testIds } from '../../../../src/constants/testIds';
 import { StorageEvents } from '../../../../src/lib/event-names';
-import { StorageKeys } from '../../../../src/lib/storage-keys';
+import { StorageKeys, buildVersionedContentStorageKey } from '../../../../src/lib/storage-keys';
 import { dismissBadgeCelebrations } from './badge-celebrations';
 import { STEP_ROOT_SELECTOR } from './constants';
 import { FatalTransitionError, type FatalTransitionKind } from './transition-error';
@@ -37,15 +37,28 @@ async function activeGuideTab(page: Page): Promise<{ id: string; url: string }> 
 }
 
 async function inspectE2EProgressStorage(page: Page): Promise<E2EProgressStorageState> {
+  const legacyPrefixes = {
+    steps: `${StorageKeys.INTERACTIVE_STEPS_PREFIX}${E2E_GUIDE_URL}-`,
+    collapse: `${StorageKeys.SECTION_COLLAPSE_PREFIX}${E2E_GUIDE_URL}-`,
+    acknowledged: `${StorageKeys.SECTION_ACKNOWLEDGED_PREFIX}${E2E_GUIDE_URL}-`,
+    done: `${StorageKeys.SECTION_DONE_PREFIX}${E2E_GUIDE_URL}-`,
+  };
+
+  const versionedPrefixes = {
+    steps: `${buildVersionedContentStorageKey(StorageKeys.INTERACTIVE_STEPS_PREFIX, E2E_GUIDE_URL)}:`,
+    collapse: `${buildVersionedContentStorageKey(StorageKeys.SECTION_COLLAPSE_PREFIX, E2E_GUIDE_URL)}:`,
+    acknowledged: `${buildVersionedContentStorageKey(StorageKeys.SECTION_ACKNOWLEDGED_PREFIX, E2E_GUIDE_URL)}:`,
+    done: `${buildVersionedContentStorageKey(StorageKeys.SECTION_DONE_PREFIX, E2E_GUIDE_URL)}:`,
+  };
+
+  const markerKey = buildVersionedContentStorageKey(StorageKeys.CONTENT_PROGRESS_V2_PREFIX, E2E_GUIDE_URL);
+
   return page.evaluate(
-    ({ contentKey, keys, timestampSuffix }) => {
-      const stepsPrefix = `${keys.stepsPrefix}${contentKey}-`;
-      const matchingPrefixes = [
-        stepsPrefix,
-        `${keys.collapsePrefix}${contentKey}-`,
-        `${keys.acknowledgedPrefix}${contentKey}-`,
-        `${keys.donePrefix}${contentKey}-`,
-      ];
+    ({ contentKey, completionKey, timestampSuffix, markerKey, legacyPrefixes, versionedPrefixes }) => {
+      const prefixes = localStorage.getItem(markerKey) !== null ? versionedPrefixes : legacyPrefixes;
+
+      const matchingPrefixes = [prefixes.steps, prefixes.collapse, prefixes.acknowledged, prefixes.done];
+
       let hasStoredCompletion = false;
       let hasMatchingStorage = false;
 
@@ -54,10 +67,13 @@ async function inspectE2EProgressStorage(page: Page): Promise<E2EProgressStorage
         if (!key || key.endsWith(timestampSuffix) || !matchingPrefixes.some((prefix) => key.startsWith(prefix))) {
           continue;
         }
+
         hasMatchingStorage = true;
-        if (!key.startsWith(stepsPrefix)) {
+
+        if (!key.startsWith(prefixes.steps)) {
           continue;
         }
+
         const value = localStorage.getItem(key);
         try {
           const completedIds = value ? JSON.parse(value) : [];
@@ -67,10 +83,11 @@ async function inspectE2EProgressStorage(page: Page): Promise<E2EProgressStorage
         } catch {
           // A malformed step value is ambiguous and requires the mounted reset path.
         }
+
         hasStoredCompletion = true;
       }
 
-      const completionValue = localStorage.getItem(keys.completion);
+      const completionValue = localStorage.getItem(completionKey);
       if (completionValue) {
         try {
           const completion = JSON.parse(completionValue);
@@ -92,14 +109,11 @@ async function inspectE2EProgressStorage(page: Page): Promise<E2EProgressStorage
     },
     {
       contentKey: E2E_GUIDE_URL,
-      keys: {
-        stepsPrefix: StorageKeys.INTERACTIVE_STEPS_PREFIX,
-        collapsePrefix: StorageKeys.SECTION_COLLAPSE_PREFIX,
-        acknowledgedPrefix: StorageKeys.SECTION_ACKNOWLEDGED_PREFIX,
-        donePrefix: StorageKeys.SECTION_DONE_PREFIX,
-        completion: StorageKeys.INTERACTIVE_COMPLETION,
-      },
+      completionKey: StorageKeys.INTERACTIVE_COMPLETION,
       timestampSuffix: HYBRID_STORAGE_TIMESTAMP_SUFFIX,
+      markerKey,
+      legacyPrefixes,
+      versionedPrefixes,
     }
   );
 }
@@ -204,42 +218,51 @@ async function requireEmptyE2EProgressStorage(page: Page): Promise<void> {
 }
 
 async function clearNoCompletionResidue(page: Page): Promise<void> {
+  const markerKey = buildVersionedContentStorageKey(StorageKeys.CONTENT_PROGRESS_V2_PREFIX, E2E_GUIDE_URL);
+
+  const versionedPrefixes = [
+    StorageKeys.INTERACTIVE_STEPS_PREFIX,
+    StorageKeys.SECTION_COLLAPSE_PREFIX,
+    StorageKeys.SECTION_ACKNOWLEDGED_PREFIX,
+    StorageKeys.SECTION_DONE_PREFIX,
+  ].map((prefix) => `${buildVersionedContentStorageKey(prefix, E2E_GUIDE_URL)}:`);
+
   await page.evaluate(
-    ({ contentKey, keys }) => {
-      const prefixes = [keys.stepsPrefix, keys.collapsePrefix, keys.acknowledgedPrefix, keys.donePrefix].map(
-        (prefix) => `${prefix}${contentKey}-`
-      );
+    ({ contentKey, completionKey, markerKey, versionedPrefixes }) => {
       const keysToRemove: string[] = [];
+
       for (let index = 0; index < localStorage.length; index++) {
         const key = localStorage.key(index);
-        if (key && prefixes.some((prefix) => key.startsWith(prefix))) {
+        if (key && versionedPrefixes.some((prefix) => key.startsWith(prefix))) {
           keysToRemove.push(key);
         }
       }
+
       keysToRemove.forEach((key) => localStorage.removeItem(key));
 
-      const completionValue = localStorage.getItem(keys.completion);
+      // Legacy section keys cannot be deleted safely because content keys may
+      // share a prefix. Switching this content key to v2 makes those entries
+      // logically inactive while preserving sibling-guide progress.
+      localStorage.setItem(markerKey, 'true');
+
+      const completionValue = localStorage.getItem(completionKey);
       if (completionValue) {
         try {
           const completion = JSON.parse(completionValue);
           if (completion && typeof completion === 'object' && !Array.isArray(completion)) {
             delete completion[contentKey];
-            localStorage.setItem(keys.completion, JSON.stringify(completion));
+            localStorage.setItem(completionKey, JSON.stringify(completion));
           }
         } catch {
-          localStorage.removeItem(keys.completion);
+          localStorage.removeItem(completionKey);
         }
       }
     },
     {
       contentKey: E2E_GUIDE_URL,
-      keys: {
-        stepsPrefix: StorageKeys.INTERACTIVE_STEPS_PREFIX,
-        collapsePrefix: StorageKeys.SECTION_COLLAPSE_PREFIX,
-        acknowledgedPrefix: StorageKeys.SECTION_ACKNOWLEDGED_PREFIX,
-        donePrefix: StorageKeys.SECTION_DONE_PREFIX,
-        completion: StorageKeys.INTERACTIVE_COMPLETION,
-      },
+      completionKey: StorageKeys.INTERACTIVE_COMPLETION,
+      markerKey,
+      versionedPrefixes,
     }
   );
 }


### PR DESCRIPTION
## What does this PR do?

Fixes progress resets deleting data for guides whose content keys share a prefix.

Previously, `clearAllForContent()` removed section progress by scanning legacy localStorage keys with a `${contentKey}-` prefix. This could incorrectly match another guide, for example:

- `bundled:welcome-to-grafana`
- `bundled:welcome-to-grafana-cloud`

This PR introduces collision-safe, length-prefixed section keys for content after it has been reset.

Existing guides continue to read their legacy keys until reset. On reset, a per-content v2 marker switches that guide to the versioned key format, making its legacy entries logically inactive without deleting potentially overlapping sibling-guide data.

The change also updates cross-tab cache invalidation and the E2E guide cleanup path to understand the versioned storage format.

Regression coverage verifies that:

- resetting a guide does not remove progress from a prefix-sharing sibling
- step, collapse, acknowledgement, and section-done state remain isolated
- progress written after migration is cleared correctly by subsequent resets
- cross-tab storage events invalidate versioned progress correctly

## Linked issue(s)

Closes #1846

## Checklist

- [x] This PR addresses a **single concern** (one bug fix or feature, or a set of closely-related changes). Unrelated changes belong in separate PRs; see [CONTRIBUTING.md](./CONTRIBUTING.md#pull-request-scope).
- [x] All commits are signed (required, or the checks will not pass). See [CONTRIBUTING.md](./CONTRIBUTING.md#signed-commits).
- [x] I've added or updated tests for the change.
- [x] `npm run check` passes locally — the pre-merge gate.
- [x] UI text and docs use [sentence case](https://grafana.com/docs/writers-toolkit/write/style-guide/capitalization-punctuation/#capitalization).