### PR TITLE
fix(coda): surface terminal protocol mismatches

### DIFF
--- a/src/integrations/coda/useTerminalLive.hook.test.ts
+++ b/src/integrations/coda/useTerminalLive.hook.test.ts
@@ -29,6 +29,10 @@ jest.mock('../../lib/logging', () => ({
 }));
 
 const mockedCreateSession = createSession as jest.MockedFunction<typeof createSession>;
+const mockedLogger = jest.requireMock('../../lib/logging').logger as {
+  error: jest.Mock;
+  warn: jest.Mock;
+};
 
 const SESSION_ID = 's_0123456789abcdef0123456789abcdef';
 
@@ -171,6 +175,42 @@ describe('useTerminalLive session lifetime', () => {
 
     expect(hook.result.current.sessionId).toBeNull();
     expect(close).toHaveBeenCalled();
+  });
+
+  it('surfaces a protocol mismatch without closing the live session', async () => {
+    const { hook, terminalRef, handlers, close } = await connectedHook();
+
+    act(() => {
+      handlers.current.onProtocolError?.({
+        detail: 'event payload failed validation',
+        sessionId: SESSION_ID,
+        vmId: 'vm-1',
+      });
+    });
+
+    expect(hook.result.current.status).toBe('error');
+    expect(hook.result.current.error).toBe(
+      'Unreadable message from the sandbox backend — the plugin and backend may be out of sync.'
+    );
+    expect(hook.result.current.sessionId).toBe(SESSION_ID);
+    expect(close).not.toHaveBeenCalled();
+
+    expect(mockedLogger.error).toHaveBeenCalledWith(
+      '[Terminal] Coda protocol mismatch',
+      expect.objectContaining({
+        detail: 'event payload failed validation',
+        sessionId: SESSION_ID,
+        vmId: 'vm-1',
+        category: 'protocol_error',
+      })
+    );
+    expect(mockedLogger.warn).not.toHaveBeenCalled();
+
+    const writeln = terminalRef.current.writeln as jest.Mock;
+    expect(writeln).toHaveBeenCalledWith('\r\n');
+    expect(writeln).toHaveBeenCalledWith(
+      '\x1b[31m✖ Error: Unreadable message from the sandbox backend — the plugin and backend may be out of sync.\x1b[0m'
+    );
   });
 });
 

--- a/src/integrations/coda/useTerminalLive.hook.ts
+++ b/src/integrations/coda/useTerminalLive.hook.ts
@@ -53,6 +53,9 @@ function codaSessionErrorMessage(err: unknown): string {
   return codaErrorCodeMessage(codaErr.code, codaErr.message);
 }
 
+const PROTOCOL_MISMATCH_MESSAGE =
+  'Unreadable message from the sandbox backend — the plugin and backend may be out of sync.';
+
 interface UseTerminalLiveOptions {
   /** Terminal instance ref - accessed in callbacks, not during render */
   terminalRef: RefObject<Terminal | null>;
@@ -307,12 +310,17 @@ export function useTerminalLive({ terminalRef }: UseTerminalLiveOptions): UseTer
         },
 
         onProtocolError: ({ detail, sessionId: sid, vmId }) => {
-          connectionLogRef.current.warn('Coda protocol mismatch', {
+          connectionLogRef.current.error('Coda protocol mismatch', undefined, {
             detail,
             sessionId: sid,
             vmId,
             category: 'protocol_error',
           });
+
+          terminal.writeln('\r\n');
+          terminal.writeln(`\x1b[31m✖ Error: ${PROTOCOL_MISMATCH_MESSAGE}\x1b[0m`);
+          setError(PROTOCOL_MISMATCH_MESSAGE);
+          setStatus('error');
         },
       });
     },


### PR DESCRIPTION
## What

Surface Coda terminal protocol mismatches in the terminal UI and connection state.

## Why

`CodaSession` reports a malformed frame through `onProtocolError`. The hook previously logged it at warn level only, so users saw no explanation and the warning could be filtered before a Pathfinder surface opened. The change logs at error level, renders a visible terminal diagnostic, and sets error state while leaving the session object alive for the SDK's non-fatal contract.

## Verification

- Added regression coverage for error-level logging, visible terminal output, error state, and the non-closing session behavior.
- `npx jest src/integrations/coda --coverage=false --runInBand` (141 passed)
- `npm run typecheck`
- Target ESLint and Prettier checks, `git diff --check`, and `npm run test:review-contract` (85 passed)
- The governance import-graph path assertions have existing Windows separator failures, reproduced on a clean baseline.


## Follow-up

The follow-up restores the SDK's documented non-fatal onProtocolError contract: it preserves the connected status and session id and allows later compatible frames, while keeping the diagnostic visible. The onError and onClosed paths remain the terminal teardown boundary.

Fixes #1527