### PR TITLE
fix(scripts): quote Authorization header in curl config

### DIFF
--- a/scripts/lib/app-platform.sh
+++ b/scripts/lib/app-platform.sh
@@ -49,11 +49,11 @@ AP_CURL_CONFIG=
 
 # curl reads the Authorization header from a 0600 config file rather than an
 # argv -H, so the token is not exposed in the process table for the length of a
-# multi-resource run. Unquoted on purpose: curl takes the rest of the line
-# verbatim, which quoting would subject to backslash escaping.
+# multi-resource run. Quote the value because curl config values containing
+# whitespace must be quoted.
 ap_auth_init() {
   AP_CURL_CONFIG=$(mktemp)
-  printf 'header = Authorization: Bearer %s\n' "$1" >"$AP_CURL_CONFIG"
+  printf 'header = "Authorization: Bearer %s"\n' "$1" >"$AP_CURL_CONFIG"
 }
 
 ap_auth_cleanup() {

--- a/scripts/tests/app-platform.test.sh
+++ b/scripts/tests/app-platform.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
+
+# shellcheck source=scripts/lib/app-platform.sh
+source "${REPO_ROOT}/scripts/lib/app-platform.sh"
+
+WORK=$(mktemp -d)
+SERVER_PID=
+
+cleanup() {
+  [[ -z "$SERVER_PID" ]] || kill "$SERVER_PID" 2>/dev/null || true
+  ap_auth_cleanup
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+PORT_FILE="${WORK}/port"
+HEADER_FILE="${WORK}/authorization"
+SERVER_FILE="${WORK}/server.js"
+
+cat >"$SERVER_FILE" <<'JS'
+const fs = require('node:fs');
+const http = require('node:http');
+
+const [portFile, headerFile] = process.argv.slice(2);
+
+const server = http.createServer((req, res) => {
+  fs.writeFileSync(headerFile, req.headers.authorization ?? '');
+  res.writeHead(200);
+  res.end('ok');
+  server.close();
+});
+
+server.listen(0, '127.0.0.1', () => {
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    process.exit(1);
+  }
+  fs.writeFileSync(portFile, String(address.port));
+});
+JS
+
+node "$SERVER_FILE" "$PORT_FILE" "$HEADER_FILE" &
+SERVER_PID=$!
+
+for _ in {1..100}; do
+  [[ -s "$PORT_FILE" ]] && break
+  sleep 0.05
+done
+
+if [[ ! -s "$PORT_FILE" ]]; then
+  echo "FAIL: local HTTP server did not start" >&2
+  exit 1
+fi
+
+TOKEN="sentinel-config-token"
+ap_auth_init "$TOKEN"
+
+PORT=$(cat "$PORT_FILE")
+if ! curl -sS --fail --noproxy '*' --config "$AP_CURL_CONFIG" \
+  "http://127.0.0.1:${PORT}/" >/dev/null; then
+  echo "FAIL: curl request failed" >&2
+  exit 1
+fi
+
+wait "$SERVER_PID"
+SERVER_PID=
+
+ACTUAL=$(cat "$HEADER_FILE")
+if [[ "$ACTUAL" != "Bearer ${TOKEN}" ]]; then
+  echo "FAIL: Authorization header was not parsed from the curl config" >&2
+  exit 1
+fi
+
+echo "  ok   real curl receives the Authorization header from its config"


### PR DESCRIPTION
## Summary

Fixes authentication for the external API upsert scripts by quoting the `Authorization` header value written to curl's config file.

`ap_auth_init` currently writes:

```text
header = Authorization: Bearer <token>
```

curl does not treat the rest of an unquoted config value as verbatim text. The value is terminated at the first whitespace, so curl parses the line as an `Authorization:` header without the bearer token.

For curl, a bare header name followed by `:` means that the header should be removed. As a result, requests made by both `upsert-guide.sh` and `upsert-learning-path.sh` are sent without an `Authorization` header and fail authentication.

The config now writes:

```text
header = "Authorization: Bearer <token>"
```

so curl parses and sends the complete header.

## Why

Both upsert scripts use the shared `ap_auth_init` / `ap_curl` path from `scripts/lib/app-platform.sh`, so the bug affects authentication for both supported external guide upload flows.

The surrounding comment also documented the previous value as intentionally unquoted. That comment was incorrect according to curl's config parsing behaviour, so this PR updates it alongside the fix.

The token continues to be stored in the temporary curl config file rather than passed through `-H` or another command-line argument. This preserves the existing security property of keeping the service-account token out of curl's process arguments during a multi-resource upload.

## Regression coverage

The existing upsert tests use a stubbed curl implementation. That is useful for validating request construction, but the stub does not run curl's real config parser, which is why the malformed config value was not caught.

This PR adds `scripts/tests/app-platform.test.sh`, which exercises the config with real curl:

1. Starts a temporary HTTP server bound to `127.0.0.1`.
2. Calls `ap_auth_init` with a sentinel token.
3. Makes a request using real curl and the generated config file.
4. Captures the `Authorization` header received by the server.
5. Verifies that the value is exactly:

```text
Bearer sentinel-config-token
```

The regression test was also checked against the previous implementation. It fails with the unquoted config value:

```text
FAIL: Authorization header was not parsed from the curl config
```

and passes once the header value is quoted.

The test invokes real curl directly rather than the existing curl stub so that curl's config-file parsing is part of the test.

## How to verify

The script test suite passes:

```bash
npm run test:scripts
```

The full pre-merge check also passes:

```bash
npm run check
```

Result:

```text
check: all 9 steps passed
```

The regression test can also be run directly:

```bash
bash scripts/tests/app-platform.test.sh
```

which reports:

```text
ok   real curl receives the Authorization header from its config
```

## Breaking changes

None.

The request format, external API contract, token source, and upsert behaviour are unchanged. This only corrects how the existing `Authorization` header is serialized into curl's config file.

## Reversibility

Fully reversible. The production change is limited to quoting the curl config value and correcting the accompanying comment.

The added test has no runtime effect. Reverting the production change would restore the previous authentication failure but would not require any data migration or cleanup.

## Linked issue(s)

Closes #1869

## Checklist

- [x] This PR addresses a **single concern** (one bug fix or feature, or a set of closely-related changes).
- [x] All commits are signed.
- [x] I've added or updated tests for the change.
- [x] `npm run check` passes locally.
- [x] UI text and docs use sentence case.