### PR TITLE
fix(interactive): forward objectives and hints into useStepChecker

### DIFF
--- a/docs/developer/interactive-examples/json-guide-format.md
+++ b/docs/developer/interactive-examples/json-guide-format.md
@@ -1009,6 +1009,7 @@ A code snippet with copy-to-clipboard and (in supported contexts) an Insert butt
 | `requirements` | string[] | ❌       | Conditions that must be met for this step                              |
 | `objectives`   | string[] | ❌       | Conditions that auto-complete this step when already satisfied         |
 | `skippable`    | boolean  | ❌       | Allow skipping                                                         |
+| `hint`         | string   | ❌       | Hint shown when step cannot be completed                               |
 
 #### Terminal Block
 
@@ -1028,6 +1029,7 @@ A shell command shown with copy-to-clipboard and an "Execute" button that runs t
 | `command`      | string   | ✅       | The shell command                                           |
 | `requirements` | string[] | ❌       | Conditions that must be met (commonly `is-terminal-active`) |
 | `skippable`    | boolean  | ❌       | Allow skipping                                              |
+| `hint`         | string   | ❌       | Hint shown when step cannot be completed                    |
 
 Terminal blocks only render in the docs panel when the administrator has enabled the Coda terminal integration.
 

--- a/src/components/interactive-tutorial/code-block-step.test.tsx
+++ b/src/components/interactive-tutorial/code-block-step.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { CodeBlockStep } from './code-block-step';
 
 const mockClearAndInsertCode = jest.fn();
@@ -27,6 +27,29 @@ describe('CodeBlockStep: currentCode resync with the code prop', () => {
     rerender(<CodeBlockStep code="query_range(node_cpu_seconds_total)" refTarget="#editor" />);
 
     expect(container.querySelector('code')).toHaveTextContent('query_range(node_cpu_seconds_total)');
+  });
+});
+
+describe('CodeBlockStep: hints', () => {
+  const UNSATISFIABLE_REQUIREMENT = 'on-page:/pathfinder-code-block-never-here';
+
+  it('explains an unmet requirement with the authored hint', async () => {
+    render(
+      <CodeBlockStep
+        code="query_range(up)"
+        refTarget="#editor"
+        requirements={UNSATISFIABLE_REQUIREMENT}
+        hints="Open the Explore query editor before inserting this query."
+      />
+    );
+
+    expect(await screen.findByText('Open the Explore query editor before inserting this query.')).toBeInTheDocument();
+  });
+
+  it('falls back to the generic requirement message when no hint is authored', async () => {
+    render(<CodeBlockStep code="query_range(up)" refTarget="#editor" requirements={UNSATISFIABLE_REQUIREMENT} />);
+
+    expect(await screen.findByText(/Navigate to the .* page first/)).toBeInTheDocument();
   });
 });
 

--- a/src/components/interactive-tutorial/code-block-step.tsx
+++ b/src/components/interactive-tutorial/code-block-step.tsx
@@ -178,6 +178,7 @@ export const CodeBlockStep = forwardRef<
     const checker = useStepChecker({
       requirements: requirements || '',
       objectives: objectives || '',
+      hints,
       targetAction: 'noop',
       refTarget: '',
       stepId: renderedStepId,

--- a/src/components/interactive-tutorial/interactive-step.test.tsx
+++ b/src/components/interactive-tutorial/interactive-step.test.tsx
@@ -6,6 +6,7 @@ import { ControllerChannelProvider } from '../../global-state/controller-channel
 import { TEST_PAIRING } from '../../test-utils/fake-cross-tab-transport';
 import { createPairingAcceptProof } from '../../lib/pairing-manager';
 import { testIds } from '../../constants/testIds';
+import { resetCompletionStoreForTests } from '../../global-state/completion-store';
 
 describe('executeWithLazyScroll: step outcome propagation', () => {
   afterEach(() => {
@@ -83,6 +84,102 @@ describe('InteractiveStep: showMeText label override', () => {
     const step = screen.getByTestId(testIds.interactive.step('show-only-failure'));
     await waitFor(() => expect(step).toHaveAttribute('data-test-step-state', 'error'));
     expect(screen.queryByTestId(testIds.interactive.stepCompleted('show-only-failure'))).not.toBeInTheDocument();
+  });
+});
+
+describe('InteractiveStep: objectives', () => {
+  const SATISFIED_OBJECTIVE_TARGET = '#objectives-target';
+  const UNSATISFIABLE_REQUIREMENT = 'on-page:/pathfinder-objectives-never-here';
+
+  beforeEach(() => {
+    const target = document.createElement('div');
+    target.id = 'objectives-target';
+    document.body.appendChild(target);
+  });
+
+  afterEach(() => {
+    document.getElementById('objectives-target')?.remove();
+    resetCompletionStoreForTests();
+  });
+
+  it('auto-completes a step whose objectives are satisfied even while its requirements fail', async () => {
+    const onComplete = jest.fn();
+
+    render(
+      <InteractiveStep
+        stepId="objectives-autocomplete"
+        targetAction="highlight"
+        refTarget={SATISFIED_OBJECTIVE_TARGET}
+        requirements={UNSATISFIABLE_REQUIREMENT}
+        objectives="exists-reftarget"
+        onComplete={onComplete}
+      >
+        Example
+      </InteractiveStep>
+    );
+
+    const step = screen.getByTestId(testIds.interactive.step('objectives-autocomplete'));
+    await waitFor(() => expect(step).toHaveAttribute('data-test-step-state', 'completed'));
+    expect(screen.getByTestId(testIds.interactive.stepCompleted('objectives-autocomplete'))).toBeInTheDocument();
+    await waitFor(() => expect(onComplete).toHaveBeenCalled());
+  });
+
+  it('suppresses the blocking requirements explanation once objectives are satisfied', async () => {
+    render(
+      <InteractiveStep
+        stepId="objectives-suppress"
+        targetAction="highlight"
+        refTarget={SATISFIED_OBJECTIVE_TARGET}
+        requirements={UNSATISFIABLE_REQUIREMENT}
+        objectives="exists-reftarget"
+      >
+        Example
+      </InteractiveStep>
+    );
+
+    const step = screen.getByTestId(testIds.interactive.step('objectives-suppress'));
+    await waitFor(() => expect(step).toHaveAttribute('data-test-step-state', 'completed'));
+    expect(screen.queryByTestId(testIds.interactive.requirementCheck('objectives-suppress'))).not.toBeInTheDocument();
+  });
+
+  it('still blocks on the same failing requirements when no objectives are authored', async () => {
+    render(
+      <InteractiveStep
+        stepId="objectives-absent"
+        targetAction="highlight"
+        refTarget={SATISFIED_OBJECTIVE_TARGET}
+        requirements={UNSATISFIABLE_REQUIREMENT}
+      >
+        Example
+      </InteractiveStep>
+    );
+
+    expect(await screen.findByTestId(testIds.interactive.requirementCheck('objectives-absent'))).toBeInTheDocument();
+    expect(screen.getByTestId(testIds.interactive.step('objectives-absent'))).toHaveAttribute(
+      'data-test-step-state',
+      'requirements-unmet'
+    );
+  });
+
+  it('reports a section-managed step complete through the objectives path', async () => {
+    const onStepComplete = jest.fn();
+
+    render(
+      <InteractiveStep
+        stepId="section-1-step-1"
+        sectionId="section-1"
+        targetAction="highlight"
+        refTarget={SATISFIED_OBJECTIVE_TARGET}
+        requirements={UNSATISFIABLE_REQUIREMENT}
+        objectives="exists-reftarget"
+        onStepComplete={onStepComplete}
+      >
+        Example
+      </InteractiveStep>
+    );
+
+    await waitFor(() => expect(onStepComplete).toHaveBeenCalledWith('section-1-step-1'));
+    expect(screen.getByTestId(testIds.interactive.stepCompleted('section-1-step-1'))).toBeInTheDocument();
   });
 });
 

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -1062,14 +1062,11 @@ export const InteractiveStep = forwardRef<
             {doIt &&
               !isNoopAction &&
               !isCompletedWithObjectives &&
-              (finalIsEnabled || checker.completionReason === 'objectives') && (
+              finalIsEnabled && (
                 <Button
                   onClick={handleDoAction}
                   disabled={
-                    disabled ||
-                    isAnyActionRunning ||
-                    (checker.isChecking && !lazyScrollAvailable) ||
-                    (!finalIsEnabled && checker.completionReason !== 'objectives')
+                    disabled || isAnyActionRunning || (checker.isChecking && !lazyScrollAvailable) || !finalIsEnabled
                   }
                   size="sm"
                   variant="primary"

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -204,7 +204,6 @@ export const InteractiveStep = forwardRef<
       description,
       children,
       requirements,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- grandfathered: arrives from the section but is never forwarded to useStepChecker; see #1815
       objectives,
       hints,
       onComplete,
@@ -320,6 +319,7 @@ export const InteractiveStep = forwardRef<
 
     const checker = useStepChecker({
       requirements,
+      objectives,
       hints,
       targetAction,
       refTarget,
@@ -390,9 +390,6 @@ export const InteractiveStep = forwardRef<
         }
       }
     }, [isNoopAction, isEligibleForChecking, disabled, stepId, onStepComplete, onComplete]);
-
-    // NOTE: Auto-completion when objectives are met is now handled by useStepChecker
-    // via the onObjectivesComplete callback passed above.
 
     const shouldShowExplanation = isPartOfSection
       ? !isNoopAction && (!isEligibleForChecking || (requirements && !checker.isEnabled && !lazyScrollAvailable))

--- a/src/components/interactive-tutorial/interactive-step.tsx
+++ b/src/components/interactive-tutorial/interactive-step.tsx
@@ -1059,41 +1059,38 @@ export const InteractiveStep = forwardRef<
 
             {/* Only show "Do it" button when doIt prop is true AND not a noop action */}
             {/* Noop actions are informational only - no buttons needed */}
-            {doIt &&
-              !isNoopAction &&
-              !isCompletedWithObjectives &&
-              finalIsEnabled && (
-                <Button
-                  onClick={handleDoAction}
-                  disabled={
-                    disabled || isAnyActionRunning || (checker.isChecking && !lazyScrollAvailable) || !finalIsEnabled
-                  }
-                  size="sm"
-                  variant="primary"
-                  className="interactive-step-do-btn"
-                  data-testid={testIds.interactive.doItButton(renderedStepId)}
-                  title={
-                    hints ||
-                    (targetAction === 'navigate'
-                      ? `Go there: ${getActionDescription()}`
-                      : isPopoutAction
-                        ? `${popoutButtonLabel}: ${getActionDescription()}`
-                        : `Do it: ${getActionDescription()}`)
-                  }
-                >
-                  {isDoRunning || isCurrentlyExecuting
-                    ? targetAction === 'navigate'
-                      ? 'Going...'
-                      : isPopoutAction
-                        ? popoutButtonRunningLabel
-                        : 'Executing...'
-                    : targetAction === 'navigate'
-                      ? 'Go there'
-                      : isPopoutAction
-                        ? popoutButtonLabel
-                        : 'Do it'}
-                </Button>
-              )}
+            {doIt && !isNoopAction && !isCompletedWithObjectives && finalIsEnabled && (
+              <Button
+                onClick={handleDoAction}
+                disabled={
+                  disabled || isAnyActionRunning || (checker.isChecking && !lazyScrollAvailable) || !finalIsEnabled
+                }
+                size="sm"
+                variant="primary"
+                className="interactive-step-do-btn"
+                data-testid={testIds.interactive.doItButton(renderedStepId)}
+                title={
+                  hints ||
+                  (targetAction === 'navigate'
+                    ? `Go there: ${getActionDescription()}`
+                    : isPopoutAction
+                      ? `${popoutButtonLabel}: ${getActionDescription()}`
+                      : `Do it: ${getActionDescription()}`)
+                }
+              >
+                {isDoRunning || isCurrentlyExecuting
+                  ? targetAction === 'navigate'
+                    ? 'Going...'
+                    : isPopoutAction
+                      ? popoutButtonRunningLabel
+                      : 'Executing...'
+                  : targetAction === 'navigate'
+                    ? 'Go there'
+                    : isPopoutAction
+                      ? popoutButtonLabel
+                      : 'Do it'}
+              </Button>
+            )}
 
             {/* Show "Skip" button when step is skippable (always available, not just on error) */}
             {/* Noop actions don't need skip - they're just informational */}

--- a/src/components/interactive-tutorial/terminal-step.hints.test.tsx
+++ b/src/components/interactive-tutorial/terminal-step.hints.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * `hints` coverage for TerminalStep, against the real `useStepChecker`.
+ *
+ * Lives apart from `terminal-step.test.tsx` because that suite mocks the whole
+ * requirements-manager barrel, which would make a hint assertion vacuous.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { TerminalStep } from './terminal-step';
+
+jest.mock('../../integrations/coda/TerminalContext', () => ({
+  useTerminalContext: () => ({
+    status: 'connected',
+    sendCommand: jest.fn(),
+    openTerminal: jest.fn(),
+    isTerminalRegistered: true,
+    vmId: 'test-vm',
+  }),
+}));
+
+jest.mock('../../integrations/coda/useCodaAvailability.hook', () => ({
+  useCodaTerminalGate: () => 'configured',
+  useCodaSessionEligibility: () => ({ state: 'eligible' }),
+  codaUnavailableMessage: () => null,
+  useReportSandboxUnavailable: jest.fn(),
+}));
+
+describe('TerminalStep: hints', () => {
+  const UNSATISFIABLE_REQUIREMENT = 'on-page:/pathfinder-terminal-never-here';
+
+  it('explains an unmet requirement with the authored hint', async () => {
+    render(
+      <TerminalStep
+        command="ls -la"
+        requirements={UNSATISFIABLE_REQUIREMENT}
+        hints="Connect the sandbox terminal before running this command."
+      />
+    );
+
+    expect(await screen.findByText('Connect the sandbox terminal before running this command.')).toBeInTheDocument();
+  });
+
+  it('falls back to the generic requirement message when no hint is authored', async () => {
+    render(<TerminalStep command="ls -la" requirements={UNSATISFIABLE_REQUIREMENT} />);
+
+    expect(await screen.findByText(/Navigate to the .* page first/)).toBeInTheDocument();
+  });
+});

--- a/src/components/interactive-tutorial/terminal-step.tsx
+++ b/src/components/interactive-tutorial/terminal-step.tsx
@@ -167,6 +167,7 @@ export const TerminalStep = forwardRef<
     const checker = useStepChecker({
       requirements: requirements || '',
       objectives: objectives || '',
+      hints,
       targetAction: 'noop',
       refTarget: '',
       stepId: renderedStepId,

--- a/src/validation/unused-bindings-lint-config.test.ts
+++ b/src/validation/unused-bindings-lint-config.test.ts
@@ -131,14 +131,10 @@ function lintProbe(source: string): LintMessage[] {
  * Whoever clears #1815 updates this list in the same pull request: the
  * assertion below is strict equality in both directions, so a new unused
  * binding fails as growth and a fixed one fails as drift until it is removed
- * here. The nineteenth grandfathered binding — `objectives` in
- * `interactive-step.tsx` — is deliberately absent: it uses an inline
- * `eslint-disable-next-line`, which ESLint's own unused-disable-directive
- * reporting self-clears once the binding becomes used.
+ * here.
  */
 const GRANDFATHERED: Record<string, string[]> = {
   'src/components/interactive-tutorial/code-block-step.tsx': [
-    'hints',
     'onStepReset',
     'resetTrigger',
     'sectionTitle',
@@ -154,7 +150,6 @@ const GRANDFATHERED: Record<string, string[]> = {
     'totalSteps',
   ],
   'src/components/interactive-tutorial/terminal-step.tsx': [
-    'hints',
     'onStepReset',
     'resetTrigger',
     'sectionTitle',


### PR DESCRIPTION
## Summary

`useStepChecker` accepts `objectives` and `hints` as two independent inputs, but the three step components forwarded them as exact mirror images of each other. `interactive-step.tsx` forwarded `hints` and dropped `objectives` behind an inline `no-unused-vars` disable; `code-block-step.tsx` and `terminal-step.tsx` forwarded `objectives` and dropped `hints`. Both props are authored guide content, so both drops lost real behavior:

- An `InteractiveStep` whose `objectives` were already satisfied could never reach `completionReason === 'objectives'`. That made three branches already written against it structurally unreachable: the objectives auto-completion, the section-step enabled/complete shortcut, and the suppression of the blocking requirements explanation. The step stayed blocked on its own `requirements` even where the author had declared the work already done.
- A `CodeBlockStep` or `TerminalStep` with unmet requirements rendered the generic mapped requirement message instead of the author's hint, because `getRequirementExplanation` never received one.

This is the first of six scoped PRs paying down the `@typescript-eslint/no-unused-vars` grandfather baseline from #1815 (the follow-up to the ratchet landed in #1816). It is framed as a bugfix rather than lint cleanup: clearing 3 of the 19 grandfathered bindings is a side effect, not the point.

## Why this scope and no more

`resetTrigger`, `stepIndex`/`totalSteps`/`sectionTitle`, `isEligibleForChecking`, and `onStepReset` are deliberately untouched — they are PRs 2 through 5 of the same sequence, and folding them in would turn a reviewable bugfix into a grab-bag.

`eslint.config.mjs`'s exemption block is also deliberately untouched: all three files still carry other grandfathered bindings after this PR, so they all correctly stay listed. Only the per-file binding list in `unused-bindings-lint-config.test.ts` shrinks, and that suite asserts strict equality in both directions, so a fixed binding has to be removed there in the same PR or it fails as drift.

`hints` is forwarded as a plain `hints,` rather than matching the adjacent `objectives: objectives || ''`, because the hook's parameter is optional and `getRequirementExplanation` treats `''` and `undefined` identically — the coercion would be noise, and `interactive-step.tsx` already forwards the same prop this way.

## What Changed

- `interactive-step.tsx` now passes `objectives` to `useStepChecker` (replacing the inline `no-unused-vars` disable that documented the dropped prop), so a step whose objectives are already satisfied can reach `completionReason === 'objectives'` and take its auto-completion, section-completion, and explanation-suppression paths. `code-block-step.tsx` and `terminal-step.tsx` now pass `hints`, so `getRequirementExplanation` renders the authored hint instead of the generic mapped requirement message.
- Collapsed the "Do it" button gate in `interactive-step.tsx`: with objectives forwarded, `isCompletedWithObjectives` already covers `completionReason === 'objectives'`, so the extra disjuncts in the render condition and the `disabled` expression were unreachable. Also removed a stale comment naming a nonexistent `onObjectivesComplete` callback.
- Added behavioral coverage — objectives auto-completion, explanation suppression, and section-managed completion in `interactive-step.test.tsx`; hint-vs-generic-fallback pairs in `code-block-step.test.tsx` and a new `terminal-step.hints.test.tsx` (separate file because `terminal-step.test.tsx` mocks the whole requirements-manager barrel). Dropped the two now-fixed `hints` entries from `GRANDFATHERED` in `unused-bindings-lint-config.test.ts`, and documented the `hint` field for code-block and terminal blocks in `json-guide-format.md`.

## Risk Assessment

✅ Low: The change is a narrow, symmetric prop-forwarding fix backed by fail-before/pass-after behavioral tests against the real checker, the fix-round commit is verifiably behavior-preserving and scope-respecting, every stated intent constraint holds, and the only remaining finding is a cosmetic dead condition in pre-existing lines.

## Known follow-ups (deferred, not fixed here)

Automated review raised four findings. All four are downstream consequences of promoting a previously-unreachable path to live on the most common step type, not defects in the forwarded lines, and all four are deliberately left open rather than folded into this PR. Recording them so they are not silently dropped:

1. **Completion-store reason relabel on objectives auto-complete** (warning). The checker's objectives effect writes `markStepCompleted(..., 'objectives')` and then synchronously calls `onStepComplete(stepId)`; the section's `handleStepComplete` guards on a `useSyncExternalStore` render snapshot that does not yet contain the step, so it falls through and rewrites the same entry as `'manual'`. `'objectives'` is not sticky in `completion-store.ts` the way `'skipped'` is, so the label only recovers on the next commit. Net effect today is three `localStorage` persists and three progress events per objectives-completed step, and a persisted `reason` that is correct only by accident — nothing user-visible, because no subscriber branches on `reason` and completion records set their own `source`. This hazard already exists for `CodeBlockStep`/`TerminalStep` objectives (both already forwarded `objectives`); this PR extends it to `InteractiveStep`. The fix belongs in `completion-store.ts`, giving `'objectives'` the non-downgradable treatment `'skipped'` already has — a shared store-semantics change that deserves its own PR.
2. **Redo is effectively inert on an objectives-completed step** (info). The completed badge, and therefore the Redo button, now render for objectives-completed steps for the first time. `handleStepRedo` has no objectives guard, so clicking it bulk-resets this step and every step after it, then the 50ms recheck re-evaluates the still-satisfied objective and snaps the step straight back to completed. Arguably correct under the documented "objectives always win" rule, but the affordance reads as broken while still discarding downstream progress. Hiding Redo when `completionReason === 'objectives'` is a product call.
3. **Objectives are evaluated in the controller tab, never round-tripped** (info). The objectives branch of `checkStep` omits `remote: true`, so tab-local tokens (`exists-reftarget`, `navmenu-open`, `on-page`, `form-valid`) are evaluated against whichever tab runs the checker. `docs/developer/CROSS_TAB_CONTROLLER.md` states this is deliberate, but that note predates objectives being live on the dominant step path, so it is worth an explicit confirm or a doc update rather than implicit inheritance.
4. **The same dead conditions remain in the explanation gate** (info). This PR collapsed two provably-dead `completionReason` conditions in the "Do it" button gate, where `!isCompletedWithObjectives` already implies them. The explanation gate about 160 lines below carries the identical redundancy on pre-existing lines. Left alone to keep the diff honest about what this change forces; a behavior-identical collapse if someone wants it.

A fifth, unrelated finding: the per-block field tables in `json-guide-format.md` are hand-maintained while the fields are Zod-schema-backed, and the docs test only pins that each block type has a summary row and a heading, not that its field rows match the schema. Pre-existing drift, out of scope.

## Testing

I ran the five targeted Jest suites touched by the change plus the adjacent Do-it-button and section suites, and all pass. To prove the tests pin the fix rather than the current code, I removed the single forwarding line from each of the three components and re-ran: exactly the five behavioral tests failed and the three intended control cases still passed, matching the author's claim. For reviewer-visible evidence I rendered the real components against the real useStepChecker, serialized each render with its emotion stylesheet, and screenshotted a before/after comparison in Chrome — it shows the InteractiveStep flipping from the blocking "Navigate to the … page first / Fix this" explanation to "✓ Completed / Redo" when its objective is satisfied, and CodeBlockStep and TerminalStep showing the author's hint in place of the generic mapped requirement message. I also confirmed the review follow-up commit's dead-condition collapse is behavior-preserving by rendering the Do-it gate under both the pre-collapse and collapsed conditions for both reachable outcomes and finding the DOM byte-identical. The visual evidence is a jsdom render of the real components screenshotted in a browser rather than a live Grafana instance, because the scenarios depend on a deliberately unsatisfiable requirement paired with a satisfied objective, which cannot be staged in a running stack. The throwaway capture harness was deleted and the working tree is clean.

- Evidence: Before/after screenshot: objectives and hints forwarding across all three step components (local file: <code>/Users/davidallen/.no-mistakes/evidence/01M28FS4F412R81MAMSTVTXX35/objectives-hints-before-after.png</code>)
- Evidence: Screenshot: Do-it gate identical under pre-collapse and collapsed conditions (local file: <code>/Users/davidallen/.no-mistakes/evidence/01M28FS4F412R81MAMSTVTXX35/do-it-gate-collapse.png</code>)

<details>
<summary>Evidence: Self-contained rendered-HTML comparison page (real component output plus stylesheet)</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><title>Pathfinder #1815 — objectives/hints forwarding</title><style>




    /* Blocker overlay visuals (used by GlobalInteractionBlocker) */
    #interactive-blocking-overlay {
      background: transparent !important;
      /* Always-visible subtle border */
      border: 1px solid rgba(170, 170, 170, 0.35);
      /* Breathing pulse layered on top */
      box-shadow: inset 0 0 0 0 rgba(170, 170, 170, 0.22);
      animation: blocker-breathe 3.2s ease-in-out infinite;
    }

    /* When a modal is active, remove breathing pulse to avoid visual clash and keep overlay subtle */
    #interactive-blocking-overlay.no-breathe {
      animation: none !important;
      box-shadow: none !important;
      border: none !important;
    }

    /* Full-screen overlay for modal blocking */
    #interactive-fullscreen-overlay {
      background: transparent !important;
      /* Gray pulse around the outside edge - more visible for full screen */
      border: 2px solid rgba(170, 170, 170, 0.4);
      box-shadow: inset 0 0 0 0 rgba(170, 170, 170, 0.3);
      animation: fullscreen-breathe 2.8s ease-in-out infinite;
    }

    /* Header overlay styling */
    #interactive-header-overlay {
      background: transparent !important;
      border: 1px solid rgba(170, 170, 170, 0.35);
      box-shadow: inset 0 0 0 0 rgba(170, 170, 170, 0.22);
      animation: blocker-breathe 3.2s ease-in-out infinite;
    }

    @keyframes blocker-breathe {
      0% {
        box-shadow: inset 0 0 0 0 rgba(170, 170, 170, 0.18);
      }
      50% {
        box-shadow: inset 0 0 0 6px rgba(170, 170, 170, 0.20);
      }
      100% {
        box-shadow: inset 0 0 0 0 rgba(170, 170, 170, 0.18);
      }
    }

    @keyframes fullscreen-breathe {
      0% {
        box-shadow: inset 0 0 0 0 rgba(170, 170, 170, 0.25);
        border-color: rgba(170, 170, 170, 0.35);
      }
      50% {
        box-shadow: inset 0 0 0 8px rgba(170, 170, 170, 0.30);
        border-color: rgba(170, 170, 170, 0.45);
      }
      100% {
        box-shadow: inset 0 0 0 0 rgba(170, 170, 170, 0.25);
        border-color: rgba(170, 170, 170, 0.35);
      }
    }
    /* Global interactive highlight styles */
    .interactive-highlight-outline {
      position: fixed;
      top: var(--highlight-top);
      left: var(--highlight-left);
      width: var(--highlight-width);
      height: var(--highlight-height);
      pointer-events: none;
      z-index: 9999;
      border-radius: 4px;
      /* Draw border clockwise using four gradient strokes (no fill) */
      --hl-color: rgba(255, 136, 0, 0.85);
      --hl-thickness: 2px;
      background:
        linear-gradient(var(--hl-color) 0 0) top left / 0 var(--hl-thickness) no-repeat,
        linear-gradient(var(--hl-color) 0 0) top right / var(--hl-thickness) 0 no-repeat,
        linear-gradient(var(--hl-color) 0 0) bottom right / 0 var(--hl-thickness) no-repeat,
        linear-gradient(var(--hl-color) 0 0) bottom left / var(--hl-thickness) 0 no-repeat;
      opacity: 0.95;
      /* Draw border animation, then breathing glow (2 cycles), then fade out
       * Total: 1625ms draw + 3s breathe + 0.5s fade = 5.125s
       * JS cleanup at 5625ms (500ms buffer after CSS completes)
       */
      animation:
        interactive-draw-border 1625ms cubic-bezier(0.18, 0.6, 0.2, 1) forwards,
        interactive-glow-breathe 1500ms ease-in-out 1625ms 2,
        interactive-outline-fade 500ms ease-out 4625ms forwards;
    }

    /* Subtle variant to reuse animation cadence for blocked areas */
    .interactive-highlight-outline--subtle {
      border-color: rgba(180, 180, 180, 0.4);
      background-color: rgba(180, 180, 180, 0.08);
      box-shadow: 0 0 0 4px rgba(180, 180, 180, 0.12);
      animation: subtle-highlight-pulse 1.6s ease-in-out infinite;
    }

    /* Hover highlight for element inspector (watch/record mode) */
    .interactive-hover-highlight-outline {
      position: fixed;
      top: var(--highlight-top);
      left: var(--highlight-left);
      width: var(--highlight-width);
      height: var(--highlight-height);
      pointer-events: none;
      z-index: 9999;
      border-radius: 4px;
      /* Same orange color as regular highlights for consistency */
      --hl-color: rgba(255, 136, 0, 0.85);
      --hl-thickness: 2px;
      background:
        linear-gradient(var(--hl-color) 0 0) top left / 0 var(--hl-thickness) no-repeat,
        linear-gradient(var(--hl-color) 0 0) top right / var(--hl-thickness) 0 no-repeat,
        linear-gradient(var(--hl-color) 0 0) bottom right / 0 var(--hl-thickness) no-repeat,
        linear-gradient(var(--hl-color) 0 0) bottom left / var(--hl-thickness) 0 no-repeat;
      /* No animation for hover - instant feedback */
      background-size: 100% var(--hl-thickness), var(--hl-thickness) 100%, 100% var(--hl-thickness), var(--hl-thickness) 100%;
      opacity: 0.95;
      /* Smooth transitions when moving between elements */
      transition: top 0.05s ease-out, left 0.05s ease-out, width 0.05s ease-out, height 0.05s ease-out;
    }

    @keyframes interactive-draw-border {
      0% {
        background-size: 0 var(--hl-thickness), var(--hl-thickness) 0, 0 var(--hl-thickness), var(--hl-thickness) 0;
      }
      25% {
        background-size: 100% var(--hl-thickness), var(--hl-thickness) 0, 0 var(--hl-thickness), var(--hl-thickness) 0;
      }
      50% {
        background-size: 100% var(--hl-thickness), var(--hl-thickness) 100%, 0 var(--hl-thickness), var(--hl-thickness) 0;
      }
      75% {
        background-size: 100% var(--hl-thickness), var(--hl-thickness) 100%, 100% var(--hl-thickness), var(--hl-thickness) 0;
      }
      100% {
        background-size: 100% var(--hl-thickness), var(--hl-thickness) 100%, 100% var(--hl-thickness), var(--hl-thickness) 100%;
      }
    }

    /* Breathing orange glow that activates after border draw completes */
    @keyframes interactive-glow-breathe {
      0%, 100% {
        box-shadow: 0 0 8px 2px rgba(255, 136, 0, 0.3);
      }
      50% {
        box-shadow: 0 0 16px 4px rgba(255, 136, 0, 0.5);
      }
    }

    /* Fade out animation for bounding box after breathing completes */
    @keyframes interactive-outline-fade {
      from {
        opacity: 0.95;
        box-shadow: 0 0 8px 2px rgba(255, 136, 0, 0.3);
      }
      to {
        opacity: 0;
        box-shadow: 0 0 4px 1px rgba(255, 136, 0, 0);
      }
    }

    /* Instant highlight - no draw animation, just breathing glow then fade
     * Instant: 2 breathe cycles (3s) + 0.5s fade = 3.5s
     */
    .interactive-highlight-outline--instant {
      animation: 
        interactive-glow-breathe 1500ms ease-in-out 2,
        interactive-outline-fade 500ms ease-out 3000ms forwards !important;
      background-size: 100% var(--hl-thickness), var(--hl-thickness) 100%, 100% var(--hl-thickness), var(--hl-thickness) 100% !important;
    }

    /* Pulsing dot indicator for small/hidden elements (< 10px width or height)
     * Threshold defined in INTERACTIVE_CONFIG.highlighting.minDimensionForBox
     */
    .interactive-highlight-dot {
      position: fixed;
      top: var(--highlight-top);
      left: var(--highlight-left);
      width: 16px;
      height: 16px;
      border-radius: 50%;
      background: rgba(255, 136, 0, 0.9);
      pointer-events: none;
      z-index: 9999;
      transform: translate(-50%, -50%); /* Center on the point */
      box-shadow: 0 0 12px 4px rgba(255, 136, 0, 0.5);
      /* Finite animation: 2 pulse cycles (3s) then fade out (0.5s) = 3.5s total
       * JS cleanup at 4000ms (500ms buffer after CSS completes)
       */
      animation: 
        interactive-dot-pulse 1500ms ease-in-out 2,
        interactive-dot-fade 500ms ease-out 3000ms forwards;
    }

    @keyframes interactive-dot-pulse {
      0%, 100% {
        transform: translate(-50%, -50%) scale(1);
        opacity: 0.9;
      }
      50% {
        transform: translate(-50%, -50%) scale(1.3);
        opacity: 1;
      }
    }

    @keyframes interactive-dot-fade {
      from {
        opacity: 0.9;
        transform: translate(-50%, -50%) scale(1);
      }
      to {
        opacity: 0;
       

... [22074 bytes truncated] ...

se differs.</p><section><h2>InteractiveStep — objectives satisfied while requirements fail</h2><p class="note">objectives now reach useStepChecker: the step auto-completes and the blocking explanation is suppressed</p><div class="row"><div class="pane"><div class="tag before">BEFORE — forwarding removed</div><div class="surface"><div class="interactive-step" data-test-step-kind="plain" data-test-step-id="evidence-objectives" data-targetaction="highlight" data-reftarget="#objectives-target" data-step-id="evidence-objectives" data-testid="interactive-step-evidence-objectives" data-test-step-state="requirements-unmet" data-test-fix-type="location" data-test-requirements-state="unmet"><div class="interactive-step-content"><div class="interactive-step-title">Connect your Prometheus data source</div>Example step</div><div class="interactive-step-actions"><div class="interactive-step-action-buttons"></div></div><div class="interactive-step-requirement-explanation" data-testid="interactive-requirement-evidence-objectives"><span id="requirement-explanation-evidence-objectives">Navigate to the '/pathfinder-objectives-never-here' page first.</span><div class="interactive-step-requirement-buttons"><button class="interactive-requirement-retry-btn" data-testid="interactive-requirement-fix-evidence-objectives" title="Apply the automatic fix for this requirement" aria-describedby="requirement-explanation-evidence-objectives">Fix this</button></div></div></div></div></div><div class="pane"><div class="tag after">AFTER — this change</div><div class="surface"><div class="interactive-step completed" data-test-step-kind="plain" data-test-step-id="evidence-objectives" data-targetaction="highlight" data-reftarget="#objectives-target" data-step-id="evidence-objectives" data-testid="interactive-step-evidence-objectives" data-test-step-state="completed" data-test-fix-type="none" data-test-requirements-state="met"><div class="interactive-step-content"><div class="interactive-step-title">Connect your Prometheus data source</div>Example step</div><div class="interactive-step-actions"><div class="interactive-step-action-buttons"></div><div class="interactive-guided-completed"><div class="interactive-guided-completed-badge"><span class="interactive-guided-completed-icon" data-testid="interactive-step-completed-evidence-objectives">✓</span><span class="interactive-guided-completed-text">Completed</span></div><button class="css-1nuwwf8-button" type="button" data-testid="interactive-redo-evidence-objectives" title="Redo this step (execute again)" aria-disabled="false"><span class="css-1riaxdn">↻ Redo</span></button></div></div></div></div></div></div></section><section><h2>CodeBlockStep — unmet requirement with an authored hint</h2><p class="note">hints now reach useStepChecker: the author hint replaces the generic mapped requirement message</p><div class="row"><div class="pane"><div class="tag before">BEFORE — forwarding removed</div><div class="surface"><div class="interactive-step css-1e07izz" data-test-step-kind="codeblock" data-test-step-id="code-block-step-1" data-test-step-state="requirements-unmet" data-testid="code-block-step-code-block-step-1"><div class="css-19idom"><div class="code-block"><div class="code-block-header"><span class="code-block-language">javascript</span></div><pre class="code-block-pre language-javascript" tabindex="0"><code class="language-javascript"><span class="token function">query_range</span><span class="token punctuation">(</span>up<span class="token punctuation">)</span></code></pre></div></div><div class="css-unqe4j">Navigate to the '/pathfinder-code-block-never-here' page first.</div></div></div></div><div class="pane"><div class="tag after">AFTER — this change</div><div class="surface"><div class="interactive-step css-1e07izz" data-test-step-kind="codeblock" data-test-step-id="code-block-step-1" data-test-step-state="requirements-unmet" data-testid="code-block-step-code-block-step-1"><div class="css-19idom"><div class="code-block"><div class="code-block-header"><span class="code-block-language">javascript</span></div><pre class="code-block-pre language-javascript" tabindex="0"><code class="language-javascript"><span class="token function">query_range</span><span class="token punctuation">(</span>up<span class="token punctuation">)</span></code></pre></div></div><div class="css-unqe4j">Open the Explore query editor before inserting this query.</div></div></div></div></div></section><section><h2>TerminalStep — unmet requirement with an authored hint</h2><p class="note">hints now reach useStepChecker: the author hint replaces the generic mapped requirement message</p><div class="row"><div class="pane"><div class="tag before">BEFORE — forwarding removed</div><div class="surface"><div class="interactive-step css-1e07izz" data-test-step-kind="terminal" data-test-step-id="terminal-step-1" data-test-step-state="requirements-unmet" data-testid="interactive-terminal-terminal-step-1"><div class="css-1lijhim"><code>ls -la</code></div><div class="css-unqe4j">Navigate to the '/pathfinder-terminal-never-here' page first.</div></div></div></div><div class="pane"><div class="tag after">AFTER — this change</div><div class="surface"><div class="interactive-step css-1e07izz" data-test-step-kind="terminal" data-test-step-id="terminal-step-1" data-test-step-state="requirements-unmet" data-testid="interactive-terminal-terminal-step-1"><div class="css-1lijhim"><code>ls -la</code></div><div class="css-unqe4j">Connect the sandbox terminal before running this command.</div></div></div></div></div></section><section><h2>Do-it button gate — dead-condition collapse (review follow-up commit)</h2><p class="note">Rendered DOM is byte-identical between the pre-collapse and collapsed gate for both reachable outcomes, confirming the collapse is behavior-preserving.</p><div class="row"><div class="pane"><div class="tag neutral">objectives-completed — Redo, no Do it</div><div class="surface"><div class="interactive-step completed" data-test-step-kind="plain" data-test-step-id="doit-objectives" data-targetaction="highlight" data-reftarget="#doit-target" data-step-id="doit-objectives" data-testid="interactive-step-doit-objectives" data-test-step-state="completed" data-test-fix-type="none" data-test-requirements-state="met"><div class="interactive-step-content"><div class="interactive-step-title">Objectives satisfied</div>Example step</div><div class="interactive-step-actions"><div class="interactive-step-action-buttons"></div><div class="interactive-guided-completed"><div class="interactive-guided-completed-badge"><span class="interactive-guided-completed-icon" data-testid="interactive-step-completed-doit-objectives">✓</span><span class="interactive-guided-completed-text">Completed</span></div><button class="css-1nuwwf8-button" type="button" data-testid="interactive-redo-doit-objectives" title="Redo this step (execute again)" aria-disabled="false"><span class="css-1riaxdn">↻ Redo</span></button></div></div></div></div></div><div class="pane"><div class="tag neutral">requirements satisfied — Do it present</div><div class="surface"><div class="interactive-step" data-test-step-kind="plain" data-test-step-id="doit-enabled" data-targetaction="highlight" data-reftarget="#doit-target" data-step-id="doit-enabled" data-testid="interactive-step-doit-enabled" data-test-step-state="idle" data-test-fix-type="none" data-test-requirements-state="met"><div class="interactive-step-content"><div class="interactive-step-title">Requirements satisfied</div>Example step</div><div class="interactive-step-actions"><div class="interactive-step-action-buttons"><button class="css-1nuwwf8-button interactive-step-show-btn" type="button" data-testid="interactive-show-me-doit-enabled" title="Show me: Highlight element" aria-disabled="false"><span class="css-1riaxdn">Show me</span></button><button class="css-xf7q69-button interactive-step-do-btn" type="button" data-testid="interactive-do-it-doit-enabled" title="Do it: Highlight element" aria-disabled="false"><span class="css-1riaxdn">Do it</span></button></div></div></div></div></div></div></section></div></body></html>
```
</details>
<details>
<summary>Evidence: Per-test result with the forwarding reverted (fails before the fix, passes after)</summary>

<code>FAIL TerminalStep: hints explains an unmet requirement with the authored hint&#10;PASS TerminalStep: hints falls back to the generic requirement message when no hint is authored&#10;FAIL CodeBlockStep: hints explains an unmet requirement with the authored hint&#10;PASS CodeBlockStep: hints falls back to the generic requirement message when no hint is authored&#10;FAIL InteractiveStep: objectives auto-completes a step whose objectives are satisfied even while its requirements fail&#10;FAIL InteractiveStep: objectives suppresses the blocking requirements explanation once objectives are satisfied&#10;PASS InteractiveStep: objectives still blocks on the same failing requirements when no objectives are authored&#10;FAIL InteractiveStep: objectives reports a section-managed step complete through the objectives path&#10;&#10;With the forwarding restored (this change), all 8 pass. The 3 PASS rows are the intended control cases: they pass either way.</code>

```text
Per-test result with the objectives/hints forwarding line removed from each component
(everything else, including the new tests, unchanged):

FAIL  TerminalStep: hints explains an unmet requirement with the authored hint
PASS  TerminalStep: hints falls back to the generic requirement message when no hint is authored
FAIL  CodeBlockStep: hints explains an unmet requirement with the authored hint
PASS  CodeBlockStep: hints falls back to the generic requirement message when no hint is authored
FAIL  InteractiveStep: objectives auto-completes a step whose objectives are satisfied even while its requirements fail
FAIL  InteractiveStep: objectives suppresses the blocking requirements explanation once objectives are satisfied
PASS  InteractiveStep: objectives still blocks on the same failing requirements when no objectives are authored
FAIL  InteractiveStep: objectives reports a section-managed step complete through the objectives path

With the forwarding restored (this change), all 8 pass.
The 3 PASS rows are the intended control cases: they pass either way.
```
</details>
<details>
<summary>Evidence: Do-it gate DOM equality: pre-collapse vs collapsed</summary>

<code>doit-objectives-completed: rendered DOM identical pre-collapse vs collapsed = true&#10;doit-enabled: rendered DOM identical pre-collapse vs collapsed = true</code>

```text
doit-objectives-completed: rendered DOM identical pre-collapse vs collapsed = true
doit-enabled: rendered DOM identical pre-collapse vs collapsed = true
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"af09ec86059fb500c8ec01750fe44ece7ad8550d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/components/interactive-tutorial/interactive-step.tsx:322` - Forwarding `objectives` makes the checker&#39;s objectives auto-complete effect (step-checker.hook.ts:899) reachable for section-managed InteractiveSteps, which exposes a store-reason ping-pong. The effect runs `writeStoreCompletion(&#39;objectives&#39;)` and then synchronously `onStepComplete(stepId)`; the section&#39;s `handleStepComplete` (interactive-section.tsx:542) guards on `completedSteps`, a useSyncExternalStore render snapshot that does not yet contain the step, so it falls through to `markStepCompleted(stepId, sectionId, &#39;manual&#39;)`. `markStepCompleted` (completion-store.ts:383) only early-returns when the existing reason equals the new one or is `&#39;skipped&#39;` — `&#39;objectives&#39;` is not sticky — so the entry is relabeled &#39;manual&#39;, persisted, and a second `pathfinder:progress` event fires with reason &#39;manual&#39;. The label only recovers because `handleStepComplete`&#39;s identity changes on the next commit and re-runs the effect, writing &#39;objectives&#39; a third time; had that callback been stably memoized, the persisted reason would stay &#39;manual&#39; permanently. Separately, on reload of a guide whose step was genuinely completed by the user (&#39;manual&#39;), a still-satisfied objective now rewrites that entry to &#39;objectives&#39;. Today `reason` is only metadata (no subscriber branches on it, and completion records hardcode their own `source`), so nothing user-visible is wrong — but it is three localStorage persists and three progress events per objectives-completed step, and a persisted value that is right only by accident. The earliest shared boundary is completion-store.ts:383: give `&#39;objectives&#39;` the same non-downgradable treatment `&#39;skipped&#39;` already has, whose comment describes this exact section-writes-&#39;manual&#39; hazard.
- ℹ️ `src/components/interactive-tutorial/interactive-step.tsx:1148` - The completed badge block at line 1132 renders on `isCompletedWithObjectives`, which now includes `completionReason === &#39;objectives&#39;`, so the Redo button appears on objectives-completed steps for the first time. `handleStepRedo` (line 903) has no objectives guard: it calls `checker.resetStep()` — which schedules a recheck 50ms later (step-checker.hook.ts:859) that re-evaluates the still-satisfied objective and re-completes the step — and `onStepReset(stepId)`, which makes the section bulk-reset this step and every step after it (interactive-section.tsx:587-593). Concrete sequence: a section step with `objectives=&#34;has-datasource:prometheus&#34;` auto-completes, the user clicks Redo, the tail steps&#39; progress is cleared, and the step snaps straight back to Completed. Arguably correct under the documented &#34;objectives always win&#34; rule, but the affordance now reads as broken while still discarding downstream progress; consider hiding Redo when `completionReason === &#39;objectives&#39;`.
- ℹ️ `src/requirements-manager/step-checker.hook.ts:499` - The objectives branch of `checkStep` omits `remote: true`, so objectives are always evaluated against the tab running the checker. `TAB_LOCAL_REQUIREMENTS` (controller-requirements.ts:12) lists `exists-reftarget`, `navmenu-open`, `on-page`, `form-valid` as tokens that must round-trip to the live tab; requirements do that, objectives do not. Forwarding `objectives` extends this to InteractiveStep, which is the step type two-tab controller sessions actually drive. Concrete case: a controller-mode session where the guide tab sits on /dashboards and the live tab is on /explore — a step with `objectives=&#34;on-page:/dashboards&#34;` now evaluates the controller tab&#39;s own URL, auto-completes, writes a completion, and suppresses its explanation, for work the live tab never reached. docs/developer/CROSS_TAB_CONTROLLER.md:160 states this is deliberate (&#34;Guide objectives are evaluated in the controller tab and never cross this wire&#34;), so this is not an accidental defect — but that note predates objectives being live on the dominant step path, so it is worth a deliberate confirm (or a doc update) rather than an implicit inheritance.
- ℹ️ `src/components/interactive-tutorial/interactive-step.tsx:1065` - Now that `completionReason === &#39;objectives&#39;` is reachable here, this gate is provably dead rather than merely unexercised: the enclosing `!isCompletedWithObjectives` on line 1064 is false whenever `completionReason === &#39;objectives&#39;` (line 354 defines `isCompletedWithObjectives` to include exactly that), so `|| checker.completionReason === &#39;objectives&#39;` can never be the reason this branch renders, and the mirrored `(!finalIsEnabled &amp;&amp; checker.completionReason !== &#39;objectives&#39;)` inside `disabled` at line 1072 can never see an &#39;objectives&#39; value either. Collapsing both to `finalIsEnabled` and `!finalIsEnabled` is behavior-preserving and removes a condition that now invites a reader to conclude the Do-it button shows for objectives-completed steps.

🔧 Fix: collapse dead objectives conditions in do-it button gate
1 info still open:

- ℹ️ `src/components/interactive-tutorial/interactive-step.tsx:1226` - Same dead-condition class the fix round just collapsed in the Do-it gate, still present in the explanation gate. `isCompletedWithObjectives` (line 353) is `storedCompleted || completionReason === &#39;objectives&#39; || completionReason === &#39;skipped&#39;`, and line 1229 of this same conjunction already requires `!isCompletedWithObjectives`. So `checker.completionReason !== &#39;objectives&#39;` (1226) and `checker.completionReason !== &#39;skipped&#39;` (1227) are implied by a later conjunct and can never be the reason this block is suppressed. Dropping both leaves `shouldShowExplanation &amp;&amp; !isCompletedWithObjectives &amp;&amp; explanationText`, which is behavior-identical in every render pass. Pre-existing lines, not introduced by this diff, and it changes nothing user-visible - flagging it only because the objectives forwarding is what makes a reader newly expect these guards to be load-bearing, and because the identical redundancy three conditions earlier was judged worth collapsing.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx jest --coverage=false src/components/interactive-tutorial/interactive-step.test.tsx src/components/interactive-tutorial/code-block-step.test.tsx src/components/interactive-tutorial/terminal-step.hints.test.tsx src/components/interactive-tutorial/terminal-step.test.tsx src/validation/unused-bindings-lint-config.test.ts` — 52 passed</code>
- <code>Regression check: temporarily removed the `objectives`/`hints` forwarding line from `interactive-step.tsx`, `code-block-step.tsx`, and `terminal-step.tsx` and re-ran the three suites via `--json` reporting — exactly the 5 behavioral tests failed and the 3 control cases passed; restored the source and confirmed all 8 pass</code>
- <code>`npx jest --coverage=false src/components/interactive-tutorial/data-attributes.contract.test.tsx src/components/interactive-tutorial/interactive-section.fullscreen-fallback.test.tsx src/components/content-renderer/content-renderer.fullscreen-fallback.test.tsx src/components/interactive-tutorial/interactive-multi-step.test.tsx src/components/interactive-tutorial/terminal-step.test.tsx` — adjacent suites exercising the Do-it button and section-managed steps, 81 passed / 12 skipped</code>
- <code>Manual visual capture: rendered InteractiveStep (objectives satisfied, requirements failing), CodeBlockStep (unmet requirement + authored hint), and TerminalStep (unmet requirement + authored hint) against the real `useStepChecker` in a throwaway jsdom harness, serialized each real component render with its emotion stylesheet, and screenshotted the before/after comparison page in Chrome via `chrome-devtools-axi screenshot`</code>
- <code>Behavior-preservation check for commit `377e68cb`: captured the Do-it gate for both reachable outcomes (objectives-completed, and requirements-satisfied) using `git show 0d00ef8e:src/components/interactive-tutorial/interactive-step.tsx` versus the collapsed version, and compared the rendered DOM strings — byte-identical in both cases</code>
- <code>Removed the throwaway capture harness (`src/components/interactive-tutorial/__evidence-capture.test.tsx`) and confirmed `git status --porcelain` and `git diff --stat` are empty</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/developer/interactive-examples/json-guide-format.md:1029` - Out-of-scope follow-up, not fixed here. The per-block field tables are hand-maintained while the fields themselves are schema-backed, and `src/validation/json-guide-format-docs.test.ts` only pins that each block type has a summary row and a section heading - not that its field rows match the Zod schema. Pre-existing drift that predates this change and is unrelated to objectives/hints forwarding: the Terminal Block table omits `objectives` (accepted by `JsonTerminalBlockSchema` and forwarded by `terminal-step.tsx` before this change), and neither the Terminal nor the Code Block table lists `id`. Worth a separate change that either generates these rows from `JsonBlockSchema` or extends the existing drift test to per-field coverage, per the generated-facts policy; folding it into this bugfix would expand the diff beyond the fact this change altered.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

